### PR TITLE
Darling control plane Stage 2: service honors config_command commands

### DIFF
--- a/Darling/Darling.Tests/DarlingCliCommandsTests.cs
+++ b/Darling/Darling.Tests/DarlingCliCommandsTests.cs
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using PerformanceMonitor.Darling.Service;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// The <c>--test-connection</c>/<c>--validate-config</c> CLI verb. The connectivity probe itself needs a live
+/// SQL Server, but the verb recognition and the pure per-server PASS/FAIL formatting are unit-tested here; the
+/// probe is shared with the <c>test_connect</c> command (<see cref="DarlingServerConnector.ProbeAsync"/>), so
+/// what validates from the CLI connects identically under the running service.
+/// </summary>
+public sealed class DarlingCliCommandsTests
+{
+    [Theory]
+    [InlineData("--test-connection", true)]
+    [InlineData("--validate-config", true)]
+    [InlineData("--TEST-CONNECTION", true)]
+    [InlineData("--encrypt-password", false)]
+    [InlineData("--nonsense", false)]
+    public void IsValidateConfigVerb_RecognizesBothAliases_CaseInsensitive(string arg, bool expected)
+    {
+        Assert.Equal(expected, DarlingCliCommands.IsValidateConfigVerb(arg));
+    }
+
+    [Fact]
+    public void FormatProbeLine_Success_ShowsVersionEditionAndMsdb()
+    {
+        var probe = new ConnectionProbeResult(
+            Success: true, MajorVersion: 16, EngineEdition: 3, EngineEditionDescription: "Enterprise",
+            IsAzureSqlDb: false, IsAzureManagedInstance: false, IsAwsRds: false, HasMsdbAccess: true, Error: null);
+
+        var line = DarlingCliCommands.FormatProbeLine("SQL01", probe);
+
+        Assert.Contains("[PASS]", line, StringComparison.Ordinal);
+        Assert.Contains("SQL01", line, StringComparison.Ordinal);
+        Assert.Contains("SQL major version 16", line, StringComparison.Ordinal);
+        Assert.Contains("Enterprise", line, StringComparison.Ordinal);
+        Assert.Contains("msdb access: yes", line, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FormatProbeLine_Success_NoMsdb_WarnsFailedJobsUnavailable()
+    {
+        var probe = new ConnectionProbeResult(
+            Success: true, MajorVersion: 15, EngineEdition: 2, EngineEditionDescription: "Standard",
+            IsAzureSqlDb: false, IsAzureManagedInstance: false, IsAwsRds: false, HasMsdbAccess: false, Error: null);
+
+        var line = DarlingCliCommands.FormatProbeLine("SQL02", probe);
+
+        Assert.Contains("[PASS]", line, StringComparison.Ordinal);
+        Assert.Contains("msdb access: NO", line, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FormatProbeLine_MissingDescription_FallsBackToEditionDescriber()
+    {
+        var probe = new ConnectionProbeResult(
+            Success: true, MajorVersion: 16, EngineEdition: 8, EngineEditionDescription: null,
+            IsAzureSqlDb: false, IsAzureManagedInstance: true, IsAwsRds: false, HasMsdbAccess: true, Error: null);
+
+        var line = DarlingCliCommands.FormatProbeLine("MI01", probe);
+
+        /* Edition 8 -> Managed Instance, resolved by the shared describer when the probe carries no text. */
+        Assert.Contains("Azure SQL Managed Instance", line, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FormatProbeLine_Failure_ShowsError()
+    {
+        var probe = new ConnectionProbeResult(
+            Success: false, MajorVersion: 0, EngineEdition: 0, EngineEditionDescription: null,
+            IsAzureSqlDb: false, IsAzureManagedInstance: false, IsAwsRds: false, HasMsdbAccess: false,
+            Error: "Login failed for user 'monitor'.");
+
+        var line = DarlingCliCommands.FormatProbeLine("SQL03", probe);
+
+        Assert.Contains("[FAIL]", line, StringComparison.Ordinal);
+        Assert.Contains("SQL03", line, StringComparison.Ordinal);
+        Assert.Contains("Login failed", line, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DescribeEngineEdition_MapsKnownEditions()
+    {
+        Assert.Equal("Enterprise", DarlingServerConnector.DescribeEngineEdition(3));
+        Assert.Equal("Azure SQL Database", DarlingServerConnector.DescribeEngineEdition(5));
+        Assert.Equal("Azure SQL Managed Instance", DarlingServerConnector.DescribeEngineEdition(8));
+        Assert.Contains("Unknown", DarlingServerConnector.DescribeEngineEdition(999), StringComparison.Ordinal);
+    }
+}

--- a/Darling/Darling.Tests/DarlingCommandExecutorTests.cs
+++ b/Darling/Darling.Tests/DarlingCommandExecutorTests.cs
@@ -1,0 +1,417 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+using PerformanceMonitor.Darling.Service;
+using PerformanceMonitor.Darling.Storage;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// The control-plane Stage 2 command executor. The pure tests pin the two correctness-critical pieces with
+/// no database — the atomic-claim SQL shape (FOR UPDATE SKIP LOCKED, oldest-pending, mark in_progress) and
+/// the PURE dispatch (<see cref="DarlingCommandExecutor.ResolvePlan"/>: one plan per command_type, argument
+/// validation, unknown -> fail) — plus the test_connect result mapping. The live tests (gated on
+/// DARLING_TEST_PG) prove the claim/execute/report round-trip against real Postgres and are transaction-
+/// rolled-back (or sentinel-scoped + cleaned up) so they never clobber a shared dev store's singleton rows.
+/// </summary>
+/* Live-fixture tests share one Postgres store; the collection serializes them so cross-test row churn
+   (inserts/deletes on config_command / config_collector_schedules) cannot race another class's assertions. */
+[Collection("live-postgres")]
+public sealed class DarlingCommandExecutorTests
+{
+    /// <summary>A fake host — the store-write / probe branches never call it; asserts if they do.</summary>
+    private sealed class ThrowingHost : IDarlingCommandHost
+    {
+        public Task<CommandOutcome> SnapshotNowAsync(int serverId, CancellationToken cancellationToken)
+            => throw new InvalidOperationException("host should not be called for this command");
+
+        public Task<CommandOutcome> AnalyzeNowAsync(int serverId, CancellationToken cancellationToken)
+            => throw new InvalidOperationException("host should not be called for this command");
+    }
+
+    private static ClaimedCommand Command(string type, int? target = null, string? args = null) =>
+        new(1, type, target, args, "tester");
+
+    /* ---------------- pure: the atomic-claim SQL shape (pin) ---------------- */
+
+    [Fact]
+    public void ClaimCommandSql_IsAtomicOldestPendingSkipLocked()
+    {
+        var sql = DarlingCommandExecutor.ClaimCommandSql;
+
+        /* Multi-instance safety: the sub-select locks the chosen row and SKIPs rows another instance holds. */
+        Assert.Contains("FOR UPDATE SKIP LOCKED", sql, StringComparison.Ordinal);
+        /* Claims only pending rows and marks the claimed one in_progress (so it is never re-claimed). */
+        Assert.Contains("status = 'pending'", sql, StringComparison.Ordinal);
+        Assert.Contains("status = 'in_progress'", sql, StringComparison.Ordinal);
+        /* FIFO, exactly one, and returns the row so the executor can dispatch it. */
+        Assert.Contains("ORDER BY command_id", sql, StringComparison.Ordinal);
+        Assert.Contains("LIMIT 1", sql, StringComparison.Ordinal);
+        Assert.Contains("RETURNING", sql, StringComparison.Ordinal);
+        /* Records which instance claimed it. */
+        Assert.Contains("service_instance = $1", sql, StringComparison.Ordinal);
+    }
+
+    /* ---------------- pure: dispatch (one plan per command_type) ---------------- */
+
+    [Fact]
+    public void ResolvePlan_PauseResume_WriteConfigServicePaused()
+    {
+        var pause = DarlingCommandExecutor.ResolvePlan(Command("pause"));
+        Assert.Equal(CommandKind.StoreWrite, pause.Kind);
+        Assert.Contains("config_service", pause.Sql, StringComparison.Ordinal);
+        Assert.Contains("paused = TRUE", pause.Sql, StringComparison.Ordinal);
+        Assert.Equal("paused", pause.SuccessStatus);
+
+        var resume = DarlingCommandExecutor.ResolvePlan(Command("resume"));
+        Assert.Equal(CommandKind.StoreWrite, resume.Kind);
+        Assert.Contains("paused = FALSE", resume.Sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ResolvePlan_Reload_BumpsConfigServiceWithoutStateChange()
+    {
+        var plan = DarlingCommandExecutor.ResolvePlan(Command("reload"));
+        Assert.Equal(CommandKind.StoreWrite, plan.Kind);
+        Assert.Contains("UPDATE config.config_service", plan.Sql, StringComparison.Ordinal);
+        /* Only touches updated_at — the self-bump trigger increments config_version. */
+        Assert.DoesNotContain("paused", plan.Sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ResolvePlan_EnableDisableServer_RequireTarget_ThenParameterizeIt()
+    {
+        Assert.Equal(CommandKind.Fail, DarlingCommandExecutor.ResolvePlan(Command("enable_server")).Kind);
+        Assert.Equal(CommandKind.Fail, DarlingCommandExecutor.ResolvePlan(Command("disable_server")).Kind);
+
+        var enable = DarlingCommandExecutor.ResolvePlan(Command("enable_server", target: 42));
+        Assert.Equal(CommandKind.StoreWrite, enable.Kind);
+        Assert.Contains("is_enabled = TRUE", enable.Sql, StringComparison.Ordinal);
+        Assert.Contains("WHERE server_id = $1", enable.Sql, StringComparison.Ordinal);
+        Assert.Equal(42, enable.Parameters![0]);
+
+        var disable = DarlingCommandExecutor.ResolvePlan(Command("disable_server", target: 42));
+        Assert.Contains("is_enabled = FALSE", disable.Sql, StringComparison.Ordinal);
+        Assert.Equal(42, disable.Parameters![0]);
+    }
+
+    [Fact]
+    public void ResolvePlan_EnableCollector_FleetVsPerServer_ValidatesName()
+    {
+        /* Missing collector_name -> fail. */
+        Assert.Equal(CommandKind.Fail, DarlingCommandExecutor.ResolvePlan(Command("enable_collector", args: "{}")).Kind);
+
+        /* Unknown collector -> fail (no junk override row). */
+        Assert.Equal(CommandKind.Fail,
+            DarlingCommandExecutor.ResolvePlan(Command("enable_collector", args: "{\"collector_name\":\"not_a_collector\"}")).Kind);
+
+        /* Fleet-wide (no server scope) -> the server_id IS NULL partial-index arbiter, one param (the name). */
+        var fleet = DarlingCommandExecutor.ResolvePlan(Command("enable_collector", args: "{\"collector_name\":\"wait_stats\"}"));
+        Assert.Equal(CommandKind.StoreWrite, fleet.Kind);
+        Assert.Contains("VALUES (NULL, $1, TRUE)", fleet.Sql, StringComparison.Ordinal);
+        Assert.Contains("ON CONFLICT (collector_name) WHERE server_id IS NULL", fleet.Sql, StringComparison.Ordinal);
+        Assert.Single(fleet.Parameters!);
+        Assert.Equal("wait_stats", fleet.Parameters![0]);
+
+        /* Per-server (target scope) -> the (server_id, collector_name) arbiter, two params. */
+        var perServer = DarlingCommandExecutor.ResolvePlan(Command("disable_collector", target: 7, args: "{\"collector_name\":\"wait_stats\"}"));
+        Assert.Contains("VALUES ($1, $2, FALSE)", perServer.Sql, StringComparison.Ordinal);
+        Assert.Contains("ON CONFLICT (server_id, collector_name) WHERE server_id IS NOT NULL", perServer.Sql, StringComparison.Ordinal);
+        Assert.Equal(7, perServer.Parameters![0]);
+        Assert.Equal("wait_stats", perServer.Parameters![1]);
+    }
+
+    [Fact]
+    public void ResolvePlan_TestConnect_RequiresArgsJson_ElseProbe()
+    {
+        Assert.Equal(CommandKind.Fail, DarlingCommandExecutor.ResolvePlan(Command("test_connect")).Kind);
+        Assert.Equal(CommandKind.Probe, DarlingCommandExecutor.ResolvePlan(Command("test_connect", args: "{\"host\":\"sql01\"}")).Kind);
+    }
+
+    [Fact]
+    public void ResolvePlan_SnapshotAndAnalyze_RequireTarget()
+    {
+        Assert.Equal(CommandKind.Fail, DarlingCommandExecutor.ResolvePlan(Command("snapshot_now")).Kind);
+        Assert.Equal(CommandKind.Fail, DarlingCommandExecutor.ResolvePlan(Command("analyze_now")).Kind);
+        Assert.Equal(CommandKind.Snapshot, DarlingCommandExecutor.ResolvePlan(Command("snapshot_now", target: 3)).Kind);
+        Assert.Equal(CommandKind.Analyze, DarlingCommandExecutor.ResolvePlan(Command("analyze_now", target: 3)).Kind);
+    }
+
+    [Theory]
+    [InlineData("bogus")]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("PAUSE_NOW")]
+    public void ResolvePlan_UnknownType_FailsWithClearReason(string type)
+    {
+        var plan = DarlingCommandExecutor.ResolvePlan(Command(type));
+        Assert.Equal(CommandKind.Fail, plan.Kind);
+        Assert.Equal("unknown command_type", plan.FailReason);
+    }
+
+    [Fact]
+    public void ResolvePlan_CommandTypeIsCaseInsensitive()
+    {
+        Assert.Equal(CommandKind.StoreWrite, DarlingCommandExecutor.ResolvePlan(Command("PAUSE")).Kind);
+        Assert.Equal(CommandKind.Snapshot, DarlingCommandExecutor.ResolvePlan(Command("Snapshot_Now", target: 1)).Kind);
+    }
+
+    /* ---------------- pure: test_connect result mapping ---------------- */
+
+    [Fact]
+    public void MapProbeResult_Success_CarriesTheProbeFacts()
+    {
+        var probe = new ConnectionProbeResult(
+            Success: true, MajorVersion: 16, EngineEdition: 3, EngineEditionDescription: "Enterprise",
+            IsAzureSqlDb: false, IsAzureManagedInstance: false, IsAwsRds: false, HasMsdbAccess: true, Error: null);
+
+        var (status, json) = DarlingCommandExecutor.MapProbeResult(probe);
+
+        Assert.Equal("connected", status);
+        Assert.Contains("\"success\":true", json, StringComparison.Ordinal);
+        Assert.Contains("\"majorVersion\":16", json, StringComparison.Ordinal);
+        Assert.Contains("\"engineEdition\":3", json, StringComparison.Ordinal);
+        Assert.Contains("Enterprise", json, StringComparison.Ordinal);
+        Assert.Contains("\"hasMsdbAccess\":true", json, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MapProbeResult_Failure_CarriesTheError_NoFacts()
+    {
+        var probe = new ConnectionProbeResult(
+            Success: false, MajorVersion: 0, EngineEdition: 0, EngineEditionDescription: null,
+            IsAzureSqlDb: false, IsAzureManagedInstance: false, IsAwsRds: false, HasMsdbAccess: false,
+            Error: "A network-related or instance-specific error occurred");
+
+        var (status, json) = DarlingCommandExecutor.MapProbeResult(probe);
+
+        Assert.Equal("connection_failed", status);
+        Assert.Contains("\"success\":false", json, StringComparison.Ordinal);
+        Assert.Contains("network-related", json, StringComparison.Ordinal);
+    }
+
+    /* ---------------- live (DARLING_TEST_PG): claim + execute + report ---------------- */
+
+    /// <summary>Distinctive sentinel — a real server_id is a storage-name hash, never this.</summary>
+    private const int SentinelServerId = -515151;
+
+    [Fact]
+    public async Task ClaimCommandSql_ClaimsOldestPendingFifo_MarksInProgress_RolledBack()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the command-claim test.");
+
+        var ct = TestContext.Current.CancellationToken;
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(ct);
+        await PgMigrations.MigrateAsync(connection, ct);
+
+        await using var tx = await connection.BeginTransactionAsync(ct);
+
+        /* Neutralize any pre-existing pending rows WITHIN this rolled-back tx so the claim sees only ours. */
+        await ExecAsync(connection, tx, "UPDATE config.config_command SET status = 'in_progress' WHERE status = 'pending'", ct);
+
+        await ExecAsync(connection, tx,
+            "INSERT INTO config.config_command (command_type, status) VALUES ('reload', 'pending'), ('pause', 'pending')", ct);
+
+        /* First claim -> the OLDEST pending (reload), marked in_progress. */
+        var first = await ClaimAsync(connection, tx, ct);
+        Assert.NotNull(first);
+        Assert.Equal("reload", first!.Value.Type);
+
+        var second = await ClaimAsync(connection, tx, ct);
+        Assert.NotNull(second);
+        Assert.Equal("pause", second!.Value.Type);
+        Assert.True(second.Value.Id > first.Value.Id, "second claim must be a later command_id (FIFO)");
+
+        /* Queue drained -> nothing left to claim. */
+        var third = await ClaimAsync(connection, tx, ct);
+        Assert.Null(third);
+
+        /* Both are now in_progress (claimed), none still pending. */
+        var pending = Convert.ToInt64(await ScalarAsync(connection, tx,
+            $"SELECT COUNT(*) FROM config.config_command WHERE command_id IN ({first.Value.Id}, {second.Value.Id}) AND status = 'pending'", ct));
+        Assert.Equal(0, pending);
+
+        await tx.RollbackAsync(ct);
+    }
+
+    [Fact]
+    public async Task PauseResume_FlipsConfigServicePaused_AndBumpsVersion_RolledBack()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the pause/resume command test.");
+
+        var ct = TestContext.Current.CancellationToken;
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(ct);
+        await PgMigrations.MigrateAsync(connection, ct);
+
+        await using var tx = await connection.BeginTransactionAsync(ct);
+        await ExecAsync(connection, tx,
+            "INSERT INTO config.config_service (id, updated_at) VALUES (1, now() AT TIME ZONE 'UTC') ON CONFLICT (id) DO NOTHING", ct);
+
+        /* Drive the executor's ACTUAL resolved SQL — the same string the running service runs. */
+        var pauseSql = DarlingCommandExecutor.ResolvePlan(Command("pause")).Sql!;
+        var resumeSql = DarlingCommandExecutor.ResolvePlan(Command("resume")).Sql!;
+
+        var beforeVersion = Convert.ToInt64(await ScalarAsync(connection, tx, "SELECT config_version FROM config.config_service WHERE id = 1", ct));
+
+        await ExecAsync(connection, tx, pauseSql, ct);
+        Assert.True((bool)(await ScalarAsync(connection, tx, "SELECT paused FROM config.config_service WHERE id = 1", ct))!);
+        var afterPause = Convert.ToInt64(await ScalarAsync(connection, tx, "SELECT config_version FROM config.config_service WHERE id = 1", ct));
+        Assert.True(afterPause > beforeVersion, "pause must bump config_version (so the loop reloads and honors it)");
+
+        await ExecAsync(connection, tx, resumeSql, ct);
+        Assert.False((bool)(await ScalarAsync(connection, tx, "SELECT paused FROM config.config_service WHERE id = 1", ct))!);
+
+        await tx.RollbackAsync(ct);
+    }
+
+    [Fact]
+    public async Task ExecuteAndReport_EnableCollector_RoundTrip_AgainstDevPostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the command execute/report round-trip.");
+
+        var ct = TestContext.Current.CancellationToken;
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(ct);
+        await PgMigrations.MigrateAsync(connection, ct);
+
+        await CleanupSentinelAsync(connection, ct);
+
+        /* A real pending command row for the executor to claim, execute, and report on. */
+        long commandId;
+        using (var insert = new NpgsqlCommand(
+            "INSERT INTO config.config_command (command_type, target_server_id, args_json, status) " +
+            "VALUES ('enable_collector', $1, '{\"collector_name\":\"wait_stats\"}'::jsonb, 'pending') RETURNING command_id", connection))
+        {
+            insert.Parameters.AddWithValue(SentinelServerId);
+            commandId = Convert.ToInt64(await insert.ExecuteScalarAsync(ct));
+        }
+
+        await using var postgres = NpgsqlDataSource.Create(connectionString!);
+        var executor = new DarlingCommandExecutor(postgres, new ThrowingHost(), "test-instance", null);
+
+        /* Claim through the executor's own path (the queue holds only our sentinel row now), then execute+report. */
+        var claimed = await executor.ClaimNextAsync(ct);
+        Assert.NotNull(claimed);
+        Assert.Equal(commandId, claimed!.CommandId);
+        Assert.Equal("enable_collector", claimed.CommandType);
+        Assert.Equal(SentinelServerId, claimed.TargetServerId);
+
+        await executor.ExecuteAndReportAsync(claimed, ct);
+
+        /* The store effect: a per-server schedule override row with enabled = TRUE. */
+        using (var read = new NpgsqlCommand(
+            "SELECT enabled FROM config.config_collector_schedules WHERE server_id = $1 AND collector_name = 'wait_stats'", connection))
+        {
+            read.Parameters.AddWithValue(SentinelServerId);
+            Assert.Equal(true, await read.ExecuteScalarAsync(ct));
+        }
+
+        /* The reported terminal outcome on the command row. */
+        using (var read = new NpgsqlCommand(
+            "SELECT status, result_status, result_json::text, completed_at FROM config.config_command WHERE command_id = $1", connection))
+        {
+            read.Parameters.AddWithValue(commandId);
+            using var reader = await read.ExecuteReaderAsync(ct);
+            Assert.True(await reader.ReadAsync(ct));
+            Assert.Equal("succeeded", reader.GetString(0));
+            Assert.Equal("collector enabled", reader.GetString(1));
+            Assert.Contains("\"success\":true", reader.GetString(2), StringComparison.Ordinal);
+            Assert.False(reader.IsDBNull(3), "completed_at must be stamped");
+        }
+
+        await CleanupSentinelAsync(connection, ct);
+    }
+
+    [Fact]
+    public async Task ExecuteAndReport_UnknownType_ReportsFailed_NeverThrows()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the unknown-command test.");
+
+        var ct = TestContext.Current.CancellationToken;
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(ct);
+        await PgMigrations.MigrateAsync(connection, ct);
+        await CleanupSentinelAsync(connection, ct);
+
+        long commandId;
+        using (var insert = new NpgsqlCommand(
+            "INSERT INTO config.config_command (command_type, requested_by, status) VALUES ('nonsense_command', 'sentinel-test', 'in_progress') RETURNING command_id", connection))
+        {
+            commandId = Convert.ToInt64(await insert.ExecuteScalarAsync(ct));
+        }
+
+        await using var postgres = NpgsqlDataSource.Create(connectionString!);
+        var executor = new DarlingCommandExecutor(postgres, new ThrowingHost(), "test-instance", null);
+
+        /* Directly report on the row (bypass ClaimNextAsync so we never claim an unrelated command). */
+        await executor.ExecuteAndReportAsync(
+            new ClaimedCommand(commandId, "nonsense_command", null, null, "sentinel-test"), ct);
+
+        using (var read = new NpgsqlCommand("SELECT status, result_status FROM config.config_command WHERE command_id = $1", connection))
+        {
+            read.Parameters.AddWithValue(commandId);
+            using var reader = await read.ExecuteReaderAsync(ct);
+            Assert.True(await reader.ReadAsync(ct));
+            Assert.Equal("failed", reader.GetString(0));
+            Assert.Equal("unknown command_type", reader.GetString(1));
+        }
+
+        using (var cleanup = new NpgsqlCommand("DELETE FROM config.config_command WHERE requested_by = 'sentinel-test'", connection))
+        {
+            await cleanup.ExecuteNonQueryAsync(ct);
+        }
+    }
+
+    private static async Task CleanupSentinelAsync(NpgsqlConnection connection, CancellationToken ct)
+    {
+        using var cleanup = new NpgsqlCommand(
+            $"DELETE FROM config.config_collector_schedules WHERE server_id = {SentinelServerId}; " +
+            $"DELETE FROM config.config_command WHERE target_server_id = {SentinelServerId} OR requested_by = 'sentinel-test'", connection);
+        await cleanup.ExecuteNonQueryAsync(ct);
+    }
+
+    private static async Task<(long Id, string Type)?> ClaimAsync(NpgsqlConnection connection, NpgsqlTransaction tx, CancellationToken ct)
+    {
+        using var command = new NpgsqlCommand(DarlingCommandExecutor.ClaimCommandSql, connection, tx);
+        command.Parameters.AddWithValue("claim-test");
+        using var reader = await command.ExecuteReaderAsync(ct);
+        if (!await reader.ReadAsync(ct))
+        {
+            return null;
+        }
+
+        return (reader.GetInt64(0), reader.GetString(1));
+    }
+
+    private static async Task ExecAsync(NpgsqlConnection connection, NpgsqlTransaction tx, string sql, CancellationToken ct)
+    {
+        using var command = new NpgsqlCommand(sql, connection, tx);
+        await command.ExecuteNonQueryAsync(ct);
+    }
+
+    private static async Task<object?> ScalarAsync(NpgsqlConnection connection, NpgsqlTransaction tx, string sql, CancellationToken ct)
+    {
+        using var command = new NpgsqlCommand(sql, connection, tx);
+        return await command.ExecuteScalarAsync(ct);
+    }
+}

--- a/Darling/Darling.Tests/DarlingObservabilityTests.cs
+++ b/Darling/Darling.Tests/DarlingObservabilityTests.cs
@@ -358,10 +358,92 @@ public sealed class DarlingObservabilityTests
         await DeleteTestRowsAsync(connection);
     }
 
+    [Fact]
+    public async Task SyncServerEnabledStates_MirrorsDesiredOntoObservedRegistry_AgainstDevPostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the enable-state sync test.");
+
+        using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await PgMigrations.MigrateAsync(connection, TestContext.Current.CancellationToken);
+        await DeleteTestRowsAsync(connection);
+
+        /* Desired: DISABLED. Observed (a stale row from a prior connect): still ENABLED. */
+        await ExecAsync(connection,
+            "INSERT INTO config.config_monitored_servers (server_id, name, host, is_enabled) VALUES ($1, 'sync-test', 'sync-host', FALSE)");
+        await ExecAsync(connection,
+            "INSERT INTO collect.servers (server_id, server_name, is_enabled, created_date, modified_date) VALUES ($1, 'sync-host', TRUE, now() AT TIME ZONE 'UTC', now() AT TIME ZONE 'UTC')");
+
+        await using var postgres = NpgsqlDataSource.Create(connectionString!);
+
+        await DarlingObservability.SyncServerEnabledStatesAsync(postgres, null, TestContext.Current.CancellationToken);
+        Assert.Equal(false, await ReadObservedEnabledAsync(connection));
+
+        /* Re-enable desired -> the sync flips the observed row back to TRUE. */
+        await ExecAsync(connection, "UPDATE config.config_monitored_servers SET is_enabled = TRUE WHERE server_id = $1");
+        await DarlingObservability.SyncServerEnabledStatesAsync(postgres, null, TestContext.Current.CancellationToken);
+        Assert.Equal(true, await ReadObservedEnabledAsync(connection));
+
+        await DeleteTestRowsAsync(connection);
+    }
+
+    [Fact]
+    public async Task UpsertServer_ReconnectDoesNotReEnableADisabledObservedRow_AgainstDevPostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the upsert no-clobber test.");
+
+        using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await PgMigrations.MigrateAsync(connection, TestContext.Current.CancellationToken);
+        await DeleteTestRowsAsync(connection);
+
+        /* An observed row that has been DISABLED via the control plane. */
+        await ExecAsync(connection,
+            "INSERT INTO collect.servers (server_id, server_name, is_enabled, created_date, modified_date) VALUES ($1, 'noclobber-host', FALSE, now() AT TIME ZONE 'UTC', now() AT TIME ZONE 'UTC')");
+
+        var server = new ServerRuntime
+        {
+            Config = new MonitoredServer { Name = "noclobber", Host = "noclobber-host" },
+            ConnectionString = "Server=noclobber-host",
+            Target = new CollectorTargetInfo { SqlMajorVersion = 16 },
+            StorageName = "noclobber-host",
+            ServerId = TestServerId,
+            EngineEdition = 3,
+        };
+
+        await using var postgres = NpgsqlDataSource.Create(connectionString!);
+
+        /* A re-connect upsert (ON CONFLICT) must NOT resurrect is_enabled to TRUE (Stage 2 fix). */
+        await DarlingObservability.UpsertServerAsync(postgres, server, null, TestContext.Current.CancellationToken);
+        Assert.Equal(false, await ReadObservedEnabledAsync(connection));
+
+        await DeleteTestRowsAsync(connection);
+    }
+
+    private static async Task<bool> ReadObservedEnabledAsync(NpgsqlConnection connection)
+    {
+        using var read = new NpgsqlCommand("SELECT is_enabled FROM collect.servers WHERE server_id = $1", connection);
+        read.Parameters.AddWithValue(TestServerId);
+        return (bool)(await read.ExecuteScalarAsync(TestContext.Current.CancellationToken))!;
+    }
+
+    private static async Task ExecAsync(NpgsqlConnection connection, string sql)
+    {
+        using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue(TestServerId);
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
     private static async Task DeleteTestRowsAsync(NpgsqlConnection connection)
     {
         using var cleanup = new NpgsqlCommand(
-            $"DELETE FROM collection_log WHERE server_id = {TestServerId}; DELETE FROM servers WHERE server_id = {TestServerId};", connection);
+            $"DELETE FROM collection_log WHERE server_id = {TestServerId}; " +
+            $"DELETE FROM collect.servers WHERE server_id = {TestServerId}; " +
+            $"DELETE FROM config.config_monitored_servers WHERE server_id = {TestServerId};", connection);
         await cleanup.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
     }
 }

--- a/Darling/Darling.Tests/DarlingWorkerTests.cs
+++ b/Darling/Darling.Tests/DarlingWorkerTests.cs
@@ -67,6 +67,18 @@ public sealed class DarlingWorkerTests
     }
 
     /// <summary>
+    /// The Stage 2 pause gate: the collection sweep runs only when NOT paused. This pins the gate the loop
+    /// keys off (config_service.paused -> _paused -> skip collection/alert/analysis/purge) so a future edit
+    /// can't silently invert or drop it; the command loop keeps running while paused so a resume is honored.
+    /// </summary>
+    [Fact]
+    public void ShouldRunCollection_SkipsOnlyWhenPaused()
+    {
+        Assert.True(DarlingWorker.ShouldRunCollection(paused: false));
+        Assert.False(DarlingWorker.ShouldRunCollection(paused: true));
+    }
+
+    /// <summary>
     /// A connection string that ALREADY specifies a Search Path (managed mode carries it, and a BYO
     /// operator may set their own) is returned untouched — no double-set, and a non-default choice
     /// is respected.

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingCliCommands.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingCliCommands.cs
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PerformanceMonitor.Darling.Service;
+
+/// <summary>
+/// One-shot CLI verbs the service exe supports alongside the Windows-service host — currently the
+/// <c>--test-connection</c> / <c>--validate-config</c> pre-flight (Stage 2). It loads darling.json,
+/// validates its shape, and probes EVERY configured server for reachability + permissions, reusing the SAME
+/// <see cref="DarlingServerConnector.ProbeAsync"/> path the <c>test_connect</c> command runs — so a config
+/// that validates from the CLI connects identically under the running service. Pure output formatting
+/// (<see cref="FormatProbeLine"/>) is split out so it is unit-testable without live SQL.
+/// </summary>
+public static class DarlingCliCommands
+{
+    /// <summary>The verb aliases handled by <see cref="TryGetValidateConfigVerb"/>.</summary>
+    public static bool IsValidateConfigVerb(string arg) =>
+        string.Equals(arg, "--test-connection", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(arg, "--validate-config", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Loads + validates darling.json, then probes every server. Prints one PASS/FAIL line per server and a
+    /// summary. Returns 0 only when the config is valid AND every server is reachable; 1 otherwise (so it is
+    /// usable as a deployment gate). Store/collection are never touched — this is a pure config pre-flight.
+    /// </summary>
+    public static async Task<int> ValidateConfigAsync(
+        string? configPath, TextWriter output, TextWriter error, CancellationToken cancellationToken)
+    {
+        DarlingConfig config;
+        try
+        {
+            config = DarlingConfig.Load(configPath);
+        }
+        catch (Exception ex)
+        {
+            error.WriteLine($"Could not load configuration: {ex.Message}");
+            return 1;
+        }
+
+        var problems = config.Validate();
+        if (problems.Count > 0)
+        {
+            error.WriteLine("Configuration is invalid:");
+            foreach (var problem in problems)
+            {
+                error.WriteLine("  - " + problem);
+            }
+
+            return 1;
+        }
+
+        output.WriteLine($"Validating connectivity to {config.Servers.Count} server(s)...");
+
+        var allReachable = true;
+        foreach (var server in config.Servers)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var probe = await DarlingServerConnector.ProbeAsync(server, null, cancellationToken);
+            output.WriteLine(FormatProbeLine(server.DisplayName, probe));
+            if (!probe.Success)
+            {
+                allReachable = false;
+            }
+        }
+
+        output.WriteLine(allReachable
+            ? "All servers reachable."
+            : "One or more servers failed the connection pre-flight (see above).");
+        return allReachable ? 0 : 1;
+    }
+
+    /// <summary>Formats one server's probe outcome as a PASS/FAIL line (pure — unit-testable).</summary>
+    public static string FormatProbeLine(string serverName, ConnectionProbeResult probe)
+    {
+        if (!probe.Success)
+        {
+            return $"  [FAIL] {serverName}: {probe.Error}";
+        }
+
+        var edition = string.IsNullOrEmpty(probe.EngineEditionDescription)
+            ? DarlingServerConnector.DescribeEngineEdition(probe.EngineEdition)
+            : probe.EngineEditionDescription;
+        var msdb = probe.HasMsdbAccess ? "msdb access: yes" : "msdb access: NO (failed-job alerts unavailable)";
+        return $"  [PASS] {serverName}: SQL major version {probe.MajorVersion}, {edition}, {msdb}";
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingCommandExecutor.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingCommandExecutor.cs
@@ -1,0 +1,465 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+using NpgsqlTypes;
+using PerformanceMonitor.Collectors;
+
+namespace PerformanceMonitor.Darling.Service;
+
+/// <summary>
+/// The service side of the store&lt;-&gt;service COMMAND plane (Stage 2): the Viewer (Stage 3) enqueues rows
+/// into <c>config.config_command</c>; this executor CLAIMS one at a time, EXECUTES it, and REPORTS the
+/// terminal outcome back on the same row so the Viewer can poll for the result (esp. <c>test_connect</c>'s
+/// probe facts). Mirrors <see cref="StoreConfigProvider"/>'s style: pure, testable dispatch
+/// (<see cref="ResolvePlan"/>) separated from the store I/O, failure-isolated (a bad command is reported
+/// <c>failed</c>, never thrown out of the poller).
+///
+/// <para>The claim is safe against multiple service instances: <see cref="ClaimCommandSql"/> selects the
+/// oldest <c>pending</c> row <c>FOR UPDATE SKIP LOCKED</c>, so two services polling the same store each
+/// grab a DIFFERENT row (or none) instead of racing the same one. The desired-state commands
+/// (pause/resume/enable/disable/reload) only WRITE the <c>config.*</c> tables — the bump trigger fires the
+/// <c>config_version</c> reload beacon and the worker's existing reconcile applies them; the executor never
+/// mutates the live collection loop's state directly. The imperative commands that DO need the running loop
+/// (<c>snapshot_now</c>/<c>analyze_now</c>) are delegated to the worker through
+/// <see cref="IDarlingCommandHost"/>.</para>
+/// </summary>
+public sealed class DarlingCommandExecutor
+{
+    /// <summary>
+    /// The atomic claim (the correctness-critical piece): mark the OLDEST <c>pending</c> row
+    /// <c>in_progress</c> and RETURN it, guarded by <c>FOR UPDATE SKIP LOCKED</c> in the sub-select so
+    /// concurrent service instances never claim the same row. Public const so a test can pin the shape.
+    /// </summary>
+    public const string ClaimCommandSql = @"
+UPDATE config.config_command
+SET status = 'in_progress',
+    claimed_at = now() AT TIME ZONE 'UTC',
+    service_instance = $1
+WHERE command_id = (
+    SELECT command_id
+    FROM config.config_command
+    WHERE status = 'pending'
+    ORDER BY command_id
+    LIMIT 1
+    FOR UPDATE SKIP LOCKED
+)
+RETURNING command_id, command_type, target_server_id, args_json, requested_by";
+
+    /// <summary>
+    /// Writes the terminal outcome back on the claimed row (succeeded/failed + result_status/json). Internal
+    /// so the round-trip test can pin + exercise it; $1 command_id, $2 status, $3 result_status, $4 result_json.
+    /// </summary>
+    internal const string ReportCommandSql = @"
+UPDATE config.config_command
+SET status = $2,
+    completed_at = now() AT TIME ZONE 'UTC',
+    result_status = $3,
+    result_json = $4
+WHERE command_id = $1";
+
+    private static readonly JsonSerializerOptions s_jsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true,
+    };
+
+    private readonly NpgsqlDataSource _postgres;
+    private readonly IDarlingCommandHost _host;
+    private readonly string _serviceInstance;
+    private readonly ILogger? _logger;
+
+    public DarlingCommandExecutor(NpgsqlDataSource postgres, IDarlingCommandHost host, string serviceInstance, ILogger? logger = null)
+    {
+        _postgres = postgres ?? throw new ArgumentNullException(nameof(postgres));
+        _host = host ?? throw new ArgumentNullException(nameof(host));
+        _serviceInstance = serviceInstance ?? throw new ArgumentNullException(nameof(serviceInstance));
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Claims and executes at most one pending command, reporting its outcome. Returns true if a command was
+    /// claimed (so the caller can drain a backlog by looping until it returns false). Store-unreachable and
+    /// any per-command failure are swallowed (logged) — the poller must never die for one bad tick.
+    /// </summary>
+    public async Task<bool> PollOnceAsync(CancellationToken cancellationToken)
+    {
+        ClaimedCommand? claimed;
+        try
+        {
+            claimed = await ClaimNextAsync(cancellationToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger?.LogWarning("Could not poll the command queue — will retry next tick: {Message}", ex.Message);
+            return false;
+        }
+
+        if (claimed is null)
+        {
+            return false;
+        }
+
+        await ExecuteAndReportAsync(claimed, cancellationToken);
+        return true;
+    }
+
+    /// <summary>Atomically claims the oldest pending command (or null when the queue is empty).</summary>
+    public async Task<ClaimedCommand?> ClaimNextAsync(CancellationToken cancellationToken)
+    {
+        await using var connection = await _postgres.OpenConnectionAsync(cancellationToken);
+        using var command = new NpgsqlCommand(ClaimCommandSql, connection);
+        command.Parameters.AddWithValue(_serviceInstance);
+
+        using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken))
+        {
+            return null;
+        }
+
+        return new ClaimedCommand(
+            CommandId: reader.GetInt64(0),
+            CommandType: reader.GetString(1),
+            TargetServerId: reader.IsDBNull(2) ? null : reader.GetInt32(2),
+            ArgsJson: reader.IsDBNull(3) ? null : reader.GetFieldValue<string>(3),
+            RequestedBy: reader.IsDBNull(4) ? null : reader.GetString(4));
+    }
+
+    /// <summary>
+    /// Executes one claimed command and writes its terminal result. Never throws out (an unexpected
+    /// exception is caught and reported as <c>failed</c>/<c>error</c>), so the poller keeps running.
+    /// </summary>
+    public async Task ExecuteAndReportAsync(ClaimedCommand command, CancellationToken cancellationToken)
+    {
+        CommandOutcome outcome;
+        try
+        {
+            outcome = await RunAsync(command, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError("Command {Id} ({Type}) failed: {Message}", command.CommandId, command.CommandType, ex.Message);
+            outcome = new CommandOutcome(false, "error", ErrorJson(ex.Message));
+        }
+
+        await ReportAsync(command.CommandId, outcome, cancellationToken);
+    }
+
+    private async Task<CommandOutcome> RunAsync(ClaimedCommand command, CancellationToken cancellationToken)
+    {
+        var plan = ResolvePlan(command);
+        switch (plan.Kind)
+        {
+            case CommandKind.Fail:
+                _logger?.LogWarning("Command {Id}: {Reason} (type '{Type}')", command.CommandId, plan.FailReason, command.CommandType);
+                return new CommandOutcome(false, plan.FailReason!, ErrorJson(plan.FailReason!));
+
+            case CommandKind.StoreWrite:
+                await ExecuteStoreWriteAsync(plan, cancellationToken);
+                _logger?.LogInformation("Command {Id} ({Type}) => {Result}", command.CommandId, command.CommandType, plan.SuccessStatus);
+                return new CommandOutcome(true, plan.SuccessStatus, DetailJson(plan.SuccessStatus));
+
+            case CommandKind.Probe:
+            {
+                var server = DeserializeServer(command.ArgsJson!);
+                if (server is null)
+                {
+                    return new CommandOutcome(false, "invalid args_json", ErrorJson("test_connect args_json did not deserialize to a server definition"));
+                }
+
+                var probe = await DarlingServerConnector.ProbeAsync(server, _logger, cancellationToken);
+                var (resultStatus, resultJson) = MapProbeResult(probe);
+                _logger?.LogInformation("Command {Id} (test_connect '{Server}') => {Result}", command.CommandId, server.DisplayName, resultStatus);
+                return new CommandOutcome(probe.Success, resultStatus, resultJson);
+            }
+
+            case CommandKind.Snapshot:
+                return await _host.SnapshotNowAsync(command.TargetServerId!.Value, cancellationToken);
+
+            case CommandKind.Analyze:
+                return await _host.AnalyzeNowAsync(command.TargetServerId!.Value, cancellationToken);
+
+            default:
+                return new CommandOutcome(false, "unknown command_type", ErrorJson("unknown command_type"));
+        }
+    }
+
+    /// <summary>
+    /// PURE dispatch: maps a claimed command to a plan without touching the store, so every branch — incl.
+    /// the argument-validation failures and the unknown-type fallback — is unit-testable. Store-write
+    /// commands carry their parameterized SQL (the toggled boolean is a compile-time literal, never user
+    /// input; every value is a bound parameter); the imperative/probe commands carry only a kind.
+    /// </summary>
+    internal static CommandPlan ResolvePlan(ClaimedCommand command)
+    {
+        switch ((command.CommandType ?? string.Empty).Trim().ToLowerInvariant())
+        {
+            case "pause":
+                return StoreWrite("UPDATE config.config_service SET paused = TRUE WHERE id = 1", null, "paused");
+
+            case "resume":
+                return StoreWrite("UPDATE config.config_service SET paused = FALSE WHERE id = 1", null, "resumed");
+
+            case "reload":
+                /* No state change — an UPDATE bumps config_version via the self-bump trigger, forcing the
+                   worker's next-sweep reload (an explicit resync). */
+                return StoreWrite("UPDATE config.config_service SET updated_at = now() AT TIME ZONE 'UTC' WHERE id = 1", null, "reload signaled");
+
+            case "enable_server":
+                return command.TargetServerId is int enableId
+                    ? StoreWrite(
+                        "UPDATE config.config_monitored_servers SET is_enabled = TRUE, modified_at = now() AT TIME ZONE 'UTC' WHERE server_id = $1",
+                        new object?[] { enableId }, "server enabled")
+                    : Fail("enable_server requires target_server_id");
+
+            case "disable_server":
+                return command.TargetServerId is int disableId
+                    ? StoreWrite(
+                        "UPDATE config.config_monitored_servers SET is_enabled = FALSE, modified_at = now() AT TIME ZONE 'UTC' WHERE server_id = $1",
+                        new object?[] { disableId }, "server disabled")
+                    : Fail("disable_server requires target_server_id");
+
+            case "enable_collector":
+                return ResolveCollectorToggle(command, enabled: true);
+
+            case "disable_collector":
+                return ResolveCollectorToggle(command, enabled: false);
+
+            case "test_connect":
+                return string.IsNullOrWhiteSpace(command.ArgsJson)
+                    ? Fail("test_connect requires args_json with the server definition")
+                    : new CommandPlan(CommandKind.Probe, null, null, "connected", null);
+
+            case "snapshot_now":
+                return command.TargetServerId is int
+                    ? new CommandPlan(CommandKind.Snapshot, null, null, "snapshot complete", null)
+                    : Fail("snapshot_now requires target_server_id");
+
+            case "analyze_now":
+                return command.TargetServerId is int
+                    ? new CommandPlan(CommandKind.Analyze, null, null, "analysis complete", null)
+                    : Fail("analyze_now requires target_server_id");
+
+            default:
+                return Fail("unknown command_type");
+        }
+    }
+
+    /// <summary>
+    /// enable/disable_collector -> upsert <c>config_collector_schedules.enabled</c> for the collector named in
+    /// args_json, scoped to <c>target_server_id</c> (else args_json.server_id, else fleet-wide when both are
+    /// absent). Touches ONLY the enabled column (ON CONFLICT DO UPDATE), so an existing frequency/retention
+    /// override is preserved. The two ON CONFLICT arbiters match V17's partial unique indexes (a PK cannot
+    /// span the nullable server_id).
+    /// </summary>
+    private static CommandPlan ResolveCollectorToggle(ClaimedCommand command, bool enabled)
+    {
+        var verb = enabled ? "enable_collector" : "disable_collector";
+        var collectorName = TryReadString(command.ArgsJson, "collector_name", "collectorName");
+        if (string.IsNullOrWhiteSpace(collectorName))
+        {
+            return Fail($"{verb} requires args_json.collector_name");
+        }
+
+        if (!CollectorScheduleDefaults.All.ContainsKey(collectorName))
+        {
+            return Fail($"{verb}: unknown collector '{collectorName}'");
+        }
+
+        var flag = enabled ? "TRUE" : "FALSE";
+        var successStatus = enabled ? "collector enabled" : "collector disabled";
+        var serverId = command.TargetServerId ?? TryReadInt(command.ArgsJson, "server_id", "serverId");
+
+        if (serverId is int scopedId)
+        {
+            return StoreWrite(
+                "INSERT INTO config.config_collector_schedules (server_id, collector_name, enabled) VALUES ($1, $2, " + flag + ") " +
+                "ON CONFLICT (server_id, collector_name) WHERE server_id IS NOT NULL DO UPDATE SET enabled = EXCLUDED.enabled",
+                new object?[] { scopedId, collectorName }, successStatus);
+        }
+
+        return StoreWrite(
+            "INSERT INTO config.config_collector_schedules (server_id, collector_name, enabled) VALUES (NULL, $1, " + flag + ") " +
+            "ON CONFLICT (collector_name) WHERE server_id IS NULL DO UPDATE SET enabled = EXCLUDED.enabled",
+            new object?[] { collectorName }, successStatus + " (fleet-wide)");
+    }
+
+    /// <summary>test_connect result mapping (pure): success carries the probe facts, failure the error.</summary>
+    internal static (string ResultStatus, string ResultJson) MapProbeResult(ConnectionProbeResult probe)
+    {
+        if (probe.Success)
+        {
+            var json = JsonSerializer.Serialize(new
+            {
+                success = true,
+                majorVersion = probe.MajorVersion,
+                engineEdition = probe.EngineEdition,
+                engineEditionDescription = probe.EngineEditionDescription,
+                isAzureSqlDb = probe.IsAzureSqlDb,
+                isAzureManagedInstance = probe.IsAzureManagedInstance,
+                isAwsRds = probe.IsAwsRds,
+                hasMsdbAccess = probe.HasMsdbAccess,
+            });
+            return ("connected", json);
+        }
+
+        return ("connection_failed", ErrorJson(probe.Error ?? "connection failed"));
+    }
+
+    private async Task ExecuteStoreWriteAsync(CommandPlan plan, CancellationToken cancellationToken)
+    {
+        await using var connection = await _postgres.OpenConnectionAsync(cancellationToken);
+        using var command = new NpgsqlCommand(plan.Sql, connection);
+        if (plan.Parameters is not null)
+        {
+            foreach (var parameter in plan.Parameters)
+            {
+                command.Parameters.AddWithValue(parameter ?? (object)DBNull.Value);
+            }
+        }
+
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    private async Task ReportAsync(long commandId, CommandOutcome outcome, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var connection = await _postgres.OpenConnectionAsync(cancellationToken);
+            using var command = new NpgsqlCommand(ReportCommandSql, connection);
+            command.Parameters.AddWithValue(commandId);
+            command.Parameters.AddWithValue(outcome.Success ? "succeeded" : "failed");
+            command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text, Value = (object?)outcome.ResultStatus ?? DBNull.Value });
+            command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Jsonb, Value = (object?)outcome.ResultJson ?? DBNull.Value });
+            await command.ExecuteNonQueryAsync(cancellationToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            /* Failure-isolated: a store blip writing the result must not kill the poller; the row stays
+               in_progress and a later reader can see it never terminated. */
+            _logger?.LogWarning("Could not write result for command {Id}: {Message}", commandId, ex.Message);
+        }
+    }
+
+    private static MonitoredServer? DeserializeServer(string argsJson)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<MonitoredServer>(argsJson, s_jsonOptions);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string? TryReadString(string? json, params string[] names)
+    {
+        var value = TryReadProperty(json, names);
+        return value.HasValue && value.Value.ValueKind == JsonValueKind.String ? value.Value.GetString() : null;
+    }
+
+    private static int? TryReadInt(string? json, params string[] names)
+    {
+        var value = TryReadProperty(json, names);
+        return value.HasValue && value.Value.ValueKind == JsonValueKind.Number && value.Value.TryGetInt32(out var i) ? i : null;
+    }
+
+    private static JsonElement? TryReadProperty(string? json, string[] names)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                return null;
+            }
+
+            foreach (var name in names)
+            {
+                if (document.RootElement.TryGetProperty(name, out var element))
+                {
+                    return element.Clone();
+                }
+            }
+        }
+        catch (JsonException)
+        {
+            /* Malformed args_json — the caller degrades to "missing". */
+        }
+
+        return null;
+    }
+
+    private static CommandPlan StoreWrite(string sql, object?[]? parameters, string successStatus) =>
+        new(CommandKind.StoreWrite, sql, parameters, successStatus, null);
+
+    private static CommandPlan Fail(string reason) =>
+        new(CommandKind.Fail, null, null, string.Empty, reason);
+
+    private static string ErrorJson(string error) => JsonSerializer.Serialize(new { success = false, error });
+
+    private static string DetailJson(string detail) => JsonSerializer.Serialize(new { success = true, detail });
+}
+
+/// <summary>A row claimed from <c>config.config_command</c>.</summary>
+public sealed record ClaimedCommand(long CommandId, string CommandType, int? TargetServerId, string? ArgsJson, string? RequestedBy);
+
+/// <summary>The terminal outcome written back on a command row.</summary>
+public sealed record CommandOutcome(bool Success, string ResultStatus, string? ResultJson);
+
+/// <summary>How a command is carried out — the four execution shapes plus the fail-fast fallback.</summary>
+public enum CommandKind
+{
+    /// <summary>A parameterized write to the <c>config.*</c> tables (the bump trigger drives the reload).</summary>
+    StoreWrite,
+
+    /// <summary><c>test_connect</c>: deserialize args_json, probe the server, report the facts/error.</summary>
+    Probe,
+
+    /// <summary><c>snapshot_now</c>: run the running loop's collectors for a server now (via the host).</summary>
+    Snapshot,
+
+    /// <summary><c>analyze_now</c>: force an immediate analysis pass for a server now (via the host).</summary>
+    Analyze,
+
+    /// <summary>Bad arguments or an unknown command_type — report failed without touching the store.</summary>
+    Fail,
+}
+
+/// <summary>The resolved (pure) plan for one command — see <see cref="DarlingCommandExecutor.ResolvePlan"/>.</summary>
+public sealed record CommandPlan(CommandKind Kind, string? Sql, object?[]? Parameters, string SuccessStatus, string? FailReason);
+
+/// <summary>
+/// The worker's callback surface for the two imperative commands that need the LIVE collection loop:
+/// <c>snapshot_now</c> (run a server's collectors now) and <c>analyze_now</c> (force an analysis pass now).
+/// Kept an interface so the executor's dispatch is testable with a fake host, and so the executor never
+/// reaches into the worker's mutable loop state directly.
+/// </summary>
+public interface IDarlingCommandHost
+{
+    Task<CommandOutcome> SnapshotNowAsync(int serverId, CancellationToken cancellationToken);
+
+    Task<CommandOutcome> AnalyzeNowAsync(int serverId, CancellationToken cancellationToken);
+}

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingObservability.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingObservability.cs
@@ -26,26 +26,43 @@ namespace PerformanceMonitor.Darling.Service;
 /// </summary>
 public static class DarlingObservability
 {
+    /* is_enabled is written ONLY on first insert (a server reaching a connect is enabled by definition —
+       only enabled servers are in the loop). The ON CONFLICT re-connect deliberately does NOT touch
+       is_enabled, so a control-plane disable (config_monitored_servers.is_enabled = FALSE, mirrored onto
+       this observed row by SyncServerEnabledStatesAsync) is never clobbered back to TRUE on the next
+       connect. Before Stage 2 this forced is_enabled = TRUE on every connect and nothing ever read it. */
     private const string UpsertServerSql = @"
 INSERT INTO servers (server_id, server_name, display_name, is_enabled, sql_engine_edition, sql_major_version, created_date, modified_date, monthly_cost_usd)
 VALUES ($1, $2, $3, TRUE, $4, $5, $6, $6, $7)
 ON CONFLICT (server_id) DO UPDATE SET
     server_name = EXCLUDED.server_name,
     display_name = EXCLUDED.display_name,
-    is_enabled = TRUE,
     sql_engine_edition = EXCLUDED.sql_engine_edition,
     sql_major_version = EXCLUDED.sql_major_version,
     modified_date = EXCLUDED.modified_date,
     monthly_cost_usd = EXCLUDED.monthly_cost_usd;";
+
+    /* Mirror the DESIRED enable state (config.config_monitored_servers.is_enabled) onto the OBSERVED
+       registry (collect.servers.is_enabled). A disabled server drops out of the collection loop and stops
+       upserting, so without this its observed row would keep its last (TRUE) value forever; the viewer /
+       FinOps read collect.servers, so the observed flag must track the desired one. Runs on every reload. */
+    private const string SyncEnabledStatesSql = @"
+UPDATE collect.servers s
+SET is_enabled = c.is_enabled,
+    modified_date = (now() AT TIME ZONE 'UTC')
+FROM config.config_monitored_servers c
+WHERE s.server_id = c.server_id
+  AND s.is_enabled IS DISTINCT FROM c.is_enabled;";
 
     private const string InsertCollectionLogSql = @"
 INSERT INTO collection_log (log_id, server_id, server_name, collector_name, collection_time, duration_ms, status, error_message, rows_collected, sql_duration_ms, duckdb_duration_ms)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11);";
 
     /// <summary>
-    /// Registers (or refreshes) a connected server in the registry: created_date is written only
-    /// on first insert, modified_date on every connect, and a disabled row is re-enabled — a
-    /// server present in darling.json is by definition monitored.
+    /// Registers (or refreshes) a connected server in the registry: created_date is written only on first
+    /// insert, modified_date on every connect. is_enabled is set TRUE on first insert only and left
+    /// UNTOUCHED on re-connect (Stage 2) so a control-plane disable is not resurrected — the desired enable
+    /// state is mirrored onto this observed row by <see cref="SyncServerEnabledStatesAsync"/> on each reload.
     /// </summary>
     public static async Task UpsertServerAsync(NpgsqlDataSource postgres, ServerRuntime server, ILogger? logger, CancellationToken cancellationToken)
     {
@@ -71,6 +88,32 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11);";
             /* Failure-isolated by design — an observability write must never break the collection loop. */
             logger?.LogDebug("Observability: servers upsert for '{Server}' failed: {Message}",
                 server.Config.DisplayName, ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Mirrors the DESIRED enable state (<c>config.config_monitored_servers.is_enabled</c>) onto the
+    /// OBSERVED registry (<c>collect.servers.is_enabled</c>) for every server present in both — so a
+    /// control-plane <c>disable_server</c> flips the observed row to FALSE even though the disabled server
+    /// stops upserting, and a later <c>enable_server</c> flips it back. Runs on each control-plane reload.
+    /// Failure-isolated (Debug + no-op) like the other observability writes.
+    /// </summary>
+    public static async Task SyncServerEnabledStatesAsync(NpgsqlDataSource postgres, ILogger? logger, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var connection = await postgres.OpenConnectionAsync(cancellationToken);
+            using var command = new NpgsqlCommand(SyncEnabledStatesSql, connection);
+            var changed = await command.ExecuteNonQueryAsync(cancellationToken);
+            if (changed > 0)
+            {
+                logger?.LogInformation("Synced observed enable-state for {Count} server(s) from the desired config", changed);
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            /* Failure-isolated by design — an observability write must never break the collection loop. */
+            logger?.LogDebug("Observability: server enable-state sync failed: {Message}", ex.Message);
         }
     }
 

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingServerConnector.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingServerConnector.cs
@@ -127,4 +127,83 @@ FROM sys.dm_os_sys_info";
             EngineEdition = engineEdition,
         };
     }
