### PR TITLE
Darling viewer Collection Health: honor exact custom time range

### DIFF
--- a/Darling/Darling.Tests/ViewerDailyHealthTests.cs
+++ b/Darling/Darling.Tests/ViewerDailyHealthTests.cs
@@ -130,14 +130,17 @@ public sealed class ViewerCollectionHealthSqlTests
     }
 
     [Fact]
-    public void RecentCollectionLogSql_ReadsTheLogNewestFirst_Capped()
+    public void RecentCollectionLogSql_BoundsTheWindowOnBothSides_NewestFirst_Capped()
     {
         var sql = ViewerDataService.RecentCollectionLogSql;
         Assert.Contains("FROM v_collection_log", sql, StringComparison.Ordinal);
         Assert.Contains("WHERE server_id = $1", sql, StringComparison.Ordinal);
+        /* Both-sided window bound so the toolbar's custom From/To is honored EXACTLY (not rounded to a
+           now-relative hours-back span). $2 = window start, $3 = window end, $4 = row cap. */
         Assert.Contains("collection_time >= $2", sql, StringComparison.Ordinal);
+        Assert.Contains("collection_time <= $3", sql, StringComparison.Ordinal);
         Assert.Contains("ORDER BY collection_time DESC", sql, StringComparison.Ordinal);
-        Assert.Contains("LIMIT $3", sql, StringComparison.Ordinal);
+        Assert.Contains("LIMIT $4", sql, StringComparison.Ordinal);
         /* The two phase-timing columns the grid surfaces (Store (ms) = duckdb_duration_ms). */
         Assert.Contains("sql_duration_ms", sql, StringComparison.Ordinal);
         Assert.Contains("duckdb_duration_ms", sql, StringComparison.Ordinal);
@@ -552,6 +555,51 @@ public sealed class ViewerDailyHealthLivePostgresTests
             Assert.Equal(t1.Ticks, logs[1].CollectionTime.Ticks);
             Assert.Equal(120, logs[1].DurationMs);
             Assert.Equal(20, logs[1].DuckDbDurationMs);             // the store-phase column
+        }
+        finally
+        {
+            await DeleteHealthLogRowsAsync(connection);
+        }
+    }
+
+    [Fact]
+    public async Task RecentCollectionLog_HonorsTheExactWindow_ExcludingRowsOutsideBothBounds_AgainstDevPostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the live windowed-log test.");
+
+        using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await PgMigrations.MigrateAsync(connection, TestContext.Current.CancellationToken);
+        await DeleteHealthLogRowsAsync(connection);
+
+        await using var viewer = new ViewerDataService(connectionString!);
+
+        try
+        {
+            /* A three-hour custom window [start, end] set entirely in the PAST (end is an hour ago). A row 30
+               min BEFORE start and a row 30 min AFTER end must BOTH be excluded. The after-end exclusion is
+               the behavior the old hours-back read (a single now-relative lower bound) could not express — it
+               would have swept everything up to "now", pulling in the after-end row. */
+            var end = TruncateToSeconds(DateTime.UtcNow.AddHours(-1));
+            var start = end.AddHours(-3);
+            var beforeStart = start.AddMinutes(-30);
+            var inWindowEarly = start.AddMinutes(15);
+            var inWindowLate = end.AddMinutes(-15);
+            var afterEnd = end.AddMinutes(30);
+
+            await InsertCollectionLogAsync(connection, HealthServerId, "wait_stats", beforeStart, "SUCCESS");
+            await InsertCollectionLogAsync(connection, HealthServerId, "wait_stats", inWindowEarly, "SUCCESS");
+            await InsertCollectionLogAsync(connection, HealthServerId, "cpu_utilization", inWindowLate, "SUCCESS");
+            await InsertCollectionLogAsync(connection, HealthServerId, "wait_stats", afterEnd, "SUCCESS");
+
+            var logs = await viewer.GetRecentCollectionLogAsync(HealthServerId, start, end);
+
+            Assert.Equal(2, logs.Count);
+            Assert.All(logs, l => Assert.InRange(l.CollectionTime.Ticks, start.Ticks, end.Ticks));
+            Assert.Equal(inWindowLate.Ticks, logs[0].CollectionTime.Ticks);    // newest first
+            Assert.Equal(inWindowEarly.Ticks, logs[1].CollectionTime.Ticks);
         }
         finally
         {

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.CollectionHealth.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.CollectionHealth.cs
@@ -21,12 +21,20 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// query and its simple <c>CollectorHealthRow</c> record, both removed from <c>ViewerDataService.cs</c>)
 /// with Lite's rich 7-day aggregate: per-collector run/success/error counts, average duration, last
 /// success / last run / last error timestamps, and the <see cref="CollectorHealthRow.HealthStatus"/>
-/// banding. The SQL is byte-portable between DuckDB and Postgres (positional <c>$1/$2/$3</c>, plain
-/// aggregates), so only the parameter binding differs: window-start <see cref="DateTime"/>s go in with
+/// banding. The SQL is byte-portable between DuckDB and Postgres (positional params, plain aggregates),
+/// so only the parameter binding differs: window <see cref="DateTime"/>s go in with
 /// <c>DateTimeKind.Unspecified</c> (the naive-UTC store convention), and the SUM/COUNT/AVG results are
 /// read type-agnostically (Postgres returns <c>bigint</c> for the counts and <c>numeric</c> for AVG,
 /// where DuckDB returned HUGEINT/DECIMAL) — the same intent as Lite's <c>ToInt64</c>/<c>ToDouble</c>
 /// helpers, minus the DuckDB BigInteger case Postgres never produces.
+/// <para>
+/// The <b>Health Summary</b> aggregate keeps Lite's fixed 7-day horizon (its staleness banding needs a
+/// stable window regardless of the toolbar). The <b>Collection Log</b> read (feeding the log grid + the
+/// Duration Trends chart) diverges from Lite in ONE deliberate way: it bounds <c>collection_time</c> on
+/// BOTH sides so the per-server toolbar's custom From/To is honored EXACTLY — Lite (and this file's first
+/// port) took a single now-relative <c>hoursBack</c> lower bound, which rounded a custom range to a
+/// hours-back-from-now span.
+/// </para>
 /// </summary>
 public sealed partial class ViewerDataService
 {
@@ -57,9 +65,13 @@ public sealed partial class ViewerDataService
         """;
 
     /// <summary>
-    /// Lite's recent-log read (<c>GetRecentCollectionLogAsync</c>) verbatim: the collection_log rows for
-    /// one server since the window start, newest first, capped. Feeds the Collection Log sub-tab grid.
-    /// $1 server_id, $2 window start (naive UTC), $3 row cap.
+    /// The Collection Log sub-tab's recent-log read, adapted from Lite's <c>GetRecentCollectionLogAsync</c>
+    /// to honor the per-server toolbar's settable window EXACTLY: the collection_log rows for one server
+    /// between the window's start and end bounds, newest first, capped. Where Lite (and the shell's first
+    /// port) passed a single now-relative <c>hoursBack</c> lower bound — so a custom From/To rounded to a
+    /// hours-back-from-now span — this bounds <c>collection_time</c> on BOTH sides, matching how the Wait
+    /// Stats / Blocking tabs window their reads. $1 server_id, $2 window start, $3 window end (all naive
+    /// UTC), $4 row cap.
     /// </summary>
     public const string RecentCollectionLogSql = """
         SELECT
@@ -75,8 +87,9 @@ public sealed partial class ViewerDataService
         FROM v_collection_log
         WHERE server_id = $1
         AND   collection_time >= $2
+        AND   collection_time <= $3
         ORDER BY collection_time DESC
-        LIMIT $3
+        LIMIT $4
         """;
 
     /// <summary>
@@ -140,16 +153,23 @@ public sealed partial class ViewerDataService
     }
 
     /// <summary>
-    /// Recent collection_log entries for one server, most recent first. Copied from Lite's
-    /// <c>GetRecentCollectionLogAsync</c> (default 4-hour window, 500-row cap).
+    /// Collection_log entries for one server between the window's naive-UTC start/end bounds, most recent
+    /// first (500-row cap). Feeds the Collection Log sub-tab grid and the Duration Trends chart. The window
+    /// is the per-server toolbar's settable range (<c>GetWindowUtc</c>): a preset ends "now", a custom
+    /// From/To bounds EXACTLY — unlike the old hours-back read, a custom range no longer rounds to a
+    /// hours-back-from-now span. Mirrors how <see cref="GetDistinctWaitTypesAsync"/> windows its read.
     /// </summary>
-    public async Task<List<CollectionLogRow>> GetRecentCollectionLogAsync(int serverId, int hoursBack = 4, int maxRows = 500, CancellationToken cancellationToken = default)
+    public async Task<List<CollectionLogRow>> GetRecentCollectionLogAsync(int serverId, DateTime startUtc, DateTime endUtc, int maxRows = 500, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(RecentCollectionLogSql);
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime>
         {
-            TypedValue = DateTime.SpecifyKind(DateTime.UtcNow.AddHours(-hoursBack), DateTimeKind.Unspecified),
+            TypedValue = DateTime.SpecifyKind(startUtc, DateTimeKind.Unspecified),
+        });
+        command.Parameters.Add(new NpgsqlParameter<DateTime>
+        {
+            TypedValue = DateTime.SpecifyKind(endUtc, DateTimeKind.Unspecified),
         });
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = maxRows });
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.CollectionHealth.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.CollectionHealth.cs
@@ -55,8 +55,13 @@ public partial class ViewerServerTab
     /// </summary>
     private async Task LoadHealthAsync()
     {
+        /* Health Summary stays Lite's fixed 7-day per-collector rollup (its staleness banding needs a
+           stable horizon regardless of the toolbar window). The Collection Log + Duration Trends honor the
+           settable window EXACTLY — a preset or a custom From/To — via GetWindowUtc(), matching the Wait
+           Stats / Blocking tabs (the old GetWindowHoursBack() rounded a custom range to a now-relative span). */
+        var (startUtc, endUtc) = GetWindowUtc();
         var healthTask = _dataService.GetCollectionHealthAsync(_server.ServerId);
-        var logTask = _dataService.GetRecentCollectionLogAsync(_server.ServerId, GetWindowHoursBack());
+        var logTask = _dataService.GetRecentCollectionLogAsync(_server.ServerId, startUtc, endUtc);
         await Task.WhenAll(healthTask, logTask);
 
         _collectionHealthFilterMgr!.UpdateData(healthTask.Result);


### PR DESCRIPTION
## What

The per-server toolbar (#1399) added a settable time window to the Darling viewer, but the **Collection Health** tab's data read took an integer `hoursBack` (via `GetWindowHoursBack()`), not a `[start, end]` window. A custom From/To range therefore rounded to a **now-relative hours-back span** — presets were exact, custom was approximate. This makes Collection Health honor `[startUtc, endUtc]` exactly, matching how the Wait Stats / Blocking tabs already window their reads.

## Which reads now honor the exact custom range

| Sub-tab | Read | Before | After |
|---|---|---|---|
| **Collection Log** | `GetRecentCollectionLogAsync` | `collection_time >= now - hoursBack` (single now-relative lower bound; custom range rounded up to `ceil(span)` hours back from now) | `collection_time >= $2 AND collection_time <= $3`, bounds from `GetWindowUtc()` — **exact From/To, both sides** |
| **Duration Trends** (chart) | *(same read — `logTask.Result`)* | rounded with the log | **exact** (fed by the corrected log read) |
| **Health Summary** (rollup) | `GetCollectionHealthAsync` | fixed 7-day per-collector aggregate | **unchanged** — kept as a fixed horizon on purpose |

`GetRecentCollectionLogAsync(int serverId, int hoursBack, ...)` → `GetRecentCollectionLogAsync(int serverId, DateTime startUtc, DateTime endUtc, ...)`. The SQL adds `AND collection_time <= $3` and shifts the row cap to `LIMIT $4`. Params stamp `DateTimeKind.Unspecified` (the naive-UTC store convention), identical to the Wait Stats read. `LoadHealthAsync` now reads `GetWindowUtc()` and passes the bounds through.

## Matches Lite

- **Health Summary** is a **fixed 7-day per-collector rollup in Lite** (`LocalDataService.CollectionHealth.GetCollectionHealthAsync` uses `UtcNow.AddDays(-7)`, no window param) because its staleness banding needs a stable horizon regardless of the toolbar. Kept identical here.
- The **per-collector drill window** (double-click a Health Summary row → `CollectionLogWindow` → `GetCollectionLogByCollectorAsync`) is a **fixed 7-day full history in Lite** too. Left unchanged — matching Lite, not invented.
- The **both-sided window bound** on the Collection Log mirrors the viewer's own Wait Stats / Blocking reads (`collection_time >= $2 AND collection_time <= $3`), the ported-and-windowed equivalents of Lite's `fromDate/toDate` tabs.

### Parity note (for a follow-up decision, not in this PR's scope)

Lite's own `RefreshCollectionHealthAsync(hoursBack, fromDate, toDate)` currently passes **only `hoursBack`** to `GetRecentCollectionLogAsync` and ignores `fromDate/toDate` — so Lite's Collection Log / Duration Trends **also** round a custom range to a now-relative span (the same gap this PR fixes in Darling). After this PR, Darling's Collection Log bounds a custom From/To *more precisely* than Lite's does. If exact parity is wanted, Lite's `RefreshCollectionHealthAsync` + `GetRecentCollectionLogAsync` need the same both-sided treatment. Out of scope here (task was Viewer + Darling.Tests only), flagged so it can be picked up deliberately.

## Tests

- Updated the `RecentCollectionLogSql` pin (`RecentCollectionLogSql_BoundsTheWindowOnBothSides_NewestFirst_Capped`) to assert `collection_time <= $3` and `LIMIT $4`.
- Added a gated live-Postgres test (`RecentCollectionLog_HonorsTheExactWindow_ExcludingRowsOutsideBothBounds_AgainstDevPostgres`) that plants rows before-start / in-window / after-end and asserts only the two in-window rows return, newest first. The **after-end exclusion** is the behavior the old now-relative-lower-bound read could not express.

## Build / test

- Viewer `-c Release`: **Build succeeded, 0 errors** (11 pre-existing CA analyzer warnings).
- `Darling/Darling.Tests -c Release`: **Failed: 0, Passed: 909, Skipped: 88, Total: 997.** The 88 skipped are the `DARLING_TEST_PG`-gated live tests (env var unset here; they run in CI/locally when set). The new live test is among them (compiled + discovered); the updated non-gated SQL pin passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
