### PR TITLE
Port Lite time-display mode (Server/Local/UTC) into the Darling viewer

### DIFF
--- a/Darling/Darling.Tests/DarlingObservabilityTests.cs
+++ b/Darling/Darling.Tests/DarlingObservabilityTests.cs
@@ -32,9 +32,9 @@ public sealed class DarlingObservabilityTests
     private const int TestServerId = -424242;
 
     [Fact]
-    public void MigrationScripts_FifteenVersions_V14RefreshViews_V15IndexMetadata()
+    public void MigrationScripts_SixteenVersions_V15IndexMetadata_V16ServerUtcOffset()
     {
-        Assert.Equal(15, PgMigrations.Scripts.Count);
+        Assert.Equal(16, PgMigrations.Scripts.Count);
         Assert.Equal(1, PgMigrations.Scripts[0].Version);
         Assert.Equal(2, PgMigrations.Scripts[1].Version);
         Assert.Equal(3, PgMigrations.Scripts[2].Version);
@@ -50,7 +50,8 @@ public sealed class DarlingObservabilityTests
         Assert.Equal(13, PgMigrations.Scripts[12].Version);
         Assert.Equal(14, PgMigrations.Scripts[13].Version);
         Assert.Equal(15, PgMigrations.Scripts[14].Version);
-        Assert.Equal(15, StorageVersion.SchemaVersion);
+        Assert.Equal(16, PgMigrations.Scripts[15].Version);
+        Assert.Equal(16, StorageVersion.SchemaVersion);
 
         /* V5 completes the v_* twin of Lite's DuckDB view layer -- the copy-parity tail tabs
            (Running Jobs, Configuration, Daily Summary, Collection Health) read these five, so
@@ -230,6 +231,14 @@ public sealed class DarlingObservabilityTests
         Assert.Contains("ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS allow_row_locks boolean;", v15, StringComparison.Ordinal);
         Assert.Contains("ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS is_indexed_view boolean;", v15, StringComparison.Ordinal);
         Assert.Contains("CREATE OR REPLACE VIEW v_index_object_stats AS SELECT * FROM index_object_stats;", v15, StringComparison.Ordinal);
+
+        /* V16 adds server_properties.utc_offset_minutes additively (the monitored server's UTC offset the
+           shared collector now writes), so the headless viewer's Server-time display mode can render
+           timestamps in the server's own local time — one nullable ADD COLUMN IF NOT EXISTS, appended to
+           keep the positional binary COPY aligned. server_properties has no v_* view, so nothing to refresh. */
+        var v16 = PgMigrations.Scripts[15].Sql;
+        Assert.Equal("server-utc-offset", PgMigrations.Scripts[15].Name);
+        Assert.Contains("ALTER TABLE server_properties ADD COLUMN IF NOT EXISTS utc_offset_minutes integer;", v16, StringComparison.Ordinal);
 
         var v2 = PgMigrations.Scripts[1].Sql;
         Assert.Contains("CREATE TABLE IF NOT EXISTS servers (", v2, StringComparison.Ordinal);

--- a/Darling/Darling.Tests/ViewerDataServiceTests.cs
+++ b/Darling/Darling.Tests/ViewerDataServiceTests.cs
@@ -19,8 +19,9 @@ namespace Darling.Tests;
 
 /// <summary>
 /// Pins the viewer's SQL against the Darling store contract (no live Postgres needed) and
-/// unit-tests the pure display helpers: the version label and the naive-UTC-to-local conversion.
-/// (The Overview trend reads + wait-category roll-up are pinned in <c>ViewerTrendsTests</c>.)
+/// unit-tests the pure display helpers: the version label. (The naive-UTC → display conversion moved to
+/// the mode-aware <c>ViewerTimeHelper</c>, pinned in <c>ViewerTimeHelperTests</c>; the Overview trend
+/// reads + wait-category roll-up are pinned in <c>ViewerTrendsTests</c>.)
 /// </summary>
 public sealed class ViewerDataServiceTests
 {
@@ -49,17 +50,8 @@ public sealed class ViewerDataServiceTests
         Assert.Equal(expected, ViewerDataService.SqlVersionLabel(major));
     }
 
-    [Fact]
-    public void ToLocalTime_TreatsTheNaiveValueAsUtc()
-    {
-        var naive = new DateTime(2026, 7, 1, 12, 0, 0, DateTimeKind.Unspecified);
-
-        var local = ViewerDataService.ToLocalTime(naive);
-
-        Assert.Equal(DateTimeKind.Local, local.Kind);
-        /* Round-tripping back to UTC recovers the stored value, whatever the machine's zone. */
-        Assert.Equal(naive.Ticks, local.ToUniversalTime().Ticks);
-    }
+    /* The naive-UTC → display conversion moved from ViewerDataService.ToLocalTime to the mode-aware
+       ViewerTimeHelper (Server/Local/UTC); it is pinned in ViewerTimeHelperTests. */
 
     [Fact]
     public void DarlingServer_VersionLabel_ComesFromTheMajorVersion()

--- a/Darling/Darling.Tests/ViewerQueriesRestTests.cs
+++ b/Darling/Darling.Tests/ViewerQueriesRestTests.cs
@@ -213,7 +213,7 @@ public sealed class ViewerActiveQueriesDisplayTests
         /* collection_time is naive UTC in the store; the display converts to local (unlike the raw
            server-clock last_execution_time). MinValue (no row) renders empty. */
         var row = new ViewerQuerySnapshotRow { CollectionTime = new DateTime(2026, 7, 1, 12, 0, 0, DateTimeKind.Unspecified) };
-        var expected = ViewerDataService.ToLocalTime(row.CollectionTime).ToString("yyyy-MM-dd HH:mm:ss");
+        var expected = ViewerTimeHelper.ForDisplay(row.CollectionTime).ToString("yyyy-MM-dd HH:mm:ss");
         Assert.Equal(expected, row.CollectionTimeLocal);
         Assert.Equal("", new ViewerQuerySnapshotRow().CollectionTimeLocal);
     }

--- a/Darling/Darling.Tests/ViewerSystemEventsTests.cs
+++ b/Darling/Darling.Tests/ViewerSystemEventsTests.cs
@@ -412,7 +412,7 @@ public sealed class ViewerSystemEventsTests
     public void Rows_EventTimeLocal_RendersTheUtcTimestampAsMachineLocal()
     {
         var utc = new DateTime(2026, 7, 5, 12, 0, 5, DateTimeKind.Utc);
-        var expected = ViewerDataService.ToLocalTime(utc).ToString("yyyy-MM-dd HH:mm:ss");
+        var expected = ViewerTimeHelper.ForDisplay(utc).ToString("yyyy-MM-dd HH:mm:ss");
 
         Assert.Equal(expected, new SchedulerIssueRow(new SchedulerIssueRecord { EventTime = utc }).EventTimeLocal);
         Assert.Equal(expected, new SignificantWaitRow(new SignificantWaitRecord { EventTime = utc }).EventTimeLocal);
@@ -437,7 +437,7 @@ public sealed class ViewerSystemEventsTests
     public void CpuTasksRow_And_IoIssuesRow_ProjectRecordFields()
     {
         var utc = new DateTime(2026, 7, 5, 12, 6, 0, DateTimeKind.Utc);
-        var expected = ViewerDataService.ToLocalTime(utc).ToString("yyyy-MM-dd HH:mm:ss");
+        var expected = ViewerTimeHelper.ForDisplay(utc).ToString("yyyy-MM-dd HH:mm:ss");
 
         var cpu = new CpuTasksRow(new CpuTasksRecord
             { EventTime = utc, State = "WARNING", PendingTasks = 15, DidBlockingOccur = true });

--- a/Darling/Darling.Tests/ViewerTimeHelperTests.cs
+++ b/Darling/Darling.Tests/ViewerTimeHelperTests.cs
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using PerformanceMonitor.Darling.Viewer;
+using PerformanceMonitor.Ui;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Pins <see cref="ViewerTimeHelper"/> — the viewer's port of Lite's ServerTimeHelper and the single
+/// chokepoint every rendered timestamp routes through. The store is naive-UTC, so: UTC = raw, Local =
+/// machine-local (SpecifyKind(Utc).ToLocalTime()), Server = UTC + the server's collected offset. Also pins
+/// the inverse used by the custom-range pickers and the per-server offset read SQL. The conversion core is
+/// exercised through the pure <c>ConvertToDisplay</c>/<c>ConvertFromDisplay</c> overloads so the process-
+/// wide statics are not mutated; two focused tests confirm the static <c>ForDisplay</c>/<c>DisplayToNaiveUtc</c>
+/// delegate to them (saving/restoring the statics).
+/// </summary>
+public sealed class ViewerTimeHelperTests
+{
+    private static readonly DateTime NaiveUtc = new(2026, 7, 1, 12, 0, 0, DateTimeKind.Unspecified);
+
+    [Fact]
+    public void ConvertToDisplay_Utc_ReturnsRawStoredValue()
+    {
+        Assert.Equal(NaiveUtc, ViewerTimeHelper.ConvertToDisplay(NaiveUtc, TimeDisplayMode.UTC, utcOffsetMinutes: 330));
+    }
+
+    [Fact]
+    public void ConvertToDisplay_Local_MatchesMachineLocalConvention()
+    {
+        /* The viewer's historical convention (the former ViewerDataService.ToLocalTime): treat the
+           Unspecified store value as UTC, then convert to the viewer machine's local time. Offset is ignored. */
+        var expected = DateTime.SpecifyKind(NaiveUtc, DateTimeKind.Utc).ToLocalTime();
+        var actual = ViewerTimeHelper.ConvertToDisplay(NaiveUtc, TimeDisplayMode.LocalTime, utcOffsetMinutes: 999);
+        Assert.Equal(expected, actual);
+        Assert.Equal(DateTimeKind.Local, actual.Kind);
+    }
+
+    [Theory]
+    [InlineData(0, 0)]        // a UTC server: Server == UTC
+    [InlineData(330, 330)]    // India +05:30
+    [InlineData(-480, -480)]  // US Pacific standard -08:00
+    [InlineData(-300, -300)]  // US Eastern standard -05:00
+    public void ConvertToDisplay_Server_AddsCollectedOffset(int offsetMinutes, int expectedShiftMinutes)
+    {
+        Assert.Equal(
+            NaiveUtc.AddMinutes(expectedShiftMinutes),
+            ViewerTimeHelper.ConvertToDisplay(NaiveUtc, TimeDisplayMode.ServerTime, offsetMinutes));
+    }
+
+    [Theory]
+    [InlineData(TimeDisplayMode.UTC)]
+    [InlineData(TimeDisplayMode.LocalTime)]
+    [InlineData(TimeDisplayMode.ServerTime)]
+    public void ConvertFromDisplay_InvertsConvertToDisplay(TimeDisplayMode mode)
+    {
+        const int offset = -300;
+        var display = ViewerTimeHelper.ConvertToDisplay(NaiveUtc, mode, offset);
+        var backToStore = ViewerTimeHelper.ConvertFromDisplay(display, mode, offset);
+
+        /* Round-trips to the original naive-UTC store value, re-stamped Unspecified (the kind the reads send). */
+        Assert.Equal(NaiveUtc, backToStore);
+        Assert.Equal(DateTimeKind.Unspecified, backToStore.Kind);
+    }
+
+    [Fact]
+    public void ConvertFromDisplay_Server_SubtractsOffset()
+    {
+        /* A picker value the user typed in Server time maps back to the naive-UTC window bound. */
+        var serverWallClock = new DateTime(2026, 7, 1, 7, 0, 0);   // 07:00 on a -05:00 server
+        var expectedUtc = DateTime.SpecifyKind(new DateTime(2026, 7, 1, 12, 0, 0), DateTimeKind.Unspecified);
+        Assert.Equal(expectedUtc, ViewerTimeHelper.ConvertFromDisplay(serverWallClock, TimeDisplayMode.ServerTime, -300));
+    }
+
+    [Fact]
+    public void ForDisplay_ReadsProcessWideStatics()
+    {
+        var savedMode = ViewerTimeHelper.CurrentDisplayMode;
+        var savedOffset = ViewerTimeHelper.UtcOffsetMinutes;
+        try
+        {
+            ViewerTimeHelper.UtcOffsetMinutes = 90;
+
+            ViewerTimeHelper.CurrentDisplayMode = TimeDisplayMode.ServerTime;
+            Assert.Equal(NaiveUtc.AddMinutes(90), ViewerTimeHelper.ForDisplay(NaiveUtc));
+
+            ViewerTimeHelper.CurrentDisplayMode = TimeDisplayMode.UTC;
+            Assert.Equal(NaiveUtc, ViewerTimeHelper.ForDisplay(NaiveUtc));
+
+            ViewerTimeHelper.CurrentDisplayMode = TimeDisplayMode.LocalTime;
+            Assert.Equal(DateTime.SpecifyKind(NaiveUtc, DateTimeKind.Utc).ToLocalTime(), ViewerTimeHelper.ForDisplay(NaiveUtc));
+        }
+        finally
+        {
+            ViewerTimeHelper.CurrentDisplayMode = savedMode;
+            ViewerTimeHelper.UtcOffsetMinutes = savedOffset;
+        }
+    }
+
+    [Fact]
+    public void DisplayToNaiveUtc_ReadsProcessWideStatics_AndRoundTripsForDisplay()
+    {
+        var savedMode = ViewerTimeHelper.CurrentDisplayMode;
+        var savedOffset = ViewerTimeHelper.UtcOffsetMinutes;
+        try
+        {
+            ViewerTimeHelper.UtcOffsetMinutes = -300;
+            ViewerTimeHelper.CurrentDisplayMode = TimeDisplayMode.ServerTime;
+
+            var display = ViewerTimeHelper.ForDisplay(NaiveUtc);
+            Assert.Equal(NaiveUtc, ViewerTimeHelper.DisplayToNaiveUtc(display));
+        }
+        finally
+        {
+            ViewerTimeHelper.CurrentDisplayMode = savedMode;
+            ViewerTimeHelper.UtcOffsetMinutes = savedOffset;
+        }
+    }
+
+    [Fact]
+    public void ServerUtcOffsetSql_ReadsLatestNonNullOffsetForServer()
+    {
+        var sql = ViewerDataService.ServerUtcOffsetSql;
+        Assert.Contains("utc_offset_minutes", sql, StringComparison.Ordinal);
+        Assert.Contains("FROM server_properties", sql, StringComparison.Ordinal);
+        Assert.Contains("WHERE server_id = $1", sql, StringComparison.Ordinal);
+        Assert.Contains("utc_offset_minutes IS NOT NULL", sql, StringComparison.Ordinal);
+        Assert.Contains("ORDER BY collection_time DESC", sql, StringComparison.Ordinal);
+        Assert.Contains("LIMIT 1", sql, StringComparison.Ordinal);
+        /* Darling has no v_server_properties view — the base table, bare-name resolved via the Search Path. */
+        Assert.DoesNotContain("v_server_properties", sql, StringComparison.Ordinal);
+    }
+}

--- a/Darling/Darling.Tests/ViewerWave2Tests.cs
+++ b/Darling/Darling.Tests/ViewerWave2Tests.cs
@@ -154,7 +154,7 @@ public sealed class ViewerWave2DisplayTests
         var storedUtc = new DateTime(2026, 7, 1, 3, 30, 0, DateTimeKind.Unspecified);
         var row = new ViewerBlockedProcessRow { EventTime = storedUtc };
 
-        Assert.Equal(ViewerDataService.ToLocalTime(storedUtc).ToString("yyyy-MM-dd HH:mm:ss"), row.EventTimeLocal);
+        Assert.Equal(ViewerTimeHelper.ForDisplay(storedUtc).ToString("yyyy-MM-dd HH:mm:ss"), row.EventTimeLocal);
         Assert.Equal("", new ViewerBlockedProcessRow().EventTimeLocal);
     }
 

--- a/Darling/PerformanceMonitor.Darling.Storage/PgMigrations.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/PgMigrations.cs
@@ -59,6 +59,7 @@ public static class PgMigrations
         new Migration(13, "system-health-events-collector", PgSchemaGenerator.GenerateV13AddSystemHealthEvents()),
         new Migration(14, "refresh-passthrough-views", PgSchemaGenerator.GenerateV14RefreshViews()),
         new Migration(15, "index-metadata-columns", V15Sql),
+        new Migration(16, "server-utc-offset", V16Sql),
     };
 
     /// <summary>
@@ -318,6 +319,19 @@ ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS allow_row_locks boolean;
 ALTER TABLE index_object_stats ADD COLUMN IF NOT EXISTS is_indexed_view boolean;
 
 CREATE OR REPLACE VIEW v_index_object_stats AS SELECT * FROM index_object_stats;";