+
+    /// <summary>
+    /// Non-throwing connect-and-probe: runs <see cref="ConnectAsync"/> and packages the outcome as a
+    /// <see cref="ConnectionProbeResult"/> — success carries the probed version/edition/engine facts, a
+    /// failure carries the error message (never plaintext credentials). Shared by the <c>test_connect</c>
+    /// command (the Stage-3 Add-dialog validates a server BEFORE saving; the SERVICE holds the network
+    /// path + credentials) and the <c>--test-connection</c>/<c>--validate-config</c> CLI verb, so both
+    /// classify a server identically. <see cref="OperationCanceledException"/> propagates (shutdown).
+    /// </summary>
+    public static async Task<ConnectionProbeResult> ProbeAsync(MonitoredServer config, ILogger? logger, CancellationToken cancellationToken)
+    {
+        if (config is null)
+        {
+            throw new ArgumentNullException(nameof(config));
+        }
+
+        try
+        {
+            var runtime = await ConnectAsync(config, logger, cancellationToken);
+            return new ConnectionProbeResult(
+                Success: true,
+                MajorVersion: runtime.Target.SqlMajorVersion,
+                EngineEdition: runtime.EngineEdition,
+                EngineEditionDescription: DescribeEngineEdition(runtime.EngineEdition),
+                IsAzureSqlDb: runtime.Target.IsAzureSqlDb,
+                IsAzureManagedInstance: runtime.Target.IsAzureManagedInstance,
+                IsAwsRds: runtime.IsAwsRds,
+                HasMsdbAccess: runtime.HasMsdbAccess,
+                Error: null);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return new ConnectionProbeResult(
+                Success: false,
+                MajorVersion: 0,
+                EngineEdition: 0,
+                EngineEditionDescription: null,
+                IsAzureSqlDb: false,
+                IsAzureManagedInstance: false,
+                IsAwsRds: false,
+                HasMsdbAccess: false,
+                Error: ex.Message);
+        }
+    }
+
+    /// <summary>Human-readable SERVERPROPERTY('EngineEdition') description for the probe result.</summary>
+    public static string DescribeEngineEdition(int engineEdition) => engineEdition switch
+    {
+        1 => "Personal/Desktop",
+        2 => "Standard",
+        3 => "Enterprise",
+        4 => "Express",
+        5 => "Azure SQL Database",
+        6 => "Azure Synapse Analytics",
+        8 => "Azure SQL Managed Instance",
+        9 => "Azure SQL Edge",
+        11 => "Azure Synapse serverless SQL pool",
+        _ => $"Unknown ({engineEdition})",
+    };
 }
