### PR TITLE
Stage 3a: viewer server-management writes the control-plane store

### DIFF
--- a/Darling/Darling.Tests/ViewerServerManagementTests.cs
+++ b/Darling/Darling.Tests/ViewerServerManagementTests.cs
@@ -1,0 +1,471 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.Darling.Service;
+using PerformanceMonitor.Darling.Viewer;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// The control-plane Stage-3a viewer writes to <c>config.config_monitored_servers</c> — the write partial's
+/// SQL shape (parameterization, ON CONFLICT semantics, the V17 column parity with the service's
+/// <see cref="StoreConfigProvider"/>) and the shared <c>server_id</c> identity, pinned with no live Postgres
+/// exactly like the mute-rule + command pins.
+/// </summary>
+public sealed class ViewerMonitoredServerSqlTests
+{
+    private static readonly string[] StoreColumns =
+    {
+        "server_id", "name", "host", "database", "auth", "username", "encrypted_password", "encrypt_mode",
+        "trust_server_certificate", "read_only_intent", "multi_subnet_failover", "excluded_databases",
+        "monthly_cost_usd", "capture_plans", "is_enabled",
+    };
+
+    [Fact]
+    public void UpsertSql_WritesEveryV17Column_AsBoundParameters_OnConflictUpdate()
+    {
+        var sql = ViewerDataService.MonitoredServerUpsertSql;
+
+        Assert.Contains("INSERT INTO config_monitored_servers", sql, StringComparison.Ordinal);
+        foreach (var column in StoreColumns)
+        {
+            Assert.Contains(column, sql, StringComparison.Ordinal);
+        }
+
+        /* Every value is a $N parameter (15 columns), never inlined. */
+        for (var i = 1; i <= 15; i++)
+        {
+            Assert.Contains("$" + i.ToString(System.Globalization.CultureInfo.InvariantCulture), sql, StringComparison.Ordinal);
+        }
+
+        /* Upsert on the shared identity; created_at is server-side, never clobbered on update. */
+        Assert.Contains("ON CONFLICT (server_id) DO UPDATE", sql, StringComparison.Ordinal);
+        Assert.Contains("modified_at = (now() AT TIME ZONE 'UTC')", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void InsertIfAbsentSql_DoesNothingOnConflict_SoTheMigrateNeverDoubleSeeds()
+    {
+        var sql = ViewerDataService.MonitoredServerInsertIfAbsentSql;
+        Assert.Contains("INSERT INTO config_monitored_servers", sql, StringComparison.Ordinal);
+        Assert.Contains("ON CONFLICT (server_id) DO NOTHING", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DeleteAndTargetedUpdates_KeyOnServerId()
+    {
+        Assert.Contains("DELETE FROM config_monitored_servers WHERE server_id = $1", ViewerDataService.MonitoredServerDeleteSql, StringComparison.Ordinal);
+        Assert.Contains("WHERE server_id = $1", ViewerDataService.MonitoredServerSetEnabledSql, StringComparison.Ordinal);
+        Assert.Contains("is_enabled = $2", ViewerDataService.MonitoredServerSetEnabledSql, StringComparison.Ordinal);
+        Assert.Contains("WHERE server_id = $1", ViewerDataService.MonitoredServerSetExcludedDatabasesSql, StringComparison.Ordinal);
+        Assert.Contains("excluded_databases = $2", ViewerDataService.MonitoredServerSetExcludedDatabasesSql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ManagedServersSql_IsConfigAuthoritative_EnrichedByCollectServers()
+    {
+        var sql = ViewerDataService.ManagedServersSql;
+        /* Membership from the DESIRED-state config table, facts LEFT JOINed from the observed registry. */
+        Assert.Contains("FROM config_monitored_servers c", sql, StringComparison.Ordinal);
+        Assert.Contains("LEFT JOIN servers s ON s.server_id = c.server_id", sql, StringComparison.Ordinal);
+        Assert.Contains("c.is_enabled", sql, StringComparison.Ordinal);
+        Assert.Contains("c.monthly_cost_usd", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SelectSql_ReadsCreatedAt_ForTheManageServersGrid()
+    {
+        Assert.Contains("created_at", ViewerDataService.MonitoredServersSelectSql, StringComparison.Ordinal);
+        Assert.Contains("created_at", ViewerDataService.MonitoredServerByIdSql, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("SQL2022", null, false)]
+    [InlineData("myazure.database.windows.net", "AdventureWorks", false)]
+    [InlineData("ag-listener", null, true)]
+    [InlineData("host", "db", true)]
+    public void ComputeServerId_MatchesTheSharedHelper(string host, string? database, bool readOnlyIntent)
+    {
+        var expected = ServerIdHelper.GetDeterministicHashCode(ServerIdHelper.BuildStorageName(host, database, readOnlyIntent));
+        Assert.Equal(expected, ViewerDataService.ComputeServerId(host, database, readOnlyIntent));
+    }
+
+    [Fact]
+    public void ComputeServerId_MatchesTheServiceMonitoredServerIdentity()
+    {
+        /* The service seeds server_id from its MonitoredServer.StorageName; the viewer must derive the SAME id
+           for the same host/database/read-only-intent so a viewer-written row JOINs collected data and the
+           service's reconcile matches it. */
+        var svc = new MonitoredServer { Host = "SQL2022", Database = "tpcc", ReadOnlyIntent = true };
+        Assert.Equal(
+            ServerIdHelper.GetDeterministicHashCode(svc.StorageName),
+            ViewerDataService.ComputeServerId("SQL2022", "tpcc", true));
+    }
+}
+
+/// <summary>
+/// The viewer half of the command plane — the enqueue/poll SQL shape, the terminal-state helper, and the
+/// <c>test_connect</c> args_json that the service's <see cref="DarlingCommandExecutor"/> deserializes as a
+/// <see cref="MonitoredServer"/> (proving the two ends agree, and that the password rides as the DPAPI blob,
+/// never plaintext, into Postgres).
+/// </summary>
+public sealed class ViewerCommandSqlTests
+{
+    private static readonly JsonSerializerOptions s_caseInsensitive = new() { PropertyNameCaseInsensitive = true };
+
+    [Fact]
+    public void EnqueueSql_InsertsPendingAndReturnsCommandId()
+    {
+        var sql = ViewerDataService.CommandEnqueueSql;
+        Assert.Contains("INSERT INTO config_command", sql, StringComparison.Ordinal);
+        Assert.Contains("'pending'", sql, StringComparison.Ordinal);
+        Assert.Contains("RETURNING command_id", sql, StringComparison.Ordinal);
+        /* requested_by, command_type, target_server_id, args_json bound as $1..$4. */
+        Assert.Contains("$1, $2, $3, $4", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PollSql_ReadsStatusAndResult_ByCommandId()
+    {
+        var sql = ViewerDataService.CommandPollSql;
+        Assert.Contains("SELECT status, result_status, result_json FROM config_command", sql, StringComparison.Ordinal);
+        Assert.Contains("WHERE command_id = $1", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DeleteSql_RemovesTheCredentialBearingRow_ByCommandId()
+    {
+        /* The viewer cleans up its own terminal test_connect command so the DPAPI blob in args_json does not
+           linger in the store. */
+        Assert.Equal("DELETE FROM config_command WHERE command_id = $1", ViewerDataService.CommandDeleteSql);
+    }
+
+    [Theory]
+    [InlineData("succeeded", true)]
+    [InlineData("failed", true)]
+    [InlineData("pending", false)]
+    [InlineData("in_progress", false)]
+    [InlineData(null, false)]
+    public void IsTerminal_OnlyForSucceededOrFailed(string? status, bool expected)
+    {
+        Assert.Equal(expected, ViewerDataService.IsTerminal(status));
+    }
+
+    [Fact]
+    public void BuildTestConnectArgs_DeserializesIntoTheServiceMonitoredServer_WithNoPlaintextPassword()
+    {
+        var args = new TestConnectServer
+        {
+            Name = "Prod",
+            Host = "SQL2022",
+            Database = "tpcc",
+            Auth = "sql",
+            Username = "monitor",
+            EncryptedPassword = "DPAPI-BLOB==",
+            ReadOnlyIntent = true,
+            TrustServerCertificate = true,
+            EncryptMode = "Strict",
+            MultiSubnetFailover = true,
+        };
+
+        var json = ViewerDataService.BuildTestConnectArgs(args);
+
+        /* The service uses PropertyNameCaseInsensitive; the viewer emits the MonitoredServer's [JsonPropertyName]
+           (camelCase) names, so the round-trip reconstructs the server the probe connects with. */
+        var server = JsonSerializer.Deserialize<MonitoredServer>(json, s_caseInsensitive);
+        Assert.NotNull(server);
+        Assert.Equal("SQL2022", server!.Host);
+        Assert.Equal("tpcc", server.Database);
+        Assert.Equal("sql", server.Auth);
+        Assert.Equal("monitor", server.Username);
+        Assert.Equal("DPAPI-BLOB==", server.EncryptedPassword);
+        Assert.True(server.ReadOnlyIntent);
+        Assert.True(server.TrustServerCertificate);
+        Assert.Equal("Strict", server.EncryptMode);
+        Assert.True(server.MultiSubnetFailover);
+
+        /* The plaintext password field is NEVER emitted — the secret only ever travels as the DPAPI blob. */
+        Assert.Null(server.Password);
+        Assert.DoesNotContain("\"password\"", json, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildTestConnectArgs_IntegratedAuth_OmitsUsernameAndSecret()
+    {
+        var json = ViewerDataService.BuildTestConnectArgs(new TestConnectServer { Host = "SQL2022", Auth = "integrated" });
+        var server = JsonSerializer.Deserialize<MonitoredServer>(json, s_caseInsensitive);
+        Assert.NotNull(server);
+        Assert.Equal("integrated", server!.Auth);
+        Assert.Null(server.Username);
+        Assert.Null(server.EncryptedPassword);
+    }
+}
+
+/// <summary>The pure auth mapping — the service honors integrated + SQL only; the three Azure/Entra modes block.</summary>
+public sealed class ServerStoreCredentialTests
+{
+    [Theory]
+    [InlineData(AuthenticationTypes.Windows, "integrated")]
+    [InlineData(AuthenticationTypes.SqlServer, "sql")]
+    public void MapAuth_SupportedModes_MapToStoreAuth(string authType, string expected)
+    {
+        Assert.Equal(expected, ServerStoreCredential.MapAuth(authType));
+        Assert.True(ServerStoreCredential.IsSupported(authType));
+    }
+
+    [Theory]
+    [InlineData(AuthenticationTypes.EntraMFA)]
+    [InlineData(AuthenticationTypes.ServicePrincipal)]
+    [InlineData(AuthenticationTypes.ManagedIdentity)]
+    public void MapAuth_AzureModes_AreUnsupported(string authType)
+    {
+        Assert.Null(ServerStoreCredential.MapAuth(authType));
+        Assert.False(ServerStoreCredential.IsSupported(authType));
+    }
+
+    [Fact]
+    public void RequiresSecret_OnlyForSql()
+    {
+        Assert.True(ServerStoreCredential.RequiresSecret(AuthenticationTypes.SqlServer));
+        Assert.False(ServerStoreCredential.RequiresSecret(AuthenticationTypes.Windows));
+        Assert.False(ServerStoreCredential.RequiresSecret(AuthenticationTypes.ManagedIdentity));
+    }
+}
+
+/// <summary>
+/// The DPAPI blob the viewer writes into <c>encrypted_password</c> must be readable by the SERVICE, and vice
+/// versa — a cross-project round trip against <see cref="DarlingSecrets"/> proving the entropy + scope match
+/// (Windows-only; DPAPI is unavailable elsewhere).
+/// </summary>
+public sealed class ViewerServerSecretTests
+{
+    [Fact]
+    public void ViewerProtect_IsReadableByTheService()
+    {
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "DPAPI requires Windows.");
+        var blob = ViewerServerSecret.Protect("s3cr3t!");
+        Assert.Equal("s3cr3t!", DarlingSecrets.Unprotect(blob));
+    }
+
+    [Fact]
+    public void ServiceProtect_IsReadableByTheViewer()
+    {
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "DPAPI requires Windows.");
+        var blob = DarlingSecrets.Protect("another-pw");
+        Assert.Equal("another-pw", ViewerServerSecret.TryUnprotect(blob));
+    }
+
+    [Fact]
+    public void TryUnprotect_ReturnsNullOnGarbage_NeverThrows()
+    {
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "DPAPI requires Windows.");
+        Assert.Null(ViewerServerSecret.TryUnprotect(null));
+        Assert.Null(ViewerServerSecret.TryUnprotect(""));
+        Assert.Null(ViewerServerSecret.TryUnprotect("not-base64!!"));
+        Assert.Null(ViewerServerSecret.TryUnprotect(Convert.ToBase64String(new byte[] { 1, 2, 3, 4 })));
+    }
+}
+
+/// <summary>
+/// The one-time viewer-servers.json → config migrate-in: the per-entry projection (auth mapping + secret
+/// resolution + the shared server_id) and the once-marker guard. Uses an in-memory secret fake + temp files,
+/// never the real vault or a live store.
+/// </summary>
+public sealed class ViewerServerMigrationTests
+{
+    [Fact]
+    public void Projection_IntegratedEntry_ImportsWithNoSecret_OnTheSharedIdentity()
+    {
+        using var fixture = new Fixture();
+        fixture.ServerStore.AddServer(
+            new ViewerServerEntry { ServerName = "SQL2022", DisplayName = "Prod", AuthenticationType = AuthenticationTypes.Windows },
+            null, null);
+
+        var (row, reason) = fixture.Migration.TryProjectEntry(fixture.ServerStore.GetAllServers()[0]);
+
+        Assert.Null(reason);
+        Assert.NotNull(row);
+        Assert.Equal("integrated", row!.Auth);
+        Assert.Null(row.EncryptedPassword);
+        Assert.Equal("SQL2022", row.Host);
+        Assert.Equal("Prod", row.Name);
+        Assert.Equal(ViewerDataService.ComputeServerId("SQL2022", null, false), row.ServerId);
+    }
+
+    [Fact]
+    public void Projection_SqlEntry_SealsTheSecretAsAServiceReadableBlob()
+    {
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "DPAPI requires Windows.");
+
+        using var fixture = new Fixture();
+        var entry = new ViewerServerEntry { ServerName = "SQL2019", DisplayName = "Dev", AuthenticationType = AuthenticationTypes.SqlServer };
+        fixture.ServerStore.AddServer(entry, "monitor", "p@ss");
+
+        var (row, reason) = fixture.Migration.TryProjectEntry(fixture.ServerStore.GetByServerName("SQL2019")!);
+
+        Assert.Null(reason);
+        Assert.NotNull(row);
+        Assert.Equal("sql", row!.Auth);
+        Assert.Equal("monitor", row.Username);
+        Assert.NotNull(row.EncryptedPassword);
+        /* The service must be able to read what the migrate wrote. */
+        Assert.Equal("p@ss", DarlingSecrets.Unprotect(row.EncryptedPassword!));
+    }
+
+    [Fact]
+    public void Projection_SqlEntry_WithNoStoredSecret_IsSkipped()
+    {
+        using var fixture = new Fixture();
+        /* SQL auth but no secret saved (username/password null) — an un-connectable row; skip, don't import broken. */
+        fixture.ServerStore.AddServer(
+            new ViewerServerEntry { ServerName = "SQL2016", DisplayName = "Old", AuthenticationType = AuthenticationTypes.SqlServer },
+            null, null);
+
+        var (row, reason) = fixture.Migration.TryProjectEntry(fixture.ServerStore.GetAllServers()[0]);
+
+        Assert.Null(row);
+        Assert.Contains("no stored password", reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData(AuthenticationTypes.EntraMFA)]
+    [InlineData(AuthenticationTypes.ServicePrincipal)]
+    [InlineData(AuthenticationTypes.ManagedIdentity)]
+    public void Projection_AzureAuth_IsSkipped(string authType)
+    {
+        using var fixture = new Fixture();
+        fixture.ServerStore.AddServer(
+            new ViewerServerEntry { ServerName = "azure", DisplayName = "Azure", AuthenticationType = authType },
+            null, null);
+
+        var (row, reason) = fixture.Migration.TryProjectEntry(fixture.ServerStore.GetAllServers()[0]);
+
+        Assert.Null(row);
+        Assert.Contains("not supported", reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Projection_CarriesConnectionOptionsAndExcludedDatabases()
+    {
+        using var fixture = new Fixture();
+        fixture.ServerStore.AddServer(new ViewerServerEntry
+        {
+            ServerName = "ag",
+            DisplayName = "AG",
+            AuthenticationType = AuthenticationTypes.Windows,
+            ReadOnlyIntent = true,
+            MultiSubnetFailover = true,
+            TrustServerCertificate = true,
+            EncryptMode = "Strict",
+            MonthlyCostUsd = 250m,
+            IsEnabled = false,
+            ExcludedDatabases = new List<string> { "ReportServer", "ReportServerTempDB" },
+        }, null, null);
+
+        var (row, _) = fixture.Migration.TryProjectEntry(fixture.ServerStore.GetAllServers()[0]);
+
+        Assert.NotNull(row);
+        Assert.True(row!.ReadOnlyIntent);
+        Assert.True(row.MultiSubnetFailover);
+        Assert.True(row.TrustServerCertificate);
+        Assert.Equal("Strict", row.EncryptMode);
+        Assert.Equal(250m, row.MonthlyCostUsd);
+        Assert.False(row.IsEnabled);
+        Assert.Equal(new[] { "ReportServer", "ReportServerTempDB" }, row.ExcludedDatabases);
+        /* Read-only intent participates in the identity. */
+        Assert.Equal(ViewerDataService.ComputeServerId("ag", null, true), row.ServerId);
+    }
+
+    [Fact]
+    public void Marker_GatesTheOnceGuard()
+    {
+        using var fixture = new Fixture();
+        Assert.False(fixture.Migration.AlreadyMigrated);
+
+        File.WriteAllText(fixture.MarkerPath, "done");
+        Assert.True(new ViewerServerMigration(fixture.ServerStore, fixture.ProfileStore, fixture.MarkerPath).AlreadyMigrated);
+    }
+
+    /// <summary>Temp files + an in-memory secret fake so the migration never touches the real vault or store.</summary>
+    private sealed class Fixture : IDisposable
+    {
+        private readonly string _serversPath = Path.Combine(Path.GetTempPath(), $"vs-{Guid.NewGuid():N}.json");
+        private readonly string _profilesPath = Path.Combine(Path.GetTempPath(), $"vp-{Guid.NewGuid():N}.json");
+
+        public string MarkerPath { get; } = Path.Combine(Path.GetTempPath(), $"vm-{Guid.NewGuid():N}.marker");
+        public ViewerServerStore ServerStore { get; }
+        public ViewerProfileStore ProfileStore { get; }
+        public ViewerServerMigration Migration { get; }
+
+        public Fixture()
+        {
+            var secrets = new FakeSecretStore();
+            ServerStore = new ViewerServerStore(_serversPath, secrets);
+            ProfileStore = new ViewerProfileStore(ServerStore, _profilesPath, secrets);
+            Migration = new ViewerServerMigration(ServerStore, ProfileStore, MarkerPath);
+        }
+
+        public void Dispose()
+        {
+            foreach (var path in new[] { _serversPath, _profilesPath, MarkerPath })
+            {
+                try { File.Delete(path); } catch { /* best-effort */ }
+            }
+        }
+    }
+
+    private sealed class FakeSecretStore : IViewerServerSecretStore
+    {
+        private readonly Dictionary<string, (string Username, string Password)> _map = new();
+        public void Save(string id, string username, string password) => _map[id] = (username, password);
+        public (string Username, string Password)? Get(string id) => _map.TryGetValue(id, out var v) ? v : null;
+        public void Delete(string id) => _map.Remove(id);
+    }
+}
+
+/// <summary>
+/// The read-only degradation: a viewer connected read-only cannot write server config or enqueue commands.
+/// The proactive gating hides the affordances; these pin that the write paths still fail safe (the reactive
+/// 42501 → <see cref="ViewerReadOnlyException"/> backstop is shared with the mute-rule path, tested there).
+/// </summary>
+public sealed class ViewerServerManagementReadOnlyTests
+{
+    [Fact]
+    public async System.Threading.Tasks.Task MigrateAsync_Disconnected_IsANoOp()
+    {
+        using var serverDir = new TempDir();
+        var secrets = new NoopSecretStore();
+        var serverStore = new ViewerServerStore(Path.Combine(serverDir.Path, "s.json"), secrets);
+        var profileStore = new ViewerProfileStore(serverStore, Path.Combine(serverDir.Path, "p.json"), secrets);
+        var migration = new ViewerServerMigration(serverStore, profileStore, Path.Combine(serverDir.Path, "m.marker"));
+
+        /* No store → nothing imported, and the once-marker is NOT written (so a later connected run still runs). */
+        var imported = await migration.MigrateAsync(dataService: null);
+        Assert.Equal(0, imported);
+        Assert.False(migration.AlreadyMigrated);
+    }
+
+    private sealed class TempDir : IDisposable
+    {
+        public string Path { get; } = Directory.CreateTempSubdirectory("darling-cp-").FullName;
+        public void Dispose() { try { Directory.Delete(Path, recursive: true); } catch { /* best-effort */ } }
+    }
+
+    private sealed class NoopSecretStore : IViewerServerSecretStore
+    {
+        public void Save(string id, string username, string password) { }
+        public (string Username, string Password)? Get(string id) => null;
+        public void Delete(string id) { }
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/AddServerDialog.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/AddServerDialog.xaml
@@ -24,7 +24,7 @@
         </Grid.RowDefinitions>
 
         <!-- Header -->
-        <TextBlock Grid.Row="0" Text="Add SQL Server Connection" FontSize="18" FontWeight="Bold" Margin="0,0,0,15"
+        <TextBlock Grid.Row="0" x:Name="HeaderText" Text="Add SQL Server Connection" FontSize="18" FontWeight="Bold" Margin="0,0,0,15"
                    Foreground="{DynamicResource ForegroundBrush}"/>
 
         <!-- Server Name -->
@@ -129,18 +129,9 @@
             <CheckBox x:Name="FavoriteCheckBox" Content="Mark as favorite (appears at top of list)"
                       Foreground="{DynamicResource ForegroundBrush}" Margin="0,6,0,0"/>
             <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
-                <TextBlock Text="Description:" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Width="80"/>
-                <TextBox x:Name="DescriptionTextBox" Width="250"/>
-            </StackPanel>
-            <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
                 <TextBlock Text="Database:" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Width="80"/>
                 <TextBox x:Name="DatabaseNameBox" Width="250"
                          ToolTip="Required for Azure SQL Database. Leave empty for on-premises SQL Server."/>
-            </StackPanel>
-            <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
-                <TextBlock Text="Utility DB:" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Width="80"/>
-                <TextBox x:Name="UtilityDatabaseBox" Width="250"
-                         ToolTip="Database where community stored procedures (sp_IndexCleanup) are installed. Leave empty to use the connection database."/>
             </StackPanel>
             <CheckBox x:Name="ReadOnlyIntentCheckBox" Content="Read-only intent (for AG listeners and readable replicas)"
                       Foreground="{DynamicResource ForegroundBrush}" Margin="0,6,0,0"
@@ -153,25 +144,20 @@
                 <TextBox x:Name="MonthlyCostBox" Width="100" TextAlignment="Right" Text="0"
                          ToolTip="What this server costs per month (license, compute, storage combined). Used for FinOps cost attribution. Leave 0 to hide cost columns."/>
             </StackPanel>
-            <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
-                <TextBlock Text="Alert delivery:" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Width="110"/>
-                <ComboBox x:Name="AlertDeliveryOverrideBox" Width="240" SelectedIndex="0"
-                          ToolTip="How deadlock/blocking alerts for THIS server are delivered. 'Use global setting' follows the app-wide Alerts setting; override to force Summary or Per-event for just this server.">
-                    <ComboBoxItem Content="Use global setting"/>
-                    <ComboBoxItem Content="Summary — one card per cycle"/>
-                    <ComboBoxItem Content="Per-event — one notification per incident"/>
-                </ComboBox>
-            </StackPanel>
         </StackPanel>
 
         <!-- Status -->
         <TextBlock Grid.Row="10" x:Name="StatusText" Foreground="{DynamicResource ForegroundMutedBrush}"
                    TextWrapping="Wrap" VerticalAlignment="Bottom" Margin="0,0,0,8"/>
 
-        <!-- Buttons (no Test Connection: the viewer never connects to monitored servers) -->
-        <StackPanel Grid.Row="11" Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button x:Name="SaveButton" Content="Save" Width="80" Height="30" Click="SaveButton_Click" Style="{StaticResource AccentButton}" Margin="0,0,8,0"/>
-            <Button Content="Cancel" Width="80" Height="30" Click="CancelButton_Click"/>
-        </StackPanel>
+        <!-- Buttons. Test Connection enqueues a test_connect command; the SERVICE opens the connection and
+             writes the probe result back, which the dialog polls for and shows. -->
+        <DockPanel Grid.Row="11" LastChildFill="False">
+            <Button x:Name="TestConnectionButton" Content="Test Connection" Width="130" Height="30"
+                    Click="TestConnectionButton_Click" DockPanel.Dock="Left"
+                    ToolTip="Asks the Darling service to connect to this server and report the version/edition, before saving."/>
+            <Button Content="Cancel" Width="80" Height="30" Click="CancelButton_Click" DockPanel.Dock="Right"/>
+            <Button x:Name="SaveButton" Content="Save" Width="80" Height="30" Click="SaveButton_Click" Style="{StaticResource AccentButton}" DockPanel.Dock="Right" Margin="0,0,8,0"/>
+        </DockPanel>
     </Grid>
 </Window>

--- a/Darling/PerformanceMonitor.Darling.Viewer/AddServerDialog.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/AddServerDialog.xaml.cs
@@ -8,44 +8,144 @@
 
 using System;
 using System.Globalization;
-using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
 using System.Windows;
 using PerformanceMonitor.Common;
-using PerformanceMonitor.Notifications;
 
 namespace PerformanceMonitor.Darling.Viewer;
 
 /// <summary>
-/// The viewer's Add / Edit server dialog — a faithful port of Lite's <c>AddServerDialog</c>, with the one
-/// live-connection affordance dropped as a hard viewer fact: there is no <b>Test Connection</b> button (the
-/// viewer never opens a SqlClient connection to a monitored server — it reads only the Postgres store).
-/// Everything else — all five inline auth modes AND the shared credential-profile picker (credential
-/// MANAGEMENT is fully in scope; only live connection resolution is the service's job), encryption,
-/// connection options, database / utility DB, cost, alert-delivery override, favorite — is captured into a
-/// <see cref="ViewerServerEntry"/> and persisted through <see cref="ViewerServerStore"/> (per-server
-/// secrets to Credential Manager; a chosen profile via <see cref="ViewerServerEntry.CredentialProfileId"/>).
-/// Making the running service honor the saved definition is the separate wiring flagged in the PR.
+/// The viewer's Add / Edit server dialog — the control-plane authoring surface. It WRITES the server
+/// definition to <c>config.config_monitored_servers</c> through <see cref="ViewerDataService"/> so the
+/// running Darling service actually collects it (Stage 3), replacing the severed
+/// <c>viewer-servers.json</c> definition writes. <b>Test Connection</b> is restored as a
+/// <c>test_connect</c> command the SERVICE executes (it holds the network path + credentials); the dialog
+/// enqueues it and polls the result.
+///
+/// <para><b>Auth + secrets.</b> The service connects with Windows (integrated) or SQL auth only, so those
+/// are the two modes written (Windows → <c>integrated</c>, SQL → <c>sql</c> + a DPAPI-LocalMachine password
+/// blob via <see cref="ViewerServerSecret"/>, never plaintext). A SQL credential PROFILE is resolved to its
+/// concrete username + secret at write time. The three Azure/Entra modes have no service connect path yet
+/// (<see cref="ServerStoreCredential"/>) and are blocked with a clear message rather than written
+/// un-honorable. Favorites stay viewer-local (<see cref="ViewerServerStore.SetFavorite"/>).</para>
 /// </summary>
 public partial class AddServerDialog : Window
 {
+    private readonly ViewerDataService? _dataService;
     private readonly ViewerServerStore _serverStore;
     private readonly ViewerProfileStore _profileStore;
 
-    /// <summary>The server that was added or edited, or null when the dialog was cancelled.</summary>
-    public ViewerServerEntry? AddedServer { get; private set; }
+    /// <summary>The row being edited (null when adding); carries the existing DPAPI blob so a blank password on edit is kept.</summary>
+    private readonly MonitoredServerRow? _existing;
 
-    public AddServerDialog(ViewerServerStore serverStore, ViewerProfileStore profileStore)
+    /// <summary>The identity of the row being edited; when the identity fields change, the old row is replaced.</summary>
+    private readonly int? _originalServerId;
+
+    private bool _testInFlight;
+
+    /// <summary>The display name of the server that was saved (for the caller's status message), or null when cancelled.</summary>
+    public string? SavedDisplayName { get; private set; }
+
+    /// <summary>Add constructor. <paramref name="seedServerName"/>/<paramref name="seedDisplayName"/> prefill the
+    /// address/name when "adopting" a server the sidebar shows but the store does not have yet.</summary>
+    public AddServerDialog(
+        ViewerDataService? dataService,
+        ViewerServerStore serverStore,
+        ViewerProfileStore profileStore,
+        string? seedServerName = null,
+        string? seedDisplayName = null)
     {
         InitializeComponent();
+        _dataService = dataService;
         _serverStore = serverStore;
         _profileStore = profileStore;
         PopulateProfilePicker();
+
+        if (!string.IsNullOrWhiteSpace(seedServerName))
+        {
+            ServerNameBox.Text = seedServerName;
+        }
+        if (!string.IsNullOrWhiteSpace(seedDisplayName))
+        {
+            DisplayNameBox.Text = seedDisplayName;
+        }
+
+        ApplyReadOnlyGate();
     }
 
-    /// <summary>
-    /// Populates the profile dropdown from the current profile list. Disables the "use profile" option
-    /// when no profiles exist.
-    /// </summary>
+    /// <summary>Edit constructor — prefills from an existing store row.</summary>
+    public AddServerDialog(
+        ViewerDataService dataService,
+        ViewerServerStore serverStore,
+        ViewerProfileStore profileStore,
+        MonitoredServerRow existing,
+        bool isFavorite)
+        : this(dataService, serverStore, profileStore)
+    {
+        ArgumentNullException.ThrowIfNull(existing);
+
+        _existing = existing;
+        _originalServerId = existing.ServerId;
+        Title = "Edit SQL Server";
+        HeaderText.Text = "Edit SQL Server Connection";
+
+        ServerNameBox.Text = existing.Host;
+        DisplayNameBox.Text = existing.Name;
+        DatabaseNameBox.Text = existing.Database ?? "";
+        EnabledCheckBox.IsChecked = existing.IsEnabled;
+        TrustCertCheckBox.IsChecked = existing.TrustServerCertificate;
+        ReadOnlyIntentCheckBox.IsChecked = existing.ReadOnlyIntent;
+        MultiSubnetFailoverCheckBox.IsChecked = existing.MultiSubnetFailover;
+        MonthlyCostBox.Text = existing.MonthlyCostUsd.ToString(CultureInfo.InvariantCulture);
+        FavoriteCheckBox.IsChecked = isFavorite;
+
+        EncryptModeComboBox.SelectedIndex = existing.EncryptMode switch
+        {
+            "Mandatory" => 1,
+            "Strict" => 2,
+            _ => 0
+        };
+
+        if (string.Equals(existing.Auth, ServerStoreCredential.Sql, StringComparison.OrdinalIgnoreCase))
+        {
+            SqlAuthRadio.IsChecked = true;
+            UsernameBox.Text = existing.Username ?? "";
+            /* Decrypt the stored blob to pre-fill the password (same-machine managed deploy). A blob produced
+               on another machine can't be read here — leave it blank; a blank password on save keeps the
+               existing blob (see the save path), so the server is not broken by an un-readable pre-fill. */
+            var decrypted = OperatingSystem.IsWindows() ? ViewerServerSecret.TryUnprotect(existing.EncryptedPassword) : null;
+            PasswordBox.Password = decrypted ?? "";
+            if (decrypted is null && !string.IsNullOrEmpty(existing.EncryptedPassword))
+            {
+                StatusText.Text = "The stored password can't be read on this machine — leave it blank to keep it, or type a new one.";
+            }
+        }
+        else
+        {
+            WindowsAuthRadio.IsChecked = true;
+        }
+    }
+
+    /// <summary>Disables the write actions on a read-only connection (or when disconnected), with a clear note.</summary>
+    private void ApplyReadOnlyGate()
+    {
+        if (_dataService is null)
+        {
+            SaveButton.IsEnabled = false;
+            TestConnectionButton.IsEnabled = false;
+            StatusText.Text = "Not connected to a Darling store — server changes are unavailable.";
+        }
+        else if (_dataService.IsReadOnly)
+        {
+            SaveButton.IsEnabled = false;
+            /* Test Connection enqueues a command (a config write), so a read-only seat can't run it either. */
+            TestConnectionButton.IsEnabled = false;
+            StatusText.Text = "This viewer is connected read-only, so servers can't be added or changed. " +
+                "Set postgres.connectAs to \"admin\" in darling.json and restart.";
+        }
+    }
+
     private void PopulateProfilePicker()
     {
         var profiles = _profileStore.GetAll();
@@ -57,104 +157,12 @@ public partial class AddServerDialog : Window
         }
     }
 
-    /// <summary>Constructor for editing an existing server definition.</summary>
-    public AddServerDialog(ViewerServerStore serverStore, ViewerProfileStore profileStore, ViewerServerEntry existing)
-        : this(serverStore, profileStore)
-    {
-        Title = "Edit SQL Server";
-        ServerNameBox.Text = existing.ServerName;
-        DisplayNameBox.Text = existing.DisplayName;
-        EnabledCheckBox.IsChecked = existing.IsEnabled;
-        TrustCertCheckBox.IsChecked = existing.TrustServerCertificate;
-
-        EncryptModeComboBox.SelectedIndex = existing.EncryptMode switch
-        {
-            "Mandatory" => 1,
-            "Strict" => 2,
-            _ => 0
-        };
-
-        FavoriteCheckBox.IsChecked = existing.IsFavorite;
-        DescriptionTextBox.Text = existing.Description ?? "";
-        DatabaseNameBox.Text = existing.DatabaseName ?? "";
-        UtilityDatabaseBox.Text = existing.UtilityDatabase ?? "";
-        ReadOnlyIntentCheckBox.IsChecked = existing.ReadOnlyIntent;
-        MultiSubnetFailoverCheckBox.IsChecked = existing.MultiSubnetFailover;
-        MonthlyCostBox.Text = existing.MonthlyCostUsd.ToString(CultureInfo.InvariantCulture);
-        AlertDeliveryOverrideBox.SelectedIndex = existing.AlertDeliveryModeOverride switch
-        {
-            AlertNotificationMode.Summary => 1,
-            AlertNotificationMode.PerEvent => 2,
-            _ => 0
-        };
-
-        /* Profile-backed server: preselect "use profile" + the dropdown; the inline auth panels stay
-           hidden (CredentialSource_Changed, fired by IsChecked). No per-server secret is loaded. */
-        if (!string.IsNullOrEmpty(existing.CredentialProfileId))
-        {
-            UseProfileRadio.IsChecked = true;
-            var match = _profileStore.GetProfile(existing.CredentialProfileId);
-            if (match is not null)
-            {
-                ProfileComboBox.SelectedItem = ProfileComboBox.Items
-                    .Cast<ViewerCredentialProfile>().FirstOrDefault(p => p.Id == match.Id);
-            }
-
-            AddedServer = existing;
-            return;
-        }
-
-        if (existing.AuthenticationType == AuthenticationTypes.EntraMFA)
-        {
-            EntraMfaAuthRadio.IsChecked = true;
-            EntraMfaUsernameBox.Text = existing.EntraUsername ?? "";
-        }
-        else if (existing.AuthenticationType == AuthenticationTypes.SqlServer)
-        {
-            SqlAuthRadio.IsChecked = true;
-            var cred = _serverStore.GetCredential(existing.Id);
-            if (cred.HasValue)
-            {
-                UsernameBox.Text = cred.Value.Username;
-                PasswordBox.Password = cred.Value.Password;
-            }
-        }
-        else if (existing.AuthenticationType == AuthenticationTypes.ServicePrincipal)
-        {
-            ServicePrincipalAuthRadio.IsChecked = true;
-            AzureClientIdBox.Text = existing.AzureClientId ?? "";
-            AzureTenantIdBox.Text = existing.AzureTenantId ?? "";
-            var cred = _serverStore.GetCredential(existing.Id);
-            if (cred.HasValue)
-            {
-                if (string.IsNullOrEmpty(AzureClientIdBox.Text))
-                {
-                    AzureClientIdBox.Text = cred.Value.Username;
-                }
-                AzureClientSecretBox.Password = cred.Value.Password;
-            }
-        }
-        else if (existing.AuthenticationType == AuthenticationTypes.ManagedIdentity)
-        {
-            ManagedIdentityAuthRadio.IsChecked = true;
-            ManagedIdentityClientIdBox.Text = existing.ManagedIdentityClientId ?? "";
-        }
-        else
-        {
-            WindowsAuthRadio.IsChecked = true;
-        }
-
-        AddedServer = existing;
-    }
-
     /// <summary>
     /// Toggles between the inline per-server auth UI and the credential-profile picker. When a profile is
-    /// chosen the inline auth radios + all per-mode credential panels are hidden (the profile fully
-    /// overrides the server's auth type + creds).
+    /// chosen the inline auth radios + all per-mode credential panels are hidden.
     /// </summary>
     private void CredentialSource_Changed(object sender, RoutedEventArgs e)
     {
-        /* Guard against early Checked events during InitializeComponent. */
         if (ProfilePickerPanel is null || InlineAuthRadios is null)
         {
             return;
@@ -167,7 +175,6 @@ public partial class AddServerDialog : Window
 
         if (useProfile)
         {
-            /* Hide every per-mode inline credential panel. */
             if (SqlCredentialsPanel is not null) SqlCredentialsPanel.Visibility = Visibility.Collapsed;
             if (EntraMfaPanel is not null) EntraMfaPanel.Visibility = Visibility.Collapsed;
             if (ServicePrincipalPanel is not null) ServicePrincipalPanel.Visibility = Visibility.Collapsed;
@@ -175,7 +182,6 @@ public partial class AddServerDialog : Window
         }
         else
         {
-            /* Re-show the panel for the currently selected inline auth mode. */
             AuthMode_Changed(sender, e);
         }
     }
@@ -192,14 +198,21 @@ public partial class AddServerDialog : Window
         EntraMfaPanel.Visibility = EntraMfaAuthRadio.IsChecked == true ? Visibility.Visible : Visibility.Collapsed;
         ServicePrincipalPanel.Visibility = ServicePrincipalAuthRadio.IsChecked == true ? Visibility.Visible : Visibility.Collapsed;
         ManagedIdentityPanel.Visibility = ManagedIdentityAuthRadio.IsChecked == true ? Visibility.Visible : Visibility.Collapsed;
-    }
 
-    private AlertNotificationMode? GetSelectedDeliveryOverride() => AlertDeliveryOverrideBox.SelectedIndex switch
-    {
-        1 => AlertNotificationMode.Summary,
-        2 => AlertNotificationMode.PerEvent,
-        _ => null
-    };
+        /* Warn as soon as an Azure/Entra mode is picked — the service can't connect with it, and Save/Test
+           will block. (A profile-backed Azure identity is caught at resolve time.) */
+        var azureSelected = EntraMfaAuthRadio.IsChecked == true
+            || ServicePrincipalAuthRadio.IsChecked == true
+            || ManagedIdentityAuthRadio.IsChecked == true;
+        if (azureSelected)
+        {
+            StatusText.Text = ServerStoreCredential.UnsupportedAuthMessage;
+        }
+        else if (StatusText.Text == ServerStoreCredential.UnsupportedAuthMessage)
+        {
+            StatusText.Text = "";
+        }
+    }
 
     private string GetSelectedEncryptMode() => EncryptModeComboBox.SelectedIndex switch
     {
@@ -208,89 +221,115 @@ public partial class AddServerDialog : Window
         _ => "Optional"
     };
 
-    private void SaveButton_Click(object sender, RoutedEventArgs e)
+    /// <summary>
+    /// Resolves the chosen credential source into the store's (auth, username, encrypted blob), or a
+    /// user-facing error. Shared by Save and Test Connection so both apply the identical rules — including
+    /// blocking the Azure/Entra modes the service can't honor and keeping an existing blob when the password
+    /// box is left blank on edit.
+    /// </summary>
+    private bool TryResolveCredential(out string auth, out string? username, out string? encryptedPassword, out string? error)
     {
-        var serverName = ServerNameBox.Text.Trim();
-        if (string.IsNullOrEmpty(serverName))
+        auth = ServerStoreCredential.Integrated;
+        username = null;
+        encryptedPassword = null;
+        error = null;
+
+        if (UseProfileRadio.IsChecked == true)
         {
-            StatusText.Text = "Server name is required.";
-            return;
+            if (ProfileComboBox.SelectedItem is not ViewerCredentialProfile profile)
+            {
+                error = "Select a credential profile, or choose \"Configure credentials on this server\".";
+                return false;
+            }
+
+            var mapped = ServerStoreCredential.MapAuth(profile.AuthType);
+            if (mapped is null)
+            {
+                error = ServerStoreCredential.UnsupportedAuthMessage;
+                return false;
+            }
+
+            /* Profile auth is SqlServer here (the only profile type the service honors). Resolve its concrete
+               secret and write those onto the row — the store keeps concrete creds; profiles are a viewer
+               authoring convenience the store needs no table for. */
+            var secret = _profileStore.GetSecret(profile.Id);
+            if (secret is null || string.IsNullOrEmpty(secret.Value.Password))
+            {
+                error = $"The credential profile '{profile.Name}' has no stored secret on this machine. Re-enter it under Credential Profiles.";
+                return false;
+            }
+
+            auth = mapped;
+            username = string.IsNullOrWhiteSpace(secret.Value.Username) ? profile.Username : secret.Value.Username;
+            encryptedPassword = ViewerServerSecret.Protect(secret.Value.Password);
+            return true;
+        }
+
+        if (WindowsAuthRadio.IsChecked == true)
+        {
+            auth = ServerStoreCredential.Integrated;
+            return true;
+        }
+
+        if (SqlAuthRadio.IsChecked == true)
+        {
+            auth = ServerStoreCredential.Sql;
+            username = UsernameBox.Text.Trim();
+            if (string.IsNullOrEmpty(username))
+            {
+                error = "Username is required for SQL Server authentication.";
+                return false;
+            }
+
+            var typed = PasswordBox.Password;
+            if (!string.IsNullOrEmpty(typed))
+            {
+                encryptedPassword = ViewerServerSecret.Protect(typed);
+                return true;
+            }
+
+            /* Blank password on edit → keep the existing stored blob (Lite's "blank means leave it"). */
+            if (_existing is not null && !string.IsNullOrEmpty(_existing.EncryptedPassword))
+            {
+                encryptedPassword = _existing.EncryptedPassword;
+                return true;
+            }
+
+            error = "Password is required for SQL Server authentication.";
+            return false;
+        }
+
+        /* EntraMFA / ServicePrincipal / ManagedIdentity — no Darling service connect path. */
+        error = ServerStoreCredential.UnsupportedAuthMessage;
+        return false;
+    }
+
+    /// <summary>Reads the form into a fresh store row (server_id derived from identity), or a user-facing error.</summary>
+    private MonitoredServerRow? BuildRowFromForm(out string? error)
+    {
+        error = null;
+
+        var host = ServerNameBox.Text.Trim();
+        if (string.IsNullOrEmpty(host))
+        {
+            error = "Server name is required.";
+            return null;
+        }
+
+        if (!TryResolveCredential(out var auth, out var username, out var encryptedPassword, out var credError))
+        {
+            error = credError;
+            return null;
         }
 
         var displayName = DisplayNameBox.Text.Trim();
         if (string.IsNullOrEmpty(displayName))
         {
-            displayName = serverName;
+            displayName = host;
         }
 
-        /* Credential source: a shared profile, or inline per-server auth. */
-        var useProfile = UseProfileRadio.IsChecked == true;
-        ViewerCredentialProfile? selectedProfile = null;
-
-        string authenticationType;
-        string? username = null;
-        string? password = null;
-        string? entraUsername = null;
-
-        if (useProfile)
-        {
-            selectedProfile = ProfileComboBox.SelectedItem as ViewerCredentialProfile;
-            if (selectedProfile is null)
-            {
-                StatusText.Text = "Select a credential profile, or choose \"Configure credentials on this server\".";
-                return;
-            }
-            /* The profile fully overrides the server's auth; mirror its auth type onto the entry (display
-               only). Resolution always comes from the profile via CredentialProfileId; no per-server
-               secret is stored. */
-            authenticationType = selectedProfile.AuthType;
-        }
-        else if (WindowsAuthRadio.IsChecked == true)
-        {
-            authenticationType = AuthenticationTypes.Windows;
-        }
-        else if (EntraMfaAuthRadio.IsChecked == true)
-        {
-            authenticationType = AuthenticationTypes.EntraMFA;
-            entraUsername = EntraMfaUsernameBox.Text.Trim();
-        }
-        else if (ServicePrincipalAuthRadio.IsChecked == true)
-        {
-            authenticationType = AuthenticationTypes.ServicePrincipal;
-            username = AzureClientIdBox.Text.Trim();
-            password = AzureClientSecretBox.Password;
-
-            if (string.IsNullOrEmpty(username))
-            {
-                StatusText.Text = "Client (Application) ID is required for service principal authentication.";
-                return;
-            }
-            if (string.IsNullOrEmpty(password))
-            {
-                StatusText.Text = "Client secret is required for service principal authentication.";
-                return;
-            }
-        }
-        else if (ManagedIdentityAuthRadio.IsChecked == true)
-        {
-            authenticationType = AuthenticationTypes.ManagedIdentity;
-        }
-        else if (SqlAuthRadio.IsChecked == true)
-        {
-            authenticationType = AuthenticationTypes.SqlServer;
-            username = UsernameBox.Text.Trim();
-            password = PasswordBox.Password;
-
-            if (string.IsNullOrEmpty(username))
-            {
-                StatusText.Text = "Username is required for SQL Server authentication.";
-                return;
-            }
-        }
-        else
-        {
-            authenticationType = AuthenticationTypes.Windows;
-        }
+        var database = string.IsNullOrWhiteSpace(DatabaseNameBox.Text) ? null : DatabaseNameBox.Text.Trim();
+        var readOnlyIntent = ReadOnlyIntentCheckBox.IsChecked == true;
 
         decimal monthlyCost = 0m;
         if (decimal.TryParse(MonthlyCostBox.Text, NumberStyles.Any, CultureInfo.InvariantCulture, out var parsedCost) && parsedCost >= 0)
@@ -298,88 +337,229 @@ public partial class AddServerDialog : Window
             monthlyCost = parsedCost;
         }
 
+        return new MonitoredServerRow
+        {
+            ServerId = ViewerDataService.ComputeServerId(host, database, readOnlyIntent),
+            Name = displayName,
+            Host = host,
+            Database = database,
+            Auth = auth,
+            Username = username,
+            EncryptedPassword = encryptedPassword,
+            EncryptMode = GetSelectedEncryptMode(),
+            TrustServerCertificate = TrustCertCheckBox.IsChecked == true,
+            ReadOnlyIntent = readOnlyIntent,
+            MultiSubnetFailover = MultiSubnetFailoverCheckBox.IsChecked == true,
+            /* Preserve the excluded-databases (edited via the dedicated dialog), not lost on a plain save. */
+            ExcludedDatabases = _existing?.ExcludedDatabases ?? new System.Collections.Generic.List<string>(),
+            MonthlyCostUsd = monthlyCost,
+            CapturePlans = _existing?.CapturePlans,
+            IsEnabled = EnabledCheckBox.IsChecked == true,
+        };
+    }
+
+    private async void SaveButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (_dataService is null)
+        {
+            return;
+        }
+
         try
         {
-            if (AddedServer is not null && Title == "Edit SQL Server")
-            {
-                /* Editing an existing definition — mutate in place and re-persist. */
-                var entry = AddedServer;
-                entry.ServerName = serverName;
-                entry.DisplayName = displayName;
-                entry.AuthenticationType = authenticationType;
-                entry.CredentialProfileId = useProfile ? selectedProfile!.Id : null;
-                entry.EntraUsername = (!useProfile && authenticationType == AuthenticationTypes.EntraMFA)
-                    ? (string.IsNullOrWhiteSpace(entraUsername) ? null : entraUsername)
-                    : null;
-                entry.AzureClientId = (!useProfile && authenticationType == AuthenticationTypes.ServicePrincipal)
-                    ? (string.IsNullOrWhiteSpace(AzureClientIdBox.Text) ? null : AzureClientIdBox.Text.Trim())
-                    : null;
-                entry.AzureTenantId = (!useProfile && authenticationType == AuthenticationTypes.ServicePrincipal)
-                    ? (string.IsNullOrWhiteSpace(AzureTenantIdBox.Text) ? null : AzureTenantIdBox.Text.Trim())
-                    : null;
-                entry.ManagedIdentityClientId = (!useProfile && authenticationType == AuthenticationTypes.ManagedIdentity)
-                    ? (string.IsNullOrWhiteSpace(ManagedIdentityClientIdBox.Text) ? null : ManagedIdentityClientIdBox.Text.Trim())
-                    : null;
-                entry.IsEnabled = EnabledCheckBox.IsChecked == true;
-                entry.TrustServerCertificate = TrustCertCheckBox.IsChecked == true;
-                entry.EncryptMode = GetSelectedEncryptMode();
-                entry.IsFavorite = FavoriteCheckBox.IsChecked == true;
-                entry.Description = DescriptionTextBox.Text.Trim();
-                entry.DatabaseName = string.IsNullOrWhiteSpace(DatabaseNameBox.Text) ? null : DatabaseNameBox.Text.Trim();
-                entry.UtilityDatabase = string.IsNullOrWhiteSpace(UtilityDatabaseBox.Text) ? null : UtilityDatabaseBox.Text.Trim();
-                entry.ReadOnlyIntent = ReadOnlyIntentCheckBox.IsChecked == true;
-                entry.MultiSubnetFailover = MultiSubnetFailoverCheckBox.IsChecked == true;
-                entry.MonthlyCostUsd = monthlyCost;
-                entry.AlertDeliveryModeOverride = GetSelectedDeliveryOverride();
+            SaveButton.IsEnabled = false;
 
-                /* Profile-backed → store no per-server secret (UpdateServer with null creds deletes any
-                   stale one, matching Lite's switch-cleanup). */
-                _serverStore.UpdateServer(entry, useProfile ? null : username, useProfile ? null : password);
-            }
-            else
+            /* Build (incl. DPAPI Protect, which can throw) inside the try so nothing escapes this async void. */
+            var row = BuildRowFromForm(out var error);
+            if (row is null)
             {
-                /* Adding a new definition. */
-                AddedServer = new ViewerServerEntry
-                {
-                    ServerName = serverName,
-                    DisplayName = displayName,
-                    AuthenticationType = authenticationType,
-                    CredentialProfileId = useProfile ? selectedProfile!.Id : null,
-                    EntraUsername = (!useProfile && authenticationType == AuthenticationTypes.EntraMFA)
-                        ? (string.IsNullOrWhiteSpace(entraUsername) ? null : entraUsername)
-                        : null,
-                    AzureClientId = (!useProfile && authenticationType == AuthenticationTypes.ServicePrincipal)
-                        ? (string.IsNullOrWhiteSpace(AzureClientIdBox.Text) ? null : AzureClientIdBox.Text.Trim())
-                        : null,
-                    AzureTenantId = (!useProfile && authenticationType == AuthenticationTypes.ServicePrincipal)
-                        ? (string.IsNullOrWhiteSpace(AzureTenantIdBox.Text) ? null : AzureTenantIdBox.Text.Trim())
-                        : null,
-                    ManagedIdentityClientId = (!useProfile && authenticationType == AuthenticationTypes.ManagedIdentity)
-                        ? (string.IsNullOrWhiteSpace(ManagedIdentityClientIdBox.Text) ? null : ManagedIdentityClientIdBox.Text.Trim())
-                        : null,
-                    IsEnabled = EnabledCheckBox.IsChecked == true,
-                    TrustServerCertificate = TrustCertCheckBox.IsChecked == true,
-                    EncryptMode = GetSelectedEncryptMode(),
-                    IsFavorite = FavoriteCheckBox.IsChecked == true,
-                    Description = DescriptionTextBox.Text.Trim(),
-                    DatabaseName = string.IsNullOrWhiteSpace(DatabaseNameBox.Text) ? null : DatabaseNameBox.Text.Trim(),
-                    UtilityDatabase = string.IsNullOrWhiteSpace(UtilityDatabaseBox.Text) ? null : UtilityDatabaseBox.Text.Trim(),
-                    ReadOnlyIntent = ReadOnlyIntentCheckBox.IsChecked == true,
-                    MultiSubnetFailover = MultiSubnetFailoverCheckBox.IsChecked == true,
-                    MonthlyCostUsd = monthlyCost,
-                    AlertDeliveryModeOverride = GetSelectedDeliveryOverride()
-                };
-
-                _serverStore.AddServer(AddedServer, useProfile ? null : username, useProfile ? null : password);
+                StatusText.Text = error;
+                SaveButton.IsEnabled = true;
+                return;
             }
 
+            /* Refuse to silently overwrite a DIFFERENT existing server that shares this identity — the upsert's
+               ON CONFLICT DO UPDATE would clobber its excluded databases / capture override. Covers Add and an
+               edit that re-points host/database/read-only-intent onto another server's identity. */
+            if (_originalServerId != row.ServerId
+                && await _dataService.GetMonitoredServerAsync(row.ServerId) is not null)
+            {
+                StatusText.Text = "A server with this address (and database / read-only intent) is already monitored. Edit it from Manage Servers instead.";
+                SaveButton.IsEnabled = true;
+                return;
+            }
+
+            /* Write the NEW row first, THEN drop the old identity on an edit that moved it — if the delete
+               fails we leave a recoverable duplicate rather than losing the definition entirely. */
+            await _dataService.UpsertMonitoredServerAsync(row);
+            if (_originalServerId is int original && original != row.ServerId)
+            {
+                await _dataService.DeleteMonitoredServerAsync(original);
+            }
+
+            /* Favorites are viewer-local (the service never reads them) — keyed by the server address. */
+            _serverStore.SetFavorite(row.Host, FavoriteCheckBox.IsChecked == true);
+
+            SavedDisplayName = row.Name;
             DialogResult = true;
             Close();
         }
+        catch (ViewerReadOnlyException ex)
+        {
+            StatusText.Text = ex.Message;
+            SaveButton.IsEnabled = true;
+        }
         catch (Exception ex)
         {
-            StatusText.Text = $"Error: {ex.Message}";
+            StatusText.Text = $"Error saving server: {ex.Message}";
+            SaveButton.IsEnabled = true;
             ViewerLogger.Error("AddServerDialog", "Failed to save server definition", ex);
+        }
+    }
+
+    private async void TestConnectionButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (_dataService is null || _testInFlight)
+        {
+            return;
+        }
+
+        try
+        {
+            _testInFlight = true;
+            TestConnectionButton.IsEnabled = false;
+            SaveButton.IsEnabled = false;
+
+            /* Build (incl. DPAPI Protect) inside the try — a crypto failure must not escape this async void. */
+            var row = BuildRowFromForm(out var error);
+            if (row is null)
+            {
+                StatusText.Text = error;
+                return;
+            }
+
+            var args = new TestConnectServer
+            {
+                Name = row.Name,
+                Host = row.Host,
+                Database = row.Database,
+                Auth = row.Auth,
+                Username = row.Username,
+                EncryptedPassword = row.EncryptedPassword,
+                ReadOnlyIntent = row.ReadOnlyIntent,
+                TrustServerCertificate = row.TrustServerCertificate,
+                EncryptMode = row.EncryptMode,
+                MultiSubnetFailover = row.MultiSubnetFailover,
+            };
+
+            StatusText.Text = "Testing connection via the Darling service…";
+
+            /* Enqueue + poll + delete the credential-bearing command row on a terminal result. */
+            var result = await _dataService.RunTestConnectAsync(
+                ViewerDataService.BuildTestConnectArgs(args),
+                requestedBy: "viewer");
+
+            StatusText.Text = DescribeTestResult(result);
+        }
+        catch (ViewerReadOnlyException ex)
+        {
+            StatusText.Text = ex.Message;
+        }
+        catch (Exception ex)
+        {
+            StatusText.Text = $"Could not run the connection test: {ex.Message}";
+            ViewerLogger.Error("AddServerDialog", "test_connect failed", ex);
+        }
+        finally
+        {
+            _testInFlight = false;
+            /* Stay disabled on a read-only / disconnected seat (matches ApplyReadOnlyGate). */
+            var writable = _dataService is { IsReadOnly: false };
+            TestConnectionButton.IsEnabled = writable;
+            SaveButton.IsEnabled = writable;
+        }
+    }
+
+    /// <summary>Turns a polled <c>test_connect</c> result into a one-line status: the probed facts on success,
+    /// the service's error on failure, or a still-running note on timeout.</summary>
+    private static string DescribeTestResult(CommandResult? result)
+    {
+        if (result is null)
+        {
+            return "The connection test is still running on the service — try again in a moment.";
+        }
+
+        if (result.Status == ViewerDataService.StatusSucceeded)
+        {
+            return DescribeProbeFacts(result.ResultJson);
+        }
+
+        var error = TryReadJsonString(result.ResultJson, "error");
+        return string.IsNullOrWhiteSpace(error)
+            ? $"Connection failed ({result.ResultStatus ?? "error"})."
+            : $"Connection failed: {error}";
+    }
+
+    private static string DescribeProbeFacts(string? resultJson)
+    {
+        if (string.IsNullOrWhiteSpace(resultJson))
+        {
+            return "Connected.";
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(resultJson);
+            var root = document.RootElement;
+
+            var major = root.TryGetProperty("majorVersion", out var mv) && mv.ValueKind == JsonValueKind.Number ? mv.GetInt32() : 0;
+            var edition = root.TryGetProperty("engineEditionDescription", out var ed) && ed.ValueKind == JsonValueKind.String
+                ? ed.GetString()
+                : null;
+
+            var versionLabel = ViewerDataService.SqlVersionLabel(major == 0 ? null : major);
+            var parts = new System.Collections.Generic.List<string> { "Connected" };
+            if (!string.IsNullOrEmpty(versionLabel))
+            {
+                parts.Add(versionLabel);
+            }
+            if (!string.IsNullOrWhiteSpace(edition))
+            {
+                parts.Add(edition!);
+            }
+
+            if (root.TryGetProperty("hasMsdbAccess", out var msdb) && msdb.ValueKind == JsonValueKind.False)
+            {
+                parts.Add("no msdb access (SQL Agent job data unavailable)");
+            }
+
+            return string.Join(" — ", parts) + ".";
+        }
+        catch (JsonException)
+        {
+            return "Connected.";
+        }
+    }
+
+    private static string? TryReadJsonString(string? json, string property)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            return document.RootElement.ValueKind == JsonValueKind.Object
+                && document.RootElement.TryGetProperty(property, out var element)
+                && element.ValueKind == JsonValueKind.String
+                ? element.GetString()
+                : null;
+        }
+        catch (JsonException)
+        {
+            return null;
         }
     }
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ExcludedDatabasesDialog.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ExcludedDatabasesDialog.xaml.cs
@@ -24,54 +24,49 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// connects to the monitored server); the viewer never connects, but the store already holds the
 /// collected databases (<c>v_database_config</c> / <c>v_database_size_stats</c>), so the picker offers
 /// those instead of a free-text editor. A not-yet-collected database can still be added by hand (the
-/// manual fallback). Persists the checked names to <see cref="ViewerServerEntry.ExcludedDatabases"/>
-/// through <see cref="ViewerServerStore.UpdateServer(ViewerServerEntry)"/> for the Darling service to consume.
+/// manual fallback). Persists the checked names to <c>config.config_monitored_servers.excluded_databases</c>
+/// (Stage 3) so the Darling service honors them on its next reload — keyed by the shared <c>server_id</c>,
+/// which is why the collected-database read needs no name→id lookup.
 /// </summary>
 public partial class ExcludedDatabasesDialog : Window
 {
-    private readonly ViewerServerStore _serverStore;
-    private readonly ViewerServerEntry _entry;
-    private readonly ViewerDataService? _dataService;
+    private readonly ViewerDataService _dataService;
+    private readonly MonitoredServerRow _row;
     private ObservableCollection<ExcludedDatabaseItem> _items = new();
 
     /// <summary>Set true when the exclusion list was changed and saved, so the caller refreshes.</summary>
     public bool ExclusionsModified { get; private set; }
 
-    /// <param name="dataService">The store reader used to populate the collected-database list; null (viewer
-    /// not connected) degrades to a manual-only editor seeded with the existing exclusions.</param>
-    public ExcludedDatabasesDialog(ViewerServerStore serverStore, ViewerServerEntry entry, ViewerDataService? dataService)
+    /// <param name="dataService">The store this reads the collected-database list from and writes the exclusions to.</param>
+    /// <param name="row">The store row being edited (its <c>ExcludedDatabases</c> is updated in place on save).</param>
+    /// <param name="displayName">The header label (the server's display name with its read-only-intent suffix).</param>
+    public ExcludedDatabasesDialog(ViewerDataService dataService, MonitoredServerRow row, string displayName)
     {
         InitializeComponent();
-        _serverStore = serverStore;
-        _entry = entry;
-        _dataService = dataService;
-        HeaderText.Text = $"Excluded Databases — {entry.DisplayNameWithIntent}";
+        _dataService = dataService ?? throw new ArgumentNullException(nameof(dataService));
+        _row = row ?? throw new ArgumentNullException(nameof(row));
+        HeaderText.Text = $"Excluded Databases — {displayName}";
         Loaded += async (_, _) => await LoadAsync();
     }
 
     private async Task LoadAsync()
     {
-        var existing = _entry.ExcludedDatabases ?? new List<string>();
+        var existing = _row.ExcludedDatabases ?? new List<string>();
         StatusText.Text = "Loading collected databases…";
 
         List<string> collected = new();
         var collectedCount = 0;
-        if (_dataService is not null)
+        try
         {
-            try
-            {
-                var serverId = await _dataService.GetServerIdByNameAsync(_entry.ServerName);
-                if (serverId.HasValue)
-                {
-                    collected = await _dataService.GetCollectedDatabaseNamesAsync(serverId.Value);
-                    collectedCount = collected.Count;
-                }
-            }
-            catch (Exception ex)
-            {
-                /* A store read failure must never block editing exclusions — fall back to manual-only. */
-                ViewerLogger.Warn("ExcludedDatabasesDialog", $"Could not read collected databases: {ex.Message}");
-            }
+            /* The config row already carries the shared server_id, so the collected-database read needs no
+               name→id lookup (unlike the old registry path). */
+            collected = await _dataService.GetCollectedDatabaseNamesAsync(_row.ServerId);
+            collectedCount = collected.Count;
+        }
+        catch (Exception ex)
+        {
+            /* A store read failure must never block editing exclusions — fall back to manual-only. */
+            ViewerLogger.Warn("ExcludedDatabasesDialog", $"Could not read collected databases: {ex.Message}");
         }
 
         _items = new ObservableCollection<ExcludedDatabaseItem>(BuildDatabaseItems(collected, existing));
@@ -79,9 +74,7 @@ public partial class ExcludedDatabasesDialog : Window
 
         StatusText.Text = collectedCount > 0
             ? $"{collectedCount} collected database(s), {existing.Count} currently excluded."
-            : _dataService is null
-                ? $"Viewer not connected to a store — enter database names to exclude. {existing.Count} currently excluded."
-                : $"No collected databases for this server yet — add names to exclude. {existing.Count} currently excluded.";
+            : $"No collected databases for this server yet — add names to exclude. {existing.Count} currently excluded.";
     }
 
     /// <summary>
@@ -178,19 +171,24 @@ public partial class ExcludedDatabasesDialog : Window
         ManualAddBox.Focus();
     }
 
-    private void Save_Click(object sender, RoutedEventArgs e)
+    private async void Save_Click(object sender, RoutedEventArgs e)
     {
         try
         {
-            _entry.ExcludedDatabases = _items
+            var names = _items
                 .Where(i => i.IsExcluded)
                 .Select(i => i.Name)
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToList();
 
-            _serverStore.UpdateServer(_entry);
+            await _dataService.SetMonitoredServerExcludedDatabasesAsync(_row.ServerId, names);
+            _row.ExcludedDatabases = names;
             ExclusionsModified = true;
             DialogResult = true;
+        }
+        catch (ViewerReadOnlyException ex)
+        {
+            StatusText.Text = ex.Message;
         }
         catch (Exception ex)
         {

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.ServerManagement.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.ServerManagement.cs
@@ -22,14 +22,13 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// the sidebar's favorite pinning + collection-freshness status dots, the right-click server menu, the
 /// footer Add / Manage / Import / log buttons, the sidebar collapse toggle, and the multi-field status bar.
 ///
-/// <para>Adaptation (hard viewer facts, matching the rest of the Lite→Darling port). The sidebar lists the
-/// servers the Darling service is actually COLLECTING (the Postgres <c>servers</c> table), so its dots come
-/// from collection freshness — the viewer never pings a monitored server — and Connect/Disconnect have no
-/// meaning and are omitted. Add / Manage / Edit / Remove operate on the viewer's OWN registry
-/// (<see cref="ViewerServerStore"/> → viewer-servers.json); an added/edited server appears in the sidebar
-/// once the service registers it into the store (that service wiring is the follow-up flagged in the PR).
-/// Favorites are the one thing the viewer acts on today: pinned in the registry (matched by server name),
-/// starred and sorted-to-top here.</para>
+/// <para>Control plane (Stage 3): Add / Edit / Remove / Enable WRITE the desired-state
+/// <c>config.config_monitored_servers</c> through <see cref="ViewerDataService"/>, so the Darling service
+/// starts/stops collecting on its next reload — the sidebar shows that config-driven managed set
+/// (<see cref="ViewerDataService.GetManagedServersAsync"/>), enriched with the observed collection facts.
+/// The dots still come from collection freshness (the viewer never pings a monitored server), and
+/// Connect/Disconnect have no meaning and are omitted. Favorites remain viewer-local
+/// (<see cref="ViewerServerStore"/>, matched by server name), starred and sorted-to-top here.</para>
 /// </summary>
 public partial class MainWindow
 {
@@ -223,40 +222,51 @@ public partial class MainWindow
         StatusText.Text = isFavorite ? $"Pinned {server.DisplayName}" : $"Unpinned {server.DisplayName}";
     }
 
-    private void ServerContextMenu_Edit_Click(object sender, RoutedEventArgs e)
+    private async void ServerContextMenu_Edit_Click(object sender, RoutedEventArgs e)
     {
         var server = GetServerFromContextMenu(sender);
-        if (server is null)
+        if (server is null || _dataService is null)
         {
             return;
         }
 
-        /* Edit the matching registry entry, or "adopt" the collected server into the registry by seeding a
-           new entry from its name/display (the service registered it; the viewer had no definition yet). */
-        var entry = _serverStore.GetByServerName(server.ServerName)
-            ?? new ViewerServerEntry { ServerName = server.ServerName, DisplayName = server.DisplayName };
-
-        var dialog = new AddServerDialog(_serverStore, ProfileStore, entry) { Owner = this };
-        if (dialog.ShowDialog() == true)
+        try
         {
-            ReapplyFavoritesToServerList();
-            StatusText.Text = $"Saved '{server.DisplayName}' to the viewer registry.";
+            /* Load the store row by the shared server_id. It is normally present (the sidebar shows the
+               config-driven set); on a pre-seed store showing collect.servers, seed a new definition from the
+               server's name so the operator can add it to the store. */
+            var row = await _dataService.GetMonitoredServerAsync(server.ServerId);
+            var favorite = _serverStore.IsFavorite(server.ServerName);
+
+            var dialog = row is not null
+                ? new AddServerDialog(_dataService, _serverStore, ProfileStore, row, favorite) { Owner = this }
+                : new AddServerDialog(_dataService, _serverStore, ProfileStore, server.ServerName, server.DisplayName) { Owner = this };
+
+            if (dialog.ShowDialog() == true)
+            {
+                await LoadServersAsync(preserveSelection: true);
+                StatusText.Text = $"Saved '{dialog.SavedDisplayName ?? server.DisplayName}'.";
+            }
+        }
+        catch (Exception ex)
+        {
+            ViewerLogger.Error("ServerManagement", "Failed to open the edit dialog", ex);
+            StatusText.Text = $"Could not edit the server: {ex.Message}";
         }
     }
 
-    private void ServerContextMenu_Remove_Click(object sender, RoutedEventArgs e)
+    private async void ServerContextMenu_Remove_Click(object sender, RoutedEventArgs e)
     {
         var server = GetServerFromContextMenu(sender);
-        if (server is null)
+        if (server is null || _dataService is null)
         {
             return;
         }
 
         var result = MessageBox.Show(
-            $"Remove '{server.DisplayName}' from the viewer's registry?\n\n" +
-            "This removes only the viewer-side definition and its favorite pin. The Darling service keeps " +
-            "collecting this server (stopping collection is service-side — see the release notes), so its row " +
-            "stays in the list until the service is reconfigured.",
+            $"Remove '{server.DisplayName}' from monitoring?\n\n" +
+            "This deletes the server definition from the store, so the Darling service stops collecting it on " +
+            "its next reload. Already-collected history is kept.",
             "Remove Server",
             MessageBoxButton.YesNo,
             MessageBoxImage.Question);
@@ -266,38 +276,79 @@ public partial class MainWindow
             return;
         }
 
-        var entry = _serverStore.GetByServerName(server.ServerName);
-        if (entry is not null)
+        try
         {
-            _serverStore.DeleteServer(entry.Id);
+            await _dataService.DeleteMonitoredServerAsync(server.ServerId);
+            /* Drop the viewer-local favorite pin too. */
+            _serverStore.SetFavorite(server.ServerName, false);
+            await LoadServersAsync(preserveSelection: true);
+            StatusText.Text = $"Removed '{server.DisplayName}' from monitoring.";
         }
-
-        server.IsFavorite = false;
-        ReapplyFavoritesToServerList();
-        StatusText.Text = $"Removed '{server.DisplayName}' from the viewer registry.";
+        catch (ViewerReadOnlyException ex)
+        {
+            StatusText.Text = ex.Message;
+        }
+        catch (Exception ex)
+        {
+            ViewerLogger.Error("ServerManagement", "Failed to remove server", ex);
+            StatusText.Text = $"Could not remove the server: {ex.Message}";
+        }
     }
 
     // ── Footer buttons (Add / Manage / Import Settings / View Log / Open Log Folder) ─────
 
-    private void AddServerButton_Click(object sender, RoutedEventArgs e)
+    private async void AddServerButton_Click(object sender, RoutedEventArgs e)
     {
-        var dialog = new AddServerDialog(_serverStore, ProfileStore) { Owner = this };
-        if (dialog.ShowDialog() == true && dialog.AddedServer is not null)
+        if (_dataService is null)
         {
-            ReapplyFavoritesToServerList();
-            StatusText.Text =
-                $"Saved server '{dialog.AddedServer.DisplayName}' to the viewer registry. " +
-                "The Darling service will collect it once server-registration wiring lands.";
+            StatusText.Text = "Connect to a Darling store before adding servers.";
+            return;
+        }
+
+        var dialog = new AddServerDialog(_dataService, _serverStore, ProfileStore) { Owner = this };
+        if (dialog.ShowDialog() == true)
+        {
+            await LoadServersAsync(preserveSelection: true);
+            StatusText.Text = string.IsNullOrEmpty(dialog.SavedDisplayName)
+                ? "Server saved."
+                : $"Saved '{dialog.SavedDisplayName}'. The Darling service will start collecting it on its next reload.";
         }
     }
 
-    private void ManageServersButton_Click(object sender, RoutedEventArgs e)
+    private async void ManageServersButton_Click(object sender, RoutedEventArgs e)
     {
         var window = new ManageServersWindow(_serverStore, ProfileStore, _dataService) { Owner = this };
         window.ShowDialog();
         if (window.ServersChanged)
         {
-            ReapplyFavoritesToServerList();
+            await LoadServersAsync(preserveSelection: true);
+        }
+    }
+
+    /// <summary>
+    /// One-time import of the pre-Stage-3 <c>viewer-servers.json</c> server DEFINITIONS into the store, run
+    /// once on first connect (see <see cref="ViewerServerMigration"/>). Best-effort: a failure never blocks
+    /// startup — the sidebar still shows whatever the store already holds.
+    /// </summary>
+    private async Task MigrateViewerServersAsync()
+    {
+        if (_dataService is null || !OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        try
+        {
+            var migration = new ViewerServerMigration(_serverStore, ProfileStore);
+            var imported = await migration.MigrateAsync(_dataService);
+            if (imported > 0)
+            {
+                ViewerLogger.Info("ServerMigration", $"Imported {imported} viewer-registered server(s) into the store.");
+            }
+        }
+        catch (Exception ex)
+        {
+            ViewerLogger.Warn("ServerMigration", $"viewer-servers.json migrate-in failed: {ex.Message}");
         }
     }
 
@@ -343,9 +394,11 @@ public partial class MainWindow
     /// <summary>
     /// Imports server definitions (and copies viewer settings/preferences when absent) from a previous
     /// viewer's per-user config folder — the Darling analog of Lite's Import Settings. Lite's DuckDB
-    /// "Import Data" has no viewer meaning and is omitted.
+    /// "Import Data" has no viewer meaning and is omitted. The migratable definitions are pushed into the
+    /// store (Stage 3) so the service picks them up; cross-machine secrets don't travel, so SQL servers
+    /// without a locally-resolvable secret land in the local registry only until re-credentialed.
     /// </summary>
-    private void ImportSettingsButton_Click(object sender, RoutedEventArgs e)
+    private async void ImportSettingsButton_Click(object sender, RoutedEventArgs e)
     {
         var dialog = new Microsoft.Win32.OpenFolderDialog
         {
@@ -393,10 +446,22 @@ public partial class MainWindow
                 }
             }
 
+            /* Push the migratable definitions into the store so the service collects them (integrated auth
+               travels; a SQL server's secret does not cross machines, so it lands locally only). */
+            var pushedToStore = 0;
+            if (_dataService is not null && !_dataService.IsReadOnly && OperatingSystem.IsWindows())
+            {
+                pushedToStore = await ViewerServerMigration.ImportFromStoreAsync(_serverStore, ProfileStore, _dataService);
+            }
+
             var message = $"Imported {imported} server definition(s).";
             if (skipped > 0)
             {
                 message += $"\nSkipped {skipped} already-configured server(s).";
+            }
+            if (pushedToStore > 0)
+            {
+                message += $"\nAdded {pushedToStore} to the monitored store (the service will collect them on its next reload).";
             }
             if (copied > 0)
             {
@@ -407,9 +472,9 @@ public partial class MainWindow
 
             MessageBox.Show(message, "Import Settings", MessageBoxButton.OK, MessageBoxImage.Information);
 
-            if (imported > 0)
+            if (imported > 0 || pushedToStore > 0)
             {
-                ReapplyFavoritesToServerList();
+                await LoadServersAsync(preserveSelection: true);
             }
         }
         catch (Exception ex)

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
@@ -129,6 +129,11 @@ public partial class MainWindow : Window
         FinOpsContent.StatusChanged += OnServerTabStatusChanged;
         FinOpsContent.PlanRequested += OpenStoredPlanInPlanViewer;
 
+        /* One-time import of any pre-Stage-3 viewer-servers.json definitions into the store, before the first
+           list load so imported servers appear immediately. Guarded (marker + ON CONFLICT DO NOTHING) so it
+           never double-seeds the service's darling.json seed nor resurrects a removed server. */
+        await MigrateViewerServersAsync();
+
         await LoadServersAsync();
 
         /* --open-server <name>: deep-link straight into a server's per-server tab on startup —
@@ -259,7 +264,7 @@ public partial class MainWindow : Window
         await RefreshVisibleAsync();
     }
 
-    private async Task LoadServersAsync()
+    private async Task LoadServersAsync(bool preserveSelection = false)
     {
         if (_dataService is null)
         {
@@ -268,9 +273,12 @@ public partial class MainWindow : Window
 
         try
         {
-            /* Enrich the Postgres-sourced list with the viewer's favorite pins (matched by server name) and
-               sort favorites-first (Lite's ordering) before it drives the sidebar and the selectors. */
-            var servers = ApplyFavoritesAndSort(await _dataService.GetServersAsync());
+            var previousSelection = (ServerList.SelectedItem as DarlingServer)?.ServerId;
+
+            /* The DESIRED-state managed set (config_monitored_servers), enriched with the observed
+               collect.servers facts by the shared server_id, so a viewer add/remove/enable is reflected at
+               once. Stamp the viewer's favorite pins (matched by server name) and sort favorites-first. */
+            var servers = ApplyFavoritesAndSort(await _dataService.GetManagedServersAsync());
             ServerList.ItemsSource = servers;
             ServerCountText.Text = $"Servers: {servers.Count}";
 
@@ -298,8 +306,20 @@ public partial class MainWindow : Window
 
             if (hasServers)
             {
-                /* Triggers SelectionChanged, which loads the active aggregate tab for the first server. */
-                ServerList.SelectedIndex = 0;
+                /* Triggers SelectionChanged, which loads the active aggregate tab. Restore the prior
+                   selection after a server add/edit/remove (preserveSelection) so the view doesn't jump
+                   back to the first server; the initial load selects the first. */
+                var restore = preserveSelection && previousSelection is int prev
+                    ? servers.Find(s => s.ServerId == prev)
+                    : null;
+                if (restore is not null)
+                {
+                    ServerList.SelectedItem = restore;
+                }
+                else
+                {
+                    ServerList.SelectedIndex = 0;
+                }
             }
             else
             {

--- a/Darling/PerformanceMonitor.Darling.Viewer/ManageServersWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ManageServersWindow.xaml
@@ -10,6 +10,7 @@
         <ResourceDictionary>
             <ContextMenu x:Key="DataGridContextMenu">
                 <MenuItem Header="Edit" Click="EditMenuItem_Click"/>
+                <MenuItem Header="Enable / Disable Collection" Click="ToggleEnabledMenuItem_Click"/>
                 <MenuItem Header="Excluded Databases" Click="ExcludedDatabases_Click"/>
                 <MenuItem Header="Delete" Click="DeleteMenuItem_Click"
                           Foreground="{DynamicResource ErrorBrush}"/>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ManageServersWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ManageServersWindow.xaml.cs
@@ -7,7 +7,9 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Reflection;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
 using PerformanceMonitor.Ui;
@@ -15,13 +17,11 @@ using PerformanceMonitor.Ui;
 namespace PerformanceMonitor.Darling.Viewer;
 
 /// <summary>
-/// The viewer's Manage Servers window — a faithful port of Lite's, over the viewer's own registry
-/// (<see cref="ViewerServerStore"/>). Adds / edits / removes server DEFINITIONS, edits per-server excluded
-/// databases (populated from the store's collected database list), and manages shared credential profiles
-/// (<see cref="ViewerProfileStore"/>) via the "Credential Profiles…" button — credential MANAGEMENT is in
-/// scope even though the viewer never makes the live connection (the Darling service resolves a chosen
-/// profile at connect time). Making the service honor these definitions is the separate wiring flagged in
-/// the PR.
+/// The viewer's Manage Servers window — the control-plane server list. It reads the DESIRED-state
+/// <c>config.config_monitored_servers</c> through <see cref="ViewerDataService"/> (the source of truth for
+/// what the Darling service collects, Stage 3) and Add / Edit / Delete / Enable-Disable all WRITE that store,
+/// so a change here starts or stops collection on the service's next reload. Excluded-databases editing and
+/// shared credential-profile management ride along. Favorites stay viewer-local (<see cref="ViewerServerStore"/>).
 /// </summary>
 public partial class ManageServersWindow : Window
 {
@@ -32,27 +32,50 @@ public partial class ManageServersWindow : Window
     /// <summary>True when servers were modified, so the caller refreshes the sidebar.</summary>
     public bool ServersChanged { get; private set; }
 
-    /// <param name="dataService">Store reader for the Excluded Databases picker's collected-database list;
-    /// null (viewer not connected) degrades that picker to manual-only.</param>
+    /// <param name="dataService">The store the server list reads + writes; null (viewer not connected) shows an
+    /// empty list with a note — server management needs the store.</param>
     public ManageServersWindow(ViewerServerStore serverStore, ViewerProfileStore profileStore, ViewerDataService? dataService)
     {
         InitializeComponent();
         _serverStore = serverStore;
         _profileStore = profileStore;
         _dataService = dataService;
-        RefreshGrid();
+        Loaded += async (_, _) => await RefreshGridAsync();
     }
 
-    private void RefreshGrid()
+    private async Task RefreshGridAsync()
     {
-        ServersGrid.ItemsSource = null;
-        var servers = _serverStore.GetAllServers();
-        var appVersion = GetAppVersion();
-        foreach (var s in servers)
+        if (_dataService is null)
         {
-            s.InstalledVersion = appVersion;
+            ServersGrid.ItemsSource = null;
+            return;
         }
-        ServersGrid.ItemsSource = servers;
+
+        try
+        {
+            /* Preserve the selected row across the reload (after Edit/Delete/Enable), matching the sidebar. */
+            var previouslySelected = (ServersGrid.SelectedItem as ManagedServerListItem)?.Row.ServerId;
+
+            var rows = await _dataService.GetMonitoredServersAsync();
+            var appVersion = GetAppVersion();
+            var items = new List<ManagedServerListItem>(rows.Count);
+            foreach (var row in rows)
+            {
+                items.Add(new ManagedServerListItem(row, _serverStore.IsFavorite(row.Host)) { InstalledVersion = appVersion });
+            }
+
+            ServersGrid.ItemsSource = items;
+            if (previouslySelected is int prev)
+            {
+                ServersGrid.SelectedItem = items.Find(i => i.Row.ServerId == prev);
+            }
+        }
+        catch (Exception ex)
+        {
+            ViewerLogger.Error("ManageServersWindow", "Failed to read the configured servers", ex);
+            MessageBox.Show($"Could not read the configured servers: {ex.Message}",
+                "Manage Servers", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
     }
 
     private static string GetAppVersion()
@@ -69,13 +92,18 @@ public partial class ManageServersWindow : Window
             : trimmed;
     }
 
-    private void AddButton_Click(object sender, RoutedEventArgs e)
+    private async void AddButton_Click(object sender, RoutedEventArgs e)
     {
-        var dialog = new AddServerDialog(_serverStore, _profileStore) { Owner = this };
+        if (_dataService is null)
+        {
+            return;
+        }
+
+        var dialog = new AddServerDialog(_dataService, _serverStore, _profileStore) { Owner = this };
         if (dialog.ShowDialog() == true)
         {
             ServersChanged = true;
-            RefreshGrid();
+            await RefreshGridAsync();
         }
     }
 
@@ -83,24 +111,50 @@ public partial class ManageServersWindow : Window
 
     private void ServersGrid_MouseDoubleClick(object sender, MouseButtonEventArgs e) => EditSelected();
 
-    private void EditSelected()
+    private async void EditSelected()
     {
-        if (ServersGrid.SelectedItem is not ViewerServerEntry selected)
+        if (_dataService is null || ServersGrid.SelectedItem is not ManagedServerListItem selected)
         {
             return;
         }
 
-        var dialog = new AddServerDialog(_serverStore, _profileStore, selected) { Owner = this };
+        var dialog = new AddServerDialog(_dataService, _serverStore, _profileStore, selected.Row, selected.IsFavorite) { Owner = this };
         if (dialog.ShowDialog() == true)
         {
             ServersChanged = true;
-            RefreshGrid();
+            await RefreshGridAsync();
         }
     }
 
     private void EditMenuItem_Click(object sender, RoutedEventArgs e) => EditSelected();
 
     private void DeleteMenuItem_Click(object sender, RoutedEventArgs e) => DeleteButton_Click(sender, e);
+
+    private async void ToggleEnabledMenuItem_Click(object sender, RoutedEventArgs e)
+    {
+        if (_dataService is null || ServersGrid.SelectedItem is not ManagedServerListItem selected)
+        {
+            return;
+        }
+
+        var newState = !selected.Row.IsEnabled;
+        try
+        {
+            await _dataService.SetMonitoredServerEnabledAsync(selected.Row.ServerId, newState);
+            ServersChanged = true;
+            await RefreshGridAsync();
+        }
+        catch (ViewerReadOnlyException ex)
+        {
+            MessageBox.Show(ex.Message, "Manage Servers", MessageBoxButton.OK, MessageBoxImage.Information);
+        }
+        catch (Exception ex)
+        {
+            ViewerLogger.Error("ManageServersWindow", "Failed to toggle collection", ex);
+            MessageBox.Show($"Could not change collection state: {ex.Message}",
+                "Manage Servers", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+    }
 
     private void CredentialProfiles_Click(object sender, RoutedEventArgs e)
     {
@@ -109,43 +163,62 @@ public partial class ManageServersWindow : Window
         if (dialog.ProfilesChanged)
         {
             /* Server rows may reference a profile; refresh to reflect reassignments. */
-            RefreshGrid();
+            _ = RefreshGridAsync();
         }
     }
 
-    private void ExcludedDatabases_Click(object sender, RoutedEventArgs e)
+    private async void ExcludedDatabases_Click(object sender, RoutedEventArgs e)
     {
-        if (ServersGrid.SelectedItem is not ViewerServerEntry selected)
+        if (_dataService is null || ServersGrid.SelectedItem is not ManagedServerListItem selected)
         {
             return;
         }
 
-        var dialog = new ExcludedDatabasesDialog(_serverStore, selected, _dataService) { Owner = this };
+        var dialog = new ExcludedDatabasesDialog(_dataService, selected.Row, selected.DisplayNameWithIntent) { Owner = this };
         if (dialog.ShowDialog() == true && dialog.ExclusionsModified)
         {
             ServersChanged = true;
-            RefreshGrid();
+            await RefreshGridAsync();
         }
     }
 
-    private void DeleteButton_Click(object sender, RoutedEventArgs e)
+    private async void DeleteButton_Click(object sender, RoutedEventArgs e)
     {
-        if (ServersGrid.SelectedItem is not ViewerServerEntry selected)
+        if (_dataService is null || ServersGrid.SelectedItem is not ManagedServerListItem selected)
         {
             return;
         }
 
         var result = MessageBox.Show(
-            $"Delete server '{selected.DisplayNameWithIntent}'?\n\nThis will remove the server definition and its stored credentials.",
+            $"Delete server '{selected.DisplayNameWithIntent}'?\n\n" +
+            "This removes the server definition from the store, so the Darling service stops collecting it on " +
+            "its next reload. Already-collected history is kept.",
             "Delete Server",
             MessageBoxButton.YesNo,
             MessageBoxImage.Warning);
 
-        if (result == MessageBoxResult.Yes)
+        if (result != MessageBoxResult.Yes)
         {
-            _serverStore.DeleteServer(selected.Id);
+            return;
+        }
+
+        try
+        {
+            await _dataService.DeleteMonitoredServerAsync(selected.Row.ServerId);
+            /* Drop the viewer-local favorite pin too, so a removed server doesn't linger starred. */
+            _serverStore.SetFavorite(selected.Row.Host, false);
             ServersChanged = true;
-            RefreshGrid();
+            await RefreshGridAsync();
+        }
+        catch (ViewerReadOnlyException ex)
+        {
+            MessageBox.Show(ex.Message, "Delete Server", MessageBoxButton.OK, MessageBoxImage.Information);
+        }
+        catch (Exception ex)
+        {
+            ViewerLogger.Error("ManageServersWindow", "Failed to delete server", ex);
+            MessageBox.Show($"Could not delete the server: {ex.Message}",
+                "Delete Server", MessageBoxButton.OK, MessageBoxImage.Error);
         }
     }
 
@@ -155,4 +228,41 @@ public partial class ManageServersWindow : Window
     private void ExportToCsv_Click(object sender, RoutedEventArgs e) => DataGridExport.ExportToCsv(sender, "servers", ViewerExportSettings.CsvSeparator);
 
     private void CloseButton_Click(object sender, RoutedEventArgs e) => Close();
+}
+
+/// <summary>
+/// One Manage-Servers grid row — a display projection of a <see cref="MonitoredServerRow"/> from the store.
+/// The bound property names match the grid's columns (<c>DisplayNameWithIntent</c> / <c>ServerNameDisplay</c>
+/// / <c>AuthenticationDisplay</c> / <c>StatusDisplay</c> / <c>MonthlyCostUsd</c> / <c>CreatedDate</c>), so the
+/// XAML is unchanged from the former <c>ViewerServerEntry</c> binding; the underlying <see cref="Row"/> drives
+/// the Edit / Delete / Enable / Excluded-Databases actions.
+/// </summary>
+public sealed class ManagedServerListItem
+{
+    public ManagedServerListItem(MonitoredServerRow row, bool isFavorite)
+    {
+        Row = row ?? throw new ArgumentNullException(nameof(row));
+        IsFavorite = isFavorite;
+    }
+
+    public MonitoredServerRow Row { get; }
+
+    public bool IsFavorite { get; }
+
+    /// <summary>Set once before binding; one viewer shows the same version for every row.</summary>
+    public string? InstalledVersion { get; set; }
+
+    public string DisplayNameWithIntent => Row.ReadOnlyIntent ? $"{Row.Name} (Read-Only)" : Row.Name;
+
+    public string ServerNameDisplay => Row.ReadOnlyIntent ? $"{Row.Host} (Read-Only)" : Row.Host;
+
+    public string AuthenticationDisplay =>
+        string.Equals(Row.Auth, ServerStoreCredential.Sql, StringComparison.OrdinalIgnoreCase) ? "SQL Server" : "Windows";
+
+    public string StatusDisplay => Row.IsEnabled ? "Enabled" : "Disabled";
+
+    public decimal MonthlyCostUsd => Row.MonthlyCostUsd;
+
+    /// <summary>The store's creation time (local, for the grid's "Added" column); falls back to now for a row read without it.</summary>
+    public DateTime CreatedDate => (Row.CreatedAt ?? DateTime.UtcNow).ToLocalTime();
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ServerStoreCredential.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ServerStoreCredential.cs
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using PerformanceMonitor.Common;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// Maps a viewer auth choice onto the <c>config.config_monitored_servers.auth</c> value the Darling
+/// SERVICE can actually honor. The service's connect path
+/// (<c>PerformanceMonitor.Darling.Service.MonitoredServerConnection</c>) supports exactly two modes —
+/// <see cref="Integrated"/> (Windows / integrated security) and <see cref="Sql"/> (SQL login + password) —
+/// so those are the only two the control-plane writes.
+///
+/// <para>The viewer UI (a faithful Lite port) also offers Microsoft Entra MFA, Azure Service Principal, and
+/// Azure Managed Identity. The Darling service has NO Azure/AAD connect path (verified: nothing in the
+/// Service project builds an access token), so writing one of those into the store would produce a row the
+/// service rejects or silently mis-connects as integrated. Rather than persist an un-honorable definition,
+/// the write path BLOCKS those modes with <see cref="UnsupportedAuthMessage"/>. Adding an Azure connect path
+/// is a Service-project feature, out of scope here — surfaced in the PR, not silently dropped.</para>
+/// </summary>
+public static class ServerStoreCredential
+{
+    /// <summary>Windows / integrated security — no per-server secret.</summary>
+    public const string Integrated = "integrated";
+
+    /// <summary>SQL login — username + a DPAPI-protected password blob.</summary>
+    public const string Sql = "sql";
+
+    /// <summary>
+    /// The store <c>auth</c> value for a viewer <see cref="AuthenticationTypes"/> mode, or null when the
+    /// Darling service cannot honor it (the three Azure/Entra modes). Callers treat null as "block the save".
+    /// </summary>
+    public static string? MapAuth(string? authenticationType) => authenticationType switch
+    {
+        AuthenticationTypes.Windows => Integrated,
+        AuthenticationTypes.SqlServer => Sql,
+        _ => null,
+    };
+
+    /// <summary>True when the Darling service can connect with this viewer auth mode (Windows or SQL).</summary>
+    public static bool IsSupported(string? authenticationType) => MapAuth(authenticationType) is not null;
+
+    /// <summary>True when the mapped store auth needs a per-server secret (SQL only).</summary>
+    public static bool RequiresSecret(string? authenticationType) =>
+        MapAuth(authenticationType) == Sql;
+
+    /// <summary>The user-facing message shown when an Azure/Entra auth mode is chosen (service can't honor it).</summary>
+    public const string UnsupportedAuthMessage =
+        "The Darling service connects with Windows (integrated) or SQL authentication only. " +
+        "Microsoft Entra MFA, Service Principal, and Managed Identity aren't supported by the service's " +
+        "collection path yet — choose Windows or SQL authentication, or a SQL credential profile.";
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Commands.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Commands.cs
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The viewer half of the store&lt;-&gt;service COMMAND plane (Stage 2's <c>DarlingCommandExecutor</c> is the
+/// service half): the viewer INSERTs a <c>pending</c> row into <c>config.config_command</c> and POLLS that
+/// row until the service claims, executes, and writes back a terminal <c>status</c>
+/// (<c>succeeded</c>/<c>failed</c>) plus <c>result_status</c>/<c>result_json</c>. This is how the Add-server
+/// dialog drives <c>test_connect</c> now (the SERVICE holds the network path + credentials and does the
+/// actual connect) and how Stage 3b will drive <c>snapshot_now</c>/<c>analyze_now</c>.
+///
+/// <para>Same discipline as the config writes: public-const SQL, bound <c>$N</c> parameters, the enqueue
+/// routed through <see cref="ExecuteWriteScalarAsync"/> so a read-only <c>viewer</c> seat degrades to
+/// <see cref="ViewerReadOnlyException"/> (correct — it can't command the service). The bare table name
+/// resolves through the search_path to <c>config.config_command</c>. <c>args_json</c> is bound as
+/// <c>jsonb</c>.</para>
+/// </summary>
+public sealed partial class ViewerDataService
+{
+    /// <summary>Enqueues a pending command and returns its generated id. $1 requested_by, $2 command_type,
+    /// $3 target_server_id (nullable), $4 args_json (jsonb, nullable).</summary>
+    public const string CommandEnqueueSql = @"
+INSERT INTO config_command (requested_by, command_type, target_server_id, args_json, status, created_at)
+VALUES ($1, $2, $3, $4, 'pending', (now() AT TIME ZONE 'UTC'))
+RETURNING command_id";
+
+    /// <summary>Reads a command's current status + terminal result for the poll loop. $1 command_id.</summary>
+    public const string CommandPollSql =
+        "SELECT status, result_status, result_json FROM config_command WHERE command_id = $1";
+
+    /// <summary>Deletes a command row by id. $1 command_id.</summary>
+    public const string CommandDeleteSql = "DELETE FROM config_command WHERE command_id = $1";
+
+    /// <summary>The two terminal command states (the poll stops when it sees either).</summary>
+    public const string StatusSucceeded = "succeeded";
+    public const string StatusFailed = "failed";
+
+    /// <summary>Default overall wait for a command's terminal result: the service polls the queue on a ~5s
+    /// tick and a <c>test_connect</c> carries a 15s SqlClient connect budget, so 45s comfortably covers a
+    /// slow claim + a timing-out connection without hanging the dialog forever.</summary>
+    public static readonly TimeSpan DefaultCommandTimeout = TimeSpan.FromSeconds(45);
+
+    private static readonly TimeSpan s_commandPollInterval = TimeSpan.FromMilliseconds(400);
+
+    private static readonly JsonSerializerOptions s_argsJsonOptions = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    /// <summary>
+    /// Enqueues a command and returns its <c>command_id</c>. A read-only seat throws
+    /// <see cref="ViewerReadOnlyException"/> (it cannot command the service — correct).
+    /// </summary>
+    public async Task<long> EnqueueCommandAsync(
+        string commandType,
+        int? targetServerId,
+        string? argsJson,
+        string? requestedBy,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(commandType))
+        {
+            throw new ArgumentException("commandType is required.", nameof(commandType));
+        }
+
+        await using var command = _dataSource.CreateCommand(CommandEnqueueSql);
+        AddNullableText(command, requestedBy);                                              // $1
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = commandType });  // $2
+        command.Parameters.Add(new NpgsqlParameter                                          // $3
+        {
+            NpgsqlDbType = NpgsqlDbType.Integer,
+            Value = targetServerId.HasValue ? targetServerId.Value : DBNull.Value,
+        });
+        command.Parameters.Add(new NpgsqlParameter                                          // $4
+        {
+            NpgsqlDbType = NpgsqlDbType.Jsonb,
+            Value = (object?)argsJson ?? DBNull.Value,
+        });
+
+        var result = await ExecuteWriteScalarAsync(command, cancellationToken);
+        return Convert.ToInt64(result, System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
+    /// Reads a command row's current status + result (one poll). Returns null when the row is gone (never,
+    /// under normal use — a command is never deleted before it terminates).
+    /// </summary>
+    public async Task<CommandResult?> ReadCommandResultAsync(long commandId, CancellationToken cancellationToken = default)
+    {
+        await using var command = _dataSource.CreateCommand(CommandPollSql);
+        command.Parameters.Add(new NpgsqlParameter<long> { TypedValue = commandId });
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken))
+        {
+            return null;
+        }
+
+        return new CommandResult(
+            Status: reader.GetString(0),
+            ResultStatus: reader.IsDBNull(1) ? null : reader.GetString(1),
+            ResultJson: reader.IsDBNull(2) ? null : reader.GetFieldValue<string>(2));
+    }
+
+    /// <summary>
+    /// Polls a command row until it reaches a terminal state (<c>succeeded</c>/<c>failed</c>) or the timeout
+    /// elapses, returning the terminal <see cref="CommandResult"/> or null on timeout (the caller shows a
+    /// "still running / try again" message). Polls every <see cref="s_commandPollInterval"/>.
+    /// </summary>
+    public async Task<CommandResult?> PollCommandResultAsync(
+        long commandId,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        var deadline = Stopwatch.StartNew();
+        var budget = timeout ?? DefaultCommandTimeout;
+
+        while (deadline.Elapsed < budget)
+        {
+            var result = await ReadCommandResultAsync(commandId, cancellationToken);
+            if (result is not null && IsTerminal(result.Status))
+            {
+                return result;
+            }
+
+            await Task.Delay(s_commandPollInterval, cancellationToken);
+        }
+
+        return null;
+    }
+
+    /// <summary>Enqueue + poll in one call — the common "run a command and wait for its result" path.</summary>
+    public async Task<CommandResult?> RunCommandAsync(
+        string commandType,
+        int? targetServerId,
+        string? argsJson,
+        string? requestedBy,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        var commandId = await EnqueueCommandAsync(commandType, targetServerId, argsJson, requestedBy, cancellationToken);
+        return await PollCommandResultAsync(commandId, timeout, cancellationToken);
+    }
+
+    /// <summary>
+    /// Runs a <c>test_connect</c>: enqueue the inline server definition, poll for the probe result, then
+    /// DELETE the command row so its <c>args_json</c> DPAPI credential blob does not linger in the store. On a
+    /// poll timeout the row is LEFT in place (the service may still be connecting) — a service-side retention
+    /// sweep is the backstop for that case. Best-effort cleanup: a delete failure never masks the result.
+    /// </summary>
+    public async Task<CommandResult?> RunTestConnectAsync(
+        string argsJson,
+        string? requestedBy,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        var commandId = await EnqueueCommandAsync("test_connect", targetServerId: null, argsJson, requestedBy, cancellationToken);
+        var result = await PollCommandResultAsync(commandId, timeout, cancellationToken);
+
+        if (result is not null)
+        {
+            try
+            {
+                await DeleteCommandAsync(commandId, cancellationToken);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                /* The credential-bearing row couldn't be cleaned up now; the service-side purge is the
+                   backstop. Never let cleanup hide the probe result the user is waiting on. */
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>Deletes a command row (the viewer cleans up its own terminal test_connect command).</summary>
+    public async Task DeleteCommandAsync(long commandId, CancellationToken cancellationToken = default)
+    {
+        await using var command = _dataSource.CreateCommand(CommandDeleteSql);
+        command.Parameters.Add(new NpgsqlParameter<long> { TypedValue = commandId });
+        await ExecuteWriteAsync(command, cancellationToken);
+    }
+
+    /// <summary>Whether a status string is one of the two terminal states.</summary>
+    public static bool IsTerminal(string? status) =>
+        status is StatusSucceeded or StatusFailed;
+
+    /// <summary>
+    /// Serializes a <c>test_connect</c> server definition into the <c>args_json</c> the service deserializes
+    /// as its <c>MonitoredServer</c> (property names match its <c>[JsonPropertyName]</c> contract, camelCase).
+    /// The password rides as the DPAPI <c>encryptedPassword</c> blob, NOT plaintext — the service decrypts it
+    /// on its own host (same-machine managed deploy) exactly as it does a stored server's password, so no
+    /// plaintext credential ever lands in Postgres. Pure — pinned by Darling.Tests.
+    /// </summary>
+    public static string BuildTestConnectArgs(TestConnectServer server)
+    {
+        ArgumentNullException.ThrowIfNull(server);
+        return JsonSerializer.Serialize(server, s_argsJsonOptions);
+    }
+}
+
+/// <summary>A command row's polled status + terminal result (<c>result_json</c> is the service's probe facts
+/// or error, as raw JSON text).</summary>
+public sealed record CommandResult(string Status, string? ResultStatus, string? ResultJson);
+
+/// <summary>
+/// The inline server definition a <c>test_connect</c> command carries in <c>args_json</c>. The property
+/// names/casing mirror the service's <c>MonitoredServer</c> <c>[JsonPropertyName]</c> contract so its
+/// case-insensitive deserializer reconstructs the server and probes it. Carries only the connect-relevant
+/// fields; the password is the DPAPI <see cref="EncryptedPassword"/> blob (never plaintext).
+/// </summary>
+public sealed class TestConnectServer
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = "";
+
+    [JsonPropertyName("host")]
+    public string Host { get; set; } = "";
+
+    [JsonPropertyName("database")]
+    public string? Database { get; set; }
+
+    [JsonPropertyName("auth")]
+    public string Auth { get; set; } = ServerStoreCredential.Integrated;
+
+    [JsonPropertyName("username")]
+    public string? Username { get; set; }
+
+    /// <summary>DPAPI-LocalMachine blob (<see cref="ViewerServerSecret.Protect"/>) — the service decrypts it on its host.</summary>
+    [JsonPropertyName("encryptedPassword")]
+    public string? EncryptedPassword { get; set; }
+
+    [JsonPropertyName("readOnlyIntent")]
+    public bool ReadOnlyIntent { get; set; }
+
+    [JsonPropertyName("trustServerCertificate")]
+    public bool TrustServerCertificate { get; set; }
+
+    [JsonPropertyName("encryptMode")]
+    public string EncryptMode { get; set; } = "Mandatory";
+
+    [JsonPropertyName("multiSubnetFailover")]
+    public bool MultiSubnetFailover { get; set; }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.MonitoredServers.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.MonitoredServers.cs
@@ -1,0 +1,386 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+using NpgsqlTypes;
+using PerformanceMonitor.Common;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The viewer's control-plane writes to <c>config.config_monitored_servers</c> — the desired-state twin of
+/// the observed <c>collect.servers</c> registry the Stage-1 <c>StoreConfigProvider</c> reads and reconciles
+/// its monitored set from on every reload beacon. Adding/editing a server here makes the running Darling
+/// service COLLECT it (on its next ~15s sweep); removing stops it; the enable flag drives collection. This
+/// is the write half of the Stage-3 rewire that replaces the severed <c>viewer-servers.json</c>.
+///
+/// <para>Mirrors <see cref="GetMuteRulesAsync"/>'s discipline exactly: public-const SQL (so Darling.Tests
+/// pin the dialect + column parity with the service's <c>StoreConfigProvider</c> without a live Postgres),
+/// all values bound as <c>$N</c> parameters, writes routed through <see cref="ExecuteWriteAsync"/> so a
+/// read-only <c>viewer</c> seat degrades to <see cref="ViewerReadOnlyException"/> (SQLSTATE 42501) rather
+/// than a silent no-op. Timestamps are set server-side with <c>now() AT TIME ZONE 'UTC'</c> (naive UTC,
+/// matching the DDL defaults and the command executor). The bare table name resolves through the
+/// <c>collect,config,public</c> search_path to <c>config.config_monitored_servers</c>.</para>
+///
+/// <para><b>Identity.</b> <c>server_id</c> is <c>ServerIdHelper.GetDeterministicHashCode(BuildStorageName(
+/// host, database, readOnlyIntent))</c> — the SAME identity the collectors stamp and the service's seed uses
+/// (<see cref="ComputeServerId"/>), so a viewer-written row JOINs the collected data and the service's
+/// reconcile matches it. <b>Secrets.</b> <c>encrypted_password</c> is a DPAPI-LocalMachine blob produced by
+/// <see cref="ViewerServerSecret"/> (never plaintext); integrated auth stores none. Azure/Entra auth modes
+/// are not written — the service can't honor them (see <see cref="ServerStoreCredential"/>).</para>
+/// </summary>
+public sealed partial class ViewerDataService
+{
+    /* The full column list, shared by the upsert (Add/Edit) and the insert-if-absent (migrate-in). The
+       toggled-boolean-free VALUES bind every field as a parameter; created_at/modified_at are server-side. */
+    private const string MonitoredServerColumns =
+        "server_id, name, host, database, auth, username, encrypted_password, encrypt_mode, " +
+        "trust_server_certificate, read_only_intent, multi_subnet_failover, excluded_databases, " +
+        "monthly_cost_usd, capture_plans, is_enabled";
+
+    private const string MonitoredServerValues =
+        "$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, " +
+        "(now() AT TIME ZONE 'UTC'), (now() AT TIME ZONE 'UTC')";
+
+    /// <summary>Upsert by <c>server_id</c> — the Add/Edit save. ON CONFLICT rewrites every field but
+    /// <c>created_at</c>, bumping <c>modified_at</c> (and, via the V17 trigger, <c>config_version</c>).</summary>
+    public const string MonitoredServerUpsertSql = @"
+INSERT INTO config_monitored_servers (" + MonitoredServerColumns + @", created_at, modified_at)
+VALUES (" + MonitoredServerValues + @")
+ON CONFLICT (server_id) DO UPDATE SET
+    name = EXCLUDED.name,
+    host = EXCLUDED.host,
+    database = EXCLUDED.database,
+    auth = EXCLUDED.auth,
+    username = EXCLUDED.username,
+    encrypted_password = EXCLUDED.encrypted_password,
+    encrypt_mode = EXCLUDED.encrypt_mode,
+    trust_server_certificate = EXCLUDED.trust_server_certificate,
+    read_only_intent = EXCLUDED.read_only_intent,
+    multi_subnet_failover = EXCLUDED.multi_subnet_failover,
+    excluded_databases = EXCLUDED.excluded_databases,
+    monthly_cost_usd = EXCLUDED.monthly_cost_usd,
+    capture_plans = EXCLUDED.capture_plans,
+    is_enabled = EXCLUDED.is_enabled,
+    modified_at = (now() AT TIME ZONE 'UTC')";
+
+    /// <summary>Insert only when the <c>server_id</c> is absent — the one-time <c>viewer-servers.json</c>
+    /// migrate-in. DO NOTHING so it never overwrites a row the service already seeded from darling.json (no
+    /// double-seed) or a later viewer edit.</summary>
+    public const string MonitoredServerInsertIfAbsentSql = @"
+INSERT INTO config_monitored_servers (" + MonitoredServerColumns + @", created_at, modified_at)
+VALUES (" + MonitoredServerValues + @")
+ON CONFLICT (server_id) DO NOTHING";
+
+    /// <summary>Deletes a server definition (the Remove action) — the service drops it from the monitored
+    /// set on its next reload. $1 server_id.</summary>
+    public const string MonitoredServerDeleteSql = "DELETE FROM config_monitored_servers WHERE server_id = $1";
+
+    /// <summary>Flips just <c>is_enabled</c> without rewriting the other columns (the enable toggle). $1
+    /// server_id, $2 enabled.</summary>
+    public const string MonitoredServerSetEnabledSql =
+        "UPDATE config_monitored_servers SET is_enabled = $2, modified_at = (now() AT TIME ZONE 'UTC') WHERE server_id = $1";
+
+    /// <summary>Rewrites just <c>excluded_databases</c> (the Excluded Databases editor). $1 server_id, $2 text[].</summary>
+    public const string MonitoredServerSetExcludedDatabasesSql =
+        "UPDATE config_monitored_servers SET excluded_databases = $2, modified_at = (now() AT TIME ZONE 'UTC') WHERE server_id = $1";
+
+    /// <summary>All configured servers, for the Manage Servers list. Ordered by display name.</summary>
+    public const string MonitoredServersSelectSql = @"
+SELECT server_id, name, host, database, auth, username, encrypted_password, encrypt_mode,
+       trust_server_certificate, read_only_intent, multi_subnet_failover, excluded_databases,
+       monthly_cost_usd, capture_plans, is_enabled, created_at
+FROM config_monitored_servers
+ORDER BY name";
+
+    /// <summary>One configured server by id (the Edit prefill, incl. the DPAPI blob for the password box). $1 server_id.</summary>
+    public const string MonitoredServerByIdSql = @"
+SELECT server_id, name, host, database, auth, username, encrypted_password, encrypt_mode,
+       trust_server_certificate, read_only_intent, multi_subnet_failover, excluded_databases,
+       monthly_cost_usd, capture_plans, is_enabled, created_at
+FROM config_monitored_servers
+WHERE server_id = $1";
+
+    /// <summary>Row count — the migrate-in / reconcile "is the config-server set seeded yet?" guard.</summary>
+    public const string MonitoredServersCountSql = "SELECT COUNT(*) FROM config_monitored_servers";
+
+    /// <summary>
+    /// Whether the service has seeded the config store yet — <c>config_service</c> is written LAST in the
+    /// Stage-1 seed (its presence marks the seed complete). Distinguishes a genuinely empty managed set (the
+    /// user removed every server) from a pre-Stage-1 store the service has never seeded, so the sidebar
+    /// reconcile can be config-authoritative in the former and fall back to <c>collect.servers</c> in the
+    /// latter (never worse than today).
+    /// </summary>
+    public const string ConfigSeededSql = "SELECT EXISTS (SELECT 1 FROM config_service WHERE id = 1)";
+
+    /// <summary>
+    /// The managed server set the sidebar shows, sourced from the DESIRED-state
+    /// <c>config_monitored_servers</c> and enriched with the OBSERVED <c>collect.servers</c> facts (SQL major
+    /// version, and the collected server/display names) by the shared <c>server_id</c>. This makes a
+    /// viewer-added server appear immediately (before its first collection) and a removed one disappear at
+    /// once, instead of waiting for the service's next reconcile. <c>is_enabled</c> and <c>monthly_cost_usd</c>
+    /// come from config so a viewer toggle/edit is reflected without a round-trip through the service.
+    /// </summary>
+    public const string ManagedServersSql = @"
+SELECT
+    c.server_id,
+    COALESCE(s.server_name, c.host) AS server_name,
+    COALESCE(s.display_name, c.name) AS display_name,
+    c.is_enabled,
+    s.sql_major_version,
+    c.monthly_cost_usd
+FROM config_monitored_servers c
+LEFT JOIN servers s ON s.server_id = c.server_id
+ORDER BY COALESCE(s.display_name, c.name)";
+
+    /// <summary>
+    /// The managed server set for the sidebar. Config-authoritative once the service has seeded the store
+    /// (added servers appear, removed ones disappear); on a pre-seed store (<c>config_service</c> absent) it
+    /// falls back to the observed <see cref="GetServersAsync"/> read so the viewer never shows fewer servers
+    /// than it does today.
+    /// </summary>
+    public async Task<List<DarlingServer>> GetManagedServersAsync(CancellationToken cancellationToken = default)
+    {
+        if (!await IsConfigSeededAsync(cancellationToken))
+        {
+            return await GetServersAsync(cancellationToken);
+        }
+
+        var servers = new List<DarlingServer>();
+
+        await using var command = _dataSource.CreateCommand(ManagedServersSql);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            var serverName = reader.GetString(1);
+            servers.Add(new DarlingServer(
+                reader.GetInt32(0),
+                serverName,
+                reader.IsDBNull(2) ? serverName : reader.GetString(2),
+                !reader.IsDBNull(3) && reader.GetBoolean(3),
+                reader.IsDBNull(4) ? null : reader.GetInt32(4),
+                reader.IsDBNull(5) ? 0m : Convert.ToDecimal(reader.GetValue(5))));
+        }
+
+        return servers;
+    }
+
+    /// <summary>
+    /// Whether the service has seeded the config store (the reconcile fallback signal). Fails safe to
+    /// <c>false</c> on ANY non-cancellation error — most importantly a pre-V17 store where
+    /// <c>config_service</c> does not exist yet (Postgres 42P01): a rolling upgrade where the viewer is newer
+    /// than the service must degrade to the observed <see cref="GetServersAsync"/> read, never blank the
+    /// sidebar. Mirrors <see cref="DetectReadOnlyAsync"/>'s fail-safe posture.
+    /// </summary>
+    public async Task<bool> IsConfigSeededAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await using var command = _dataSource.CreateCommand(ConfigSeededSql);
+            var result = await command.ExecuteScalarAsync(cancellationToken);
+            return result is true;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// The shared-identity <c>server_id</c> for a server: FNV-1a hash of the canonical storage name
+    /// (<c>host[:database][:RO]</c>). Identical to the service's seed
+    /// (<c>ServerIdHelper.GetDeterministicHashCode(server.StorageName)</c>) and the collectors' stamp, so the
+    /// row JOINs collected data and the service reconcile matches it. Pure — unit-testable.
+    /// </summary>
+    public static int ComputeServerId(string host, string? database, bool readOnlyIntent) =>
+        ServerIdHelper.GetDeterministicHashCode(ServerIdHelper.BuildStorageName(host, database, readOnlyIntent));
+
+    /// <summary>All configured servers (Manage Servers list + the sidebar reconcile source).</summary>
+    public async Task<List<MonitoredServerRow>> GetMonitoredServersAsync(CancellationToken cancellationToken = default)
+    {
+        var servers = new List<MonitoredServerRow>();
+
+        await using var command = _dataSource.CreateCommand(MonitoredServersSelectSql);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            servers.Add(ReadMonitoredServerRow(reader));
+        }
+
+        return servers;
+    }
+
+    /// <summary>One configured server by id, or null when it is not in the store (the Edit prefill).</summary>
+    public async Task<MonitoredServerRow?> GetMonitoredServerAsync(int serverId, CancellationToken cancellationToken = default)
+    {
+        await using var command = _dataSource.CreateCommand(MonitoredServerByIdSql);
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        return await reader.ReadAsync(cancellationToken) ? ReadMonitoredServerRow(reader) : null;
+    }
+
+    /// <summary>How many servers the config-server registry holds (the migrate-in / reconcile guard).</summary>
+    public async Task<long> GetMonitoredServerCountAsync(CancellationToken cancellationToken = default)
+    {
+        await using var command = _dataSource.CreateCommand(MonitoredServersCountSql);
+        var result = await command.ExecuteScalarAsync(cancellationToken);
+        return result is null or DBNull ? 0 : Convert.ToInt64(result, System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
+    /// Upserts a server definition (Add / Edit save). The row's <c>server_id</c> is (re)derived from
+    /// host/database/read-only-intent so a definition always lands on its shared identity; the caller passes
+    /// a row whose <see cref="MonitoredServerRow.ServerId"/> is already <see cref="ComputeServerId"/>.
+    /// </summary>
+    public async Task UpsertMonitoredServerAsync(MonitoredServerRow row, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(row);
+
+        await using var command = _dataSource.CreateCommand(MonitoredServerUpsertSql);
+        BindMonitoredServer(command, row);
+        await ExecuteWriteAsync(command, cancellationToken);
+    }
+
+    /// <summary>
+    /// Inserts a server definition only when its <c>server_id</c> is absent — the migrate-in. Returns true
+    /// when a row was actually written (so the caller can count the imported servers), false when the id
+    /// already existed (the service seed or a prior migrate already has it).
+    /// </summary>
+    public async Task<bool> InsertMonitoredServerIfAbsentAsync(MonitoredServerRow row, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(row);
+
+        await using var command = _dataSource.CreateCommand(MonitoredServerInsertIfAbsentSql);
+        BindMonitoredServer(command, row);
+        return await ExecuteWriteAsync(command, cancellationToken) > 0;
+    }
+
+    /// <summary>Removes a server definition by id (the Remove action).</summary>
+    public async Task DeleteMonitoredServerAsync(int serverId, CancellationToken cancellationToken = default)
+    {
+        await using var command = _dataSource.CreateCommand(MonitoredServerDeleteSql);
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+        await ExecuteWriteAsync(command, cancellationToken);
+    }
+
+    /// <summary>Toggles a server's <c>is_enabled</c> flag without rewriting its other columns.</summary>
+    public async Task SetMonitoredServerEnabledAsync(int serverId, bool enabled, CancellationToken cancellationToken = default)
+    {
+        await using var command = _dataSource.CreateCommand(MonitoredServerSetEnabledSql);
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+        command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = enabled });
+        await ExecuteWriteAsync(command, cancellationToken);
+    }
+
+    /// <summary>Rewrites a server's excluded-databases list (the Excluded Databases editor).</summary>
+    public async Task SetMonitoredServerExcludedDatabasesAsync(int serverId, IEnumerable<string> excludedDatabases, CancellationToken cancellationToken = default)
+    {
+        await using var command = _dataSource.CreateCommand(MonitoredServerSetExcludedDatabasesSql);
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+        AddTextArray(command, excludedDatabases);
+        await ExecuteWriteAsync(command, cancellationToken);
+    }
+
+    /// <summary>Binds the 15 upsert/insert parameters ($1..$15) from a row (created_at/modified_at are server-side).</summary>
+    private static void BindMonitoredServer(NpgsqlCommand command, MonitoredServerRow row)
+    {
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = row.ServerId });                 // $1
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = row.Name });                  // $2
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = row.Host });                  // $3
+        AddNullableText(command, row.Database);                                                          // $4
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = row.Auth });                  // $5
+        AddNullableText(command, row.Username);                                                          // $6
+        AddNullableText(command, row.EncryptedPassword);                                                 // $7
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = row.EncryptMode });           // $8
+        command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = row.TrustServerCertificate });  // $9
+        command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = row.ReadOnlyIntent });          // $10
+        command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = row.MultiSubnetFailover });     // $11
+        AddTextArray(command, row.ExcludedDatabases);                                                    // $12
+        command.Parameters.Add(new NpgsqlParameter<decimal> { TypedValue = row.MonthlyCostUsd });       // $13
+        AddNullableBool(command, row.CapturePlans);                                                      // $14
+        command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = row.IsEnabled });               // $15
+    }
+
+    private static MonitoredServerRow ReadMonitoredServerRow(NpgsqlDataReader reader) => new()
+    {
+        ServerId = reader.GetInt32(0),
+        Name = reader.GetString(1),
+        Host = reader.GetString(2),
+        Database = reader.IsDBNull(3) ? null : reader.GetString(3),
+        Auth = reader.GetString(4),
+        Username = reader.IsDBNull(5) ? null : reader.GetString(5),
+        EncryptedPassword = reader.IsDBNull(6) ? null : reader.GetString(6),
+        EncryptMode = reader.GetString(7),
+        TrustServerCertificate = reader.GetBoolean(8),
+        ReadOnlyIntent = reader.GetBoolean(9),
+        MultiSubnetFailover = reader.GetBoolean(10),
+        ExcludedDatabases = reader.IsDBNull(11) ? new List<string>() : reader.GetFieldValue<string[]>(11).ToList(),
+        MonthlyCostUsd = reader.GetDecimal(12),
+        CapturePlans = reader.IsDBNull(13) ? null : reader.GetBoolean(13),
+        IsEnabled = reader.GetBoolean(14),
+        CreatedAt = reader.IsDBNull(15) ? null : DateTime.SpecifyKind(reader.GetDateTime(15), DateTimeKind.Utc),
+    };
+
+    private static void AddTextArray(NpgsqlCommand command, IEnumerable<string>? values) =>
+        command.Parameters.Add(new NpgsqlParameter
+        {
+            NpgsqlDbType = NpgsqlDbType.Array | NpgsqlDbType.Text,
+            Value = (values ?? Enumerable.Empty<string>()).ToArray(),
+        });
+
+    private static void AddNullableBool(NpgsqlCommand command, bool? value) =>
+        command.Parameters.Add(new NpgsqlParameter
+        {
+            NpgsqlDbType = NpgsqlDbType.Boolean,
+            Value = value.HasValue ? value.Value : DBNull.Value,
+        });
+}
+
+/// <summary>
+/// A <c>config.config_monitored_servers</c> row as the viewer authors + reads it — the connection definition
+/// the Darling service reconstructs a <c>MonitoredServer</c> from. Deliberately carries only the columns the
+/// store (and hence the service) has; the viewer-only cosmetics some Lite fields kept (description, utility
+/// DB, per-server alert-delivery override, the Azure client ids) are NOT part of the service-honored server
+/// model and stay out of the store. <see cref="EncryptedPassword"/> is a DPAPI-LocalMachine blob, never
+/// plaintext. Favorites remain viewer-local (<see cref="ViewerServerStore"/>).
+/// </summary>
+public sealed class MonitoredServerRow
+{
+    public int ServerId { get; set; }
+    public string Name { get; set; } = "";
+    public string Host { get; set; } = "";
+    public string? Database { get; set; }
+
+    /// <summary><see cref="ServerStoreCredential.Integrated"/> or <see cref="ServerStoreCredential.Sql"/>.</summary>
+    public string Auth { get; set; } = ServerStoreCredential.Integrated;
+
+    public string? Username { get; set; }
+
+    /// <summary>DPAPI-LocalMachine base64 blob (<see cref="ViewerServerSecret.Protect"/>), or null for integrated auth.</summary>
+    public string? EncryptedPassword { get; set; }
+
+    public string EncryptMode { get; set; } = "Mandatory";
+    public bool TrustServerCertificate { get; set; }
+    public bool ReadOnlyIntent { get; set; }
+    public bool MultiSubnetFailover { get; set; }
+    public List<string> ExcludedDatabases { get; set; } = new();
+    public decimal MonthlyCostUsd { get; set; }
+
+    /// <summary>Per-server plan-capture override; null = follow the global <c>config_service.capture_plans</c>.</summary>
+    public bool? CapturePlans { get; set; }
+
+    public bool IsEnabled { get; set; } = true;
+
+    /// <summary>Server-set creation time (read-only, from the store's <c>created_at</c>); null when not read.</summary>
+    public DateTime? CreatedAt { get; set; }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.cs
@@ -309,6 +309,23 @@ LIMIT 1";
         }
     }
 
