### PR TITLE
Stage 3b: viewer Settings + on-demand actions drive the control-plane store

### DIFF
--- a/Darling/Darling.Tests/ViewerControlPlaneStage3bTests.cs
+++ b/Darling/Darling.Tests/ViewerControlPlaneStage3bTests.cs
@@ -1,0 +1,467 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using PerformanceMonitor.Collectors;
+using PerformanceMonitor.Darling.Service;
+using PerformanceMonitor.Darling.Viewer;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Stage 3b — the viewer's control-plane writes for the OPERATOR config sections: alert settings, notification
+/// (SMTP + webhooks), the service flags, and the collector-schedule overrides. Pins the SQL shape
+/// (parameterization, single-row id=1 upserts, the sparse-schedule ON CONFLICT arbiters) + the column parity
+/// with the service's <see cref="StoreConfigProvider"/>, plus the pure overlay/preset/migration logic — all
+/// with no live Postgres, exactly like the Stage-3a server + mute pins.
+/// </summary>
+public sealed class ViewerAlertSettingsSqlTests
+{
+    /* The 27 AlertsConfig + AnalysisConfig columns the service reads (StoreConfigProvider.ReadAlertSettingsAsync). */
+    private static readonly string[] Columns =
+    {
+        "enabled", "cpu_enabled", "cpu_threshold_percent", "cpu_mode", "blocking_enabled", "blocking_count_threshold",
+        "deadlock_enabled", "deadlock_count_threshold", "poison_wait_enabled", "poison_wait_threshold_ms",
+        "long_running_query_enabled", "long_running_query_threshold_minutes", "tempdb_space_enabled",
+        "tempdb_space_threshold_percent", "low_disk_enabled", "low_disk_threshold_percent", "low_disk_threshold_gb",
+        "long_running_job_enabled", "long_running_job_multiplier", "failed_job_enabled", "failed_job_lookback_minutes",
+        "cooldown_minutes", "excluded_databases", "analysis_enabled", "analysis_interval_minutes",
+        "analysis_notifications_enabled", "analysis_notify_severity",
+    };
+
+    [Fact]
+    public void UpsertSql_WritesEveryColumn_AsBoundParameters_SingleRowOnConflictUpdate()
+    {
+        var sql = ViewerDataService.AlertSettingsUpsertSql;
+
+        Assert.Contains("INSERT INTO config_alert_settings", sql, StringComparison.Ordinal);
+        Assert.Contains("VALUES (1,", sql, StringComparison.Ordinal); /* pinned to the single global row */
+        foreach (var column in Columns)
+        {
+            Assert.Contains(column, sql, StringComparison.Ordinal);
+        }
+
+        for (var i = 1; i <= 27; i++)
+        {
+            Assert.Contains("$" + i.ToString(System.Globalization.CultureInfo.InvariantCulture), sql, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("ON CONFLICT (id) DO UPDATE", sql, StringComparison.Ordinal);
+        Assert.Contains("modified_at = (now() AT TIME ZONE 'UTC')", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SelectSql_ReadsEveryColumn_FromTheSingleRow()
+    {
+        var sql = ViewerDataService.AlertSettingsSelectSql;
+        Assert.Contains("FROM config_alert_settings WHERE id = 1", sql, StringComparison.Ordinal);
+        foreach (var column in Columns)
+        {
+            Assert.Contains(column, sql, StringComparison.Ordinal);
+        }
+    }
+
+    [Theory]
+    [InlineData("Total", "total")]
+    [InlineData("SqlOnly", "sql")]
+    public void CpuMode_MapsToTheServiceVocabulary_RoundTrips(string viewer, string store)
+    {
+        /* The service compares cpu_mode case-insensitively against "sql"; the viewer must emit that word. */
+        Assert.Equal(store, ViewerDataService.MapCpuModeToStore(viewer));
+        Assert.Equal(viewer, ViewerDataService.MapCpuModeFromStore(store));
+    }
+
+    [Fact]
+    public void DefaultsRow_EqualsItself_AndDiffersOnAnyChange()
+    {
+        var a = AlertSettingsRow.Defaults();
+        Assert.True(a.ValueEquals(AlertSettingsRow.Defaults()));
+
+        var b = AlertSettingsRow.Defaults();
+        b.CpuThresholdPercent = 55;
+        Assert.False(a.ValueEquals(b));
+
+        var c = AlertSettingsRow.Defaults();
+        c.ExcludedDatabases = new List<string> { "msdb" };
+        Assert.False(a.ValueEquals(c));
+    }
+}
+
+/// <summary>The notification write partial: SQL shape + the DPAPI SMTP blob (never plaintext into Postgres).</summary>
+public sealed class ViewerNotificationSqlTests
+{
+    private static readonly string[] Columns =
+    {
+        "smtp_host", "smtp_port", "smtp_use_ssl", "smtp_username", "smtp_encrypted_password", "smtp_from_address",
+        "smtp_recipients", "email_cooldown_minutes", "teams_url", "teams_proxy", "slack_url", "slack_proxy",
+    };
+
+    [Fact]
+    public void UpsertSql_WritesEveryColumn_AsBoundParameters_SingleRowOnConflictUpdate()
+    {
+        var sql = ViewerDataService.NotificationUpsertSql;
+        Assert.Contains("INSERT INTO config_notification", sql, StringComparison.Ordinal);
+        Assert.Contains("VALUES (1,", sql, StringComparison.Ordinal);
+        foreach (var column in Columns)
+        {
+            Assert.Contains(column, sql, StringComparison.Ordinal);
+        }
+
+        for (var i = 1; i <= 12; i++)
+        {
+            Assert.Contains("$" + i.ToString(System.Globalization.CultureInfo.InvariantCulture), sql, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("ON CONFLICT (id) DO UPDATE", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SelectSql_ReadsEveryColumn_FromTheSingleRow()
+    {
+        var sql = ViewerDataService.NotificationSelectSql;
+        Assert.Contains("FROM config_notification WHERE id = 1", sql, StringComparison.Ordinal);
+        foreach (var column in Columns)
+        {
+            Assert.Contains(column, sql, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void SmtpPassword_IsSealedAsAServiceReadableBlob_NeverPlaintext()
+    {
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "DPAPI requires Windows.");
+
+        var settings = new ViewerAppSettings
+        {
+            SmtpEnabled = true,
+            SmtpServer = "smtp.contoso.com",
+            SmtpFromAddress = "alerts@contoso.com",
+            SmtpRecipients = "dba@contoso.com",
+        };
+
+        var row = ViewerControlPlaneMigration.BuildNotificationRow(settings, "hunter2", "", "");
+
+        Assert.NotNull(row.SmtpEncryptedPassword);
+        Assert.NotEqual("hunter2", row.SmtpEncryptedPassword); /* not plaintext */
+        /* The SERVICE must be able to read what the viewer sealed (identical DPAPI entropy + scope). */
+        Assert.Equal("hunter2", DarlingSecrets.Unprotect(row.SmtpEncryptedPassword!));
+    }
+
+    [Fact]
+    public void DisabledChannels_WriteEmptyFields_SoTheServiceTreatsThemOff()
+    {
+        var settings = new ViewerAppSettings
+        {
+            SmtpEnabled = false,
+            SmtpServer = "smtp.contoso.com", /* typed but disabled */
+            TeamsWebhookEnabled = false,
+            SlackWebhookEnabled = false,
+        };
+
+        var row = ViewerControlPlaneMigration.BuildNotificationRow(settings, "pw", "https://teams", "https://slack");
+
+        Assert.Equal("", row.SmtpHost);
+        Assert.Null(row.SmtpEncryptedPassword);
+        Assert.Equal("", row.TeamsUrl);
+        Assert.Equal("", row.SlackUrl);
+    }
+}
+
+/// <summary>The service-config write partial: the flag update touches only the viewer-owned columns (never
+/// paused), and the reload-signal touch bumps the beacon (F16).</summary>
+public sealed class ViewerServiceConfigSqlTests
+{
+    [Fact]
+    public void UpdateFlagsSql_SetsOnlyCapturePlansMcp_OnTheSingleRow_NeverPaused()
+    {
+        var sql = ViewerDataService.ServiceConfigUpdateFlagsSql;
+        Assert.Contains("UPDATE config_service", sql, StringComparison.Ordinal);
+        Assert.Contains("capture_plans = $1", sql, StringComparison.Ordinal);
+        Assert.Contains("mcp_enabled = $2", sql, StringComparison.Ordinal);
+        Assert.Contains("mcp_port = $3", sql, StringComparison.Ordinal);
+        Assert.Contains("WHERE id = 1", sql, StringComparison.Ordinal);
+        /* paused is a command, not a settings write — the flag update must never touch it. */
+        Assert.DoesNotContain("paused", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SelectSql_ReadsPausedAndTheThreeFlags()
+    {
+        Assert.Contains("SELECT paused, capture_plans, mcp_enabled, mcp_port FROM config_service WHERE id = 1",
+            ViewerDataService.ServiceConfigSelectSql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ReloadSignalSql_TouchesConfigService_ToBumpTheBeacon_WithoutChangingAFlag()
+    {
+        /* F16: config_mute_rules has no bump trigger, so a viewer mute write must touch config_service to fire
+           the self-bump (config_version++) and make the service re-LoadAsync() its mute cache next sweep. */
+        var sql = ViewerDataService.ConfigReloadSignalSql;
+        Assert.Contains("UPDATE config_service SET updated_at = (now() AT TIME ZONE 'UTC') WHERE id = 1", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("paused", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("capture_plans", sql, StringComparison.Ordinal);
+    }
+}
+
+/// <summary>The collector-schedule write partial: the sparse-table ON CONFLICT arbiters must match V17's partial
+/// unique indexes AND the service's own enable/disable_collector upsert shape.</summary>
+public sealed class ViewerCollectorSchedulesSqlTests
+{
+    [Fact]
+    public void FleetUpsert_ArbitratesOnCollectorName_WhereServerIdIsNull()
+    {
+        var sql = ViewerDataService.CollectorScheduleFleetUpsertSql;
+        Assert.Contains("INSERT INTO config_collector_schedules", sql, StringComparison.Ordinal);
+        Assert.Contains("VALUES (NULL, $1, $2, $3, $4)", sql, StringComparison.Ordinal);
+        Assert.Contains("ON CONFLICT (collector_name) WHERE server_id IS NULL DO UPDATE", sql, StringComparison.Ordinal);
+        Assert.Contains("frequency_minutes = EXCLUDED.frequency_minutes", sql, StringComparison.Ordinal);
+        Assert.Contains("retention_days = EXCLUDED.retention_days", sql, StringComparison.Ordinal);
+        Assert.Contains("enabled = EXCLUDED.enabled", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ServerUpsert_ArbitratesOnServerIdCollectorName_WhereServerIdIsNotNull()
+    {
+        var sql = ViewerDataService.CollectorScheduleServerUpsertSql;
+        Assert.Contains("VALUES ($1, $2, $3, $4, $5)", sql, StringComparison.Ordinal);
+        Assert.Contains("ON CONFLICT (server_id, collector_name) WHERE server_id IS NOT NULL DO UPDATE", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DeleteScopeSql_KeyOnTheScope()
+    {
+        Assert.Contains("DELETE FROM config_collector_schedules WHERE server_id IS NULL",
+            ViewerDataService.CollectorScheduleDeleteFleetScopeSql, StringComparison.Ordinal);
+        Assert.Contains("DELETE FROM config_collector_schedules WHERE server_id = $1",
+            ViewerDataService.CollectorScheduleDeleteServerScopeSql, StringComparison.Ordinal);
+    }
+}
+
+/// <summary>The pure store↔editor overlay + the preset table (ported from Lite, frequency-only).</summary>
+public sealed class ViewerCollectorScheduleLogicTests
+{
+    [Fact]
+    public void BuildDefaultSchedule_CoversEveryKnownCollector_AtItsCodeDefault()
+    {
+        var schedule = CollectorSchedulePresets.BuildDefaultSchedule();
+        Assert.Equal(CollectorScheduleDefaults.All.Count, schedule.Count);
+
+        foreach (var item in schedule)
+        {
+            var def = CollectorScheduleDefaults.All[item.Name];
+            Assert.Equal(def.FrequencyMinutes, item.FrequencyMinutes);
+            Assert.Equal(def.RetentionDays, item.RetentionDays);
+            Assert.True(item.Enabled);
+        }
+    }
+
+    [Fact]
+    public void Presets_OnlyReferenceKnownCollectors()
+    {
+        foreach (var (_, intervals) in CollectorSchedulePresets.Presets)
+        {
+            foreach (var collector in intervals.Keys)
+            {
+                Assert.True(CollectorScheduleDefaults.All.ContainsKey(collector), $"preset references unknown collector '{collector}'");
+            }
+        }
+    }
+
+    [Fact]
+    public void ApplyPreset_ChangesFrequenciesOnly_AndDetectRoundTrips()
+    {
+        var schedule = CollectorSchedulePresets.BuildDefaultSchedule();
+        var retentionBefore = schedule.ToDictionary(s => s.Name, s => s.RetentionDays);
+
+        CollectorSchedulePresets.ApplyPreset(schedule, "Low-Impact");
+
+        /* Frequencies now match the Low-Impact table; retention untouched. */
+        Assert.Equal(30, schedule.First(s => s.Name == "query_store").FrequencyMinutes);
+        foreach (var item in schedule)
+        {
+            Assert.Equal(retentionBefore[item.Name], item.RetentionDays);
+        }
+
+        Assert.Equal("Low-Impact", CollectorSchedulePresets.DetectPreset(schedule));
+    }
+
+    [Fact]
+    public void Overlay_FleetRowWins_OverCodeDefault_AndPerServerWinsOverFleet()
+    {
+        var overrides = new List<CollectorScheduleRow>
+        {
+            new(null, "wait_stats", 9, null, true),   /* fleet: freq 9 (retention falls through) */
+            new(1234, "wait_stats", 3, 45, true),     /* server 1234: freq 3, retention 45 */
+        };
+
+        var fleet = CollectorScheduleOverlay.BuildEffectiveSchedule(overrides, serverId: null)
+            .First(s => s.Name == "wait_stats");
+        Assert.Equal(9, fleet.FrequencyMinutes);
+        Assert.Equal(CollectorScheduleDefaults.All["wait_stats"].RetentionDays, fleet.RetentionDays); /* NULL fell through */
+
+        var server = CollectorScheduleOverlay.BuildEffectiveSchedule(overrides, serverId: 1234)
+            .First(s => s.Name == "wait_stats");
+        Assert.Equal(3, server.FrequencyMinutes);
+        Assert.Equal(45, server.RetentionDays);
+    }
+
+    [Fact]
+    public void FleetOverrideRows_AreSparse_OnlyForCollectorsDifferingFromDefault()
+    {
+        var edited = CollectorSchedulePresets.BuildDefaultSchedule();
+        edited.First(s => s.Name == "wait_stats").FrequencyMinutes = 15; /* the only change */
+
+        var rows = CollectorScheduleOverlay.ToFleetOverrideRows(edited);
+
+        var row = Assert.Single(rows);
+        Assert.Null(row.ServerId);
+        Assert.Equal("wait_stats", row.CollectorName);
+        Assert.Equal(15, row.FrequencyMinutes);
+    }
+
+    [Fact]
+    public void ServerOverrideRows_AreAFullSnapshot_ForWysiwyg()
+    {
+        var edited = CollectorSchedulePresets.BuildDefaultSchedule();
+        var rows = CollectorScheduleOverlay.ToServerOverrideRows(edited, serverId: 7);
+
+        Assert.Equal(CollectorScheduleDefaults.All.Count, rows.Count);
+        Assert.All(rows, r => Assert.Equal(7, r.ServerId));
+    }
+
+    [Fact]
+    public void ServerHasOverride_ReflectsTheServersRows()
+    {
+        var overrides = new List<CollectorScheduleRow> { new(7, "wait_stats", 5, null, true) };
+        Assert.True(CollectorScheduleOverlay.ServerHasOverride(overrides, 7));
+        Assert.False(CollectorScheduleOverlay.ServerHasOverride(overrides, 8));
+    }
+}
+
+/// <summary>The viewer's control commands agree with the service executor's dispatch (the two ends must use the
+/// same command_type words).</summary>
+public sealed class ViewerControlCommandParityTests
+{
+    private static ClaimedCommand Command(string type, int? target = null) => new(1, type, target, null, "viewer");
+
+    [Fact]
+    public void PauseResume_AreRecognizedStoreWrites()
+    {
+        Assert.Equal("pause", ViewerDataService.CommandPause);
+        Assert.Equal("resume", ViewerDataService.CommandResume);
+        Assert.Equal(CommandKind.StoreWrite, DarlingCommandExecutor.ResolvePlan(Command(ViewerDataService.CommandPause)).Kind);
+        Assert.Equal(CommandKind.StoreWrite, DarlingCommandExecutor.ResolvePlan(Command(ViewerDataService.CommandResume)).Kind);
+    }
+
+    [Fact]
+    public void SnapshotAnalyze_AreRecognizedImperatives_RequiringATarget()
+    {
+        Assert.Equal("snapshot_now", ViewerDataService.CommandSnapshotNow);
+        Assert.Equal("analyze_now", ViewerDataService.CommandAnalyzeNow);
+
+        Assert.Equal(CommandKind.Snapshot, DarlingCommandExecutor.ResolvePlan(Command(ViewerDataService.CommandSnapshotNow, target: 1)).Kind);
+        Assert.Equal(CommandKind.Analyze, DarlingCommandExecutor.ResolvePlan(Command(ViewerDataService.CommandAnalyzeNow, target: 1)).Kind);
+
+        /* Without a target they fail — matching the viewer only ever sending them with a server id. */
+        Assert.Equal(CommandKind.Fail, DarlingCommandExecutor.ResolvePlan(Command(ViewerDataService.CommandSnapshotNow)).Kind);
+        Assert.Equal(CommandKind.Fail, DarlingCommandExecutor.ResolvePlan(Command(ViewerDataService.CommandAnalyzeNow)).Kind);
+    }
+}
+
+/// <summary>The one-time operational migrate-in: the defaults-only import decision + the projection, with no
+/// live store or vault.</summary>
+public sealed class ViewerControlPlaneMigrationTests
+{
+    [Fact]
+    public void ShouldImportAlerts_OnlyWhenStoreIsDefault_AndViewerDiffers()
+    {
+        var defaults = AlertSettingsRow.Defaults();
+
+        var viewerCustom = AlertSettingsRow.Defaults();
+        viewerCustom.CpuThresholdPercent = 60;
+
+        Assert.True(ViewerControlPlaneMigration.ShouldImportAlerts(AlertSettingsRow.Defaults(), viewerCustom));  /* store default, viewer differs */
+        Assert.False(ViewerControlPlaneMigration.ShouldImportAlerts(AlertSettingsRow.Defaults(), defaults));      /* viewer also default -> nothing to carry */
+
+        var storeCustom = AlertSettingsRow.Defaults();
+        storeCustom.CpuThresholdPercent = 95;
+        Assert.False(ViewerControlPlaneMigration.ShouldImportAlerts(storeCustom, viewerCustom));                  /* store already tuned -> never clobber */
+    }
+
+    [Fact]
+    public void ShouldImportMcp_OnlyWhenStoreMcpIsDefault_AndViewerDiffers()
+    {
+        var storeDefault = new ServiceConfigRow();                                  /* mcp off, 5152 */
+        var storeTuned = new ServiceConfigRow { McpEnabled = true, McpPort = 6000 };
+
+        Assert.True(ViewerControlPlaneMigration.ShouldImportMcp(storeDefault, new ViewerAppSettings { McpEnabled = true }));
+        Assert.False(ViewerControlPlaneMigration.ShouldImportMcp(storeDefault, new ViewerAppSettings()));         /* viewer also default */
+        Assert.False(ViewerControlPlaneMigration.ShouldImportMcp(storeTuned, new ViewerAppSettings { McpEnabled = true }));
+    }
+
+    [Fact]
+    public void BuildAlertRow_ProjectsEveryFieldAndMapsCpuMode()
+    {
+        var settings = new ViewerAppSettings
+        {
+            AlertsEnabled = false,
+            AlertCpuThreshold = 66,
+            AlertCpuMode = "SqlOnly",
+            AlertExcludedDatabases = new List<string> { "msdb", "tempdb" },
+            AnalysisIntervalMinutes = 45,
+            AnalysisNotifySeverity = 1.2,
+        };
+
+        var row = ViewerControlPlaneMigration.BuildAlertRow(settings);
+
+        Assert.False(row.Enabled);
+        Assert.Equal(66, row.CpuThresholdPercent);
+        Assert.Equal("sql", row.CpuMode);
+        Assert.Equal(new[] { "msdb", "tempdb" }, row.ExcludedDatabases);
+        Assert.Equal(45, row.AnalysisIntervalMinutes);
+        Assert.Equal(1.2, row.AnalysisNotifySeverity, 3);
+    }
+
+    [Fact]
+    public async Task MigrateAsync_Disconnected_IsANoOp_AndLeavesTheMarkerUnwritten()
+    {
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "The migrate-in path is Windows-only (DPAPI secret re-seal).");
+
+        using var dir = new TempDir();
+        var marker = Path.Combine(dir.Path, "cp.marker");
+        var migration = new ViewerControlPlaneMigration(new ViewerAppSettings(), marker);
+
+        var imported = await migration.MigrateAsync(dataService: null);
+
+        Assert.Equal(0, imported);
+        Assert.False(migration.AlreadyMigrated);
+        Assert.False(File.Exists(marker));
+    }
+
+    [Fact]
+    public void Marker_GatesTheOnceGuard()
+    {
+        using var dir = new TempDir();
+        var marker = Path.Combine(dir.Path, "cp.marker");
+        Assert.False(new ViewerControlPlaneMigration(new ViewerAppSettings(), marker).AlreadyMigrated);
+
+        File.WriteAllText(marker, "done");
+        Assert.True(new ViewerControlPlaneMigration(new ViewerAppSettings(), marker).AlreadyMigrated);
+    }
+
+    private sealed class TempDir : IDisposable
+    {
+        public string Path { get; } = Directory.CreateTempSubdirectory("darling-cp3b-").FullName;
+        public void Dispose() { try { Directory.Delete(Path, recursive: true); } catch { /* best-effort */ } }
+    }
+}

--- a/Darling/Darling.Tests/ViewerControlPlaneStage3bTests.cs
+++ b/Darling/Darling.Tests/ViewerControlPlaneStage3bTests.cs
@@ -459,6 +459,29 @@ public sealed class ViewerControlPlaneMigrationTests
         Assert.True(new ViewerControlPlaneMigration(new ViewerAppSettings(), marker).AlreadyMigrated);
     }
 
+    [Fact]
+    public async Task MigrateAsync_UnseededOrUnreachableStore_IsANoOp_AndLeavesTheMarkerUnwritten()
+    {
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "The migrate-in path is Windows-only (DPAPI secret re-seal).");
+
+        using var dir = new TempDir();
+        var marker = Path.Combine(dir.Path, "cp.marker");
+
+        /* An unreachable store: IsConfigSeededAsync fails safe to false, so the migrate must import nothing AND
+           NOT burn the once-marker (a later, seeded run still carries the operator's settings across). This
+           pins the seeded-guard that prevents a partially-seeded store from stranding the import. Port 1 has no
+           listener -> a fast connection-refused; Timeout=1 caps it. */
+        await using var dataService = new ViewerDataService(
+            "Host=127.0.0.1;Port=1;Username=x;Password=x;Timeout=1;Command Timeout=1");
+        var migration = new ViewerControlPlaneMigration(new ViewerAppSettings(), marker);
+
+        var imported = await migration.MigrateAsync(dataService);
+
+        Assert.Equal(0, imported);
+        Assert.False(migration.AlreadyMigrated);
+        Assert.False(File.Exists(marker));
+    }
+
     private sealed class TempDir : IDisposable
     {
         public string Path { get; } = Directory.CreateTempSubdirectory("darling-cp3b-").FullName;

--- a/Darling/PerformanceMonitor.Darling.Viewer/CollectorScheduleEditorWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/CollectorScheduleEditorWindow.xaml
@@ -1,0 +1,98 @@
+<Window x:Class="PerformanceMonitor.Darling.Viewer.CollectorScheduleEditorWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Collector Schedules"
+        Height="620" Width="760"
+        MinHeight="440" MinWidth="620"
+        WindowStartupLocation="CenterOwner"
+        Icon="EDD.ico"
+        ResizeMode="CanResizeWithGrip"
+        Background="#22252b"
+        Foreground="#E4E6EB">
+    <!-- The Darling viewer's collector-schedule editor: a faithful port of Lite's CollectorScheduleEditorWindow,
+         rewired to write the control-plane config.config_collector_schedules the running service honors (scope =
+         All servers / a specific server; presets change frequencies only). Dark-styled via the shared
+         ViewerDarkTheme resource dictionary, like the other write-back dialogs. -->
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="ViewerDarkTheme.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Window.Resources>
+
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0" Margin="0,0,0,10">
+            <TextBlock x:Name="HeaderText" Text="Collector Schedules" FontSize="18" FontWeight="Bold"/>
+            <TextBlock x:Name="SubHeaderText" FontSize="12" Foreground="{StaticResource DimTextBrush}" Margin="0,4,0,0" TextWrapping="Wrap"
+                       Text="Override how often the Darling service collects each metric, and how long it keeps it. Blank overrides fall back to the built-in defaults."/>
+            <TextBlock x:Name="ReadOnlyBanner" FontSize="12" Foreground="#E0A030" Margin="0,6,0,0" TextWrapping="Wrap"
+                       Visibility="Collapsed"
+                       Text="This viewer is connected with a read-only role, so collector schedules can't be changed here."/>
+        </StackPanel>
+
+        <!-- Scope + use-default -->
+        <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,0,0,8">
+            <TextBlock Text="Scope:" VerticalAlignment="Center" Margin="0,0,8,0"/>
+            <ComboBox x:Name="ScopeCombo" Width="280" VerticalAlignment="Center"
+                      SelectionChanged="ScopeCombo_SelectionChanged"
+                      ToolTip="Edit the fleet-wide default schedule or one server's custom override"/>
+            <CheckBox x:Name="UseDefaultCheckBox" Content="Use default schedule" VerticalAlignment="Center" Margin="20,0,0,0"
+                      Visibility="Collapsed"
+                      Checked="UseDefaultCheckBox_Changed" Unchecked="UseDefaultCheckBox_Changed"
+                      ToolTip="When checked, this server follows the fleet-wide default (no custom override)"/>
+        </StackPanel>
+
+        <!-- Preset + copy/reset -->
+        <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,0,0,8">
+            <TextBlock Text="Preset:" VerticalAlignment="Center" Margin="0,0,8,0"/>
+            <ComboBox x:Name="PresetCombo" Width="150" VerticalAlignment="Center"
+                      SelectionChanged="PresetCombo_SelectionChanged"
+                      ToolTip="Bulk-set collection frequencies; enabled state and retention are not affected">
+                <ComboBoxItem Content="Custom"/>
+                <ComboBoxItem Content="Aggressive"/>
+                <ComboBoxItem Content="Balanced"/>
+                <ComboBoxItem Content="Low-Impact"/>
+            </ComboBox>
+            <Button x:Name="ResetDefaultsButton" Content="Reset to Defaults" Margin="16,0,0,0" Click="ResetDefaults_Click"
+                    ToolTip="Replace the current values with the built-in default frequencies and retention"/>
+            <TextBlock Text="Copy from:" VerticalAlignment="Center" Margin="20,0,8,0"/>
+            <ComboBox x:Name="CopyFromServerCombo" Width="180" VerticalAlignment="Center"/>
+            <Button x:Name="CopyFromServerButton" Content="Copy" Margin="8,0,0,0" Click="CopyFromServer_Click"
+                    ToolTip="Replace these values with a copy of another server's effective schedule"/>
+        </StackPanel>
+
+        <TextBlock Grid.Row="3" x:Name="StatusText" FontSize="11" FontStyle="Italic"
+                   Foreground="{StaticResource DimTextBrush}" Margin="0,0,0,6" TextWrapping="Wrap"/>
+
+        <DataGrid Grid.Row="4" x:Name="ScheduleGrid" Style="{StaticResource DarkGrid}"
+                  AutoGenerateColumns="False" CanUserAddRows="False" CanUserDeleteRows="False"
+                  HeadersVisibility="Column" HorizontalScrollBarVisibility="Auto">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Collector" Binding="{Binding Name}" Width="180" IsReadOnly="True"/>
+                <DataGridCheckBoxColumn Header="Enabled" Binding="{Binding Enabled, UpdateSourceTrigger=PropertyChanged}" Width="70"/>
+                <DataGridTextColumn Header="Every (min)" Binding="{Binding FrequencyMinutes}" Width="90"/>
+                <DataGridTextColumn Header="Keep (days)" Binding="{Binding RetentionDays}" Width="90"/>
+                <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="*" IsReadOnly="True"/>
+            </DataGrid.Columns>
+        </DataGrid>
+
+        <TextBlock Grid.Row="5" Margin="0,8,0,0" FontSize="11" Foreground="{StaticResource DimTextBrush}" TextWrapping="Wrap"
+                   Text="Every (min): 0 collects once on server load. Keep (days) must be at least 1. Changes apply on the service's next reload."/>
+
+        <StackPanel Grid.Row="6" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
+            <Button x:Name="SaveButton" Content="Save" Click="SaveButton_Click" Margin="0,0,8,0" MinWidth="80"/>
+            <Button Content="Cancel" Click="CancelButton_Click" MinWidth="80"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Darling/PerformanceMonitor.Darling.Viewer/CollectorScheduleEditorWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/CollectorScheduleEditorWindow.xaml.cs
@@ -1,0 +1,354 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The viewer's collector-schedule editor — a faithful port of Lite's <c>CollectorScheduleEditorWindow</c>,
+/// rewired onto the control-plane store: it edits the fleet-wide default schedule (<c>server_id</c> NULL) or a
+/// single server's override, overlays the store's sparse <c>config.config_collector_schedules</c> rows on the
+/// shared <see cref="CollectorSchedulePresets.BuildDefaultSchedule"/> baseline, and writes the result back via
+/// <see cref="ViewerDataService.ReplaceFleetSchedulesAsync"/> / <see cref="ViewerDataService.ReplaceServerSchedulesAsync"/>.
+/// Presets change frequencies only (enabled + retention untouched), exactly as Lite. A read-only seat shows a
+/// banner and disables the writes.
+/// </summary>
+public partial class CollectorScheduleEditorWindow : Window
+{
+    private readonly ViewerDataService _dataService;
+    private readonly IReadOnlyList<DarlingServer> _servers;
+
+    private List<CollectorScheduleRow> _allOverrides = new();
+    private List<CollectorScheduleEditItem> _editing = new();
+    private int? _scopeServerId;           // null = fleet-wide default scope
+    private bool _suppressPresetChange;
+    private bool _suppressScopeReload;
+
+    /// <summary>True when the user saved changes (the caller then re-reads if it cares).</summary>
+    public bool Saved { get; private set; }
+
+    public CollectorScheduleEditorWindow(ViewerDataService dataService, IReadOnlyList<DarlingServer> servers)
+    {
+        ArgumentNullException.ThrowIfNull(dataService);
+        ArgumentNullException.ThrowIfNull(servers);
+
+        InitializeComponent();
+        _dataService = dataService;
+        _servers = servers;
+
+        Loaded += OnLoaded;
+    }
+
+    private async void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        Loaded -= OnLoaded;
+
+        if (_dataService.IsReadOnly)
+        {
+            ReadOnlyBanner.Visibility = Visibility.Visible;
+            SaveButton.IsEnabled = false;
+        }
+
+        PopulateScopeCombos();
+
+        try
+        {
+            _allOverrides = await _dataService.GetCollectorSchedulesAsync();
+        }
+        catch (Exception ex)
+        {
+            _allOverrides = new List<CollectorScheduleRow>();
+            StatusText.Text = $"Could not read the current schedules: {ex.Message}";
+        }
+
+        /* Default to the fleet scope (index 0). */
+        _suppressScopeReload = true;
+        ScopeCombo.SelectedIndex = 0;
+        _suppressScopeReload = false;
+        LoadScopeSchedule();
+    }
+
+    private void PopulateScopeCombos()
+    {
+        ScopeCombo.Items.Clear();
+        ScopeCombo.Items.Add(new ComboBoxItem { Content = "All servers (default schedule)", Tag = null });
+        foreach (var server in _servers)
+        {
+            ScopeCombo.Items.Add(new ComboBoxItem { Content = server.DisplayName, Tag = server.ServerId });
+        }
+
+        CopyFromServerCombo.ItemsSource = _servers;
+        CopyFromServerCombo.DisplayMemberPath = nameof(DarlingServer.DisplayName);
+        if (_servers.Count > 0)
+        {
+            CopyFromServerCombo.SelectedIndex = 0;
+        }
+        else
+        {
+            CopyFromServerCombo.IsEnabled = false;
+            CopyFromServerButton.IsEnabled = false;
+        }
+    }
+
+    private void ScopeCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_suppressScopeReload)
+        {
+            return;
+        }
+
+        LoadScopeSchedule();
+    }
+
+    private void LoadScopeSchedule()
+    {
+        _scopeServerId = (ScopeCombo.SelectedItem as ComboBoxItem)?.Tag as int?;
+
+        var isServerScope = _scopeServerId is not null;
+        UseDefaultCheckBox.Visibility = isServerScope ? Visibility.Visible : Visibility.Collapsed;
+
+        if (isServerScope)
+        {
+            HeaderText.Text = $"Collector Schedules — {(ScopeCombo.SelectedItem as ComboBoxItem)?.Content}";
+            SubHeaderText.Text = "This server's custom schedule. Uncheck 'Use default schedule' to override the fleet-wide defaults for it.";
+            var hasOverride = CollectorScheduleOverlay.ServerHasOverride(_allOverrides, _scopeServerId!.Value);
+
+            _suppressPresetChange = true;
+            UseDefaultCheckBox.IsChecked = !hasOverride;
+            _suppressPresetChange = false;
+        }
+        else
+        {
+            HeaderText.Text = "Collector Schedules — All servers";
+            SubHeaderText.Text = "The fleet-wide default schedule. Every server without its own override collects on this schedule.";
+        }
+
+        RebuildEditingForScope();
+    }
+
+    /// <summary>Rebuilds the editable list for the current scope + use-default state and re-binds the grid.</summary>
+    private void RebuildEditingForScope()
+    {
+        var usesDefault = _scopeServerId is not null && UseDefaultCheckBox.IsChecked == true;
+
+        /* Fleet scope, or a server "using default", shows the fleet-over-default effective (server rows
+           excluded); a customizing server shows its own effective schedule. */
+        var overlayScope = usesDefault ? (int?)null : _scopeServerId;
+        _editing = CollectorScheduleOverlay.BuildEffectiveSchedule(_allOverrides, overlayScope);
+
+        BindGrid();
+        UpdateEditableState(!usesDefault);
+        DetectActivePreset();
+    }
+
+    private void BindGrid()
+    {
+        ScheduleGrid.ItemsSource = null;
+        ScheduleGrid.ItemsSource = _editing;
+    }
+
+    private void UpdateEditableState(bool editable)
+    {
+        var writable = editable && !_dataService.IsReadOnly;
+        ScheduleGrid.IsReadOnly = !writable;
+        ScheduleGrid.Opacity = writable ? 1.0 : 0.6;
+        PresetCombo.IsEnabled = writable;
+        ResetDefaultsButton.IsEnabled = writable;
+        CopyFromServerCombo.IsEnabled = writable && _servers.Count > 0;
+        CopyFromServerButton.IsEnabled = writable && _servers.Count > 0;
+
+        if (_dataService.IsReadOnly)
+        {
+            StatusText.Text = "Read-only connection — schedules can't be changed.";
+        }
+        else if (_scopeServerId is null)
+        {
+            StatusText.Text = "Fleet-wide default schedule. Applies to every server without its own override.";
+        }
+        else
+        {
+            StatusText.Text = writable
+                ? "Custom schedule. Changes apply only to this server."
+                : "Using the fleet-wide default (read-only). Uncheck 'Use default schedule' to customize this server.";
+        }
+    }
+
+    private void UseDefaultCheckBox_Changed(object sender, RoutedEventArgs e)
+    {
+        if (_suppressPresetChange || _scopeServerId is null)
+        {
+            return;
+        }
+
+        RebuildEditingForScope();
+    }
+
+    private void DetectActivePreset()
+    {
+        _suppressPresetChange = true;
+        try
+        {
+            var active = CollectorSchedulePresets.DetectPreset(_editing);
+            for (var i = 0; i < PresetCombo.Items.Count; i++)
+            {
+                if (PresetCombo.Items[i] is ComboBoxItem item &&
+                    string.Equals(item.Content?.ToString(), active, StringComparison.OrdinalIgnoreCase))
+                {
+                    PresetCombo.SelectedIndex = i;
+                    return;
+                }
+            }
+
+            PresetCombo.SelectedIndex = 0; /* Custom */
+        }
+        finally
+        {
+            _suppressPresetChange = false;
+        }
+    }
+
+    private void PresetCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_suppressPresetChange || PresetCombo.SelectedItem is not ComboBoxItem selected)
+        {
+            return;
+        }
+
+        var presetName = selected.Content?.ToString() ?? "";
+        if (presetName == CollectorSchedulePresets.Custom)
+        {
+            return;
+        }
+
+        var result = MessageBox.Show(
+            $"Apply the \"{presetName}\" preset?\n\nThis changes all collection frequencies. Enabled/disabled state and retention are not affected.",
+            "Apply Collection Preset", MessageBoxButton.YesNo, MessageBoxImage.Question);
+
+        if (result != MessageBoxResult.Yes)
+        {
+            DetectActivePreset();
+            return;
+        }
+
+        CollectorSchedulePresets.ApplyPreset(_editing, presetName);
+        BindGrid();
+        DetectActivePreset();
+    }
+
+    private void ResetDefaults_Click(object sender, RoutedEventArgs e)
+    {
+        var result = MessageBox.Show(
+            "Replace the current values with the built-in default frequencies and retention?",
+            "Reset to Defaults", MessageBoxButton.YesNo, MessageBoxImage.Question);
+
+        if (result != MessageBoxResult.Yes)
+        {
+            return;
+        }
+
+        _editing = CollectorSchedulePresets.BuildDefaultSchedule();
+        BindGrid();
+        DetectActivePreset();
+    }
+
+    private void CopyFromServer_Click(object sender, RoutedEventArgs e)
+    {
+        if (CopyFromServerCombo.SelectedItem is not DarlingServer source)
+        {
+            return;
+        }
+
+        var result = MessageBox.Show(
+            $"Replace the current values with a copy of {source.DisplayName}'s effective schedule?",
+            "Copy from Server", MessageBoxButton.YesNo, MessageBoxImage.Question);
+
+        if (result != MessageBoxResult.Yes)
+        {
+            return;
+        }
+
+        _editing = CollectorScheduleOverlay.BuildEffectiveSchedule(_allOverrides, source.ServerId);
+        BindGrid();
+        DetectActivePreset();
+    }
+
+    private async void SaveButton_Click(object sender, RoutedEventArgs e)
+    {
+        /* Flush any in-progress cell edit into the bound items before we read them. */
+        ScheduleGrid.CommitEdit(DataGridEditingUnit.Row, true);
+
+        var usesDefault = _scopeServerId is not null && UseDefaultCheckBox.IsChecked == true;
+
+        if (!usesDefault && !ValidateSchedule(out var error))
+        {
+            MessageBox.Show(error, "Collector Schedules", MessageBoxButton.OK, MessageBoxImage.Warning);
+            return;
+        }
+
+        SaveButton.IsEnabled = false;
+        try
+        {
+            if (_scopeServerId is int serverId)
+            {
+                var rows = usesDefault
+                    ? new List<CollectorScheduleRow>()
+                    : CollectorScheduleOverlay.ToServerOverrideRows(_editing, serverId);
+                await _dataService.ReplaceServerSchedulesAsync(serverId, rows);
+            }
+            else
+            {
+                await _dataService.ReplaceFleetSchedulesAsync(CollectorScheduleOverlay.ToFleetOverrideRows(_editing));
+            }
+
+            Saved = true;
+            Close();
+        }
+        catch (ViewerReadOnlyException ex)
+        {
+            MessageBox.Show(ex.Message, "Read-only connection", MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Could not save the collector schedules:\n\n{ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+        finally
+        {
+            SaveButton.IsEnabled = !_dataService.IsReadOnly;
+        }
+    }
+
+    /// <summary>Enforces the V17 CHECK constraints before the write (frequency &gt;= 0, retention &gt;= 1) so a
+    /// bad value surfaces as a friendly message rather than a raw Postgres error.</summary>
+    private bool ValidateSchedule(out string error)
+    {
+        foreach (var item in _editing)
+        {
+            if (item.FrequencyMinutes < 0)
+            {
+                error = $"'{item.Name}': frequency (minutes) can't be negative. Use 0 to collect once on server load.";
+                return false;
+            }
+
+            if (item.RetentionDays < 1)
+            {
+                error = $"'{item.Name}': retention (days) must be at least 1.";
+                return false;
+            }
+        }
+
+        error = "";
+        return true;
+    }
+
+    private void CancelButton_Click(object sender, RoutedEventArgs e) => Close();
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/CollectorScheduleOverlay.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/CollectorScheduleOverlay.cs
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using PerformanceMonitor.Collectors;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// Pure store↔editor resolution for the Collector Schedule editor — builds the EFFECTIVE editable schedule
+/// the grid shows (the same per-column layering the service's
+/// <c>StoreConfigProvider.ResolveSchedule</c> applies: per-server override &gt; fleet override &gt; the shared
+/// <see cref="CollectorScheduleDefaults"/> code default) and turns an edited schedule back into the sparse
+/// override rows to persist. No WPF or I/O, so Darling.Tests exercise the round-trip without a live store.
+/// </summary>
+public static class CollectorScheduleOverlay
+{
+    /// <summary>
+    /// The effective editable schedule for a scope: start from the code defaults, apply the fleet overrides
+    /// (<c>server_id</c> NULL), then — when <paramref name="serverId"/> is a server — apply that server's
+    /// overrides on top (each override's non-null column wins; a NULL column falls through). Editing the fleet
+    /// scope (<paramref name="serverId"/> null) shows code-default-over-fleet; editing a server shows the full
+    /// effective schedule it currently collects on.
+    /// </summary>
+    public static List<CollectorScheduleEditItem> BuildEffectiveSchedule(
+        IReadOnlyList<CollectorScheduleRow> allOverrides, int? serverId)
+    {
+        ArgumentNullException.ThrowIfNull(allOverrides);
+
+        var schedule = CollectorSchedulePresets.BuildDefaultSchedule();
+
+        ApplyScope(schedule, allOverrides.Where(o => o.ServerId is null));
+        if (serverId is int sid)
+        {
+            ApplyScope(schedule, allOverrides.Where(o => o.ServerId == sid));
+        }
+
+        return schedule;
+    }
+
+    private static void ApplyScope(List<CollectorScheduleEditItem> schedule, IEnumerable<CollectorScheduleRow> scopeRows)
+    {
+        foreach (var row in scopeRows)
+        {
+            var item = schedule.FirstOrDefault(s => s.Name.Equals(row.CollectorName, StringComparison.OrdinalIgnoreCase));
+            if (item is null)
+            {
+                continue; /* An override for a collector this build no longer defines — ignore it. */
+            }
+
+            if (row.FrequencyMinutes is int freq)
+            {
+                item.FrequencyMinutes = freq;
+            }
+
+            if (row.RetentionDays is int retention)
+            {
+                item.RetentionDays = retention;
+            }
+
+            item.Enabled = row.Enabled;
+        }
+    }
+
+    /// <summary>True when the store holds any override row for this server (the editor's "custom vs. use
+    /// default" initial state).</summary>
+    public static bool ServerHasOverride(IReadOnlyList<CollectorScheduleRow> allOverrides, int serverId)
+    {
+        ArgumentNullException.ThrowIfNull(allOverrides);
+        return allOverrides.Any(o => o.ServerId == serverId);
+    }
+
+    /// <summary>
+    /// The SPARSE fleet override rows to persist: one explicit row per collector that differs from its code
+    /// default (frequency, retention, or disabled) — collectors matching the default emit no row, so the fleet
+    /// scope stays sparse and un-set collectors fall through to the code default.
+    /// </summary>
+    public static List<CollectorScheduleRow> ToFleetOverrideRows(IReadOnlyList<CollectorScheduleEditItem> edited)
+    {
+        ArgumentNullException.ThrowIfNull(edited);
+
+        var rows = new List<CollectorScheduleRow>();
+        foreach (var item in edited)
+        {
+            if (!CollectorScheduleDefaults.All.TryGetValue(item.Name, out var def))
+            {
+                continue; /* Not a known collector — never persist an override for it. */
+            }
+
+            if (item.FrequencyMinutes == def.FrequencyMinutes && item.RetentionDays == def.RetentionDays && item.Enabled)
+            {
+                continue; /* Matches the code default — no override row (keeps the table sparse). */
+            }
+
+            rows.Add(new CollectorScheduleRow(null, item.Name, item.FrequencyMinutes, item.RetentionDays, item.Enabled));
+        }
+
+        return rows;
+    }
+
+    /// <summary>
+    /// The full PER-SERVER override rows to persist: one explicit row per known collector (a full snapshot,
+    /// matching Lite's per-server schedule model) so the server collects on EXACTLY the shown schedule
+    /// regardless of the fleet layer — WYSIWYG. Used only when the server is "custom" (not using defaults).
+    /// </summary>
+    public static List<CollectorScheduleRow> ToServerOverrideRows(IReadOnlyList<CollectorScheduleEditItem> edited, int serverId)
+    {
+        ArgumentNullException.ThrowIfNull(edited);
+
+        return edited
+            .Where(item => CollectorScheduleDefaults.All.ContainsKey(item.Name))
+            .Select(item => new CollectorScheduleRow(serverId, item.Name, item.FrequencyMinutes, item.RetentionDays, item.Enabled))
+            .ToList();
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/CollectorSchedulePresets.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/CollectorSchedulePresets.cs
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using PerformanceMonitor.Collectors;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// One editable collector row in the viewer's Collector Schedule editor — the effective (override-resolved)
+/// schedule for a collector, mutated in place by the grid and the presets. Plain mutable class (matching
+/// Lite's <c>CollectorSchedule</c>) so the WPF DataGrid two-way-binds its cells; the editor re-binds the grid
+/// after a preset apply. <see cref="FrequencyMinutes"/> 0 = collect once on server load only.
+/// </summary>
+public sealed class CollectorScheduleEditItem
+{
+    public string Name { get; set; } = "";
+    public string Description { get; set; } = "";
+    public bool Enabled { get; set; } = true;
+    public int FrequencyMinutes { get; set; }
+    public int RetentionDays { get; set; }
+}
+
+/// <summary>
+/// The viewer's port of Lite's collection-cadence presets (<c>ScheduleManager.s_presets</c> +
+/// <c>DetectPreset</c>/<c>ApplyPreset</c>) — the SINGLE source of preset logic for the Darling schedule
+/// editor. The three tables (Aggressive / Balanced / Low-Impact) are duplicated byte-for-byte from Lite's
+/// (the projects don't share a schedule library); a Darling.Tests pin asserts they cannot drift from Lite's
+/// intervals. A preset changes FREQUENCIES ONLY — enabled and retention are untouched — exactly as Lite's.
+/// </summary>
+public static class CollectorSchedulePresets
+{
+    public const string Custom = "Custom";
+
+    /// <summary>The preset names offered in the editor combo (plus the <see cref="Custom"/> sentinel).</summary>
+    public static readonly string[] Names = { "Aggressive", "Balanced", "Low-Impact" };
+
+    /// <summary>Per-preset collector→frequency (minutes) tables — duplicated from Lite's ScheduleManager.s_presets.</summary>
+    public static readonly IReadOnlyDictionary<string, IReadOnlyDictionary<string, int>> Presets =
+        new Dictionary<string, IReadOnlyDictionary<string, int>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Aggressive"] = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["wait_stats"] = 1, ["latch_stats"] = 1, ["spinlock_stats"] = 1,
+                ["cpu_scheduler_stats"] = 1, ["plan_cache_stats"] = 2,
+                ["query_stats"] = 1, ["procedure_stats"] = 1,
+                ["query_store"] = 2, ["query_snapshots"] = 1, ["cpu_utilization"] = 1,
+                ["file_io_stats"] = 1, ["memory_stats"] = 1, ["memory_clerks"] = 2,
+                ["memory_pressure_events"] = 5,
+                ["tempdb_stats"] = 1, ["perfmon_stats"] = 1, ["deadlocks"] = 1,
+                ["memory_grant_stats"] = 1, ["waiting_tasks"] = 1,
+                ["dmv_blocking_snapshot"] = 1,
+                ["blocked_process_report"] = 1, ["running_jobs"] = 2,
+                ["session_summary_stats"] = 2, ["system_health_events"] = 2,
+            },
+            ["Balanced"] = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["wait_stats"] = 1, ["latch_stats"] = 1, ["spinlock_stats"] = 1,
+                ["cpu_scheduler_stats"] = 1, ["plan_cache_stats"] = 5,
+                ["query_stats"] = 1, ["procedure_stats"] = 1,
+                ["query_store"] = 5, ["query_snapshots"] = 1, ["cpu_utilization"] = 1,
+                ["file_io_stats"] = 1, ["memory_stats"] = 1, ["memory_clerks"] = 5,
+                ["memory_pressure_events"] = 5,
+                ["tempdb_stats"] = 1, ["perfmon_stats"] = 1, ["deadlocks"] = 1,
+                ["memory_grant_stats"] = 1, ["waiting_tasks"] = 1,
+                ["dmv_blocking_snapshot"] = 1,
+                ["blocked_process_report"] = 1, ["running_jobs"] = 5,
+                ["session_summary_stats"] = 5, ["system_health_events"] = 5,
+            },
+            ["Low-Impact"] = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["wait_stats"] = 5, ["latch_stats"] = 5, ["spinlock_stats"] = 5,
+                ["cpu_scheduler_stats"] = 5, ["plan_cache_stats"] = 15,
+                ["query_stats"] = 10, ["procedure_stats"] = 10,
+                ["query_store"] = 30, ["query_snapshots"] = 5, ["cpu_utilization"] = 5,
+                ["file_io_stats"] = 10, ["memory_stats"] = 10, ["memory_clerks"] = 30,
+                ["memory_pressure_events"] = 15,
+                ["tempdb_stats"] = 5, ["perfmon_stats"] = 5, ["deadlocks"] = 5,
+                ["memory_grant_stats"] = 5, ["waiting_tasks"] = 5,
+                ["dmv_blocking_snapshot"] = 5,
+                ["blocked_process_report"] = 5, ["running_jobs"] = 30,
+                ["session_summary_stats"] = 15, ["system_health_events"] = 15,
+            },
+        };
+
+    /// <summary>
+    /// The full editable schedule seeded from the shared <see cref="CollectorScheduleDefaults"/> (every
+    /// collector, at its code-default frequency/retention, enabled) — the baseline the editor overlays store
+    /// overrides onto. Ordered by collector name for a stable grid.
+    /// </summary>
+    public static List<CollectorScheduleEditItem> BuildDefaultSchedule() =>
+        CollectorScheduleDefaults.All
+            .OrderBy(kv => kv.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(kv => new CollectorScheduleEditItem
+            {
+                Name = kv.Key,
+                Enabled = true,
+                FrequencyMinutes = kv.Value.FrequencyMinutes,
+                RetentionDays = kv.Value.RetentionDays,
+            })
+            .ToList();
+
+    /// <summary>Detects which preset a schedule's frequencies match, or <see cref="Custom"/> (mirrors
+    /// Lite's <c>ScheduleManager.DetectPreset</c> — frequency-only comparison).</summary>
+    public static string DetectPreset(IReadOnlyList<CollectorScheduleEditItem> schedules)
+    {
+        ArgumentNullException.ThrowIfNull(schedules);
+
+        foreach (var (presetName, intervals) in Presets)
+        {
+            var matches = true;
+            foreach (var (collector, freq) in intervals)
+            {
+                var schedule = schedules.FirstOrDefault(s => s.Name.Equals(collector, StringComparison.OrdinalIgnoreCase));
+                if (schedule is not null && schedule.FrequencyMinutes != freq)
+                {
+                    matches = false;
+                    break;
+                }
+            }
+
+            if (matches)
+            {
+                return presetName;
+            }
+        }
+
+        return Custom;
+    }
+
+    /// <summary>Applies a named preset's frequencies to a schedule list IN PLACE (enabled + retention
+    /// untouched); an unknown name is a no-op (mirrors Lite's <c>ScheduleManager.ApplyPreset</c>).</summary>
+    public static void ApplyPreset(IReadOnlyList<CollectorScheduleEditItem> schedules, string presetName)
+    {
+        ArgumentNullException.ThrowIfNull(schedules);
+
+        if (!Presets.TryGetValue(presetName, out var intervals))
+        {
+            return;
+        }
+
+        foreach (var (collector, freq) in intervals)
+        {
+            var schedule = schedules.FirstOrDefault(s => s.Name.Equals(collector, StringComparison.OrdinalIgnoreCase));
+            if (schedule is not null)
+            {
+                schedule.FrequencyMinutes = freq;
+            }
+        }
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.ServerManagement.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.ServerManagement.cs
@@ -352,6 +352,35 @@ public partial class MainWindow
         }
     }
 
+    /// <summary>
+    /// One-time import of the pre-Stage-3b viewer-local OPERATIONAL settings (alert engine, automated
+    /// analysis, SMTP + Teams/Slack, MCP) out of viewer-settings.json into the control-plane store — the
+    /// operational twin of <see cref="MigrateViewerServersAsync"/>. Defaults-only + marker-guarded (see
+    /// <see cref="ViewerControlPlaneMigration"/>): never clobbers an operator-tuned store, runs once,
+    /// best-effort. Read-only/disconnected seats skip.
+    /// </summary>
+    private async Task MigrateControlPlaneSettingsAsync()
+    {
+        if (_dataService is null || !OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        try
+        {
+            var migration = new ViewerControlPlaneMigration(_appSettingsStore.Load());
+            var imported = await migration.MigrateAsync(_dataService);
+            if (imported > 0)
+            {
+                ViewerLogger.Info("ControlPlaneMigration", $"Imported {imported} viewer-local settings section(s) into the store.");
+            }
+        }
+        catch (Exception ex)
+        {
+            ViewerLogger.Warn("ControlPlaneMigration", $"viewer-settings.json operational migrate-in failed: {ex.Message}");
+        }
+    }
+
     private void ViewLogButton_Click(object sender, RoutedEventArgs e)
     {
         var logFile = ViewerLogger.GetCurrentLogFile();

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
@@ -701,6 +701,10 @@
                             <Button Content="Refresh" Margin="10,0,0,0" Padding="12,4" Style="{StaticResource DarkButton}"
                                     Click="RecommendationsRefresh_Click"
                                     ToolTip="Re-read recommendations for the selected server"/>
+                            <Button x:Name="RecommendationsGenerateButton" Content="Generate now" Margin="8,0,0,0" Padding="12,4"
+                                    Style="{StaticResource DarkButton}"
+                                    Click="RecommendationsGenerateNow_Click"
+                                    ToolTip="Ask the Darling service to run analysis for this server now, then refresh"/>
                             <TextBlock x:Name="RecommendationsStatusText" Margin="12,0,0,0" VerticalAlignment="Center"
                                        FontStyle="Italic" Foreground="#8B93A1"/>
                         </StackPanel>

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
@@ -117,6 +117,9 @@ public partial class MainWindow : Window
            the write paths translate a live 42501 into a friendly message as a backstop. */
         await _dataService.DetectReadOnlyAsync();
 
+        /* A read-only seat cannot command the service, so "Generate now" (analyze_now) is disabled. */
+        RecommendationsGenerateButton.IsEnabled = !_dataService.IsReadOnly;
+
         /* The Alerts tab is a self-loading control (all-servers by default); give it the store and let
            it surface load/dismiss/mute outcomes on the shared status bar. */
         AlertsHistoryContent.Initialize(_dataService);
@@ -133,6 +136,11 @@ public partial class MainWindow : Window
            list load so imported servers appear immediately. Guarded (marker + ON CONFLICT DO NOTHING) so it
            never double-seeds the service's darling.json seed nor resurrects a removed server. */
         await MigrateViewerServersAsync();
+
+        /* One-time import of any pre-Stage-3b viewer-local operational settings (alerts, analysis, SMTP,
+           Teams/Slack, MCP) into the control-plane store — only when the store section is still at defaults,
+           so an operator-tuned store is never clobbered. Guarded by a marker; read-only/disconnected skip. */
+        await MigrateControlPlaneSettingsAsync();
 
         await LoadServersAsync();
 
@@ -697,6 +705,54 @@ public partial class MainWindow : Window
         => await RefreshVisibleAsync();
 
     /// <summary>
+    /// "Generate now" — asks the Darling service to run an immediate analysis pass for the selected server via
+    /// an <c>analyze_now</c> command, then refreshes the cards from the fresh findings. Restores Lite's
+    /// on-demand analysis (the Darling service otherwise runs it on its own ~30-minute cadence). A read-only
+    /// seat can't command the service (the button is disabled); a timeout surfaces a "still running" note.
+    /// </summary>
+    private async void RecommendationsGenerateNow_Click(object sender, RoutedEventArgs e)
+    {
+        if (_dataService is null || _dataService.IsReadOnly)
+        {
+            return;
+        }
+
+        if (RecommendationsServerSelector.SelectedItem is not DarlingServer server)
+        {
+            return;
+        }
+
+        RecommendationsGenerateButton.IsEnabled = false;
+        RecommendationsStatusText.Text = $"Analyzing {server.DisplayName}...";
+        try
+        {
+            var result = await _dataService.RequestAnalyzeNowAsync(server.ServerId);
+            if (result is null)
+            {
+                RecommendationsStatusText.Text = "Analysis is still running — refresh in a moment.";
+            }
+            else if (result.Status != ViewerDataService.StatusSucceeded)
+            {
+                RecommendationsStatusText.Text = $"Analysis did not complete: {result.ResultStatus}";
+            }
+
+            await LoadRecommendationsAsync();
+        }
+        catch (ViewerReadOnlyException ex)
+        {
+            MessageBox.Show(ex.Message, "Read-only connection", MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
+        catch (Exception ex)
+        {
+            RecommendationsStatusText.Text = $"Generate now failed: {ex.Message}";
+        }
+        finally
+        {
+            RecommendationsGenerateButton.IsEnabled = _dataService?.IsReadOnly == false;
+        }
+    }
+
+    /// <summary>
     /// Copies a card's suggested T-SQL to the clipboard (advise-only). SetDataObject with copy=false
     /// avoids WPF's problematic Clipboard.Flush() (matches the Lite convention).
     /// </summary>
@@ -741,7 +797,9 @@ public partial class MainWindow : Window
     /// </summary>
     private void SettingsButton_Click(object sender, RoutedEventArgs e)
     {
-        var settings = new SettingsWindow(_preferences, _appSettingsStore, _dataService) { Owner = this };
+        /* Hand the current managed-server list to the collector-schedule editor's per-server scope. */
+        var servers = (ServerList.ItemsSource as IReadOnlyList<DarlingServer>) ?? Array.Empty<DarlingServer>();
+        var settings = new SettingsWindow(_preferences, _appSettingsStore, _dataService, servers) { Owner = this };
         if (settings.ShowDialog() == true && settings.Result is not null)
         {
             _preferences = settings.Result;

--- a/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml
@@ -54,19 +54,29 @@
 
         <!-- Collection Control -->
         <Border Grid.Row="1" Background="{DynamicResource BackgroundLightBrush}" CornerRadius="4" Padding="12" Margin="0,0,0,12">
-            <Grid>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="Auto"/>
-                </Grid.ColumnDefinitions>
-                <StackPanel Grid.Column="0">
-                    <TextBlock Text="Data Collection" FontSize="14" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundBrush}"/>
-                    <TextBlock x:Name="CollectionStatusText" Text="Status: Managed by the Darling service" FontSize="12"
-                               Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,4,0,0" TextWrapping="Wrap"/>
-                </StackPanel>
-                <Button Grid.Column="1" x:Name="PauseResumeButton" Content="Pause Collection"
-                        Click="PauseResumeButton_Click" VerticalAlignment="Center"/>
-            </Grid>
+            <StackPanel>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Grid.Column="0">
+                        <TextBlock Text="Data Collection" FontSize="14" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundBrush}"/>
+                        <TextBlock x:Name="CollectionStatusText" Text="Status: Managed by the Darling service" FontSize="12"
+                                   Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,4,0,0" TextWrapping="Wrap"/>
+                    </StackPanel>
+                    <Button Grid.Column="1" x:Name="PauseResumeButton" Content="Pause Collection"
+                            Click="PauseResumeButton_Click" VerticalAlignment="Center"/>
+                </Grid>
+                <CheckBox x:Name="CapturePlansCheckBox" Content="Capture execution plans (all servers)" Margin="0,12,0,0"
+                          Foreground="{DynamicResource ForegroundBrush}"/>
+                <TextBlock Text="Store query and Query Store execution-plan XML across the fleet. Disable to shave storage on a very large fleet; a per-server override lives on each server's dialog."
+                           FontSize="11" FontStyle="Italic" Foreground="{DynamicResource ForegroundMutedBrush}"
+                           Margin="0,4,0,0" TextWrapping="Wrap"/>
+                <TextBlock x:Name="SettingsReadOnlyBanner" FontSize="12" Foreground="#E0A030" Margin="0,8,0,0" TextWrapping="Wrap"
+                           Visibility="Collapsed"
+                           Text="This viewer is connected with a read-only role. Monitoring settings below are shown for reference but can't be changed from here."/>
+            </StackPanel>
         </Border>
 
         <!-- MCP Server Settings -->
@@ -532,13 +542,15 @@
             </StackPanel>
         </Border>
 
-        <!-- Collection Schedule (service-managed) -->
+        <!-- Collection Schedule (control-plane editor) -->
         <Border Grid.Row="7" Background="{DynamicResource BackgroundLightBrush}" CornerRadius="4" Padding="12" Margin="0,0,0,12">
             <StackPanel>
                 <TextBlock Text="Collection Schedule" FontSize="14" FontWeight="SemiBold"
                            Foreground="{DynamicResource ForegroundBrush}"/>
-                <TextBlock Text="Collection cadence is managed by the Darling service (darling.json). The service collects from every registered server on its own schedule; the viewer reads what it has collected and does not control the schedule."
+                <TextBlock Text="Tune how often the Darling service collects each metric and how long it keeps it — fleet-wide or per server. Blank overrides fall back to the built-in defaults; presets bulk-set frequencies."
                            FontSize="12" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,6,0,0" TextWrapping="Wrap"/>
+                <Button x:Name="EditSchedulesButton" Content="Edit Collector Schedules..." HorizontalAlignment="Left"
+                        Padding="12,4" Margin="0,8,0,0" Click="EditSchedulesButton_Click"/>
             </StackPanel>
         </Border>
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml.cs
@@ -23,30 +23,21 @@ namespace PerformanceMonitor.Darling.Viewer;
 
 /// <summary>
 /// The viewer's full Settings window — a faithful, section-for-section port of Performance Monitor Lite's
-/// <c>SettingsWindow</c> (Lite/Windows/SettingsWindow.xaml.cs), adapted DuckDB/in-process → Postgres/service
-/// the same way the rest of the viewer was ported. Every section from Lite is present: Data Collection, MCP
-/// server, viewer defaults (with the #1401 time-range + auto-refresh preferences folded in), the full
-/// notifications block (alert thresholds, toggles, LRQ filters, cooldowns, delivery mode, global filters,
-/// mute-rule default, automated analysis), SMTP email, Teams/Slack webhooks, and the collection schedule.
+/// <c>SettingsWindow</c>, now (Stage 3b) writing the CONTROL-PLANE store so the running Darling service honors
+/// the operator's changes. The Notifications (alert engine + automated analysis), Email (SMTP), and Teams/Slack
+/// sections write <c>config.config_alert_settings</c> + <c>config.config_notification</c>; the MCP toggle/port
+/// and the global plan-capture flag write <c>config.config_service</c>; the Data Collection Pause/Resume button
+/// drives a <c>pause</c>/<c>resume</c> command; and the Collection Schedule section opens the real per-server /
+/// per-collector editor (<see cref="CollectorScheduleEditorWindow"/>) writing <c>config.config_collector_schedules</c>.
+/// Each store write flows through <see cref="ViewerDataService"/> (the shared 42501 → <see
+/// cref="ViewerReadOnlyException"/> gate); a read-only seat shows a banner and the writes degrade gracefully.
 ///
-/// <para>
-/// Persistence: the alert/notification/SMTP/webhook/MCP values are persisted in <see cref="ViewerAppSettings"/>
-/// (the Darling equivalent of Lite's <c>App.*</c> + settings.json); secrets go to Windows Credential Manager
-/// via <see cref="ViewerSecretStore"/>, exactly as Lite stores them. The folded-in viewer preferences round-trip
-/// through <see cref="ViewerPreferences"/> (handed back to <see cref="MainWindow"/> via <see cref="Result"/>).
-/// In Darling those alert/collection values are the SERVICE's domain (darling.json); the window persists them
-/// faithfully so it is complete and its state survives a restart — the service honoring a change is a separate
-/// wiring concern (see the PR body). The controls that act inside the viewer TODAY work immediately: Manage Mute
-/// Rules (writes Postgres), Send Test Email / Send Test Notification (the shared, connection-independent
-/// renderers), Validate Settings, and the viewer preferences.
-/// </para>
-///
-/// <para>
-/// Two Lite-only MECHANISMS are adapted sensibly (matching how "Pause Collection" is handled in the port):
-/// the Data Collection Pause button can't reach the remote service, so it is shown disabled with a
-/// service-managed status; and the per-server Collector Schedule editor (Lite's ScheduleManager +
-/// CollectorScheduleEditorWindow) has no store model in Darling, so the section is an informational panel.
-/// </para>
+/// <para>The genuinely viewer-LOCAL preferences stay in <see cref="ViewerAppSettings"/> /
+/// <see cref="ViewerPreferences"/>: the default time range + auto-refresh, connection timeout, CSV separator,
+/// timestamp-display mode, tray-minimize, the connection-change/LRQ-noise/delivery-mode/mute-default/dismissal-
+/// logging toggles the service has no honored column for, and the theme (dark-only). Send Test Email / Send Test
+/// Notification stay working — they render + send straight from the live UI via the shared, connection-
+/// independent renderers, so the operator verifies exactly what they typed before saving.</para>
 /// </summary>
 public partial class SettingsWindow : Window
 {
@@ -56,6 +47,21 @@ public partial class SettingsWindow : Window
     private readonly ViewerAppSettingsStore _appSettingsStore;
     private readonly ViewerAppSettings _appSettings;
     private readonly ViewerDataService? _dataService;
+    private readonly IReadOnlyList<DarlingServer> _servers;
+
+    /// <summary>The store's current SMTP blob, held so an unchanged (or undecryptable) password survives a Save
+    /// without being wiped — mirrors the server dialog's DPAPI "re-enter to change" handling.</summary>
+    private string? _loadedSmtpBlob;
+
+    /// <summary>The service's paused state as last read from <c>config_service</c>, reflected on the button.</summary>
+    private bool _paused;
+
+    /// <summary>
+    /// True once the operator config was READ from the store without error. Save writes the store sections only
+    /// when this is set — so a transient read failure (which leaves the controls showing defaults) can never
+    /// clobber an operator-tuned store back to defaults. False when disconnected or a read threw.
+    /// </summary>
+    private bool _storeLoaded;
 
     /// <summary>
     /// The edited viewer preferences (default time range + auto-refresh), populated on a successful Save so
@@ -65,9 +71,14 @@ public partial class SettingsWindow : Window
     public ViewerPreferences? Result { get; private set; }
 
     /// <param name="preferences">Current viewer preferences (the toolbar-seed defaults) to seed the controls.</param>
-    /// <param name="appSettingsStore">The store this window loads from and saves the app settings to.</param>
-    /// <param name="dataService">The store connection, for "Manage Mute Rules"; null when not connected yet (button disabled).</param>
-    public SettingsWindow(ViewerPreferences preferences, ViewerAppSettingsStore appSettingsStore, ViewerDataService? dataService)
+    /// <param name="appSettingsStore">The store for the viewer-LOCAL preferences (operational settings now live in the control-plane store).</param>
+    /// <param name="dataService">The control-plane connection; null when not connected yet (store surfaces disabled).</param>
+    /// <param name="servers">The managed servers, for the collector-schedule editor's per-server scope.</param>
+    public SettingsWindow(
+        ViewerPreferences preferences,
+        ViewerAppSettingsStore appSettingsStore,
+        ViewerDataService? dataService,
+        IReadOnlyList<DarlingServer>? servers = null)
     {
         ArgumentNullException.ThrowIfNull(preferences);
         ArgumentNullException.ThrowIfNull(appSettingsStore);
@@ -77,6 +88,7 @@ public partial class SettingsWindow : Window
         _appSettingsStore = appSettingsStore;
         _appSettings = appSettingsStore.Load();
         _dataService = dataService;
+        _servers = servers ?? Array.Empty<DarlingServer>();
 
         LoadViewerPreferences(preferences);
         UpdateCollectionStatus();
@@ -85,12 +97,83 @@ public partial class SettingsWindow : Window
         LoadConnectionTimeout();
         LoadCsvSeparator();
         LoadTimeDisplayMode();
-        LoadAlertSettings();
-        LoadSmtpSettings();
-        LoadWebhookSettings();
+        LoadViewerLocalAlertFields();
+        SeedAlertControlsFrom(AlertSettingsRow.Defaults());
+        SeedNotificationControlsFrom(NotificationRow.Defaults());
+        /* Default the global plan-capture flag to the store's default (TRUE) so an unread/unseeded state never
+           shows it off — the store read overwrites it, and Save is guarded by _storeLoaded regardless. */
+        CapturePlansCheckBox.IsChecked = true;
 
         /* Manage Mute Rules writes the shared Postgres config; needs a live store connection. */
         ManageMuteRulesButton.IsEnabled = _dataService is not null;
+        EditSchedulesButton.IsEnabled = _dataService is not null;
+
+        /* Read the authoritative operator config from the store (async), then apply read-only gating. */
+        Loaded += async (_, _) => await LoadFromStoreAsync();
+    }
+
+    /// <summary>
+    /// Overwrites the store-backed controls with the authoritative values from the control-plane store (the
+    /// alert engine + analysis, SMTP + webhooks, MCP + plan capture, and the paused state), leaving the
+    /// synchronous defaults in place if the store is unreachable or has not seeded a section yet. Then applies
+    /// read-only gating. Runs once on load.
+    /// </summary>
+    private async Task LoadFromStoreAsync()
+    {
+        if (_dataService is not null)
+        {
+            try
+            {
+                var alert = await _dataService.GetAlertSettingsAsync();
+                if (alert is not null)
+                {
+                    SeedAlertControlsFrom(alert);
+                }
+
+                var notify = await _dataService.GetNotificationAsync();
+                if (notify is not null)
+                {
+                    SeedNotificationControlsFrom(notify);
+                }
+
+                var service = await _dataService.GetServiceConfigAsync();
+                if (service is not null)
+                {
+                    CapturePlansCheckBox.IsChecked = service.CapturePlans;
+                    McpEnabledCheckBox.IsChecked = service.McpEnabled;
+                    McpPortTextBox.Text = service.McpPort.ToString(CultureInfo.InvariantCulture);
+                    _paused = service.Paused;
+                }
+
+                /* All reads completed — Save may now write the store sections without risk of clobbering
+                   tuned config with the on-screen defaults. */
+                _storeLoaded = true;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"SettingsWindow: could not read the control-plane store, showing defaults: {ex.Message}");
+            }
+        }
+
+        ApplyReadOnlyGating();
+        UpdateCollectionStatus();
+        UpdateMcpStatus();
+        UpdateAlertControlStates();
+        UpdateSmtpControlStates();
+        UpdateTeamsControlStates();
+        UpdateSlackControlStates();
+    }
+
+    /// <summary>Reflects a read-only seat: a banner + the operator-action buttons disabled. The threshold
+    /// inputs stay visible for reference; a Save attempt surfaces the friendly read-only message.</summary>
+    private void ApplyReadOnlyGating()
+    {
+        var readOnly = _dataService?.IsReadOnly == true;
+        SettingsReadOnlyBanner.Visibility = readOnly ? Visibility.Visible : Visibility.Collapsed;
+        if (readOnly)
+        {
+            PauseResumeButton.IsEnabled = false;
+        }
     }
 
     // ── Viewer preferences (folded in from #1401: default time range + auto-refresh) ──
@@ -128,27 +211,77 @@ public partial class SettingsWindow : Window
         }
     }
 
-    // ── Data Collection (adapted: collection runs in the remote service) ──
+    // ── Data Collection (pause/resume drives the service via the command plane) ──
 
     private void UpdateCollectionStatus()
     {
-        /* The viewer has no in-process collector to pause — collection runs in the Darling service, which the
-           viewer cannot reach to pause. Present it honestly and disable the button (Lite disables it the same
-           way when it has no background service). */
-        CollectionStatusText.Text = "Status: Managed by the Darling service (the viewer cannot pause remote collection)";
-        PauseResumeButton.IsEnabled = false;
+        if (_dataService is null)
+        {
+            CollectionStatusText.Text = "Status: not connected to the Darling store";
+            PauseResumeButton.IsEnabled = false;
+            PauseResumeButton.Content = "Pause Collection";
+            return;
+        }
+
+        CollectionStatusText.Text = _paused
+            ? "Status: Paused — the Darling service is not collecting"
+            : "Status: Collecting — managed by the Darling service";
+        PauseResumeButton.Content = _paused ? "Resume Collection" : "Pause Collection";
+        PauseResumeButton.IsEnabled = !_dataService.IsReadOnly;
     }
 
-    private void PauseResumeButton_Click(object sender, RoutedEventArgs e)
+    /// <summary>Enqueues a <c>pause</c>/<c>resume</c> command, waits for the result, then reflects the new
+    /// state. A read-only seat can't command the service (the button is disabled; a stray click no-ops).</summary>
+    private async void PauseResumeButton_Click(object sender, RoutedEventArgs e)
     {
-        /* No-op: collection runs in the remote service. The button is disabled; this handler only satisfies
-           the XAML binding. */
+        if (_dataService is null || _dataService.IsReadOnly)
+        {
+            return;
+        }
+
+        var pausing = !_paused;
+        PauseResumeButton.IsEnabled = false;
+        PauseResumeButton.Content = pausing ? "Pausing..." : "Resuming...";
+        try
+        {
+            var result = pausing
+                ? await _dataService.PauseServiceAsync()
+                : await _dataService.ResumeServiceAsync();
+
+            if (result is null)
+            {
+                CollectionStatusText.Text = "Status: command sent — the service has not confirmed yet";
+            }
+            else if (result.Status == ViewerDataService.StatusSucceeded)
+            {
+                _paused = pausing;
+            }
+            else
+            {
+                MessageBox.Show(
+                    $"The service could not {(pausing ? "pause" : "resume")} collection: {result.ResultStatus}",
+                    "Data Collection", MessageBoxButton.OK, MessageBoxImage.Warning);
+            }
+        }
+        catch (ViewerReadOnlyException ex)
+        {
+            MessageBox.Show(ex.Message, "Read-only connection", MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Could not reach the service: {ex.Message}", "Data Collection", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+        finally
+        {
+            UpdateCollectionStatus();
+        }
     }
 
-    // ── MCP server (the service hosts the MCP; the viewer persists the desired config) ──
+    // ── MCP server (config_service.mcp_enabled / mcp_port) ──
 
     private void LoadMcpSettings()
     {
+        /* Seed from the last-known viewer copy for an immediate, non-blank UI; the store read overwrites it. */
         McpEnabledCheckBox.IsChecked = _appSettings.McpEnabled;
         McpPortTextBox.Text = _appSettings.McpPort.ToString(CultureInfo.InvariantCulture);
     }
@@ -156,22 +289,25 @@ public partial class SettingsWindow : Window
     private void UpdateMcpStatus()
     {
         McpStatusText.Text = McpEnabledCheckBox.IsChecked == true
-            ? "The MCP server is hosted by the Darling service; restart the service to apply changes."
+            ? "The Darling service hosts the MCP server; it applies on the service's next reload."
             : "Status: Disabled";
     }
 
-    /// <summary>Applies the MCP fields to <see cref="_appSettings"/>. Returns false only when an ENABLED server has a bad port.</summary>
-    private bool SaveMcpSettings()
+    /// <summary>Validates the MCP port and the (always-valid) capture-plans + enabled flags for the
+    /// <c>config_service</c> write. Returns false only when an ENABLED MCP server has a bad port.</summary>
+    private bool TryReadServiceFlags(out bool capturePlans, out bool mcpEnabled, out int mcpPort)
     {
-        _appSettings.McpEnabled = McpEnabledCheckBox.IsChecked == true;
+        capturePlans = CapturePlansCheckBox.IsChecked == true;
+        mcpEnabled = McpEnabledCheckBox.IsChecked == true;
+        mcpPort = _appSettings.McpPort;
 
         if (int.TryParse(McpPortTextBox.Text, out var port) && port is >= 1024 and <= 65535)
         {
-            _appSettings.McpPort = port;
+            mcpPort = port;
             return true;
         }
 
-        if (_appSettings.McpEnabled)
+        if (mcpEnabled)
         {
             MessageBox.Show(
                 "MCP port must be between 1024 and 65535.\nPorts 0–1023 are well-known privileged ports reserved by the operating system.",
@@ -219,7 +355,20 @@ public partial class SettingsWindow : Window
         }
     }
 
-    // ── Viewer defaults (connection timeout, CSV separator, timestamp display) ──
+    // ── Collection schedule (the real per-server / per-collector editor) ──
+
+    private void EditSchedulesButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (_dataService is null)
+        {
+            return;
+        }
+
+        var editor = new CollectorScheduleEditorWindow(_dataService, _servers) { Owner = this };
+        editor.ShowDialog();
+    }
+
+    // ── Viewer defaults (connection timeout, CSV separator, timestamp display) — viewer-local ──
 
     private void LoadConnectionTimeout() =>
         ConnectionTimeoutBox.Text = _appSettings.ConnectionTimeoutSeconds.ToString(CultureInfo.InvariantCulture);
@@ -282,40 +431,18 @@ public partial class SettingsWindow : Window
 
     // ── Notifications / alert thresholds ──
 
-    private void LoadAlertSettings()
+    /// <summary>Seeds the viewer-LOCAL alert fields (no honored store column: tray minimize, connection-change
+    /// notify, LRQ max-results + the five noise filters, delivery mode, mute-rule default, dismissal logging).</summary>
+    private void LoadViewerLocalAlertFields()
     {
         MinimizeToTrayCheckBox.IsChecked = _appSettings.MinimizeToTray;
-        AlertsEnabledCheckBox.IsChecked = _appSettings.AlertsEnabled;
         NotifyConnectionCheckBox.IsChecked = _appSettings.NotifyConnectionChanges;
-        AlertCpuCheckBox.IsChecked = _appSettings.AlertCpuEnabled;
-        AlertCpuThresholdBox.Text = _appSettings.AlertCpuThreshold.ToString(CultureInfo.InvariantCulture);
-        AlertCpuModeBox.SelectedIndex = _appSettings.AlertCpuMode == "SqlOnly" ? 1 : 0;
-        AlertBlockingCheckBox.IsChecked = _appSettings.AlertBlockingEnabled;
-        AlertBlockingThresholdBox.Text = _appSettings.AlertBlockingThreshold.ToString(CultureInfo.InvariantCulture);
-        AlertDeadlockCheckBox.IsChecked = _appSettings.AlertDeadlockEnabled;
-        AlertDeadlockThresholdBox.Text = _appSettings.AlertDeadlockThreshold.ToString(CultureInfo.InvariantCulture);
-        AlertPoisonWaitCheckBox.IsChecked = _appSettings.AlertPoisonWaitEnabled;
-        AlertPoisonWaitThresholdBox.Text = _appSettings.AlertPoisonWaitThresholdMs.ToString(CultureInfo.InvariantCulture);
-        AlertLongRunningQueryCheckBox.IsChecked = _appSettings.AlertLongRunningQueryEnabled;
-        AlertLongRunningQueryThresholdBox.Text = _appSettings.AlertLongRunningQueryThresholdMinutes.ToString(CultureInfo.InvariantCulture);
         AlertLongRunningQueryMaxResultsBox.Text = _appSettings.AlertLongRunningQueryMaxResults.ToString(CultureInfo.InvariantCulture);
         LrqExcludeSpServerDiagnosticsCheckBox.IsChecked = _appSettings.AlertLongRunningQueryExcludeSpServerDiagnostics;
         LrqExcludeWaitForCheckBox.IsChecked = _appSettings.AlertLongRunningQueryExcludeWaitFor;
         LrqExcludeBackupsCheckBox.IsChecked = _appSettings.AlertLongRunningQueryExcludeBackups;
         LrqExcludeMiscWaitsCheckBox.IsChecked = _appSettings.AlertLongRunningQueryExcludeMiscWaits;
         LrqExcludeCdcCheckBox.IsChecked = _appSettings.AlertLongRunningQueryExcludeCdc;
-        AlertExcludedDatabasesBox.Text = string.Join(", ", _appSettings.AlertExcludedDatabases);
-        AlertTempDbSpaceCheckBox.IsChecked = _appSettings.AlertTempDbSpaceEnabled;
-        AlertTempDbSpaceThresholdBox.Text = _appSettings.AlertTempDbSpaceThresholdPercent.ToString(CultureInfo.InvariantCulture);
-        AlertLowDiskCheckBox.IsChecked = _appSettings.AlertLowDiskEnabled;
-        AlertLowDiskThresholdPercentBox.Text = _appSettings.AlertLowDiskThresholdPercent.ToString(CultureInfo.InvariantCulture);
-        AlertLowDiskThresholdGbBox.Text = _appSettings.AlertLowDiskThresholdGb.ToString(CultureInfo.InvariantCulture);
-        AlertLongRunningJobCheckBox.IsChecked = _appSettings.AlertLongRunningJobEnabled;
-        AlertLongRunningJobMultiplierBox.Text = _appSettings.AlertLongRunningJobMultiplier.ToString(CultureInfo.InvariantCulture);
-        AlertFailedJobCheckBox.IsChecked = _appSettings.AlertFailedJobEnabled;
-        AlertFailedJobLookbackBox.Text = _appSettings.AlertFailedJobLookbackMinutes.ToString(CultureInfo.InvariantCulture);
-        AlertCooldownBox.Text = _appSettings.AlertCooldownMinutes.ToString(CultureInfo.InvariantCulture);
-        EmailCooldownBox.Text = _appSettings.EmailCooldownMinutes.ToString(CultureInfo.InvariantCulture);
         AlertDeliveryModeBox.SelectedIndex = _appSettings.AlertDeliveryMode == "PerEvent" ? 1 : 0;
         AlertPerEventMaxBox.Text = _appSettings.AlertPerEventMaxPerCycle.ToString(CultureInfo.InvariantCulture);
         MuteRuleDefaultExpirationCombo.SelectedIndex = _appSettings.MuteRuleDefaultExpiration switch
@@ -326,34 +453,113 @@ public partial class SettingsWindow : Window
             _ => 3
         };
         LogAlertDismissalsCheckBox.IsChecked = _appSettings.LogAlertDismissals;
-        AnalysisEnabledCheckBox.IsChecked = _appSettings.AnalysisEnabled;
-        AnalysisNotificationsCheckBox.IsChecked = _appSettings.AnalysisNotificationsEnabled;
-        AnalysisIntervalBox.Text = _appSettings.AnalysisIntervalMinutes.ToString(CultureInfo.InvariantCulture);
-        AnalysisNotifySeverityBox.Text = _appSettings.AnalysisNotifySeverity.ToString("0.0", CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>Seeds the STORE-backed alert + analysis controls from a <see cref="AlertSettingsRow"/> (the
+    /// store's authoritative values, or defaults before the store read completes).</summary>
+    private void SeedAlertControlsFrom(AlertSettingsRow r)
+    {
+        AlertsEnabledCheckBox.IsChecked = r.Enabled;
+        AlertCpuCheckBox.IsChecked = r.CpuEnabled;
+        AlertCpuThresholdBox.Text = r.CpuThresholdPercent.ToString(CultureInfo.InvariantCulture);
+        AlertCpuModeBox.SelectedIndex = ViewerDataService.MapCpuModeFromStore(r.CpuMode) == "SqlOnly" ? 1 : 0;
+        AlertBlockingCheckBox.IsChecked = r.BlockingEnabled;
+        AlertBlockingThresholdBox.Text = r.BlockingCountThreshold.ToString(CultureInfo.InvariantCulture);
+        AlertDeadlockCheckBox.IsChecked = r.DeadlockEnabled;
+        AlertDeadlockThresholdBox.Text = r.DeadlockCountThreshold.ToString(CultureInfo.InvariantCulture);
+        AlertPoisonWaitCheckBox.IsChecked = r.PoisonWaitEnabled;
+        AlertPoisonWaitThresholdBox.Text = r.PoisonWaitThresholdMs.ToString(CultureInfo.InvariantCulture);
+        AlertLongRunningQueryCheckBox.IsChecked = r.LongRunningQueryEnabled;
+        AlertLongRunningQueryThresholdBox.Text = r.LongRunningQueryThresholdMinutes.ToString(CultureInfo.InvariantCulture);
+        AlertExcludedDatabasesBox.Text = string.Join(", ", r.ExcludedDatabases);
+        AlertTempDbSpaceCheckBox.IsChecked = r.TempDbSpaceEnabled;
+        AlertTempDbSpaceThresholdBox.Text = r.TempDbSpaceThresholdPercent.ToString(CultureInfo.InvariantCulture);
+        AlertLowDiskCheckBox.IsChecked = r.LowDiskEnabled;
+        AlertLowDiskThresholdPercentBox.Text = r.LowDiskThresholdPercent.ToString(CultureInfo.InvariantCulture);
+        AlertLowDiskThresholdGbBox.Text = r.LowDiskThresholdGb.ToString(CultureInfo.InvariantCulture);
+        AlertLongRunningJobCheckBox.IsChecked = r.LongRunningJobEnabled;
+        AlertLongRunningJobMultiplierBox.Text = r.LongRunningJobMultiplier.ToString(CultureInfo.InvariantCulture);
+        AlertFailedJobCheckBox.IsChecked = r.FailedJobEnabled;
+        AlertFailedJobLookbackBox.Text = r.FailedJobLookbackMinutes.ToString(CultureInfo.InvariantCulture);
+        AlertCooldownBox.Text = r.CooldownMinutes.ToString(CultureInfo.InvariantCulture);
+        AnalysisEnabledCheckBox.IsChecked = r.AnalysisEnabled;
+        AnalysisIntervalBox.Text = r.AnalysisIntervalMinutes.ToString(CultureInfo.InvariantCulture);
+        AnalysisNotificationsCheckBox.IsChecked = r.AnalysisNotificationsEnabled;
+        AnalysisNotifySeverityBox.Text = r.AnalysisNotifySeverity.ToString("0.0", CultureInfo.InvariantCulture);
         UpdateAlertControlStates();
     }
 
-    private bool SaveAlertSettings()
+    /// <summary>Builds the store row from the alert + analysis controls, validating the numeric fields. Adds
+    /// range errors to <paramref name="errors"/>; a bad field keeps its default rather than throwing.</summary>
+    private AlertSettingsRow BuildAlertRowFromControls(List<string> errors)
+    {
+        var row = new AlertSettingsRow
+        {
+            Enabled = AlertsEnabledCheckBox.IsChecked == true,
+            CpuEnabled = AlertCpuCheckBox.IsChecked == true,
+            CpuMode = ViewerDataService.MapCpuModeToStore((AlertCpuModeBox.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "Total"),
+            BlockingEnabled = AlertBlockingCheckBox.IsChecked == true,
+            DeadlockEnabled = AlertDeadlockCheckBox.IsChecked == true,
+            PoisonWaitEnabled = AlertPoisonWaitCheckBox.IsChecked == true,
+            LongRunningQueryEnabled = AlertLongRunningQueryCheckBox.IsChecked == true,
+            TempDbSpaceEnabled = AlertTempDbSpaceCheckBox.IsChecked == true,
+            LowDiskEnabled = AlertLowDiskCheckBox.IsChecked == true,
+            LongRunningJobEnabled = AlertLongRunningJobCheckBox.IsChecked == true,
+            FailedJobEnabled = AlertFailedJobCheckBox.IsChecked == true,
+            AnalysisEnabled = AnalysisEnabledCheckBox.IsChecked == true,
+            AnalysisNotificationsEnabled = AnalysisNotificationsCheckBox.IsChecked == true,
+            ExcludedDatabases = AlertExcludedDatabasesBox.Text
+                .Split(',')
+                .Select(s => s.Trim())
+                .Where(s => s.Length > 0)
+                .ToList(),
+        };
+
+        if (int.TryParse(AlertCpuThresholdBox.Text, out var cpu) && cpu is > 0 and <= 100)
+            row.CpuThresholdPercent = cpu;
+        if (int.TryParse(AlertBlockingThresholdBox.Text, out var blocking) && blocking > 0)
+            row.BlockingCountThreshold = blocking;
+        if (int.TryParse(AlertDeadlockThresholdBox.Text, out var deadlock) && deadlock > 0)
+            row.DeadlockCountThreshold = deadlock;
+        if (int.TryParse(AlertPoisonWaitThresholdBox.Text, out var poisonWait) && poisonWait > 0)
+            row.PoisonWaitThresholdMs = poisonWait;
+        if (int.TryParse(AlertLongRunningQueryThresholdBox.Text, out var lrq) && lrq > 0)
+            row.LongRunningQueryThresholdMinutes = lrq;
+        if (int.TryParse(AlertTempDbSpaceThresholdBox.Text, out var tempDb) && tempDb is > 0 and <= 100)
+            row.TempDbSpaceThresholdPercent = tempDb;
+        if (int.TryParse(AlertLowDiskThresholdPercentBox.Text, out var lowDiskPct) && lowDiskPct is >= 0 and <= 100)
+            row.LowDiskThresholdPercent = lowDiskPct;
+        if (int.TryParse(AlertLowDiskThresholdGbBox.Text, out var lowDiskGb) && lowDiskGb >= 0)
+            row.LowDiskThresholdGb = lowDiskGb;
+        if (int.TryParse(AlertLongRunningJobMultiplierBox.Text, out var jobMult) && jobMult is >= 2 and <= 20)
+            row.LongRunningJobMultiplier = jobMult;
+        if (int.TryParse(AlertFailedJobLookbackBox.Text, out var failedJobLookback) && failedJobLookback is >= 1 and <= 1440)
+            row.FailedJobLookbackMinutes = failedJobLookback;
+
+        if (int.TryParse(AlertCooldownBox.Text, out var alertCooldown) && alertCooldown is >= 1 and <= 120)
+            row.CooldownMinutes = alertCooldown;
+        else
+            errors.Add("Tray notification cooldown must be between 1 and 120 minutes.");
+
+        if (int.TryParse(AnalysisIntervalBox.Text, out var analysisInterval) && analysisInterval is >= 5 and <= 360)
+            row.AnalysisIntervalMinutes = analysisInterval;
+        else
+            errors.Add("Analysis interval must be between 5 and 360 minutes.");
+
+        if (double.TryParse(AnalysisNotifySeverityBox.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var analysisSeverity)
+            && analysisSeverity is >= 0.0 and <= 2.0)
+            row.AnalysisNotifySeverity = analysisSeverity;
+        else
+            errors.Add("Analysis notify severity must be between 0.0 and 2.0.");
+
+        return row;
+    }
+
+    /// <summary>Persists the viewer-LOCAL alert fields to <see cref="ViewerAppSettings"/> (the store never sees them).</summary>
+    private void SaveViewerLocalAlertFields(List<string> errors)
     {
         _appSettings.MinimizeToTray = MinimizeToTrayCheckBox.IsChecked == true;
-        _appSettings.AlertsEnabled = AlertsEnabledCheckBox.IsChecked == true;
         _appSettings.NotifyConnectionChanges = NotifyConnectionCheckBox.IsChecked == true;
-        _appSettings.AlertCpuEnabled = AlertCpuCheckBox.IsChecked == true;
-        if (int.TryParse(AlertCpuThresholdBox.Text, out var cpu) && cpu is > 0 and <= 100)
-            _appSettings.AlertCpuThreshold = cpu;
-        _appSettings.AlertCpuMode = AlertCpuModeBox.SelectedIndex == 1 ? "SqlOnly" : "Total";
-        _appSettings.AlertBlockingEnabled = AlertBlockingCheckBox.IsChecked == true;
-        if (int.TryParse(AlertBlockingThresholdBox.Text, out var blocking) && blocking > 0)
-            _appSettings.AlertBlockingThreshold = blocking;
-        _appSettings.AlertDeadlockEnabled = AlertDeadlockCheckBox.IsChecked == true;
-        if (int.TryParse(AlertDeadlockThresholdBox.Text, out var deadlock) && deadlock > 0)
-            _appSettings.AlertDeadlockThreshold = deadlock;
-        _appSettings.AlertPoisonWaitEnabled = AlertPoisonWaitCheckBox.IsChecked == true;
-        if (int.TryParse(AlertPoisonWaitThresholdBox.Text, out var poisonWait) && poisonWait > 0)
-            _appSettings.AlertPoisonWaitThresholdMs = poisonWait;
-        _appSettings.AlertLongRunningQueryEnabled = AlertLongRunningQueryCheckBox.IsChecked == true;
-        if (int.TryParse(AlertLongRunningQueryThresholdBox.Text, out var lrq) && lrq > 0)
-            _appSettings.AlertLongRunningQueryThresholdMinutes = lrq;
         if (int.TryParse(AlertLongRunningQueryMaxResultsBox.Text, out var lrqMax) && lrqMax >= 1)
             _appSettings.AlertLongRunningQueryMaxResults = lrqMax;
         _appSettings.AlertLongRunningQueryExcludeSpServerDiagnostics = LrqExcludeSpServerDiagnosticsCheckBox.IsChecked == true;
@@ -361,64 +567,13 @@ public partial class SettingsWindow : Window
         _appSettings.AlertLongRunningQueryExcludeBackups = LrqExcludeBackupsCheckBox.IsChecked == true;
         _appSettings.AlertLongRunningQueryExcludeMiscWaits = LrqExcludeMiscWaitsCheckBox.IsChecked == true;
         _appSettings.AlertLongRunningQueryExcludeCdc = LrqExcludeCdcCheckBox.IsChecked == true;
-        _appSettings.AlertExcludedDatabases = AlertExcludedDatabasesBox.Text
-            .Split(',')
-            .Select(s => s.Trim())
-            .Where(s => s.Length > 0)
-            .ToList();
-        _appSettings.AlertTempDbSpaceEnabled = AlertTempDbSpaceCheckBox.IsChecked == true;
-        if (int.TryParse(AlertTempDbSpaceThresholdBox.Text, out var tempDb) && tempDb is > 0 and <= 100)
-            _appSettings.AlertTempDbSpaceThresholdPercent = tempDb;
-        _appSettings.AlertLowDiskEnabled = AlertLowDiskCheckBox.IsChecked == true;
-        if (int.TryParse(AlertLowDiskThresholdPercentBox.Text, out var lowDiskPct) && lowDiskPct is >= 0 and <= 100)
-            _appSettings.AlertLowDiskThresholdPercent = lowDiskPct;
-        if (int.TryParse(AlertLowDiskThresholdGbBox.Text, out var lowDiskGb) && lowDiskGb >= 0)
-            _appSettings.AlertLowDiskThresholdGb = lowDiskGb;
-        _appSettings.AlertLongRunningJobEnabled = AlertLongRunningJobCheckBox.IsChecked == true;
-        if (int.TryParse(AlertLongRunningJobMultiplierBox.Text, out var jobMult) && jobMult is >= 2 and <= 20)
-            _appSettings.AlertLongRunningJobMultiplier = jobMult;
-        _appSettings.AlertFailedJobEnabled = AlertFailedJobCheckBox.IsChecked == true;
-        if (int.TryParse(AlertFailedJobLookbackBox.Text, out var failedJobLookback) && failedJobLookback is >= 1 and <= 1440)
-            _appSettings.AlertFailedJobLookbackMinutes = failedJobLookback;
-
-        var validationErrors = new List<string>();
-        if (int.TryParse(AlertCooldownBox.Text, out var alertCooldown) && alertCooldown is >= 1 and <= 120)
-            _appSettings.AlertCooldownMinutes = alertCooldown;
-        else
-            validationErrors.Add("Tray notification cooldown must be between 1 and 120 minutes.");
-        if (int.TryParse(EmailCooldownBox.Text, out var emailCooldown) && emailCooldown is >= 1 and <= 120)
-            _appSettings.EmailCooldownMinutes = emailCooldown;
-        else
-            validationErrors.Add("Email alert cooldown must be between 1 and 120 minutes.");
         _appSettings.AlertDeliveryMode = AlertDeliveryModeBox.SelectedIndex == 1 ? "PerEvent" : "Summary";
         if (int.TryParse(AlertPerEventMaxBox.Text, out var perEventMax) && perEventMax is >= 1 and <= 100)
             _appSettings.AlertPerEventMaxPerCycle = perEventMax;
         else
-            validationErrors.Add("Per-event max-per-cycle must be between 1 and 100.");
+            errors.Add("Per-event max-per-cycle must be between 1 and 100.");
         _appSettings.MuteRuleDefaultExpiration = (MuteRuleDefaultExpirationCombo.SelectedItem as ComboBoxItem)?.Content?.ToString() ?? "24 hours";
         _appSettings.LogAlertDismissals = LogAlertDismissalsCheckBox.IsChecked == true;
-        _appSettings.AnalysisEnabled = AnalysisEnabledCheckBox.IsChecked == true;
-        _appSettings.AnalysisNotificationsEnabled = AnalysisNotificationsCheckBox.IsChecked == true;
-        if (int.TryParse(AnalysisIntervalBox.Text, out var analysisInterval) && analysisInterval is >= 5 and <= 360)
-            _appSettings.AnalysisIntervalMinutes = analysisInterval;
-        else
-            validationErrors.Add("Analysis interval must be between 5 and 360 minutes.");
-        if (double.TryParse(AnalysisNotifySeverityBox.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var analysisSeverity)
-            && analysisSeverity is >= 0.0 and <= 2.0)
-            _appSettings.AnalysisNotifySeverity = analysisSeverity;
-        else
-            validationErrors.Add("Analysis notify severity must be between 0.0 and 2.0.");
-
-        if (validationErrors.Count > 0)
-        {
-            MessageBox.Show(
-                "Some alert settings have invalid values and were not changed:\n\n" +
-                string.Join("\n", validationErrors),
-                "Settings", MessageBoxButton.OK, MessageBoxImage.Warning);
-            return false;
-        }
-
-        return true;
     }
 
     private void AlertsEnabledCheckBox_Changed(object sender, RoutedEventArgs e) => UpdateAlertControlStates();
@@ -516,43 +671,93 @@ public partial class SettingsWindow : Window
         UpdateAlertPreviewText();
     }
 
-    // ── SMTP email ──
+    // ── SMTP email + webhooks (config_notification) ──
 
-    private void LoadSmtpSettings()
+    /// <summary>Seeds the SMTP + Teams/Slack controls from a <see cref="NotificationRow"/> (the store's values,
+    /// or defaults). The SMTP enable toggle reflects whether the store carries connect fields; the password box
+    /// is prefilled from the decrypted store blob (blank + remembered when it was sealed on another machine).</summary>
+    private void SeedNotificationControlsFrom(NotificationRow r)
     {
-        SmtpEnabledCheckBox.IsChecked = _appSettings.SmtpEnabled;
-        SmtpServerBox.Text = _appSettings.SmtpServer;
-        SmtpPortBox.Text = _appSettings.SmtpPort.ToString(CultureInfo.InvariantCulture);
-        SmtpSslCheckBox.IsChecked = _appSettings.SmtpUseSsl;
-        SmtpUsernameBox.Text = _appSettings.SmtpUsername;
-        SmtpFromBox.Text = _appSettings.SmtpFromAddress;
-        SmtpRecipientsBox.Text = _appSettings.SmtpRecipients;
+        var smtpConfigured = !string.IsNullOrWhiteSpace(r.SmtpHost)
+            || !string.IsNullOrWhiteSpace(r.SmtpFromAddress)
+            || !string.IsNullOrWhiteSpace(r.SmtpRecipients);
+        SmtpEnabledCheckBox.IsChecked = smtpConfigured;
+        SmtpServerBox.Text = r.SmtpHost;
+        SmtpPortBox.Text = r.SmtpPort.ToString(CultureInfo.InvariantCulture);
+        SmtpSslCheckBox.IsChecked = r.SmtpUseSsl;
+        SmtpUsernameBox.Text = r.SmtpUsername ?? "";
+        SmtpFromBox.Text = r.SmtpFromAddress;
+        SmtpRecipientsBox.Text = r.SmtpRecipients;
+        EmailCooldownBox.Text = r.EmailCooldownMinutes.ToString(CultureInfo.InvariantCulture);
 
-        var password = ViewerSecretStore.GetSmtpPassword();
-        if (!string.IsNullOrEmpty(password))
-        {
-            SmtpPasswordBox.Password = password;
-        }
+        _loadedSmtpBlob = r.SmtpEncryptedPassword;
+        SmtpPasswordBox.Password = OperatingSystem.IsWindows()
+            ? ViewerServerSecret.TryUnprotect(r.SmtpEncryptedPassword) ?? ""
+            : "";
+
+        TeamsWebhookEnabledCheckBox.IsChecked = !string.IsNullOrWhiteSpace(r.TeamsUrl);
+        TeamsWebhookUrlBox.Text = r.TeamsUrl;
+        TeamsProxyAddressBox.Text = r.TeamsProxy;
+        SlackWebhookEnabledCheckBox.IsChecked = !string.IsNullOrWhiteSpace(r.SlackUrl);
+        SlackWebhookUrlBox.Text = r.SlackUrl;
+        SlackProxyAddressBox.Text = r.SlackProxy;
 
         UpdateSmtpControlStates();
+        UpdateTeamsControlStates();
+        UpdateSlackControlStates();
     }
 
-    private void SaveSmtpSettings()
+    /// <summary>Builds the <see cref="NotificationRow"/> from the SMTP + webhook controls. A DISABLED channel
+    /// writes EMPTY key fields so the service (which derives enablement from non-empty fields) treats it as off;
+    /// an enabled SMTP channel seals the typed password (or preserves the existing blob when left unchanged).</summary>
+    private NotificationRow BuildNotificationRowFromControls(List<string> errors)
     {
-        _appSettings.SmtpEnabled = SmtpEnabledCheckBox.IsChecked == true;
-        _appSettings.SmtpServer = SmtpServerBox.Text?.Trim() ?? "";
-        if (int.TryParse(SmtpPortBox.Text, out var port) && port is > 0 and < 65536)
-            _appSettings.SmtpPort = port;
-        _appSettings.SmtpUseSsl = SmtpSslCheckBox.IsChecked == true;
-        _appSettings.SmtpUsername = SmtpUsernameBox.Text?.Trim() ?? "";
-        _appSettings.SmtpFromAddress = SmtpFromBox.Text?.Trim() ?? "";
-        _appSettings.SmtpRecipients = SmtpRecipientsBox.Text?.Trim() ?? "";
+        var row = new NotificationRow();
 
-        /* Password goes to Windows Credential Manager, never the JSON settings file. */
-        if (!string.IsNullOrEmpty(SmtpPasswordBox.Password))
+        if (int.TryParse(EmailCooldownBox.Text, out var emailCooldown) && emailCooldown is >= 1 and <= 120)
+            row.EmailCooldownMinutes = emailCooldown;
+        else
+            errors.Add("Email alert cooldown must be between 1 and 120 minutes.");
+
+        if (SmtpEnabledCheckBox.IsChecked == true)
         {
-            ViewerSecretStore.SaveSmtpPassword(_appSettings.SmtpUsername, SmtpPasswordBox.Password);
+            row.SmtpHost = SmtpServerBox.Text?.Trim() ?? "";
+            if (int.TryParse(SmtpPortBox.Text, out var port) && port is > 0 and < 65536)
+                row.SmtpPort = port;
+            row.SmtpUseSsl = SmtpSslCheckBox.IsChecked == true;
+            var username = SmtpUsernameBox.Text?.Trim();
+            row.SmtpUsername = string.IsNullOrWhiteSpace(username) ? null : username;
+            row.SmtpFromAddress = SmtpFromBox.Text?.Trim() ?? "";
+            row.SmtpRecipients = SmtpRecipientsBox.Text?.Trim() ?? "";
+            row.SmtpEncryptedPassword = ResolveSmtpBlob();
         }
+
+        if (TeamsWebhookEnabledCheckBox.IsChecked == true)
+        {
+            row.TeamsUrl = TeamsWebhookUrlBox.Text?.Trim() ?? "";
+            row.TeamsProxy = TeamsProxyAddressBox.Text?.Trim() ?? "";
+        }
+
+        if (SlackWebhookEnabledCheckBox.IsChecked == true)
+        {
+            row.SlackUrl = SlackWebhookUrlBox.Text?.Trim() ?? "";
+            row.SlackProxy = SlackProxyAddressBox.Text?.Trim() ?? "";
+        }
+
+        return row;
+    }
+
+    /// <summary>The SMTP blob to persist: seal the typed password when the box holds one; otherwise keep the
+    /// store's existing blob (so an unchanged — or another-machine, undecryptable — password survives Save).</summary>
+    private string? ResolveSmtpBlob()
+    {
+        var typed = SmtpPasswordBox.Password;
+        if (!string.IsNullOrEmpty(typed) && OperatingSystem.IsWindows())
+        {
+            return ViewerServerSecret.Protect(typed);
+        }
+
+        return string.IsNullOrEmpty(typed) ? _loadedSmtpBlob : null;
     }
 
     private void SmtpEnabledCheckBox_Changed(object sender, RoutedEventArgs e) => UpdateSmtpControlStates();
@@ -624,32 +829,6 @@ public partial class SettingsWindow : Window
             TestEmailButton.Content = "Send Test Email";
             TestEmailButton.IsEnabled = true;
         }
-    }
-
-    // ── Webhooks (Teams / Slack) ──
-
-    private void LoadWebhookSettings()
-    {
-        TeamsWebhookEnabledCheckBox.IsChecked = _appSettings.TeamsWebhookEnabled;
-        TeamsWebhookUrlBox.Text = ViewerSecretStore.GetTeamsWebhookUrl();
-        TeamsProxyAddressBox.Text = _appSettings.TeamsProxyAddress;
-        SlackWebhookEnabledCheckBox.IsChecked = _appSettings.SlackWebhookEnabled;
-        SlackWebhookUrlBox.Text = ViewerSecretStore.GetSlackWebhookUrl();
-        SlackProxyAddressBox.Text = _appSettings.SlackProxyAddress;
-        UpdateTeamsControlStates();
-        UpdateSlackControlStates();
-    }
-
-    private void SaveWebhookSettings()
-    {
-        _appSettings.TeamsWebhookEnabled = TeamsWebhookEnabledCheckBox.IsChecked == true;
-        _appSettings.TeamsProxyAddress = TeamsProxyAddressBox.Text?.Trim() ?? "";
-        _appSettings.SlackWebhookEnabled = SlackWebhookEnabledCheckBox.IsChecked == true;
-        _appSettings.SlackProxyAddress = SlackProxyAddressBox.Text?.Trim() ?? "";
-
-        /* Webhook URLs go to Windows Credential Manager, never the JSON settings file. */
-        ViewerSecretStore.SaveTeamsWebhookUrl(TeamsWebhookUrlBox.Text?.Trim() ?? "");
-        ViewerSecretStore.SaveSlackWebhookUrl(SlackWebhookUrlBox.Text?.Trim() ?? "");
     }
 
     private void TeamsWebhookEnabledCheckBox_Changed(object sender, RoutedEventArgs e) => UpdateTeamsControlStates();
@@ -746,26 +925,70 @@ public partial class SettingsWindow : Window
 
     // ── Save / Close ──
 
-    private void SaveButton_Click(object sender, RoutedEventArgs e)
+    private async void SaveButton_Click(object sender, RoutedEventArgs e)
     {
-        var mcpValid = SaveMcpSettings();
+        var errors = new List<string>();
+        var mcpValid = TryReadServiceFlags(out var capturePlans, out var mcpEnabled, out var mcpPort);
+        var alertRow = BuildAlertRowFromControls(errors);
+        SaveViewerLocalAlertFields(errors);
+        var notifyRow = BuildNotificationRowFromControls(errors);
+
+        /* Persist the viewer-LOCAL preferences immediately (valid values applied above), and capture the
+           edited viewer preferences for MainWindow to save + re-seed tabs from. */
         SaveConnectionTimeout();
         SaveCsvSeparator();
         SaveTimeDisplayMode();
-        var alertsValid = SaveAlertSettings();
-        SaveSmtpSettings();
-        SaveWebhookSettings();
-
-        /* Persist the app settings (valid values were applied above; invalid ones were skipped and warned
-           about) and capture the edited viewer preferences for MainWindow to save + re-seed tabs from. */
         _appSettingsStore.Save(_appSettings);
         Result = BuildViewerPreferences();
 
-        /* Leave the window open on a validation warning so the user can fix the flagged value; otherwise
-           the close IS the confirmation (mirrors the viewer's other dialogs). */
-        if (!alertsValid || !mcpValid)
+        if (errors.Count > 0)
         {
+            MessageBox.Show(
+                "Some settings have invalid values and were not saved:\n\n" + string.Join("\n", errors),
+                "Settings", MessageBoxButton.OK, MessageBoxImage.Warning);
             return;
+        }
+
+        if (!mcpValid)
+        {
+            return; /* TryReadServiceFlags already warned about the bad MCP port. */
+        }
+
+        /* Guard against clobbering: if the current settings could not be READ (a transient store error left the
+           controls at defaults), do NOT write them back — that would overwrite an operator-tuned store with the
+           on-screen defaults. Save the viewer-local preferences (already done above) and say so. */
+        if (_dataService is not null && !_storeLoaded)
+        {
+            MessageBox.Show(
+                "Your viewer preferences were saved. The current monitoring settings could not be read from the " +
+                "Darling store, so they were left unchanged (to avoid overwriting them). Try again once the store " +
+                "is reachable.",
+                "Settings", MessageBoxButton.OK, MessageBoxImage.Warning);
+            return;
+        }
+
+        /* Write the operator config to the control-plane store (the service reloads on the config_version bump).
+           A read-only seat surfaces the friendly message and the window stays open. */
+        if (_dataService is not null)
+        {
+            try
+            {
+                await _dataService.UpsertAlertSettingsAsync(alertRow);
+                await _dataService.UpsertNotificationAsync(notifyRow);
+                await _dataService.UpdateServiceFlagsAsync(capturePlans, mcpEnabled, mcpPort);
+            }
+            catch (ViewerReadOnlyException ex)
+            {
+                MessageBox.Show(ex.Message, "Read-only connection", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(
+                    $"The viewer-local preferences were saved, but the monitoring settings could not be written to the store:\n\n{ex.Message}",
+                    "Settings", MessageBoxButton.OK, MessageBoxImage.Error);
+                return;
+            }
         }
 
         DialogResult = true;
@@ -807,6 +1030,7 @@ public partial class SettingsWindow : Window
         public static TestAlertSettings FromUi(SettingsWindow w)
         {
             int.TryParse(w.SmtpPortBox.Text, out var smtpPort);
+            int.TryParse(w.EmailCooldownBox.Text, out var emailCooldown);
             return new TestAlertSettings
             {
                 SmtpEnabled = w.SmtpEnabledCheckBox.IsChecked == true,
@@ -817,7 +1041,7 @@ public partial class SettingsWindow : Window
                 SmtpFromAddress = w.SmtpFromBox.Text?.Trim() ?? "",
                 SmtpRecipients = w.SmtpRecipientsBox.Text?.Trim() ?? "",
                 SmtpPassword = w.SmtpPasswordBox.Password,
-                EmailCooldownMinutes = w._appSettings.EmailCooldownMinutes,
+                EmailCooldownMinutes = emailCooldown,
                 TeamsWebhookEnabled = w.TeamsWebhookEnabledCheckBox.IsChecked == true,
                 TeamsWebhookUrl = w.TeamsWebhookUrlBox.Text?.Trim() ?? "",
                 TeamsProxyAddress = w.TeamsProxyAddressBox.Text?.Trim() ?? "",

--- a/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml.cs
@@ -145,9 +145,13 @@ public partial class SettingsWindow : Window
                     _paused = service.Paused;
                 }
 
-                /* All reads completed — Save may now write the store sections without risk of clobbering
-                   tuned config with the on-screen defaults. */
-                _storeLoaded = true;
+                /* Save may write the store sections only when it is SEEDED — config_service is written LAST by
+                   the service (its presence marks the seed complete), so a non-null row here guarantees the
+                   alert/notification sections read real rows too. On a reachable-but-UNSEEDED store every read
+                   returns null and the controls hold on-screen defaults; upserting those would INSERT id=1
+                   defaults and make the service SKIP seeding those sections from darling.json (COUNT != 0),
+                   silently shadowing operator-tuned config. Leaving this false makes Save decline + say so. */
+                _storeLoaded = service is not null;
             }
             catch (Exception ex)
             {
@@ -961,8 +965,8 @@ public partial class SettingsWindow : Window
         {
             MessageBox.Show(
                 "Your viewer preferences were saved. The current monitoring settings could not be read from the " +
-                "Darling store, so they were left unchanged (to avoid overwriting them). Try again once the store " +
-                "is reachable.",
+                "Darling store (it may be unreachable, or the service hasn't finished initializing its settings " +
+                "yet), so they were left unchanged to avoid overwriting them. Try again in a moment.",
                 "Settings", MessageBoxButton.OK, MessageBoxImage.Warning);
             return;
         }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerControlPlaneMigration.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerControlPlaneMigration.cs
@@ -79,6 +79,16 @@ public sealed class ViewerControlPlaneMigration
             return 0;
         }
 
+        /* Wait for the service to finish seeding before importing. config_service is written LAST (its presence
+           marks the seed complete), so on a reachable-but-unseeded (or partially-seeded) store every section
+           read returns null: importing nothing AND burning the once-marker would strand the operator's pre-3b
+           settings forever, and a partial seed would drop the MCP section. Return WITHOUT the marker so a
+           later, fully-seeded run carries everything across. */
+        if (!await dataService.IsConfigSeededAsync(cancellationToken))
+        {
+            return 0;
+        }
+
         var imported = 0;
         try
         {

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerControlPlaneMigration.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerControlPlaneMigration.cs
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.Versioning;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The one-time import of a pre-Stage-3b viewer's OPERATIONAL settings (the alert engine, automated analysis,
+/// SMTP + Teams/Slack delivery, and the MCP toggle) out of the now-severed <c>viewer-settings.json</c>
+/// (<see cref="ViewerAppSettings"/>) into the control-plane store. Stage 3b makes the store the source of
+/// truth for what the running service honors; this carries a viewer's existing customizations across so they
+/// keep taking effect without re-entering them — the operational twin of <see cref="ViewerServerMigration"/>
+/// (which carried the SERVER definitions).
+///
+/// <para><b>Defaults-only, no clobber.</b> A section is imported ONLY when the store's copy is still at the
+/// V17 seed defaults (the operator has NOT configured it service-side via darling.json) AND the viewer's copy
+/// actually differs from those defaults (there is a real customization to carry). So a store an operator
+/// already tuned is never overwritten, and a fresh viewer with nothing customized writes nothing (no spurious
+/// <c>config_version</c> bump). <b>Runs once.</b> A marker file guards it after a clean pass. Read-only seats
+/// and a disconnected viewer skip it (nothing to write); a <see cref="ViewerReadOnlyException"/> mid-pass
+/// leaves the marker unwritten so a later writable run finishes.</para>
+///
+/// <para><b>Secrets.</b> The SMTP password is read from Windows Credential Manager (the old viewer-local vault)
+/// and re-sealed as the service-decryptable DPAPI-LocalMachine blob (<see cref="ViewerServerSecret"/>); the
+/// Teams/Slack URLs (also formerly in the vault) carry as the store's plain-text channel URLs. So the SMTP
+/// secret path is Windows-only; the alert/analysis/MCP imports are platform-independent.</para>
+///
+/// <para><b>Schedules.</b> There is deliberately NO schedule import: the Darling viewer never had a local
+/// collector-schedule editor (it was an informational panel before Stage 3b), so there is no source to carry —
+/// an un-customized store already collects on the shared <c>CollectorScheduleDefaults</c>, which is the intent.</para>
+/// </summary>
+public sealed class ViewerControlPlaneMigration
+{
+    private readonly ViewerAppSettings _appSettings;
+    private readonly string _markerPath;
+
+    /// <param name="appSettings">The loaded viewer app settings (the pre-Stage-3b operational values).</param>
+    /// <param name="markerPath">Override the once-marker path (tests pass a temp file); null uses <see cref="DefaultMarkerPath"/>.</param>
+    public ViewerControlPlaneMigration(ViewerAppSettings appSettings, string? markerPath = null)
+    {
+        _appSettings = appSettings ?? throw new ArgumentNullException(nameof(appSettings));
+        _markerPath = markerPath ?? DefaultMarkerPath();
+    }
+
+    /// <summary>%APPDATA%\PerformanceMonitorDarling\viewer-controlplane-migrated.marker.</summary>
+    public static string DefaultMarkerPath()
+    {
+        var directory = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "PerformanceMonitorDarling");
+        return Path.Combine(directory, "viewer-controlplane-migrated.marker");
+    }
+
+    /// <summary>True once the migrate-in has completed a clean pass (the marker exists).</summary>
+    public bool AlreadyMigrated => File.Exists(_markerPath);
+
+    /// <summary>
+    /// Imports every still-default store section the viewer has a customization for, then writes the marker. A
+    /// no-op (returns 0) when the viewer is disconnected, connected read-only, or already migrated. Returns the
+    /// number of sections actually written (0–3). A <see cref="ViewerReadOnlyException"/> mid-pass stops
+    /// without marking done, so a later writable run retries.
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    public async Task<int> MigrateAsync(ViewerDataService? dataService, CancellationToken cancellationToken = default)
+    {
+        if (dataService is null || dataService.IsReadOnly || AlreadyMigrated)
+        {
+            return 0;
+        }
+
+        var imported = 0;
+        try
+        {
+            /* Alerts + automated analysis. */
+            var storeAlerts = await dataService.GetAlertSettingsAsync(cancellationToken);
+            var viewerAlerts = BuildAlertRow(_appSettings);
+            if (storeAlerts is not null && ShouldImportAlerts(storeAlerts, viewerAlerts))
+            {
+                await dataService.UpsertAlertSettingsAsync(viewerAlerts, cancellationToken);
+                imported++;
+            }
+
+            /* SMTP + Teams/Slack delivery (secrets from the old vault, re-sealed for the service). */
+            var storeNotify = await dataService.GetNotificationAsync(cancellationToken);
+            var viewerNotify = BuildNotificationRow(
+                _appSettings,
+                ViewerSecretStore.GetSmtpPassword(),
+                ViewerSecretStore.GetTeamsWebhookUrl(),
+                ViewerSecretStore.GetSlackWebhookUrl());
+            if (storeNotify is not null && ShouldImportNotification(storeNotify, viewerNotify))
+            {
+                await dataService.UpsertNotificationAsync(viewerNotify, cancellationToken);
+                imported++;
+            }
+
+            /* MCP toggle/port (config_service, UPDATE-only; preserve the store's current capture_plans). */
+            var storeService = await dataService.GetServiceConfigAsync(cancellationToken);
+            if (storeService is not null && ShouldImportMcp(storeService, _appSettings))
+            {
+                await dataService.UpdateServiceFlagsAsync(storeService.CapturePlans, _appSettings.McpEnabled, _appSettings.McpPort, cancellationToken);
+                imported++;
+            }
+        }
+        catch (ViewerReadOnlyException)
+        {
+            /* Grants tightened under us — leave the marker unwritten so a later writable run finishes. */
+            ViewerLogger.Warn("ViewerControlPlaneMigration", "Store went read-only mid-migrate; will retry next run.");
+            return imported;
+        }
+
+        WriteMarker();
+        return imported;
+    }
+
+    /// <summary>Projects the viewer's alert + analysis app settings onto a store row (pure — pinned by tests).</summary>
+    public static AlertSettingsRow BuildAlertRow(ViewerAppSettings s)
+    {
+        ArgumentNullException.ThrowIfNull(s);
+        return new AlertSettingsRow
+        {
+            Enabled = s.AlertsEnabled,
+            CpuEnabled = s.AlertCpuEnabled,
+            CpuThresholdPercent = s.AlertCpuThreshold,
+            CpuMode = ViewerDataService.MapCpuModeToStore(s.AlertCpuMode),
+            BlockingEnabled = s.AlertBlockingEnabled,
+            BlockingCountThreshold = s.AlertBlockingThreshold,
+            DeadlockEnabled = s.AlertDeadlockEnabled,
+            DeadlockCountThreshold = s.AlertDeadlockThreshold,
+            PoisonWaitEnabled = s.AlertPoisonWaitEnabled,
+            PoisonWaitThresholdMs = s.AlertPoisonWaitThresholdMs,
+            LongRunningQueryEnabled = s.AlertLongRunningQueryEnabled,
+            LongRunningQueryThresholdMinutes = s.AlertLongRunningQueryThresholdMinutes,
+            TempDbSpaceEnabled = s.AlertTempDbSpaceEnabled,
+            TempDbSpaceThresholdPercent = s.AlertTempDbSpaceThresholdPercent,
+            LowDiskEnabled = s.AlertLowDiskEnabled,
+            LowDiskThresholdPercent = s.AlertLowDiskThresholdPercent,
+            LowDiskThresholdGb = s.AlertLowDiskThresholdGb,
+            LongRunningJobEnabled = s.AlertLongRunningJobEnabled,
+            LongRunningJobMultiplier = s.AlertLongRunningJobMultiplier,
+            FailedJobEnabled = s.AlertFailedJobEnabled,
+            FailedJobLookbackMinutes = s.AlertFailedJobLookbackMinutes,
+            CooldownMinutes = s.AlertCooldownMinutes,
+            ExcludedDatabases = new List<string>(s.AlertExcludedDatabases ?? new List<string>()),
+            AnalysisEnabled = s.AnalysisEnabled,
+            AnalysisIntervalMinutes = s.AnalysisIntervalMinutes,
+            AnalysisNotificationsEnabled = s.AnalysisNotificationsEnabled,
+            AnalysisNotifySeverity = s.AnalysisNotifySeverity,
+        };
+    }
+
+    /// <summary>
+    /// Projects the viewer's SMTP/webhook app settings + the vault secrets onto a store row (pure — pinned by
+    /// tests). A DISABLED channel writes EMPTY key fields (SMTP host/from/to; a webhook URL) so the service —
+    /// which derives enablement from non-empty fields — treats it as off; an enabled channel carries its
+    /// values, with the SMTP password sealed as the service-decryptable DPAPI blob.
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    public static NotificationRow BuildNotificationRow(ViewerAppSettings s, string? smtpPassword, string teamsUrl, string slackUrl)
+    {
+        ArgumentNullException.ThrowIfNull(s);
+        var row = new NotificationRow
+        {
+            EmailCooldownMinutes = s.EmailCooldownMinutes,
+        };
+
+        if (s.SmtpEnabled)
+        {
+            row.SmtpHost = s.SmtpServer ?? "";
+            row.SmtpPort = s.SmtpPort;
+            row.SmtpUseSsl = s.SmtpUseSsl;
+            row.SmtpUsername = string.IsNullOrWhiteSpace(s.SmtpUsername) ? null : s.SmtpUsername;
+            row.SmtpFromAddress = s.SmtpFromAddress ?? "";
+            row.SmtpRecipients = s.SmtpRecipients ?? "";
+            row.SmtpEncryptedPassword = string.IsNullOrEmpty(smtpPassword) ? null : ViewerServerSecret.Protect(smtpPassword);
+        }
+
+        if (s.TeamsWebhookEnabled)
+        {
+            row.TeamsUrl = teamsUrl ?? "";
+            row.TeamsProxy = s.TeamsProxyAddress ?? "";
+        }
+
+        if (s.SlackWebhookEnabled)
+        {
+            row.SlackUrl = slackUrl ?? "";
+            row.SlackProxy = s.SlackProxyAddress ?? "";
+        }
+
+        return row;
+    }
+
+    /// <summary>Import alerts only when the store section is untouched (defaults) AND the viewer has a real
+    /// customization to carry — never clobber an operator-tuned store, never write defaults-over-defaults.</summary>
+    public static bool ShouldImportAlerts(AlertSettingsRow storeRow, AlertSettingsRow viewerRow)
+    {
+        ArgumentNullException.ThrowIfNull(storeRow);
+        ArgumentNullException.ThrowIfNull(viewerRow);
+        return storeRow.ValueEquals(AlertSettingsRow.Defaults()) && !viewerRow.ValueEquals(AlertSettingsRow.Defaults());
+    }
+
+    /// <summary>Import notification config only when the store section is untouched AND the viewer differs.</summary>
+    public static bool ShouldImportNotification(NotificationRow storeRow, NotificationRow viewerRow)
+    {
+        ArgumentNullException.ThrowIfNull(storeRow);
+        ArgumentNullException.ThrowIfNull(viewerRow);
+        return storeRow.ValueEquals(NotificationRow.Defaults()) && !viewerRow.ValueEquals(NotificationRow.Defaults());
+    }
+
+    /// <summary>Import the MCP toggle/port only when the store's MCP flags are still at defaults AND the viewer
+    /// differs (capture_plans/paused are not viewer-local, so they don't gate this).</summary>
+    public static bool ShouldImportMcp(ServiceConfigRow storeRow, ViewerAppSettings viewer)
+    {
+        ArgumentNullException.ThrowIfNull(storeRow);
+        ArgumentNullException.ThrowIfNull(viewer);
+        var storeAtMcpDefaults = !storeRow.McpEnabled && storeRow.McpPort == 5152;
+        var viewerCustomized = viewer.McpEnabled || viewer.McpPort != 5152;
+        return storeAtMcpDefaults && viewerCustomized;
+    }
+
+    private void WriteMarker()
+    {
+        try
+        {
+            var directory = Path.GetDirectoryName(_markerPath);
+            if (!string.IsNullOrEmpty(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            File.WriteAllText(_markerPath, $"migrated {DateTime.UtcNow:O}");
+        }
+        catch (Exception ex)
+        {
+            /* A failed marker write only means the migrate re-runs next launch; the defaults-only guard makes
+               a re-run a no-op once the store carries the imported values. Don't crash the viewer. */
+            ViewerLogger.Warn("ViewerControlPlaneMigration", $"Could not write the migrate marker '{_markerPath}': {ex.Message}");
+        }
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.AlertSettings.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.AlertSettings.cs
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The viewer's control-plane writes to <c>config.config_alert_settings</c> — the single-row (id=1) desired
+/// state for the shared alert engine's toggles/thresholds plus the scheduled-analysis cadence knobs the
+/// Stage-1 <c>StoreConfigProvider</c> reads and hot-swaps into the running service's
+/// <c>DarlingAlertSettings</c>/<c>AnalysisConfig</c> on every reload beacon. This is the Stage-3b rewire that
+/// replaces the severed <c>viewer-settings.json</c> alert block: saving the Settings window's Notifications +
+/// Automated-Analysis sections now drives the running service.
+///
+/// <para>Mirrors <see cref="MonitoredServerUpsertSql"/>/<see cref="GetMuteRulesAsync"/> discipline exactly:
+/// public-const SQL (so Darling.Tests pin the dialect + column parity with the service's
+/// <c>StoreConfigProvider.ReadAlertSettingsAsync</c> without a live Postgres), every value bound as a
+/// <c>$N</c> parameter, the write routed through <see cref="ExecuteWriteAsync"/> so a read-only <c>viewer</c>
+/// seat degrades to <see cref="ViewerReadOnlyException"/> (42501). The single global row is pinned to
+/// <c>id = 1</c>; <c>modified_at</c> is server-side naive-UTC. The bare table name resolves through the
+/// <c>collect,config,public</c> search_path to <c>config.config_alert_settings</c>.</para>
+///
+/// <para><b>cpu_mode.</b> The store carries the SERVICE's vocabulary — <c>"sql"</c> (SQL-process CPU) vs
+/// <c>"total"</c> (all non-idle CPU) — which the service compares case-insensitively against <c>"sql"</c>.
+/// The viewer's <see cref="AlertSettingsRow.CpuMode"/> holds that same store value; the Settings window maps
+/// its "Total"/"SqlOnly" combo to/from it (see <see cref="MapCpuModeToStore"/>).</para>
+/// </summary>
+public sealed partial class ViewerDataService
+{
+    /* The 27 AlertsConfig + AnalysisConfig columns in the SAME order the service reads them
+       (StoreConfigProvider.ReadAlertSettingsAsync), so the parity test pins one list against both ends. */
+    private const string AlertSettingsColumns =
+        "enabled, cpu_enabled, cpu_threshold_percent, cpu_mode, blocking_enabled, blocking_count_threshold, " +
+        "deadlock_enabled, deadlock_count_threshold, poison_wait_enabled, poison_wait_threshold_ms, " +
+        "long_running_query_enabled, long_running_query_threshold_minutes, tempdb_space_enabled, " +
+        "tempdb_space_threshold_percent, low_disk_enabled, low_disk_threshold_percent, low_disk_threshold_gb, " +
+        "long_running_job_enabled, long_running_job_multiplier, failed_job_enabled, failed_job_lookback_minutes, " +
+        "cooldown_minutes, excluded_databases, analysis_enabled, analysis_interval_minutes, " +
+        "analysis_notifications_enabled, analysis_notify_severity";
+
+    /// <summary>The single global alert-settings row (id=1), for the Settings window prefill + the migrate-in
+    /// defaults check. Column order matches <see cref="AlertSettingsColumns"/>.</summary>
+    public const string AlertSettingsSelectSql =
+        "SELECT " + AlertSettingsColumns + " FROM config_alert_settings WHERE id = 1";
+
+    /// <summary>Upserts the single global alert-settings row (Settings window Save). ON CONFLICT rewrites every
+    /// column and bumps <c>modified_at</c> (and, via the V17 statement trigger, <c>config_version</c> — the
+    /// service reloads on its next sweep). $1..$27 bind the columns in <see cref="AlertSettingsColumns"/> order.</summary>
+    public const string AlertSettingsUpsertSql = @"
+INSERT INTO config_alert_settings (id, " + AlertSettingsColumns + @", modified_at)
+VALUES (1, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22,
+        $23, $24, $25, $26, $27, (now() AT TIME ZONE 'UTC'))
+ON CONFLICT (id) DO UPDATE SET
+    enabled = EXCLUDED.enabled,
+    cpu_enabled = EXCLUDED.cpu_enabled,
+    cpu_threshold_percent = EXCLUDED.cpu_threshold_percent,
+    cpu_mode = EXCLUDED.cpu_mode,
+    blocking_enabled = EXCLUDED.blocking_enabled,
+    blocking_count_threshold = EXCLUDED.blocking_count_threshold,
+    deadlock_enabled = EXCLUDED.deadlock_enabled,
+    deadlock_count_threshold = EXCLUDED.deadlock_count_threshold,
+    poison_wait_enabled = EXCLUDED.poison_wait_enabled,
+    poison_wait_threshold_ms = EXCLUDED.poison_wait_threshold_ms,
+    long_running_query_enabled = EXCLUDED.long_running_query_enabled,
+    long_running_query_threshold_minutes = EXCLUDED.long_running_query_threshold_minutes,
+    tempdb_space_enabled = EXCLUDED.tempdb_space_enabled,
+    tempdb_space_threshold_percent = EXCLUDED.tempdb_space_threshold_percent,
+    low_disk_enabled = EXCLUDED.low_disk_enabled,
+    low_disk_threshold_percent = EXCLUDED.low_disk_threshold_percent,
+    low_disk_threshold_gb = EXCLUDED.low_disk_threshold_gb,
+    long_running_job_enabled = EXCLUDED.long_running_job_enabled,
+    long_running_job_multiplier = EXCLUDED.long_running_job_multiplier,
+    failed_job_enabled = EXCLUDED.failed_job_enabled,
+    failed_job_lookback_minutes = EXCLUDED.failed_job_lookback_minutes,
+    cooldown_minutes = EXCLUDED.cooldown_minutes,
+    excluded_databases = EXCLUDED.excluded_databases,
+    analysis_enabled = EXCLUDED.analysis_enabled,
+    analysis_interval_minutes = EXCLUDED.analysis_interval_minutes,
+    analysis_notifications_enabled = EXCLUDED.analysis_notifications_enabled,
+    analysis_notify_severity = EXCLUDED.analysis_notify_severity,
+    modified_at = (now() AT TIME ZONE 'UTC')";
+
+    /// <summary>The two <c>cpu_mode</c> values the service honors (it compares case-insensitively against
+    /// <see cref="CpuModeSql"/>; anything else is total).</summary>
+    public const string CpuModeSql = "sql";
+    public const string CpuModeTotal = "total";
+
+    /// <summary>Reads the single global alert-settings row, or null when the store has not seeded it yet
+    /// (a pre-Stage-1 store, or the service has not started) — the caller then shows viewer defaults.</summary>
+    public async Task<AlertSettingsRow?> GetAlertSettingsAsync(CancellationToken cancellationToken = default)
+    {
+        await using var command = _dataSource.CreateCommand(AlertSettingsSelectSql);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        return await reader.ReadAsync(cancellationToken) ? ReadAlertSettingsRow(reader) : null;
+    }
+
+    /// <summary>Upserts the single global alert-settings row (Settings window Save). Read-only seats throw
+    /// <see cref="ViewerReadOnlyException"/> via <see cref="ExecuteWriteAsync"/>.</summary>
+    public async Task UpsertAlertSettingsAsync(AlertSettingsRow row, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(row);
+
+        await using var command = _dataSource.CreateCommand(AlertSettingsUpsertSql);
+        BindAlertSettings(command, row);
+        await ExecuteWriteAsync(command, cancellationToken);
+    }
+
+    private static void BindAlertSettings(NpgsqlCommand command, AlertSettingsRow r)
+    {
+        command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = r.Enabled });                          // $1
+        command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = r.CpuEnabled });                       // $2
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = r.CpuThresholdPercent });               // $3
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = r.CpuMode });                        // $4
+        command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = r.BlockingEnabled });                  // $5
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = r.BlockingCountThreshold });            // $6
+        command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = r.DeadlockEnabled });                  // $7
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = r.DeadlockCountThreshold });            // $8
+        command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = r.PoisonWaitEnabled });                // $9
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = r.PoisonWaitThresholdMs });             // $10
+        command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = r.LongRunningQueryEnabled });          // $11
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = r.LongRunningQueryThresholdMinutes });  // $12
+        command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = r.TempDbSpaceEnabled });               // $13
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = r.TempDbSpaceThresholdPercent });       // $14
+        command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = r.LowDiskEnabled });                   // $15
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = r.LowDiskThresholdPercent });           // $16
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = r.LowDiskThresholdGb });                // $17
+        command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = r.LongRunningJobEnabled });            // $18
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = r.LongRunningJobMultiplier });          // $19
+        command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = r.FailedJobEnabled });                 // $20
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = r.FailedJobLookbackMinutes });          // $21
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = r.CooldownMinutes });                   // $22
+        AddTextArray(command, r.ExcludedDatabases);                                                             // $23
+        command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = r.AnalysisEnabled });                  // $24
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = r.AnalysisIntervalMinutes });           // $25
+        command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = r.AnalysisNotificationsEnabled });     // $26
+        command.Parameters.Add(new NpgsqlParameter<double> { TypedValue = r.AnalysisNotifySeverity });         // $27
+    }
+
+    private static AlertSettingsRow ReadAlertSettingsRow(NpgsqlDataReader reader) => new()
+    {
+        Enabled = reader.GetBoolean(0),
+        CpuEnabled = reader.GetBoolean(1),
+        CpuThresholdPercent = reader.GetInt32(2),
+        CpuMode = reader.GetString(3),
+        BlockingEnabled = reader.GetBoolean(4),
+        BlockingCountThreshold = reader.GetInt32(5),
+        DeadlockEnabled = reader.GetBoolean(6),
+        DeadlockCountThreshold = reader.GetInt32(7),
+        PoisonWaitEnabled = reader.GetBoolean(8),
+        PoisonWaitThresholdMs = reader.GetInt32(9),
+        LongRunningQueryEnabled = reader.GetBoolean(10),
+        LongRunningQueryThresholdMinutes = reader.GetInt32(11),
+        TempDbSpaceEnabled = reader.GetBoolean(12),
+        TempDbSpaceThresholdPercent = reader.GetInt32(13),
+        LowDiskEnabled = reader.GetBoolean(14),
+        LowDiskThresholdPercent = reader.GetInt32(15),
+        LowDiskThresholdGb = reader.GetInt32(16),
+        LongRunningJobEnabled = reader.GetBoolean(17),
+        LongRunningJobMultiplier = reader.GetInt32(18),
+        FailedJobEnabled = reader.GetBoolean(19),
+        FailedJobLookbackMinutes = reader.GetInt32(20),
+        CooldownMinutes = reader.GetInt32(21),
+        ExcludedDatabases = reader.IsDBNull(22) ? new List<string>() : reader.GetFieldValue<string[]>(22).ToList(),
+        AnalysisEnabled = reader.GetBoolean(23),
+        AnalysisIntervalMinutes = reader.GetInt32(24),
+        AnalysisNotificationsEnabled = reader.GetBoolean(25),
+        AnalysisNotifySeverity = reader.GetDouble(26),
+    };
+
+    /// <summary>Maps the Settings window's CPU-mode combo tag ("Total"/"SqlOnly") to the store value.</summary>
+    public static string MapCpuModeToStore(string viewerMode) =>
+        string.Equals(viewerMode, "SqlOnly", StringComparison.OrdinalIgnoreCase) ? CpuModeSql : CpuModeTotal;
+
+    /// <summary>Maps the store value back to the Settings window's combo tag.</summary>
+    public static string MapCpuModeFromStore(string? storeMode) =>
+        string.Equals(storeMode, CpuModeSql, StringComparison.OrdinalIgnoreCase) ? "SqlOnly" : "Total";
+}
+
+/// <summary>
+/// A <c>config.config_alert_settings</c> row (the single id=1 global row) as the viewer authors + reads it —
+/// the desired-state twin of the service's <c>AlertsConfig</c> + <c>AnalysisConfig</c> the store hot-swaps in.
+/// Carries ONLY the columns the store (and hence the service) has: the viewer-only alert fields the Settings
+/// window also edits (tray minimize, connection-change notify, LRQ max-results + the five noise filters,
+/// Summary/Per-event delivery, mute-rule default expiration, dismissal logging, analysis re-notify cooldown)
+/// are NOT service-honored config and stay viewer-local in <see cref="ViewerAppSettings"/>. Defaults mirror
+/// the V17 DDL (and Lite's <c>App.*</c>) member-for-member so <see cref="Defaults"/> equals a freshly-seeded row.
+/// </summary>
+public sealed class AlertSettingsRow
+{
+    public bool Enabled { get; set; } = true;
+    public bool CpuEnabled { get; set; } = true;
+    public int CpuThresholdPercent { get; set; } = 80;
+
+    /// <summary><see cref="ViewerDataService.CpuModeSql"/> or <see cref="ViewerDataService.CpuModeTotal"/>.</summary>
+    public string CpuMode { get; set; } = ViewerDataService.CpuModeTotal;
+
+    public bool BlockingEnabled { get; set; } = true;
+    public int BlockingCountThreshold { get; set; } = 1;
+    public bool DeadlockEnabled { get; set; } = true;
+    public int DeadlockCountThreshold { get; set; } = 1;
+    public bool PoisonWaitEnabled { get; set; } = true;
+    public int PoisonWaitThresholdMs { get; set; } = 500;
+    public bool LongRunningQueryEnabled { get; set; } = true;
+    public int LongRunningQueryThresholdMinutes { get; set; } = 30;
+    public bool TempDbSpaceEnabled { get; set; } = true;
+    public int TempDbSpaceThresholdPercent { get; set; } = 80;
+    public bool LowDiskEnabled { get; set; } = true;
+    public int LowDiskThresholdPercent { get; set; } = 10;
+    public int LowDiskThresholdGb { get; set; } = 5;
+    public bool LongRunningJobEnabled { get; set; } = true;
+    public int LongRunningJobMultiplier { get; set; } = 3;
+    public bool FailedJobEnabled { get; set; } = true;
+    public int FailedJobLookbackMinutes { get; set; } = 60;
+    public int CooldownMinutes { get; set; } = 5;
+    public List<string> ExcludedDatabases { get; set; } = new();
+    public bool AnalysisEnabled { get; set; } = true;
+    public int AnalysisIntervalMinutes { get; set; } = 30;
+
+    /// <summary>Darling's shipped default is TRUE (Lite's App default is false) — matches the V17 DDL.</summary>
+    public bool AnalysisNotificationsEnabled { get; set; } = true;
+    public double AnalysisNotifySeverity { get; set; } = 1.5;
+
+    /// <summary>A row equal to the V17 seed defaults — the migrate-in "is the service section still at defaults?" baseline.</summary>
+    public static AlertSettingsRow Defaults() => new();
+
+    /// <summary>Value-equality against another row (sequence-comparing the excluded-databases list) — the
+    /// migrate-in uses it to detect an untouched (default) store section and a genuine viewer customization.</summary>
+    public bool ValueEquals(AlertSettingsRow other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+        return Enabled == other.Enabled
+            && CpuEnabled == other.CpuEnabled
+            && CpuThresholdPercent == other.CpuThresholdPercent
+            && string.Equals(CpuMode, other.CpuMode, StringComparison.OrdinalIgnoreCase)
+            && BlockingEnabled == other.BlockingEnabled
+            && BlockingCountThreshold == other.BlockingCountThreshold
+            && DeadlockEnabled == other.DeadlockEnabled
+            && DeadlockCountThreshold == other.DeadlockCountThreshold
+            && PoisonWaitEnabled == other.PoisonWaitEnabled
+            && PoisonWaitThresholdMs == other.PoisonWaitThresholdMs
+            && LongRunningQueryEnabled == other.LongRunningQueryEnabled
+            && LongRunningQueryThresholdMinutes == other.LongRunningQueryThresholdMinutes
+            && TempDbSpaceEnabled == other.TempDbSpaceEnabled
+            && TempDbSpaceThresholdPercent == other.TempDbSpaceThresholdPercent
+            && LowDiskEnabled == other.LowDiskEnabled
+            && LowDiskThresholdPercent == other.LowDiskThresholdPercent
+            && LowDiskThresholdGb == other.LowDiskThresholdGb
+            && LongRunningJobEnabled == other.LongRunningJobEnabled
+            && LongRunningJobMultiplier == other.LongRunningJobMultiplier
+            && FailedJobEnabled == other.FailedJobEnabled
+            && FailedJobLookbackMinutes == other.FailedJobLookbackMinutes
+            && CooldownMinutes == other.CooldownMinutes
+            && (ExcludedDatabases ?? new List<string>()).SequenceEqual(other.ExcludedDatabases ?? new List<string>())
+            && AnalysisEnabled == other.AnalysisEnabled
+            && AnalysisIntervalMinutes == other.AnalysisIntervalMinutes
+            && AnalysisNotificationsEnabled == other.AnalysisNotificationsEnabled
+            && Math.Abs(AnalysisNotifySeverity - other.AnalysisNotifySeverity) < 0.0001;
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.CollectorSchedules.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.CollectorSchedules.cs
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The viewer's control-plane writes to <c>config.config_collector_schedules</c> — the SPARSE per-collector
+/// override table (absent row / NULL column = the shared <c>CollectorScheduleDefaults</c> code default;
+/// <c>server_id</c> NULL = fleet-wide) the Stage-1 <c>StoreConfigProvider.ResolveSchedule</c> layers over the
+/// code defaults (per-server override &gt; fleet override &gt; default, per column). This restores Lite's
+/// per-server/per-collector schedule editor + presets, now writing the store the running service honors.
+///
+/// <para>Same discipline as the sibling write partials: public-const SQL (Darling.Tests pin the dialect + the
+/// two ON CONFLICT arbiters against V17's partial-unique indexes AND the service's own
+/// <c>DarlingCommandExecutor.ResolveCollectorToggle</c> upsert shape), bound <c>$N</c> parameters, routed
+/// through <see cref="ExecuteWriteAsync"/> so a read-only seat degrades to <see cref="ViewerReadOnlyException"/>.
+/// A PRIMARY KEY cannot span the nullable <c>server_id</c>, so the fleet upsert arbitrates on
+/// <c>(collector_name) WHERE server_id IS NULL</c> and the per-server upsert on
+/// <c>(server_id, collector_name) WHERE server_id IS NOT NULL</c>.</para>
+///
+/// <para>A whole-scope Save is atomic: the replace deletes the scope's rows and re-inserts its overrides
+/// inside ONE transaction, so a mid-save failure never leaves a half-written schedule, and the many
+/// per-collector writes collapse into a single service reload (the worker reads the latest
+/// <c>config_version</c> once per sweep). The fleet scope stays sparse (only collectors that differ from the
+/// code default get a row); a per-server "custom" scope writes an explicit row per collector, matching Lite's
+/// full-snapshot per-server override so the grid is WYSIWYG regardless of the fleet layer.</para>
+/// </summary>
+public sealed partial class ViewerDataService
+{
+    /// <summary>All override rows (both scopes), for the editor to overlay on the code defaults. Column order
+    /// matches the service's <c>ReadScheduleOverridesAsync</c>.</summary>
+    public const string CollectorSchedulesSelectSql =
+        "SELECT server_id, collector_name, frequency_minutes, retention_days, enabled FROM config_collector_schedules ORDER BY server_id NULLS FIRST, collector_name";
+
+    /// <summary>Upserts one FLEET-WIDE override row (server_id NULL). Arbiter matches V17's
+    /// <c>ux_config_collector_schedules_fleet</c>. $1 collector_name, $2 frequency (nullable), $3 retention
+    /// (nullable), $4 enabled.</summary>
+    public const string CollectorScheduleFleetUpsertSql = @"
+INSERT INTO config_collector_schedules (server_id, collector_name, frequency_minutes, retention_days, enabled)
+VALUES (NULL, $1, $2, $3, $4)
+ON CONFLICT (collector_name) WHERE server_id IS NULL DO UPDATE SET
+    frequency_minutes = EXCLUDED.frequency_minutes,
+    retention_days = EXCLUDED.retention_days,
+    enabled = EXCLUDED.enabled";
+
+    /// <summary>Upserts one PER-SERVER override row. Arbiter matches V17's
+    /// <c>ux_config_collector_schedules_server</c>. $1 server_id, $2 collector_name, $3 frequency (nullable),
+    /// $4 retention (nullable), $5 enabled.</summary>
+    public const string CollectorScheduleServerUpsertSql = @"
+INSERT INTO config_collector_schedules (server_id, collector_name, frequency_minutes, retention_days, enabled)
+VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT (server_id, collector_name) WHERE server_id IS NOT NULL DO UPDATE SET
+    frequency_minutes = EXCLUDED.frequency_minutes,
+    retention_days = EXCLUDED.retention_days,
+    enabled = EXCLUDED.enabled";
+
+    /// <summary>Deletes every fleet-wide override row (revert the fleet scope to code defaults).</summary>
+    public const string CollectorScheduleDeleteFleetScopeSql =
+        "DELETE FROM config_collector_schedules WHERE server_id IS NULL";
+
+    /// <summary>Deletes every override row for one server (the "use default schedule" revert). $1 server_id.</summary>
+    public const string CollectorScheduleDeleteServerScopeSql =
+        "DELETE FROM config_collector_schedules WHERE server_id = $1";
+
+    /// <summary>All override rows in the store (both fleet + per-server), for the editor overlay.</summary>
+    public async Task<List<CollectorScheduleRow>> GetCollectorSchedulesAsync(CancellationToken cancellationToken = default)
+    {
+        var rows = new List<CollectorScheduleRow>();
+
+        await using var command = _dataSource.CreateCommand(CollectorSchedulesSelectSql);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            rows.Add(new CollectorScheduleRow(
+                reader.IsDBNull(0) ? null : reader.GetInt32(0),
+                reader.GetString(1),
+                reader.IsDBNull(2) ? null : reader.GetInt32(2),
+                reader.IsDBNull(3) ? null : reader.GetInt32(3),
+                reader.GetBoolean(4)));
+        }
+
+        return rows;
+    }
+
+    /// <summary>
+    /// Atomically replaces the FLEET scope's overrides: delete every fleet row, then upsert the supplied ones
+    /// (pass only collectors that differ from the code default to keep the table sparse). Read-only seats throw
+    /// <see cref="ViewerReadOnlyException"/>.
+    /// </summary>
+    public Task ReplaceFleetSchedulesAsync(IEnumerable<CollectorScheduleRow> rows, CancellationToken cancellationToken = default) =>
+        ReplaceScheduleScopeAsync(serverId: null, rows, cancellationToken);
+
+    /// <summary>
+    /// Atomically replaces one SERVER's overrides: delete the server's rows, then upsert the supplied ones. Pass
+    /// an empty sequence to revert the server to the fleet/default schedule (the "use default" case).
+    /// </summary>
+    public Task ReplaceServerSchedulesAsync(int serverId, IEnumerable<CollectorScheduleRow> rows, CancellationToken cancellationToken = default) =>
+        ReplaceScheduleScopeAsync(serverId, rows, cancellationToken);
+
+    private async Task ReplaceScheduleScopeAsync(int? serverId, IEnumerable<CollectorScheduleRow> rows, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+
+        try
+        {
+            await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken);
+            await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
+
+            /* Clear the scope first so removed overrides don't linger, then re-insert the current set. */
+            await using (var delete = new NpgsqlCommand(
+                serverId is null ? CollectorScheduleDeleteFleetScopeSql : CollectorScheduleDeleteServerScopeSql, connection, transaction))
+            {
+                if (serverId is int sid)
+                {
+                    delete.Parameters.Add(new NpgsqlParameter<int> { TypedValue = sid });
+                }
+
+                await delete.ExecuteNonQueryAsync(cancellationToken);
+            }
+
+            foreach (var row in rows)
+            {
+                await using var upsert = new NpgsqlCommand(
+                    serverId is null ? CollectorScheduleFleetUpsertSql : CollectorScheduleServerUpsertSql, connection, transaction);
+                if (serverId is int sid)
+                {
+                    upsert.Parameters.Add(new NpgsqlParameter<int> { TypedValue = sid });                    // $1 (server scope)
+                }
+
+                upsert.Parameters.Add(new NpgsqlParameter<string> { TypedValue = row.CollectorName });       // $1 fleet / $2 server
+                AddNullableInt(upsert, row.FrequencyMinutes);                                                 // frequency
+                AddNullableInt(upsert, row.RetentionDays);                                                    // retention
+                upsert.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = row.Enabled });               // enabled
+                await upsert.ExecuteNonQueryAsync(cancellationToken);
+            }
+
+            await transaction.CommitAsync(cancellationToken);
+        }
+        catch (PostgresException ex) when (ex.SqlState == InsufficientPrivilegeSqlState)
+        {
+            throw new ViewerReadOnlyException(ex);
+        }
+    }
+
+    private static void AddNullableInt(NpgsqlCommand command, int? value) =>
+        command.Parameters.Add(new NpgsqlParameter
+        {
+            NpgsqlDbType = NpgsqlDbType.Integer,
+            Value = value.HasValue ? value.Value : DBNull.Value,
+        });
+}
+
+/// <summary>
+/// One <c>config.config_collector_schedules</c> override row as the viewer authors + reads it — the twin of
+/// the service's <c>ScheduleOverride</c>. <see cref="ServerId"/> NULL = fleet-wide; a NULL
+/// <see cref="FrequencyMinutes"/>/<see cref="RetentionDays"/> falls through to the next resolution level (the
+/// service's per-column layering). The editor works in effective values and only emits rows for collectors
+/// that carry an actual override.
+/// </summary>
+public sealed record CollectorScheduleRow(int? ServerId, string CollectorName, int? FrequencyMinutes, int? RetentionDays, bool Enabled);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ControlCommands.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ControlCommands.cs
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The viewer's typed wrappers over the Stage-2 command plane (<see cref="EnqueueCommandAsync"/> /
+/// <see cref="RunCommandAsync"/>) for the operator's imperative actions: <c>pause</c>/<c>resume</c> the whole
+/// service (the Settings window's Data Collection toggle), <c>snapshot_now</c> for one server (the "Latest
+/// Snapshot" button), and <c>analyze_now</c> for one server (the Recommendations "Generate now" button). The
+/// command TYPES match <c>DarlingCommandExecutor.ResolvePlan</c> exactly so the two ends agree; Darling.Tests
+/// pin the constants against the executor's cases.
+///
+/// <para>Each is a write (enqueue), so a read-only <c>viewer</c> seat throws
+/// <see cref="ViewerReadOnlyException"/> from <see cref="EnqueueCommandAsync"/> — correct: a read-only seat
+/// can neither pause the service nor command a capture. Pause/resume only WRITE <c>config_service.paused</c>
+/// (the service's reconcile applies it) so a 45s wait is ample; <c>snapshot_now</c>/<c>analyze_now</c> drive
+/// the running collection/analysis loop for a server and can run a full sweep, so they use a longer
+/// <see cref="ImperativeCommandTimeout"/>. <c>snapshot_now</c> runs EVEN WHILE PAUSED (explicit operator
+/// intent — the service honors it), so the button stays enabled while paused.</para>
+/// </summary>
+public sealed partial class ViewerDataService
+{
+    /// <summary>The four control-command types the viewer enqueues (must match the service executor's cases).</summary>
+    public const string CommandPause = "pause";
+    public const string CommandResume = "resume";
+    public const string CommandSnapshotNow = "snapshot_now";
+    public const string CommandAnalyzeNow = "analyze_now";
+
+    /// <summary>A full-server snapshot or analysis pass can take longer than a config write's <see
+    /// cref="DefaultCommandTimeout"/>, so the imperative per-server commands wait up to three minutes for the
+    /// running loop to finish before the UI reports "still running / try again".</summary>
+    public static readonly TimeSpan ImperativeCommandTimeout = TimeSpan.FromMinutes(3);
+
+    /// <summary>Enqueues a <c>pause</c> (service stops collecting on its next reconcile) and waits for the
+    /// terminal result. Returns null on timeout. Read-only seats throw <see cref="ViewerReadOnlyException"/>.</summary>
+    public Task<CommandResult?> PauseServiceAsync(CancellationToken cancellationToken = default) =>
+        RunCommandAsync(CommandPause, targetServerId: null, argsJson: null, RequestedBy(), timeout: null, cancellationToken);
+
+    /// <summary>Enqueues a <c>resume</c> (service resumes collecting) and waits for the terminal result.</summary>
+    public Task<CommandResult?> ResumeServiceAsync(CancellationToken cancellationToken = default) =>
+        RunCommandAsync(CommandResume, targetServerId: null, argsJson: null, RequestedBy(), timeout: null, cancellationToken);
+
+    /// <summary>Enqueues a <c>snapshot_now</c> for one server (run its collectors now, even while paused) and
+    /// waits for the terminal result. Returns null on timeout.</summary>
+    public Task<CommandResult?> RequestSnapshotNowAsync(int serverId, CancellationToken cancellationToken = default) =>
+        RunCommandAsync(CommandSnapshotNow, serverId, argsJson: null, RequestedBy(), ImperativeCommandTimeout, cancellationToken);
+
+    /// <summary>Enqueues an <c>analyze_now</c> for one server (force an analysis pass now) and waits for the
+    /// terminal result. Returns null on timeout.</summary>
+    public Task<CommandResult?> RequestAnalyzeNowAsync(int serverId, CancellationToken cancellationToken = default) =>
+        RunCommandAsync(CommandAnalyzeNow, serverId, argsJson: null, RequestedBy(), ImperativeCommandTimeout, cancellationToken);
+
+    /// <summary>The audit label stamped on <c>config_command.requested_by</c> — the interactive user + a viewer tag.</summary>
+    private static string RequestedBy()
+    {
+        try
+        {
+            return $"{Environment.UserName} (viewer)";
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return "viewer";
+        }
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.MuteRules.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.MuteRules.cs
@@ -122,6 +122,7 @@ WHERE id = $1";
         AddNullableText(command, rule.WaitTypePattern);
         AddNullableText(command, rule.JobNamePattern);
         await ExecuteWriteAsync(command, cancellationToken);
+        await SignalConfigReloadAsync(cancellationToken);
     }
 
     /// <summary>Updates an existing mute rule (the Edit dialog's Save).</summary>
@@ -144,6 +145,7 @@ WHERE id = $1";
         AddNullableText(command, rule.WaitTypePattern);
         AddNullableText(command, rule.JobNamePattern);
         await ExecuteWriteAsync(command, cancellationToken);
+        await SignalConfigReloadAsync(cancellationToken);
     }
 
     /// <summary>Toggles a rule's enabled flag without rewriting its other columns.</summary>
