### PR TITLE
Restore cheap data-present grid/column/badge parity in the Darling viewer

### DIFF
--- a/Darling/Darling.Tests/ViewerCpuSchedulerTests.cs
+++ b/Darling/Darling.Tests/ViewerCpuSchedulerTests.cs
@@ -191,6 +191,101 @@ public sealed class ViewerCpuSchedulerProjectionTests
         Assert.Equal("N/A", rows.Single(r => r.Metric == "Total Requests").Value);
         Assert.Equal("N/A", rows.Single(r => r.Metric == "Runnable %").Value);
     }
+
+    [Fact]
+    public void BuildMetrics_LeadsWithThePressureLevelAndRecommendationRows()
+    {
+        /* Item 4: the rolled-up pressure badge + recommendation are the first two headline rows, ahead of
+           the raw metrics. A calm snapshot is NORMAL and does not highlight. */
+        var rows = ViewerServerTab.BuildCpuSchedulerMetrics(Snapshot());
+
+        Assert.Equal("Pressure Level", rows[0].Metric);
+        Assert.Equal("Recommendation", rows[1].Metric);
+        Assert.Equal("NORMAL", rows[0].Value);
+        Assert.False(rows[0].IsWarning);
+    }
+
+    [Fact]
+    public void BuildMetrics_PressureLevelRow_HighlightsWhenNotNormal()
+    {
+        /* worker_thread_exhaustion_warning drives a CRITICAL pressure level, which must highlight. */
+        var rows = ViewerServerTab.BuildCpuSchedulerMetrics(Snapshot(workerExhaustion: true));
+
+        var pressure = rows.Single(r => r.Metric == "Pressure Level");
+        Assert.StartsWith("CRITICAL", pressure.Value, StringComparison.Ordinal);
+        Assert.True(pressure.IsWarning);
+    }
+}
+
+/// <summary>
+/// Pins the rolled-up CPU-scheduler pressure classification
+/// (<see cref="ViewerServerTab.ClassifyCpuPressure"/>) against install/47's report.cpu_scheduler_pressure
+/// CASE ordering: runnable task queue &gt; 50 / &gt; 20 / &gt; 10, then worker-utilization &gt; 90%, then the
+/// collector's warning flags; plus the paired recommendation.
+/// </summary>
+public sealed class ViewerCpuPressureTests
+{
+    private static CpuSchedulerSnapshot Snapshot(
+        int runnableTasks = 0, int maxWorkers = 512, int currentWorkers = 100,
+        int queuedRequests = 0, bool workerExhaustion = false, bool runnableWarn = false,
+        bool queuedWarn = false)
+        => new(
+            CollectionTime: new DateTime(2026, 6, 1, 12, 0, 0, DateTimeKind.Unspecified),
+            MaxWorkersCount: maxWorkers, SchedulerCount: 8, CpuCount: 8,
+            TotalRunnableTasksCount: runnableTasks, TotalWorkQueueCount: 0,
+            TotalCurrentWorkersCount: currentWorkers, AvgRunnableTasksCount: 0m,
+            TotalActiveRequestCount: 0, TotalQueuedRequestCount: queuedRequests, TotalBlockedTaskCount: 0,
+            TotalActiveParallelThreadCount: 0, RunnableRequestCount: 0, TotalRequestCount: 0,
+            RunnablePercent: 0m, WorkerThreadExhaustionWarning: workerExhaustion,
+            RunnableTasksWarning: runnableWarn, BlockedTasksWarning: false, QueuedRequestsWarning: queuedWarn,
+            TotalPhysicalMemoryKb: 0, AvailablePhysicalMemoryKb: 0, SystemMemoryStateDesc: null,
+            PhysicalMemoryPressureWarning: false, TotalNodeCount: 1, NodesOnlineCount: 1,
+            OfflineCpuCount: 0, OfflineCpuWarning: false);
+
+    [Theory]
+    [InlineData(60, "CRITICAL - High runnable task queue")]
+    [InlineData(51, "CRITICAL - High runnable task queue")]
+    [InlineData(50, "HIGH - Moderate runnable task queue")]  // 50 is not > 50, but > 20
+    [InlineData(25, "HIGH - Moderate runnable task queue")]
+    [InlineData(21, "HIGH - Moderate runnable task queue")]
+    [InlineData(15, "MEDIUM - Some runnable tasks queued")]
+    [InlineData(11, "MEDIUM - Some runnable tasks queued")]
+    [InlineData(5, "NORMAL")]
+    public void ClassifyCpuPressure_BandsOnRunnableTaskQueue(int runnable, string expectedLevel)
+        => Assert.Equal(expectedLevel, ViewerServerTab.ClassifyCpuPressure(Snapshot(runnableTasks: runnable)).Level);
+
+    [Fact]
+    public void ClassifyCpuPressure_WorkerUtilizationOver90_IsHigh_WhenRunnableIsLow()
+    {
+        /* 95 / 100 = 95% > 90, runnable low → the worker-utilization branch. */
+        var pressure = ViewerServerTab.ClassifyCpuPressure(Snapshot(maxWorkers: 100, currentWorkers: 95));
+        Assert.Equal("HIGH - Worker thread exhaustion", pressure.Level);
+    }
+
+    [Fact]
+    public void ClassifyCpuPressure_FallsThroughToWarningFlags_InOrder()
+    {
+        Assert.Equal("CRITICAL - Worker thread exhaustion warning",
+            ViewerServerTab.ClassifyCpuPressure(Snapshot(workerExhaustion: true)).Level);
+        Assert.Equal("HIGH - Runnable tasks warning",
+            ViewerServerTab.ClassifyCpuPressure(Snapshot(runnableWarn: true)).Level);
+        Assert.Equal("MEDIUM - Queued requests warning",
+            ViewerServerTab.ClassifyCpuPressure(Snapshot(queuedWarn: true)).Level);
+    }
+
+    [Fact]
+    public void ClassifyCpuPressure_ZeroMaxWorkers_DoesNotDivideByZero_StaysNormal()
+        => Assert.Equal("NORMAL", ViewerServerTab.ClassifyCpuPressure(Snapshot(maxWorkers: 0, currentWorkers: 0)).Level);
+
+    [Theory]
+    [InlineData(25, false, 0, "CPU pressure detected - check for CPU-intensive queries, consider adding CPU cores")]
+    [InlineData(0, true, 0, "Worker thread exhaustion - check max worker threads setting")]
+    [InlineData(0, false, 5, "Requests queued for execution - CPU or worker thread pressure")]
+    [InlineData(0, false, 0, "No CPU scheduler pressure detected")]
+    public void ClassifyCpuPressure_Recommendation_MirrorsTheProcCase(
+        int runnable, bool workerExhaustion, int queuedRequests, string expected)
+        => Assert.Equal(expected, ViewerServerTab.ClassifyCpuPressure(
+            Snapshot(runnableTasks: runnable, workerExhaustion: workerExhaustion, queuedRequests: queuedRequests)).Recommendation);
 }
 
 /// <summary>

--- a/Darling/Darling.Tests/ViewerDailyHealthTests.cs
+++ b/Darling/Darling.Tests/ViewerDailyHealthTests.cs
@@ -56,8 +56,23 @@ public sealed class ViewerDailySummarySqlTests
         Assert.Contains("status = 'ERROR'", sql, StringComparison.Ordinal);
         Assert.Contains("FROM v_collection_log", sql, StringComparison.Ordinal);
 
+        /* Memory pressure: the displayed count (process OR system indicator >= 2) and the MEMORY_CRITICAL
+           escalation source (process indicator >= 3), both off v_memory_pressure_events (Dashboard parity). */
+        Assert.Contains("FROM v_memory_pressure_events", sql, StringComparison.Ordinal);
+        Assert.Contains("(memory_indicators_process >= 2 OR memory_indicators_system >= 2)", sql, StringComparison.Ordinal);
+        Assert.Contains("memory_indicators_process >= 3", sql, StringComparison.Ordinal);
+
         /* Every subquery windows on the half-open [dayStart, dayEnd) range. */
         Assert.Contains("collection_time >= $2 AND collection_time < $3", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DailySummarySql_MemoryPressureColumns_ExistInTheGeneratedSourceTable()
+    {
+        var ddl = PgSchemaGenerator.CreateTable(MemoryPressureEventsCollector.Instance);
+        Assert.Contains("memory_indicators_process", ddl, StringComparison.Ordinal);
+        Assert.Contains("memory_indicators_system", ddl, StringComparison.Ordinal);
+        Assert.Contains("v_memory_pressure_events", PgSchemaGenerator.AllPassthroughViews);
     }
 
     [Fact]
@@ -214,6 +229,43 @@ public sealed class ViewerDailyHealthRowTests
         var row = new DailySummaryRow { SummaryDate = new DateTime(2026, 7, 3, 14, 0, 0, DateTimeKind.Utc) };
         Assert.Equal("2026-07-03", row.SummaryDateFormatted);
     }
