### PR TITLE
Add unified cross-source Expensive Queries tab to the Darling viewer

### DIFF
--- a/Darling/Darling.Tests/ViewerExpensiveQueriesTests.cs
+++ b/Darling/Darling.Tests/ViewerExpensiveQueriesTests.cs
@@ -1,0 +1,471 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Threading.Tasks;
+using Npgsql;
+using PerformanceMonitor.Darling.Storage;
+using PerformanceMonitor.Darling.Viewer;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Pins the unified "Expensive Queries" cross-source UNION SQL against the Darling store contract (no live
+/// Postgres): the three base tables it UNIONs, the per-source source-label constants, the both-sides window
+/// bound on every branch, the average-worker ranking + TOP-per-source + final cap, the CAST-back-to-bigint
+/// on summed deltas, and the store-driven deviations from the Dashboard's <c>report.expensive_queries_today</c>
+/// (query_stats has no object columns → 'Adhoc'; procedure grant is NULL; Query Store grant is 8-KB-pages→MB
+/// and its plan column is query_plan_text). Ordinal correctness + PG execution are covered by the gated live
+/// round-trip below.
+/// </summary>
+public sealed class ViewerUnifiedExpensiveQueriesSqlTests
+{
+    [Fact]
+    public void UnifiedSql_UnionsAllThreeBaseTables_NotTheViews()
+    {
+        var sql = ViewerDataService.UnifiedExpensiveQueriesSql;
+        Assert.Contains("FROM query_stats", sql, StringComparison.Ordinal);
+        Assert.Contains("FROM procedure_stats", sql, StringComparison.Ordinal);
+        Assert.Contains("FROM query_store_stats", sql, StringComparison.Ordinal);
+        /* viewer reads base tables, never the v_* passthrough views */
+        Assert.DoesNotContain("v_query_stats", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("v_procedure_stats", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("v_query_store_stats", sql, StringComparison.Ordinal);
+        /* three source subqueries → exactly two UNION ALLs */
+        Assert.Equal(2, CountOccurrences(sql, "UNION ALL"));
+    }
+
+    [Fact]
+    public void UnifiedSql_EmitsTheSourceLabelConstants_PerBranch()
+    {
+        var sql = ViewerDataService.UnifiedExpensiveQueriesSql;
+        Assert.Contains($"'{ViewerDataService.ExpensiveSourceQueryStats}' AS source", sql, StringComparison.Ordinal);
+        Assert.Contains($"'{ViewerDataService.ExpensiveSourceQueryStore}' AS source", sql, StringComparison.Ordinal);
+        /* the procedure branch maps object_type → the three procedure source labels via a CASE */
+        Assert.Contains($"THEN '{ViewerDataService.ExpensiveSourceStoredProcedure}'", sql, StringComparison.Ordinal);
+        Assert.Contains($"THEN '{ViewerDataService.ExpensiveSourceTrigger}'", sql, StringComparison.Ordinal);
+        Assert.Contains($"THEN '{ViewerDataService.ExpensiveSourceFunction}'", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UnifiedSql_IsBothSidesWindowBound_OnEveryBranch()
+    {
+        var sql = ViewerDataService.UnifiedExpensiveQueriesSql;
+        /* Each of the three source subqueries binds the window on collection_time on BOTH sides. */
+        Assert.Equal(3, CountOccurrences(sql, "collection_time >= $2"));
+        Assert.Equal(3, CountOccurrences(sql, "collection_time <= $3"));
+        /* server_id is re-scoped 6× — the 3 ranked subqueries PLUS the 3 LATERAL latest-text/plan joins. */
+        Assert.Equal(6, CountOccurrences(sql, "WHERE server_id = $1"));
+    }
+
+    [Fact]
+    public void UnifiedSql_RanksEachSourceByAverageWorkerTime_TopPerSource_ThenFinalRankAndCap()
+    {
+        var sql = ViewerDataService.UnifiedExpensiveQueriesSql;
+        /* query_stats + procedure_stats rank by avg worker = SUM(delta_worker_time)/SUM(delta_execution_count). */
+        Assert.Contains("ORDER BY SUM(delta_worker_time)::double precision / NULLIF(SUM(delta_execution_count), 0) DESC", sql, StringComparison.Ordinal);
+        /* query_store ranks by avg worker = SUM(avg_cpu_time_us * execution_count)/SUM(execution_count). */
+        Assert.Contains("ORDER BY SUM(avg_cpu_time_us * execution_count)::double precision / NULLIF(SUM(execution_count), 0) DESC", sql, StringComparison.Ordinal);
+        /* TOP-per-source ($4) three times, one per branch. */
+        Assert.Equal(3, CountOccurrences(sql, "LIMIT $4"));
+        /* the merged list is re-ranked by avg worker (ms) and capped ($5). */
+        Assert.Contains("ORDER BY avg_worker_ms DESC NULLS LAST", sql, StringComparison.Ordinal);
+        Assert.Contains("LIMIT $5", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UnifiedSql_CastsSummedDeltasBackToBigint_AndConvertsUnitsInTheOuterProjection()
+    {
+        var sql = ViewerDataService.UnifiedExpensiveQueriesSql;
+        /* Postgres SUM(bigint) is numeric; the typed readers need the CAST back to bigint (like TopQueriesSql). */
+        Assert.Contains("CAST(SUM(delta_execution_count) AS bigint)", sql, StringComparison.Ordinal);
+        Assert.Contains("CAST(SUM(delta_worker_time) AS bigint)", sql, StringComparison.Ordinal);
+        Assert.Contains("CAST(SUM(avg_cpu_time_us * execution_count) AS bigint)", sql, StringComparison.Ordinal);
+        /* worker/elapsed µs → sec + per-exec ms in the outer projection (the Dashboard view's units). */
+        Assert.Contains("total_worker_us / 1000000.0 AS total_worker_sec", sql, StringComparison.Ordinal);
+        Assert.Contains("total_worker_us / 1000.0 / NULLIF(execution_count, 0) AS avg_worker_ms", sql, StringComparison.Ordinal);
+        Assert.Contains("total_elapsed_us / 1000000.0 AS total_elapsed_sec", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UnifiedSql_QueryStatsObjectNameIsAdhoc_BecauseTheStoreLacksObjectColumns()
+    {
+        /* Darling's query_stats has NO object_type/schema_name/object_name columns (the Dashboard's does), so
+           the Query Stats source's object_name is the constant 'Adhoc' — the Dashboard view's STATEMENT case. */
+        var sql = ViewerDataService.UnifiedExpensiveQueriesSql;
+        Assert.Contains("'Adhoc' AS object_name", sql, StringComparison.Ordinal);
+        Assert.Contains("GROUP BY database_name, query_hash", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UnifiedSql_ProcedureGrantIsNull_QueryStoreGrantIs8KbPagesToMb()
+    {
+        var sql = ViewerDataService.UnifiedExpensiveQueriesSql;
+        /* Procedure DMVs carry no grant columns → NULL (the Dashboard view carries NULL too). */
+        Assert.Contains("NULL::double precision AS max_grant_mb", sql, StringComparison.Ordinal);
+        /* query_stats grant is genuine KB → MB. */
+        Assert.Contains("(MAX(max_grant_kb) / 1024.0)::double precision AS max_grant_mb", sql, StringComparison.Ordinal);
+        /* Query Store max_query_max_used_memory is 8-KB PAGES → MB (* 8 / 1024) — unit-correct + consistent with
+           Darling's Query Store tab; the Dashboard view treats the page count as KB (a latent 8x unit bug). */
+        Assert.Contains("(MAX(max_query_max_used_memory) * 8.0 / 1024.0)::double precision AS max_grant_mb", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UnifiedSql_QueryStorePlanColumnIsQueryPlanText_AliasedToQueryPlanXml()
+    {
+        /* query_stats/procedure_stats store the plan in query_plan_xml; query_store_stats stores it in
+           query_plan_text — the QS branch aliases it so every branch's plan column lines up. */
+        var sql = ViewerDataService.UnifiedExpensiveQueriesSql;
+        Assert.Contains("t.query_plan_text AS query_plan_xml", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UnifiedSql_IsPostgresDialect_FivePositionalParams_NoTsqlIsms()
+    {
+        var sql = ViewerDataService.UnifiedExpensiveQueriesSql;
+        Assert.DoesNotContain("getdate", sql.ToLowerInvariant());
+        /* No T-SQL national-string literals or @named params (the "N'" guard the sibling reads use is skipped
+           here — it false-positives on the 'FUNCTION' object_type literal, whose word ends in N; the @ + getdate
+           + positional-param checks are the meaningful T-SQL-ism guards). */
+        Assert.DoesNotContain("@", sql, StringComparison.Ordinal);
+        Assert.Contains("$1", sql, StringComparison.Ordinal);
+        Assert.Contains("$5", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("$6", sql, StringComparison.Ordinal);
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        int count = 0, index = 0;
+        while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+        return count;
+    }
+}
+
+/// <summary>The unified Expensive Queries row's pure display + source-classification helpers.</summary>
+public sealed class ViewerUnifiedExpensiveQueriesRowTests
+{
+    [Fact]
+    public void SourceLabelConstants_HaveTheExpectedValues()
+    {
+        Assert.Equal("Query Stats", ViewerDataService.ExpensiveSourceQueryStats);
+        Assert.Equal("Stored Procedure", ViewerDataService.ExpensiveSourceStoredProcedure);
+        Assert.Equal("Trigger", ViewerDataService.ExpensiveSourceTrigger);
+        Assert.Equal("Function", ViewerDataService.ExpensiveSourceFunction);
+        Assert.Equal("Query Store", ViewerDataService.ExpensiveSourceQueryStore);
+    }
+
+    [Theory]
+    [InlineData("Query Stats", true)]
+    [InlineData("Query Store", true)]
+    [InlineData("Stored Procedure", false)]
+    [InlineData("Trigger", false)]
+    [InlineData("Function", false)]
+    public void IsStatementSource_TrueOnlyForTheStatementSources(string source, bool expected)
+    {
+        /* Only the statement sources carry runnable query text; the procedure sources carry the object name, so
+           they gate OUT of "Copy Repro Script" (matching Lite, where procedure rows have no repro). */
+        Assert.Equal(expected, new ViewerExpensiveQueryRow { Source = source }.IsStatementSource);
+    }
+
+    [Fact]
+    public void HasQueryPlan_ReflectsTheInRowPlanPresence()
+    {
+        Assert.True(new ViewerExpensiveQueryRow { QueryPlanXml = "<ShowPlanXML/>" }.HasQueryPlan);
+        Assert.False(new ViewerExpensiveQueryRow { QueryPlanXml = null }.HasQueryPlan);
+        Assert.False(new ViewerExpensiveQueryRow { QueryPlanXml = "" }.HasQueryPlan);
+    }
+
+    [Fact]
+    public void ExecutionTimes_FormatAsRawServerClock_EmptyForNull()
+    {
+        var row = new ViewerExpensiveQueryRow
+        {
+            FirstExecutionTime = new DateTime(2026, 7, 1, 8, 30, 0),
+            LastExecutionTime = null,
+        };
+        Assert.Equal("2026-07-01 08:30:00", row.FirstExecutionTimeLocal);
+        Assert.Equal("", row.LastExecutionTimeLocal);
+    }
+}
+
+/// <summary>
+/// The unified Expensive Queries row's "Copy Repro Script" mapping (through the shared
+/// <see cref="ViewerServerTab.BuildReproScriptForRow"/>): the statement sources build a repro from their
+/// in-row stored plan; the procedure sources (no runnable text) no-op. Pure mapping — no connection.
+/// </summary>
+public sealed class ViewerUnifiedExpensiveQueriesReproTests
+{
+    private const string Product = "SQL Server Performance Monitor Test";
+
+    [Fact]
+    public void QueryStatsSourceRow_BuildsReproFromInRowText_AndInRowStoredPlan()
+    {
+        var row = new ViewerExpensiveQueryRow
+        {
+            Source = ViewerDataService.ExpensiveSourceQueryStats,
+            QueryText = "SELECT COUNT(*) FROM dbo.Orders",
+            DatabaseName = "sales",
+            QueryPlanXml = "<ShowPlanXML>x</ShowPlanXML>",
+        };
+
+        /* enrichedPlanXml is ignored for this source — the plan rides in-row (like the Active Queries case). */
+        var script = ViewerServerTab.BuildReproScriptForRow(row, enrichedPlanXml: null, Product);
+
+        Assert.NotNull(script);
+        Assert.Contains("SELECT COUNT(*) FROM dbo.Orders", script!, StringComparison.Ordinal);
+        Assert.Contains("USE [sales];", script, StringComparison.Ordinal);
+        Assert.Contains("Source: Expensive Queries", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void QueryStoreSourceRow_BuildsRepro()
+    {
+        var row = new ViewerExpensiveQueryRow
+        {
+            Source = ViewerDataService.ExpensiveSourceQueryStore,
+            QueryText = "UPDATE dbo.Inventory SET Qty = Qty - 1",
+            DatabaseName = "wh",
+        };
+
+        var script = ViewerServerTab.BuildReproScriptForRow(row, enrichedPlanXml: null, Product);
+
+        Assert.NotNull(script);
+        Assert.Contains("UPDATE dbo.Inventory SET Qty = Qty - 1", script!, StringComparison.Ordinal);
+        Assert.Contains("Source: Expensive Queries", script, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("Stored Procedure")]
+    [InlineData("Trigger")]
+    [InlineData("Function")]
+    public void ProcedureSourceRow_NoOps_BecauseItHasNoRunnableStatementText(string source)
+    {
+        /* The procedure sources carry the object name as their "query text", not a runnable statement, so the
+           repro no-ops (returns null) exactly like Lite's procedure rows — no malformed EXEC is produced. */
+        var row = new ViewerExpensiveQueryRow
+        {
+            Source = source,
+            QueryText = "sales.dbo.usp_DoWork",
+            DatabaseName = "sales",
+            QueryPlanXml = "<ShowPlanXML/>",
+        };
+
+        Assert.Null(ViewerServerTab.BuildReproScriptForRow(row, enrichedPlanXml: null, Product));
+    }
+
+    [Fact]
+    public void StatementSourceRow_WithEmptyText_ReturnsNull()
+    {
+        var row = new ViewerExpensiveQueryRow { Source = ViewerDataService.ExpensiveSourceQueryStats, QueryText = "" };
+        Assert.Null(ViewerServerTab.BuildReproScriptForRow(row, enrichedPlanXml: null, Product));
+    }
+}
+
+/// <summary>
+/// Gated (DARLING_TEST_PG) live round-trip for the unified Expensive Queries read: plants query-stats,
+/// procedure-stats and query-store rows for a negative sentinel server across two collections each, then
+/// asserts the read merges all three sources into one list, ranks by average worker time, applies the correct
+/// per-source unit conversions (µs→sec/ms, 8-KB pages→MB), and carries the store-driven object_name / grant
+/// deviations end-to-end (the string pins can't catch a dialect error or an ordinal slip). Shares the
+/// serialized "live-postgres" collection and cleans up in finally.
+/// </summary>
+[Collection("live-postgres")]
+public sealed class ViewerUnifiedExpensiveQueriesLivePostgresTests
+{
+    private const int ServerId = -970901;
+
+    private static string? ConnectionString => Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+
+    [Fact]
+    public async Task Unified_MergesThreeSources_RanksByAvgWorker_ConvertsUnits_AgainstDevPostgres()
+    {
+        var cs = ConnectionString;
+        Assert.SkipWhen(string.IsNullOrEmpty(cs), "Set DARLING_TEST_PG to a Postgres connection string to run the live unified Expensive Queries test.");
+
+        using var connection = new NpgsqlConnection(cs);
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await PgMigrations.MigrateAsync(connection, TestContext.Current.CancellationToken);
+        await DeleteRowsAsync(connection, "query_stats");
+        await DeleteRowsAsync(connection, "procedure_stats");
+        await DeleteRowsAsync(connection, "query_store_stats");
+
+        await using var viewer = new ViewerDataService(cs!);
+        var end = TruncateToSeconds(DateTime.UtcNow);
+        var start = end.AddHours(-24);
+        var t1 = start.AddHours(1);
+        var t2 = start.AddHours(2);
+
+        try
+        {
+            /* Query Stats: highest avg worker. Two collections summed → exec 5, worker 500_000 us → avg 100 ms. */
+            await InsertQueryStatsAsync(connection, t1, "StackOverflow", "0xHOT",
+                deltaExec: 2, deltaWorker: 200_000, deltaElapsed: 400_000, deltaReads: 200,
+                maxGrantKb: 2048, queryText: "SELECT hot", planXml: "<ShowPlanXML>qs</ShowPlanXML>");
+            await InsertQueryStatsAsync(connection, t2, "StackOverflow", "0xHOT",
+                deltaExec: 3, deltaWorker: 300_000, deltaElapsed: 600_000, deltaReads: 300,
+                maxGrantKb: 2048, queryText: "SELECT hot", planXml: "<ShowPlanXML>qs</ShowPlanXML>");
+
+            /* Procedure: medium avg worker. exec 4, worker 200_000 us → avg 50 ms. No grant column. */
+            await InsertProcedureStatsAsync(connection, t1, "StackOverflow", "dbo", "usp_Mid", "PROCEDURE",
+                deltaExec: 4, deltaWorker: 200_000, deltaElapsed: 400_000, deltaReads: 400,
+                planXml: "<ShowPlanXML>ps</ShowPlanXML>");
+
+            /* Query Store: lowest avg worker. exec 10, worker = avg 10_000 us * 10 → avg 10 ms. Grant 1024 pages. */
+            await InsertQueryStoreAsync(connection, t1, "StackOverflow", queryId: 99, module: "dbo.usp_Qs",
+                execCount: 10, avgCpuUs: 10_000, avgDurationUs: 20_000, maxMemPages: 1024,
+                queryText: "SELECT qs", planText: "<ShowPlanXML>qsd</ShowPlanXML>");
+
+            var rows = await viewer.GetUnifiedExpensiveQueriesAsync(ServerId, start, end);
+
+            Assert.Equal(3, rows.Count);
+
+            /* Ranked by average worker time descending: Query Stats (100 ms) > Procedure (50 ms) > Query Store (10 ms). */
+            Assert.Equal(ViewerDataService.ExpensiveSourceQueryStats, rows[0].Source);
+            Assert.Equal("Adhoc", rows[0].ObjectName);              /* store has no object columns for query_stats */
+            Assert.Equal(5, rows[0].ExecutionCount);                /* 2 + 3 summed across collections */
+            Assert.Equal(100.0, rows[0].AvgWorkerTimeMs, 3);        /* 500_000 us / 5 execs → ms */
+            Assert.Equal(0.5, rows[0].TotalWorkerTimeSec, 3);       /* 500_000 us → sec */
+            Assert.Equal(2.0, rows[0].MaxGrantMb!.Value, 3);        /* 2048 KB → 2 MB */
+            Assert.Equal("SELECT hot", rows[0].QueryText);
+            Assert.Equal("<ShowPlanXML>qs</ShowPlanXML>", rows[0].QueryPlanXml);
+
+            Assert.Equal(ViewerDataService.ExpensiveSourceStoredProcedure, rows[1].Source);
+            Assert.Equal("dbo.usp_Mid", rows[1].ObjectName);
+            Assert.Equal(50.0, rows[1].AvgWorkerTimeMs, 3);
+            Assert.Null(rows[1].MaxGrantMb);                        /* procedure DMVs carry no grant */
+
+            Assert.Equal(ViewerDataService.ExpensiveSourceQueryStore, rows[2].Source);
+            Assert.Equal("dbo.usp_Qs", rows[2].ObjectName);
+            Assert.Equal(10, rows[2].ExecutionCount);
+            Assert.Equal(10.0, rows[2].AvgWorkerTimeMs, 3);
+            Assert.Equal(8.0, rows[2].MaxGrantMb!.Value, 3);        /* 1024 pages * 8 KB / 1024 → 8 MB */
+        }
+        finally
+        {
+            await DeleteRowsAsync(connection, "query_stats");
+            await DeleteRowsAsync(connection, "procedure_stats");
+            await DeleteRowsAsync(connection, "query_store_stats");
+        }
+    }
+
+    // ── Insert helpers (only the columns the unified read touches; the rest default to NULL) ──
+
+    private static async Task InsertQueryStatsAsync(
+        NpgsqlConnection connection, DateTime collectionTimeUtc, string databaseName, string queryHash,
+        long deltaExec, long deltaWorker, long deltaElapsed, long deltaReads, long maxGrantKb, string queryText, string planXml)
+    {
+        using var command = new NpgsqlCommand(@"
+INSERT INTO query_stats
+    (collection_id, collection_time, server_id, server_name,
+     database_name, query_hash, creation_time, last_execution_time,
+     delta_execution_count, delta_worker_time, delta_elapsed_time,
+     delta_logical_reads, delta_logical_writes, delta_physical_reads,
+     max_grant_kb, query_text, query_plan_xml)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)", connection);
+        command.Parameters.AddWithValue(1L);
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTimeUtc, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(ServerId);
+        command.Parameters.AddWithValue("viewer-expensive-e2e");
+        command.Parameters.AddWithValue(databaseName);
+        command.Parameters.AddWithValue(queryHash);
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTimeUtc.AddHours(-1), DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTimeUtc, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(deltaExec);
+        command.Parameters.AddWithValue(deltaWorker);
+        command.Parameters.AddWithValue(deltaElapsed);
+        command.Parameters.AddWithValue(deltaReads);
+        command.Parameters.AddWithValue(0L);
+        command.Parameters.AddWithValue(0L);
+        command.Parameters.AddWithValue(maxGrantKb);
+        command.Parameters.AddWithValue(queryText);
+        command.Parameters.AddWithValue(planXml);
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static async Task InsertProcedureStatsAsync(
+        NpgsqlConnection connection, DateTime collectionTimeUtc,
+        string databaseName, string schemaName, string objectName, string objectType,
+        long deltaExec, long deltaWorker, long deltaElapsed, long deltaReads, string planXml)
+    {
+        using var command = new NpgsqlCommand(@"
+INSERT INTO procedure_stats
+    (collection_id, collection_time, server_id, server_name,
+     database_name, schema_name, object_name, object_type,
+     cached_time, last_execution_time,
+     delta_execution_count, delta_worker_time, delta_elapsed_time,
+     delta_logical_reads, delta_logical_writes, delta_physical_reads, query_plan_xml)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)", connection);
+        command.Parameters.AddWithValue(1L);
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTimeUtc, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(ServerId);
+        command.Parameters.AddWithValue("viewer-expensive-e2e");
+        command.Parameters.AddWithValue(databaseName);
+        command.Parameters.AddWithValue(schemaName);
+        command.Parameters.AddWithValue(objectName);
+        command.Parameters.AddWithValue(objectType);
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTimeUtc.AddHours(-1), DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTimeUtc, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(deltaExec);
+        command.Parameters.AddWithValue(deltaWorker);
+        command.Parameters.AddWithValue(deltaElapsed);
+        command.Parameters.AddWithValue(deltaReads);
+        command.Parameters.AddWithValue(0L);
+        command.Parameters.AddWithValue(0L);
+        command.Parameters.AddWithValue(planXml);
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static async Task InsertQueryStoreAsync(
+        NpgsqlConnection connection, DateTime collectionTimeUtc, string databaseName,
+        long queryId, string module, long execCount, long avgCpuUs, long avgDurationUs, long maxMemPages,
+        string queryText, string planText)
+    {
+        using var command = new NpgsqlCommand(@"
+INSERT INTO query_store_stats
+    (collection_id, collection_time, server_id, server_name,
+     database_name, query_id, plan_id, module_name, query_text, query_plan_text,
+     first_execution_time, last_execution_time,
+     execution_count, avg_duration_us, avg_cpu_time_us,
+     avg_logical_io_reads, avg_logical_io_writes, avg_physical_io_reads, max_query_max_used_memory)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)", connection);
+        command.Parameters.AddWithValue(1L);
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTimeUtc, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(ServerId);
+        command.Parameters.AddWithValue("viewer-expensive-e2e");
+        command.Parameters.AddWithValue(databaseName);
+        command.Parameters.AddWithValue(queryId);
+        command.Parameters.AddWithValue(1L);
+        command.Parameters.AddWithValue(module);
+        command.Parameters.AddWithValue(queryText);
+        command.Parameters.AddWithValue(planText);
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTimeUtc.AddHours(-1), DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTimeUtc, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(execCount);
+        command.Parameters.AddWithValue(avgDurationUs);
+        command.Parameters.AddWithValue(avgCpuUs);
+        command.Parameters.AddWithValue(0L);
+        command.Parameters.AddWithValue(0L);
+        command.Parameters.AddWithValue(0L);
+        command.Parameters.AddWithValue(maxMemPages);
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static DateTime TruncateToSeconds(DateTime value) =>
+        DateTime.SpecifyKind(new DateTime(value.Ticks - (value.Ticks % TimeSpan.TicksPerSecond)), DateTimeKind.Unspecified);
+
+    private static async Task DeleteRowsAsync(NpgsqlConnection connection, string table)
+    {
+        using var cleanup = new NpgsqlCommand($"DELETE FROM {table} WHERE server_id = {ServerId};", connection);
+        await cleanup.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ExpensiveQueries.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ExpensiveQueries.cs
@@ -1,0 +1,390 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+using PerformanceMonitor.Ui;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// One row of the unified "Expensive Queries" ranked list — the viewer copy of the Dashboard's
+/// <c>ExpensiveQueryItem</c> (Dashboard/Models/ExpensiveQueryItem.cs), fed by the cross-source UNION
+/// that mirrors <c>report.expensive_queries_today</c> (install/46_create_query_plan_views.sql:147).
+/// A single row is one query/proc/query-store group ranked by average worker (CPU) time, carrying the
+/// same metric set the Dashboard view carries: execution count, total/avg worker + elapsed time,
+/// logical/physical reads + writes, max grant, the query-text sample, and the stored plan XML.
+///
+/// <para>Numeric members already carry display units (worker/elapsed in seconds + ms, grant in MB) —
+/// the read does the microsecond→ms/sec and KB/page→MB conversions in SQL, exactly like the Dashboard
+/// view's outer projection. <see cref="FirstExecutionTime"/>/<see cref="LastExecutionTime"/> are shown
+/// raw via <see cref="ViewerDataService.FormatServerClock"/> (query_stats/procedure_stats carry the SQL
+/// server's local wall clock; query_store carries naive UTC — neither is re-based, matching both the
+/// Dashboard view and the existing per-source viewer tabs). <see cref="QueryPlanXml"/> rides IN-ROW
+/// (like the Active Queries snapshot grid, and unlike the Top Queries/Procedures/Query Store grids which
+/// fetch on demand) because the unified row has no single per-source key to re-fetch by — the final list
+/// is capped at a handful of rows, so carrying the stored plan inline is cheap and lets "View Plan" +
+/// "Copy Repro Script" run with zero extra reads and zero live SQL.</para>
+/// </summary>
+public sealed class ViewerExpensiveQueryRow
+{
+    public string Source { get; set; } = "";
+    public string DatabaseName { get; set; } = "";
+    public string ObjectName { get; set; } = "";
+    public long ExecutionCount { get; set; }
+    public double TotalWorkerTimeSec { get; set; }
+    public double AvgWorkerTimeMs { get; set; }
+    public double TotalElapsedTimeSec { get; set; }
+    public double AvgElapsedTimeMs { get; set; }
+    public long TotalLogicalReads { get; set; }
+    public long AvgLogicalReads { get; set; }
+    public long TotalLogicalWrites { get; set; }
+    public long AvgLogicalWrites { get; set; }
+    public long TotalPhysicalReads { get; set; }
+    public long AvgPhysicalReads { get; set; }
+    /// <summary>Max requested memory grant in MB, or null for the procedure sources (the module-level DMVs
+    /// expose no grant columns — the Dashboard view carries NULL for them too).</summary>
+    public double? MaxGrantMb { get; set; }
+    /// <summary>The query-text sample: the statement text for the Query Stats / Query Store sources, the
+    /// 3-part object name for the procedure sources (module-level stats carry no statement text — matching
+    /// the Dashboard view's query_text_sample).</summary>
+    public string QueryText { get; set; } = "";
+    /// <summary>The collector's STORED plan XML for the row, carried in-row so "View Plan" / "Copy Repro
+    /// Script" need no extra read; null when no plan was captured (best-effort, or aged out of retention).</summary>
+    public string? QueryPlanXml { get; set; }
+    public DateTime? FirstExecutionTime { get; set; }
+    public DateTime? LastExecutionTime { get; set; }
+
+    public string FirstExecutionTimeLocal => ViewerDataService.FormatServerClock(FirstExecutionTime);
+    public string LastExecutionTimeLocal => ViewerDataService.FormatServerClock(LastExecutionTime);
+
+    /// <summary>One-line preview of the query-text sample for the grid cell (whitespace-collapsed + capped).</summary>
+    public string QueryTextPreview => ViewerDataService.TruncateForCell(QueryText);
+
+    /// <summary>The fuller (line-break-preserving) query text for the cell tooltip.</summary>
+    public string QueryTextTooltip => ViewerDataService.TruncateForTooltip(QueryText);
+
+    /// <summary>Whether a stored plan rode back for this row — gates the "View Plan" context item so a
+    /// plan-less row shows it disabled instead of shown-and-failed.</summary>
+    public bool HasQueryPlan => !string.IsNullOrEmpty(QueryPlanXml);
+
+    /// <summary>
+    /// True when <see cref="QueryText"/> holds a RUNNABLE statement (the Query Stats / Query Store
+    /// sources), so "Copy Repro Script" produces a repro. The procedure sources carry only the object
+    /// name (no statement text), so they no-op the repro exactly like Lite's procedure rows.
+    /// </summary>
+    public bool IsStatementSource =>
+        Source == ViewerDataService.ExpensiveSourceQueryStats ||
+        Source == ViewerDataService.ExpensiveSourceQueryStore;
+}
+
+public sealed partial class ViewerDataService
+{
+    // ── Source labels (the `source` column values the UNION emits; pinned by test against the SQL) ──
+
+    /// <summary>Ad-hoc statements from query_stats (sys.dm_exec_query_stats).</summary>
+    public const string ExpensiveSourceQueryStats = "Query Stats";
+
+    /// <summary>Stored procedures from procedure_stats (object_type = 'PROCEDURE').</summary>
+    public const string ExpensiveSourceStoredProcedure = "Stored Procedure";
+
+    /// <summary>Triggers from procedure_stats (object_type = 'TRIGGER').</summary>
+    public const string ExpensiveSourceTrigger = "Trigger";
+
+    /// <summary>
+    /// Functions from procedure_stats (object_type = 'FUNCTION'). Darling's procedure_stats collector
+    /// labels ALL functions 'FUNCTION' (sys.dm_exec_function_stats covers scalar + table-valued alike and
+    /// does not distinguish them), so — unlike the Dashboard view's 'Scalar Function' / 'Table Function'
+    /// split — the store cannot tell them apart; this single 'Function' label is the faithful adaptation.
+    /// </summary>
+    public const string ExpensiveSourceFunction = "Function";
+
+    /// <summary>Queries from query_store_stats.</summary>
+    public const string ExpensiveSourceQueryStore = "Query Store";
+
+    /// <summary>TOP(N) per source before the cross-source rank + cap (the Dashboard view's TOP(20)/source).</summary>
+    public const int UnifiedExpensiveQueriesTopPerSource = 20;
+
+    /// <summary>Final cap on the merged ranked list (the Dashboard view's outer TOP(20)).</summary>
+    public const int UnifiedExpensiveQueriesFinalTop = 20;
+
+    /// <summary>
+    /// The unified "Expensive Queries" read — a cross-source UNION ALL of the three query engines, each
+    /// grouped and TOP(N)-ranked by AVERAGE worker (CPU) time, then merged and re-ranked by average worker
+    /// time and capped. Mirrors the Dashboard's <c>report.expensive_queries_today</c>
+    /// (install/46_create_query_plan_views.sql:147) adapted DuckDB/SQL-Server → Postgres against Darling's
+    /// base tables.
+    ///
+    /// <para>Per-source idioms are reused from the existing viewer reads: the query_stats / query_store
+    /// branches SUM the collected DELTAS (never the raw cumulative DMV totals, which would over-count across
+    /// snapshots — exactly why <see cref="TopQueriesSql"/> sums delta columns), CAST every summed bigint
+    /// back to bigint for the typed readers, and a LATERAL fetches each group's LATEST query text + stored
+    /// plan. The query_store branch weights each interval average by <c>execution_count</c> for its totals
+    /// (like the Query Store slicer/comparison). Every branch is both-sides window-bound on
+    /// <c>collection_time</c> (naive UTC).</para>
+    ///
+    /// <para>Store-driven deviations from the Dashboard view (all reported, none silently dropped):
+    /// (1) Darling's query_stats table has NO object_type/schema_name/object_name columns (the Dashboard's
+    /// collect.query_stats does), so the Query Stats source's object_name is the constant 'Adhoc' — the
+    /// overwhelmingly common STATEMENT case the Dashboard view itself maps to 'Adhoc' — and the statement
+    /// text carries the identity. (2) The procedure collector labels all functions 'FUNCTION', so the
+    /// 'Scalar Function'/'Table Function' split collapses to <see cref="ExpensiveSourceFunction"/>.
+    /// (3) The Query Store grant is converted 8-KB-pages → MB (<c>* 8.0 / 1024.0</c>), staying consistent
+    /// with Darling's Query Store tab (<see cref="QueryStoreTopSql"/>); the Dashboard view treats the same
+    /// page count as KB (a latent unit bug, off by 8×) — matching Darling's own read is the unit-correct
+    /// choice and avoids the SAME query showing 8× different grants across two viewer tabs.</para>
+    ///
+    /// <para>$1 server_id, $2 window start, $3 window end (naive UTC), $4 TOP-per-source, $5 final TOP.</para>
+    ///
+    /// <para>NAME: "Unified" distinguishes this cross-source view from the FinOps-cost, query_stats-only
+    /// <see cref="ExpensiveQueriesSql"/> / <see cref="GetExpensiveQueriesAsync"/> in
+    /// ViewerDataService.FinOps.Workload.cs (a different surface — single source, cost-share focus).</para>
+    /// </summary>
+    public const string UnifiedExpensiveQueriesSql = """
+        WITH all_sources AS (
+            /* Ad-hoc queries from query_stats — grouped by (database, query_hash), ranked by avg worker time.
+               No object_type/schema_name/object_name columns in Darling's query_stats, so object_name is the
+               constant 'Adhoc' (the Dashboard view's STATEMENT case); the statement text carries the identity. */
+            SELECT
+                'Query Stats' AS source,
+                r.database_name,
+                'Adhoc' AS object_name,
+                r.execution_count,
+                r.total_worker_us,
+                r.total_elapsed_us,
+                r.total_logical_reads,
+                r.total_logical_writes,
+                r.total_physical_reads,
+                r.max_grant_mb,
+                COALESCE(t.query_text, '') AS query_text_sample,
+                t.query_plan_xml,
+                r.first_execution_time,
+                r.last_execution_time
+            FROM (
+                SELECT
+                    database_name,
+                    query_hash,
+                    CAST(SUM(delta_execution_count) AS bigint) AS execution_count,
+                    CAST(SUM(delta_worker_time) AS bigint) AS total_worker_us,
+                    CAST(SUM(delta_elapsed_time) AS bigint) AS total_elapsed_us,
+                    CAST(SUM(delta_logical_reads) AS bigint) AS total_logical_reads,
+                    CAST(SUM(delta_logical_writes) AS bigint) AS total_logical_writes,
+                    CAST(SUM(delta_physical_reads) AS bigint) AS total_physical_reads,
+                    (MAX(max_grant_kb) / 1024.0)::double precision AS max_grant_mb,
+                    MIN(creation_time) AS first_execution_time,
+                    MAX(last_execution_time) AS last_execution_time
+                FROM query_stats
+                WHERE server_id = $1
+                AND   collection_time >= $2
+                AND   collection_time <= $3
+                GROUP BY database_name, query_hash
+                HAVING SUM(delta_execution_count) > 0 OR SUM(delta_elapsed_time) > 0
+                ORDER BY SUM(delta_worker_time)::double precision / NULLIF(SUM(delta_execution_count), 0) DESC
+                LIMIT $4
+            ) AS r
+            LEFT JOIN LATERAL (
+                SELECT query_text, query_plan_xml
+                FROM query_stats
+                WHERE server_id = $1
+                AND   database_name = r.database_name
+                AND   query_hash = r.query_hash
+                AND   query_text IS NOT NULL
+                ORDER BY collection_time DESC
+                LIMIT 1
+            ) AS t ON TRUE
+
+            UNION ALL
+
+            /* Stored procedures / triggers / functions from procedure_stats — grouped by object, ranked by
+               avg worker time. The procedure DMVs expose no memory-grant columns, so max_grant_mb is NULL
+               (the Dashboard view carries NULL too); the query-text sample is the 3-part object name. */
+            SELECT
+                CASE r.object_type
+                    WHEN 'PROCEDURE' THEN 'Stored Procedure'
+                    WHEN 'TRIGGER'   THEN 'Trigger'
+                    WHEN 'FUNCTION'  THEN 'Function'
+                    ELSE 'Procedure'
+                END AS source,
+                r.database_name,
+                r.schema_name || '.' || r.object_name AS object_name,
+                r.execution_count,
+                r.total_worker_us,
+                r.total_elapsed_us,
+                r.total_logical_reads,
+                r.total_logical_writes,
+                r.total_physical_reads,
+                NULL::double precision AS max_grant_mb,
+                r.database_name || '.' || r.schema_name || '.' || r.object_name AS query_text_sample,
+                p.query_plan_xml,
+                r.first_execution_time,
+                r.last_execution_time
+            FROM (
+                SELECT
+                    database_name,
+                    schema_name,
+                    object_name,
+                    object_type,
+                    CAST(SUM(delta_execution_count) AS bigint) AS execution_count,
+                    CAST(SUM(delta_worker_time) AS bigint) AS total_worker_us,
+                    CAST(SUM(delta_elapsed_time) AS bigint) AS total_elapsed_us,
+                    CAST(SUM(delta_logical_reads) AS bigint) AS total_logical_reads,
+                    CAST(SUM(delta_logical_writes) AS bigint) AS total_logical_writes,
+                    CAST(SUM(delta_physical_reads) AS bigint) AS total_physical_reads,
+                    MIN(cached_time) AS first_execution_time,
+                    MAX(last_execution_time) AS last_execution_time
+                FROM procedure_stats
+                WHERE server_id = $1
+                AND   collection_time >= $2
+                AND   collection_time <= $3
+                GROUP BY database_name, schema_name, object_name, object_type
+                HAVING SUM(delta_execution_count) > 0 OR SUM(delta_elapsed_time) > 0
+                ORDER BY SUM(delta_worker_time)::double precision / NULLIF(SUM(delta_execution_count), 0) DESC
+                LIMIT $4
+            ) AS r
+            LEFT JOIN LATERAL (
+                SELECT query_plan_xml
+                FROM procedure_stats
+                WHERE server_id = $1
+                AND   database_name = r.database_name
+                AND   schema_name = r.schema_name
+                AND   object_name = r.object_name
+                AND   query_plan_xml IS NOT NULL
+                ORDER BY collection_time DESC
+                LIMIT 1
+            ) AS p ON TRUE
+
+            UNION ALL
+
+            /* Query Store — grouped by (database, query_id, module), ranked by avg worker time. Query Store
+               rows are per-interval averages, so totals weight each average by execution_count (like the
+               Query Store slicer). The grant is 8-KB pages → MB (* 8 / 1024), consistent with the Query
+               Store tab; the plan column is query_plan_text (not query_plan_xml). */
+            SELECT
+                'Query Store' AS source,
+                r.database_name,
+                COALESCE(r.module_name, 'Ad Hoc') AS object_name,
+                r.execution_count,
+                r.total_worker_us,
+                r.total_elapsed_us,
+                r.total_logical_reads,
+                r.total_logical_writes,
+                r.total_physical_reads,
+                r.max_grant_mb,
+                COALESCE(t.query_text, '') AS query_text_sample,
+                t.query_plan_text AS query_plan_xml,
+                r.first_execution_time,
+                r.last_execution_time
+            FROM (
+                SELECT
+                    database_name,
+                    query_id,
+                    module_name,
+                    CAST(SUM(execution_count) AS bigint) AS execution_count,
+                    CAST(SUM(avg_cpu_time_us * execution_count) AS bigint) AS total_worker_us,
+                    CAST(SUM(avg_duration_us * execution_count) AS bigint) AS total_elapsed_us,
+                    CAST(SUM(avg_logical_io_reads * execution_count) AS bigint) AS total_logical_reads,
+                    CAST(SUM(avg_logical_io_writes * execution_count) AS bigint) AS total_logical_writes,
+                    CAST(SUM(avg_physical_io_reads * execution_count) AS bigint) AS total_physical_reads,
+                    (MAX(max_query_max_used_memory) * 8.0 / 1024.0)::double precision AS max_grant_mb,
+                    MIN(first_execution_time) AS first_execution_time,
+                    MAX(last_execution_time) AS last_execution_time
+                FROM query_store_stats
+                WHERE server_id = $1
+                AND   collection_time >= $2
+                AND   collection_time <= $3
+                GROUP BY database_name, query_id, module_name
+                HAVING SUM(execution_count) > 0
+                ORDER BY SUM(avg_cpu_time_us * execution_count)::double precision / NULLIF(SUM(execution_count), 0) DESC
+                LIMIT $4
+            ) AS r
+            LEFT JOIN LATERAL (
+                SELECT query_text, query_plan_text
+                FROM query_store_stats
+                WHERE server_id = $1
+                AND   database_name = r.database_name
+                AND   query_id = r.query_id
+                AND   query_text IS NOT NULL
+                ORDER BY collection_time DESC
+                LIMIT 1
+            ) AS t ON TRUE
+        )
+        SELECT
+            source,
+            database_name,
+            object_name,
+            execution_count,
+            total_worker_us / 1000000.0 AS total_worker_sec,
+            total_worker_us / 1000.0 / NULLIF(execution_count, 0) AS avg_worker_ms,
+            total_elapsed_us / 1000000.0 AS total_elapsed_sec,
+            total_elapsed_us / 1000.0 / NULLIF(execution_count, 0) AS avg_elapsed_ms,
+            total_logical_reads,
+            total_logical_reads / NULLIF(execution_count, 0) AS avg_logical_reads,
+            total_logical_writes,
+            total_logical_writes / NULLIF(execution_count, 0) AS avg_logical_writes,
+            total_physical_reads,
+            total_physical_reads / NULLIF(execution_count, 0) AS avg_physical_reads,
+            max_grant_mb,
+            query_text_sample,
+            query_plan_xml,
+            first_execution_time,
+            last_execution_time
+        FROM all_sources
+        ORDER BY avg_worker_ms DESC NULLS LAST
+        LIMIT $5
+        """;
+
+    /// <summary>
+    /// The unified Expensive Queries list for one server over [<paramref name="startUtc"/>,
+    /// <paramref name="endUtc"/>] — a cross-source ranked merge (see <see cref="UnifiedExpensiveQueriesSql"/>),
+    /// pre-sorted by average worker time descending (the grid's default sort). Distinct from the FinOps-cost
+    /// <see cref="GetExpensiveQueriesAsync"/> (query_stats-only, hours-back, cost-share).
+    /// </summary>
+    public async Task<List<ViewerExpensiveQueryRow>> GetUnifiedExpensiveQueriesAsync(
+        int serverId, DateTime startUtc, DateTime endUtc,
+        int topPerSource = UnifiedExpensiveQueriesTopPerSource, int finalTop = UnifiedExpensiveQueriesFinalTop,
+        CancellationToken cancellationToken = default)
+    {
+        var rows = new List<ViewerExpensiveQueryRow>();
+
+        await using var command = _dataSource.CreateCommand(UnifiedExpensiveQueriesSql);
+        AddServerWindowParameters(command, serverId, startUtc, endUtc);
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = topPerSource });
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = finalTop });
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            rows.Add(new ViewerExpensiveQueryRow
+            {
+                Source = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                DatabaseName = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                ObjectName = reader.IsDBNull(2) ? "" : reader.GetString(2),
+                ExecutionCount = reader.IsDBNull(3) ? 0 : Convert.ToInt64(reader.GetValue(3)),
+                TotalWorkerTimeSec = reader.IsDBNull(4) ? 0 : Convert.ToDouble(reader.GetValue(4)),
+                AvgWorkerTimeMs = reader.IsDBNull(5) ? 0 : Convert.ToDouble(reader.GetValue(5)),
+                TotalElapsedTimeSec = reader.IsDBNull(6) ? 0 : Convert.ToDouble(reader.GetValue(6)),
+                AvgElapsedTimeMs = reader.IsDBNull(7) ? 0 : Convert.ToDouble(reader.GetValue(7)),
+                TotalLogicalReads = reader.IsDBNull(8) ? 0 : Convert.ToInt64(reader.GetValue(8)),
+                AvgLogicalReads = reader.IsDBNull(9) ? 0 : Convert.ToInt64(reader.GetValue(9)),
+                TotalLogicalWrites = reader.IsDBNull(10) ? 0 : Convert.ToInt64(reader.GetValue(10)),
+                AvgLogicalWrites = reader.IsDBNull(11) ? 0 : Convert.ToInt64(reader.GetValue(11)),
+                TotalPhysicalReads = reader.IsDBNull(12) ? 0 : Convert.ToInt64(reader.GetValue(12)),
+                AvgPhysicalReads = reader.IsDBNull(13) ? 0 : Convert.ToInt64(reader.GetValue(13)),
+                MaxGrantMb = reader.IsDBNull(14) ? null : Convert.ToDouble(reader.GetValue(14)),
+                QueryText = reader.IsDBNull(15) ? "" : reader.GetString(15),
+                QueryPlanXml = reader.IsDBNull(16) ? null : reader.GetString(16),
+                FirstExecutionTime = reader.IsDBNull(17) ? null : reader.GetDateTime(17),
+                LastExecutionTime = reader.IsDBNull(18) ? null : reader.GetDateTime(18),
+            });
+        }
+
+        return rows;
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.CopyExport.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.CopyExport.cs
@@ -126,6 +126,16 @@ public partial class ViewerServerTab
                     qs.QueryText, qs.DatabaseName, enrichedPlanXml, null,
                     "Query Store", productName: productName);
 
+            /* The unified Expensive Queries row carries its STORED plan in-row (ignore enrichedPlanXml, like
+               the Active Queries snapshot case). Only the statement sources (Query Stats / Query Store) have
+               runnable text; the procedure sources carry only the object name, so IsStatementSource is false
+               and they fall to the default no-op — matching Lite, where procedure rows have no repro. */
+            case ViewerExpensiveQueryRow eq when eq.IsStatementSource:
+                if (string.IsNullOrEmpty(eq.QueryText)) return null;
+                return ReproScriptBuilder.BuildReproScript(
+                    eq.QueryText, eq.DatabaseName, eq.QueryPlanXml, null,
+                    "Expensive Queries", productName: productName);
+
             default:
                 return null;
         }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Filters.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Filters.cs
@@ -41,6 +41,7 @@ public partial class ViewerServerTab : UserControl
     private DataGridFilterManager<ViewerQueryStatsRow>? _queryStatsFilterMgr;
     private DataGridFilterManager<ViewerProcedureStatsRow>? _procStatsFilterMgr;
     private DataGridFilterManager<ViewerQueryStoreRow>? _queryStoreFilterMgr;
+    private DataGridFilterManager<ViewerExpensiveQueryRow>? _expensiveQueriesFilterMgr;
     private DataGridFilterManager<CollectorHealthRow>? _collectionHealthFilterMgr;
     private DataGridFilterManager<CollectionLogRow>? _collectionLogFilterMgr;
 
@@ -63,6 +64,7 @@ public partial class ViewerServerTab : UserControl
         _queryStatsFilterMgr = new DataGridFilterManager<ViewerQueryStatsRow>(QueryStatsGrid);
         _procStatsFilterMgr = new DataGridFilterManager<ViewerProcedureStatsRow>(ProcedureStatsGrid);
         _queryStoreFilterMgr = new DataGridFilterManager<ViewerQueryStoreRow>(QueryStoreGrid);
+        _expensiveQueriesFilterMgr = new DataGridFilterManager<ViewerExpensiveQueryRow>(ExpensiveQueriesGrid);
         _collectionHealthFilterMgr = new DataGridFilterManager<CollectorHealthRow>(CollectionHealthGrid);
         _collectionLogFilterMgr = new DataGridFilterManager<CollectionLogRow>(CollectionLogGrid);
 
@@ -77,6 +79,7 @@ public partial class ViewerServerTab : UserControl
         _filterManagers[QueryStatsGrid] = _queryStatsFilterMgr;
         _filterManagers[ProcedureStatsGrid] = _procStatsFilterMgr;
         _filterManagers[QueryStoreGrid] = _queryStoreFilterMgr;
+        _filterManagers[ExpensiveQueriesGrid] = _expensiveQueriesFilterMgr;
         _filterManagers[CollectionHealthGrid] = _collectionHealthFilterMgr;
         _filterManagers[CollectionLogGrid] = _collectionLogFilterMgr;
     }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Plans.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Plans.cs
@@ -171,6 +171,14 @@ public partial class ViewerServerTab
                 queryText = null; /* the procedure grid carries no statement text; the plan XML holds its own */
                 fetch = ct => _dataService.GetProcedureStatsPlanXmlAsync(_server.ServerId, proc.DatabaseName, proc.SchemaName, proc.ObjectName, ct);
                 break;
+            case ViewerExpensiveQueryRow expensive:
+                /* The unified Expensive Queries row carries its STORED plan in-row (like the Active Queries
+                   snapshot grid) — the merged row has no single per-source key to re-fetch by — so hand the
+                   in-row XML straight to the host (null → the null-plan branch below shows "No Plan Available"). */
+                label = $"Plan - {expensive.Source}: {expensive.ObjectName}";
+                queryText = expensive.IsStatementSource ? expensive.QueryText : null;
+                fetch = _ => Task.FromResult(expensive.QueryPlanXml);
+                break;
             default:
                 /* Comparison items / anything else: no stored plan keyed on the row — deferred. */
                 return;

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Queries.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Queries.cs
@@ -34,14 +34,16 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// </summary>
 public partial class ViewerServerTab
 {
-    /* Queries sub-tab order — matches Lite's QueriesSubTabControl exactly (W1f-2 completed the tab):
-       Performance Trends, Active Queries, the three grids, then Query Heatmap last. */
+    /* Queries sub-tab order — matches Lite's QueriesSubTabControl (W1f-2), plus the Darling-only unified
+       Expensive Queries grid inserted after the three per-source grids (Dashboard parity), keeping Query
+       Heatmap last: Performance Trends, Active Queries, the three grids, Expensive Queries, Query Heatmap. */
     private const int PerformanceTrendsSubTabIndex = 0;
     private const int ActiveQueriesSubTabIndex = 1;
     private const int TopQueriesSubTabIndex = 2;
     private const int TopProceduresSubTabIndex = 3;
     private const int QueryStoreSubTabIndex = 4;
-    private const int QueryHeatmapSubTabIndex = 5;
+    private const int ExpensiveQueriesSubTabIndex = 5;
+    private const int QueryHeatmapSubTabIndex = 6;
 
     private string _queryStatsSlicerMetric = "TotalCpu";
     private List<TimeSliceBucket>? _queryStatsSlicerData;
@@ -130,6 +132,9 @@ public partial class ViewerServerTab
             case QueryStoreSubTabIndex:
                 await LoadQueryStoreAsync(startUtc, endUtc);
                 break;
+            case ExpensiveQueriesSubTabIndex:
+                await LoadExpensiveQueriesAsync(startUtc, endUtc);
+                break;
             case QueryHeatmapSubTabIndex:
                 await LoadQueryHeatmapAsync(startUtc, endUtc);
                 break;
@@ -165,6 +170,19 @@ public partial class ViewerServerTab
         SetDefaultSortIfNone(QueryStoreGrid, "TotalDurationMs", ListSortDirection.Descending);
         await LoadQueryStoreSlicerAsync(startUtc, endUtc);
         await RefreshQueryStoreComparisonAsync(startUtc, endUtc);
+    }
+
+    /// <summary>
+    /// Loads the unified Expensive Queries grid — one cross-source ranked list (Query Stats + Stored
+    /// Procedures + Query Store) over the toolbar's settable window. No slicer / comparison (the read is
+    /// already a cross-source merge, not a single time series); the default sort matches the read's
+    /// average-CPU ranking so the first render is stable.
+    /// </summary>
+    private async Task LoadExpensiveQueriesAsync(DateTime startUtc, DateTime endUtc)
+    {
+        var rows = await _dataService.GetUnifiedExpensiveQueriesAsync(_server.ServerId, startUtc, endUtc);
+        _expensiveQueriesFilterMgr!.UpdateData(rows);
+        SetDefaultSortIfNone(ExpensiveQueriesGrid, "AvgWorkerTimeMs", ListSortDirection.Descending);
     }
 
     // ── Slicers (Lite's ServerTab.Slicers.cs; the slicer sends UTC bounds, the viewer reads take naive UTC) ──

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
@@ -1401,6 +1401,88 @@
                             </DataGrid>
                         </Grid>
                     </TabItem>
+                    <!-- Expensive Queries: the unified cross-source ranked list (Dashboard parity —
+                         report.expensive_queries_today). ONE grid UNIONing query_stats (Query Stats),
+                         procedure_stats (Stored Procedure/Trigger/Function), and query_store_stats
+                         (Query Store), each TOP-20-per-source then merged + re-ranked by average CPU
+                         (worker) time, over the toolbar's settable window. Uses the plan-enabled row
+                         style (Copy/Repro/Export + View Plan) — the stored plan rides in-row, so View
+                         Plan opens it directly (no live SQL, no re-fetch). -->
+                    <TabItem Header="Expensive Queries">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="*"/>
+                            </Grid.RowDefinitions>
+                            <TextBlock Grid.Row="0" Margin="8,4,0,4" FontSize="11"
+                                       Foreground="{DynamicResource ForegroundMutedBrush}"
+                                       Text="Top resource consumers across Query Stats, Stored Procedures/Triggers/Functions, and Query Store — ranked by average CPU (worker) time over the selected window."/>
+                            <DataGrid Grid.Row="1" x:Name="ExpensiveQueriesGrid" Style="{StaticResource DarkGrid}"
+                                      RowStyle="{StaticResource QueryPlanGridRowStyle}"
+                                      HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+                                <DataGrid.Columns>
+                                    <DataGridTextColumn Binding="{Binding Source}" Width="130">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Source" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Source" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding DatabaseName}" Width="130">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DatabaseName" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Database" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding ObjectName}" Width="180">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ObjectName" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Object" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding ExecutionCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ExecutionCount" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Executions" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding TotalWorkerTimeSec, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalWorkerTimeSec" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Total CPU (s)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding AvgWorkerTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgWorkerTimeMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Avg CPU (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding TotalElapsedTimeSec, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalElapsedTimeSec" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Total Duration (s)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding AvgElapsedTimeMs, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgElapsedTimeMs" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Avg Duration (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding TotalLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalReads" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Total Reads" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding AvgLogicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgLogicalReads" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Avg Reads" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding TotalLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalLogicalWrites" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Total Writes" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding AvgLogicalWrites, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgLogicalWrites" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Avg Writes" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding TotalPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalPhysicalReads" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Physical Reads" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding AvgPhysicalReads, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgPhysicalReads" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Avg Phys Reads" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding MaxGrantMb, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="MaxGrantMb" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Max Grant (MB)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding FirstExecutionTimeLocal}" Width="150">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="FirstExecutionTimeLocal" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="First Execution" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding LastExecutionTimeLocal}" Width="150">
+                                        <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastExecutionTimeLocal" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Last Execution" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                    </DataGridTextColumn>
+                                    <DataGridTemplateColumn Header="Query / Object" Width="400" SortMemberPath="QueryText">
+                                        <DataGridTemplateColumn.CellTemplate>
+                                            <DataTemplate>
+                                                <TextBlock Text="{Binding QueryTextPreview}" TextTrimming="CharacterEllipsis" Margin="5,2" ToolTip="{Binding QueryTextTooltip}"/>
+                                            </DataTemplate>
+                                        </DataGridTemplateColumn.CellTemplate>
+                                    </DataGridTemplateColumn>
+                                </DataGrid.Columns>
+                            </DataGrid>
+                        </Grid>
+                    </TabItem>
                     <!-- Query Heatmap (Lite ServerTab.xaml:1160-1180): metric combo + heatmap of query
                          counts per (5-min bin x per-execution magnitude bucket). Right-click drills into
                          Active Queries for the clicked bin's window. -->


### PR DESCRIPTION
Ports the Dashboard's **Unified "Expensive Queries" ranked view** (`report.expensive_queries_today`, `install/46_create_query_plan_views.sql:147`; `DatabaseService.QueryPerformance.cs:29`; `get_expensive_queries`) onto the Darling viewer — one ranked list that UNIONs all three query-engine sources. Viewer + Darling.Tests only.

## Tab placement
New **"Expensive Queries"** sub-tab inside the per-server **Queries** tab, beside Top Queries / Top Procedures / Query Store (before Query Heatmap, which stays last). Wired into the server tab's refresh + the per-server toolbar time window, so it honors the settable range + Apply-to-all. Column filtering/sort via `DataGridFilterManager`, the `DarkGrid` style, times via `FormatServerClock` (raw, matching the sibling grids + the Dashboard view).

## The UNION read (`ViewerDataService.ExpensiveQueries.cs`)
`GetUnifiedExpensiveQueriesAsync` — a TOP(20)-per-source `UNION ALL`, each source grouped + ranked by **average worker (CPU) time**, then merged, re-ranked by avg worker time, and capped at 20. Parameterized ($1 server, $2/$3 naive-UTC window on both sides, $4 per-source, $5 final), sums collected **deltas** (not cumulative DMV totals — reusing the QueryStats/ProcedureStats/QueryStore idioms), CASTs summed bigints back for the typed readers, and a LATERAL fetches each group's latest text + stored plan. Named `Unified*` to avoid colliding with the existing FinOps-cost, query_stats-only `ExpensiveQueriesSql`/`GetExpensiveQueriesAsync` (a different surface).

Carries the full Dashboard-view shape: `source`, database, object_name, execution_count, total/avg worker (sec/ms), total/avg elapsed (sec/ms), total/avg logical reads + writes, total/avg physical reads, max grant (MB), query-text sample, stored plan XML, first/last execution time.

### Columns VERIFIED per source (against the collector definitions that generate the PG schema)
- **query_stats** (Query Stats): `delta_execution_count/worker_time/elapsed_time/logical_reads/logical_writes/physical_reads`, `max_grant_kb`, `creation_time`, `last_execution_time`, `query_text`, `query_plan_xml` — all present. ⚠️ **No `object_type`/`schema_name`/`object_name`** columns (the Dashboard's `collect.query_stats` has them; Darling's does not) → object_name is the constant `'Adhoc'` (the Dashboard view's STATEMENT case), statement text carries identity.
- **procedure_stats** (Stored Procedure/Trigger/Function): `object_type`, `schema_name`, `object_name`, `delta_*`, `cached_time`, `last_execution_time`, `query_plan_xml` — all present. No grant columns → `max_grant` is NULL (the Dashboard view carries NULL too). ⚠️ `object_type` is only `PROCEDURE`/`TRIGGER`/`FUNCTION` — the collector labels **all functions `FUNCTION`** (no scalar/table split), so the Dashboard view's `Scalar Function`/`Table Function` collapse to `Function`.
- **query_store_stats** (Query Store): `execution_count`, `avg_cpu_time_us`, `avg_duration_us`, `avg_logical_io_reads/writes`, `avg_physical_io_reads`, `max_query_max_used_memory`, `first/last_execution_time`, `query_text`, `query_plan_text`, `module_name` — all present. Plan column is `query_plan_text` (not `query_plan_xml`); grant is 8-KB **pages** → MB (`* 8 / 1024`), **unit-correct + consistent with Darling's Query Store tab** — the Dashboard view treats the page count as KB (a latent 8× unit bug), so this intentionally deviates to stay correct and avoid the same query showing 8× different grants across two viewer tabs.

**No store column was found missing for a metric the task required** — the two `object_name`/`function-split` items above are store-shape adaptations (reported, best-faithful value produced), not dropped scope.

## Row context menu
The shared #1419 plan-enabled menu (`QueryPlanGridRowStyle`): **View Plan** (the stored plan rides in-row — no re-fetch, no live SQL), **Copy Repro Script** (statement sources build from the in-row plan; procedure sources no-op like Lite), Copy Cell/Row/All, Export to CSV. **No Get Actual Plan** (viewer hard fact).

## Testing
`Darling.Tests -c Release`: full suite green (a lone parallel flake vanished on re-run). New `ViewerExpensiveQueriesTests.cs` — SQL pins (UNIONs the 3 base tables, source-label constants, both-sides window bound ×3, avg-worker ranking + TOP-per-source + final cap, CAST-to-bigint, the object_name/grant/plan-column deviations, PG dialect), the row model (IsStatementSource / HasQueryPlan / clock formatting), the repro mapping, and a **gated live round-trip that PASSES against the running Darling Postgres store** (merges 3 sources, ranks by avg worker, validates the µs→sec/ms + 8KB-pages→MB conversions and all 19 ordinals end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
