### PR TITLE
Enrich Darling viewer Overview health cards to Dashboard parity

### DIFF
--- a/Darling/Darling.Tests/ViewerW2aTests.cs
+++ b/Darling/Darling.Tests/ViewerW2aTests.cs
@@ -87,6 +87,8 @@ public sealed class ViewerOverviewSqlTests
         /* Count + worst wait from each source; the caller applies Lite's XE-preferred, DMV-fallback rule. */
         Assert.Contains("COUNT(*)", sql, StringComparison.Ordinal);
         Assert.Contains("MAX(wait_time_ms)", sql, StringComparison.Ordinal);
+        /* Newest event ever (unbounded) for the "Last: N ago" detail when the window is clear. */
+        Assert.Contains("MAX(event_time)", sql, StringComparison.Ordinal);
         Assert.Contains("FROM v_blocked_process_reports", sql, StringComparison.Ordinal);
         Assert.Contains("FROM v_dmv_blocking_snapshots", sql, StringComparison.Ordinal);
         Assert.Contains("event_time >= $2", sql, StringComparison.Ordinal);
@@ -94,12 +96,15 @@ public sealed class ViewerOverviewSqlTests
     }
 
     [Fact]
-    public void SummaryDeadlockSql_CountsOverTheWindow_OnDeadlockTime()
+    public void SummaryDeadlockSql_CountsOverTheWindow_AndNewestEver()
     {
         var sql = ViewerDataService.ServerSummaryDeadlockSql;
         Assert.Contains("FROM v_deadlocks", sql, StringComparison.Ordinal);
         Assert.Contains("WHERE server_id = $1", sql, StringComparison.Ordinal);
+        Assert.Contains("COUNT(*)", sql, StringComparison.Ordinal);
         Assert.Contains("deadlock_time >= $2", sql, StringComparison.Ordinal);
+        /* Newest deadlock ever (unbounded) for the "Last: N ago" detail. */
+        Assert.Contains("MAX(deadlock_time)", sql, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -436,10 +441,22 @@ public sealed class ViewerServerSummaryDisplayTests
     }
 
     [Fact]
-    public void BlockingDetail_ShowsMaxDuration_WhenBlocked_BlankWhenClear()
+    public void BlockingDetail_MaxWhenBlocked_LastAgoWhenClear_BlankWhenNever()
     {
         Assert.Equal("max: 42s", new ServerSummaryItem { BlockingCount = 3, MaxBlockingWaitMs = 42000 }.BlockingDetail);
-        Assert.Equal("", new ServerSummaryItem { BlockingCount = 0, MaxBlockingWaitMs = 0 }.BlockingDetail);
+        /* Window clear but blocking happened earlier → the Dashboard's "Last: N ago". */
+        Assert.Equal("Last: 3h ago", new ServerSummaryItem { BlockingCount = 0, LastBlockingMinutesAgo = 180 }.BlockingDetail);
+        Assert.Equal("Last: 2d ago", new ServerSummaryItem { BlockingCount = 0, LastBlockingMinutesAgo = 2880 }.BlockingDetail);
+        /* Never any blocking → blank. */
+        Assert.Equal("", new ServerSummaryItem { BlockingCount = 0 }.BlockingDetail);
+    }
+
+    [Fact]
+    public void DeadlockDetail_ShowsLastAgo_WhenKnown_BlankWhenNever()
+    {
+        Assert.Equal("Last: 5m ago", new ServerSummaryItem { LastDeadlockMinutesAgo = 5 }.DeadlockDetail);
+        Assert.Equal("Last: just now", new ServerSummaryItem { LastDeadlockMinutesAgo = 0 }.DeadlockDetail);
+        Assert.Equal("", new ServerSummaryItem().DeadlockDetail);
     }
 
     [Fact]
@@ -741,11 +758,12 @@ public sealed class ViewerW2aLivePostgresTests
             Assert.True(summary.HasMemoryPressure);
             Assert.Equal(HealthSeverity.Critical, summary.MemorySeverity);
 
-            /* Blocking — count + worst wait, both from the XE source. */
+            /* Blocking — count + worst wait, both from the XE source; last-event read populated. */
             Assert.Equal(2, summary.BlockingCount);
             Assert.Equal(42000, summary.MaxBlockingWaitMs);
             Assert.Equal("max: 42s", summary.BlockingDetail);
             Assert.Equal(HealthSeverity.Warning, summary.BlockingSeverity);
+            Assert.NotNull(summary.LastBlockingMinutesAgo);
 
             /* Collectors — REUSE of the 7-day banding (one HEALTHY, one FAILING). */
             Assert.Equal(1, summary.HealthyCollectorCount);

--- a/Darling/Darling.Tests/ViewerW2aTests.cs
+++ b/Darling/Darling.Tests/ViewerW2aTests.cs
@@ -41,22 +41,52 @@ public sealed class ViewerOverviewSqlTests
     }
 
     [Fact]