+
+    [Fact]
+    public void ClassifyDailyHealth_Normal_WhenNothingBreaches()
+        => Assert.Equal("NORMAL", ViewerDataService.ClassifyDailyHealth(deadlocks: 0, highCpuEvents: 0, memoryCriticalEvents: 0, blockingEvents: 0));
+
+    [Fact]
+    public void ClassifyDailyHealth_Deadlocks_WinAllOtherBands()
+        => Assert.Equal("DEADLOCKS", ViewerDataService.ClassifyDailyHealth(deadlocks: 1, highCpuEvents: 99, memoryCriticalEvents: 99, blockingEvents: 99));
+
+    [Fact]
+    public void ClassifyDailyHealth_CpuCritical_WhenMoreThanFiveHighCpuAndNoDeadlocks()
+        => Assert.Equal("CPU_CRITICAL", ViewerDataService.ClassifyDailyHealth(deadlocks: 0, highCpuEvents: 6, memoryCriticalEvents: 99, blockingEvents: 99));
+
+    [Fact]
+    public void ClassifyDailyHealth_MemoryCritical_WhenSevereMemoryPressure_AndNoDeadlockOrCpu()
+    {
+        /* Item 5: the escalation the viewer dropped — a severe memory-pressure day (process indicator >= 3,
+           memoryCriticalEvents > 0) bands MEMORY_CRITICAL, ranking ahead of BLOCKING. */
+        Assert.Equal("MEMORY_CRITICAL",
+            ViewerDataService.ClassifyDailyHealth(deadlocks: 0, highCpuEvents: 5, memoryCriticalEvents: 1, blockingEvents: 99));
+    }
+
+    [Fact]
+    public void ClassifyDailyHealth_Blocking_WhenOverTenBlockingAndNoHigherBand()
+        => Assert.Equal("BLOCKING", ViewerDataService.ClassifyDailyHealth(deadlocks: 0, highCpuEvents: 0, memoryCriticalEvents: 0, blockingEvents: 11));
+
+    [Theory]
+    [InlineData(5, "NORMAL")]     // exactly 5 is NOT > 5
+    [InlineData(6, "CPU_CRITICAL")]
+    public void ClassifyDailyHealth_HighCpuThreshold_IsStrictlyGreaterThanFive(long highCpu, string expected)
+        => Assert.Equal(expected, ViewerDataService.ClassifyDailyHealth(0, highCpu, 0, 0));
+
+    [Theory]
+    [InlineData(10, "NORMAL")]    // exactly 10 is NOT > 10
+    [InlineData(11, "BLOCKING")]
+    public void ClassifyDailyHealth_BlockingThreshold_IsStrictlyGreaterThanTen(long blocking, string expected)
+        => Assert.Equal(expected, ViewerDataService.ClassifyDailyHealth(0, 0, 0, blocking));
 
     [Fact]
     public void CollectorHealthRow_NeverRun_WhenNoRuns()

--- a/Darling/Darling.Tests/ViewerMemoryTests.cs
+++ b/Darling/Darling.Tests/ViewerMemoryTests.cs
@@ -116,8 +116,9 @@ public sealed class ViewerMemorySqlTests
         /* pool_id is the integer group key, selected raw (GetInt32). */
         Assert.Contains("pool_id", sql, StringComparison.Ordinal);
 
-        /* The three sizing MB SUMs CAST to double precision. */
-        foreach (var col in new[] { "available_memory_mb", "granted_memory_mb", "used_memory_mb" })
+        /* The three sizing MB SUMs plus the workspace-memory ceiling (target / max target — item 2) all
+           CAST to double precision. */
+        foreach (var col in new[] { "available_memory_mb", "granted_memory_mb", "used_memory_mb", "target_memory_mb", "max_target_memory_mb" })
         {
             Assert.Contains($"CAST(SUM({col}) AS double precision)", sql, StringComparison.Ordinal);
         }
