### PR TITLE
Add "Open in Active Queries" deep-link to Darling recommendation cards

### DIFF
--- a/Darling/Darling.Tests/ViewerRecommendationsTests.cs
+++ b/Darling/Darling.Tests/ViewerRecommendationsTests.cs
@@ -196,6 +196,7 @@ public sealed class ViewerRecommendationCardTests
         Assert.Equal("ALTER DATABASE [StackOverflow] SET AUTO_SHRINK OFF;", item.CopyPasteSql);
         Assert.Equal("inc-1", item.IncidentId);
         Assert.Equal("SQL2022", item.ServerName);
+        Assert.Equal(1, item.ServerId);                                     // carried from the finding (drives the deep-link tab)
         Assert.Equal(DateTimeKind.Utc, item.WindowStartUtc!.Value.Kind);
         Assert.Equal(new DateTime(2026, 7, 1, 10, 0, 0), item.WindowStartUtc!.Value);
     }
@@ -228,6 +229,64 @@ public sealed class ViewerRecommendationCardTests
         Assert.False(noSql.ShowCopyFix);
         Assert.True(noSql.ShowAskAi);
     }
+
+    // ── "Open in Active Queries" deep-link affordance + window (Dashboard-parity port) ──────
+
+    [Fact]
+    public void Card_ShowOpenInActiveQueries_TrueOnlyWithBothATimeWindowAndAServerId()
+    {
+        var window = (new DateTime(2026, 7, 1, 10, 0, 0, DateTimeKind.Utc), new DateTime(2026, 7, 1, 12, 0, 0, DateTimeKind.Utc));
+
+        // Incident: has a time window AND a server id -> shown.
+        var incident = Card(serverId: 7, windowStart: window.Item1, windowEnd: window.Item2);
+        Assert.True(incident.ShowOpenInActiveQueries);
+        Assert.Equal(7, incident.ServerId);
+
+        // No time anchor (config-only finding read with no window) -> hidden.
+        var noWindow = Card(serverId: 7, windowStart: null, windowEnd: null);
+        Assert.False(noWindow.ShowOpenInActiveQueries);
+
+        // Half a window is not enough (defensive; the reader always maps both or neither) -> hidden.
+        Assert.False(Card(serverId: 7, windowStart: window.Item1, windowEnd: null).ShowOpenInActiveQueries);
+
+        // No server anchor (a real server id is never 0) -> hidden even with a window.
+        var noServer = Card(serverId: 0, windowStart: window.Item1, windowEnd: window.Item2);
+        Assert.False(noServer.ShowOpenInActiveQueries);
+    }
+
+    [Fact]
+    public void Card_DeepLinkWindowUtc_UsesTheFindingsOwnRangeWhenItCarriesOne()
+    {
+        var start = new DateTime(2026, 7, 1, 10, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2026, 7, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        var (from, to) = Card(serverId: 7, windowStart: start, windowEnd: end).DeepLinkWindowUtc();
+
+        Assert.Equal(start, from);
+        Assert.Equal(end, to);
+    }
+
+    [Fact]
+    public void Card_DeepLinkWindowUtc_WidensADegeneratePointByTheDrillHalfWindow()
+    {
+        // start == end (a point) -> widen to +/- #1409's DrillDownHalfWindowMinutes so the read isn't empty.
+        var point = new DateTime(2026, 7, 1, 11, 0, 0, DateTimeKind.Utc);
+
+        var (from, to) = Card(serverId: 7, windowStart: point, windowEnd: point).DeepLinkWindowUtc();
+
+        Assert.Equal(point.AddMinutes(-ViewerServerTab.DrillDownHalfWindowMinutes), from);
+        Assert.Equal(point.AddMinutes(ViewerServerTab.DrillDownHalfWindowMinutes), to);
+    }
+
+    private static RecommendationCardViewModel Card(int serverId, DateTime? windowStart, DateTime? windowEnd)
+        => new(new RecommendationItem
+        {
+            Severity = RecommendationSeverity.Warning,
+            Title = "CPU is on fire",
+            ServerId = serverId,
+            WindowStartUtc = windowStart,
+            WindowEndUtc = windowEnd,
+        });
 
     [Theory]
     [InlineData(RecommendationSeverity.Critical, "CRITICAL", "")]

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
@@ -626,7 +626,7 @@
                      selector (independent of the sidebar), a Refresh button, and a status line that
                      shows the last analysis time; then a scrollable list of collapsible Expander
                      sections grouped by incident, each holding severity-banded cards (badge + [db] +
-                     title + advice + Copy fix + Ask AI). Advise-only: no Apply, and (per the re-skin
+                     title + advice + Open in Active Queries + Copy fix + Ask AI). Advise-only: no Apply, and (per the re-skin
                      brief) no mute — mute lives on the Alert History surface. Card templates copy Lite's
                      RecommendationsTab.xaml and resolve their {DynamicResource} theme keys from the
                      app-merged Dark theme. NO "Generate now": the Darling service runs analysis on its
@@ -638,8 +638,9 @@
                         <BooleanToVisibilityConverter x:Key="RecoBoolToVis"/>
 
                         <!-- One card: severity badge + [database] + title + advice, then advise-only
-                             affordances (Copy fix when derivable + Ask AI). Copied from Lite's
-                             LiteRecommendationCardTemplate. -->
+                             affordances (Open in Active Queries for incidents + Copy fix when derivable +
+                             Ask AI). Copied from Lite's LiteRecommendationCardTemplate; the Open-in-Active-
+                             Queries deep-link is the Dashboard incident affordance ported to the viewer. -->
                         <DataTemplate x:Key="RecoCardTemplate">
                             <Border Background="{DynamicResource BackgroundLightBrush}"
                                     BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"
@@ -677,8 +678,13 @@
                                                Visibility="{Binding HasAdvice, Converter={StaticResource RecoBoolToVis}}"
                                                Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
 
-                                    <!-- Affordances (advise-only): Copy fix (when derivable) + Ask AI. -->
+                                    <!-- Affordances (advise-only): Open in Active Queries (incidents), Copy
+                                         fix (when derivable), Ask AI. -->
                                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,8,0,0">
+                                        <Button Content="Open in Active Queries" Padding="10,3" Margin="0,0,8,0"
+                                                Visibility="{Binding ShowOpenInActiveQueries, Converter={StaticResource RecoBoolToVis}}"
+                                                Click="OpenInActiveQueries_Click"
+                                                ToolTip="Open this server's Active Queries scoped to the finding's time window"/>
                                         <Button Content="Copy fix" Padding="10,3" Margin="0,0,8,0"
                                                 Visibility="{Binding ShowCopyFix, Converter={StaticResource RecoBoolToVis}}"
                                                 Click="CopyFix_Click"

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
@@ -414,19 +414,21 @@ public partial class MainWindow : Window
 
     /// <summary>
     /// Opens the given server's per-server tab, or focuses it if already open (dedupe by server id).
-    /// The new tab's <see cref="ViewerServerTab"/> loads its active inner tab on first show.
+    /// The new tab's <see cref="ViewerServerTab"/> loads its active inner tab on first show. Returns the
+    /// tab's <see cref="ViewerServerTab"/> so a caller (the Recommendations deep-link) can navigate inside
+    /// it after opening; null only when the data service is not yet ready.
     /// </summary>
-    private void OpenServerTab(DarlingServer server)
+    private ViewerServerTab? OpenServerTab(DarlingServer server)
     {
         if (_dataService is null)
         {
-            return;
+            return null;
         }
 
         if (_openServerTabs.TryGet(server.ServerId, out var existing))
         {
             MainTabs.SelectedItem = existing;
-            return;
+            return existing.Content as ViewerServerTab;
         }
 
         var serverTab = new ViewerServerTab(_dataService, server, _preferences);
@@ -443,6 +445,7 @@ public partial class MainWindow : Window
         _openServerTabs.Add(server.ServerId, tabItem);
         MainTabs.Items.Add(tabItem);
         MainTabs.SelectedItem = tabItem;
+        return serverTab;
     }
 
     /// <summary>Removes a per-server tab and unwires it. WPF selects an adjacent tab when the closed one was active.</summary>
@@ -783,6 +786,57 @@ public partial class MainWindow : Window
         Clipboard.SetDataObject(card.AskAiPrompt, false);
         RecommendationsStatusText.Text = "AI prompt copied to clipboard.";
     }
