### PR TITLE
Stage 4: Darling service self-alerts (collection-stopped, connection lost/restored, capture-down) + resolution history

### DIFF
--- a/Darling/Darling.Tests/DarlingSelfAlertTests.cs
+++ b/Darling/Darling.Tests/DarlingSelfAlertTests.cs
@@ -1,0 +1,576 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+using PerformanceMonitor.Alerting;
+using PerformanceMonitor.Darling.Service;
+using PerformanceMonitor.Darling.Storage;
+using PerformanceMonitor.Notifications;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Pins Stage 4 of the Darling control plane — the SERVICE's self-alerts
+/// (<see cref="DarlingSelfAlertEvaluator"/>). The pure detection (<c>IsCollectionStopped</c>) and the
+/// EDGE behavior (fire once on the transition, not every sweep; write the resolution history row on
+/// recovery) are tested ungated against a recording deliverer + fake history store + a controllable
+/// clock; the two collection_log reads run against a real Postgres gated on <c>DARLING_TEST_PG</c>
+/// (skipped otherwise), mirroring <see cref="DarlingAlertingTests"/>.
+/// </summary>
+[Collection("live-postgres")]
+public sealed class DarlingSelfAlertTests
+{
+    private const int ServerId = 424242;
+    private const string Key = "424242";
+    private const string Name = "SELF-ALERT-SRV";
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    /* ---------------- fakes ---------------- */
+
+    private sealed class FakeSettings : IAlertEngineSettings
+    {
+        public bool AlertsEnabled { get; set; } = true;
+        public bool CpuEnabled { get; set; }
+        public bool BlockingEnabled { get; set; } = true;
+        public bool DeadlockEnabled { get; set; } = true;
+        public bool PoisonWaitEnabled { get; set; }
+        public bool LongRunningQueryEnabled { get; set; }
+        public bool TempDbSpaceEnabled { get; set; }
+        public bool LowDiskEnabled { get; set; }
+        public bool LongRunningJobEnabled { get; set; }
+        public bool FailedJobEnabled { get; set; }
+        public int CpuThresholdPercent { get; set; } = 80;
+        public int BlockingCountThreshold { get; set; } = 1;
+        public int DeadlockCountThreshold { get; set; } = 1;
+        public int PoisonWaitThresholdMs { get; set; } = 500;
+        public int LongRunningQueryThresholdMinutes { get; set; } = 30;
+        public int LongRunningQueryMaxResults { get; set; } = 5;
+        public bool LongRunningQueryExcludeSpServerDiagnostics { get; set; } = true;
+        public bool LongRunningQueryExcludeWaitFor { get; set; } = true;
+        public bool LongRunningQueryExcludeBackups { get; set; } = true;
+        public bool LongRunningQueryExcludeMiscWaits { get; set; } = true;
+        public bool LongRunningQueryExcludeCdc { get; set; } = true;
+        public int TempDbSpaceThresholdPercent { get; set; } = 80;
+        public int LowDiskThresholdPercent { get; set; } = 10;
+        public int LowDiskThresholdGb { get; set; } = 5;
+        public int LongRunningJobMultiplier { get; set; } = 3;
+        public int FailedJobLookbackMinutes { get; set; } = 60;
+        public int CooldownMinutes { get; set; } = 5;
+        public List<string> ExcludedDatabasesList { get; } = new();
+        public IReadOnlyList<string> ExcludedDatabases => ExcludedDatabasesList;
+        public CpuAlertMode CpuAlertMode { get; set; } = CpuAlertMode.TotalServer;
+    }
+
+    private sealed class RecordingDeliverer : IAlertDeliverer
+    {
+        public List<AlertOutcome> Outcomes { get; } = new();
+
+        public Task DeliverAsync(AlertOutcome outcome, CancellationToken cancellationToken = default)
+        {
+            Outcomes.Add(outcome);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FakeHistoryStore : IAlertHistoryStore
+    {
+        public List<AlertHistoryRecord> Records { get; } = new();
+
+        public Task RecordAlertAsync(AlertHistoryRecord record)
+        {
+            Records.Add(record);
+            return Task.CompletedTask;
+        }
+
+        public Task<DateTime?> GetLastEmailSentUtcAsync(string serverId, string metricName, string? dedupKey = null) =>
+            Task.FromResult<DateTime?>(null);
+
+        public Task<DateTime?> GetLastWebhookSentUtcAsync(string serverId, string metricName, string? dedupKey = null) =>
+            Task.FromResult<DateTime?>(null);
+
+        public Task<DateTime?> GetLastAlertTimeAsync(string serverId, string metricName) =>
+            Task.FromResult<DateTime?>(null);
+    }
+
+    /// <summary>One evaluator + fakes + a controllable clock per test.</summary>
+    private sealed class Harness
+    {
+        public FakeSettings Settings { get; } = new();
+        public RecordingDeliverer Deliverer { get; } = new();
+        public FakeHistoryStore History { get; } = new();
+        public bool Muted { get; set; }
+        public DateTime Now { get; set; } = new(2026, 7, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        public DarlingSelfAlertEvaluator Build() => new(
+            Settings, Deliverer, History, _ => Muted, logger: null, utcNow: () => Now);
+    }
+
+    /* ---------------- collection-stopped detection (pure) ---------------- */
+
+    [Fact]
+    public void IsCollectionStopped_FreshSuccess_NotStopped()
+    {
+        var now = new DateTime(2026, 7, 1, 12, 0, 0, DateTimeKind.Utc);
+        /* Last success two minutes ago, recent runs all succeeded — healthy. */
+        Assert.False(DarlingSelfAlertEvaluator.IsCollectionStopped(now.AddMinutes(-2), 10, 10, now, out var reason));
+        Assert.Equal("", reason);
+    }
+
+    [Fact]
+    public void IsCollectionStopped_NoSuccessWithinStaleWindow_Stopped()
+    {
+        var now = new DateTime(2026, 7, 1, 12, 0, 0, DateTimeKind.Utc);
+        /* Last success 45 minutes ago (>= the 30-minute window), recent runs mixed — stale => stopped. */
+        Assert.True(DarlingSelfAlertEvaluator.IsCollectionStopped(now.AddMinutes(-45), 5, 3, now, out var reason));
+        Assert.Contains("45 minutes", reason);
+    }
+
+    [Fact]
+    public void IsCollectionStopped_ExactlyAtStaleWindow_Stopped()
+    {
+        var now = new DateTime(2026, 7, 1, 12, 0, 0, DateTimeKind.Utc);
+        /* Boundary: elapsed == StaleWindow counts as stale (>=). */
+        Assert.True(DarlingSelfAlertEvaluator.IsCollectionStopped(
+            now - DarlingSelfAlertEvaluator.StaleWindow, 5, 4, now, out _));
+    }
+
+    [Fact]
+    public void IsCollectionStopped_NeverRan_NotStopped()
+    {
+        var now = new DateTime(2026, 7, 1, 12, 0, 0, DateTimeKind.Utc);
+        /* A freshly-added / never-connected server (no success ever, no runs) must NOT read as stopped —
+           the connection-lost alert covers that, and a warming-up server is not "broken". */
+        Assert.False(DarlingSelfAlertEvaluator.IsCollectionStopped(null, 0, 0, now, out _));
+    }
+
+    [Fact]
+    public void IsCollectionStopped_ConsecutiveFailuresNoSuccessEver_Stopped()
+    {
+        var now = new DateTime(2026, 7, 1, 12, 0, 0, DateTimeKind.Utc);
+        /* Connected but every one of the last N runs failed (never a success) => stopped fast, before the
+           staleness backstop would trip. */
+        Assert.True(DarlingSelfAlertEvaluator.IsCollectionStopped(
+            null, DarlingSelfAlertEvaluator.ConsecutiveFailureThreshold, 0, now, out var reason));
+        Assert.Contains("failed", reason);
+    }
+
+    [Fact]
+    public void IsCollectionStopped_ConsecutiveFailuresButSomeSuccessInWindow_NotStopped()
+    {
+        var now = new DateTime(2026, 7, 1, 12, 0, 0, DateTimeKind.Utc);
+        /* The last N runs include at least one success and the last success is recent — not stopped
+           (a single failing collector among healthy ones must not trip the server-level alert). */
+        Assert.False(DarlingSelfAlertEvaluator.IsCollectionStopped(
+            now.AddMinutes(-1), DarlingSelfAlertEvaluator.ConsecutiveFailureThreshold, 2, now, out _));
+    }
+
+    [Fact]
+    public void IsCollectionStopped_FewFailuresRecentSuccess_NotStopped()
+    {
+        var now = new DateTime(2026, 7, 1, 12, 0, 0, DateTimeKind.Utc);
+        /* Fewer than the consecutive threshold and a recent success — a brief hiccup, not stopped. */
+        Assert.False(DarlingSelfAlertEvaluator.IsCollectionStopped(now.AddMinutes(-1), 3, 0, now, out _));
+    }
+
+    /* ---------------- collection-stopped edge ---------------- */
+
+    [Fact]
+    public async Task CollectionStopped_FiresOnce_ThenCooldownSuppresses_ThenReFires()
+    {
+        var h = new Harness();
+        var e = h.Build();
+
+        await e.ApplyCollectionStoppedAsync(ServerId, Name, stopped: true, "no recent collection", Ct);
+        var fired = Assert.Single(h.Deliverer.Outcomes);
+        Assert.Equal("Collection Stopped", fired.MetricName);
+        Assert.Equal("collecting", fired.ThresholdValue);
+        Assert.Equal(AlertSeverityLevel.Critical, fired.Severity);
+        Assert.Equal(Key, fired.ServerKey);
+
+        /* Still stopped one minute later — inside the 5-minute cooldown, no re-fire (the EDGE: once,
+           not every sweep). */
+        h.Now = h.Now.AddMinutes(1);
+        await e.ApplyCollectionStoppedAsync(ServerId, Name, stopped: true, "no recent collection", Ct);
+        Assert.Single(h.Deliverer.Outcomes);
+
+        /* After the cooldown the standing condition re-fires. */
+        h.Now = h.Now.AddMinutes(5);
+        await e.ApplyCollectionStoppedAsync(ServerId, Name, stopped: true, "no recent collection", Ct);
+        Assert.Equal(2, h.Deliverer.Outcomes.Count);
+    }
+
+    [Fact]
+    public async Task CollectionStopped_Recovery_WritesOneResumedHistoryRow()
+    {
+        var h = new Harness();
+        var e = h.Build();
+
+        await e.ApplyCollectionStoppedAsync(ServerId, Name, stopped: true, "no recent collection", Ct);
+        Assert.Empty(h.History.Records);
+
+        /* Recovery: exactly one "Collection Resumed" audit row, no email/webhook (it went to the history
+           store, not the deliverer). */
+        await e.ApplyCollectionStoppedAsync(ServerId, Name, stopped: false, "", Ct);
+        var resumed = Assert.Single(h.History.Records);
+        Assert.Equal("Collection Resumed", resumed.MetricName);
+        Assert.True(resumed.AlertSent);
+        Assert.Equal("tray", resumed.NotificationType);
+        Assert.Single(h.Deliverer.Outcomes); /* only the original fire went to the deliverer */
+
+        /* Still healthy on the next sweep — no duplicate resumed row (resolution is edge-triggered too). */
+        await e.ApplyCollectionStoppedAsync(ServerId, Name, stopped: false, "", Ct);
+        Assert.Single(h.History.Records);
+    }
+
+    [Fact]
+    public async Task CollectionStopped_Muted_RecordedMutedNotSuppressed()
+    {
+        var h = new Harness { Muted = true };
+        var e = h.Build();
+
+        await e.ApplyCollectionStoppedAsync(ServerId, Name, stopped: true, "no recent collection", Ct);
+        var fired = Assert.Single(h.Deliverer.Outcomes);
+        Assert.True(fired.Muted); /* the deliverer skips channels but still records — same as the engine */
+    }
+
+    /* ---------------- capture-down edge ---------------- */
+
+    [Fact]
+    public async Task CaptureDown_FiresOnce_ThenRestoredHistoryRow()
+    {
+        var h = new Harness();
+        var e = h.Build();
+
+        await e.ApplyCaptureDownAsync(ServerId, Name, new[] { "Blocking", "Deadlock" }, Ct);
+        var fired = Assert.Single(h.Deliverer.Outcomes);
+        Assert.Equal("Capture Down", fired.MetricName);
+        Assert.Equal("Blocking and Deadlock", fired.CurrentValue);
+        Assert.Equal(AlertSeverityLevel.Critical, fired.Severity);
+
+        /* Still down inside the cooldown — no re-fire. */
+        h.Now = h.Now.AddMinutes(1);
+        await e.ApplyCaptureDownAsync(ServerId, Name, new[] { "Blocking", "Deadlock" }, Ct);
+        Assert.Single(h.Deliverer.Outcomes);
+
+        /* Sessions back — one "Capture Restored" audit row. */
+        await e.ApplyCaptureDownAsync(ServerId, Name, Array.Empty<string>(), Ct);
+        var restored = Assert.Single(h.History.Records);
+        Assert.Equal("Capture Restored", restored.MetricName);
+    }
+
+    [Fact]
+    public async Task CaptureDown_BlockingAndDeadlockDisabled_DoesNotFire()
+    {
+        var h = new Harness();
+        h.Settings.BlockingEnabled = false;
+        h.Settings.DeadlockEnabled = false;
+        var e = h.Build();
+
+        await e.ApplyCaptureDownAsync(ServerId, Name, new[] { "Blocking" }, Ct);
+        Assert.Empty(h.Deliverer.Outcomes);
+    }
+
+    /* ---------------- connection lost / restored edge ---------------- */
+
+    [Fact]
+    public async Task Connection_FirstConnect_IsSilentBaseline()
+    {
+        var h = new Harness();
+        var e = h.Build();
+
+        /* Unknown -> Online on the first-ever connect: no "restored" (there was no prior loss),
+           mirroring the Dashboard's skip-first-check. */
+        await e.ApplyConnectionOutcomeAsync(ServerId, Name, online: true, error: null, Ct);
+        Assert.Empty(h.Deliverer.Outcomes);
+    }
+
+    [Fact]
+    public async Task Connection_DownAtStartup_StaysDown_NeverFires()
+    {
+        var h = new Harness();
+        var e = h.Build();
+
+        /* Unknown -> Offline (baseline) then Offline -> Offline: a server simply down at startup never
+           pages; only a transition FROM a known-online state does. */
+        await e.ApplyConnectionOutcomeAsync(ServerId, Name, online: false, error: "no route", Ct);
+        await e.ApplyConnectionOutcomeAsync(ServerId, Name, online: false, error: "no route", Ct);
+        Assert.Empty(h.Deliverer.Outcomes);
+    }
+
+    [Fact]
+    public async Task Connection_Lost_FiresOnce_RepeatedFailedReconnectDoesNotReFire()
+    {
+        var h = new Harness();
+        var e = h.Build();
+
+        /* Establish an online baseline (silent). */
+        await e.ApplyConnectionOutcomeAsync(ServerId, Name, online: true, error: null, Ct);
+        Assert.Empty(h.Deliverer.Outcomes);
+
+        /* Online -> Offline: fire "Server Unreachable" ONCE. */
+        await e.ApplyConnectionOutcomeAsync(ServerId, Name, online: false, error: "Login timeout expired", Ct);
+        var lost = Assert.Single(h.Deliverer.Outcomes);
+        Assert.Equal("Server Unreachable", lost.MetricName);
+        Assert.Equal(AlertSeverityLevel.Critical, lost.Severity);
+        Assert.Equal("Login timeout expired", lost.CurrentValue);
+
+        /* Offline -> Offline (the 60s retry keeps failing): the EDGE — no re-fire. */
+        await e.ApplyConnectionOutcomeAsync(ServerId, Name, online: false, error: "Login timeout expired", Ct);
+        await e.ApplyConnectionOutcomeAsync(ServerId, Name, online: false, error: "Login timeout expired", Ct);
+        Assert.Single(h.Deliverer.Outcomes);
+    }
+
+    [Fact]
+    public async Task Connection_Restored_FiresOnce_AfterALoss()
+    {
+        var h = new Harness();
+        var e = h.Build();
+
+        await e.ApplyConnectionOutcomeAsync(ServerId, Name, online: true, error: null, Ct);   /* baseline */
+        await e.ApplyConnectionOutcomeAsync(ServerId, Name, online: false, error: "boom", Ct); /* lost */
+        Assert.Single(h.Deliverer.Outcomes);
+
+        /* Offline -> Online: fire "Server Restored" once (Severity null so the shared map renders it green). */
+        await e.ApplyConnectionOutcomeAsync(ServerId, Name, online: true, error: null, Ct);
+        Assert.Equal(2, h.Deliverer.Outcomes.Count);
+        var restored = h.Deliverer.Outcomes[1];
+        Assert.Equal("Server Restored", restored.MetricName);
+        Assert.Null(restored.Severity);
+
+        /* Staying online does not re-fire. */
+        await e.ApplyConnectionOutcomeAsync(ServerId, Name, online: true, error: null, Ct);
+        Assert.Equal(2, h.Deliverer.Outcomes.Count);
+    }
+
+    [Fact]
+    public async Task Connection_Forget_ResetsToBaseline()
+    {
+        var h = new Harness();
+        var e = h.Build();
+
+        await e.ApplyConnectionOutcomeAsync(ServerId, Name, online: true, error: null, Ct);  /* Online baseline */
+        e.Forget(ServerId);
+
+        /* After Forget the next offline is a fresh Unknown->Offline baseline again — no spurious "lost". */
+        await e.ApplyConnectionOutcomeAsync(ServerId, Name, online: false, error: "gone", Ct);
+        Assert.Empty(h.Deliverer.Outcomes);
+    }
+
+    /* ---------------- master switch ---------------- */
+
+    [Fact]
+    public async Task AlertsDisabled_ConnectionEdge_TracksStateButDoesNotFire_AndReEnableResumes()
+    {
+        var h = new Harness();
+        h.Settings.AlertsEnabled = false;
+        var e = h.Build();
+
+        /* Disabled: transitions are tracked (so re-enabling has a correct baseline) but nothing fires. */
+        await e.ApplyConnectionOutcomeAsync(ServerId, Name, online: true, error: null, Ct);
+        await e.ApplyConnectionOutcomeAsync(ServerId, Name, online: false, error: "x", Ct);
+        Assert.Empty(h.Deliverer.Outcomes);
+
+        /* Re-enable, then recover: the tracked Offline baseline makes this a real Offline->Online, so
+           "Server Restored" fires (state was not lost while disabled). */
+        h.Settings.AlertsEnabled = true;
+        await e.ApplyConnectionOutcomeAsync(ServerId, Name, online: true, error: null, Ct);
+        var restored = Assert.Single(h.Deliverer.Outcomes);
+        Assert.Equal("Server Restored", restored.MetricName);
+    }
+
+    [Fact]
+    public async Task AlertsDisabled_EvaluateStoreAlerts_ShortCircuitsBeforeAnyStoreRead()
+    {
+        var h = new Harness();
+        h.Settings.AlertsEnabled = false;
+        var e = h.Build();
+
+        /* The master gate returns before touching the store, so a null data source is never dereferenced;
+           if the gate were ever moved after the read this NREs (i.e. still fails, flagging the regression). */
+        await e.EvaluateStoreAlertsAsync(null!, ServerId, Name, connected: true, Ct);
+        Assert.Empty(h.Deliverer.Outcomes);
+        Assert.Empty(h.History.Records);
+    }
+
+    /* ---------------- resolution-record shape + engine wiring (finding #4) ---------------- */
+
+    [Fact]
+    public void BuildResolutionRecord_MirrorsDashboardClearedRowShape()
+    {
+        var record = DarlingSelfAlertEvaluator.BuildResolutionRecord(
+            new AlertResolution(Key, Name, "High CPU", "CPU Resolved", $"{Name}: Total CPU back to 12%"));
+
+        Assert.Equal(Key, record.ServerId);
+        Assert.Equal(Name, record.ServerName);
+        Assert.Equal("CPU Resolved", record.MetricName);           /* the "…Resolved/Cleared" title, Dashboard shape */
+        Assert.Equal($"{Name}: Total CPU back to 12%", record.DetailText);
+        Assert.True(record.AlertSent);
+        Assert.Equal("tray", record.NotificationType);
+        Assert.Null(record.SendError);
+        Assert.False(record.Muted);
+    }
+
+    [Fact]
+    public async Task EngineResolution_WritesResolvedHistoryRow_ThroughBuildResolutionRecord()
+    {
+        /* Replicates DarlingWorker.BuildAlertEngine's resolution wiring: the shared engine's resolution
+           callback writes a resolved-flavored history row (finding #4 — previously it only logged). */
+        var settings = new FakeSettings { CpuEnabled = true };
+        var history = new FakeHistoryStore();
+        var deliverer = new RecordingDeliverer();
+        var now = new DateTime(2026, 7, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        var engine = new AlertEngine(
+            settings, new StubReadAdapter(), new StubStateStore(), deliverer,
+            isAlertMuted: _ => false,
+            failedJobsFetcher: null,
+            resolutionCallback: async (resolution, _) =>
+                await history.RecordAlertAsync(DarlingSelfAlertEvaluator.BuildResolutionRecord(resolution)),
+            logger: null,
+            utcNow: () => now);
+
+        /* Fire: total CPU 90 >= 80. */
+        await engine.EvaluateServerAsync(new AlertServerSnapshot(Key, Name, IsOnline: true, 90, 90, false, false), Ct);
+        Assert.Single(deliverer.Outcomes);
+        Assert.Empty(history.Records); /* no resolution yet */
+
+        /* Clear: CPU back below threshold => the engine emits a resolution => a history row is written. */
+        now = now.AddMinutes(1);
+        await engine.EvaluateServerAsync(new AlertServerSnapshot(Key, Name, IsOnline: true, 10, 10, false, false), Ct);
+        var resolved = Assert.Single(history.Records);
+        Assert.Equal("CPU Resolved", resolved.MetricName);
+        Assert.Equal("tray", resolved.NotificationType);
+    }
+
+    private sealed class StubReadAdapter : IAlertReadAdapter
+    {
+        public Task<List<BlockedProcessAlertRow>> GetRecentBlockedProcessReportsAsync(string serverKey, int hoursBack, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new List<BlockedProcessAlertRow>());
+        public Task<List<DeadlockAlertRow>> GetRecentDeadlocksAsync(string serverKey, int hoursBack, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new List<DeadlockAlertRow>());
+        public Task<List<PoisonWaitDelta>> GetPoisonWaitDeltasAsync(string serverKey, double thresholdMs, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new List<PoisonWaitDelta>());
+        public Task<List<LongRunningQueryInfo>> GetLongRunningQueriesAsync(
+            string serverKey, int thresholdMinutes, int maxResults,
+            bool excludeSpServerDiagnostics, bool excludeWaitFor, bool excludeBackups, bool excludeMiscWaits, bool excludeCdc,
+            IReadOnlyList<string> excludedDatabases, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new List<LongRunningQueryInfo>());
+        public Task<List<VolumeFreeSpaceInfo>> GetVolumeFreeSpaceAsync(string serverKey, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new List<VolumeFreeSpaceInfo>());
+        public Task<TempDbSpaceInfo?> GetTempDbSpaceAsync(string serverKey, CancellationToken cancellationToken = default) =>
+            Task.FromResult<TempDbSpaceInfo?>(null);
+        public Task<List<AnomalousJobInfo>> GetAnomalousJobsAsync(string serverKey, int multiplier, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new List<AnomalousJobInfo>());
+    }
+
+    private sealed class StubStateStore : IAlertStateStore
+    {
+        public Task<int?> LoadEdgeTriggerWatermarkAsync(string serverKey, string metricName) => Task.FromResult<int?>(null);
+        public Task SaveEdgeTriggerWatermarkAsync(string serverKey, string metricName, int watermark) => Task.CompletedTask;
+        public Task<DateTime?> LoadFailedJobWatermarkAsync(string serverKey) => Task.FromResult<DateTime?>(null);
+        public Task SaveFailedJobWatermarkAsync(string serverKey, DateTime watermark) => Task.CompletedTask;
+    }
+
+    /* ---------------- live collection_log reads (gated on DARLING_TEST_PG) ---------------- */
+
+    private const int LiveServerId = -770077;
+
+    [Fact]
+    public async Task LiveStoreReads_ComputeCollectionStoppedAndCaptureDown()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the live self-alert store reads.");
+
+        var ct = Ct;
+        using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(ct);
+        await PgMigrations.MigrateAsync(connection, ct);
+        await DeleteLiveRowsAsync(connection, ct);
+
+        await using var postgres = NpgsqlDataSource.Create(connectionString!);
+        try
+        {
+            var utcNow = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Unspecified);
+
+            /* One old SUCCESS (45 min ago), then 12 recent ERRORs — the last 10 runs are all failures and
+               the last success is well past the staleness window. */
+            long logId = 9_000_000;
+            await InsertLogAsync(connection, ct, logId++, "wait_stats", utcNow.AddMinutes(-45), "SUCCESS");
+            for (int i = 0; i < 12; i++)
+            {
+                await InsertLogAsync(connection, ct, logId++, "wait_stats", utcNow.AddMinutes(-2), "ERROR");
+            }
+
+            var (lastSuccess, recentRuns, recentSuccess) = await DarlingSelfAlertEvaluator.ReadCollectionSignalsAsync(
+                postgres, LiveServerId, DarlingSelfAlertEvaluator.ConsecutiveFailureThreshold, ct);
+
+            Assert.NotNull(lastSuccess);
+            Assert.Equal(DarlingSelfAlertEvaluator.ConsecutiveFailureThreshold, recentRuns);
+            Assert.Equal(0, recentSuccess);
+            Assert.True(DarlingSelfAlertEvaluator.IsCollectionStopped(
+                lastSuccess, recentRuns, recentSuccess, DateTime.UtcNow, out _));
+
+            /* Full path: EvaluateStoreAlertsAsync must NOT fire collection-stopped until the server has been
+               online this run (the restart-staleness guard), then must fire once it has. Real-time clock so
+               the 45-minute-old success reads as stale against the seeded rows. */
+            var h = new Harness { Now = DateTime.UtcNow };
+            var evaluator = h.Build();
+
+            await evaluator.EvaluateStoreAlertsAsync(postgres, LiveServerId, Name, connected: true, ct);
+            Assert.DoesNotContain(h.Deliverer.Outcomes, o => o.MetricName == "Collection Stopped");
+
+            await evaluator.ApplyConnectionOutcomeAsync(LiveServerId, Name, online: true, error: null, ct); /* arm */
+            await evaluator.EvaluateStoreAlertsAsync(postgres, LiveServerId, Name, connected: true, ct);
+            Assert.Contains(h.Deliverer.Outcomes, o => o.MetricName == "Collection Stopped");
+
+            /* Capture-down: latest deadlocks run is SESSION_MISSING, latest blocked_process_report is fine. */
+            await InsertLogAsync(connection, ct, logId++, "blocked_process_report", utcNow.AddMinutes(-1), "SUCCESS");
+            await InsertLogAsync(connection, ct, logId++, "deadlocks", utcNow.AddMinutes(-1), "SESSION_MISSING");
+
+            var missing = await DarlingSelfAlertEvaluator.ReadMissingCaptureSessionsAsync(postgres, LiveServerId, ct);
+            Assert.Equal(new[] { "Deadlock" }, missing);
+
+            await evaluator.EvaluateStoreAlertsAsync(postgres, LiveServerId, Name, connected: true, ct);
+            Assert.Contains(h.Deliverer.Outcomes, o => o.MetricName == "Capture Down");
+        }
+        finally
+        {
+            await DeleteLiveRowsAsync(connection, ct);
+        }
+    }
+
+    private static async Task InsertLogAsync(
+        NpgsqlConnection connection, CancellationToken ct, long logId, string collector, DateTime time, string status)
+    {
+        using var command = new NpgsqlCommand(@"
+INSERT INTO collection_log (log_id, server_id, server_name, collector_name, collection_time, duration_ms, status, error_message, rows_collected, sql_duration_ms, duckdb_duration_ms)
+VALUES ($1, $2, $3, $4, $5, 0, $6, NULL, 0, 0, 0)", connection);
+        command.Parameters.AddWithValue(logId);
+        command.Parameters.AddWithValue(LiveServerId);
+        command.Parameters.AddWithValue(Name);
+        command.Parameters.AddWithValue(collector);
+        command.Parameters.AddWithValue(time);
+        command.Parameters.AddWithValue(status);
+        await command.ExecuteNonQueryAsync(ct);
+    }
+
+    private static async Task DeleteLiveRowsAsync(NpgsqlConnection connection, CancellationToken ct)
+    {
+        using var cleanup = new NpgsqlCommand(
+            $"DELETE FROM collection_log WHERE server_id = {LiveServerId.ToString(CultureInfo.InvariantCulture)};", connection);
+        await cleanup.ExecuteNonQueryAsync(ct);
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingSelfAlertEvaluator.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingSelfAlertEvaluator.cs
@@ -410,7 +410,8 @@ FROM
     AND   cl.collector_name IN ('deadlocks', 'blocked_process_report')
 ) AS x
 WHERE x.n = 1
-AND   x.status = 'SESSION_MISSING'", connection);
+AND   x.status = 'SESSION_MISSING'
+ORDER BY x.collector_name", connection);
         command.Parameters.AddWithValue(serverId);
 
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingSelfAlertEvaluator.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingSelfAlertEvaluator.cs
@@ -1,0 +1,483 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+using PerformanceMonitor.Alerting;
+using PerformanceMonitor.Notifications;
+
+namespace PerformanceMonitor.Darling.Service;
+
+/// <summary>
+/// Stage 4 of the Darling control plane — the SERVICE's self-alerts: the "is my collection actually
+/// working" conditions that matter most for an unattended 24/7 headless service where nobody is
+/// watching a dashboard. Three conditions, each a reframe of a Dashboard health check onto Darling's
+/// own signals, all routed through the SAME <see cref="IAlertDeliverer"/> the shared alert engine
+/// uses (so they inherit its email/webhook delivery, per-fingerprint delivery cooldown, and restart
+/// replay) and the SAME <c>config_alert_log</c> history store:
+/// <list type="number">
+/// <item><b>Collection Stopped / collector failure</b> — the server's <c>collection_log</c> shows no
+///   SUCCESS within a staleness window OR the last N runs all failed (reframes the Dashboard's
+///   "Collection Stopped", <c>MainWindow.AlertEngine.cs</c> + <c>NocHealth.GetCollectionStoppedAsync</c>,
+///   onto Darling's collection_log instead of msdb Agent-job state).</item>
+/// <item><b>Server Unreachable / Restored</b> — fired on the connect edge in
+///   <see cref="DarlingWorker"/>'s loop (online→offline and back), the headless twin of the
+///   Dashboard's <c>NotifyOnConnectionLost</c>/<c>Restored</c> (<c>MainWindow.xaml.cs</c>). Uses the
+///   Dashboard's exact metric names ("Server Unreachable" / "Server Restored") so the alert history
+///   vocabulary and the shared <c>AlertSeverity</c> map (Critical / green RESOLVED) match cross-app.</item>
+/// <item><b>Capture Down</b> — a missing/denied blocking-deadlock XE session, surfaced from the
+///   <c>SESSION_MISSING</c> collection_log status the tolerant XE readers now write (reframes the
+///   Dashboard's #1086 "Capture Down", <c>NocHealth.GetMissingCaptureSessionsAsync</c>).</item>
+/// </list>
+/// Each condition is EDGE-TRIGGERED (in-memory active flag + the shared alert cooldown for the polled
+/// conditions; a per-server connection state machine for the connect edge) so it fires once on the
+/// transition, not every sweep — exactly the Dashboard's <c>_activeXAlert</c>/<c>_lastXAlert</c> shape.
+/// On recovery a "…Resumed"/"…Restored" row is written to alert history (closing the audit loop the
+/// same way the engine's resolution callback now does — see <see cref="BuildResolutionRecord"/>).
+/// Gated on the master <c>alerts.enabled</c> switch; thresholds are sensible hardcoded defaults
+/// (defaults over speculative config — no new config knobs, no migration).
+/// </summary>
+internal sealed class DarlingSelfAlertEvaluator
+{
+    /* No successful collection within this window (a server that HAS collected before) reads as
+       stopped — matches the Dashboard's CollectionStaleThresholdMinutes (NocHealth.cs). The frequent
+       Darling collectors run every ~1 minute, so 30 minutes of no success is unambiguously dead; the
+       connection-lost alert covers the fast path for an unreachable server, and the consecutive-failure
+       check below covers the fast path for a server that is connected but erroring every collector. */
+    internal static readonly TimeSpan StaleWindow = TimeSpan.FromMinutes(30);
+
+    /* The last N logged runs all failing (no SUCCESS/SKIPPED among them) fires "Collection Stopped"
+       faster than the staleness backstop when a connected server's collectors are erroring on every
+       cycle. 10 spans a couple of minutes of total failure across the frequently-scheduled collectors. */
+    internal const int ConsecutiveFailureThreshold = 10;
+
+    private readonly IAlertEngineSettings _settings;
+    private readonly IAlertDeliverer _deliverer;
+    private readonly IAlertHistoryStore _historyStore;
+    private readonly Func<AlertMuteContext, bool> _isAlertMuted;
+    private readonly ILogger? _logger;
+    private readonly Func<DateTime> _utcNow;
+
+    /* Edge state, keyed by the engine's serverKey (the server_id as an invariant string — the same
+       identity the deliverer/history/watermark stores use). In-memory only, exactly like the shared
+       engine's active-condition flags; the restart replay protection is the deliverer's own
+       history-seeded email/webhook cooldown, not these. */
+    private readonly ConcurrentDictionary<string, bool> _activeCollectionStopped = new();
+    private readonly ConcurrentDictionary<string, DateTime> _lastCollectionStoppedAlert = new();
+    private readonly ConcurrentDictionary<string, bool> _activeCaptureDown = new();
+    private readonly ConcurrentDictionary<string, DateTime> _lastCaptureDownAlert = new();
+    private readonly ConcurrentDictionary<string, ConnectionState> _connectionState = new();
+
+    /* Whether the service has successfully connected to this server at least once THIS process-run. Guards
+       collection-stopped: unlike the Dashboard (whose target-side collection_log keeps filling regardless of
+       the app), Darling IS the collector, so the service's own downtime makes collection_log stale. Without
+       this guard a service restart after >30 min of downtime would false-alarm "Collection Stopped" on a
+       perfectly healthy server before its first fresh collection lands. Gating on a prior successful connect
+       makes collection-stopped a clean "was collecting, then stopped" transition (the same philosophy as the
+       connection-lost edge and the Dashboard's skip-first-check) rather than a judgement on pre-restart data. */
+    private readonly ConcurrentDictionary<string, bool> _hasBeenOnline = new();
+
+    public DarlingSelfAlertEvaluator(
+        IAlertEngineSettings settings,
+        IAlertDeliverer deliverer,
+        IAlertHistoryStore historyStore,
+        Func<AlertMuteContext, bool> isAlertMuted,
+        ILogger? logger = null,
+        Func<DateTime>? utcNow = null)
+    {
+        _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+        _deliverer = deliverer ?? throw new ArgumentNullException(nameof(deliverer));
+        _historyStore = historyStore ?? throw new ArgumentNullException(nameof(historyStore));
+        _isAlertMuted = isAlertMuted ?? throw new ArgumentNullException(nameof(isAlertMuted));
+        _logger = logger;
+        _utcNow = utcNow ?? (() => DateTime.UtcNow);
+    }
+
+    private enum ConnectionState
+    {
+        /* Never yet observed — the baseline. Unknown→online/offline never fires (mirrors the
+           Dashboard's "skip the first check" so a server that is simply down at startup does not
+           page; only a transition FROM a known state does). */
+        Unknown,
+        Online,
+        Offline
+    }
+
+    /* ---------------- store-polled self-alerts (collection-stopped + capture-down) ---------------- */
+
+    /// <summary>
+    /// Evaluates the store-polled self-alerts for one server from its <c>collection_log</c>. Gated on the
+    /// master alerts switch (mirrors the engine's early return). Collection-stopped runs for EVERY server
+    /// whether or not it is currently connected (an unreachable server has stopped collecting — that is
+    /// exactly the case to catch); capture-down runs only for a connected server (its XE collectors only
+    /// run then). Failure-isolated per condition so a bad store read never breaks the loop.
+    /// </summary>
+    public async Task EvaluateStoreAlertsAsync(
+        NpgsqlDataSource postgres, int serverId, string serverName, bool connected, CancellationToken cancellationToken)
+    {
+        if (!_settings.AlertsEnabled)
+        {
+            return;
+        }
+
+        /* Only judge collection-stopped once the service has actually collected from this server this run
+           (see _hasBeenOnline) — otherwise pre-restart / pre-re-add stale rows would false-alarm before the
+           first fresh collection lands. */
+        if (_hasBeenOnline.ContainsKey(Key(serverId)))
+        {
+            try
+            {
+                var (lastSuccess, recentRuns, recentSuccess) =
+                    await ReadCollectionSignalsAsync(postgres, serverId, ConsecutiveFailureThreshold, cancellationToken);
+                bool stopped = IsCollectionStopped(lastSuccess, recentRuns, recentSuccess, _utcNow(), out var reason);
+                await ApplyCollectionStoppedAsync(serverId, serverName, stopped, reason, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError("[{Server}] Collection-health self-alert failed: {Message}", serverName, ex.Message);
+            }
+        }
+
+        if (!connected)
+        {
+            return;
+        }
+
+        try
+        {
+            var missing = await ReadMissingCaptureSessionsAsync(postgres, serverId, cancellationToken);
+            await ApplyCaptureDownAsync(serverId, serverName, missing, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError("[{Server}] Capture-down self-alert failed: {Message}", serverName, ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Pure collection-stopped decision from the three store signals — no I/O, so it pins directly.
+    /// A NEVER-succeeded server (<paramref name="lastSuccessUtc"/> null) is deliberately NOT flagged by
+    /// the staleness backstop: a freshly-added or never-connected server must not be misread as "stopped"
+    /// (the connection-lost alert covers that). It IS flagged by the consecutive-failure path if it has
+    /// actually run and failed N times.
+    /// </summary>
+    internal static bool IsCollectionStopped(
+        DateTime? lastSuccessUtc, int recentRunCount, int recentSuccessCount, DateTime nowUtc, out string reason)
+    {
+        /* Fast path: the most-recent N runs all failed. */
+        if (recentRunCount >= ConsecutiveFailureThreshold && recentSuccessCount == 0)
+        {
+            reason = $"The last {recentRunCount.ToString(CultureInfo.InvariantCulture)} collector runs all failed — no data is landing.";
+            return true;
+        }
+
+        /* Backstop: a server that HAS collected before but hasn't succeeded within the staleness window. */
+        if (lastSuccessUtc.HasValue && nowUtc - lastSuccessUtc.Value >= StaleWindow)
+        {
+            int minutes = (int)(nowUtc - lastSuccessUtc.Value).TotalMinutes;
+            reason = $"No successful collection in {minutes.ToString(CultureInfo.InvariantCulture)} minutes — the collectors are failing or the server is unreachable.";
+            return true;
+        }
+
+        reason = "";
+        return false;
+    }
+
+    /// <summary>
+    /// Edge-applies the collection-stopped decision (mirrors the Dashboard's
+    /// <c>_activeCollectionStoppedAlert</c>/<c>_lastCollectionStoppedAlert</c>): fire once on entry, re-fire
+    /// only after the alert cooldown while it persists, and write ONE "Collection Resumed" history row on
+    /// recovery. Testable directly with a recording deliverer + a controllable clock.
+    /// </summary>
+    internal async Task ApplyCollectionStoppedAsync(
+        int serverId, string serverName, bool stopped, string reason, CancellationToken cancellationToken)
+    {
+        var key = Key(serverId);
+        var now = _utcNow();
+
+        if (stopped)
+        {
+            _activeCollectionStopped[key] = true;
+            if (CooldownElapsed(_lastCollectionStoppedAlert, key, now))
+            {
+                _lastCollectionStoppedAlert[key] = now;
+                await FireAsync(
+                    key, serverName, "Collection Stopped", reason, "collecting",
+                    detail: reason + " A headless service has no dashboard to watch, so this is the primary " +
+                        "signal that a server's data has gone stale. Check the service log and the server's " +
+                        "reachability, credentials, and collector permissions.",
+                    severity: AlertSeverityLevel.Critical,
+                    shortMessage: reason, cancellationToken);
+            }
+        }
+        else if (_activeCollectionStopped.TryRemove(key, out var was) && was)
+        {
+            await RecordResolutionAsync(new AlertResolution(
+                key, serverName, "Collection Stopped",
+                "Collection Resumed", $"{serverName}: Data collection is running again"), cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Edge-applies capture-down (mirrors the Dashboard's <c>_activeCaptureDownAlert</c>): gated on
+    /// blocking OR deadlock alerts being enabled (the alerts this protects — if the operator wants those,
+    /// they need to know when the data feeding them stops existing). Fire once on entry, re-fire only after
+    /// the cooldown, write ONE "Capture Restored" row on recovery.
+    /// </summary>
+    internal async Task ApplyCaptureDownAsync(
+        int serverId, string serverName, IReadOnlyList<string> missing, CancellationToken cancellationToken)
+    {
+        if (!_settings.BlockingEnabled && !_settings.DeadlockEnabled)
+        {
+            return;
+        }
+
+        var key = Key(serverId);
+        var now = _utcNow();
+
+        if (missing.Count > 0)
+        {
+            _activeCaptureDown[key] = true;
+            if (CooldownElapsed(_lastCaptureDownAlert, key, now))
+            {
+                _lastCaptureDownAlert[key] = now;
+                var list = string.Join(" and ", missing);
+                await FireAsync(
+                    key, serverName, "Capture Down", list, "session running",
+                    detail: $"The {list} Extended Events session(s) are missing and could not be created. " +
+                        "Blocking/deadlock data is NOT being captured, so those alerts can never fire. Check the " +
+                        "collection log for the SESSION_MISSING detail (usually a permissions problem: " +
+                        "ALTER ANY EVENT SESSION on-prem, CREATE ANY DATABASE EVENT SESSION on Azure SQL DB).",
+                    severity: AlertSeverityLevel.Critical,
+                    shortMessage: $"{list} capture is not running — XE session missing", cancellationToken);
+            }
+        }
+        else if (_activeCaptureDown.TryRemove(key, out var was) && was)
+        {
+            await RecordResolutionAsync(new AlertResolution(
+                key, serverName, "Capture Down",
+                "Capture Restored", $"{serverName}: Blocking/deadlock capture is running again"), cancellationToken);
+        }
+    }
+
+    /* ---------------- connection lost / restored (connect-edge driven) ---------------- */
+
+    /// <summary>
+    /// Applies a connect-attempt outcome for one server and fires the connection edge. Called from the
+    /// loop's <see cref="DarlingWorker.TryConnectAsync"/> success (online) and failure (offline) branches.
+    /// The per-server state machine fires "Server Unreachable" only on a genuine online→offline transition
+    /// and "Server Restored" only on offline→online — a repeated failed reconnect (offline→offline) does
+    /// NOT re-fire, and the first-ever outcome (Unknown→online/offline) is a silent baseline, mirroring the
+    /// Dashboard's skip-first-check. Both edges are FULL alerts (email/webhook, Dashboard parity — the
+    /// restore is not a silent resolution). State is tracked even while alerts are disabled so re-enabling
+    /// resumes from the correct baseline; only delivery is gated on the master switch.
+    /// </summary>
+    public async Task ApplyConnectionOutcomeAsync(
+        int serverId, string serverName, bool online, string? error, CancellationToken cancellationToken)
+    {
+        var key = Key(serverId);
+        var previous = _connectionState.TryGetValue(key, out var s) ? s : ConnectionState.Unknown;
+        _connectionState[key] = online ? ConnectionState.Online : ConnectionState.Offline;
+
+        /* Record that collection is now possible for this server this run — arms the collection-stopped
+           check (tracked regardless of the alerts switch, so re-enabling has a correct baseline). */
+        if (online)
+        {
+            _hasBeenOnline[key] = true;
+        }
+
+        if (!_settings.AlertsEnabled)
+        {
+            return;
+        }
+
+        if (online && previous == ConnectionState.Offline)
+        {
+            /* Severity null → the shared AlertSeverity map renders "Server Restored" green/RESOLVED. */
+            await FireAsync(
+                key, serverName, "Server Restored", "Online", "Online",
+                detail: $"{serverName}: connection restored",
+                severity: null,
+                shortMessage: "connection restored", cancellationToken);
+        }
+        else if (!online && previous == ConnectionState.Online)
+        {
+            var reason = string.IsNullOrWhiteSpace(error) ? "Connection failed" : error!;
+            await FireAsync(
+                key, serverName, "Server Unreachable", reason, "Online",
+                detail: reason,
+                severity: AlertSeverityLevel.Critical,
+                shortMessage: reason, cancellationToken);
+        }
+        /* previous == Unknown → baseline only (no fire). */
+    }
+
+    /// <summary>Drops all edge state for a server removed from the monitored set (reconcile), so a later
+    /// re-add starts fresh at the Unknown baseline rather than inheriting a stale connection/active flag.</summary>
+    public void Forget(int serverId)
+    {
+        var key = Key(serverId);
+        _activeCollectionStopped.TryRemove(key, out _);
+        _lastCollectionStoppedAlert.TryRemove(key, out _);
+        _activeCaptureDown.TryRemove(key, out _);
+        _lastCaptureDownAlert.TryRemove(key, out _);
+        _connectionState.TryRemove(key, out _);
+        _hasBeenOnline.TryRemove(key, out _);
+    }
+
+    /* ---------------- store reads ---------------- */
+
+    /// <summary>
+    /// One round trip for the collection-stopped signals: the newest SUCCESS/SKIPPED time across all of the
+    /// server's collectors (a SKIPPED is a healthy no-op, matching the viewer's GetCollectionHealthAsync),
+    /// plus — over the most recent <paramref name="recentWindow"/> logged runs — the run count and the
+    /// success count (feeding the consecutive-failure fast path). Static + parameterized so the gated live
+    /// test can seed rows and assert the raw signals directly.
+    /// </summary>
+    internal static async Task<(DateTime? LastSuccessUtc, int RecentRunCount, int RecentSuccessCount)> ReadCollectionSignalsAsync(
+        NpgsqlDataSource postgres, int serverId, int recentWindow, CancellationToken cancellationToken)
+    {
+        await using var connection = await postgres.OpenConnectionAsync(cancellationToken);
+        using var command = new NpgsqlCommand(@"
+SELECT
+    (SELECT MAX(collection_time)
+     FROM collection_log
+     WHERE server_id = $1
+     AND   status IN ('SUCCESS', 'SKIPPED'))                                        AS last_success,
+    (SELECT COUNT(*)
+     FROM (SELECT log_id FROM collection_log WHERE server_id = $1 ORDER BY log_id DESC LIMIT $2) r) AS recent_runs,
+    (SELECT COUNT(*)
+     FROM (SELECT status FROM collection_log WHERE server_id = $1 ORDER BY log_id DESC LIMIT $2) r
+     WHERE r.status IN ('SUCCESS', 'SKIPPED'))                                       AS recent_success", connection);
+        command.Parameters.AddWithValue(serverId);
+        command.Parameters.AddWithValue(recentWindow);
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken))
+        {
+            return (null, 0, 0);
+        }
+
+        DateTime? lastSuccess = reader.IsDBNull(0)
+            ? null
+            : DateTime.SpecifyKind(reader.GetDateTime(0), DateTimeKind.Utc);
+        int recentRuns = reader.IsDBNull(1) ? 0 : Convert.ToInt32(reader.GetValue(1), CultureInfo.InvariantCulture);
+        int recentSuccess = reader.IsDBNull(2) ? 0 : Convert.ToInt32(reader.GetValue(2), CultureInfo.InvariantCulture);
+        return (lastSuccess, recentRuns, recentSuccess);
+    }
+
+    /// <summary>
+    /// The blocking/deadlock XE collectors whose LATEST run logged <c>SESSION_MISSING</c> — the session is
+    /// absent and couldn't be created, so capture is non-functional even though the tolerant reader "succeeds"
+    /// with zero rows. The Darling twin of the Dashboard's <c>GetMissingCaptureSessionsAsync</c>, on Darling's
+    /// collector names. Returns the friendly capture names ("Blocking" / "Deadlock").
+    /// </summary>
+    internal static async Task<IReadOnlyList<string>> ReadMissingCaptureSessionsAsync(
+        NpgsqlDataSource postgres, int serverId, CancellationToken cancellationToken)
+    {
+        var missing = new List<string>();
+
+        await using var connection = await postgres.OpenConnectionAsync(cancellationToken);
+        using var command = new NpgsqlCommand(@"
+SELECT x.collector_name
+FROM
+(
+    SELECT
+        cl.collector_name,
+        cl.status,
+        ROW_NUMBER() OVER (PARTITION BY cl.collector_name ORDER BY cl.log_id DESC) AS n
+    FROM collection_log AS cl
+    WHERE cl.server_id = $1
+    AND   cl.collector_name IN ('deadlocks', 'blocked_process_report')
+) AS x
+WHERE x.n = 1
+AND   x.status = 'SESSION_MISSING'", connection);
+        command.Parameters.AddWithValue(serverId);
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            var collectorName = reader.GetString(0);
+            missing.Add(collectorName == "deadlocks" ? "Deadlock" : "Blocking");
+        }
+
+        return missing;
+    }
+
+    /* ---------------- shared helpers ---------------- */
+
+    /// <summary>
+    /// Builds a resolved-flavored history row for a recovered condition — the Darling twin of the
+    /// Dashboard's explicit "…Cleared/Resolved/Restored" <c>RecordAlert</c> rows. Used by BOTH this
+    /// evaluator's self-alert recoveries (Collection Resumed / Capture Restored) and the shared alert
+    /// engine's resolution callback (CPU Resolved, Blocking Cleared, …) so an operator reviewing alert
+    /// history sees the paired "Detected" then "Cleared" entries. Never email/webhook (a resolution has no
+    /// send channel — the deliverer's fire path is untouched): recorded as a delivered tray/history row.
+    /// </summary>
+    public static AlertHistoryRecord BuildResolutionRecord(AlertResolution resolution) => new(
+        resolution.ServerKey, resolution.ServerName, resolution.Title,
+        CurrentValueText: "resolved", ThresholdValueText: "",
+        NumericCurrentValue: null, NumericThresholdValue: null,
+        AlertSent: true, NotificationType: "tray", SendError: null,
+        Muted: false, DetailText: resolution.Message, ContextJson: null);
+
+    private async Task FireAsync(
+        string serverKey, string serverName, string metricName, string currentValue, string thresholdValue,
+        string detail, AlertSeverityLevel? severity, string shortMessage, CancellationToken cancellationToken)
+    {
+        /* Same mute treatment as the engine: a muted self-alert is still recorded (flagged muted) but its
+           channels are skipped — the deliverer honors AlertOutcome.Muted. */
+        bool muted = _isAlertMuted(new AlertMuteContext { ServerName = serverName, MetricName = metricName });
+
+        await _deliverer.DeliverAsync(new AlertOutcome(
+            serverKey, serverName, metricName, currentValue, thresholdValue,
+            Context: null, DetailText: detail,
+            NumericCurrentValue: null, NumericThresholdValue: null,
+            Muted: muted, Severity: severity, ShortMessage: shortMessage), cancellationToken);
+    }
+
+    private async Task RecordResolutionAsync(AlertResolution resolution, CancellationToken cancellationToken)
+    {
+        _logger?.LogInformation("[{Server}] {Title}: {Message}",
+            resolution.ServerName, resolution.Title, resolution.Message);
+        try
+        {
+            await _historyStore.RecordAlertAsync(BuildResolutionRecord(resolution));
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            /* An audit-row write must never break the loop (RecordAlertAsync is already failure-isolated;
+               this is belt-and-suspenders for any other IAlertHistoryStore). */
+            _logger?.LogError("Failed to record resolution '{Title}': {Message}", resolution.Title, ex.Message);
+        }
+    }
+
+    private bool CooldownElapsed(ConcurrentDictionary<string, DateTime> lastFired, string key, DateTime now) =>
+        !lastFired.TryGetValue(key, out var last)
+        || now - last >= TimeSpan.FromMinutes(_settings.CooldownMinutes);
+
+    private static string Key(int serverId) => serverId.ToString(CultureInfo.InvariantCulture);
+}

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -126,6 +126,12 @@ public sealed class DarlingWorker : BackgroundService
        branches the retention purge onto drop_chunks. */
     private bool _timescaleAvailable;
 
+    /* Stage 4 service self-alerts (collection-stopped, connection lost/restored, capture-down). Built
+       once in RunCollectionLoopAsync over the SAME deliverer/history the shared engine uses, so the
+       self-alerts inherit its delivery/cooldown/restart-replay. Held as a field because the connection
+       edge fires from TryConnectAsync and the reconcile drops per-server state through it. */
+    private DarlingSelfAlertEvaluator? _selfAlerts;
+
     public DarlingWorker(ILogger<DarlingWorker> logger, ILoggerFactory loggerFactory)
     {
         _logger = logger;
@@ -143,6 +149,12 @@ public sealed class DarlingWorker : BackgroundService
 
         /* MinValue = the first loop pass after connect evaluates alerts immediately. */
         public DateTime NextAlertSweep { get; set; } = DateTime.MinValue;
+
+        /* MinValue = the first loop pass evaluates the Stage 4 service self-alerts (collection-stopped,
+           capture-down) immediately. Separate from NextAlertSweep because the self-alert sweep runs for
+           a DISCONNECTED server too (collection-stopped is exactly the unreachable-server case), above
+           the Runtime-null connect gate. */
+        public DateTime NextSelfAlertSweep { get; set; } = DateTime.MinValue;
 
         /* MinValue = the first loop pass after connect runs analysis immediately; the
            pipeline's own 24h data-span gate no-ops it until the store has enough history
@@ -375,7 +387,18 @@ public sealed class DarlingWorker : BackgroundService
         var muteRuleService = new MuteRuleService(
             new PgMuteRuleStore(postgres, _logger), _loggerFactory.CreateLogger<MuteRuleService>());
         await muteRuleService.LoadAsync();
-        var engine = BuildAlertEngine(config, servers, alertSettings, historyStore, webhookAlertService, muteRuleService);
+
+        /* The shared record-and-send deliverer — hoisted so BOTH the shared alert engine and the Stage 4
+           service self-alerts (DarlingSelfAlertEvaluator) fire through the SAME instance: identical
+           email/webhook delivery, per-fingerprint delivery cooldown, and history-seeded restart replay. */
+        var deliverer = new DarlingAlertDeliverer(alertSettings, historyStore, webhookAlertService, _logger);
+        var engine = BuildAlertEngine(config, servers, alertSettings, historyStore, muteRuleService, deliverer);
+
+        /* Stage 4: the service self-alerts, over the SAME deliverer + history + mute check the engine uses.
+           collection-stopped / capture-down are polled from collection_log on the alert cadence below;
+           connection lost/restored fire on the connect edges in TryConnectAsync. */
+        _selfAlerts = new DarlingSelfAlertEvaluator(
+            alertSettings, deliverer, historyStore, muteRuleService.IsAlertMuted, _logger);
 
         /* Phase-5 analysis slice AN3: the analysis pipeline's shared pieces, constructed once.
            The plan fetcher resolves a finding's serverId to the CONNECTED runtime's connection
@@ -454,6 +477,23 @@ public sealed class DarlingWorker : BackgroundService
                 if (stoppingToken.IsCancellationRequested)
                 {
                     break;
+                }
+
+                /* Stage 4 service self-alerts (store-polled): collection-stopped is evaluated for EVERY
+                   server — connected or not — because an unreachable server has stopped collecting, which
+                   is exactly the case a headless service must page on. Capture-down is evaluated only for a
+                   connected server. Own 30s cadence; the master alerts gate + edge-trigger live inside the
+                   evaluator. Runs ABOVE the Runtime-null connect gate so a disconnected server is still
+                   checked. Connection lost/restored fire on the connect edges in TryConnectAsync. */
+                if (DateTime.UtcNow >= server.NextSelfAlertSweep)
+                {
+                    server.NextSelfAlertSweep = DateTime.UtcNow.Add(s_alertSweepInterval);
+                    await _selfAlerts!.EvaluateStoreAlertsAsync(
+                        postgres,
+                        ServerIdHelper.GetDeterministicHashCode(server.Config.StorageName),
+                        server.Config.DisplayName,
+                        connected: server.Runtime is not null,
+                        stoppingToken);
                 }
 
                 if (server.Runtime is null)
@@ -647,6 +687,9 @@ public sealed class DarlingWorker : BackgroundService
                     "[{Server}] Removed from the monitored set (disabled/deleted) — stopping collection",
                     state.Config.DisplayName);
                 state.Runtime = null;
+                /* Drop the Stage 4 self-alert edge state so a later re-add starts from the Unknown baseline
+                   (no stale "was online" / "was stopped" flag carried across a remove+re-add). */
+                _selfAlerts?.Forget(id);
                 servers.RemoveAt(i);
                 continue;
             }
@@ -777,20 +820,16 @@ public sealed class DarlingWorker : BackgroundService
     /// </summary>
     private AlertEngine BuildAlertEngine(
         DarlingConfig config, List<ServerLoopState> servers,
-        DarlingAlertSettings alertSettings, PgAlertHistoryStore historyStore, WebhookAlertService webhookAlertService,
-        MuteRuleService muteRuleService)
+        DarlingAlertSettings alertSettings, PgAlertHistoryStore historyStore,
+        MuteRuleService muteRuleService, DarlingAlertDeliverer deliverer)
     {
         var postgres = _postgres!;
         var stateStore = new PgAlertStateStore(postgres, _logger);
 
         /* The mute service is loaded + owned by the caller (RunCollectionLoopAsync) so a control-plane
            reload can re-LoadAsync() the SAME instance and mute the very next sweep (F16). The engine
-           binds its IsAlertMuted delegate, which reads the refreshed cache. */
-
-        /* The webhook service was constructed first and injected into the deliverer's send core
-           (Lite's MainWindow wiring); the shared history store seeds both channels' cooldowns
-           across a service restart (#1145). */
-        var deliverer = new DarlingAlertDeliverer(alertSettings, historyStore, webhookAlertService, _logger);
+           binds its IsAlertMuted delegate, which reads the refreshed cache. The deliverer is hoisted by
+           the caller and shared with the Stage 4 self-alerts (same delivery/cooldown/restart-replay). */
 
         return new AlertEngine(
             alertSettings,
@@ -800,11 +839,16 @@ public sealed class DarlingWorker : BackgroundService
             muteRuleService.IsAlertMuted,
             failedJobsFetcher: (serverKey, lookbackMinutes, ct) =>
                 FetchFailedJobsAsync(servers, serverKey, lookbackMinutes, ct),
-            resolutionCallback: (resolution, _) =>
+            resolutionCallback: async (resolution, _) =>
             {
                 _logger.LogInformation("[{Server}] {Title}: {Message}",
                     resolution.ServerName, resolution.Title, resolution.Message);
-                return Task.CompletedTask;
+                /* Stage 4 parity-gap fix: record a resolved-flavored history row so an operator reviewing
+                   alert history sees the paired "Detected" then "Cleared/Resolved" entries (the Dashboard
+                   records these explicitly; Darling previously only logged them). A resolution has no send
+                   channel, so this never emails/webhooks; RecordAlertAsync is failure-isolated so it can
+                   never break the sweep. */
+                await historyStore.RecordAlertAsync(DarlingSelfAlertEvaluator.BuildResolutionRecord(resolution));
             },
             logger: _logger);
     }
@@ -1184,12 +1228,25 @@ LIMIT 1", connection);
                     server.NextDue[name] = now;
                 }
             }
+
+            /* Stage 4: the offline->online connection edge (Server Restored) — fires only if this server
+               was previously seen offline (the state machine makes the first-ever connect a silent
+               baseline, mirroring the Dashboard's skip-first-check). */
+            await _selfAlerts!.ApplyConnectionOutcomeAsync(
+                server.Runtime.ServerId, server.Config.DisplayName, online: true, error: null, cancellationToken);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             server.Runtime = null;
             server.NextConnectAttempt = DateTime.UtcNow.AddSeconds(60);
             _logger.LogWarning("[{Server}] Connect failed, retrying in 60s: {Message}", server.Config.DisplayName, ex.Message);
+
+            /* Stage 4: the online->offline connection edge (Server Unreachable) — fires once when a
+               previously-connected server can no longer be reached; a repeated failed reconnect does NOT
+               re-fire (the state machine dedups). server_id is derived from the config since Runtime is null. */
+            await _selfAlerts!.ApplyConnectionOutcomeAsync(
+                ServerIdHelper.GetDeterministicHashCode(server.Config.StorageName),
+                server.Config.DisplayName, online: false, error: ex.Message, cancellationToken);
         }
     }
 
@@ -1342,6 +1399,19 @@ LIMIT 1", connection);
         {
             throw;
         }
+        catch (DarlingXeSessionMissingException ex)
+        {
+            /* The blocking/deadlock XE session is missing and couldn't be created — log a distinct
+               SESSION_MISSING status the Stage 4 Capture Down self-alert reads. Non-fatal, like a
+               permissions skip: log it and continue the rest of the sweep. Must be caught BEFORE the
+               229/297/300 permissions filter (297 overlaps the missing-session numbers). */
+            _logger.LogWarning("  [{Server}] {Collector} => XE session missing (capture down): {Message}",
+                server.Config.DisplayName, collectorName, ex.Message);
+
+            await DarlingObservability.LogCollectionAsync(
+                _postgres!, runtime, collectorName, "SESSION_MISSING", 0, 0, 0, ex.Message, _logger, cancellationToken);
+            return 0;
+        }
         catch (SqlException ex) when (ex.Number is 229 or 297 or 300)
         {
             _logger.LogWarning("  [{Server}] {Collector} => insufficient permissions ({Number}): {Message}",
@@ -1417,6 +1487,18 @@ LIMIT 1", connection);
         ["system_health_events"] = (r, s, ct) => r.RunAsync(SystemHealthEventsCollector.Instance, s, ct),
     };
 
+    /// <summary>
+    /// Signals that a blocking/deadlock XE session is missing or inaccessible so the reader returned no
+    /// events. <see cref="RunXeTolerantAsync"/> throws it, <see cref="RunOneAsync"/> catches it and logs a
+    /// distinct <c>SESSION_MISSING</c> collection_log status. Before Stage 4 this case swallowed to zero
+    /// rows and logged SUCCESS — indistinguishable from a genuinely idle session, so the Capture Down
+    /// self-alert had no signal to read.
+    /// </summary>
+    private sealed class DarlingXeSessionMissingException : Exception
+    {
+        public DarlingXeSessionMissingException(string message, Exception inner) : base(message, inner) { }
+    }
+
     private static async Task<CollectorRunResult> RunXeTolerantAsync<TRow>(
         ICollectorDefinition<TRow> definition, DarlingCollectorRunner runner, ServerRuntime server, CancellationToken cancellationToken)
     {
@@ -1426,8 +1508,12 @@ LIMIT 1", connection);
         }
         catch (SqlException ex) when (ex.Number == 297 || ex.Number == 15151 || ex.Message.Contains("XE session"))
         {
-            /* XE session not found or not accessible — zero rows, mirrors Lite. */
-            return new CollectorRunResult(0, 0, 0);
+            /* XE session not found or not accessible. Lite swallows this to zero rows, but a headless
+               service (like the Dashboard) must surface it: raise it as a distinct SESSION_MISSING
+               collection_log status so the Stage 4 Capture Down self-alert can detect that blocking/
+               deadlock capture is non-functional. RunOneAsync catches this and continues the sweep, so
+               collection is still tolerant — only the logged status differs from a real zero-row success. */
+            throw new DarlingXeSessionMissingException(ex.Message, ex);
         }
     }
 

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -1190,16 +1190,30 @@ LIMIT 1", connection);
 
         try
         {
-            server.Runtime = await DarlingServerConnector.ConnectAsync(server.Config, _logger, cancellationToken);
+            var runtime = await DarlingServerConnector.ConnectAsync(server.Config, _logger, cancellationToken);
+            server.Runtime = runtime;
+            /* Capture the id once, while the connection is freshly established and non-null: an on-load
+               RunOneAsync below can drop server.Runtime on a mid-collection connection-level failure, so any
+               later read of server.Runtime.ServerId (the schedule resolve, the connection edge) would NRE. */
+            var serverId = runtime.ServerId;
             _logger.LogInformation("[{Server}] Connected (major {Major}, edition {Edition}, server_id {ServerId})",
                 server.Config.DisplayName,
-                server.Runtime.Target.SqlMajorVersion,
-                server.Runtime.Target.IsAzureSqlDb ? "AzureSqlDb" : server.Runtime.Target.IsAzureManagedInstance ? "ManagedInstance" : "Box",
-                server.Runtime.ServerId);
+                runtime.Target.SqlMajorVersion,
+                runtime.Target.IsAzureSqlDb ? "AzureSqlDb" : runtime.Target.IsAzureManagedInstance ? "ManagedInstance" : "Box",
+                serverId);
 
-            await DarlingObservability.UpsertServerAsync(_postgres!, server.Runtime, _logger, cancellationToken);
+            /* Stage 4: the offline->online connection edge (Server Restored) — fired HERE, right after the
+               connection is established and BEFORE the on-load collectors run, using the captured serverId.
+               The connect succeeded regardless of what the on-load collectors do next, so this is the correct
+               point to record "online" (and it can't NRE on a Runtime the on-load loop might drop). Fires only
+               if the server was previously seen offline; the first-ever connect is a silent baseline (the
+               state machine mirrors the Dashboard's skip-first-check). */
+            await _selfAlerts!.ApplyConnectionOutcomeAsync(
+                serverId, server.Config.DisplayName, online: true, error: null, cancellationToken);
 
-            await DarlingXeSessions.EnsureAllAsync(server.Runtime, _logger, cancellationToken);
+            await DarlingObservability.UpsertServerAsync(_postgres!, runtime, _logger, cancellationToken);
+
+            await DarlingXeSessions.EnsureAllAsync(runtime, _logger, cancellationToken);
 
             /* On-load config snapshots (effective FrequencyMinutes 0) run once per connect, then every
                scheduled collector becomes immediately due — mirrors Lite's server-open behavior. The
@@ -1213,7 +1227,9 @@ LIMIT 1", connection);
             var now = DateTime.UtcNow;
             foreach (var name in CollectorScheduleDefaults.All.Keys)
             {
-                var effective = StoreConfigProvider.ResolveSchedule(name, server.Runtime.ServerId, _scheduleOverrides);
+                /* Captured serverId, not server.Runtime.ServerId: an earlier on-load RunOneAsync in this loop
+                   can null server.Runtime on a connection-level failure, which would otherwise NRE here. */
+                var effective = StoreConfigProvider.ResolveSchedule(name, serverId, _scheduleOverrides);
                 if (!effective.Enabled)
                 {
                     continue;
@@ -1228,12 +1244,6 @@ LIMIT 1", connection);
                     server.NextDue[name] = now;
                 }
             }
-
-            /* Stage 4: the offline->online connection edge (Server Restored) — fires only if this server
-               was previously seen offline (the state machine makes the first-ever connect a silent
-               baseline, mirroring the Dashboard's skip-first-check). */
-            await _selfAlerts!.ApplyConnectionOutcomeAsync(
-                server.Runtime.ServerId, server.Config.DisplayName, online: true, error: null, cancellationToken);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -1403,8 +1413,12 @@ LIMIT 1", connection);
         {
             /* The blocking/deadlock XE session is missing and couldn't be created — log a distinct
                SESSION_MISSING status the Stage 4 Capture Down self-alert reads. Non-fatal, like a
-               permissions skip: log it and continue the rest of the sweep. Must be caught BEFORE the
-               229/297/300 permissions filter (297 overlaps the missing-session numbers). */
+               permissions skip: log it and continue the rest of the sweep. RunXeTolerantAsync already
+               classified this (wrapping an XE 297/15151/'XE session' into the distinct type), so this
+               catch and the SqlException permissions filter below match disjoint types — their relative
+               order is not load-bearing; it only needs to precede the general Exception catch (which would
+               otherwise mislabel it ERROR). A non-XE 297 arrives as a plain SqlException and correctly
+               hits the permissions filter. */
             _logger.LogWarning("  [{Server}] {Collector} => XE session missing (capture down): {Message}",
                 server.Config.DisplayName, collectorName, ex.Message);
 


### PR DESCRIPTION
## Stage 4 of the Darling control plane — the service's self-alerts

The alerts that matter most for an unattended 24/7 headless service where nobody is watching a dashboard. All four findings from the parity-audit inventory, each routed through the **same** `DarlingAlertDeliverer` + `PgAlertHistoryStore` + mute check + edge-trigger the shared `AlertEngine` already uses — so they inherit its email/webhook delivery, per-fingerprint delivery cooldown, and restart replay. Gated on the master `alerts.enabled` switch; thresholds are sensible hardcoded defaults.

### The 4 alerts and how each edge-triggers

| Alert | Source | Fires once by | Recovery |
|---|---|---|---|
| **Collection Stopped** | `collection_log`: no SUCCESS in 30 min **OR** last 10 runs all failed | in-memory active flag + shared alert cooldown (Dashboard `_activeX`/`_lastX` shape) | writes **Collection Resumed** history row |
| **Server Unreachable / Restored** | the loop's connect edge (online↔offline) in `TryConnectAsync` | per-server state machine — a repeated failed reconnect does **not** re-fire; first-ever outcome is a silent baseline (Dashboard skip-first-check) | **Server Restored** is itself a full alert (email), Dashboard parity |
| **Capture Down** | the new `SESSION_MISSING` `collection_log` status for the XE collectors | active flag + cooldown | writes **Capture Restored** history row |
| **Alert resolution notices** (parity-gap) | the engine's `resolutionCallback` | n/a (edge already in the engine) | now writes a resolved-flavored history row (CPU Resolved / Blocking Cleared / …) instead of only logging |

All fired self-alerts go through `deliverer.DeliverAsync` (email + webhook + history + cooldown); resolutions go to the history store directly (no channel), exactly like the engine's resolutions and the Dashboard's tray/history-only "…Resumed/Restored" rows.

### Key design notes for review

- **Capture Down needed a signal that didn't exist.** `RunXeTolerantAsync` previously swallowed a missing XE session to `CollectorRunResult(0,0,0)`, which `RunOneAsync` logged as **SUCCESS** — indistinguishable from a genuinely idle session. It now throws `DarlingXeSessionMissingException`; `RunOneAsync` catches it (ordered **before** the 229/297/300 permissions filter, since 297 overlaps) and logs a distinct **`SESSION_MISSING`** status, mirroring the Dashboard's vocabulary. Collection stays tolerant (still non-fatal, sweep continues) — only the logged status changes. `collection_log.status` is unconstrained `text`, so **no migration**. Side benefit: the viewer's Collection Health now shows a missing capture session as unhealthy instead of falsely healthy (no viewer file touched).
- **Darling-specific restart guard.** Unlike the Dashboard (whose target-side collection runs independently of the app), Darling **is** the collector — its own downtime makes `collection_log` stale. Collection Stopped is therefore guarded by `_hasBeenOnline`: it only judges a server the service has actually collected from this run, so a service restart after >30 min of downtime can't false-alarm a healthy server. This makes Collection Stopped a clean "was collecting → stopped" transition, consistent with the connection-lost philosophy.
- **Metric names** "Server Unreachable" / "Server Restored" / "Capture Down" match the shared `AlertSeverity` map (Critical / green RESOLVED) and the Dashboard's alert-history vocabulary cross-app.

### Migration

**None.** No V18, no `StorageVersion` bump, no pin-test changes — the self-alerts use hardcoded defaults (defaults-over-speculative-config) and `SESSION_MISSING` needs no schema change.

### Testing

- **21 ungated tests**: `IsCollectionStopped` detection (staleness / consecutive-failure / never-ran guard / boundaries), the connection edge (fires once on transition, **not** every sweep; baseline; forget-reset), the capture-down edge, the resolution-record shape, the engine `resolutionCallback` → history wiring, the master switch, and mute handling.
- **1 `DARLING_TEST_PG`-gated live test** (skips in CI): proves both new `collection_log` queries and the full store→fire path against real Postgres.
- **Validated live** against Postgres 17.10 in an isolated scratch DB (dropped after) — the live test passes; it caught a genuine Postgres-vs-T-SQL syntax bug during development (`n = ROW_NUMBER()` → `ROW_NUMBER() … AS n`).
- Full `Darling.Tests -c Release`: **1053 passed, 98 skipped, 0 failed**. Whole Darling solution builds `-c Release`.

**Scope:** only the Service (new `DarlingSelfAlertEvaluator`, modified `DarlingWorker`) and `Darling.Tests`. No Viewer, no `install/*.sql`, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)