+
+/// <summary>
+/// The outcome of a connect-and-probe attempt (<see cref="DarlingServerConnector.ProbeAsync"/>): the
+/// success flag plus the probed target facts, or the error message on failure. Deliberately carries NO
+/// credentials so it is safe to serialize into <c>config_command.result_json</c> and print from the CLI.
+/// </summary>
+public sealed record ConnectionProbeResult(
+    bool Success,
+    int MajorVersion,
+    int EngineEdition,
+    string? EngineEditionDescription,
+    bool IsAzureSqlDb,
+    bool IsAzureManagedInstance,
+    bool IsAwsRds,
+    bool HasMsdbAccess,
+    string? Error);

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Globalization;
 using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
@@ -59,6 +60,13 @@ public sealed class DarlingWorker : BackgroundService
        edge-trigger gates shape delivery on top of this. */
     private static readonly TimeSpan s_alertSweepInterval = TimeSpan.FromSeconds(30);
 
+    /* The command plane's poll cadence (Stage 2): a tighter 5-second tick, run on its OWN loop
+       independent of the 15-second collection sweep and the 30-second alert sweep, so an operator
+       command (pause, test_connect, snapshot_now, ...) is picked up within ~5s and a slow command
+       (a test_connect against an unreachable host can block for the connect timeout) never starves
+       collection — the two loops share a cancellation token and the guarded server set only. */
+    private static readonly TimeSpan s_commandPollInterval = TimeSpan.FromSeconds(5);
+
     /* The analysis pipeline's per-run budget — Lite's App default hardcoded (AnalysisTimeoutSeconds
        120; not a control-plane knob). The CADENCE (interval), the enabled gate, and the notify gate
        are now control-plane knobs read live from config.Analysis (config_alert_settings' analysis
@@ -72,6 +80,14 @@ public sealed class DarlingWorker : BackgroundService
     /// <summary>Test hook: the hardcoded per-run analysis budget, pinned against Lite's default.</summary>
     internal static TimeSpan AnalysisTimeout => s_analysisTimeout;
 
+    /// <summary>
+    /// The Stage 2 pause gate: whether the collection sweep does work this tick. FALSE while the service is
+    /// paused (<c>config_service.paused</c>, mirrored into <c>_paused</c> on reload) — the loop then skips all
+    /// collection/alert/analysis/purge work but keeps polling the reload beacon and the command queue, so a
+    /// resume un-pauses it on the next tick. Pure so the gate is unit-testable without driving the loop.
+    /// </summary>
+    internal static bool ShouldRunCollection(bool paused) => !paused;
+
     private readonly ILogger<DarlingWorker> _logger;
     private readonly ILoggerFactory _loggerFactory;
 
@@ -83,6 +99,19 @@ public sealed class DarlingWorker : BackgroundService
        read by the schedule-resolution path (TryConnectAsync / RunDueCollectorsAsync) and the reload. */
     private long _lastConfigVersion = -1;
     private IReadOnlyList<ScheduleOverride> _scheduleOverrides = Array.Empty<ScheduleOverride>();
