### PR TITLE
Restore chart + grid right-click context menus in the Darling viewer

### DIFF
--- a/Darling/Darling.Tests/ViewerContextMenuTests.cs
+++ b/Darling/Darling.Tests/ViewerContextMenuTests.cs
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Linq;
+using PerformanceMonitor.Darling.Viewer;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Pins the chart + grid right-click menus restored from Lite (the last Phase B parity cluster): the composed
+/// per-chart menu order (drill-down item + copy/save/export coexisting in ONE menu, so #1409's drill-downs
+/// still resolve), the chart-data CSV shape, the "Copy Repro Script" STORED-fields mapping (no live
+/// connection), and the read-only-seat server-list SQL (no encrypted_password). Pure logic + SQL pins only —
+/// the same no-WPF discipline as the rest of Darling.Tests.
+/// </summary>
+public sealed class ViewerChartContextMenuTests
+{
+    private const string DrillLabel = "Show Active Queries at This Time";
+
+    [Fact]
+    public void ChartMenuHeaderOrder_DrillDownChart_CarriesBothTheDrillDownAndTheCopyExportItems()
+    {
+        /* The coexistence pin: a drill-down chart's menu = [drill-down] [separator] [Copy/Save/Export]. This is
+           what keeps the B1 (#1409) drill-downs working AFTER the copy/export menu was merged into the same
+           ContextMenu instance. */
+        var order = ViewerServerTab.ChartMenuHeaderOrder(DrillLabel, includeDataSource: false);
+
+        /* Drill-down is FIRST, then a separator, so the drill-down still shows and resolves. */
+        Assert.Equal(DrillLabel, order[0]);
+        Assert.Equal(ViewerServerTab.MenuSeparatorMarker, order[1]);
+
+        /* ...AND every copy/save/export item is present in the SAME menu. */
+        Assert.Contains(ViewerServerTab.CopyImageHeader, order);
+        Assert.Contains(ViewerServerTab.SaveImageHeader, order);
+        Assert.Contains(ViewerServerTab.OpenInNewWindowHeader, order);
+        Assert.Contains(ViewerServerTab.RevertHeader, order);
+        Assert.Contains(ViewerServerTab.ExportDataToCsvHeader, order);
+    }
+
+    [Fact]
+    public void ChartMenuHeaderOrder_NoDrillDownChart_IsJustTheCopyExportBlock()
+    {
+        var order = ViewerServerTab.ChartMenuHeaderOrder(drillDownLabel: null, includeDataSource: false);
+
+        /* No drill-down → the menu opens straight into Copy Image (no leading item / separator). */
+        Assert.Equal(ViewerServerTab.CopyImageHeader, order[0]);
+        Assert.DoesNotContain(DrillLabel, order);
+        Assert.Contains(ViewerServerTab.ExportDataToCsvHeader, order);
+        Assert.DoesNotContain(ViewerServerTab.ShowDataSourceHeader, order);
+    }
+
+    [Fact]
+    public void ChartMenuHeaderOrder_WithDataSource_AppendsShowDataSource()
+    {
+        var order = ViewerServerTab.ChartMenuHeaderOrder(DrillLabel, includeDataSource: true);
+
+        Assert.Equal(ViewerServerTab.ShowDataSourceHeader, order[^1]);
+        Assert.Contains(DrillLabel, order);
+    }
+
+    [Theory]
+    [InlineData(",", "DateTime,Series,Value")]
+    [InlineData(";", "DateTime;Series;Value")]
+    [InlineData("\t", "DateTime\tSeries\tValue")]
+    public void ChartCsvHeaderLine_IsDateTimeSeriesValue_InTheChosenSeparator(string separator, string expected)
+    {
+        Assert.Equal(expected, ViewerServerTab.ChartCsvHeaderLine(separator));
+    }
+
+    [Fact]
+    public void FormatChartCsvLine_EmitsInvariantTimestampSeriesAndValue()
+    {
+        var line = ViewerServerTab.FormatChartCsvLine(new DateTime(2026, 7, 6, 14, 20, 5), "CPU %", 42.5, ",");
+        Assert.Equal("2026-07-06 14:20:05,CPU %,42.5", line);
+    }
+
+    [Fact]
+    public void FormatChartCsvLine_QuotesASeriesNameContainingTheSeparator()
+    {
+        /* A series label with the separator must be RFC-4180 quoted so the CSV column count stays right. */
+        var line = ViewerServerTab.FormatChartCsvLine(new DateTime(2026, 7, 6, 0, 0, 0), "reads, writes", 3, ",");
+        Assert.Equal("2026-07-06 00:00:00,\"reads, writes\",3", line);
+    }
+
+    [Theory]
+    [InlineData("plain", ",", "plain")]
+    [InlineData("a,b", ",", "\"a,b\"")]
+    [InlineData("a;b", ";", "\"a;b\"")]
+    [InlineData("has\"quote", ",", "\"has\"\"quote\"")]
+    public void CsvEscape_QuotesOnlyWhenNeeded_AndDoublesEmbeddedQuotes(string value, string separator, string expected)
+    {
+        Assert.Equal(expected, ViewerServerTab.CsvEscape(value, separator));
+    }
+}
+
+/// <summary>
+/// "Copy Repro Script" builds from STORED row fields with NO live connection (the inventory found the
+/// "needs a live connection" rationale OVERSTATED): Active Queries carries its plan + isolation in-row; Top
+/// Queries / Query Store take a best-effort STORED plan the caller already read from Postgres. Pure mapping,
+/// so the pin never opens a connection.
+/// </summary>
+public sealed class ViewerReproScriptTests
+{
+    private const string Product = "SQL Server Performance Monitor Test";
+
+    [Fact]
+    public void ActiveQueriesRow_BuildsFromInRowStoredFields_NoConnection()
+    {
+        var row = new ViewerQuerySnapshotRow
+        {
+            QueryText = "SELECT * FROM dbo.Users WHERE Id = 1",
+            DatabaseName = "tpcc",
+            TransactionIsolationLevel = "ReadCommitted",
+            QueryPlan = null,
+        };
+
+        var script = ViewerServerTab.BuildReproScriptForRow(row, enrichedPlanXml: null, Product);
+
+        Assert.NotNull(script);
+        Assert.Contains("SELECT * FROM dbo.Users WHERE Id = 1", script!, StringComparison.Ordinal);
+        Assert.Contains("USE [tpcc];", script, StringComparison.Ordinal);
+        Assert.Contains("Source: Active Queries", script, StringComparison.Ordinal);
+        Assert.Contains(Product, script, StringComparison.Ordinal);
+        /* The stored isolation level rides through to the SET statement. */
+        Assert.Contains("SET TRANSACTION ISOLATION LEVEL", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ActiveQueriesRow_UsesItsInRowPlan_NotTheCallersEnrichedPlan()
+    {
+        /* The snapshot carries QueryPlan in-row; enrichedPlanXml (which the caller supplies only for the
+           aggregate grids) must be ignored here. With a null in-row plan the script reports plan-unavailable
+           even though a non-null enrichedPlanXml was passed — proving the snapshot branch reads in-row. */
+        var row = new ViewerQuerySnapshotRow { QueryText = "SELECT 1", DatabaseName = "db", QueryPlan = null };
+
+        var script = ViewerServerTab.BuildReproScriptForRow(row, enrichedPlanXml: "<ShowPlanXML/>", Product);
+
+        Assert.NotNull(script);
+        Assert.Contains("plan XML not available", script!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TopQueriesRow_BuildsFromStoredFields_WithBestEffortStoredPlan()
+    {
+        var row = new ViewerQueryStatsRow
+        {
+            QueryText = "SELECT COUNT(*) FROM dbo.Orders",
+            DatabaseName = "sales",
+            QueryHash = "0xABCD",
+        };
+
+        /* enrichedPlanXml is the STORED plan the caller read from Postgres (a read, not a live exec). Passing
+           null still produces a plan-less repro. */
+        var script = ViewerServerTab.BuildReproScriptForRow(row, enrichedPlanXml: null, Product);
+
+        Assert.NotNull(script);
+        Assert.Contains("SELECT COUNT(*) FROM dbo.Orders", script!, StringComparison.Ordinal);
+        Assert.Contains("Source: Top Queries (dm_exec_query_stats)", script, StringComparison.Ordinal);
+        Assert.Contains("USE [sales];", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void QueryStoreRow_BuildsFromStoredFields()
+    {
+        var row = new ViewerQueryStoreRow
+        {
+            QueryText = "UPDATE dbo.Inventory SET Qty = Qty - 1",
+            DatabaseName = "wh",
+            QueryId = 42,
+            PlanId = 7,
+        };
+
+        var script = ViewerServerTab.BuildReproScriptForRow(row, enrichedPlanXml: null, Product);
+
+        Assert.NotNull(script);
+        Assert.Contains("UPDATE dbo.Inventory SET Qty = Qty - 1", script!, StringComparison.Ordinal);
+        Assert.Contains("Source: Query Store", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RowWithNoQueryText_ReturnsNull_SoTheHandlerNoOps()
+    {
+        var empty = new ViewerQuerySnapshotRow { QueryText = "", DatabaseName = "db" };
+        Assert.Null(ViewerServerTab.BuildReproScriptForRow(empty, enrichedPlanXml: null, Product));
+    }
+
+    [Fact]
+    public void UnsupportedRowType_ReturnsNull()
+    {
+        /* Comparison-aggregate rows / config rows / anything else: no repro, the handler no-ops (Lite's
+           default branch). */
+        Assert.Null(ViewerServerTab.BuildReproScriptForRow(new object(), enrichedPlanXml: null, Product));
+    }
+}
+
+/// <summary>
+/// The read-only-seat fix (#1416 revoked the viewer role's SELECT on <c>encrypted_password</c>): the server
+/// LIST read must not reference the secret column, or a read-only <c>connectAs: viewer</c> seat 42501s on the
+/// Manage Servers grid + sidebar. The secret stays only in the by-id edit-load read (an admin action).
+/// </summary>
+public sealed class ViewerServerListReadOnlyTests
+{
+    [Fact]
+    public void MonitoredServersSelectSql_DoesNotSelectTheSecret_SoAReadOnlySeatCanListServers()
+    {
+        var sql = ViewerDataService.MonitoredServersSelectSql;
+        Assert.DoesNotContain("encrypted_password", sql, StringComparison.Ordinal);
+        /* Still selects everything the grid displays. */
+        Assert.Contains("server_id", sql, StringComparison.Ordinal);
+        Assert.Contains("name", sql, StringComparison.Ordinal);
+        Assert.Contains("host", sql, StringComparison.Ordinal);
+        Assert.Contains("created_at", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ManagedServersSql_DoesNotSelectTheSecret()
+    {
+        /* The sidebar's config-authoritative read never carried the secret; pin it stays that way. */
+        Assert.DoesNotContain("encrypted_password", ViewerDataService.ManagedServersSql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MonitoredServerByIdSql_KeepsTheSecret_ForTheEditDialogPrefill()
+    {
+        /* Editing (an admin-role action) reloads the row by id and needs the DPAPI blob to keep the password
+           when the user doesn't retype it. */
+        Assert.Contains("encrypted_password", ViewerDataService.MonitoredServerByIdSql, StringComparison.Ordinal);
+    }
+}

--- a/Darling/Darling.Tests/packages.lock.json
+++ b/Darling/Darling.Tests/packages.lock.json
@@ -883,6 +883,7 @@
           "PerformanceMonitor.Darling.Analysis": "[1.0.0, )",
           "PerformanceMonitor.Darling.Storage": "[1.0.0, )",
           "PerformanceMonitor.Notifications": "[1.0.0, )",
+          "PerformanceMonitor.PlanAnalysis": "[1.0.0, )",
           "PerformanceMonitor.Ui": "[1.0.0, )",
           "ScottPlot.WPF": "[5.1.58, )"
         }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ManageServersWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ManageServersWindow.xaml.cs
@@ -118,7 +118,26 @@ public partial class ManageServersWindow : Window
             return;
         }
 
-        var dialog = new AddServerDialog(_dataService, _serverStore, _profileStore, selected.Row, selected.IsFavorite) { Owner = this };
+        /* The Manage Servers LIST read no longer carries encrypted_password (#1416: a read-only viewer seat
+           lost SELECT on it, so MonitoredServersSelectSql omits the column). Editing needs the DPAPI blob to
+           keep the password when the user doesn't retype it, so reload the full row by id here — the edit-load
+           read (MonitoredServerByIdSql) DOES select the secret, which an admin-role seat can read. On a
+           read-only seat this read 42501s and the edit is aborted with a message (a read-only seat can't save
+           anyway). */
+        MonitoredServerRow row;
+        try
+        {
+            row = await _dataService.GetMonitoredServerAsync(selected.Row.ServerId) ?? selected.Row;
+        }
+        catch (Exception ex)
+        {
+            ViewerLogger.Error("ManageServersWindow", "Failed to load the server for editing", ex);
+            MessageBox.Show($"Could not load the server for editing: {ex.Message}",
+                "Edit Server", MessageBoxButton.OK, MessageBoxImage.Error);
+            return;
+        }
+
+        var dialog = new AddServerDialog(_dataService, _serverStore, _profileStore, row, selected.IsFavorite) { Owner = this };
         if (dialog.ShowDialog() == true)
         {
             ServersChanged = true;

--- a/Darling/PerformanceMonitor.Darling.Viewer/PerformanceMonitor.Darling.Viewer.csproj
+++ b/Darling/PerformanceMonitor.Darling.Viewer/PerformanceMonitor.Darling.Viewer.csproj
@@ -32,6 +32,9 @@
   <ItemGroup>
     <ProjectReference Include="..\..\PerformanceMonitor.Common\PerformanceMonitor.Common.csproj" />
     <ProjectReference Include="..\..\PerformanceMonitor.Ui\PerformanceMonitor.Ui.csproj" />
+    <!-- ReproScriptBuilder for the query grids' "Copy Repro Script" (built from stored row fields, no live
+         connection). Reachable transitively via .Ui, but referenced explicitly since it is a direct dependency. -->
+    <ProjectReference Include="..\..\PerformanceMonitor.PlanAnalysis\PerformanceMonitor.PlanAnalysis.csproj" />
     <!-- Wave 2: the shared blocked-process row/merge (Alerting), the finding model + advice
          table (Analysis), the persisted-action serializer (Notifications), and the Darling
          finding store the Recommendations tab reads through (Darling.Analysis). -->

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.MonitoredServers.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.MonitoredServers.cs
@@ -95,9 +95,13 @@ ON CONFLICT (server_id) DO NOTHING";
     public const string MonitoredServerSetExcludedDatabasesSql =
         "UPDATE config_monitored_servers SET excluded_databases = $2, modified_at = (now() AT TIME ZONE 'UTC') WHERE server_id = $1";
 
-    /// <summary>All configured servers, for the Manage Servers list. Ordered by display name.</summary>
+    /// <summary>All configured servers, for the Manage Servers list. Ordered by display name. Deliberately
+    /// OMITS <c>encrypted_password</c>: the list is a display / sidebar-reconcile read that never needs the
+    /// secret, and #1416 revoked the read-only <c>viewer</c> role's SELECT on that column — selecting it here
+    /// would fail the whole list with SQLSTATE 42501 for a read-only seat. The Edit dialog reloads the row
+    /// (including the DPAPI blob) by id via <see cref="MonitoredServerByIdSql"/>, which is an admin-role action.</summary>
     public const string MonitoredServersSelectSql = @"
-SELECT server_id, name, host, database, auth, username, encrypted_password, encrypt_mode,
+SELECT server_id, name, host, database, auth, username, encrypt_mode,
        trust_server_certificate, read_only_intent, multi_subnet_failover, excluded_databases,
        monthly_cost_usd, capture_plans, is_enabled, created_at
 FROM config_monitored_servers
@@ -205,7 +209,9 @@ ORDER BY COALESCE(s.display_name, c.name)";
     public static int ComputeServerId(string host, string? database, bool readOnlyIntent) =>
         ServerIdHelper.GetDeterministicHashCode(ServerIdHelper.BuildStorageName(host, database, readOnlyIntent));
 
-    /// <summary>All configured servers (Manage Servers list + the sidebar reconcile source).</summary>
+    /// <summary>All configured servers (Manage Servers list + the sidebar reconcile source), read without the
+    /// <c>encrypted_password</c> secret so a read-only <c>viewer</c> seat can list them (#1416). The Edit dialog
+    /// reloads the blob by id via <see cref="GetMonitoredServerAsync"/>.</summary>
     public async Task<List<MonitoredServerRow>> GetMonitoredServersAsync(CancellationToken cancellationToken = default)
     {
         var servers = new List<MonitoredServerRow>();
@@ -214,7 +220,7 @@ ORDER BY COALESCE(s.display_name, c.name)";
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
         {
-            servers.Add(ReadMonitoredServerRow(reader));
+            servers.Add(ReadMonitoredServerRowNoSecret(reader));
         }
 
         return servers;
@@ -329,6 +335,34 @@ ORDER BY COALESCE(s.display_name, c.name)";
         CapturePlans = reader.IsDBNull(13) ? null : reader.GetBoolean(13),
         IsEnabled = reader.GetBoolean(14),
         CreatedAt = reader.IsDBNull(15) ? null : DateTime.SpecifyKind(reader.GetDateTime(15), DateTimeKind.Utc),
+    };
+
+    /// <summary>
+    /// Reads a <see cref="MonitoredServerRow"/> from the secret-free LIST projection
+    /// (<see cref="MonitoredServersSelectSql"/>): identical to <see cref="ReadMonitoredServerRow"/> but the
+    /// query omits <c>encrypted_password</c> (a read-only <c>viewer</c> seat lost SELECT on it, #1416), so
+    /// <see cref="MonitoredServerRow.EncryptedPassword"/> stays null and every column after <c>username</c>
+    /// shifts down one ordinal. The Manage Servers grid never displays the secret; the Edit dialog reloads the
+    /// blob by id (<see cref="GetMonitoredServerAsync"/>).
+    /// </summary>
+    private static MonitoredServerRow ReadMonitoredServerRowNoSecret(NpgsqlDataReader reader) => new()
+    {
+        ServerId = reader.GetInt32(0),
+        Name = reader.GetString(1),
+        Host = reader.GetString(2),
+        Database = reader.IsDBNull(3) ? null : reader.GetString(3),
+        Auth = reader.GetString(4),
+        Username = reader.IsDBNull(5) ? null : reader.GetString(5),
+        EncryptedPassword = null, /* not selected — the LIST read omits the secret column (#1416) */
+        EncryptMode = reader.GetString(6),
+        TrustServerCertificate = reader.GetBoolean(7),
+        ReadOnlyIntent = reader.GetBoolean(8),
+        MultiSubnetFailover = reader.GetBoolean(9),
+        ExcludedDatabases = reader.IsDBNull(10) ? new List<string>() : reader.GetFieldValue<string[]>(10).ToList(),
+        MonthlyCostUsd = reader.GetDecimal(11),
+        CapturePlans = reader.IsDBNull(12) ? null : reader.GetBoolean(12),
+        IsEnabled = reader.GetBoolean(13),
+        CreatedAt = reader.IsDBNull(14) ? null : DateTime.SpecifyKind(reader.GetDateTime(14), DateTimeKind.Utc),
     };
 
     private static void AddTextArray(NpgsqlCommand command, IEnumerable<string>? values) =>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.ChartContextMenu.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.ChartContextMenu.cs
@@ -1,0 +1,317 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media.Imaging;
+using Microsoft.Win32;
+using ScottPlot.WPF;
+using PerformanceMonitor.Ui;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The per-chart right-click Copy / Save / Export menu — a faithful <b>Darling-local</b> port of Lite's
+/// <c>ContextMenuHelper.SetupChartContextMenu</c> (Lite/Helpers/ContextMenuHelper.cs:185). Lite's helper is a
+/// Lite-only static class that reads Lite's <c>App.CsvSeparator</c>, so it is ported here rather than shared —
+/// the same choice #1409 made for the drill-down menus, and consistent with the viewer being a Lite front-end
+/// copy. The single behavioral difference from Lite is inherent to the viewer: it never re-executes a query,
+/// so there is no live-plan surface here (the menu is pure chart chrome).
+///
+/// <para><b>Coexistence with the B1 drill-downs (#1409).</b> Each drill-down chart's menu is ONE
+/// <see cref="ContextMenu"/> = [drill-down item] + [separator] + [these copy/save/export items], exactly like
+/// Lite: <see cref="BuildChartContextMenu"/> builds the copy/export items and takes over right-click (via the
+/// shared <c>AttachChartContextMenu</c> in ViewerServerTab.DrillDown.cs), then the drill-down wiring
+/// <c>Insert</c>s its item at the top of the SAME menu. Charts that have no drill-down (latch/spinlock,
+/// CPU scheduler, plan cache, collector duration, System Events) get this menu on its own via
+/// <see cref="WireChartContextMenus"/>.</para>
+/// </summary>
+public partial class ViewerServerTab
+{
+    /* The menu-item headers — the single source of truth shared by the real WPF construction below and the
+       pure ChartMenuHeaderOrder contract the tests pin. */
+    internal const string CopyImageHeader = "Copy Image";
+    internal const string SaveImageHeader = "Save Image As...";
+    internal const string OpenInNewWindowHeader = "Open in New Window";
+    internal const string RevertHeader = "Revert (or double-click)";
+    internal const string ExportDataToCsvHeader = "Export Data to CSV...";
+    internal const string ShowDataSourceHeader = "Show Data Source";
+
+    /// <summary>Sentinel for a <see cref="Separator"/> in the pure <see cref="ChartMenuHeaderOrder"/> contract.</summary>
+    internal const string MenuSeparatorMarker = "---";
+
+    /// <summary>
+    /// The canonical ordered header list of a per-chart menu (pure, unit-tested): the drill-down item first
+    /// (when the chart has one) followed by a separator, then the copy/save/export block, and the optional
+    /// Show Data Source tail. This is the contract <see cref="BuildChartContextMenu"/> +
+    /// <c>AddChartDrillDownMenuItem</c> compose — the test pins that a drill-down chart's menu carries BOTH the
+    /// drill-down item AND the copy/export items, drill-down first (so #1409's drill-downs still resolve).
+    /// </summary>
+    internal static IReadOnlyList<string> ChartMenuHeaderOrder(string? drillDownLabel, bool includeDataSource)
+    {
+        var items = new List<string>();
+        if (drillDownLabel is not null)
+        {
+            items.Add(drillDownLabel);
+            items.Add(MenuSeparatorMarker);
+        }
+
+        items.Add(CopyImageHeader);
+        items.Add(SaveImageHeader);
+        items.Add(OpenInNewWindowHeader);
+        items.Add(MenuSeparatorMarker);
+        items.Add(RevertHeader);
+        items.Add(MenuSeparatorMarker);
+        items.Add(ExportDataToCsvHeader);
+        if (includeDataSource)
+        {
+            items.Add(MenuSeparatorMarker);
+            items.Add(ShowDataSourceHeader);
+        }
+
+        return items;
+    }
+
+    /* The chart-data CSV shape: DateTime,Series,Value (Lite's ContextMenuHelper CSV export verbatim). Pure so
+       the tests pin the header + row format without a WpfPlot. */
+    private static readonly string[] s_chartCsvColumns = { "DateTime", "Series", "Value" };
+
+    /// <summary>The chart-data CSV header line ("DateTime{sep}Series{sep}Value").</summary>
+    internal static string ChartCsvHeaderLine(string separator) => string.Join(separator, s_chartCsvColumns);
+
+    /// <summary>One chart-data CSV row: an invariant <c>yyyy-MM-dd HH:mm:ss</c> timestamp, the escaped series
+    /// name, and the invariant value (Lite's exact row shape).</summary>
+    internal static string FormatChartCsvLine(DateTime dateTime, string series, double value, string separator) =>
+        string.Join(separator, new[]
+        {
+            dateTime.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture),
+            CsvEscape(series, separator),
+            value.ToString(CultureInfo.InvariantCulture),
+        });
+
+    /// <summary>RFC-4180 CSV quoting (Lite's ContextMenuHelper.CsvEscape).</summary>
+    internal static string CsvEscape(string value, string separator)
+    {
+        if (value.Contains(separator, StringComparison.Ordinal) || value.Contains('"') || value.Contains('\n') || value.Contains('\r'))
+        {
+            return "\"" + value.Replace("\"", "\"\"", StringComparison.Ordinal) + "\"";
+        }
+
+        return value;
+    }
+
+    /// <summary>
+    /// Builds the copy/save/export <see cref="ContextMenu"/> for a chart and takes right-click over from
+    /// ScottPlot (Lite's <c>SetupChartContextMenu</c>). Returns the menu so a drill-down caller can
+    /// <c>Insert</c> its item at the top of the SAME instance; charts without a drill-down get the returned
+    /// menu as-is. Also wires double-click → revert/autoscale (Lite parity).
+    /// </summary>
+    private ContextMenu BuildChartContextMenu(WpfPlot chart, string chartName, string? dataSource = null)
+    {
+        var menu = new ContextMenu();
+
+        var copyItem = new MenuItem { Header = CopyImageHeader, Icon = new TextBlock { Text = "\U0001f4cb" } };
+        copyItem.Click += (_, _) => CopyChartImage(chart);
+        menu.Items.Add(copyItem);
+
+        var saveItem = new MenuItem { Header = SaveImageHeader, Icon = new TextBlock { Text = "\U0001f4be" } };
+        saveItem.Click += (_, _) => SaveChartImage(chart, chartName);
+        menu.Items.Add(saveItem);
+
+        var openWindowItem = new MenuItem { Header = OpenInNewWindowHeader, Icon = new TextBlock { Text = "\U0001f5d7" } };
+        openWindowItem.Click += (_, _) => OpenChartInNewWindow(chart, chartName);
+        menu.Items.Add(openWindowItem);
+
+        menu.Items.Add(new Separator());
+
+        var autoscaleItem = new MenuItem { Header = RevertHeader, Icon = new TextBlock { Text = "↩" } };
+        autoscaleItem.Click += (_, _) => RevertChartAxes(chart);
+        menu.Items.Add(autoscaleItem);
+
+        menu.Items.Add(new Separator());
+
+        var exportCsvItem = new MenuItem { Header = ExportDataToCsvHeader, Icon = new TextBlock { Text = "\U0001f4ca" } };
+        exportCsvItem.Click += (_, _) => ExportChartDataToCsv(chart, chartName);
+        menu.Items.Add(exportCsvItem);
+
+        /* Show Data Source only when a source string is supplied — matches Lite (no ServerTab chart wires one,
+           so like Lite the item is absent by default; the capability is ported for parity). */
+        if (!string.IsNullOrEmpty(dataSource))
+        {
+            menu.Items.Add(new Separator());
+            var dataSourceItem = new MenuItem { Header = ShowDataSourceHeader, Icon = new TextBlock { Text = "ℹ" } };
+            dataSourceItem.Click += (_, _) => MessageBox.Show(
+                $"Data Source:\n\n{dataSource}", "Chart Data Source", MessageBoxButton.OK, MessageBoxImage.Information);
+            menu.Items.Add(dataSourceItem);
+        }
+
+        /* Own right-click (removes ScottPlot's context/pan responses + PreviewMouseRightButtonDown) — the
+           shared path with the drill-down charts and the query heatmap (ViewerServerTab.DrillDown.cs). */
+        AttachChartContextMenu(chart, menu);
+
+        /* Revert on double-click too (Lite parity): drop ScottPlot's own double-click autoscale so ours (which
+           also clears an active click-isolate) runs instead. */
+        chart.UserInputProcessor.UserActionResponses.RemoveAll(r =>
+            r.GetType().Name.Contains("DoubleClick", StringComparison.Ordinal));
+        chart.PreviewMouseDoubleClick += (_, e) =>
+        {
+            e.Handled = true;
+            RevertChartAxes(chart);
+        };
+
+        return menu;
+    }
+
+    /// <summary>
+    /// Wires the copy/save/export menu onto every chart that has NO drill-down (Lite gives every chart the
+    /// menu; the drill-down charts get theirs in <c>WireChartDrillDowns</c>, the heatmap in
+    /// <c>WireHeatmapDrillDownMenu</c>). Called from the constructor after the drill-downs.
+    /// </summary>
+    private void WireChartContextMenus()
+    {
+        /* Darling-only collectors Lite lacks (latch/spinlock, CPU scheduler, plan cache) + the collector
+           duration chart Lite also leaves drill-less. */
+        BuildChartContextMenu(LatchStatsChart, "Latch_Stats");
+        BuildChartContextMenu(SpinlockStatsChart, "Spinlock_Stats");
+        BuildChartContextMenu(CpuSchedulerChart, "CPU_Scheduler");
+        BuildChartContextMenu(PlanCacheChart, "Plan_Cache");
+        BuildChartContextMenu(CollectorDurationChart, "Collector_Duration");
+
+        /* System Events (system_health XE) charts. */
+        BuildChartContextMenu(BadPagesChart, "Bad_Pages");
+        BuildChartContextMenu(DumpRequestsChart, "Dump_Requests");
+        BuildChartContextMenu(AccessViolationsChart, "Access_Violations");
+        BuildChartContextMenu(WriteAccessViolationsChart, "Write_Access_Violations");
+        BuildChartContextMenu(NonYieldingTasksChart, "Non_Yielding_Tasks");
+        BuildChartContextMenu(LatchWarningsChart, "Latch_Warnings");
+        BuildChartContextMenu(SickSpinlocksChart, "Sick_Spinlocks");
+        BuildChartContextMenu(CpuComparisonChart, "CPU_Comparison");
+    }
+
+    private static void CopyChartImage(WpfPlot chart)
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"chart_copy_{Guid.NewGuid()}.png");
+        try
+        {
+            chart.Plot.SavePng(tempFile, (int)chart.ActualWidth, (int)chart.ActualHeight);
+            var bitmap = new BitmapImage();
+            bitmap.BeginInit();
+            bitmap.CacheOption = BitmapCacheOption.OnLoad;
+            bitmap.UriSource = new Uri(tempFile);
+            bitmap.EndInit();
+            bitmap.Freeze();
+            Clipboard.SetDataObject(new DataObject(DataFormats.Bitmap, bitmap), false);
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+    }
+
+    private static void SaveChartImage(WpfPlot chart, string chartName)
+    {
+        var timestamp = DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss", CultureInfo.InvariantCulture);
+        var saveDialog = new SaveFileDialog
+        {
+            Filter = "PNG Image|*.png|JPEG Image|*.jpg|BMP Image|*.bmp",
+            FileName = $"{chartName}_{timestamp}.png",
+            DefaultExt = ".png",
+        };
+
+        if (saveDialog.ShowDialog() == true)
+        {
+            chart.Plot.SavePng(saveDialog.FileName, (int)chart.ActualWidth, (int)chart.ActualHeight);
+        }
+    }
+
+    private static void OpenChartInNewWindow(WpfPlot chart, string chartName)
+    {
+        var newWindow = new Window
+        {
+            Title = chartName.Replace("_", " ", StringComparison.Ordinal),
+            Width = 800,
+            Height = 600,
+        };
+
+        var tempFile = Path.Combine(Path.GetTempPath(), $"chart_temp_{Guid.NewGuid()}.png");
+        try
+        {
+            chart.Plot.SavePng(tempFile, 800, 600);
+            var image = new Image();
+            var bitmap = new BitmapImage();
+            bitmap.BeginInit();
+            bitmap.CacheOption = BitmapCacheOption.OnLoad;
+            bitmap.UriSource = new Uri(tempFile);
+            bitmap.EndInit();
+            bitmap.Freeze();
+            image.Source = bitmap;
+            newWindow.Content = image;
+        }
+        finally
+        {
+            if (File.Exists(tempFile)) File.Delete(tempFile);
+        }
+
+        newWindow.Show();
+    }
+
+    private static void RevertChartAxes(WpfPlot chart)
+    {
+        /* Clear an active click-isolate first so it doesn't leave series dimmed / state stale (Lite parity). */
+        if (ChartHoverHelper.TryGetForChart(chart, out var h)) h.Restore();
+        chart.Plot.Axes.AutoScale();
+        chart.Refresh();
+    }
+
+    private static void ExportChartDataToCsv(WpfPlot chart, string chartName)
+    {
+        var timestamp = DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss", CultureInfo.InvariantCulture);
+        var saveDialog = new SaveFileDialog
+        {
+            Filter = "CSV Files|*.csv|All Files|*.*",
+            FileName = $"{chartName}_data_{timestamp}.csv",
+            DefaultExt = ".csv",
+        };
+
+        if (saveDialog.ShowDialog() != true) return;
+
+        try
+        {
+            var sep = ViewerExportSettings.CsvSeparator;
+            var sb = new StringBuilder();
+            sb.AppendLine(ChartCsvHeaderLine(sep));
+
+            var seriesIndex = 1;
+            foreach (var plottable in chart.Plot.GetPlottables())
+            {
+                if (plottable is ScottPlot.Plottables.Scatter scatter)
+                {
+                    var seriesName = scatter.LegendText ?? $"Series{seriesIndex}";
+                    foreach (var point in scatter.Data.GetScatterPoints())
+                    {
+                        sb.AppendLine(FormatChartCsvLine(DateTime.FromOADate(point.X), seriesName, point.Y, sep));
+                    }
+
+                    seriesIndex++;
+                }
+            }
+
+            File.WriteAllText(saveDialog.FileName, sb.ToString(), Encoding.UTF8);
+            MessageBox.Show($"Data exported to:\n{saveDialog.FileName}", "Export Complete", MessageBoxButton.OK, MessageBoxImage.Information);
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Error exporting data:\n\n{ex.Message}", "Export Error", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.CopyExport.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.CopyExport.cs
@@ -9,23 +9,30 @@
 using System;
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using Microsoft.Win32;
+using PerformanceMonitor.PlanAnalysis;
 using PerformanceMonitor.Ui;
 
 namespace PerformanceMonitor.Darling.Viewer;
 
 /// <summary>
-/// The Blocking-tab grid copy/export + XML-save handlers (W1e), copied from Lite's
+/// The grid copy/export + Copy-Repro-Script + XML-save handlers (W1e / W1f), copied from Lite's
 /// <c>ServerTab.CopyExport.cs</c> / <c>ServerTab.Plans.cs</c>. Copy/Export delegate to the shared
 /// PerformanceMonitor.Ui <see cref="DataGridExport"/>; the XML-save buttons write the row's stored graph /
-/// report XML to a file. These are the handlers the blocked-process and deadlock context menus + XML Save
-/// columns bind to. (Lite's "Copy Repro Script" and "Get Actual Plan" stay deferred — both need a live SQL
-/// connection the viewer doesn't have; the stored-plan "View Plan" host lives in ViewerServerTab.Plans.cs.)
+/// report XML to a file. <see cref="CopyReproScript_Click"/> builds a paste-ready T-SQL repro from the query
+/// grids' STORED row fields (no live connection — Active Queries carries its plan in-row; Top Queries / Query
+/// Store best-effort read the collector's STORED plan from Postgres to enrich parameters). Only Lite's
+/// "Get Actual Plan" (a LIVE re-execution) stays omitted; the stored-plan "View Plan" host lives in
+/// ViewerServerTab.Plans.cs.
 /// </summary>
 public partial class ViewerServerTab
 {
+    /* The product tag ReproScriptBuilder stamps in the repro-script header comment. */
+    private const string ReproProductName = "SQL Server Performance Monitor";
+
     /// <summary>Finds the parent DataGrid from a context menu opened on a DataGridRow.</summary>
     private static DataGrid? FindParentDataGrid(MenuItem menuItem)
     {
@@ -46,6 +53,83 @@ public partial class ViewerServerTab
 
     private void ExportToCsv_Click(object sender, RoutedEventArgs e) =>
         DataGridExport.ExportToCsv(sender, _server.DisplayName, ViewerExportSettings.CsvSeparator);
+
+    /// <summary>
+    /// "Copy Repro Script" for the query grids — builds a paste-ready T-SQL reproduction from the row's STORED
+    /// fields and copies it to the clipboard. NO live SQL connection: Active Queries carries its query text /
+    /// plan / isolation in-row; Top Queries / Query Store best-effort read their STORED plan from Postgres (a
+    /// read via <see cref="ViewerDataService"/>, not a live re-exec) to enrich the extracted parameters, then
+    /// fall back to a plan-less repro. (Lite fetches these plans live from the monitored server — the viewer
+    /// reads the collector's stored copy, its only seam-difference; Lite's "Get Actual Plan" has no equivalent.)
+    /// </summary>
+    private async void CopyReproScript_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not MenuItem menuItem) return;
+        var grid = FindParentDataGrid(menuItem);
+        if (grid?.CurrentItem is not { } row) return;
+
+        /* Best-effort STORED-plan enrichment for the aggregate grids (a Postgres read, never a live SQL
+           connection). Active Queries needs none — its plan rides in-row. Failures fall through to a
+           plan-less repro. */
+        string? enrichedPlanXml = null;
+        try
+        {
+            switch (row)
+            {
+                case ViewerQueryStatsRow stats when !string.IsNullOrEmpty(stats.QueryHash):
+                    enrichedPlanXml = await _dataService.GetQueryStatsPlanXmlAsync(_server.ServerId, stats.DatabaseName, stats.QueryHash);
+                    break;
+                case ViewerQueryStoreRow qs:
+                    enrichedPlanXml = await _dataService.GetQueryStorePlanTextAsync(_server.ServerId, qs.DatabaseName, qs.QueryId, qs.PlanId);
+                    break;
+            }
+        }
+        catch
+        {
+            /* Stored-plan enrichment is best-effort — build the repro from the row's other stored fields. */
+        }
+
+        var script = BuildReproScriptForRow(row, enrichedPlanXml, ReproProductName);
+        if (string.IsNullOrEmpty(script)) return;
+
+        /* SetDataObject(copy=false) avoids WPF's problematic Clipboard.Flush(); see dotnet/wpf#9901. */
+        Clipboard.SetDataObject(script, false);
+    }
+
+    /// <summary>
+    /// Maps a query-grid row to a repro script built from its STORED fields (pure, unit-tested). Active Queries
+    /// uses its in-row plan + isolation (<paramref name="enrichedPlanXml"/> ignored); Top Queries / Query Store
+    /// use the caller's best-effort stored <paramref name="enrichedPlanXml"/> (null → a plan-less repro, which
+    /// ReproScriptBuilder still produces with a "plan not available" note). Returns null for a row with no query
+    /// text (comparison aggregates / procedures) or an unsupported row type — the caller then no-ops, exactly
+    /// like Lite's default branch. NO row type here reads a live connection.
+    /// </summary>
+    internal static string? BuildReproScriptForRow(object row, string? enrichedPlanXml, string productName)
+    {
+        switch (row)
+        {
+            case ViewerQuerySnapshotRow snapshot:
+                if (string.IsNullOrEmpty(snapshot.QueryText)) return null;
+                return ReproScriptBuilder.BuildReproScript(
+                    snapshot.QueryText, snapshot.DatabaseName, snapshot.QueryPlan, snapshot.TransactionIsolationLevel,
+                    "Active Queries", productName: productName);
+
+            case ViewerQueryStatsRow stats:
+                if (string.IsNullOrEmpty(stats.QueryText)) return null;
+                return ReproScriptBuilder.BuildReproScript(
+                    stats.QueryText, stats.DatabaseName, enrichedPlanXml, null,
+                    "Top Queries (dm_exec_query_stats)", productName: productName);
+
+            case ViewerQueryStoreRow qs:
+                if (string.IsNullOrEmpty(qs.QueryText)) return null;
+                return ReproScriptBuilder.BuildReproScript(
+                    qs.QueryText, qs.DatabaseName, enrichedPlanXml, null,
+                    "Query Store", productName: productName);
+
+            default:
+                return null;
+        }
+    }
 
     private void DownloadBlockedProcessXml_Click(object sender, RoutedEventArgs e)
     {

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.DrillDown.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.DrillDown.cs
@@ -25,10 +25,11 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// "Show Blocking / Deadlocks at This Time"; the Wait Stats chart gets a wait-specific
 /// "Show Queries With &lt;wait&gt;" that opens the <see cref="WaitDrillDownWindow"/>.
 ///
-/// <para>Two adaptations from Lite, both inherent to the viewer: (1) Lite builds these on its
-/// <c>ContextMenuHelper</c> chart menu (Copy/Save Image, CSV, …), which is Lite-only and never ported, so the
-/// viewer attaches a single-item WPF <see cref="ContextMenu"/> per chart the same way the ported heatmap
-/// drill-down does (<see cref="RemoveScottPlotContextMenuResponses"/> takes over right-click from ScottPlot).
+/// <para>Two notes, both inherent to the viewer: (1) Like Lite, each drill-down item is Inserted at the top of
+/// the chart's copy/save/export <see cref="ContextMenu"/> (now a Darling-local port of Lite's
+/// <c>ContextMenuHelper</c>, in ViewerServerTab.ChartContextMenu.cs) — <see cref="BuildChartContextMenu"/>
+/// builds that menu and takes right-click over from ScottPlot (<see cref="RemoveScottPlotContextMenuResponses"/>),
+/// then <see cref="AddChartDrillDownMenuItem"/> adds the drill-down item to the SAME menu, so both coexist.
 /// (2) The chart X axis is display-time (every viewer chart plots through
 /// <see cref="ViewerTimeHelper.ForDisplay"/>), so the nearest-series time the <see cref="ChartHoverHelper"/>
 /// returns is converted back to the store's naive UTC via <see cref="ViewerTimeHelper.DisplayToNaiveUtc"/>
@@ -46,62 +47,72 @@ public partial class ViewerServerTab
     /// </summary>
     private void WireChartDrillDowns()
     {
-        /* The hover accessors are lambdas, not captured values: WaitStats + Perfmon create their
+        /* Each drill-down chart's menu is ONE ContextMenu = [drill-down item] + [separator] + [copy/save/
+           export items], exactly like Lite (ServerTab.xaml.cs:318-365 pairs SetupChartContextMenu with
+           AddChartDrillDownMenuItem on the SAME menu). BuildChartContextMenu builds the copy/export items and
+           takes right-click over from ScottPlot; AddChart/WaitDrillDownMenuItem then Insert their item at the
+           top of that returned menu — one right-click owner, no competing handler.
+
+           The hover accessors are lambdas, not captured values: WaitStats + Perfmon create their
            ChartHoverHelper LAZILY on the tab's first load (not in an Initialize*Charts call), so their fields
            are still null here in the constructor. Reading the field at menu-Opened time (by which point the
            tab has loaded and the hover exists) is correct for both the eager and the lazy charts. */
 
         /* Wait Stats — the specialized "Show Queries With <wait>" drill-down (opens WaitDrillDownWindow). */
-        AddWaitDrillDownMenuItem(WaitStatsChart, () => _waitStatsHover);
+        AddWaitDrillDownMenuItem(WaitStatsChart, BuildChartContextMenu(WaitStatsChart, "Wait_Stats"), () => _waitStatsHover);
 
         /* CPU / Memory / tempdb / Perfmon — "Show Active Queries at This Time" (Item 2, 10 charts). */
-        AddChartDrillDownMenuItem(CpuChart, () => _cpuHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
-        AddChartDrillDownMenuItem(MemoryChart, () => _memoryHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
-        AddChartDrillDownMenuItem(MemoryClerksChart, () => _memoryClerksHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
-        AddChartDrillDownMenuItem(MemoryGrantSizingChart, () => _memoryGrantSizingHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
-        AddChartDrillDownMenuItem(MemoryGrantActivityChart, () => _memoryGrantActivityHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
-        AddChartDrillDownMenuItem(MemoryPressureEventsChart, () => _memoryPressureEventsHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
-        AddChartDrillDownMenuItem(TempDbChart, () => _tempDbHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
-        AddChartDrillDownMenuItem(TempDbSizeChart, () => _tempDbSizeHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
-        AddChartDrillDownMenuItem(TempDbFileIoChart, () => _tempDbFileIoHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
-        AddChartDrillDownMenuItem(PerfmonChart, () => _perfmonHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        AddChartDrillDownMenuItem(CpuChart, BuildChartContextMenu(CpuChart, "CPU_Usage"), () => _cpuHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        AddChartDrillDownMenuItem(MemoryChart, BuildChartContextMenu(MemoryChart, "Memory_Usage"), () => _memoryHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        AddChartDrillDownMenuItem(MemoryClerksChart, BuildChartContextMenu(MemoryClerksChart, "Memory_Clerks"), () => _memoryClerksHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        AddChartDrillDownMenuItem(MemoryGrantSizingChart, BuildChartContextMenu(MemoryGrantSizingChart, "Memory_Grant_Sizing"), () => _memoryGrantSizingHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        AddChartDrillDownMenuItem(MemoryGrantActivityChart, BuildChartContextMenu(MemoryGrantActivityChart, "Memory_Grant_Activity"), () => _memoryGrantActivityHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        AddChartDrillDownMenuItem(MemoryPressureEventsChart, BuildChartContextMenu(MemoryPressureEventsChart, "Memory_Pressure_Events"), () => _memoryPressureEventsHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        AddChartDrillDownMenuItem(TempDbChart, BuildChartContextMenu(TempDbChart, "TempDB_Stats"), () => _tempDbHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        AddChartDrillDownMenuItem(TempDbSizeChart, BuildChartContextMenu(TempDbSizeChart, "TempDB_Allocated_Size"), () => _tempDbSizeHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        AddChartDrillDownMenuItem(TempDbFileIoChart, BuildChartContextMenu(TempDbFileIoChart, "TempDB_File_IO"), () => _tempDbFileIoHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        AddChartDrillDownMenuItem(PerfmonChart, BuildChartContextMenu(PerfmonChart, "Perfmon_Counters"), () => _perfmonHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
 
         /* Performance Trends — "Show Active Queries at This Time" (Item 3, 4 charts). */
-        AddChartDrillDownMenuItem(QueryDurationTrendChart, () => _queryDurationTrendHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
-        AddChartDrillDownMenuItem(ProcDurationTrendChart, () => _procDurationTrendHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
-        AddChartDrillDownMenuItem(QueryStoreDurationTrendChart, () => _queryStoreDurationTrendHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
-        AddChartDrillDownMenuItem(ExecutionCountTrendChart, () => _executionCountTrendHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        AddChartDrillDownMenuItem(QueryDurationTrendChart, BuildChartContextMenu(QueryDurationTrendChart, "Query_Duration_Trends"), () => _queryDurationTrendHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        AddChartDrillDownMenuItem(ProcDurationTrendChart, BuildChartContextMenu(ProcDurationTrendChart, "Procedure_Duration_Trends"), () => _procDurationTrendHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        AddChartDrillDownMenuItem(QueryStoreDurationTrendChart, BuildChartContextMenu(QueryStoreDurationTrendChart, "QueryStore_Duration_Trends"), () => _queryStoreDurationTrendHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        AddChartDrillDownMenuItem(ExecutionCountTrendChart, BuildChartContextMenu(ExecutionCountTrendChart, "Execution_Count_Trends"), () => _executionCountTrendHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
 
         /* Blocking Trends — Lock Wait + Blocking -> "Show Blocking at This Time"; Deadlock ->
            "Show Deadlocks at This Time" (Item 3, 3 charts). */
-        AddChartDrillDownMenuItem(LockWaitTrendChart, () => _lockWaitTrendHover, "Show Blocking at This Time", OnBlockingDrillDown);
-        AddChartDrillDownMenuItem(BlockingTrendChart, () => _blockingTrendHover, "Show Blocking at This Time", OnBlockingDrillDown);
-        AddChartDrillDownMenuItem(DeadlockTrendChart, () => _deadlockTrendHover, "Show Deadlocks at This Time", OnDeadlockDrillDown);
+        AddChartDrillDownMenuItem(LockWaitTrendChart, BuildChartContextMenu(LockWaitTrendChart, "Lock_Wait_Trends"), () => _lockWaitTrendHover, "Show Blocking at This Time", OnBlockingDrillDown);
+        AddChartDrillDownMenuItem(BlockingTrendChart, BuildChartContextMenu(BlockingTrendChart, "Blocking_Trends"), () => _blockingTrendHover, "Show Blocking at This Time", OnBlockingDrillDown);
+        AddChartDrillDownMenuItem(DeadlockTrendChart, BuildChartContextMenu(DeadlockTrendChart, "Deadlock_Trends"), () => _deadlockTrendHover, "Show Deadlocks at This Time", OnDeadlockDrillDown);
 
         /* File I/O (4) + Blocking > Current Waits (2) — the rest of Lite's "Show Active Queries at This Time"
            set (ServerTab.xaml.cs:340-363, in the same referenced block). Charts in this same viewer surface,
            same drill target; wired for faithful parity so no sibling chart is left without the drill-down. */
-        AddChartDrillDownMenuItem(FileIoReadChart, () => _fileIoReadHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
-        AddChartDrillDownMenuItem(FileIoWriteChart, () => _fileIoWriteHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
-        AddChartDrillDownMenuItem(FileIoReadThroughputChart, () => _fileIoReadThroughputHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
-        AddChartDrillDownMenuItem(FileIoWriteThroughputChart, () => _fileIoWriteThroughputHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
-        AddChartDrillDownMenuItem(CurrentWaitsDurationChart, () => _currentWaitsDurationHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
-        AddChartDrillDownMenuItem(CurrentWaitsBlockedChart, () => _currentWaitsBlockedHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        AddChartDrillDownMenuItem(FileIoReadChart, BuildChartContextMenu(FileIoReadChart, "File_IO_Read_Latency"), () => _fileIoReadHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        AddChartDrillDownMenuItem(FileIoWriteChart, BuildChartContextMenu(FileIoWriteChart, "File_IO_Write_Latency"), () => _fileIoWriteHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        AddChartDrillDownMenuItem(FileIoReadThroughputChart, BuildChartContextMenu(FileIoReadThroughputChart, "File_IO_Read_Throughput"), () => _fileIoReadThroughputHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        AddChartDrillDownMenuItem(FileIoWriteThroughputChart, BuildChartContextMenu(FileIoWriteThroughputChart, "File_IO_Write_Throughput"), () => _fileIoWriteThroughputHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        AddChartDrillDownMenuItem(CurrentWaitsDurationChart, BuildChartContextMenu(CurrentWaitsDurationChart, "Current_Waits_Duration"), () => _currentWaitsDurationHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        AddChartDrillDownMenuItem(CurrentWaitsBlockedChart, BuildChartContextMenu(CurrentWaitsBlockedChart, "Current_Waits_Blocked"), () => _currentWaitsBlockedHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
     }
 
     /// <summary>
-    /// Attaches a single-item right-click drill-down menu to a chart (Lite's
-    /// <c>AddChartDrillDownMenuItem</c>). The Opened handler resolves the nearest-series display-time under
-    /// the cursor via the chart's hover helper (disabling the item when the cursor is off any series); the
-    /// Click routes that time to <paramref name="handler"/>, which converts it back to UTC and reads the window.
-    /// <paramref name="hoverAccessor"/> is read at Opened time (not captured) so lazily-created hovers resolve.
+    /// Inserts a right-click drill-down item at the TOP of a chart's existing copy/export
+    /// <paramref name="menu"/> (Lite's <c>AddChartDrillDownMenuItem</c>: <c>Insert(0, item)</c> +
+    /// <c>Insert(0, separator)</c>, so the menu reads [drill-down] [separator] [copy/save/export]). The menu's
+    /// right-click was already taken over by <see cref="BuildChartContextMenu"/>; this only adds the item +
+    /// its Opened/Click behavior, so the two coexist in one menu. The Opened handler resolves the
+    /// nearest-series display-time under the cursor via the chart's hover helper (disabling the item off any
+    /// series); the Click routes that time to <paramref name="handler"/>, which converts it back to UTC and
+    /// reads the window. <paramref name="hoverAccessor"/> is read at Opened time (not captured) so
+    /// lazily-created hovers resolve.
     /// </summary>
     private void AddChartDrillDownMenuItem(
-        ScottPlot.WPF.WpfPlot chart, Func<ChartHoverHelper?> hoverAccessor, string label, Action<DateTime> handler)
+        ScottPlot.WPF.WpfPlot chart, ContextMenu menu, Func<ChartHoverHelper?> hoverAccessor, string label, Action<DateTime> handler)
     {
-        var menu = new ContextMenu();
+        menu.Items.Insert(0, new Separator());
         var item = new MenuItem { Header = label };
-        menu.Items.Add(item);
+        menu.Items.Insert(0, item);
 
         menu.Opened += (_, _) =>
         {
@@ -123,21 +134,21 @@ public partial class ViewerServerTab
             if (item.Tag is DateTime displayTime)
                 handler(displayTime);
         };
-
-        AttachChartContextMenu(chart, menu);
     }
 
     /// <summary>
     /// The Wait Stats chart's specialized right-click "Show Queries With &lt;wait&gt;" (Lite's
-    /// <c>AddWaitDrillDownMenuItem</c>): the hover's nearest series is a wait TYPE (the series label), so the
-    /// item header names it and the Click opens the <see cref="WaitDrillDownWindow"/> for that wait over the
-    /// drill window. Underscores in the wait type are doubled so WPF doesn't treat them as an access key.
+    /// <c>AddWaitDrillDownMenuItem</c>), inserted at the top of the chart's copy/export <paramref name="menu"/>
+    /// (same coexistence as <see cref="AddChartDrillDownMenuItem"/>). The hover's nearest series is a wait TYPE
+    /// (the series label), so the item header names it and the Click opens the <see cref="WaitDrillDownWindow"/>
+    /// for that wait over the drill window. Underscores in the wait type are doubled so WPF doesn't treat them
+    /// as an access key.
     /// </summary>
-    private void AddWaitDrillDownMenuItem(ScottPlot.WPF.WpfPlot chart, Func<ChartHoverHelper?> hoverAccessor)
+    private void AddWaitDrillDownMenuItem(ScottPlot.WPF.WpfPlot chart, ContextMenu menu, Func<ChartHoverHelper?> hoverAccessor)
     {
-        var menu = new ContextMenu();
+        menu.Items.Insert(0, new Separator());
         var item = new MenuItem { Header = "Show Queries With This Wait" };
-        menu.Items.Add(item);
+        menu.Items.Insert(0, item);
 
         menu.Opened += (_, _) =>
         {
@@ -161,8 +172,6 @@ public partial class ViewerServerTab
             if (item.Tag is ValueTuple<string, DateTime> tag)
                 ShowQueriesForWaitType(tag.Item1, tag.Item2);
         };
-
-        AttachChartContextMenu(chart, menu);
     }
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.QueryHeatmap.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.QueryHeatmap.cs
@@ -73,16 +73,19 @@ public partial class ViewerServerTab
     }
 
     /// <summary>
-    /// Builds the heatmap's right-click "Show Active Queries at This Time" menu — Lite's heatmap drill-down
-    /// (ServerTab.xaml.cs:285-315) minus the ContextMenuHelper save/export chrome. ScottPlot's own
-    /// right-click responses are removed so the WPF menu shows; the Opened handler resolves the time bin
-    /// under the cursor and the Click routes it to <see cref="OnHeatmapDrillDown"/>.
+    /// Builds the heatmap's right-click menu — Lite's heatmap drill-down (ServerTab.xaml.cs:285-315): the
+    /// "Show Active Queries at This Time" item Inserted at the TOP of the chart's copy/save/export menu
+    /// (<see cref="BuildChartContextMenu"/>), so it reads [drill-down] [separator] [Copy/Save/Export] like
+    /// every other drill-down chart. BuildChartContextMenu already takes right-click over from ScottPlot; the
+    /// Opened handler resolves the time bin under the cursor and the Click routes it to
+    /// <see cref="OnHeatmapDrillDown"/>.
     /// </summary>
     private void WireHeatmapDrillDownMenu()
     {
-        var menu = new ContextMenu();
+        var menu = BuildChartContextMenu(QueryHeatmapChart, "Query_Heatmap");
         var drillItem = new MenuItem { Header = "Show Active Queries at This Time" };
-        menu.Items.Add(drillItem);
+        menu.Items.Insert(0, drillItem);
+        menu.Items.Insert(1, new Separator());
 
         menu.Opened += (_, _) =>
         {
@@ -112,17 +115,6 @@ public partial class ViewerServerTab
         {
             if (drillItem.Tag is DateTime bucketTime)
                 _ = OnHeatmapDrillDown(bucketTime);
-        };
-
-        /* Take over right-click from ScottPlot's default menu/pan so our WPF menu shows (shared with the
-           per-chart drill-downs in ViewerServerTab.DrillDown.cs). */
-        RemoveScottPlotContextMenuResponses(QueryHeatmapChart);
-        QueryHeatmapChart.PreviewMouseRightButtonDown += (_, e) =>
-        {
-            e.Handled = true;
-            menu.PlacementTarget = QueryHeatmapChart;
-            menu.Placement = PlacementMode.MousePoint;
-            menu.IsOpen = true;
         };
     }
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
@@ -46,8 +46,32 @@
             <Setter Property="FontWeight" Value="SemiBold"/>
         </Style>
 
+        <!-- Copy / Export menu for every plain grid (W1f cluster), copied from Lite's ServerTab.xaml
+             DataGridContextMenu (its copy/export half — the query grids get the plan-aware variants below).
+             Set on the base DarkGridRow so every DarkGrid grid that doesn't override RowStyle (RunningJobs,
+             ServerConfig, DatabaseConfig, DatabaseScopedConfig, TraceFlags, DailySummary, CollectionHealth,
+             latch/spinlock, CPU scheduler, plan cache, System Events, …) gets it. Copy/Export delegate to the
+             shared PerformanceMonitor.Ui DataGridExport (ViewerServerTab.CopyExport.cs). Defined before
+             DarkGridRow so the StaticResource resolves. -->
+        <ContextMenu x:Key="DataGridContextMenu">
+            <MenuItem Header="Copy Cell" Click="CopyCell_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Header="Copy Row" Click="CopyRow_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4C4;"/></MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4D1;"/></MenuItem.Icon>
+            </MenuItem>
+            <Separator/>
+            <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
+            </MenuItem>
+        </ContextMenu>
+
         <Style x:Key="DarkGridRow" TargetType="DataGridRow">
             <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="ContextMenu" Value="{StaticResource DataGridContextMenu}"/>
             <Style.Triggers>
                 <Trigger Property="IsMouseOver" Value="True">
                     <Setter Property="Background" Value="#1f232b"/>
@@ -176,9 +200,11 @@
              a comparison row is a current-vs-baseline aggregate with no single stored plan keyed on it, and
              the snapshot grid has its own dedicated Estimated / Actual plan buttons — so neither needs a
              "View Plan" context item. (Top Procedures moved OFF this menu to the plan-enabled variant below:
-             procedure_stats DOES store the plan since #1368 / V7.) Lite's "Get Actual Plan" (needs a live
-             execution) and "Copy Repro Script" (needs a live connection string) stay deferred everywhere.
-             Copy/Export delegate to the shared PerformanceMonitor.Ui DataGridExport (ViewerServerTab.CopyExport.cs). -->
+             procedure_stats DOES store the plan since #1368 / V7.) "Copy Repro Script" builds from STORED row
+             fields — Active Queries carries QueryText/DatabaseName/QueryPlan/TransactionIsolationLevel in-row,
+             so no live connection is needed (the comparison rows have no query text and no-op). Only Lite's
+             "Get Actual Plan" (a LIVE re-execution) stays omitted. Copy/Export/Repro delegate to
+             ViewerServerTab.CopyExport.cs (Copy/Export via the shared PerformanceMonitor.Ui DataGridExport). -->
         <ContextMenu x:Key="QueryGridContextMenu">
             <MenuItem Header="Copy Cell" Click="CopyCell_Click">
                 <MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon>
@@ -189,6 +215,9 @@
             <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click">
                 <MenuItem.Icon><TextBlock Text="&#x1F4D1;"/></MenuItem.Icon>
             </MenuItem>
+            <MenuItem Header="Copy Repro Script" Click="CopyReproScript_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4DD;"/></MenuItem.Icon>
+            </MenuItem>
             <Separator/>
             <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
                 <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
@@ -198,7 +227,10 @@
         <!-- PLAN-enabled variant for Top Queries + Query Store + Top Procedures, whose plans the collector
              stores (query_stats.query_plan_xml / query_store_stats.query_plan_text, PR #1349;
              procedure_stats.query_plan_xml, #1368 / V7). "View Plan" opens the stored plan in the Plan
-             Viewer tab via ViewPlan_Click (ViewerServerTab.Plans.cs), which fetches by the row's key. -->
+             Viewer tab via ViewPlan_Click (ViewerServerTab.Plans.cs), which fetches by the row's key.
+             "Copy Repro Script" builds from stored fields; for these aggregate rows it best-effort reads the
+             STORED plan from Postgres (not a live connection) to enrich the extracted parameters, then falls
+             back to a plan-less repro (CopyReproScript_Click). Lite's "Get Actual Plan" (live) stays omitted. -->
         <ContextMenu x:Key="QueryPlanGridContextMenu">
             <MenuItem Header="Copy Cell" Click="CopyCell_Click">
                 <MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon>
@@ -208,6 +240,9 @@
             </MenuItem>
             <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click">
                 <MenuItem.Icon><TextBlock Text="&#x1F4D1;"/></MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Header="Copy Repro Script" Click="CopyReproScript_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4DD;"/></MenuItem.Icon>
             </MenuItem>
             <Separator/>
             <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml.cs
@@ -161,8 +161,11 @@ public partial class ViewerServerTab : UserControl
 
         /* Right-click chart drill-downs (ViewerServerTab.DrillDown.cs) + slicer overlay-on-select
            (ViewerServerTab.SlicerOverlay.cs). Wired LAST — after every Initialize*Charts has created its
-           hover helpers, which the drill-down menus read for the nearest-series time. */
+           hover helpers, which the drill-down menus read for the nearest-series time. WireChartDrillDowns
+           builds each drill-down chart's copy/save/export menu (BuildChartContextMenu) and adds the drill-down
+           to it; WireChartContextMenus gives the same menu to every chart that has NO drill-down. */
         WireChartDrillDowns();
+        WireChartContextMenus();
         WireSlicerOverlays();
 
         /* Per-row double-click history windows (ViewerServerTab.History.cs) on the three query grids — a


### PR DESCRIPTION
Restores the **chart + grid right-click context menus** the Darling viewer had dropped from Lite — the last Phase B parity cluster — coexisting with B1's per-chart drill-downs (#1409). Touches only the Viewer project + Darling.Tests.

## 1. Per-chart context menu (Darling-local port of Lite's `ContextMenuHelper.SetupChartContextMenu`)
New `ViewerServerTab.ChartContextMenu.cs` builds: **Copy Image**, **Save Image As…** (pre-named `<Chart>_<ts>.png`), **Open in New Window** (enlarged), **Revert / Autoscale** (also on double-click), **Export Data to CSV…** (the chart's scatter series as `DateTime,Series,Value`), and the **Show Data Source** capability.

**Darling-local vs shared:** ported **Darling-local** (not shared to `PerformanceMonitor.Ui`), because Lite's `ContextMenuHelper` reads Lite's `App.CsvSeparator` and lives in the Lite namespace — sharing would mean refactoring Lite's working code, which the unattended-run brief said to avoid. This mirrors how #1409 ported the drill-down menus local.

### Coexistence with B1's drill-downs (verified both work)
In Lite each chart's menu is ONE `ContextMenu` = `[drill-down] [separator] [copy/save/export]`. Reproduced exactly: `BuildChartContextMenu` builds the copy/export half and takes right-click over from ScottPlot (via B1's `AttachChartContextMenu`); the **refactored** `AddChartDrillDownMenuItem` / `AddWaitDrillDownMenuItem` now take that returned menu and `Insert(0, item)` + `Insert(0, separator)` at the top (mirroring Lite) **instead of** creating a second competing right-click handler. The query heatmap's inline menu is refactored the same way. So there is exactly **one** right-click owner per chart, and B1's drill-downs still resolve.

Wired on **all 38 charts**: 24 drill-down charts (via `WireChartDrillDowns`), the heatmap (via `WireHeatmapDrillDownMenu`), and 13 no-drill charts — latch/spinlock, CPU scheduler, plan cache, collector duration, and the 8 System Events charts (via the new `WireChartContextMenus`).

> **Note — Show Data Source:** ported as an optional capability exactly like Lite, which never wires a data-source string for any ServerTab chart, so (like Lite) the item is absent by default. Wiring a per-chart source string would mean inventing content Lite doesn't have (35 chart→view mappings); flagged here rather than invented. Say the word if you want data sources wired.

## 2. Grid copy/export context menu
A shared `DataGridContextMenu` (Copy Cell / Copy Row / Copy All Rows / Export to CSV) set on the base **`DarkGridRow`** style, so every plain `DarkGrid` grid that doesn't override `RowStyle` gets it: **RunningJobs, ServerConfig, DatabaseConfig, DatabaseScopedConfig, TraceFlags, DailySummary, CollectionHealth**, plus latch/spinlock, CPU scheduler, plan cache, collection log, and the System Events grids. The query / blocking / deadlock grids keep their existing plan-aware `RowStyle` overrides (View Plan already present where a plan column exists). **Get Actual Plan** stays omitted everywhere (live re-exec — the genuine viewer hard-fact).

## 3. Copy Repro Script on the query grids (stored fields, no live connection)
Added to both `QueryGridContextMenu` and `QueryPlanGridContextMenu`, handled by `CopyReproScript_Click` → pure `BuildReproScriptForRow`. **Active Queries** builds entirely from in-row `QueryText`/`DatabaseName`/`QueryPlan`/`TransactionIsolationLevel` (zero connection); **Top Queries / Query Store** best-effort read their **stored** plan from Postgres (a read, not a live re-exec) to enrich extracted parameters, then fall back to a plan-less repro. Comparison / procedure rows with no statement text no-op (Lite's default branch).

## Extra: read-only-seat fix
#1416 revoked the read-only `viewer` role's SELECT on `config_monitored_servers.encrypted_password`, but the Manage Servers **LIST** read (`MonitoredServersSelectSql`) still selected it → a `connectAs: viewer` seat got 42501 on the whole server list. Fix: drop the secret from the LIST read (new `ReadMonitoredServerRowNoSecret`), keep it **only** in the by-id edit-load read (`MonitoredServerByIdSql`), and reload the row by id when the Edit dialog opens so an admin seat still preserves the password when it isn't retyped. (`ManagedServersSql`, the sidebar read, never carried the secret.)

## Testing
- **Build:** whole Darling stack `-c Release` — 0 errors (Viewer + Darling.Tests; warnings are all pre-existing).
- **Darling.Tests `-c Release`:** **1188 passed, 0 failed, 101 skipped** (the skips are the live-PG tests, `DARLING_TEST_PG` unset). Known flakes (ViewerWave2 time-statics, DarlingSecuritySplit V8_Moves) passed this run.
- **New tests** (`ViewerContextMenuTests.cs`, pure/no-WPF like the rest of the suite): composed chart-menu order pins BOTH the drill-down AND copy/export items coexist (drill-down first); chart CSV shape (`DateTime,Series,Value` + escaping); `BuildReproScriptForRow` stored-fields mapping for all three row types + null cases; read-only-seat list-SQL pin (no `encrypted_password`, secret kept in the by-id read). Grid copy/export delegates to the shared `DataGridExport`, already tested in `Dashboard.Tests/DataGridExportTests.cs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)