-    public void SummaryMemorySql_ReadsLatestTotalServerMemory_CastToDouble()
+    public void SummaryMemorySql_ReadsLatestTotalServerMemoryAndBufferPool_CastToDouble()
     {
         var sql = ViewerDataService.ServerSummaryMemorySql;
         Assert.Contains("FROM v_memory_stats", sql, StringComparison.Ordinal);
         Assert.Contains("CAST(total_server_memory_mb AS double precision)", sql, StringComparison.Ordinal);
+        Assert.Contains("CAST(buffer_pool_mb AS double precision)", sql, StringComparison.Ordinal);
         Assert.Contains("WHERE server_id = $1", sql, StringComparison.Ordinal);
         Assert.Contains("ORDER BY collection_time DESC", sql, StringComparison.Ordinal);
         Assert.Contains("LIMIT 1", sql, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void SummaryBlockingSql_XeCount_FallsBackToDmvSnapshot_OverTheWindow()
+    public void SummaryMemoryPressureSql_SumsSemaphoreColumns_AtTheLatestCollection()
+    {
+        var sql = ViewerDataService.ServerSummaryMemoryPressureSql;
+        Assert.Contains("FROM v_memory_grant_stats", sql, StringComparison.Ordinal);
+        Assert.Contains("SUM(waiter_count)", sql, StringComparison.Ordinal);
+        Assert.Contains("SUM(timeout_error_count_delta)", sql, StringComparison.Ordinal);
+        Assert.Contains("SUM(forced_grant_count_delta)", sql, StringComparison.Ordinal);
+        Assert.Contains("SUM(granted_memory_mb)", sql, StringComparison.Ordinal);
+        Assert.Contains("WHERE server_id = $1", sql, StringComparison.Ordinal);
+        /* Latest collection instant = MAX(collection_time), summed across every pool at that instant. */
+        Assert.Contains("collection_time = (SELECT MAX(collection_time) FROM v_memory_grant_stats WHERE server_id = $1)", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SummaryThreadsSql_ReadsLatestSchedulerSnapshot_WorkerPressureColumns()
+    {
+        var sql = ViewerDataService.ServerSummaryThreadsSql;
+        Assert.Contains("FROM v_cpu_scheduler_stats", sql, StringComparison.Ordinal);
+        Assert.Contains("max_workers_count", sql, StringComparison.Ordinal);
+        Assert.Contains("total_current_workers_count", sql, StringComparison.Ordinal);
+        Assert.Contains("total_runnable_tasks_count", sql, StringComparison.Ordinal);
+        Assert.Contains("total_work_queue_count", sql, StringComparison.Ordinal);
+        Assert.Contains("WHERE server_id = $1", sql, StringComparison.Ordinal);
+        Assert.Contains("ORDER BY collection_time DESC", sql, StringComparison.Ordinal);
+        Assert.Contains("LIMIT 1", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SummaryBlockingSql_CountAndMaxWait_FromBothSources_OverTheWindow()
     {
         var sql = ViewerDataService.ServerSummaryBlockingSql;
-        /* COALESCE(NULLIF(xe,0), dmv) — Lite's fallback shape. */
-        Assert.Contains("COALESCE(NULLIF(", sql, StringComparison.Ordinal);
+        /* Count + worst wait from each source; the caller applies Lite's XE-preferred, DMV-fallback rule. */
+        Assert.Contains("COUNT(*)", sql, StringComparison.Ordinal);
+        Assert.Contains("MAX(wait_time_ms)", sql, StringComparison.Ordinal);
         Assert.Contains("FROM v_blocked_process_reports", sql, StringComparison.Ordinal);
         Assert.Contains("FROM v_dmv_blocking_snapshots", sql, StringComparison.Ordinal);
         Assert.Contains("event_time >= $2", sql, StringComparison.Ordinal);
@@ -88,6 +118,8 @@ public sealed class ViewerOverviewSqlTests
         {
             ViewerDataService.ServerSummaryCpuSql,
             ViewerDataService.ServerSummaryMemorySql,
+            ViewerDataService.ServerSummaryMemoryPressureSql,
+            ViewerDataService.ServerSummaryThreadsSql,
             ViewerDataService.ServerSummaryBlockingSql,
             ViewerDataService.ServerSummaryDeadlockSql,
             ViewerDataService.ServerSummaryLastCollectionSql,
@@ -108,7 +140,27 @@ public sealed class ViewerOverviewSqlTests
         Assert.Contains("other_process_cpu_utilization", cpu, StringComparison.Ordinal);
         Assert.Contains("sample_time", cpu, StringComparison.Ordinal);
 
-        Assert.Contains("total_server_memory_mb", PgSchemaGenerator.CreateTable(MemoryStatsCollector.Instance), StringComparison.Ordinal);
+        var memory = PgSchemaGenerator.CreateTable(MemoryStatsCollector.Instance);
+        Assert.Contains("total_server_memory_mb", memory, StringComparison.Ordinal);
+        Assert.Contains("buffer_pool_mb", memory, StringComparison.Ordinal);
+
+        /* Enrichment: the Threads row's four scheduler columns + the Memory row's semaphore columns. */
+        var scheduler = PgSchemaGenerator.CreateTable(CpuSchedulerStatsCollector.Instance);
+        Assert.Contains("max_workers_count", scheduler, StringComparison.Ordinal);
+        Assert.Contains("total_current_workers_count", scheduler, StringComparison.Ordinal);
+        Assert.Contains("total_runnable_tasks_count", scheduler, StringComparison.Ordinal);
+        Assert.Contains("total_work_queue_count", scheduler, StringComparison.Ordinal);
+
+        var grants = PgSchemaGenerator.CreateTable(MemoryGrantsCollector.Instance);
+        Assert.Contains("waiter_count", grants, StringComparison.Ordinal);
+        Assert.Contains("timeout_error_count_delta", grants, StringComparison.Ordinal);
+        Assert.Contains("forced_grant_count_delta", grants, StringComparison.Ordinal);
+        Assert.Contains("granted_memory_mb", grants, StringComparison.Ordinal);
+
+        /* Blocking duration comes from wait_time_ms on both blocking sources. */
+        Assert.Contains("wait_time_ms", PgSchemaGenerator.CreateTable(BlockedProcessReportCollector.Instance), StringComparison.Ordinal);
+        Assert.Contains("wait_time_ms", PgSchemaGenerator.CreateTable(DmvBlockingSnapshotCollector.Instance), StringComparison.Ordinal);
+
         Assert.Contains("event_time", PgSchemaGenerator.CreateTable(BlockedProcessReportCollector.Instance), StringComparison.Ordinal);
         Assert.Contains("event_time", PgSchemaGenerator.CreateTable(DmvBlockingSnapshotCollector.Instance), StringComparison.Ordinal);
         Assert.Contains("deadlock_time", PgSchemaGenerator.CreateTable(DeadlocksCollector.Instance), StringComparison.Ordinal);
@@ -120,7 +172,8 @@ public sealed class ViewerOverviewSqlTests
         var allMigrationSql = string.Concat(PgMigrations.Scripts.Select(m => m.Sql));
         foreach (var view in new[]
         {
-            "v_cpu_utilization_stats", "v_memory_stats", "v_blocked_process_reports",
+            "v_cpu_utilization_stats", "v_memory_stats", "v_memory_grant_stats",
+            "v_cpu_scheduler_stats", "v_blocked_process_reports",
             "v_dmv_blocking_snapshots", "v_deadlocks", "v_collection_log",
         })
         {
@@ -269,6 +322,181 @@ public sealed class ViewerServerSummaryDisplayTests
         calm.ApplyFreshness(Now);
         Assert.Equal("#FF2A2D35", calm.CardBorderBrush.Color.ToString());
     }
+
+    // ── Enrichment: per-metric severity bands (verbatim mirrors of ServerHealthStatus) ──────────────
+
+    [Theory]
+    [InlineData(40.0, HealthSeverity.Healthy)]
+    [InlineData(79.0, HealthSeverity.Healthy)]
+    [InlineData(80.0, HealthSeverity.Warning)]   // ServerHealthStatus.CpuSeverity: >=80 Warning
+    [InlineData(94.0, HealthSeverity.Warning)]
+    [InlineData(95.0, HealthSeverity.Critical)]  // >=95 Critical
+    [InlineData(100.0, HealthSeverity.Critical)]
+    public void CpuSeverity_BandsOnTotalCpu(double sqlCpu, HealthSeverity expected)
+    {
+        Assert.Equal(expected, new ServerSummaryItem { CpuPercent = sqlCpu }.CpuSeverity);
+    }
+
+    [Fact]
+    public void CpuSeverity_NoData_IsUnknown()
+    {
+        Assert.Equal(HealthSeverity.Unknown, new ServerSummaryItem().CpuSeverity);
+    }
+
+    [Fact]
+    public void CpuSeverity_UsesTotalNotSqlOnly()
+    {
+        // SQL 60 + other 40 = 100 total → Critical, though SQL alone is only Warning.
+        Assert.Equal(HealthSeverity.Critical,
+            new ServerSummaryItem { CpuPercent = 60, OtherProcessCpuPercent = 40 }.CpuSeverity);
+    }
+
+    [Fact]
+    public void ThreadsSeverity_NoSnapshot_IsUnknown_DisplayDashes()
+    {
+        var item = new ServerSummaryItem();  // TotalThreads null (e.g. Azure SQL DB — collector n/a)
+        Assert.Equal(HealthSeverity.Unknown, item.ThreadsSeverity);
+        Assert.Equal("--", item.ThreadsDisplay);
+        Assert.Equal("", item.ThreadsDetail);
+        Assert.Null(item.AvailableThreads);
+    }
+
+    [Fact]
+    public void ThreadsSeverity_WorkQueueStarvation_IsCritical()
+    {
+        // ServerHealthStatus.ThreadsSeverity: requests_waiting_for_threads (work queue) > 0 → Critical
+        var item = new ServerSummaryItem { TotalThreads = 512, CurrentWorkers = 100, RequestsWaitingForThreads = 3 };
+        Assert.Equal(HealthSeverity.Critical, item.ThreadsSeverity);
+        Assert.Equal("3 starved", item.ThreadsDisplay);
+    }
+
+    [Fact]
+    public void ThreadsSeverity_ManyRunnableWaitingForCpu_IsWarning()
+    {
+        // >=20 runnable tasks waiting for CPU → Warning
+        var item = new ServerSummaryItem { TotalThreads = 512, CurrentWorkers = 100, ThreadsWaitingForCpu = 20 };
+        Assert.Equal(HealthSeverity.Warning, item.ThreadsSeverity);
+        Assert.Equal("20 runnable", item.ThreadsDisplay);
+    }
+
+    [Fact]
+    public void ThreadsSeverity_LessThanTenPercentAvailable_IsWarning()
+    {
+        // available = 512 - 470 = 42 < 51.2 (10% of 512) → Warning, "Low"
+        var item = new ServerSummaryItem { TotalThreads = 512, CurrentWorkers = 470 };
+        Assert.Equal(HealthSeverity.Warning, item.ThreadsSeverity);
+        Assert.Equal("Low", item.ThreadsDisplay);
+        Assert.Equal(42, item.AvailableThreads);
+    }
+
+    [Fact]
+    public void ThreadsSeverity_HealthyShowsAvailableDetail()
+    {
+        var item = new ServerSummaryItem { TotalThreads = 512, CurrentWorkers = 100 };
+        Assert.Equal(HealthSeverity.Healthy, item.ThreadsSeverity);
+        Assert.Equal("OK", item.ThreadsDisplay);
+        Assert.Equal(412, item.AvailableThreads);
+        Assert.Equal("Available: 412/512", item.ThreadsDetail);
+    }
+
+    [Fact]
+    public void MemorySeverity_NoPressure_IsHealthy_DetailShowsSizes()
+    {
+        var item = new ServerSummaryItem { MemoryMb = 8192, BufferPoolMb = 6144, GrantedMemoryMb = 1024 };
+        Assert.Equal(HealthSeverity.Healthy, item.MemorySeverity);
+        Assert.False(item.HasMemoryPressure);
+        Assert.Equal("BP 6.0, QMG 1.0 GB", item.MemoryDetail);
+    }
+
+    [Theory]
+    [InlineData(3, 0, 0, "3 grant waiters")]                          // ServerHealthStatus: waiter_count > 0 → Critical
+    [InlineData(1, 0, 0, "1 grant waiter")]
+    [InlineData(0, 2, 0, "2 timeouts")]                               // viewer extends to timeouts (collected delta)
+    [InlineData(0, 0, 1, "1 forced")]                                 // and forced grants
+    [InlineData(2, 1, 1, "2 grant waiters, 1 timeout, 1 forced")]
+    public void MemorySeverity_AnyPressure_IsCritical_DetailNamesIt(long waiters, long timeouts, long forced, string expectedDetail)
+    {
+        var item = new ServerSummaryItem { MemoryWaiterCount = waiters, MemoryTimeoutCount = timeouts, MemoryForcedCount = forced };
+        Assert.Equal(HealthSeverity.Critical, item.MemorySeverity);
+        Assert.True(item.HasMemoryPressure);
+        Assert.Equal(expectedDetail, item.MemoryDetail);
+    }
+
+    [Theory]
+    [InlineData(0, 0, HealthSeverity.Healthy)]
+    [InlineData(1, 0, HealthSeverity.Warning)]        // any blocking at all → Warning
+    [InlineData(2, 0, HealthSeverity.Warning)]        // >=2 events → Warning
+    [InlineData(5, 0, HealthSeverity.Critical)]       // >=5 events → Critical
+    [InlineData(1, 10000, HealthSeverity.Warning)]    // 10s max wait → Warning
+    [InlineData(1, 59000, HealthSeverity.Warning)]
+    [InlineData(1, 60000, HealthSeverity.Critical)]   // 60s max wait → Critical
+    public void BlockingSeverity_BandsOnCountAndDuration(int count, long maxWaitMs, HealthSeverity expected)
+    {
+        Assert.Equal(expected, new ServerSummaryItem { BlockingCount = count, MaxBlockingWaitMs = maxWaitMs }.BlockingSeverity);
+    }
+
+    [Fact]
+    public void BlockingDetail_ShowsMaxDuration_WhenBlocked_BlankWhenClear()
+    {
+        Assert.Equal("max: 42s", new ServerSummaryItem { BlockingCount = 3, MaxBlockingWaitMs = 42000 }.BlockingDetail);
+        Assert.Equal("", new ServerSummaryItem { BlockingCount = 0, MaxBlockingWaitMs = 0 }.BlockingDetail);
+    }
+
+    [Fact]
+    public void CollectorSeverity_FailingIsWarning_HealthyOtherwise()
+    {
+        Assert.Equal(HealthSeverity.Healthy, new ServerSummaryItem { HealthyCollectorCount = 30 }.CollectorSeverity);
+        var failing = new ServerSummaryItem { HealthyCollectorCount = 28, FailedCollectorCount = 2 };
+        Assert.Equal(HealthSeverity.Warning, failing.CollectorSeverity);
+        Assert.Equal("2 failed", failing.CollectorDisplay);
+        Assert.Equal("Healthy: 28, Failing: 2", failing.CollectorDetail);
+        Assert.Equal("OK", new ServerSummaryItem { HealthyCollectorCount = 30 }.CollectorDisplay);
+    }
+
+    [Fact]
+    public void DeadlockSeverity_AnyInWindow_IsCritical()
+    {
+        Assert.Equal(HealthSeverity.Healthy, new ServerSummaryItem { DeadlockCount = 0 }.DeadlockSeverity);
+        Assert.Equal(HealthSeverity.Critical, new ServerSummaryItem { DeadlockCount = 1 }.DeadlockSeverity);
+    }
+
+    [Fact]
+    public void OverallMetricSeverity_TakesTheWorstBand_UnknownDoesNotEscalate()
+    {
+        // Threads Critical dominates even when every other metric is calm/unknown.
+        var item = new ServerSummaryItem { TotalThreads = 512, CurrentWorkers = 100, RequestsWaitingForThreads = 1 };
+        Assert.Equal(HealthSeverity.Critical, item.OverallMetricSeverity);
+
+        // A pure Warning (collectors) with no Critical → Warning.
+        Assert.Equal(HealthSeverity.Warning, new ServerSummaryItem { FailedCollectorCount = 1 }.OverallMetricSeverity);
+
+        // No data anywhere (CPU Unknown, rest Healthy) → Healthy baseline (Unknown never escalates).
+        Assert.Equal(HealthSeverity.Healthy, new ServerSummaryItem().OverallMetricSeverity);
+    }
+
+    [Fact]
+    public void CardBorderBrush_EnrichedBands_ThreadsCriticalRed_CollectorsWarningOrange()
+    {
+        var threadsCritical = new ServerSummaryItem
+        {
+            TotalThreads = 512, CurrentWorkers = 100, RequestsWaitingForThreads = 1, LastCollectionTime = Now,
+        };
+        threadsCritical.ApplyFreshness(Now);
+        Assert.Equal("#FFE57373", threadsCritical.CardBorderBrush.Color.ToString());
+
+        var collectorsWarning = new ServerSummaryItem { FailedCollectorCount = 1, LastCollectionTime = Now };
+        collectorsWarning.ApplyFreshness(Now);
+        Assert.Equal("#FFFFB74D", collectorsWarning.CardBorderBrush.Color.ToString());
+    }
+
+    [Fact]
+    public void SeverityBrushes_MapBandsToDarkPalette()
+    {
+        Assert.Equal("#FF81C784", new ServerSummaryItem { CpuPercent = 10 }.CpuSeverityBrush.Color.ToString());  // Healthy green
+        Assert.Equal("#FFFFB74D", new ServerSummaryItem { CpuPercent = 85 }.CpuSeverityBrush.Color.ToString());  // Warning amber
+        Assert.Equal("#FFE57373", new ServerSummaryItem { CpuPercent = 96 }.CpuSeverityBrush.Color.ToString());  // Critical red
+        Assert.Equal("#FF888888", new ServerSummaryItem().ThreadsSeverityBrush.Color.ToString());                // Unknown gray
+    }
 }
 
 /// <summary>
@@ -364,6 +592,7 @@ public sealed class ViewerW2aLivePostgresTests
     private const int FallbackServerId = -929202;
     private const int DismissServerA = -929203;
     private const int DismissServerB = -929204;
+    private const int EnrichServerId = -929205;
     private const string ServerName = "viewer-w2a-e2e";
 
     [Fact]
@@ -451,6 +680,81 @@ public sealed class ViewerW2aLivePostgresTests
         finally
         {
             await DeleteSummaryRowsAsync(connection, FallbackServerId);
+        }
+    }
+
+    [Fact]
+    public async Task ServerSummary_ReadsEnrichedThreadsMemoryBlockingCollectors_AgainstDevPostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the live enrichment test.");
+
+        using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await PgMigrations.MigrateAsync(connection, TestContext.Current.CancellationToken);
+        await DeleteEnrichmentRowsAsync(connection, EnrichServerId);
+
+        await using var viewer = new ViewerDataService(connectionString!);
+
+        try
+        {
+            var now = TruncateToSeconds(DateTime.UtcNow);
+            var latest = now.AddMinutes(-1);
+            var older = now.AddMinutes(-2);
+            var withinHour = now.AddMinutes(-20);
+
+            /* Memory: total + buffer pool. */
+            await InsertMemoryWithBufferPoolAsync(connection, EnrichServerId, now, totalServerMemoryMb: 8192.00m, bufferPoolMb: 6144.00m);
+
+            /* Resource semaphore: an older heavy sample (must be IGNORED) + the latest two-pool sample (summed). */
+            await InsertGrantAsync(connection, EnrichServerId, older, poolId: 1, grantedMb: 4096m, waiter: 99, timeoutDelta: 0, forcedDelta: 0);
+            await InsertGrantAsync(connection, EnrichServerId, latest, poolId: 1, grantedMb: 512m, waiter: 1, timeoutDelta: 0, forcedDelta: 0);
+            await InsertGrantAsync(connection, EnrichServerId, latest, poolId: 2, grantedMb: 512m, waiter: 2, timeoutDelta: 0, forcedDelta: 0);
+
+            /* Scheduler snapshot: 512 ceiling, 128 in use → 384 available; 5 runnable, no work-queue starvation. */
+            await InsertSchedulerAsync(connection, EnrichServerId, now, runnable: 5);
+
+            /* Two XE blocked-process reports in the window; the worst wait is 42s. */
+            await InsertBlockedProcessWithWaitAsync(connection, EnrichServerId, withinHour, waitTimeMs: 5000);
+            await InsertBlockedProcessWithWaitAsync(connection, EnrichServerId, withinHour, waitTimeMs: 42000);
+
+            /* Collection health: one HEALTHY collector (recent success) + one FAILING (error, never succeeded). */
+            await InsertCollectionLogAsync(connection, EnrichServerId, "cpu_utilization", now, "SUCCESS");
+            await InsertCollectionLogAsync(connection, EnrichServerId, "memory_stats", now, "ERROR");
+
+            var summary = await viewer.GetServerSummaryAsync(EnrichServerId, "Enrich E2E");
+
+            /* Threads — the latest scheduler snapshot (available = ceiling − in-use). */
+            Assert.Equal(512, summary.TotalThreads);
+            Assert.Equal(384, summary.AvailableThreads);
+            Assert.Equal(5, summary.ThreadsWaitingForCpu);
+            Assert.Equal(0, summary.RequestsWaitingForThreads);
+            Assert.Equal(HealthSeverity.Healthy, summary.ThreadsSeverity);
+            Assert.Equal("Available: 384/512", summary.ThreadsDetail);
+
+            /* Memory — total + buffer pool + resource-semaphore pressure summed at the LATEST collection only. */
+            Assert.Equal(8192.0, summary.MemoryMb!.Value, precision: 1);
+            Assert.Equal(6144.0, summary.BufferPoolMb!.Value, precision: 1);
+            Assert.Equal(3, summary.MemoryWaiterCount);            // 1 + 2 at latest; the older 99 is ignored
+            Assert.Equal(1024.0, summary.GrantedMemoryMb!.Value, precision: 1);
+            Assert.True(summary.HasMemoryPressure);
+            Assert.Equal(HealthSeverity.Critical, summary.MemorySeverity);
+
+            /* Blocking — count + worst wait, both from the XE source. */
+            Assert.Equal(2, summary.BlockingCount);
+            Assert.Equal(42000, summary.MaxBlockingWaitMs);
+            Assert.Equal("max: 42s", summary.BlockingDetail);
+            Assert.Equal(HealthSeverity.Warning, summary.BlockingSeverity);
+
+            /* Collectors — REUSE of the 7-day banding (one HEALTHY, one FAILING). */
+            Assert.Equal(1, summary.HealthyCollectorCount);
+            Assert.Equal(1, summary.FailedCollectorCount);
+            Assert.Equal(HealthSeverity.Warning, summary.CollectorSeverity);
+        }
+        finally
+        {
+            await DeleteEnrichmentRowsAsync(connection, EnrichServerId);
         }
     }
 
@@ -602,6 +906,85 @@ public sealed class ViewerW2aLivePostgresTests
         await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
     }
 
+    private static async Task InsertMemoryWithBufferPoolAsync(
+        NpgsqlConnection connection, int serverId, DateTime collectionTime, decimal totalServerMemoryMb, decimal bufferPoolMb)
+    {
+        using var command = new NpgsqlCommand(
+            "INSERT INTO memory_stats (collection_id, collection_time, server_id, server_name, total_server_memory_mb, buffer_pool_mb) VALUES ($1, $2, $3, $4, $5, $6)",
+            connection);
+        command.Parameters.AddWithValue(1L);
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTime, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(serverId);
+        command.Parameters.AddWithValue(ServerName);
+        command.Parameters.AddWithValue(totalServerMemoryMb);
+        command.Parameters.AddWithValue(bufferPoolMb);
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static async Task InsertGrantAsync(
+        NpgsqlConnection connection, int serverId, DateTime collectionTime, int poolId, decimal grantedMb, int waiter, long timeoutDelta, long forcedDelta)
+    {
+        using var command = new NpgsqlCommand(@"
+INSERT INTO memory_grant_stats
+    (collection_id, collection_time, server_id, server_name, pool_id,
+     available_memory_mb, granted_memory_mb, used_memory_mb,
+     grantee_count, waiter_count, timeout_error_count_delta, forced_grant_count_delta)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)", connection);
+        command.Parameters.AddWithValue(CollectionIdGenerator.Next());
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTime, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(serverId);
+        command.Parameters.AddWithValue(ServerName);
+        command.Parameters.AddWithValue(poolId);
+        command.Parameters.AddWithValue(1000m);        // available_memory_mb
+        command.Parameters.AddWithValue(grantedMb);
+        command.Parameters.AddWithValue(500m);         // used_memory_mb
+        command.Parameters.AddWithValue(1);            // grantee_count
+        command.Parameters.AddWithValue(waiter);
+        command.Parameters.AddWithValue(timeoutDelta);
+        command.Parameters.AddWithValue(forcedDelta);
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static async Task InsertSchedulerAsync(
+        NpgsqlConnection connection, int serverId, DateTime collectionTime, int runnable)
+    {
+        using var command = new NpgsqlCommand(@"
+INSERT INTO cpu_scheduler_stats
+    (collection_id, collection_time, server_id, server_name,
+     max_workers_count, scheduler_count, cpu_count,
+     total_runnable_tasks_count, total_work_queue_count, total_current_workers_count,
+     avg_runnable_tasks_count, total_active_request_count, total_queued_request_count,
+     total_blocked_task_count, total_active_parallel_thread_count,
+     runnable_request_count, total_request_count, runnable_percent,
+     worker_thread_exhaustion_warning, runnable_tasks_warning, blocked_tasks_warning,
+     queued_requests_warning, total_physical_memory_kb, available_physical_memory_kb,
+     system_memory_state_desc, physical_memory_pressure_warning,
+     total_node_count, nodes_online_count, offline_cpu_count, offline_cpu_warning)
+VALUES ($1, $2, $3, $4, 512, 8, 8, $5, 0, 128, 0.5, 2, 0, 0, 0, 3, 20, 12.5,
+        false, false, false, false, 67108864, 8388608, 'ok', false, 2, 2, 0, false)", connection);
+        command.Parameters.AddWithValue(CollectionIdGenerator.Next());
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTime, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(serverId);
+        command.Parameters.AddWithValue(ServerName);
+        command.Parameters.AddWithValue(runnable);
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static async Task InsertBlockedProcessWithWaitAsync(
+        NpgsqlConnection connection, int serverId, DateTime eventTime, long waitTimeMs)
+    {
+        using var command = new NpgsqlCommand(
+            "INSERT INTO blocked_process_reports (blocked_report_id, collection_time, server_id, server_name, event_time, wait_time_ms) VALUES ($1, $2, $3, $4, $5, $6)",
+            connection);
+        command.Parameters.AddWithValue(CollectionIdGenerator.Next());
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(eventTime, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(serverId);
+        command.Parameters.AddWithValue(ServerName);
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(eventTime, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(waitTimeMs);
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
     private static async Task InsertAlertAsync(
         NpgsqlConnection connection, DateTime alertTimeUtc, int serverId, string serverName, string metric)
     {
@@ -635,6 +1018,19 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)", connection);
         {
             "cpu_utilization_stats", "memory_stats", "blocked_process_reports",
             "dmv_blocking_snapshots", "deadlocks", "collection_log",
+        })
+        {
+            using var cleanup = new NpgsqlCommand($"DELETE FROM {table} WHERE server_id = {serverId};", connection);
+            await cleanup.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+        }
+    }
+
+    private static async Task DeleteEnrichmentRowsAsync(NpgsqlConnection connection, int serverId)
+    {
+        foreach (var table in new[]
+        {
+            "memory_stats", "memory_grant_stats", "cpu_scheduler_stats",
+            "blocked_process_reports", "collection_log",
         })
         {
             using var cleanup = new NpgsqlCommand($"DELETE FROM {table} WHERE server_id = {serverId};", connection);

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
@@ -591,6 +591,7 @@
                                                     <Ellipse Grid.Row="4" Grid.Column="0" Width="9" Height="9" Fill="{Binding DeadlockSeverityBrush}" VerticalAlignment="Center" Margin="0,2,6,2"/>
                                                     <TextBlock Grid.Row="4" Grid.Column="1" Text="Deadlocks:" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,2,8,2"/>
                                                     <TextBlock Grid.Row="4" Grid.Column="2" Text="{Binding DeadlockDisplay}" FontSize="11" Foreground="{Binding DeadlockSeverityBrush}" FontWeight="SemiBold" Margin="0,2,8,2"/>
+                                                    <TextBlock Grid.Row="4" Grid.Column="3" Text="{Binding DeadlockDetail}" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis" Margin="0,2"/>
 
                                                     <!-- Collectors (enrichment) -->
                                                     <Ellipse Grid.Row="5" Grid.Column="0" Width="9" Height="9" Fill="{Binding CollectorSeverityBrush}" VerticalAlignment="Center" Margin="0,2,6,2"/>

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
@@ -526,7 +526,7 @@
                                             BorderBrush="{Binding CardBorderBrush}"
                                             BorderThickness="2" CornerRadius="6"
                                             Margin="6"
-                                            Width="260" MinHeight="160"
+                                            Width="300" MinHeight="210"
                                             Cursor="Hand"
                                             MouseLeftButtonDown="OverviewCard_MouseLeftButtonDown">
                                         <Grid>
@@ -539,8 +539,17 @@
                                                 </DockPanel>
                                                 <TextBlock Text="{Binding StatusDisplay}" Foreground="{Binding StatusBrush}"
                                                            FontSize="11" Margin="0,0,0,10"/>
+                                                <!-- Metric rows: [severity dot] [label] [value] [detail],
+                                                     mirroring the Dashboard's ServerHealthCard. Each dot +
+                                                     value is coloured by the metric's band (ServerSummaryItem
+                                                     reproduces ServerHealthStatus's CASE logic). Threads +
+                                                     Collectors are the enrichment rows; Memory / Blocking gain
+                                                     resource-semaphore + duration detail. Last Collect keeps
+                                                     its neutral footer row (no dot). -->
                                                 <Grid>
                                                     <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                        <ColumnDefinition Width="Auto"/>
                                                         <ColumnDefinition Width="Auto"/>
                                                         <ColumnDefinition Width="*"/>
                                                     </Grid.ColumnDefinitions>
@@ -550,17 +559,48 @@
                                                         <RowDefinition Height="Auto"/>
                                                         <RowDefinition Height="Auto"/>
                                                         <RowDefinition Height="Auto"/>
+                                                        <RowDefinition Height="Auto"/>
+                                                        <RowDefinition Height="Auto"/>
                                                     </Grid.RowDefinitions>
-                                                    <TextBlock Grid.Row="0" Grid.Column="0" Text="CPU:" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,2"/>
-                                                    <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding CpuDisplay}" Foreground="{Binding CpuBrush}" FontWeight="SemiBold" Margin="8,2" HorizontalAlignment="Right"/>
-                                                    <TextBlock Grid.Row="1" Grid.Column="0" Text="Memory:" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,2"/>
-                                                    <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding MemoryDisplay}" Foreground="{DynamicResource ForegroundBrush}" FontWeight="SemiBold" Margin="8,2" HorizontalAlignment="Right"/>
-                                                    <TextBlock Grid.Row="2" Grid.Column="0" Text="Blocking:" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,2"/>
-                                                    <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding BlockingDisplay}" Foreground="{Binding BlockingBrush}" FontWeight="SemiBold" Margin="8,2" HorizontalAlignment="Right"/>
-                                                    <TextBlock Grid.Row="3" Grid.Column="0" Text="Deadlocks:" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,2"/>
-                                                    <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding DeadlockDisplay}" Foreground="{Binding DeadlockBrush}" FontWeight="SemiBold" Margin="8,2" HorizontalAlignment="Right"/>
-                                                    <TextBlock Grid.Row="4" Grid.Column="0" Text="Last Collect:" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,2"/>
-                                                    <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding LastCollectionDisplay}" Foreground="{DynamicResource ForegroundBrush}" FontWeight="SemiBold" Margin="8,2" HorizontalAlignment="Right"/>
+
+                                                    <!-- CPU -->
+                                                    <Ellipse Grid.Row="0" Grid.Column="0" Width="9" Height="9" Fill="{Binding CpuSeverityBrush}" VerticalAlignment="Center" Margin="0,2,6,2"/>
+                                                    <TextBlock Grid.Row="0" Grid.Column="1" Text="CPU:" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,2,8,2"/>
+                                                    <TextBlock Grid.Row="0" Grid.Column="2" Text="{Binding CpuDisplay}" FontSize="11" Foreground="{Binding CpuSeverityBrush}" FontWeight="SemiBold" Margin="0,2,8,2"/>
+                                                    <TextBlock Grid.Row="0" Grid.Column="3" Text="{Binding CpuDetail}" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis" Margin="0,2"/>
+
+                                                    <!-- Threads (enrichment) -->
+                                                    <Ellipse Grid.Row="1" Grid.Column="0" Width="9" Height="9" Fill="{Binding ThreadsSeverityBrush}" VerticalAlignment="Center" Margin="0,2,6,2"/>
+                                                    <TextBlock Grid.Row="1" Grid.Column="1" Text="Threads:" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,2,8,2"/>
+                                                    <TextBlock Grid.Row="1" Grid.Column="2" Text="{Binding ThreadsDisplay}" FontSize="11" Foreground="{Binding ThreadsSeverityBrush}" FontWeight="SemiBold" Margin="0,2,8,2"/>
+                                                    <TextBlock Grid.Row="1" Grid.Column="3" Text="{Binding ThreadsDetail}" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis" Margin="0,2"/>
+
+                                                    <!-- Memory (richer: total value + resource-semaphore detail) -->
+                                                    <Ellipse Grid.Row="2" Grid.Column="0" Width="9" Height="9" Fill="{Binding MemorySeverityBrush}" VerticalAlignment="Center" Margin="0,2,6,2"/>
+                                                    <TextBlock Grid.Row="2" Grid.Column="1" Text="Memory:" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,2,8,2"/>
+                                                    <TextBlock Grid.Row="2" Grid.Column="2" Text="{Binding MemoryDisplay}" FontSize="11" Foreground="{DynamicResource ForegroundBrush}" FontWeight="SemiBold" Margin="0,2,8,2"/>
+                                                    <TextBlock Grid.Row="2" Grid.Column="3" Text="{Binding MemoryDetail}" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis" Margin="0,2"/>
+
+                                                    <!-- Blocking (richer: count value + max-duration detail) -->
+                                                    <Ellipse Grid.Row="3" Grid.Column="0" Width="9" Height="9" Fill="{Binding BlockingSeverityBrush}" VerticalAlignment="Center" Margin="0,2,6,2"/>
+                                                    <TextBlock Grid.Row="3" Grid.Column="1" Text="Blocking:" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,2,8,2"/>
+                                                    <TextBlock Grid.Row="3" Grid.Column="2" Text="{Binding BlockingDisplay}" FontSize="11" Foreground="{Binding BlockingSeverityBrush}" FontWeight="SemiBold" Margin="0,2,8,2"/>
+                                                    <TextBlock Grid.Row="3" Grid.Column="3" Text="{Binding BlockingDetail}" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis" Margin="0,2"/>
+
+                                                    <!-- Deadlocks -->
+                                                    <Ellipse Grid.Row="4" Grid.Column="0" Width="9" Height="9" Fill="{Binding DeadlockSeverityBrush}" VerticalAlignment="Center" Margin="0,2,6,2"/>
+                                                    <TextBlock Grid.Row="4" Grid.Column="1" Text="Deadlocks:" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,2,8,2"/>
+                                                    <TextBlock Grid.Row="4" Grid.Column="2" Text="{Binding DeadlockDisplay}" FontSize="11" Foreground="{Binding DeadlockSeverityBrush}" FontWeight="SemiBold" Margin="0,2,8,2"/>
+
+                                                    <!-- Collectors (enrichment) -->
+                                                    <Ellipse Grid.Row="5" Grid.Column="0" Width="9" Height="9" Fill="{Binding CollectorSeverityBrush}" VerticalAlignment="Center" Margin="0,2,6,2"/>
+                                                    <TextBlock Grid.Row="5" Grid.Column="1" Text="Collectors:" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,2,8,2"/>
+                                                    <TextBlock Grid.Row="5" Grid.Column="2" Text="{Binding CollectorDisplay}" FontSize="11" Foreground="{Binding CollectorSeverityBrush}" FontWeight="SemiBold" Margin="0,2,8,2"/>
+                                                    <TextBlock Grid.Row="5" Grid.Column="3" Text="{Binding CollectorDetail}" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis" Margin="0,2"/>
+
+                                                    <!-- Last Collect (footer row, no severity dot) -->
+                                                    <TextBlock Grid.Row="6" Grid.Column="1" Text="Last Collect:" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,2,8,2"/>
+                                                    <TextBlock Grid.Row="6" Grid.Column="2" Text="{Binding LastCollectionDisplay}" FontSize="11" Foreground="{DynamicResource ForegroundBrush}" FontWeight="SemiBold" Margin="0,2,8,2"/>
                                                 </Grid>
                                             </StackPanel>
                                             <!-- Offline overlay -->

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Overview.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Overview.cs
@@ -7,6 +7,8 @@
  */
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Media;
@@ -17,19 +19,29 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// <summary>
 /// The Overview server-cards read (W2a viewer copy-parity), copied from Lite's
 /// <c>LocalDataService.Overview.cs</c> (GetServerSummaryAsync + ServerSummaryItem) and rewired to the
-/// Darling Postgres store. The five per-server reads mirror Lite's exactly — latest CPU (SQL + other),
-/// latest total server memory, blocking count in the last hour (XE blocked-process reports, falling
-/// back to the always-on DMV snapshot when the XE count is zero), deadlock count in the last hour, and
-/// the last collection time — over the same <c>v_*</c> passthrough views the other viewer tabs read.
-/// The SQL lives in public constants so tests can pin the load-bearing clauses without a live Postgres.
+/// Darling Postgres store, then ENRICHED toward the Dashboard's richer <c>ServerHealthCard</c>
+/// (Dashboard/Controls/ServerHealthCard.xaml + Dashboard/Models/ServerHealthStatus.cs). Alongside Lite's
+/// original five per-server reads — latest CPU (SQL + other), latest total server memory, blocking count
+/// in the last hour (XE blocked-process reports, falling back to the always-on DMV snapshot when the XE
+/// count is zero), deadlock count in the last hour, and the last collection time — the card now also
+/// surfaces the Dashboard's <b>Threads</b> row (worker-thread pressure from the latest
+/// <c>cpu_scheduler_stats</c> snapshot), <b>Collectors</b> row (healthy / failing counts reusing the
+/// viewer's own <see cref="CollectorHealthRow.HealthStatus"/> banding), a richer <b>Memory</b> signal
+/// (resource-semaphore waiters / timeouts / forced grants from <c>memory_grant_stats</c>, not just total
+/// MB), and a <b>Blocking</b> duration (max wait in the window). Every metric drives a per-row severity
+/// band that mirrors <c>ServerHealthStatus</c>'s deterministic CASE logic. All reads run over the same
+/// <c>v_*</c> passthrough views the other viewer tabs read; the SQL lives in public constants so tests can
+/// pin the load-bearing clauses without a live Postgres.
 ///
-/// <para><b>The one semantic change (#1262 headless plan).</b> Lite's <c>IsOnline</c> comes from a live
+/// <para><b>The viewer adaptations (#1262 headless plan).</b> (1) Lite's <c>IsOnline</c> comes from a live
 /// per-server connection ping; the viewer has no live connection to the monitored servers, so it derives
 /// the card's status from COLLECTION FRESHNESS instead — how old the newest <c>v_collection_log</c> row
 /// is (see <see cref="ServerSummaryItem.ClassifyFreshness"/>): fresh → Online (green), stale (older than
 /// twice the fastest collector's cadence) → Warning (amber), and no collection / long-dead → Offline
-/// (the red overlay). The freshness result is mapped onto Lite's own (IsOnline, HasCollectorErrors)
-/// inputs so the card view-model is otherwise a verbatim copy of Lite's.</para>
+/// (the red overlay). (2) The Dashboard's health card live-queries currently-blocked sessions / current
+/// scheduler state; the viewer reads the newest COLLECTED snapshot instead (the freshness band already
+/// answers "is this server reporting"). The severity BANDS themselves are reproduced verbatim from
+/// <c>ServerHealthStatus</c> so a viewer card colours a metric exactly as the Dashboard would.</para>
 /// </summary>
 public sealed partial class ViewerDataService
 {
@@ -41,23 +53,69 @@ WHERE server_id = $1
 ORDER BY sample_time DESC
 LIMIT 1";
 
-    /// <summary>Latest total server memory (MB) for one server. $1 server_id.</summary>
+    /// <summary>Latest total server memory + buffer pool (MB) for one server. $1 server_id.</summary>
     public const string ServerSummaryMemorySql = @"
-SELECT CAST(total_server_memory_mb AS double precision)
+SELECT
+    CAST(total_server_memory_mb AS double precision),
+    CAST(buffer_pool_mb AS double precision)
 FROM v_memory_stats
 WHERE server_id = $1
 ORDER BY collection_time DESC
 LIMIT 1";
 
     /// <summary>
-    /// Blocking events in the window: XE blocked-process reports, falling back to the always-on DMV
-    /// blocking snapshot count when the XE count is zero (AWS RDS has no XE) — Lite's
-    /// <c>COALESCE(NULLIF(...))</c> shape. $1 server_id, $2 window start (naive UTC).
+    /// The latest resource-semaphore pressure for one server — the workspace-memory signal the Dashboard's
+    /// <c>get_resource_semaphore</c> / <c>ServerHealthStatus.MemorySeverity</c> reads: grant waiters,
+    /// timeout-error and forced-grant deltas, and total granted MB, summed across every pool at the newest
+    /// collection instant. The Dashboard live-sums <c>sys.dm_exec_query_resource_semaphores.waiter_count</c>
+    /// (WHERE max_target_memory_kb IS NOT NULL, which the <c>memory_grant_stats</c> collector already
+    /// applies at capture); the viewer sums the collected per-pool rows at MAX(collection_time). $1 server_id.
+    /// </summary>
+    public const string ServerSummaryMemoryPressureSql = @"
+SELECT
+    CAST(COALESCE(SUM(waiter_count), 0) AS bigint),
+    CAST(COALESCE(SUM(timeout_error_count_delta), 0) AS bigint),
+    CAST(COALESCE(SUM(forced_grant_count_delta), 0) AS bigint),
+    CAST(COALESCE(SUM(granted_memory_mb), 0) AS double precision)
+FROM v_memory_grant_stats
+WHERE server_id = $1
+AND   collection_time = (SELECT MAX(collection_time) FROM v_memory_grant_stats WHERE server_id = $1)";
+
+    /// <summary>
+    /// The latest worker-thread pressure for one server — the Dashboard's Threads row inputs
+    /// (<c>ServerHealthStatus.ThreadsSeverity</c>) from the newest <c>cpu_scheduler_stats</c> snapshot:
+    /// total worker ceiling (<c>max_workers_count</c>), workers in use (<c>total_current_workers_count</c> —
+    /// available = ceiling − in-use, the same figure the collector's own worker-thread-exhaustion warning
+    /// bands on at 90%), runnable tasks waiting for CPU (<c>total_runnable_tasks_count</c>), and requests
+    /// starved of a worker (<c>total_work_queue_count</c>). A point-in-time snapshot collector, so the
+    /// newest row is the current state. NULL/absent on Azure SQL DB (the collector does not apply there),
+    /// which the card renders as "--". $1 server_id.
+    /// </summary>
+    public const string ServerSummaryThreadsSql = @"
+SELECT
+    max_workers_count,
+    total_current_workers_count,
+    total_runnable_tasks_count,
+    total_work_queue_count
+FROM v_cpu_scheduler_stats
+WHERE server_id = $1
+ORDER BY collection_time DESC
+LIMIT 1";
+
+    /// <summary>
+    /// Blocking events in the window with their worst wait — XE blocked-process reports preferred, the
+    /// always-on DMV blocking snapshot as fallback (AWS RDS has no XE), keeping Lite's XE→DMV fallback but
+    /// returning the COUNT and the MAX wait (ms) from the SAME source so the card's count and its
+    /// "max: Ns" duration can never come from different feeds. The caller applies the fallback in C#
+    /// (identical to Lite's <c>COALESCE(NULLIF(xe,0), dmv)</c>: use XE when it has any row, else DMV).
+    /// $1 server_id, $2 window start (naive UTC).
     /// </summary>
     public const string ServerSummaryBlockingSql = @"
-SELECT COALESCE(NULLIF(
-    (SELECT COUNT(*) FROM v_blocked_process_reports WHERE server_id = $1 AND event_time >= $2), 0),
-    (SELECT COUNT(*) FROM v_dmv_blocking_snapshots WHERE server_id = $1 AND event_time >= $2))";
+SELECT
+    (SELECT COUNT(*)          FROM v_blocked_process_reports WHERE server_id = $1 AND event_time >= $2),
+    (SELECT MAX(wait_time_ms) FROM v_blocked_process_reports WHERE server_id = $1 AND event_time >= $2),
+    (SELECT COUNT(*)          FROM v_dmv_blocking_snapshots   WHERE server_id = $1 AND event_time >= $2),
+    (SELECT MAX(wait_time_ms) FROM v_dmv_blocking_snapshots   WHERE server_id = $1 AND event_time >= $2)";
 
     /// <summary>Deadlock count in the window. $1 server_id, $2 window start (naive UTC).</summary>
     public const string ServerSummaryDeadlockSql = @"
@@ -73,10 +131,13 @@ FROM v_collection_log
 WHERE server_id = $1";
 
     /// <summary>
-    /// One server's Overview-card summary — Lite's <c>GetServerSummaryAsync</c> ported to Postgres. The
-    /// caller sets <see cref="ServerSummaryItem.ServerName"/> and applies the freshness-derived status
+    /// One server's Overview-card summary — Lite's <c>GetServerSummaryAsync</c> ported to Postgres and
+    /// enriched toward the Dashboard's <c>ServerHealthCard</c>. The caller sets
+    /// <see cref="ServerSummaryItem.ServerName"/> and applies the freshness-derived status
     /// (<see cref="ServerSummaryItem.ApplyFreshness"/>) after the read, exactly where Lite set IsOnline
-    /// from the live ping. Blocking / deadlock counts use a one-hour window (Lite's window).
+    /// from the live ping. Blocking / deadlock counts use a one-hour window (Lite's window); the Threads /
+    /// Memory-pressure reads take the newest snapshot; the Collectors row REUSES the viewer's 7-day
+    /// <see cref="GetCollectionHealthAsync"/> banding.
     /// </summary>
     public async Task<ServerSummaryItem> GetServerSummaryAsync(int serverId, string displayName, CancellationToken cancellationToken = default)
     {
@@ -85,9 +146,21 @@ WHERE server_id = $1";
         double? cpuPercent = null;
         double? otherProcessCpuPercent = null;
         double? memoryMb = null;
+        double? bufferPoolMb = null;
         var blockingCount = 0;
+        long maxBlockingWaitMs = 0;
         var deadlockCount = 0;
         DateTime? lastCollection = null;
+
+        int? totalThreads = null;
+        int? currentWorkers = null;
+        var threadsWaitingForCpu = 0;
+        long requestsWaitingForThreads = 0;
+
+        long memoryWaiterCount = 0;
+        long memoryTimeoutCount = 0;
+        long memoryForcedCount = 0;
+        double? grantedMemoryMb = null;
 
         /* Latest CPU — SQL and other-process, so the card can show total non-idle CPU with the SQL-only
            number alongside (Lite's headline). */
@@ -102,24 +175,72 @@ WHERE server_id = $1";
             }
         }
 
-        /* Latest total server memory. */
+        /* Latest total server memory + buffer pool. */
         await using (var command = _dataSource.CreateCommand(ServerSummaryMemorySql))
         {
             command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
-            var result = await command.ExecuteScalarAsync(cancellationToken);
-            if (result is not null && result != DBNull.Value)
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            if (await reader.ReadAsync(cancellationToken))
             {
-                memoryMb = Convert.ToDouble(result);
+                memoryMb = reader.IsDBNull(0) ? null : Convert.ToDouble(reader.GetValue(0));
+                bufferPoolMb = reader.IsDBNull(1) ? null : Convert.ToDouble(reader.GetValue(1));
             }
         }
 
-        /* Blocking count in the last hour (XE, DMV fallback). */
+        /* Latest resource-semaphore pressure (grant waiters / timeouts / forced grants + granted MB). */
+        await using (var command = _dataSource.CreateCommand(ServerSummaryMemoryPressureSql))
+        {
+            command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            if (await reader.ReadAsync(cancellationToken))
+            {
+                memoryWaiterCount = reader.IsDBNull(0) ? 0 : Convert.ToInt64(reader.GetValue(0));
+                memoryTimeoutCount = reader.IsDBNull(1) ? 0 : Convert.ToInt64(reader.GetValue(1));
+                memoryForcedCount = reader.IsDBNull(2) ? 0 : Convert.ToInt64(reader.GetValue(2));
+                grantedMemoryMb = reader.IsDBNull(3) ? null : Convert.ToDouble(reader.GetValue(3));
+            }
+        }
+
+        /* Latest worker-thread pressure (max / in-use / runnable-waiting / work-queue). Absent on Azure. */
+        await using (var command = _dataSource.CreateCommand(ServerSummaryThreadsSql))
+        {
+            command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            if (await reader.ReadAsync(cancellationToken))
+            {
+                totalThreads = reader.IsDBNull(0) ? null : Convert.ToInt32(reader.GetValue(0));
+                currentWorkers = reader.IsDBNull(1) ? null : Convert.ToInt32(reader.GetValue(1));
+                threadsWaitingForCpu = reader.IsDBNull(2) ? 0 : Convert.ToInt32(reader.GetValue(2));
+                requestsWaitingForThreads = reader.IsDBNull(3) ? 0 : Convert.ToInt64(reader.GetValue(3));
+            }
+        }
+
+        /* Blocking count + worst wait in the last hour (XE preferred, DMV fallback — same source for both). */
         await using (var command = _dataSource.CreateCommand(ServerSummaryBlockingSql))
         {
             command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
             command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = windowStart });
-            var result = await command.ExecuteScalarAsync(cancellationToken);
-            blockingCount = result is null || result == DBNull.Value ? 0 : Convert.ToInt32(result);
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            if (await reader.ReadAsync(cancellationToken))
+            {
+                var xeCount = reader.IsDBNull(0) ? 0 : Convert.ToInt32(reader.GetValue(0));
+                var xeMaxWait = reader.IsDBNull(1) ? 0L : Convert.ToInt64(reader.GetValue(1));
+                var dmvCount = reader.IsDBNull(2) ? 0 : Convert.ToInt32(reader.GetValue(2));
+                var dmvMaxWait = reader.IsDBNull(3) ? 0L : Convert.ToInt64(reader.GetValue(3));
+
+                /* Lite's fallback: use XE when it has any row this window, else the DMV snapshot. Both the
+                   count and the max wait come from whichever source wins, so they never disagree. */
+                if (xeCount > 0)
+                {
+                    blockingCount = xeCount;
+                    maxBlockingWaitMs = xeMaxWait;
+                }
+                else
+                {
+                    blockingCount = dmvCount;
+                    maxBlockingWaitMs = dmvMaxWait;
+                }
+            }
         }
 
         /* Deadlock count in the last hour. */
@@ -142,6 +263,11 @@ WHERE server_id = $1";
             }
         }
 
+        /* Collectors row — REUSE the viewer's own 7-day per-collector health banding (the same STALE /
+           FAILING / NEVER_RUN / HEALTHY logic the Collection Health tab renders), mirroring the Dashboard's
+           SUM(CASE health_status = 'HEALTHY' / 'FAILING') over report.collection_health. */
+        var (healthyCollectors, failingCollectors) = await GetCollectorHealthCountsAsync(serverId, cancellationToken);
+
         return new ServerSummaryItem
         {
             DisplayName = displayName,
@@ -149,10 +275,38 @@ WHERE server_id = $1";
             CpuPercent = cpuPercent,
             OtherProcessCpuPercent = otherProcessCpuPercent,
             MemoryMb = memoryMb,
+            BufferPoolMb = bufferPoolMb,
+            GrantedMemoryMb = grantedMemoryMb,
+            MemoryWaiterCount = memoryWaiterCount,
+            MemoryTimeoutCount = memoryTimeoutCount,
+            MemoryForcedCount = memoryForcedCount,
             BlockingCount = blockingCount,
+            MaxBlockingWaitMs = maxBlockingWaitMs,
             DeadlockCount = deadlockCount,
+            TotalThreads = totalThreads,
+            CurrentWorkers = currentWorkers,
+            ThreadsWaitingForCpu = threadsWaitingForCpu,
+            RequestsWaitingForThreads = requestsWaitingForThreads,
+            HealthyCollectorCount = healthyCollectors,
+            FailedCollectorCount = failingCollectors,
             LastCollectionTime = lastCollection,
         };
+    }
+
+    /// <summary>
+    /// Healthy / failing collector counts for one server, derived from the viewer's own 7-day collection
+    /// health banding (<see cref="GetCollectionHealthAsync"/> → <see cref="CollectorHealthRow.HealthStatus"/>).
+    /// Mirrors the Dashboard's <c>GetCollectorStatusAsync</c> (SUM of HEALTHY / FAILING over
+    /// <c>report.collection_health</c>) — HEALTHY and FAILING are the two bands the card surfaces; the
+    /// STALE / WARNING / NO_PERMISSIONS / NEVER_RUN rows count as neither (a failing collector is one the
+    /// banding calls FAILING: no success in over 24h).
+    /// </summary>
+    private async Task<(int Healthy, int Failing)> GetCollectorHealthCountsAsync(int serverId, CancellationToken cancellationToken)
+    {
+        var rows = await GetCollectionHealthAsync(serverId, cancellationToken);
+        var healthy = rows.Count(r => r.HealthStatus == "HEALTHY");
+        var failing = rows.Count(r => r.HealthStatus == "FAILING");
+        return (healthy, failing);
     }
 }
 