@@ -153,10 +155,19 @@ WHERE id = $1";
         command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = ruleId });
         command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = enabled });
         await ExecuteWriteAsync(command, cancellationToken);
+        await SignalConfigReloadAsync(cancellationToken);
     }
 
     /// <summary>Deletes a mute rule by id (the Delete action).</summary>
     public async Task DeleteMuteRuleAsync(string ruleId, CancellationToken cancellationToken = default)
+    {
+        await DeleteMuteRuleRawAsync(ruleId, cancellationToken);
+        await SignalConfigReloadAsync(cancellationToken);
+    }
+
+    /// <summary>The bare delete without the reload signal — shared by the single delete and the purge so the
+    /// purge signals the beacon ONCE for the whole batch rather than per row.</summary>
+    private async Task DeleteMuteRuleRawAsync(string ruleId, CancellationToken cancellationToken)
     {
         await using var command = _dataSource.CreateCommand(MuteRuleDeleteSql);
         command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = ruleId });
@@ -167,6 +178,7 @@ WHERE id = $1";
     /// Deletes every currently-expired rule (the "Purge Expired" action). Returns the number
     /// removed. Expiry is evaluated in memory from the read (matching Lite's
     /// <see cref="MuteRuleService.PurgeExpiredRulesAsync"/> flow: load, pick expired, delete).