@@ -208,6 +209,8 @@ public sealed class ViewerMemorySqlTests
         {
             "pool_id", "available_memory_mb", "granted_memory_mb", "used_memory_mb",
             "grantee_count", "waiter_count", "timeout_error_count_delta", "forced_grant_count_delta",
+            /* Item 2 verification: the workspace-memory ceiling columns the viewer now surfaces are collected. */
+            "target_memory_mb", "max_target_memory_mb",
         })
         {
             Assert.Contains(col, grantDdl, StringComparison.Ordinal);

--- a/Darling/Darling.Tests/ViewerPerfmonRunningJobsTests.cs
+++ b/Darling/Darling.Tests/ViewerPerfmonRunningJobsTests.cs
@@ -155,19 +155,20 @@ public sealed class ViewerRunningJobsSqlTests
 
     [Theory]
     [InlineData("PERMISSIONS", true)]
-    [InlineData("ERROR", true)]
     [InlineData("permissions", true)]   // case-insensitive
+    [InlineData("Permissions", true)]
+    [InlineData("ERROR", false)]        // a transient ERROR is NOT a permission problem — banner must stay hidden
+    [InlineData("error", false)]
     [InlineData("SUCCESS", false)]
+    [InlineData("SKIPPED", false)]
+    [InlineData("", false)]
     [InlineData(null, false)]           // collector never ran
-    public void MsdbBannerVisibility_DerivedFromLatestCollectorStatus(string? status, bool expectVisible)
+    public void MsdbBanner_ShowsOnlyForPermissionsStatus_NotTransientError(string? status, bool expectVisible)
     {
-        /* Behavior spec mirroring LoadRunningJobsAsync's store-derived banner: the banner shows for a
-           PERMISSIONS or ERROR latest status (case-insensitive), and hides for SUCCESS / never-ran. */
-        bool lacksMsdbAccess =
-            string.Equals(status, "PERMISSIONS", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(status, "ERROR", StringComparison.OrdinalIgnoreCase);
-
-        Assert.Equal(expectVisible, lacksMsdbAccess);
+        /* Item 6: the banner is restricted to the running_jobs collector's PERMISSIONS outcome (the store
+           stand-in for Lite's real _hasMsdbAccess probe). A generic ERROR (timeout/blip) must no longer
+           raise the misleading "grant msdb access" guidance. Calls the real production decision. */
+        Assert.Equal(expectVisible, ViewerServerTab.ShouldShowMsdbBanner(status));
     }
 
     [Theory]

--- a/Darling/Darling.Tests/ViewerPlanCacheTests.cs
+++ b/Darling/Darling.Tests/ViewerPlanCacheTests.cs
@@ -71,8 +71,10 @@ public sealed class ViewerPlanCacheSqlTests
         Assert.Contains("FROM v_plan_cache_stats", sql, StringComparison.Ordinal);
         Assert.Contains("SELECT MAX(collection_time) AS mx", sql, StringComparison.Ordinal);
         Assert.Contains("collection_time = (SELECT mx FROM latest)", sql, StringComparison.Ordinal);
-        /* TRUE total across every group + oldest plan; COALESCE so an empty window yields 0 not NULL. */
+        /* TRUE total across every group + single-use total (for the bloat badge) + oldest plan; COALESCE so
+           an empty window yields 0 not NULL. */
         Assert.Contains("COALESCE(SUM(total_plans), 0)", sql, StringComparison.Ordinal);
+        Assert.Contains("COALESCE(SUM(single_use_plans), 0)", sql, StringComparison.Ordinal);
         Assert.Contains("MIN(oldest_plan_create_time)", sql, StringComparison.Ordinal);
         /* Must NOT be capped — the summary is the exact total, independent of the grid's LIMIT 30. */
         Assert.DoesNotContain("LIMIT", sql, StringComparison.Ordinal);
@@ -119,6 +121,49 @@ public sealed class ViewerPlanCacheSqlTests
     [Fact]
     public void PlanCacheView_IsPinnedInTheAuthoritativeViewList()
         => Assert.Contains("v_plan_cache_stats", PgSchemaGenerator.AllPassthroughViews);
+}
+
+/// <summary>
+/// Pins the derived single-use plan-cache bloat badge (<see cref="ViewerDataService.ClassifyPlanCacheBloat"/>),
+/// a pure client-side CASE mirroring install/47's report.plan_cache_bloat: bloat_level banding on the
+/// single-use / total plan ratio (&gt; 50 CRITICAL / &gt; 30 HIGH / &gt; 20 MEDIUM / else NORMAL) and the
+/// paired forced-parameterization recommendation flipping at the same &gt; 20% threshold.
+/// </summary>
+public sealed class ViewerPlanCacheBloatTests
+{
+    [Theory]
+    [InlineData(100, 60, "CRITICAL")]   // 60% > 50
+    [InlineData(100, 51, "CRITICAL")]
+    [InlineData(100, 50, "HIGH")]       // exactly 50 is NOT > 50 → HIGH
+    [InlineData(100, 40, "HIGH")]       // 40% > 30
+    [InlineData(100, 31, "HIGH")]
+    [InlineData(100, 30, "MEDIUM")]     // exactly 30 → MEDIUM
+    [InlineData(100, 25, "MEDIUM")]     // 25% > 20
+    [InlineData(100, 21, "MEDIUM")]
+    [InlineData(100, 20, "NORMAL")]     // exactly 20 → NORMAL
+    [InlineData(100, 5, "NORMAL")]
+    [InlineData(0, 0, "NORMAL")]        // empty cache → no divide-by-zero, NORMAL
+    public void ClassifyPlanCacheBloat_BandsOnSingleUsePercent(long total, long singleUse, string expectedLevel)
+        => Assert.Equal(expectedLevel, ViewerDataService.ClassifyPlanCacheBloat(total, singleUse).Level);
+
+    [Theory]
+    [InlineData(100, 25, true)]         // > 20% → forced-parameterization hint
+    [InlineData(100, 21, true)]
+    [InlineData(100, 20, false)]        // <= 20% → healthy
+    [InlineData(100, 0, false)]
+    [InlineData(0, 0, false)]
+    public void ClassifyPlanCacheBloat_RecommendationFlipsAtTwentyPercent(long total, long singleUse, bool expectHint)
+    {
+        var rec = ViewerDataService.ClassifyPlanCacheBloat(total, singleUse).Recommendation;
+        if (expectHint)
+        {
+            Assert.Contains("Forced Parameterization", rec, StringComparison.Ordinal);
+        }
+        else
+        {
+            Assert.Equal("Plan cache composition is healthy", rec);
+        }
+    }
 }
 
 /// <summary>

--- a/Darling/Darling.Tests/ViewerQueriesRestTests.cs
+++ b/Darling/Darling.Tests/ViewerQueriesRestTests.cs
@@ -10,6 +10,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Npgsql;
+using PerformanceMonitor.Collectors;
 using PerformanceMonitor.Darling.Storage;
 using PerformanceMonitor.Darling.Viewer;
 using Xunit;
@@ -193,6 +194,40 @@ public sealed class ViewerQuerySnapshotsSqlTests
         Assert.Contains("WHERE server_id = $1", sql, StringComparison.Ordinal);
         Assert.Contains("ORDER BY bucket", sql, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void QuerySnapshotColumns_SelectTheHash286TriageColumns_ForTheWaitDrillDownGrid()
+    {
+        /* Item 8: the #1286 memory-grant / tempdb / transaction triage columns Lite's WaitDrillDownWindow
+           binds are now selected (they were dropped from the viewer's ~26-column read). Pinned via the
+           shared LatestQuerySnapshotsSql, which is built from QuerySnapshotColumns. */
+        var sql = ViewerDataService.LatestQuerySnapshotsSql;
+        foreach (var column in new[]
+        {
+            "requested_memory_mb", "used_memory_mb", "max_used_memory_mb",
+            "tempdb_current_mb", "tempdb_allocations_mb", "tran_log_used_mb", "tran_start_time", "request_id",
+        })
+        {
+            Assert.Contains(column, sql, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void QuerySnapshotTriageColumns_ExistInTheGeneratedStoreTable()
+    {
+        /* Verification gate for item 8: every triage column the viewer now surfaces IS collected into
+           query_snapshots (no collector gap). */
+        Assert.Equal("query_snapshots", QuerySnapshotsCollector.Instance.TargetTable);
+        var ddl = PgSchemaGenerator.CreateTable(QuerySnapshotsCollector.Instance);
+        foreach (var column in new[]
+        {
+            "requested_memory_mb", "used_memory_mb", "max_used_memory_mb",
+            "tempdb_current_mb", "tempdb_allocations_mb", "tran_log_used_mb", "tran_start_time", "request_id",
+        })
+        {
+            Assert.Contains(column, ddl, StringComparison.Ordinal);
+        }
+    }
 }
 
 /// <summary>The W1f-2 row models' pure helpers: snapshot plan gating + naive-UTC collection-time display.</summary>
@@ -224,6 +259,17 @@ public sealed class ViewerActiveQueriesDisplayTests
         var p = new QueryTrendPoint { CollectionTime = new DateTime(2026, 7, 1, 9, 0, 0), Value = 2.5, ExecutionCount = 7 };
         Assert.Equal(2.5, p.Value);
         Assert.Equal(7, p.ExecutionCount);
+    }
+
+    [Fact]
+    public void QuerySnapshotRow_TranStartTimeLocal_RendersRawServerClock_EmptyWhenNoOpenTransaction()
+    {
+        /* Item 8: the WaitDrillDownWindow's "Tran Start" column. transaction_begin_time is a server-local
+           wall-clock time (NOT naive UTC), so it renders raw via FormatServerClock like the other dm_exec_*
+           times — no UTC→display conversion. A null TranStartTime (no open transaction) renders empty. */
+        Assert.Equal("", new ViewerQuerySnapshotRow().TranStartTimeLocal);
+        var row = new ViewerQuerySnapshotRow { TranStartTime = new DateTime(2026, 7, 1, 12, 0, 0, DateTimeKind.Unspecified) };
+        Assert.Equal("2026-07-01 12:00:00", row.TranStartTimeLocal);
     }
 }
 

--- a/Darling/Darling.Tests/ViewerQueriesTests.cs
+++ b/Darling/Darling.Tests/ViewerQueriesTests.cs
@@ -113,6 +113,9 @@ public sealed class ViewerQueriesSqlTests
         Assert.Contains("CAST(SUM(delta_execution_count) AS bigint)", sql, StringComparison.Ordinal);
         /* avg_spills is the one derived double in the proc read. */
         Assert.Contains("CAST(SUM(delta_spills) AS double precision) / NULLIF(SUM(delta_execution_count), 0)", sql, StringComparison.Ordinal);
+        /* Item 7: whether the collector stored a plan for the object — gates the grid's Download button on the
+           same query_plan_xml IS NOT NULL filter GetProcedureStatsPlanXmlAsync fetches on. */
+        Assert.Contains("bool_or(query_plan_xml IS NOT NULL) AS has_query_plan", sql, StringComparison.Ordinal);
     }
 
     // ── Query Store ──

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.DailySummary.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.DailySummary.cs
@@ -91,7 +91,28 @@ public sealed partial class ViewerDataService
                  WHERE server_id = $1
                  AND   status = 'ERROR'
                  AND   collection_time >= $2 AND collection_time < $3), 0
