### PR TITLE
Add Configuration Changes history tab to the Darling viewer

### DIFF
--- a/Darling/Darling.Tests/ViewerConfigChangesTests.cs
+++ b/Darling/Darling.Tests/ViewerConfigChangesTests.cs
@@ -1,0 +1,531 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Npgsql;
+using PerformanceMonitor.Collectors;
+using PerformanceMonitor.Darling.Storage;
+using PerformanceMonitor.Darling.Viewer;
+using Xunit;
+
+using Snap = PerformanceMonitor.Darling.Viewer.ViewerDataService;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Pins the Configuration Changes tab's snapshot-read SQL (the Dashboard's ConfigChangesContent ported to the
+/// viewer). Unlike the latest-snapshot Configuration reads, the change reads are WINDOWED — but only the UPPER
+/// bound (<c>capture_time &lt;= $2</c>, the window end) is applied in SQL; the window START is applied to the
+/// computed change_time in C# (see <see cref="ViewerConfigChangesDiffTests"/>), so the snapshot immediately
+/// BEFORE the window is kept as the diff baseline. That mirrors the Dashboard, whose report.*_changes views LAG
+/// over the full history and then filter change_time to [from,to]. Reads take server_id ($1) and window-end ($2)
+/// only — never a lower $3 (which would drop the baseline).
+/// </summary>
+public sealed class ViewerConfigChangesSqlTests
+{
+    private static string StripWhitespace(string sql) =>
+        new string(sql.Where(c => !char.IsWhiteSpace(c)).ToArray());
+
+    [Fact]
+    public void ServerConfigChangesSnapshotsSql_ReadsView_UpperBounded_OrderedForPerNameDiff()
+    {
+        var sql = ViewerDataService.ServerConfigChangesSnapshotsSql;
+        Assert.Contains("FROM v_server_config", sql, StringComparison.Ordinal);
+        Assert.Contains("capture_time", sql, StringComparison.Ordinal);
+        Assert.Contains("value_configured", sql, StringComparison.Ordinal);
+        Assert.Contains("value_in_use", sql, StringComparison.Ordinal);
+        Assert.Contains("WHERE server_id = $1", sql, StringComparison.Ordinal);
+        Assert.Contains("capture_time <= $2", sql, StringComparison.Ordinal);
+        Assert.Contains("ORDER BY configuration_name, capture_time", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DatabaseConfigChangesSnapshotsSql_ReadsView_CastsSettingsToText_UpperBounded()
+    {
+        var sql = ViewerDataService.DatabaseConfigChangesSnapshotsSql;
+        Assert.Contains("FROM v_database_config", sql, StringComparison.Ordinal);
+        Assert.Contains("is_read_committed_snapshot_on::text", sql, StringComparison.Ordinal);
+        Assert.Contains("compatibility_level::text", sql, StringComparison.Ordinal);
+        Assert.Contains("is_optimized_locking_on::text", sql, StringComparison.Ordinal);
+        Assert.Contains("WHERE server_id = $1", sql, StringComparison.Ordinal);
+        Assert.Contains("capture_time <= $2", sql, StringComparison.Ordinal);
+        Assert.Contains("ORDER BY database_name, capture_time", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TraceFlagChangesSnapshotsSql_ReadsView_UpperBounded_OrderedForSetDiff()
+    {
+        var sql = ViewerDataService.TraceFlagChangesSnapshotsSql;
+        Assert.Contains("FROM v_trace_flags", sql, StringComparison.Ordinal);
+        Assert.Contains("trace_flag", sql, StringComparison.Ordinal);
+        Assert.Contains("is_global", sql, StringComparison.Ordinal);
+        Assert.Contains("WHERE server_id = $1", sql, StringComparison.Ordinal);
+        Assert.Contains("capture_time <= $2", sql, StringComparison.Ordinal);
+        Assert.Contains("ORDER BY capture_time, trace_flag", sql, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("server")]
+    [InlineData("database")]
+    [InlineData("traceflags")]
+    public void ChangeReads_PgDialect_ServerIdAndWindowEnd_NoLowerBound_NoBareNow_NoNLiterals(string which)
+    {
+        var sql = which switch
+        {
+            "server" => ViewerDataService.ServerConfigChangesSnapshotsSql,
+            "database" => ViewerDataService.DatabaseConfigChangesSnapshotsSql,
+            _ => ViewerDataService.TraceFlagChangesSnapshotsSql,
+        };
+
+        var lower = sql.ToLowerInvariant();
+        Assert.DoesNotContain("getdate", lower);
+        Assert.DoesNotContain("now(", lower);
+        Assert.DoesNotContain("convert(", lower); /* ::text casts, not T-SQL CONVERT */
+        Assert.DoesNotContain("top (", lower);
+        Assert.DoesNotContain("isnull(", lower);
+        Assert.DoesNotContain("N'", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("@", sql, StringComparison.Ordinal);
+        Assert.Contains("$1", sql, StringComparison.Ordinal);
+        Assert.Contains("$2", sql, StringComparison.Ordinal);
+        /* Upper bound only — the window START is applied to change_time in C# so the pre-window baseline is
+           kept for correct left-edge change detection. A lower $3 read bound would under-report. */
+        Assert.DoesNotContain("$3", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DatabaseConfigChangeSettingNames_Match27CollectorColumns_InOrder()
+    {
+        var table = PgSchemaGenerator.CreateTable(DatabaseConfigCollector.Instance);
+        Assert.Equal(27, ViewerDataService.DatabaseConfigChangeSettingNames.Count);
+        foreach (var name in ViewerDataService.DatabaseConfigChangeSettingNames)
+            Assert.Contains(name, table, StringComparison.Ordinal);
+
+        /* The wide-row diff walks these positionally, so the order must match the SELECT's column order. */
+        Assert.Equal("state_desc", ViewerDataService.DatabaseConfigChangeSettingNames[0]);
+        Assert.Equal("is_optimized_locking_on", ViewerDataService.DatabaseConfigChangeSettingNames[^1]);
+    }
+
+    [Fact]
+    public void ServerConfigChangesSnapshotsSql_ReadsColumnsThatExistInTheGeneratedTable()
+    {
+        Assert.Equal("server_config", ServerConfigCollector.Instance.TargetTable);
+        var ddl = PgSchemaGenerator.CreateTable(ServerConfigCollector.Instance);
+        foreach (var column in new[] { "capture_time", "configuration_name", "value_configured", "value_in_use", "is_dynamic", "is_advanced" })
+            Assert.Contains(column, ddl, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TraceFlagChangesSnapshotsSql_ReadsColumnsThatExistInTheGeneratedTable()
+    {
+        Assert.Equal("trace_flags", TraceFlagsCollector.Instance.TargetTable);
+        var ddl = PgSchemaGenerator.CreateTable(TraceFlagsCollector.Instance);
+        foreach (var column in new[] { "capture_time", "trace_flag", "status", "is_global", "is_session" })
+            Assert.Contains(column, ddl, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DatabaseConfigChangesSnapshotsSql_ReadsColumnsThatExistInTheGeneratedTable()
+    {
+        Assert.Equal("database_config", DatabaseConfigCollector.Instance.TargetTable);
+        var ddl = PgSchemaGenerator.CreateTable(DatabaseConfigCollector.Instance);
+        Assert.Contains("capture_time", ddl, StringComparison.Ordinal);
+        Assert.Contains("database_name", ddl, StringComparison.Ordinal);
+        foreach (var column in ViewerDataService.DatabaseConfigChangeSettingNames)
+            Assert.Contains(column, ddl, StringComparison.Ordinal);
+    }
+}
+
+/// <summary>
+/// The C# snapshot-diff logic (pure, no live PG) — mirrors DarlingConfigHistoryReader's diff (PR #1421) plus the
+/// window's UPPER bound and the derived display columns the Dashboard grids show. Exercises value moves, the
+/// &gt;= 2-snapshot rule, BOTH window edges on change_time, the crucial pre-window baseline (a change landing on
+/// the first in-window snapshot is still detected), the wide-row UNPIVOT, trace-flag enable/disable/modify, and
+/// the derived requires_restart / change_description / scope columns.
+/// </summary>
+public sealed class ViewerConfigChangesDiffTests
+{
+    private static readonly DateTime T0 = new(2026, 7, 1, 0, 0, 0, DateTimeKind.Unspecified);
+    private static readonly DateTime T1 = new(2026, 7, 2, 0, 0, 0, DateTimeKind.Unspecified);
+    private static readonly DateTime T2 = new(2026, 7, 3, 0, 0, 0, DateTimeKind.Unspecified);
+    private static readonly DateTime T3 = new(2026, 7, 4, 0, 0, 0, DateTimeKind.Unspecified);
+
+    /* ---------------- server config ---------------- */
+
+    [Fact]
+    public void ServerConfigChanges_DetectsValueMove_NewestFirst()
+    {
+        var snapshots = new List<Snap.ServerConfigSnapshot>
+        {
+            new(T0, "max degree of parallelism", 0, 0, true, true),
+            new(T1, "max degree of parallelism", 4, 4, true, true),   /* changed */
+            new(T0, "cost threshold for parallelism", 5, 5, true, true),
+            new(T1, "cost threshold for parallelism", 5, 5, true, true), /* unchanged */
+        };
+
+        var changes = ViewerDataService.DiffServerConfigChanges(snapshots, T0, T3);
+        var change = Assert.Single(changes);
+        Assert.Equal("max degree of parallelism", change.ConfigurationName);
+        Assert.Equal(0L, change.OldValueConfigured);
+        Assert.Equal(4L, change.NewValueConfigured);
+        Assert.Equal(T1, change.ChangeTime);
+    }
+
+    [Fact]
+    public void ServerConfigChanges_SingleSnapshot_YieldsNothing()
+    {
+        var single = new List<Snap.ServerConfigSnapshot> { new(T0, "max server memory (MB)", 8000, 8000, true, true) };
+        Assert.Empty(ViewerDataService.DiffServerConfigChanges(single, T0, T3));
+    }
+
+    [Fact]
+    public void ServerConfigChanges_WindowBoundsBothSides_OnChangeTime()
+    {
+        var two = new List<Snap.ServerConfigSnapshot>
+        {
+            new(T1, "max server memory (MB)", 8000, 8000, true, true),
+            new(T2, "max server memory (MB)", 16000, 16000, true, true),  /* change at T2 */
+        };
+
+        /* Change at T2 is inside [T0, T3]. */
+        Assert.Single(ViewerDataService.DiffServerConfigChanges(two, T0, T3));
+        /* Window START after the change (start T3) excludes it. */
+        Assert.Empty(ViewerDataService.DiffServerConfigChanges(two, T3, T3));
+        /* Window END before the change (end T1) excludes it. */
+        Assert.Empty(ViewerDataService.DiffServerConfigChanges(two, T0, T1));
+    }
+
+    [Fact]
+    public void ServerConfigChanges_PreWindowBaseline_ChangeOnFirstInWindowSnapshot_IsDetected()
+    {
+        /* T0 is BEFORE the window [T1, T3]; the value moves T0 -> T1. The change at T1 must still be detected,
+           using the pre-window T0 as the diff baseline — this is why the read is not lower-bounded. */
+        var snapshots = new List<Snap.ServerConfigSnapshot>
+        {
+            new(T0, "max degree of parallelism", 0, 0, true, true),
+            new(T1, "max degree of parallelism", 8, 8, true, true),
+        };
+
+        var change = Assert.Single(ViewerDataService.DiffServerConfigChanges(snapshots, T1, T3));
+        Assert.Equal(0L, change.OldValueConfigured);
+        Assert.Equal(8L, change.NewValueConfigured);
+        Assert.Equal(T1, change.ChangeTime);
+    }
+
+    [Fact]
+    public void ServerConfigChanges_DerivedColumns_RestartAndDescription()
+    {
+        /* Non-dynamic, new configured != new in-use => requires restart; configured value moved. */
+        var restartNeeded = new List<Snap.ServerConfigSnapshot>
+        {
+            new(T0, "max server memory (MB)", 8000, 8000, false, false),
+            new(T1, "max server memory (MB)", 16000, 8000, false, false),
+        };
+        var change = Assert.Single(ViewerDataService.DiffServerConfigChanges(restartNeeded, T0, T3));
+        Assert.True(change.RequiresRestart);
+        Assert.Equal("Yes", change.RequiresRestartDisplay);
+        Assert.Equal("No", change.DynamicDisplay);
+        Assert.Equal("Configured value changed from 8000 to 16000", change.ChangeDescription);
+
+        /* Dynamic setting whose in-use caught up => no restart; in-use narrative when configured is stable. */
+        var inUseMove = new List<Snap.ServerConfigSnapshot>
+        {
+            new(T0, "cost threshold for parallelism", 50, 5, true, true),
+            new(T1, "cost threshold for parallelism", 50, 50, true, true),
+        };
+        var c2 = Assert.Single(ViewerDataService.DiffServerConfigChanges(inUseMove, T0, T3));
+        Assert.False(c2.RequiresRestart);
+        Assert.Equal("In-use value changed from 5 to 50", c2.ChangeDescription);
+    }
+
+    /* ---------------- database config (wide-row unpivot) ---------------- */
+
+    [Fact]
+    public void DatabaseConfigChanges_UnpivotsWideRow_NamesTheChangedColumn_WithDescription()
+    {
+        const int rcsiIndex = 10; /* is_read_committed_snapshot_on */
+        Assert.Equal("is_read_committed_snapshot_on", ViewerDataService.DatabaseConfigChangeSettingNames[rcsiIndex]);
+
+        var snapshots = new List<Snap.DatabaseConfigSnapshot>
+        {
+            new(T0, "StackOverflow", DbValues()),
+            new(T1, "StackOverflow", DbValues((rcsiIndex, "true"))),  /* RCSI flipped on */
+        };
+
+        var change = Assert.Single(ViewerDataService.DiffDatabaseConfigChanges(snapshots, T0, T3));
+        Assert.Equal("StackOverflow", change.DatabaseName);
+        Assert.Equal("is_read_committed_snapshot_on", change.SettingName);
+        Assert.Equal("false", change.OldValue);
+        Assert.Equal("true", change.NewValue);
+        Assert.Equal(T1, change.ChangeTime);
+        Assert.Equal("Changed from false to true", change.ChangeDescription);
+    }
+
+    [Fact]
+    public void DatabaseConfigChanges_PerDatabase_UnchangedYieldsNothing()
+    {
+        var snapshots = new List<Snap.DatabaseConfigSnapshot>
+        {
+            new(T0, "DbA", DbValues()),
+            new(T1, "DbA", DbValues()),                 /* no change */
+            new(T0, "DbB", DbValues((3, "FULL"))),
+            new(T1, "DbB", DbValues((3, "SIMPLE"))),    /* recovery_model changed */
+        };
+
+        var change = Assert.Single(ViewerDataService.DiffDatabaseConfigChanges(snapshots, T0, T3));
+        Assert.Equal("DbB", change.DatabaseName);
+        Assert.Equal("recovery_model", change.SettingName);
+        Assert.Equal("FULL", change.OldValue);
+        Assert.Equal("SIMPLE", change.NewValue);
+    }
+
+    [Fact]
+    public void DatabaseConfigChanges_NullTransitions_SetAndCleared()
+    {
+        var setValue = new List<Snap.DatabaseConfigSnapshot>
+        {
+            new(T0, "Db", DbValues((3, null))),
+            new(T1, "Db", DbValues((3, "SIMPLE"))),
+        };
+        Assert.Equal("Set to: SIMPLE", Assert.Single(ViewerDataService.DiffDatabaseConfigChanges(setValue, T0, T3)).ChangeDescription);
+
+        var cleared = new List<Snap.DatabaseConfigSnapshot>
+        {
+            new(T0, "Db", DbValues((3, "SIMPLE"))),
+            new(T1, "Db", DbValues((3, null))),
+        };
+        Assert.Equal("Cleared (was: SIMPLE)", Assert.Single(ViewerDataService.DiffDatabaseConfigChanges(cleared, T0, T3)).ChangeDescription);
+    }
+
+    /* ---------------- trace flags (set-diff) ---------------- */
+
+    [Fact]
+    public void TraceFlagChanges_DetectsEnableDisableModify()
+    {
+        var snapshots = new List<Snap.TraceFlagSnapshot>
+        {
+            /* T0: 3226 global on. */
+            new(T0, 3226, true, true, false),
+            /* T1: 3226 still on, 1117 appears (enabled). */
+            new(T1, 3226, true, true, false),
+            new(T1, 1117, true, true, false),
+            /* T2: 1117 disappears (disabled), 3226 becomes session-scoped (modified). */
+            new(T2, 3226, true, false, true),
+        };
+
+        var changes = ViewerDataService.DiffTraceFlagChanges(snapshots, T0, T3);
+        Assert.Equal(3, changes.Count);
+
+        var enabled = Assert.Single(changes, c => c.TraceFlag == 1117 && c.ChangeType == "enabled");
+        Assert.Equal(T1, enabled.ChangeTime);
+        Assert.Equal("Trace flag 1117 ENABLED", enabled.ChangeDescription);
+        Assert.Equal("", enabled.PreviousStatusDisplay);
+        Assert.Equal("ON", enabled.NewStatusDisplay);
+        Assert.Equal("GLOBAL", enabled.Scope);
+
+        var disabled = Assert.Single(changes, c => c.TraceFlag == 1117 && c.ChangeType == "disabled");
+        Assert.Equal(T2, disabled.ChangeTime);
+        Assert.Equal("Trace flag 1117 DISABLED", disabled.ChangeDescription);
+        Assert.Equal("", disabled.NewStatusDisplay);
+
+        var modified = Assert.Single(changes, c => c.TraceFlag == 3226 && c.ChangeType == "modified");
+        Assert.Equal("SESSION", modified.Scope);
+        Assert.Equal("No", modified.GlobalDisplay);
+        Assert.Equal("Yes", modified.SessionDisplay);
+        Assert.Equal("Trace flag 3226 scope changed", modified.ChangeDescription);
+    }
+
+    [Fact]
+    public void TraceFlagChanges_StableYieldsNothing_AndWindowBoundsBothSides()
+    {
+        var stable = new List<Snap.TraceFlagSnapshot>
+        {
+            new(T0, 3226, true, true, false),
+            new(T1, 3226, true, true, false),
+        };
+        Assert.Empty(ViewerDataService.DiffTraceFlagChanges(stable, T0, T3));
+
+        var enableAtT2 = new List<Snap.TraceFlagSnapshot>
+        {
+            new(T1, 3226, true, true, false),
+            new(T1, 1117, true, true, false),
+            new(T2, 3226, true, true, false),   /* 1117 gone at T2 => disabled at T2 */
+        };
+        Assert.Single(ViewerDataService.DiffTraceFlagChanges(enableAtT2, T0, T3));   /* T2 in window */
+        Assert.Empty(ViewerDataService.DiffTraceFlagChanges(enableAtT2, T0, T1));    /* window ends at T1 */
+        Assert.Empty(ViewerDataService.DiffTraceFlagChanges(enableAtT2, T3, T3));    /* window starts at T3 */
+    }
+
+    private static string?[] DbValues(params (int Index, string? Value)[] overrides)
+    {
+        var values = new string?[ViewerDataService.DatabaseConfigChangeSettingNames.Count];
+        for (var i = 0; i < values.Length; i++)
+            values[i] = "false";
+        foreach (var (index, value) in overrides)
+            values[index] = value;
+        return values;
+    }
+}
+
+/// <summary>
+/// Pins the inner-tab renumber: the Configuration Changes tab is inserted immediately after the latest-snapshot
+/// Configuration tab, so every tab after it shifts up by one. A stale constant would send LoadInnerTabAsync's
+/// switch to the wrong loader.
+/// </summary>
+public sealed class ViewerConfigChangesTabTests
+{
+    [Fact]
+    public void InnerTabIndices_ConfigChangesInsertedAfterConfiguration_ShiftsRest()
+    {
+        Assert.Equal(13, ViewerServerTab.ConfigurationInnerTabIndex);
+        Assert.Equal(14, ViewerServerTab.ConfigChangesInnerTabIndex);
+        Assert.Equal(15, ViewerServerTab.DailySummaryInnerTabIndex);
+        Assert.Equal(16, ViewerServerTab.HealthInnerTabIndex);
+        Assert.Equal(17, ViewerServerTab.SystemEventsInnerTabIndex);
+    }
+}
+
+/// <summary>
+/// Gated (DARLING_TEST_PG) live round-trips for the change reads — validates the snapshot-read SQL end-to-end
+/// (columns exist, params bind, the <c>capture_time &lt;= $2</c> upper bound trims post-window captures while the
+/// pre-window baseline is kept). Plants two server-config captures (one changed) and two trace-flag captures (a
+/// flag disappears), then asserts the change reads surface the drift and that a window ending before the change
+/// hides it. Shares the serialized "live-postgres" collection and cleans up in finally.
+/// </summary>
+[Collection("live-postgres")]
+public sealed class ViewerConfigChangesLivePostgresTests
+{
+    private const int ServerConfigServerId = -970801;
+    private const int TraceFlagsServerId = -970802;
+
+    [Fact]
+    public async Task ServerConfigChanges_SurfaceInWindow_ExcludedWhenWindowEndsBeforeChange_AgainstDevPostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the live server-config-changes test.");
+
+        using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await PgMigrations.MigrateAsync(connection, TestContext.Current.CancellationToken);
+        await DeleteRowsAsync(connection, "server_config", ServerConfigServerId);
+
+        await using var viewer = new ViewerDataService(connectionString!);
+
+        try
+        {
+            var older = TruncateToSeconds(DateTime.UtcNow.AddMinutes(-10));
+            var newer = older.AddMinutes(5);
+
+            await InsertServerConfigAsync(connection, older, "max degree of parallelism", 0, 0, true, true);
+            await InsertServerConfigAsync(connection, newer, "max degree of parallelism", 4, 4, true, true);
+
+            /* Window covers both captures: the 0 -> 4 change at `newer` surfaces. */
+            var inWindow = await viewer.GetServerConfigChangesAsync(ServerConfigServerId, older.AddMinutes(-1), newer.AddMinutes(1));
+            var change = Assert.Single(inWindow);
+            Assert.Equal("max degree of parallelism", change.ConfigurationName);
+            Assert.Equal(0L, change.OldValueConfigured);
+            Assert.Equal(4L, change.NewValueConfigured);
+
+            /* Window ends before `newer` (upper bound trims the newer capture) => no change. */
+            var trimmed = await viewer.GetServerConfigChangesAsync(ServerConfigServerId, older.AddMinutes(-1), older.AddMinutes(1));
+            Assert.Empty(trimmed);
+        }
+        finally
+        {
+            await DeleteRowsAsync(connection, "server_config", ServerConfigServerId);
+        }
+    }
+
+    [Fact]
+    public async Task TraceFlagChanges_SetDiffDisable_SurfacesInWindow_AgainstDevPostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the live trace-flag-changes test.");
+
+        using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await PgMigrations.MigrateAsync(connection, TestContext.Current.CancellationToken);
+        await DeleteRowsAsync(connection, "trace_flags", TraceFlagsServerId);
+
+        await using var viewer = new ViewerDataService(connectionString!);
+
+        try
+        {
+            var older = TruncateToSeconds(DateTime.UtcNow.AddMinutes(-10));
+            var newer = older.AddMinutes(5);
+
+            /* 1117 present at the older capture, absent at the newer => 'disabled' at `newer`. 3226 anchors the
+               newer capture so it exists as a distinct set-diff snapshot. */
+            await InsertTraceFlagAsync(connection, older, 1117, status: true, isGlobal: true, isSession: false);
+            await InsertTraceFlagAsync(connection, newer, 3226, status: true, isGlobal: true, isSession: false);
+
+            var changes = await viewer.GetTraceFlagChangesAsync(TraceFlagsServerId, older.AddMinutes(-1), newer.AddMinutes(1));
+            var disabled = Assert.Single(changes, c => c.TraceFlag == 1117);
+            Assert.Equal("disabled", disabled.ChangeType);
+            Assert.Equal("Trace flag 1117 DISABLED", disabled.ChangeDescription);
+        }
+        finally
+        {
+            await DeleteRowsAsync(connection, "trace_flags", TraceFlagsServerId);
+        }
+    }
+
+    private static async Task InsertServerConfigAsync(
+        NpgsqlConnection connection, DateTime captureTimeUtc,
+        string configurationName, long valueConfigured, long valueInUse, bool isDynamic, bool isAdvanced)
+    {
+        using var command = new NpgsqlCommand(@"
+INSERT INTO server_config
+    (config_id, capture_time, server_id, server_name,
+     configuration_name, value_configured, value_in_use, is_dynamic, is_advanced)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)", connection);
+        command.Parameters.AddWithValue(1L);
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(captureTimeUtc, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(ServerConfigServerId);
+        command.Parameters.AddWithValue("viewer-server-config-changes-e2e");
+        command.Parameters.AddWithValue(configurationName);
+        command.Parameters.AddWithValue(valueConfigured);
+        command.Parameters.AddWithValue(valueInUse);
+        command.Parameters.AddWithValue(isDynamic);
+        command.Parameters.AddWithValue(isAdvanced);
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static async Task InsertTraceFlagAsync(
+        NpgsqlConnection connection, DateTime captureTimeUtc,
+        int traceFlag, bool status, bool isGlobal, bool isSession)
+    {
+        using var command = new NpgsqlCommand(@"
+INSERT INTO trace_flags
+    (config_id, capture_time, server_id, server_name,
+     trace_flag, status, is_global, is_session)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)", connection);
+        command.Parameters.AddWithValue(1L);
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(captureTimeUtc, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(TraceFlagsServerId);
+        command.Parameters.AddWithValue("viewer-trace-flag-changes-e2e");
+        command.Parameters.AddWithValue(traceFlag);
+        command.Parameters.AddWithValue(status);
+        command.Parameters.AddWithValue(isGlobal);
+        command.Parameters.AddWithValue(isSession);
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static DateTime TruncateToSeconds(DateTime value) =>
+        DateTime.SpecifyKind(new DateTime(value.Ticks - (value.Ticks % TimeSpan.TicksPerSecond)), DateTimeKind.Unspecified);
+
+    private static async Task DeleteRowsAsync(NpgsqlConnection connection, string table, int serverId)
+    {
+        using var cleanup = new NpgsqlCommand($"DELETE FROM {table} WHERE server_id = {serverId};", connection);
+        await cleanup.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ConfigChanges.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ConfigChanges.cs
@@ -1,0 +1,495 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The Configuration Changes tab's three change histories (Dashboard's <c>ConfigChangesContent</c> ported to
+/// the viewer): server-config, database-config and trace-flag DRIFT over time. The Dashboard reads
+/// pre-materialized <c>report.*_configuration_changes</c> / <c>report.trace_flag_changes</c> views (LAG-diff
+/// over a persisted config history); Darling has no such views, so — exactly like the service's
+/// <c>DarlingConfigHistoryReader</c> (PR #1421, the reference this mirrors) — the change history is computed
+/// in C# by diffing the store's APPEND-ONLY config snapshots (<c>v_server_config</c> / <c>v_database_config</c>
+/// / <c>v_trace_flags</c>, every setting written every capture, keyed by <c>capture_time</c>). The diff runs in
+/// C# (not SQL) so it is unit-testable without a live Postgres and so trace-flag enable/disable (a flag row
+/// appearing / disappearing between snapshots) is handled by set-diff.
+///
+/// <para>
+/// WINDOWING — the read is upper-bounded at the window end (<c>capture_time &lt;= $2</c>) and the window START
+/// is applied to the computed <c>change_time</c> in C# (NOT to the snapshot read). This deliberately keeps the
+/// snapshot immediately BEFORE the window as the diff baseline, so a change landing on the first in-window
+/// snapshot is still detected — mirroring the Dashboard, whose <c>report.*_changes</c> views LAG over the full
+/// history and then filter <c>change_time &gt;= @from AND change_time &lt;= @to</c>. Strictly lower-bounding the
+/// snapshot read would drop that baseline and under-report the left-edge change. Both window edges are honored:
+/// the upper on the read (<c>$2</c>), the lower (and, redundantly, the upper) on <c>change_time</c> in the diff.
+/// </para>
+///
+/// <para>
+/// COLLECTION-CADENCE + SHAPE CAVEATS (surfaced honestly, never silently dropped): the config collectors run ON
+/// CONNECT only (<c>FrequencyMinutes = 0</c>), so change granularity equals the service's connect/restart
+/// cadence, and a fresh / stably-connected server may hold a single snapshot — then there is no change yet (the
+/// diff needs &gt;= 2 snapshots). The change grids emit ONLY collected values; the Dashboard enrichment columns
+/// Darling does not collect are OMITTED (not fabricated): server-config <c>description</c> (the setting's
+/// human blurb) and database-config <c>setting_type</c> (the store is WIDE — <c>setting_name</c> is the literal
+/// column name). <c>requires_restart</c> is NOT one of the gaps: it is derivable from collected columns
+/// (<c>is_dynamic = false AND value_configured != value_in_use</c>, the Dashboard view's own definition), so it
+/// is kept as a derived column. The per-row change narrative is DERIVED here from the values (allowed), matching
+/// the Dashboard view's wording.
+/// </para>
+/// </summary>
+public sealed partial class ViewerDataService
+{
+    /* ─────────────────────────── snapshot-read SQL (upper-bound at window end) ─────────────────────────── */
+
+    /// <summary>Every sys.configurations snapshot for a server up to the window end, oldest-first per name —
+    /// the diff walks consecutive captures per configuration_name (every config row is present in every
+    /// snapshot, so a per-name walk suffices). $1 server_id, $2 window end (naive UTC).</summary>
+    public const string ServerConfigChangesSnapshotsSql = """
+        SELECT
+            capture_time,
+            configuration_name,
+            value_configured,
+            value_in_use,
+            is_dynamic,
+            is_advanced
+        FROM v_server_config
+        WHERE server_id = $1
+        AND   capture_time <= $2
+        ORDER BY configuration_name, capture_time
+        """;
+
+    /// <summary>Every sys.databases snapshot for a server up to the window end, with the 27 setting columns
+    /// CAST to text for a uniform value-diff. $1 server_id, $2 window end (naive UTC). The SELECT order is
+    /// <see cref="DatabaseConfigChangeSettingNames"/> (load-bearing — the diff walks the wide row positionally).</summary>
+    public const string DatabaseConfigChangesSnapshotsSql = """
+        SELECT
+            capture_time,
+            database_name,
+            state_desc,
+            compatibility_level::text,
+            collation_name,
+            recovery_model,
+            is_read_only::text,
+            is_auto_close_on::text,
+            is_auto_shrink_on::text,
+            is_auto_create_stats_on::text,
+            is_auto_update_stats_on::text,
+            is_auto_update_stats_async_on::text,
+            is_read_committed_snapshot_on::text,
+            snapshot_isolation_state,
+            is_parameterization_forced::text,
+            is_query_store_on::text,
+            is_encrypted::text,
+            is_trustworthy_on::text,
+            is_db_chaining_on::text,
+            is_broker_enabled::text,
+            is_cdc_enabled::text,
+            is_mixed_page_allocation_on::text,
+            log_reuse_wait_desc,
+            page_verify_option,
+            target_recovery_time_seconds::text,
+            delayed_durability,
+            is_accelerated_database_recovery_on::text,
+            is_memory_optimized_enabled::text,
+            is_optimized_locking_on::text
+        FROM v_database_config
+        WHERE server_id = $1
+        AND   capture_time <= $2
+        ORDER BY database_name, capture_time
+        """;
+
+    /// <summary>Every trace-flag snapshot for a server up to the window end (a row exists only while a flag is
+    /// enabled), oldest-first — the diff set-diffs consecutive captures. $1 server_id, $2 window end (naive UTC).</summary>
+    public const string TraceFlagChangesSnapshotsSql = """
+        SELECT
+            capture_time,
+            trace_flag,
+            status,
+            is_global,
+            is_session
+        FROM v_trace_flags
+        WHERE server_id = $1
+        AND   capture_time <= $2
+        ORDER BY capture_time, trace_flag
+        """;
+
+    /// <summary>The 27 database-config setting names, in the collector's exact column order — the WIDE store
+    /// row is UNPIVOTed to a change row per changed setting, with this literal column name as the setting_name.
+    /// Byte-identical to the service reader's list (DarlingConfigHistoryReader.DatabaseConfigSettingNames) and
+    /// to the Configuration tab's 28-column read (minus its leading database_name).</summary>
+    public static readonly IReadOnlyList<string> DatabaseConfigChangeSettingNames = new[]
+    {
+        "state_desc", "compatibility_level", "collation_name", "recovery_model", "is_read_only",
+        "is_auto_close_on", "is_auto_shrink_on", "is_auto_create_stats_on", "is_auto_update_stats_on",
+        "is_auto_update_stats_async_on", "is_read_committed_snapshot_on", "snapshot_isolation_state",
+        "is_parameterization_forced", "is_query_store_on", "is_encrypted", "is_trustworthy_on",
+        "is_db_chaining_on", "is_broker_enabled", "is_cdc_enabled", "is_mixed_page_allocation_on",
+        "log_reuse_wait_desc", "page_verify_option", "target_recovery_time_seconds", "delayed_durability",
+        "is_accelerated_database_recovery_on", "is_memory_optimized_enabled", "is_optimized_locking_on",
+    };
+
+    /* ─────────────────────────── snapshot row records (internal — the diff's raw input) ─────────────────────────── */
+
+    internal sealed record ServerConfigSnapshot(
+        DateTime CaptureTime, string ConfigurationName, long? ValueConfigured, long? ValueInUse, bool? IsDynamic, bool? IsAdvanced);
+
+    internal sealed record DatabaseConfigSnapshot(
+        DateTime CaptureTime, string DatabaseName, IReadOnlyList<string?> Values);
+
+    internal sealed record TraceFlagSnapshot(
+        DateTime CaptureTime, int TraceFlag, bool? Status, bool? IsGlobal, bool? IsSession);
+
+    /* ─────────────────────────── public read + diff (composes the two) ─────────────────────────── */
+
+    /// <summary>Server-configuration changes in the window [startUtc, endUtc]. Reads every snapshot up to
+    /// endUtc (so the pre-window baseline is kept) then diffs per configuration_name in C#.</summary>
+    public async Task<List<ServerConfigChangeRow>> GetServerConfigChangesAsync(
+        int serverId, DateTime startUtc, DateTime endUtc, CancellationToken cancellationToken = default)
+    {
+        var snapshots = await ReadServerConfigSnapshotsAsync(serverId, endUtc, cancellationToken);
+        return DiffServerConfigChanges(snapshots, startUtc, endUtc);
+    }
+
+    /// <summary>Database-configuration changes in the window [startUtc, endUtc]. Reads every snapshot up to
+    /// endUtc then UNPIVOTs the wide row per (database, setting) whose value moved.</summary>
+    public async Task<List<DatabaseConfigChangeRow>> GetDatabaseConfigChangesAsync(
+        int serverId, DateTime startUtc, DateTime endUtc, CancellationToken cancellationToken = default)
+    {
+        var snapshots = await ReadDatabaseConfigSnapshotsAsync(serverId, endUtc, cancellationToken);
+        return DiffDatabaseConfigChanges(snapshots, startUtc, endUtc);
+    }
+
+    /// <summary>Trace-flag changes in the window [startUtc, endUtc]. Reads every snapshot up to endUtc then
+    /// set-diffs consecutive captures (flag appears = enabled, disappears = disabled, status/scope moves =
+    /// modified).</summary>
+    public async Task<List<TraceFlagChangeRow>> GetTraceFlagChangesAsync(
+        int serverId, DateTime startUtc, DateTime endUtc, CancellationToken cancellationToken = default)
+    {
+        var snapshots = await ReadTraceFlagSnapshotsAsync(serverId, endUtc, cancellationToken);
+        return DiffTraceFlagChanges(snapshots, startUtc, endUtc);
+    }
+
+    private async Task<List<ServerConfigSnapshot>> ReadServerConfigSnapshotsAsync(
+        int serverId, DateTime endUtc, CancellationToken cancellationToken)
+    {
+        var rows = new List<ServerConfigSnapshot>();
+        await using var command = _dataSource.CreateCommand(ServerConfigChangesSnapshotsSql);
+        AddServerIdAndWindowEnd(command, serverId, endUtc);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            rows.Add(new ServerConfigSnapshot(
+                reader.GetDateTime(0),
+                reader.IsDBNull(1) ? "" : reader.GetString(1),
+                reader.IsDBNull(2) ? null : reader.GetInt64(2),
+                reader.IsDBNull(3) ? null : reader.GetInt64(3),
+                reader.IsDBNull(4) ? null : reader.GetBoolean(4),
+                reader.IsDBNull(5) ? null : reader.GetBoolean(5)));
+        }
+
+        return rows;
+    }
+
+    private async Task<List<DatabaseConfigSnapshot>> ReadDatabaseConfigSnapshotsAsync(
+        int serverId, DateTime endUtc, CancellationToken cancellationToken)
+    {
+        var rows = new List<DatabaseConfigSnapshot>();
+        await using var command = _dataSource.CreateCommand(DatabaseConfigChangesSnapshotsSql);
+        AddServerIdAndWindowEnd(command, serverId, endUtc);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            var values = new string?[DatabaseConfigChangeSettingNames.Count];
+            for (var i = 0; i < values.Length; i++)
+            {
+                var ordinal = i + 2; /* capture_time, database_name precede the settings */
+                values[i] = reader.IsDBNull(ordinal) ? null : reader.GetString(ordinal);
+            }
+
+            rows.Add(new DatabaseConfigSnapshot(
+                reader.GetDateTime(0),
+                reader.IsDBNull(1) ? "" : reader.GetString(1),
+                values));
+        }
+
+        return rows;
+    }
+
+    private async Task<List<TraceFlagSnapshot>> ReadTraceFlagSnapshotsAsync(
+        int serverId, DateTime endUtc, CancellationToken cancellationToken)
+    {
+        var rows = new List<TraceFlagSnapshot>();
+        await using var command = _dataSource.CreateCommand(TraceFlagChangesSnapshotsSql);
+        AddServerIdAndWindowEnd(command, serverId, endUtc);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            rows.Add(new TraceFlagSnapshot(
+                reader.GetDateTime(0),
+                reader.IsDBNull(1) ? 0 : reader.GetInt32(1),
+                reader.IsDBNull(2) ? null : reader.GetBoolean(2),
+                reader.IsDBNull(3) ? null : reader.GetBoolean(3),
+                reader.IsDBNull(4) ? null : reader.GetBoolean(4)));
+        }
+
+        return rows;
+    }
+
+    /// <summary>$1 server_id, $2 window end re-stamped naive-UTC (the store is naive-UTC, matching the other
+    /// windowed viewer reads — see ViewerDataService.SystemEvents.cs).</summary>
+    private static void AddServerIdAndWindowEnd(NpgsqlCommand command, int serverId, DateTime endUtc)
+    {
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+        command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = DateTime.SpecifyKind(endUtc, DateTimeKind.Unspecified) });
+    }
+
+    /* ─────────────────────────── C# snapshot diffs (pure, unit-testable, no live PG) ─────────────────────────── */
+
+    /// <summary>
+    /// Diffs the sys.configurations snapshots into a change per (configuration_name) whose configured or in-use
+    /// value moved between two consecutive captures (every config row is present in every snapshot, so a
+    /// per-name walk is the whole story). Emits changes whose newer capture falls in [<paramref name="startUtc"/>,
+    /// <paramref name="endUtc"/>], newest first. Mirrors DarlingConfigHistoryReader.ComputeServerConfigChanges
+    /// plus the window's upper bound.
+    /// </summary>
+    internal static List<ServerConfigChangeRow> DiffServerConfigChanges(
+        IReadOnlyList<ServerConfigSnapshot> snapshots, DateTime startUtc, DateTime endUtc)
+    {
+        var changes = new List<ServerConfigChangeRow>();
+        foreach (var group in snapshots.GroupBy(s => s.ConfigurationName))
+        {
+            ServerConfigSnapshot? prev = null;
+            foreach (var cur in group.OrderBy(s => s.CaptureTime))
+            {
+                if (prev is not null
+                    && (prev.ValueConfigured != cur.ValueConfigured || prev.ValueInUse != cur.ValueInUse)
+                    && cur.CaptureTime >= startUtc && cur.CaptureTime <= endUtc)
+                {
+                    changes.Add(new ServerConfigChangeRow
+                    {
+                        ChangeTime = cur.CaptureTime,
+                        ConfigurationName = cur.ConfigurationName,
+                        OldValueConfigured = prev.ValueConfigured,
+                        NewValueConfigured = cur.ValueConfigured,
+                        OldValueInUse = prev.ValueInUse,
+                        NewValueInUse = cur.ValueInUse,
+                        IsDynamic = cur.IsDynamic,
+                        IsAdvanced = cur.IsAdvanced,
+                    });
+                }
+
+                prev = cur;
+            }
+        }
+
+        return changes.OrderByDescending(c => c.ChangeTime).ThenBy(c => c.ConfigurationName, StringComparer.Ordinal).ToList();
+    }
+
+    /// <summary>
+    /// Diffs the sys.databases snapshots into a change per (database, setting) whose value moved between two
+    /// consecutive captures — the WIDE row is UNPIVOTed against <see cref="DatabaseConfigChangeSettingNames"/> so
+    /// the setting_name is the literal column name. Emits changes in [<paramref name="startUtc"/>,
+    /// <paramref name="endUtc"/>]. Mirrors DarlingConfigHistoryReader.ComputeDatabaseConfigChanges plus the upper bound.
+    /// </summary>
+    internal static List<DatabaseConfigChangeRow> DiffDatabaseConfigChanges(
+        IReadOnlyList<DatabaseConfigSnapshot> snapshots, DateTime startUtc, DateTime endUtc)
+    {
+        var changes = new List<DatabaseConfigChangeRow>();
+        foreach (var dbGroup in snapshots.GroupBy(s => s.DatabaseName))
+        {
+            DatabaseConfigSnapshot? prev = null;
+            foreach (var cur in dbGroup.OrderBy(s => s.CaptureTime))
+            {
+                if (prev is not null && cur.CaptureTime >= startUtc && cur.CaptureTime <= endUtc)
+                {
+                    for (var i = 0; i < DatabaseConfigChangeSettingNames.Count; i++)
+                    {
+                        var oldVal = i < prev.Values.Count ? prev.Values[i] : null;
+                        var newVal = i < cur.Values.Count ? cur.Values[i] : null;
+                        if (!string.Equals(oldVal, newVal, StringComparison.Ordinal))
+                        {
+                            changes.Add(new DatabaseConfigChangeRow
+                            {
+                                ChangeTime = cur.CaptureTime,
+                                DatabaseName = cur.DatabaseName,
+                                SettingName = DatabaseConfigChangeSettingNames[i],
+                                OldValue = oldVal,
+                                NewValue = newVal,
+                            });
+                        }
+                    }
+                }
+
+                prev = cur;
+            }
+        }
+
+        return changes
+            .OrderByDescending(c => c.ChangeTime)
+            .ThenBy(c => c.DatabaseName, StringComparer.Ordinal)
+            .ThenBy(c => c.SettingName, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Set-diffs consecutive full trace-flag snapshots: a flag present in the newer capture but not the older =
+    /// <c>enabled</c>; present in the older but not the newer = <c>disabled</c>; present in both with a changed
+    /// status/scope = <c>modified</c>. Emits changes in [<paramref name="startUtc"/>, <paramref name="endUtc"/>].
+    /// Mirrors DarlingConfigHistoryReader.ComputeTraceFlagChanges plus the upper bound.
+    /// </summary>
+    internal static List<TraceFlagChangeRow> DiffTraceFlagChanges(
+        IReadOnlyList<TraceFlagSnapshot> snapshots, DateTime startUtc, DateTime endUtc)
+    {
+        var changes = new List<TraceFlagChangeRow>();
+        var byCapture = snapshots.GroupBy(s => s.CaptureTime).OrderBy(g => g.Key).ToList();
+
+        for (var i = 1; i < byCapture.Count; i++)
+        {
+            var changeTime = byCapture[i].Key;
+            if (changeTime < startUtc || changeTime > endUtc)
+            {
+                continue;
+            }
+
+            var prevSnap = byCapture[i - 1].GroupBy(s => s.TraceFlag).ToDictionary(g => g.Key, g => g.First());
+            var curSnap = byCapture[i].GroupBy(s => s.TraceFlag).ToDictionary(g => g.Key, g => g.First());
+
+            foreach (var (flag, c) in curSnap)
+            {
+                if (!prevSnap.TryGetValue(flag, out var p))
+                {
+                    changes.Add(new TraceFlagChangeRow
+                    {
+                        ChangeTime = changeTime, TraceFlag = flag, PreviousStatus = null, NewStatus = c.Status,
+                        IsGlobal = c.IsGlobal, IsSession = c.IsSession, ChangeType = "enabled",
+                    });
+                }
+                else if (p.Status != c.Status || p.IsGlobal != c.IsGlobal || p.IsSession != c.IsSession)
+                {
+                    changes.Add(new TraceFlagChangeRow
+                    {
+                        ChangeTime = changeTime, TraceFlag = flag, PreviousStatus = p.Status, NewStatus = c.Status,
+                        IsGlobal = c.IsGlobal, IsSession = c.IsSession, ChangeType = "modified",
+                    });
+                }
+            }
+
+            foreach (var (flag, p) in prevSnap)
+            {
+                if (!curSnap.ContainsKey(flag))
+                {
+                    changes.Add(new TraceFlagChangeRow
+                    {
+                        ChangeTime = changeTime, TraceFlag = flag, PreviousStatus = p.Status, NewStatus = null,
+                        IsGlobal = p.IsGlobal, IsSession = p.IsSession, ChangeType = "disabled",
+                    });
+                }
+            }
+        }
+
+        return changes.OrderByDescending(c => c.ChangeTime).ThenBy(c => c.TraceFlag).ToList();
+    }
+}
+
+/* ─────────────────────────── grid row view-models (display props are pure C#, evaluated at bind time on the
+   UI thread AFTER ViewerTimeHelper's offset is applied — same pattern as the System Events rows) ─────────────────────────── */
+
+/// <summary>One server-configuration change (Server Config Changes grid). <see cref="RequiresRestart"/> and
+/// <see cref="ChangeDescription"/> are DERIVED from the collected values, matching the Dashboard's
+/// <c>report.server_configuration_changes</c> view definitions.</summary>
+public sealed class ServerConfigChangeRow
+{
+    public DateTime ChangeTime { get; set; }
+    public string ConfigurationName { get; set; } = "";
+    public long? OldValueConfigured { get; set; }
+    public long? NewValueConfigured { get; set; }
+    public long? OldValueInUse { get; set; }
+    public long? NewValueInUse { get; set; }
+    public bool? IsDynamic { get; set; }
+    public bool? IsAdvanced { get; set; }
+
+    public string ChangeTimeDisplay => ViewerTimeHelper.ForDisplay(ChangeTime).ToString("yyyy-MM-dd HH:mm:ss");
+    public string DynamicDisplay => IsDynamic == true ? "Yes" : "No";
+    public string AdvancedDisplay => IsAdvanced == true ? "Yes" : "No";
+
+    /* requires_restart = a non-dynamic setting whose configured value differs from the in-use value (the
+       Dashboard view's exact definition: is_dynamic = 0 AND value_configured != value_in_use). Derivable from
+       collected columns, so it is kept — NOT a collection gap. */
+    public bool RequiresRestart => IsDynamic == false && NewValueConfigured != NewValueInUse;
+    public string RequiresRestartDisplay => RequiresRestart ? "Yes" : "No";
+
+    /* Derived narrative matching report.server_configuration_changes.change_description wording. */
+    public string ChangeDescription =>
+        OldValueConfigured != NewValueConfigured
+            ? $"Configured value changed from {OldValueConfigured} to {NewValueConfigured}"
+            : OldValueInUse != NewValueInUse
+                ? $"In-use value changed from {OldValueInUse} to {NewValueInUse}"
+                : "Value unchanged";
+}
+
+/// <summary>One database-configuration change (Database Config Changes grid). The Dashboard's
+/// <c>setting_type</c> column is OMITTED (Darling's WIDE store has no setting_type — <see cref="SettingName"/>
+/// is the literal column name); <see cref="ChangeDescription"/> is DERIVED, matching the Dashboard view.</summary>
+public sealed class DatabaseConfigChangeRow
+{
+    public DateTime ChangeTime { get; set; }
+    public string DatabaseName { get; set; } = "";
+    public string SettingName { get; set; } = "";
+    public string? OldValue { get; set; }
+    public string? NewValue { get; set; }
+
+    public string ChangeTimeDisplay => ViewerTimeHelper.ForDisplay(ChangeTime).ToString("yyyy-MM-dd HH:mm:ss");
+
+    /* Derived narrative matching report.database_configuration_changes.change_description wording. */
+    public string ChangeDescription =>
+        OldValue is null && NewValue is not null ? $"Set to: {NewValue}"
+        : OldValue is not null && NewValue is null ? $"Cleared (was: {OldValue})"
+        : $"Changed from {OldValue} to {NewValue}";
+}
+
+/// <summary>One trace-flag change (Trace Flag Changes grid). <see cref="Scope"/> and
+/// <see cref="ChangeDescription"/> are DERIVED, matching the Dashboard's <c>report.trace_flag_changes</c> view.</summary>
+public sealed class TraceFlagChangeRow
+{
+    public DateTime ChangeTime { get; set; }
+    public int TraceFlag { get; set; }
+    public bool? PreviousStatus { get; set; }
+    public bool? NewStatus { get; set; }
+    public bool? IsGlobal { get; set; }
+    public bool? IsSession { get; set; }
+
+    /// <summary>enabled / disabled / modified (the set-diff outcome).</summary>
+    public string ChangeType { get; set; } = "";
+
+    public string ChangeTimeDisplay => ViewerTimeHelper.ForDisplay(ChangeTime).ToString("yyyy-MM-dd HH:mm:ss");
+    public string PreviousStatusDisplay => StatusText(PreviousStatus);
+    public string NewStatusDisplay => StatusText(NewStatus);
+    public string GlobalDisplay => IsGlobal == true ? "Yes" : "No";
+    public string SessionDisplay => IsSession == true ? "Yes" : "No";
+
+    /* Matches report.trace_flag_changes.scope (GLOBAL / SESSION / UNKNOWN). */
+    public string Scope => IsGlobal == true ? "GLOBAL" : IsSession == true ? "SESSION" : "UNKNOWN";
+
+    /* Derived narrative matching report.trace_flag_changes.change_description wording. */
+    public string ChangeDescription => ChangeType switch
+    {
+        "enabled" => $"Trace flag {TraceFlag} ENABLED",
+        "disabled" => $"Trace flag {TraceFlag} DISABLED",
+        "modified" => $"Trace flag {TraceFlag} scope changed",
+        _ => "Status unchanged",
+    };
+
+    private static string StatusText(bool? status) => status is null ? "" : status.Value ? "ON" : "OFF";
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.ConfigChanges.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.ConfigChanges.cs
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The Configuration Changes inner tab — the Dashboard's dedicated <c>ConfigChangesContent</c> ported as its
+/// own per-server tab (three grids: server-config, database-config, trace-flag DRIFT over the window). The
+/// read + C# snapshot-diff lives in <see cref="ViewerDataService"/> (ViewerDataService.ConfigChanges.cs,
+/// mirroring the service's DarlingConfigHistoryReader / #1421); this loader just windows on the per-server
+/// toolbar's settable range (so "Apply to All" flows through unchanged) and hands each result to its column
+/// filter manager (registered in ViewerServerTab.Filters.cs) so active filters survive a refresh. Each grid's
+/// EmptyHint overlay shows the honest "needs &gt;= 2 captures" state when the diff yields nothing (config is
+/// captured on connect/restart, not on a timer, so change history is inherently sparse). LoadInnerTabAsync
+/// owns the try/catch that surfaces failures on the status bar.
+/// </summary>
+public partial class ViewerServerTab : UserControl
+{
+    private async Task LoadConfigChangesAsync()
+    {
+        var (startUtc, endUtc) = GetWindowUtc();
+
+        var serverTask = _dataService.GetServerConfigChangesAsync(_server.ServerId, startUtc, endUtc);
+        var databaseTask = _dataService.GetDatabaseConfigChangesAsync(_server.ServerId, startUtc, endUtc);
+        var traceFlagTask = _dataService.GetTraceFlagChangesAsync(_server.ServerId, startUtc, endUtc);
+
+        await Task.WhenAll(serverTask, databaseTask, traceFlagTask);
+
+        var serverChanges = serverTask.Result;
+        var databaseChanges = databaseTask.Result;
+        var traceFlagChanges = traceFlagTask.Result;
+
+        _serverConfigChangesFilterMgr!.UpdateData(serverChanges);
+        _databaseConfigChangesFilterMgr!.UpdateData(databaseChanges);
+        _traceFlagChangesFilterMgr!.UpdateData(traceFlagChanges);
+
+        /* Empty state keyed on the unfiltered change count (a real "no drift in this window" signal), matching
+           the Dashboard's data.Count == 0 check — independent of any active column filter. */
+        ServerConfigChangesNoDataMessage.Visibility = serverChanges.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+        DatabaseConfigChangesNoDataMessage.Visibility = databaseChanges.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+        TraceFlagChangesNoDataMessage.Visibility = traceFlagChanges.Count == 0 ? Visibility.Visible : Visibility.Collapsed;
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Filters.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Filters.cs
@@ -44,6 +44,9 @@ public partial class ViewerServerTab : UserControl
     private DataGridFilterManager<ViewerExpensiveQueryRow>? _expensiveQueriesFilterMgr;
     private DataGridFilterManager<CollectorHealthRow>? _collectionHealthFilterMgr;
     private DataGridFilterManager<CollectionLogRow>? _collectionLogFilterMgr;
+    private DataGridFilterManager<ServerConfigChangeRow>? _serverConfigChangesFilterMgr;
+    private DataGridFilterManager<DatabaseConfigChangeRow>? _databaseConfigChangesFilterMgr;
+    private DataGridFilterManager<TraceFlagChangeRow>? _traceFlagChangesFilterMgr;
 
     private Popup? _filterPopup;
     private ColumnFilterPopup? _filterPopupContent;
@@ -67,6 +70,9 @@ public partial class ViewerServerTab : UserControl
         _expensiveQueriesFilterMgr = new DataGridFilterManager<ViewerExpensiveQueryRow>(ExpensiveQueriesGrid);
         _collectionHealthFilterMgr = new DataGridFilterManager<CollectorHealthRow>(CollectionHealthGrid);
         _collectionLogFilterMgr = new DataGridFilterManager<CollectionLogRow>(CollectionLogGrid);
+        _serverConfigChangesFilterMgr = new DataGridFilterManager<ServerConfigChangeRow>(ServerConfigChangesGrid);
+        _databaseConfigChangesFilterMgr = new DataGridFilterManager<DatabaseConfigChangeRow>(DatabaseConfigChangesGrid);
+        _traceFlagChangesFilterMgr = new DataGridFilterManager<TraceFlagChangeRow>(TraceFlagChangesGrid);
 
         _filterManagers[ServerConfigGrid] = _serverConfigFilterMgr;
         _filterManagers[DatabaseConfigGrid] = _databaseConfigFilterMgr;
@@ -82,6 +88,9 @@ public partial class ViewerServerTab : UserControl
         _filterManagers[ExpensiveQueriesGrid] = _expensiveQueriesFilterMgr;
         _filterManagers[CollectionHealthGrid] = _collectionHealthFilterMgr;
         _filterManagers[CollectionLogGrid] = _collectionLogFilterMgr;
+        _filterManagers[ServerConfigChangesGrid] = _serverConfigChangesFilterMgr;
+        _filterManagers[DatabaseConfigChangesGrid] = _databaseConfigChangesFilterMgr;
+        _filterManagers[TraceFlagChangesGrid] = _traceFlagChangesFilterMgr;
     }
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
@@ -2405,6 +2405,79 @@
             </Grid>
         </TabItem>
 
+        <!-- Configuration Changes Tab — the Dashboard's dedicated ConfigChangesContent ported as its own tab
+             (sits immediately after the latest-snapshot Configuration tab). Three grids showing server-config /
+             database-config / trace-flag DRIFT over the selected window, computed in C# by diffing the store's
+             APPEND-ONLY config snapshots (ViewerDataService.ConfigChanges.cs), mirroring the service's
+             DarlingConfigHistoryReader (#1421). Dashboard enrichment Darling does not collect is OMITTED (not
+             fabricated): server-config Setting Description, database-config Setting Type. requires_restart is
+             KEPT (it is derivable: is_dynamic = 0 AND configured != in-use). Grids use the shared DarkGrid chrome
+             (its DarkGridRow carries the #1419 copy/export context menu) + the column-filter headers; change
+             times render through ViewerTimeHelper. -->
+        <TabItem Header="Configuration Changes">
+            <Grid Margin="8">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <TextBlock Grid.Row="0" Margin="2,0,2,8" TextWrapping="Wrap" Foreground="#8B93A1" FontSize="12"
+                           Text="Configuration is captured on connect/restart (the config collectors run on connect, not on a timer), so these histories reflect that cadence — a setting appears here only when at least two captures bracket the change within the selected time window."/>
+                <TabControl Grid.Row="1" Background="Transparent" BorderThickness="0" ItemContainerStyle="{DynamicResource SubTabItemStyle}">
+                    <TabItem Header="Server Config Changes">
+                        <Grid>
+                            <DataGrid x:Name="ServerConfigChangesGrid" Style="{StaticResource DarkGrid}" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+                                <DataGrid.Columns>
+                                    <DataGridTextColumn Binding="{Binding ChangeTimeDisplay}" Width="150"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ChangeTimeDisplay" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Change Time" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding ConfigurationName}" Width="260"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ConfigurationName" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Configuration" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding OldValueConfigured}" ElementStyle="{StaticResource NumericCell}" Width="110"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="OldValueConfigured" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Old Configured" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding NewValueConfigured}" ElementStyle="{StaticResource NumericCell}" Width="110"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="NewValueConfigured" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="New Configured" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding OldValueInUse}" ElementStyle="{StaticResource NumericCell}" Width="100"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="OldValueInUse" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Old In Use" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding NewValueInUse}" ElementStyle="{StaticResource NumericCell}" Width="100"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="NewValueInUse" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="New In Use" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding RequiresRestartDisplay}" Width="80"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="RequiresRestartDisplay" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Restart?" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding DynamicDisplay}" Width="80"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DynamicDisplay" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Dynamic" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding AdvancedDisplay}" Width="80"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AdvancedDisplay" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Advanced" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding ChangeDescription}" Width="*" MinWidth="250"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ChangeDescription" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Change Description" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                </DataGrid.Columns>
+                            </DataGrid>
+                            <TextBlock x:Name="ServerConfigChangesNoDataMessage" Style="{StaticResource EmptyHint}" Text="No server configuration changes in the selected time window (needs at least two config captures bracketing a change)."/>
+                        </Grid>
+                    </TabItem>
+                    <TabItem Header="Database Config Changes">
+                        <Grid>
+                            <DataGrid x:Name="DatabaseConfigChangesGrid" Style="{StaticResource DarkGrid}" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+                                <DataGrid.Columns>
+                                    <DataGridTextColumn Binding="{Binding ChangeTimeDisplay}" Width="150"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ChangeTimeDisplay" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Change Time" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding DatabaseName}" Width="180"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DatabaseName" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Database" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding SettingName}" Width="230"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SettingName" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Setting Name" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding OldValue}" Width="160"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="OldValue" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Old Value" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding NewValue}" Width="160"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="NewValue" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="New Value" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding ChangeDescription}" Width="*" MinWidth="250"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ChangeDescription" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Change Description" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                </DataGrid.Columns>
+                            </DataGrid>
+                            <TextBlock x:Name="DatabaseConfigChangesNoDataMessage" Style="{StaticResource EmptyHint}" Text="No database configuration changes in the selected time window (needs at least two config captures bracketing a change)."/>
+                        </Grid>
+                    </TabItem>
+                    <TabItem Header="Trace Flag Changes">
+                        <Grid>
+                            <DataGrid x:Name="TraceFlagChangesGrid" Style="{StaticResource DarkGrid}" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+                                <DataGrid.Columns>
+                                    <DataGridTextColumn Binding="{Binding ChangeTimeDisplay}" Width="150"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ChangeTimeDisplay" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Change Time" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding TraceFlag}" ElementStyle="{StaticResource NumericCell}" Width="100"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TraceFlag" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Trace Flag" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding PreviousStatusDisplay}" Width="110"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="PreviousStatusDisplay" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Previous Status" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding NewStatusDisplay}" Width="110"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="NewStatusDisplay" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="New Status" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding Scope}" Width="90"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Scope" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Scope" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding GlobalDisplay}" Width="80"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="GlobalDisplay" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Global" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding SessionDisplay}" Width="80"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SessionDisplay" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Session" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                    <DataGridTextColumn Binding="{Binding ChangeDescription}" Width="*" MinWidth="230"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ChangeDescription" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Change Description" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
+                                </DataGrid.Columns>
+                            </DataGrid>
+                            <TextBlock x:Name="TraceFlagChangesNoDataMessage" Style="{StaticResource EmptyHint}" Text="No trace flag changes in the selected time window (needs at least two config captures bracketing an enable/disable)."/>
+                        </Grid>
+                    </TabItem>
+                </TabControl>
+            </Grid>
+        </TabItem>
+
         <!-- Daily Summary Tab — copied from Lite's ServerTab.xaml Daily Summary tab: a date picker
              (Today / an explicit date, UTC) driving a single-row daily roll-up — total wait, top wait
              type, unique queries, deadlocks, blocking events, high-CPU count, collect errors — with the

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml.cs
@@ -41,37 +41,43 @@ public partial class ViewerServerTab : UserControl
        tempdb, Perfmon/Running Jobs sit between Blocking and Configuration, and Daily Summary sits between
        Configuration and Collection Health, matching Lite's own order), so the constants renumber when a
        wave lands between existing tabs. */
-    private const int OverviewInnerTabIndex = 0;
-    private const int WaitStatsInnerTabIndex = 1;
+    internal const int OverviewInnerTabIndex = 0;
+    internal const int WaitStatsInnerTabIndex = 1;
 
     /* Latches & Spinlocks sits BETWEEN Wait Stats and Queries — the contention-stats grouping mirroring
        the Dashboard (its Latch/Spinlock sub-tabs live alongside waits in ResourceMetrics). A new top-level
        tab holding two sub-tabs (Latch Stats + Spinlock Stats); everything after it renumbers by one. */
-    private const int LatchSpinlockInnerTabIndex = 2;
-    private const int QueriesInnerTabIndex = 3;
-    private const int PlanViewerInnerTabIndex = 4;
-    private const int CpuInnerTabIndex = 5;
-    private const int MemoryInnerTabIndex = 6;
-    private const int FileIoInnerTabIndex = 7;
-    private const int TempDbInnerTabIndex = 8;
-    private const int BlockingInnerTabIndex = 9;
-    private const int PerfmonInnerTabIndex = 10;
+    internal const int LatchSpinlockInnerTabIndex = 2;
+    internal const int QueriesInnerTabIndex = 3;
+    internal const int PlanViewerInnerTabIndex = 4;
+    internal const int CpuInnerTabIndex = 5;
+    internal const int MemoryInnerTabIndex = 6;
+    internal const int FileIoInnerTabIndex = 7;
+    internal const int TempDbInnerTabIndex = 8;
+    internal const int BlockingInnerTabIndex = 9;
+    internal const int PerfmonInnerTabIndex = 10;
 
     /* Session Stats sits BETWEEN Perfmon and Running Jobs — the Dashboard-parity port of
        ResourceMetricsContent's Session Stats sub-tab (which the Dashboard places right after Perfmon). Not a
        Lite ServerTab tab (it is Dashboard-only), so it has no Lite position to mirror; a new top-level tab,
        and everything after it renumbers by one. */
-    private const int SessionStatsInnerTabIndex = 11;
-    private const int RunningJobsInnerTabIndex = 12;
-    private const int ConfigurationInnerTabIndex = 13;
-    private const int DailySummaryInnerTabIndex = 14;
-    private const int HealthInnerTabIndex = 15;
+    internal const int SessionStatsInnerTabIndex = 11;
+    internal const int RunningJobsInnerTabIndex = 12;
+    internal const int ConfigurationInnerTabIndex = 13;
+
+    /* Configuration Changes sits immediately AFTER Configuration (the latest-snapshot tab): the Dashboard's
+       dedicated ConfigChangesContent ported as its own tab — three grids diffing the append-only config
+       snapshots into server-config / database-config / trace-flag DRIFT over the window. A new top-level tab,
+       so everything after it renumbers by one. */
+    internal const int ConfigChangesInnerTabIndex = 14;
+    internal const int DailySummaryInnerTabIndex = 15;
+    internal const int HealthInnerTabIndex = 16;
 
     /* System Events is appended AFTER Collection Health (system_health parity, Stage 2b): six parse-on-read
        sub-tabs, one per unique system_health warning category. FinOps used to sit between them as a per-server
        inner tab, but it was promoted to a top-level cross-server aggregate tab (FinOpsTab, in MainWindow's
        MainTabs), so System Events now takes Collection Health's next slot. */
-    private const int SystemEventsInnerTabIndex = 16;
+    internal const int SystemEventsInnerTabIndex = 17;
 
     private readonly ViewerDataService _dataService;
     private readonly DarlingServer _server;
@@ -291,6 +297,9 @@ public partial class ViewerServerTab : UserControl
                     break;
                 case ConfigurationInnerTabIndex:
                     await LoadConfigurationAsync();
+                    break;
+                case ConfigChangesInnerTabIndex:
+                    await LoadConfigChangesAsync();
                     break;
                 case DailySummaryInnerTabIndex:
                     await LoadDailySummaryAsync();


### PR DESCRIPTION
Ports the Dashboard's dedicated **Configuration Changes** tab (`ConfigChangesContent`) onto the Darling viewer: server / database / trace-flag config **drift over time**, computed by diffing the store's append-only config snapshots.

## Tab placement + renumber
New top-level per-server inner tab **"Configuration Changes"**, inserted immediately after the latest-snapshot **Configuration** tab (the Dashboard makes it its own tab). Inner-tab index constants renumbered accordingly (`ConfigChanges = 14`; Daily Summary / Collection Health / System Events each shift up by one) and made `internal` so the renumber is pinned in a test. `LoadInnerTabAsync` gets the new `case`. `MainWindow` loads via `RefreshActiveInnerTabAsync` (no literal indices) and all `InnerTabs.SelectedIndex` navigations use named constants, so nothing else moves.

## The three grids
Server Config Changes / Database Config Changes / Trace Flag Changes, each: change time, the setting identity, old -> new value, plus a derived change description. They ride the shared `DarkGrid` chrome (whose `DarkGridRow` carries the #1419 copy / export-to-CSV context menu) + the column-filter headers; change times render through `ViewerTimeHelper`; windowed on the per-server toolbar's settable range, so **Apply to All** flows through unchanged.

## The read + diff (`ViewerDataService.ConfigChanges.cs`)
Mirrors the service's `DarlingConfigHistoryReader` (#1421) viewer-side (the viewer can't reference the Service project): reads the append-only `v_server_config` / `v_database_config` / `v_trace_flags` snapshots and diffs them in C# per setting (trace flags via set-diff of on-flags between captures). Snapshot columns verified against the collector-generated tables in tests.

**Windowing note (surfaced deliberately):** the snapshot read is upper-bounded at the window end (`capture_time <= $2`) and the window **start** is applied to the computed `change_time` in C# — *not* to the raw snapshot read. This keeps the snapshot immediately before the window as the diff baseline, so a change landing on the first in-window snapshot is still detected. That matches the Dashboard, whose `report.*_changes` views LAG over the full history and then filter `change_time` to `[from, to]`. Strictly lower-bounding the snapshot read would drop the baseline and under-report the left edge, so I did not do that.

## Honestly omitted vs. derived
- **Omitted** (verified collection gaps, not fabricated): server-config **Setting Description**, database-config **Setting Type** (Darling's store is WIDE — the setting name *is* the literal column name).
- **Kept as derived** (challenging the "gap" framing): **requires_restart** is *not* a collection gap — it is derivable from collected columns (`is_dynamic = 0 AND value_configured != value_in_use`, the Dashboard view's own definition), so it is included as a derived column. Change narratives and trace-flag scope are likewise derived to match the Dashboard view wording.

## Connect-cadence caveat (surfaced honestly)
Config collectors run **on connect only** (`FrequencyMinutes = 0`), so change granularity = connect/restart cadence and a change needs >= 2 captures bracketing it. An always-visible note at the top of the tab plus per-grid "needs at least two captures" empty states make this honest.

## Tests (`ViewerConfigChangesTests`)
- Snapshot-read SQL pins: views, columns, `capture_time <= $2` upper bound, `$1`/`$2`-only params (no lower `$3`), PG dialect, 27-setting list vs the collector table, and read columns exist in the generated tables.
- Pure C# diff: value move (newest first), the >= 2-snapshot rule, **both** window edges on `change_time`, **pre-window baseline detection** (change on the first in-window snapshot), wide-row UNPIVOT names the changed column, trace-flag enable/disable/modify, and the derived `requires_restart` / change-description / scope columns.
- The tab renumber.
- Gated (`DARLING_TEST_PG`) live round-trips validating the read SQL end-to-end.

**Whole Darling solution builds `-c Release`; `Darling.Tests -c Release` green: 1354 passed, 110 skipped (live-PG gated), 0 failed.** Touches only the Viewer project + `Darling.Tests` — no Service / Storage / Config / Migrations / install files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