@@ -170,14 +324,30 @@ public enum ServerFreshness
 }
 
 /// <summary>
+/// Per-metric health bands for the Overview card's severity dots, a verbatim mirror of the Dashboard's
+/// <c>PerformanceMonitorDashboard.Models.HealthSeverity</c>. <see cref="Unknown"/> is a metric with no
+/// collected data (e.g. Threads on Azure SQL DB) — a grey dot, and it never escalates the card's overall
+/// band.
+/// </summary>
+public enum HealthSeverity
+{
+    Unknown,
+    Healthy,
+    Warning,
+    Critical,
+}
+
+/// <summary>
 /// One Overview server card's view-model — copied from Lite's <c>ServerSummaryItem</c>
-/// (Lite/Services/LocalDataService.Overview.cs) with two viewer adaptations, both from the headless
-/// plan (#1262): <see cref="CpuPercentForAlert"/> is always total non-idle CPU (the viewer has no
-/// per-app <c>CpuAlertMode</c> preference — total is what the alert engine evaluates by default), and
-/// the status is derived from collection freshness rather than a live ping (see
-/// <see cref="ClassifyFreshness"/> / <see cref="ApplyFreshness"/>, which set Lite's own
-/// (<see cref="IsOnline"/>, <see cref="HasCollectorErrors"/>) inputs). Every display property and brush
-/// is otherwise Lite's verbatim.
+/// (Lite/Services/LocalDataService.Overview.cs) and enriched toward the Dashboard's
+/// <c>ServerHealthStatus</c> (Threads / Collectors rows, the resource-semaphore Memory signal, blocking
+/// duration, and a per-metric severity band for each row's dot). Two viewer adaptations carry over from
+/// the headless plan (#1262): <see cref="CpuPercentForAlert"/> is always total non-idle CPU (the viewer
+/// has no per-app <c>CpuAlertMode</c> preference — total is what the alert engine evaluates by default),
+/// and the connection status is derived from collection freshness rather than a live ping (see
+/// <see cref="ClassifyFreshness"/> / <see cref="ApplyFreshness"/>). Every severity BAND reproduces
+/// <c>ServerHealthStatus</c>'s deterministic CASE logic so a viewer card colours a metric exactly as the
+/// Dashboard would; every display / brush is otherwise a pure format of the stored values.
 /// </summary>
 public sealed class ServerSummaryItem
 {
@@ -193,6 +363,12 @@ public sealed class ServerSummaryItem
 
     /// <summary>Older than this (or no collection at all) = the server is treated as Offline.</summary>
     public static readonly TimeSpan OfflineThreshold = TimeSpan.FromMinutes(15);
+
+    /* Per-severity dot / value brushes, frozen once (the viewer's dark-theme palette). */
+    private static readonly SolidColorBrush s_criticalBrush = MakeBrush("#E57373");
+    private static readonly SolidColorBrush s_warningBrush = MakeBrush("#FFB74D");
+    private static readonly SolidColorBrush s_healthyBrush = MakeBrush("#81C784");
+    private static readonly SolidColorBrush s_unknownBrush = MakeBrush("#888888");
 
     public string DisplayName { get; set; } = "";
     public string ServerName { get; set; } = "";
@@ -220,8 +396,51 @@ public sealed class ServerSummaryItem
     public double? CpuPercentForAlert => TotalCpuPercent ?? CpuPercent;
 
     public double? MemoryMb { get; set; }
+
+    /// <summary>Latest buffer-pool MB (v_memory_stats.buffer_pool_mb) — the "BP" figure in the Memory detail.</summary>
+    public double? BufferPoolMb { get; set; }
+
+    /// <summary>Total granted query-memory MB across all pools at the newest grant snapshot — the "QMG" figure.</summary>
+    public double? GrantedMemoryMb { get; set; }
+
+    /// <summary>Grant waiters at the newest snapshot — the primary resource-semaphore pressure signal.</summary>
+    public long MemoryWaiterCount { get; set; }
+
+    /// <summary>Grant timeout-error delta at the newest snapshot (a query gave up waiting for memory).</summary>
+    public long MemoryTimeoutCount { get; set; }
+
+    /// <summary>Forced-grant delta at the newest snapshot (a grant was forced through under pressure).</summary>
+    public long MemoryForcedCount { get; set; }
+
     public int BlockingCount { get; set; }
+
+    /// <summary>The worst blocking wait (ms) observed in the window — the "max: Ns" detail + Critical band input.</summary>
+    public long MaxBlockingWaitMs { get; set; }
+
     public int DeadlockCount { get; set; }
+
+    /// <summary>Worker-thread ceiling (max_workers_count). NULL = no scheduler snapshot (e.g. Azure SQL DB).</summary>
+    public int? TotalThreads { get; set; }
+
+    /// <summary>Workers in use (total_current_workers_count); available = ceiling − in-use.</summary>
+    public int? CurrentWorkers { get; set; }
+
+    /// <summary>Runnable tasks waiting for a CPU (total_runnable_tasks_count).</summary>
+    public int ThreadsWaitingForCpu { get; set; }
+
+    /// <summary>Requests starved of a worker thread (total_work_queue_count) — thread-pool starvation.</summary>
+    public long RequestsWaitingForThreads { get; set; }
+
+    /// <summary>Available worker threads = ceiling − in-use, or NULL when there is no scheduler snapshot.</summary>
+    public int? AvailableThreads =>
+        TotalThreads.HasValue ? TotalThreads.Value - (CurrentWorkers ?? 0) : null;
+
+    /// <summary>Collectors whose 7-day band is HEALTHY (mirrors report.collection_health).</summary>
+    public int HealthyCollectorCount { get; set; }
+
+    /// <summary>Collectors whose 7-day band is FAILING (no success in over 24h).</summary>
+    public int FailedCollectorCount { get; set; }
+
     public DateTime? LastCollectionTime { get; set; }
 
     /// <summary>
@@ -238,9 +457,68 @@ public sealed class ServerSummaryItem
         }
     }
 