-            ) AS collection_errors
+            ) AS collection_errors,
+            /* Memory-pressure events for the day (Dashboard's report.daily_summary parity,
+               DatabaseService.Overview.cs:105-113): a RING_BUFFER_RESOURCE_MONITOR sample counts as pressure
+               when the process OR system indicator reached medium (>= 2). Windowed on collection_time (the
+               prefix time, matching the Dashboard) — not the payload sample_time the chart uses. */
+            COALESCE(
+                (SELECT COUNT(*)
+                 FROM v_memory_pressure_events
+                 WHERE server_id = $1
+                 AND   collection_time >= $2 AND collection_time < $3
+                 AND   (memory_indicators_process >= 2 OR memory_indicators_system >= 2)), 0
+            ) AS memory_pressure_events,
+            /* MEMORY_CRITICAL escalation source: any process indicator that reached severe (>= 3) in the day
+               (Dashboard's overall_health branch, DatabaseService.Overview.cs:151-160). Not displayed as a
+               column — it only decides the health band. */
+            COALESCE(
+                (SELECT COUNT(*)
+                 FROM v_memory_pressure_events
+                 WHERE server_id = $1
+                 AND   collection_time >= $2 AND collection_time < $3
+                 AND   memory_indicators_process >= 3), 0
+            ) AS memory_critical_events
         """;
 
     /// <summary>
@@ -116,11 +137,8 @@ public sealed partial class ViewerDataService
         var deadlocks = reader.IsDBNull(3) ? 0L : Convert.ToInt64(reader.GetValue(3));
         var blocking = reader.IsDBNull(4) ? 0L : Convert.ToInt64(reader.GetValue(4));
         var highCpu = reader.IsDBNull(5) ? 0L : Convert.ToInt64(reader.GetValue(5));
-
-        var health = "NORMAL";
-        if (deadlocks > 0) health = "DEADLOCKS";
-        else if (highCpu > 5) health = "CPU_CRITICAL";
-        else if (blocking > 10) health = "BLOCKING";
+        var memoryPressure = reader.IsDBNull(7) ? 0L : Convert.ToInt64(reader.GetValue(7));
+        var memoryCritical = reader.IsDBNull(8) ? 0L : Convert.ToInt64(reader.GetValue(8));
 
         return new DailySummaryRow
         {
@@ -131,9 +149,27 @@ public sealed partial class ViewerDataService
             DeadlockCount = deadlocks,
             BlockingEvents = blocking,
             HighCpuEvents = highCpu,
+            MemoryPressureEvents = memoryPressure,
             CollectionErrors = reader.IsDBNull(6) ? 0L : Convert.ToInt64(reader.GetValue(6)),
-            OverallHealth = health
+            OverallHealth = ClassifyDailyHealth(deadlocks, highCpu, memoryCritical, blocking)
         };
+    }
+
+    /// <summary>
+    /// The Daily Summary health band, computed on the read (Lite's <c>LocalDataService.DailySummary.cs</c>
+    /// bands NORMAL / DEADLOCKS / CPU_CRITICAL / BLOCKING) plus the Dashboard's MEMORY_CRITICAL escalation
+    /// (report.daily_summary / DatabaseService.Overview.cs:151-160): a severe memory-pressure day
+    /// (<paramref name="memoryCriticalEvents"/> &gt; 0, from a process indicator &gt;= 3) ranks with the other
+    /// critical bands, ahead of BLOCKING. Severity order: deadlocks &gt; high-CPU &gt; memory-critical &gt;
+    /// blocking. Static + internal so the banding is unit-testable without Postgres.
+    /// </summary>
+    internal static string ClassifyDailyHealth(long deadlocks, long highCpuEvents, long memoryCriticalEvents, long blockingEvents)
+    {
+        if (deadlocks > 0) return "DEADLOCKS";
+        if (highCpuEvents > 5) return "CPU_CRITICAL";
+        if (memoryCriticalEvents > 0) return "MEMORY_CRITICAL";
+        if (blockingEvents > 10) return "BLOCKING";
+        return "NORMAL";
     }
 }
 
@@ -150,6 +186,7 @@ public class DailySummaryRow
     public long DeadlockCount { get; set; }
     public long BlockingEvents { get; set; }
     public long HighCpuEvents { get; set; }
+    public long MemoryPressureEvents { get; set; }
     public long CollectionErrors { get; set; }
     public string OverallHealth { get; set; } = "";
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Memory.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Memory.cs
@@ -49,10 +49,13 @@ public sealed record MemoryClerkTrendPoint(
     double MemoryMb);
 
 /// <summary>One aggregated Memory Grants chart point (per collection_time + resource pool): the three
-/// sizing MB metrics and the four activity counts, a mirror of Lite's <c>MemoryGrantChartPoint</c>. MB
-/// SUMs CAST to double precision; the count SUMs CAST to bigint (Postgres <c>SUM(integer)</c> widens to
-/// bigint and <c>SUM(bigint)</c> to numeric — the CAST keeps the typed GetInt64 reader happy either way,
-/// the same reason the perfmon trend CASTs its aggregates).</summary>
+/// sizing MB metrics, the workspace-memory ceiling (<see cref="TargetMemoryMb"/> = the semaphore's current
+/// grant target, <see cref="MaxTargetMemoryMb"/> = its hard maximum — the granted-vs-ceiling headroom
+/// signal the Dashboard's get_resource_semaphore surfaces), and the four activity counts. A mirror of Lite's
+/// <c>MemoryGrantChartPoint</c> plus the ceiling columns. MB SUMs CAST to double precision; the count SUMs
+/// CAST to bigint (Postgres <c>SUM(integer)</c> widens to bigint and <c>SUM(bigint)</c> to numeric — the CAST
+/// keeps the typed GetInt64 reader happy either way, the same reason the perfmon trend CASTs its
+/// aggregates).</summary>
 public sealed record MemoryGrantChartPoint(
     DateTime CollectionTime,
     int PoolId,
@@ -62,7 +65,9 @@ public sealed record MemoryGrantChartPoint(
     int GranteeCount,
     int WaiterCount,
     long TimeoutErrorCountDelta,
-    long ForcedGrantCountDelta);
+    long ForcedGrantCountDelta,
+    double TargetMemoryMb,
+    double MaxTargetMemoryMb);
 
 /// <summary>One RING_BUFFER_RESOURCE_MONITOR sample for the Memory Pressure Events chart, a mirror of
 /// Lite's <c>MemoryPressureEventRow</c>: the sample time plus SQL Server (process) and OS (system)
@@ -189,7 +194,9 @@ public sealed partial class ViewerDataService
             CAST(SUM(grantee_count) AS bigint) AS grantee_count,
             CAST(SUM(waiter_count) AS bigint) AS waiter_count,
             CAST(SUM(timeout_error_count_delta) AS bigint) AS timeout_error_count_delta,
-            CAST(SUM(forced_grant_count_delta) AS bigint) AS forced_grant_count_delta
+            CAST(SUM(forced_grant_count_delta) AS bigint) AS forced_grant_count_delta,
+            CAST(SUM(target_memory_mb) AS double precision) AS target_memory_mb,
+            CAST(SUM(max_target_memory_mb) AS double precision) AS max_target_memory_mb
         FROM v_memory_grant_stats
         WHERE server_id = $1
         AND   collection_time >= $2
@@ -375,7 +382,9 @@ public sealed partial class ViewerDataService
                 reader.IsDBNull(5) ? 0 : (int)reader.GetInt64(5),
                 reader.IsDBNull(6) ? 0 : (int)reader.GetInt64(6),
                 reader.IsDBNull(7) ? 0 : reader.GetInt64(7),
-                reader.IsDBNull(8) ? 0 : reader.GetInt64(8)));
+                reader.IsDBNull(8) ? 0 : reader.GetInt64(8),
+                reader.IsDBNull(9) ? 0 : reader.GetDouble(9),
+                reader.IsDBNull(10) ? 0 : reader.GetDouble(10)));
         }
 
         return items;

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.PlanCache.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.PlanCache.cs
@@ -35,10 +35,16 @@ public sealed record PlanCacheSnapshotRow(
     int AvgSizeKb,
     DateTime? OldestPlanCreateTime);
 
-/// <summary>The Plan Cache summary strip's two stability figures for the latest snapshot in the window:
-/// the TRUE total plan count (summed across every group, not just the displayed top-N) and the oldest
-/// cached plan's create time — matching the Dashboard, which computes both over the full latest snapshot.</summary>
-public sealed record PlanCacheSummary(long TotalPlans, DateTime? OldestPlanCreateTime);
+/// <summary>The Plan Cache summary strip's figures for the latest snapshot in the window: the TRUE total
+/// plan count and single-use plan count (both summed across every group, not just the displayed top-N) and
+/// the oldest cached plan's create time — matching the Dashboard, which computes these over the full latest
+/// snapshot. <see cref="SingleUsePlans"/> feeds the derived bloat-level badge
+/// (<see cref="ViewerDataService.ClassifyPlanCacheBloat"/>).</summary>
+public sealed record PlanCacheSummary(long TotalPlans, long SingleUsePlans, DateTime? OldestPlanCreateTime);
+
+/// <summary>The plan-cache bloat classification for the summary badge: the banded severity level plus the
+/// paired recommendation, mirroring install/47's report.plan_cache_bloat.</summary>
+public sealed record PlanCacheBloat(string Level, string Recommendation);
 
 public sealed partial class ViewerDataService
 {
@@ -114,11 +120,37 @@ public sealed partial class ViewerDataService
         )
         SELECT
             COALESCE(SUM(total_plans), 0) AS total_plans,
+            COALESCE(SUM(single_use_plans), 0) AS single_use_plans,
             MIN(oldest_plan_create_time) AS oldest_plan_create_time
         FROM v_plan_cache_stats
         WHERE server_id = $1
         AND   collection_time = (SELECT mx FROM latest)
         """;