+    /// <summary>
+    /// The <c>RETURNING</c>-shaped sibling of <see cref="ExecuteWriteAsync"/>: runs a write that yields a
+    /// scalar (e.g. the <c>config_command.command_id</c> a command enqueue returns), translating a 42501 on a
+    /// read-only seat into <see cref="ViewerReadOnlyException"/> the same way. Any other failure propagates.
+    /// </summary>
+    internal async Task<object?> ExecuteWriteScalarAsync(NpgsqlCommand command, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await command.ExecuteScalarAsync(cancellationToken);
+        }
+        catch (PostgresException ex) when (ex.SqlState == InsufficientPrivilegeSqlState)
+        {
+            throw new ViewerReadOnlyException(ex);
+        }
+    }
+
     public ValueTask DisposeAsync() => _dataSource.DisposeAsync();
 }
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerMigration.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerMigration.cs
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.Versioning;
+using System.Threading;
+using System.Threading.Tasks;
+using PerformanceMonitor.Common;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The one-time import of the (now severed) <c>viewer-servers.json</c> server DEFINITIONS into the
+/// control-plane <c>config.config_monitored_servers</c>. Stage 3 makes the store the source of truth for
+/// what the service collects; this carries a pre-Stage-3 viewer's registered servers across so they keep
+/// being collected without re-adding them.
+///
+/// <para><b>No double-seed.</b> Each row is written with <c>INSERT … ON CONFLICT (server_id) DO NOTHING</c>
+/// (<see cref="ViewerDataService.InsertMonitoredServerIfAbsentAsync"/>), so a server the service already
+/// seeded from darling.json (same shared <c>server_id</c>) is left untouched — the migrate imports only the
+/// entries the store LACKS. <b>Runs once.</b> A marker file guards it so a later run cannot RESURRECT a
+/// server the user has since removed from the store (the marker is written only after a clean pass).
+/// Read-only seats and a disconnected viewer skip it (nothing to write).</para>
+///
+/// <para><b>Secrets.</b> An integrated-auth entry migrates with no secret. A SQL-auth entry (inline or via a
+/// SQL credential profile) has its password read from Windows Credential Manager and re-sealed as the
+/// service-decryptable DPAPI-LocalMachine blob (<see cref="ViewerServerSecret"/>); a SQL entry whose secret
+/// cannot be resolved is skipped rather than imported broken. Azure/Entra auth modes the service can't honor
+/// (<see cref="ServerStoreCredential"/>) are skipped. Favorites are NOT migrated — they stay viewer-local in
+/// <see cref="ViewerServerStore"/>.</para>
+/// </summary>
+public sealed class ViewerServerMigration
+{
+    private readonly ViewerServerStore _serverStore;
+    private readonly ViewerProfileStore _profileStore;
+    private readonly string _markerPath;
+
+    /// <param name="markerPath">Override the once-marker path (tests pass a temp file); null uses <see cref="DefaultMarkerPath"/>.</param>
+    public ViewerServerMigration(ViewerServerStore serverStore, ViewerProfileStore profileStore, string? markerPath = null)
+    {
+        _serverStore = serverStore ?? throw new ArgumentNullException(nameof(serverStore));
+        _profileStore = profileStore ?? throw new ArgumentNullException(nameof(profileStore));
+        _markerPath = markerPath ?? DefaultMarkerPath();
+    }
+
+    /// <summary>%APPDATA%\PerformanceMonitorDarling\viewer-servers-migrated.marker.</summary>
+    public static string DefaultMarkerPath()
+    {
+        var directory = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "PerformanceMonitorDarling");
+        return Path.Combine(directory, "viewer-servers-migrated.marker");
+    }
+
+    /// <summary>True once the migrate-in has completed a clean pass (the marker exists).</summary>
+    public bool AlreadyMigrated => File.Exists(_markerPath);
+
+    /// <summary>
+    /// Imports every migratable <c>viewer-servers.json</c> entry the store lacks, then writes the once-marker.
+    /// A no-op (returns 0) when the viewer is disconnected, connected read-only, or already migrated. A
+    /// <see cref="ViewerReadOnlyException"/> mid-pass (grants changed under us) stops without marking done, so
+    /// a later run can retry. Returns the number of servers actually imported.
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    public async Task<int> MigrateAsync(ViewerDataService? dataService, CancellationToken cancellationToken = default)
+    {
+        if (dataService is null || dataService.IsReadOnly || AlreadyMigrated)
+        {
+            return 0;
+        }
+
+        var imported = 0;
+        try
+        {
+            foreach (var entry in _serverStore.GetAllServers())
+            {
+                var (row, _) = TryProjectEntry(entry);
+                if (row is null)
+                {
+                    continue;
+                }
+
+                if (await dataService.InsertMonitoredServerIfAbsentAsync(row, cancellationToken))
+                {
+                    imported++;
+                }
+            }
+        }
+        catch (ViewerReadOnlyException)
+        {
+            /* Lost the write race (grants tightened under us) — leave the marker unwritten so a later,
+               writable run finishes the import. */
+            ViewerLogger.Warn("ViewerServerMigration", "Store went read-only mid-migrate; will retry next run.");
+            return imported;
+        }
+
+        WriteMarker();
+        return imported;
+    }
+
+    /// <summary>
+    /// Imports every migratable entry of an EXTERNAL registry (a folder chosen in Import Settings) into the
+    /// store — the same projection + <c>ON CONFLICT DO NOTHING</c> as <see cref="MigrateAsync"/>, but ungated
+    /// by the once-marker (an explicit user action) and against a caller-supplied source store. Returns the
+    /// number imported. Cross-machine secrets don't travel (they live in the source machine's Credential
+    /// Manager), so SQL servers with no locally-resolvable secret are skipped — matching Import's existing
+    /// "credentials are not importable" caveat; integrated servers import fully.
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    public static async Task<int> ImportFromStoreAsync(
+        ViewerServerStore sourceStore,
+        ViewerProfileStore sourceProfiles,
+        ViewerDataService dataService,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(sourceStore);
+        ArgumentNullException.ThrowIfNull(sourceProfiles);
+        ArgumentNullException.ThrowIfNull(dataService);
+
+        var projector = new ViewerServerMigration(sourceStore, sourceProfiles);
+        var imported = 0;
+        foreach (var entry in sourceStore.GetAllServers())
+        {
+            var (row, _) = projector.TryProjectEntry(entry);
+            if (row is not null && await dataService.InsertMonitoredServerIfAbsentAsync(row, cancellationToken))
+            {
+                imported++;
+            }
+        }
+
+        return imported;
+    }
+
+    /// <summary>
+    /// Projects a viewer registry entry to the store row the migrate writes, or returns a skip reason. Public
+    /// so Darling.Tests can pin the auth mapping + secret resolution without a live store. Reads Windows
+    /// Credential Manager (through the injected stores) and DPAPI-seals a SQL secret, so the SQL path is
+    /// Windows-only; the integrated + unsupported-auth + missing-secret branches are platform-independent.
+    /// </summary>
+    public (MonitoredServerRow? Row, string? SkipReason) TryProjectEntry(ViewerServerEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        if (string.IsNullOrWhiteSpace(entry.ServerName))
+        {
+            return (null, "no server name");
+        }
+
+        /* A profile-backed entry resolves to the PROFILE's auth type + concrete secret; otherwise the
+           entry's own inline auth. */
+        var profile = string.IsNullOrEmpty(entry.CredentialProfileId)
+            ? null
+            : _profileStore.GetProfile(entry.CredentialProfileId);
+
+        var effectiveAuthType = profile?.AuthType ?? entry.AuthenticationType;
+        var storeAuth = ServerStoreCredential.MapAuth(effectiveAuthType);
+        if (storeAuth is null)
+        {
+            /* Entra MFA / Service Principal / Managed Identity — no Darling service connect path. */
+            return (null, $"auth '{effectiveAuthType}' is not supported by the service");
+        }
+
+        var row = BuildBaseRow(entry, storeAuth);
+
+        if (storeAuth != ServerStoreCredential.Sql)
+        {
+            /* Integrated — no secret. */
+            return (row, null);
+        }
+
+        var credential = profile is not null
+            ? _profileStore.GetSecret(profile.Id)
+            : _serverStore.GetCredential(entry.Id);
+
+        if (credential is null || string.IsNullOrEmpty(credential.Value.Password))
+        {
+            return (null, "SQL auth with no stored password");
+        }
+
+        row.Username = string.IsNullOrWhiteSpace(credential.Value.Username) ? row.Username : credential.Value.Username;
+        row.EncryptedPassword = ViewerServerSecret.Protect(credential.Value.Password);
+        return (row, null);
+    }
+
+    /// <summary>Assembles the non-secret fields of the store row from a registry entry (server_id + connection options).</summary>
+    private static MonitoredServerRow BuildBaseRow(ViewerServerEntry entry, string storeAuth) => new()
+    {
+        ServerId = ViewerDataService.ComputeServerId(entry.ServerName, entry.DatabaseName, entry.ReadOnlyIntent),
+        Name = string.IsNullOrWhiteSpace(entry.DisplayName) ? entry.ServerName : entry.DisplayName,
+        Host = entry.ServerName,
+        Database = string.IsNullOrWhiteSpace(entry.DatabaseName) ? null : entry.DatabaseName,
+        Auth = storeAuth,
+        EncryptMode = entry.EncryptMode,
+        TrustServerCertificate = entry.TrustServerCertificate,
+        ReadOnlyIntent = entry.ReadOnlyIntent,
+        MultiSubnetFailover = entry.MultiSubnetFailover,
+        ExcludedDatabases = entry.ExcludedDatabases ?? new List<string>(),
+        MonthlyCostUsd = entry.MonthlyCostUsd,
+        IsEnabled = entry.IsEnabled,
+    };
+
+    private void WriteMarker()
+    {
+        try
+        {
+            var directory = Path.GetDirectoryName(_markerPath);
+            if (!string.IsNullOrEmpty(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            File.WriteAllText(_markerPath, $"migrated {DateTime.UtcNow:O}");
+        }
+        catch (Exception ex)
+        {
+            /* A failed marker write only means the migrate re-runs next launch; the ON CONFLICT DO NOTHING
+               writes are idempotent, so at worst it re-attempts (and skips) the same imports. Don't crash. */
+            ViewerLogger.Warn("ViewerServerMigration", $"Could not write the migrate marker '{_markerPath}': {ex.Message}");
+        }
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerSecret.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerSecret.cs
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Runtime.Versioning;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// Produces (and reads back) the DPAPI-LocalMachine password blob the control-plane writes into
+/// <c>config.config_monitored_servers.encrypted_password</c> — the SAME format the service's
+/// <c>PerformanceMonitor.Darling.Service.DarlingSecrets</c> reads with <c>--encrypt-password</c>.
+///
+/// <para>This is DELIBERATELY distinct from <see cref="ViewerSecretStore"/> /
+/// <see cref="WindowsCredentialServerSecretStore"/>, which keep viewer-local secrets in the per-USER
+/// Windows Credential Manager. A monitored-server secret has to be decryptable by the SERVICE account,
+/// so it must be a DPAPI-<b>LocalMachine</b> blob with the service's entropy, not a per-user vault entry.
+/// LocalMachine scope is exactly why the service uses it (its comment: an administrator can encrypt a
+/// password interactively that the service account later decrypts on the same machine). This works for
+/// the managed single-box deploy (viewer + service on one host); a remote viewer producing a blob a
+/// different service host can't decrypt is the documented service-side-provision path.</para>
+///
+/// <para>The entropy string is duplicated from the service's <c>DarlingSecrets.s_entropy</c> byte-for-byte
+/// under the SAME "sliver rule" <see cref="ViewerSettings"/> already follows for the managed-Postgres
+/// credential (the viewer does not reference the Service project); a Darling.Tests round-trip pins them in
+/// lockstep so a drift is caught.</para>
+/// </summary>
+[SupportedOSPlatform("windows")]
+public static class ViewerServerSecret
+{
+    /* Must equal PerformanceMonitor.Darling.Service.DarlingSecrets.s_entropy byte-for-byte, or a
+       blob this viewer writes cannot be decrypted by the service (pinned by ViewerServerSecretTests). */
+    private static readonly byte[] s_entropy = Encoding.UTF8.GetBytes("PerformanceMonitor.Darling.v1");
+
+    /// <summary>DPAPI-LocalMachine-protects a plaintext password and returns the base64 blob for the store.</summary>
+    public static string Protect(string plaintext)
+    {
+        ArgumentNullException.ThrowIfNull(plaintext);
+
+        var protectedBytes = ProtectedData.Protect(
+            Encoding.UTF8.GetBytes(plaintext), s_entropy, DataProtectionScope.LocalMachine);
+        return Convert.ToBase64String(protectedBytes);
+    }
+
+    /// <summary>
+    /// Reverses <see cref="Protect"/> for the Edit dialog's password pre-fill, returning null (never throwing)
+    /// when the blob is empty, malformed, or was produced on a different machine (a remote-viewer blob this
+    /// host's DPAPI key can't open) — the dialog then shows a blank password with a "re-enter to change" hint
+    /// rather than dead-clicking into a cryptographic error.
+    /// </summary>
+    public static string? TryUnprotect(string? base64Blob)
+    {
+        if (string.IsNullOrWhiteSpace(base64Blob))
+        {
+            return null;
+        }
+
+        try
+        {
+            var plainBytes = ProtectedData.Unprotect(
+                Convert.FromBase64String(base64Blob), s_entropy, DataProtectionScope.LocalMachine);
+            return Encoding.UTF8.GetString(plainBytes);
+        }
+        catch (Exception ex) when (ex is FormatException or CryptographicException)
+        {
+            return null;
+        }
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerStore.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerStore.cs
@@ -237,6 +237,49 @@ public sealed class ViewerServerStore
         return entry.IsFavorite;
     }
 
+    /// <summary>
+    /// Sets (not toggles) the favorite flag for a server by name, creating a minimal viewer-local entry when
+    /// none exists, and persists. Favorites are the one thing this store keeps after Stage 3 moved server
+    /// DEFINITIONS to <c>config.config_monitored_servers</c> — they are viewer-local (the service never reads
+    /// them), so they legitimately stay in viewer-servers.json. Returns the resulting state.
+    /// </summary>
+    public bool SetFavorite(string serverName, bool isFavorite)
+    {
+        if (string.IsNullOrWhiteSpace(serverName))
+        {
+            return false;
+        }
+
+        var entry = GetByServerName(serverName);
+        if (entry is null)
+        {
+            if (!isFavorite)
+            {
+                /* Nothing pinned and nothing to pin — don't write an empty registry entry. */
+                return false;
+            }
+
+            _servers.Add(new ViewerServerEntry
+            {
+                ServerName = serverName,
+                DisplayName = serverName,
+                IsFavorite = true
+            });
+        }
+        else
+        {
+            if (entry.IsFavorite == isFavorite)
+            {
+                return isFavorite;
+            }
+
+            entry.IsFavorite = isFavorite;
+        }
+
+        Save();
+        return isFavorite;
+    }
+
     /// <summary>The stored (username, password) for a server id, or null — used to pre-fill the Edit dialog.</summary>
     public (string Username, string Password)? GetCredential(string id) => _secrets.Get(id);
 


### PR DESCRIPTION
## Stage 3a — viewer server-management writes the control-plane store

First half of the control-plane keystone. Stages 1+2 gave the service a `config_monitored_servers` table it reads live and a `config_command` queue it claims/executes. **This rewires the viewer's server management from the severed `viewer-servers.json` to those tables**, so adding/removing/enabling a server actually starts/stops collection and **Test Connection** validates through the service. Touches only the Viewer project + Darling.Tests.

### Deliverables

**1. `ViewerDataService.MonitoredServers.cs`** (new write partial, mirrors `MuteRules.cs`) — upsert (Add/Edit), insert-if-absent (migrate), delete, set-enabled, set-excluded-databases on `config_monitored_servers`. `server_id = ServerIdHelper.GetDeterministicHashCode(BuildStorageName(host,db,ro))` — the *same* identity the service seed + collectors use (pinned against the service's `MonitoredServer.StorageName`). All 15 V17 columns, fully parameterized, `ExecuteWriteAsync` → SQLSTATE 42501 → `ViewerReadOnlyException`.

**2. `ViewerDataService.Commands.cs`** (new) — enqueue a `config_command` row + poll-for-terminal-result. `BuildTestConnectArgs` emits the service's `MonitoredServer` JSON contract.

**3. Server-management rewire** — `AddServerDialog` / `ManageServersWindow` / `ExcludedDatabasesDialog` / `MainWindow` sidebar+context-menu all read/write the store instead of the JSON file. Add makes the service collect; remove deletes the definition; the enable checkbox + a new Enable/Disable menu drive `is_enabled`.

**4. Credential/secret handling (the decided design)**
- **integrated** → no secret.
- **SQL** → a **DPAPI-LocalMachine blob** in `encrypted_password`, produced by `ViewerServerSecret` with the *same* entropy/scope as the service's `DarlingSecrets` (cross-project round-trip pinned in tests). The service decrypts on its own host (managed single-box). **Never plaintext to Postgres.**
- **credential PROFILE (SqlServer)** → resolved to concrete username + DPAPI blob at write time (the store keeps concrete creds; no profiles table).
- **Azure/Entra (EntraMFA / Service Principal / Managed Identity)** → the Darling service has **no AAD connect path** (verified — nothing in the Service project builds a token), so these are **blocked with a clear message**, not written un-honorable. Surfaced, not silently dropped.

**5. Restored Test Connection** — enqueues a `test_connect` carrying the inline server def in `args_json` (the password rides as the DPAPI blob, **no plaintext in the queue**), polls for the service's probe result, shows version/edition/msdb or the error, then **deletes its own credential-bearing command row**.

**6. Sidebar reconcile** — `GetManagedServersAsync`: config-authoritative membership (`config_monitored_servers` LEFT JOIN `collect.servers` by `server_id`), so an added server appears immediately and a removed one disappears. Fails safe to the observed `collect.servers` read on a pre-seed / pre-V17 store (never blanks the sidebar).

**7. Migrate-in** — `ViewerServerMigration`: one-time import of `viewer-servers.json` definitions into the store, `INSERT … ON CONFLICT (server_id) DO NOTHING` so it **never double-seeds** the service's darling.json seed, guarded by a once-marker so it can't resurrect a removed server. Integrated migrates fully; SQL re-seals the Credential-Manager secret to a DPAPI blob; Azure/secret-less SQL skip. Favorites stay viewer-local.

### Secret approach + remote-viewer gap (explicit)
Everything targets the **managed single-box** deploy (viewer + service on one host): DPAPI-LocalMachine means the service decrypts what the viewer wrote. A **remote viewer + SQL auth** produces a blob a *different* service host can't decrypt — that server's password must be provisioned service-side (`--encrypt-password`), the documented path. Test Connection has the same boundary. Integrated auth (the recommended default) has no such gap.

### Migrate vs the service seed
`InsertIfAbsent` (DO NOTHING on `server_id` conflict) means any server already in the store from the service's darling.json seed is left untouched — the migrate imports only entries the store lacks. The once-marker prevents re-running (no resurrection of a viewer-removed server).

### Tests
`ViewerServerManagementTests.cs` (38 tests) — MonitoredServers write-SQL pins + parameterization + column parity with the service `StoreConfigProvider`; `server_id` identity vs the service's `MonitoredServer`; command enqueue/poll/delete shape; `test_connect` args_json round-tripped into the *actual service* `MonitoredServer` type (asserts no plaintext `password`); auth mapping; DPAPI blob cross-compat with `DarlingSecrets`; migrate projection (integrated/sql/azure/no-secret) + marker. **Darling.Tests: 1109 pass / 98 skip (live-PG gated) / 0 fail.**

### Review findings addressed
Ran correctness + security review agents. In-scope fixes applied:
- **Correctness:** identity-change edit now upserts-new-**before**-delete-old (no vanished definition on a failed delete); `IsConfigSeededAsync` fails safe on a pre-V17 store (no blank sidebar); Add blocks silently overwriting a different same-identity server (would wipe its excluded-DBs/capture); `BuildRowFromForm` moved inside the `try` (no unobserved crypto exception on `async void`); ManageServers grid preserves selection across reloads.
- **Security:** Test Connection disabled on a read-only seat; `test_connect` command row deleted after a terminal result so its credential blob doesn't linger.

### Surfaced (NOT fixed — out of my scope)
- **[Security, Medium] The read-only `viewer` Postgres role can `SELECT encrypted_password`** from `config_monitored_servers` (and `config_command.args_json`). The store now holds SQL credential blobs the viewer role can read; the DPAPI entropy is public + LocalMachine, so the blob is decryptable by anyone with a foothold on the service host. **The fix is role/grant ACLs** (`DarlingManagedRoles.cs` / `provision-roles.sql` — column-level grants or withhold `config_command` from `viewer`), which are **Service/tools files and explicitly out of this stage's scope** ("do NOT change provisioning/role ACLs"). The plan already tracks this as a Stage-3 role-model decision. **Recommend the lead take the grant change as the paired security item.**
- **[Security, Low] `config_command` rows accumulate** their credential blobs (the viewer deletes its own `test_connect` row on success, but a timeout/crash leaves it, and future `snapshot_now`/`analyze_now` have none). The complete fix is a service-side retention sweep / null-`args_json`-on-terminal in `DarlingWorker`/`DarlingCommandExecutor` (Service files, out of scope).

### Deliberately not carried into the store
Viewer-only Lite-port fields with no service consumer and no `config_monitored_servers` column — **Description, Utility DB, per-server alert-delivery override** — were removed from the Add/Edit dialog (they'd otherwise silently vanish on reopen). The service never honored them. Per-server `capture_plans` column exists and is preserved on edit but has no dialog knob yet (Stage-1 follow-up: global-only honoring).

**Out of scope for 3a (Stage 3b):** SettingsWindow alert/SMTP/webhook rewire, Pause/Resume, Live Snapshot, Recommendations Generate-now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