+
+    /// <summary>
+    /// V16 — the monitored server's UTC offset, added additively to <c>server_properties</c> so the
+    /// headless viewer can render timestamps in the server's own local time (the Server-time display
+    /// mode ported from Lite). The store is naive-UTC; Server-time = UTC + this offset. It is nullable
+    /// and appended, so a fresh store's V1 <c>server_properties</c> (generated from the current collector
+    /// definition, which now includes it) already has it and <c>ADD COLUMN IF NOT EXISTS</c> no-ops,
+    /// while an upgraded store gets the real add — with an identical physical column order for the binary
+    /// COPY either way. <c>server_properties</c> has no <c>v_*</c> passthrough view, so nothing to refresh.
+    /// Runs after V8, so the bare name resolves through <c>search_path = collect, config, public</c>.
+    /// </summary>
+    private const string V16Sql = @"
+ALTER TABLE server_properties ADD COLUMN IF NOT EXISTS utc_offset_minutes integer;";
 
     private const string VersionTableSql = @"
 CREATE TABLE IF NOT EXISTS darling_schema_version (

--- a/Darling/PerformanceMonitor.Darling.Storage/StorageVersion.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/StorageVersion.cs
@@ -16,5 +16,5 @@ namespace PerformanceMonitor.Darling.Storage;
 /// </summary>
 public static class StorageVersion
 {
-    public const int SchemaVersion = 15;
+    public const int SchemaVersion = 16;
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/CorrelatedTimelineLanesControl.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/CorrelatedTimelineLanesControl.xaml.cs
@@ -17,13 +17,13 @@
  *   - PerformanceMonitorLite.Analysis BaselineBucket + MetricNames -> the structurally-identical
  *     PerformanceMonitor.Darling.Analysis twins (PgBaselineProvider.cs).
  *   - AppLogger -> Debug.WriteLine.
- *   - Time axis: Lite shifts by its per-server ServerTimeHelper.UtcOffsetMinutes; the viewer has no
- *     per-server offset, so every lane plots collection_time (naive-UTC) through
- *     ViewerDataService.ToLocalTime (the naive-UTC-to-viewer-local convention every Darling chart uses).
+ *   - Time axis: every lane plots collection_time (naive-UTC) through ViewerTimeHelper.ForDisplay, the
+ *     viewer's mode-aware Server/Local/UTC conversion (Server mode adds the collected
+ *     server_properties.utc_offset_minutes, matching Lite's per-server ServerTimeHelper shift).
  *     The CPU lane's sample_time is the monitored server's LOCAL wall clock, so GetCpuUtilizationAsync
- *     de-skews it to naive UTC in SQL before it too goes through ToLocalTime (#1262: per-batch offset =
- *     round(MAX(sample_time) over the batch - collection_time) to 15 min, recovered from the batch
- *     because the viewer has no per-server timezone config). The CPU lane therefore aligns with the
+ *     de-skews it to naive UTC in SQL before it too goes through ForDisplay (#1262: per-batch offset =
+ *     round(MAX(sample_time) over the batch - collection_time) to 15 min, recovered from the batch — a
+ *     data correction independent of the display mode). The CPU lane therefore aligns with the
  *     collection_time lanes on any server timezone; a UTC server is unchanged.
  * Deliberately dropped for v1 (noted in the PR): Lite's comparison-range ghost-line overlay (the whole
  * comparisonRange block, AddGhostLine, ComparisonLabel). The "Show Active Queries at This Time"
@@ -197,8 +197,8 @@ public partial class CorrelatedTimelineLanesControl : UserControl
             {
                 /* Total non-idle CPU = SQL + other-process (Lite's CpuUtilizationData.TotalCpu). The
                    viewer's raw read exposes the two components; sum them here for the Total series. */
-                var sqlSeries = cpuTask.Result.Select(d => (ViewerDataService.ToLocalTime(d.SampleTime).ToOADate(), (double)d.SqlServerCpu)).ToList();
-                var totalSeries = cpuTask.Result.Select(d => (ViewerDataService.ToLocalTime(d.SampleTime).ToOADate(), (double)(d.SqlServerCpu + d.OtherProcessCpu))).ToList();
+                var sqlSeries = cpuTask.Result.Select(d => (ViewerTimeHelper.ForDisplay(d.SampleTime).ToOADate(), (double)d.SqlServerCpu)).ToList();
+                var totalSeries = cpuTask.Result.Select(d => (ViewerTimeHelper.ForDisplay(d.SampleTime).ToOADate(), (double)(d.SqlServerCpu + d.OtherProcessCpu))).ToList();
                 UpdateCpuLane(sqlSeries, totalSeries, cpuBaseline);
             }
             else
@@ -206,24 +206,24 @@ public partial class CorrelatedTimelineLanesControl : UserControl
 
             if (waitTask.IsCompletedSuccessfully)
                 UpdateLane(WaitStatsChart, "Wait ms/sec",
-                    waitTask.Result.Select(d => (ViewerDataService.ToLocalTime(d.CollectionTime).ToOADate(), d.WaitTimeMsPerSecond)).ToList(),
+                    waitTask.Result.Select(d => (ViewerTimeHelper.ForDisplay(d.CollectionTime).ToOADate(), d.WaitTimeMsPerSecond)).ToList(),
                     "#FFB74D", baseline: waitBaseline, minAnomalyValue: 100);
             else
                 ShowEmpty(WaitStatsChart, "Wait ms/sec");
 
             {
                 var blockingData = blockingTask.IsCompletedSuccessfully
-                    ? blockingTask.Result.Select(d => (ViewerDataService.ToLocalTime(d.Time).ToOADate(), (double)d.Count)).ToList()
+                    ? blockingTask.Result.Select(d => (ViewerTimeHelper.ForDisplay(d.Time).ToOADate(), (double)d.Count)).ToList()
                     : new List<(double, double)>();
                 var deadlockData = deadlockTask.IsCompletedSuccessfully
-                    ? deadlockTask.Result.Select(d => (ViewerDataService.ToLocalTime(d.Time).ToOADate(), (double)d.Count)).ToList()
+                    ? deadlockTask.Result.Select(d => (ViewerTimeHelper.ForDisplay(d.Time).ToOADate(), (double)d.Count)).ToList()
                     : new List<(double, double)>();
                 UpdateBlockingLane(blockingData, deadlockData, blockingBaseline);
             }
 
             if (memoryTask.IsCompletedSuccessfully)
                 UpdateLane(MemoryChart, "Buffer Pool MB",
-                    memoryTask.Result.Select(d => (ViewerDataService.ToLocalTime(d.CollectionTime).ToOADate(), d.BufferPoolMb)).ToList(),
+                    memoryTask.Result.Select(d => (ViewerTimeHelper.ForDisplay(d.CollectionTime).ToOADate(), d.BufferPoolMb)).ToList(),
                     "#CE93D8");
             else
                 ShowEmpty(MemoryChart, "Memory MB");
@@ -233,7 +233,7 @@ public partial class CorrelatedTimelineLanesControl : UserControl
                 var ioGrouped = fileIoTask.Result
                     .GroupBy(d => d.CollectionTime)
                     .OrderBy(g => g.Key)
-                    .Select(g => (ViewerDataService.ToLocalTime(g.Key).ToOADate(), g.Average(x => x.AvgReadLatencyMs)))
+                    .Select(g => (ViewerTimeHelper.ForDisplay(g.Key).ToOADate(), g.Average(x => x.AvgReadLatencyMs)))
                     .ToList();
                 UpdateLane(FileIoChart, "I/O ms", ioGrouped, "#81C784", baseline: ioBaseline, minAnomalyValue: 2);
             }
@@ -540,12 +540,12 @@ public partial class CorrelatedTimelineLanesControl : UserControl
         DateTime xStart, xEnd;
         if (fromDate.HasValue && toDate.HasValue)
         {
-            xStart = ViewerDataService.ToLocalTime(fromDate.Value);
-            xEnd = ViewerDataService.ToLocalTime(toDate.Value);
+            xStart = ViewerTimeHelper.ForDisplay(fromDate.Value);
+            xEnd = ViewerTimeHelper.ForDisplay(toDate.Value);
         }
         else
         {
-            xEnd = ViewerDataService.ToLocalTime(DateTime.UtcNow);
+            xEnd = ViewerTimeHelper.ForDisplay(DateTime.UtcNow);
             xStart = xEnd.AddHours(-hoursBack);
         }
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
@@ -17,6 +17,7 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Threading;
 using PerformanceMonitor.Common;
+using PerformanceMonitor.Ui;
 
 namespace PerformanceMonitor.Darling.Viewer;
 
@@ -75,9 +76,14 @@ public partial class MainWindow : Window
     {
         InitializeComponent();
         _preferences = _preferencesStore.Load();
-        /* Seed the one persisted app setting the viewer honors at runtime (the CSV export separator) so grid
-           exports use the chosen separator from the first one, before the Settings window is ever opened. */
-        ViewerExportSettings.Apply(_appSettingsStore.Load());
+        /* Seed the persisted app settings the viewer honors at runtime BEFORE any tab/chart renders: the CSV
+           export separator (grid exports) and the Server/Local/UTC time-display mode (every timestamp render
+           routes through ViewerTimeHelper, which reads CurrentDisplayMode). UiTimeContext is deliberately left
+           at its identity default — Darling charts pre-convert their X through ForDisplay, so wiring it would
+           double-convert on hover/crosshair. */
+        var appSettings = _appSettingsStore.Load();
+        ViewerExportSettings.Apply(appSettings);
+        ApplyTimeDisplayMode(appSettings.TimeDisplayMode);
         Loaded += OnLoaded;
         Closed += OnClosed;
     }
@@ -398,6 +404,7 @@ public partial class MainWindow : Window
         var serverTab = new ViewerServerTab(_dataService, server, _preferences);
         serverTab.StatusChanged += OnServerTabStatusChanged;
         serverTab.ApplyTimeRangeRequested += OnApplyTimeRangeToAllRequested;
+        serverTab.DisplayModeChanged += OnDisplayModeChanged;
 
         var tabItem = new TabItem
         {
@@ -422,6 +429,7 @@ public partial class MainWindow : Window
         {
             serverTab.StatusChanged -= OnServerTabStatusChanged;
             serverTab.ApplyTimeRangeRequested -= OnApplyTimeRangeToAllRequested;
+            serverTab.DisplayModeChanged -= OnDisplayModeChanged;
             /* One dispose path: tears down every chart hover helper the tab's partials own. */
             serverTab.Dispose();
         }
@@ -469,8 +477,8 @@ public partial class MainWindow : Window
 
     /// <summary>
     /// "Apply to All" from one server tab's toolbar: copy its selected range (and, for a custom range, the
-    /// From/To in machine-local display time) to every OTHER open server tab so they window on the same
-    /// period. The source tab is skipped — it already holds the range.
+    /// From/To in the current display-mode wall clock) to every OTHER open server tab so they window on the
+    /// same period. The source tab is skipped — it already holds the range.
     /// </summary>
     private void OnApplyTimeRangeToAllRequested(ViewerServerTab source, int index, DateTime? customFromLocal, DateTime? customToLocal)
     {
@@ -481,6 +489,43 @@ public partial class MainWindow : Window
                 serverTab.ApplyExternalTimeRange(index, customFromLocal, customToLocal);
             }
         }
+    }
+
+    // ── Time-display mode (Server / Local / UTC) ─────────────────────────────────────
+
+    /// <summary>
+    /// A server tab's Server/Local/UTC picker changed (the raising tab already set the global mode via
+    /// <see cref="ViewerTimeHelper.CurrentDisplayMode"/> and reloaded itself). Persist the new mode and sync
+    /// every OTHER open tab's picker so they agree — the mode is process-wide, and a background tab reloads
+    /// on activation and picks it up.
+    /// </summary>
+    private void OnDisplayModeChanged(TimeDisplayMode mode)
+    {
+        var settings = _appSettingsStore.Load();
+        settings.TimeDisplayMode = mode.ToString();
+        _appSettingsStore.Save(settings);
+        SyncDisplayModeToOpenTabs(mode);
+    }
+
+    /// <summary>Sets every open server tab's toolbar picker to <paramref name="mode"/> without raising a
+    /// change (each tab suppresses it), keeping the process-wide mode's UI in sync across tabs.</summary>
+    private void SyncDisplayModeToOpenTabs(TimeDisplayMode mode)
+    {
+        foreach (var tab in _openServerTabs.Values)
+        {
+            if (tab.Content is ViewerServerTab serverTab)
+            {
+                serverTab.SetDisplayModeSelection(mode);
+            }
+        }
+    }
+
+    /// <summary>Sets the process-wide display mode from a persisted string ("ServerTime"/"LocalTime"/"UTC");
+    /// an invalid/absent value falls to Server-time (Lite's default, matching ViewerAppSettings.Normalize).</summary>
+    private static void ApplyTimeDisplayMode(string? modeText)
+    {
+        ViewerTimeHelper.CurrentDisplayMode =
+            Enum.TryParse<TimeDisplayMode>(modeText, ignoreCase: true, out var mode) ? mode : TimeDisplayMode.ServerTime;
     }
 
     // ── Overview tab (all-servers server cards; refreshes on its own 30s timer) ──────
@@ -683,9 +728,18 @@ public partial class MainWindow : Window
             _preferencesStore.Save(_preferences);
         }
 
-        /* Re-seed the runtime export separator from whatever the window persisted (it self-saves the app
-           settings), so a CSV-separator change takes effect on the next export without a restart. */
-        ViewerExportSettings.Apply(_appSettingsStore.Load());
+        /* Re-seed the runtime settings the viewer honors from whatever the window persisted (it self-saves):
+           the CSV export separator (next export) and the Server/Local/UTC time-display mode. If the mode
+           changed there, sync every open tab's picker and reload the visible tab so its timestamps re-render. */
+        var reloaded = _appSettingsStore.Load();
+        ViewerExportSettings.Apply(reloaded);
+        var previousMode = ViewerTimeHelper.CurrentDisplayMode;
+        ApplyTimeDisplayMode(reloaded.TimeDisplayMode);
+        if (ViewerTimeHelper.CurrentDisplayMode != previousMode)
+        {
+            SyncDisplayModeToOpenTabs(ViewerTimeHelper.CurrentDisplayMode);
+            _ = LoadVisibleTabAsync();
+        }
     }
 
     // ── About ────────────────────────────────────────────────────────────────────────

--- a/Darling/PerformanceMonitor.Darling.Viewer/TimeRangeSlicerControl.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/TimeRangeSlicerControl.xaml.cs
@@ -25,7 +25,7 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// so <see cref="SelectionStartUtc"/>/<see cref="SelectionEndUtc"/> and the <see cref="RangeChanged"/>
 /// payload are UTC and flow straight into the viewer's naive-UTC reads with no clock conversion. The
 /// only deviation from Lite is the two display strings (axis labels + range label): Lite's per-server
-/// <c>ServerTimeHelper.FormatServerTime</c> becomes <see cref="ViewerDataService.ToLocalTime"/> (the
+/// <c>ServerTimeHelper.FormatServerTime</c> becomes <see cref="ViewerTimeHelper.ForDisplay"/> (the
 /// viewer's one machine-local convention).
 /// </summary>
 public partial class TimeRangeSlicerControl : UserControl
@@ -260,7 +260,7 @@ public partial class TimeRangeSlicerControl : UserControl
             var x = NormAtUtc(tickTime) * w;
             if (x - lastLabelX < minLabelSpacingPx) continue;
             if (x < 10 || x > w - 40) continue;
-            var dt = ViewerDataService.ToLocalTime(tickTime).ToString("MM/dd HH:mm");
+            var dt = ViewerTimeHelper.ForDisplay(tickTime).ToString("MM/dd HH:mm");
             var tb = new TextBlock { Text = dt, FontSize = 9, Foreground = labelBrush };
             Canvas.SetLeft(tb, x - 25);
             Canvas.SetTop(tb, chartBottom + 2);