+
+    /// <summary>
+    /// "Open in Active Queries" deep-link on an incident card (Dashboard-parity port): resolves the
+    /// finding's server (the aggregate Recommendations tab is cross-server, so the card carries its own
+    /// server id), opens/focuses that server's per-server tab via the shell's existing open-tab path, then
+    /// navigates it straight to Active Queries scoped to the finding's window. The whole hop is pure viewer
+    /// navigation over already-stored data — no live query, no control-plane write. Only incident cards
+    /// (a finding with a time window + server id) show the button, so the predicate is already satisfied.
+    /// </summary>
+    private async void OpenInActiveQueries_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not FrameworkElement fe || fe.DataContext is not RecommendationCardViewModel card)
+        {
+            return;
+        }
+
+        if (!card.ShowOpenInActiveQueries)
+        {
+            return;
+        }
+
+        var server = FindManagedServerById(card.ServerId);
+        if (server is null)
+        {
+            RecommendationsStatusText.Text = "Cannot open Active Queries — the finding's server is no longer registered.";
+            return;
+        }
+
+        var (fromUtc, toUtc) = card.DeepLinkWindowUtc();
+        var serverTab = OpenServerTab(server);
+        if (serverTab is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await serverTab.DeepLinkToActiveQueriesAsync(fromUtc, toUtc);
+        }
+        catch (Exception ex)
+        {
+            RecommendationsStatusText.Text = $"Open in Active Queries failed: {ex.Message}";
+        }
+    }
+
+    /// <summary>Finds a registered server by id in the Recommendations tab's own selector list (populated
+    /// from the same managed-server set as the sidebar); null when the server is no longer registered.</summary>
+    private DarlingServer? FindManagedServerById(int serverId)
+        => RecommendationsServerSelector.ItemsSource is IEnumerable<DarlingServer> servers
+            ? servers.FirstOrDefault(s => s.ServerId == serverId)
+            : null;
 
     // ── Settings ─────────────────────────────────────────────────────────────────────
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/RecommendationsViewModel.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/RecommendationsViewModel.cs
@@ -106,6 +106,13 @@ public sealed class RecommendationItem
     /// <summary>The monitored server's display name (for the Ask-AI prompt).</summary>
     public string ServerName { get; init; } = string.Empty;
 