+
+    /// <summary>
+    /// The plan-cache bloat classification (single-use plan bloat), a pure client-side derivation mirroring
+    /// install/47's <c>report.plan_cache_bloat</c> (bloat_level + recommendation) and the Dashboard's
+    /// <c>PlanCacheStatsItem.BloatLevel/Recommendation</c>. The ratio is single-use plans / total plans:
+    /// &gt; 50% CRITICAL, &gt; 30% HIGH, &gt; 20% MEDIUM, else NORMAL; the recommendation flips to the
+    /// "unparameterized queries / Forced Parameterization" hint at the same &gt; 20% threshold. Static + pure
+    /// so it is unit-testable without Postgres. An empty cache (<paramref name="totalPlans"/> == 0) is NORMAL.
+    /// </summary>
+    public static PlanCacheBloat ClassifyPlanCacheBloat(long totalPlans, long singleUsePlans)
+    {
+        double singleUsePercent = totalPlans > 0 ? singleUsePlans * 100.0 / totalPlans : 0.0;
+
+        var level =
+            singleUsePercent > 50 ? "CRITICAL" :
+            singleUsePercent > 30 ? "HIGH" :
+            singleUsePercent > 20 ? "MEDIUM" :
+            "NORMAL";
+
+        var recommendation = singleUsePercent > 20
+            ? "Check for unparameterized queries / Consider Forced Parameterization"
+            : "Plan cache composition is healthy";
+
+        return new PlanCacheBloat(level, recommendation);
+    }
 
     /// <summary>The single-use vs multi-use plan-cache size trend over the window (empty when none).</summary>
     public async Task<List<PlanCacheTrendPoint>> GetPlanCacheTrendAsync(
@@ -178,11 +210,12 @@ public sealed partial class ViewerDataService
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         if (!await reader.ReadAsync(cancellationToken))
         {
-            return new PlanCacheSummary(0, null);
+            return new PlanCacheSummary(0, 0, null);
         }
 
         return new PlanCacheSummary(
             reader.IsDBNull(0) ? 0 : reader.GetInt64(0),
-            reader.IsDBNull(1) ? null : reader.GetDateTime(1));
+            reader.IsDBNull(1) ? 0 : reader.GetInt64(1),
+            reader.IsDBNull(2) ? null : reader.GetDateTime(2));
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ProcedureStats.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ProcedureStats.cs
@@ -53,6 +53,9 @@ public sealed class ViewerProcedureStatsRow
     public DateTime? LastExecutionTime { get; set; }
     public string SqlHandle { get; set; } = "";
     public string PlanHandle { get; set; } = "";
+    /// <summary>Whether the collector stored an execution plan for this object in the window — gates the
+    /// grid's per-row "Query Plan" Download button (mirrors Lite's Top Procedures HasQueryPlan gating).</summary>
+    public bool HasQueryPlan { get; set; }
     public string FullName => string.IsNullOrEmpty(SchemaName) ? ObjectName : $"{SchemaName}.{ObjectName}";
     public double TotalCpuMs => TotalCpuUs / 1000.0;
     public double TotalElapsedMs => TotalElapsedUs / 1000.0;
@@ -108,7 +111,11 @@ public sealed partial class ViewerDataService
             MAX(last_execution_time) AS last_execution_time,
             MAX(sql_handle) AS sql_handle,
             MAX(plan_handle) AS plan_handle,
-            CAST(SUM(delta_spills) AS double precision) / NULLIF(SUM(delta_execution_count), 0) AS avg_spills
+            CAST(SUM(delta_spills) AS double precision) / NULLIF(SUM(delta_execution_count), 0) AS avg_spills,
+            /* Whether the collector captured a plan for this object anywhere in the window — gates the grid's
+               per-row "Query Plan" Download button, matching the same query_plan_xml IS NOT NULL filter
+               GetProcedureStatsPlanXmlAsync fetches on. */
+            bool_or(query_plan_xml IS NOT NULL) AS has_query_plan
         FROM procedure_stats
         WHERE server_id = $1
         AND   collection_time >= $2
@@ -164,6 +171,7 @@ public sealed partial class ViewerDataService
                 SqlHandle = reader.IsDBNull(25) ? "" : reader.GetString(25),
                 PlanHandle = reader.IsDBNull(26) ? "" : reader.GetString(26),
                 AvgSpills = reader.IsDBNull(27) ? 0 : Convert.ToDouble(reader.GetValue(27)),
+                HasQueryPlan = !reader.IsDBNull(28) && reader.GetBoolean(28),
             });
         }
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QuerySnapshots.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QuerySnapshots.cs
@@ -17,7 +17,9 @@ namespace PerformanceMonitor.Darling.Viewer;
 
 /// <summary>
 /// One Active-Queries snapshot row — the viewer copy of Lite's <c>QuerySnapshotRow</c>
-/// (LocalDataService.Blocking.cs) trimmed to the ~26 columns the viewer's grid binds. A captured
+/// (LocalDataService.Blocking.cs). Carries the full column set Lite's two grids bind: the Active Queries
+/// grid's columns plus the #1286 memory-grant / tempdb / transaction triage columns Lite's WaitDrillDownWindow
+/// adds (all verified present in the query_snapshots store). A captured
 /// running request from one collection cycle. <see cref="CollectionTime"/> is the collector's naive-UTC
 /// capture time, so <see cref="CollectionTimeLocal"/> converts through <see cref="ViewerTimeHelper.ForDisplay"/>
 /// (Lite's <c>ServerTimeHelper.FormatServerTime</c>). <see cref="QueryPlan"/> / <see cref="LiveQueryPlan"/>
@@ -54,6 +56,18 @@ public sealed class ViewerQuerySnapshotRow
     public decimal PercentComplete { get; set; }
     public string QueryHash { get; set; } = "";
 
+    /* #1286 memory-grant / tempdb / transaction triage columns — collected into query_snapshots (verified
+       present) and surfaced by Lite's WaitDrillDownWindow grid (not its leaner Active Queries grid). The
+       Darling WaitDrillDownWindow mirrors that grid, so these bind there. */
+    public double RequestedMemoryMb { get; set; }
+    public double UsedMemoryMb { get; set; }
+    public double MaxUsedMemoryMb { get; set; }
+    public double TempdbCurrentMb { get; set; }
+    public double TempdbAllocationsMb { get; set; }
+    public double TranLogUsedMb { get; set; }
+    public DateTime? TranStartTime { get; set; }
+    public int RequestId { get; set; }
+
     /* Chain-view metadata (Wait Stats "Show Queries With This Wait" drill-down, LCK_M_* chain branch):
        set only when WaitDrillDownWindow walks blocking chains — the transitive blocked-session count and
        the "Head SPID X blocking N session(s)" path. Default 0 / empty for every other read. Mirrors Lite's
@@ -65,6 +79,13 @@ public sealed class ViewerQuerySnapshotRow
     public bool HasLiveQueryPlan => !string.IsNullOrEmpty(LiveQueryPlan);
     public string CollectionTimeLocal =>
         CollectionTime == DateTime.MinValue ? "" : ViewerTimeHelper.ForDisplay(CollectionTime).ToString("yyyy-MM-dd HH:mm:ss");
+
+    /// <summary>The transaction begin time, empty when the request has no open transaction. Mirrors Lite's
+    /// <c>QuerySnapshotRow.TranStartTimeLocal</c> (raw server-clock <c>FormatServerTime</c>):
+    /// transaction_begin_time from sys.dm_tran_active_transactions is a SQL-server-local wall-clock time (NOT
+    /// naive UTC), so it renders raw via <see cref="ViewerDataService.FormatServerClock"/> like the other
+    /// dm_exec_* times (last_execution_time / cached_time), NOT through the UTC-converting ForDisplay.</summary>
+    public string TranStartTimeLocal => ViewerDataService.FormatServerClock(TranStartTime);
 }
 
 public sealed partial class ViewerDataService
@@ -98,7 +119,15 @@ public sealed partial class ViewerDataService
             program_name,
             open_transaction_count,
             percent_complete,
-            query_hash
+            query_hash,
+            requested_memory_mb,
+            used_memory_mb,
+            max_used_memory_mb,
+            tempdb_current_mb,
+            tempdb_allocations_mb,
+            tran_log_used_mb,
+            tran_start_time,
+            request_id
         """;
 
     /// <summary>
@@ -222,6 +251,14 @@ public sealed partial class ViewerDataService
                 OpenTransactionCount = reader.IsDBNull(24) ? 0 : reader.GetInt32(24),
                 PercentComplete = reader.IsDBNull(25) ? 0m : Convert.ToDecimal(reader.GetValue(25)),
                 QueryHash = reader.IsDBNull(26) ? "" : reader.GetString(26),
+                RequestedMemoryMb = reader.IsDBNull(27) ? 0 : Convert.ToDouble(reader.GetValue(27)),
+                UsedMemoryMb = reader.IsDBNull(28) ? 0 : Convert.ToDouble(reader.GetValue(28)),
+                MaxUsedMemoryMb = reader.IsDBNull(29) ? 0 : Convert.ToDouble(reader.GetValue(29)),
+                TempdbCurrentMb = reader.IsDBNull(30) ? 0 : Convert.ToDouble(reader.GetValue(30)),
+                TempdbAllocationsMb = reader.IsDBNull(31) ? 0 : Convert.ToDouble(reader.GetValue(31)),
+                TranLogUsedMb = reader.IsDBNull(32) ? 0 : Convert.ToDouble(reader.GetValue(32)),
+                TranStartTime = reader.IsDBNull(33) ? null : reader.GetDateTime(33),
+                RequestId = reader.IsDBNull(34) ? 0 : reader.GetInt32(34),
             });
         }
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.CpuScheduler.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.CpuScheduler.cs
@@ -22,6 +22,11 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// presented as this metric/value list — the grid analog of the Dashboard's CPU-pressure summary strip.</summary>
 public sealed record CpuSchedulerMetricRow(string Metric, string Value, bool IsWarning);
 
+/// <summary>The rolled-up CPU-scheduler pressure classification for the metric grid's headline rows: the
+/// banded pressure level plus its paired recommendation, mirroring install/47's report.cpu_scheduler_pressure
+/// and the Dashboard's <c>CpuPressureItem.PressureLevel/Recommendation</c>.</summary>
+public sealed record CpuPressure(string Level, string Recommendation);
+
 /// <summary>
 /// The CPU Scheduler sub-tab (under the CPU tab, alongside CPU Utilization) — the Darling-viewer surface
 /// for the cpu_scheduler_stats collector (scheduler / worker-thread / runnable-task / NUMA / OS-memory
@@ -120,8 +125,15 @@ public partial class ViewerServerTab
             ? (double)s.TotalCurrentWorkersCount / s.MaxWorkersCount * 100.0
             : 0;
 
+        /* Rolled-up pressure badge + recommendation (install/47 report.cpu_scheduler_pressure parity): the
+           raw warning booleans are kept below, but these two headline rows give the one-glance severity +
+           next step the Dashboard surfaces. The level row highlights whenever it is not NORMAL. */
+        var pressure = ClassifyCpuPressure(s);
+
         var rows = new List<CpuSchedulerMetricRow>
         {
+            new("Pressure Level", pressure.Level, !pressure.Level.StartsWith("NORMAL", StringComparison.Ordinal)),
+            new("Recommendation", pressure.Recommendation, false),
             new("Schedulers", Int(s.SchedulerCount), false),
             new("Logical CPUs", Int(s.CpuCount), false),
             new("NUMA Nodes (online / total)", $"{s.NodesOnlineCount} / {s.TotalNodeCount}", false),
@@ -146,6 +158,39 @@ public partial class ViewerServerTab
         };
 
         return rows;
