### PR TITLE
Harden Darling control plane: viewer credential-column ACLs, stale-command reaper, args_json retention

### DIFF
--- a/Darling/Darling.Tests/DarlingAnalysisStoreTests.cs
+++ b/Darling/Darling.Tests/DarlingAnalysisStoreTests.cs
@@ -241,7 +241,10 @@ public sealed class DarlingAnalysisStoreTests
 
         using (var versions = new NpgsqlCommand("SELECT COUNT(*) FROM darling_schema_version", connection))
         {
-            Assert.Equal(15L, await versions.ExecuteScalarAsync(TestContext.Current.CancellationToken));
+            /* One row per applied migration, so the count tracks the current schema version. Reference the
+               constant rather than a literal — this was hardcoded to a since-superseded number (15) and, as a
+               live-only assertion CI skips, silently rotted until the schema reached V17. */
+            Assert.Equal((long)StorageVersion.SchemaVersion, await versions.ExecuteScalarAsync(TestContext.Current.CancellationToken));
         }
 
         /* Clear leftovers from an earlier aborted run so the assertions below are deterministic. */

--- a/Darling/Darling.Tests/DarlingCommandExecutorTests.cs
+++ b/Darling/Darling.Tests/DarlingCommandExecutorTests.cs
@@ -10,6 +10,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql;
+using NpgsqlTypes;
 using PerformanceMonitor.Darling.Service;
 using PerformanceMonitor.Darling.Storage;
 using Xunit;
@@ -60,6 +61,37 @@ public sealed class DarlingCommandExecutorTests
         Assert.Contains("RETURNING", sql, StringComparison.Ordinal);
         /* Records which instance claimed it. */
         Assert.Contains("service_instance = $1", sql, StringComparison.Ordinal);
+    }
+
+    /* ---------------- pure: reaper + terminal secret-scrub SQL shape (pin) ---------------- */
+
+    [Fact]
+    public void ReclaimStaleCommandsSql_MarksFailed_NullsArgs_FiltersStaleInProgress()
+    {
+        var sql = DarlingCommandExecutor.ReclaimStaleCommandsSql;
+
+        /* Reclaim = terminal failed with a clear reason (so the Viewer's poll completes) — NOT re-queued to
+           pending (which would re-run a non-idempotent snapshot_now or loop on a poison command). */
+        Assert.Contains("status = 'failed'", sql, StringComparison.Ordinal);
+        Assert.Contains("result_status = 'reclaimed", sql, StringComparison.Ordinal);
+        /* Terminal secret scrub: a reclaimed test_connect's credential args are nulled too. */
+        Assert.Contains("args_json = NULL", sql, StringComparison.Ordinal);
+        /* Only genuinely-abandoned rows: in_progress AND claimed before the parameterized threshold. */
+        Assert.Contains("WHERE status = 'in_progress'", sql, StringComparison.Ordinal);
+        Assert.Contains("claimed_at <", sql, StringComparison.Ordinal);
+        Assert.Contains("$1", sql, StringComparison.Ordinal);
+
+        /* A generous margin over the slowest command (test_connect ~15-30s, analyze_now caps 120s), so the
+           reaper can never catch a command that is merely slow. */
+        Assert.Equal(TimeSpan.FromMinutes(5), DarlingCommandExecutor.StaleCommandTimeout);
+    }
+
+    [Fact]
+    public void ReportCommandSql_NullsArgsJson_OnTerminalState()
+    {
+        /* The terminal report scrubs the credential-carrying args_json (#1262 Low retention follow-up); the
+           Viewer reads result_status/result_json on completion, never args, so this is transparent. */
+        Assert.Contains("args_json = NULL", DarlingCommandExecutor.ReportCommandSql, StringComparison.Ordinal);
     }
 
     /* ---------------- pure: dispatch (one plan per command_type) ---------------- */
@@ -324,20 +356,89 @@ public sealed class DarlingCommandExecutorTests
             Assert.Equal(true, await read.ExecuteScalarAsync(ct));
         }
 
-        /* The reported terminal outcome on the command row. */
+        /* The reported terminal outcome on the command row, including the args_json secret scrub. */
         using (var read = new NpgsqlCommand(
-            "SELECT status, result_status, result_json::text, completed_at FROM config.config_command WHERE command_id = $1", connection))
+            "SELECT status, result_status, result_json::text, completed_at, args_json FROM config.config_command WHERE command_id = $1", connection))
         {
             read.Parameters.AddWithValue(commandId);
             using var reader = await read.ExecuteReaderAsync(ct);
             Assert.True(await reader.ReadAsync(ct));
             Assert.Equal("succeeded", reader.GetString(0));
             Assert.Equal("collector enabled", reader.GetString(1));
-            Assert.Contains("\"success\":true", reader.GetString(2), StringComparison.Ordinal);
+            /* result_json is jsonb, so its ::text is normalized with a space after the colon (key order is
+               jsonb's, not the serializer's) — assert on the stored/normalized form, not the raw serializer output. */
+            Assert.Contains("\"success\": true", reader.GetString(2), StringComparison.Ordinal);
             Assert.False(reader.IsDBNull(3), "completed_at must be stamped");
+            Assert.True(reader.IsDBNull(4), "args_json must be nulled on terminal state (#1262 secret retention)");
         }
 
         await CleanupSentinelAsync(connection, ct);