+    /// <summary>
+    /// The finding's monitored-server id (<see cref="AnalysisFinding.ServerId"/>) — drives which
+    /// per-server tab the "Open in Active Queries" deep-link opens. A real server id is never 0, so the
+    /// deep-link predicate treats 0 as "no server anchor".
+    /// </summary>
+    public int ServerId { get; init; }
+
     /// <summary>UTC start of the finding's time window (analysis TimeRangeStart), or null.</summary>
     public DateTime? WindowStartUtc { get; init; }
 
@@ -182,6 +189,48 @@ public sealed class RecommendationCardViewModel
     /// investigation tools the prompt references, so any finding can be handed to AI.
     /// </summary>
     public bool ShowAskAi => true;
+
+    // ---- "Open in Active Queries" deep-link (aggregate → per-server tab) ---------------
+
+    /// <summary>The finding's monitored-server id, so the shell opens the right per-server tab.</summary>
+    public int ServerId => Item.ServerId;
+
+    /// <summary>Raw UTC start of the finding window (drives the deep-link read), or null.</summary>
+    public DateTime? WindowStartUtc => Item.WindowStartUtc;
+
+    /// <summary>Raw UTC end of the finding window (drives the deep-link read), or null.</summary>
+    public DateTime? WindowEndUtc => Item.WindowEndUtc;
+
+    /// <summary>
+    /// Whether the "Open in Active Queries" deep-link is shown — an incident-type finding that carries
+    /// BOTH a time window (to scope the Active Queries read to when it fired) AND a server id (to open the
+    /// right per-server tab). This is the Dashboard's incident affordance (<c>ShowOpenInActiveQueries</c>)
+    /// ported to the viewer's advise-only model: the viewer has no RecommendationSetting/structured-fix
+    /// taxonomy, so the gate is simply "has a time anchor + a server" — a finding with no time window
+    /// (or no server id) hides it, because deep-linking to Active Queries needs both.
+    /// </summary>
+    public bool ShowOpenInActiveQueries =>
+        Item.ServerId != 0 && Item.WindowStartUtc.HasValue && Item.WindowEndUtc.HasValue;
+
+    /// <summary>
+    /// The UTC window the deep-link scopes Active Queries to: the finding's own window when it carries a
+    /// real range, widened to +/-<see cref="ViewerServerTab.DrillDownHalfWindowMinutes"/> around the point
+    /// for a degenerate (start &gt;= end) window so the read is never empty. Reuses #1409's drill
+    /// half-window for consistency with the chart/heatmap drills. Only meaningful when
+    /// <see cref="ShowOpenInActiveQueries"/> is true; falls back to a "now"-anchored band otherwise.
+    /// </summary>
+    public (DateTime FromUtc, DateTime ToUtc) DeepLinkWindowUtc()
+    {
+        var from = Item.WindowStartUtc ?? DateTime.UtcNow;
+        var to = Item.WindowEndUtc ?? from;
+        if (to <= from)
+        {
+            from = from.AddMinutes(-ViewerServerTab.DrillDownHalfWindowMinutes);
+            to = to.AddMinutes(ViewerServerTab.DrillDownHalfWindowMinutes);
+        }
+
+        return (from, to);
+    }
 
     /// <summary>
     /// The MCP investigation prompt copied to the clipboard by "Ask AI". The window is rendered in