+    }
+
+    /// <summary>
+    /// The rolled-up CPU-scheduler pressure classification, a pure client-side derivation mirroring
+    /// install/47's <c>report.cpu_scheduler_pressure</c> (pressure_level + recommendation) and the
+    /// Dashboard's <c>CpuPressureItem</c>. The banding is the proc's own CASE, in the same order: runnable
+    /// task queue &gt; 50 CRITICAL / &gt; 20 HIGH / &gt; 10 MEDIUM, then worker-utilization &gt; 90% HIGH,
+    /// then the collector's worker-exhaustion / runnable-tasks / queued-requests warning flags. Static + pure
+    /// so it is unit-testable without Postgres.
+    /// </summary>
+    internal static CpuPressure ClassifyCpuPressure(CpuSchedulerSnapshot s)
+    {
+        double workerUtil = s.MaxWorkersCount > 0
+            ? (double)s.TotalCurrentWorkersCount / s.MaxWorkersCount * 100.0
+            : 0;
+
+        var level =
+            s.TotalRunnableTasksCount > 50 ? "CRITICAL - High runnable task queue" :
+            s.TotalRunnableTasksCount > 20 ? "HIGH - Moderate runnable task queue" :
+            s.TotalRunnableTasksCount > 10 ? "MEDIUM - Some runnable tasks queued" :
+            workerUtil > 90 ? "HIGH - Worker thread exhaustion" :
+            s.WorkerThreadExhaustionWarning ? "CRITICAL - Worker thread exhaustion warning" :
+            s.RunnableTasksWarning ? "HIGH - Runnable tasks warning" :
+            s.QueuedRequestsWarning ? "MEDIUM - Queued requests warning" :
+            "NORMAL";
+
+        var recommendation =
+            s.TotalRunnableTasksCount > 20 ? "CPU pressure detected - check for CPU-intensive queries, consider adding CPU cores" :
+            s.WorkerThreadExhaustionWarning ? "Worker thread exhaustion - check max worker threads setting" :
+            s.TotalQueuedRequestCount > 0 ? "Requests queued for execution - CPU or worker thread pressure" :
+            "No CPU scheduler pressure detected";
+
+        return new CpuPressure(level, recommendation);
     }
 
     private static string Int(int value) => value.ToString("N0", CultureInfo.CurrentCulture);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Memory.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Memory.cs
@@ -241,13 +241,18 @@ public partial class ViewerServerTab
         var poolIds = data.Select(d => d.PoolId).Distinct().OrderBy(p => p).ToList();
         int colorIndex = 0;
 
-        /* Chart 1: Memory Grant Sizing — Available, Granted, Used MB per pool */
+        /* Chart 1: Memory Grant Sizing — Available, Granted, Used MB per pool, plus the workspace-memory
+           ceiling (Target / Max Target MB) as dashed lines so the granted-vs-ceiling headroom is visible
+           (the resource-semaphore signal the Dashboard's get_resource_semaphore exposes). IsCeiling marks
+           the two dashed ceiling series. */
         double sizingMax = 0;
-        var sizingMetrics = new (string Name, Func<MemoryGrantChartPoint, double> Selector)[]
+        var sizingMetrics = new (string Name, Func<MemoryGrantChartPoint, double> Selector, bool IsCeiling)[]
         {
-            ("Available MB", d => d.AvailableMemoryMb),
-            ("Granted MB", d => d.GrantedMemoryMb),
-            ("Used MB", d => d.UsedMemoryMb)
+            ("Available MB", d => d.AvailableMemoryMb, false),
+            ("Granted MB", d => d.GrantedMemoryMb, false),
+            ("Used MB", d => d.UsedMemoryMb, false),
+            ("Target MB", d => d.TargetMemoryMb, true),
+            ("Max Target MB", d => d.MaxTargetMemoryMb, true)
         };
 
         foreach (var poolId in poolIds)
@@ -263,6 +268,9 @@ public partial class ViewerServerTab
                 plot.LegendText = label;
                 plot.Color = ScottPlot.Color.FromHex(SeriesColors[colorIndex % SeriesColors.Length]);
                 ChartStyle.StyleScatter(plot);
+                /* Ceiling lines dashed so they read as a limit, not another measured series (mirrors the
+                   Memory Overview chart's dashed Target Memory line). */
+                if (metric.IsCeiling) plot.LineStyle.Pattern = ScottPlot.LinePattern.Dashed;
                 _memoryGrantSizingHover?.Add(plot, label);
                 if (values.Length > 0) sizingMax = Math.Max(sizingMax, values.Max());
                 colorIndex++;

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.PlanCache.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.PlanCache.cs
@@ -110,8 +110,18 @@ public partial class ViewerServerTab
         {
             PlanCacheTotalPlansText.Text = "--";
             PlanCacheOldestPlanText.Text = "--";
+            PlanCacheBloatLevelText.Text = "--";
+            PlanCacheBloatLevelText.Foreground = System.Windows.Media.Brushes.Gray;
+            PlanCacheRecommendationText.Text = "";
             return;
         }
+
+        /* Derived single-use bloat badge + forced-parameterization hint (install/47 report.plan_cache_bloat
+           parity): a pure client-side CASE on the single-use / total ratio Darling already reads. */
+        var bloat = ViewerDataService.ClassifyPlanCacheBloat(summary.TotalPlans, summary.SingleUsePlans);
+        PlanCacheBloatLevelText.Text = bloat.Level;
+        PlanCacheBloatLevelText.Foreground = BloatLevelBrush(bloat.Level);
+        PlanCacheRecommendationText.Text = bloat.Recommendation;
 
         PlanCacheTotalPlansText.Text = summary.TotalPlans.ToString("N0", CultureInfo.CurrentCulture);
 
@@ -133,6 +143,23 @@ public partial class ViewerServerTab
             : age.TotalHours >= 1
                 ? $"{age.Hours}h {age.Minutes}m"
                 : $"{age.Minutes}m";