+    }
+
+    [Fact]
+    public async Task ReclaimStaleCommands_FailsStaleInProgress_LeavesFreshUntouched_RolledBack()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the stale-command reaper test.");
+
+        var ct = TestContext.Current.CancellationToken;
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(ct);
+        await PgMigrations.MigrateAsync(connection, ct);
+
+        await using var tx = await connection.BeginTransactionAsync(ct);
+
+        /* One command claimed 10 minutes ago (past the 5-minute stale timeout) and still carrying a
+           test_connect credential blob, plus one claimed just now (a command legitimately in flight). */
+        long staleId, freshId;
+        using (var insert = new NpgsqlCommand(
+            "INSERT INTO config.config_command (command_type, args_json, status, claimed_at, service_instance) " +
+            "VALUES ('test_connect', '{\"password\":\"secret\"}'::jsonb, 'in_progress', (now() AT TIME ZONE 'UTC') - interval '10 minutes', 'crashed-instance') RETURNING command_id", connection, tx))
+        {
+            staleId = Convert.ToInt64(await insert.ExecuteScalarAsync(ct));
+        }
+
+        using (var insert = new NpgsqlCommand(
+            "INSERT INTO config.config_command (command_type, args_json, status, claimed_at, service_instance) " +
+            "VALUES ('test_connect', '{\"password\":\"secret\"}'::jsonb, 'in_progress', (now() AT TIME ZONE 'UTC'), 'live-instance') RETURNING command_id", connection, tx))
+        {
+            freshId = Convert.ToInt64(await insert.ExecuteScalarAsync(ct));
+        }
+
+        /* Drive the executor's ACTUAL reaper SQL, with the real 5-minute timeout bound as a PG interval. */
+        using (var reap = new NpgsqlCommand(DarlingCommandExecutor.ReclaimStaleCommandsSql, connection, tx))
+        {
+            reap.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Interval, Value = DarlingCommandExecutor.StaleCommandTimeout });
+            await reap.ExecuteNonQueryAsync(ct);
+        }
+
+        /* The stale row is reclaimed: terminal failed, a clear result_status, credential args scrubbed,
+           completed_at stamped. */
+        using (var read = new NpgsqlCommand(
+            "SELECT status, result_status, args_json IS NULL, completed_at IS NOT NULL FROM config.config_command WHERE command_id = $1", connection, tx))
+        {
+            read.Parameters.AddWithValue(staleId);
+            using var reader = await read.ExecuteReaderAsync(ct);
+            Assert.True(await reader.ReadAsync(ct));
+            Assert.Equal("failed", reader.GetString(0));
+            Assert.Contains("reclaimed", reader.GetString(1), StringComparison.Ordinal);
+            Assert.True(reader.GetBoolean(2), "stale row's args_json must be nulled");
+            Assert.True(reader.GetBoolean(3), "stale row's completed_at must be stamped");
+        }
+
+        /* The fresh row (a command still legitimately running) is untouched — still in_progress, args kept. */
+        using (var read = new NpgsqlCommand(
+            "SELECT status, args_json IS NULL FROM config.config_command WHERE command_id = $1", connection, tx))
+        {
+            read.Parameters.AddWithValue(freshId);
+            using var reader = await read.ExecuteReaderAsync(ct);
+            Assert.True(await reader.ReadAsync(ct));
+            Assert.Equal("in_progress", reader.GetString(0));
+            Assert.False(reader.GetBoolean(1), "fresh row's args_json must be preserved (still executing)");
+        }
+
+        await tx.RollbackAsync(ct);
     }
 
     [Fact]

--- a/Darling/Darling.Tests/DarlingManagedRolesTests.cs
+++ b/Darling/Darling.Tests/DarlingManagedRolesTests.cs
@@ -7,6 +7,8 @@
  */
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using PerformanceMonitor.Darling.Service;
 using Xunit;
 
