### PR TITLE
Add Session Stats per-server chart tab to the Darling viewer

### DIFF
--- a/Darling/Darling.Tests/ViewerSessionStatsTests.cs
+++ b/Darling/Darling.Tests/ViewerSessionStatsTests.cs
@@ -1,0 +1,349 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Npgsql;
+using PerformanceMonitor.Collectors;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.Darling.Storage;
+using PerformanceMonitor.Darling.Viewer;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Pins the Session Stats tab's read + chart mapping against the Darling store contract (no live Postgres).
+/// The tab is the Dashboard-parity port of ResourceMetricsContent's Session Stats sub-tab; its feed is the
+/// server-wide <c>v_session_summary_stats</c> view (the <see cref="SessionSummaryStatsCollector"/> that is
+/// the 1:1 port of the Dashboard's <c>session_stats</c> table), NOT the per-application
+/// <c>v_session_stats</c> FinOps' Application Connections read uses. These tests verify that every one of the
+/// Dashboard's seven chart series + three summary fields maps to a column that actually exists in that
+/// table, that the read is both-sides window-bound, and that the pure series/summary helpers shape the data
+/// exactly as the Dashboard does.
+/// </summary>
+public sealed class ViewerSessionStatsSqlTests
+{
+    [Fact]
+    public void SessionStatsSql_ReadsSessionSummaryView_BothSidesWindow_OrderedOldestFirst()
+    {
+        var sql = ViewerDataService.SessionStatsSql;
+
+        /* The server-wide SUMMARY view, not the per-application v_session_stats. */
+        Assert.Contains("FROM v_session_summary_stats", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("FROM v_session_stats", sql, StringComparison.Ordinal);
+
+        Assert.Contains("WHERE server_id = $1", sql, StringComparison.Ordinal);
+        Assert.Contains("collection_time >= $2", sql, StringComparison.Ordinal);
+        Assert.Contains("collection_time <= $3", sql, StringComparison.Ordinal);
+        Assert.Contains("ORDER BY collection_time", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SessionStatsSql_SelectsEveryDashboardSeriesAndSummaryColumn()
+    {
+        var sql = ViewerDataService.SessionStatsSql;
+
+        /* The seven chart series columns + the three summary columns (+ the two connection counts) — every
+           field the Dashboard's SessionStatsItem carries, so no series is silently dropped. */
+        foreach (var column in new[]
+        {
+            "collection_time",
+            "total_sessions",
+            "running_sessions",
+            "sleeping_sessions",
+            "background_sessions",
+            "dormant_sessions",
+            "idle_sessions_over_30min",
+            "sessions_waiting_for_memory",
+            "databases_with_connections",
+            "top_application_name",
+            "top_application_connections",
+            "top_host_name",
+            "top_host_connections",
+        })
+        {
+            Assert.Contains(column, sql, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void SessionStatsSql_PgDialect_PositionalParams_NoBareNow_NoNLiterals()
+    {
+        var sql = ViewerDataService.SessionStatsSql;
+
+        Assert.DoesNotContain("now(", sql.ToLowerInvariant());
+        Assert.DoesNotContain("N'", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("@", sql, StringComparison.Ordinal);
+        Assert.Contains("$1", sql, StringComparison.Ordinal);
+        Assert.Contains("$2", sql, StringComparison.Ordinal);
+        Assert.Contains("$3", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SessionStatsSql_ReadsColumnsThatExistInTheGeneratedSessionSummaryTable()
+    {
+        /* The verified-columns pin: every column the read selects is a real column of the collector's
+           generated table, so a series can never reference a column the store does not have. */
+        Assert.Equal("session_summary_stats", SessionSummaryStatsCollector.Instance.TargetTable);
+
+        var ddl = PgSchemaGenerator.CreateTable(SessionSummaryStatsCollector.Instance);
+        foreach (var column in new[]
+        {
+            "collection_time", "total_sessions", "running_sessions", "sleeping_sessions",
+            "background_sessions", "dormant_sessions", "idle_sessions_over_30min",
+            "sessions_waiting_for_memory", "databases_with_connections", "top_application_name",
+            "top_application_connections", "top_host_name", "top_host_connections",
+        })
+        {
+            Assert.Contains(column, ddl, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void SessionSummaryView_IsPinnedInTheAuthoritativeViewList()
+    {
+        /* The tab reads the v_ passthrough view; it must be in the store's authoritative view set (so V14
+           refreshes it and the migration test cross-checks it). */
+        Assert.Contains("v_session_summary_stats", PgSchemaGenerator.AllPassthroughViews);
+    }
+}
+
+/// <summary>
+/// Pins the Session Stats chart's pure series mapping + summary formatting (no WpfPlot): the seven series
+/// and their shared-palette colors, and the "name (count)" / N/A summary shaping — the same no-WPF
+/// discipline as the rest of Darling.Tests. The render loop and the summary setter both consume these, so
+/// the pins guard the exact Dashboard-parity mapping.
+/// </summary>
+public sealed class ViewerSessionStatsMappingTests
+{
+    [Fact]
+    public void SessionSeriesSpecs_AreTheSevenDashboardSeries_InOrder()
+    {
+        var legends = ViewerServerTab.SessionSeriesSpecs.Select(s => s.Legend).ToList();
+
+        Assert.Equal(
+            new[] { "Total", "Running", "Sleeping", "Background", "Dormant", "Idle >30m", "Waiting for Memory" },
+            legends);
+    }
+
+    [Fact]
+    public void SessionSeriesSpecs_EachSeriesResolvesToADistinctSharedPaletteColor()
+    {
+        var keys = ViewerServerTab.SessionSeriesSpecs.Select(s => s.PaletteKey).ToList();
+
+        Assert.Equal(
+            new[] { "SessionTotal", "SessionRunning", "SessionSleeping", "SessionBackground", "SessionDormant", "SessionIdle", "SessionWaiting" },
+            keys);
+
+        /* Every key resolves through the shared palette to a valid #RRGGBB (so a typo'd key that fell back
+           to a cycling color would still be a hex, but the exact-key list above pins the intended mapping). */
+        var colors = keys.Select(ChartPalette.SeriesColor).ToList();
+        Assert.All(colors, c => Assert.Matches("^#[0-9A-Fa-f]{6}$", c));
+
+        /* The seven status series must be visually distinguishable — distinct colors. */
+        Assert.Equal(keys.Count, colors.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+    }
+
+    [Fact]
+    public void SessionSeriesSpecs_Selectors_ReadTheMatchingStatusColumn()
+    {
+        /* Distinct value per column so a mis-wired selector (e.g. Running reading Sleeping) fails. */
+        var point = new SessionStatsPoint(
+            CollectionTime: DateTime.UtcNow,
+            TotalSessions: 100,
+            RunningSessions: 11,
+            SleepingSessions: 22,
+            BackgroundSessions: 33,
+            DormantSessions: 44,
+            IdleSessionsOver30Min: 55,
+            SessionsWaitingForMemory: 66,
+            DatabasesWithConnections: 7,
+            TopApplicationName: "AppA",
+            TopApplicationConnections: 40,
+            TopHostName: "Host1",
+            TopHostConnections: 30);
+
+        var byLegend = ViewerServerTab.SessionSeriesSpecs.ToDictionary(s => s.Legend, s => s.Value(point));
+
+        Assert.Equal(100, byLegend["Total"]);
+        Assert.Equal(11, byLegend["Running"]);
+        Assert.Equal(22, byLegend["Sleeping"]);
+        Assert.Equal(33, byLegend["Background"]);
+        Assert.Equal(44, byLegend["Dormant"]);
+        Assert.Equal(55, byLegend["Idle >30m"]);
+        Assert.Equal(66, byLegend["Waiting for Memory"]);
+    }
+
+    [Fact]
+    public void FormatSessionSummary_Null_YieldsNAForAllThree()
+    {
+        var (topApp, topHost, databases) = ViewerServerTab.FormatSessionSummary(null);
+
+        Assert.Equal("N/A", topApp);
+        Assert.Equal("N/A", topHost);
+        Assert.Equal("N/A", databases);
+    }
+
+    [Fact]
+    public void FormatSessionSummary_FullPoint_RendersNameAndConnectionCount()
+    {
+        var point = Point(topApp: "SQLAgent", topAppConns: 42, topHost: "APPSRV01", topHostConns: 18, dbs: 9);
+
+        var (topApp, topHost, databases) = ViewerServerTab.FormatSessionSummary(point);
+
+        Assert.Equal("SQLAgent (42)", topApp);
+        Assert.Equal("APPSRV01 (18)", topHost);
+        Assert.Equal("9", databases);
+    }
+
+    [Fact]
+    public void FormatSessionSummary_MissingApplicationOrHost_YieldsNA_ButKeepsDatabaseCount()
+    {
+        var point = Point(topApp: null, topAppConns: null, topHost: "", topHostConns: null, dbs: 3);
+
+        var (topApp, topHost, databases) = ViewerServerTab.FormatSessionSummary(point);
+
+        Assert.Equal("N/A", topApp);
+        Assert.Equal("N/A", topHost);
+        Assert.Equal("3", databases);
+    }
+
+    private static SessionStatsPoint Point(string? topApp, int? topAppConns, string? topHost, int? topHostConns, int dbs) =>
+        new(
+            CollectionTime: DateTime.UtcNow,
+            TotalSessions: 0,
+            RunningSessions: 0,
+            SleepingSessions: 0,
+            BackgroundSessions: 0,
+            DormantSessions: 0,
+            IdleSessionsOver30Min: 0,
+            SessionsWaitingForMemory: 0,
+            DatabasesWithConnections: dbs,
+            TopApplicationName: topApp,
+            TopApplicationConnections: topAppConns,
+            TopHostName: topHost,
+            TopHostConnections: topHostConns);
+}
+
+/// <summary>
+/// Gated (DARLING_TEST_PG) live round-trip for the Session Stats read: two in-window snapshots plus one
+/// out-of-window snapshot prove the oldest-first ordering, the inclusive both-sides window bound, and the
+/// latest-snapshot summary attribution. Shares the serialized "live-postgres" collection; uses a negative
+/// sentinel server_id and cleans up in finally.
+/// </summary>
+[Collection("live-postgres")]
+public sealed class ViewerSessionStatsLivePostgresTests
+{
+    private const int SessionServerId = -940003;
+    private const string SessionServerName = "viewer-session-summary-e2e";
+
+    [Fact]
+    public async Task SessionStats_OrderedInWindow_ExcludesOutOfWindow_LatestSummary_AgainstDevPostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the live session-stats test.");
+
+        using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await PgMigrations.MigrateAsync(connection, TestContext.Current.CancellationToken);
+        await DeleteAsync(connection, SessionServerId);
+
+        await using var viewer = new ViewerDataService(connectionString!);
+
+        try
+        {
+            var t1 = TruncateToSeconds(DateTime.UtcNow.AddMinutes(-10));
+            var t2 = t1.AddMinutes(5);
+            var tOut = t2.AddMinutes(10); // AFTER the window end below — must be excluded
+
+            await InsertAsync(connection, 1, t1, total: 100, running: 5, sleeping: 90, background: 3, dormant: 2,
+                idle: 10, waiting: 1, dbs: 7, topApp: "AppA", topAppConns: 40, topHost: "Host1", topHostConns: 30);
+            await InsertAsync(connection, 2, t2, total: 120, running: 8, sleeping: 105, background: 4, dormant: 3,
+                idle: 15, waiting: 2, dbs: 9, topApp: "AppB", topAppConns: 55, topHost: "Host2", topHostConns: 45);
+            await InsertAsync(connection, 3, tOut, total: 999, running: 0, sleeping: 0, background: 0, dormant: 0,
+                idle: 0, waiting: 0, dbs: 0, topApp: "OutOfWindow", topAppConns: 1, topHost: "OutHost", topHostConns: 1);
+
+            var window = await viewer.GetSessionStatsAsync(SessionServerId, t1.AddMinutes(-1), t2.AddMinutes(1));
+
+            /* Both-sides bound: only the two in-window rows, oldest-first. */
+            Assert.Equal(2, window.Count);
+            Assert.Equal(t1, window[0].CollectionTime);
+            Assert.Equal(t2, window[1].CollectionTime);
+            Assert.DoesNotContain(window, p => p.TotalSessions == 999);
+
+            /* Column mapping on the latest snapshot. */
+            var latest = window[^1];
+            Assert.Equal(120, latest.TotalSessions);
+            Assert.Equal(8, latest.RunningSessions);
+            Assert.Equal(105, latest.SleepingSessions);
+            Assert.Equal(4, latest.BackgroundSessions);
+            Assert.Equal(3, latest.DormantSessions);
+            Assert.Equal(15, latest.IdleSessionsOver30Min);
+            Assert.Equal(2, latest.SessionsWaitingForMemory);
+            Assert.Equal(9, latest.DatabasesWithConnections);
+            Assert.Equal("AppB", latest.TopApplicationName);
+            Assert.Equal(55, latest.TopApplicationConnections);
+            Assert.Equal("Host2", latest.TopHostName);
+            Assert.Equal(45, latest.TopHostConnections);
+
+            /* The summary strip reads that latest snapshot. */
+            var (topApp, topHost, databases) = ViewerServerTab.FormatSessionSummary(latest);
+            Assert.Equal("AppB (55)", topApp);
+            Assert.Equal("Host2 (45)", topHost);
+            Assert.Equal("9", databases);
+        }
+        finally
+        {
+            await DeleteAsync(connection, SessionServerId);
+        }
+    }
+
+    private static async Task InsertAsync(
+        NpgsqlConnection connection, long collectionId, DateTime collectionTimeUtc,
+        int total, int running, int sleeping, int background, int dormant, int idle, int waiting, int dbs,
+        string topApp, int topAppConns, string topHost, int topHostConns)
+    {
+        using var command = new NpgsqlCommand(@"
+INSERT INTO session_summary_stats
+    (collection_id, collection_time, server_id, server_name,
+     total_sessions, running_sessions, sleeping_sessions, background_sessions, dormant_sessions,
+     idle_sessions_over_30min, sessions_waiting_for_memory, databases_with_connections,
+     top_application_name, top_application_connections, top_host_name, top_host_connections)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)", connection);
+        command.Parameters.AddWithValue(collectionId);
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTimeUtc, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(SessionServerId);
+        command.Parameters.AddWithValue(SessionServerName);
+        command.Parameters.AddWithValue(total);
+        command.Parameters.AddWithValue(running);
+        command.Parameters.AddWithValue(sleeping);
+        command.Parameters.AddWithValue(background);
+        command.Parameters.AddWithValue(dormant);
+        command.Parameters.AddWithValue(idle);
+        command.Parameters.AddWithValue(waiting);
+        command.Parameters.AddWithValue(dbs);
+        command.Parameters.AddWithValue(topApp);
+        command.Parameters.AddWithValue(topAppConns);
+        command.Parameters.AddWithValue(topHost);
+        command.Parameters.AddWithValue(topHostConns);
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static DateTime TruncateToSeconds(DateTime value) =>
+        DateTime.SpecifyKind(new DateTime(value.Ticks - (value.Ticks % TimeSpan.TicksPerSecond)), DateTimeKind.Unspecified);
+
+    private static async Task DeleteAsync(NpgsqlConnection connection, int serverId)
+    {
+        using var cleanup = new NpgsqlCommand($"DELETE FROM session_summary_stats WHERE server_id = {serverId};", connection);
+        await cleanup.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.SessionStats.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.SessionStats.cs
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// One point on the Session Stats trend: a single server-wide session-summary snapshot from
+/// <c>session_summary_stats</c> — the status-count breakdown that drives the chart's seven series plus the
+/// attribution columns (top application / top host / distinct databases) the summary panel shows.
+/// </summary>
+/// <remarks>
+/// <b>Source note (verified).</b> This is the server-wide <c>session_summary_stats</c> table (view
+/// <c>v_session_summary_stats</c>), the <see cref="PerformanceMonitor.Collectors.SessionSummaryStatsCollector"/>
+/// that is the 1:1 Dashboard-parity port of <c>install/36_collect_session_stats.sql</c> — one aggregate row
+/// per collection with all twelve columns the Dashboard's <c>SessionStatsItem</c> carries. It is deliberately
+/// NOT the per-application <c>session_stats</c> table (view <c>v_session_stats</c>, one row per
+/// <c>program_name</c>) that FinOps' Application Connections read uses — that table has no
+/// background/idle/waiting-for-memory/host/database columns, so it cannot feed the Dashboard's chart or
+/// summary. The names are intentionally distinct so the two never collide.
+/// </remarks>
+public sealed record SessionStatsPoint(
+    DateTime CollectionTime,
+    int TotalSessions,
+    int RunningSessions,
+    int SleepingSessions,
+    int BackgroundSessions,
+    int DormantSessions,
+    int IdleSessionsOver30Min,
+    int SessionsWaitingForMemory,
+    int DatabasesWithConnections,
+    string? TopApplicationName,
+    int? TopApplicationConnections,
+    string? TopHostName,
+    int? TopHostConnections);
+
+public sealed partial class ViewerDataService
+{
+    /// <summary>
+    /// The Session Stats trend read: every server-wide session-summary snapshot in the settable window,
+    /// ordered oldest-first, so the chart plots the seven status counts over time and the summary panel
+    /// reads the latest point's attribution columns (the same shape the Dashboard's
+    /// <c>GetSessionStatsAsync</c> returns). Runs on the <c>v_session_summary_stats</c> passthrough view;
+    /// both bounds are inclusive (<c>&gt;= $2 AND &lt;= $3</c>, naive UTC via
+    /// <see cref="AddWindowParameters"/>). $1 server_id, $2 window start, $3 window end.
+    /// </summary>
+    public const string SessionStatsSql = """
+        SELECT
+            collection_time,
+            total_sessions,
+            running_sessions,
+            sleeping_sessions,
+            background_sessions,
+            dormant_sessions,
+            idle_sessions_over_30min,
+            sessions_waiting_for_memory,
+            databases_with_connections,
+            top_application_name,
+            top_application_connections,
+            top_host_name,
+            top_host_connections
+        FROM v_session_summary_stats
+        WHERE server_id = $1
+        AND   collection_time >= $2
+        AND   collection_time <= $3
+        ORDER BY collection_time
+        """;
+
+    /// <summary>The server-wide session-summary snapshots over the window, oldest-first (empty when none).</summary>
+    public async Task<List<SessionStatsPoint>> GetSessionStatsAsync(
+        int serverId, DateTime startUtc, DateTime endUtc, CancellationToken cancellationToken = default)
+    {
+        var result = new List<SessionStatsPoint>();
+
+        await using var command = _dataSource.CreateCommand(SessionStatsSql);
+        AddWindowParameters(command, serverId, startUtc, endUtc);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            result.Add(new SessionStatsPoint(
+                reader.GetDateTime(0),
+                reader.IsDBNull(1) ? 0 : reader.GetInt32(1),
+                reader.IsDBNull(2) ? 0 : reader.GetInt32(2),
+                reader.IsDBNull(3) ? 0 : reader.GetInt32(3),
+                reader.IsDBNull(4) ? 0 : reader.GetInt32(4),
+                reader.IsDBNull(5) ? 0 : reader.GetInt32(5),
+                reader.IsDBNull(6) ? 0 : reader.GetInt32(6),
+                reader.IsDBNull(7) ? 0 : reader.GetInt32(7),
+                reader.IsDBNull(8) ? 0 : reader.GetInt32(8),
+                reader.IsDBNull(9) ? null : reader.GetString(9),
+                reader.IsDBNull(10) ? null : reader.GetInt32(10),
+                reader.IsDBNull(11) ? null : reader.GetString(11),
+                reader.IsDBNull(12) ? null : reader.GetInt32(12)));
+        }
+
+        return result;
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.ChartContextMenu.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.ChartContextMenu.cs
@@ -183,6 +183,7 @@ public partial class ViewerServerTab
            duration chart Lite also leaves drill-less. */
         BuildChartContextMenu(LatchStatsChart, "Latch_Stats");
         BuildChartContextMenu(SpinlockStatsChart, "Spinlock_Stats");
+        BuildChartContextMenu(SessionStatsChart, "Session_Stats");
         BuildChartContextMenu(CpuSchedulerChart, "CPU_Scheduler");
         BuildChartContextMenu(PlanCacheChart, "Plan_Cache");
         BuildChartContextMenu(CollectorDurationChart, "Collector_Duration");

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Charts.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Charts.cs
@@ -85,6 +85,7 @@ public partial class ViewerServerTab : IDisposable
         DisposePlanCacheHelpers();
         DisposeCpuSchedulerHelpers();
         DisposeLatchSpinlockHelpers();
+        DisposeSessionStatsHelpers();
         DisposeFileIoHelpers();
         DisposeBlockingHelpers();
         DisposePerfmonHelpers();

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.SessionStats.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.SessionStats.cs
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.Ui;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The Session Stats inner tab — the Dashboard-parity port of ResourceMetricsContent's Session Stats
+/// sub-tab (Dashboard/Controls/ResourceMetricsContent.SessionStats.cs) into the Darling viewer. A single
+/// trend chart plots the server-wide session-status counts over the settable window — Total / Running /
+/// Sleeping / Background / Dormant / Idle &gt;30m / Waiting for Memory — and a summary strip below it shows
+/// the non-chartable attribution the latest snapshot carries: the top application and top host by
+/// connection count, and the number of distinct databases with connections.
+/// <para>
+/// The feed is <see cref="ViewerDataService.GetSessionStatsAsync"/> over <c>v_session_summary_stats</c>
+/// (the server-wide summary collector, 1:1 with the Dashboard's <c>session_stats</c> table) — NOT the
+/// per-application <c>v_session_stats</c> FinOps' Application Connections read uses. Each status series
+/// rides its own fixed <see cref="ChartPalette.SeriesColor"/> (the shared "Session*" keys the Dashboard
+/// chart also uses), and, mirroring the Dashboard, a series is only drawn when it has a non-zero value in
+/// the window so all-zero states (e.g. Background/Waiting) don't clutter the legend. Chart chrome / legend
+/// / line polish / Y-floor-at-0 flow through the shared <see cref="ChartStyle"/> and the
+/// <c>ViewerServerTab.ChartHelpers.cs</c> bridge, exactly like the sibling trend tabs; the chart's
+/// Copy/Save/CSV right-click menu is wired in <c>ViewerServerTab.ChartContextMenu.cs</c>.
+/// </para>
+/// </summary>
+public partial class ViewerServerTab
+{
+    private ChartHoverHelper? _sessionStatsHover;
+
+    /// <summary>One chart series: its legend label, its shared-palette color key, and the accessor that
+    /// pulls its status count out of a <see cref="SessionStatsPoint"/>. Pure data so the mapping (which
+    /// column drives which colored series) is unit-testable without a WpfPlot; the render loop and the
+    /// tests share this single source of truth.</summary>
+    internal readonly record struct SessionSeriesSpec(string Legend, string PaletteKey, Func<SessionStatsPoint, double> Value);
+
+    /// <summary>
+    /// The seven session-status series in the Dashboard's order (Total first, then the status breakdown),
+    /// each pinned to the shared <c>Session*</c> palette key the Dashboard chart uses. The tuple's accessor
+    /// is the verified <c>session_summary_stats</c> column each series reads.
+    /// </summary>
+    internal static IReadOnlyList<SessionSeriesSpec> SessionSeriesSpecs { get; } = new[]
+    {
+        new SessionSeriesSpec("Total", "SessionTotal", p => p.TotalSessions),
+        new SessionSeriesSpec("Running", "SessionRunning", p => p.RunningSessions),
+        new SessionSeriesSpec("Sleeping", "SessionSleeping", p => p.SleepingSessions),
+        new SessionSeriesSpec("Background", "SessionBackground", p => p.BackgroundSessions),
+        new SessionSeriesSpec("Dormant", "SessionDormant", p => p.DormantSessions),
+        new SessionSeriesSpec("Idle >30m", "SessionIdle", p => p.IdleSessionsOver30Min),
+        new SessionSeriesSpec("Waiting for Memory", "SessionWaiting", p => p.SessionsWaitingForMemory),
+    };
+
+    /// <summary>Applies the shared chrome + hover to the Session Stats chart up front (constructor), so it
+    /// doesn't flash white before the tab's first load — matching the CPU/Memory/latch charts.</summary>
+    private void InitializeSessionStatsChart()
+    {
+        ApplyTheme(SessionStatsChart);
+        SessionStatsChart.Refresh();
+        _sessionStatsHover = new ChartHoverHelper(SessionStatsChart, "sessions");
+    }
+
+    /// <summary>Loads the Session Stats tab: the session-summary snapshots over the toolbar's settable
+    /// window, then renders the status-count chart and the top-app / top-host / databases summary.</summary>
+    private async Task LoadSessionStatsAsync()
+    {
+        var (startUtc, endUtc) = GetWindowUtc();
+        var data = await _dataService.GetSessionStatsAsync(_server.ServerId, startUtc, endUtc);
+        RenderSessionStatsChart(data);
+    }
+
+    private void RenderSessionStatsChart(List<SessionStatsPoint> data)
+    {
+        ClearChart(SessionStatsChart);
+        _sessionStatsHover?.Clear();
+        ApplyTheme(SessionStatsChart);
+
+        var (startUtc, endUtc) = GetWindowUtc();
+        SessionStatsChart.Plot.YLabel("Session Count");
+
+        var ordered = data.OrderBy(d => d.CollectionTime).ToList();
+        if (ordered.Count == 0)
+        {
+            UpdateSessionStatsSummary(null);
+            FinishSessionStatsChart(startUtc, endUtc, 0);
+            return;
+        }
+
+        var times = ordered.Select(d => ViewerTimeHelper.ForDisplay(d.CollectionTime).ToOADate()).ToArray();
+
+        double globalMax = 0;
+        foreach (var spec in SessionSeriesSpecs)
+        {
+            var values = ordered.Select(spec.Value).ToArray();
+
+            /* Mirror the Dashboard: only draw a series that is non-zero somewhere in the window, so
+               all-zero states (often Background / Dormant / Waiting for Memory) stay out of the legend. */
+            if (!values.Any(v => v > 0))
+            {
+                continue;
+            }
+
+            var plot = SessionStatsChart.Plot.Add.Scatter(times, values);
+            plot.LegendText = spec.Legend;
+            plot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor(spec.PaletteKey));
+            ChartStyle.StyleScatter(plot);
+            _sessionStatsHover?.Add(plot, spec.Legend);
+
+            globalMax = Math.Max(globalMax, values.Max());
+        }
+
+        /* Summary panel reflects the latest snapshot in the window (Dashboard uses the last data point). */
+        UpdateSessionStatsSummary(ordered[^1]);
+        FinishSessionStatsChart(startUtc, endUtc, globalMax);
+    }
+
+    /// <summary>Shared chart finish for the Session Stats trend: date axis, window X-limits, Y floor at 0
+    /// with legend padding, and the legend — the one place the window bounds + Y-floor fix apply.</summary>
+    private void FinishSessionStatsChart(DateTime startUtc, DateTime endUtc, double globalMax)
+    {
+        SessionStatsChart.Plot.Axes.DateTimeTicksBottomDateChange();
+        var rangeStart = ViewerTimeHelper.ForDisplay(startUtc);
+        var rangeEnd = ViewerTimeHelper.ForDisplay(endUtc);
+        SessionStatsChart.Plot.Axes.SetLimitsX(rangeStart.ToOADate(), rangeEnd.ToOADate());
+        ReapplyAxisColors(SessionStatsChart);
+        SetChartYLimitsWithLegendPadding(SessionStatsChart, 0, globalMax > 0 ? globalMax : 10);
+        ShowChartLegend(SessionStatsChart);
+        SessionStatsChart.Refresh();
+    }
+
+    /// <summary>Writes the latest snapshot's attribution into the summary strip (Dashboard parity: the
+    /// non-chartable Top Application / Top Host / Databases values), delegating the formatting to the pure
+    /// <see cref="FormatSessionSummary"/> so the "name (count)" / N/A shaping is unit-tested.</summary>
+    private void UpdateSessionStatsSummary(SessionStatsPoint? data)
+    {
+        var (topApp, topHost, databases) = FormatSessionSummary(data);
+        SessionStatsTopAppText.Text = topApp;
+        SessionStatsTopHostText.Text = topHost;
+        SessionStatsDatabasesText.Text = databases;
+    }
+
+    /// <summary>
+    /// Pure formatter for the summary strip (mirrors the Dashboard's <c>UpdateSessionStatsSummary</c>):
+    /// Top Application / Top Host render as "<c>name (count)</c>" when the latest snapshot has one and
+    /// "N/A" otherwise; Databases is the distinct-databases count. A null point (no data in the window)
+    /// yields "N/A" for all three.
+    /// </summary>
+    internal static (string TopApplication, string TopHost, string Databases) FormatSessionSummary(SessionStatsPoint? data)
+    {
+        if (data is null)
+        {
+            return ("N/A", "N/A", "N/A");
+        }
+
+        var topApp = !string.IsNullOrEmpty(data.TopApplicationName)
+            ? $"{data.TopApplicationName} ({data.TopApplicationConnections ?? 0})"
+            : "N/A";
+        var topHost = !string.IsNullOrEmpty(data.TopHostName)
+            ? $"{data.TopHostName} ({data.TopHostConnections ?? 0})"
+            : "N/A";
+        var databases = data.DatabasesWithConnections.ToString(CultureInfo.CurrentCulture);
+
+        return (topApp, topHost, databases);
+    }
+
+    /// <summary>Tears down the Session Stats hover helper (mirrors the other tabs' dispose) so its tooltip
+    /// popup + chart event handlers don't outlive a closed server tab.</summary>
+    public void DisposeSessionStatsHelpers()
+    {
+        _sessionStatsHover?.Dispose();
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
@@ -2160,6 +2160,36 @@
             </Grid>
         </TabItem>
 
+        <!-- Session Stats Tab — the Dashboard-parity port of ResourceMetricsContent's Session Stats sub-tab.
+             A single server-wide session-count trend chart (Total / Running / Sleeping / Background / Dormant /
+             Idle >30m / Waiting for Memory) over the settable window, with a summary strip below for the
+             non-chartable attribution (top application / top host by connections + distinct databases with
+             connections). Feed is v_session_summary_stats (the server-wide SUMMARY collector = 1:1 with the
+             Dashboard's session_stats table), NOT the per-application v_session_stats FinOps uses. Placed
+             after Perfmon, mirroring the Dashboard's Perfmon -> Session Stats adjacency. -->
+        <TabItem Header="Session Stats">
+            <Grid Margin="8">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+                <TextBlock Grid.Row="0" Text="Session Counts Over Time" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,0,0,4"/>
+                <scottplot:WpfPlot Grid.Row="1" x:Name="SessionStatsChart"/>
+                <Border Grid.Row="2" Background="{DynamicResource BackgroundDarkBrush}" BorderBrush="{DynamicResource BorderBrush}"
+                        BorderThickness="0,1,0,0" Padding="10,8" Margin="0,8,0,0" CornerRadius="0,0,4,4">
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                        <TextBlock Text="Top Application:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                        <TextBlock x:Name="SessionStatsTopAppText" Text="N/A" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Margin="0,0,20,0"/>
+                        <TextBlock Text="Top Host:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                        <TextBlock x:Name="SessionStatsTopHostText" Text="N/A" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Margin="0,0,20,0"/>
+                        <TextBlock Text="Databases:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                        <TextBlock x:Name="SessionStatsDatabasesText" Text="N/A" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </Border>
+            </Grid>
+        </TabItem>
+
         <!-- Running Jobs Tab — copied from Lite's ServerTab.xaml Running Jobs tab: the latest-snapshot
              grid of currently-running SQL Agent jobs (8 columns, IsRunningLong row highlight) with the
              W1g column-filter headers. Reads rewired to Postgres; the msdb-access banner is derived

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml.cs
@@ -56,16 +56,22 @@ public partial class ViewerServerTab : UserControl
     private const int TempDbInnerTabIndex = 8;
     private const int BlockingInnerTabIndex = 9;
     private const int PerfmonInnerTabIndex = 10;
-    private const int RunningJobsInnerTabIndex = 11;
-    private const int ConfigurationInnerTabIndex = 12;
-    private const int DailySummaryInnerTabIndex = 13;
-    private const int HealthInnerTabIndex = 14;
+
+    /* Session Stats sits BETWEEN Perfmon and Running Jobs — the Dashboard-parity port of
+       ResourceMetricsContent's Session Stats sub-tab (which the Dashboard places right after Perfmon). Not a
+       Lite ServerTab tab (it is Dashboard-only), so it has no Lite position to mirror; a new top-level tab,
+       and everything after it renumbers by one. */
+    private const int SessionStatsInnerTabIndex = 11;
+    private const int RunningJobsInnerTabIndex = 12;
+    private const int ConfigurationInnerTabIndex = 13;
+    private const int DailySummaryInnerTabIndex = 14;
+    private const int HealthInnerTabIndex = 15;
 
     /* System Events is appended AFTER Collection Health (system_health parity, Stage 2b): six parse-on-read
        sub-tabs, one per unique system_health warning category. FinOps used to sit between them as a per-server
        inner tab, but it was promoted to a top-level cross-server aggregate tab (FinOpsTab, in MainWindow's
        MainTabs), so System Events now takes Collection Health's next slot. */
-    private const int SystemEventsInnerTabIndex = 15;
+    private const int SystemEventsInnerTabIndex = 16;
 
     private readonly ViewerDataService _dataService;
     private readonly DarlingServer _server;
@@ -118,6 +124,10 @@ public partial class ViewerServerTab : UserControl
         /* Latches & Spinlocks inner-tab charts (latch_stats/spinlock_stats parity): the two per-second
            contention trend charts, themed up front + hover. */
         InitializeLatchSpinlockCharts();
+
+        /* Session Stats inner-tab chart (session_summary_stats parity): the server-wide session-count trend,
+           themed up front + hover. */
+        InitializeSessionStatsChart();
 
         /* File I/O + Blocking-trend inner-tab charts (copied from Lite): same up-front theme + hover. */
         InitializeFileIoCharts();
@@ -272,6 +282,9 @@ public partial class ViewerServerTab : UserControl
                     break;
                 case PerfmonInnerTabIndex:
                     await LoadPerfmonAsync();
+                    break;
+                case SessionStatsInnerTabIndex:
+                    await LoadSessionStatsAsync();
                     break;
                 case RunningJobsInnerTabIndex:
                     await LoadRunningJobsAsync();


### PR DESCRIPTION
Surfaces the one ResourceMetricsContent sub-tab the Darling viewer had not yet ported: the Dashboard's **Session Stats** chart + summary (`Dashboard/Controls/ResourceMetricsContent.SessionStats.cs`).

## Source correction (please note)
The task pointed at `v_session_stats`, but that is the **per-application** FinOps table (one row per `program_name`; `ViewerDataService.FinOps.Workload.cs` reads it). It has no background / idle>30m / waiting-for-memory / host / database columns, so it **cannot** feed the Dashboard's chart or summary — sourcing from it would force dropping 3 series + 2 summary fields.

The correct 1:1 source is **`v_session_summary_stats`** — the server-wide `session_summary_stats` collector (`SessionSummaryStatsCollector`, #1377), which is the verbatim port of the Dashboard's `install/36_collect_session_stats.sql` and carries **all twelve** columns the Dashboard's `SessionStatsItem` has. Building from it gives full parity with **zero dropped series**. All twelve columns were verified against the collector `PayloadColumns` + `PgSchemaGenerator.CreateTable(...)`.

## Tab placement
New **top-level per-server tab "Session Stats"**, inserted after **Perfmon** (index 11), mirroring the Dashboard's Perfmon → Session Stats adjacency. Darling flattened the Dashboard's ResourceMetricsContent composite into top-level tabs (Wait Stats / tempdb / Perfmon are already top-level), so this matches the established layout. Inner-tab index constants renumbered (+1 for Running Jobs → System Events); all tab switches use the named constants, so nothing else moved.

## The chart (7 series — every column verified present)
Session counts over the settable window, each series drawn only when non-zero (Dashboard parity), on the shared `Session*` `ChartPalette` keys, with hover + the #1419 chart context menu (Copy/Save Image, Open in New Window, Export Data to CSV):

| Series | Column (verified in `session_summary_stats`) |
|---|---|
| Total | `total_sessions` |
| Running | `running_sessions` |
| Sleeping | `sleeping_sessions` |
| Background | `background_sessions` |
| Dormant | `dormant_sessions` |
| Idle >30m | `idle_sessions_over_30min` |
| Waiting for Memory | `sessions_waiting_for_memory` |

## The summary strip
From the latest snapshot in the window (Dashboard parity): **Top Application** `name (count)` (`top_application_name` / `top_application_connections`), **Top Host** `name (count)` (`top_host_name` / `top_host_connections`), and **Databases** (`databases_with_connections`). Shaping is a pure `FormatSessionSummary` helper so it is unit-tested.

## The read
New `ViewerDataService.SessionStats.cs` partial: `SessionStatsSql` (public const, pinned) over `v_session_summary_stats`, parameterized `$1/$2/$3`, both-sides window-bound (`>= $2 AND <= $3`), naive UTC via the shared `AddWindowParameters`, ordered oldest-first — mirroring the other viewer time-series reads.

## Tests (`ViewerSessionStatsTests.cs`)
- SQL pins: reads `v_session_summary_stats` (not the per-app view), both-sides window bound, ordered, selects every one of the 12 columns; PG dialect (positional params, no `now(`/`N'`/`@`).
- Verified-columns pin: every selected column exists in `PgSchemaGenerator.CreateTable(SessionSummaryStatsCollector.Instance)`; view is in `AllPassthroughViews`.
- Pure mapping: the 7 series (order + palette keys + column selectors) and the summary formatter (`name (count)` / N/A).
- Gated live-Postgres round-trip (skips without `DARLING_TEST_PG`): ordering, inclusive both-sides bound (out-of-window row excluded), latest-snapshot attribution.

## Build / test
- Whole Darling stack builds `-c Release` (0 errors).
- `Darling.Tests -c Release`: **1269 passed / 104 skipped (live-PG gated) / 0 failed**.

Touches only the Viewer project + Darling.Tests (no Service/Storage/Config/Migrations files).