### PR TITLE
Add the 5 plan-analysis MCP tools to Darling's service

### DIFF
--- a/Darling/Darling.Tests/DarlingMcpPlanToolsTests.cs
+++ b/Darling/Darling.Tests/DarlingMcpPlanToolsTests.cs
@@ -1,0 +1,593 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Server;
+using Npgsql;
+using PerformanceMonitor.Collectors;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.Darling.Service.Mcp;
+using PerformanceMonitor.Darling.Storage;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Pins the plan-analysis MCP slice — the five plan tools (analyze_query_plan,
+/// analyze_procedure_plan, analyze_query_store_plan, analyze_plan_xml, get_plan_xml) over the
+/// Postgres store, the same names the Dashboard and Lite expose. Ungated: the tool surface is
+/// EXACTLY the five names (all static, the McpSchemaCompat requirement, on a [McpServerToolType]
+/// class); each tool's MCP parameter contract matches the Dashboard's required params (with the
+/// store's finer keys — database_name / plan_id — as OPTIONAL refinements); the three stored-plan
+/// reads are Postgres-dialect, positional-param, and read the collector columns the schema
+/// generator actually emits (query_stats.query_plan_xml, procedure_stats.query_plan_xml +
+/// sql_handle, query_store_stats.query_plan_text); and analyze_plan_xml's no-fetch path is
+/// resilient (empty → the bare message, malformed → no throw). Gated on DARLING_TEST_PG: register
+/// a server the way the worker does, plant stored plans, call the tool METHODS directly (not over
+/// the wire) and assert each fetch + analysis round-trips, the optional keys refine, and an absent
+/// key returns the #1224 "unavailable" envelope.
+/// </summary>
+public sealed class DarlingMcpPlanToolsSurfaceAndSqlTests
+{
+    /* ---------------- ungated: tool-surface pin ---------------- */
+
+    /// <summary>The five plan-analysis tool names, ordinal-sorted — the same names the Dashboard's
+    /// and Lite's McpPlanTools register, so MCP clients see one consistent product.</summary>
+    private static readonly string[] SharedPlanToolSurface =
+    {
+        "analyze_plan_xml",
+        "analyze_procedure_plan",
+        "analyze_query_plan",
+        "analyze_query_store_plan",
+        "get_plan_xml"
+    };
+
+    private static MethodInfo[] ToolMethods() => typeof(DarlingMcpPlanTools)
+        .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance)
+        .Where(m => m.GetCustomAttribute<McpServerToolAttribute>() is not null)
+        .ToArray();
+
+    [Fact]
+    public void ToolSurface_ExactlyTheFivePlanTools()
+    {
+        var toolMethods = ToolMethods();
+
+        var names = toolMethods
+            .Select(m => m.GetCustomAttribute<McpServerToolAttribute>()!.Name)
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(SharedPlanToolSurface, names);
+
+        /* Discoverable as a tool type, every tool static (WithGeminiCompatibleTools REJECTS instance
+           methods), and every tool returning the string envelope both apps' tools return (Task<string>
+           for the fetching tools, string for the synchronous analyze_plan_xml). */
+        Assert.NotNull(typeof(DarlingMcpPlanTools).GetCustomAttribute<McpServerToolTypeAttribute>());
+        Assert.All(toolMethods, m => Assert.True(m.IsStatic, $"{m.Name} must be static for WithGeminiCompatibleTools"));
+        Assert.All(toolMethods, m => Assert.True(
+            m.ReturnType == typeof(Task<string>) || m.ReturnType == typeof(string),
+            $"{m.Name} must return string or Task<string>"));
+    }
+
+    /* ---------------- ungated: per-tool MCP parameter contract ---------------- */
+
+    /// <summary>The MCP input parameters of a tool are those decorated with [Description]; the
+    /// injected DI services (NpgsqlDataSource) carry no [Description] and are not part of the schema.</summary>
+    private static (string Name, bool Optional)[] McpParams(string toolName)
+    {
+        var method = ToolMethods().Single(m =>
+            m.GetCustomAttribute<McpServerToolAttribute>()!.Name == toolName);
+        return method.GetParameters()
+            .Where(p => p.GetCustomAttribute<DescriptionAttribute>() is not null)
+            .Select(p => (p.Name!, p.HasDefaultValue))
+            .ToArray();
+    }
+
+    [Fact]
+    public void ParamContract_AnalyzeQueryPlan_QueryHashRequired_DatabaseAndServerOptional()
+    {
+        var p = McpParams("analyze_query_plan");
+        Assert.Equal(new[] { "query_hash", "server_name", "database_name" }, p.Select(x => x.Name).ToArray());
+        Assert.False(Optional(p, "query_hash"));      /* required — the Dashboard's key */
+        Assert.True(Optional(p, "server_name"));      /* optional — sole-server auto-select */
+        Assert.True(Optional(p, "database_name"));    /* optional refinement over the Dashboard's contract */
+    }
+
+    [Fact]
+    public void ParamContract_AnalyzeProcedurePlan_SqlHandleRequired_ServerOptional()
+    {
+        var p = McpParams("analyze_procedure_plan");
+        Assert.Equal(new[] { "sql_handle", "server_name" }, p.Select(x => x.Name).ToArray());
+        Assert.False(Optional(p, "sql_handle"));
+        Assert.True(Optional(p, "server_name"));
+    }
+
+    [Fact]
+    public void ParamContract_AnalyzeQueryStorePlan_DatabaseAndQueryIdRequired_PlanIdAndServerOptional()
+    {
+        var p = McpParams("analyze_query_store_plan");
+        Assert.Equal(new[] { "database_name", "query_id", "server_name", "plan_id" }, p.Select(x => x.Name).ToArray());
+        Assert.False(Optional(p, "database_name"));   /* required — the Dashboard's key */
+        Assert.False(Optional(p, "query_id"));        /* required — the Dashboard's key */
+        Assert.True(Optional(p, "server_name"));
+        Assert.True(Optional(p, "plan_id"));          /* optional refinement over the Dashboard's contract */
+    }
+
+    [Fact]
+    public void ParamContract_AnalyzePlanXml_TakesOnlyRawXml_NoDbFetch()
+    {
+        var p = McpParams("analyze_plan_xml");
+        Assert.Equal(new[] { "plan_xml" }, p.Select(x => x.Name).ToArray());
+        Assert.False(Optional(p, "plan_xml"));
+    }
+
+    [Fact]
+    public void ParamContract_GetPlanXml_QueryHashRequired_DatabaseAndServerOptional()
+    {
+        var p = McpParams("get_plan_xml");
+        Assert.Equal(new[] { "query_hash", "server_name", "database_name" }, p.Select(x => x.Name).ToArray());
+        Assert.False(Optional(p, "query_hash"));
+        Assert.True(Optional(p, "server_name"));
+        Assert.True(Optional(p, "database_name"));
+    }
+
+    private static bool Optional((string Name, bool Optional)[] p, string name) =>
+        p.Single(x => x.Name == name).Optional;
+
+    /* ---------------- ungated: stored-plan read SQL pins ---------------- */
+
+    [Fact]
+    public void QueryStatsPlanSql_ReadsStoredXml_KeyedByHash_OptionalDatabase_LatestNonNull()
+    {
+        var sql = DarlingStoredPlanReader.QueryStatsPlanXmlByHashSql;
+        Assert.Contains("SELECT query_plan_xml", sql, StringComparison.Ordinal);
+        Assert.Contains("FROM query_stats", sql, StringComparison.Ordinal);
+        Assert.Contains("WHERE server_id = $1", sql, StringComparison.Ordinal);
+        Assert.Contains("query_hash = $2", sql, StringComparison.Ordinal);                    /* the Dashboard's key */
+        Assert.Contains("$3::text IS NULL OR database_name = $3", sql, StringComparison.Ordinal); /* optional database refinement */
+        Assert.Contains("query_plan_xml IS NOT NULL", sql, StringComparison.Ordinal);         /* skip rows the collector left NULL */
+        Assert.Contains("ORDER BY collection_time DESC", sql, StringComparison.Ordinal);      /* most-recent plan for the key */
+        Assert.Contains("LIMIT 1", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ProcedurePlanSql_ReadsStoredXml_KeyedBySqlHandle_LatestNonNull()
+    {
+        var sql = DarlingStoredPlanReader.ProcedurePlanXmlBySqlHandleSql;
+        Assert.Contains("SELECT query_plan_xml", sql, StringComparison.Ordinal);
+        Assert.Contains("FROM procedure_stats", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("v_procedure_stats", sql, StringComparison.Ordinal);            /* plan column is on the base table */
+        Assert.Contains("WHERE server_id = $1", sql, StringComparison.Ordinal);
+        Assert.Contains("sql_handle = $2", sql, StringComparison.Ordinal);                    /* the Dashboard's key */
+        Assert.Contains("query_plan_xml IS NOT NULL", sql, StringComparison.Ordinal);
+        Assert.Contains("ORDER BY collection_time DESC", sql, StringComparison.Ordinal);
+        Assert.Contains("LIMIT 1", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void QueryStorePlanSql_ReadsStoredText_KeyedByDatabaseQueryId_OptionalPlanId_LatestNonNull()
+    {
+        var sql = DarlingStoredPlanReader.QueryStorePlanTextSql;
+        Assert.Contains("SELECT query_plan_text", sql, StringComparison.Ordinal);
+        Assert.Contains("FROM query_store_stats", sql, StringComparison.Ordinal);
+        Assert.Contains("WHERE server_id = $1", sql, StringComparison.Ordinal);
+        Assert.Contains("database_name = $2", sql, StringComparison.Ordinal);                 /* the Dashboard's key */
+        Assert.Contains("query_id = $3", sql, StringComparison.Ordinal);                      /* the Dashboard's key */
+        Assert.Contains("$4::bigint IS NULL OR plan_id = $4", sql, StringComparison.Ordinal); /* optional plan_id refinement */
+        Assert.Contains("query_plan_text IS NOT NULL", sql, StringComparison.Ordinal);
+        Assert.Contains("ORDER BY collection_time DESC", sql, StringComparison.Ordinal);
+        Assert.Contains("LIMIT 1", sql, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(nameof(DarlingStoredPlanReader.QueryStatsPlanXmlByHashSql))]
+    [InlineData(nameof(DarlingStoredPlanReader.ProcedurePlanXmlBySqlHandleSql))]
+    [InlineData(nameof(DarlingStoredPlanReader.QueryStorePlanTextSql))]
+    public void PlanReads_ArePostgresDialect_PositionalParams_NoTsqlIsms(string sqlName)
+    {
+        var sql = sqlName switch
+        {
+            nameof(DarlingStoredPlanReader.QueryStatsPlanXmlByHashSql) => DarlingStoredPlanReader.QueryStatsPlanXmlByHashSql,
+            nameof(DarlingStoredPlanReader.ProcedurePlanXmlBySqlHandleSql) => DarlingStoredPlanReader.ProcedurePlanXmlBySqlHandleSql,
+            _ => DarlingStoredPlanReader.QueryStorePlanTextSql,
+        };
+        var lower = sql.ToLowerInvariant();
+        Assert.DoesNotContain("getdate", lower);
+        Assert.DoesNotContain("convert(", lower);   /* no T-SQL binary CONVERT — the store keeps hex strings as text */
+        Assert.DoesNotContain("top (", lower);      /* LIMIT, not TOP */
+        Assert.DoesNotContain("N'", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("@", sql, StringComparison.Ordinal);
+        Assert.Contains("$1", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PlanColumns_ExistInTheGeneratedCollectorTables()
+    {
+        /* The reads depend on these collector columns; pin that the schema generator emits them. */
+        Assert.Equal("query_stats", QueryStatsCollector.Instance.TargetTable);
+        Assert.Contains("query_plan_xml", PgSchemaGenerator.CreateTable(QueryStatsCollector.Instance), StringComparison.Ordinal);
+
+        Assert.Equal("procedure_stats", ProcedureStatsCollector.Instance.TargetTable);
+        var procTable = PgSchemaGenerator.CreateTable(ProcedureStatsCollector.Instance);
+        Assert.Contains("query_plan_xml", procTable, StringComparison.Ordinal);
+        Assert.Contains("sql_handle", procTable, StringComparison.Ordinal);
+
+        Assert.Equal("query_store_stats", QueryStoreCollector.Instance.TargetTable);
+        Assert.Contains("query_plan_text", PgSchemaGenerator.CreateTable(QueryStoreCollector.Instance), StringComparison.Ordinal);
+    }
+
+    /* ---------------- ungated: analyze_plan_xml no-fetch path ---------------- */
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void AnalyzePlanXml_EmptyOrWhitespace_ReturnsBareMessage(string? input)
+    {
+        Assert.Equal("No plan XML provided.", DarlingMcpPlanTools.AnalyzePlanXml(input!));
+    }
+
+    [Theory]
+    [InlineData("<not-a-plan/>")]
+    [InlineData("<ShowPlanXML>truncated...")]
+    [InlineData("{\"json\":true}")]
+    public void AnalyzePlanXml_Malformed_DoesNotThrow_ReturnsNonEmptyString(string input)
+    {
+        /* The tool's try/catch degrades a parse failure to a message string — it never throws
+           (mirrors the shared PlanAdvisoryAggregator resilience contract). */
+        string? result = null;
+        var ex = Record.Exception(() => result = DarlingMcpPlanTools.AnalyzePlanXml(input));
+        Assert.Null(ex);
+        Assert.False(string.IsNullOrEmpty(result));
+    }
+
+    [Fact]
+    public void AnalyzePlanXml_WellFormedShowPlan_ReturnsXmlSourcedEnvelope()
+    {
+        /* The shared McpPlanAnalysisFormatter runs and serializes the envelope (server null, source
+           "xml"); this also proves the sample plan parses cleanly for the gated fetch tests below. */
+        var json = DarlingMcpPlanTools.AnalyzePlanXml(DarlingPlanFixtures.SamplePlanXml);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.Equal("xml", root.GetProperty("source").GetString());
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("server").ValueKind);
+        Assert.True(root.TryGetProperty("statement_count", out _));
+        Assert.True(root.TryGetProperty("total_warnings", out _));
+        Assert.True(root.TryGetProperty("total_missing_indexes", out _));
+    }
+
+    /* ---------------- ungated: advertised MCP schema (the #1074 Gemini contract) ---------------- */
+
+    /// <summary>
+    /// Builds the exact protocol tools the host advertises in tools/list, registering the plan-tool
+    /// class through the SAME WithGeminiCompatibleTools path Program wiring uses. NpgsqlDataSource (the
+    /// only DI-injected tool parameter) is registered as a no-op singleton so it is excluded from the
+    /// schema; the test reads schemas only and never invokes a tool.
+    /// </summary>
+    private static List<ModelContextProtocol.Protocol.Tool> BuildPlanToolSchemas()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(typeof(NpgsqlDataSource), _ => null!);
+        services.AddMcpServer().WithGeminiCompatibleTools<DarlingMcpPlanTools>();
+        using var provider = services.BuildServiceProvider();
+        return provider.GetServices<McpServerTool>().Select(t => t.ProtocolTool).ToList();
+    }
+
+    private static List<string> SchemaViolations(string toolName, JsonElement schema)
+    {
+        var violations = new List<string>();
+        Walk(schema, toolName);
+        return violations;
+
+        void Walk(JsonElement element, string path)
+        {
+            switch (element.ValueKind)
+            {
+                case JsonValueKind.Object:
+                    foreach (var property in element.EnumerateObject())
+                    {
+                        /* Gemini/Antigravity drops the whole tool set on a union "type" array or a
+                           "default" keyword (issue #1074); assert neither survives the transform. */
+                        if (property.NameEquals("type") && property.Value.ValueKind == JsonValueKind.Array)
+                            violations.Add($"{path}: union type {property.Value.GetRawText()}");
+                        if (property.NameEquals("default"))
+                            violations.Add($"{path}: default = {property.Value.GetRawText()}");
+                        Walk(property.Value, $"{path}.{property.Name}");
+                    }
+                    break;
+                case JsonValueKind.Array:
+                    var i = 0;
+                    foreach (var item in element.EnumerateArray())
+                        Walk(item, $"{path}[{i++}]");
+                    break;
+            }
+        }
+    }
+
+    [Fact]
+    public void AdvertisedSchema_IsGeminiClean_ForAllFivePlanTools()
+    {
+        var tools = BuildPlanToolSchemas();
+        Assert.Equal(5, tools.Count);
+
+        var violations = tools.SelectMany(t => SchemaViolations(t.Name, t.InputSchema)).ToList();
+        Assert.True(violations.Count == 0,
+            "Gemini-incompatible schema keywords leaked into tools/list:\n" + string.Join("\n", violations));
+    }
+
+    [Fact]
+    public void AdvertisedSchema_RequiredParams_MatchTheDashboardContract()
+    {
+        var tools = BuildPlanToolSchemas().ToDictionary(t => t.Name, t => t.InputSchema);
+
+        /* The required set is the Dashboard's key params; the store's finer keys (database_name /
+           plan_id) are optional refinements, so they must NOT appear in required. */
+        Assert.Equal(new[] { "query_hash" }, RequiredOf(tools["analyze_query_plan"]));
+        Assert.Equal(new[] { "sql_handle" }, RequiredOf(tools["analyze_procedure_plan"]));
+        Assert.Equal(new[] { "database_name", "query_id" }, RequiredOf(tools["analyze_query_store_plan"]));
+        Assert.Equal(new[] { "plan_xml" }, RequiredOf(tools["analyze_plan_xml"]));
+        Assert.Equal(new[] { "query_hash" }, RequiredOf(tools["get_plan_xml"]));
+    }
+
+    [Fact]
+    public void AdvertisedSchema_NullableLongPlanId_CollapsesToInteger_NotAUnion()
+    {
+        /* plan_id is the product's first nullable value-type MCP parameter (long?). Prove the Gemini
+           transform collapses its ["integer","null"] union to a single "integer" type. */
+        var schema = BuildPlanToolSchemas().Single(t => t.Name == "analyze_query_store_plan").InputSchema;
+        var planId = schema.GetProperty("properties").GetProperty("plan_id");
+        Assert.Equal(JsonValueKind.String, planId.GetProperty("type").ValueKind);
+        Assert.Equal("integer", planId.GetProperty("type").GetString());
+        Assert.DoesNotContain("plan_id", RequiredOf(schema));
+    }
+
+    private static string[] RequiredOf(JsonElement schema) =>
+        schema.TryGetProperty("required", out var req) && req.ValueKind == JsonValueKind.Array
+            ? req.EnumerateArray().Select(e => e.GetString()!).ToArray()
+            : Array.Empty<string>();
+}
+
+/// <summary>Shared, well-formed ShowPlanXML fixtures (the same minimal shape the viewer's plan tests
+/// round-trip through the store). Kept in one place so the ungated parse test and the gated fetch
+/// tests use identical text.</summary>
+internal static class DarlingPlanFixtures
+{
+    public const string SamplePlanXml =
+        "<?xml version=\"1.0\" encoding=\"utf-16\"?>" +
+        "<ShowPlanXML xmlns=\"http://schemas.microsoft.com/sqlserver/2004/07/showplan\" Version=\"1.539\" Build=\"16.0.1000.6\">" +
+        "<BatchSequence><Batch><Statements>" +
+        "<StmtSimple StatementText=\"SELECT 1\" StatementId=\"1\" StatementType=\"SELECT\" />" +
+        "</Statements></Batch></BatchSequence></ShowPlanXML>";
+
+    public const string NewerPlanXml =
+        "<?xml version=\"1.0\" encoding=\"utf-16\"?>" +
+        "<ShowPlanXML xmlns=\"http://schemas.microsoft.com/sqlserver/2004/07/showplan\" Version=\"1.539\" Build=\"16.0.1000.6\">" +
+        "<BatchSequence><Batch><Statements>" +
+        "<StmtSimple StatementText=\"SELECT 2\" StatementId=\"1\" StatementType=\"SELECT\" />" +
+        "</Statements></Batch></BatchSequence></ShowPlanXML>";
+}
+
+/// <summary>
+/// Gated (DARLING_TEST_PG) live round-trips for the five plan tools. Registers a sentinel server the
+/// worker's way, plants stored plans in query_stats / procedure_stats / query_store_stats (with and
+/// without a plan, across two databases), then calls the tool methods and asserts: the raw fetch
+/// (get_plan_xml) returns the exact stored XML with newest-wins ordering; the optional database_name /
+/// plan_id keys refine the fetch; each analyze_* tool returns its source-tagged analysis envelope; an
+/// absent key returns the "unavailable" miss envelope; and an unknown server name returns the listing
+/// error. Shares the serialized "live-postgres" collection and cleans up in finally.
+/// </summary>
+[Collection("live-postgres")]
+public sealed class DarlingMcpPlanToolsLivePostgresTests
+{
+    private const string ServerName = "darling-mcp-plan-e2e";
+    private static readonly int ServerId = ServerIdHelper.GetDeterministicHashCode(ServerName);
+
+    private const string QueryHash = "0xE2EQUERYHASH01";
+    private const string SqlHandle = "0xE2ESQLHANDLE01";
+    private const string Db1 = "StackOverflow";
+    private const string Db2 = "AdventureWorks";
+
+    private static string? ConnectionString => Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+
+    [Fact]
+    public async Task PlanTools_FetchAndAnalyzeStoredPlans_AgainstDevPostgres()
+    {
+        var cs = ConnectionString;
+        Assert.SkipWhen(string.IsNullOrEmpty(cs),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the live plan-tools test.");
+
+        var ct = TestContext.Current.CancellationToken;
+
+        using var connection = new NpgsqlConnection(cs);
+        await connection.OpenAsync(ct);
+        await PgMigrations.MigrateAsync(connection, ct);
+        await DeleteRowsAsync(connection);
+
+        await using var postgres = NpgsqlDataSource.Create(cs!);
+
+        try
+        {
+            await RegisterServerAsync(connection);
+
+            var older = TruncateToSeconds(DateTime.UtcNow).AddHours(-3);
+            var newer = older.AddHours(1);
+
+            /* Same query_hash in two databases: Db1's plan is older, Db2's is newer — the coarse
+               (hash-only) read returns Db2's newest plan, the database-scoped read returns Db1's. */
+            await InsertQueryStatsAsync(connection, older, Db1, QueryHash, DarlingPlanFixtures.SamplePlanXml);
+            await InsertQueryStatsAsync(connection, newer, Db2, QueryHash, DarlingPlanFixtures.NewerPlanXml);
+
+            /* A procedure plan keyed by sql_handle. */
+            await InsertProcedureStatsAsync(connection, newer, Db1, "dbo", "usp_Widget", SqlHandle, DarlingPlanFixtures.SamplePlanXml);
+
+            /* Query Store: query_id 42 has a plan on plan_id 7 and NO plan on plan_id 9. */
+            await InsertQueryStoreAsync(connection, newer, Db1, queryId: 42, planId: 7, planText: DarlingPlanFixtures.SamplePlanXml);
+            await InsertQueryStoreAsync(connection, newer, Db1, queryId: 42, planId: 9, planText: null);
+
+            /* ---- get_plan_xml: raw stored XML, newest-wins, with the optional database filter. */
+            var rawNewest = await DarlingMcpPlanTools.GetPlanXml(postgres, QueryHash, ServerName);
+            Assert.Equal(DarlingPlanFixtures.NewerPlanXml, rawNewest);          /* Db2 newest across the hash */
+
+            var rawDb1 = await DarlingMcpPlanTools.GetPlanXml(postgres, QueryHash, ServerName, Db1);
+            Assert.Equal(DarlingPlanFixtures.SamplePlanXml, rawDb1);            /* database_name pins Db1 */
+
+            var rawMiss = await DarlingMcpPlanTools.GetPlanXml(postgres, "0xNOSUCHHASH", ServerName);
+            Assert.Equal("unavailable", StatusOf(rawMiss));
+
+            /* ---- analyze_query_plan: the source-tagged analysis envelope. */
+            var q = await DarlingMcpPlanTools.AnalyzeQueryPlan(postgres, QueryHash, ServerName);
+            AssertAnalysisEnvelope(q, "query_stats");
+
+            var qDb1 = await DarlingMcpPlanTools.AnalyzeQueryPlan(postgres, QueryHash, ServerName, Db1);
+            AssertAnalysisEnvelope(qDb1, "query_stats");
+
+            var qMiss = await DarlingMcpPlanTools.AnalyzeQueryPlan(postgres, "0xNOSUCHHASH", ServerName);
+            Assert.Equal("unavailable", StatusOf(qMiss));
+
+            /* ---- analyze_procedure_plan: by sql_handle. */
+            var p = await DarlingMcpPlanTools.AnalyzeProcedurePlan(postgres, SqlHandle, ServerName);
+            AssertAnalysisEnvelope(p, "procedure_stats");
+
+            var pMiss = await DarlingMcpPlanTools.AnalyzeProcedurePlan(postgres, "0xNOSUCHHANDLE", ServerName);
+            Assert.Equal("unavailable", StatusOf(pMiss));
+
+            /* ---- analyze_query_store_plan: by (db, query_id), with the optional plan_id. */
+            var qs = await DarlingMcpPlanTools.AnalyzeQueryStorePlan(postgres, Db1, 42, ServerName);
+            AssertAnalysisEnvelope(qs, "query_store");
+
+            var qsPlan7 = await DarlingMcpPlanTools.AnalyzeQueryStorePlan(postgres, Db1, 42, ServerName, 7);
+            AssertAnalysisEnvelope(qsPlan7, "query_store");
+
+            /* plan_id 9 exists but its plan text is NULL -> unavailable; an absent plan_id likewise. */
+            var qsPlan9 = await DarlingMcpPlanTools.AnalyzeQueryStorePlan(postgres, Db1, 42, ServerName, 9);
+            Assert.Equal("unavailable", StatusOf(qsPlan9));
+            var qsPlan999 = await DarlingMcpPlanTools.AnalyzeQueryStorePlan(postgres, Db1, 42, ServerName, 999);
+            Assert.Equal("unavailable", StatusOf(qsPlan999));
+
+            /* ---- server resolution flows through the tool: an unknown name returns the listing error. */
+            var unknown = await DarlingMcpPlanTools.AnalyzeQueryPlan(postgres, QueryHash, "darling-mcp-no-such-server");
+            Assert.StartsWith("Could not resolve server.", unknown, StringComparison.Ordinal);
+        }
+        finally
+        {
+            await DeleteRowsAsync(connection);
+        }
+    }
+
+    private static void AssertAnalysisEnvelope(string json, string expectedSource)
+    {
+        Assert.False(json.StartsWith("Error during", StringComparison.Ordinal), $"tool returned an error: {json}");
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.Equal(expectedSource, root.GetProperty("source").GetString());
+        Assert.Equal(ServerName, root.GetProperty("server").GetString());
+        Assert.True(root.TryGetProperty("statement_count", out _));
+    }
+
+    private static string StatusOf(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.GetProperty("status").GetString()!;
+    }
+
+    private static async Task RegisterServerAsync(NpgsqlConnection connection)
+    {
+        using var command = new NpgsqlCommand(@"
+INSERT INTO servers (server_id, server_name, display_name, is_enabled, created_date, modified_date)
+VALUES ($1, $2, $3, TRUE, $4, $4)
+ON CONFLICT (server_id) DO UPDATE SET
+    server_name = EXCLUDED.server_name,
+    display_name = EXCLUDED.display_name,
+    is_enabled = TRUE,
+    modified_date = EXCLUDED.modified_date;", connection);
+        command.Parameters.AddWithValue(ServerId);
+        command.Parameters.AddWithValue(ServerName);
+        command.Parameters.AddWithValue(ServerName);
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Unspecified));
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    /* Payload columns are nullable (PgSchemaGenerator emits only the framework columns NOT NULL), so
+       each insert supplies just the identity + plan columns the reads key on. */
+
+    private static async Task InsertQueryStatsAsync(
+        NpgsqlConnection connection, DateTime collectionTimeUtc, string databaseName, string queryHash, string? planXml)
+    {
+        using var command = new NpgsqlCommand(@"
+INSERT INTO query_stats
+    (collection_id, collection_time, server_id, server_name, database_name, query_hash, query_plan_xml)
+VALUES ($1, $2, $3, $4, $5, $6, $7)", connection);
+        command.Parameters.AddWithValue(CollectionIdGenerator.Next());
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTimeUtc, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(ServerId);
+        command.Parameters.AddWithValue(ServerName);
+        command.Parameters.AddWithValue(databaseName);
+        command.Parameters.AddWithValue(queryHash);
+        command.Parameters.AddWithValue((object?)planXml ?? DBNull.Value);
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static async Task InsertProcedureStatsAsync(
+        NpgsqlConnection connection, DateTime collectionTimeUtc, string databaseName, string schemaName,
+        string objectName, string sqlHandle, string? planXml)
+    {
+        using var command = new NpgsqlCommand(@"
+INSERT INTO procedure_stats
+    (collection_id, collection_time, server_id, server_name, database_name, schema_name, object_name, sql_handle, query_plan_xml)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)", connection);
+        command.Parameters.AddWithValue(CollectionIdGenerator.Next());
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTimeUtc, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(ServerId);
+        command.Parameters.AddWithValue(ServerName);
+        command.Parameters.AddWithValue(databaseName);
+        command.Parameters.AddWithValue(schemaName);
+        command.Parameters.AddWithValue(objectName);
+        command.Parameters.AddWithValue(sqlHandle);
+        command.Parameters.AddWithValue((object?)planXml ?? DBNull.Value);
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static async Task InsertQueryStoreAsync(
+        NpgsqlConnection connection, DateTime collectionTimeUtc, string databaseName,
+        long queryId, long planId, string? planText)
+    {
+        using var command = new NpgsqlCommand(@"
+INSERT INTO query_store_stats
+    (collection_id, collection_time, server_id, server_name, database_name, query_id, plan_id, query_plan_text)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)", connection);
+        command.Parameters.AddWithValue(CollectionIdGenerator.Next());
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTimeUtc, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(ServerId);
+        command.Parameters.AddWithValue(ServerName);
+        command.Parameters.AddWithValue(databaseName);
+        command.Parameters.AddWithValue(queryId);
+        command.Parameters.AddWithValue(planId);
+        command.Parameters.AddWithValue((object?)planText ?? DBNull.Value);
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static DateTime TruncateToSeconds(DateTime value) =>
+        DateTime.SpecifyKind(new DateTime(value.Ticks - (value.Ticks % TimeSpan.TicksPerSecond)), DateTimeKind.Unspecified);
+
+    private static async Task DeleteRowsAsync(NpgsqlConnection connection)
+    {
+        using var cleanup = new NpgsqlCommand(
+            $"DELETE FROM query_stats WHERE server_id = {ServerId}; " +
+            $"DELETE FROM procedure_stats WHERE server_id = {ServerId}; " +
+            $"DELETE FROM query_store_stats WHERE server_id = {ServerId}; " +
+            $"DELETE FROM servers WHERE server_id = {ServerId};", connection);
+        await cleanup.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/Darling/Darling.Tests/packages.lock.json
+++ b/Darling/Darling.Tests/packages.lock.json
@@ -863,6 +863,7 @@
           "PerformanceMonitor.Common": "[1.0.0, )",
           "PerformanceMonitor.Darling.Analysis": "[1.0.0, )",
           "PerformanceMonitor.Darling.Storage": "[1.0.0, )",
+          "PerformanceMonitor.PlanAnalysis": "[1.0.0, )",
           "System.IO.FileSystem.AccessControl": "[5.0.0, )"
         }
       },

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpHostService.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpHostService.cs
@@ -157,7 +157,12 @@ public sealed class DarlingMcpHostService : BackgroundService
                 /* WithGeminiCompatibleTools (not the SDK's WithTools) rewrites parameter schemas into
                    the subset Gemini/Antigravity accepts — collapsing nullable type unions and
                    dropping the default keyword. The companion to stateless transport for issue #1074. */
-                .WithGeminiCompatibleTools<DarlingMcpTools>();
+                .WithGeminiCompatibleTools<DarlingMcpTools>()
+                /* The five plan-analysis tools (analyze_query_plan / analyze_procedure_plan /
+                   analyze_query_store_plan / analyze_plan_xml / get_plan_xml) — the same names the
+                   Dashboard and Lite expose, fetching the collectors' STORED plan XML from Postgres
+                   (no live monitored-server hit) and running the SHARED PlanAnalysis engine. */
+                .WithGeminiCompatibleTools<DarlingMcpPlanTools>();
 
             _app = builder.Build();
             _app.MapMcp();

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpInstructions.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpInstructions.cs
@@ -40,7 +40,9 @@ internal static class DarlingMcpInstructions
 
         ## Tool Reference
 
-        This server exposes the six diagnostic-analysis tools (the same analysis surface Performance Monitor Lite and the Dashboard expose):
+        This server exposes eleven tools (the same names Performance Monitor Lite and the Dashboard expose): six diagnostic-analysis tools and five plan-analysis tools.
+
+        ### Diagnostic-analysis tools
 
         | Tool | Purpose | Key Parameters |
         |------|---------|----------------|
@@ -51,7 +53,19 @@ internal static class DarlingMcpInstructions
         | `get_analysis_findings` | Retrieves persisted findings from previous analysis runs (the service also analyzes on its own schedule, every 30 minutes per server) | `server_name`, `hours_back` (default 24) |
         | `mute_analysis_finding` | Mutes a finding pattern by story_path_hash so it won't appear in future runs | `story_path_hash` (required), `server_name`, `reason` |
 
-        Note on `next_tools`: analyze_server findings include `next_tools` recommendations naming the product's DATA tools (get_wait_stats, get_top_queries_by_cpu, ...). Those tools live on the companion Performance Monitor Lite / Dashboard MCP servers, not on this one — if you are also connected to one of those, follow the recommendations there; otherwise treat them as investigation hints.
+        ### Plan-analysis tools
+
+        These run the shared execution-plan analyzer over the plan XML the collectors already captured into the store (a STORED-plan read — no live query to the monitored server), returning warnings, missing indexes, parameters, memory grants, and top operators.
+
+        | Tool | Purpose | Key Parameters |
+        |------|---------|----------------|
+        | `analyze_query_plan` | Analyzes a stored query-stats plan by query_hash | `query_hash` (required), `server_name`, `database_name` (optional refinement) |
+        | `analyze_procedure_plan` | Analyzes a stored procedure-stats plan by sql_handle | `sql_handle` (required), `server_name` |
+        | `analyze_query_store_plan` | Analyzes a stored Query Store plan by database + query_id | `database_name` (required), `query_id` (required), `server_name`, `plan_id` (optional refinement) |
+        | `analyze_plan_xml` | Analyzes raw showplan XML passed directly (no fetch) | `plan_xml` (required) |
+        | `get_plan_xml` | Returns the raw stored plan XML for a query by query_hash (truncated at 500KB) | `query_hash` (required), `server_name`, `database_name` (optional refinement) |
+
+        Note on `next_tools`: analyze_server findings include `next_tools` recommendations. The plan-analysis recommendations (`analyze_query_plan`, `analyze_query_store_plan`) ARE hosted on this server — follow them here. The DATA-tool recommendations (get_wait_stats, get_top_queries_by_cpu, ...) live on the companion Performance Monitor Lite / Dashboard MCP servers, not on this one — if you are also connected to one of those, follow them there; otherwise treat them as investigation hints. (get_top_queries_by_cpu / get_top_procedures_by_cpu / get_query_store_top on those servers are where the query_hash / sql_handle / query_id + plan_id keys for the plan-analysis tools come from.)
 
         ## Recommended Workflow
 
@@ -61,5 +75,6 @@ internal static class DarlingMcpInstructions
         4. **Compare**: `compare_analysis` — see if problems are new (compare last 4 hours vs yesterday same time)
         5. **Config**: `audit_config` — edition-aware configuration recommendations
         6. **Silence noise**: `mute_analysis_finding` — mute a finding pattern the operator has accepted
+        7. **Analyze a plan**: `analyze_query_plan` / `analyze_procedure_plan` / `analyze_query_store_plan` — when a finding or a companion data tool points at a specific expensive query/procedure, analyze its captured plan for warnings, missing indexes, and grant/spill problems (or `analyze_plan_xml` for plan XML you already have)
         """;
 }

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpPlanTools.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpPlanTools.cs
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using ModelContextProtocol.Server;
+using Npgsql;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.PlanAnalysis;
+
+#pragma warning disable CA1707 // MCP tools use snake_case naming convention
+
+namespace PerformanceMonitor.Darling.Service.Mcp;
+
+/// <summary>
+/// The five plan-analysis MCP tools — the SAME tool surface the Dashboard and Lite expose
+/// (analyze_query_plan, analyze_procedure_plan, analyze_query_store_plan, analyze_plan_xml,
+/// get_plan_xml), served over Darling's Postgres store. Each tool body mirrors the Dashboard's
+/// <c>McpPlanTools</c> field-for-field (same tool names, same required parameters, the #1224 miss
+/// vocabulary via <see cref="McpHelpers.Status"/>, and the SHARED
+/// <see cref="McpPlanAnalysisFormatter"/> projection both apps already call) so an MCP client sees one
+/// consistent product across all three SKUs.
+///
+/// <para>
+/// THE SEAM: where the Dashboard fetches the plan XML from its SQL-Server store (query_hash → binary
+/// CONVERT, most-recent by last_execution_time) and Lite from DuckDB, Darling reads the plan text the
+/// collectors persisted into Postgres via <see cref="DarlingStoredPlanReader"/> — a STORED-plan read
+/// (no live monitored-server hit), keyed by the same object identity the Dashboard's tools use, with
+/// server resolution through the Postgres <c>servers</c> registry (<see cref="DarlingServerResolver"/>)
+/// instead of the Dashboard's ServerManager. Two tools additionally accept the finer store key the
+/// viewer's grids carry (database_name on the query-stats read, plan_id on the query-store read) as an
+/// OPTIONAL refinement; omitting it reproduces the Dashboard's coarse-key behavior exactly, so a client
+/// relying on the Dashboard contract works identically here.
+/// </para>
+/// </summary>
+[McpServerToolType]
+public sealed class DarlingMcpPlanTools
+{
+    [McpServerTool(Name = "analyze_query_plan"), Description(
+        "Analyzes a stored execution plan captured from query stats by query_hash. " +
+        "Use after get_top_queries_by_cpu to understand why a query is expensive. " +
+        "Returns warnings, missing indexes, parameters, memory grants, and top operators.")]
+    public static async Task<string> AnalyzeQueryPlan(
+        NpgsqlDataSource postgres,
+        [Description("The query_hash value from get_top_queries_by_cpu.")] string query_hash,
+        [Description("Server name or display name.")] string? server_name = null,
+        [Description("Optional database name to disambiguate the same query_hash across databases. Omit for the most recently captured plan.")] string? database_name = null)
+    {
+        var (resolved, error) = await DarlingServerResolver.ResolveOrErrorAsync(postgres, server_name);
+        if (error != null) return error;
+
+        try
+        {
+            var xml = await DarlingStoredPlanReader.GetQueryStatsPlanXmlByHashAsync(
+                postgres, resolved.Value.ServerId, query_hash, database_name);
+            if (string.IsNullOrEmpty(xml))
+                return McpHelpers.Status(
+                    "unavailable",
+                    $"No stored plan found for query_hash '{query_hash}'{DbSuffix(database_name)}. The plan collector may not have captured a plan for this query, or the row has aged out of the store.");
+
+            return McpPlanAnalysisFormatter.BuildAnalysisResult(xml, resolved.Value.ServerName, "query_stats", query_hash);
+        }
+        catch (Exception ex)
+        {
+            return McpHelpers.FormatError("analyze_query_plan", ex);
+        }
+    }
+
+    [McpServerTool(Name = "analyze_procedure_plan"), Description(
+        "Analyzes a stored execution plan captured from procedure stats by sql_handle. " +
+        "Use after get_top_procedures_by_cpu to understand why a procedure is expensive. " +
+        "Returns warnings, missing indexes, parameters, memory grants, and top operators.")]
+    public static async Task<string> AnalyzeProcedurePlan(
+        NpgsqlDataSource postgres,
+        [Description("The sql_handle value from get_top_procedures_by_cpu.")] string sql_handle,
+        [Description("Server name or display name.")] string? server_name = null)
+    {
+        var (resolved, error) = await DarlingServerResolver.ResolveOrErrorAsync(postgres, server_name);
+        if (error != null) return error;
+
+        try
+        {
+            var xml = await DarlingStoredPlanReader.GetProcedurePlanXmlBySqlHandleAsync(
+                postgres, resolved.Value.ServerId, sql_handle);
+            if (string.IsNullOrEmpty(xml))
+                return McpHelpers.Status(
+                    "unavailable",
+                    $"No stored plan found for sql_handle '{sql_handle}'. The plan collector may not have captured a plan for this procedure, or the row has aged out of the store.");
+
+            return McpPlanAnalysisFormatter.BuildAnalysisResult(xml, resolved.Value.ServerName, "procedure_stats", sql_handle);
+        }
+        catch (Exception ex)
+        {
+            return McpHelpers.FormatError("analyze_procedure_plan", ex);
+        }
+    }
+
+    [McpServerTool(Name = "analyze_query_store_plan"), Description(
+        "Analyzes a stored Query Store execution plan by database name and query ID. " +
+        "Use after get_query_store_top to understand why a query is expensive. " +
+        "Returns warnings, missing indexes, parameters, memory grants, and top operators.")]
+    public static async Task<string> AnalyzeQueryStorePlan(
+        NpgsqlDataSource postgres,
+        [Description("The database_name from get_query_store_top.")] string database_name,
+        [Description("The query_id from get_query_store_top.")] long query_id,
+        [Description("Server name or display name.")] string? server_name = null,
+        [Description("Optional plan_id to pin one specific compiled plan. Omit for the most recently captured plan for the query.")] long? plan_id = null)
+    {
+        var (resolved, error) = await DarlingServerResolver.ResolveOrErrorAsync(postgres, server_name);
+        if (error != null) return error;
+
+        try
+        {
+            var xml = await DarlingStoredPlanReader.GetQueryStorePlanTextAsync(
+                postgres, resolved.Value.ServerId, database_name, query_id, plan_id);
+            if (string.IsNullOrEmpty(xml))
+                return McpHelpers.Status(
+                    "unavailable",
+                    $"No stored Query Store plan found for query_id {query_id} in database '{database_name}'{PlanSuffix(plan_id)}. Query Store plan capture may be disabled for this database, or the plan has been purged.");
+
+            var identifier = plan_id is null ? $"{database_name}:{query_id}" : $"{database_name}:{query_id}:{plan_id}";
+            return McpPlanAnalysisFormatter.BuildAnalysisResult(xml, resolved.Value.ServerName, "query_store", identifier);
+        }
+        catch (Exception ex)
+        {
+            return McpHelpers.FormatError("analyze_query_store_plan", ex);
+        }
+    }
+
+    [McpServerTool(Name = "analyze_plan_xml"), Description(
+        "Analyzes raw showplan XML directly. Use when you have plan XML from any source " +
+        "(clipboard, file, another tool). Returns warnings, missing indexes, parameters, " +
+        "memory grants, and top operators.")]
+    public static string AnalyzePlanXml(
+        [Description("Raw showplan XML content.")] string plan_xml)
+    {
+        if (string.IsNullOrWhiteSpace(plan_xml))
+            return "No plan XML provided.";
+
+        try
+        {
+            return McpPlanAnalysisFormatter.BuildAnalysisResult(plan_xml, null, "xml", null);
+        }
+        catch (Exception ex)
+        {
+            return McpHelpers.FormatError("analyze_plan_xml", ex);
+        }
+    }
+
+    [McpServerTool(Name = "get_plan_xml"), Description(
+        "Returns the raw stored showplan XML for a query identified by query_hash. " +
+        "Use when you need to inspect plan details not captured in the structured analysis. " +
+        "Truncated at 500KB.")]
+    public static async Task<string> GetPlanXml(
+        NpgsqlDataSource postgres,
+        [Description("The query_hash value from get_top_queries_by_cpu.")] string query_hash,
+        [Description("Server name or display name.")] string? server_name = null,
+        [Description("Optional database name to disambiguate the same query_hash across databases. Omit for the most recently captured plan.")] string? database_name = null)
+    {
+        var (resolved, error) = await DarlingServerResolver.ResolveOrErrorAsync(postgres, server_name);
+        if (error != null) return error;
+
+        try
+        {
+            var xml = await DarlingStoredPlanReader.GetQueryStatsPlanXmlByHashAsync(
+                postgres, resolved.Value.ServerId, query_hash, database_name);
+            if (string.IsNullOrEmpty(xml))
+                return McpHelpers.Status("unavailable", $"No stored plan found for query_hash '{query_hash}'{DbSuffix(database_name)}.");
+
+            return McpHelpers.Truncate(xml, 512_000) ?? "No plan XML available.";
+        }
+        catch (Exception ex)
+        {
+            return McpHelpers.FormatError("get_plan_xml", ex);
+        }
+    }
+
+    /// <summary>" in database 'X'" when a database was supplied, else empty — keeps the miss message honest
+    /// about the coarse-vs-fine key the caller actually used.</summary>
+    private static string DbSuffix(string? databaseName) =>
+        string.IsNullOrEmpty(databaseName) ? "" : $" in database '{databaseName}'";
+
+    /// <summary>" (plan_id N)" when a plan_id was supplied, else empty.</summary>
+    private static string PlanSuffix(long? planId) =>
+        planId is null ? "" : $" (plan_id {planId})";
+}

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingStoredPlanReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingStoredPlanReader.cs
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace PerformanceMonitor.Darling.Service.Mcp;
+
+/// <summary>
+/// Service-side stored-plan reads for the plan-analysis MCP tools — the SAME stored-plan-XML the
+/// collectors persist alongside the query/query-store/procedure stats (query_stats.query_plan_xml,
+/// query_store_stats.query_plan_text, procedure_stats.query_plan_xml; captured when
+/// <c>CollectorContext.CapturePlanXml</c> is set — Darling sets it true, TOAST compresses the text).
+///
+/// <para>
+/// This mirrors the viewer's <c>ViewerDataService.Plans.cs</c> reads (adapted DuckDB/Dashboard →
+/// Postgres) but lives service-side so the MCP host never touches the WPF viewer project: the MCP
+/// server reads the STORE exactly like <c>analyze_server</c> does, never the live monitored SQL
+/// Server — consistent with Darling's read-only-from-collected-data posture (contrast
+/// <c>PgPlanFetcher</c>, which the analysis engine uses to pull a live plan from the cache on demand).
+/// </para>
+///
+/// <para>
+/// Each read keys on server_id + the object identity the Dashboard's McpPlanTools use (query_hash /
+/// sql_handle / query_id) so the MCP contract matches the Dashboard's. Two of the reads accept an
+/// OPTIONAL finer key the Postgres store carries (database_name for the query-stats read, plan_id for
+/// the query-store read); when null the read behaves exactly like the Dashboard's (most-recently
+/// collected plan for the coarse key), and when supplied it pins the exact row the viewer's grids key
+/// on. <c>ORDER BY collection_time DESC LIMIT 1</c> returns the most recently captured plan; the
+/// <c>IS NOT NULL</c> guard skips rows where no plan was captured. If a change here alters a stored
+/// column, the viewer's twin read must move with it.
+/// </para>
+/// </summary>
+internal static class DarlingStoredPlanReader
+{
+    /// <summary>
+    /// The latest captured query_stats plan for a query, keyed by (server, query_hash) with an OPTIONAL
+    /// database filter — the Dashboard's GetPlanXmlByQueryHashAsync keys on query_hash alone (most recent
+    /// wins); the $3 null-guard adds the viewer's (database, query_hash) precision when the caller knows the
+    /// database. $1 server_id, $2 query_hash, $3 database_name (NULL = no database filter).
+    /// </summary>
+    public const string QueryStatsPlanXmlByHashSql = """
+        SELECT query_plan_xml
+        FROM query_stats
+        WHERE server_id = $1
+        AND   query_hash = $2
+        AND   ($3::text IS NULL OR database_name = $3)
+        AND   query_plan_xml IS NOT NULL
+        ORDER BY collection_time DESC
+        LIMIT 1
+        """;
+
+    /// <summary>
+    /// The latest captured procedure_stats plan for a procedure, keyed by (server, sql_handle) — the
+    /// Dashboard's GetProcedurePlanXmlBySqlHandleAsync key. procedure_stats carries sql_handle as the
+    /// '0x...' hex string the collector stamps (CONVERT(varchar(64), ..., 1)), so the match is a direct
+    /// text compare (no varbinary CONVERT the SQL-Server side needs). $1 server_id, $2 sql_handle.
+    /// </summary>
+    public const string ProcedurePlanXmlBySqlHandleSql = """
+        SELECT query_plan_xml
+        FROM procedure_stats
+        WHERE server_id = $1
+        AND   sql_handle = $2
+        AND   query_plan_xml IS NOT NULL
+        ORDER BY collection_time DESC
+        LIMIT 1
+        """;
+
+    /// <summary>
+    /// The latest captured query_store_stats plan for a query, keyed by (server, database, query_id) with an
+    /// OPTIONAL plan_id filter — the Dashboard's GetQueryStorePlanXmlAsync keys on (database, query_id); the
+    /// $4 null-guard adds the viewer's (query_id, plan_id) precision (a plan_id names one specific compiled
+    /// plan) when the caller knows it. $1 server_id, $2 database_name, $3 query_id, $4 plan_id (NULL = latest
+    /// plan for the query).
+    /// </summary>
+    public const string QueryStorePlanTextSql = """
+        SELECT query_plan_text
+        FROM query_store_stats
+        WHERE server_id = $1
+        AND   database_name = $2
+        AND   query_id = $3
+        AND   ($4::bigint IS NULL OR plan_id = $4)
+        AND   query_plan_text IS NOT NULL
+        ORDER BY collection_time DESC
+        LIMIT 1
+        """;
+
+    /// <summary>
+    /// The stored execution plan XML for a query (query_stats), or null when no plan was captured for the
+    /// key. Read as text — no length cap (the collector stored the whole plan; the MCP tool truncates for
+    /// transport).
+    /// </summary>
+    public static async Task<string?> GetQueryStatsPlanXmlByHashAsync(
+        NpgsqlDataSource postgres, int serverId, string queryHash, string? databaseName,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(queryHash))
+        {
+            return null;
+        }
+
+        await using var command = postgres.CreateCommand(QueryStatsPlanXmlByHashSql);
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = queryHash });
+        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text, Value = (object?)databaseName ?? DBNull.Value });
+        var result = await command.ExecuteScalarAsync(cancellationToken);
+        return result is string s ? s : null;
+    }
+
+    /// <summary>
+    /// The stored execution plan XML for a procedure (procedure_stats), or null when no plan was captured
+    /// for the sql_handle.
+    /// </summary>
+    public static async Task<string?> GetProcedurePlanXmlBySqlHandleAsync(
+        NpgsqlDataSource postgres, int serverId, string sqlHandle,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(sqlHandle))
+        {
+            return null;
+        }
+
+        await using var command = postgres.CreateCommand(ProcedurePlanXmlBySqlHandleSql);
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = sqlHandle });
+        var result = await command.ExecuteScalarAsync(cancellationToken);
+        return result is string s ? s : null;
+    }
+
+    /// <summary>
+    /// The stored Query Store execution plan for a query (query_store_stats.query_plan_text — Query Store
+    /// already stores plans as ShowPlanXML text), or null when no plan text was captured for the key.
+    /// </summary>
+    public static async Task<string?> GetQueryStorePlanTextAsync(
+        NpgsqlDataSource postgres, int serverId, string databaseName, long queryId, long? planId,
+        CancellationToken cancellationToken = default)
+    {
+        await using var command = postgres.CreateCommand(QueryStorePlanTextSql);
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = databaseName ?? "" });
+        command.Parameters.Add(new NpgsqlParameter<long> { TypedValue = queryId });
+        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Bigint, Value = (object?)planId ?? DBNull.Value });
+        var result = await command.ExecuteScalarAsync(cancellationToken);
+        return result is string s ? s : null;
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Service/PerformanceMonitor.Darling.Service.csproj
+++ b/Darling/PerformanceMonitor.Darling.Service/PerformanceMonitor.Darling.Service.csproj
@@ -40,6 +40,10 @@
     <!-- AN3: the analysis pipeline (DarlingAnalysisService/PgPlanFetcher). Dependency points
          service → analysis only; the analysis library never references the service. -->
     <ProjectReference Include="..\PerformanceMonitor.Darling.Analysis\PerformanceMonitor.Darling.Analysis.csproj" />
+    <!-- The plan-analysis MCP tools run the SHARED ShowPlanParser/PlanAnalyzer and serialize via
+         McpPlanAnalysisFormatter (the same projection both apps' McpPlanTools call). Referenced
+         directly (it also flows transitively through Darling.Analysis) since it is a direct dependency. -->
+    <ProjectReference Include="..\..\PerformanceMonitor.PlanAnalysis\PerformanceMonitor.PlanAnalysis.csproj" />
     <ProjectReference Include="..\PerformanceMonitor.Darling.Storage\PerformanceMonitor.Darling.Storage.csproj" />
   </ItemGroup>
 

--- a/Darling/README.md
+++ b/Darling/README.md
@@ -269,7 +269,10 @@ A channel is enabled by a non-empty URL.
 
 ### mcp
 
-The embedded MCP server: the six diagnostic-analysis tools — `analyze_server`, `get_analysis_facts`, `compare_analysis`, `audit_config`, `get_analysis_findings`, `mute_analysis_finding` — the same analysis surface Lite and the Dashboard expose, over Streamable HTTP bound to `localhost` only.
+The embedded MCP server, over Streamable HTTP bound to `localhost` only. It exposes the same tool names Lite and the Dashboard expose:
+
+- **Six diagnostic-analysis tools** — `analyze_server`, `get_analysis_facts`, `compare_analysis`, `audit_config`, `get_analysis_findings`, `mute_analysis_finding`.
+- **Five plan-analysis tools** — `analyze_query_plan` (by `query_hash`), `analyze_procedure_plan` (by `sql_handle`), `analyze_query_store_plan` (by `database_name` + `query_id`), `analyze_plan_xml` (raw showplan XML, no fetch), and `get_plan_xml` (raw stored plan XML by `query_hash`). These run the shared execution-plan analyzer over the plan XML the collectors already captured into the store — a stored-plan read, never a live query against the monitored server. `analyze_query_plan`/`get_plan_xml` accept an optional `database_name`, and `analyze_query_store_plan` an optional `plan_id`, to pin the exact stored plan when the caller knows it.
 
 | Key | Default | Notes |
 |---|---|---|


### PR DESCRIPTION
## Summary

Ports the **5 plan-analysis MCP tools** from the Dashboard onto Darling's always-on service MCP host — slice 1 of the MCP data-tool port (the "highest-fit, lowest-risk slice": Darling's 24/7 service hosts MCP and centrally stores plan XML in Postgres). The tool **names + required parameter contract match the Dashboard exactly**, so an MCP client that relies on the contract works identically against Darling.

All five are **stored-plan reads** — the collectors already persist plan XML into Postgres (gated on `CollectorContext.CapturePlanXml`, which Darling sets true), so the tools read the store like `analyze_server` does and **never hit the live monitored server**, consistent with Darling's read-only-from-collected-data posture. (Contrast `PgPlanFetcher`, which the analysis engine uses to pull a live plan on demand — a different path, left untouched.)

## The 5 tools + the store read each performs

| Tool | Key params (required) | Store read |
|---|---|---|
| `analyze_query_plan` | `query_hash` | `query_stats.query_plan_xml` WHERE `server_id` + `query_hash` (optional `database_name`), newest by `collection_time` |
| `analyze_procedure_plan` | `sql_handle` | `procedure_stats.query_plan_xml` WHERE `server_id` + `sql_handle`, newest |
| `analyze_query_store_plan` | `database_name`, `query_id` | `query_store_stats.query_plan_text` WHERE `server_id` + `database_name` + `query_id` (optional `plan_id`), newest |
| `analyze_plan_xml` | `plan_xml` | none (analyzes raw XML directly) |
| `get_plan_xml` | `query_hash` | same as `analyze_query_plan`, returns raw XML (truncated 500KB) |

Server names resolve through the Postgres `servers` registry via the existing `DarlingServerResolver` (same as the six analysis tools), not the Dashboard's ServerManager.

## Formatter: SHARED, not ported

`McpPlanAnalysisFormatter` (and `ShowPlanParser` / `PlanAnalyzer`) already live in the **shared** `PerformanceMonitor.PlanAnalysis` library — both apps' `McpPlanTools` call it. Darling calls the same `McpPlanAnalysisFormatter.BuildAnalysisResult(...)` unchanged, so the analysis projection (warnings, missing indexes, parameters, memory grants, top operators, same JSON shape) stays byte-identical across all three SKUs. Added an explicit `PerformanceMonitor.PlanAnalysis` project reference to the service csproj (it also flowed transitively via `Darling.Analysis`).

## Plan-XML columns verified (collector `PayloadColumns` + `PgSchemaGenerator`)

- `query_stats.query_plan_xml`, `query_stats.query_hash` — `QueryStatsCollector`
- `procedure_stats.query_plan_xml`, `procedure_stats.sql_handle` — `ProcedureStatsCollector`
- `query_store_stats.query_plan_text`, `query_store_stats.query_id` / `plan_id` — `QueryStoreCollector`

A test pins each column against `PgSchemaGenerator.CreateTable(...)`. Store columns hold the collector's `'0x...'` hex strings as text, so the reads match by string equality — no T-SQL `CONVERT(varbinary...)` the SQL-Server side needs.

## One decision to flag (did NOT scope down)

The Dashboard's contract keys `analyze_query_plan`/`get_plan_xml` on `query_hash` alone and `analyze_query_store_plan` on `(database_name, query_id)`. The Darling store carries finer keys the viewer's grids use (`database_name` for query plans, `plan_id` for query-store plans). I kept the Dashboard's **required** params exact and added those finer keys as **OPTIONAL** refinements: omitting them reproduces the Dashboard's coarse-key "most-recent plan" behavior; supplying them pins the exact stored row. This is a strict superset — a Dashboard-contract caller is unaffected. (The task deliverables call these out as `(+ database)` / `(+ plan_id)`.) Happy to drop the optional params if you'd rather match the Dashboard byte-for-byte.

## Tests (`Darling.Tests`, matching the existing convention)

Ungated: tool surface = exactly the 5 names (all static, `[McpServerToolType]`); per-tool MCP parameter contract; the **advertised** Gemini-compatible schema for all 5 tools (no union types / no `default` — the #1074 guard — including the product's **first nullable value-type MCP param**, `plan_id long?`, which correctly collapses to `"integer"`); the 3 fetch SQL pins (Postgres dialect, positional params, `IS NOT NULL` + newest-wins); plan-column existence; and the no-fetch `analyze_plan_xml` path (empty → bare message, malformed → no throw, well-formed → `xml`-sourced envelope).

Gated on `DARLING_TEST_PG`: live round-trips that register a server, plant stored plans across two databases (with/without a plan, null vs present `plan_id`), and assert each tool fetches + analyzes, the optional keys refine, newest-wins, and an absent key returns the `unavailable` miss envelope.

**Result: 1094 passed, 99 skipped (all `DARLING_TEST_PG`-gated, incl. the 1 live plan-tools test), 0 failed.** Whole Darling stack builds `-c Release` (Service 0/0). No Viewer files touched.

## Next slices (for the lead to commission)

The remaining MCP data-read tool slices are pure store reads the Darling schema already backs: **CPU/scheduler** (`get_cpu_utilization`, `get_cpu_scheduler_pressure`), **waits** (`get_wait_stats`, `get_wait_trend`), **memory** (`get_memory_stats`/`_clerks`/`_grants`/`_pressure_events`), **I/O** (`get_file_io_stats`/`_trend`), **blocking/deadlocks**, **query/procedure/Query-Store tops**, **tempdb**, **perfmon**, **jobs**, **sessions**, **config/trace-flags**, and the **discovery/health** tools (`list_servers`, `get_collection_health`). Each is a `DarlingServerResolver` + Postgres read + JSON envelope, mirroring the six analysis tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
