### PR TITLE
Add per-object execution-history drill-down windows to the Darling viewer

### DIFF
--- a/Darling/Darling.Tests/ViewerHistoryWindowTests.cs
+++ b/Darling/Darling.Tests/ViewerHistoryWindowTests.cs
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using PerformanceMonitor.Darling.Viewer;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Pins the per-row double-click execution-history drill-down windows (parity-gap "Per-row double-click history
+/// windows missing on all 3 query grids" + port-candidate "Per-object execution-history drill-downs"): the
+/// three fuller history SQL reads' shape + parameterization, the row models' delta / average / total
+/// derivations, the metric-selector chart projection, and the row → window-parameter mapping (which fields
+/// identify the double-clicked item, and when a row can't open a window). Pure logic + SQL pins only — no live
+/// Postgres, and nothing here touches <see cref="ViewerTimeHelper"/>'s process-wide statics.
+/// </summary>
+public sealed class ViewerHistoryWindowTests
+{
+    // ── History reads' SQL shape (both-sides window-bound, positional PG params) ──
+
+    [Fact]
+    public void QueryStatsHistorySql_FiltersOneQueryHashOverTheWindow_OrderedByTime()
+    {
+        var sql = ViewerDataService.QueryStatsHistorySql;
+        Assert.Contains("FROM query_stats", sql, StringComparison.Ordinal);
+        Assert.Contains("server_id = $1", sql, StringComparison.Ordinal);
+        Assert.Contains("database_name = $2", sql, StringComparison.Ordinal);
+        Assert.Contains("query_hash = $3", sql, StringComparison.Ordinal);
+        Assert.Contains("collection_time >= $4", sql, StringComparison.Ordinal);
+        Assert.Contains("collection_time <= $5", sql, StringComparison.Ordinal);
+        Assert.Contains("ORDER BY collection_time", sql, StringComparison.Ordinal);
+        /* The window needs the delta, cumulative, and min/max columns the narrow overlay read lacks. */
+        Assert.Contains("delta_worker_time", sql, StringComparison.Ordinal);
+        Assert.Contains("total_worker_time", sql, StringComparison.Ordinal);
+        Assert.Contains("min_grant_kb", sql, StringComparison.Ordinal);
+        Assert.Contains("sample_interval_seconds", sql, StringComparison.Ordinal);
+        AssertPgPositionalDialect(sql);
+    }
+
+    [Fact]
+    public void ProcStatsHistorySql_FiltersOneSchemaObjectOverTheWindow_AndDerivesTheInterval()
+    {
+        var sql = ViewerDataService.ProcStatsHistorySql;
+        Assert.Contains("FROM procedure_stats", sql, StringComparison.Ordinal);
+        Assert.Contains("server_id = $1", sql, StringComparison.Ordinal);
+        Assert.Contains("database_name = $2", sql, StringComparison.Ordinal);
+        Assert.Contains("schema_name = $3", sql, StringComparison.Ordinal);
+        Assert.Contains("object_name = $4", sql, StringComparison.Ordinal);
+        Assert.Contains("collection_time >= $5", sql, StringComparison.Ordinal);
+        Assert.Contains("collection_time <= $6", sql, StringComparison.Ordinal);
+        Assert.Contains("ORDER BY collection_time", sql, StringComparison.Ordinal);
+        /* procedure_stats has no sample_interval_seconds column — it's derived from the previous row's gap. */
+        Assert.Contains("LAG(collection_time)", sql, StringComparison.Ordinal);
+        Assert.Contains("total_spills", sql, StringComparison.Ordinal);
+        AssertPgPositionalDialect(sql);
+    }
+
+    [Fact]
+    public void QueryStoreHistorySql_IsQueryScoped_AcrossEveryPlan_OverTheWindow()
+    {
+        var sql = ViewerDataService.QueryStoreHistorySql;
+        Assert.Contains("FROM query_store_stats", sql, StringComparison.Ordinal);
+        Assert.Contains("server_id = $1", sql, StringComparison.Ordinal);
+        Assert.Contains("database_name = $2", sql, StringComparison.Ordinal);
+        Assert.Contains("query_id = $3", sql, StringComparison.Ordinal);
+        Assert.Contains("collection_time >= $4", sql, StringComparison.Ordinal);
+        Assert.Contains("collection_time <= $5", sql, StringComparison.Ordinal);
+        Assert.Contains("ORDER BY collection_time", sql, StringComparison.Ordinal);
+        /* Query-scoped, NOT plan-filtered — plan_id rides back so the chart draws one series per plan. */
+        Assert.DoesNotContain("plan_id = $", sql, StringComparison.Ordinal);
+        Assert.Contains("plan_id", sql, StringComparison.Ordinal);
+        Assert.Contains("is_forced_plan", sql, StringComparison.Ordinal);
+        AssertPgPositionalDialect(sql);
+    }
+
+    // ── Row model derivations (delta µs → ms, per-execution averages, cumulative totals) ──
+
+    [Fact]
+    public void QueryStatsHistoryRow_ConvertsMicrosecondsAndDividesByExecutionDelta()
+    {
+        var row = new ViewerQueryStatsHistoryRow
+        {
+            DeltaExecutions = 10,
+            DeltaCpuUs = 5_000,           // 5 ms across 10 execs → 0.5 ms avg
+            DeltaElapsedUs = 20_000,      // 20 ms across 10 execs → 2 ms avg
+            DeltaLogicalReads = 500,      // 50 avg
+            MinCpuUs = 2_000,             // 2 ms
+            MaxCpuUs = 9_000,             // 9 ms
+            TotalCpuUs = 100_000,         // 100 ms
+            TotalClrTimeUs = 3_000,       // 3 ms
+        };
+
+        Assert.Equal(5.0, row.DeltaCpuMs, precision: 6);
+        Assert.Equal(20.0, row.DeltaElapsedMs, precision: 6);
+        Assert.Equal(0.5, row.AvgCpuMs, precision: 6);
+        Assert.Equal(2.0, row.AvgElapsedMs, precision: 6);
+        Assert.Equal(50.0, row.AvgReads, precision: 6);
+        Assert.Equal(2.0, row.MinCpuMs, precision: 6);
+        Assert.Equal(9.0, row.MaxCpuMs, precision: 6);
+        Assert.Equal(100.0, row.TotalCpuMs, precision: 6);
+        Assert.Equal(3.0, row.TotalClrMs, precision: 6);
+    }
+
+    [Fact]
+    public void QueryStatsHistoryRow_ZeroExecutionDelta_YieldsZeroAverages_NoDivideByZero()
+    {
+        var row = new ViewerQueryStatsHistoryRow { DeltaExecutions = 0, DeltaCpuUs = 5_000, DeltaLogicalReads = 99 };
+        Assert.Equal(0.0, row.AvgCpuMs);
+        Assert.Equal(0.0, row.AvgReads);
+        Assert.Equal(5.0, row.DeltaCpuMs, precision: 6); // the delta itself is still surfaced
+    }
+
+    [Fact]
+    public void ProcedureHistoryRow_DerivesMinCpuFromWorkerTime_AndAvgSpills()
+    {
+        var row = new ViewerProcedureStatsHistoryRow
+        {
+            DeltaExecutions = 4,
+            DeltaSpills = 8,               // 2 avg
+            MinWorkerTimeUs = 1_500,      // 1.5 ms
+            MaxWorkerTimeUs = 6_000,      // 6 ms
+            TotalCpuUs = 40_000,          // 40 ms
+        };
+
+        Assert.Equal(2.0, row.AvgSpills, precision: 6);
+        Assert.Equal(1.5, row.MinCpuMs, precision: 6);
+        Assert.Equal(6.0, row.MaxCpuMs, precision: 6);
+        Assert.Equal(40.0, row.TotalCpuMs, precision: 6);
+    }
+
+    [Fact]
+    public void QueryStoreHistoryRow_TotalsScalePerExecutionAveragesByExecutionCount()
+    {
+        var row = new ViewerQueryStoreHistoryRow { ExecutionCount = 25, AvgDurationMs = 4, AvgCpuTimeMs = 2 };
+        Assert.Equal(100.0, row.TotalDurationMs, precision: 6);
+        Assert.Equal(50.0, row.TotalCpuMs, precision: 6);
+    }
+
+    // ── Metric-selector chart projection (each window's GetMetricValue switch) ──
+
+    [Fact]
+    public void QueryStatsGetMetricValue_MapsEachSelectorTag_UnknownFallsBackToAvgCpu()
+    {
+        var row = new ViewerQueryStatsHistoryRow
+        {
+            DeltaExecutions = 2, DeltaCpuUs = 4_000, DeltaLogicalReads = 6, DeltaSpills = 3,
+        };
+        Assert.Equal(row.AvgCpuMs, QueryStatsHistoryWindow.GetMetricValue(row, "AvgCpuMs"), precision: 6);
+        Assert.Equal(row.AvgReads, QueryStatsHistoryWindow.GetMetricValue(row, "AvgReads"), precision: 6);
+        Assert.Equal(row.DeltaExecutions, QueryStatsHistoryWindow.GetMetricValue(row, "DeltaExecutions"), precision: 6);
+        Assert.Equal(row.DeltaCpuMs, QueryStatsHistoryWindow.GetMetricValue(row, "DeltaCpuMs"), precision: 6);
+        Assert.Equal(row.DeltaSpills, QueryStatsHistoryWindow.GetMetricValue(row, "DeltaSpills"), precision: 6);
+        Assert.Equal(row.AvgCpuMs, QueryStatsHistoryWindow.GetMetricValue(row, "not-a-metric"), precision: 6);
+    }
+
+    [Fact]
+    public void QueryStoreGetMetricValue_MapsTotalsAndExecutionCount()
+    {
+        var row = new ViewerQueryStoreHistoryRow { ExecutionCount = 7, AvgDurationMs = 3, AvgCpuTimeMs = 1.5 };
+        Assert.Equal(row.TotalDurationMs, QueryStoreHistoryWindow.GetMetricValue(row, "TotalDurationMs"), precision: 6);
+        Assert.Equal(row.TotalCpuMs, QueryStoreHistoryWindow.GetMetricValue(row, "TotalCpuMs"), precision: 6);
+        Assert.Equal(row.ExecutionCount, QueryStoreHistoryWindow.GetMetricValue(row, "ExecutionCount"), precision: 6);
+        Assert.Equal(row.AvgCpuTimeMs, QueryStoreHistoryWindow.GetMetricValue(row, "unknown"), precision: 6);
+    }
+
+    // ── Row → window-parameter mapping (the fields that identify the double-clicked item) ──
+
+    [Fact]
+    public void MapQueryStatsHistoryKey_CarriesDbHashAndText_WhenBothKeyFieldsPresent()
+    {
+        var key = ViewerServerTab.MapQueryStatsHistoryKey(new ViewerQueryStatsRow
+        {
+            DatabaseName = "Sales", QueryHash = "0xABCD", QueryText = "SELECT 1",
+        });
+        Assert.NotNull(key);
+        Assert.Equal("Sales", key!.DatabaseName);
+        Assert.Equal("0xABCD", key.QueryHash);
+        Assert.Equal("SELECT 1", key.QueryText);
+    }
+
+    [Theory]
+    [InlineData("", "0xABCD")]  // no database
+    [InlineData("Sales", "")]   // no query hash
+    public void MapQueryStatsHistoryKey_ReturnsNull_WhenAKeyFieldIsMissing(string db, string hash)
+        => Assert.Null(ViewerServerTab.MapQueryStatsHistoryKey(
+            new ViewerQueryStatsRow { DatabaseName = db, QueryHash = hash }));
+
+    [Fact]
+    public void MapProcedureHistoryKey_CarriesDbSchemaObject_WhenDbAndObjectPresent()
+    {
+        var key = ViewerServerTab.MapProcedureHistoryKey(new ViewerProcedureStatsRow
+        {
+            DatabaseName = "Sales", SchemaName = "dbo", ObjectName = "usp_Get",
+        });
+        Assert.NotNull(key);
+        Assert.Equal("Sales", key!.DatabaseName);
+        Assert.Equal("dbo", key.SchemaName);
+        Assert.Equal("usp_Get", key.ObjectName);
+    }
+
+    [Theory]
+    [InlineData("", "usp_Get")]  // no database
+    [InlineData("Sales", "")]    // no object name
+    public void MapProcedureHistoryKey_ReturnsNull_WhenAKeyFieldIsMissing(string db, string obj)
+        => Assert.Null(ViewerServerTab.MapProcedureHistoryKey(
+            new ViewerProcedureStatsRow { DatabaseName = db, ObjectName = obj }));
+
+    [Fact]
+    public void MapQueryStoreHistoryKey_CarriesDbQueryIdPlanIdText_WhenDbAndQueryIdPresent()
+    {
+        var key = ViewerServerTab.MapQueryStoreHistoryKey(new ViewerQueryStoreRow
+        {
+            DatabaseName = "Sales", QueryId = 42, PlanId = 7, QueryText = "SELECT 2",
+        });
+        Assert.NotNull(key);
+        Assert.Equal("Sales", key!.DatabaseName);
+        Assert.Equal(42, key.QueryId);
+        Assert.Equal(7, key.PlanId);
+        Assert.Equal("SELECT 2", key.QueryText);
+    }
+
+    [Theory]
+    [InlineData("", 42)]      // no database
+    [InlineData("Sales", 0)]  // no query_id
+    public void MapQueryStoreHistoryKey_ReturnsNull_WhenAKeyFieldIsMissing(string db, long queryId)
+        => Assert.Null(ViewerServerTab.MapQueryStoreHistoryKey(
+            new ViewerQueryStoreRow { DatabaseName = db, QueryId = queryId }));
+
+    // ── Shared PG positional-dialect assertion (mirrors ViewerDrillDownTests) ──
+
+    private static void AssertPgPositionalDialect(string sql)
+    {
+        Assert.DoesNotContain("@", sql, StringComparison.Ordinal);   // no T-SQL named params
+        Assert.DoesNotContain("N'", sql, StringComparison.Ordinal);  // no T-SQL unicode literals
+        Assert.Contains("$1", sql, StringComparison.Ordinal);
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ProcedureHistoryWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ProcedureHistoryWindow.xaml
@@ -1,0 +1,145 @@
+<Window x:Class="PerformanceMonitor.Darling.Viewer.ProcedureHistoryWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:scottplot="clr-namespace:ScottPlot.WPF;assembly=ScottPlot.WPF"
+        Title="Procedure Execution History" Width="1200" Height="800"
+        WindowStartupLocation="CenterOwner"
+        Icon="EDD.ico"
+        TextOptions.TextFormattingMode="Display"
+        UseLayoutRounding="True"
+        Background="#22252b"
+        Foreground="#E4E6EB">
+    <!-- Ported from Lite's Windows/ProcedureHistoryWindow.xaml (the Top Procedures per-row double-click
+         history window): the selected procedure's metric trend chart + a filterable grid of its per-collection
+         snapshots. Data repointed to ViewerDataService Postgres reads; "View Plan" / the per-row Download
+         button surface the STORED plan (GetProcedureStatsPlanXmlAsync). Procedures were already View-Plan-only
+         in Lite (re-executing a proc without parameter values is unsafe), so nothing extra is dropped here. -->
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="ViewerDarkTheme.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+
+            <Style x:Key="NumericCell" TargetType="TextBlock">
+                <Setter Property="TextAlignment" Value="Right"/>
+            </Style>
+
+            <ContextMenu x:Key="DataGridContextMenu">
+                <MenuItem Header="Copy Cell" Click="CopyCell_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy Row" Click="CopyRow_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4C4;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4D1;"/></MenuItem.Icon>
+                </MenuItem>
+                <Separator/>
+                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
+                </MenuItem>
+                <Separator/>
+                <MenuItem Header="View Plan" Click="ViewPlan_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F50D;"/></MenuItem.Icon>
+                </MenuItem>
+            </ContextMenu>
+        </ResourceDictionary>
+    </Window.Resources>
+
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="250"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,10">
+            <TextBlock x:Name="ProcIdentifierText" FontSize="16" FontWeight="Bold"/>
+            <TextBlock x:Name="SummaryText" FontSize="12" Margin="0,4,0,0" Foreground="#B8BCC4"/>
+        </StackPanel>
+
+        <!-- Chart -->
+        <Border Grid.Row="1" Background="#111217" BorderBrush="#2a2d35" BorderThickness="1" CornerRadius="3">
+            <Grid>
+                <ComboBox x:Name="MetricSelector" Width="180" Height="26"
+                          VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0,6,10,0"
+                          SelectionChanged="MetricSelector_SelectionChanged">
+                    <ComboBoxItem Content="Avg CPU (ms)" Tag="AvgCpuMs" IsSelected="True"/>
+                    <ComboBoxItem Content="Avg Duration (ms)" Tag="AvgElapsedMs"/>
+                    <ComboBoxItem Content="Avg Logical Reads" Tag="AvgReads"/>
+                    <ComboBoxItem Content="Execution Count Delta" Tag="DeltaExecutions"/>
+                    <ComboBoxItem Content="CPU Delta (ms)" Tag="DeltaCpuMs"/>
+                    <ComboBoxItem Content="Logical Reads Delta" Tag="DeltaLogicalReads"/>
+                    <ComboBoxItem Content="Spills Delta" Tag="DeltaSpills"/>
+                </ComboBox>
+                <scottplot:WpfPlot x:Name="HistoryChart" Margin="0,0,0,0"/>
+            </Grid>
+        </Border>
+
+        <!-- Data Grid -->
+        <DataGrid Grid.Row="2" x:Name="HistoryDataGrid" Margin="0,10,0,0"
+                  Style="{StaticResource DarkGrid}"
+                  AutoGenerateColumns="False" IsReadOnly="True"
+                  CanUserSortColumns="True" CanUserReorderColumns="True"
+                  HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto"
+                  ContextMenu="{StaticResource DataGridContextMenu}">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Collection Time" Binding="{Binding CollectionTimeLocal}" Width="130"/>
+                <DataGridTextColumn Header="Last Execution" Binding="{Binding LastExecutionTimeLocal}" Width="130"/>
+                <DataGridTextColumn Header="Cached Time" Binding="{Binding CachedTimeLocal}" Width="130"/>
+                <DataGridTextColumn Header="Object Type" Binding="{Binding ObjectType}" Width="95"/>
+                <DataGridTextColumn Header="Exec Delta" Binding="{Binding DeltaExecutions, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="Total Executions" Binding="{Binding TotalExecutions, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                <DataGridTextColumn Header="CPU Delta (ms)" Binding="{Binding DeltaCpuMs, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                <DataGridTextColumn Header="Duration Delta (ms)" Binding="{Binding DeltaElapsedMs, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="130"/>
+                <DataGridTextColumn Header="Avg CPU (ms)" Binding="{Binding AvgCpuMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Avg Duration (ms)" Binding="{Binding AvgElapsedMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Total CPU (ms)" Binding="{Binding TotalCpuMs, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                <DataGridTextColumn Header="Total Duration (ms)" Binding="{Binding TotalElapsedMs, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="130"/>
+                <DataGridTextColumn Header="Logical Reads" Binding="{Binding DeltaLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Avg Reads" Binding="{Binding AvgReads, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="Total Logical Reads" Binding="{Binding TotalLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="125"/>
+                <DataGridTextColumn Header="Writes" Binding="{Binding DeltaLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80"/>
+                <DataGridTextColumn Header="Avg Writes" Binding="{Binding AvgWrites, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="95"/>
+                <DataGridTextColumn Header="Total Writes" Binding="{Binding TotalLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Physical Reads" Binding="{Binding DeltaPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Avg Phys Reads" Binding="{Binding AvgPhysicalReads, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                <DataGridTextColumn Header="Total Phys Reads" Binding="{Binding TotalPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Spills" Binding="{Binding DeltaSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="70"/>
+                <DataGridTextColumn Header="Avg Spills" Binding="{Binding AvgSpills, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="Total Spills" Binding="{Binding TotalSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="95"/>
+                <DataGridTextColumn Header="Min CPU (ms)" Binding="{Binding MinCpuMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Max CPU (ms)" Binding="{Binding MaxCpuMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Min Duration (ms)" Binding="{Binding MinElapsedMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Max Duration (ms)" Binding="{Binding MaxElapsedMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Min Reads" Binding="{Binding MinLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Max Reads" Binding="{Binding MaxLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Min Phys Reads" Binding="{Binding MinPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                <DataGridTextColumn Header="Max Phys Reads" Binding="{Binding MaxPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                <DataGridTextColumn Header="Min Writes" Binding="{Binding MinLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Max Writes" Binding="{Binding MaxLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Min Spills" Binding="{Binding MinSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="Max Spills" Binding="{Binding MaxSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="Interval (sec)" Binding="{Binding SampleIntervalSeconds}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="SQL Handle" Binding="{Binding SqlHandle}" Width="140"/>
+                <DataGridTextColumn Header="Plan Handle" Binding="{Binding PlanHandle}" Width="140"/>
+                <DataGridTemplateColumn Header="Plan" Width="Auto" MinWidth="80">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <Button Content="Download" Click="DownloadPlan_Click"
+                                    HorizontalAlignment="Center" VerticalAlignment="Center"
+                                    Padding="6,2"/>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+            </DataGrid.Columns>
+        </DataGrid>
+
+        <!-- Footer -->
+        <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="Close" Padding="20,6" Click="Close_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ProcedureHistoryWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ProcedureHistoryWindow.xaml.cs
@@ -1,0 +1,301 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using Microsoft.Win32;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.Ui;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The Top Procedures per-row double-click history window — ported from Lite's
+/// <c>Windows/ProcedureHistoryWindow.xaml.cs</c>. Shows the selected procedure's (by database + schema +
+/// object) metric trend over the window plus a filterable grid of its per-collection snapshots, with a metric
+/// selector driving the chart. Reads come from <see cref="ViewerDataService.GetProcedureStatsHistoryAsync"/>
+/// (Postgres). "View Plan" and the per-row Download button surface the STORED plan
+/// (<see cref="ViewerDataService.GetProcedureStatsPlanXmlAsync"/>); procedures were already View-Plan-only in
+/// Lite (re-executing a proc without parameter values is unsafe), so nothing extra is dropped.
+/// </summary>
+public partial class ProcedureHistoryWindow : Window
+{
+    private readonly ViewerDataService _dataService;
+    private readonly int _serverId;
+    private readonly string _databaseName;
+    private readonly string _schemaName;
+    private readonly string _objectName;
+    private readonly DateTime _startUtc;
+    private readonly DateTime _endUtc;
+    private List<ViewerProcedureStatsHistoryRow> _historyData = new();
+    private ChartHoverHelper? _chartHover;
+    private readonly DataGridFilterManager<ViewerProcedureStatsHistoryRow> _filterManager;
+    private Popup? _filterPopup;
+    private ColumnFilterPopup? _filterPopupContent;
+
+    public ProcedureHistoryWindow(
+        ViewerDataService dataService, int serverId, string databaseName, string schemaName, string objectName,
+        DateTime startUtc, DateTime endUtc)
+    {
+        InitializeComponent();
+        _dataService = dataService;
+        _serverId = serverId;
+        _databaseName = databaseName;
+        _schemaName = schemaName;
+        _objectName = objectName;
+        _startUtc = startUtc;
+        _endUtc = endUtc;
+
+        _filterManager = new DataGridFilterManager<ViewerProcedureStatsHistoryRow>(HistoryDataGrid);
+        DataGridFilterColumns.AddFilterButtons(HistoryDataGrid, Filter_Click);
+        _filterManager.UpdateFilterButtonStyles();
+
+        var fullName = string.IsNullOrEmpty(schemaName) ? objectName : $"{schemaName}.{objectName}";
+        ProcIdentifierText.Text = $"Procedure History: {fullName} in [{databaseName}]";
+        Loaded += async (_, _) => await LoadHistoryAsync();
+        ThemeManager.ThemeChanged += OnThemeChanged;
+        Closed += (_, _) => ThemeManager.ThemeChanged -= OnThemeChanged;
+    }
+
+    private async Task LoadHistoryAsync()
+    {
+        try
+        {
+            _historyData = await _dataService.GetProcedureStatsHistoryAsync(_serverId, _databaseName, _schemaName, _objectName, _startUtc, _endUtc);
+            _filterManager.UpdateData(_historyData);
+
+            if (_historyData.Count > 0)
+            {
+                var totalExec = _historyData.Sum(r => r.DeltaExecutions);
+                var totalCpu = _historyData.Sum(r => r.DeltaCpuMs);
+                var first = ViewerTimeHelper.ForDisplay(_historyData.First().CollectionTime);
+                var last = ViewerTimeHelper.ForDisplay(_historyData.Last().CollectionTime);
+                SummaryText.Text = $"{_historyData.Count} samples from {first:MM/dd HH:mm} to {last:MM/dd HH:mm} | " +
+                                   $"Total Executions: {totalExec:N0} | Total CPU: {totalCpu:N1} ms";
+            }
+            else
+            {
+                SummaryText.Text = "No history data found for this procedure in the selected time range.";
+            }
+
+            UpdateChart();
+        }
+        catch (Exception ex)
+        {
+            SummaryText.Text = $"Error loading history: {ex.Message}";
+        }
+    }
+
+    private void UpdateChart()
+    {
+        if (_historyData == null || _historyData.Count == 0)
+        {
+            HistoryChart.Plot.Clear();
+            HistoryChart.Refresh();
+            return;
+        }
+
+        HistoryChart.Plot.Clear();
+
+        var selected = MetricSelector.SelectedItem as ComboBoxItem;
+        var tag = selected?.Tag?.ToString() ?? "AvgCpuMs";
+        var label = selected?.Content?.ToString() ?? "Avg CPU (ms)";
+
+        var xs = _historyData.Select(r => ViewerTimeHelper.ForDisplay(r.CollectionTime).ToOADate()).ToArray();
+        var ys = _historyData.Select(r => GetMetricValue(r, tag)).ToArray();
+
+        var scatter = HistoryChart.Plot.Add.Scatter(xs, ys);
+        scatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("MetricTrend"));
+        ChartStyle.StyleScatter(scatter);
+        scatter.LegendText = label;
+
+        var unit = tag.Contains("Ms") ? "ms" : "";
+        if (_chartHover == null)
+            _chartHover = new ChartHoverHelper(HistoryChart, unit);
+        else
+            _chartHover.Unit = unit;
+        _chartHover.Clear();
+        _chartHover.Add(scatter, label);
+
+        HistoryChart.Plot.Axes.DateTimeTicksBottom();
+        ApplyTheme(HistoryChart);
+
+        HistoryChart.Refresh();
+    }
+
+    /// <summary>Projects one history row to the metric the selector shows — the chart's Y value. Pure +
+    /// static for unit testing (mirrors Lite's GetMetricValue switch).</summary>
+    internal static double GetMetricValue(ViewerProcedureStatsHistoryRow row, string tag) => tag switch
+    {
+        "AvgCpuMs" => row.AvgCpuMs,
+        "AvgElapsedMs" => row.AvgElapsedMs,
+        "AvgReads" => row.AvgReads,
+        "DeltaExecutions" => row.DeltaExecutions,
+        "DeltaCpuMs" => row.DeltaCpuMs,
+        "DeltaLogicalReads" => row.DeltaLogicalReads,
+        "DeltaSpills" => row.DeltaSpills,
+        _ => row.AvgCpuMs
+    };
+
+    private void MetricSelector_SelectionChanged(object sender, SelectionChangedEventArgs e) { if (IsLoaded) UpdateChart(); }
+
+    private static void ApplyTheme(ScottPlot.WPF.WpfPlot chart) => ChartStyle.ApplyMinimalChartTheme(chart);
+
+    private void OnThemeChanged(string _)
+    {
+        ApplyTheme(HistoryChart);
+        HistoryChart.Refresh();
+        _filterManager.UpdateFilterButtonStyles();
+    }
+
+    // ── Stored plan surface (viewer has no live server — Lite's live fetch becomes a stored read) ──
+
+    private async void DownloadPlan_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button btn) return;
+        if (string.IsNullOrEmpty(_objectName)) return;
+
+        btn.IsEnabled = false;
+        btn.Content = "...";
+        try
+        {
+            var plan = await _dataService.GetProcedureStatsPlanXmlAsync(_serverId, _databaseName, _schemaName, _objectName);
+            if (string.IsNullOrEmpty(plan))
+            {
+                MessageBox.Show(this, "No plan was captured in the collected data for this procedure.",
+                    "Plan Not Found", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            var dialog = new SaveFileDialog
+            {
+                Filter = "SQL Plan files (*.sqlplan)|*.sqlplan|All files (*.*)|*.*",
+                DefaultExt = ".sqlplan",
+                FileName = $"proc_plan_{_objectName}_{DateTime.Now:yyyyMMdd_HHmmss}.sqlplan"
+            };
+
+            if (dialog.ShowDialog() != true) return;
+            File.WriteAllText(dialog.FileName, plan, Encoding.UTF8);
+            btn.Content = "Saved";
+            return;
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show(this, $"Failed to retrieve plan: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+        finally
+        {
+            if (btn.Content is "...")
+                btn.Content = "Download";
+            btn.IsEnabled = true;
+        }
+    }
+
+    /// <summary>"View Plan" — shows the procedure's stored estimated plan in a shared
+    /// <see cref="PlanViewerControl"/> floated above this window. Procedures are View-Plan-only (Lite too).</summary>
+    private async void ViewPlan_Click(object sender, RoutedEventArgs e)
+    {
+        var fullName = string.IsNullOrEmpty(_schemaName) ? _objectName : $"{_schemaName}.{_objectName}";
+        string? planXml;
+        try
+        {
+            planXml = await _dataService.GetProcedureStatsPlanXmlAsync(_serverId, _databaseName, _schemaName, _objectName);
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show(this, $"Failed to retrieve plan: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            return;
+        }
+
+        if (string.IsNullOrEmpty(planXml))
+        {
+            MessageBox.Show(this, "No plan was captured in the collected data for this procedure.",
+                "No Plan Available", MessageBoxButton.OK, MessageBoxImage.Information);
+            return;
+        }
+
+        var label = $"Est Plan - {fullName}";
+        var viewer = new PlanViewerControl();
+        try
+        {
+            await viewer.LoadPlan(planXml, label, queryText: null);
+        }
+        catch (Exception ex)
+        {
+            viewer.Cleanup();
+            MessageBox.Show(this, $"Failed to load the execution plan:\n\n{ex.Message}",
+                "Plan Load Error", MessageBoxButton.OK, MessageBoxImage.Warning);
+            return;
+        }
+
+        var window = GraphViewerWindow.ShowGraph(this, viewer, label);
+        window.Closed += (_, _) => viewer.Cleanup();
+    }
+
+    // ── Column Filter Popup (mirrors WaitDrillDownWindow / ViewerServerTab.Filters.cs) ──
+
+    private void EnsureFilterPopup()
+    {
+        if (_filterPopup == null)
+        {
+            _filterPopupContent = new ColumnFilterPopup();
+            _filterPopup = new Popup
+            {
+                Child = _filterPopupContent,
+                StaysOpen = false,
+                Placement = PlacementMode.Bottom,
+                AllowsTransparency = true
+            };
+        }
+    }
+
+    private void Filter_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button button || button.Tag is not string columnName) return;
+
+        EnsureFilterPopup();
+
+        _filterPopupContent!.FilterApplied -= FilterPopup_FilterApplied;
+        _filterPopupContent.FilterCleared -= FilterPopup_FilterCleared;
+        _filterPopupContent.FilterApplied += FilterPopup_FilterApplied;
+        _filterPopupContent.FilterCleared += FilterPopup_FilterCleared;
+
+        _filterManager.Filters.TryGetValue(columnName, out var existingFilter);
+        _filterPopupContent.Initialize(columnName, existingFilter);
+
+        _filterPopup!.PlacementTarget = button;
+        _filterPopup.IsOpen = true;
+    }
+
+    private void FilterPopup_FilterApplied(object? sender, FilterAppliedEventArgs e)
+    {
+        if (_filterPopup != null) _filterPopup.IsOpen = false;
+        _filterManager.SetFilter(e.FilterState);
+    }
+
+    private void FilterPopup_FilterCleared(object? sender, EventArgs e)
+    {
+        if (_filterPopup != null) _filterPopup.IsOpen = false;
+    }
+
+    // ── Copy / Export / Close ──
+
+    private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
+    private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
+    private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
+    private void ExportToCsv_Click(object sender, RoutedEventArgs e) => DataGridExport.ExportToCsv(sender, "procedure_history", ViewerExportSettings.CsvSeparator);
+
+    private void Close_Click(object sender, RoutedEventArgs e) => Close();
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/QueryStatsHistoryWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/QueryStatsHistoryWindow.xaml
@@ -1,0 +1,161 @@
+<Window x:Class="PerformanceMonitor.Darling.Viewer.QueryStatsHistoryWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:scottplot="clr-namespace:ScottPlot.WPF;assembly=ScottPlot.WPF"
+        Title="Query Stats History" Width="1400" Height="800"
+        WindowStartupLocation="CenterOwner"
+        Icon="EDD.ico"
+        TextOptions.TextFormattingMode="Display"
+        UseLayoutRounding="True"
+        Background="#22252b"
+        Foreground="#E4E6EB">
+    <!-- Ported from Lite's Windows/QueryStatsHistoryWindow.xaml (the Top Queries per-row double-click
+         history window): the selected query's metric trend chart + a filterable grid of its per-collection
+         snapshots, delta columns and all. Data repointed to ViewerDataService Postgres reads; the one viewer
+         adaptation is the plan surface — Lite fetches the plan live (DuckDB cache then the monitored server),
+         the viewer shows/downloads the STORED plan (GetQueryStatsPlanXmlAsync), and Lite's live "Get Actual
+         Plan" is dropped. Dark-styled via the shared ViewerDarkTheme dictionary + a local NumericCell,
+         mirroring WaitDrillDownWindow; column filter buttons added at runtime by DataGridFilterColumns. -->
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="ViewerDarkTheme.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+
+            <Style x:Key="NumericCell" TargetType="TextBlock">
+                <Setter Property="TextAlignment" Value="Right"/>
+            </Style>
+
+            <ContextMenu x:Key="DataGridContextMenu">
+                <MenuItem Header="Copy Cell" Click="CopyCell_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy Row" Click="CopyRow_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4C4;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4D1;"/></MenuItem.Icon>
+                </MenuItem>
+                <Separator/>
+                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
+                </MenuItem>
+                <Separator/>
+                <MenuItem Header="View Plan" Click="ViewPlan_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F50D;"/></MenuItem.Icon>
+                </MenuItem>
+            </ContextMenu>
+        </ResourceDictionary>
+    </Window.Resources>
+
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="250"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,10">
+            <TextBlock x:Name="QueryIdentifierText" FontSize="16" FontWeight="Bold"/>
+            <TextBlock x:Name="SummaryText" FontSize="12" Margin="0,4,0,0" Foreground="#B8BCC4"/>
+        </StackPanel>
+
+        <!-- Chart -->
+        <Border Grid.Row="1" Background="#111217" BorderBrush="#2a2d35" BorderThickness="1" CornerRadius="3">
+            <Grid>
+                <ComboBox x:Name="MetricSelector" Width="180" Height="26"
+                          VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0,6,10,0"
+                          SelectionChanged="MetricSelector_SelectionChanged">
+                    <ComboBoxItem Content="Avg CPU (ms)" Tag="AvgCpuMs" IsSelected="True"/>
+                    <ComboBoxItem Content="Avg Duration (ms)" Tag="AvgElapsedMs"/>
+                    <ComboBoxItem Content="Avg Logical Reads" Tag="AvgReads"/>
+                    <ComboBoxItem Content="Execution Count Delta" Tag="DeltaExecutions"/>
+                    <ComboBoxItem Content="CPU Delta (ms)" Tag="DeltaCpuMs"/>
+                    <ComboBoxItem Content="Logical Reads Delta" Tag="DeltaLogicalReads"/>
+                    <ComboBoxItem Content="Spills Delta" Tag="DeltaSpills"/>
+                </ComboBox>
+                <scottplot:WpfPlot x:Name="HistoryChart" Margin="0,0,0,0"/>
+            </Grid>
+        </Border>
+
+        <!-- Data Grid -->
+        <DataGrid Grid.Row="2" x:Name="HistoryDataGrid" Margin="0,10,0,0"
+                  Style="{StaticResource DarkGrid}"
+                  AutoGenerateColumns="False" IsReadOnly="True"
+                  CanUserSortColumns="True" CanUserReorderColumns="True"
+                  HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto"
+                  ContextMenu="{StaticResource DataGridContextMenu}">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Collection Time" Binding="{Binding CollectionTimeLocal}" Width="130"/>
+                <DataGridTextColumn Header="Last Execution" Binding="{Binding LastExecutionTimeLocal}" Width="130"/>
+                <DataGridTextColumn Header="Creation Time" Binding="{Binding CreationTimeLocal}" Width="130"/>
+                <DataGridTextColumn Header="Exec Delta" Binding="{Binding DeltaExecutions, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="Total Executions" Binding="{Binding TotalExecutions, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                <DataGridTextColumn Header="CPU Delta (ms)" Binding="{Binding DeltaCpuMs, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                <DataGridTextColumn Header="Duration Delta (ms)" Binding="{Binding DeltaElapsedMs, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="130"/>
+                <DataGridTextColumn Header="Avg CPU (ms)" Binding="{Binding AvgCpuMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Avg Duration (ms)" Binding="{Binding AvgElapsedMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Total CPU (ms)" Binding="{Binding TotalCpuMs, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                <DataGridTextColumn Header="Total Duration (ms)" Binding="{Binding TotalElapsedMs, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="130"/>
+                <DataGridTextColumn Header="Logical Reads" Binding="{Binding DeltaLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Avg Reads" Binding="{Binding AvgReads, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="Total Logical Reads" Binding="{Binding TotalLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="125"/>
+                <DataGridTextColumn Header="Rows" Binding="{Binding DeltaRows, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80"/>
+                <DataGridTextColumn Header="Avg Rows" Binding="{Binding AvgRows, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="Total Rows" Binding="{Binding TotalRows, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="95"/>
+                <DataGridTextColumn Header="Writes" Binding="{Binding DeltaLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80"/>
+                <DataGridTextColumn Header="Avg Writes" Binding="{Binding AvgWrites, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="95"/>
+                <DataGridTextColumn Header="Total Writes" Binding="{Binding TotalLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Physical Reads" Binding="{Binding DeltaPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Avg Phys Reads" Binding="{Binding AvgPhysicalReads, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                <DataGridTextColumn Header="Total Phys Reads" Binding="{Binding TotalPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Spills" Binding="{Binding DeltaSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="70"/>
+                <DataGridTextColumn Header="Total Spills" Binding="{Binding TotalSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="95"/>
+                <DataGridTextColumn Header="Min CPU (ms)" Binding="{Binding MinCpuMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Max CPU (ms)" Binding="{Binding MaxCpuMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Min Duration (ms)" Binding="{Binding MinElapsedMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Max Duration (ms)" Binding="{Binding MaxElapsedMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Min DOP" Binding="{Binding MinDop}" ElementStyle="{StaticResource NumericCell}" Width="70"/>
+                <DataGridTextColumn Header="Max DOP" Binding="{Binding MaxDop}" ElementStyle="{StaticResource NumericCell}" Width="70"/>
+                <DataGridTextColumn Header="Min Phys Reads" Binding="{Binding MinPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                <DataGridTextColumn Header="Max Phys Reads" Binding="{Binding MaxPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                <DataGridTextColumn Header="Min Rows" Binding="{Binding MinRows, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80"/>
+                <DataGridTextColumn Header="Max Rows" Binding="{Binding MaxRows, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80"/>
+                <DataGridTextColumn Header="Min Spills" Binding="{Binding MinSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80"/>
+                <DataGridTextColumn Header="Max Spills" Binding="{Binding MaxSpills, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80"/>
+                <DataGridTextColumn Header="Min Grant KB" Binding="{Binding MinGrantKb, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Max Grant KB" Binding="{Binding MaxGrantKb, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Min Used Grant KB" Binding="{Binding MinUsedGrantKb, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Max Used Grant KB" Binding="{Binding MaxUsedGrantKb, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Min Ideal Grant KB" Binding="{Binding MinIdealGrantKb, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Max Ideal Grant KB" Binding="{Binding MaxIdealGrantKb, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Min Reserved Threads" Binding="{Binding MinReservedThreads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="130"/>
+                <DataGridTextColumn Header="Max Reserved Threads" Binding="{Binding MaxReservedThreads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="130"/>
+                <DataGridTextColumn Header="Min Used Threads" Binding="{Binding MinUsedThreads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Max Used Threads" Binding="{Binding MaxUsedThreads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Total CLR (ms)" Binding="{Binding TotalClrMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                <DataGridTextColumn Header="Interval (sec)" Binding="{Binding SampleIntervalSeconds}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="SQL Handle" Binding="{Binding SqlHandle}" Width="140"/>
+                <DataGridTextColumn Header="Plan Handle" Binding="{Binding PlanHandle}" Width="140"/>
+                <DataGridTextColumn Header="Query Hash" Binding="{Binding QueryHash}" Width="140"/>
+                <DataGridTextColumn Header="Plan Hash" Binding="{Binding QueryPlanHash}" Width="140"/>
+                <DataGridTemplateColumn Header="Plan" Width="Auto" MinWidth="80">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <Button Content="Download" Click="DownloadPlan_Click"
+                                    HorizontalAlignment="Center" VerticalAlignment="Center"
+                                    Padding="6,2"/>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+            </DataGrid.Columns>
+        </DataGrid>
+
+        <!-- Footer -->
+        <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="Close" Padding="20,6" Click="Close_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Darling/PerformanceMonitor.Darling.Viewer/QueryStatsHistoryWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/QueryStatsHistoryWindow.xaml.cs
@@ -1,0 +1,299 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using Microsoft.Win32;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.Ui;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The Top Queries per-row double-click history window — ported from Lite's
+/// <c>Windows/QueryStatsHistoryWindow.xaml.cs</c>. Shows the selected query's (by query_hash) metric trend
+/// over the window plus a filterable grid of its per-collection snapshots, with a metric selector driving the
+/// chart. The reads come from <see cref="ViewerDataService.GetQueryStatsHistoryAsync"/> (Postgres). The one
+/// viewer adaptation: Lite fetches the plan live (DuckDB cache then the monitored server) — the viewer never
+/// opens a SqlClient, so "View Plan" and the per-row Download button surface the STORED plan
+/// (<see cref="ViewerDataService.GetQueryStatsPlanXmlAsync"/>), and Lite's live "Get Actual Plan" is dropped.
+/// </summary>
+public partial class QueryStatsHistoryWindow : Window
+{
+    private readonly ViewerDataService _dataService;
+    private readonly int _serverId;
+    private readonly string _databaseName;
+    private readonly string _queryHash;
+    private readonly string _queryText;
+    private readonly DateTime _startUtc;
+    private readonly DateTime _endUtc;
+    private List<ViewerQueryStatsHistoryRow> _historyData = new();
+    private ChartHoverHelper? _chartHover;
+    private readonly DataGridFilterManager<ViewerQueryStatsHistoryRow> _filterManager;
+    private Popup? _filterPopup;
+    private ColumnFilterPopup? _filterPopupContent;
+
+    public QueryStatsHistoryWindow(
+        ViewerDataService dataService, int serverId, string databaseName, string queryHash,
+        string queryText, DateTime startUtc, DateTime endUtc)
+    {
+        InitializeComponent();
+        _dataService = dataService;
+        _serverId = serverId;
+        _databaseName = databaseName;
+        _queryHash = queryHash;
+        _queryText = queryText;
+        _startUtc = startUtc;
+        _endUtc = endUtc;
+
+        _filterManager = new DataGridFilterManager<ViewerQueryStatsHistoryRow>(HistoryDataGrid);
+        DataGridFilterColumns.AddFilterButtons(HistoryDataGrid, Filter_Click);
+        _filterManager.UpdateFilterButtonStyles();
+
+        QueryIdentifierText.Text = $"Query Stats History: {queryHash} in [{databaseName}]";
+        Loaded += async (_, _) => await LoadHistoryAsync();
+        ThemeManager.ThemeChanged += OnThemeChanged;
+        Closed += (_, _) => ThemeManager.ThemeChanged -= OnThemeChanged;
+    }
+
+    private async Task LoadHistoryAsync()
+    {
+        try
+        {
+            _historyData = await _dataService.GetQueryStatsHistoryAsync(_serverId, _databaseName, _queryHash, _startUtc, _endUtc);
+            _filterManager.UpdateData(_historyData);
+
+            if (_historyData.Count > 0)
+            {
+                var totalExec = _historyData.Sum(r => r.DeltaExecutions);
+                var totalCpu = _historyData.Sum(r => r.DeltaCpuMs);
+                var first = ViewerTimeHelper.ForDisplay(_historyData.First().CollectionTime);
+                var last = ViewerTimeHelper.ForDisplay(_historyData.Last().CollectionTime);
+                SummaryText.Text = $"{_historyData.Count} samples from {first:MM/dd HH:mm} to {last:MM/dd HH:mm} | " +
+                                   $"Total Executions: {totalExec:N0} | Total CPU: {totalCpu:N1} ms";
+            }
+            else
+            {
+                SummaryText.Text = "No history data found for this query in the selected time range.";
+            }
+
+            UpdateChart();
+        }
+        catch (Exception ex)
+        {
+            SummaryText.Text = $"Error loading history: {ex.Message}";
+        }
+    }
+
+    private void UpdateChart()
+    {
+        if (_historyData == null || _historyData.Count == 0)
+        {
+            HistoryChart.Plot.Clear();
+            HistoryChart.Refresh();
+            return;
+        }
+
+        HistoryChart.Plot.Clear();
+
+        var selected = MetricSelector.SelectedItem as ComboBoxItem;
+        var tag = selected?.Tag?.ToString() ?? "AvgCpuMs";
+        var label = selected?.Content?.ToString() ?? "Avg CPU (ms)";
+
+        var xs = _historyData.Select(r => ViewerTimeHelper.ForDisplay(r.CollectionTime).ToOADate()).ToArray();
+        var ys = _historyData.Select(r => GetMetricValue(r, tag)).ToArray();
+
+        var scatter = HistoryChart.Plot.Add.Scatter(xs, ys);
+        scatter.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("MetricTrend"));
+        ChartStyle.StyleScatter(scatter);
+        scatter.LegendText = label;
+
+        var unit = tag.Contains("Ms") ? "ms" : "";
+        if (_chartHover == null)
+            _chartHover = new ChartHoverHelper(HistoryChart, unit);
+        else
+            _chartHover.Unit = unit;
+        _chartHover.Clear();
+        _chartHover.Add(scatter, label);
+
+        HistoryChart.Plot.Axes.DateTimeTicksBottom();
+        ApplyTheme(HistoryChart);
+
+        HistoryChart.Refresh();
+    }
+
+    /// <summary>Projects one history row to the metric the selector shows — the chart's Y value. Pure +
+    /// static for unit testing (mirrors Lite's GetMetricValue switch).</summary>
+    internal static double GetMetricValue(ViewerQueryStatsHistoryRow row, string tag) => tag switch
+    {
+        "AvgCpuMs" => row.AvgCpuMs,
+        "AvgElapsedMs" => row.AvgElapsedMs,
+        "AvgReads" => row.AvgReads,
+        "DeltaExecutions" => row.DeltaExecutions,
+        "DeltaCpuMs" => row.DeltaCpuMs,
+        "DeltaLogicalReads" => row.DeltaLogicalReads,
+        "DeltaSpills" => row.DeltaSpills,
+        _ => row.AvgCpuMs
+    };
+
+    private void MetricSelector_SelectionChanged(object sender, SelectionChangedEventArgs e) { if (IsLoaded) UpdateChart(); }
+
+    private static void ApplyTheme(ScottPlot.WPF.WpfPlot chart) => ChartStyle.ApplyMinimalChartTheme(chart);
+
+    private void OnThemeChanged(string _)
+    {
+        ApplyTheme(HistoryChart);
+        HistoryChart.Refresh();
+        _filterManager.UpdateFilterButtonStyles();
+    }
+
+    // ── Stored plan surface (viewer has no live server — Lite's live fetch becomes a stored read) ──
+
+    private async void DownloadPlan_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button btn) return;
+        if (string.IsNullOrEmpty(_queryHash)) return;
+
+        btn.IsEnabled = false;
+        btn.Content = "...";
+        try
+        {
+            var plan = await _dataService.GetQueryStatsPlanXmlAsync(_serverId, _databaseName, _queryHash);
+            if (string.IsNullOrEmpty(plan))
+            {
+                MessageBox.Show(this, "No query plan was captured in the collected data for this query hash.",
+                    "Plan Not Found", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            var dialog = new SaveFileDialog
+            {
+                Filter = "SQL Plan files (*.sqlplan)|*.sqlplan|All files (*.*)|*.*",
+                DefaultExt = ".sqlplan",
+                FileName = $"query_plan_{_queryHash}_{DateTime.Now:yyyyMMdd_HHmmss}.sqlplan"
+            };
+
+            if (dialog.ShowDialog() != true) return;
+            File.WriteAllText(dialog.FileName, plan, Encoding.UTF8);
+            btn.Content = "Saved";
+            return;
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show(this, $"Failed to retrieve plan: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+        finally
+        {
+            if (btn.Content is "...")
+                btn.Content = "Download";
+            btn.IsEnabled = true;
+        }
+    }
+
+    /// <summary>"View Plan" — shows the row's stored estimated plan in a shared <see cref="PlanViewerControl"/>
+    /// floated above this window. No live "Get Actual Plan" (the viewer never re-executes).</summary>
+    private async void ViewPlan_Click(object sender, RoutedEventArgs e)
+    {
+        string? planXml;
+        try
+        {
+            planXml = await _dataService.GetQueryStatsPlanXmlAsync(_serverId, _databaseName, _queryHash);
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show(this, $"Failed to retrieve plan: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            return;
+        }
+
+        if (string.IsNullOrEmpty(planXml))
+        {
+            MessageBox.Show(this, "No query plan was captured in the collected data for this query hash.",
+                "No Plan Available", MessageBoxButton.OK, MessageBoxImage.Information);
+            return;
+        }
+
+        var label = $"Est Plan - {_queryHash}";
+        var viewer = new PlanViewerControl();
+        try
+        {
+            await viewer.LoadPlan(planXml, label, _queryText);
+        }
+        catch (Exception ex)
+        {
+            viewer.Cleanup();
+            MessageBox.Show(this, $"Failed to load the execution plan:\n\n{ex.Message}",
+                "Plan Load Error", MessageBoxButton.OK, MessageBoxImage.Warning);
+            return;
+        }
+
+        var window = GraphViewerWindow.ShowGraph(this, viewer, label);
+        window.Closed += (_, _) => viewer.Cleanup();
+    }
+
+    // ── Column Filter Popup (mirrors WaitDrillDownWindow / ViewerServerTab.Filters.cs) ──
+
+    private void EnsureFilterPopup()
+    {
+        if (_filterPopup == null)
+        {
+            _filterPopupContent = new ColumnFilterPopup();
+            _filterPopup = new Popup
+            {
+                Child = _filterPopupContent,
+                StaysOpen = false,
+                Placement = PlacementMode.Bottom,
+                AllowsTransparency = true
+            };
+        }
+    }
+
+    private void Filter_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button button || button.Tag is not string columnName) return;
+
+        EnsureFilterPopup();
+
+        _filterPopupContent!.FilterApplied -= FilterPopup_FilterApplied;
+        _filterPopupContent.FilterCleared -= FilterPopup_FilterCleared;
+        _filterPopupContent.FilterApplied += FilterPopup_FilterApplied;
+        _filterPopupContent.FilterCleared += FilterPopup_FilterCleared;
+
+        _filterManager.Filters.TryGetValue(columnName, out var existingFilter);
+        _filterPopupContent.Initialize(columnName, existingFilter);
+
+        _filterPopup!.PlacementTarget = button;
+        _filterPopup.IsOpen = true;
+    }
+
+    private void FilterPopup_FilterApplied(object? sender, FilterAppliedEventArgs e)
+    {
+        if (_filterPopup != null) _filterPopup.IsOpen = false;
+        _filterManager.SetFilter(e.FilterState);
+    }
+
+    private void FilterPopup_FilterCleared(object? sender, EventArgs e)
+    {
+        if (_filterPopup != null) _filterPopup.IsOpen = false;
+    }
+
+    // ── Copy / Export / Close ──
+
+    private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
+    private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
+    private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
+    private void ExportToCsv_Click(object sender, RoutedEventArgs e) => DataGridExport.ExportToCsv(sender, "query_stats_history", ViewerExportSettings.CsvSeparator);
+
+    private void Close_Click(object sender, RoutedEventArgs e) => Close();
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/QueryStoreHistoryWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/QueryStoreHistoryWindow.xaml
@@ -1,0 +1,158 @@
+<Window x:Class="PerformanceMonitor.Darling.Viewer.QueryStoreHistoryWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:scottplot="clr-namespace:ScottPlot.WPF;assembly=ScottPlot.WPF"
+        Title="Query Store History" Width="1200" Height="800"
+        WindowStartupLocation="CenterOwner"
+        Icon="EDD.ico"
+        TextOptions.TextFormattingMode="Display"
+        UseLayoutRounding="True"
+        Background="#22252b"
+        Foreground="#E4E6EB">
+    <!-- Ported from Lite's Windows/QueryStoreHistoryWindow.xaml (the Query Store per-row double-click history
+         window): the selected query's per-plan metric trend over the window (one chart series per plan_id, so
+         plan switches / regressions are visible) plus a filterable grid of its per-collection snapshots. Data
+         repointed to ViewerDataService Postgres reads; "View Plan" / the per-row Download button surface the
+         STORED Query Store plan (GetQueryStorePlanTextAsync) and Lite's live "Get Actual Plan" is dropped. -->
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="ViewerDarkTheme.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+
+            <Style x:Key="NumericCell" TargetType="TextBlock">
+                <Setter Property="TextAlignment" Value="Right"/>
+            </Style>
+
+            <ContextMenu x:Key="DataGridContextMenu">
+                <MenuItem Header="Copy Cell" Click="CopyCell_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy Row" Click="CopyRow_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4C4;"/></MenuItem.Icon>
+                </MenuItem>
+                <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4D1;"/></MenuItem.Icon>
+                </MenuItem>
+                <Separator/>
+                <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
+                </MenuItem>
+                <Separator/>
+                <MenuItem Header="View Plan" Click="ViewPlan_Click">
+                    <MenuItem.Icon><TextBlock Text="&#x1F50D;"/></MenuItem.Icon>
+                </MenuItem>
+            </ContextMenu>
+        </ResourceDictionary>
+    </Window.Resources>
+
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="250"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <!-- Header -->
+        <StackPanel Grid.Row="0" Margin="0,0,0,10">
+            <TextBlock x:Name="QueryIdentifierText" FontSize="16" FontWeight="Bold"/>
+            <TextBlock x:Name="SummaryText" FontSize="12" Margin="0,4,0,0" Foreground="#B8BCC4"/>
+        </StackPanel>
+
+        <!-- Chart -->
+        <Border Grid.Row="1" Background="#111217" BorderBrush="#2a2d35" BorderThickness="1" CornerRadius="3">
+            <Grid>
+                <ComboBox x:Name="MetricSelector" Width="180" Height="26"
+                          VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0,6,10,0"
+                          SelectionChanged="MetricSelector_SelectionChanged">
+                    <ComboBoxItem Content="Avg CPU (ms)" Tag="AvgCpuTimeMs" IsSelected="True"/>
+                    <ComboBoxItem Content="Avg Duration (ms)" Tag="AvgDurationMs"/>
+                    <ComboBoxItem Content="Avg Logical Reads" Tag="AvgLogicalReads"/>
+                    <ComboBoxItem Content="Avg Rows" Tag="AvgRowcount"/>
+                    <ComboBoxItem Content="Execution Count" Tag="ExecutionCount"/>
+                    <ComboBoxItem Content="Total CPU (ms)" Tag="TotalCpuMs"/>
+                    <ComboBoxItem Content="Total Duration (ms)" Tag="TotalDurationMs"/>
+                </ComboBox>
+                <scottplot:WpfPlot x:Name="HistoryChart" Margin="0,0,0,0"/>
+            </Grid>
+        </Border>
+
+        <!-- Data Grid -->
+        <DataGrid Grid.Row="2" x:Name="HistoryDataGrid" Margin="0,10,0,0"
+                  Style="{StaticResource DarkGrid}"
+                  AutoGenerateColumns="False" IsReadOnly="True"
+                  CanUserSortColumns="True" CanUserReorderColumns="True"
+                  HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto"
+                  ContextMenu="{StaticResource DataGridContextMenu}">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Collection Time" Binding="{Binding CollectionTimeLocal}" Width="130"/>
+                <DataGridTextColumn Header="Plan ID" Binding="{Binding PlanId}" ElementStyle="{StaticResource NumericCell}" Width="70"/>
+                <DataGridTextColumn Header="Exec Type" Binding="{Binding ExecutionTypeDesc}" Width="90"/>
+                <DataGridTextColumn Header="First Execution" Binding="{Binding FirstExecutionTimeLocal}" Width="130"/>
+                <DataGridTextColumn Header="Last Execution" Binding="{Binding LastExecutionTimeLocal}" Width="130"/>
+                <DataGridTextColumn Header="Module" Binding="{Binding ModuleName}" Width="160"/>
+                <DataGridTextColumn Header="Executions" Binding="{Binding ExecutionCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="Total Duration (ms)" Binding="{Binding TotalDurationMs, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="130"/>
+                <DataGridTextColumn Header="Avg Duration (ms)" Binding="{Binding AvgDurationMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Min Duration (ms)" Binding="{Binding MinDurationMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Max Duration (ms)" Binding="{Binding MaxDurationMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Total CPU (ms)" Binding="{Binding TotalCpuMs, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                <DataGridTextColumn Header="Avg CPU (ms)" Binding="{Binding AvgCpuTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Min CPU (ms)" Binding="{Binding MinCpuTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Max CPU (ms)" Binding="{Binding MaxCpuTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Avg CLR (ms)" Binding="{Binding AvgClrTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Min CLR (ms)" Binding="{Binding MinClrTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Max CLR (ms)" Binding="{Binding MaxClrTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Avg Reads" Binding="{Binding AvgLogicalReads, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="Min Reads" Binding="{Binding MinLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="Max Reads" Binding="{Binding MaxLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="Avg Writes" Binding="{Binding AvgLogicalWrites, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="Min Writes" Binding="{Binding MinLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="Max Writes" Binding="{Binding MaxLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="Avg Log (MB)" Binding="{Binding AvgLogMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Min Log (MB)" Binding="{Binding MinLogMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Max Log (MB)" Binding="{Binding MaxLogMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Avg Physical Reads" Binding="{Binding AvgPhysicalReads, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Min Physical Reads" Binding="{Binding MinPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Max Physical Reads" Binding="{Binding MaxPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                <DataGridTextColumn Header="Avg Num Physical Reads" Binding="{Binding AvgNumPhysicalReads, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="150"/>
+                <DataGridTextColumn Header="Min Num Physical Reads" Binding="{Binding MinNumPhysicalReads, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="150"/>
+                <DataGridTextColumn Header="Max Num Physical Reads" Binding="{Binding MaxNumPhysicalReads, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="150"/>
+                <DataGridTextColumn Header="Avg Rows" Binding="{Binding AvgRowcount, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="Min Rows" Binding="{Binding MinRowcount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="85"/>
+                <DataGridTextColumn Header="Max Rows" Binding="{Binding MaxRowcount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="85"/>
+                <DataGridTextColumn Header="Avg Memory (MB)" Binding="{Binding AvgMemoryMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Min Memory (MB)" Binding="{Binding MinMemoryMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Max Memory (MB)" Binding="{Binding MaxMemoryMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Avg tempdb (MB)" Binding="{Binding AvgTempdbMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Min tempdb (MB)" Binding="{Binding MinTempdbMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Max tempdb (MB)" Binding="{Binding MaxTempdbMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="115"/>
+                <DataGridTextColumn Header="Min DOP" Binding="{Binding MinDop}" ElementStyle="{StaticResource NumericCell}" Width="70"/>
+                <DataGridTextColumn Header="Max DOP" Binding="{Binding MaxDop}" ElementStyle="{StaticResource NumericCell}" Width="70"/>
+                <DataGridTextColumn Header="Plan Type" Binding="{Binding PlanType}" Width="100"/>
+                <DataGridCheckBoxColumn Header="Forced" Binding="{Binding IsForcedPlan}" Width="60"/>
+                <DataGridTextColumn Header="Force Failures" Binding="{Binding ForceFailureCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                <DataGridTextColumn Header="Last Failure Reason" Binding="{Binding LastForceFailureReason}" Width="150"/>
+                <DataGridTextColumn Header="Forcing Type" Binding="{Binding PlanForcingType}" Width="100"/>
+                <DataGridTextColumn Header="Compat Level" Binding="{Binding CompatibilityLevel}" ElementStyle="{StaticResource NumericCell}" Width="90"/>
+                <DataGridTextColumn Header="Query Hash" Binding="{Binding QueryHash}" Width="140"/>
+                <DataGridTextColumn Header="Query Plan Hash" Binding="{Binding QueryPlanHash}" Width="140"/>
+                <DataGridTemplateColumn Header="Plan" Width="Auto" MinWidth="80">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <Button Content="Download" Click="DownloadPlan_Click"
+                                    HorizontalAlignment="Center" VerticalAlignment="Center"
+                                    Padding="6,2"/>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+            </DataGrid.Columns>
+        </DataGrid>
+
+        <!-- Footer -->
+        <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="Close" Padding="20,6" Click="Close_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Darling/PerformanceMonitor.Darling.Viewer/QueryStoreHistoryWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/QueryStoreHistoryWindow.xaml.cs
@@ -1,0 +1,332 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using Microsoft.Win32;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.Ui;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The Query Store per-row double-click history window — ported from Lite's
+/// <c>Windows/QueryStoreHistoryWindow.xaml.cs</c>. Shows the selected query's (by query_id, across every plan)
+/// metric trend over the window — one chart series per plan_id, so plan switches / regressions are visible —
+/// plus a filterable grid of its per-collection snapshots. Reads come from
+/// <see cref="ViewerDataService.GetQueryStoreHistoryAsync"/> (Postgres, query-scoped). "View Plan" and the
+/// per-row Download button surface the STORED Query Store plan for that row's plan_id
+/// (<see cref="ViewerDataService.GetQueryStorePlanTextAsync"/>); Lite's live "Get Actual Plan" is dropped.
+/// </summary>
+public partial class QueryStoreHistoryWindow : Window
+{
+    private readonly ViewerDataService _dataService;
+    private readonly int _serverId;
+    private readonly string _databaseName;
+    private readonly long _queryId;
+    private readonly long _planId;
+    private readonly string _queryText;
+    private readonly DateTime _startUtc;
+    private readonly DateTime _endUtc;
+    private List<ViewerQueryStoreHistoryRow> _historyData = new();
+    private ChartHoverHelper? _chartHover;
+    private ScottPlot.IPanel? _legendPanel;
+    private readonly DataGridFilterManager<ViewerQueryStoreHistoryRow> _filterManager;
+    private Popup? _filterPopup;
+    private ColumnFilterPopup? _filterPopupContent;
+
+    public QueryStoreHistoryWindow(
+        ViewerDataService dataService, int serverId, string databaseName, long queryId, long planId,
+        string queryText, DateTime startUtc, DateTime endUtc)
+    {
+        InitializeComponent();
+        _dataService = dataService;
+        _serverId = serverId;
+        _databaseName = databaseName;
+        _queryId = queryId;
+        _planId = planId;
+        _queryText = queryText;
+        _startUtc = startUtc;
+        _endUtc = endUtc;
+
+        _filterManager = new DataGridFilterManager<ViewerQueryStoreHistoryRow>(HistoryDataGrid);
+        DataGridFilterColumns.AddFilterButtons(HistoryDataGrid, Filter_Click);
+        _filterManager.UpdateFilterButtonStyles();
+
+        var displayText = queryText.Length > 120 ? queryText[..120] + "..." : queryText;
+        QueryIdentifierText.Text = $"Query Store History: Query {queryId} in [{databaseName}]";
+        SummaryText.Text = displayText;
+        Loaded += async (_, _) => await LoadHistoryAsync();
+        ThemeManager.ThemeChanged += OnThemeChanged;
+        Closed += (_, _) => ThemeManager.ThemeChanged -= OnThemeChanged;
+    }
+
+    private async Task LoadHistoryAsync()
+    {
+        try
+        {
+            _historyData = await _dataService.GetQueryStoreHistoryAsync(_serverId, _databaseName, _queryId, _startUtc, _endUtc);
+            _filterManager.UpdateData(_historyData);
+
+            if (_historyData.Count > 0)
+            {
+                var totalExec = _historyData.Sum(r => r.ExecutionCount);
+                var planCount = _historyData.Select(r => r.PlanId).Distinct().Count();
+                var first = ViewerTimeHelper.ForDisplay(_historyData.First().CollectionTime);
+                var last = ViewerTimeHelper.ForDisplay(_historyData.Last().CollectionTime);
+                SummaryText.Text = $"{_historyData.Count} samples from {first:MM/dd HH:mm} to {last:MM/dd HH:mm} | " +
+                                   $"Total Executions: {totalExec:N0} | " +
+                                   (planCount > 1 ? $"{planCount} different plans" : "Single plan");
+            }
+            else
+            {
+                SummaryText.Text = "No history data found for this query in the selected time range.";
+            }
+
+            UpdateChart();
+        }
+        catch (Exception ex)
+        {
+            SummaryText.Text = $"Error loading history: {ex.Message}";
+        }
+    }
+
+    private void UpdateChart()
+    {
+        if (_historyData == null || _historyData.Count == 0)
+        {
+            HistoryChart.Plot.Clear();
+            HistoryChart.Refresh();
+            return;
+        }
+
+        if (_legendPanel != null)
+        {
+            HistoryChart.Plot.Axes.Remove(_legendPanel);
+            _legendPanel = null;
+        }
+        HistoryChart.Plot.Clear();
+
+        var selected = MetricSelector.SelectedItem as ComboBoxItem;
+        var tag = selected?.Tag?.ToString() ?? "AvgCpuTimeMs";
+        var label = selected?.Content?.ToString() ?? "Avg CPU (ms)";
+
+        var unit = tag.Contains("Ms") ? "ms" : "";
+        if (_chartHover == null)
+            _chartHover = new ChartHoverHelper(HistoryChart, unit);
+        else
+            _chartHover.Unit = unit;
+        _chartHover.Clear();
+
+        // One series per plan so plan switches/regressions are visible — same as Lite / the Dashboard drilldown.
+        var planGroups = _historyData.GroupBy(r => r.PlanId).OrderBy(g => g.Key).ToList();
+        var colors = ChartPalette.CyclingPalette.Select(ScottPlot.Color.FromHex).ToArray();
+
+        int colorIndex = 0;
+        foreach (var planGroup in planGroups)
+        {
+            var ordered = planGroup.OrderBy(r => r.CollectionTime).ToList();
+            var xs = ordered.Select(r => ViewerTimeHelper.ForDisplay(r.CollectionTime).ToOADate()).ToArray();
+            var ys = ordered.Select(r => GetMetricValue(r, tag)).ToArray();
+
+            var scatter = HistoryChart.Plot.Add.Scatter(xs, ys);
+            scatter.Color = colors[colorIndex % colors.Length];
+            ChartStyle.StyleScatter(scatter);
+            var seriesLabel = planGroups.Count > 1 ? $"Plan {planGroup.Key}" : label;
+            scatter.LegendText = seriesLabel;
+            _chartHover.Add(scatter, seriesLabel);
+            colorIndex++;
+        }
+
+        HistoryChart.Plot.Axes.DateTimeTicksBottom();
+        if (planGroups.Count > 1)
+        {
+            _legendPanel = HistoryChart.Plot.ShowLegend(ScottPlot.Edge.Bottom);
+            HistoryChart.Plot.Legend.FontSize = 12;
+        }
+        ApplyTheme(HistoryChart);
+
+        HistoryChart.Refresh();
+    }
+
+    /// <summary>Projects one history row to the metric the selector shows — the chart's Y value. Pure +
+    /// static for unit testing (mirrors Lite's GetMetricValue switch).</summary>
+    internal static double GetMetricValue(ViewerQueryStoreHistoryRow row, string tag) => tag switch
+    {
+        "AvgCpuTimeMs" => row.AvgCpuTimeMs,
+        "AvgDurationMs" => row.AvgDurationMs,
+        "AvgLogicalReads" => row.AvgLogicalReads,
+        "AvgRowcount" => row.AvgRowcount,
+        "ExecutionCount" => row.ExecutionCount,
+        "TotalCpuMs" => row.TotalCpuMs,
+        "TotalDurationMs" => row.TotalDurationMs,
+        _ => row.AvgCpuTimeMs
+    };
+
+    private void MetricSelector_SelectionChanged(object sender, SelectionChangedEventArgs e) { if (IsLoaded) UpdateChart(); }
+
+    private static void ApplyTheme(ScottPlot.WPF.WpfPlot chart) => ChartStyle.ApplyMinimalChartTheme(chart);
+
+    private void OnThemeChanged(string _)
+    {
+        ApplyTheme(HistoryChart);
+        HistoryChart.Refresh();
+        _filterManager.UpdateFilterButtonStyles();
+    }
+
+    // ── Stored plan surface (viewer has no live server — Lite's live fetch becomes a stored read) ──
+
+    private async void DownloadPlan_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button btn) return;
+        // Rows can span multiple plans — download the plan for THIS row, not the launching one.
+        var rowPlanId = (btn.DataContext as ViewerQueryStoreHistoryRow)?.PlanId ?? _planId;
+        if (string.IsNullOrEmpty(_databaseName) || rowPlanId == 0) return;
+
+        btn.IsEnabled = false;
+        btn.Content = "...";
+        try
+        {
+            var plan = await _dataService.GetQueryStorePlanTextAsync(_serverId, _databaseName, _queryId, rowPlanId);
+            if (string.IsNullOrEmpty(plan))
+            {
+                MessageBox.Show(this, "No Query Store plan was captured in the collected data for this plan ID.",
+                    "Plan Not Found", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            var dialog = new SaveFileDialog
+            {
+                Filter = "SQL Plan files (*.sqlplan)|*.sqlplan|All files (*.*)|*.*",
+                DefaultExt = ".sqlplan",
+                FileName = $"qs_plan_{_queryId}_{rowPlanId}_{DateTime.Now:yyyyMMdd_HHmmss}.sqlplan"
+            };
+
+            if (dialog.ShowDialog() != true) return;
+            File.WriteAllText(dialog.FileName, plan, Encoding.UTF8);
+            btn.Content = "Saved";
+            return;
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show(this, $"Failed to retrieve plan: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+        finally
+        {
+            if (btn.Content is "...")
+                btn.Content = "Download";
+            btn.IsEnabled = true;
+        }
+    }
+
+    private long SelectedPlanId =>
+        ((HistoryDataGrid.CurrentItem ?? HistoryDataGrid.SelectedItem) as ViewerQueryStoreHistoryRow)?.PlanId ?? _planId;
+
+    /// <summary>"View Plan" — shows the selected row's stored Query Store plan in a shared
+    /// <see cref="PlanViewerControl"/> floated above this window. No live "Get Actual Plan".</summary>
+    private async void ViewPlan_Click(object sender, RoutedEventArgs e)
+    {
+        var planId = SelectedPlanId;
+        string? planXml;
+        try
+        {
+            planXml = await _dataService.GetQueryStorePlanTextAsync(_serverId, _databaseName, _queryId, planId);
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show(this, $"Failed to retrieve plan: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            return;
+        }
+
+        if (string.IsNullOrEmpty(planXml))
+        {
+            MessageBox.Show(this, "No Query Store plan was captured in the collected data for this plan ID.",
+                "No Plan Available", MessageBoxButton.OK, MessageBoxImage.Information);
+            return;
+        }
+
+        var label = $"Est Plan - QS {_queryId}/{planId}";
+        var viewer = new PlanViewerControl();
+        try
+        {
+            await viewer.LoadPlan(planXml, label, _queryText);
+        }
+        catch (Exception ex)
+        {
+            viewer.Cleanup();
+            MessageBox.Show(this, $"Failed to load the execution plan:\n\n{ex.Message}",
+                "Plan Load Error", MessageBoxButton.OK, MessageBoxImage.Warning);
+            return;
+        }
+
+        var window = GraphViewerWindow.ShowGraph(this, viewer, label);
+        window.Closed += (_, _) => viewer.Cleanup();
+    }
+
+    // ── Column Filter Popup (mirrors WaitDrillDownWindow / ViewerServerTab.Filters.cs) ──
+
+    private void EnsureFilterPopup()
+    {
+        if (_filterPopup == null)
+        {
+            _filterPopupContent = new ColumnFilterPopup();
+            _filterPopup = new Popup
+            {
+                Child = _filterPopupContent,
+                StaysOpen = false,
+                Placement = PlacementMode.Bottom,
+                AllowsTransparency = true
+            };
+        }
+    }
+
+    private void Filter_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button button || button.Tag is not string columnName) return;
+
+        EnsureFilterPopup();
+
+        _filterPopupContent!.FilterApplied -= FilterPopup_FilterApplied;
+        _filterPopupContent.FilterCleared -= FilterPopup_FilterCleared;
+        _filterPopupContent.FilterApplied += FilterPopup_FilterApplied;
+        _filterPopupContent.FilterCleared += FilterPopup_FilterCleared;
+
+        _filterManager.Filters.TryGetValue(columnName, out var existingFilter);
+        _filterPopupContent.Initialize(columnName, existingFilter);
+
+        _filterPopup!.PlacementTarget = button;
+        _filterPopup.IsOpen = true;
+    }
+
+    private void FilterPopup_FilterApplied(object? sender, FilterAppliedEventArgs e)
+    {
+        if (_filterPopup != null) _filterPopup.IsOpen = false;
+        _filterManager.SetFilter(e.FilterState);
+    }
+
+    private void FilterPopup_FilterCleared(object? sender, EventArgs e)
+    {
+        if (_filterPopup != null) _filterPopup.IsOpen = false;
+    }
+
+    // ── Copy / Export / Close ──
+
+    private void CopyCell_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyCell(sender);
+    private void CopyRow_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyRow(sender);
+    private void CopyAllRows_Click(object sender, RoutedEventArgs e) => DataGridExport.CopyAllRows(sender);
+    private void ExportToCsv_Click(object sender, RoutedEventArgs e) => DataGridExport.ExportToCsv(sender, "query_store_history", ViewerExportSettings.CsvSeparator);
+
+    private void Close_Click(object sender, RoutedEventArgs e) => Close();
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ItemHistory.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ItemHistory.cs
@@ -1,0 +1,446 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// Per-item execution HISTORY reads backing the double-click drill-down windows (Query Stats / Procedure /
+/// Query Store): the full per-collection-snapshot row set for one query (by query_hash), procedure (by
+/// db+schema+object), or Query Store query (by query_id, across every plan) over the window. This is the
+/// FULLER companion to <see cref="ItemTimelinePoint"/> (ViewerDataService.ItemTimeline.cs, #1409): that read
+/// returns a five-metric per-interval curve for the slicer overlay; the history windows need every collected
+/// column (the deltas, the min/max spreads, the memory-grant / spill / thread columns, the plan identity), so
+/// these reads carry Lite's whole <c>Get{QueryStats,ProcedureStats,QueryStore}HistoryAsync</c> column list
+/// (LocalDataService.QueryStats.cs / .QueryStore.cs) ported DuckDB → Postgres. Every column was verified
+/// present in the shared collector schema (QueryStatsCollector / ProcedureStatsCollector / query_store_stats).
+///
+/// <para>
+/// Convention deviations from Lite (matching every other viewer read): (1) reads are both-sides window-bound
+/// on naive-UTC <c>collection_time</c> ($ positional params, Kind=Unspecified); (2) <c>collection_time</c> is
+/// naive UTC and renders through <see cref="ViewerTimeHelper.ForDisplay"/>, while the DMV wall-clock stamps
+/// (creation_time / last_execution_time / cached_time / first_execution_time) are the SQL server's own local
+/// time and render raw through <see cref="FormatServerClock"/>; (3) Darling's <c>delta_*</c> columns are
+/// already per-collection-cycle deltas, so — like the overlay — there is no C# row-over-row differencing
+/// (Lite's history rows carry the same collector-computed deltas). Numeric columns read through
+/// <c>Convert.ToXxx(GetValue)</c> so a bigint / integer / numeric provider type all bind cleanly.
+/// </para>
+/// </summary>
+public sealed partial class ViewerDataService
+{
+    // ══════════════════════════════ Query Stats history ══════════════════════════════
+
+    /// <summary>
+    /// Every collected query_stats snapshot for one (database, query_hash) over the window — Lite's
+    /// <c>GetQueryStatsHistoryAsync</c> column list against the base <c>query_stats</c> table (Lite reads its
+    /// <c>v_query_stats</c> view; Darling's collector writes the deltas directly, so the base table already
+    /// carries the per-cycle <c>delta_*</c> the view computes). $1 server_id, $2 database_name, $3 query_hash,
+    /// $4 window start, $5 window end (naive UTC).
+    /// </summary>
+    public const string QueryStatsHistorySql = """
+        SELECT
+            collection_time,
+            delta_execution_count,
+            delta_worker_time,
+            delta_elapsed_time,
+            delta_logical_reads,
+            delta_logical_writes,
+            delta_physical_reads,
+            delta_rows,
+            delta_spills,
+            min_dop,
+            max_dop,
+            min_worker_time,
+            max_worker_time,
+            min_elapsed_time,
+            max_elapsed_time,
+            query_plan_hash,
+            min_grant_kb,
+            max_grant_kb,
+            min_used_grant_kb,
+            max_used_grant_kb,
+            min_ideal_grant_kb,
+            max_ideal_grant_kb,
+            min_reserved_threads,
+            max_reserved_threads,
+            min_used_threads,
+            max_used_threads,
+            min_physical_reads,
+            max_physical_reads,
+            min_rows,
+            max_rows,
+            min_spills,
+            max_spills,
+            total_clr_time,
+            creation_time,
+            last_execution_time,
+            execution_count,
+            total_worker_time,
+            total_elapsed_time,
+            total_logical_reads,
+            total_logical_writes,
+            total_physical_reads,
+            total_rows,
+            total_spills,
+            sql_handle,
+            plan_handle,
+            query_hash,
+            sample_interval_seconds
+        FROM query_stats
+        WHERE server_id = $1
+        AND   database_name = $2
+        AND   query_hash = $3
+        AND   collection_time >= $4
+        AND   collection_time <= $5
+        ORDER BY collection_time
+        """;
+
+    /// <summary>The selected Top-Queries row's full per-collection history over [<paramref name="startUtc"/>,
+    /// <paramref name="endUtc"/>], ordered by collection time (the drill-down window's grid + metric chart).</summary>
+    public async Task<List<ViewerQueryStatsHistoryRow>> GetQueryStatsHistoryAsync(
+        int serverId, string databaseName, string queryHash, DateTime startUtc, DateTime endUtc,
+        CancellationToken cancellationToken = default)
+    {
+        var rows = new List<ViewerQueryStatsHistoryRow>();
+
+        await using var command = _dataSource.CreateCommand(QueryStatsHistorySql);
+        AddItemWindowParameters(command, serverId, databaseName, queryHash, startUtc, endUtc);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            rows.Add(new ViewerQueryStatsHistoryRow
+            {
+                CollectionTime = reader.GetDateTime(0),
+                DeltaExecutions = ReadLong(reader, 1),
+                DeltaCpuUs = ReadLong(reader, 2),
+                DeltaElapsedUs = ReadLong(reader, 3),
+                DeltaLogicalReads = ReadLong(reader, 4),
+                DeltaLogicalWrites = ReadLong(reader, 5),
+                DeltaPhysicalReads = ReadLong(reader, 6),
+                DeltaRows = ReadLong(reader, 7),
+                DeltaSpills = ReadLong(reader, 8),
+                MinDop = ReadInt(reader, 9),
+                MaxDop = ReadInt(reader, 10),
+                MinCpuUs = ReadLong(reader, 11),
+                MaxCpuUs = ReadLong(reader, 12),
+                MinElapsedUs = ReadLong(reader, 13),
+                MaxElapsedUs = ReadLong(reader, 14),
+                QueryPlanHash = reader.IsDBNull(15) ? "" : reader.GetString(15),
+                MinGrantKb = ReadLong(reader, 16),
+                MaxGrantKb = ReadLong(reader, 17),
+                MinUsedGrantKb = ReadLong(reader, 18),
+                MaxUsedGrantKb = ReadLong(reader, 19),
+                MinIdealGrantKb = ReadLong(reader, 20),
+                MaxIdealGrantKb = ReadLong(reader, 21),
+                MinReservedThreads = ReadLong(reader, 22),
+                MaxReservedThreads = ReadLong(reader, 23),
+                MinUsedThreads = ReadLong(reader, 24),
+                MaxUsedThreads = ReadLong(reader, 25),
+                MinPhysicalReads = ReadLong(reader, 26),
+                MaxPhysicalReads = ReadLong(reader, 27),
+                MinRows = ReadLong(reader, 28),
+                MaxRows = ReadLong(reader, 29),
+                MinSpills = ReadLong(reader, 30),
+                MaxSpills = ReadLong(reader, 31),
+                TotalClrTimeUs = ReadLong(reader, 32),
+                CreationTime = reader.IsDBNull(33) ? null : reader.GetDateTime(33),
+                LastExecutionTime = reader.IsDBNull(34) ? null : reader.GetDateTime(34),
+                TotalExecutions = ReadLong(reader, 35),
+                TotalCpuUs = ReadLong(reader, 36),
+                TotalElapsedUs = ReadLong(reader, 37),
+                TotalLogicalReads = ReadLong(reader, 38),
+                TotalLogicalWrites = ReadLong(reader, 39),
+                TotalPhysicalReads = ReadLong(reader, 40),
+                TotalRows = ReadLong(reader, 41),
+                TotalSpills = ReadLong(reader, 42),
+                SqlHandle = reader.IsDBNull(43) ? "" : reader.GetString(43),
+                PlanHandle = reader.IsDBNull(44) ? "" : reader.GetString(44),
+                QueryHash = reader.IsDBNull(45) ? "" : reader.GetString(45),
+                SampleIntervalSeconds = reader.IsDBNull(46) ? null : ReadInt(reader, 46),
+            });
+        }
+
+        return rows;
+    }
+
+    // ══════════════════════════════ Procedure stats history ══════════════════════════════
+
+    /// <summary>
+    /// Every collected procedure_stats snapshot for one (database, schema, object) over the window — Lite's
+    /// <c>GetProcedureStatsHistoryAsync</c> column list against the base <c>procedure_stats</c> table.
+    /// procedure_stats has no <c>sample_interval_seconds</c> column (unlike query_stats), so — exactly as Lite
+    /// does — the interval is derived per row from the gap to the previous collection via
+    /// <c>LAG(collection_time)</c> (identical syntax in Postgres). $1 server_id, $2 database_name, $3
+    /// schema_name, $4 object_name, $5 window start, $6 window end (naive UTC).
+    /// </summary>
+    public const string ProcStatsHistorySql = """
+        SELECT
+            collection_time,
+            delta_execution_count,
+            delta_worker_time,
+            delta_elapsed_time,
+            delta_logical_reads,
+            delta_logical_writes,
+            delta_physical_reads,
+            min_worker_time,
+            max_worker_time,
+            min_elapsed_time,
+            max_elapsed_time,
+            total_spills,
+            min_logical_reads,
+            max_logical_reads,
+            min_physical_reads,
+            max_physical_reads,
+            min_logical_writes,
+            max_logical_writes,
+            min_spills,
+            max_spills,
+            sql_handle,
+            plan_handle,
+            cached_time,
+            last_execution_time,
+            object_type,
+            execution_count,
+            total_worker_time,
+            total_elapsed_time,
+            total_logical_reads,
+            total_physical_reads,
+            total_logical_writes,
+            delta_spills,
+            CAST(extract(epoch FROM (date_trunc('second', collection_time) - date_trunc('second', LAG(collection_time) OVER (ORDER BY collection_time)))) AS bigint) AS sample_interval_seconds
+        FROM procedure_stats
+        WHERE server_id = $1
+        AND   database_name = $2
+        AND   schema_name = $3
+        AND   object_name = $4
+        AND   collection_time >= $5
+        AND   collection_time <= $6
+        ORDER BY collection_time
+        """;
+
+    /// <summary>The selected Top-Procedures row's full per-collection history over [<paramref name="startUtc"/>,
+    /// <paramref name="endUtc"/>], ordered by collection time.</summary>
+    public async Task<List<ViewerProcedureStatsHistoryRow>> GetProcedureStatsHistoryAsync(
+        int serverId, string databaseName, string schemaName, string objectName, DateTime startUtc, DateTime endUtc,
+        CancellationToken cancellationToken = default)
+    {
+        var rows = new List<ViewerProcedureStatsHistoryRow>();
+
+        await using var command = _dataSource.CreateCommand(ProcStatsHistorySql);
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = databaseName ?? "" });
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = schemaName ?? "" });
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = objectName ?? "" });
+        command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = DateTime.SpecifyKind(startUtc, DateTimeKind.Unspecified) });
+        command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = DateTime.SpecifyKind(endUtc, DateTimeKind.Unspecified) });
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            rows.Add(new ViewerProcedureStatsHistoryRow
+            {
+                CollectionTime = reader.GetDateTime(0),
+                DeltaExecutions = ReadLong(reader, 1),
+                DeltaCpuUs = ReadLong(reader, 2),
+                DeltaElapsedUs = ReadLong(reader, 3),
+                DeltaLogicalReads = ReadLong(reader, 4),
+                DeltaLogicalWrites = ReadLong(reader, 5),
+                DeltaPhysicalReads = ReadLong(reader, 6),
+                MinWorkerTimeUs = ReadLong(reader, 7),
+                MaxWorkerTimeUs = ReadLong(reader, 8),
+                MinElapsedTimeUs = ReadLong(reader, 9),
+                MaxElapsedTimeUs = ReadLong(reader, 10),
+                TotalSpills = ReadLong(reader, 11),
+                MinLogicalReads = ReadLong(reader, 12),
+                MaxLogicalReads = ReadLong(reader, 13),
+                MinPhysicalReads = ReadLong(reader, 14),
+                MaxPhysicalReads = ReadLong(reader, 15),
+                MinLogicalWrites = ReadLong(reader, 16),
+                MaxLogicalWrites = ReadLong(reader, 17),
+                MinSpills = ReadLong(reader, 18),
+                MaxSpills = ReadLong(reader, 19),
+                SqlHandle = reader.IsDBNull(20) ? "" : reader.GetString(20),
+                PlanHandle = reader.IsDBNull(21) ? "" : reader.GetString(21),
+                CachedTime = reader.IsDBNull(22) ? null : reader.GetDateTime(22),
+                LastExecutionTime = reader.IsDBNull(23) ? null : reader.GetDateTime(23),
+                ObjectType = reader.IsDBNull(24) ? "" : reader.GetString(24),
+                TotalExecutions = ReadLong(reader, 25),
+                TotalCpuUs = ReadLong(reader, 26),
+                TotalElapsedUs = ReadLong(reader, 27),
+                TotalLogicalReads = ReadLong(reader, 28),
+                TotalPhysicalReads = ReadLong(reader, 29),
+                TotalLogicalWrites = ReadLong(reader, 30),
+                DeltaSpills = ReadLong(reader, 31),
+                SampleIntervalSeconds = reader.IsDBNull(32) ? null : ReadInt(reader, 32),
+            });
+        }
+
+        return rows;
+    }
+
+    // ══════════════════════════════ Query Store history ══════════════════════════════
+
+    /// <summary>
+    /// Every collected query_store_stats snapshot for one (database, query_id) over the window — Lite's
+    /// <c>GetQueryStoreHistoryAsync</c> column list against the base <c>query_store_stats</c> table. Query-scoped
+    /// (NOT plan-filtered): the window returns every plan the query ran under so plan switches / regressions
+    /// draw as separate chart series, exactly like Lite. Duration / CPU / CLR convert us → ms and memory pages
+    /// → MB in SQL (mirroring the DuckDB casts). $1 server_id, $2 database_name, $3 query_id, $4 window start,
+    /// $5 window end (naive UTC).
+    /// </summary>
+    public const string QueryStoreHistorySql = """
+        SELECT
+            collection_time,
+            execution_count,
+            CAST(avg_duration_us AS double precision) / 1000.0 AS avg_duration_ms,
+            CAST(avg_cpu_time_us AS double precision) / 1000.0 AS avg_cpu_time_ms,
+            CAST(avg_logical_io_reads AS double precision) AS avg_logical_reads,
+            CAST(avg_logical_io_writes AS double precision) AS avg_logical_writes,
+            CAST(avg_physical_io_reads AS double precision) AS avg_physical_reads,
+            CAST(avg_rowcount AS double precision) AS avg_rowcount,
+            last_execution_time,
+            min_dop,
+            max_dop,
+            execution_type_desc,
+            first_execution_time,
+            module_name,
+            CAST(avg_num_physical_io_reads AS double precision) AS avg_num_physical_reads,
+            CAST(min_num_physical_io_reads AS double precision) AS min_num_physical_reads,
+            CAST(max_num_physical_io_reads AS double precision) AS max_num_physical_reads,
+            CAST(avg_clr_time_us AS double precision) / 1000.0 AS avg_clr_time_ms,
+            CAST(min_clr_time_us AS double precision) / 1000.0 AS min_clr_time_ms,
+            CAST(max_clr_time_us AS double precision) / 1000.0 AS max_clr_time_ms,
+            CAST(avg_log_bytes_used AS double precision) / 1048576.0 AS avg_log_mb,
+            CAST(min_log_bytes_used AS double precision) / 1048576.0 AS min_log_mb,
+            CAST(max_log_bytes_used AS double precision) / 1048576.0 AS max_log_mb,
+            plan_id,
+            CAST(min_duration_us AS double precision) / 1000.0 AS min_duration_ms,
+            CAST(max_duration_us AS double precision) / 1000.0 AS max_duration_ms,
+            CAST(min_cpu_time_us AS double precision) / 1000.0 AS min_cpu_time_ms,
+            CAST(max_cpu_time_us AS double precision) / 1000.0 AS max_cpu_time_ms,
+            CAST(min_logical_io_reads AS double precision) AS min_logical_reads,
+            CAST(max_logical_io_reads AS double precision) AS max_logical_reads,
+            CAST(min_logical_io_writes AS double precision) AS min_logical_writes,
+            CAST(max_logical_io_writes AS double precision) AS max_logical_writes,
+            CAST(min_physical_io_reads AS double precision) AS min_physical_reads,
+            CAST(max_physical_io_reads AS double precision) AS max_physical_reads,
+            CAST(min_rowcount AS double precision) AS min_rowcount,
+            CAST(max_rowcount AS double precision) AS max_rowcount,
+            CAST(avg_query_max_used_memory AS double precision) * 8.0 / 1024.0 AS avg_memory_mb,
+            CAST(min_query_max_used_memory AS double precision) * 8.0 / 1024.0 AS min_memory_mb,
+            CAST(max_query_max_used_memory AS double precision) * 8.0 / 1024.0 AS max_memory_mb,
+            CAST(avg_tempdb_space_used AS double precision) * 8.0 / 1024.0 AS avg_tempdb_mb,
+            CAST(min_tempdb_space_used AS double precision) * 8.0 / 1024.0 AS min_tempdb_mb,
+            CAST(max_tempdb_space_used AS double precision) * 8.0 / 1024.0 AS max_tempdb_mb,
+            plan_type,
+            is_forced_plan,
+            force_failure_count,
+            last_force_failure_reason,
+            plan_forcing_type,
+            compatibility_level,
+            query_hash,
+            query_plan_hash
+        FROM query_store_stats
+        WHERE server_id = $1
+        AND   database_name = $2
+        AND   query_id = $3
+        AND   collection_time >= $4
+        AND   collection_time <= $5
+        ORDER BY collection_time
+        """;
+
+    /// <summary>The selected Query Store row's full per-collection history for its query_id (every plan) over
+    /// [<paramref name="startUtc"/>, <paramref name="endUtc"/>], ordered by collection time.</summary>
+    public async Task<List<ViewerQueryStoreHistoryRow>> GetQueryStoreHistoryAsync(
+        int serverId, string databaseName, long queryId, DateTime startUtc, DateTime endUtc,
+        CancellationToken cancellationToken = default)
+    {
+        var rows = new List<ViewerQueryStoreHistoryRow>();
+
+        await using var command = _dataSource.CreateCommand(QueryStoreHistorySql);
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = databaseName ?? "" });
+        command.Parameters.Add(new NpgsqlParameter<long> { TypedValue = queryId });
+        command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = DateTime.SpecifyKind(startUtc, DateTimeKind.Unspecified) });
+        command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = DateTime.SpecifyKind(endUtc, DateTimeKind.Unspecified) });
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            rows.Add(new ViewerQueryStoreHistoryRow
+            {
+                CollectionTime = reader.GetDateTime(0),
+                ExecutionCount = ReadLong(reader, 1),
+                AvgDurationMs = ReadDouble(reader, 2),
+                AvgCpuTimeMs = ReadDouble(reader, 3),
+                AvgLogicalReads = ReadDouble(reader, 4),
+                AvgLogicalWrites = ReadDouble(reader, 5),
+                AvgPhysicalReads = ReadDouble(reader, 6),
+                AvgRowcount = ReadDouble(reader, 7),
+                LastExecutionTime = reader.IsDBNull(8) ? null : reader.GetDateTime(8),
+                MinDop = ReadLong(reader, 9),
+                MaxDop = ReadLong(reader, 10),
+                ExecutionTypeDesc = reader.IsDBNull(11) ? "" : reader.GetString(11),
+                FirstExecutionTime = reader.IsDBNull(12) ? null : reader.GetDateTime(12),
+                ModuleName = reader.IsDBNull(13) ? "" : reader.GetString(13),
+                AvgNumPhysicalReads = ReadDouble(reader, 14),
+                MinNumPhysicalReads = ReadDouble(reader, 15),
+                MaxNumPhysicalReads = ReadDouble(reader, 16),
+                AvgClrTimeMs = ReadDouble(reader, 17),
+                MinClrTimeMs = ReadDouble(reader, 18),
+                MaxClrTimeMs = ReadDouble(reader, 19),
+                AvgLogMb = ReadDouble(reader, 20),
+                MinLogMb = ReadDouble(reader, 21),
+                MaxLogMb = ReadDouble(reader, 22),
+                PlanId = ReadLong(reader, 23),
+                MinDurationMs = ReadDouble(reader, 24),
+                MaxDurationMs = ReadDouble(reader, 25),
+                MinCpuTimeMs = ReadDouble(reader, 26),
+                MaxCpuTimeMs = ReadDouble(reader, 27),
+                MinLogicalReads = ReadDouble(reader, 28),
+                MaxLogicalReads = ReadDouble(reader, 29),
+                MinLogicalWrites = ReadDouble(reader, 30),
+                MaxLogicalWrites = ReadDouble(reader, 31),
+                MinPhysicalReads = ReadDouble(reader, 32),
+                MaxPhysicalReads = ReadDouble(reader, 33),
+                MinRowcount = ReadDouble(reader, 34),
+                MaxRowcount = ReadDouble(reader, 35),
+                AvgMemoryMb = ReadDouble(reader, 36),
+                MinMemoryMb = ReadDouble(reader, 37),
+                MaxMemoryMb = ReadDouble(reader, 38),
+                AvgTempdbMb = ReadDouble(reader, 39),
+                MinTempdbMb = ReadDouble(reader, 40),
+                MaxTempdbMb = ReadDouble(reader, 41),
+                PlanType = reader.IsDBNull(42) ? "" : reader.GetString(42),
+                IsForcedPlan = !reader.IsDBNull(43) && reader.GetBoolean(43),
+                ForceFailureCount = ReadLong(reader, 44),
+                LastForceFailureReason = reader.IsDBNull(45) ? "" : reader.GetString(45),
+                PlanForcingType = reader.IsDBNull(46) ? "" : reader.GetString(46),
+                CompatibilityLevel = ReadInt(reader, 47),
+                QueryHash = reader.IsDBNull(48) ? "" : reader.GetString(48),
+                QueryPlanHash = reader.IsDBNull(49) ? "" : reader.GetString(49),
+            });
+        }
+
+        return rows;
+    }
+
+    // ── Type-tolerant column readers (the history reads pull raw bigint / integer / numeric columns) ──
+
+    private static long ReadLong(NpgsqlDataReader reader, int ordinal)
+        => reader.IsDBNull(ordinal) ? 0L : Convert.ToInt64(reader.GetValue(ordinal));
+
+    private static int ReadInt(NpgsqlDataReader reader, int ordinal)
+        => reader.IsDBNull(ordinal) ? 0 : Convert.ToInt32(reader.GetValue(ordinal));
+
+    private static double ReadDouble(NpgsqlDataReader reader, int ordinal)
+        => reader.IsDBNull(ordinal) ? 0.0 : Convert.ToDouble(reader.GetValue(ordinal));
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerHistoryRows.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerHistoryRows.cs
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// Row models for the per-item execution-history drill-down windows — the viewer copies of Lite's
+/// <c>QueryStatsHistoryRow</c> / <c>ProcedureStatsHistoryRow</c> / <c>QueryStoreHistoryRow</c>
+/// (LocalDataService.QueryStats.cs / .QueryStore.cs). Numeric members stay in the store's units (microseconds
+/// for CPU/duration, KB for grants); the display properties convert, mirroring Lite's grid + metric chart.
+/// The one viewer adaptation is time display: <see cref="CollectionTime"/> is the collector's naive-UTC
+/// capture time and routes through <see cref="ViewerTimeHelper.ForDisplay"/>, while the DMV / Query Store
+/// wall-clock stamps (creation / last-execution / cached / first-execution) are the SQL server's own local
+/// time and render raw through <see cref="ViewerDataService.FormatServerClock"/> — the same split every other
+/// viewer query row uses (see <see cref="ViewerQueryStatsRow"/>).
+/// </summary>
+internal static class HistoryTime
+{
+    /// <summary>Formats a naive-UTC collection timestamp in the current display mode (Server / Local / UTC).</summary>
+    public static string CollectionLocal(DateTime collectionTimeUtc)
+        => ViewerTimeHelper.ForDisplay(collectionTimeUtc).ToString("yyyy-MM-dd HH:mm:ss");
+}
+
+/// <summary>One collected query_stats snapshot for a single (database, query_hash) — Lite's
+/// <c>QueryStatsHistoryRow</c>. The <c>delta_*</c> members are the collector's per-cycle deltas (no C#
+/// differencing); the Avg* properties divide the cycle delta by that cycle's execution delta, matching Lite.</summary>
+public sealed class ViewerQueryStatsHistoryRow
+{
+    public DateTime CollectionTime { get; set; }
+    public long DeltaExecutions { get; set; }
+    public long DeltaCpuUs { get; set; }
+    public long DeltaElapsedUs { get; set; }
+    public long DeltaLogicalReads { get; set; }
+    public long DeltaLogicalWrites { get; set; }
+    public long DeltaPhysicalReads { get; set; }
+    public long DeltaRows { get; set; }
+    public long DeltaSpills { get; set; }
+    public int MinDop { get; set; }
+    public int MaxDop { get; set; }
+    public long MinCpuUs { get; set; }
+    public long MaxCpuUs { get; set; }
+    public long MinElapsedUs { get; set; }
+    public long MaxElapsedUs { get; set; }
+    public long MinGrantKb { get; set; }
+    public long MaxGrantKb { get; set; }
+    public long MinUsedGrantKb { get; set; }
+    public long MaxUsedGrantKb { get; set; }
+    public long MinIdealGrantKb { get; set; }
+    public long MaxIdealGrantKb { get; set; }
+    public long MinReservedThreads { get; set; }
+    public long MaxReservedThreads { get; set; }
+    public long MinUsedThreads { get; set; }
+    public long MaxUsedThreads { get; set; }
+    public long MinPhysicalReads { get; set; }
+    public long MaxPhysicalReads { get; set; }
+    public long MinRows { get; set; }
+    public long MaxRows { get; set; }
+    public long MinSpills { get; set; }
+    public long MaxSpills { get; set; }
+    public long TotalClrTimeUs { get; set; }
+    public string QueryPlanHash { get; set; } = "";
+    public DateTime? CreationTime { get; set; }
+    public DateTime? LastExecutionTime { get; set; }
+    public long TotalExecutions { get; set; }
+    public long TotalCpuUs { get; set; }
+    public long TotalElapsedUs { get; set; }
+    public long TotalLogicalReads { get; set; }
+    public long TotalLogicalWrites { get; set; }
+    public long TotalPhysicalReads { get; set; }
+    public long TotalRows { get; set; }
+    public long TotalSpills { get; set; }
+    public string SqlHandle { get; set; } = "";
+    public string PlanHandle { get; set; } = "";
+    public string QueryHash { get; set; } = "";
+    public int? SampleIntervalSeconds { get; set; }
+    public double DeltaCpuMs => DeltaCpuUs / 1000.0;
+    public double DeltaElapsedMs => DeltaElapsedUs / 1000.0;
+    public double AvgCpuMs => DeltaExecutions > 0 ? DeltaCpuMs / DeltaExecutions : 0;
+    public double AvgElapsedMs => DeltaExecutions > 0 ? DeltaElapsedMs / DeltaExecutions : 0;
+    public double AvgReads => DeltaExecutions > 0 ? (double)DeltaLogicalReads / DeltaExecutions : 0;
+    public double AvgPhysicalReads => DeltaExecutions > 0 ? (double)DeltaPhysicalReads / DeltaExecutions : 0;
+    public double AvgWrites => DeltaExecutions > 0 ? (double)DeltaLogicalWrites / DeltaExecutions : 0;
+    public double AvgRows => DeltaExecutions > 0 ? (double)DeltaRows / DeltaExecutions : 0;
+    public double MinCpuMs => MinCpuUs / 1000.0;
+    public double MaxCpuMs => MaxCpuUs / 1000.0;
+    public double MinElapsedMs => MinElapsedUs / 1000.0;
+    public double MaxElapsedMs => MaxElapsedUs / 1000.0;
+    public double TotalClrMs => TotalClrTimeUs / 1000.0;
+    public double TotalCpuMs => TotalCpuUs / 1000.0;
+    public double TotalElapsedMs => TotalElapsedUs / 1000.0;
+    public string CollectionTimeLocal => HistoryTime.CollectionLocal(CollectionTime);
+    public string CreationTimeLocal => ViewerDataService.FormatServerClock(CreationTime);
+    public string LastExecutionTimeLocal => ViewerDataService.FormatServerClock(LastExecutionTime);
+}
+
+/// <summary>One collected procedure_stats snapshot for a single (database, schema, object) — Lite's
+/// <c>ProcedureStatsHistoryRow</c>.</summary>
+public sealed class ViewerProcedureStatsHistoryRow
+{
+    public DateTime CollectionTime { get; set; }
+    public long DeltaExecutions { get; set; }
+    public long DeltaCpuUs { get; set; }
+    public long DeltaElapsedUs { get; set; }
+    public long DeltaLogicalReads { get; set; }
+    public long DeltaLogicalWrites { get; set; }
+    public long DeltaPhysicalReads { get; set; }
+    public long MinWorkerTimeUs { get; set; }
+    public long MaxWorkerTimeUs { get; set; }
+    public long MinElapsedTimeUs { get; set; }
+    public long MaxElapsedTimeUs { get; set; }
+    public long TotalSpills { get; set; }
+    public long MinLogicalReads { get; set; }
+    public long MaxLogicalReads { get; set; }
+    public long MinPhysicalReads { get; set; }
+    public long MaxPhysicalReads { get; set; }
+    public long MinLogicalWrites { get; set; }
+    public long MaxLogicalWrites { get; set; }
+    public long MinSpills { get; set; }
+    public long MaxSpills { get; set; }
+    public string SqlHandle { get; set; } = "";
+    public string PlanHandle { get; set; } = "";
+    public DateTime? CachedTime { get; set; }
+    public DateTime? LastExecutionTime { get; set; }
+    public string ObjectType { get; set; } = "";
+    public long TotalExecutions { get; set; }
+    public long TotalCpuUs { get; set; }
+    public long TotalElapsedUs { get; set; }
+    public long TotalLogicalReads { get; set; }
+    public long TotalPhysicalReads { get; set; }
+    public long TotalLogicalWrites { get; set; }
+    public long DeltaSpills { get; set; }
+    public int? SampleIntervalSeconds { get; set; }
+    public double DeltaCpuMs => DeltaCpuUs / 1000.0;
+    public double DeltaElapsedMs => DeltaElapsedUs / 1000.0;
+    public double AvgCpuMs => DeltaExecutions > 0 ? DeltaCpuMs / DeltaExecutions : 0;
+    public double AvgElapsedMs => DeltaExecutions > 0 ? DeltaElapsedMs / DeltaExecutions : 0;
+    public double AvgReads => DeltaExecutions > 0 ? (double)DeltaLogicalReads / DeltaExecutions : 0;
+    public double AvgPhysicalReads => DeltaExecutions > 0 ? (double)DeltaPhysicalReads / DeltaExecutions : 0;
+    public double AvgWrites => DeltaExecutions > 0 ? (double)DeltaLogicalWrites / DeltaExecutions : 0;
+    public double AvgSpills => DeltaExecutions > 0 ? (double)DeltaSpills / DeltaExecutions : 0;
+    public double MinCpuMs => MinWorkerTimeUs / 1000.0;
+    public double MaxCpuMs => MaxWorkerTimeUs / 1000.0;
+    public double MinElapsedMs => MinElapsedTimeUs / 1000.0;
+    public double MaxElapsedMs => MaxElapsedTimeUs / 1000.0;
+    public double TotalCpuMs => TotalCpuUs / 1000.0;
+    public double TotalElapsedMs => TotalElapsedUs / 1000.0;
+    public string CollectionTimeLocal => HistoryTime.CollectionLocal(CollectionTime);
+    public string CachedTimeLocal => ViewerDataService.FormatServerClock(CachedTime);
+    public string LastExecutionTimeLocal => ViewerDataService.FormatServerClock(LastExecutionTime);
+}
+
+/// <summary>One collected query_store_stats snapshot for a single (database, query_id) plan — Lite's
+/// <c>QueryStoreHistoryRow</c>. The avg / min / max metric members are already ms (duration/CPU/CLR) or MB
+/// (memory / tempdb / log) — converted in SQL. A query can span several plans over the window; the drill-down
+/// chart draws one series per <see cref="PlanId"/>.</summary>
+public sealed class ViewerQueryStoreHistoryRow
+{
+    public DateTime CollectionTime { get; set; }
+    public long ExecutionCount { get; set; }
+    public double AvgDurationMs { get; set; }
+    public double AvgCpuTimeMs { get; set; }
+    public double AvgLogicalReads { get; set; }
+    public double AvgLogicalWrites { get; set; }
+    public double AvgPhysicalReads { get; set; }
+    public double AvgRowcount { get; set; }
+    public DateTime? LastExecutionTime { get; set; }
+    public long MinDop { get; set; }
+    public long MaxDop { get; set; }
+    public string ExecutionTypeDesc { get; set; } = "";
+    public DateTime? FirstExecutionTime { get; set; }
+    public string ModuleName { get; set; } = "";
+    public double AvgNumPhysicalReads { get; set; }
+    public double MinNumPhysicalReads { get; set; }
+    public double MaxNumPhysicalReads { get; set; }
+    public double AvgClrTimeMs { get; set; }
+    public double MinClrTimeMs { get; set; }
+    public double MaxClrTimeMs { get; set; }
+    public double AvgLogMb { get; set; }
+    public double MinLogMb { get; set; }
+    public double MaxLogMb { get; set; }
+    public long PlanId { get; set; }
+    public double MinDurationMs { get; set; }
+    public double MaxDurationMs { get; set; }
+    public double MinCpuTimeMs { get; set; }
+    public double MaxCpuTimeMs { get; set; }
+    public double MinLogicalReads { get; set; }
+    public double MaxLogicalReads { get; set; }
+    public double MinLogicalWrites { get; set; }
+    public double MaxLogicalWrites { get; set; }
+    public double MinPhysicalReads { get; set; }
+    public double MaxPhysicalReads { get; set; }
+    public double MinRowcount { get; set; }
+    public double MaxRowcount { get; set; }
+    public double AvgMemoryMb { get; set; }
+    public double MinMemoryMb { get; set; }
+    public double MaxMemoryMb { get; set; }
+    public double AvgTempdbMb { get; set; }
+    public double MinTempdbMb { get; set; }
+    public double MaxTempdbMb { get; set; }
+    public string PlanType { get; set; } = "";
+    public bool IsForcedPlan { get; set; }
+    public long ForceFailureCount { get; set; }
+    public string LastForceFailureReason { get; set; } = "";
+    public string PlanForcingType { get; set; } = "";
+    public int CompatibilityLevel { get; set; }
+    public string QueryHash { get; set; } = "";
+    public string QueryPlanHash { get; set; } = "";
+
+    public double TotalDurationMs => ExecutionCount * AvgDurationMs;
+    public double TotalCpuMs => ExecutionCount * AvgCpuTimeMs;
+    public string CollectionTimeLocal => HistoryTime.CollectionLocal(CollectionTime);
+    public string FirstExecutionTimeLocal => ViewerDataService.FormatServerClock(FirstExecutionTime);
+    public string LastExecutionTimeLocal => ViewerDataService.FormatServerClock(LastExecutionTime);
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.History.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.History.cs
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The per-row double-click execution-history drill-downs — a port of Lite's <c>ServerTab.Grids.cs</c>
+/// <c>*Grid_MouseDoubleClick</c> handlers: double-clicking a Top Queries / Top Procedures / Query Store row
+/// opens that item's history window (<see cref="QueryStatsHistoryWindow"/> / <see cref="ProcedureHistoryWindow"/>
+/// / <see cref="QueryStoreHistoryWindow"/>), showing its metric trend + per-collection snapshot grid over the
+/// toolbar's current window (<see cref="GetWindowUtc"/>). This is a DIFFERENT event from #1409's grid
+/// SelectionChanged slicer overlay (ViewerServerTab.SlicerOverlay.cs) — both are wired on the same three grids
+/// and coexist (a double-click also selects the row, so the overlay updates too). The row → window-parameter
+/// mapping (which fields identify the double-clicked item, and when a row can't open a window) is factored into
+/// pure static <c>Map*HistoryKey</c> methods so it is unit-testable without WPF.
+/// </summary>
+public partial class ViewerServerTab
+{
+    /// <summary>The fields that identify a double-clicked Top-Queries row's history window (Lite gates on a
+    /// non-empty database + query_hash).</summary>
+    public sealed record QueryStatsHistoryKey(string DatabaseName, string QueryHash, string QueryText);
+
+    /// <summary>The fields that identify a double-clicked Top-Procedures row's history window (Lite gates on a
+    /// non-empty database + object name).</summary>
+    public sealed record ProcedureHistoryKey(string DatabaseName, string SchemaName, string ObjectName);
+
+    /// <summary>The fields that identify a double-clicked Query Store row's history window (Lite gates on a
+    /// non-empty database + a non-zero query_id; the window is query-scoped, plan_id seeds the launched row).</summary>
+    public sealed record QueryStoreHistoryKey(string DatabaseName, long QueryId, long PlanId, string QueryText);
+
+    /// <summary>
+    /// Wires the three query grids' MouseDoubleClick to their history windows. Called from the constructor
+    /// after InitializeComponent, so the named grids exist. Subscribed for the life of the tab (the grids are
+    /// never re-created); no unsubscribe needed — the same lifetime rule <see cref="WireSlicerOverlays"/> uses.
+    /// </summary>
+    private void WireHistoryDrillDowns()
+    {
+        QueryStatsGrid.MouseDoubleClick += QueryStatsGrid_MouseDoubleClick;
+        ProcedureStatsGrid.MouseDoubleClick += ProcedureStatsGrid_MouseDoubleClick;
+        QueryStoreGrid.MouseDoubleClick += QueryStoreGrid_MouseDoubleClick;
+    }
+
+    /// <summary>Maps a Top-Queries grid row to its history-window key, or null when the row can't open one
+    /// (missing database or query_hash) — Lite's <c>QueryStatsGrid_MouseDoubleClick</c> guard. Pure + static.</summary>
+    internal static QueryStatsHistoryKey? MapQueryStatsHistoryKey(ViewerQueryStatsRow? row)
+        => row is null || string.IsNullOrEmpty(row.DatabaseName) || string.IsNullOrEmpty(row.QueryHash)
+            ? null
+            : new QueryStatsHistoryKey(row.DatabaseName, row.QueryHash, row.QueryText);
+
+    /// <summary>Maps a Top-Procedures grid row to its history-window key, or null when the row can't open one
+    /// (missing database or object name) — Lite's <c>ProcedureStatsGrid_MouseDoubleClick</c> guard. Pure + static.</summary>
+    internal static ProcedureHistoryKey? MapProcedureHistoryKey(ViewerProcedureStatsRow? row)
+        => row is null || string.IsNullOrEmpty(row.DatabaseName) || string.IsNullOrEmpty(row.ObjectName)
+            ? null
+            : new ProcedureHistoryKey(row.DatabaseName, row.SchemaName, row.ObjectName);
+
+    /// <summary>Maps a Query Store grid row to its history-window key, or null when the row can't open one
+    /// (missing database or a zero query_id) — Lite's <c>QueryStoreGrid_MouseDoubleClick</c> guard. Pure + static.</summary>
+    internal static QueryStoreHistoryKey? MapQueryStoreHistoryKey(ViewerQueryStoreRow? row)
+        => row is null || string.IsNullOrEmpty(row.DatabaseName) || row.QueryId == 0
+            ? null
+            : new QueryStoreHistoryKey(row.DatabaseName, row.QueryId, row.PlanId, row.QueryText);
+
+    private void QueryStatsGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+    {
+        if (MapQueryStatsHistoryKey(QueryStatsGrid.SelectedItem as ViewerQueryStatsRow) is not { } key) return;
+
+        var (startUtc, endUtc) = GetWindowUtc();
+        var window = new QueryStatsHistoryWindow(
+            _dataService, _server.ServerId, key.DatabaseName, key.QueryHash, key.QueryText, startUtc, endUtc)
+        {
+            Owner = Window.GetWindow(this),
+        };
+        window.ShowDialog();
+    }
+
+    private void ProcedureStatsGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+    {
+        if (MapProcedureHistoryKey(ProcedureStatsGrid.SelectedItem as ViewerProcedureStatsRow) is not { } key) return;
+
+        var (startUtc, endUtc) = GetWindowUtc();
+        var window = new ProcedureHistoryWindow(
+            _dataService, _server.ServerId, key.DatabaseName, key.SchemaName, key.ObjectName, startUtc, endUtc)
+        {
+            Owner = Window.GetWindow(this),
+        };
+        window.ShowDialog();
+    }
+
+    private void QueryStoreGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+    {
+        if (MapQueryStoreHistoryKey(QueryStoreGrid.SelectedItem as ViewerQueryStoreRow) is not { } key) return;
+
+        var (startUtc, endUtc) = GetWindowUtc();
+        var window = new QueryStoreHistoryWindow(
+            _dataService, _server.ServerId, key.DatabaseName, key.QueryId, key.PlanId, key.QueryText, startUtc, endUtc)
+        {
+            Owner = Window.GetWindow(this),
+        };
+        window.ShowDialog();
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Queries.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Queries.cs
@@ -27,9 +27,10 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// time-range slicer whose drag re-reads over the selection; sorting a grid re-labels the slicer's
 /// aggregate curve (Lite's *Grid_Sorting). The Performance Trends charts / Active Queries grid+slicer /
 /// Query Heatmap live in their own partials (<c>ViewerServerTab.QueryTrends.cs</c> /
-/// <c>.ActiveQueries.cs</c> / <c>.QueryHeatmap.cs</c>). Deferred on the grids (no plan host / no live
-/// server, matching W1e's Blocking tab): the per-row double-click history windows and the slicer
-/// overlay-on-select — only drag-to-narrow + sort-driven metric re-labeling are wired.
+/// <c>.ActiveQueries.cs</c> / <c>.QueryHeatmap.cs</c>). The grids also carry the slicer overlay-on-select
+/// (#1409, <c>ViewerServerTab.SlicerOverlay.cs</c>) and the per-row double-click history windows
+/// (<c>ViewerServerTab.History.cs</c>), so all four Lite interactions — drag-to-narrow, sort-driven metric
+/// re-labeling, overlay-on-select, and double-click-for-history — are wired.
 /// </summary>
 public partial class ViewerServerTab
 {

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml.cs
@@ -164,6 +164,10 @@ public partial class ViewerServerTab : UserControl
            hover helpers, which the drill-down menus read for the nearest-series time. */
         WireChartDrillDowns();
         WireSlicerOverlays();
+
+        /* Per-row double-click history windows (ViewerServerTab.History.cs) on the three query grids — a
+           different event from the SelectionChanged slicer overlay wired just above; both coexist. */
+        WireHistoryDrillDowns();
     }
 
     /// <summary>The server this tab is bound to; MainWindow keys open tabs by this for dedupe/close.</summary>


### PR DESCRIPTION
## What

Adds the **per-object execution-history drill-down windows** the Darling viewer dropped from Lite/Dashboard — double-click a Top Queries / Top Procedures / Query Store row to see that item's metric trend over time plus a grid of its per-collection snapshots. Closes two inventory findings at once:

- parity-gap: *"Per-row double-click history windows missing on all 3 query grids (Query Stats / Procedure / Query Store History)"* (high/large)
- port-candidate: *"Per-object execution-history drill-downs (procedure / query / query-stats over time)"* (high/medium)

Faithful port of Lite's three history windows, data layer adapted DuckDB → Postgres.

## The three windows

Each mirrors its Lite counterpart (`Lite/Windows/{QueryStats,Procedure,QueryStore}HistoryWindow`): a `HistoryChart` (the selected item's metric trend over the window) + a filterable grid of that item's per-collection snapshots + a metric selector.

- **`QueryStatsHistoryWindow`** — the selected query (by `query_hash`) trended; full Lite column set (delta / avg / total / min-max, grants, threads, spills, CLR, interval, handles).
- **`ProcedureHistoryWindow`** — the selected procedure (by db + schema + object); View-Plan-only, matching Lite.
- **`QueryStoreHistoryWindow`** — the selected query (by `query_id`, **across every plan**); one chart series per `plan_id` so plan switches/regressions are visible, with a legend when >1 plan.

All three use the established viewer patterns: `ViewerTimeHelper.ForDisplay` for the naive-UTC collection time, `DataGridFilterManager` + `DataGridFilterColumns.AddFilterButtons` + `ColumnFilterPopup` for the grid, `ChartStyle`/`ChartHoverHelper`/`ChartPalette` (ScottPlot) for the chart, and the shared dark theme (mirrors `WaitDrillDownWindow`).

## Double-click wiring

`ViewerServerTab.History.cs` adds `MouseDoubleClick` handlers to `QueryStatsGrid` / `ProcedureStatsGrid` / `QueryStoreGrid`, wired from the constructor right after #1409's `WireSlicerOverlays()`. **This is a different event from #1409's `SelectionChanged` slicer overlay — both are wired on the same grids and coexist** (a double-click also selects the row, so the overlay updates too). The row → window-parameter mapping is factored into pure static `Map*HistoryKey` methods for unit testing.

## Store reads — reused vs. extended (#1409)

#1409's `ViewerDataService.ItemTimeline.cs` (`QueryStats/ProcStats/QueryStoreItemTimelineSql`) returns a **narrow five-metric per-interval curve** for the slicer overlay. The history windows need **every collected column**, so I added the fuller companion reads in `ViewerDataService.ItemHistory.cs` (`GetQueryStatsHistoryAsync` / `GetProcedureStatsHistoryAsync` / `GetQueryStoreHistoryAsync`) carrying Lite's whole `Get*HistoryAsync` column list. The overlay reads are left untouched and still power the overlay. All reads parameterized, both-sides window-bound, naive-UTC. procedure_stats has no `sample_interval_seconds` column, so the interval is derived per row via `LAG(collection_time)` exactly as Lite does. Every column was verified present in the shared collector schema.

## The one genuine hard-fact dropped

The viewer has no live `SqlClient` to a monitored server, so Lite's **live plan / "Get Actual Plan" fetch becomes "show the STORED plan"** — `GetQueryStatsPlanXmlAsync` / `GetProcedureStatsPlanXmlAsync` / `GetQueryStorePlanTextAsync` back both "View Plan" (in a `PlanViewerControl` via `GraphViewerWindow`) and the per-row Download button (saves the stored plan to `.sqlplan`). "Get Actual Plan" is dropped, matching every other viewer surface. Nothing else was cut — every window, column, metric, and behavior ports.

## Tests

`Darling.Tests/ViewerHistoryWindowTests.cs` (18 tests): pins the three history SQL reads (FROM table + positional params + `ORDER BY collection_time` + PG dialect + the LAG-derived procedure interval + query-scoped-not-plan-filtered QS), the row-model delta/avg/total derivations (µs→ms, per-execution averages, zero-guard, QS total = avg × exec_count), each window's `GetMetricValue` projection, and the pure `Map*HistoryKey` row→window mappers.

- Whole Darling solution builds in **Release** (Viewer + Service + Storage + Analysis), 0 errors.
- `Darling.Tests -c Release`: **1050 passed / 97 skipped (live-PG, gated on DARLING_TEST_PG) / 0 failed**.
- Touches only the Viewer project + Darling.Tests (no Service/Storage/Config/Migrations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)