+
+    /* The service-pause flag (Stage 2): read from config_service.paused on every reload and honored by
+       the collection loop (skip collection/alert/analysis/purge while paused — Lite's IsPaused gate). Set
+       ONLY by the main loop's reload (single writer); the command loop keeps running while paused so a
+       resume command is processed. A pause/resume command writes the store, the bump trigger fires the
+       reload beacon, and the reload sets this — the same path every other control-plane setting takes. */
+    private bool _paused;
+
+    /* Guards structural access to the monitored-server list because the command loop (a concurrent task)
+       looks servers up by id while the main loop reconciles (adds/removes) them and the alert / analysis
+       plan/failed-job fetchers enumerate them. Only ever held for the microsecond lookup/mutation — never
+       across collection I/O — so a long-running command never blocks the collection loop on it. */
+    private readonly object _serversLock = new();
 
     /* Server IDs whose scheduled analysis is currently running — prevents relaunching
        analysis for a server whose previous (possibly hung) pass has not finished
@@ -120,6 +149,13 @@ public sealed class DarlingWorker : BackgroundService
            (Lite's GetTotalDataSpanHoursAsync gate), so a fresh server simply re-checks
            every interval while an already-populated store analyzes right away. */
         public DateTime NextAnalysisDue { get; set; } = DateTime.MinValue;