+    /// <summary>The non-SQL host CPU alongside the headline (the Dashboard's CPU detail), when known.</summary>
+    public string CpuDetail => OtherProcessCpuPercent.HasValue ? $"Other: {OtherProcessCpuPercent:F0}%" : "";
+
     public string MemoryDisplay => MemoryMb.HasValue ? $"{MemoryMb / 1024.0:F1} GB" : "--";
+
+    /// <summary>
+    /// The Memory detail: under resource-semaphore pressure it names the pressure (grant waiters, then
+    /// timeouts / forced grants when present) — mirroring the Dashboard's "N waiting"; when calm it shows
+    /// the buffer-pool and query-memory-grant sizes (the Dashboard's "BP: x, QMG: y").
+    /// </summary>
+    public string MemoryDetail
+    {
+        get
+        {
+            if (HasMemoryPressure)
+            {
+                var parts = new List<string>();
+                if (MemoryWaiterCount > 0) parts.Add($"{MemoryWaiterCount} grant waiter{(MemoryWaiterCount == 1 ? "" : "s")}");
+                if (MemoryTimeoutCount > 0) parts.Add($"{MemoryTimeoutCount} timeout{(MemoryTimeoutCount == 1 ? "" : "s")}");
+                if (MemoryForcedCount > 0) parts.Add($"{MemoryForcedCount} forced");
+                return string.Join(", ", parts);
+            }
+
+            var sizes = new List<string>();
+            if (BufferPoolMb.HasValue) sizes.Add($"BP {BufferPoolMb.Value / 1024.0:F1}");
+            if (GrantedMemoryMb is > 0) sizes.Add($"QMG {GrantedMemoryMb.Value / 1024.0:F1}");
+            return sizes.Count > 0 ? string.Join(", ", sizes) + " GB" : "";
+        }
+    }
+
     public string BlockingDisplay => BlockingCount > 0 ? BlockingCount.ToString() : "0";