@@ -330,6 +379,7 @@ public sealed class RecommendationsViewModel
             CopyPasteSql = BuildCopyPasteSql(finding.Remediation),
             IncidentId = finding.IncidentId,
             ServerName = serverName ?? string.Empty,
+            ServerId = finding.ServerId,
             WindowStartUtc = AsUtc(finding.TimeRangeStart),
             WindowEndUtc = AsUtc(finding.TimeRangeEnd)
         };

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.ActiveQueries.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.ActiveQueries.cs
@@ -39,6 +39,17 @@ public partial class ViewerServerTab
        InnerTabs_SelectionChanged, QueriesSubTabs_SelectionChanged, and BlockingSubTabs_SelectionChanged
        (the Blocking/Deadlock chart drills target the Blocking tab). */
     private bool _suppressDrillDownAutoRefresh;
+
+    /* A one-shot Active Queries window "shield" for the aggregate-tab deep-link (the "Open in Active
+       Queries" button on a Recommendations card). Unlike the within-tab drills (heatmap / per-chart /
+       Overview lane), the deep-link opens/focuses THIS server tab from the aggregate Recommendations tab,
+       which triggers MainWindow's tab-activation refresh — and that path (RefreshActiveInnerTabAsync ->
+       LoadQueriesAsync -> LoadActiveQueriesAsync) is NOT gated by _suppressDrillDownAutoRefresh, so it
+       would reload the grid over the toolbar window and clobber the targeted read via an async race. While
+       this is set, the next Active Queries load (whichever path wins) uses THIS narrow window + indicator
+       instead; it is consumed once, so a later auto-refresh reverts to the toolbar window like the other
+       drills. Set by DeepLinkToActiveQueriesAsync, consumed by LoadActiveQueriesAsync. */
+    private (DateTime FromUtc, DateTime ToUtc, string Indicator)? _pendingActiveQueriesWindow;
     /* OpenPlanTab is implemented by the plan-host partial (ViewerServerTab.Plans.cs). */
 
     /// <summary>Wires the Active Queries slicer's RangeChanged (drag re-reads the grid). Called from