+
+        /* Serializes this server's collector batch so an on-demand snapshot_now (from the command loop)
+           and the scheduled sweep (from the main loop) never run the same server's collectors at once —
+           which would double-COPY overlapping rows and race the shared delta baselines. The main loop
+           try-acquires with a zero timeout (skip this server this sweep if a snapshot holds it); the
+           snapshot waits its turn. Binary (1,1). */
+        public SemaphoreSlim CollectionGate { get; } = new(1, 1);
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -301,6 +337,13 @@ public sealed class DarlingWorker : BackgroundService
             StoreConfigProvider.ApplyToConfig(config, initialView);
             _scheduleOverrides = initialView.ScheduleOverrides;
             _lastConfigVersion = initialView.ConfigVersion;
+            /* Stage 2: honor config_service.paused from the very first sweep (a service that was paused
+               before a restart comes back up paused). */
+            _paused = initialView.Paused;
+            /* Reconcile the observed collect.servers.is_enabled to the desired state up front, so a server
+               disabled in the store while the service was down shows disabled even though it never connects
+               (never upserts) this run. */
+            await DarlingObservability.SyncServerEnabledStatesAsync(postgres, _logger, stoppingToken);
             /* Post-seed the store carries darling.json's servers; fall back to the file only if the store
                read is empty (a partially-seeded store), so the service never starts up monitoring nothing. */
             if (initialView.EnabledServers.Count > 0)
