### PR TITLE
Restore 3 wrongly-accepted parity downscopes (Darling viewer credential profiles + excluded-DB picker; Lite collection-health custom range)

### DIFF
--- a/Darling/Darling.Tests/ExcludedDatabasesTests.cs
+++ b/Darling/Darling.Tests/ExcludedDatabasesTests.cs
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Npgsql;
+using PerformanceMonitor.Collectors;
+using PerformanceMonitor.Darling.Storage;
+using PerformanceMonitor.Darling.Viewer;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Pins the Excluded Databases picker's population from the store's collected database list (the fix for
+/// the PR #1403 "manual text editor" downscope). Two halves: the pure <see
+/// cref="ExcludedDatabasesDialog.BuildDatabaseItems"/> merge (collected ∪ existing exclusions, checked
+/// state, not-collected preservation, dedup/order — no store) and the load-bearing store SQL pinned
+/// against the generated schema (no live Postgres, matching the ViewerDailySummarySqlTests convention).
+/// </summary>
+public sealed class ExcludedDatabasesPickerTests
+{
+    [Fact]
+    public void BuildDatabaseItems_CollectedAreCheckboxes_CheckedWhenExcluded_SortedByName()
+    {
+        var collected = new[] { "AppB", "AppA", "AppC" };   // deliberately unsorted
+        var existing = new[] { "AppB" };
+
+        var items = ExcludedDatabasesDialog.BuildDatabaseItems(collected, existing);
+
+        Assert.Equal(new[] { "AppA", "AppB", "AppC" }, items.Select(i => i.Name));   // sorted
+        Assert.All(items, i => Assert.True(i.IsCollected));
+        Assert.All(items, i => Assert.True(i.IsEnabled));
+        Assert.False(items.Single(i => i.Name == "AppA").IsExcluded);
+        Assert.True(items.Single(i => i.Name == "AppB").IsExcluded);   // already excluded → checked
+        Assert.False(items.Single(i => i.Name == "AppC").IsExcluded);
+    }
+
+    [Fact]
+    public void BuildDatabaseItems_PreservesExclusionsTheStoreHasNotCollected_AsCheckedNotCollectedRows()
+    {
+        var collected = new[] { "AppA" };
+        var existing = new[] { "AppA", "ZombieDb" };   // ZombieDb no longer collected
+
+        var items = ExcludedDatabasesDialog.BuildDatabaseItems(collected, existing);
+
+        var zombie = items.Single(i => i.Name == "ZombieDb");
+        Assert.True(zombie.IsExcluded);          // preserved, checked — a save must not drop it
+        Assert.False(zombie.IsCollected);
+        Assert.True(zombie.IsEnabled);           // still removable (viewer can't verify liveness)
+        Assert.Contains("not collected", zombie.DisplayName, StringComparison.OrdinalIgnoreCase);
+
+        /* Collected rows come first, the not-collected exclusion last. */
+        Assert.Equal(new[] { "AppA", "ZombieDb" }, items.Select(i => i.Name));
+    }
+
+    [Fact]
+    public void BuildDatabaseItems_IsCaseInsensitive_NoDuplicateForDifferentlyCasedExclusion()
+    {
+        var items = ExcludedDatabasesDialog.BuildDatabaseItems(new[] { "MyDb" }, new[] { "mydb" });
+
+        var item = Assert.Single(items);
+        Assert.Equal("MyDb", item.Name);   // collected casing wins, no separate "mydb" row
+        Assert.True(item.IsExcluded);
+        Assert.True(item.IsCollected);
+    }
+
+    [Fact]
+    public void BuildDatabaseItems_NoCollectedList_SeedsExistingExclusionsAsManualRows()
+    {
+        var items = ExcludedDatabasesDialog.BuildDatabaseItems(Array.Empty<string>(), new[] { "X", "Y" });
+
+        Assert.Equal(2, items.Count);
+        Assert.All(items, i => Assert.True(i.IsExcluded));
+        Assert.All(items, i => Assert.False(i.IsCollected));
+    }
+
+    [Fact]
+    public void CollectedDatabaseNamesSql_UnionsBothStores_ExcludesSystemDatabases_PgDialect()
+    {
+        var sql = ViewerDataService.CollectedDatabaseNamesSql;
+
+        Assert.Contains("FROM v_database_config", sql, StringComparison.Ordinal);
+        Assert.Contains("FROM v_database_size_stats", sql, StringComparison.Ordinal);
+        Assert.Contains("UNION", sql, StringComparison.Ordinal);
+        Assert.Contains("NOT IN ('master', 'model', 'msdb', 'tempdb')", sql, StringComparison.Ordinal);
+        Assert.Contains("ORDER BY database_name", sql, StringComparison.Ordinal);
+
+        /* Positional param, no bare now(), no N'' literals, no @-params. */
+        Assert.Contains("$1", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("@", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("N'", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("now(", sql.ToLowerInvariant());
+    }
+
+    [Fact]
+    public void ServerIdByNameSql_MatchesServerOrDisplayName_SingleRow()
+    {
+        var sql = ViewerDataService.ServerIdByNameSql;
+
+        Assert.Contains("FROM servers", sql, StringComparison.Ordinal);
+        Assert.Contains("server_name", sql, StringComparison.Ordinal);
+        Assert.Contains("display_name", sql, StringComparison.Ordinal);
+        Assert.Contains("$1", sql, StringComparison.Ordinal);
+        Assert.Contains("LIMIT 1", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CollectedDatabaseNamesSql_ReadsDatabaseNameColumnThatExistsInBothSourceTables()
+    {
+        Assert.Contains("database_name", PgSchemaGenerator.CreateTable(DatabaseConfigCollector.Instance), StringComparison.Ordinal);
+        Assert.Contains("database_name", PgSchemaGenerator.CreateTable(DatabaseSizeStatsCollector.Instance), StringComparison.Ordinal);
+    }
+}
+
+/// <summary>
+/// Live round-trip for the collected-database reads against a dev Postgres (skipped unless DARLING_TEST_PG
+/// is set): the picker's list is the DISTINCT user databases across <c>v_database_config</c> and
+/// <c>v_database_size_stats</c>, system databases removed, resolved from the registry server name.
+/// </summary>
+public sealed class ExcludedDatabasesStoreLiveTests
+{
+    private const int ServerId = 990_101;
+    private const string ServerName = "ExclDbTestServer";
+
+    [Fact]
+    public async Task GetCollectedDatabaseNames_ReturnsDistinctUserDatabases_AcrossBothStores_AgainstDevPostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the live collected-databases test.");
+
+        using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await PgMigrations.MigrateAsync(connection, TestContext.Current.CancellationToken);
+        await CleanupAsync(connection);
+
+        await using var viewer = new ViewerDataService(connectionString!);
+
+        try
+        {
+            await InsertServerAsync(connection);
+            var now = DateTime.UtcNow;
+
+            /* database_config: two user DBs + a system DB (master, must be filtered). */
+            await InsertDatabaseConfigAsync(connection, now, "AppA");
+            await InsertDatabaseConfigAsync(connection, now, "AppB");
+            await InsertDatabaseConfigAsync(connection, now, "master");
+            /* database_size_stats: a DUP (AppB) + a new user DB + a system DB (tempdb). */
+            await InsertDatabaseSizeAsync(connection, now, "AppB");
+            await InsertDatabaseSizeAsync(connection, now, "AppC");
+            await InsertDatabaseSizeAsync(connection, now, "tempdb");
+
+            var resolvedId = await viewer.GetServerIdByNameAsync(ServerName);
+            Assert.Equal(ServerId, resolvedId);
+
+            var names = await viewer.GetCollectedDatabaseNamesAsync(ServerId);
+
+            /* DISTINCT across both stores, system DBs removed, sorted. */
+            Assert.Equal(new[] { "AppA", "AppB", "AppC" }, names);
+        }
+        finally
+        {
+            await CleanupAsync(connection);
+        }
+    }
+
+    private static async Task InsertServerAsync(NpgsqlConnection connection)
+    {
+        using var command = new NpgsqlCommand(
+            "INSERT INTO servers (server_id, server_name, display_name) VALUES ($1, $2, $3)", connection);
+        command.Parameters.AddWithValue(ServerId);
+        command.Parameters.AddWithValue(ServerName);
+        command.Parameters.AddWithValue(ServerName);
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static async Task InsertDatabaseConfigAsync(NpgsqlConnection connection, DateTime captureTimeUtc, string databaseName)
+    {
+        using var command = new NpgsqlCommand(
+            "INSERT INTO database_config (config_id, capture_time, server_id, server_name, database_name) VALUES ($1, $2, $3, $4, $5)",
+            connection);
+        command.Parameters.AddWithValue(CollectionIdGenerator.Next());
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(captureTimeUtc, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(ServerId);
+        command.Parameters.AddWithValue(ServerName);
+        command.Parameters.AddWithValue(databaseName);
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static async Task InsertDatabaseSizeAsync(NpgsqlConnection connection, DateTime collectionTimeUtc, string databaseName)
+    {
+        using var command = new NpgsqlCommand(
+            "INSERT INTO database_size_stats (collection_id, collection_time, server_id, server_name, database_name) VALUES ($1, $2, $3, $4, $5)",
+            connection);
+        command.Parameters.AddWithValue(CollectionIdGenerator.Next());
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTimeUtc, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(ServerId);
+        command.Parameters.AddWithValue(ServerName);
+        command.Parameters.AddWithValue(databaseName);
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static async Task CleanupAsync(NpgsqlConnection connection)
+    {
+        foreach (var table in new[] { "database_config", "database_size_stats", "servers" })
+        {
+            using var command = new NpgsqlCommand($"DELETE FROM {table} WHERE server_id = $1", connection);
+            command.Parameters.AddWithValue(ServerId);
+            await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+        }
+    }
+}

--- a/Darling/Darling.Tests/ViewerProfileStoreTests.cs
+++ b/Darling/Darling.Tests/ViewerProfileStoreTests.cs
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.Darling.Viewer;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Pins the viewer's credential-profile registry (<see cref="ViewerProfileStore"/>, the port of Lite's
+/// ProfileManager): JSON round-trip, secret keying under <c>profile_{id}</c> (never the JSON, never the
+/// bare server key), ManagedIdentity's no-secret rule, CRUD, per-process name uniqueness, and the
+/// referential-integrity delete-constraint (blocked while a server references it, allowed after reassign).
+/// Every test uses a temp file and an in-memory secret fake, so nothing touches the real registry or
+/// Windows Credential Manager.
+/// </summary>
+public sealed class ViewerProfileStoreTests : IDisposable
+{
+    private readonly string _profilePath = Path.Combine(Path.GetTempPath(), $"viewer-profiles-{Guid.NewGuid():N}.json");
+    private readonly string _serverPath = Path.Combine(Path.GetTempPath(), $"viewer-servers-{Guid.NewGuid():N}.json");
+    private readonly FakeSecretStore _profileSecrets = new();
+    private readonly FakeSecretStore _serverSecrets = new();
+
+    private ViewerServerStore NewServerStore() => new(_serverPath, _serverSecrets);
+    private ViewerProfileStore NewProfileStore(ViewerServerStore serverStore) => new(serverStore, _profilePath, _profileSecrets);
+
+    public void Dispose()
+    {
+        foreach (var path in new[] { _profilePath, _serverPath })
+        {
+            try { if (File.Exists(path)) File.Delete(path); }
+            catch { /* best-effort temp cleanup */ }
+        }
+    }
+
+    [Fact]
+    public void AddProfile_RoundTripsThroughDisk_AndStoresSecretUnderProfileKey_NotJson()
+    {
+        var store = NewProfileStore(NewServerStore());
+        var profile = new ViewerCredentialProfile
+        {
+            Name = "sql-fleet",
+            AuthType = AuthenticationTypes.SqlServer,
+            Username = "sa"
+        };
+
+        store.AddProfile(profile, "sa", "the-password");
+
+        /* Secret under profile_{id}, NOT a bare id key. */
+        Assert.NotNull(_profileSecrets.Get(ViewerProfileStore.ProfileCredentialId(profile.Id)));
+        Assert.Null(_profileSecrets.Get(profile.Id));
+
+        /* viewer-profiles.json holds the profile, never the secret. */
+        var json = File.ReadAllText(_profilePath);
+        Assert.Contains("sql-fleet", json);
+        Assert.DoesNotContain("the-password", json);
+
+        /* A fresh store over the same file reloads it. */
+        var reloaded = NewProfileStore(NewServerStore()).GetProfile(profile.Id);
+        Assert.NotNull(reloaded);
+        Assert.Equal("sql-fleet", reloaded!.Name);
+        Assert.Equal(AuthenticationTypes.SqlServer, reloaded.AuthType);
+        Assert.Equal("sa", reloaded.Username);
+    }
+
+    [Fact]
+    public void ManagedIdentityProfile_StoresNoSecret_ButHasStoredSecretIsTrue()
+    {
+        var store = NewProfileStore(NewServerStore());
+        var profile = new ViewerCredentialProfile { Name = "mi", AuthType = AuthenticationTypes.ManagedIdentity };
+
+        store.AddProfile(profile, username: null, secret: null);
+
+        Assert.Null(_profileSecrets.Get(ViewerProfileStore.ProfileCredentialId(profile.Id)));
+        Assert.True(store.HasStoredSecret(profile));  // MI needs none
+    }
+
+    [Fact]
+    public void GetAll_SortsByName()
+    {
+        var store = NewProfileStore(NewServerStore());
+        store.AddProfile(new ViewerCredentialProfile { Name = "Zeta", AuthType = AuthenticationTypes.ManagedIdentity });
+        store.AddProfile(new ViewerCredentialProfile { Name = "alpha", AuthType = AuthenticationTypes.ManagedIdentity });
+
+        Assert.Equal(new[] { "alpha", "Zeta" }, store.GetAll().Select(p => p.Name));
+    }
+
+    [Fact]
+    public void AddProfile_RejectsDuplicateName()
+    {
+        var store = NewProfileStore(NewServerStore());
+        store.AddProfile(new ViewerCredentialProfile { Name = "dup", AuthType = AuthenticationTypes.ManagedIdentity });
+
+        Assert.Throws<InvalidOperationException>(() =>
+            store.AddProfile(new ViewerCredentialProfile { Name = "dup", AuthType = AuthenticationTypes.ManagedIdentity }));
+    }
+
+    [Fact]
+    public void UpdateProfile_BlankSecret_LeavesStoredSecretUnchanged_FreshSecretReplacesIt()
+    {
+        var store = NewProfileStore(NewServerStore());
+        var profile = new ViewerCredentialProfile { Name = "p", AuthType = AuthenticationTypes.SqlServer, Username = "sa" };
+        store.AddProfile(profile, "sa", "pw1");
+
+        /* Rename only (blank secret) → the stored secret is untouched. */
+        profile.Name = "renamed";
+        store.UpdateProfile(profile);
+        Assert.Equal("pw1", _profileSecrets.Get(ViewerProfileStore.ProfileCredentialId(profile.Id))!.Value.Password);
+
+        /* Fresh secret → replaces it. */
+        store.UpdateProfile(profile, "sa", "pw2");
+        Assert.Equal("pw2", _profileSecrets.Get(ViewerProfileStore.ProfileCredentialId(profile.Id))!.Value.Password);
+        Assert.Equal("renamed", NewProfileStore(NewServerStore()).GetProfile(profile.Id)!.Name);
+    }
+
+    [Fact]
+    public void DeleteProfile_RemovesProfileAndSecret()
+    {
+        var store = NewProfileStore(NewServerStore());
+        var profile = new ViewerCredentialProfile { Name = "to-delete", AuthType = AuthenticationTypes.ServicePrincipal, AzureClientId = "cid" };
+        store.AddProfile(profile, "cid", "sec");
+
+        store.DeleteProfile(profile.Id);
+
+        Assert.Null(store.GetProfile(profile.Id));
+        Assert.Null(_profileSecrets.Get(ViewerProfileStore.ProfileCredentialId(profile.Id)));
+        Assert.Empty(NewProfileStore(NewServerStore()).GetAll());
+    }
+
+    [Fact]
+    public void DeleteProfile_BlockedWhileServerReferencesIt_AllowedAfterReassign()
+    {
+        var serverStore = NewServerStore();
+        var profileStore = NewProfileStore(serverStore);
+
+        var profile = new ViewerCredentialProfile { Name = "shared", AuthType = AuthenticationTypes.SqlServer, Username = "sa" };
+        profileStore.AddProfile(profile, "sa", "pw");
+
+        var server = new ViewerServerEntry { ServerName = "s", DisplayName = "s", CredentialProfileId = profile.Id };
+        serverStore.AddServer(server, null, null);
+
+        Assert.Equal(1, profileStore.CountServersUsingProfile(profile.Id));
+
+        /* Blocked while referenced. */
+        var ex = Assert.Throws<InvalidOperationException>(() => profileStore.DeleteProfile(profile.Id));
+        Assert.Contains("used by", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.NotNull(profileStore.GetProfile(profile.Id));
+
+        /* Reassign (clear the reference) then delete succeeds. */
+        server.CredentialProfileId = null;
+        serverStore.UpdateServer(server);
+        profileStore.DeleteProfile(profile.Id);
+        Assert.Null(profileStore.GetProfile(profile.Id));
+    }
+
+    /// <summary>In-memory <see cref="IViewerServerSecretStore"/> so tests never touch Windows Credential Manager.</summary>
+    private sealed class FakeSecretStore : IViewerServerSecretStore
+    {
+        private readonly Dictionary<string, (string Username, string Password)> _map = new();
+
+        public void Save(string id, string username, string password) => _map[id] = (username, password);
+
+        public (string Username, string Password)? Get(string id) =>
+            _map.TryGetValue(id, out var v) ? v : null;
+
+        public void Delete(string id) => _map.Remove(id);
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/AddServerDialog.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/AddServerDialog.xaml
@@ -35,11 +35,30 @@
         <TextBlock Grid.Row="3" Text="Display Name (optional)" FontWeight="Bold" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
         <TextBox Grid.Row="4" x:Name="DisplayNameBox" Margin="0,0,0,12"/>
 
-        <!-- Authentication (inline per-server auth — the viewer never connects, so this is declarative
-             config the Darling service will consume; there is no shared credential-profile picker here). -->
+        <!-- Authentication. The credential source is either inline per-server auth or a shared credential
+             profile (the Darling service resolves the profile at connect time — the viewer never connects).
+             This is declarative config the service consumes. -->
         <TextBlock Grid.Row="5" Text="Authentication" FontWeight="Bold" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
         <StackPanel Grid.Row="6" Margin="0,0,0,12">
-            <StackPanel x:Name="InlineAuthRadios">
+            <!-- Credential source: inline (per-server) vs a shared credential profile -->
+            <RadioButton Content="Configure credentials on this server"
+                         Foreground="{DynamicResource ForegroundBrush}" IsChecked="True"
+                         Checked="CredentialSource_Changed" Margin="0,0,0,4"/>
+            <RadioButton x:Name="UseProfileRadio" Content="Use a credential profile"
+                         Foreground="{DynamicResource ForegroundBrush}"
+                         Checked="CredentialSource_Changed" Margin="0,0,0,4"
+                         ToolTip="Use a named, shared credential (set up under Manage Servers → Credential Profiles). The profile fully overrides this server's auth type and credentials."/>
+
+            <!-- Profile picker (shown when 'Use a credential profile' is selected) -->
+            <StackPanel x:Name="ProfilePickerPanel" Visibility="Collapsed" Margin="0,4,0,0">
+                <TextBlock Text="Credential Profile" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+                <ComboBox x:Name="ProfileComboBox" DisplayMemberPath="PickerDisplay"/>
+                <TextBlock x:Name="NoProfilesNote" TextWrapping="Wrap" FontSize="11" Visibility="Collapsed"
+                           Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,4,0,0"
+                           Text="No credential profiles exist yet. Create one under Manage Servers → Credential Profiles."/>
+            </StackPanel>
+
+            <StackPanel x:Name="InlineAuthRadios" Margin="0,4,0,0">
                 <RadioButton x:Name="WindowsAuthRadio" Content="Windows Authentication" Foreground="{DynamicResource ForegroundBrush}"
                              IsChecked="True" Checked="AuthMode_Changed" Margin="0,0,0,4"/>
                 <RadioButton x:Name="SqlAuthRadio" Content="SQL Server Authentication" Foreground="{DynamicResource ForegroundBrush}"

--- a/Darling/PerformanceMonitor.Darling.Viewer/AddServerDialog.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/AddServerDialog.xaml.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Globalization;
+using System.Linq;
 using System.Windows;
 using PerformanceMonitor.Common;
 using PerformanceMonitor.Notifications;
@@ -15,31 +16,50 @@ using PerformanceMonitor.Notifications;
 namespace PerformanceMonitor.Darling.Viewer;
 
 /// <summary>
-/// The viewer's Add / Edit server dialog — a faithful port of Lite's <c>AddServerDialog</c>, with the two
-/// live-connection affordances dropped as hard viewer facts: there is no <b>Test Connection</b> button (the
-/// viewer never opens a SqlClient connection to a monitored server — it reads only the Postgres store) and
-/// no shared credential-profile picker (the viewer has no <c>ProfileManager</c>). Everything else — all five
-/// inline auth modes, encryption, connection options, database / utility DB, cost, alert-delivery override,
-/// favorite — is captured verbatim into a <see cref="ViewerServerEntry"/> and persisted through
-/// <see cref="ViewerServerStore"/> (secrets to Credential Manager). Making the running service honor the
-/// saved definition is the separate wiring flagged in the PR.
+/// The viewer's Add / Edit server dialog — a faithful port of Lite's <c>AddServerDialog</c>, with the one
+/// live-connection affordance dropped as a hard viewer fact: there is no <b>Test Connection</b> button (the
+/// viewer never opens a SqlClient connection to a monitored server — it reads only the Postgres store).
+/// Everything else — all five inline auth modes AND the shared credential-profile picker (credential
+/// MANAGEMENT is fully in scope; only live connection resolution is the service's job), encryption,
+/// connection options, database / utility DB, cost, alert-delivery override, favorite — is captured into a
+/// <see cref="ViewerServerEntry"/> and persisted through <see cref="ViewerServerStore"/> (per-server
+/// secrets to Credential Manager; a chosen profile via <see cref="ViewerServerEntry.CredentialProfileId"/>).
+/// Making the running service honor the saved definition is the separate wiring flagged in the PR.
 /// </summary>
 public partial class AddServerDialog : Window
 {
     private readonly ViewerServerStore _serverStore;
+    private readonly ViewerProfileStore _profileStore;
 
     /// <summary>The server that was added or edited, or null when the dialog was cancelled.</summary>
     public ViewerServerEntry? AddedServer { get; private set; }
 
-    public AddServerDialog(ViewerServerStore serverStore)
+    public AddServerDialog(ViewerServerStore serverStore, ViewerProfileStore profileStore)
     {
         InitializeComponent();
         _serverStore = serverStore;
+        _profileStore = profileStore;
+        PopulateProfilePicker();
+    }
+
+    /// <summary>
+    /// Populates the profile dropdown from the current profile list. Disables the "use profile" option
+    /// when no profiles exist.
+    /// </summary>
+    private void PopulateProfilePicker()
+    {
+        var profiles = _profileStore.GetAll();
+        ProfileComboBox.ItemsSource = profiles;
+        if (profiles.Count == 0)
+        {
+            UseProfileRadio.IsEnabled = false;
+            NoProfilesNote.Visibility = Visibility.Visible;
+        }
     }
 
     /// <summary>Constructor for editing an existing server definition.</summary>
-    public AddServerDialog(ViewerServerStore serverStore, ViewerServerEntry existing)
-        : this(serverStore)
+    public AddServerDialog(ViewerServerStore serverStore, ViewerProfileStore profileStore, ViewerServerEntry existing)
+        : this(serverStore, profileStore)
     {
         Title = "Edit SQL Server";
         ServerNameBox.Text = existing.ServerName;
@@ -67,6 +87,22 @@ public partial class AddServerDialog : Window
             AlertNotificationMode.PerEvent => 2,
             _ => 0
         };
+
+        /* Profile-backed server: preselect "use profile" + the dropdown; the inline auth panels stay
+           hidden (CredentialSource_Changed, fired by IsChecked). No per-server secret is loaded. */
+        if (!string.IsNullOrEmpty(existing.CredentialProfileId))
+        {
+            UseProfileRadio.IsChecked = true;
+            var match = _profileStore.GetProfile(existing.CredentialProfileId);
+            if (match is not null)
+            {
+                ProfileComboBox.SelectedItem = ProfileComboBox.Items
+                    .Cast<ViewerCredentialProfile>().FirstOrDefault(p => p.Id == match.Id);
+            }
+
+            AddedServer = existing;
+            return;
+        }
 
         if (existing.AuthenticationType == AuthenticationTypes.EntraMFA)
         {
@@ -109,6 +145,39 @@ public partial class AddServerDialog : Window
         }
 
         AddedServer = existing;
+    }
+
+    /// <summary>
+    /// Toggles between the inline per-server auth UI and the credential-profile picker. When a profile is
+    /// chosen the inline auth radios + all per-mode credential panels are hidden (the profile fully
+    /// overrides the server's auth type + creds).
+    /// </summary>
+    private void CredentialSource_Changed(object sender, RoutedEventArgs e)
+    {
+        /* Guard against early Checked events during InitializeComponent. */
+        if (ProfilePickerPanel is null || InlineAuthRadios is null)
+        {
+            return;
+        }
+
+        var useProfile = UseProfileRadio.IsChecked == true;
+
+        ProfilePickerPanel.Visibility = useProfile ? Visibility.Visible : Visibility.Collapsed;
+        InlineAuthRadios.Visibility = useProfile ? Visibility.Collapsed : Visibility.Visible;
+
+        if (useProfile)
+        {
+            /* Hide every per-mode inline credential panel. */
+            if (SqlCredentialsPanel is not null) SqlCredentialsPanel.Visibility = Visibility.Collapsed;
+            if (EntraMfaPanel is not null) EntraMfaPanel.Visibility = Visibility.Collapsed;
+            if (ServicePrincipalPanel is not null) ServicePrincipalPanel.Visibility = Visibility.Collapsed;
+            if (ManagedIdentityPanel is not null) ManagedIdentityPanel.Visibility = Visibility.Collapsed;
+        }
+        else
+        {
+            /* Re-show the panel for the currently selected inline auth mode. */
+            AuthMode_Changed(sender, e);
+        }
     }
 
     private void AuthMode_Changed(object sender, RoutedEventArgs e)
@@ -154,12 +223,29 @@ public partial class AddServerDialog : Window
             displayName = serverName;
         }
 
+        /* Credential source: a shared profile, or inline per-server auth. */
+        var useProfile = UseProfileRadio.IsChecked == true;
+        ViewerCredentialProfile? selectedProfile = null;
+
         string authenticationType;
         string? username = null;
         string? password = null;
         string? entraUsername = null;
 
-        if (WindowsAuthRadio.IsChecked == true)
+        if (useProfile)
+        {
+            selectedProfile = ProfileComboBox.SelectedItem as ViewerCredentialProfile;
+            if (selectedProfile is null)
+            {
+                StatusText.Text = "Select a credential profile, or choose \"Configure credentials on this server\".";
+                return;
+            }
+            /* The profile fully overrides the server's auth; mirror its auth type onto the entry (display
+               only). Resolution always comes from the profile via CredentialProfileId; no per-server
+               secret is stored. */
+            authenticationType = selectedProfile.AuthType;
+        }
+        else if (WindowsAuthRadio.IsChecked == true)
         {
             authenticationType = AuthenticationTypes.Windows;
         }
@@ -221,16 +307,17 @@ public partial class AddServerDialog : Window
                 entry.ServerName = serverName;
                 entry.DisplayName = displayName;
                 entry.AuthenticationType = authenticationType;
-                entry.EntraUsername = authenticationType == AuthenticationTypes.EntraMFA
+                entry.CredentialProfileId = useProfile ? selectedProfile!.Id : null;
+                entry.EntraUsername = (!useProfile && authenticationType == AuthenticationTypes.EntraMFA)
                     ? (string.IsNullOrWhiteSpace(entraUsername) ? null : entraUsername)
                     : null;
-                entry.AzureClientId = authenticationType == AuthenticationTypes.ServicePrincipal
+                entry.AzureClientId = (!useProfile && authenticationType == AuthenticationTypes.ServicePrincipal)
                     ? (string.IsNullOrWhiteSpace(AzureClientIdBox.Text) ? null : AzureClientIdBox.Text.Trim())
                     : null;
-                entry.AzureTenantId = authenticationType == AuthenticationTypes.ServicePrincipal
+                entry.AzureTenantId = (!useProfile && authenticationType == AuthenticationTypes.ServicePrincipal)
                     ? (string.IsNullOrWhiteSpace(AzureTenantIdBox.Text) ? null : AzureTenantIdBox.Text.Trim())
                     : null;
-                entry.ManagedIdentityClientId = authenticationType == AuthenticationTypes.ManagedIdentity
+                entry.ManagedIdentityClientId = (!useProfile && authenticationType == AuthenticationTypes.ManagedIdentity)
                     ? (string.IsNullOrWhiteSpace(ManagedIdentityClientIdBox.Text) ? null : ManagedIdentityClientIdBox.Text.Trim())
                     : null;
                 entry.IsEnabled = EnabledCheckBox.IsChecked == true;
@@ -245,7 +332,9 @@ public partial class AddServerDialog : Window
                 entry.MonthlyCostUsd = monthlyCost;
                 entry.AlertDeliveryModeOverride = GetSelectedDeliveryOverride();
 
-                _serverStore.UpdateServer(entry, username, password);
+                /* Profile-backed → store no per-server secret (UpdateServer with null creds deletes any
+                   stale one, matching Lite's switch-cleanup). */
+                _serverStore.UpdateServer(entry, useProfile ? null : username, useProfile ? null : password);
             }
             else
             {
@@ -255,16 +344,17 @@ public partial class AddServerDialog : Window
                     ServerName = serverName,
                     DisplayName = displayName,
                     AuthenticationType = authenticationType,
-                    EntraUsername = authenticationType == AuthenticationTypes.EntraMFA
+                    CredentialProfileId = useProfile ? selectedProfile!.Id : null,
+                    EntraUsername = (!useProfile && authenticationType == AuthenticationTypes.EntraMFA)
                         ? (string.IsNullOrWhiteSpace(entraUsername) ? null : entraUsername)
                         : null,
-                    AzureClientId = authenticationType == AuthenticationTypes.ServicePrincipal
+                    AzureClientId = (!useProfile && authenticationType == AuthenticationTypes.ServicePrincipal)
                         ? (string.IsNullOrWhiteSpace(AzureClientIdBox.Text) ? null : AzureClientIdBox.Text.Trim())
                         : null,
-                    AzureTenantId = authenticationType == AuthenticationTypes.ServicePrincipal
+                    AzureTenantId = (!useProfile && authenticationType == AuthenticationTypes.ServicePrincipal)
                         ? (string.IsNullOrWhiteSpace(AzureTenantIdBox.Text) ? null : AzureTenantIdBox.Text.Trim())
                         : null,
-                    ManagedIdentityClientId = authenticationType == AuthenticationTypes.ManagedIdentity
+                    ManagedIdentityClientId = (!useProfile && authenticationType == AuthenticationTypes.ManagedIdentity)
                         ? (string.IsNullOrWhiteSpace(ManagedIdentityClientIdBox.Text) ? null : ManagedIdentityClientIdBox.Text.Trim())
                         : null,
                     IsEnabled = EnabledCheckBox.IsChecked == true,
@@ -280,7 +370,7 @@ public partial class AddServerDialog : Window
                     AlertDeliveryModeOverride = GetSelectedDeliveryOverride()
                 };
 
-                _serverStore.AddServer(AddedServer, username, password);
+                _serverStore.AddServer(AddedServer, useProfile ? null : username, useProfile ? null : password);
             }
 
             DialogResult = true;

--- a/Darling/PerformanceMonitor.Darling.Viewer/EditCredentialProfileDialog.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/EditCredentialProfileDialog.xaml
@@ -1,0 +1,77 @@
+<Window x:Class="PerformanceMonitor.Darling.Viewer.EditCredentialProfileDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Credential Profile"
+        SizeToContent="Height" Width="440"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        Icon="EDD.ico"
+        Background="{DynamicResource BackgroundBrush}">
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Text="Credential Profile" FontSize="18" FontWeight="Bold" Margin="0,0,0,12"
+                   Foreground="{DynamicResource ForegroundBrush}"/>
+
+        <TextBlock Grid.Row="1" Text="Profile Name" FontWeight="Bold" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+        <TextBox Grid.Row="2" x:Name="NameBox" Margin="0,0,0,12"/>
+
+        <TextBlock Grid.Row="3" Text="Authentication" FontWeight="Bold" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+        <StackPanel Grid.Row="4" Margin="0,0,0,12">
+            <RadioButton x:Name="SqlAuthRadio" Content="SQL Server Authentication" Foreground="{DynamicResource ForegroundBrush}"
+                         IsChecked="True" Checked="AuthMode_Changed" Margin="0,0,0,4"/>
+            <RadioButton x:Name="ServicePrincipalAuthRadio" Content="Azure — Service Principal" Foreground="{DynamicResource ForegroundBrush}"
+                         Checked="AuthMode_Changed" Margin="0,0,0,4"
+                         ToolTip="Non-interactive Azure SQL auth using an Entra app registration (client id + secret)."/>
+            <RadioButton x:Name="ManagedIdentityAuthRadio" Content="Azure — Managed Identity" Foreground="{DynamicResource ForegroundBrush}"
+                         Checked="AuthMode_Changed"
+                         ToolTip="Non-interactive Azure SQL auth using the managed identity of the Azure resource running the Darling service."/>
+        </StackPanel>
+
+        <!-- SQL Auth -->
+        <StackPanel Grid.Row="5" x:Name="SqlCredentialsPanel" Margin="0,0,0,12">
+            <TextBlock Text="Username" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+            <TextBox x:Name="UsernameBox" Margin="0,0,0,8"/>
+            <TextBlock Text="Password" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+            <PasswordBox x:Name="PasswordBox"/>
+        </StackPanel>
+
+        <!-- Service Principal -->
+        <StackPanel Grid.Row="5" x:Name="ServicePrincipalPanel" Visibility="Collapsed" Margin="0,0,0,12">
+            <TextBlock Text="Client (Application) ID" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+            <TextBox x:Name="AzureClientIdBox" Margin="0,0,0,8"
+                     ToolTip="The Application (client) ID of the Entra app registration / service principal."/>
+            <TextBlock Text="Client Secret" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+            <PasswordBox x:Name="AzureClientSecretBox" Margin="0,0,0,8"/>
+            <TextBlock Text="Tenant ID (optional)" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+            <TextBox x:Name="AzureTenantIdBox" Margin="0,0,0,4"
+                     ToolTip="Optional. Stored for reference; the tenant is resolved automatically from the target server."/>
+        </StackPanel>
+
+        <!-- Managed Identity -->
+        <StackPanel Grid.Row="5" x:Name="ManagedIdentityPanel" Visibility="Collapsed" Margin="0,0,0,12">
+            <TextBlock Text="User-Assigned Identity Client ID (optional)" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+            <TextBox x:Name="ManagedIdentityClientIdBox" Margin="0,0,0,8"
+                     ToolTip="Leave blank to use the system-assigned managed identity. Set to a client id to use a specific user-assigned identity."/>
+            <TextBlock TextWrapping="Wrap" Foreground="{DynamicResource ForegroundMutedBrush}" FontSize="11"
+                       Text="Managed Identity only works when the Darling service runs on an Azure VM / resource that has a managed identity assigned. Use Service Principal for non-interactive auth from a workstation."/>
+        </StackPanel>
+
+        <TextBlock Grid.Row="6" x:Name="StatusText" Foreground="{DynamicResource ForegroundMutedBrush}"
+                   TextWrapping="Wrap" Margin="0,0,0,8"/>
+
+        <StackPanel Grid.Row="7" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Content="Save" Width="80" Height="30" Click="SaveButton_Click" Style="{StaticResource AccentButton}" Margin="0,0,8,0"/>
+            <Button Content="Cancel" Width="80" Height="30" Click="CancelButton_Click" IsCancel="True"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Darling/PerformanceMonitor.Darling.Viewer/EditCredentialProfileDialog.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/EditCredentialProfileDialog.xaml.cs
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Windows;
+using PerformanceMonitor.Common;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// Add/Edit editor for a single <see cref="ViewerCredentialProfile"/> — the viewer port of Lite's
+/// <c>EditCredentialProfileDialog</c>. Offers only the three profile-eligible auth types
+/// (SqlServer / ServicePrincipal / ManagedIdentity). Secrets are entered into a PasswordBox and stored
+/// only in Windows Credential Manager via <see cref="ViewerProfileStore"/> — never in viewer-profiles.json.
+/// </summary>
+public partial class EditCredentialProfileDialog : Window
+{
+    private readonly ViewerProfileStore _profileStore;
+    private readonly ViewerCredentialProfile? _existing;
+
+    /// <summary>The saved/updated profile, or null if cancelled.</summary>
+    public ViewerCredentialProfile? SavedProfile { get; private set; }
+
+    public EditCredentialProfileDialog(ViewerProfileStore profileStore, ViewerCredentialProfile? existing = null)
+    {
+        InitializeComponent();
+        _profileStore = profileStore;
+        _existing = existing;
+
+        if (existing is not null)
+        {
+            Title = "Edit Credential Profile";
+            NameBox.Text = existing.Name;
+
+            switch (existing.AuthType)
+            {
+                case AuthenticationTypes.ServicePrincipal:
+                    ServicePrincipalAuthRadio.IsChecked = true;
+                    AzureClientIdBox.Text = existing.AzureClientId ?? "";
+                    AzureTenantIdBox.Text = existing.AzureTenantId ?? "";
+                    break;
+                case AuthenticationTypes.ManagedIdentity:
+                    ManagedIdentityAuthRadio.IsChecked = true;
+                    ManagedIdentityClientIdBox.Text = existing.ManagedIdentityClientId ?? "";
+                    break;
+                default:
+                    SqlAuthRadio.IsChecked = true;
+                    UsernameBox.Text = existing.Username ?? "";
+                    break;
+            }
+
+            /* Pre-fill the secret + username from Credential Manager (pre-fill-on-edit pattern). */
+            if (existing.AuthType is AuthenticationTypes.SqlServer or AuthenticationTypes.ServicePrincipal)
+            {
+                var cred = _profileStore.GetSecret(existing.Id);
+                if (cred.HasValue)
+                {
+                    if (existing.AuthType == AuthenticationTypes.SqlServer)
+                    {
+                        if (string.IsNullOrEmpty(UsernameBox.Text))
+                        {
+                            UsernameBox.Text = cred.Value.Username;
+                        }
+                        PasswordBox.Password = cred.Value.Password;
+                    }
+                    else
+                    {
+                        if (string.IsNullOrEmpty(AzureClientIdBox.Text))
+                        {
+                            AzureClientIdBox.Text = cred.Value.Username;
+                        }
+                        AzureClientSecretBox.Password = cred.Value.Password;
+                    }
+                }
+            }
+
+            var inUse = _profileStore.CountServersUsingProfile(existing.Id);
+            if (inUse > 0)
+            {
+                StatusText.Text = $"{inUse} server(s) use this profile — editing its secret affects all of them.";
+            }
+        }
+    }
+
+    private void AuthMode_Changed(object sender, RoutedEventArgs e)
+    {
+        if (SqlCredentialsPanel is null || ServicePrincipalPanel is null || ManagedIdentityPanel is null)
+        {
+            return;
+        }
+
+        SqlCredentialsPanel.Visibility = SqlAuthRadio.IsChecked == true ? Visibility.Visible : Visibility.Collapsed;
+        ServicePrincipalPanel.Visibility = ServicePrincipalAuthRadio.IsChecked == true ? Visibility.Visible : Visibility.Collapsed;
+        ManagedIdentityPanel.Visibility = ManagedIdentityAuthRadio.IsChecked == true ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    private void SaveButton_Click(object sender, RoutedEventArgs e)
+    {
+        var name = NameBox.Text.Trim();
+        if (string.IsNullOrEmpty(name))
+        {
+            StatusText.Text = "Profile name is required.";
+            return;
+        }
+
+        string authType;
+        string? username = null;
+        string? secret = null;
+        string? azureClientId = null;
+        string? azureTenantId = null;
+        string? miClientId = null;
+
+        if (ServicePrincipalAuthRadio.IsChecked == true)
+        {
+            authType = AuthenticationTypes.ServicePrincipal;
+            azureClientId = string.IsNullOrWhiteSpace(AzureClientIdBox.Text) ? null : AzureClientIdBox.Text.Trim();
+            azureTenantId = string.IsNullOrWhiteSpace(AzureTenantIdBox.Text) ? null : AzureTenantIdBox.Text.Trim();
+            username = azureClientId;
+            secret = AzureClientSecretBox.Password;
+
+            if (string.IsNullOrEmpty(azureClientId))
+            {
+                StatusText.Text = "Client (Application) ID is required for service principal profiles.";
+                return;
+            }
+            /* On add (or when no stored secret yet), require the secret. On edit, a blank secret means
+               "leave the stored secret unchanged". */
+            if (_existing is null && string.IsNullOrEmpty(secret))
+            {
+                StatusText.Text = "Client secret is required for service principal profiles.";
+                return;
+            }
+        }
+        else if (ManagedIdentityAuthRadio.IsChecked == true)
+        {
+            authType = AuthenticationTypes.ManagedIdentity;
+            miClientId = string.IsNullOrWhiteSpace(ManagedIdentityClientIdBox.Text) ? null : ManagedIdentityClientIdBox.Text.Trim();
+        }
+        else
+        {
+            authType = AuthenticationTypes.SqlServer;
+            username = UsernameBox.Text.Trim();
+            secret = PasswordBox.Password;
+
+            if (string.IsNullOrEmpty(username))
+            {
+                StatusText.Text = "Username is required for SQL Server profiles.";
+                return;
+            }
+            if (_existing is null && string.IsNullOrEmpty(secret))
+            {
+                StatusText.Text = "Password is required for SQL Server profiles.";
+                return;
+            }
+        }
+
+        try
+        {
+            if (_existing is null)
+            {
+                var profile = new ViewerCredentialProfile
+                {
+                    Name = name,
+                    AuthType = authType,
+                    Username = username,
+                    AzureClientId = azureClientId,
+                    AzureTenantId = azureTenantId,
+                    ManagedIdentityClientId = miClientId
+                };
+                _profileStore.AddProfile(profile, username, secret);
+                SavedProfile = profile;
+            }
+            else
+            {
+                _existing.Name = name;
+                _existing.AuthType = authType;
+                _existing.Username = username;
+                _existing.AzureClientId = azureClientId;
+                _existing.AzureTenantId = azureTenantId;
+                _existing.ManagedIdentityClientId = miClientId;
+
+                /* A blank secret on edit leaves the stored secret unchanged (pass null username so
+                   UpdateProfile skips the re-store); a non-blank one updates it. */
+                if (string.IsNullOrEmpty(secret))
+                {
+                    _profileStore.UpdateProfile(_existing);
+                }
+                else
+                {
+                    _profileStore.UpdateProfile(_existing, username, secret);
+                }
+
+                SavedProfile = _existing;
+            }
+
+            DialogResult = true;
+            Close();
+        }
+        catch (Exception ex)
+        {
+            StatusText.Text = $"Error: {ex.Message}";
+        }
+    }
+
+    private void CancelButton_Click(object sender, RoutedEventArgs e)
+    {
+        DialogResult = false;
+        Close();
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ExcludedDatabasesDialog.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ExcludedDatabasesDialog.xaml
@@ -2,9 +2,10 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Excluded Databases"
-        Height="440" Width="460"
+        Height="520" Width="500"
         WindowStartupLocation="CenterOwner"
         Icon="EDD.ico"
+        ResizeMode="CanResizeWithGrip"
         Background="{DynamicResource BackgroundBrush}">
     <Grid Margin="16">
         <Grid.RowDefinitions>
@@ -13,28 +14,48 @@
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <TextBlock Grid.Row="0" x:Name="HeaderText" Text="Excluded Databases" FontSize="16" FontWeight="Bold"
                    Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
 
-        <!-- The viewer never connects to the monitored server, so it can't enumerate the live database list
-             the way Lite's dialog does. This is a manual editor for the same field the Darling service will
-             consume — one database name per line. -->
+        <!-- The viewer never connects to the monitored server, but the Darling store HAS the databases the
+             service collected — so the list below is the collected user databases (not a free-text editor).
+             A not-yet-collected database can still be added by hand at the bottom. -->
         <TextBlock Grid.Row="1" TextWrapping="Wrap" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,0,0,8"
-                   Text="User databases to skip in per-database collectors — one name per line. System databases and the connection database are always excluded. The viewer can't list the server's live databases (it never connects to it), so enter the names to exclude here."/>
+                   Text="User databases to skip in per-database collectors. Checked databases are excluded. The list is the databases the Darling service has collected for this server; system databases (master/model/msdb/tempdb) are always excluded. Add a not-yet-collected database by name below."/>
 
-        <TextBox Grid.Row="2" x:Name="ExclusionsBox"
-                 AcceptsReturn="True" TextWrapping="NoWrap"
-                 VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto"
-                 FontFamily="Consolas" Margin="0,0,0,8"/>
+        <Border Grid.Row="2" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" CornerRadius="4">
+            <ScrollViewer VerticalScrollBarVisibility="Auto" Padding="8">
+                <ItemsControl x:Name="DatabasesItemsControl">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <CheckBox Content="{Binding DisplayName}"
+                                      IsChecked="{Binding IsExcluded, Mode=TwoWay}"
+                                      IsEnabled="{Binding IsEnabled}"
+                                      Foreground="{Binding ForegroundBrush}"
+                                      Margin="2,3"/>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </ScrollViewer>
+        </Border>
 
-        <TextBlock Grid.Row="3" x:Name="StatusText" Foreground="{DynamicResource ForegroundMutedBrush}"
-                   TextWrapping="Wrap" Margin="0,0,0,8"/>
+        <!-- Manual add for a database the store hasn't collected yet. -->
+        <StackPanel Grid.Row="3" Orientation="Horizontal" Margin="0,8,0,0">
+            <TextBox x:Name="ManualAddBox" Width="360" VerticalContentAlignment="Center"
+                     KeyDown="ManualAddBox_KeyDown"
+                     ToolTip="Enter a database name the service has not collected yet, then click Add."/>
+            <Button Content="Add" Width="70" Height="26" Margin="8,0,0,0" Click="ManualAdd_Click"/>
+        </StackPanel>
 
-        <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button Content="Save" Width="80" Height="30" Click="Save_Click" Style="{StaticResource AccentButton}" Margin="0,0,8,0"/>
-            <Button Content="Cancel" Width="80" Height="30" Click="Cancel_Click"/>
+        <TextBlock Grid.Row="4" x:Name="StatusText" FontSize="10" FontStyle="Italic"
+                   Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,8,0,0"/>
+
+        <StackPanel Grid.Row="5" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
+            <Button Content="Save" Width="80" Height="28" Margin="0,0,8,0" Click="Save_Click" Style="{StaticResource AccentButton}"/>
+            <Button Content="Cancel" Width="80" Height="28" Click="Cancel_Click" IsCancel="True"/>
         </StackPanel>
     </Grid>
 </Window>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ExcludedDatabasesDialog.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ExcludedDatabasesDialog.xaml.cs
@@ -7,44 +7,184 @@
  */
 
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Input;
+using System.Windows.Media;
 
 namespace PerformanceMonitor.Darling.Viewer;
 
 /// <summary>
-/// The viewer's Excluded Databases editor — adapted from Lite's dialog. Lite reads the server's LIVE
-/// database list (it connects to the monitored server) and offers a checkbox per database; the Darling
-/// viewer never connects to monitored servers, so this is a manual, one-name-per-line editor for the same
-/// <see cref="ViewerServerEntry.ExcludedDatabases"/> field the Darling service will consume. Persisted
-/// through <see cref="ViewerServerStore.UpdateServer(ViewerServerEntry)"/>.
+/// The viewer's Excluded Databases editor — a checkbox picker over the databases the Darling service has
+/// COLLECTED for this server, adapted from Lite's dialog. Lite reads the server's LIVE database list (it
+/// connects to the monitored server); the viewer never connects, but the store already holds the
+/// collected databases (<c>v_database_config</c> / <c>v_database_size_stats</c>), so the picker offers
+/// those instead of a free-text editor. A not-yet-collected database can still be added by hand (the
+/// manual fallback). Persists the checked names to <see cref="ViewerServerEntry.ExcludedDatabases"/>
+/// through <see cref="ViewerServerStore.UpdateServer(ViewerServerEntry)"/> for the Darling service to consume.
 /// </summary>
 public partial class ExcludedDatabasesDialog : Window
 {
     private readonly ViewerServerStore _serverStore;
     private readonly ViewerServerEntry _entry;
+    private readonly ViewerDataService? _dataService;
+    private ObservableCollection<ExcludedDatabaseItem> _items = new();
 
     /// <summary>Set true when the exclusion list was changed and saved, so the caller refreshes.</summary>
     public bool ExclusionsModified { get; private set; }
 
-    public ExcludedDatabasesDialog(ViewerServerStore serverStore, ViewerServerEntry entry)
+    /// <param name="dataService">The store reader used to populate the collected-database list; null (viewer
+    /// not connected) degrades to a manual-only editor seeded with the existing exclusions.</param>
+    public ExcludedDatabasesDialog(ViewerServerStore serverStore, ViewerServerEntry entry, ViewerDataService? dataService)
     {
         InitializeComponent();
         _serverStore = serverStore;
         _entry = entry;
+        _dataService = dataService;
         HeaderText.Text = $"Excluded Databases — {entry.DisplayNameWithIntent}";
-        ExclusionsBox.Text = string.Join(Environment.NewLine, entry.ExcludedDatabases ?? new System.Collections.Generic.List<string>());
-        StatusText.Text = $"{(entry.ExcludedDatabases?.Count ?? 0)} database(s) currently excluded.";
+        Loaded += async (_, _) => await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        var existing = _entry.ExcludedDatabases ?? new List<string>();
+        StatusText.Text = "Loading collected databases…";
+
+        List<string> collected = new();
+        var collectedCount = 0;
+        if (_dataService is not null)
+        {
+            try
+            {
+                var serverId = await _dataService.GetServerIdByNameAsync(_entry.ServerName);
+                if (serverId.HasValue)
+                {
+                    collected = await _dataService.GetCollectedDatabaseNamesAsync(serverId.Value);
+                    collectedCount = collected.Count;
+                }
+            }
+            catch (Exception ex)
+            {
+                /* A store read failure must never block editing exclusions — fall back to manual-only. */
+                ViewerLogger.Warn("ExcludedDatabasesDialog", $"Could not read collected databases: {ex.Message}");
+            }
+        }
+
+        _items = new ObservableCollection<ExcludedDatabaseItem>(BuildDatabaseItems(collected, existing));
+        DatabasesItemsControl.ItemsSource = _items;
+
+        StatusText.Text = collectedCount > 0
+            ? $"{collectedCount} collected database(s), {existing.Count} currently excluded."
+            : _dataService is null
+                ? $"Viewer not connected to a store — enter database names to exclude. {existing.Count} currently excluded."
+                : $"No collected databases for this server yet — add names to exclude. {existing.Count} currently excluded.";
+    }
+
+    /// <summary>
+    /// Merges the store's collected user-database names with the entry's existing exclusions into the
+    /// checkbox list: every collected database is a checkbox (checked when already excluded), and any
+    /// existing exclusion the store has NOT collected is preserved as a checked "(not collected)" row so
+    /// saving never silently drops it (the viewer can't verify liveness, so it stays enabled/removable).
+    /// Pure so it is unit-testable without a store. Case-insensitive throughout.
+    /// </summary>
+    public static List<ExcludedDatabaseItem> BuildDatabaseItems(IEnumerable<string> collectedNames, IEnumerable<string> existingExclusions)
+    {
+        var excluded = new HashSet<string>(
+            (existingExclusions ?? Enumerable.Empty<string>())
+                .Where(n => !string.IsNullOrWhiteSpace(n))
+                .Select(n => n.Trim()),
+            StringComparer.OrdinalIgnoreCase);
+
+        var collected = (collectedNames ?? Enumerable.Empty<string>())
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .Select(n => n.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var collectedSet = new HashSet<string>(collected, StringComparer.OrdinalIgnoreCase);
+
+        var items = new List<ExcludedDatabaseItem>();
+        foreach (var name in collected)
+        {
+            items.Add(new ExcludedDatabaseItem
+            {
+                Name = name,
+                DisplayName = name,
+                IsExcluded = excluded.Contains(name),
+                IsCollected = true
+            });
+        }
+
+        /* Existing exclusions the store hasn't collected (yet, or ever): keep them, checked, so a save
+           preserves them. Enabled (not disabled like Lite's stale rows) — the viewer can't confirm the
+           database is truly gone, and this is exactly the not-yet-collected manual case. */
+        foreach (var name in excluded.Where(n => !collectedSet.Contains(n)).OrderBy(n => n, StringComparer.OrdinalIgnoreCase))
+        {
+            items.Add(new ExcludedDatabaseItem
+            {
+                Name = name,
+                DisplayName = $"{name}  (not collected)",
+                IsExcluded = true,
+                IsCollected = false
+            });
+        }
+
+        return items;
+    }
+
+    private void ManualAddBox_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Enter)
+        {
+            AddManualDatabase();
+            e.Handled = true;
+        }
+    }
+
+    private void ManualAdd_Click(object sender, RoutedEventArgs e) => AddManualDatabase();
+
+    private void AddManualDatabase()
+    {
+        var name = ManualAddBox.Text.Trim();
+        if (name.Length == 0)
+        {
+            return;
+        }
+
+        var match = _items.FirstOrDefault(i => string.Equals(i.Name, name, StringComparison.OrdinalIgnoreCase));
+        if (match is not null)
+        {
+            /* Already listed (collected or previously added) — just tick it. */
+            match.IsExcluded = true;
+            StatusText.Text = $"'{name}' is already in the list — marked excluded.";
+        }
+        else
+        {
+            _items.Insert(0, new ExcludedDatabaseItem
+            {
+                Name = name,
+                DisplayName = $"{name}  (not collected)",
+                IsExcluded = true,
+                IsCollected = false
+            });
+            StatusText.Text = $"Added '{name}'.";
+        }
+
+        ManualAddBox.Clear();
+        ManualAddBox.Focus();
     }
 
     private void Save_Click(object sender, RoutedEventArgs e)
     {
         try
         {
-            _entry.ExcludedDatabases = ExclusionsBox.Text
-                .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
-                .Select(name => name.Trim())
-                .Where(name => name.Length > 0)
+            _entry.ExcludedDatabases = _items
+                .Where(i => i.IsExcluded)
+                .Select(i => i.Name)
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToList();
 
@@ -60,4 +200,36 @@ public partial class ExcludedDatabasesDialog : Window
     }
 
     private void Cancel_Click(object sender, RoutedEventArgs e) => DialogResult = false;
+}
+
+/// <summary>
+/// One row of the Excluded Databases picker — a database name, its checked (excluded) state, and whether
+/// the store has actually collected it. Mirrors Lite's <c>DatabaseExclusionItem</c>; the viewer keeps
+/// not-collected rows enabled (Lite disabled its stale rows) because the viewer can't verify liveness.
+/// </summary>
+public sealed class ExcludedDatabaseItem : INotifyPropertyChanged
+{
+    public string Name { get; set; } = "";
+    public string DisplayName { get; set; } = "";
+
+    private bool _isExcluded;
+    public bool IsExcluded
+    {
+        get => _isExcluded;
+        set { _isExcluded = value; OnPropertyChanged(nameof(IsExcluded)); }
+    }
+
+    /// <summary>True when the store has collected this database; false for a manually-added / not-yet-collected name.</summary>
+    public bool IsCollected { get; set; } = true;
+
+    /// <summary>Always editable — the viewer can't confirm a database is truly gone, so nothing is disabled.</summary>
+    public bool IsEnabled => true;
+
+    public Brush ForegroundBrush => IsCollected
+        ? (Brush)Application.Current.FindResource("ForegroundBrush")
+        : (Brush)Application.Current.FindResource("ForegroundMutedBrush");
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    private void OnPropertyChanged(string propertyName)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.ServerManagement.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.ServerManagement.cs
@@ -36,6 +36,10 @@ public partial class MainWindow
     /// <summary>The viewer's own server-definition registry, backing Add / Manage / Edit / Remove + favorites.</summary>
     private readonly ViewerServerStore _serverStore = new();
 
+    /// <summary>The viewer's credential-profile registry, lazily built (it depends on <see cref="_serverStore"/>).</summary>
+    private ViewerProfileStore? _profileStoreInstance;
+    private ViewerProfileStore ProfileStore => _profileStoreInstance ??= new ViewerProfileStore(_serverStore);
+
     private bool _sidebarCollapsed;
 
     // ── Server-list enrichment (favorites + freshness) ──────────────────────────────
@@ -232,7 +236,7 @@ public partial class MainWindow
         var entry = _serverStore.GetByServerName(server.ServerName)
             ?? new ViewerServerEntry { ServerName = server.ServerName, DisplayName = server.DisplayName };
 
-        var dialog = new AddServerDialog(_serverStore, entry) { Owner = this };
+        var dialog = new AddServerDialog(_serverStore, ProfileStore, entry) { Owner = this };
         if (dialog.ShowDialog() == true)
         {
             ReapplyFavoritesToServerList();
@@ -277,7 +281,7 @@ public partial class MainWindow
 
     private void AddServerButton_Click(object sender, RoutedEventArgs e)
     {
-        var dialog = new AddServerDialog(_serverStore) { Owner = this };
+        var dialog = new AddServerDialog(_serverStore, ProfileStore) { Owner = this };
         if (dialog.ShowDialog() == true && dialog.AddedServer is not null)
         {
             ReapplyFavoritesToServerList();
@@ -289,7 +293,7 @@ public partial class MainWindow
 
     private void ManageServersButton_Click(object sender, RoutedEventArgs e)
     {
-        var window = new ManageServersWindow(_serverStore) { Owner = this };
+        var window = new ManageServersWindow(_serverStore, ProfileStore, _dataService) { Owner = this };
         window.ShowDialog();
         if (window.ServersChanged)
         {
@@ -374,7 +378,9 @@ public partial class MainWindow
             var copied = 0;
             if (!string.IsNullOrEmpty(targetDir))
             {
-                foreach (var fileName in new[] { "viewer-settings.json", "viewer-preferences.json" })
+                /* viewer-profiles.json rides along so imported profile-backed servers don't reference a
+                   missing profile (secrets stay per-user in Credential Manager and are re-entered). */
+                foreach (var fileName in new[] { "viewer-settings.json", "viewer-preferences.json", "viewer-profiles.json" })
                 {
                     var source = Path.Combine(dialog.FolderName, fileName);
                     var destination = Path.Combine(targetDir, fileName);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ManageCredentialProfilesDialog.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ManageCredentialProfilesDialog.xaml
@@ -1,0 +1,54 @@
+<Window x:Class="PerformanceMonitor.Darling.Viewer.ManageCredentialProfilesDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Credential Profiles"
+        Height="420" Width="640"
+        WindowStartupLocation="CenterOwner"
+        Icon="EDD.ico"
+        ResizeMode="CanResizeWithGrip"
+        Background="{DynamicResource BackgroundBrush}">
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Text="Credential Profiles" FontWeight="Bold" FontSize="16"
+                   Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,8"/>
+
+        <TextBlock Grid.Row="1" TextWrapping="Wrap" FontSize="11"
+                   Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,0,0,12"
+                   Text="A credential profile is a named, reusable identity (a shared SQL login, an Azure service principal, or a managed identity) that many servers can reference. Secrets are stored only in Windows Credential Manager, never in config files. A profile can't be deleted while a server still uses it."/>
+
+        <DataGrid Grid.Row="2" x:Name="ProfilesGrid" AutoGenerateColumns="False" IsReadOnly="True"
+                  CanUserAddRows="False" HeadersVisibility="Column" SelectionMode="Single"
+                  MouseDoubleClick="ProfilesGrid_MouseDoubleClick">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*"/>
+                <DataGridTextColumn Header="Auth Type" Binding="{Binding AuthTypeDisplay}" Width="200"/>
+                <DataGridTextColumn Header="Username / Client ID" Width="200">
+                    <DataGridTextColumn.Binding>
+                        <PriorityBinding>
+                            <Binding Path="Username"/>
+                            <Binding Path="AzureClientId"/>
+                            <Binding Path="ManagedIdentityClientId"/>
+                        </PriorityBinding>
+                    </DataGridTextColumn.Binding>
+                </DataGridTextColumn>
+            </DataGrid.Columns>
+        </DataGrid>
+
+        <TextBlock Grid.Row="3" x:Name="StatusText" FontSize="10" FontStyle="Italic"
+                   Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,8,0,0"/>
+
+        <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
+            <Button Content="Add…" Width="80" Height="28" Margin="0,0,8,0" Click="AddButton_Click" Style="{StaticResource AccentButton}"/>
+            <Button Content="Edit…" Width="80" Height="28" Margin="0,0,8,0" Click="EditButton_Click"/>
+            <Button Content="Delete" Width="80" Height="28" Margin="0,0,8,0" Click="DeleteButton_Click"/>
+            <Button Content="Close" Width="80" Height="28" Click="CloseButton_Click" IsCancel="True"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ManageCredentialProfilesDialog.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ManageCredentialProfilesDialog.xaml.cs
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Windows;
+using System.Windows.Input;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// Manages the list of <see cref="ViewerCredentialProfile"/> records (Add/Edit/Delete) — the viewer port
+/// of Lite's <c>ManageCredentialProfilesDialog</c>, launched from <see cref="ManageServersWindow"/>.
+/// Delete is a constraint, not a cascade: a profile referenced by a server can't be deleted until the
+/// server is reassigned.
+/// </summary>
+public partial class ManageCredentialProfilesDialog : Window
+{
+    private readonly ViewerProfileStore _profileStore;
+
+    /// <summary>True if any profile was added/edited/deleted, so the caller can refresh.</summary>
+    public bool ProfilesChanged { get; private set; }
+
+    public ManageCredentialProfilesDialog(ViewerProfileStore profileStore)
+    {
+        InitializeComponent();
+        _profileStore = profileStore;
+        RefreshGrid();
+    }
+
+    private void RefreshGrid()
+    {
+        ProfilesGrid.ItemsSource = null;
+        var profiles = _profileStore.GetAll();
+        ProfilesGrid.ItemsSource = profiles;
+        StatusText.Text = $"{profiles.Count} profile(s).";
+    }
+
+    private void AddButton_Click(object sender, RoutedEventArgs e)
+    {
+        var dialog = new EditCredentialProfileDialog(_profileStore) { Owner = this };
+        if (dialog.ShowDialog() == true)
+        {
+            ProfilesChanged = true;
+            RefreshGrid();
+        }
+    }
+
+    private void EditButton_Click(object sender, RoutedEventArgs e) => EditSelected();
+
+    private void ProfilesGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e) => EditSelected();
+
+    private void EditSelected()
+    {
+        if (ProfilesGrid.SelectedItem is not ViewerCredentialProfile selected)
+        {
+            return;
+        }
+
+        var dialog = new EditCredentialProfileDialog(_profileStore, selected) { Owner = this };
+        if (dialog.ShowDialog() == true)
+        {
+            ProfilesChanged = true;
+            RefreshGrid();
+        }
+    }
+
+    private void DeleteButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (ProfilesGrid.SelectedItem is not ViewerCredentialProfile selected)
+        {
+            return;
+        }
+
+        var confirm = MessageBox.Show(
+            $"Delete credential profile '{selected.Name}'?\n\nThis removes the profile and its stored secret.",
+            "Delete Credential Profile",
+            MessageBoxButton.YesNo,
+            MessageBoxImage.Warning);
+
+        if (confirm != MessageBoxResult.Yes)
+        {
+            return;
+        }
+
+        try
+        {
+            _profileStore.DeleteProfile(selected.Id);
+            ProfilesChanged = true;
+            RefreshGrid();
+        }
+        catch (Exception ex)
+        {
+            /* Referential-integrity block (or any failure) surfaces here. */
+            MessageBox.Show(ex.Message, "Cannot Delete Profile", MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
+    }
+
+    private void CloseButton_Click(object sender, RoutedEventArgs e) => Close();
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ManageServersWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ManageServersWindow.xaml
@@ -75,6 +75,8 @@
             <Button Content="Add Server" Click="AddButton_Click" Style="{StaticResource AccentButton}" Margin="0,0,8,0"/>
             <Button Content="Edit" Click="EditButton_Click" Margin="0,0,8,0"/>
             <Button Content="Excluded Databases" Click="ExcludedDatabases_Click" Margin="0,0,8,0"/>
+            <Button Content="Credential Profiles…" Click="CredentialProfiles_Click" Margin="0,0,8,0"
+                    ToolTip="Manage named, reusable credentials that many servers can share."/>
             <Button Content="Delete" Click="DeleteButton_Click" Margin="0,0,8,0"/>
             <Button Content="Close" Click="CloseButton_Click"/>
         </StackPanel>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ManageServersWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ManageServersWindow.xaml.cs
@@ -16,22 +16,30 @@ namespace PerformanceMonitor.Darling.Viewer;
 
 /// <summary>
 /// The viewer's Manage Servers window — a faithful port of Lite's, over the viewer's own registry
-/// (<see cref="ViewerServerStore"/>). Adds / edits / removes server DEFINITIONS and edits per-server
-/// excluded databases; the "Credential Profiles…" affordance is dropped (the viewer has no
-/// <c>ProfileManager</c> — profiles only matter for live shared connections the viewer never makes).
-/// Making the Darling service honor these definitions is the separate wiring flagged in the PR.
+/// (<see cref="ViewerServerStore"/>). Adds / edits / removes server DEFINITIONS, edits per-server excluded
+/// databases (populated from the store's collected database list), and manages shared credential profiles
+/// (<see cref="ViewerProfileStore"/>) via the "Credential Profiles…" button — credential MANAGEMENT is in
+/// scope even though the viewer never makes the live connection (the Darling service resolves a chosen
+/// profile at connect time). Making the service honor these definitions is the separate wiring flagged in
+/// the PR.
 /// </summary>
 public partial class ManageServersWindow : Window
 {
     private readonly ViewerServerStore _serverStore;
+    private readonly ViewerProfileStore _profileStore;
+    private readonly ViewerDataService? _dataService;
 
     /// <summary>True when servers were modified, so the caller refreshes the sidebar.</summary>
     public bool ServersChanged { get; private set; }
 
-    public ManageServersWindow(ViewerServerStore serverStore)
+    /// <param name="dataService">Store reader for the Excluded Databases picker's collected-database list;
+    /// null (viewer not connected) degrades that picker to manual-only.</param>
+    public ManageServersWindow(ViewerServerStore serverStore, ViewerProfileStore profileStore, ViewerDataService? dataService)
     {
         InitializeComponent();
         _serverStore = serverStore;
+        _profileStore = profileStore;
+        _dataService = dataService;
         RefreshGrid();
     }
 
@@ -63,7 +71,7 @@ public partial class ManageServersWindow : Window
 
     private void AddButton_Click(object sender, RoutedEventArgs e)
     {
-        var dialog = new AddServerDialog(_serverStore) { Owner = this };
+        var dialog = new AddServerDialog(_serverStore, _profileStore) { Owner = this };
         if (dialog.ShowDialog() == true)
         {
             ServersChanged = true;
@@ -82,7 +90,7 @@ public partial class ManageServersWindow : Window
             return;
         }
 
-        var dialog = new AddServerDialog(_serverStore, selected) { Owner = this };
+        var dialog = new AddServerDialog(_serverStore, _profileStore, selected) { Owner = this };
         if (dialog.ShowDialog() == true)
         {
             ServersChanged = true;
@@ -94,6 +102,17 @@ public partial class ManageServersWindow : Window
 
     private void DeleteMenuItem_Click(object sender, RoutedEventArgs e) => DeleteButton_Click(sender, e);
 
+    private void CredentialProfiles_Click(object sender, RoutedEventArgs e)
+    {
+        var dialog = new ManageCredentialProfilesDialog(_profileStore) { Owner = this };
+        dialog.ShowDialog();
+        if (dialog.ProfilesChanged)
+        {
+            /* Server rows may reference a profile; refresh to reflect reassignments. */
+            RefreshGrid();
+        }
+    }
+
     private void ExcludedDatabases_Click(object sender, RoutedEventArgs e)
     {
         if (ServersGrid.SelectedItem is not ViewerServerEntry selected)
@@ -101,7 +120,7 @@ public partial class ManageServersWindow : Window
             return;
         }
 
-        var dialog = new ExcludedDatabasesDialog(_serverStore, selected) { Owner = this };
+        var dialog = new ExcludedDatabasesDialog(_serverStore, selected, _dataService) { Owner = this };
         if (dialog.ShowDialog() == true && dialog.ExclusionsModified)
         {
             ServersChanged = true;

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerCredentialProfile.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerCredentialProfile.cs
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Text.Json.Serialization;
+using PerformanceMonitor.Common;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// A named, reusable credential that many <see cref="ViewerServerEntry"/> definitions can reference via
+/// <see cref="ViewerServerEntry.CredentialProfileId"/> — the Darling viewer's port of Lite's
+/// <c>CredentialProfile</c>. One identity (a shared SQL login, an Azure service principal, or a managed
+/// identity) covers a whole fleet of servers without per-server secret entry, and the Darling service
+/// consumes the reference when it connects.
+///
+/// <para>SECURITY: this type holds NO secret. The SQL password / SP client secret lives ONLY in Windows
+/// Credential Manager (DPAPI), keyed by <c>profile_{Id}</c> under the viewer's <c>PerformanceMonitorDarling_</c>
+/// prefix, via <see cref="ViewerProfileStore"/> — mirroring the secret-free discipline of
+/// <see cref="ViewerServerEntry"/>. viewer-profiles.json never stores a secret. As with the rest of the
+/// Lite→Darling port the viewer persists these faithfully; the running SERVICE honoring a profile-backed
+/// server is the separate wiring flagged in the PR.</para>
+/// </summary>
+public sealed class ViewerCredentialProfile
+{
+    /// <summary>Stable unique identifier (Guid string) — the REAL key; display-name uniqueness is a per-process UX nicety.</summary>
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+
+    /// <summary>Human-friendly display name shown in the profile picker.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Authentication type. Only the three profile-eligible modes are valid:
+    /// <see cref="AuthenticationTypes.SqlServer"/>, <see cref="AuthenticationTypes.ServicePrincipal"/>,
+    /// or <see cref="AuthenticationTypes.ManagedIdentity"/>. Windows (no credential) and EntraMFA
+    /// (interactive, per-user) are NOT profile-eligible — a shared profile is meaningless for them.
+    /// </summary>
+    public string AuthType { get; set; } = AuthenticationTypes.SqlServer;
+
+    /// <summary>SQL login username for <see cref="AuthenticationTypes.SqlServer"/> profiles. Non-secret.</summary>
+    public string? Username { get; set; }
+
+    /// <summary>Service-principal application/client id for <see cref="AuthenticationTypes.ServicePrincipal"/> profiles. Non-secret.</summary>
+    public string? AzureClientId { get; set; }
+
+    /// <summary>Optional Microsoft Entra tenant id. Stored for display/reference only.</summary>
+    public string? AzureTenantId { get; set; }
+
+    /// <summary>Optional user-assigned managed-identity client id for <see cref="AuthenticationTypes.ManagedIdentity"/> profiles. Blank = system-assigned. Non-secret.</summary>
+    public string? ManagedIdentityClientId { get; set; }
+
+    /// <summary>Display-only label for the profile's auth type.</summary>
+    [JsonIgnore]
+    public string AuthTypeDisplay => AuthType switch
+    {
+        AuthenticationTypes.SqlServer => "SQL Server",
+        AuthenticationTypes.ServicePrincipal => "Azure — Service Principal",
+        AuthenticationTypes.ManagedIdentity => "Azure — Managed Identity",
+        _ => AuthType
+    };
+
+    /// <summary>
+    /// Display text for the profile picker: name plus a short id suffix to disambiguate duplicate display
+    /// names (the shared file can hold same-named profiles; the Id is the real key).
+    /// </summary>
+    [JsonIgnore]
+    public string PickerDisplay =>
+        string.IsNullOrEmpty(Id) || Id.Length < 8
+            ? $"{Name} ({AuthTypeDisplay})"
+            : $"{Name} ({AuthTypeDisplay}) — {Id[..8]}";
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ExcludedDatabases.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ExcludedDatabases.cs
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// Store reads backing the Excluded Databases picker. The viewer never connects to a monitored SQL
+/// Server (so it can't enumerate its LIVE database list the way Lite's dialog does), but the Darling
+/// store already HAS the databases the service collected — <c>v_database_config</c> (the sys.databases
+/// snapshot) and <c>v_database_size_stats</c> (per-file sizes). The picker offers those collected user
+/// databases as checkboxes instead of a free-text editor, keeping a manual-add fallback for a
+/// not-yet-collected database. System databases (master/model/msdb/tempdb) are always excluded from the
+/// list — they mirror Lite's <c>database_id &gt; 4</c> user-database filter and are never per-database
+/// collector targets anyway.
+/// </summary>
+public sealed partial class ViewerDataService
+{
+    /// <summary>
+    /// DISTINCT user-database names the store has collected for one server, from either the database
+    /// config snapshot or the per-file size stats (UNION dedupes across both), system databases removed,
+    /// ordered by name. $1 server_id.
+    /// </summary>
+    public const string CollectedDatabaseNamesSql = """
+        SELECT database_name
+        FROM (
+            SELECT database_name FROM v_database_config WHERE server_id = $1
+            UNION
+            SELECT database_name FROM v_database_size_stats WHERE server_id = $1
+        ) AS d
+        WHERE database_name IS NOT NULL
+        AND   database_name NOT IN ('master', 'model', 'msdb', 'tempdb')
+        ORDER BY database_name
+        """;
+
+    /// <summary>The store's server_id for a registry server name, matched on server_name or display_name. $1 name.</summary>
+    public const string ServerIdByNameSql = """
+        SELECT server_id
+        FROM servers
+        WHERE lower(server_name) = lower($1)
+        OR    lower(display_name) = lower($1)
+        ORDER BY server_id
+        LIMIT 1
+        """;
+
+    /// <summary>
+    /// The distinct user databases the store has collected for one server (empty when nothing has been
+    /// collected yet). Feeds the Excluded Databases picker's checkbox list.
+    /// </summary>
+    public async Task<List<string>> GetCollectedDatabaseNamesAsync(int serverId, CancellationToken cancellationToken = default)
+    {
+        var names = new List<string>();
+
+        await using var command = _dataSource.CreateCommand(CollectedDatabaseNamesSql);
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            names.Add(reader.GetString(0));
+        }
+
+        return names;
+    }
+
+    /// <summary>
+    /// Resolves a viewer-registry server name to the store's server_id, or null when the service has not
+    /// registered a server by that name yet (nothing collected → the picker falls back to manual-only).
+    /// </summary>
+    public async Task<int?> GetServerIdByNameAsync(string serverName, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(serverName))
+        {
+            return null;
+        }
+
+        await using var command = _dataSource.CreateCommand(ServerIdByNameSql);
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = serverName });
+        var result = await command.ExecuteScalarAsync(cancellationToken);
+        return result is null or DBNull ? null : Convert.ToInt32(result, System.Globalization.CultureInfo.InvariantCulture);
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerProfileStore.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerProfileStore.cs
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using PerformanceMonitor.Common;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The viewer's registry of named, reusable <see cref="ViewerCredentialProfile"/> records — the Darling
+/// port of Lite's <c>ProfileManager</c>, backing the Add / Edit / Delete surfaces launched from
+/// <see cref="ManageServersWindow"/>. Persists a bare list as indented JSON in the viewer's per-user
+/// directory (%APPDATA%\PerformanceMonitorDarling\viewer-profiles.json), alongside
+/// <see cref="ViewerServerStore"/>'s registry, and stores each profile's secret in Windows Credential
+/// Manager keyed by <c>profile_{id}</c> (never in the JSON) through the SAME
+/// <see cref="IViewerServerSecretStore"/> the server store uses — the <c>profile_</c> prefix keeps
+/// profile secrets from colliding with per-server secrets (bare GUID keys).
+///
+/// <para>Holds a ONE-WAY reference to <see cref="ViewerServerStore"/> for the referential-integrity
+/// (in-use) query only: a profile can't be deleted while a server still references it. Both the on-disk
+/// path and the secret store are injectable so tests round-trip against a temp file and an in-memory
+/// secret fake without touching the real registry or vault. As with the rest of the Lite→Darling port,
+/// this persists faithfully; the running SERVICE resolving a profile-backed connection is separate wiring
+/// flagged in the PR (the viewer itself never opens SqlClient — only credential MANAGEMENT lives here).</para>
+/// </summary>
+public sealed class ViewerProfileStore
+{
+    /// <summary>Credential Manager key prefix for profile secrets, combined with the bare id → <c>profile_{id}</c>.</summary>
+    public const string ProfileKeyPrefix = "profile_";
+
+    private static readonly JsonSerializerOptions s_jsonOptions = new() { WriteIndented = true };
+
+    private readonly string _filePath;
+    private readonly IViewerServerSecretStore _secrets;
+    private readonly ViewerServerStore _serverStore;
+    private readonly List<ViewerCredentialProfile> _profiles;
+
+    /// <summary>Builds the Credential Manager key for a profile's secret (<c>profile_{id}</c>).</summary>
+    public static string ProfileCredentialId(string profileId) => $"{ProfileKeyPrefix}{profileId}";
+
+    /// <param name="serverStore">The server registry, queried for the referential-integrity (in-use) check.</param>
+    /// <param name="filePath">Override the on-disk location (tests pass a temp file); null uses <see cref="DefaultFilePath"/>.</param>
+    /// <param name="secretStore">Override the credential vault (tests pass an in-memory fake); null uses the real Credential Manager.</param>
+    public ViewerProfileStore(ViewerServerStore serverStore, string? filePath = null, IViewerServerSecretStore? secretStore = null)
+    {
+        _serverStore = serverStore ?? throw new ArgumentNullException(nameof(serverStore));
+        _filePath = filePath ?? DefaultFilePath();
+        _secrets = secretStore ?? new WindowsCredentialServerSecretStore();
+        _profiles = LoadFromDisk();
+    }
+
+    /// <summary>The resolved registry file path (surfaced for tests and diagnostics).</summary>
+    public string FilePath => _filePath;
+
+    /// <summary>%APPDATA%\PerformanceMonitorDarling\viewer-profiles.json.</summary>
+    public static string DefaultFilePath()
+    {
+        var directory = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "PerformanceMonitorDarling");
+        return Path.Combine(directory, "viewer-profiles.json");
+    }
+
+    /// <summary>All profiles, sorted by display name (case-insensitive). Fresh snapshot; safe to mutate.</summary>
+    public List<ViewerCredentialProfile> GetAll() =>
+        _profiles.OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase).ToList();
+
+    /// <summary>The profile with this id, or null.</summary>
+    public ViewerCredentialProfile? GetProfile(string id)
+    {
+        if (string.IsNullOrEmpty(id))
+        {
+            return null;
+        }
+
+        return _profiles.FirstOrDefault(p => p.Id == id);
+    }
+
+    /// <summary>
+    /// Adds a new profile and stores its secret. For SqlServer/ServicePrincipal the secret goes to
+    /// Credential Manager under <c>profile_{id}</c>; ManagedIdentity stores none. Rejects a duplicate id
+    /// or (per-process) a duplicate display name.
+    /// </summary>
+    public void AddProfile(ViewerCredentialProfile profile, string? username = null, string? secret = null)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+
+        if (_profiles.Any(p => p.Id == profile.Id))
+        {
+            throw new InvalidOperationException($"Profile with ID {profile.Id} already exists");
+        }
+        if (_profiles.Any(p => string.Equals(p.Name, profile.Name, StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new InvalidOperationException($"A profile named '{profile.Name}' already exists");
+        }
+
+        _profiles.Add(profile);
+        StoreSecretIfNeeded(profile, username, secret);
+        Save();
+    }
+
+    /// <summary>
+    /// Updates an existing profile (and re-stores its secret when a fresh one is supplied). Editing a
+    /// profile's secret intentionally affects ALL servers that reference it. A blank secret on edit leaves
+    /// the stored secret unchanged; switching to ManagedIdentity clears any stale stored secret.
+    /// </summary>
+    public void UpdateProfile(ViewerCredentialProfile profile, string? username = null, string? secret = null)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+
+        var existing = _profiles.FirstOrDefault(p => p.Id == profile.Id)
+            ?? throw new InvalidOperationException($"Profile with ID {profile.Id} not found");
+        if (_profiles.Any(p => p.Id != profile.Id &&
+                               string.Equals(p.Name, profile.Name, StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new InvalidOperationException($"A profile named '{profile.Name}' already exists");
+        }
+
+        _profiles[_profiles.IndexOf(existing)] = profile;
+
+        if (profile.AuthType == AuthenticationTypes.ManagedIdentity)
+        {
+            /* MI never has a secret; clear any stale one (e.g. profile retyped from SP -> MI). */
+            _secrets.Delete(ProfileCredentialId(profile.Id));
+        }
+        else if (!string.IsNullOrEmpty(username) && secret is not null)
+        {
+            /* Only re-store when a fresh secret was supplied (a blank PasswordBox on edit means "leave it"). */
+            _secrets.Save(ProfileCredentialId(profile.Id), username, secret);
+        }
+
+        Save();
+    }
+
+    /// <summary>
+    /// Deletes a profile and its stored secret. Blocked (throws) while ANY server references it —
+    /// referential integrity is a delete-constraint, not a cascade.
+    /// </summary>
+    public void DeleteProfile(string id)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(id);
+
+        var inUse = CountServersUsingProfile(id);
+        if (inUse > 0)
+        {
+            throw new InvalidOperationException(
+                $"This profile is used by {inUse} server(s). Reassign or remove them first.");
+        }
+
+        var profile = _profiles.FirstOrDefault(p => p.Id == id);
+        if (profile is not null)
+        {
+            _profiles.Remove(profile);
+            _secrets.Delete(ProfileCredentialId(id));
+            Save();
+        }
+    }
+
+    /// <summary>The servers (in the registry) that reference the given profile id.</summary>
+    public int CountServersUsingProfile(string profileId)
+    {
+        if (string.IsNullOrEmpty(profileId))
+        {
+            return 0;
+        }
+
+        return _serverStore.GetAllServers().Count(s => s.CredentialProfileId == profileId);
+    }
+
+    /// <summary>
+    /// Whether a profile's secret is present in Credential Manager. SqlServer/ServicePrincipal require
+    /// one; ManagedIdentity needs none (returns true).
+    /// </summary>
+    public bool HasStoredSecret(ViewerCredentialProfile profile)
+    {
+        if (profile.AuthType == AuthenticationTypes.ManagedIdentity)
+        {
+            return true;
+        }
+
+        return _secrets.Get(ProfileCredentialId(profile.Id)) is not null;
+    }
+
+    /// <summary>The stored (username, secret) for a profile, or null — used to pre-fill the profile editor on edit.</summary>
+    public (string Username, string Password)? GetSecret(string profileId) =>
+        _secrets.Get(ProfileCredentialId(profileId));
+
+    private void StoreSecretIfNeeded(ViewerCredentialProfile profile, string? username, string? secret)
+    {
+        if (profile.AuthType == AuthenticationTypes.ManagedIdentity)
+        {
+            return; // no secret
+        }
+
+        if (!string.IsNullOrEmpty(username) && secret is not null)
+        {
+            _secrets.Save(ProfileCredentialId(profile.Id), username, secret);
+        }
+    }
+
+    private List<ViewerCredentialProfile> LoadFromDisk()
+    {
+        try
+        {
+            if (!File.Exists(_filePath))
+            {
+                return new List<ViewerCredentialProfile>();
+            }
+
+            var json = File.ReadAllText(_filePath);
+            return JsonSerializer.Deserialize<List<ViewerCredentialProfile>>(json, s_jsonOptions)
+                ?? new List<ViewerCredentialProfile>();
+        }
+        catch (Exception ex)
+        {
+            /* A corrupt or unreadable registry must never block startup — begin empty and log. */
+            ViewerLogger.Warn("ViewerProfileStore", $"Failed to load '{_filePath}': {ex.Message}");
+            return new List<ViewerCredentialProfile>();
+        }
+    }
+
+    private void Save()
+    {
+        var directory = Path.GetDirectoryName(_filePath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        File.WriteAllText(_filePath, JsonSerializer.Serialize(_profiles, s_jsonOptions));
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerEntry.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerEntry.cs
@@ -44,6 +44,14 @@ public sealed class ViewerServerEntry : INotifyPropertyChanged
     /// <summary>Windows, SqlServer, EntraMFA, ServicePrincipal, or ManagedIdentity (see <see cref="AuthenticationTypes"/>).</summary>
     public string AuthenticationType { get; set; } = AuthenticationTypes.Windows;
 
+    /// <summary>
+    /// Id of a shared <see cref="ViewerCredentialProfile"/> (from <see cref="ViewerProfileStore"/>) this
+    /// server references, or null for inline per-server auth. When set, the profile supplies the identity
+    /// (the Darling service resolves it at connect time) and no per-server secret is stored — mirroring
+    /// Lite's <c>ServerConnection.CredentialProfileId</c>.
+    /// </summary>
+    public string? CredentialProfileId { get; set; }
+
     /// <summary>Service-principal application/client id (non-secret; the SP secret lives in Credential Manager).</summary>
     public string? AzureClientId { get; set; }
 

--- a/Lite.Tests/CollectionHealthWindowTests.cs
+++ b/Lite.Tests/CollectionHealthWindowTests.cs
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using DuckDB.NET.Data;
+using PerformanceMonitorLite.Database;
+using PerformanceMonitorLite.Services;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// Pins Lite's Collection Log window bounding (parity with the Darling #1406 fix): a custom
+/// [fromDate,toDate] range set entirely in the past must bound <c>collection_time</c> on BOTH sides —
+/// a row after the To bound is EXCLUDED, which the old hours-back-only read (a single now-relative
+/// lower bound that ignored fromDate/toDate) could not express. The preset test proves a plain
+/// hoursBack read still lower-bounds "now".
+/// </summary>
+public sealed class CollectionHealthWindowTests : IDisposable
+{
+    private const int ServerId = 4242;
+
+    private readonly string _tempDir;
+    private readonly DuckDbInitializer _duckDb;
+    private long _nextId = 1;
+
+    public CollectionHealthWindowTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "LiteCollHealthTests_" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+        _duckDb = new DuckDbInitializer(Path.Combine(_tempDir, "test.duckdb"));
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDir))
+                Directory.Delete(_tempDir, recursive: true);
+        }
+        catch { /* Best-effort cleanup */ }
+    }
+
+    [Fact]
+    public async Task GetRecentCollectionLog_CustomRange_BoundsBothSides_ExcludingRowsOutsideEitherBound()
+    {
+        await _duckDb.InitializeAsync();
+        var service = new LocalDataService(_duckDb);
+
+        /* A three-hour custom window [start, end] entirely in the past (end an hour ago). A row 30 min
+           BEFORE start and a row 30 min AFTER end must BOTH be excluded. The after-end exclusion is the
+           behavior the old read (a single now-relative lower bound) could not express — it would have
+           swept everything up to "now", pulling in the after-end row. collection_time is stored UTC. */
+        var end = Truncate(DateTime.UtcNow.AddHours(-1));
+        var start = end.AddHours(-3);
+        var beforeStart = start.AddMinutes(-30);
+        var inWindowEarly = start.AddMinutes(15);
+        var inWindowLate = end.AddMinutes(-15);
+        var afterEnd = end.AddMinutes(30);
+
+        await SeedLogAsync("wait_stats", beforeStart, "SUCCESS");
+        await SeedLogAsync("wait_stats", inWindowEarly, "SUCCESS");
+        await SeedLogAsync("cpu_utilization", inWindowLate, "SUCCESS");
+        await SeedLogAsync("wait_stats", afterEnd, "SUCCESS");
+
+        /* GetTimeRange subtracts UtcOffsetMinutes from a custom from/to (server-time -> UTC); feed
+           server-time bounds so the read lands exactly on [start,end] UTC regardless of the machine tz. */
+        var offset = ServerTimeHelper.UtcOffsetMinutes;
+        var fromDate = start.AddMinutes(offset);
+        var toDate = end.AddMinutes(offset);
+
+        /* hoursBack=4 would (old bug) sweep everything >= now-4h, pulling in afterEnd (now-30m); the
+           custom To bound must exclude it. */
+        var logs = await service.GetRecentCollectionLogAsync(ServerId, hoursBack: 4, fromDate: fromDate, toDate: toDate);
+
+        Assert.Equal(2, logs.Count);
+        Assert.All(logs, l => Assert.InRange(l.CollectionTime.Ticks, start.Ticks, end.Ticks));
+        Assert.Equal(inWindowLate.Ticks, logs[0].CollectionTime.Ticks);   // newest first
+        Assert.Equal(inWindowEarly.Ticks, logs[1].CollectionTime.Ticks);
+    }
+
+    [Fact]
+    public async Task GetRecentCollectionLog_PresetHoursBack_LowerBoundsFromNow()
+    {
+        await _duckDb.InitializeAsync();
+        var service = new LocalDataService(_duckDb);
+
+        var recent = Truncate(DateTime.UtcNow.AddMinutes(-30));
+        var old = Truncate(DateTime.UtcNow.AddHours(-10));
+        await SeedLogAsync("wait_stats", recent, "SUCCESS");
+        await SeedLogAsync("wait_stats", old, "SUCCESS");
+
+        /* No custom range → hoursBack lower-bounds "now"; the 10h-old row is excluded, the 30m one kept. */
+        var logs = await service.GetRecentCollectionLogAsync(ServerId, hoursBack: 4);
+
+        Assert.Single(logs);
+        Assert.Equal(recent.Ticks, logs[0].CollectionTime.Ticks);
+    }
+
+    private static DateTime Truncate(DateTime t) =>
+        new(t.Year, t.Month, t.Day, t.Hour, t.Minute, t.Second, DateTimeKind.Unspecified);
+
+    private async Task SeedLogAsync(string collector, DateTime collectionTimeUtc, string status)
+    {
+        using var readLock = _duckDb.AcquireReadLock();
+        using var connection = _duckDb.CreateConnection();
+        await connection.OpenAsync();
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = @"
+INSERT INTO collection_log
+    (log_id, server_id, server_name, collector_name, collection_time,
+     duration_ms, status, error_message, rows_collected, sql_duration_ms, duckdb_duration_ms)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)";
+        cmd.Parameters.Add(new DuckDBParameter { Value = _nextId++ });
+        cmd.Parameters.Add(new DuckDBParameter { Value = ServerId });
+        cmd.Parameters.Add(new DuckDBParameter { Value = "TestSrv" });
+        cmd.Parameters.Add(new DuckDBParameter { Value = collector });
+        cmd.Parameters.Add(new DuckDBParameter { Value = collectionTimeUtc });
+        cmd.Parameters.Add(new DuckDBParameter { Value = 100 });
+        cmd.Parameters.Add(new DuckDBParameter { Value = status });
+        cmd.Parameters.Add(new DuckDBParameter { Value = DBNull.Value });
+        cmd.Parameters.Add(new DuckDBParameter { Value = 10 });
+        cmd.Parameters.Add(new DuckDBParameter { Value = 80 });
+        cmd.Parameters.Add(new DuckDBParameter { Value = 20 });
+        await cmd.ExecuteNonQueryAsync();
+    }
+}

--- a/Lite/Controls/ServerTab.Refresh.cs
+++ b/Lite/Controls/ServerTab.Refresh.cs
@@ -647,7 +647,7 @@ public partial class ServerTab : UserControl
         try
         {
             var collectionHealthTask = Helpers.MethodProfiler.TimeAsync("CollectionHealth.Health", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetCollectionHealthAsync(_serverId))));
-            var collectionLogTask = Helpers.MethodProfiler.TimeAsync("CollectionHealth.Log", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetRecentCollectionLogAsync(_serverId, hoursBack))));
+            var collectionLogTask = Helpers.MethodProfiler.TimeAsync("CollectionHealth.Log", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetRecentCollectionLogAsync(_serverId, hoursBack, fromDate, toDate))));
 
             await System.Threading.Tasks.Task.WhenAll(collectionHealthTask, collectionLogTask);
 

--- a/Lite/Services/LocalDataService.CollectionHealth.cs
+++ b/Lite/Services/LocalDataService.CollectionHealth.cs
@@ -67,12 +67,20 @@ ORDER BY collector_name";
     }
 
     /// <summary>
-    /// Gets recent collection log entries for a server, most recent first.
+    /// Gets recent collection log entries for a server, most recent first, bounded to the tab's
+    /// settable window. A preset ends "now" (<paramref name="hoursBack"/> from now); a custom range
+    /// (<paramref name="fromDate"/>/<paramref name="toDate"/>, both already server-time) bounds
+    /// <c>collection_time</c> on BOTH sides EXACTLY via <see cref="GetTimeRange"/> — mirroring how
+    /// <see cref="GetWaitStatsAsync"/> windows its read. The old single now-relative lower bound ignored
+    /// the custom To, rounding a custom range to a hours-back-from-now span.
     /// </summary>
-    public async Task<List<CollectionLogRow>> GetRecentCollectionLogAsync(int serverId, int hoursBack = 4, int maxRows = 500)
+    public async Task<List<CollectionLogRow>> GetRecentCollectionLogAsync(int serverId, int hoursBack = 4, DateTime? fromDate = null, DateTime? toDate = null, int maxRows = 500)
     {
         using var connection = await OpenConnectionAsync();
         using var command = connection.CreateCommand();
+
+        var (startTime, endTime) = GetTimeRange(hoursBack, fromDate, toDate);
+
         command.CommandText = @"
 SELECT
     collector_name,
@@ -87,11 +95,13 @@ SELECT
 FROM v_collection_log
 WHERE server_id = $1
 AND   collection_time >= $2
+AND   collection_time <= $3
 ORDER BY collection_time DESC
-LIMIT $3";
+LIMIT $4";
 
         command.Parameters.Add(new DuckDBParameter { Value = serverId });
-        command.Parameters.Add(new DuckDBParameter { Value = DateTime.UtcNow.AddHours(-hoursBack) });
+        command.Parameters.Add(new DuckDBParameter { Value = startTime });
+        command.Parameters.Add(new DuckDBParameter { Value = endTime });
         command.Parameters.Add(new DuckDBParameter { Value = maxRows });
 
         var items = new List<CollectionLogRow>();


### PR DESCRIPTION
Fixes three parity gaps that were accepted as hard-fact "adaptations" but are actually fixable. Faithful reproduction; **no new downscopes**.

## FIX 1 — Shared Credential Profiles (Darling viewer)
PR #1403 dropped Lite's Credential Profiles as "live-connection-only." That was wrong: a credential profile is a reusable credential **set** shared across server entries (define once, reference from many servers) — pure credential **management**, which the viewer's `ViewerServerStore` / `ManageServersWindow` / `AddServerDialog` fully support. Ported Lite's subsystem faithfully:

- `ViewerCredentialProfile` (port of `CredentialProfile`) and `ViewerProfileStore` (port of `ProfileManager`): CRUD, per-process name uniqueness, secrets stored **only** in Windows Credential Manager keyed `profile_{id}` under the `PerformanceMonitorDarling_` prefix (never in JSON), the referential-integrity delete-constraint (a profile can't be deleted while a server references it), persisted to `viewer-profiles.json` alongside `viewer-servers.json`.
- `EditCredentialProfileDialog` + `ManageCredentialProfilesDialog` (viewer ports), launched from a new **"Credential Profiles…"** button in Manage Servers.
- `AddServerDialog` gains the inline-vs-profile credential-source radios + profile picker; `ViewerServerEntry.CredentialProfileId` persists the reference; assigning a profile scrubs per-server identity + deletes any per-server secret (Lite's switch-cleanup).
- Import Settings now carries `viewer-profiles.json` too, so an imported profile-backed server doesn't reference a missing profile.
- **Only genuine hard fact adapted:** the viewer never opens SqlClient to a monitored server, so there is no live connection-string resolution here — the Darling service resolves the chosen profile at connect time. Credential *management* is 100% in scope and ported.

## FIX 2 — Excluded Databases picker (Darling viewer)
PR #1403 made this a manual text editor "because it can't enumerate live DBs." It can't query **live** — but the store already has the collected database list. The dialog is now a checkbox picker populated from `DISTINCT database_name` across `v_database_config` and `v_database_size_stats` for the server (`GetCollectedDatabaseNamesAsync`; `GetServerIdByNameAsync` resolves the registry name to the store `server_id`), system databases excluded. A **manual-add box** remains for a not-yet-collected database, and existing exclusions the store hasn't collected are preserved as checked "(not collected)" rows so a save never silently drops them. Degrades to manual-only when the viewer isn't connected to a store.

## FIX 3 — Lite Collection-Health custom range (Lite parity)
The #1406 Darling fix revealed Lite's own `RefreshCollectionHealthAsync` passed only `hoursBack` to `GetRecentCollectionLogAsync` and **ignored** `fromDate`/`toDate`, so the Collection Log + Duration Trends rounded a custom range to a hours-back-from-now span. Now honors `[fromDate,toDate]` exactly via `GetTimeRange(hoursBack, fromDate, toDate)` + `collection_time >= AND <=` — the same idiom every other windowed Lite read (`GetWaitStatsAsync`, etc.) already uses, and the analog of the Darling #1406 fix.

## Tests
- `ViewerProfileStoreTests` — profile round-trip through disk, secret keyed `profile_{id}` (not the JSON, not the bare server key), ManagedIdentity no-secret rule, CRUD, name uniqueness, referential-integrity delete-constraint.
- `ExcludedDatabasesTests` — pure `BuildDatabaseItems` population (collected as checkboxes, checked-when-excluded, not-collected preservation, case-insensitive dedup, ordering), store SQL pinned against the generated schema (no live PG), plus a live round-trip proving DISTINCT/system-exclusion (skipped unless `DARLING_TEST_PG`).
- `CollectionHealthWindowTests` — a custom `[from,to]` range excludes rows outside **either** bound (the after-`to` exclusion the old read couldn't express); a preset still lower-bounds "now."

## Verification
- Darling viewer + Lite build `-c Release`, **0 errors**.
- `Darling.Tests` (Release): **923 passed, 89 skipped (live-PG), 0 failed**.
- `Lite.Tests` (Release): **911 passed, 0 failed**.

## No new downscopes
Each fix restores capability without removing any. Credential management is fully ported (only live SqlClient resolution stays with the service — a real architectural boundary, not a scope-down). The excluded-DB picker reads real collected data with a manual fallback. FIX 3 bounds both sides exactly, matching Darling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)