+    }
+
+    /// <summary>Maps a plan-cache bloat level to its badge colour (CRITICAL red → HIGH orange → MEDIUM
+    /// goldenrod → NORMAL green), mirroring the severity palette the warning highlights use elsewhere.</summary>
+    private static System.Windows.Media.SolidColorBrush BloatLevelBrush(string level)
+    {
+        var hex = level switch
+        {
+            "CRITICAL" => "#FF6B6B",
+            "HIGH" => "#FFA94D",
+            "MEDIUM" => "#E0C341",
+            _ => "#4CAF50",
+        };
+        var brush = new System.Windows.Media.SolidColorBrush(
+            (System.Windows.Media.Color)System.Windows.Media.ColorConverter.ConvertFromString(hex));
+        brush.Freeze();
+        return brush;
     }
 
     /// <summary>Tears down the plan-cache hover helper (mirrors the other tabs' dispose).</summary>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Plans.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Plans.cs
@@ -248,6 +248,43 @@ public partial class ViewerServerTab
         }
     }
 
+    /// <summary>
+    /// The Top Procedures grid's "Query Plan" Download button (mirrors <see cref="DownloadQueryStatsPlan_Click"/>
+    /// and Lite's <c>DownloadProcedurePlan_Click</c>): reads the stored procedure_stats.query_plan_xml for the
+    /// row's object identity and saves it as a .sqlplan file. Gated on
+    /// <see cref="ViewerProcedureStatsRow.HasQueryPlan"/> in XAML, so it only fires when a plan was captured.
+    /// </summary>
+    private async void DownloadProcedureStatsPlan_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button btn || btn.DataContext is not ViewerProcedureStatsRow row) return;
+        if (string.IsNullOrEmpty(row.ObjectName)) return;
+
+        btn.Content = "...";
+        try
+        {
+            var plan = await _dataService.GetProcedureStatsPlanXmlAsync(_server.ServerId, row.DatabaseName, row.SchemaName, row.ObjectName);
+            if (string.IsNullOrEmpty(plan))
+            {
+                MessageBox.Show(
+                    "No execution plan was captured for this procedure.",
+                    "Plan Not Found",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information);
+                return;
+            }
+
+            SavePlanFile(plan, $"ProcedurePlan_{row.FullName}");
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Failed to retrieve plan: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+        finally
+        {
+            btn.Content = "Download";
+        }
+    }
+
     private void SavePlanFile(string planXml, string defaultName)
     {
         var dialog = new SaveFileDialog

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.RunningJobs.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.RunningJobs.cs
@@ -37,13 +37,17 @@ public partial class ViewerServerTab
 
         _runningJobsFilterMgr!.UpdateData(jobs);
 
-        /* msdb-access banner, derived from the store (the viewer has no live msdb probe): Lite shows
-           the banner when its login lacks msdb access; here the running_jobs collector's latest run
-           status stands in — a PERMISSIONS (or ERROR) outcome is the store-side signal that the
-           service could not read msdb. SUCCESS / null (never run) hides it. */
-        bool lacksMsdbAccess =
-            string.Equals(status, "PERMISSIONS", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(status, "ERROR", StringComparison.OrdinalIgnoreCase);
-        RunningJobsMsdbWarning.Visibility = lacksMsdbAccess ? Visibility.Visible : Visibility.Collapsed;
+        RunningJobsMsdbWarning.Visibility = ShouldShowMsdbBanner(status) ? Visibility.Visible : Visibility.Collapsed;
     }
+
+    /// <summary>
+    /// The msdb-access banner rule, derived from the store (the viewer has no live msdb probe): Lite shows
+    /// the "grant the login msdb access" banner strictly from its real <c>_hasMsdbAccess</c> probe, so the
+    /// store-side stand-in is ONLY the running_jobs collector's <c>PERMISSIONS</c> outcome — the sole signal
+    /// that the service was denied msdb. A transient <c>ERROR</c> (timeout / network blip) is NOT a
+    /// permission problem and must not raise the misleading "grant access" guidance; <c>SUCCESS</c> / null
+    /// (never run) also hides it. Static + internal so the PERMISSIONS-only condition is unit-testable.
+    /// </summary>
+    internal static bool ShouldShowMsdbBanner(string? runningJobsCollectorStatus) =>
+        string.Equals(runningJobsCollectorStatus, "PERMISSIONS", StringComparison.OrdinalIgnoreCase);
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
@@ -742,6 +742,20 @@
                                     <DataGridTextColumn Binding="{Binding MaxIdealGrantKb, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxIdealGrantKb" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Max Ideal Grant KB" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
+                                    <!-- Min/Max Spills + Min/Max DOP (Lite ServerTab.xaml:537-547): ViewerQueryStatsRow
+                                         already maps these; they were the only Top Queries columns the viewer dropped. -->
+                                    <DataGridTextColumn Binding="{Binding MinSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinSpills" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Min Spills" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding MaxSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxSpills" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Max Spills" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding MinDop}" ElementStyle="{StaticResource NumericCell}" Width="70">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinDop" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Min DOP" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding MaxDop}" ElementStyle="{StaticResource NumericCell}" Width="70">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxDop" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Max DOP" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
                                     <DataGridTextColumn Binding="{Binding MinReservedThreads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MinReservedThreads" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Min Rsvd Threads" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
@@ -1004,6 +1018,20 @@
                                     <DataGridTextColumn Binding="{Binding PlanHandle}" Width="140">
                                         <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PlanHandle" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Plan Handle" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                                     </DataGridTextColumn>
+                                    <!-- Query Plan download column (mirrors Lite's Top Procedures "Download" button + the
+                                         Top Queries column above), gated on HasQueryPlan so it's only actionable when the
+                                         collector stored a plan for this object. Saves procedure_stats.query_plan_xml to a
+                                         .sqlplan file; "View Plan" (context menu) opens it in the Plan Viewer tab instead. -->
+                                    <DataGridTemplateColumn Header="Query Plan" Width="Auto" MinWidth="90">
+                                        <DataGridTemplateColumn.CellTemplate>
+                                            <DataTemplate>
+                                                <Button Content="Download" Click="DownloadProcedureStatsPlan_Click"
+                                                        IsEnabled="{Binding HasQueryPlan}"
+                                                        HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                        Padding="8,4"/>
+                                            </DataTemplate>
+                                        </DataGridTemplateColumn.CellTemplate>
+                                    </DataGridTemplateColumn>
                                 </DataGrid.Columns>
                             </DataGrid>
                             <DataGrid Grid.Row="2" x:Name="ProcStatsComparisonGrid" Visibility="Collapsed"
@@ -1605,7 +1633,12 @@
                                 <TextBlock Text="Total Plans:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
                                 <TextBlock x:Name="PlanCacheTotalPlansText" Text="--" VerticalAlignment="Center" Margin="0,0,20,0"/>
                                 <TextBlock Text="Oldest Plan Age:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                                <TextBlock x:Name="PlanCacheOldestPlanText" Text="--" VerticalAlignment="Center"/>
+                                <TextBlock x:Name="PlanCacheOldestPlanText" Text="--" VerticalAlignment="Center" Margin="0,0,20,0"/>
+                                <!-- Derived single-use bloat badge + forced-parameterization hint (install/47
+                                     report.plan_cache_bloat parity): a client-side CASE on single-use/total plans. -->
+                                <TextBlock Text="Bloat Level:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                <TextBlock x:Name="PlanCacheBloatLevelText" Text="--" FontWeight="Bold" VerticalAlignment="Center" Margin="0,0,20,0"/>
+                                <TextBlock x:Name="PlanCacheRecommendationText" Text="" FontStyle="Italic" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" TextWrapping="Wrap"/>
                             </StackPanel>
                         </Border>
                         <DataGrid Grid.Row="2" x:Name="PlanCacheCompositionGrid" Style="{StaticResource DarkGrid}" Margin="0,8,0,0"
@@ -2273,6 +2306,9 @@
                         </DataGridTextColumn>
                         <DataGridTextColumn Binding="{Binding BlockingEvents, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
                             <DataGridTextColumn.Header><TextBlock Text="Blocking Events" FontWeight="Bold"/></DataGridTextColumn.Header>
+                        </DataGridTextColumn>
+                        <DataGridTextColumn Binding="{Binding MemoryPressureEvents, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="130">
+                            <DataGridTextColumn.Header><TextBlock Text="Memory Pressure" FontWeight="Bold"/></DataGridTextColumn.Header>
                         </DataGridTextColumn>
                         <DataGridTextColumn Binding="{Binding HighCpuEvents, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110">
                             <DataGridTextColumn.Header><TextBlock Text="High CPU" FontWeight="Bold"/></DataGridTextColumn.Header>

--- a/Darling/PerformanceMonitor.Darling.Viewer/WaitDrillDownWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/WaitDrillDownWindow.xaml
@@ -9,11 +9,11 @@
     <!-- Ported from Lite's Windows/WaitDrillDownWindow.xaml (the Wait Stats "Show Queries With <wait>"
          drill-down). Same three classified views (correlated / uncapturable / chain / filtered) driving the
          shared PerformanceMonitor.Ui WaitDrillDownHelper + blocking-chain walker; the read is repointed to