@@ -373,8 +373,8 @@ public partial class TimeRangeSlicerControl : UserControl
     private void UpdateRangeLabel()
     {
         if (_data.Count == 0) { RangeLabel.Text = ""; return; }
-        var startDisplay = ViewerDataService.ToLocalTime(UtcAtNorm(_rangeStart)).ToString("yyyy-MM-dd HH:mm");
-        var endDisplay = ViewerDataService.ToLocalTime(UtcAtNorm(_rangeEnd)).ToString("yyyy-MM-dd HH:mm");
+        var startDisplay = ViewerTimeHelper.ForDisplay(UtcAtNorm(_rangeStart)).ToString("yyyy-MM-dd HH:mm");
+        var endDisplay = ViewerTimeHelper.ForDisplay(UtcAtNorm(_rangeEnd)).ToString("yyyy-MM-dd HH:mm");
         var spanHours = (UtcAtNorm(_rangeEnd) - UtcAtNorm(_rangeStart)).TotalHours;
         var spanLabel = spanHours >= 1 ? $"{spanHours:F0}h" : $"{spanHours * 60:F0}m";
         RangeLabel.Text = $"{startDisplay} → {endDisplay}  ({spanLabel})";

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.AlertHistory.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.AlertHistory.cs
@@ -55,7 +55,7 @@ public sealed class ViewerAlertRow
     public string? ContextJson { get; init; }
 
     /// <summary>Stored naive-UTC; shown in the viewer machine's local time (the viewer convention).</summary>
-    public string TimeLocal => ViewerDataService.ToLocalTime(AlertTime).ToString("yyyy-MM-dd HH:mm:ss");
+    public string TimeLocal => ViewerTimeHelper.ForDisplay(AlertTime).ToString("yyyy-MM-dd HH:mm:ss");
 
     public string CurrentValueDisplay => FormatValue(MetricName, CurrentValue);
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Blocking.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Blocking.cs
@@ -26,7 +26,7 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// Lite's <c>BlockedProcessReportRow</c> exactly. event_time is stored naive-UTC (the XE @timestamp is
 /// UTC; the DMV snapshot stamps the collector's UTC collection time), so <see cref="EventTimeLocal"/>
 /// converts to viewer-local like every other collection_time — Lite's per-server
-/// <c>ServerTimeHelper.FormatServerTime</c> becomes <see cref="ViewerDataService.ToLocalTime"/> (the
+/// <c>ServerTimeHelper.FormatServerTime</c> becomes <see cref="ViewerTimeHelper.ForDisplay"/> (the
 /// viewer's one machine-local convention; the same swap the trend charts already document).
 /// </summary>
 public sealed class ViewerBlockedProcessRow : BlockedProcessAlertRow
@@ -62,7 +62,7 @@ public sealed class ViewerBlockedProcessRow : BlockedProcessAlertRow
 
     /// <summary>The stored naive-UTC event time in the viewer machine's local time (Lite's grid format).</summary>
     public string EventTimeLocal
-        => EventTime is { } eventTime ? ViewerDataService.ToLocalTime(eventTime).ToString("yyyy-MM-dd HH:mm:ss") : "";
+        => EventTime is { } eventTime ? ViewerTimeHelper.ForDisplay(eventTime).ToString("yyyy-MM-dd HH:mm:ss") : "";
 
     /// <summary>Lite's wait-time rendering: sub-second in ms, else one-decimal seconds.</summary>
     public string WaitTimeFormatted => ViewerDataService.FormatWaitTime(WaitTimeMs);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.CollectionHealth.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.CollectionHealth.cs
@@ -202,11 +202,10 @@ public sealed partial class ViewerDataService
 /// <summary>
 /// One row of the Collection Log grid / drill window — a single collector run's outcome. Copied
 /// VERBATIM from Lite's <c>CollectionLogRow</c> (LocalDataService.CollectionHealth.cs): every display
-/// property is a pure format of stored values, and <see cref="CollectionTimeFormatted"/>'s
-/// <c>ToLocalTime()</c> on the store's naive-UTC collection_time is correct because Npgsql reads a
-/// <c>timestamp</c> column as an <c>Unspecified</c>-kind <see cref="DateTime"/> and
-/// <see cref="DateTime.ToLocalTime"/> treats Unspecified as UTC (the same convention Lite's DuckDB
-/// reader produced). <see cref="DuckDbDurationMs"/> keeps its store column name (<c>duckdb_duration_ms</c>)
+/// property is a pure format of stored values, and <see cref="CollectionTimeFormatted"/> routes the
+/// store's naive-UTC collection_time through <see cref="ViewerTimeHelper.ForDisplay"/> — the viewer's
+/// mode-aware Server/Local/UTC conversion every other Darling timestamp also uses.
+/// <see cref="DuckDbDurationMs"/> keeps its store column name (<c>duckdb_duration_ms</c>)
 /// but in the Darling store that column records the POSTGRES write phase — the Collection Log grid
 /// labels it "Store (ms)".
 /// </summary>
@@ -225,7 +224,7 @@ public class CollectionLogRow
     public string Status { get; set; } = "";
     public string? ErrorMessage { get; set; }
 
-    public string CollectionTimeFormatted => CollectionTime.ToLocalTime().ToString("g");
+    public string CollectionTimeFormatted => ViewerTimeHelper.ForDisplay(CollectionTime).ToString("g");
 
     public string DurationFormatted => DurationMs.HasValue
         ? (DurationMs.Value < 1000 ? $"{DurationMs.Value} ms" : $"{DurationMs.Value / 1000.0:F1} s")
@@ -300,14 +299,14 @@ public class CollectorHealthRow
         : $"{AvgDurationMs / 1000:F1} s";
 
     public string LastSuccessFormatted => LastSuccessTime.HasValue
-        ? LastSuccessTime.Value.ToLocalTime().ToString("g")
+        ? ViewerTimeHelper.ForDisplay(LastSuccessTime.Value).ToString("g")
         : "Never";
 
     public string LastRunFormatted => LastRunTime.HasValue
-        ? LastRunTime.Value.ToLocalTime().ToString("g")
+        ? ViewerTimeHelper.ForDisplay(LastRunTime.Value).ToString("g")
         : "Never";
 
     public string LastErrorFormatted => LastErrorTime.HasValue
-        ? LastErrorTime.Value.ToLocalTime().ToString("g")
+        ? ViewerTimeHelper.ForDisplay(LastErrorTime.Value).ToString("g")
         : "";
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Cpu.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Cpu.cs
@@ -23,7 +23,7 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// store, read as int and cast to double at plot time, byte-for-byte with Lite's chart body.
 /// <c>SampleTime</c> is the store's server-LOCAL <c>sample_time</c> de-skewed to naive UTC by the read
 /// (see <see cref="CpuUtilizationSql"/>, #1262), so both consumers plot it through
-/// <see cref="ToLocalTime"/> like every other Darling series.
+/// <see cref="ViewerTimeHelper.ForDisplay"/> like every other Darling series.
 /// </summary>
 public sealed record CpuUtilizationSample(DateTime SampleTime, int SqlServerCpu, int OtherProcessCpu);
 
@@ -38,7 +38,7 @@ public sealed partial class ViewerDataService
     ///
     /// <para><b>sample_time de-skew (#1262).</b> Unlike every other stored column, <c>sample_time</c> is
     /// the MONITORED SERVER'S LOCAL wall clock (<c>SYSDATETIME()</c> on the server, minus each
-    /// ring-buffer sample's age), NOT naive UTC — so feeding it straight to <see cref="ToLocalTime"/>
+    /// ring-buffer sample's age), NOT naive UTC — so feeding it straight to <see cref="ViewerTimeHelper.ForDisplay"/>
     /// (which assumes naive-UTC input) shifts the whole CPU series by the server's UTC offset relative
     /// to every <c>collection_time</c>-based lane — a visible misalignment in the correlated Overview
     /// (e.g. a Pacific-time server, offset -7/-8h, sits 7-8h off).
@@ -51,7 +51,7 @@ public sealed partial class ViewerDataService
     /// the server's UTC offset plus that sub-minute anchor age; rounding to 15 minutes recovers the exact
     /// whole/half/quarter-hour offset and absorbs the anchor age (and any few-second clock skew).
     /// Subtracting that per-batch offset turns each local <c>sample_time</c> into true naive UTC, so
-    /// <see cref="ToLocalTime"/> then aligns the CPU series with every other lane. A UTC server yields
+    /// <see cref="ViewerTimeHelper.ForDisplay"/> then aligns the CPU series with every other lane. A UTC server yields
     /// offset 0 — byte-identical to the pre-fix read. The per-batch derivation also handles a DST
     /// transition inside the window (each batch recovers its own offset). Reads the base
     /// <c>cpu_utilization_stats</c> table. $1 server_id, $2 window start (naive UTC).</para>
@@ -80,7 +80,7 @@ public sealed partial class ViewerDataService
     /// Raw CPU samples for one server since <paramref name="sinceUtc"/>, time-ordered — one point per
     /// ring-buffer sample, feeding both the CPU tab's scatter chart and the Overview's CPU lane. Each
     /// sample's <c>SampleTime</c> is de-skewed to naive UTC in the read (see <see cref="CpuUtilizationSql"/>,
-    /// #1262), so both consumers can plot it through <see cref="ToLocalTime"/> unchanged.
+    /// #1262), so both consumers can plot it through <see cref="ViewerTimeHelper.ForDisplay"/> unchanged.
     /// </summary>
     public async Task<List<CpuUtilizationSample>> GetCpuUtilizationAsync(int serverId, DateTime sinceUtc, CancellationToken cancellationToken = default)
     {

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Deadlock.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Deadlock.cs
@@ -43,7 +43,7 @@ public sealed class ViewerDeadlockRow : DeadlockAlertRow
 /// (victim detection, owner/waiter modes, object names, proc-name resolution) is CPU-bound XML work, so
 /// callers run <see cref="ParseFromRows"/> off the UI thread. The only deviation is the two *Local
 /// display strings: Lite's per-server <c>ServerTimeHelper.FormatServerTime</c> becomes the viewer's one
-/// machine-local <see cref="ViewerDataService.ToLocalTime"/> (the same swap the widened BPR row makes).
+/// machine-local <see cref="ViewerTimeHelper.ForDisplay"/> (the same swap the widened BPR row makes).
 /// </summary>
 public sealed class DeadlockProcessDetail
 {
@@ -88,11 +88,11 @@ public sealed class DeadlockProcessDetail
     public DateTime? LastBatchCompleted { get; set; }
 
     public string DeadlockTimeLocal
-        => DeadlockTime is { } t ? ViewerDataService.ToLocalTime(t).ToString("yyyy-MM-dd HH:mm:ss") : "";
+        => DeadlockTime is { } t ? ViewerTimeHelper.ForDisplay(t).ToString("yyyy-MM-dd HH:mm:ss") : "";
     public string VictimDisplay => IsVictim ? "Victim" : "";
     public string WaitTimeFormatted => WaitTime > 0 ? $"{WaitTime:N0} ms" : "";
     public string LastTranStartedLocal
-        => LastTranStarted is { } t ? ViewerDataService.ToLocalTime(t).ToString("yyyy-MM-dd HH:mm:ss") : "";
+        => LastTranStarted is { } t ? ViewerTimeHelper.ForDisplay(t).ToString("yyyy-MM-dd HH:mm:ss") : "";
 
     /// <summary>
     /// Parses a list of deadlock rows into per-process detail rows.

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.Inventory.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.Inventory.cs
@@ -188,7 +188,7 @@ ORDER BY server_name";
                 CoresPerSocket = reader.IsDBNull(10) ? null : Convert.ToInt32(reader.GetValue(10)),
                 IsHadrEnabled = reader.IsDBNull(11) ? null : reader.GetBoolean(11),
                 IsClustered = reader.IsDBNull(12) ? null : reader.GetBoolean(12),
-                LastUpdated = reader.IsDBNull(13) ? null : ToLocalTime(reader.GetDateTime(13)),
+                LastUpdated = reader.IsDBNull(13) ? null : ViewerTimeHelper.ForDisplay(reader.GetDateTime(13)),
                 /* sqlserver_start_time is the server's LOCAL clock — read verbatim, shown as-is like Lite
                    (UptimeDisplay = Now - start). host OS + AG role are the collected guarded values. */
                 SqlServerStartTime = reader.IsDBNull(14) ? null : reader.GetDateTime(14),

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.Storage.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.Storage.cs
@@ -171,9 +171,9 @@ ORDER BY ds.total_size_mb DESC";
                 TotalSizeMb = reader.IsDBNull(1) ? 0m : Convert.ToDecimal(reader.GetValue(1)),
                 FileCount = reader.IsDBNull(2) ? 0 : Convert.ToInt32(reader.GetValue(2)),
                 /* last_execution_time (sys.dm_exec_query_stats) is SERVER-LOCAL in the store, not naive
-                   UTC, so it is read verbatim like Lite — NOT through ToLocalTime (which assumes UTC and
-                   would shift it by the viewer's offset). Contrast the collection_time-derived timestamps
-                   in this port, which ARE naive UTC and correctly use ToLocalTime. */
+                   UTC, so it is read verbatim like Lite — NOT through ViewerTimeHelper.ForDisplay (which
+                   assumes naive UTC and, in Local/Server mode, would shift it). Contrast the
+                   collection_time-derived timestamps in this port, which ARE naive UTC and correctly use ForDisplay. */
                 LastExecutionTime = reader.IsDBNull(3) ? null : reader.GetDateTime(3)
             });
         }
@@ -537,7 +537,7 @@ ORDER BY index_id";
                 UserUpdates = reader.IsDBNull(12) ? 0L : Convert.ToInt64(reader.GetValue(12)),
                 /* last_user_seek/scan/lookup/update (sys.dm_db_index_usage_stats) are SERVER-LOCAL in the
                    store, not naive UTC, so this GREATEST is read verbatim like Lite — NOT through
-                   ToLocalTime (which would shift it by the viewer's offset). */
+                   ViewerTimeHelper.ForDisplay (which assumes naive UTC and, in Local/Server mode, would shift it). */
                 LastUserAccess = reader.IsDBNull(13) ? null : reader.GetDateTime(13),
                 Classification = reader.IsDBNull(14) ? "" : reader.GetString(14)
             });

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.Workload.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.Workload.cs
@@ -152,8 +152,8 @@ ORDER BY max_connections DESC";
                 AvgConnections = reader.IsDBNull(1) ? 0 : Convert.ToInt32(reader.GetValue(1)),
                 MaxConnections = reader.IsDBNull(2) ? 0 : Convert.ToInt32(reader.GetValue(2)),
                 SampleCount = reader.IsDBNull(3) ? 0 : Convert.ToInt64(reader.GetValue(3)),
-                FirstSeenLocal = ToLocalTime(reader.GetDateTime(4)),
-                LastSeenLocal = ToLocalTime(reader.GetDateTime(5))
+                FirstSeenLocal = ViewerTimeHelper.ForDisplay(reader.GetDateTime(4)),
+                LastSeenLocal = ViewerTimeHelper.ForDisplay(reader.GetDateTime(5))
             });
         }
         return items;

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Findings.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Findings.cs
@@ -39,7 +39,7 @@ public sealed class ViewerFindingRow
     public required AnalysisFinding Finding { get; init; }
 
     /// <summary>The batch's analysis time in the viewer machine's local time.</summary>
-    public DateTime AnalysisTimeLocal => ViewerDataService.ToLocalTime(Finding.AnalysisTime);
+    public DateTime AnalysisTimeLocal => ViewerTimeHelper.ForDisplay(Finding.AnalysisTime);
 
     /// <summary>
     /// True when this finding's story pattern is in <c>analysis_muted</c> for the server (the

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Overview.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Overview.cs
@@ -247,7 +247,7 @@ public sealed class ServerSummaryItem
     /// (the viewer convention — Lite used its per-server offset helper instead).
     /// </summary>
     public string LastCollectionDisplay => LastCollectionTime.HasValue
-        ? ViewerDataService.ToLocalTime(LastCollectionTime.Value).ToString("HH:mm:ss")
+        ? ViewerTimeHelper.ForDisplay(LastCollectionTime.Value).ToString("HH:mm:ss")
         : "Never";
 
     /* Connection status — verbatim from Lite; in the viewer the inputs come from ApplyFreshness. */

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QuerySnapshots.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QuerySnapshots.cs
@@ -19,7 +19,7 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// One Active-Queries snapshot row — the viewer copy of Lite's <c>QuerySnapshotRow</c>
 /// (LocalDataService.Blocking.cs) trimmed to the ~26 columns the viewer's grid binds. A captured
 /// running request from one collection cycle. <see cref="CollectionTime"/> is the collector's naive-UTC
-/// capture time, so <see cref="CollectionTimeLocal"/> converts through <see cref="ViewerDataService.ToLocalTime"/>
+/// capture time, so <see cref="CollectionTimeLocal"/> converts through <see cref="ViewerTimeHelper.ForDisplay"/>
 /// (Lite's <c>ServerTimeHelper.FormatServerTime</c>). <see cref="QueryPlan"/> / <see cref="LiveQueryPlan"/>
 /// are the stored estimated / live plan XML the collector now captures inline; <see cref="HasQueryPlan"/> /
 /// <see cref="HasLiveQueryPlan"/> gate the grid's Estimated / Actual plan buttons.
@@ -57,7 +57,7 @@ public sealed class ViewerQuerySnapshotRow
     public bool HasQueryPlan => !string.IsNullOrEmpty(QueryPlan);
     public bool HasLiveQueryPlan => !string.IsNullOrEmpty(LiveQueryPlan);
     public string CollectionTimeLocal =>