+
+    /// <summary>The worst blocking wait in the window, e.g. "max: 42s"; blank when the window is clear.</summary>
+    public string BlockingDetail => BlockingCount > 0 ? $"max: {MaxBlockedSeconds:F0}s" : "";
+
+    /// <summary>The worst blocking wait in the window, in seconds.</summary>
+    public double MaxBlockedSeconds => MaxBlockingWaitMs / 1000.0;
+
     public string DeadlockDisplay => DeadlockCount > 0 ? DeadlockCount.ToString() : "0";
+
+    /// <summary>Threads value — the pressure headline (Dashboard's ThreadsDisplayText), or "--" with no snapshot.</summary>
+    public string ThreadsDisplay
+    {
+        get
+        {
+            if (!TotalThreads.HasValue) return "--";
+            if (RequestsWaitingForThreads > 0) return $"{RequestsWaitingForThreads} starved";
+            if (ThreadsWaitingForCpu >= 20) return $"{ThreadsWaitingForCpu} runnable";
+            if (TotalThreads.Value > 0 && AvailableThreads < TotalThreads.Value * 0.10) return "Low";
+            return "OK";
+        }
+    }
+
+    /// <summary>Threads detail — "Available: in/ceiling" (Dashboard's ThreadsDetailText); blank with no snapshot.</summary>
+    public string ThreadsDetail =>
+        TotalThreads is > 0 ? $"Available: {AvailableThreads}/{TotalThreads}" : "";
+
+    /// <summary>Collectors value — "N failed" or "OK" (Dashboard's CollectorDisplayText).</summary>
+    public string CollectorDisplay => FailedCollectorCount > 0 ? $"{FailedCollectorCount} failed" : "OK";
+
+    /// <summary>Collectors detail — "Healthy: N, Failing: M" (Dashboard's CollectorDetailText).</summary>
+    public string CollectorDetail => $"Healthy: {HealthyCollectorCount}, Failing: {FailedCollectorCount}";
 
     /// <summary>
     /// The stored collection_time is naive UTC; the viewer shows it in the viewer machine's local time