@@ -342,15 +385,34 @@ public sealed class DarlingWorker : BackgroundService
            Lite's cadence); the serverId resolver is Lite's shape (the finding's int id as a
            string), no silencing predicate and no tray sink (headless). */
         var planFetcher = new PgPlanFetcher(
-            serverId => servers
-                .Select(s => s.Runtime)
-                .FirstOrDefault(r => r is not null && r.ServerId == serverId)?.ConnectionString,
+            /* Enumerated from the command loop (analyze_now) as well as the main loop, so guard the read
+               against a concurrent reconcile add/remove. Held only for the lookup, never across the fetch. */
+            serverId =>
+            {
+                lock (_serversLock)
+                {
+                    return servers
+                        .Select(s => s.Runtime)
+                        .FirstOrDefault(r => r is not null && r.ServerId == serverId)?.ConnectionString;
+                }
+            },
             _logger);
         var notificationService = new AnalysisNotificationService(
             new DarlingFindingAlertSender(alertSettings, historyStore, webhookAlertService, _logger),
             alertSettings,
             finding => finding.ServerId.ToString(CultureInfo.InvariantCulture),
             _loggerFactory.CreateLogger<AnalysisNotificationService>());
+
+        /* Command plane (Stage 2): the executor claims/executes/reports config_command rows on its OWN
+           5-second loop, concurrent with the collection sweep, so a slow command never stalls collection.
+           The host lets snapshot_now/analyze_now reach the LIVE loop (the running server set + runner +
+           analysis pieces) without the executor touching that mutable state directly; every other command
+           only writes the config.* tables and rides the reload beacon. Launched here and awaited after the
+           collection loop stops so both drain cleanly on shutdown. */
+        var commandHost = new WorkerCommandHost(this, servers, runner, planFetcher, notificationService, config);
+        var serviceInstance = $"{Environment.MachineName}:{Environment.ProcessId.ToString(CultureInfo.InvariantCulture)}";
+        var commandExecutor = new DarlingCommandExecutor(postgres, commandHost, serviceInstance, _logger);
+        var commandLoop = RunCommandLoopAsync(commandExecutor, stoppingToken);
 
         _logger.LogInformation("PerformanceMonitor Darling collection loop started");
 
@@ -366,6 +428,25 @@ public sealed class DarlingWorker : BackgroundService
             {
                 _lastConfigVersion = configVersion.Value;
                 await ReloadFromStoreAsync(configProvider, config, servers, muteRuleService, stoppingToken);
+            }
+
+            /* Stage 2 pause gate (Lite's IsPaused): while paused, skip ALL collection/alert/analysis/purge
+               work but keep looping — the reload beacon above still runs (so a resume, applied via the same
+               reload, un-pauses on the very next tick) and the command loop keeps draining commands. A
+               resume that reloaded THIS iteration already flipped _paused to false above, so it takes effect
+               immediately, not a sweep later. */
+            if (!ShouldRunCollection(_paused))
+            {
+                try
+                {
+                    await Task.Delay(s_sweepInterval, stoppingToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+
+                continue;
             }
 
             foreach (var server in servers)
@@ -437,7 +518,60 @@ public sealed class DarlingWorker : BackgroundService
             }
         }
 
+        /* Drain the concurrent command loop on shutdown (it observes the same token). */
+        try
+        {
+            await commandLoop;
+        }
+        catch (OperationCanceledException)
+        {
+            /* Expected on shutdown. */
+        }
+
         _logger.LogInformation("PerformanceMonitor Darling collection loop stopped");
+    }
+
+    /// <summary>
+    /// The command plane's poll loop (Stage 2), run concurrently with the collection sweep on its own
+    /// ~5-second tick. Each tick DRAINS every currently-pending command (claim one at a time until the
+    /// queue is empty), so a burst of viewer commands is not throttled to one per 5 seconds. Never throws
+    /// out — a per-command failure is reported on the row and swallowed by the executor — so the loop lives
+    /// for the service's lifetime. Cancellation ends it cleanly.
+    /// </summary>
+    private async Task RunCommandLoopAsync(DarlingCommandExecutor executor, CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                while (await executor.PollOnceAsync(stoppingToken))
+                {
+                    if (stoppingToken.IsCancellationRequested)
+                    {
+                        return;
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+            catch (Exception ex)
+            {
+                /* Belt-and-suspenders: PollOnceAsync already swallows its own failures, but a truly
+                   unexpected throw must not kill the loop. */
+                _logger.LogWarning("Command loop tick failed: {Message}", ex.Message);
+            }
+
+            try
+            {
+                await Task.Delay(s_commandPollInterval, stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+        }
     }
 
     /// <summary>
@@ -460,15 +594,30 @@ public sealed class DarlingWorker : BackgroundService
 
         StoreConfigProvider.ApplyToConfig(config, view);
         _scheduleOverrides = view.ScheduleOverrides;
+        /* Stage 2: honor a pause/resume issued through the store (config_service.paused) — the collection
+           loop reads this on its next tick. Single writer (this reload), so no interlock needed. */
+        _paused = view.Paused;
 
-        ReconcileServers(servers, view.EnabledServers);
+        /* Structural reconcile mutates the server list; the command loop reads it concurrently, so hold
+           the lock across the add/remove. NextDue recompute mutates only per-server state (safe against a
+           concurrent id lookup) so it stays outside the lock. */
+        lock (_serversLock)
+        {
+            ReconcileServers(servers, view.EnabledServers);
+        }
+
         RecomputeNextDue(servers);
+
+        /* Mirror the desired enable state onto the observed collect.servers registry so a disable_server
+           flips its observed row FALSE even though the disabled server drops out of the loop (stops
+           upserting), and an enable_server flips it back. */
+        await DarlingObservability.SyncServerEnabledStatesAsync(_postgres!, _logger, cancellationToken);
 
         await muteRuleService.LoadAsync();
 
         _logger.LogInformation(
-            "Control-plane reload applied (config_version {Version}, {Servers} monitored server(s))",
-            _lastConfigVersion, servers.Count);
+            "Control-plane reload applied (config_version {Version}, {Servers} monitored server(s), paused: {Paused})",
+            _lastConfigVersion, servers.Count, _paused);
     }
 
     /// <summary>
@@ -759,19 +908,46 @@ LIMIT 1", connection);
             return;
         }
 
-        var serverId = runtime.ServerId;
+        /* The scheduled caller discards the outcome — the analyze_now command maps it to a result. */
+        await RunAnalysisPassAsync(
+            runtime.ServerId, runtime.StorageName, server.Config.DisplayName,
+            planFetcher, notificationService, notifyFindings, stoppingToken);
+    }
 