@@ -52,6 +63,21 @@ public partial class ViewerServerTab
     /// plus the hourly slicer. Mirrors Lite's Queries sub-tab-1 refresh.</summary>
     private async Task LoadActiveQueriesAsync(DateTime startUtc, DateTime endUtc)
     {
+        /* Deep-link shield (aggregate-tab "Open in Active Queries"): opening this server tab triggers the
+           tab-activation refresh, which lands here over the toolbar window and would clobber the targeted
+           read. Honor a pending deep-link window instead so a concurrent activation load uses the SAME
+           narrow window + indicator; consumed once (a later refresh reverts to the toolbar window, matching
+           the heatmap / per-chart drills). The ±1h slicer padding mirrors NavigateToActiveQueriesForWindowAsync. */
+        if (_pendingActiveQueriesWindow is { } pending)
+        {
+            _pendingActiveQueriesWindow = null;
+            var pendingSnapshots = await _dataService.GetLatestQuerySnapshotsAsync(_server.ServerId, pending.FromUtc, pending.ToUtc);
+            _querySnapshotsFilterMgr!.UpdateData(pendingSnapshots);
+            LatestSnapshotIndicator.Text = pending.Indicator;
+            await LoadActiveQueriesSlicerAsync(pending.FromUtc.AddHours(-1), pending.ToUtc.AddHours(1));
+            return;
+        }
+
         var snapshots = await _dataService.GetLatestQuerySnapshotsAsync(_server.ServerId, startUtc, endUtc);
         _querySnapshotsFilterMgr!.UpdateData(snapshots);
         LatestSnapshotIndicator.Text = "";
@@ -183,6 +209,30 @@ public partial class ViewerServerTab
         if (sender is not Button btn || btn.DataContext is not ViewerQuerySnapshotRow row) return;
         if (string.IsNullOrEmpty(row.LiveQueryPlan)) return;
         OpenPlanTab(row.LiveQueryPlan, $"Actual Plan — Session {row.SessionId}", row.QueryText);
+    }
+
+    /// <summary>
+    /// Deep-link entry from the aggregate Recommendations tab's "Open in Active Queries" button: navigate
+    /// this (possibly freshly-opened) server tab straight to Active Queries scoped to a finding's window.
+    /// The shell opens/focuses the tab first (its existing per-server-tab path); this then points the
+    /// process-wide time helper at THIS server's offset (so the grid/indicator render in the tab's own
+    /// time), sets a one-shot window <see cref="_pendingActiveQueriesWindow">shield</see> so the concurrent
+    /// tab-activation refresh loads the SAME narrow window (race-free — see the field comment), builds the
+    /// indicator, then reuses the shared <see cref="NavigateToActiveQueriesForWindowAsync"/> the within-tab
+    /// drills use. The raw UTC window comes from the card (the finding's own range, or #1409's ±30-minute
+    /// band around a degenerate point).
+    /// </summary>
+    internal async Task DeepLinkToActiveQueriesAsync(DateTime fromUtc, DateTime toUtc)
+    {
+        /* Load + apply this server's UTC offset before rendering (the tab may be freshly opened and not yet
+           refreshed). EnsureServerOffsetLoadedAsync caches its Task, so this shares the one load with any
+           concurrent activation refresh. */
+        await EnsureServerOffsetLoadedAsync();
+        ApplyServerOffsetToHelper();
+
+        var indicator = $"Finding window: {ViewerTimeHelper.ForDisplay(fromUtc):yyyy-MM-dd HH:mm} → {ViewerTimeHelper.ForDisplay(toUtc):HH:mm}";
+        _pendingActiveQueriesWindow = (fromUtc, toUtc, indicator);
+        await NavigateToActiveQueriesForWindowAsync(fromUtc, toUtc, indicator);
     }
 
     /// <summary>