+    /// Signals the reload beacon once if anything was removed so the service drops the rules live (F16).
     /// </summary>
     public async Task<int> PurgeExpiredMuteRulesAsync(CancellationToken cancellationToken = default)
     {
@@ -176,9 +188,14 @@ WHERE id = $1";
         {
             if (rule.IsExpired)
             {
-                await DeleteMuteRuleAsync(rule.Id, cancellationToken);
+                await DeleteMuteRuleRawAsync(rule.Id, cancellationToken);
                 removed++;
             }
+        }
+
+        if (removed > 0)
+        {
+            await SignalConfigReloadAsync(cancellationToken);
         }
 
         return removed;

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Notification.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Notification.cs
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The viewer's control-plane writes to <c>config.config_notification</c> — the single-row (id=1) desired
+/// state for SMTP + Teams/Slack alert delivery the Stage-1 <c>StoreConfigProvider</c> reads and hot-swaps into
+/// the running service's <c>SmtpConfig</c>/<c>WebhooksConfig</c>. This is the Stage-3b rewire that replaces the
+/// severed viewer-local SMTP/webhook block (formerly <see cref="ViewerAppSettings"/> + Windows Credential
+/// Manager): saving the Settings window's Email + Teams/Slack sections now drives the running service's
+/// delivery.
+///
+/// <para>Same discipline as the other write partials: public-const SQL (Darling.Tests pin the dialect +
+/// column parity with <c>StoreConfigProvider.ReadNotificationAsync</c>), bound <c>$N</c> parameters, routed
+/// through <see cref="ExecuteWriteAsync"/> so a read-only seat degrades to <see cref="ViewerReadOnlyException"/>.
+/// The single global row is <c>id = 1</c>; <c>modified_at</c> is server-side naive-UTC.</para>
+///
+/// <para><b>The SMTP secret.</b> <c>smtp_encrypted_password</c> is NEVER plaintext in Postgres — it is the
+/// DPAPI-LocalMachine blob <see cref="ViewerServerSecret.Protect"/> produces, the SAME format the service's
+/// <c>DarlingAlertSettings.GetSmtpPassword</c> reads back with <c>DarlingSecrets.Unprotect</c> (identical
+/// entropy + scope, pinned by a Darling.Tests round-trip). The managed single-box deploy (viewer + service on
+/// one host) shares the machine DPAPI key, so the service decrypts what the viewer sealed. The webhook URLs
+/// carry as plain text in <c>teams_url</c>/<c>slack_url</c> exactly as darling.json holds them (the service
+/// treats a channel as enabled by a non-empty URL — so a disabled channel writes an EMPTY url, matching the
+/// service's <c>TeamsWebhookEnabled =&gt; !IsNullOrWhiteSpace(TeamsUrl)</c> derivation).</para>
+/// </summary>
+public sealed partial class ViewerDataService
+{
+    /* The 12 SmtpConfig + WebhooksConfig columns in the SAME order the service reads them
+       (StoreConfigProvider.ReadNotificationAsync), so the parity test pins one list against both ends. */
+    private const string NotificationColumns =
+        "smtp_host, smtp_port, smtp_use_ssl, smtp_username, smtp_encrypted_password, smtp_from_address, " +
+        "smtp_recipients, email_cooldown_minutes, teams_url, teams_proxy, slack_url, slack_proxy";
+
+    /// <summary>The single global notification row (id=1), for the Settings window prefill + migrate-in check.</summary>
+    public const string NotificationSelectSql =
+        "SELECT " + NotificationColumns + " FROM config_notification WHERE id = 1";
+
+    /// <summary>Upserts the single global notification row (Settings window Save). ON CONFLICT rewrites every
+    /// column and bumps <c>config_version</c> via the V17 trigger. $1..$12 in <see cref="NotificationColumns"/> order.</summary>
+    public const string NotificationUpsertSql = @"
+INSERT INTO config_notification (id, " + NotificationColumns + @", modified_at)
+VALUES (1, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, (now() AT TIME ZONE 'UTC'))
+ON CONFLICT (id) DO UPDATE SET
+    smtp_host = EXCLUDED.smtp_host,
+    smtp_port = EXCLUDED.smtp_port,
+    smtp_use_ssl = EXCLUDED.smtp_use_ssl,
+    smtp_username = EXCLUDED.smtp_username,
+    smtp_encrypted_password = EXCLUDED.smtp_encrypted_password,
+    smtp_from_address = EXCLUDED.smtp_from_address,
+    smtp_recipients = EXCLUDED.smtp_recipients,
+    email_cooldown_minutes = EXCLUDED.email_cooldown_minutes,
+    teams_url = EXCLUDED.teams_url,
+    teams_proxy = EXCLUDED.teams_proxy,
+    slack_url = EXCLUDED.slack_url,
+    slack_proxy = EXCLUDED.slack_proxy,
+    modified_at = (now() AT TIME ZONE 'UTC')";
+
+    /// <summary>Reads the single global notification row, or null when the store has not seeded it yet.</summary>
+    public async Task<NotificationRow?> GetNotificationAsync(CancellationToken cancellationToken = default)
+    {
+        await using var command = _dataSource.CreateCommand(NotificationSelectSql);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        return await reader.ReadAsync(cancellationToken) ? ReadNotificationRow(reader) : null;
+    }
+
+    /// <summary>Upserts the single global notification row (Settings window Save). Read-only seats throw
+    /// <see cref="ViewerReadOnlyException"/> via <see cref="ExecuteWriteAsync"/>.</summary>
+    public async Task UpsertNotificationAsync(NotificationRow row, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(row);
+
+        await using var command = _dataSource.CreateCommand(NotificationUpsertSql);
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = row.SmtpHost });            // $1
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = row.SmtpPort });               // $2
+        command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = row.SmtpUseSsl });            // $3
+        AddNullableText(command, row.SmtpUsername);                                                    // $4
+        AddNullableText(command, row.SmtpEncryptedPassword);                                           // $5
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = row.SmtpFromAddress });     // $6
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = row.SmtpRecipients });      // $7
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = row.EmailCooldownMinutes });   // $8
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = row.TeamsUrl });            // $9
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = row.TeamsProxy });          // $10
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = row.SlackUrl });            // $11
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = row.SlackProxy });          // $12
+        await ExecuteWriteAsync(command, cancellationToken);
+    }
+
+    private static NotificationRow ReadNotificationRow(NpgsqlDataReader reader) => new()
+    {
+        SmtpHost = reader.GetString(0),
+        SmtpPort = reader.GetInt32(1),
+        SmtpUseSsl = reader.GetBoolean(2),
+        SmtpUsername = reader.IsDBNull(3) ? null : reader.GetString(3),
+        SmtpEncryptedPassword = reader.IsDBNull(4) ? null : reader.GetString(4),
+        SmtpFromAddress = reader.GetString(5),
+        SmtpRecipients = reader.GetString(6),
+        EmailCooldownMinutes = reader.GetInt32(7),
+        TeamsUrl = reader.GetString(8),
+        TeamsProxy = reader.GetString(9),
+        SlackUrl = reader.GetString(10),
+        SlackProxy = reader.GetString(11),
+    };
+}
+
+/// <summary>
+/// A <c>config.config_notification</c> row (the single id=1 global row) as the viewer authors + reads it —
+/// the desired-state twin of the service's <c>SmtpConfig</c> + <c>WebhooksConfig</c>. There is no per-channel
+/// "enabled" column (the service derives enablement from non-empty fields: SMTP from host+from+to, a webhook
+/// from its URL); the Settings window maps its enable toggles onto that by clearing the channel's fields when
+/// unchecked. <see cref="SmtpEncryptedPassword"/> is a DPAPI-LocalMachine blob, never plaintext. Defaults
+/// mirror the V17 DDL so <see cref="Defaults"/> equals a freshly-seeded row.
+/// </summary>
+public sealed class NotificationRow
+{
+    public string SmtpHost { get; set; } = "";
+    public int SmtpPort { get; set; } = 587;
+    public bool SmtpUseSsl { get; set; } = true;
+    public string? SmtpUsername { get; set; }
+
+    /// <summary>DPAPI-LocalMachine base64 blob (<see cref="ViewerServerSecret.Protect"/>), or null when unset.</summary>
+    public string? SmtpEncryptedPassword { get; set; }
+
+    public string SmtpFromAddress { get; set; } = "";
+    public string SmtpRecipients { get; set; } = "";
+    public int EmailCooldownMinutes { get; set; } = 15;
+    public string TeamsUrl { get; set; } = "";
+    public string TeamsProxy { get; set; } = "";
+    public string SlackUrl { get; set; } = "";
+    public string SlackProxy { get; set; } = "";
+
+    /// <summary>A row equal to the V17 seed defaults — the migrate-in "is the service section still at defaults?" baseline.</summary>
+    public static NotificationRow Defaults() => new();
+
+    /// <summary>Value-equality against another row — the migrate-in uses it to detect an untouched (default)
+    /// store section and a genuine viewer customization. The DPAPI blob is compared ordinally (it is opaque).</summary>
+    public bool ValueEquals(NotificationRow other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+        return string.Equals(SmtpHost, other.SmtpHost, StringComparison.Ordinal)
+            && SmtpPort == other.SmtpPort
+            && SmtpUseSsl == other.SmtpUseSsl
+            && string.Equals(SmtpUsername ?? "", other.SmtpUsername ?? "", StringComparison.Ordinal)
+            && string.Equals(SmtpEncryptedPassword ?? "", other.SmtpEncryptedPassword ?? "", StringComparison.Ordinal)
+            && string.Equals(SmtpFromAddress, other.SmtpFromAddress, StringComparison.Ordinal)
+            && string.Equals(SmtpRecipients, other.SmtpRecipients, StringComparison.Ordinal)
+            && EmailCooldownMinutes == other.EmailCooldownMinutes
+            && string.Equals(TeamsUrl, other.TeamsUrl, StringComparison.Ordinal)
+            && string.Equals(TeamsProxy, other.TeamsProxy, StringComparison.Ordinal)
+            && string.Equals(SlackUrl, other.SlackUrl, StringComparison.Ordinal)
+            && string.Equals(SlackProxy, other.SlackProxy, StringComparison.Ordinal);
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ServiceConfig.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ServiceConfig.cs
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The viewer's control-plane reads + writes of <c>config.config_service</c> — the single-row (id=1)
+/// service-wide flags the Stage-1 <c>StoreConfigProvider</c> honors: <c>capture_plans</c> (global plan
+/// capture), <c>mcp_enabled</c>/<c>mcp_port</c> (the service's embedded MCP), and the observed
+/// <c>paused</c> state. Saving the Settings window's Data Collection + MCP sections now drives the running
+/// service.
+///
+/// <para><b>Write shape is UPDATE-only, never INSERT.</b> The service SEEDS this row LAST in its startup
+/// (its presence marks the seed complete — the reload gate keys on <c>config_version</c>); if the viewer
+/// INSERTed it early, the service would skip seeding the OTHER desired-state sections from darling.json. So
+/// the viewer only ever <c>UPDATE ... WHERE id = 1</c> (a no-op affecting zero rows on an unseeded store —
+/// correct: nothing to change until the service has seeded). The BEFORE-UPDATE self-bump trigger increments
+/// <c>config_version</c> so the service reloads on its next sweep. <c>paused</c> is NOT written here — it is a
+/// <c>pause</c>/<c>resume</c> command (see <c>ViewerDataService.ControlCommands.cs</c>) so the imperative
+/// intent flows through the command plane; the viewer only READS it here to reflect the toggle's state.</para>
+///
+/// <para>Same discipline as the sibling write partials: public-const SQL (Darling.Tests pin the shape +
+/// parity with <c>StoreConfigProvider.ReadServiceRowAsync</c>), bound <c>$N</c> parameters, routed through
+/// <see cref="ExecuteWriteAsync"/> so a read-only seat degrades to <see cref="ViewerReadOnlyException"/>.</para>
+/// </summary>
+public sealed partial class ViewerDataService
+{
+    /// <summary>The service-wide flags (id=1): paused + the three viewer-owned toggles. Column order matches
+    /// the service's <c>ReadServiceRowAsync</c> prefix.</summary>
+    public const string ServiceConfigSelectSql =
+        "SELECT paused, capture_plans, mcp_enabled, mcp_port FROM config_service WHERE id = 1";
+
+    /// <summary>Updates ONLY the three viewer-owned service flags on the seeded row (never <c>paused</c> — a
+    /// command). The self-bump trigger fires <c>config_version</c>. $1 capture_plans, $2 mcp_enabled, $3 mcp_port.</summary>
+    public const string ServiceConfigUpdateFlagsSql = @"
+UPDATE config_service
+SET capture_plans = $1, mcp_enabled = $2, mcp_port = $3
+WHERE id = 1";
+
+    /// <summary>Reads the service-wide flags, or null when the store has not seeded <c>config_service</c> yet
+    /// (a pre-Stage-1 store, or the service has not started) — the Settings window then shows viewer defaults
+    /// and the Pause toggle reflects "unknown/not paused".</summary>
+    public async Task<ServiceConfigRow?> GetServiceConfigAsync(CancellationToken cancellationToken = default)
+    {
+        await using var command = _dataSource.CreateCommand(ServiceConfigSelectSql);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken))
+        {
+            return null;
+        }
+
+        return new ServiceConfigRow
+        {
+            Paused = reader.GetBoolean(0),
+            CapturePlans = reader.GetBoolean(1),
+            McpEnabled = reader.GetBoolean(2),
+            McpPort = reader.GetInt32(3),
+        };
+    }
+
+    /// <summary>
+    /// Whether the service reports itself paused right now (reflected on the Pause/Resume toggle). Fails safe
+    /// to <c>false</c> on ANY non-cancellation error (a pre-V17 store, a transient blip) — mirrors
+    /// <see cref="IsConfigSeededAsync"/>'s posture so the toggle degrades to "Running" rather than throwing.
+    /// </summary>
+    public async Task<bool> IsServicePausedAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var row = await GetServiceConfigAsync(cancellationToken);
+            return row?.Paused ?? false;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>Updates the three viewer-owned service flags (Settings window Save — MCP + global plan capture).
+    /// A no-op on an unseeded store (zero rows). Read-only seats throw <see cref="ViewerReadOnlyException"/>.</summary>
+    public async Task UpdateServiceFlagsAsync(bool capturePlans, bool mcpEnabled, int mcpPort, CancellationToken cancellationToken = default)
+    {
+        await using var command = _dataSource.CreateCommand(ServiceConfigUpdateFlagsSql);
+        command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = capturePlans });
+        command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = mcpEnabled });
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = mcpPort });
+        await ExecuteWriteAsync(command, cancellationToken);
+    }
+
+    /// <summary>
+    /// Touches <c>config_service</c> to bump the <c>config_version</c> reload beacon WITHOUT changing any flag
+    /// (mirrors the service's <c>reload</c> command SQL) — the self-bump trigger increments the beacon, so the
+    /// worker re-reads the store and re-<c>LoadAsync()</c>es its caches on the next sweep. This is how a write
+    /// to a <c>config.*</c> table that carries NO statement-level bump trigger — notably
+    /// <c>config_mute_rules</c> (F16): its rules live in the service's in-memory <c>MuteRuleService</c> cache,
+    /// reloaded only on the beacon — still takes effect live. A no-op on an unseeded store (zero rows).
+    /// </summary>
+    public const string ConfigReloadSignalSql =
+        "UPDATE config_service SET updated_at = (now() AT TIME ZONE 'UTC') WHERE id = 1";
+
+    /// <summary>Bumps the reload beacon (see <see cref="ConfigReloadSignalSql"/>) so the service re-reads the
+    /// store on its next sweep — used after a write to a config table without its own bump trigger.</summary>
+    public async Task SignalConfigReloadAsync(CancellationToken cancellationToken = default)
+    {
+        await using var command = _dataSource.CreateCommand(ConfigReloadSignalSql);
+        await ExecuteWriteAsync(command, cancellationToken);
+    }
+}
+
+/// <summary>The viewer-visible <c>config_service</c> flags: the observed <see cref="Paused"/> state plus the
+/// three viewer-owned toggles (<see cref="CapturePlans"/>, <see cref="McpEnabled"/>, <see cref="McpPort"/>).
+/// Defaults mirror the V17 DDL.</summary>
+public sealed class ServiceConfigRow
+{
+    public bool Paused { get; set; }
+    public bool CapturePlans { get; set; } = true;
+    public bool McpEnabled { get; set; }
+    public int McpPort { get; set; } = 5152;
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.ActiveQueries.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.ActiveQueries.cs
@@ -118,16 +118,40 @@ public partial class ViewerServerTab
     }
 
     /// <summary>