-         ViewerDataService Postgres (correlated query snapshots). Two viewer adaptations: (1) columns match the
-         viewer's trimmed ViewerQuerySnapshotRow (the ~26-column Active Queries grid) rather than Lite's wider
-         row; (2) Lite's live "Get Actual Plan" is dropped (the viewer never opens a SqlClient) — "View Plan"
-         shows the stored plan. Dark-styled via the shared ViewerDarkTheme dictionary with a local NumericCell,
-         mirroring CollectionLogWindow. -->
+         ViewerDataService Postgres (correlated query snapshots). Columns mirror Lite's WaitDrillDownWindow
+         grid in full, including the #1286 memory-grant / tempdb / transaction triage columns (all verified
+         present in query_snapshots). One viewer adaptation: Lite's live "Get Actual Plan" is dropped (the
+         viewer never opens a SqlClient) — "View Plan" shows the stored plan. Dark-styled via the shared
+         ViewerDarkTheme dictionary with a local NumericCell, mirroring CollectionLogWindow. -->
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -134,6 +134,31 @@
                 </DataGridTextColumn>
                 <DataGridTextColumn Binding="{Binding GrantedQueryMemoryGb, StringFormat=F2}" ElementStyle="{StaticResource NumericCell}" Width="90">
                     <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="GrantedQueryMemoryGb" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Memory (GB)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <!-- #1286 memory-grant / tempdb / transaction triage columns (mirrors Lite's WaitDrillDownWindow) -->
+                <DataGridTextColumn Binding="{Binding RequestedMemoryMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="RequestedMemoryMb" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Req Mem (MB)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding UsedMemoryMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="UsedMemoryMb" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Used Mem (MB)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding MaxUsedMemoryMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="130">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxUsedMemoryMb" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Max Used Mem (MB)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding TempdbCurrentMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TempdbCurrentMb" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="tempdb Cur (MB)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding TempdbAllocationsMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TempdbAllocationsMb" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="tempdb Alloc (MB)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding TranLogUsedMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="105">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TranLogUsedMb" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Tran Log (MB)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding TranStartTimeLocal}" Width="140">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TranStartTimeLocal" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Tran Start" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                </DataGridTextColumn>
+                <DataGridTextColumn Binding="{Binding RequestId}" ElementStyle="{StaticResource NumericCell}" Width="70">
+                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="RequestId" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Req ID" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
                 </DataGridTextColumn>
                 <DataGridTextColumn Binding="{Binding TransactionIsolationLevel}" Width="140">
                     <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TransactionIsolationLevel" Click="Filter_Click" Margin="0,0,4,0"/><TextBlock Text="Isolation" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>


### PR DESCRIPTION
Restores the cheap, **data-present** grid/column/badge parity the Darling viewer dropped from Lite/Dashboard. Every item surfaces data **already collected and in the Postgres store** — no new collection. Touches only `PerformanceMonitor.Darling.Viewer` + `Darling.Tests` (Service/Storage/Config/Migrations untouched).

## Per-item

1. **Top Queries grid — 4 missing columns.** Added `Min Spills` / `Max Spills` / `Min DOP` / `Max DOP` (mirrors Lite `ServerTab.xaml:537-547`). `ViewerQueryStatsRow` already declared + populated these; they were an accidental XAML omission.
2. **Memory Grants — workspace-memory ceiling.** Surface `target_memory_mb` / `max_target_memory_mb` as **dashed ceiling lines** on the Memory Grant Sizing chart (the granted-vs-target headroom signal `get_resource_semaphore` exposes). Extended `MemoryGrantChartPoint` + `MemoryGrantChartDataSql` + reader.
3. **Plan Cache — bloat_level badge + hint.** Added the derived single-use bloat badge (CRITICAL >50% / HIGH >30% / MEDIUM >20% / NORMAL) + forced-parameterization recommendation to the summary strip. Pure client-side `ClassifyPlanCacheBloat` mirroring `install/47` `report.plan_cache_bloat` + Dashboard `PlanCacheStatsItem`. `PlanCacheSummary`/`PlanCacheSummarySql` now also sum `single_use_plans`.
4. **CPU Scheduler — pressure_level rollup + recommendation.** Added the banded `Pressure Level` + `Recommendation` as the two headline metric rows (Pressure Level highlights when not NORMAL). `ClassifyCpuPressure` mirrors `install/47` `report.cpu_scheduler_pressure` CASE ordering + Dashboard `CpuPressureItem`.
5. **Daily Summary — Memory Pressure column + MEMORY_CRITICAL band.** Added the `Memory Pressure` count column (`memory_indicators_process >= 2 OR memory_indicators_system >= 2`) and the `MEMORY_CRITICAL` health escalation (`memory_indicators_process >= 3`), mirroring Dashboard `DatabaseService.Overview.cs`. Banding extracted to `ClassifyDailyHealth` (severity: deadlocks > high-CPU > memory-critical > blocking).
6. **Running Jobs msdb banner — PERMISSIONS-only.** The store-derived banner previously fired on `PERMISSIONS` **or** `ERROR`; restricted to `PERMISSIONS` only, so a transient `ERROR` (timeout/blip) no longer raises the misleading "grant msdb access" banner. Extracted to `ShouldShowMsdbBanner`.
7. **Top Procedures — per-row Query Plan Download button.** Added the template column + `DownloadProcedureStatsPlan_Click` handler (mirrors Top Queries), gated on a new `has_query_plan` indicator (`bool_or(query_plan_xml IS NOT NULL)`, matching the filter `GetProcedureStatsPlanXmlAsync` fetches on).
8. **Active Queries row + WaitDrillDownWindow — #1286 triage columns.** Added the 8 triage fields to `ViewerQuerySnapshotRow` + reader + `QuerySnapshotColumns`, and the 8 columns to the WaitDrillDownWindow grid (mirroring Lite's WaitDrillDownWindow). `TranStartTimeLocal` renders raw via `FormatServerClock` (transaction_begin_time is server-local, not naive-UTC — a bug I caught + fixed vs. an earlier ForDisplay draft).

## Store-verification (items 2, 5, 8)

Verified each column against the collector definitions (the code the Postgres schema + `v_*` `SELECT *` passthrough views are generated from) and pinned with `PgSchemaGenerator.CreateTable(...)` tests:

- **Item 2** (`memory_grant_stats`): `target_memory_mb`, `max_target_memory_mb` — **PRESENT**.
- **Item 5** (`memory_pressure_events`): `memory_indicators_process`, `memory_indicators_system` — **PRESENT** (windowed on `collection_time`, the prefix time column, matching Dashboard).
- **Item 8** (`query_snapshots`): all 8 triage columns (`requested_memory_mb`, `used_memory_mb`, `max_used_memory_mb`, `tempdb_current_mb`, `tempdb_allocations_mb`, `tran_log_used_mb`, `tran_start_time`, `request_id`) — **PRESENT**.

**No collector gaps found** — every requested column exists in the store.

## Decision to flag (item 8)

The triage columns are **not** added to the **Active Queries** grid — Lite shows them only in its **WaitDrillDownWindow**, not its (leaner) Active Queries grid, which the Darling Active Queries grid already matches column-for-column. Per "Match Lite's Active Queries grid column set", faithful parity = mirror Lite per-grid (triage → WaitDrillDownWindow only). If you'd prefer the triage columns in the main Active Queries grid too, that's a one-block XAML add — say the word.

## Testing

- Whole Darling solution builds `-c Release` (Viewer + Service + Storage + Analysis compile; 0 errors).
- `Darling.Tests -c Release`: **1007 passed, 91 skipped (live-PG gated on DARLING_TEST_PG), 0 failed.**
- New unit tests for every derived seam: `ClassifyPlanCacheBloat`, `ClassifyCpuPressure`, `ClassifyDailyHealth` (incl. MEMORY_CRITICAL), `ShouldShowMsdbBanner` (PERMISSIONS-only), `BuildCpuSchedulerMetrics` headline rows, plus SQL-pin + store-column-existence tests for items 2/5/8 and the `TranStartTimeLocal` display prop. The existing msdb test (which asserted the old ERROR→banner behavior via inline logic) was updated to call the real method and assert the new PERMISSIONS-only behavior.

_Note: one flaky failure (`ViewerWave2DisplayTests.BlockedRow_EventTimeLocal`) appeared once then passed on re-run — a pre-existing parallel-execution race on `ViewerTimeHelper`'s process-wide statics, unrelated to this change (my tests only read those statics)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