@@ -269,27 +547,125 @@ public sealed class ServerSummaryItem
 
     public bool IsOffline => IsOnline == false;
 
-    /* Color coding — verbatim from Lite. */
-    public SolidColorBrush CpuBrush
+    // ── Per-metric severity bands (verbatim mirrors of ServerHealthStatus's CASE logic) ──────────────
+
+    /// <summary>CPU band — total non-idle CPU: ≥95% Critical, ≥80% Warning (ServerHealthStatus.CpuSeverity).</summary>
+    public HealthSeverity CpuSeverity
     {
         get
         {
-            var v = CpuPercentForAlert;
-            return MakeBrush(v >= 80 ? "#E57373" : v >= 50 ? "#FFB74D" : "#81C784");
+            var total = CpuPercentForAlert;
+            if (!total.HasValue) return HealthSeverity.Unknown;
+            if (total >= 95) return HealthSeverity.Critical;
+            if (total >= 80) return HealthSeverity.Warning;
+            return HealthSeverity.Healthy;
         }
     }
 
-    public SolidColorBrush BlockingBrush => MakeBrush(BlockingCount > 0 ? "#FFB74D" : "#81C784");
-    public SolidColorBrush DeadlockBrush => MakeBrush(DeadlockCount > 0 ? "#E57373" : "#81C784");
-    public SolidColorBrush CardBorderBrush => MakeBrush(
-        IsOnline == false ? "#E57373" :
-        DeadlockCount > 0 ? "#E57373" :
-        BlockingCount > 0 ? "#FFB74D" :
-        CpuPercentForAlert >= 80 ? "#FFB74D" :
-        HasCollectorErrors ? "#FFD54F" :   // amber border when the collection is stale
-        "#2a2d35");
+    /// <summary>True when the resource semaphore shows grant waiters, timeouts, or forced grants.</summary>
+    public bool HasMemoryPressure => MemoryWaiterCount > 0 || MemoryTimeoutCount > 0 || MemoryForcedCount > 0;
+
+    /// <summary>
+    /// Memory band — Critical on resource-semaphore pressure, else Healthy. The Dashboard's
+    /// <c>MemorySeverity</c> flags Critical on <c>waiter_count &gt; 0</c>; the viewer additionally treats
+    /// recent grant timeouts / forced grants (collected as deltas) as the same workspace-memory pressure.
+    /// </summary>
+    public HealthSeverity MemorySeverity =>
+        HasMemoryPressure ? HealthSeverity.Critical : HealthSeverity.Healthy;
+
+    /// <summary>
+    /// Blocking band — mirrors <c>ServerHealthStatus.BlockingSeverity</c>: ≥60s max wait or ≥5 events
+    /// Critical; ≥10s max wait, ≥2 events, or any blocking at all Warning.
+    /// </summary>
+    public HealthSeverity BlockingSeverity
+    {
+        get
+        {
+            if (MaxBlockedSeconds >= 60) return HealthSeverity.Critical;
+            if (BlockingCount >= 5) return HealthSeverity.Critical;
+            if (MaxBlockedSeconds >= 10) return HealthSeverity.Warning;
+            if (BlockingCount >= 2) return HealthSeverity.Warning;
+            if (BlockingCount > 0) return HealthSeverity.Warning;
+            return HealthSeverity.Healthy;
+        }
+    }
+
+    /// <summary>
+    /// Deadlock band — any deadlock in the window is Critical. The Dashboard bands on a cumulative-counter
+    /// delta + minutes-since; the viewer has a windowed count (one-hour window), so a deadlock this window
+    /// is the viewer's Critical, matching Lite's red-when-&gt;0 emphasis.
+    /// </summary>
+    public HealthSeverity DeadlockSeverity =>
+        DeadlockCount > 0 ? HealthSeverity.Critical : HealthSeverity.Healthy;
+
+    /// <summary>
+    /// Threads band — mirrors <c>ServerHealthStatus.ThreadsSeverity</c>: work-queue starvation Critical;
+    /// ≥20 runnable-waiting or under 10% workers available Warning. Unknown when there is no snapshot.
+    /// </summary>
+    public HealthSeverity ThreadsSeverity
+    {
+        get
+        {
+            if (!TotalThreads.HasValue) return HealthSeverity.Unknown;
+            if (RequestsWaitingForThreads > 0) return HealthSeverity.Critical;
+            if (ThreadsWaitingForCpu >= 20) return HealthSeverity.Warning;
+            if (TotalThreads.Value > 0 && AvailableThreads < TotalThreads.Value * 0.10) return HealthSeverity.Warning;
+            return HealthSeverity.Healthy;
+        }
+    }
+
+    /// <summary>Collectors band — any FAILING collector is Warning (ServerHealthStatus.CollectorSeverity).</summary>
+    public HealthSeverity CollectorSeverity =>
+        FailedCollectorCount > 0 ? HealthSeverity.Warning : HealthSeverity.Healthy;
+
+    /// <summary>
+    /// The card's worst metric band (offline handled separately by the border / overlay). Unknown and
+    /// Healthy never escalate — matching <c>ServerHealthStatus.OverallSeverity</c>'s reduce.
+    /// </summary>
+    public HealthSeverity OverallMetricSeverity
+    {
+        get
+        {
+            var worst = HealthSeverity.Healthy;
+            foreach (var s in new[] { CpuSeverity, MemorySeverity, BlockingSeverity, ThreadsSeverity, DeadlockSeverity, CollectorSeverity })
+            {
+                if (s == HealthSeverity.Critical) return HealthSeverity.Critical;
+                if (s == HealthSeverity.Warning) worst = HealthSeverity.Warning;
+            }
+            return worst;
+        }
+    }
+
+    // ── Per-metric dot / value brushes ───────────────────────────────────────────────────────────────
+
+    public SolidColorBrush CpuSeverityBrush => SeverityBrush(CpuSeverity);
+    public SolidColorBrush MemorySeverityBrush => SeverityBrush(MemorySeverity);
+    public SolidColorBrush BlockingSeverityBrush => SeverityBrush(BlockingSeverity);
+    public SolidColorBrush DeadlockSeverityBrush => SeverityBrush(DeadlockSeverity);
+    public SolidColorBrush ThreadsSeverityBrush => SeverityBrush(ThreadsSeverity);
+    public SolidColorBrush CollectorSeverityBrush => SeverityBrush(CollectorSeverity);
 
     public bool HasAlerts => BlockingCount > 0 || DeadlockCount > 0;