-    /// "Latest Snapshot" button — re-reads the newest STORED snapshot batch (no live SQL). Semantics
-    /// change from Lite's "Live Snapshot" (query the monitored server now): the viewer only sees what the
-    /// collector persisted, so this shows the most recent captured batch of running queries.
+    /// "Latest Snapshot" button (Stage 3b) — asks the Darling service to CAPTURE a fresh snapshot NOW via a
+    /// <c>snapshot_now</c> command, then re-reads the newest stored batch to show it. This restores Lite's
+    /// "Live Snapshot" intent (a capture on demand) through the command plane rather than a direct hit on the
+    /// monitored server. <c>snapshot_now</c> runs even while the service is paused (explicit operator intent —
+    /// the service honors it), so the button stays enabled while paused. A read-only seat cannot command the
+    /// service, so it degrades to simply re-reading the most recent stored batch (the pre-3b behavior).
     /// </summary>
     private async void LatestSnapshot_Click(object sender, RoutedEventArgs e)
     {
         LatestSnapshotButton.IsEnabled = false;
-        LatestSnapshotIndicator.Text = "Loading...";
         try
         {
+            if (!_dataService.IsReadOnly)
+            {
+                LatestSnapshotIndicator.Text = "Capturing...";
+                try
+                {
+                    var result = await _dataService.RequestSnapshotNowAsync(_server.ServerId);
+                    if (result is null)
+                    {
+                        StatusChanged?.Invoke("snapshot: still running — showing the latest stored capture");
+                    }
+                    else if (result.Status != ViewerDataService.StatusSucceeded)
+                    {
+                        StatusChanged?.Invoke($"snapshot: the service reported {result.ResultStatus} — showing the latest stored capture");
+                    }
+                }
+                catch (ViewerReadOnlyException)
+                {
+                    /* Grants changed under us — fall back to reading whatever is stored. */
+                }
+            }
+
+            LatestSnapshotIndicator.Text = "Loading...";
             var (batchTime, rows) = await _dataService.GetLatestQuerySnapshotBatchAsync(_server.ServerId);
             _querySnapshotsFilterMgr!.UpdateData(rows);
             LatestSnapshotIndicator.Text = batchTime.HasValue


### PR DESCRIPTION
## Stage 3b — the viewer's Settings + on-demand actions drive the control-plane store

Completes the Darling control-plane keystone: the viewer's Settings window, Pause/Resume, Live Snapshot, and Recommendations "Generate now" now write the `config.*` store the running service reads and honors on the `config_version` reload beacon, replacing the severed `viewer-settings.json` operational block. Mirrors Stage 3a's discipline (public-const SQL, `$N` params, writes routed through `ExecuteWriteAsync` → `ViewerReadOnlyException` on SQLSTATE 42501). **Touches only the Viewer project + Darling.Tests.**

### Write partials (new `ViewerDataService.*`)
- **AlertSettings** — `config_alert_settings` (id=1): all 27 alert toggles/thresholds + cpu_mode + cooldown + excluded_databases[] + analysis cadence. Column order/names pinned to the service's `StoreConfigProvider.ReadAlertSettingsAsync`; cpu_mode maps "Total"/"SqlOnly" ↔ the service's "total"/"sql".
- **Notification** — `config_notification` (id=1): SMTP + Teams/Slack. `smtp_encrypted_password` is a **DPAPI-LocalMachine blob** via `ViewerServerSecret.Protect` (same entropy/scope as the service's `DarlingSecrets`; round-trip pinned; no plaintext to Postgres). A disabled channel writes empty key fields so the service's non-empty-field enablement treats it off.
- **ServiceConfig** — reads `paused` + flags; UPDATE-only write of `capture_plans`/`mcp_enabled`/`mcp_port` (never INSERTs — the service seeds this row last as the seed-complete marker).
- **CollectorSchedules** — sparse fleet/per-server upserts whose ON CONFLICT arbiters match V17's partial-unique indexes and the service's own `enable/disable_collector` shape; atomic whole-scope transactional replace.
- **ControlCommands** — typed pause/resume/snapshot_now/analyze_now wrappers; command-type constants pinned against the service executor's `ResolvePlan`.

### SettingsWindow rewired (audit findings closed)
- Alert engine + automated-analysis → `config_alert_settings`; SMTP + Teams/Slack → `config_notification`; MCP enable/port + a new global "Capture execution plans" toggle → `config_service`.
- **Pause/Resume** button → `pause`/`resume` command (was a permanently-disabled no-op); reflects live `config_service.paused`.
- **Collection Schedule** informational panel → a real **`CollectorScheduleEditorWindow`** (per-server/fleet frequency/retention/enabled + Aggressive/Balanced/Low-Impact presets, ported byte-for-byte from Lite's `ScheduleManager`) writing `config_collector_schedules`.
- Loads authoritative values from the store; genuinely viewer-local prefs (time-range/auto-refresh/CSV/timestamp-mode/theme + the LRQ noise filters/delivery-mode/mute-default the service has no honored column for) stay in `ViewerAppSettings`/`ViewerPreferences`. Send-Test-Email/Notification unchanged (shared renderers, live UI).
- Read-only seat → banner + disabled actions + `ViewerReadOnlyException`. A transient store-read failure blocks the Save-to-store so it can't clobber tuned config with on-screen defaults.

### On-demand actions
- **Live Snapshot** → `snapshot_now` for the server (runs even while paused), then re-reads the fresh batch; read-only degrades to re-reading stored.
- **Recommendations "Generate now"** → restored button → `analyze_now`, then refreshes findings.

### Migrate-in + F16
- **`ViewerControlPlaneMigration`** — one-time (marker-guarded, read-only/disconnected skip) import of the pre-3b viewer-settings.json alert/analysis/SMTP/webhook/MCP values into the store **only when the store section is still at defaults** (never clobbers an operator-tuned store; SMTP secret re-sealed as the service-decryptable DPAPI blob). No schedule import — the viewer never had a local schedule editor.
- **F16**: `config_mute_rules` has no bump trigger and `MuteRuleService` matches a cached list reloaded only on the beacon, so a viewer mute write would not reload live. The viewer's mute writes now touch `config_service` (`SignalConfigReloadAsync`) to fire the self-bump → the service reloads its mute cache next sweep. *A cleaner long-term fix is a service-side bump trigger on `config_mute_rules` or a per-sweep mute reload — flagged for the lead, since schema/service is out of scope here.*

### Tests
`ViewerControlPlaneStage3bTests.cs` (29): each write partial's SQL (column parity + `$N` + single-row id=1 upsert), the SMTP DPAPI round-trip + no-plaintext, the schedule overlay/preset round-trip, command-type parity with the executor, the migrate-in defaults-only decision + projection + marker/disconnected no-op. Whole Darling solution builds `-c Release`; `Darling.Tests` = **1161 passed / 0 failed / 99 skipped** (live-PG + non-Windows-DPAPI gated).

**Do not merge** — keystone completion; the lead reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)