-        /* Skip a server whose previous analysis is still running — a hung
-           connection that outlived its timeout would otherwise pile up tasks. */
+    /// <summary>Terminal states of one analysis pass — surfaced to the analyze_now command result.</summary>
+    private enum AnalysisPassStatus { Ran, Skipped, TimedOut, InsufficientData, Error }
+
+    private sealed record AnalysisPassResult(AnalysisPassStatus Status, int FindingCount, string? Message);
+
+    /// <summary>
+    /// One analysis pass for a server — the shared core of the scheduled sweep and the <c>analyze_now</c>
+    /// command. Lite's per-server body: the in-flight guard skips a server whose previous (possibly hung)
+    /// pass has not finished; a FRESH <see cref="DarlingAnalysisService"/> per run (IsAnalyzing is a single
+    /// instance flag); the 120-second timeout moves on without clearing the in-flight marker (the
+    /// continuation clears it only when the task truly finishes, so a hung server is not relaunched);
+    /// findings persist inside AnalyzeAsync and route to the notification channels only when delivery is on
+    /// (Lite's D0 split). Returns the terminal state so the command path can report it; the scheduled caller
+    /// ignores the return. Analyzes the STORAGE identity (Lite's GetServerNameForStorage), so a disconnected
+    /// but previously-collected server can still be analyzed on demand (its stored data drives the pass).
+    /// </summary>
+    private async Task<AnalysisPassResult> RunAnalysisPassAsync(
+        int serverId,
+        string storageName,
+        string displayName,
+        PgPlanFetcher planFetcher,
+        AnalysisNotificationService notificationService,
+        bool notifyFindings,
+        CancellationToken stoppingToken)
+    {
         if (!_analysisInFlight.TryAdd(serverId, 0))
         {
-            return;
+            return new AnalysisPassResult(AnalysisPassStatus.Skipped, 0, "analysis is already running for this server");
         }
 
         try
         {
             var analysisService = new DarlingAnalysisService(_postgres!, planFetcher, _logger);
-            var analyzeTask = analysisService.AnalyzeAsync(serverId, runtime.StorageName, hoursBack: 4);
+            var analyzeTask = analysisService.AnalyzeAsync(serverId, storageName, hoursBack: 4);
 
             /* Clear the in-flight marker only when the task truly finishes — not
                when the timeout below moves us on — so a hung server is not relaunched. */
@@ -783,15 +959,15 @@ LIMIT 1", connection);
 
             if (stoppingToken.IsCancellationRequested)
             {
-                return;
+                return new AnalysisPassResult(AnalysisPassStatus.Skipped, 0, "service is stopping");
             }
 
             if (finished != analyzeTask)
             {
                 _logger.LogWarning(
-                    "[{Server}] Scheduled analysis exceeded {Timeout}s — skipped this cycle",
-                    server.Config.DisplayName, (int)s_analysisTimeout.TotalSeconds);
-                return;
+                    "[{Server}] Analysis exceeded {Timeout}s — skipped this cycle",
+                    displayName, (int)s_analysisTimeout.TotalSeconds);
+                return new AnalysisPassResult(AnalysisPassStatus.TimedOut, 0, $"analysis exceeded {(int)s_analysisTimeout.TotalSeconds}s");
             }
 
             /* Analysis already persisted its findings inside AnalyzeAsync. Only route them
@@ -802,19 +978,106 @@ LIMIT 1", connection);
             {
                 await notificationService.NotifyAsync(findings);
             }
+
+            if (analysisService.InsufficientDataMessage is string insufficient)
+            {
+                return new AnalysisPassResult(AnalysisPassStatus.InsufficientData, 0, insufficient);
+            }
+
+            return new AnalysisPassResult(AnalysisPassStatus.Ran, findings.Count, null);
         }
         catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
         {
             /* Shutting down — the loop's own cancellation check ends the sweep. */
+            return new AnalysisPassResult(AnalysisPassStatus.Skipped, 0, "service is stopping");
         }
         catch (Exception ex)
         {
-            _logger.LogError("[{Server}] Scheduled analysis failed: {Message}",
-                server.Config.DisplayName, ex.Message);
+            _logger.LogError("[{Server}] Analysis failed: {Message}", displayName, ex.Message);
             /* If analyzeTask was never created (e.g. ctor threw), the continuation
                never ran — clear the marker defensively. */
             _analysisInFlight.TryRemove(serverId, out _);
+            return new AnalysisPassResult(AnalysisPassStatus.Error, 0, ex.Message);
         }
+    }
+
+    /// <summary>
+    /// The <c>analyze_now</c> command handler (Recommendations "Generate now", control-plane form): forces
+    /// an immediate analysis pass for one monitored server, bypassing its NextAnalysisDue wait, and maps the
+    /// terminal outcome to a command result. Shares the in-flight guard with the scheduled sweep, so it
+    /// no-ops (reported "already running") rather than racing a pass in flight for the same server.
+    /// </summary>
+    private async Task<CommandOutcome> RunAnalyzeNowAsync(
+        List<ServerLoopState> servers,
+        PgPlanFetcher planFetcher,
+        AnalysisNotificationService notificationService,
+        DarlingConfig config,
+        int serverId,
+        CancellationToken cancellationToken)
+    {
+        ServerLoopState? server;
+        lock (_serversLock)
+        {
+            server = servers.Find(s => ServerIdHelper.GetDeterministicHashCode(s.Config.StorageName) == serverId);
+        }
+
+        if (server is null)
+        {
+            return new CommandOutcome(false, "server not monitored", JsonError($"no monitored server with server_id {serverId}"));
+        }
+
+        var result = await RunAnalysisPassAsync(
+            serverId, server.Config.StorageName, server.Config.DisplayName,
+            planFetcher, notificationService, config.Analysis.NotificationsEnabled, cancellationToken);
+
+        return result.Status switch
+        {
+            AnalysisPassStatus.Ran => new CommandOutcome(true, "analysis complete",
+                JsonSerializer.Serialize(new { success = true, server = server.Config.DisplayName, findings = result.FindingCount })),
+            AnalysisPassStatus.InsufficientData => new CommandOutcome(true, "insufficient data",
+                JsonSerializer.Serialize(new { success = true, server = server.Config.DisplayName, message = result.Message })),
+            AnalysisPassStatus.Skipped => new CommandOutcome(false, "analysis already running", JsonError(result.Message ?? "skipped")),
+            AnalysisPassStatus.TimedOut => new CommandOutcome(false, "analysis timed out", JsonError(result.Message ?? "timed out")),
+            _ => new CommandOutcome(false, "analysis failed", JsonError(result.Message ?? "error")),
+        };
+    }
+
+    /// <summary>A failure result_json body: <c>{ "success": false, "error": ... }</c>.</summary>
+    private static string JsonError(string error) => JsonSerializer.Serialize(new { success = false, error });
+
+    /// <summary>
+    /// The worker's <see cref="IDarlingCommandHost"/> adapter (Stage 2): lets the command executor reach the
+    /// two imperative commands that need the LIVE loop (snapshot_now / analyze_now) without the executor
+    /// holding the worker's mutable loop state. Captures the running server set + collector runner + analysis
+    /// pieces created in <see cref="RunCollectionLoopAsync"/>; the worker methods it calls take the
+    /// <see cref="_serversLock"/> for the server lookup.
+    /// </summary>
+    private sealed class WorkerCommandHost : IDarlingCommandHost
+    {
+        private readonly DarlingWorker _worker;
+        private readonly List<ServerLoopState> _servers;
+        private readonly DarlingCollectorRunner _runner;
+        private readonly PgPlanFetcher _planFetcher;
+        private readonly AnalysisNotificationService _notificationService;
+        private readonly DarlingConfig _config;
+
+        public WorkerCommandHost(
+            DarlingWorker worker, List<ServerLoopState> servers, DarlingCollectorRunner runner,
+            PgPlanFetcher planFetcher, AnalysisNotificationService notificationService, DarlingConfig config)
+        {
+            _worker = worker;
+            _servers = servers;
+            _runner = runner;
+            _planFetcher = planFetcher;
+            _notificationService = notificationService;
+            _config = config;
+        }
+
+        public Task<CommandOutcome> SnapshotNowAsync(int serverId, CancellationToken cancellationToken)
+            => _worker.RunSnapshotAsync(_servers, _runner, serverId, cancellationToken);
+
+        public Task<CommandOutcome> AnalyzeNowAsync(int serverId, CancellationToken cancellationToken)
+            => _worker.RunAnalyzeNowAsync(_servers, _planFetcher, _notificationService, _config, serverId, cancellationToken);
     }
 
     /// <summary>
@@ -828,10 +1091,17 @@ LIMIT 1", connection);
     private async Task<List<FailedJobInfo>> FetchFailedJobsAsync(
         List<ServerLoopState> servers, string serverKey, int lookbackMinutes, CancellationToken cancellationToken)
     {
-        var runtime = servers
-            .Select(s => s.Runtime)
-            .FirstOrDefault(r => r is not null
-                && string.Equals(r.ServerId.ToString(CultureInfo.InvariantCulture), serverKey, StringComparison.Ordinal));
+        /* Lookup only — held briefly under the lock (the command loop reconciles the list concurrently),
+           then the connection I/O runs outside it. */
+        ServerRuntime? runtime;
+        lock (_serversLock)
+        {
+            runtime = servers
+                .Select(s => s.Runtime)
+                .FirstOrDefault(r => r is not null
+                    && string.Equals(r.ServerId.ToString(CultureInfo.InvariantCulture), serverKey, StringComparison.Ordinal));
+        }
+
         if (runtime is null || runtime.Target.IsAzureSqlDb)
         {
             return new List<FailedJobInfo>();
@@ -890,7 +1160,12 @@ LIMIT 1", connection);
             /* On-load config snapshots (effective FrequencyMinutes 0) run once per connect, then every
                scheduled collector becomes immediately due — mirrors Lite's server-open behavior. The
                effective schedule layers config_collector_schedules overrides on CollectorScheduleDefaults;
-               a collector disabled by an override is neither run on-load nor scheduled. */
+               a collector disabled by an override is neither run on-load nor scheduled.
+
+               These on-load runs are NOT under the per-server CollectionGate (unlike the scheduled sweep and
+               snapshot_now). Safe today: this path only runs while Runtime is null, and a snapshot_now needs
+               a non-null Runtime, so the two never overlap for one server. If TryConnect's timing ever changes
+               so a connect can race a snapshot, gate this loop too. */
             var now = DateTime.UtcNow;
             foreach (var name in CollectorScheduleDefaults.All.Keys)
             {
@@ -926,37 +1201,131 @@ LIMIT 1", connection);
             return;
         }
 
-        var now = DateTime.UtcNow;
-        foreach (var name in CollectorScheduleDefaults.All.Keys)
+        /* Non-blocking: if an on-demand snapshot_now holds this server's gate, skip its scheduled sweep
+           this pass (the due collectors run next sweep) — the main loop NEVER blocks on the gate, so a
+           long snapshot cannot starve collection of the OTHER servers. */
+        if (!await server.CollectionGate.WaitAsync(0, cancellationToken))
         {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return;
-            }
+            return;
+        }
 
-            /* Effective schedule = config_collector_schedules override layered on the code default.
-               A disabled or on-load-only (freq 0) collector is skipped; the frequency the NextDue stamp
-               advances by is the EFFECTIVE one, so an override takes effect immediately. */
-            var effective = StoreConfigProvider.ResolveSchedule(name, runtime.ServerId, _scheduleOverrides);
-            if (!effective.Enabled
-                || effective.FrequencyMinutes == 0
-                || !server.NextDue.TryGetValue(name, out var due)
-                || now < due)
+        try
+        {
+            var now = DateTime.UtcNow;
+            foreach (var name in CollectorScheduleDefaults.All.Keys)
             {
-                continue;
-            }
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
 
-            server.NextDue[name] = now.AddMinutes(effective.FrequencyMinutes);
-            await RunOneAsync(server, runner, name, cancellationToken);
+                /* Effective schedule = config_collector_schedules override layered on the code default.
+                   A disabled or on-load-only (freq 0) collector is skipped; the frequency the NextDue stamp
+                   advances by is the EFFECTIVE one, so an override takes effect immediately. */
+                var effective = StoreConfigProvider.ResolveSchedule(name, runtime.ServerId, _scheduleOverrides);
+                if (!effective.Enabled
+                    || effective.FrequencyMinutes == 0
+                    || !server.NextDue.TryGetValue(name, out var due)
+                    || now < due)
+                {
+                    continue;
+                }
+
+                server.NextDue[name] = now.AddMinutes(effective.FrequencyMinutes);
+                await RunOneAsync(server, runner, name, cancellationToken);
+            }
+        }
+        finally
+        {
+            server.CollectionGate.Release();
         }
     }
 