+
+    /// <summary>
+    /// The card border reflects the worst signal: offline (red) &gt; a Critical metric (red) &gt; a Warning
+    /// metric (amber-orange) &gt; a stale collection (amber) &gt; calm (dark). Enriches Lite's border (which
+    /// only knew CPU / blocking / deadlock) with the added Threads / Memory / Collectors bands via
+    /// <see cref="OverallMetricSeverity"/>.
+    /// </summary>
+    public SolidColorBrush CardBorderBrush
+    {
+        get
+        {
+            if (IsOnline == false) return s_criticalBrush;
+            return OverallMetricSeverity switch
+            {
+                HealthSeverity.Critical => s_criticalBrush,
+                HealthSeverity.Warning => s_warningBrush,
+                _ => HasCollectorErrors ? MakeBrush("#FFD54F") : MakeBrush("#2a2d35"),
+            };
+        }
+    }
 
     /// <summary>
     /// The viewer's status derivation (#1262): classify how fresh the newest collection is. Pure over
@@ -317,6 +693,14 @@ public sealed class ServerSummaryItem
         IsOnline = freshness != ServerFreshness.Offline;
         HasCollectorErrors = freshness == ServerFreshness.Stale;
     }
+
+    private static SolidColorBrush SeverityBrush(HealthSeverity severity) => severity switch
+    {
+        HealthSeverity.Critical => s_criticalBrush,
+        HealthSeverity.Warning => s_warningBrush,
+        HealthSeverity.Healthy => s_healthyBrush,
+        _ => s_unknownBrush,
+    };
 
     private static SolidColorBrush MakeBrush(string hex)
     {

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Overview.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Overview.cs
@@ -103,26 +103,34 @@ ORDER BY collection_time DESC
 LIMIT 1";
 
     /// <summary>
-    /// Blocking events in the window with their worst wait — XE blocked-process reports preferred, the
-    /// always-on DMV blocking snapshot as fallback (AWS RDS has no XE), keeping Lite's XE→DMV fallback but
-    /// returning the COUNT and the MAX wait (ms) from the SAME source so the card's count and its
-    /// "max: Ns" duration can never come from different feeds. The caller applies the fallback in C#
-    /// (identical to Lite's <c>COALESCE(NULLIF(xe,0), dmv)</c>: use XE when it has any row, else DMV).
-    /// $1 server_id, $2 window start (naive UTC).
+    /// Blocking in the window with its worst wait, plus the newest blocking event ever — XE blocked-process
+    /// reports preferred, the always-on DMV blocking snapshot as fallback (AWS RDS has no XE), keeping
+    /// Lite's XE→DMV fallback but returning the COUNT and the MAX wait (ms) from the SAME source so the
+    /// card's count and its "max: Ns" duration can never come from different feeds. The last two columns are
+    /// each source's newest event_time (unbounded — the same <c>MAX(event_time) WHERE server_id</c> read the
+    /// collector runs every cycle for its watermark), for the Dashboard's "Last: N ago" detail when the
+    /// window is clear. The caller applies the fallback in C# (identical to Lite's
+    /// <c>COALESCE(NULLIF(xe,0), dmv)</c>: use XE when it has any row, else DMV). $1 server_id, $2 window
+    /// start (naive UTC).
     /// </summary>
     public const string ServerSummaryBlockingSql = @"
 SELECT
     (SELECT COUNT(*)          FROM v_blocked_process_reports WHERE server_id = $1 AND event_time >= $2),
     (SELECT MAX(wait_time_ms) FROM v_blocked_process_reports WHERE server_id = $1 AND event_time >= $2),
     (SELECT COUNT(*)          FROM v_dmv_blocking_snapshots   WHERE server_id = $1 AND event_time >= $2),
-    (SELECT MAX(wait_time_ms) FROM v_dmv_blocking_snapshots   WHERE server_id = $1 AND event_time >= $2)";
+    (SELECT MAX(wait_time_ms) FROM v_dmv_blocking_snapshots   WHERE server_id = $1 AND event_time >= $2),
+    (SELECT MAX(event_time)   FROM v_blocked_process_reports WHERE server_id = $1),
+    (SELECT MAX(event_time)   FROM v_dmv_blocking_snapshots   WHERE server_id = $1)";
 
-    /// <summary>Deadlock count in the window. $1 server_id, $2 window start (naive UTC).</summary>
+    /// <summary>
+    /// Deadlock count in the window plus the newest deadlock ever — the windowed count for the card value,
+    /// and the unbounded MAX(deadlock_time) for the Dashboard's "Last: N ago" detail. $1 server_id, $2
+    /// window start (naive UTC).
+    /// </summary>
     public const string ServerSummaryDeadlockSql = @"
-SELECT COUNT(*)
-FROM v_deadlocks
-WHERE server_id = $1
-AND   deadlock_time >= $2";
+SELECT
+    (SELECT COUNT(*)           FROM v_deadlocks WHERE server_id = $1 AND deadlock_time >= $2),
+    (SELECT MAX(deadlock_time) FROM v_deadlocks WHERE server_id = $1)";
 
     /// <summary>Newest collection time across all collectors for one server. $1 server_id.</summary>
     public const string ServerSummaryLastCollectionSql = @"
@@ -141,7 +149,8 @@ WHERE server_id = $1";
     /// </summary>
     public async Task<ServerSummaryItem> GetServerSummaryAsync(int serverId, string displayName, CancellationToken cancellationToken = default)
     {
-        var windowStart = DateTime.SpecifyKind(DateTime.UtcNow.AddHours(-1), DateTimeKind.Unspecified);
+        var nowUtc = DateTime.UtcNow;
+        var windowStart = DateTime.SpecifyKind(nowUtc.AddHours(-1), DateTimeKind.Unspecified);
 
         double? cpuPercent = null;
         double? otherProcessCpuPercent = null;
@@ -149,7 +158,9 @@ WHERE server_id = $1";
         double? bufferPoolMb = null;
         var blockingCount = 0;
         long maxBlockingWaitMs = 0;
+        int? lastBlockingMinutesAgo = null;
         var deadlockCount = 0;
+        int? lastDeadlockMinutesAgo = null;
         DateTime? lastCollection = null;
 
         int? totalThreads = null;
@@ -240,16 +251,30 @@ WHERE server_id = $1";
                     blockingCount = dmvCount;
                     maxBlockingWaitMs = dmvMaxWait;
                 }
+
+                /* Newest blocking event across both sources (unbounded) → "Last: N ago" when the window is
+                   clear. Stored times are naive UTC; the tick subtraction against UtcNow is a true elapsed. */
+                DateTime? lastBlocking = reader.IsDBNull(4) ? null : reader.GetDateTime(4);
+                var dmvLast = reader.IsDBNull(5) ? (DateTime?)null : reader.GetDateTime(5);
+                if (dmvLast.HasValue && (!lastBlocking.HasValue || dmvLast.Value > lastBlocking.Value))
+                {
+                    lastBlocking = dmvLast;
+                }
+                lastBlockingMinutesAgo = MinutesAgo(lastBlocking, nowUtc);
             }
         }
 