-        CollectionTime == DateTime.MinValue ? "" : ViewerDataService.ToLocalTime(CollectionTime).ToString("yyyy-MM-dd HH:mm:ss");
+        CollectionTime == DateTime.MinValue ? "" : ViewerTimeHelper.ForDisplay(CollectionTime).ToString("yyyy-MM-dd HH:mm:ss");
 }
 
 public sealed partial class ViewerDataService

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryTrends.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryTrends.cs
@@ -19,7 +19,7 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// (elapsed ms/sec for the duration trends, executions/sec for the execution-count trend);
 /// <see cref="ExecutionCount"/> carries the executions/sec rate the duration trends also compute
 /// (unused by the execution-count trend). CollectionTime is naive UTC — the chart converts it
-/// through <see cref="ViewerDataService.ToLocalTime"/>.
+/// through <see cref="ViewerTimeHelper.ForDisplay"/>.
 /// </summary>
 public sealed class QueryTrendPoint
 {

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.RunningJobs.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.RunningJobs.cs
@@ -112,9 +112,9 @@ public sealed partial class ViewerDataService
 /// One row of the Running Jobs grid — a currently-running SQL Agent job with its historical duration
 /// comparison. Copied VERBATIM from Lite's <c>RunningJobRow</c> (LocalDataService.RunningJobs.cs): the
 /// duration/percent/running-long display columns are all collector-side computations, and
-/// <see cref="StartTimeLocal"/>'s <c>ToLocalTime()</c> on the store's naive-UTC start_time is
-/// identical to the viewer's <see cref="ViewerDataService.ToLocalTime"/> convention (ToLocalTime treats
-/// an Unspecified-kind DateTime as UTC).
+/// <see cref="StartTimeLocal"/> routes the store's naive-UTC start_time through
+/// <see cref="ViewerTimeHelper.ForDisplay"/> — the viewer's mode-aware Server/Local/UTC conversion every
+/// other Darling timestamp also uses.
 /// </summary>
 public class RunningJobRow
 {
@@ -130,7 +130,7 @@ public class RunningJobRow
     public bool IsRunningLong { get; set; }
     public decimal? PercentOfAverage { get; set; }
 
-    public string StartTimeLocal => StartTime.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss");
+    public string StartTimeLocal => ViewerTimeHelper.ForDisplay(StartTime).ToString("yyyy-MM-dd HH:mm:ss");
 
     public string CurrentDurationFormatted => FormatDuration(CurrentDurationSeconds);
     public string AvgDurationFormatted => FormatDuration(AvgDurationSeconds);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.SystemEvents.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.SystemEvents.cs
@@ -28,7 +28,7 @@ namespace PerformanceMonitor.Darling.Viewer;
  * The row view-models below are flat projections of the Common records (all shredded columns preserved,
  * so the grids faithfully match sp_HealthParser's per-category table shape) plus an EventTimeLocal
  * display string — the machine-local render of the event's naive-UTC XE @timestamp, via the same
- * ViewerDataService.ToLocalTime the deadlock / blocked-process grids use. Only SevereError adds a
+ * ViewerTimeHelper.ForDisplay the deadlock / blocked-process grids use. Only SevereError adds a
  * resolved DatabaseName (see ResolveDatabaseName).
  */
 
@@ -36,7 +36,7 @@ namespace PerformanceMonitor.Darling.Viewer;
 internal static class SystemEventRowFormat
 {
     public static string Local(DateTime? utc) =>
-        utc is { } t ? ViewerDataService.ToLocalTime(t).ToString("yyyy-MM-dd HH:mm:ss") : "";
+        utc is { } t ? ViewerTimeHelper.ForDisplay(t).ToString("yyyy-MM-dd HH:mm:ss") : "";
 }
 
 /// <summary>One scheduler-monitor WARNING row (Scheduler Issues sub-tab). Mirrors <c>*_SchedulerIssues</c>.</summary>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.cs
@@ -241,9 +241,32 @@ public sealed partial class ViewerDataService : IAsyncDisposable
         _ => $"SQL Server v{sqlMajorVersion}",
     };
 
-    /// <summary>The store's timestamps are naive UTC; re-stamp as UTC and convert for display.</summary>
-    public static DateTime ToLocalTime(DateTime naiveUtc)
-        => DateTime.SpecifyKind(naiveUtc, DateTimeKind.Utc).ToLocalTime();
+    /// <summary>
+    /// The active server's UTC offset in minutes from its most recent <c>server_properties</c> row — the
+    /// value the Server-time display mode adds to the naive-UTC store (UTC + offset = server local). The
+    /// naive-UTC → display conversion every rendered timestamp uses lives in <see cref="ViewerTimeHelper"/>
+    /// (it replaced this class's former fixed <c>ToLocalTime</c>); this only fetches the per-server offset
+    /// that mode feeds into it. Returns null when the column has not been collected yet (an older store
+    /// just migrated, or a server whose properties collector has not re-run since the V16 upgrade); the
+    /// caller then keeps the viewer's machine-local offset so Server mode degrades to ~Local until then.
+    /// </summary>
+    public const string ServerUtcOffsetSql = @"
+SELECT utc_offset_minutes
+FROM server_properties
+WHERE server_id = $1
+AND   utc_offset_minutes IS NOT NULL
+ORDER BY collection_time DESC
+LIMIT 1";
+
+    public async Task<int?> GetServerUtcOffsetMinutesAsync(int serverId, CancellationToken cancellationToken = default)
+    {
+        await using var command = _dataSource.CreateCommand(ServerUtcOffsetSql);
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+        var result = await command.ExecuteScalarAsync(cancellationToken);
+        return result is null or DBNull
+            ? null
+            : Convert.ToInt32(result, System.Globalization.CultureInfo.InvariantCulture);
+    }
 
     /// <summary>
     /// Binds the standard per-server window parameters shared by the settable-window tab reads:

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.ActiveQueries.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.ActiveQueries.cs
@@ -129,7 +129,7 @@ public partial class ViewerServerTab
             var (batchTime, rows) = await _dataService.GetLatestQuerySnapshotBatchAsync(_server.ServerId);
             _querySnapshotsFilterMgr!.UpdateData(rows);
             LatestSnapshotIndicator.Text = batchTime.HasValue
-                ? $"Latest snapshot: {ViewerDataService.ToLocalTime(batchTime.Value):yyyy-MM-dd HH:mm:ss}"
+                ? $"Latest snapshot: {ViewerTimeHelper.ForDisplay(batchTime.Value):yyyy-MM-dd HH:mm:ss}"
                 : "No snapshots stored";
         }
         catch (Exception ex)

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Blocking.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Blocking.cs
@@ -24,7 +24,7 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// re-hosted unchanged as the third sub-tab. The five trend-chart bodies are COPIES of Lite's
 /// <c>ServerTab.Charts.cs</c> Update* methods, reads rewired to <see cref="ViewerDataService"/> Postgres.
 /// Two render-body deviations from Lite: (1) the time axis runs through
-/// <see cref="ViewerDataService.ToLocalTime"/> instead of Lite's per-server <c>UtcOffsetMinutes</c> shift;
+/// <see cref="ViewerTimeHelper.ForDisplay"/> instead of Lite's per-server <c>UtcOffsetMinutes</c> shift;
 /// (2) the per-server toolbar's settable window supplies the X-axis range. The spike-plot /
 /// zero-line-when-empty shapes, the fixed
 /// <see cref="ChartPalette.SeriesColor"/> identities for the single-series charts, and the cycling
@@ -281,8 +281,8 @@ public partial class ViewerServerTab
         ApplyTheme(LockWaitTrendChart);
 
         var (winStartUtc, winEndUtc) = GetWindowUtc();
-        var rangeStart = ViewerDataService.ToLocalTime(winStartUtc);
-        var rangeEnd = ViewerDataService.ToLocalTime(winEndUtc);
+        var rangeStart = ViewerTimeHelper.ForDisplay(winStartUtc);
+        var rangeEnd = ViewerTimeHelper.ForDisplay(winEndUtc);
 
         _lockWaitTrendHover?.Clear();
         if (data.Count == 0)
@@ -309,7 +309,7 @@ public partial class ViewerServerTab
         for (int i = 0; i < grouped.Count; i++)
         {
             var group = grouped[i];
-            var times = group.Select(t => ViewerDataService.ToLocalTime(t.CollectionTime).ToOADate()).ToArray();
+            var times = group.Select(t => ViewerTimeHelper.ForDisplay(t.CollectionTime).ToOADate()).ToArray();
             var values = group.Select(t => t.WaitTimeMsPerSecond).ToArray();
 
             var plot = LockWaitTrendChart.Plot.Add.Scatter(times, values);
@@ -336,8 +336,8 @@ public partial class ViewerServerTab
         ApplyTheme(BlockingTrendChart);
 
         var (winStartUtc, winEndUtc) = GetWindowUtc();
-        var rangeStart = ViewerDataService.ToLocalTime(winStartUtc);
-        var rangeEnd = ViewerDataService.ToLocalTime(winEndUtc);
+        var rangeStart = ViewerTimeHelper.ForDisplay(winStartUtc);
+        var rangeEnd = ViewerTimeHelper.ForDisplay(winEndUtc);
 
         _blockingTrendHover?.Clear();
         if (data.Count == 0)
@@ -369,7 +369,7 @@ public partial class ViewerServerTab
 
         foreach (var point in data.OrderBy(d => d.Time))
         {
-            var time = ViewerDataService.ToLocalTime(point.Time).ToOADate();
+            var time = ViewerTimeHelper.ForDisplay(point.Time).ToOADate();
             /* Go to zero just before the spike */
             expandedTimes.Add(time - 0.0001);
             expandedCounts.Add(0);
@@ -406,8 +406,8 @@ public partial class ViewerServerTab
         ApplyTheme(DeadlockTrendChart);
 
         var (winStartUtc, winEndUtc) = GetWindowUtc();
-        var rangeStart = ViewerDataService.ToLocalTime(winStartUtc);
-        var rangeEnd = ViewerDataService.ToLocalTime(winEndUtc);
+        var rangeStart = ViewerTimeHelper.ForDisplay(winStartUtc);
+        var rangeEnd = ViewerTimeHelper.ForDisplay(winEndUtc);
 
         _deadlockTrendHover?.Clear();
         if (data.Count == 0)
@@ -439,7 +439,7 @@ public partial class ViewerServerTab
 
         foreach (var point in data.OrderBy(d => d.Time))
         {
-            var time = ViewerDataService.ToLocalTime(point.Time).ToOADate();
+            var time = ViewerTimeHelper.ForDisplay(point.Time).ToOADate();
             /* Go to zero just before the spike */
             expandedTimes.Add(time - 0.0001);
             expandedCounts.Add(0);
@@ -476,8 +476,8 @@ public partial class ViewerServerTab
         ApplyTheme(CurrentWaitsDurationChart);
 
         var (winStartUtc, winEndUtc) = GetWindowUtc();
-        var rangeStart = ViewerDataService.ToLocalTime(winStartUtc);
-        var rangeEnd = ViewerDataService.ToLocalTime(winEndUtc);
+        var rangeStart = ViewerTimeHelper.ForDisplay(winStartUtc);
+        var rangeEnd = ViewerTimeHelper.ForDisplay(winEndUtc);
 
         _currentWaitsDurationHover?.Clear();
         if (data.Count == 0)
@@ -505,7 +505,7 @@ public partial class ViewerServerTab
         {
             var group = grouped[i];
             var ordered = group.OrderBy(t => t.CollectionTime).ToList();
-            var times = ordered.Select(t => ViewerDataService.ToLocalTime(t.CollectionTime).ToOADate()).ToArray();
+            var times = ordered.Select(t => ViewerTimeHelper.ForDisplay(t.CollectionTime).ToOADate()).ToArray();
             var values = ordered.Select(t => (double)t.TotalWaitMs).ToArray();
 
             var plot = CurrentWaitsDurationChart.Plot.Add.Scatter(times, values);
@@ -532,8 +532,8 @@ public partial class ViewerServerTab
         ApplyTheme(CurrentWaitsBlockedChart);
 
         var (winStartUtc, winEndUtc) = GetWindowUtc();
-        var rangeStart = ViewerDataService.ToLocalTime(winStartUtc);
-        var rangeEnd = ViewerDataService.ToLocalTime(winEndUtc);
+        var rangeStart = ViewerTimeHelper.ForDisplay(winStartUtc);
+        var rangeEnd = ViewerTimeHelper.ForDisplay(winEndUtc);
 
         _currentWaitsBlockedHover?.Clear();
         if (data.Count == 0)
@@ -561,7 +561,7 @@ public partial class ViewerServerTab
         {
             var group = grouped[i];
             var ordered = group.OrderBy(t => t.CollectionTime).ToList();
-            var times = ordered.Select(t => ViewerDataService.ToLocalTime(t.CollectionTime).ToOADate()).ToArray();
+            var times = ordered.Select(t => ViewerTimeHelper.ForDisplay(t.CollectionTime).ToOADate()).ToArray();
             var values = ordered.Select(t => (double)t.BlockedCount).ToArray();
 
             var plot = CurrentWaitsBlockedChart.Plot.Add.Scatter(times, values);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Charts.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Charts.cs
@@ -21,7 +21,7 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// to <see cref="ViewerDataService"/> Postgres reads. The only render-body change is the time axis:
 /// where Lite shifts by its per-server <c>UtcOffsetMinutes</c> (CPU plots the raw server-local
 /// sample_time directly), the viewer has no server-offset concept, so every point runs through
-/// <see cref="ViewerDataService.ToLocalTime"/> — the naive-UTC-to-viewer-local convention the shell's
+/// <see cref="ViewerTimeHelper.ForDisplay"/> — the naive-UTC-to-viewer-local convention the shell's
 /// Overview charts already use. Lite's per-chart context menu and "Show Active Queries at This Time"
 /// drill-down are intentionally NOT ported (the viewer has no drill-down surfaces yet); the hover
 /// tooltips are kept. Chart chrome/legend/line polish flow through the shared <see cref="ChartStyle"/>
@@ -143,11 +143,11 @@ public partial class ViewerServerTab : IDisposable
         if (data.Count == 0) { CpuChart.Refresh(); return; }
 
         /* sample_time is the monitored server's LOCAL wall clock in the store, so GetCpuUtilizationAsync
-           de-skews it to naive UTC in SQL (#1262); it then runs through ToLocalTime like every other
-           Darling chart. (Lite instead shifts the raw server-local sample_time by its per-server
-           ServerTimeHelper.UtcOffsetMinutes; the viewer has no such config and recovers the offset from
-           the collection batch in the read.) */
-        var times = data.Select(d => ViewerDataService.ToLocalTime(d.SampleTime).ToOADate()).ToArray();
+           de-skews it to naive UTC in SQL (#1262); it then runs through ViewerTimeHelper.ForDisplay like
+           every other Darling chart. (The SQL de-skew — recovering the offset from the collection batch —
+           is a data correction independent of the Server/Local/UTC display mode ForDisplay then applies;
+           Lite instead shifts the raw server-local sample_time by its per-server ServerTimeHelper offset.) */
+        var times = data.Select(d => ViewerTimeHelper.ForDisplay(d.SampleTime).ToOADate()).ToArray();
         var sqlCpu = data.Select(d => (double)d.SqlServerCpu).ToArray();
         var otherCpu = data.Select(d => (double)d.OtherProcessCpu).ToArray();
 
@@ -180,7 +180,7 @@ public partial class ViewerServerTab : IDisposable
 
         if (data.Count == 0) { TempDbChart.Refresh(); return; }
 
-        var times = data.Select(d => ViewerDataService.ToLocalTime(d.CollectionTime).ToOADate()).ToArray();
+        var times = data.Select(d => ViewerTimeHelper.ForDisplay(d.CollectionTime).ToOADate()).ToArray();
         var userObj = data.Select(d => d.UserObjectReservedMb).ToArray();
         var internalObj = data.Select(d => d.InternalObjectReservedMb).ToArray();
         var versionStore = data.Select(d => d.VersionStoreReservedMb).ToArray();
@@ -226,7 +226,7 @@ public partial class ViewerServerTab : IDisposable
         if (data.Count == 0) { TempDbSizeChart.Refresh(); return; }
 
         var sorted = data.OrderBy(d => d.CollectionTime).ToList();
-        var times = sorted.Select(d => ViewerDataService.ToLocalTime(d.CollectionTime).ToOADate()).ToArray();
+        var times = sorted.Select(d => ViewerTimeHelper.ForDisplay(d.CollectionTime).ToOADate()).ToArray();
         var totals = sorted.Select(d => d.TotalReservedMb + d.UnallocatedMb).ToArray();
 
         var sizePlot = TempDbSizeChart.Plot.Add.Scatter(times, totals);
@@ -262,7 +262,7 @@ public partial class ViewerServerTab : IDisposable
         foreach (var fileGroup in files)
         {
             var points = fileGroup.OrderBy(d => d.CollectionTime).ToList();
-            var times = points.Select(d => ViewerDataService.ToLocalTime(d.CollectionTime).ToOADate()).ToArray();
+            var times = points.Select(d => ViewerTimeHelper.ForDisplay(d.CollectionTime).ToOADate()).ToArray();
             var latency = points.Select(d => d.AvgReadLatencyMs + d.AvgWriteLatencyMs).ToArray();
             var color = ScottPlot.Color.FromHex(SeriesColors[colorIdx % SeriesColors.Length]);
             colorIdx++;

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.CollectionHealth.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.CollectionHealth.cs
@@ -25,7 +25,7 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// Collection Log = the recent run log; Duration Trends = the per-collector success-duration scatter.
 /// The chart's only render-body change from Lite is the time axis: where Lite shifts the raw stored
 /// time by its per-server <c>UtcOffsetMinutes</c>, the viewer runs every point through
-/// <see cref="ViewerDataService.ToLocalTime"/> (the naive-UTC-to-viewer-local convention every Darling
+/// <see cref="ViewerTimeHelper.ForDisplay"/> (the naive-UTC-to-viewer-local convention every Darling
 /// chart uses), and line polish flows through the shared <see cref="ChartStyle"/> like the other viewer
 /// charts. Lite's per-chart context menu / "Open Log File" button are intentionally not ported.
 /// </summary>
@@ -83,7 +83,7 @@ public partial class ViewerServerTab
     /// Per-collector success-duration scatter over the window. Copied from Lite's
     /// <c>UpdateCollectorDurationChart</c>: one line per collector (SUCCESS runs with a duration, needing
     /// at least two points), cycling the shared palette. The one change is the time axis — every point
-    /// runs through <see cref="ViewerDataService.ToLocalTime"/> (Lite shifts by its per-server
+    /// runs through <see cref="ViewerTimeHelper.ForDisplay"/> (Lite shifts by its per-server
     /// UtcOffsetMinutes) — and line polish uses the shared <see cref="ChartStyle.StyleScatter"/>.
     /// </summary>
     private void RenderCollectorDurationChart(List<CollectionLogRow> data)
@@ -107,7 +107,7 @@ public partial class ViewerServerTab
             var points = group.OrderBy(d => d.CollectionTime).ToList();
             if (points.Count < 2) continue;
 
-            var times = points.Select(d => ViewerDataService.ToLocalTime(d.CollectionTime).ToOADate()).ToArray();
+            var times = points.Select(d => ViewerTimeHelper.ForDisplay(d.CollectionTime).ToOADate()).ToArray();
             var durations = points.Select(d => (double)d.DurationMs!.Value).ToArray();
 
             var scatter = CollectorDurationChart.Plot.Add.Scatter(times, durations);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.CpuScheduler.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.CpuScheduler.cs
@@ -73,7 +73,7 @@ public partial class ViewerServerTab
         double globalMax = 0;
         if (data.Count > 0)
         {
-            var times = data.Select(d => ViewerDataService.ToLocalTime(d.CollectionTime).ToOADate()).ToArray();
+            var times = data.Select(d => ViewerTimeHelper.ForDisplay(d.CollectionTime).ToOADate()).ToArray();
 
             var series = new (string Name, Func<CpuSchedulerTrendPoint, double> Selector)[]
             {
@@ -97,8 +97,8 @@ public partial class ViewerServerTab
         }
 
         CpuSchedulerChart.Plot.Axes.DateTimeTicksBottomDateChange();
-        var rangeStart = ViewerDataService.ToLocalTime(startUtc);
-        var rangeEnd = ViewerDataService.ToLocalTime(endUtc);
+        var rangeStart = ViewerTimeHelper.ForDisplay(startUtc);
+        var rangeEnd = ViewerTimeHelper.ForDisplay(endUtc);
         CpuSchedulerChart.Plot.Axes.SetLimitsX(rangeStart.ToOADate(), rangeEnd.ToOADate());
         ReapplyAxisColors(CpuSchedulerChart);
         SetChartYLimitsWithLegendPadding(CpuSchedulerChart, 0, globalMax > 0 ? globalMax : 5);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.FileIo.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.FileIo.cs
@@ -22,7 +22,7 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// (stacked read + write latency charts, with the queued-I/O dashed overlay) and "File I/O Throughput"
 /// (stacked read + write MB/s charts) — each plotting the top 10 files as its own cycling-colored
 /// series. The only render-body change is the time axis: Lite shifts by its per-server
-/// <c>UtcOffsetMinutes</c>, the viewer runs every point through <see cref="ViewerDataService.ToLocalTime"/>
+/// <c>UtcOffsetMinutes</c>, the viewer runs every point through <see cref="ViewerTimeHelper.ForDisplay"/>
 /// (the naive-UTC-to-viewer-local convention every Darling chart uses). Series colors ride the shared
 /// cycling <see cref="ChartPalette"/> and <see cref="ChartStyle.StyleScatter"/> line polish; hover
 /// tooltips carry the per-chart unit. Lite's per-chart context menu / save-image are NOT ported.
@@ -122,7 +122,7 @@ public partial class ViewerServerTab
         foreach (var dbGroup in databases)
         {
             var points = dbGroup.OrderBy(d => d.CollectionTime).ToList();
-            var times = points.Select(d => ViewerDataService.ToLocalTime(d.CollectionTime).ToOADate()).ToArray();
+            var times = points.Select(d => ViewerTimeHelper.ForDisplay(d.CollectionTime).ToOADate()).ToArray();
             var readLatency = points.Select(d => d.AvgReadLatencyMs).ToArray();
             var writeLatency = points.Select(d => d.AvgWriteLatencyMs).ToArray();
             var color = ScottPlot.Color.FromHex(SeriesColors[colorIdx % SeriesColors.Length]);
@@ -215,7 +215,7 @@ public partial class ViewerServerTab
         foreach (var fileGroup in files)
         {
             var points = fileGroup.OrderBy(d => d.CollectionTime).ToList();
-            var times = points.Select(d => ViewerDataService.ToLocalTime(d.CollectionTime).ToOADate()).ToArray();
+            var times = points.Select(d => ViewerTimeHelper.ForDisplay(d.CollectionTime).ToOADate()).ToArray();
             var readThroughput = points.Select(d => d.ReadMbPerSec).ToArray();
             var writeThroughput = points.Select(d => d.WriteMbPerSec).ToArray();
             var color = ScottPlot.Color.FromHex(SeriesColors[colorIdx % SeriesColors.Length]);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.LatchSpinlock.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.LatchSpinlock.cs
@@ -95,7 +95,7 @@ public partial class ViewerServerTab
         foreach (var group in byClass)
         {
             var points = group.OrderBy(d => d.CollectionTime).ToList();
-            var times = points.Select(d => ViewerDataService.ToLocalTime(d.CollectionTime).ToOADate()).ToArray();
+            var times = points.Select(d => ViewerTimeHelper.ForDisplay(d.CollectionTime).ToOADate()).ToArray();
             var values = points.Select(d => d.WaitTimeMsPerSecond).ToArray();
 
             var plot = LatchStatsChart.Plot.Add.Scatter(times, values);
@@ -136,7 +136,7 @@ public partial class ViewerServerTab
         foreach (var group in byName)
         {
             var points = group.OrderBy(d => d.CollectionTime).ToList();
-            var times = points.Select(d => ViewerDataService.ToLocalTime(d.CollectionTime).ToOADate()).ToArray();
+            var times = points.Select(d => ViewerTimeHelper.ForDisplay(d.CollectionTime).ToOADate()).ToArray();
             var values = points.Select(d => d.CollisionsPerSecond).ToArray();
 
             var plot = SpinlockStatsChart.Plot.Add.Scatter(times, values);
@@ -157,8 +157,8 @@ public partial class ViewerServerTab
     private void FinishContentionChart(ScottPlot.WPF.WpfPlot chart, DateTime startUtc, DateTime endUtc, double globalMax)
     {
         chart.Plot.Axes.DateTimeTicksBottomDateChange();
-        var rangeStart = ViewerDataService.ToLocalTime(startUtc);
-        var rangeEnd = ViewerDataService.ToLocalTime(endUtc);
+        var rangeStart = ViewerTimeHelper.ForDisplay(startUtc);
+        var rangeEnd = ViewerTimeHelper.ForDisplay(endUtc);
         chart.Plot.Axes.SetLimitsX(rangeStart.ToOADate(), rangeEnd.ToOADate());
         ReapplyAxisColors(chart);
         SetChartYLimitsWithLegendPadding(chart, 0, globalMax > 0 ? globalMax : 10);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Memory.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Memory.cs
@@ -24,7 +24,7 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// <c>UpdateMemoryPressureEventsChart</c>) and the clerk picker from Lite's <c>ServerTab.Pickers.cs</c>
 /// (<c>PopulateMemoryClerkPicker</c> … <c>UpdateMemoryClerksChartFromPickerAsync</c>), reads rewired to
 /// <see cref="ViewerDataService"/> Postgres. The only render-body changes: the time axis runs every point
-/// through <see cref="ViewerDataService.ToLocalTime"/> (where Lite shifts by its per-server
+/// through <see cref="ViewerTimeHelper.ForDisplay"/> (where Lite shifts by its per-server
 /// <c>UtcOffsetMinutes</c>), and Lite's per-chart context menu / "Show Active Queries at This Time"
 /// drill-down + <c>Task.Run</c> query wrappers are dropped (the viewer's reads are genuinely async and it
 /// has no drill-down surfaces yet); the hover tooltips are kept. The clerk picker mirrors the wait/perfmon
@@ -39,7 +39,7 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// the monitored server's LOCAL wall clock, but the per-batch de-skew the CPU read uses (#1262) assumes the
 /// newest sample is ~1 minute old — true for the dense CPU ring buffer, NOT for the sparse resource-monitor
 /// ring buffer — so it does not transfer. The pressure chart therefore windows AND plots on raw
-/// <c>sample_time</c> through <see cref="ViewerDataService.ToLocalTime"/>: bars stay inside the X range and
+/// <c>sample_time</c> through <see cref="ViewerTimeHelper.ForDisplay"/>: bars stay inside the X range and
 /// internally consistent (both bounds and bars share the one clock); for a non-UTC server the whole
 /// standalone chart shifts by the server's UTC offset. A reliable pressure-time de-skew is deferred.</para>
 /// </summary>
@@ -152,7 +152,7 @@ public partial class ViewerServerTab
     /// <summary>
     /// The Overview memory trend — Lite's <c>UpdateMemoryChart</c>: Total Server Memory, Target Memory
     /// (dashed), Buffer Pool, and the Memory Grants overlay, all MB→GB. The grant overlay draws a flat
-    /// zero line when no grant data exists. Times run through <see cref="ViewerDataService.ToLocalTime"/>.
+    /// zero line when no grant data exists. Times run through <see cref="ViewerTimeHelper.ForDisplay"/>.
     /// </summary>
     private void RenderMemoryChart(List<MemoryTrendPoint> data, List<MemoryGrantTrendPoint> grantData)
     {
@@ -162,7 +162,7 @@ public partial class ViewerServerTab
 
         if (data.Count == 0) { MemoryChart.Refresh(); return; }
 
-        var times = data.Select(d => ViewerDataService.ToLocalTime(d.CollectionTime).ToOADate()).ToArray();
+        var times = data.Select(d => ViewerTimeHelper.ForDisplay(d.CollectionTime).ToOADate()).ToArray();
         var totalMem = data.Select(d => d.TotalServerMemoryMb / 1024.0).ToArray();
         var targetMem = data.Select(d => d.TargetServerMemoryMb / 1024.0).ToArray();
         var bufferPool = data.Select(d => d.BufferPoolMb / 1024.0).ToArray();
@@ -190,7 +190,7 @@ public partial class ViewerServerTab
         double[] grantTimes, grantMb;
         if (grantData.Count > 0)
         {
-            grantTimes = grantData.Select(d => ViewerDataService.ToLocalTime(d.CollectionTime).ToOADate()).ToArray();
+            grantTimes = grantData.Select(d => ViewerTimeHelper.ForDisplay(d.CollectionTime).ToOADate()).ToArray();
             grantMb = grantData.Select(d => d.TotalGrantedMb / 1024.0).ToArray();
         }
         else
@@ -220,7 +220,7 @@ public partial class ViewerServerTab
     /// The Memory Grants sub-tab's two charts — Lite's <c>UpdateMemoryGrantCharts</c>: sizing
     /// (available/granted/used MB) and activity (grantees/waiters/timeouts/forced grants) per resource
     /// pool, each pool×metric on a cycling <c>SeriesColors</c> color. Times run through
-    /// <see cref="ViewerDataService.ToLocalTime"/>.
+    /// <see cref="ViewerTimeHelper.ForDisplay"/>.
     /// </summary>
     private void RenderMemoryGrantCharts(List<MemoryGrantChartPoint> data)
     {
@@ -253,7 +253,7 @@ public partial class ViewerServerTab
         foreach (var poolId in poolIds)
         {
             var poolData = data.Where(d => d.PoolId == poolId).OrderBy(d => d.CollectionTime).ToList();
-            var times = poolData.Select(d => ViewerDataService.ToLocalTime(d.CollectionTime).ToOADate()).ToArray();
+            var times = poolData.Select(d => ViewerTimeHelper.ForDisplay(d.CollectionTime).ToOADate()).ToArray();
 
             foreach (var metric in sizingMetrics)
             {
@@ -290,7 +290,7 @@ public partial class ViewerServerTab
         foreach (var poolId in poolIds)
         {
             var poolData = data.Where(d => d.PoolId == poolId).OrderBy(d => d.CollectionTime).ToList();
-            var times = poolData.Select(d => ViewerDataService.ToLocalTime(d.CollectionTime).ToOADate()).ToArray();
+            var times = poolData.Select(d => ViewerTimeHelper.ForDisplay(d.CollectionTime).ToOADate()).ToArray();
 
             foreach (var metric in activityMetrics)
             {
@@ -319,7 +319,7 @@ public partial class ViewerServerTab
     /// stacked bars of pressure events, SQL Server (process) vs OS (system) side-by-side and stacked by
     /// severity (medium = indicator 2, severe = indicator ≥ 3). Bar geometry copied verbatim from Lite;
     /// the X range is the toolbar's settable window and every bar/bound runs through
-    /// <see cref="ViewerDataService.ToLocalTime"/> (see the class remarks on pressure sample_time).
+    /// <see cref="ViewerTimeHelper.ForDisplay"/> (see the class remarks on pressure sample_time).
     /// </summary>
     private void RenderMemoryPressureEventsChart(List<MemoryPressureEventRow> data)
     {
@@ -328,8 +328,8 @@ public partial class ViewerServerTab
         ApplyTheme(MemoryPressureEventsChart);
 
         var (startUtc, endUtc) = GetWindowUtc();
-        double xMin = ViewerDataService.ToLocalTime(startUtc).ToOADate();
-        double xMax = ViewerDataService.ToLocalTime(endUtc).ToOADate();
+        double xMin = ViewerTimeHelper.ForDisplay(startUtc).ToOADate();
+        double xMax = ViewerTimeHelper.ForDisplay(endUtc).ToOADate();
 
         /* Only count rows where SQL Server reported actual pressure (indicator >= 2 matches sp_pressuredetector). */
         var pressureRows = data
@@ -367,7 +367,7 @@ public partial class ViewerServerTab
                 int sqlSevere = g.Count(d => d.MemoryIndicatorsProcess >= 3);
                 int osMedium = g.Count(d => d.MemoryIndicatorsSystem == 2);
                 int osSevere = g.Count(d => d.MemoryIndicatorsSystem >= 3);
-                double x = ViewerDataService.ToLocalTime(g.Key).ToOADate();
+                double x = ViewerTimeHelper.ForDisplay(g.Key).ToOADate();
 
                 if (sqlMedium > 0)
                     sqlMediumBars.Add(new ScottPlot.Bar { Position = x - barOffset, ValueBase = 0, Value = sqlMedium, Size = barSize, FillColor = sqlMediumColor, LineWidth = 0 });
@@ -545,7 +545,7 @@ public partial class ViewerServerTab
             {
                 if (!trendsByType.TryGetValue(selected[i].DisplayName, out var trend) || trend.Count == 0) continue;
 
-                var times = trend.Select(t => ViewerDataService.ToLocalTime(t.CollectionTime).ToOADate()).ToArray();
+                var times = trend.Select(t => ViewerTimeHelper.ForDisplay(t.CollectionTime).ToOADate()).ToArray();
                 var values = trend.Select(t => t.MemoryMb).ToArray();
 
                 var plot = MemoryClerksChart.Plot.Add.Scatter(times, values);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Perfmon.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Perfmon.cs
@@ -196,7 +196,7 @@ public partial class ViewerServerTab
             if (selected.Count == 0) { PerfmonChart.Refresh(); return; }
 
             /* The per-server toolbar's settable window (preset or custom From/To). The store is naive-UTC;
-               display converts via ViewerDataService.ToLocalTime. */
+               display converts via ViewerTimeHelper.ForDisplay. */
             var (startUtc, endUtc) = GetWindowUtc();
             double globalMax = 0;
 
@@ -209,7 +209,7 @@ public partial class ViewerServerTab
             {
                 if (!trendsByCounter.TryGetValue(selected[i].DisplayName, out var trend) || trend.Count == 0) continue;
 
-                var times = trend.Select(t => ViewerDataService.ToLocalTime(t.CollectionTime).ToOADate()).ToArray();
+                var times = trend.Select(t => ViewerTimeHelper.ForDisplay(t.CollectionTime).ToOADate()).ToArray();
                 var values = trend.Select(t => (double)t.DeltaValue).ToArray();
 
                 var plot = PerfmonChart.Plot.Add.Scatter(times, values);
@@ -222,8 +222,8 @@ public partial class ViewerServerTab
             }
 
             PerfmonChart.Plot.Axes.DateTimeTicksBottomDateChange();
-            var rangeStart = ViewerDataService.ToLocalTime(startUtc);
-            var rangeEnd = ViewerDataService.ToLocalTime(endUtc);
+            var rangeStart = ViewerTimeHelper.ForDisplay(startUtc);
+            var rangeEnd = ViewerTimeHelper.ForDisplay(endUtc);
             PerfmonChart.Plot.Axes.SetLimitsX(rangeStart.ToOADate(), rangeEnd.ToOADate());
             ReapplyAxisColors(PerfmonChart);
             PerfmonChart.Plot.YLabel("Value");

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.PlanCache.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.PlanCache.cs
@@ -72,7 +72,7 @@ public partial class ViewerServerTab
         double globalMax = 0;
         if (data.Count > 0)
         {
-            var times = data.Select(d => ViewerDataService.ToLocalTime(d.CollectionTime).ToOADate()).ToArray();
+            var times = data.Select(d => ViewerTimeHelper.ForDisplay(d.CollectionTime).ToOADate()).ToArray();
 
             var singleUse = data.Select(d => d.SingleUseSizeMb).ToArray();
             var singlePlot = PlanCacheChart.Plot.Add.Scatter(times, singleUse);
@@ -92,8 +92,8 @@ public partial class ViewerServerTab
         }
 
         PlanCacheChart.Plot.Axes.DateTimeTicksBottomDateChange();
-        var rangeStart = ViewerDataService.ToLocalTime(startUtc);
-        var rangeEnd = ViewerDataService.ToLocalTime(endUtc);
+        var rangeStart = ViewerTimeHelper.ForDisplay(startUtc);
+        var rangeEnd = ViewerTimeHelper.ForDisplay(endUtc);
         PlanCacheChart.Plot.Axes.SetLimitsX(rangeStart.ToOADate(), rangeEnd.ToOADate());
         ReapplyAxisColors(PlanCacheChart);
         SetChartYLimitsWithLegendPadding(PlanCacheChart, 0, globalMax > 0 ? globalMax : 10);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.QueriesComparison.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.QueriesComparison.cs
@@ -92,8 +92,8 @@ public partial class ViewerServerTab
 
         if (active && baselineRange.HasValue)
         {
-            var from = ViewerDataService.ToLocalTime(baselineRange.Value.From).ToString("yyyy-MM-dd HH:mm");
-            var to = ViewerDataService.ToLocalTime(baselineRange.Value.To).ToString("yyyy-MM-dd HH:mm");
+            var from = ViewerTimeHelper.ForDisplay(baselineRange.Value.From).ToString("yyyy-MM-dd HH:mm");
+            var to = ViewerTimeHelper.ForDisplay(baselineRange.Value.To).ToString("yyyy-MM-dd HH:mm");
             banner.Text = $"Comparing against baseline: {from} → {to}";
         }
     }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.QueryHeatmap.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.QueryHeatmap.cs
@@ -21,7 +21,7 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// (5-minute bin × per-execution magnitude bucket), copied from Lite's <c>ServerTab.Charts.cs</c>
 /// (<c>UpdateQueryHeatmapChart</c> + the hover, :1095-1252) with the read rewired to
 /// <see cref="ViewerDataService.GetQueryHeatmapAsync"/> Postgres. The only render-body change is the
-/// time axis (Lite's per-server <c>UtcOffsetMinutes</c> shift → <see cref="ViewerDataService.ToLocalTime"/>).
+/// time axis (Lite's per-server <c>UtcOffsetMinutes</c> shift → <see cref="ViewerTimeHelper.ForDisplay"/>).
 /// The right-click "Show Active Queries at This Time" drill-down IS wired here (the task calls for it, and
 /// Active Queries is a sibling sub-tab of this one) — it's the one viewer chart with a context menu, built
 /// inline (Lite's <c>ContextMenuHelper</c> is Lite-only and can't be referenced): ScottPlot's default
@@ -194,7 +194,7 @@ public partial class ViewerServerTab
         int xStep = Math.Max(1, numCols / 12); // ~12 labels max
         for (int i = 0; i < numCols; i += xStep)
         {
-            var t = ViewerDataService.ToLocalTime(result.TimeBuckets[i]);
+            var t = ViewerTimeHelper.ForDisplay(result.TimeBuckets[i]);
             xTicks.AddMajor(i, t.ToString("M/d\nHH:mm"));
         }
         QueryHeatmapChart.Plot.Axes.Bottom.TickGenerator = xTicks;
@@ -284,7 +284,7 @@ public partial class ViewerServerTab
         }
 
         var cell = _lastHeatmapResult.CellDetails[row, col];
-        var time = ViewerDataService.ToLocalTime(_lastHeatmapResult.TimeBuckets[col]);
+        var time = ViewerTimeHelper.ForDisplay(_lastHeatmapResult.TimeBuckets[col]);
         var bucketLabel = row < _lastHeatmapResult.BucketLabels.Length
             ? _lastHeatmapResult.BucketLabels[row]
             : "?";
@@ -314,7 +314,7 @@ public partial class ViewerServerTab
     {
         var fromUtc = bucketTimeUtc.AddMinutes(-5);
         var toUtc = bucketTimeUtc.AddMinutes(10);
-        var indicator = $"Drill-down: {ViewerDataService.ToLocalTime(fromUtc):HH:mm} → {ViewerDataService.ToLocalTime(toUtc):HH:mm}";
+        var indicator = $"Drill-down: {ViewerTimeHelper.ForDisplay(fromUtc):HH:mm} → {ViewerTimeHelper.ForDisplay(toUtc):HH:mm}";
         await NavigateToActiveQueriesForWindowAsync(fromUtc, toUtc, indicator);
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.QueryTrends.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.QueryTrends.cs
@@ -22,7 +22,7 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// <c>UpdateExecutionCountTrendChart</c>, :993-1091) with the data layer rewired to
 /// <see cref="ViewerDataService"/> Postgres reads. The only render-body change is the time axis: where
 /// Lite shifts each point by its per-server <c>UtcOffsetMinutes</c>, the viewer runs the naive-UTC
-/// <c>collection_time</c> through <see cref="ViewerDataService.ToLocalTime"/> — the same convention the
+/// <c>collection_time</c> through <see cref="ViewerTimeHelper.ForDisplay"/> — the same convention the
 /// shell's other copied charts use. Hover tooltips are kept; Lite's per-chart "Show Active Queries at
 /// This Time" context-menu drill-down is NOT ported (matching every other viewer chart — the viewer has
 /// no chart context menus), so these stay hover-only.
@@ -86,7 +86,7 @@ public partial class ViewerServerTab
 
         if (data.Count == 0) { RefreshEmptyChart(QueryDurationTrendChart, "Query Duration", "Duration (ms/sec)"); return; }
 
-        var times = data.Select(d => ViewerDataService.ToLocalTime(d.CollectionTime).ToOADate()).ToArray();
+        var times = data.Select(d => ViewerTimeHelper.ForDisplay(d.CollectionTime).ToOADate()).ToArray();
         var values = data.Select(d => d.Value).ToArray();
 
         _queryDurationTrendHover?.Clear();
@@ -111,7 +111,7 @@ public partial class ViewerServerTab
 
         if (data.Count == 0) { RefreshEmptyChart(ProcDurationTrendChart, "Procedure Duration", "Duration (ms/sec)"); return; }
 
-        var times = data.Select(d => ViewerDataService.ToLocalTime(d.CollectionTime).ToOADate()).ToArray();
+        var times = data.Select(d => ViewerTimeHelper.ForDisplay(d.CollectionTime).ToOADate()).ToArray();
         var values = data.Select(d => d.Value).ToArray();
 
         _procDurationTrendHover?.Clear();
@@ -136,7 +136,7 @@ public partial class ViewerServerTab
 
         if (data.Count == 0) { RefreshEmptyChart(QueryStoreDurationTrendChart, "Query Store Duration", "Duration (ms/sec)"); return; }
 
-        var times = data.Select(d => ViewerDataService.ToLocalTime(d.CollectionTime).ToOADate()).ToArray();
+        var times = data.Select(d => ViewerTimeHelper.ForDisplay(d.CollectionTime).ToOADate()).ToArray();
         var values = data.Select(d => d.Value).ToArray();
 
         _queryStoreDurationTrendHover?.Clear();
@@ -161,7 +161,7 @@ public partial class ViewerServerTab
 
         if (data.Count == 0) { RefreshEmptyChart(ExecutionCountTrendChart, "Executions", "Executions/sec"); return; }
 
-        var times = data.Select(d => ViewerDataService.ToLocalTime(d.CollectionTime).ToOADate()).ToArray();
+        var times = data.Select(d => ViewerTimeHelper.ForDisplay(d.CollectionTime).ToOADate()).ToArray();
         var values = data.Select(d => d.Value).ToArray();
 
         _executionCountTrendHover?.Clear();

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.SystemEvents.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.SystemEvents.cs
@@ -26,7 +26,7 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// keeps the sp_HealthParser-significant rows. Mirrors the FinOps tab's inner sub-tab-strip + DataGrid
 /// conventions (visible-only load, shared column filters, per-sub-tab count indicator + refresh).
 /// Timestamps render machine-local like the deadlock / blocked-process grids (the event's naive-UTC XE
-/// @timestamp via <see cref="ViewerDataService.ToLocalTime"/>).
+/// @timestamp via <see cref="ViewerTimeHelper.ForDisplay"/>).
 /// </summary>
 public partial class ViewerServerTab
 {

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.SystemHealthCharts.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.SystemHealthCharts.cs
@@ -75,8 +75,8 @@ public partial class ViewerServerTab
         var (startUtc, endUtc) = GetWindowUtc();
         var data = await _dataService.GetSystemHealthAsync(_server.ServerId, startUtc, endUtc);
 
-        double xMin = ViewerDataService.ToLocalTime(startUtc).ToOADate();
-        double xMax = ViewerDataService.ToLocalTime(endUtc).ToOADate();
+        double xMin = ViewerTimeHelper.ForDisplay(startUtc).ToOADate();
+        double xMax = ViewerTimeHelper.ForDisplay(endUtc).ToOADate();
 
         // Corruption Events (2x2).
         RenderCounterChart(BadPagesChart, _badPagesHover, data, d => d.BadPagesDetected, "Bad Pages",
@@ -118,7 +118,7 @@ public partial class ViewerServerTab
         }
         else
         {
-            var xs = data.Select(d => ViewerDataService.ToLocalTime(d.EventTime!.Value).ToOADate()).ToArray();
+            var xs = data.Select(d => ViewerTimeHelper.ForDisplay(d.EventTime!.Value).ToOADate()).ToArray();
             var ys = data.Select(d => (double)(selector(d) ?? 0)).ToArray();
 
             var scatter = chart.Plot.Add.Scatter(xs, ys);
@@ -169,7 +169,7 @@ public partial class ViewerServerTab
                 if (typeData.Count == 0)
                     continue;
 
-                var xs = typeData.Select(d => ViewerDataService.ToLocalTime(d.EventTime!.Value).ToOADate()).ToArray();
+                var xs = typeData.Select(d => ViewerTimeHelper.ForDisplay(d.EventTime!.Value).ToOADate()).ToArray();
                 var ys = typeData.Select(d => (double)(d.SpinlockBackoffs ?? 1)).ToArray();
 
                 var scatter = SickSpinlocksChart.Plot.Add.Scatter(xs, ys);
@@ -212,7 +212,7 @@ public partial class ViewerServerTab
         }
         else
         {
-            var xs = data.Select(d => ViewerDataService.ToLocalTime(d.EventTime!.Value).ToOADate()).ToArray();
+            var xs = data.Select(d => ViewerTimeHelper.ForDisplay(d.EventTime!.Value).ToOADate()).ToArray();
 
             var sysScatter = CpuComparisonChart.Plot.Add.Scatter(xs, data.Select(d => (double)(d.SystemCpuUtilization ?? 0)).ToArray());
             sysScatter.Color = ScottPlot.Color.FromHex(ChartPalette.CyclingColor(0));

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.TimeRange.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.TimeRange.cs
@@ -14,17 +14,20 @@ using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Media;
 using System.Windows.Threading;
+using PerformanceMonitor.Ui;
 
 namespace PerformanceMonitor.Darling.Viewer;
 
 /// <summary>
-/// The per-server toolbar's time-window + auto-refresh state (the header row added above the inner tab
-/// strip), mirroring Lite's <c>ServerTab.TimeRange.cs</c> but adapted to the viewer: there is no
-/// <c>ServerTimeHelper</c> / per-server UTC offset, so the custom-range pickers are read in the viewer's
-/// one machine-LOCAL display convention (<see cref="ViewerDataService.ToLocalTime"/>) and inverted back
-/// to the store's naive-UTC bounds here. This replaces the old hardcoded 24-hour <c>s_dataWindow</c>: every
-/// inner-tab load now reads <see cref="GetWindowUtc"/> (preset 1h/4h/12h/24h/7d or a custom From/To), and
-/// the auto-refresh cadence comes from the toolbar instead of MainWindow's fixed 60-second timer.
+/// The per-server toolbar's time-window + auto-refresh + time-display state (the header row added above
+/// the inner tab strip), mirroring Lite's <c>ServerTab.TimeRange.cs</c>: the custom-range pickers are read
+/// in the CURRENT display mode (Server/Local/UTC — <see cref="ViewerTimeHelper"/>, ported from Lite's
+/// <c>TimeDisplayModeBox</c>) and inverted back to the store's naive-UTC bounds here
+/// (<see cref="ViewerTimeHelper.DisplayToNaiveUtc(System.DateTime)"/>). This replaces the old hardcoded
+/// 24-hour <c>s_dataWindow</c>: every inner-tab load reads <see cref="GetWindowUtc"/> (preset
+/// 1h/4h/12h/24h/7d or a custom From/To), the auto-refresh cadence comes from the toolbar instead of
+/// MainWindow's fixed 60-second timer, and the display-mode picker re-renders the visible tab so every
+/// timestamp honors the chosen mode.
 /// </summary>
 public partial class ViewerServerTab
 {
@@ -39,10 +42,27 @@ public partial class ViewerServerTab
 
     /// <summary>
     /// Raised when the user clicks "Apply to All": MainWindow broadcasts the selected range (index plus,
-    /// for a custom range, the From/To in machine-local display time) to every other open server tab. The
-    /// source tab is carried so the broadcast can skip it (it already holds the range).
+    /// for a custom range, the From/To in the CURRENT display-mode wall clock) to every other open server
+    /// tab. The source tab is carried so the broadcast can skip it (it already holds the range).
     /// </summary>
     public event Action<ViewerServerTab, int, DateTime?, DateTime?>? ApplyTimeRangeRequested;
+
+    /// <summary>
+    /// Raised when the user changes the toolbar's Server/Local/UTC display picker. MainWindow persists the
+    /// new global mode to <see cref="ViewerAppSettings.TimeDisplayMode"/> and syncs every other open tab's
+    /// picker (the mode is process-wide). The raising tab has already updated
+    /// <see cref="ViewerTimeHelper.CurrentDisplayMode"/> and reloaded itself.
+    /// </summary>
+    public event Action<TimeDisplayMode>? DisplayModeChanged;
+
+    /// <summary>This server's UTC offset in minutes (from <c>server_properties.utc_offset_minutes</c>),
+    /// applied to <see cref="ViewerTimeHelper.UtcOffsetMinutes"/> before this tab renders so Server-time
+    /// mode shows the monitored server's own local time. Seeds to the viewer machine's offset until the
+    /// per-server value is loaded (so Server mode degrades gracefully to ~Local meanwhile).</summary>
+    private int _serverUtcOffsetMinutes = (int)TimeZoneInfo.Local.GetUtcOffset(DateTime.UtcNow).TotalMinutes;
+
+    /// <summary>Caches the one-shot offset load so repeated refreshes don't re-query it.</summary>
+    private Task? _serverOffsetLoad;
 
     /// <summary>Preset combo index → hours back. Index 5 (custom) and any stray value fall to the
     /// viewer's historical 24-hour default. Pure + static so the mapping is unit-testable.</summary>
@@ -155,25 +175,17 @@ public partial class ViewerServerTab
     /// <summary>Reads the custom From/To pickers as naive-UTC bounds, or (null,null) when either is unset.</summary>
     private (DateTime? fromUtc, DateTime? toUtc) GetCustomRangeUtc()
     {
-        var fromLocal = GetDateTimeFromPickers(FromDatePicker!, FromHourCombo, FromMinuteCombo);
-        var toLocal = GetDateTimeFromPickers(ToDatePicker!, ToHourCombo, ToMinuteCombo);
-        if (!fromLocal.HasValue || !toLocal.HasValue)
+        var fromDisplay = GetDateTimeFromPickers(FromDatePicker!, FromHourCombo, FromMinuteCombo);
+        var toDisplay = GetDateTimeFromPickers(ToDatePicker!, ToHourCombo, ToMinuteCombo);
+        if (!fromDisplay.HasValue || !toDisplay.HasValue)
         {
             return (null, null);
         }
 
-        return (LocalDisplayToNaiveUtc(fromLocal.Value), LocalDisplayToNaiveUtc(toLocal.Value));
-    }
-
-    /// <summary>
-    /// Inverts <see cref="ViewerDataService.ToLocalTime"/>: the pickers show machine-local wall-clock time
-    /// (the viewer's one display convention), and the store windows on naive UTC, so a picked local time
-    /// converts to UTC and drops its kind for the reads (which re-stamp it Unspecified).
-    /// </summary>
-    private static DateTime LocalDisplayToNaiveUtc(DateTime localDisplay)
-    {
-        var utc = DateTime.SpecifyKind(localDisplay, DateTimeKind.Local).ToUniversalTime();
-        return DateTime.SpecifyKind(utc, DateTimeKind.Unspecified);
+        /* The pickers hold wall-clock time in the CURRENT display mode; invert to the store's naive-UTC
+           window bounds (the reads re-stamp them Unspecified). ViewerTimeHelper.DisplayToNaiveUtc uses the
+           active server offset applied before each load, so a Server-mode window maps to the right UTC. */
+        return (ViewerTimeHelper.DisplayToNaiveUtc(fromDisplay.Value), ViewerTimeHelper.DisplayToNaiveUtc(toDisplay.Value));
     }
 
     private static DateTime? GetDateTimeFromPickers(DatePicker datePicker, ComboBox hourCombo, ComboBox minuteCombo)
@@ -323,6 +335,142 @@ public partial class ViewerServerTab
         }
 
         ApplyTimeRangeRequested?.Invoke(this, TimeRangeCombo.SelectedIndex, fromLocal, toLocal);
+    }
+
+    // ── Time-display mode (Server / Local / UTC) ─────────────────────────────────────
+
+    /// <summary>Maps a picker item's Tag to the mode; unknown/absent falls to Server-time (Lite's default).</summary>
+    private static TimeDisplayMode ParseDisplayMode(string? tag) => tag switch
+    {
+        "LocalTime" => TimeDisplayMode.LocalTime,
+        "UTC" => TimeDisplayMode.UTC,
+        _ => TimeDisplayMode.ServerTime,
+    };
+
+    /// <summary>
+    /// Loads this server's UTC offset once (from <c>server_properties</c>) and caches it. Awaited before
+    /// each render (see <c>RefreshActiveInnerTabAsync</c>) so the visible tab's timestamps use ITS server's
+    /// offset; a failure keeps the machine-local seed. Idempotent — the cached Task means repeated
+    /// refreshes don't re-query.
+    /// </summary>
+    internal Task EnsureServerOffsetLoadedAsync() => _serverOffsetLoad ??= LoadServerOffsetAsync();
+
+    private async Task LoadServerOffsetAsync()
+    {
+        try
+        {
+            var offset = await _dataService.GetServerUtcOffsetMinutesAsync(_server.ServerId);
+            if (offset.HasValue)
+            {
+                _serverUtcOffsetMinutes = offset.Value;
+            }
+        }
+        catch
+        {
+            /* No collected offset yet (or a read hiccup): keep the viewer machine's offset so Server mode
+               degrades gracefully to ~Local until server_properties.utc_offset_minutes is populated. */
+        }
+    }
+
+    /// <summary>Pushes this tab's server offset onto the process-wide helper. Called before every render so
+    /// the visible tab (only it renders) drives the conversions with its own server's offset.</summary>
+    internal void ApplyServerOffsetToHelper() => ViewerTimeHelper.UtcOffsetMinutes = _serverUtcOffsetMinutes;
+
+    /// <summary>
+    /// The Server/Local/UTC picker changed: apply this tab's offset, re-express the custom-range pickers
+    /// from the old mode into the new one (same absolute window, mirroring Lite's
+    /// <c>TimeDisplayMode_SelectionChanged</c>), set the new global mode, then persist (via
+    /// <see cref="DisplayModeChanged"/>) and reload the visible tab so every timestamp and chart re-renders
+    /// in the new mode. No-op while loading/suppressed or when the mode is unchanged.
+    /// </summary>
+    private async void TimeDisplayMode_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (!IsLoaded || _suppressRangeEvents)
+        {
+            return;
+        }
+        if (TimeDisplayModeBox.SelectedItem is not ComboBoxItem item)
+        {
+            return;
+        }
+
+        var mode = ParseDisplayMode(item.Tag?.ToString());
+        if (mode == ViewerTimeHelper.CurrentDisplayMode)
+        {
+            return;
+        }
+
+        var oldMode = ViewerTimeHelper.CurrentDisplayMode;
+
+        /* Server-mode conversions (and the picker re-conversion below) need this server's offset. */
+        await EnsureServerOffsetLoadedAsync();
+        ApplyServerOffsetToHelper();
+
+        /* Re-express the custom-range pickers so the same absolute window stays selected across the switch.
+           Suppress range events while rewriting them so this drives exactly one reload (below), not a cascade. */
+        _suppressRangeEvents = true;
+        try
+        {
+            var fromPicked = IsCustomRange ? GetDateTimeFromPickers(FromDatePicker!, FromHourCombo, FromMinuteCombo) : null;
+            var toPicked = IsCustomRange ? GetDateTimeFromPickers(ToDatePicker!, ToHourCombo, ToMinuteCombo) : null;
+            if (fromPicked.HasValue && toPicked.HasValue)
+            {
+                var fromUtc = ViewerTimeHelper.DisplayToNaiveUtc(fromPicked.Value, oldMode);
+                var toUtc = ViewerTimeHelper.DisplayToNaiveUtc(toPicked.Value, oldMode);
+                ViewerTimeHelper.CurrentDisplayMode = mode;
+                var fromNew = ViewerTimeHelper.ForDisplay(fromUtc);
+                var toNew = ViewerTimeHelper.ForDisplay(toUtc);
+                FromDatePicker!.SelectedDate = fromNew.Date;
+                FromHourCombo.SelectedIndex = fromNew.Hour;
+                FromMinuteCombo.SelectedIndex = fromNew.Minute / 15;
+                ToDatePicker!.SelectedDate = toNew.Date;
+                ToHourCombo.SelectedIndex = toNew.Hour;
+                ToMinuteCombo.SelectedIndex = toNew.Minute / 15;
+            }
+            else
+            {
+                ViewerTimeHelper.CurrentDisplayMode = mode;
+            }
+        }
+        finally
+        {
+            _suppressRangeEvents = false;
+        }
+
+        DisplayModeChanged?.Invoke(mode);
+        await RefreshActiveInnerTabAsync();
+    }
+
+    /// <summary>
+    /// Sets the toolbar's display-mode picker WITHOUT raising a change — used by MainWindow to keep every
+    /// open tab's picker in sync when the global mode changes elsewhere (another tab's picker, or the
+    /// Settings window). Suppressed so it drives no reload/persist. Also used to seed the picker on
+    /// construction from the persisted mode.
+    /// </summary>
+    public void SetDisplayModeSelection(TimeDisplayMode mode)
+    {
+        if (TimeDisplayModeBox is null)
+        {
+            return;
+        }
+
+        var tag = mode.ToString();
+        _suppressRangeEvents = true;
+        try
+        {
+            foreach (var candidate in TimeDisplayModeBox.Items)
+            {
+                if (candidate is ComboBoxItem item && item.Tag?.ToString() == tag)
+                {
+                    TimeDisplayModeBox.SelectedItem = item;
+                    break;
+                }
+            }
+        }
+        finally
+        {
+            _suppressRangeEvents = false;
+        }
     }
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Waits.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Waits.cs
@@ -182,7 +182,7 @@ public partial class ViewerServerTab
             if (_waitStatsHover != null) _waitStatsHover.Unit = useAvgPerWait ? "ms/wait" : "ms/sec";
 
             /* The per-server toolbar's settable window (preset or custom From/To). The store is naive-UTC;
-               display converts via ViewerDataService.ToLocalTime. */
+               display converts via ViewerTimeHelper.ForDisplay. */
             var (startUtc, endUtc) = GetWindowUtc();
             double globalMax = 0;
 
@@ -195,7 +195,7 @@ public partial class ViewerServerTab
             {
                 if (!trendsByType.TryGetValue(selected[i].DisplayName, out var trend) || trend.Count == 0) continue;
 
-                var times = trend.Select(t => ViewerDataService.ToLocalTime(t.CollectionTime).ToOADate()).ToArray();
+                var times = trend.Select(t => ViewerTimeHelper.ForDisplay(t.CollectionTime).ToOADate()).ToArray();
                 var values = useAvgPerWait
                     ? trend.Select(t => t.AvgMsPerWait).ToArray()
                     : trend.Select(t => t.WaitTimeMsPerSecond).ToArray();
@@ -210,8 +210,8 @@ public partial class ViewerServerTab
             }
 
             WaitStatsChart.Plot.Axes.DateTimeTicksBottomDateChange();
-            var rangeStart = ViewerDataService.ToLocalTime(startUtc);
-            var rangeEnd = ViewerDataService.ToLocalTime(endUtc);
+            var rangeStart = ViewerTimeHelper.ForDisplay(startUtc);
+            var rangeEnd = ViewerTimeHelper.ForDisplay(endUtc);
             WaitStatsChart.Plot.Axes.SetLimitsX(rangeStart.ToOADate(), rangeEnd.ToOADate());
             ReapplyAxisColors(WaitStatsChart);
             WaitStatsChart.Plot.YLabel(useAvgPerWait ? "Avg Wait Time (ms/wait)" : "Wait Time (ms/sec)");

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
@@ -239,11 +239,11 @@
 
         <!-- Per-server toolbar (mirrors Lite's ServerTab.xaml header): the time-range dropdown +
              custom From/To, Apply-to-all, the shared Compare baseline (moved up from the Queries tab),
-             Refresh, and the auto-refresh toggle + interval. These drive a SETTABLE window (replacing
-             the old fixed 24-hour s_dataWindow) that every inner tab reads via GetWindowUtc. A
-             Server/Local/UTC time-display picker is intentionally NOT here yet — see the class summary /
-             the PR: the viewer has no per-server UTC offset for "Server Time", so that plumbing is a
-             follow-up rather than a half-wired control. -->
+             Refresh, the auto-refresh toggle + interval, and the Server/Local/UTC time-display picker.
+             The time controls drive a SETTABLE window (replacing the old fixed 24-hour s_dataWindow) that
+             every inner tab reads via GetWindowUtc; the display picker (ported from Lite's
+             TimeDisplayModeBox) drives how every timestamp renders via ViewerTimeHelper — Server Time now
+             works because the server's UTC offset is collected in server_properties.utc_offset_minutes. -->
         <Border Grid.Row="0" Background="{DynamicResource BackgroundDarkBrush}" Padding="12,8">
             <WrapPanel Orientation="Horizontal">
                 <ComboBox x:Name="TimeRangeCombo" SelectedIndex="3" Width="120" Margin="0,0,8,4"
@@ -294,6 +294,16 @@
                     <ComboBoxItem Content="30s"/>
                     <ComboBoxItem Content="1m"/>
                     <ComboBoxItem Content="5m"/>
+                </ComboBox>
+                <Separator Style="{StaticResource {x:Static ToolBar.SeparatorStyleKey}}" Margin="8,2"/>
+                <TextBlock Text="Times:" VerticalAlignment="Center" Margin="0,0,4,0"
+                           Foreground="{DynamicResource ForegroundBrush}"/>
+                <ComboBox x:Name="TimeDisplayModeBox" Width="120" Margin="0,0,0,4"
+                          SelectionChanged="TimeDisplayMode_SelectionChanged"
+                          ToolTip="How timestamps are displayed">
+                    <ComboBoxItem Content="Server Time" Tag="ServerTime"/>
+                    <ComboBoxItem Content="Local Time" Tag="LocalTime"/>
+                    <ComboBoxItem Content="UTC" Tag="UTC"/>
                 </ComboBox>
             </WrapPanel>
         </Border>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml.cs
@@ -150,6 +150,11 @@ public partial class ViewerServerTab : UserControl
            drive replaces the removed 24-hour s_dataWindow constant. */
         InitializeTimeComboBoxes();
         InitializeAutoRefreshTimer();
+
+        /* Seed the toolbar's Server/Local/UTC picker from the persisted global mode (MainWindow set
+           ViewerTimeHelper.CurrentDisplayMode from ViewerAppSettings on startup). Suppressed inside
+           SetDisplayModeSelection, and the handler no-ops before IsLoaded anyway, so this drives no reload. */
+        SetDisplayModeSelection(ViewerTimeHelper.CurrentDisplayMode);
     }
 
     /// <summary>The server this tab is bound to; MainWindow keys open tabs by this for dedupe/close.</summary>
@@ -194,6 +199,11 @@ public partial class ViewerServerTab : UserControl
         _refreshInFlight = true;
         try
         {
+            /* Point the process-wide time helper at THIS server's UTC offset before rendering — only the
+               visible tab renders (the viewer's visible-only rule), so its offset wins. Loaded once, cached. */
+            await EnsureServerOffsetLoadedAsync();
+            ApplyServerOffsetToHelper();
+
             do
             {
                 _refreshRequested = false;

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerTimeHelper.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerTimeHelper.cs
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using PerformanceMonitor.Ui;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The viewer's port of Lite's <c>ServerTimeHelper</c>: the single chokepoint every rendered timestamp
+/// routes through, converting a stored value to the user's chosen <see cref="TimeDisplayMode"/>. It
+/// replaces the viewer's old fixed machine-local conversion (the former <c>ViewerDataService.ToLocalTime</c>,
+/// which every call site now reaches as <see cref="ForDisplay"/>).
+///
+/// <para>
+/// The Darling store is naive-UTC (every collected <c>timestamp</c> column is UTC with
+/// <see cref="DateTimeKind.Unspecified"/>), so the three modes map on as:
+/// <list type="bullet">
+///   <item><b>UTC</b> — the raw stored value.</item>
+///   <item><b>Local</b> — the viewer machine's local time (<c>SpecifyKind(Utc).ToLocalTime()</c>, the
+///   viewer's historical one-and-only convention).</item>
+///   <item><b>Server</b> — the monitored server's own local time = UTC + the server's UTC offset
+///   (<c>server_properties.utc_offset_minutes</c>, collected because a headless viewer can't query the
+///   target live the way Lite does at connect).</item>
+/// </list>
+/// </para>
+///
+/// <para>
+/// Process-wide statics mirroring <c>ServerTimeHelper</c>: <see cref="CurrentDisplayMode"/> is the global
+/// user preference (persisted in <see cref="ViewerAppSettings.TimeDisplayMode"/>), and
+/// <see cref="UtcOffsetMinutes"/> is set by the active <see cref="ViewerServerTab"/> to ITS server's
+/// offset before that tab renders — only the visible tab renders (the viewer's visible-only rule), so the
+/// visible tab's offset always wins. Charts pre-convert their X values through <see cref="ForDisplay"/>,
+/// so <see cref="UiTimeContext.ConvertForDisplay"/> is deliberately left at its identity default in the
+/// viewer (wiring it would double-convert the already-display-time chart X on hover/crosshair).
+/// </para>
+/// </summary>
+public static class ViewerTimeHelper
+{
+    /// <summary>Seeds to the viewer machine's offset so Server mode degrades gracefully to ~Local until a
+    /// server's <c>utc_offset_minutes</c> has been collected.</summary>
+    private static int _utcOffsetMinutes = (int)TimeZoneInfo.Local.GetUtcOffset(DateTime.UtcNow).TotalMinutes;
+
+    /// <summary>The active server's UTC offset in minutes (UTC + this = the server's local time).</summary>
+    public static int UtcOffsetMinutes
+    {
+        get => _utcOffsetMinutes;
+        set => _utcOffsetMinutes = value;
+    }
+
+    /// <summary>The global timestamp display mode; the default (Server-time) mirrors Lite's default.</summary>
+    public static TimeDisplayMode CurrentDisplayMode { get; set; } = TimeDisplayMode.ServerTime;
+
+    /// <summary>
+    /// Converts a stored naive-UTC timestamp to the current display mode + active server offset — the one
+    /// method every timestamp render routes through. Single overload on purpose so the many
+    /// <c>&lt;see cref="ViewerTimeHelper.ForDisplay"/&gt;</c> doc references stay unambiguous.
+    /// </summary>
+    public static DateTime ForDisplay(DateTime naiveUtc) => ConvertToDisplay(naiveUtc, CurrentDisplayMode, _utcOffsetMinutes);
+
+    /// <summary>
+    /// Pure (static-free) naive-UTC → display conversion for an explicit mode + offset. The testable core
+    /// of <see cref="ForDisplay"/>; unit tests exercise it without mutating the process-wide statics.
+    /// </summary>
+    public static DateTime ConvertToDisplay(DateTime naiveUtc, TimeDisplayMode mode, int utcOffsetMinutes) => mode switch
+    {
+        TimeDisplayMode.LocalTime => DateTime.SpecifyKind(naiveUtc, DateTimeKind.Utc).ToLocalTime(),
+        TimeDisplayMode.ServerTime => naiveUtc.AddMinutes(utcOffsetMinutes),
+        _ => naiveUtc, /* UTC — the store is already naive UTC */
+    };
+
+    /// <summary>
+    /// Inverse of <see cref="ForDisplay"/> for the custom-range pickers: a wall-clock value the user typed
+    /// IN THE CURRENT display mode, back to the store's naive-UTC window bound.
+    /// </summary>
+    public static DateTime DisplayToNaiveUtc(DateTime display) => ConvertFromDisplay(display, CurrentDisplayMode, _utcOffsetMinutes);
+
+    /// <summary>As <see cref="DisplayToNaiveUtc(DateTime)"/> but for an explicit mode (the active offset) —
+    /// used when re-reading the pickers in their OLD mode during a mode switch.</summary>
+    public static DateTime DisplayToNaiveUtc(DateTime display, TimeDisplayMode mode) => ConvertFromDisplay(display, mode, _utcOffsetMinutes);
+
+    /// <summary>Pure (static-free) display → naive-UTC inverse for an explicit mode + offset.</summary>
+    public static DateTime ConvertFromDisplay(DateTime display, TimeDisplayMode mode, int utcOffsetMinutes) => mode switch
+    {
+        TimeDisplayMode.LocalTime =>
+            DateTime.SpecifyKind(DateTime.SpecifyKind(display, DateTimeKind.Local).ToUniversalTime(), DateTimeKind.Unspecified),
+        TimeDisplayMode.ServerTime =>
+            DateTime.SpecifyKind(display.AddMinutes(-utcOffsetMinutes), DateTimeKind.Unspecified),
+        _ => DateTime.SpecifyKind(display, DateTimeKind.Unspecified), /* UTC — the picker IS naive UTC */
+    };
+}

--- a/Lite.Tests/ServerPropertiesCollectorDefinitionTests.cs
+++ b/Lite.Tests/ServerPropertiesCollectorDefinitionTests.cs
@@ -19,8 +19,9 @@ namespace Lite.Tests;
 /// <summary>
 /// Pins the parity contract of the extracted server_properties definition: the vCore parse rules,
 /// the Azure-only vCore application, the supplemental WS5 health probe (skipped on Azure,
-/// merge-by-replacement, failure leaves NULLs), and the 21-column payload incl. the
-/// enterprise_features placeholder Lite never collects.
+/// merge-by-replacement, failure leaves NULLs), and the 22-column payload incl. the
+/// enterprise_features placeholder Lite never collects and the utc_offset_minutes the viewer's
+/// Server-time display mode reads.
 /// </summary>
 public sealed class ServerPropertiesCollectorDefinitionTests
 {
@@ -64,7 +65,7 @@ public sealed class ServerPropertiesCollectorDefinitionTests
                 "socket_count", "cores_per_socket", "is_hadr_enabled", "is_clustered",
                 "enterprise_features", "service_objective", "vcore_count",
                 "lock_pages_in_memory", "instant_file_initialization_enabled", "memory_dump_count",
-                "sqlserver_start_time", "host_os_version", "ag_replica_role",
+                "sqlserver_start_time", "host_os_version", "ag_replica_role", "utc_offset_minutes",
             },
             ServerPropertiesCollector.Instance.PayloadColumns.Select(c => c.Name).ToArray());
     }
@@ -116,7 +117,7 @@ public sealed class ServerPropertiesCollectorDefinitionTests
     }
 
     [Fact]
-    public async Task WritePayload_Emits21Columns_WithNullEnterpriseFeatures()
+    public async Task WritePayload_Emits22Columns_WithNullEnterpriseFeatures()
     {
         using var reader = new FakeCollectorDataReader(AzureRow("HS_Gen5_14"));
         var rows = await ServerPropertiesCollector.Instance.ReadAsync(
@@ -125,7 +126,7 @@ public sealed class ServerPropertiesCollectorDefinitionTests
         var writer = new RecordingCollectorRowWriter();
         ServerPropertiesCollector.Instance.WritePayload(rows[0], writer, CollectorTestContext.Make(s_deltas));
 
-        Assert.Equal(21, writer.Values.Count);
+        Assert.Equal(22, writer.Values.Count);
         Assert.Equal("Azure SQL Database (General Purpose)", writer.Values[0]);
         Assert.Null(writer.Values[12]);           /* enterprise_features — never collected in Lite */
         Assert.Equal("HS_Gen5_14", writer.Values[13]);
@@ -134,15 +135,17 @@ public sealed class ServerPropertiesCollectorDefinitionTests
         Assert.Equal(new DateTime(2026, 6, 1), writer.Values[18]);
         Assert.Equal("Windows Server 2022", writer.Values[19]);
         Assert.Null(writer.Values[20]);           /* ag_replica_role — standalone in the fixture */
+        Assert.Equal(-300, writer.Values[21]);    /* utc_offset_minutes — the viewer's Server-time offset */
     }
 
-    /// <summary>17-column main-query row; index 0 (server_name) is read past by the definition.</summary>
+    /// <summary>18-column main-query row; index 0 (server_name) is read past by the definition.</summary>
     private static object[] AzureRow(string? serviceObjective) => new object[]
     {
         "myserver", "Azure SQL Database (General Purpose)", "12.0.2000.8", "RTM", DBNull.Value,
         5, 80, 8, 415800L, DBNull.Value, DBNull.Value, false, false,
         serviceObjective is null ? DBNull.Value : serviceObjective,
-        /* v36 inventory columns (#1372): sqlserver_start_time(14), host_os_version(15), ag_replica_role(16). */
-        new DateTime(2026, 6, 1), "Windows Server 2022", DBNull.Value,
+        /* v36 inventory columns (#1372): sqlserver_start_time(14), host_os_version(15), ag_replica_role(16).
+           v42 (#1409): utc_offset_minutes(17). */
+        new DateTime(2026, 6, 1), "Windows Server 2022", DBNull.Value, -300,
     };
 }

--- a/Lite/Database/DuckDbInitializer.cs
+++ b/Lite/Database/DuckDbInitializer.cs
@@ -97,7 +97,7 @@ public class DuckDbInitializer
     /// <summary>
     /// Current schema version. Increment this when schema changes require table rebuilds.
     /// </summary>
-    internal const int CurrentSchemaVersion = 41;
+    internal const int CurrentSchemaVersion = 42;
 
     private readonly string _archivePath;
 
@@ -983,6 +983,24 @@ public class DuckDbInitializer
             catch (Exception ex)
             {
                 _logger?.LogWarning("Migration to v41 encountered an error (non-fatal): {Error}", ex.Message);
+            }
+        }
+
+        if (fromVersion < 42)
+        {
+            /* v42: server_properties gains utc_offset_minutes — the monitored server's UTC offset the
+                    shared collector now writes (DATEDIFF(MINUTE, GETUTCDATE(), GETDATE())). Appended at
+                    the end to keep the positional appender aligned; the collector now writes it, so an
+                    un-migrated DB would mis-align on the next append — this ALTER is required. Nullable
+                    (DuckDB has no ADD COLUMN NOT NULL); the offset is a stored fact, not a delta. */
+            _logger?.LogInformation("Running migration to v42: adding utc_offset_minutes column to server_properties");
+            try
+            {
+                await ExecuteNonQueryAsync(connection, "ALTER TABLE server_properties ADD COLUMN IF NOT EXISTS utc_offset_minutes INTEGER");
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning("Migration to v42 encountered an error (non-fatal): {Error}", ex.Message);
             }
         }
     }

--- a/Lite/Database/Schema.cs
+++ b/Lite/Database/Schema.cs
@@ -893,7 +893,8 @@ CREATE TABLE IF NOT EXISTS server_properties (
     memory_dump_count INTEGER,
     sqlserver_start_time TIMESTAMP,
     host_os_version VARCHAR,
-    ag_replica_role VARCHAR
+    ag_replica_role VARCHAR,
+    utc_offset_minutes INTEGER
 )";
 
     public const string CreateServerPropertiesIndex = @"

--- a/PerformanceMonitor.Collectors/ServerPropertiesCollector.cs
+++ b/PerformanceMonitor.Collectors/ServerPropertiesCollector.cs
@@ -51,7 +51,8 @@ public sealed class ServerPropertiesCollector : CollectorDefinitionBase<ServerPr
         int? MemoryDumpCount,
         DateTime? SqlServerStartTime,
         string? HostOsVersion,
-        string? AgReplicaRole);
+        string? AgReplicaRole,
+        int? UtcOffsetMinutes);
 
     private const string QueryText = @"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
@@ -141,7 +142,12 @@ SELECT
     host_os_version =
         @host_os,
     ag_replica_role =
-        @ag_role
+        @ag_role,
+    /* The monitored server's UTC offset in minutes — the same live derivation Lite computes at
+       connect (ServerManager). Collected so the headless viewer, which cannot query the target
+       live, can render timestamps in the server's own local time (Server-time display mode). */
+    utc_offset_minutes =
+        DATEDIFF(MINUTE, GETUTCDATE(), GETDATE())
 FROM sys.dm_os_sys_info AS osi
 OPTION(RECOMPILE);";
 
@@ -257,6 +263,10 @@ SELECT
         new CollectorColumn("sqlserver_start_time", CollectorColumnType.Timestamp),
         new CollectorColumn("host_os_version", CollectorColumnType.Varchar),
         new CollectorColumn("ag_replica_role", CollectorColumnType.Varchar),
+        /* Appended (never inserted) so a fresh V1 store and an ALTER-migrated store keep an identical
+           physical column order for the positional writers. The monitored server's UTC offset in
+           minutes — the viewer's Server-time display mode reads it (UTC + offset = server local). */
+        new CollectorColumn("utc_offset_minutes", CollectorColumnType.Integer),
     };
 
     public override async ValueTask<List<Row>> ReadAsync(DbDataReader reader, CollectorContext context, CancellationToken cancellationToken)
@@ -275,6 +285,9 @@ SELECT
         var sqlServerStartTime = reader.IsDBNull(14) ? (DateTime?)null : reader.GetDateTime(14);
         var hostOsVersion = reader.IsDBNull(15) ? null : reader.GetString(15);
         var agReplicaRole = reader.IsDBNull(16) ? null : reader.GetString(16);
+        /* utc_offset_minutes (17): DATEDIFF(MINUTE, GETUTCDATE(), GETDATE()) — always non-null in
+           practice, guarded anyway for a defensive read. */
+        var utcOffsetMinutes = reader.IsDBNull(17) ? (int?)null : reader.GetInt32(17);
 
         /* For Azure SQL DB, sys.dm_os_sys_info.cpu_count returns the compute node's total cores,
            not the per-database vCore allocation. Parse the actual vCore count from the service
@@ -305,7 +318,8 @@ SELECT
             MemoryDumpCount: null,
             SqlServerStartTime: sqlServerStartTime,
             HostOsVersion: hostOsVersion,
-            AgReplicaRole: agReplicaRole));
+            AgReplicaRole: agReplicaRole,
+            UtcOffsetMinutes: utcOffsetMinutes));
 
         return rows;
     }
@@ -348,7 +362,8 @@ SELECT
             .Value(row.MemoryDumpCount)
             .Value(row.SqlServerStartTime)
             .Value(row.HostOsVersion)
-            .Value(row.AgReplicaRole);
+            .Value(row.AgReplicaRole)
+            .Value(row.UtcOffsetMinutes);
     }
 
     /// <summary>


### PR DESCRIPTION
Ports Lite's per-server **time-display mode** (`TimeDisplayModeBox`: Server / Local / UTC) into the Darling viewer's per-server toolbar. The prior toolbar (#1399) deferred it citing "~34 hardcoded `ToLocalTime` sites + Server-time not derivable"; both are resolved here.

## How Server/Local/UTC map onto the naive-UTC store
The Darling store is naive-UTC (every collected `timestamp` is UTC, `DateTimeKind.Unspecified`). The new `ViewerTimeHelper` (the port of Lite's `ServerTimeHelper`) maps a stored value to the chosen mode:

- **UTC** = the raw stored value.
- **Local** = the viewer machine's local time — `SpecifyKind(Utc).ToLocalTime()`, the viewer's historical one-and-only convention (the former `ViewerDataService.ToLocalTime`).
- **Server** = the monitored server's own local time = **UTC + the server's UTC offset**.

The inverse (`DisplayToNaiveUtc`) powers the custom-range pickers, which now read/write in the current mode and are re-expressed to the same absolute window when the mode switches (mirroring Lite).

## Server-offset capture was needed
Lite derives the offset from a **live** connect query (`DATEDIFF(MINUTE, GETUTCDATE(), GETDATE())` in `ServerManager`) — a headless viewer has no live target connection, so the offset must come from the store. It wasn't collected, so the shared `ServerPropertiesCollector` now collects **`utc_offset_minutes`** (same `DATEDIFF` derivation), added **additively** to both stores (the collector is shared + writes positionally):

- Collector: appended to `PayloadColumns` / `Row` / `ReadAsync` / `WritePayload` (last column).
- Darling Postgres: **V16** migration `ALTER TABLE server_properties ADD COLUMN IF NOT EXISTS utc_offset_minutes integer` (`StorageVersion` 15→16); fresh stores get it via the generated V1 schema.
- Lite DuckDB: **v42** migration + the `CREATE TABLE server_properties` column (`CurrentSchemaVersion` 41→42).

The viewer reads the latest non-null offset per server (`ViewerDataService.GetServerUtcOffsetMinutesAsync`) and applies it before each render; until it's collected, Server mode degrades gracefully to ~Local (machine offset seed). Because the collector is shared, **Lite also collects the offset** (parity), though Lite keeps using its live value.

## Every timestamp site routes through the helper — no stragglers
`grep ToLocalTime` under `Darling/PerformanceMonitor.Darling.Viewer/` now finds **zero** hardcoded conversions:
- All 110 `ViewerDataService.ToLocalTime(...)` call sites (charts, slicers, model display props, heatmap, drill-downs) → `ViewerTimeHelper.ForDisplay(...)`.
- The 5 hardcoded `.ToLocalTime()` model properties (Collection Health ×4, Running Jobs) + 3 bare FinOps calls → `ForDisplay`.
- The `ViewerDataService.ToLocalTime` definition is removed.
- Server-local values that were **already** read verbatim (`sqlserver_start_time`, `last_execution_time`, index `last_user_*`) stay verbatim — correctly NOT shifted.

`UiTimeContext.ConvertForDisplay` is deliberately left at its identity default: Darling pre-converts chart X through `ForDisplay`, so the shared crosshair/hover already honor the mode — wiring the hook would double-convert.

## Behavior
- Default mode **Server-time** (matches Lite) and persists to `ViewerAppSettings.TimeDisplayMode` (#1402). Seeded on startup + on every tab open.
- Changing the picker re-renders the visible tab (reload recomputes every timestamp + chart X), syncs the other open tabs' pickers, and persists. The Settings-window dropdown path re-applies + reloads too.

## Build + tests (Release)
- `PerformanceMonitor.Darling.Viewer`, `Darling.Tests`, `PerformanceMonitorLite`, `Lite.Tests` — **0 errors** each.
- **Darling.Tests: 909 passed, 0 failed, 87 skipped** (skips are live-Postgres, no `DARLING_TEST_PG`).
- **Lite.Tests: 909 passed, 0 failed.**
- New `ViewerTimeHelperTests` (each mode + inverse round-trip + offset SQL). Updated the collector 22-column pin, the migration V16 pin, and the row-projection tests to route through `ForDisplay`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)