@@ -85,6 +87,81 @@ public sealed class DarlingManagedRolesTests
 
         /* Fail-closed: a future serial/identity config column needs sequence USAGE for admin's INSERT. */
         Assert.Contains("GRANT USAGE, SELECT ON SEQUENCES TO admin;", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildProvisioningSql_CarvesViewerSecretColumns_FailClosed()
+    {
+        var sql = DarlingManagedRoles.BuildProvisioningSql("AdminPassword01", "ViewerPassword02");
+
+        /* The blanket config SELECT to viewer is still present (covers the non-secret config tables), but
+           the three credential-bearing tables are then carved to column-level for viewer. */
+        Assert.Contains("GRANT SELECT ON ALL TABLES IN SCHEMA config  TO admin, viewer;", sql, StringComparison.Ordinal);
+
+        foreach (var acl in DarlingManagedRoles.ViewerRestrictedConfigTables)
+        {
+            /* viewer's table-wide SELECT is dropped, then re-granted on ONLY the non-secret columns. */
+            Assert.Contains($"REVOKE SELECT ON config.{acl.Table} FROM viewer;", sql, StringComparison.Ordinal);
+            Assert.Contains($"GRANT SELECT ({string.Join(", ", acl.NonSecretColumns)}) ON config.{acl.Table} TO viewer;",
+                sql, StringComparison.Ordinal);
+
+            /* The carve is viewer-only — admin is never column-restricted (it writes these tables). */
+            Assert.DoesNotContain($"REVOKE SELECT ON config.{acl.Table} FROM admin", sql, StringComparison.Ordinal);
+        }
+
+        /* No secret column name appears anywhere in a GRANT ... TO viewer (belt over the per-table check). */
+        var viewerGrantLines = sql.Split('\n')
+            .Where(line => line.Contains("TO viewer", StringComparison.Ordinal) && line.Contains("GRANT SELECT (", StringComparison.Ordinal));
+        foreach (var secret in DarlingManagedRoles.ViewerRestrictedConfigTables.SelectMany(a => a.SecretColumns))
+        {
+            foreach (var line in viewerGrantLines)
+            {
+                Assert.DoesNotContain(secret, line, StringComparison.Ordinal);
+            }
+        }
+    }
+
+    [Fact]
+    public void ViewerRestrictedConfigTables_SecretAndNonSecretColumns_AreDisjointAndNonEmpty()
+    {
+        var expectedSecrets = new Dictionary<string, string[]>(StringComparer.Ordinal)
+        {
+            ["config_monitored_servers"] = new[] { "encrypted_password" },
+            ["config_command"] = new[] { "args_json" },
+            ["config_notification"] = new[] { "smtp_encrypted_password", "smtp_username", "teams_url", "slack_url" },
+        };
+
+        /* Exactly the three known secret-bearing tables, with the expected secret columns. */
+        Assert.Equal(
+            expectedSecrets.Keys.OrderBy(k => k, StringComparer.Ordinal),
+            DarlingManagedRoles.ViewerRestrictedConfigTables.Select(a => a.Table).OrderBy(k => k, StringComparer.Ordinal));
+
+        foreach (var acl in DarlingManagedRoles.ViewerRestrictedConfigTables)
+        {
+            Assert.NotEmpty(acl.NonSecretColumns);
+            Assert.NotEmpty(acl.SecretColumns);
+
+            /* A column is never in both sets — a granted column can't also be a denied one. */
+            Assert.Empty(acl.NonSecretColumns.Intersect(acl.SecretColumns, StringComparer.Ordinal));
+
+            Assert.Equal(
+                expectedSecrets[acl.Table].OrderBy(c => c, StringComparer.Ordinal),
+                acl.SecretColumns.OrderBy(c => c, StringComparer.Ordinal));
+        }
+    }
+
+    [Fact]
+    public void BuildViewerColumnAclSql_UsesTheGivenSchemaAndRole()
+    {
+        /* The same generator the live test applies to its throwaway roles — pin that it honors the passed
+           schema + role names (so the test and the real provisioning can never drift). */
+        var sql = DarlingManagedRoles.BuildViewerColumnAclSql("config", "sec_viewer_test");
+
+        Assert.Contains("REVOKE SELECT ON config.config_monitored_servers FROM sec_viewer_test;", sql, StringComparison.Ordinal);
+        Assert.Contains("ON config.config_monitored_servers TO sec_viewer_test;", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("encrypted_password", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("args_json", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("teams_url", sql, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/Darling/Darling.Tests/DarlingSecuritySplitLiveTests.cs
+++ b/Darling/Darling.Tests/DarlingSecuritySplitLiveTests.cs
@@ -7,6 +7,8 @@
  */
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Npgsql;
 using PerformanceMonitor.Darling.Service;
@@ -153,6 +155,60 @@ public sealed class DarlingSecuritySplitLiveTests
     }
 
     [Fact]
+    public async Task ViewerRole_DeniedSecretColumns_AllowedNonSecretColumns_OnAllThreeTables()
+    {
+        var connectionString = RequireLivePostgres();
+        var ct = TestContext.Current.CancellationToken;
+
+        await using var owner = new NpgsqlConnection(connectionString);
+        await owner.OpenAsync(ct);
+        /* Applies V17 (creates the three credential-bearing config tables) — the carve targets them. */
+        await PgMigrations.MigrateAsync(owner, ct);
+
+        await CreateTestRolesAndGrantsAsync(owner, ct);
+        try
+        {
+            await using var viewer = new NpgsqlConnection(RoleConnectionString(connectionString, ViewerRole));
+            await viewer.OpenAsync(ct);
+
+            foreach (var acl in DarlingManagedRoles.ViewerRestrictedConfigTables)
+            {
+                /* Drift guard (the safety net): the non-secret + secret sets must PARTITION the table's real
+                   columns. A migration that adds a column without classifying it here fails HERE — the new
+                   column is in neither set — forcing a deliberate secret/non-secret decision before it can
+                   ship, which is exactly what a future-secret-column ACL gap would need. */
+                var actual = await ColumnsOfConfigTableAsync(owner, acl.Table, ct);
+                var classified = acl.NonSecretColumns.Concat(acl.SecretColumns).ToHashSet(StringComparer.Ordinal);
+                Assert.True(actual.SetEquals(classified),
+                    $"config.{acl.Table}: unclassified column(s) [{string.Join(",", actual.Except(classified))}]; " +
+                    $"listed-but-absent [{string.Join(",", classified.Except(actual))}] — update DarlingManagedRoles.ViewerRestrictedConfigTables.");
+
+                /* viewer CAN read every non-secret column together (column privilege is enforced at parse
+                   time, so LIMIT 1 exercises it even against an empty table). */
+                await ExecAsync(viewer, $"SELECT {string.Join(", ", acl.NonSecretColumns)} FROM config.{acl.Table} LIMIT 1", ct);
+
+                /* viewer is DENIED each secret column — 42501 insufficient_privilege — proving the fail-closed
+                   carve actually took (the point of the whole deliverable). */
+                foreach (var secret in acl.SecretColumns)
+                {
+                    var denied = await Assert.ThrowsAsync<PostgresException>(async () =>
+                        await ExecAsync(viewer, $"SELECT {secret} FROM config.{acl.Table} LIMIT 1", ct));
+                    Assert.Equal("42501", denied.SqlState);
+                }
+
+                /* SELECT * is denied too (it touches the secret columns), so a naive read can't leak them. */
+                var star = await Assert.ThrowsAsync<PostgresException>(async () =>
+                    await ExecAsync(viewer, $"SELECT * FROM config.{acl.Table} LIMIT 1", ct));
+                Assert.Equal("42501", star.SqlState);
+            }
+        }
+        finally
+        {
+            await DropTestRolesAsync(owner, ct);
+        }
+    }
+
+    [Fact]
     public async Task CompressedHypertable_SetSchema_StaysReadableByLeastPrivilegeRole()
     {
         var connectionString = RequireLivePostgres();
@@ -268,6 +324,7 @@ GRANT USAGE ON SCHEMA collect, config TO {AdminRole}, {ViewerRole};
 GRANT SELECT ON ALL TABLES IN SCHEMA collect TO {AdminRole}, {ViewerRole};
 GRANT SELECT ON ALL TABLES IN SCHEMA config  TO {AdminRole}, {ViewerRole};
 GRANT INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA config TO {AdminRole};
+{DarlingManagedRoles.BuildViewerColumnAclSql("config", ViewerRole)}
 ALTER DEFAULT PRIVILEGES FOR ROLE {OwnerRoleOf(owner)} IN SCHEMA collect GRANT SELECT ON TABLES TO {AdminRole}, {ViewerRole};";
         await ExecAsync(owner, ddl, ct);
     }
@@ -278,22 +335,37 @@ ALTER DEFAULT PRIVILEGES FOR ROLE {OwnerRoleOf(owner)} IN SCHEMA collect GRANT S
 
     private static async Task DropTestRolesAsync(NpgsqlConnection owner, System.Threading.CancellationToken ct)
     {
-        /* Revoke first so DROP ROLE doesn't fail on dependent grants; ignore cleanup errors. */
+        /* DROP OWNED BY revokes EVERY privilege granted to these roles — table, the new column-level secret
+           carve, schema-usage, and the owner's default privileges naming them — so the following DROP ROLE
+           has no dependent grants to trip on (a plain table-level REVOKE would leave the column grants and
+           block the drop). Best-effort: a leftover disposable role in a dev store is harmless. */
         try
         {
-            var db = owner.Database;
             await ExecAsync(owner, $@"
-REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA collect FROM {AdminRole}, {ViewerRole};
-REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA config  FROM {AdminRole}, {ViewerRole};
-REVOKE ALL PRIVILEGES ON SCHEMA collect, config FROM {AdminRole}, {ViewerRole};
-ALTER DEFAULT PRIVILEGES FOR ROLE {OwnerRoleOf(owner)} IN SCHEMA collect REVOKE SELECT ON TABLES FROM {AdminRole}, {ViewerRole};
+DROP OWNED BY {AdminRole}, {ViewerRole};
 DROP ROLE IF EXISTS {AdminRole};
 DROP ROLE IF EXISTS {ViewerRole};", ct);
         }
         catch (PostgresException)
         {
-            /* Best-effort cleanup — a leftover disposable role in a dev store is harmless. */
         }
+    }
+
+    /// <summary>The actual column names of a <c>config</c>-schema table (for the ACL drift/partition guard).</summary>
+    private static async Task<HashSet<string>> ColumnsOfConfigTableAsync(
+        NpgsqlConnection connection, string table, System.Threading.CancellationToken ct)
+    {
+        var columns = new HashSet<string>(StringComparer.Ordinal);
+        using var command = new NpgsqlCommand(
+            "SELECT column_name FROM information_schema.columns WHERE table_schema = 'config' AND table_name = $1", connection);
+        command.Parameters.AddWithValue(table);
+        using var reader = await command.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+        {
+            columns.Add(reader.GetString(0));
+        }
+
+        return columns;
     }
 
     private static string RoleConnectionString(string baseConnectionString, string role)

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingCommandExecutor.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingCommandExecutor.cs
@@ -60,14 +60,59 @@ RETURNING command_id, command_type, target_server_id, args_json, requested_by";
     /// <summary>
     /// Writes the terminal outcome back on the claimed row (succeeded/failed + result_status/json). Internal
     /// so the round-trip test can pin + exercise it; $1 command_id, $2 status, $3 result_status, $4 result_json.
+    ///
+    /// <para><b>Secret retention (#1262 Low follow-up):</b> nulls <c>args_json</c> as the row reaches a
+    /// terminal state — a <c>test_connect</c> command's <c>args_json</c> carries an inline credential blob,
+    /// and there is no reason to retain it once the probe has run. The claim already captured args_json into
+    /// the in-memory <see cref="ClaimedCommand"/> before execution, and the Viewer's terminal-result poll
+    /// reads <c>result_status</c>/<c>result_json</c> (never args), so scrubbing it here is transparent. The
+    /// stale-command reaper scrubs it the same way (<see cref="ReclaimStaleCommandsSql"/>) for a row that
+    /// never reported. result_json holds only probe facts / an error string, never a secret, so it stays.</para>
     /// </summary>
     internal const string ReportCommandSql = @"
 UPDATE config.config_command
 SET status = $2,
     completed_at = now() AT TIME ZONE 'UTC',
     result_status = $3,
-    result_json = $4
+    result_json = $4,
+    args_json = NULL
 WHERE command_id = $1";
+
+    /// <summary>
+    /// The stale-command reaper (#1262 Stage 2 robustness follow-up): reclaims a command abandoned
+    /// <c>in_progress</c> because the claiming service crashed or restarted between the claim and the report.
+    /// Without this the row stays <c>in_progress</c> forever and a Viewer polling it for a terminal result
+    /// waits indefinitely. A row whose <c>claimed_at</c> is older than the stale timeout ($1, a PG interval)
+    /// is marked terminal <c>failed</c> with a clear <c>result_status</c> so the poll completes, and its
+    /// <c>args_json</c> is nulled at the same time (the same terminal secret scrub the report path does).
+    /// Public const so a test can pin the shape.
+    ///
+    /// <para><b>Why fail-terminal, not re-queue to <c>pending</c>:</b> re-running a reclaimed command is the
+    /// UNSAFE choice — the imperative commands are not all idempotent (a half-run <c>snapshot_now</c> already
+    /// wrote its collector rows, so a re-run double-writes them and races the shared delta baselines), and a
+    /// command that CRASHED the service would crash it again on every reclaim (a poison-message loop that
+    /// never drains). Marking it <c>failed</c> always unblocks the Viewer (the actual bug) and leaves the
+    /// idempotent commands (pause/resume/test_connect/toggles) for an operator to re-issue by hand. The
+    /// <see cref="StaleCommandTimeout"/> is wide enough that a merely-slow live command is never reaped.</para>
+    /// </summary>
+    public const string ReclaimStaleCommandsSql = @"
+UPDATE config.config_command
+SET status = 'failed',
+    completed_at = now() AT TIME ZONE 'UTC',
+    result_status = 'reclaimed (service restart or timeout)',
+    result_json = '{""success"": false, ""error"": ""command reclaimed: the claiming service did not report a result within the stale-command timeout (a service restart or a crash mid-command)""}'::jsonb,
+    args_json = NULL
+WHERE status = 'in_progress'
+  AND claimed_at < (now() AT TIME ZONE 'UTC') - $1";
+
+    /// <summary>
+    /// The stale-command reaper timeout: an <c>in_progress</c> command whose <c>claimed_at</c> is older than
+    /// this is reclaimed as <c>failed</c>. Five minutes is a wide margin over the slowest command — a
+    /// <c>test_connect</c> is bounded by the SQL connect timeout (~15-30s) and <c>analyze_now</c> self-caps
+    /// at 120s — so the reaper can never catch a command that is merely slow, only one genuinely abandoned.
+    /// A hardcoded default (not a config knob) per the "defaults over speculative config" rule.
+    /// </summary>
+    public static readonly TimeSpan StaleCommandTimeout = TimeSpan.FromMinutes(5);
 
     private static readonly JsonSerializerOptions s_jsonOptions = new()
     {
@@ -114,6 +159,38 @@ WHERE command_id = $1";
 
         await ExecuteAndReportAsync(claimed, cancellationToken);
         return true;
+    }
+
+    /// <summary>
+    /// Runs one stale-command reaper sweep (<see cref="ReclaimStaleCommandsSql"/>) and returns the number of
+    /// commands reclaimed. Failure-isolated like the rest of the poller — a store blip logs and returns 0
+    /// rather than killing the command loop. Cheap enough to run every tick: the WHERE is served by the
+    /// status index and matches nothing in the normal case (commands are claimed and reported within
+    /// seconds), and an UPDATE that changes no rows writes no WAL.
+    /// </summary>
+    public async Task<int> ReclaimStaleCommandsAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var connection = await _postgres.OpenConnectionAsync(cancellationToken);
+            using var command = new NpgsqlCommand(ReclaimStaleCommandsSql, connection);
+            command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Interval, Value = StaleCommandTimeout });
+
+            var reclaimed = await command.ExecuteNonQueryAsync(cancellationToken);
+            if (reclaimed > 0)
+            {
+                _logger?.LogWarning(
+                    "Reclaimed {Count} stale in_progress command(s) claimed over {Timeout} ago with no result reported (a service restart or a crash mid-command) — marked failed so the Viewer's poll completes",
+                    reclaimed, StaleCommandTimeout);
+            }
+
+            return reclaimed;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger?.LogWarning("Could not run the stale-command reaper — will retry next tick: {Message}", ex.Message);
+            return 0;
+        }
     }
 
     /// <summary>Atomically claims the oldest pending command (or null when the queue is empty).</summary>

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingManagedRoles.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingManagedRoles.cs
@@ -7,7 +7,9 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
@@ -56,6 +58,75 @@ public static class DarlingManagedRoles
     /// makes provisioning fail loud rather than reset its password/privileges.
     /// </summary>
     public const string RoleMarker = "darling-managed";
+
+    /// <summary>
+    /// The <c>config</c> tables that carry SECRET columns the read-only <c>viewer</c> role must never read,
+    /// each paired with the EXACT non-secret columns it may (#1262 Medium credential-column follow-up). The
+    /// <c>admin</c> role — which writes and therefore owns these secrets, and which the Settings window
+    /// connects as — keeps its full table-wide SELECT; only <c>viewer</c> is column-restricted.
+    /// <list type="bullet">
+    /// <item><c>config_monitored_servers.encrypted_password</c> — a DPAPI-LocalMachine password blob.</item>
+    /// <item><c>config_command.args_json</c> — carries the inline test_connect credential blob (also nulled
+    /// on terminal state; see <see cref="DarlingCommandExecutor.ReportCommandSql"/>).</item>
+    /// <item><c>config_notification</c> — the SMTP password blob + username, and the Teams/Slack webhook
+    /// URLs (a webhook URL is a bearer secret).</item>
+    /// </list>
+    ///
+    /// <para><b>Fail-CLOSED by construction:</b> <see cref="BuildViewerColumnAclSql"/> grants <c>viewer</c>
+    /// column-level SELECT on ONLY the enumerated <see cref="ViewerSecretTableAcl.NonSecretColumns"/>, so a
+    /// column added to one of these tables in a future migration is INVISIBLE to <c>viewer</c> until it is
+    /// deliberately added here — the opposite of GRANT-ALL-then-REVOKE-each-secret, which would silently
+    /// expose a new secret column. The live <c>DarlingSecuritySplitLiveTests</c> asserts the union of the
+    /// two column sets equals the table's actual columns, so a migration that adds a column without updating
+    /// this list FAILS the build's live gate. A NEW secret-bearing <c>config</c> table added later must also
+    /// be added here (its <c>ALTER DEFAULT PRIVILEGES</c> table-grant to <c>viewer</c> would otherwise
+    /// expose every column).</para>
+    /// </summary>
+    public static readonly IReadOnlyList<ViewerSecretTableAcl> ViewerRestrictedConfigTables = new[]
+    {
+        new ViewerSecretTableAcl(
+            "config_monitored_servers",
+            NonSecretColumns: new[]
+            {
+                "server_id", "name", "host", "database", "auth", "username", "encrypt_mode",
+                "trust_server_certificate", "read_only_intent", "multi_subnet_failover",
+                "excluded_databases", "monthly_cost_usd", "capture_plans", "is_enabled",
+                "created_at", "modified_at",
+            },
+            SecretColumns: new[] { "encrypted_password" }),
+
+        new ViewerSecretTableAcl(
+            "config_command",
+            NonSecretColumns: new[]
+            {
+                "command_id", "created_at", "requested_by", "command_type", "target_server_id",
+                "status", "claimed_at", "completed_at", "result_status", "result_json", "service_instance",
+            },
+            SecretColumns: new[] { "args_json" }),
+
+        new ViewerSecretTableAcl(
+            "config_notification",
+            NonSecretColumns: new[]
+            {
+                "id", "smtp_host", "smtp_port", "smtp_use_ssl", "smtp_from_address", "smtp_recipients",
+                "email_cooldown_minutes", "teams_proxy", "slack_proxy", "modified_at",
+            },
+            SecretColumns: new[] { "smtp_encrypted_password", "smtp_username", "teams_url", "slack_url" }),
+    };
+
+    /// <summary>
+    /// The fail-closed viewer column-ACL block for one <c>config</c> schema + <c>viewer</c> role: for each
+    /// <see cref="ViewerRestrictedConfigTables"/> entry, REVOKE the table-wide SELECT (undoing the blanket
+    /// <c>GRANT SELECT ON ALL TABLES</c> and the V17 <c>ALTER DEFAULT PRIVILEGES</c> grant that already
+    /// landed on it) and re-GRANT SELECT on ONLY the non-secret columns. Shared verbatim by
+    /// <see cref="BuildProvisioningSql"/> and the live security test so the two can never drift. The table
+    /// and column names are compile-time constants from this file (never user input), so interpolation is
+    /// safe — the same reasoning the password-injection guard relies on.
+    /// </summary>
+    public static string BuildViewerColumnAclSql(string configSchema, string viewerRole) =>
+        string.Join("\n", ViewerRestrictedConfigTables.Select(acl =>
+            $"REVOKE SELECT ON {configSchema}.{acl.Table} FROM {viewerRole};\n" +
+            $"GRANT SELECT ({string.Join(", ", acl.NonSecretColumns)}) ON {configSchema}.{acl.Table} TO {viewerRole};"));
 
     /// <summary>
     /// Ensures the <c>admin</c>/<c>viewer</c> roles, their DPAPI credentials, and the collect/config
@@ -177,6 +248,11 @@ public static class DarlingManagedRoles
         const string config = PgSchemaGenerator.ConfigSchema;
         const string marker = RoleMarker;
 
+        /* The fail-closed viewer column-ACL carve for the secret-bearing config tables (see
+           ViewerRestrictedConfigTables). Runs AFTER the blanket config GRANT below, so it strips
+           viewer's table-wide SELECT on those tables and re-grants only the non-secret columns. */
+        var viewerColumnAcl = BuildViewerColumnAclSql(config, viewer);
+
         return $@"
 /* Least-privilege roles for the Darling security split (#1262). Idempotent + self-healing:
    re-run every managed start, converging role state to the DPAPI credential files. */
@@ -206,10 +282,23 @@ END $do$;
 ALTER ROLE {admin}  LOGIN NOSUPERUSER PASSWORD '{adminPassword}';
 ALTER ROLE {viewer} LOGIN NOSUPERUSER PASSWORD '{viewerPassword}';
 
--- 2. Schema usage + SELECT everywhere (ALL TABLES covers tables AND views).
+-- 2. Schema usage + SELECT everywhere (ALL TABLES covers tables AND views). collect holds no secrets,
+--    so admin+viewer read all of it. config: admin (the writer, and the Settings window's identity) reads
+--    every column; viewer reads all config tables too — MINUS the secret columns carved below.
 GRANT USAGE ON SCHEMA {collect}, {config} TO {admin}, {viewer};
 GRANT SELECT ON ALL TABLES IN SCHEMA {collect} TO {admin}, {viewer};
 GRANT SELECT ON ALL TABLES IN SCHEMA {config}  TO {admin}, {viewer};
+
+-- 2b. Credential-column fail-closed ACLs (#1262 Medium follow-up). The read-only viewer must NOT read the
+--     secret columns in config_monitored_servers / config_command / config_notification (a DPAPI password
+--     blob, the test_connect credential args, the SMTP password + username, the Teams/Slack webhook URLs).
+--     Instead of GRANT-ALL-then-REVOKE-each-secret (fail-OPEN — a future secret column leaks until someone
+--     remembers to revoke it), DROP viewer's table-wide SELECT on each and re-grant ONLY the non-secret
+--     columns (fail-CLOSED — any column added later is invisible to viewer until explicitly listed in
+--     DarlingManagedRoles.ViewerRestrictedConfigTables). admin keeps its table-wide SELECT (granted above),
+--     so the Settings window is unaffected. This also undoes the table-level grant the V17 ALTER DEFAULT
+--     PRIVILEGES already landed on these tables when they were created.
+{viewerColumnAcl}
 
 -- 3. config writes -- admin only.
 GRANT INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA {config} TO {admin};
@@ -258,3 +347,14 @@ GRANT CONNECT ON DATABASE {database} TO {admin}, {viewer};
         }
     }
 }
+
+/// <summary>
+/// One secret-bearing <c>config</c> table's viewer ACL split: the <paramref name="NonSecretColumns"/> the
+/// read-only <c>viewer</c> role is granted column-level SELECT on, and the <paramref name="SecretColumns"/>
+/// it is denied (credential blobs / bearer secrets). The two sets must PARTITION the table's real columns —
+/// the live security test asserts their union equals the table's actual column set, so a migration that adds
+/// a column without classifying it here fails that gate. See
+/// <see cref="DarlingManagedRoles.ViewerRestrictedConfigTables"/>.
+/// </summary>
+public sealed record ViewerSecretTableAcl(
+    string Table, IReadOnlyList<string> NonSecretColumns, IReadOnlyList<string> SecretColumns);

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -584,6 +584,14 @@ public sealed class DarlingWorker : BackgroundService
         {
             try
             {
+                /* Robustness (Stage 2 follow-up): before draining the queue, reclaim any command left
+                   in_progress by a crashed/restarted service instance so a Viewer polling it is not stranded
+                   forever. Cheap (an indexed UPDATE matching nothing in the normal case) and safe to run
+                   every tick — the 5-minute staleness margin can never catch a merely-slow live command. A
+                   reclaimed row is marked terminal 'failed' (not re-queued), so the drain below never re-runs
+                   a non-idempotent command; see DarlingCommandExecutor.ReclaimStaleCommandsSql. */
+                await executor.ReclaimStaleCommandsAsync(stoppingToken);
+
                 while (await executor.PollOnceAsync(stoppingToken))
                 {
                     if (stoppingToken.IsCancellationRequested)

--- a/Darling/tools/provision-roles.sql
+++ b/Darling/tools/provision-roles.sql
@@ -60,10 +60,37 @@ END $$;
 ALTER ROLE admin  LOGIN NOSUPERUSER PASSWORD 'CHANGE_ME_ADMIN_PASSWORD';
 ALTER ROLE viewer LOGIN NOSUPERUSER PASSWORD 'CHANGE_ME_VIEWER_PASSWORD';
 
--- 2. Schema usage + SELECT on everything that exists now (ALL TABLES covers tables AND views).
+-- 2. Schema usage + SELECT on everything that exists now (ALL TABLES covers tables AND views). collect
+--    holds no secrets, so admin+viewer read all of it. config: admin (the writer, and the Settings
+--    window's identity) reads every column; viewer reads all config tables too -- MINUS the secret columns
+--    carved in step 2b.
 GRANT USAGE ON SCHEMA collect, config TO admin, viewer;
 GRANT SELECT ON ALL TABLES IN SCHEMA collect TO admin, viewer;
 GRANT SELECT ON ALL TABLES IN SCHEMA config  TO admin, viewer;
+
+-- 2b. Credential-column fail-closed ACLs (#1262). The read-only viewer must NOT read the secret columns of
+--     the three credential-bearing config tables: config_monitored_servers.encrypted_password (a DPAPI
+--     password blob), config_command.args_json (the inline test_connect credential blob), and
+--     config_notification's SMTP password/username + Teams/Slack webhook URLs (a webhook URL is a bearer
+--     secret). Instead of GRANT-ALL-then-REVOKE-each-secret (fail-OPEN -- a future secret column leaks until
+--     someone revokes it), DROP viewer's table-wide SELECT on each and re-grant ONLY the non-secret columns
+--     (fail-CLOSED -- a column added later is invisible to viewer until you add it below). admin keeps its
+--     table-wide SELECT from step 2. Re-running this whole script re-asserts the carve idempotently. If a
+--     later schema upgrade ADDS a column to any of these three tables, add it to the matching GRANT list
+--     below (or, if it is itself secret, deliberately leave it out).
+REVOKE SELECT ON config.config_monitored_servers FROM viewer;
+GRANT SELECT (server_id, name, host, database, auth, username, encrypt_mode, trust_server_certificate,
+              read_only_intent, multi_subnet_failover, excluded_databases, monthly_cost_usd, capture_plans,
+              is_enabled, created_at, modified_at)
+    ON config.config_monitored_servers TO viewer;
+REVOKE SELECT ON config.config_command FROM viewer;
+GRANT SELECT (command_id, created_at, requested_by, command_type, target_server_id, status, claimed_at,
+              completed_at, result_status, result_json, service_instance)
+    ON config.config_command TO viewer;
+REVOKE SELECT ON config.config_notification FROM viewer;
+GRANT SELECT (id, smtp_host, smtp_port, smtp_use_ssl, smtp_from_address, smtp_recipients,
+              email_cooldown_minutes, teams_proxy, slack_proxy, modified_at)
+    ON config.config_notification TO viewer;
 
 -- 3. config writes -- admin only.
 GRANT INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA config TO admin;


### PR DESCRIPTION
Hardens the Darling control plane against three tracked security + robustness follow-ups from control-plane Stages 1-3. **Service + `Darling/tools` + `Darling.Tests` only** — no Viewer files touched, no `install/*.sql` touched. Security-sensitive: **please review, do not auto-merge.**

## Deliverable 1 — viewer credential-column ACLs (Medium security)

The read-only `viewer` Postgres role got `GRANT SELECT ON ALL TABLES IN SCHEMA config`, so it could read credential/secret columns it must not:
- `config_monitored_servers.encrypted_password` (a DPAPI password blob)
- `config_command.args_json` (carries the inline `test_connect` credential blob)
- `config_notification.smtp_encrypted_password`, `smtp_username`, `teams_url`, `slack_url` (a webhook URL is a bearer secret)

**Mechanism chosen: fail-CLOSED column-level grants (not GRANT-ALL-then-REVOKE-secrets).** For each of the three tables, the blanket `viewer` table-SELECT is dropped and only the enumerated **non-secret** columns are re-granted. A column added to one of these tables in a future migration is invisible to `viewer` until it is deliberately classified — the opposite of revoke-the-secrets, which silently exposes a new secret column until someone remembers to revoke it. `admin` keeps its full table-wide SELECT (it writes these tables; the Settings window connects as `admin`).

- The `REVOKE` used here revokes the **table-wide** grant (to undo the blanket grant and the V17 `ALTER DEFAULT PRIVILEGES` grant that already landed), then re-grants the explicit non-secret column list — so the effective grant is the fail-closed column list, not a revoke-per-secret. Justified in the code comments.
- Applied in **both** `DarlingManagedRoles.cs` (managed mode, re-run every startup so it converges an already-provisioned store with the old broad grant) **and** `Darling/tools/provision-roles.sql` (BYO re-run).
- The column split lives in **one** place — `DarlingManagedRoles.ViewerRestrictedConfigTables` — shared by the provisioning SQL and the live test, so the SQL and the assertion cannot drift.
- Residual, documented in code: a **new secret-bearing `config` table** in a future migration must be added to that list too (its `ALTER DEFAULT PRIVILEGES` table-grant to `viewer` would otherwise expose it). The live test's partition check (below) forces a secret/non-secret decision for any new **column** on the existing three.

### Live-PG ACL validation result (real Postgres 17, isolated scratch DB)
Applied the shipped `provision-roles.sql` to an isolated `darling_hardening_test` DB on the running PG17 (:5641), then connected as the **real `viewer` role**:
- **DENIED** (permission denied): `encrypted_password`, `args_json`, `smtp_encrypted_password`, `smtp_username`, `teams_url`, `slack_url`, and `SELECT *` on all three tables.
- **ALLOWED**: every non-secret column (16 / 11 / 10 across the three tables).
- **`admin`** keeps secret access (`encrypted_password` readable). Roles + scratch DB dropped after; the live `darling` store was never touched.

## Deliverable 2 — stale-command reaper (Stage 2 robustness)

A `config_command` claimed then abandoned (service crash/restart between claim and report) stayed `in_progress` forever, so a viewer polling it waited indefinitely. The command loop now reclaims `in_progress` rows whose `claimed_at` is older than a **5-minute** timeout.

- **Timeout = 5 min**, a wide margin over the slowest command (`test_connect` is bounded by the SQL connect timeout ~15-30s; `analyze_now` self-caps at 120s), so the reaper can never reap a command that is merely slow — only one genuinely abandoned. Hardcoded default, not a config knob.
- **Reclaim semantic = mark terminal `failed`** (`result_status` = "reclaimed (service restart or timeout)"), **not** re-queue to `pending`. Re-running is the unsafe choice: `snapshot_now` is not idempotent (a half-run already wrote its collector rows; a re-run double-writes and races the delta baselines), and a command that crashed the service would poison-loop on every reclaim. Failing terminal always unblocks the viewer's poll (the actual bug) and leaves idempotent commands for an operator to re-issue. It also scrubs `args_json` (Deliverable 3).
- Runs once per command-loop tick (an indexed UPDATE matching nothing in the normal case; a 0-row UPDATE writes no WAL).

## Deliverable 3 — `args_json` retention (Low security)

The terminal report-back UPDATE now sets `args_json = NULL`, so a `test_connect` command's inline credential blob does not linger after the probe runs; the reaper scrubs it the same way. Chose null-on-terminal (simplest, immediate) over a periodic purge.
- Transparent to the viewer: Stage 3a's `ViewerDataService.Commands.cs` terminal poll reads `status, result_status, result_json` (never `args`), and it already DELETEs `test_connect` rows post-read — so this is defense-in-depth for the non-test_connect / reaper / viewer-crashed-before-delete paths.
- `result_json` holds only probe facts / an error string, never a secret, so it is retained.

## Downstream interaction to route (not a defect in this PR)

After this ACL lands, `ViewerDataService.MonitoredServers` read SQL (merged in Stage 3a) explicitly selects `encrypted_password`. The viewer app connects as **`admin` by default (unaffected)**, but an opt-in read-only **`connectAs: "viewer"`** seat would now get 42501 on the server-list read. That is the intended security boundary; the Viewer-side follow-up is to select only non-secret columns for display (the secret is not needed to render the list). Flagged here for the lead / Viewer agent — Viewer files were deliberately not touched (concurrent work).

## Tests

- **New (ungated, shape):** viewer column-carve pins in `DarlingManagedRolesTests` (REVOKE + non-secret-only GRANT per table, no secret column appears in any viewer grant, secret/non-secret sets disjoint + non-empty, `BuildViewerColumnAclSql` honors schema/role); reaper + `ReportCommandSql` SQL-shape pins in `DarlingCommandExecutorTests`.
- **New (live, DARLING_TEST_PG):** `ViewerRole_DeniedSecretColumns_AllowedNonSecretColumns_OnAllThreeTables` — asserts `viewer` is denied each secret column (42501) + `SELECT *`, allowed every non-secret column, on all three tables, **and** that the non-secret ∪ secret sets **partition** the table's actual columns (a migration that adds a column without classifying it fails this gate). Reaper round-trip: a stale `in_progress` row past the timeout is reclaimed `failed` + `args_json` scrubbed; a fresh one is untouched. `args_json` null-on-terminal asserted in the enable_collector round-trip.
- **Fixed two pre-existing latent live-test bugs** surfaced by running the DARLING_TEST_PG gate (CI skips it, so they had rotted): a `jsonb::text` assertion expecting no space after the colon, and a schema-version row-count pinned to a stale literal `15` → now references `StorageVersion.SchemaVersion` so it can't rot again.

`Darling.Tests -c Release` against the scratch DB: **1170 passed / 5 skipped / 1 failed**. The single failure is `DarlingSecuritySplitLiveTests.V8_Moves...`, a **pre-existing full-suite parallel-execution race** on the shared store (other live-PG test classes not in the `live-postgres` collection mutate it concurrently during V8's `SET SCHEMA`). It **passes cleanly in isolation** (the whole security-split class: 5 pass / 1 skip), my changes touch neither the V8 test, its migration, nor the V8 SQL, and — because the two latent bugs I fixed were also live-only — the live suite was never green before this PR either. Fixing the test-collection parallelism is a separate test-infra change, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