-        /* Deadlock count in the last hour. */
+        /* Deadlock count in the last hour + the newest deadlock ever (for "Last: N ago"). */
         await using (var command = _dataSource.CreateCommand(ServerSummaryDeadlockSql))
         {
             command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
             command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = windowStart });
-            var result = await command.ExecuteScalarAsync(cancellationToken);
-            deadlockCount = result is null || result == DBNull.Value ? 0 : Convert.ToInt32(result);
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            if (await reader.ReadAsync(cancellationToken))
+            {
+                deadlockCount = reader.IsDBNull(0) ? 0 : Convert.ToInt32(reader.GetValue(0));
+                lastDeadlockMinutesAgo = MinutesAgo(reader.IsDBNull(1) ? null : reader.GetDateTime(1), nowUtc);
+            }
         }
 
         /* Newest collection time across all collectors — drives the freshness status. */
@@ -282,7 +307,9 @@ WHERE server_id = $1";
             MemoryForcedCount = memoryForcedCount,
             BlockingCount = blockingCount,
             MaxBlockingWaitMs = maxBlockingWaitMs,
+            LastBlockingMinutesAgo = lastBlockingMinutesAgo,
             DeadlockCount = deadlockCount,
+            LastDeadlockMinutesAgo = lastDeadlockMinutesAgo,
             TotalThreads = totalThreads,
             CurrentWorkers = currentWorkers,
             ThreadsWaitingForCpu = threadsWaitingForCpu,
@@ -308,6 +335,12 @@ WHERE server_id = $1";
         var failing = rows.Count(r => r.HealthStatus == "FAILING");
         return (healthy, failing);
     }
+
+    /// <summary>Whole minutes elapsed from a stored naive-UTC instant to now (UTC), floored at 0, or null
+    /// when there is no instant. Both sides are UTC instants, so the tick subtraction is a true elapsed
+    /// regardless of Kind (the same reasoning the freshness classification documents).</summary>
+    private static int? MinutesAgo(DateTime? instantUtc, DateTime nowUtc) =>
+        instantUtc.HasValue ? Math.Max(0, (int)(nowUtc - instantUtc.Value).TotalMinutes) : null;
 }
 
 /// <summary>The three collection-freshness bands the viewer derives a card's status from.</summary>
@@ -417,7 +450,13 @@ public sealed class ServerSummaryItem
     /// <summary>The worst blocking wait (ms) observed in the window — the "max: Ns" detail + Critical band input.</summary>
     public long MaxBlockingWaitMs { get; set; }
 
+    /// <summary>Minutes since the most recent blocking event ever — the "Last: N ago" detail when the window is clear.</summary>
+    public int? LastBlockingMinutesAgo { get; set; }
+
     public int DeadlockCount { get; set; }
+
+    /// <summary>Minutes since the most recent deadlock ever — the "Last: N ago" deadlock detail.</summary>
+    public int? LastDeadlockMinutesAgo { get; set; }
 
     /// <summary>Worker-thread ceiling (max_workers_count). NULL = no scheduler snapshot (e.g. Azure SQL DB).</summary>
     public int? TotalThreads { get; set; }
@@ -489,13 +528,28 @@ public sealed class ServerSummaryItem
 
     public string BlockingDisplay => BlockingCount > 0 ? BlockingCount.ToString() : "0";
 
-    /// <summary>The worst blocking wait in the window, e.g. "max: 42s"; blank when the window is clear.</summary>
-    public string BlockingDetail => BlockingCount > 0 ? $"max: {MaxBlockedSeconds:F0}s" : "";
+    /// <summary>
+    /// The blocking detail (Dashboard's BlockingDetailText): the worst wait while blocking is present in
+    /// the window ("max: 42s"), else how long since the last blocking event ever ("Last: 3h ago"), else blank.
+    /// </summary>
+    public string BlockingDetail
+    {
+        get
+        {
+            if (BlockingCount > 0) return $"max: {MaxBlockedSeconds:F0}s";
+            if (LastBlockingMinutesAgo.HasValue) return $"Last: {FormatMinutesAgo(LastBlockingMinutesAgo.Value)}";
+            return "";
+        }
+    }
 
     /// <summary>The worst blocking wait in the window, in seconds.</summary>
     public double MaxBlockedSeconds => MaxBlockingWaitMs / 1000.0;
 
     public string DeadlockDisplay => DeadlockCount > 0 ? DeadlockCount.ToString() : "0";
+
+    /// <summary>The deadlock detail — how long since the last deadlock ever ("Last: N ago"), else blank.</summary>
+    public string DeadlockDetail =>
+        LastDeadlockMinutesAgo.HasValue ? $"Last: {FormatMinutesAgo(LastDeadlockMinutesAgo.Value)}" : "";
 
     /// <summary>Threads value — the pressure headline (Dashboard's ThreadsDisplayText), or "--" with no snapshot.</summary>
     public string ThreadsDisplay
@@ -701,6 +755,16 @@ public sealed class ServerSummaryItem
         HealthSeverity.Healthy => s_healthyBrush,
         _ => s_unknownBrush,
     };
+
+    /// <summary>Human "N ago" rendering of an elapsed minutes count — verbatim from ServerHealthStatus.</summary>
+    private static string FormatMinutesAgo(int minutes)
+    {
+        if (minutes < 1) return "just now";
+        if (minutes < 60) return $"{minutes}m ago";
+        if (minutes < 1440) return $"{minutes / 60}h ago";   // 24 hours
+        if (minutes < 10080) return $"{minutes / 1440}d ago"; // 7 days
+        return $"{minutes / 10080}w ago";
+    }
 
     private static SolidColorBrush MakeBrush(string hex)
     {


### PR DESCRIPTION
## What

Ports the Dashboard's richer `ServerHealthCard` onto the Darling viewer's per-server **Overview** cards. They were a thinner 5-row copy of Lite's `ServerSummaryItem` (CPU, Memory total MB, Blocking count, Deadlocks count, Last Collect). They now match the Dashboard's card: two added rows, a per-metric severity dot on every row, and richer Memory/Blocking/Deadlock detail — still in the viewer's dark style. The existing 5 rows are kept (this is a superset).

Reference: inventory port-candidate "Richer NOC per-server health cards"; Dashboard `Controls/ServerHealthCard.xaml` + `Models/ServerHealthStatus.cs`.

## Added rows / signals (each mirrors `ServerHealthStatus`'s deterministic band CASE logic)

- **Threads row** — available/total worker threads, runnable-tasks-waiting-for-CPU, work-queue starvation, with Critical/Warning bands (`ThreadsSeverity`, ServerHealthStatus:387). From the latest `cpu_scheduler_stats` snapshot.
- **Collectors row** — healthy/failing counts, Warning when any collector is FAILING (`CollectorSeverity`, :503). **Reuses** the viewer's own 7-day `CollectorHealthRow.HealthStatus` banding (`GetCollectionHealthAsync`), mirroring the Dashboard's `SUM(CASE health_status = 'HEALTHY'/'FAILING')` over `report.collection_health`.
- **Per-metric severity dot** — a colored dot on CPU/Threads/Memory/Blocking/Deadlocks/Collectors, driven by that metric's band (green/amber/red; grey = no data). The card border reflects the worst band (`OverallMetricSeverity`).
- **Richer Memory** — Critical on resource-semaphore pressure (grant `waiter_count` / `timeout_error_count_delta` / `forced_grant_count_delta`), not just total MB; detail shows the pressure or BP/QMG sizes.
- **Blocking duration** — "max: Ns" from `wait_time_ms`, folded into the count query so count and duration always come from the same XE-preferred / DMV-fallback source; duration also feeds the Critical/Warning band (:293).
- **Blocking / Deadlock "Last: N ago"** — the Dashboard's full detail text: when the window is clear, how long since the last blocking/deadlock event ever (`MAX(event_time)` / `MAX(deadlock_time)`, minutes-ago formatted verbatim from `FormatMinutesAgo`).

## The read (`ViewerDataService.Overview.cs`)

Extended `GetServerSummaryAsync`, parameterized, Postgres dialect. New/changed constants: `ServerSummaryThreadsSql`, `ServerSummaryMemoryPressureSql`, an extended `ServerSummaryMemorySql` (+`buffer_pool_mb`), a combined `ServerSummaryBlockingSql` (count + `MAX(wait_time_ms)` per source + each source's unbounded `MAX(event_time)`), and `ServerSummaryDeadlockSql` (windowed count + unbounded `MAX(deadlock_time)`). Collectors reuse `GetCollectionHealthAsync`. The unbounded `MAX(<time>) WHERE server_id` lookups are the same read the collector already runs every cycle for its watermark (`DarlingCollectorRunner.GetLastCollectedTimeAsync`) — proven, index-friendly, not a new full scan.

## Columns VERIFIED (against the collector definitions + `PgSchemaGenerator`)

- `cpu_scheduler_stats`: `max_workers_count`, `total_current_workers_count`, `total_runnable_tasks_count`, `total_work_queue_count` — all present. (Available = ceiling − in-use; the collector's own worker-exhaustion warning bands on `current_workers_count >= max*0.90`, confirming the semantics.)
- `memory_grant_stats`: `waiter_count`, `timeout_error_count_delta`, `forced_grant_count_delta`, `granted_memory_mb` — present.
- `memory_stats`: `buffer_pool_mb`, `total_server_memory_mb` — present.
- Blocking duration / last-event: `wait_time_ms` + `event_time` on both `blocked_process_reports` and `dmv_blocking_snapshots`; deadlock last-event: `deadlock_time` — present.

**No required metric was found uncollected** — every signal the task asked for exists in the store, and each was reproduced.

## Deliberate viewer adaptations (bands reproduced verbatim; only the source differs)

- The Dashboard health card live-queries *currently*-blocked sessions / current scheduler state; the viewer (headless, no live target connection) reads the newest **collected** snapshot instead. The severity *bands* are reproduced verbatim.
- The viewer extends the Memory Critical band to include grant timeout/forced deltas (the Dashboard live path only sums `waiter_count`); these delta columns are collected and are genuine workspace-memory pressure — called out in the task's "waiter/timeout/forced".

## Tests (`Darling.Tests/ViewerW2aTests.cs`)

- SQL pins for the new/changed reads (source view, positional params, verified columns, Pg dialect); column-existence via `PgSchemaGenerator.CreateTable`; passthrough views (`v_cpu_scheduler_stats`, `v_memory_grant_stats`) present in migrations.
- Severity-band CASE logic for Threads/Collectors/Memory/Blocking/CPU/Deadlocks + display/detail strings (incl. "max: Ns" / "Last: N ago") + the enriched card-border bands + dot palette.
- A gated (`DARLING_TEST_PG`) live round-trip planting scheduler/grant/blocking/collection-log rows and asserting the enriched summary (semaphore sums only the latest collection; the collectors-health reuse counts one HEALTHY + one FAILING; last-blocking read populated).

**Darling.Tests -c Release: 1448 passed, 115 skipped (all live-PG gated), 0 failed.** Whole Darling stack builds `-c Release`. Only Viewer + Darling.Tests touched — no Service/Storage/Config/Migrations files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