### PR DESCRIPTION
## What

Ports the Dashboard's incident-card **"Open in Active Queries"** deep-link (`Dashboard/Controls/RecommendationsViewModel.cs:159` `ShowOpenInActiveQueries`) to the Darling viewer's advise-only Recommendations cards, beside **Ask AI** + **Copy fix**. An operator seeing an incident card jumps straight to the queries that were running in that finding's time window.

Pure viewer navigation over data Darling already stores — **no SQL write, no new data, no control-plane hop**. Touches only the Viewer project + Darling.Tests.

## The command + enable predicate

- **`ShowOpenInActiveQueries`** (new on `RecommendationCardViewModel`) is shown only for a finding that carries **both a time window AND a server id** — the task's "has time + server" incident gate. The viewer's advise-only model has no `RecommendationSetting`/structured-fix taxonomy to gate on (that is Dashboard-specific), so the gate is time + server.
- **`DeepLinkWindowUtc()`** computes the read window: the finding's own `TimeRangeStart/End` range when present, widened to `+/-DrillDownHalfWindowMinutes` (#1409's 30 min) around a degenerate `start == end` point so the read is never empty.

## The aggregate → per-server-tab → Active Queries navigation (reuses #1409)

The Recommendations tab is a cross-server aggregate surface, so the card must carry its own server identity:

- `RecommendationItem.ServerId` is mapped from `AnalysisFinding.ServerId` (the finding **already carries** its server id + `TimeRangeStart/End` — nothing was missing).
- `OpenInActiveQueries_Click` resolves the finding's `DarlingServer` by id, opens/focuses that server's `ViewerServerTab` via MainWindow's **existing** `OpenServerTab` path (now returns the tab), then calls a new `DeepLinkToActiveQueriesAsync` on it, which reuses #1409's `NavigateToActiveQueriesForWindowAsync`.

## Race fix (the one non-trivial part)

Opening a server tab triggers MainWindow's tab-activation refresh, whose `RefreshActiveInnerTabAsync -> LoadQueriesAsync -> LoadActiveQueriesAsync` path is **not** gated by the drill suppress flag and would reload the grid over the toolbar window, clobbering the targeted read. A one-shot window **shield** (`_pendingActiveQueriesWindow`) makes that concurrent load use the **same** narrow window; combined with the existing inner-while "follow the selection" loop, the result is race-free in every await-continuation ordering (fresh tab, already-open-not-selected, already-open-selected). Consumed once, so a later auto-refresh reverts to the toolbar window like the heatmap / per-chart drills.

## Did the finding model carry server + time?

**Yes.** `AnalysisFinding.ServerId` (server identity) and `TimeRangeStart/End` (the analysis window, populated for every persisted finding) are both present and read back on the Darling PG path (`PgFindingStore` maps `server_id` + `time_range_start/end`). Nothing needed to be added to the model or the store. Note: because every persisted finding carries the analysis window, the predicate primarily guards a (rare) no-time-anchor finding; it does not attempt the Dashboard's incident-vs-config split (Darling has no such taxonomy).

## Tests

`Darling/Darling.Tests/ViewerRecommendationsTests.cs` (WPF-free, matches the existing convention):
- Enable predicate: shown with time + server; hidden with no window / half a window / no server id (id 0).
- Window computation: uses the finding's own range; widens a degenerate point by #1409's `DrillDownHalfWindowMinutes`.
- `MapItem` carries `ServerId` from the finding.

Full `Darling.Tests -c Release`: **1488 passed, 0 failed, 117 skipped** (live-PG gated). Whole Darling Viewer + tests build clean in Release.

## Scope

Viewer + Darling.Tests only. No Service/Storage/Config/Migrations/`install/*.sql` touched. The Darling service on :5641 was left running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)