-    private async Task RunOneAsync(ServerLoopState server, DarlingCollectorRunner runner, string collectorName, CancellationToken cancellationToken)
+    /// <summary>
+    /// The <c>snapshot_now</c> command handler (Lite's Live Snapshot, control-plane form): runs EVERY
+    /// enabled collector for one connected server immediately, bypassing the schedule, and reports the
+    /// collectors run + total rows. Serialized against the scheduled sweep by the per-server
+    /// <see cref="ServerLoopState.CollectionGate"/> so the two never double-collect. Waits its turn for the
+    /// gate (unlike the main loop, which skips) because an explicit operator snapshot should not be dropped.
+    /// </summary>
+    private async Task<CommandOutcome> RunSnapshotAsync(
+        List<ServerLoopState> servers, DarlingCollectorRunner runner, int serverId, CancellationToken cancellationToken)
+    {
+        ServerLoopState? server;
+        lock (_serversLock)
+        {
+            server = servers.Find(s => ServerIdHelper.GetDeterministicHashCode(s.Config.StorageName) == serverId);
+        }
+
+        if (server is null)
+        {
+            return new CommandOutcome(false, "server not monitored", JsonError($"no monitored server with server_id {serverId}"));
+        }
+
+        if (server.Runtime is null)
+        {
+            return new CommandOutcome(false, "server not connected",
+                JsonError($"server '{server.Config.DisplayName}' is not currently connected — snapshot skipped"));
+        }
+
+        await server.CollectionGate.WaitAsync(cancellationToken);
+        try
+        {
+            /* Runtime can be dropped by a concurrent connection failure between the check above and here;
+               re-read under the gate. */
+            var runtime = server.Runtime;
+            if (runtime is null)
+            {
+                return new CommandOutcome(false, "server not connected",
+                    JsonError($"server '{server.Config.DisplayName}' disconnected before the snapshot ran"));
+            }
+
+            var collectorsRun = 0;
+            var totalRows = 0;
+            foreach (var name in CollectorScheduleDefaults.All.Keys)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                /* Honor a disabled-by-override collector (mirrors the on-load/scheduled gates); run every
+                   enabled one NOW regardless of frequency or NextDue — that is what "snapshot" means. */
+                var effective = StoreConfigProvider.ResolveSchedule(name, runtime.ServerId, _scheduleOverrides);
+                if (!effective.Enabled)
+                {
+                    continue;
+                }
+
+                totalRows += await RunOneAsync(server, runner, name, cancellationToken);
+                collectorsRun++;
+            }
+
+            _logger.LogInformation("[{Server}] snapshot_now ran {Collectors} collector(s), {Rows} row(s)",
+                server.Config.DisplayName, collectorsRun, totalRows);
+            var json = JsonSerializer.Serialize(new
+            {
+                success = true,
+                server = server.Config.DisplayName,
+                collectorsRun,
+                rows = totalRows,
+            });
+            return new CommandOutcome(true, "snapshot complete", json);
+        }
+        finally
+        {
+            server.CollectionGate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Runs one collector for a server and logs its outcome to collection_log. Returns the rows written
+    /// (0 on skip/permissions/error) so an on-demand snapshot can tally them; the scheduled/on-load callers
+    /// simply discard the count.
+    /// </summary>
+    private async Task<int> RunOneAsync(ServerLoopState server, DarlingCollectorRunner runner, string collectorName, CancellationToken cancellationToken)
     {
         var runtime = server.Runtime;
         if (runtime is null || !s_dispatch.TryGetValue(collectorName, out var run))
         {
-            return;
+            return 0;
         }
 
         try
@@ -967,6 +1336,7 @@ LIMIT 1", connection);
 
             await DarlingObservability.LogCollectionAsync(
                 _postgres!, runtime, collectorName, "SUCCESS", result.Rows, result.SqlMs, result.StorageMs, null, _logger, cancellationToken);
+            return result.Rows;
         }
         catch (OperationCanceledException)
         {
@@ -979,6 +1349,7 @@ LIMIT 1", connection);
 
             await DarlingObservability.LogCollectionAsync(
                 _postgres!, runtime, collectorName, "PERMISSIONS", 0, 0, 0, ex.Message, _logger, cancellationToken);
+            return 0;
         }
         catch (Exception ex)
         {
@@ -995,6 +1366,7 @@ LIMIT 1", connection);
 
             await DarlingObservability.LogCollectionAsync(
                 _postgres!, runtime, collectorName, "ERROR", 0, 0, 0, ex.Message, _logger, cancellationToken);
+            return 0;
         }
     }
 

--- a/Darling/PerformanceMonitor.Darling.Service/Program.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Program.cs
@@ -7,6 +7,7 @@
  */
 
 using System;
+using System.Threading;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using PerformanceMonitor.Darling.Service;
@@ -33,6 +34,15 @@ if (args.Length > 0 && string.Equals(args[0], "--encrypt-password", StringCompar
     Console.WriteLine(DarlingSecrets.Protect(plaintext));
     Console.Error.WriteLine("Paste the line above into the server's \"encryptedPassword\" in darling.json.");
     return 0;
+}
+
+/* CLI verb: validate darling.json and probe every configured server (reachability + permission pre-flight),
+   reusing the same DarlingServerConnector probe the test_connect command runs. Optional second arg = an
+   explicit config path (else the usual DARLING_CONFIG / next-to-binary resolution). Exit 0 iff all pass. */
+if (args.Length > 0 && DarlingCliCommands.IsValidateConfigVerb(args[0]))
+{
+    var configPath = args.Length > 1 ? args[1] : null;
+    return await DarlingCliCommands.ValidateConfigAsync(configPath, Console.Out, Console.Error, CancellationToken.None);
 }
 
 var builder = Host.CreateApplicationBuilder(args);

--- a/Darling/README.md
+++ b/Darling/README.md
@@ -89,6 +89,16 @@ It prompts for the password on stdin (so the plaintext never lands in your shell
 
 **excludedDatabases** (per server) removes databases from collection: per-database collectors skip them and the exclusion is spliced into the collector queries — the same filter Lite applies. There is a second, separate `alerts.excludedDatabases` list that excludes databases from blocking/deadlock/long-running-query **alert evaluation** without affecting collection.
 
+### Validate the Config (Pre-flight)
+
+Before installing the service, check that `darling.json` is well-formed and that every monitored server is reachable with the configured credentials:
+
+```
+PerformanceMonitor.Darling.Service.exe --test-connection
+```
+
+(`--validate-config` is an alias.) It validates the file, then connects to and probes each server, printing a `[PASS]`/`[FAIL]` line per server (SQL major version, engine edition, and whether the account has msdb access for failed-job alerts). It exits `0` only when the file is valid **and** every server is reachable, so it doubles as a deployment gate. Add an explicit config path as a second argument if `darling.json` is not next to the exe and `DARLING_CONFIG` is not set. This is the same probe the Viewer's **Test Connection** button runs through the service.
+
 ### Run It — Console Mode
 
 The same executable serves interactive debugging and service installation; the Windows-service lifetime is a no-op when run from a console.


### PR DESCRIPTION
## Stage 2 of the Darling store↔service control-plane channel

Stage 1 (merged, #1408) gave the service a store-backed live config: the V17 `config.*` schema, `StoreConfigProvider`, the `config_version` reload beacon, and the server-set reconcile. **Stage 2 makes the service HONOR the imperative commands** the Stage-3 viewer will enqueue into `config.config_command` — it CLAIMS, EXECUTES, and REPORTS each — and closes the two `is_enabled`/`paused` gaps Stage 1 deliberately left. No viewer changes (that's Stage 3), no self-alerts (Stage 4), no FinOps rewire (Stage 5).

### What's built

**Command poller** — a new concurrent ~5s loop (`DarlingWorker.RunCommandLoopAsync`), independent of the 15s collection sweep and 30s alert sweep, so a slow command (e.g. a `test_connect` against an unreachable host) never starves collection. It atomically claims the oldest pending row:

```
UPDATE config.config_command SET status='in_progress', claimed_at=now() AT TIME ZONE 'UTC', service_instance=$1
WHERE command_id = (SELECT command_id FROM config.config_command WHERE status='pending'
                    ORDER BY command_id LIMIT 1 FOR UPDATE SKIP LOCKED)
RETURNING ...
```

`FOR UPDATE SKIP LOCKED` on the sub-select makes it safe against multiple service instances (each claims a *different* row or none). Each command's terminal outcome (`status` succeeded/failed, `completed_at`, `result_status`, `result_json`) is written back so the viewer can poll the row.

**Command executor** (`DarlingCommandExecutor`, mirroring `StoreConfigProvider`'s style — pure `ResolvePlan` dispatch separated from store I/O):

| command_type | behavior |
|---|---|
| `pause` / `resume` | set `config_service.paused`; the loop now **gates collection on it** (Lite's `IsPaused`) — skips collection/alert/analysis/purge while paused but keeps polling the beacon + draining commands so resume works |
| `test_connect` | build a `MonitoredServer` from `args_json`, `DarlingServerConnector.ConnectAsync`, write version/edition/engine facts (or the error) to `result_json` — how the Stage-3 Add dialog validates a server before saving |
| `enable_server` / `disable_server` | set `config_monitored_servers.is_enabled` (the reload reconcile drops a disabled server) |
| `enable_collector` / `disable_collector` | upsert `config_collector_schedules.enabled` (fleet-wide or per-server; ON CONFLICT touches only `enabled`, preserving any freq/retention override) |
| `snapshot_now` | run every enabled collector for a server now (Lite's Live Snapshot), serialized against the sweep by a per-server `CollectionGate` |
| `analyze_now` | force an analysis pass now, bypassing `NextAnalysisDue` (Recommendations "Generate now"), sharing the `_analysisInFlight` guard with the scheduled path |
| `reload` | bump `config_version` to force a resync |
| *unknown* | reported `failed` / `"unknown command_type"`, **never thrown out of the poller** |

**`is_enabled` un-clobber** — `UpsertServerAsync` no longer forces `collect.servers.is_enabled = TRUE` on re-connect, and a new `SyncServerEnabledStatesAsync` mirrors the desired `config_monitored_servers.is_enabled` onto the observed registry on each reload. So a `disable_server` actually stops collection (reconcile drops it), the observed registry the viewer/FinOps read reflects it, and the next connect no longer resurrects it.

**CLI verb** — `--test-connection` / `--validate-config` validates `darling.json` and probes every server (reachability + msdb permission pre-flight), printing a `[PASS]`/`[FAIL]` line each and exiting non-zero on any failure. It reuses the **same** `DarlingServerConnector.ProbeAsync` helper as the `test_connect` command, so what validates from the CLI connects identically under the service. README documented.

### Claim safety / concurrency

The command loop and the collection sweep share only the monitored-server list — guarded by `_serversLock` for every command-loop-reachable access (held only for microsecond lookups, never across I/O) — and a per-server `CollectionGate` semaphore that serializes `snapshot_now` against the scheduled sweep (the main loop try-acquires with a 0 timeout, so it never blocks on a long snapshot). `pause` is a single-writer flag set only by the reload. A code-review pass (concurrency-focused) confirmed acquire/release balance on all paths, the claim's multi-instance safety, correct reader/RETURNING column mapping vs the V17 schema, and no resource leaks.

### Tests

- `DarlingCommandExecutorTests` — claim-SQL shape pin (FOR UPDATE SKIP LOCKED / FIFO / RETURNING), per-command dispatch incl. `unknown → failed` and arg validation, `test_connect` result mapping; live-PG-gated: claim FIFO, pause/resume store effect + `config_version` bump, execute/report round-trip, unknown → failed.
- `DarlingCliCommandsTests` — verb recognition + PASS/FAIL formatting + edition describer.
- `DarlingWorkerTests` — `ShouldRunCollection` pause-gate pin.
- `DarlingObservabilityTests` — live-PG: enable-state sync mirrors desired→observed, and re-connect does not re-enable a disabled row.

**Darling.Tests -c Release: 957 passed, 97 skipped (live-PG gated on `DARLING_TEST_PG`, expected), 0 failed.** Whole Darling solution compiles in Release.

Plan doc: `plans/darling-control-plane-plan.md` (Stage 2). Do not merge — for lead review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
