### PR TITLE
Add Fleet-wide NOC roll-up to the Darling viewer Overview

### DIFF
--- a/Darling/Darling.Tests/ViewerFleetRollupTests.cs
+++ b/Darling/Darling.Tests/ViewerFleetRollupTests.cs
@@ -1,0 +1,520 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Npgsql;
+using PerformanceMonitor.Collectors;
+using PerformanceMonitor.Darling.Storage;
+using PerformanceMonitor.Darling.Viewer;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Pins the Fleet-wide NOC roll-up's cross-server totals read (<see cref="ViewerDataService.FleetTotalsSql"/>)
+/// against the Darling store contract — no live Postgres. This is the signature capability Darling's single
+/// central store enables and the Dashboard/Lite physically cannot do: one aggregate over EVERY server's rows,
+/// keyed by <c>server_id</c>. The pins are the load-bearing clauses — the two blocking sources counted per
+/// server (a GROUP BY), the FULL OUTER JOIN lining them up, the per-server XE→DMV fallback CASE, the
+/// cross-server deadlock COUNT, the two-sided window on every source, and the Pg dialect (no per-server
+/// filter, positional params).
+/// </summary>
+public sealed class ViewerFleetRollupSqlTests
+{
+    [Fact]
+    public void FleetTotalsSql_BlockingCountsBothSourcesPerServer_ThenAppliesXeDmvFallback()
+    {
+        var sql = ViewerDataService.FleetTotalsSql;
+
+        /* Each source counted per server (a cross-server GROUP BY), FULL OUTER JOIN so a server present in
+           only one source still appears, then Lite's per-server XE-preferred / DMV-fallback rule before the
+           fleet SUM — so an RDS server with only DMV snapshots still counts and an XE server is never
+           double-counted. */
+        Assert.Contains("FROM v_blocked_process_reports", sql, StringComparison.Ordinal);
+        Assert.Contains("FROM v_dmv_blocking_snapshots", sql, StringComparison.Ordinal);
+        Assert.Contains("GROUP BY server_id", sql, StringComparison.Ordinal);
+        Assert.Contains("FULL OUTER JOIN", sql, StringComparison.Ordinal);
+        Assert.Contains("COALESCE(xe.server_id, dmv.server_id)", sql, StringComparison.Ordinal);
+        Assert.Contains("SUM(CASE WHEN per_server.xe_count > 0 THEN per_server.xe_count ELSE per_server.dmv_count END)", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FleetTotalsSql_DeadlocksAreACrossServerCount_OverTheWindow()
+    {
+        var sql = ViewerDataService.FleetTotalsSql;
+        Assert.Contains("FROM v_deadlocks", sql, StringComparison.Ordinal);
+        Assert.Contains("COUNT(*)", sql, StringComparison.Ordinal);
+        Assert.Contains("deadlock_time >= $1", sql, StringComparison.Ordinal);
+        Assert.Contains("deadlock_time <= $2", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FleetTotalsSql_WindowsEverySource_OnBothBounds()
+    {
+        var sql = ViewerDataService.FleetTotalsSql;
+        /* Both blocking sources and the deadlock read are bounded on BOTH sides so the totals honor a
+           settable window exactly (the caller passes the same one-hour window the cards use). */
+        Assert.Contains("event_time >= $1", sql, StringComparison.Ordinal);
+        Assert.Contains("event_time <= $2", sql, StringComparison.Ordinal);
+        Assert.Equal(2, CountOccurrences(sql, "event_time >= $1"));   // one per blocking source
+        Assert.Equal(2, CountOccurrences(sql, "event_time <= $2"));
+    }
+
+    [Fact]
+    public void FleetTotalsSql_IsPgDialect_PositionalWindowParams_NoBareNow_NoNLiterals_NoPerServerFilter()
+    {
+        var sql = ViewerDataService.FleetTotalsSql;
+        Assert.DoesNotContain("now(", sql.ToLowerInvariant());
+        Assert.DoesNotContain("N'", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("@", sql, StringComparison.Ordinal);
+        Assert.Contains("$1", sql, StringComparison.Ordinal);
+        Assert.Contains("$2", sql, StringComparison.Ordinal);
+        /* The fleet read spans ALL servers — no per-server scoping predicate (unlike the per-server card
+           reads, whose signature is "WHERE server_id = $1"). */
+        Assert.DoesNotContain("server_id = $", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FleetTotals_ReferenceColumnsThatExistInTheGeneratedSourceTables()
+    {
+        /* The window is applied on event_time (both blocking sources) and deadlock_time (deadlocks); the
+           per-server GROUP BY keys on server_id, the universal store key on every collect table. */
+        Assert.Contains("event_time", PgSchemaGenerator.CreateTable(BlockedProcessReportCollector.Instance), StringComparison.Ordinal);
+        Assert.Contains("event_time", PgSchemaGenerator.CreateTable(DmvBlockingSnapshotCollector.Instance), StringComparison.Ordinal);
+        Assert.Contains("deadlock_time", PgSchemaGenerator.CreateTable(DeadlocksCollector.Instance), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PassthroughViews_ForEveryFleetSource_ExistInTheMigrations()
+    {
+        var allMigrationSql = string.Concat(PgMigrations.Scripts.Select(m => m.Sql));
+        foreach (var view in new[] { "v_blocked_process_reports", "v_dmv_blocking_snapshots", "v_deadlocks" })
+        {
+            Assert.Contains(view, allMigrationSql, StringComparison.Ordinal);
+        }
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+        return count;
+    }
+}
+
+/// <summary>
+/// The fleet roll-up's pure C# reduction (<see cref="FleetRollup.Build"/>) — no Postgres. Every band
+/// decision REUSES #1426's card banding (<see cref="ServerSummaryItem.OverallMetricSeverity"/> + freshness),
+/// so these tests prove the fleet counts / ranking never invent a new band: they classify the same cards the
+/// Overview renders. Covers the band counts, the servers-with-collection-failures roll-up, the worst-first
+/// ranking order (offline &gt; critical &gt; warning, then by how many metrics are bad), the cap + overflow,
+/// the all-clear state, and the totals passthrough.
+/// </summary>
+public sealed class ViewerFleetRollupBuilderTests
+{
+    private static ServerSummaryItem Healthy(string name, int id) =>
+        new() { DisplayName = name, ServerId = id, IsOnline = true };
+
+    private static ServerSummaryItem Critical(string name, int id, int deadlocks = 1) =>
+        new() { DisplayName = name, ServerId = id, IsOnline = true, DeadlockCount = deadlocks };
+
+    private static ServerSummaryItem WarningCollectors(string name, int id, int failed = 1) =>
+        new() { DisplayName = name, ServerId = id, IsOnline = true, FailedCollectorCount = failed };
+
+    private static ServerSummaryItem Stale(string name, int id) =>
+        new() { DisplayName = name, ServerId = id, IsOnline = true, HasCollectorErrors = true };
+
+    private static ServerSummaryItem Offline(string name, int id) =>
+        new() { DisplayName = name, ServerId = id, IsOnline = false };
+
+    private static readonly FleetTotals NoTotals = new();
+
+    // ── ClassifyBand: the fleet band is the card's banding, collapsed to one label ─────────────────
+
+    [Fact]
+    public void ClassifyBand_OfflineCollection_IsOffline()
+    {
+        Assert.Equal(FleetHealthBand.Offline, FleetRollup.ClassifyBand(Offline("s", 1)));
+    }
+
+    [Fact]
+    public void ClassifyBand_CriticalMetric_IsCritical()
+    {
+        // A deadlock in the window is the card's Critical (DeadlockSeverity) → fleet Critical.
+        Assert.Equal(FleetHealthBand.Critical, FleetRollup.ClassifyBand(Critical("s", 1)));
+        // CPU >= 95 is also the card's Critical.
+        Assert.Equal(FleetHealthBand.Critical,
+            FleetRollup.ClassifyBand(new ServerSummaryItem { IsOnline = true, CpuPercent = 96 }));
+    }
+
+    [Fact]
+    public void ClassifyBand_WarningMetric_IsWarning()
+    {
+        // A FAILING collector is the card's Warning (CollectorSeverity) — this is the reuse of
+        // CollectorHealthRow.HealthStatus that flows through the card's FailedCollectorCount.
+        Assert.Equal(FleetHealthBand.Warning, FleetRollup.ClassifyBand(WarningCollectors("s", 1)));
+    }
+
+    [Fact]
+    public void ClassifyBand_StaleCollection_IsWarning()
+    {
+        // Online but collection has gone stale (HasCollectorErrors) → the card's amber → fleet Warning,
+        // even with every metric calm.
+        Assert.Equal(FleetHealthBand.Warning, FleetRollup.ClassifyBand(Stale("s", 1)));
+    }
+
+    [Fact]
+    public void ClassifyBand_OnlineAndCalm_IsHealthy()
+    {
+        Assert.Equal(FleetHealthBand.Healthy, FleetRollup.ClassifyBand(Healthy("s", 1)));
+    }
+
+    // ── Band counts + servers-with-failures ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Build_CountsServersByBand()
+    {
+        var summaries = new[]
+        {
+            Healthy("h1", 1), Healthy("h2", 2), Healthy("h3", 3),
+            WarningCollectors("w1", 4), Stale("w2", 5),
+            Critical("c1", 6),
+            Offline("o1", 7),
+        };
+
+        var rollup = FleetRollup.Build(summaries, NoTotals);
+
+        Assert.Equal(7, rollup.TotalServers);
+        Assert.Equal(3, rollup.HealthyCount);
+        Assert.Equal(2, rollup.WarningCount);
+        Assert.Equal(1, rollup.CriticalCount);
+        Assert.Equal(1, rollup.OfflineCount);
+    }
+
+    [Fact]
+    public void Build_CountsServersWithCollectionFailures_FromTheCardsFailingCount()
+    {
+        var summaries = new[]
+        {
+            WarningCollectors("w1", 1, failed: 2),   // 2 failing collectors → counts once
+            Critical("c1", 2, deadlocks: 1),         // critical but no failing collector → not counted
+            new ServerSummaryItem { DisplayName = "c2", ServerId = 3, IsOnline = true, DeadlockCount = 1, FailedCollectorCount = 3 }, // both
+            Healthy("h1", 4),
+        };
+
+        var rollup = FleetRollup.Build(summaries, NoTotals);
+
+        // Servers whose card FailedCollectorCount > 0: w1 and c2 → 2.
+        Assert.Equal(2, rollup.ServersWithCollectionFailures);
+    }
+
+    // ── Worst-first ranking ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Build_RanksProblemServersWorstFirst_OfflineThenCriticalThenWarning()
+    {
+        var summaries = new[]
+        {
+            Healthy("h1", 1),
+            WarningCollectors("w1", 2),
+            Critical("c1", 3),
+            Offline("o1", 4),
+        };
+
+        var rollup = FleetRollup.Build(summaries, NoTotals);
+
+        // Healthy is excluded from the "needs attention" ranking; problems ordered worst-first.
+        Assert.Equal(3, rollup.WorstServers.Count);
+        Assert.Equal(new[] { "o1", "c1", "w1" }, rollup.WorstServers.Select(w => w.DisplayName).ToArray());
+        Assert.Equal(FleetHealthBand.Offline, rollup.WorstServers[0].Band);
+        Assert.Equal(FleetHealthBand.Critical, rollup.WorstServers[1].Band);
+        Assert.Equal(FleetHealthBand.Warning, rollup.WorstServers[2].Band);
+        Assert.True(rollup.HasProblems);
+    }
+
+    [Fact]
+    public void Build_WithinTheSameBand_RanksByHowManyMetricsAreBad()
+    {
+        // Two Critical servers: one with two critical metrics (CPU + deadlock), one with a single deadlock.
+        var twoCritical = new ServerSummaryItem { DisplayName = "worse", ServerId = 1, IsOnline = true, CpuPercent = 96, DeadlockCount = 1 };
+        var oneCritical = new ServerSummaryItem { DisplayName = "milder", ServerId = 2, IsOnline = true, DeadlockCount = 1 };
+
+        var rollup = FleetRollup.Build(new[] { oneCritical, twoCritical }, NoTotals);
+
+        Assert.Equal(new[] { "worse", "milder" }, rollup.WorstServers.Select(w => w.DisplayName).ToArray());
+        Assert.True(FleetRollup.FleetHealthScore(twoCritical) > FleetRollup.FleetHealthScore(oneCritical));
+    }
+
+    [Fact]
+    public void Build_CapsTheRankingAtWorstCount_AndReportsTheOverflow()
+    {
+        var summaries = Enumerable.Range(1, 8).Select(i => Critical($"c{i}", i, deadlocks: 1)).ToArray();
+
+        var rollup = FleetRollup.Build(summaries, NoTotals, worstCount: 3);
+
+        Assert.Equal(3, rollup.WorstServers.Count);
+        Assert.Equal(5, rollup.AdditionalProblemCount);            // 8 problems − 3 shown
+        Assert.Equal("+5 more need attention", rollup.AdditionalProblemText);
+    }
+
+    [Fact]
+    public void Build_AllHealthy_HasNoProblems_AndAnAllClearLine()
+    {
+        var summaries = new[] { Healthy("h1", 1), Healthy("h2", 2) };
+
+        var rollup = FleetRollup.Build(summaries, NoTotals);
+
+        Assert.False(rollup.HasProblems);
+        Assert.Empty(rollup.WorstServers);
+        Assert.Equal(0, rollup.AdditionalProblemCount);
+        Assert.Equal("", rollup.AdditionalProblemText);
+        Assert.Equal("All 2 servers healthy", rollup.AllHealthyText);
+    }
+
+    [Fact]
+    public void FleetHealthScore_BandRankDominates_AcrossBands()
+    {
+        var offline = FleetRollup.FleetHealthScore(Offline("o", 1));
+        var critical = FleetRollup.FleetHealthScore(Critical("c", 2));
+        var warning = FleetRollup.FleetHealthScore(WarningCollectors("w", 3));
+        var healthy = FleetRollup.FleetHealthScore(Healthy("h", 4));
+
+        Assert.True(offline > critical);
+        Assert.True(critical > warning);
+        Assert.True(warning > healthy);
+    }
+
+    // ── Totals passthrough + empty fleet ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Build_PassesTheCrossServerTotalsThrough()
+    {
+        var totals = new FleetTotals { TotalBlockingEvents = 42, TotalDeadlocks = 7 };
+
+        var rollup = FleetRollup.Build(new[] { Healthy("h1", 1) }, totals);
+
+        Assert.Equal(42, rollup.TotalBlockingEvents);
+        Assert.Equal(7, rollup.TotalDeadlocks);
+    }
+
+    [Fact]
+    public void Build_NoServers_StillCarriesTotals_ButHasNoRanking()
+    {
+        var totals = new FleetTotals { TotalBlockingEvents = 5, TotalDeadlocks = 2 };
+
+        var rollup = FleetRollup.Build(Array.Empty<ServerSummaryItem>(), totals);
+
+        Assert.Equal(0, rollup.TotalServers);
+        Assert.Empty(rollup.WorstServers);
+        Assert.False(rollup.HasProblems);
+        Assert.Equal(5, rollup.TotalBlockingEvents);
+        Assert.Equal(2, rollup.TotalDeadlocks);
+    }
+
+    // ── Reason text + ranked-row display ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void BuildReason_Offline_SaysSo()
+    {
+        Assert.Equal("Offline — no recent collection", FleetRollup.BuildReason(Offline("s", 1)));
+    }
+
+    [Fact]
+    public void BuildReason_NamesTheBadMetrics_FromTheCardsOwnDisplays()
+    {
+        var s = new ServerSummaryItem
+        {
+            IsOnline = true,
+            CpuPercent = 96,                 // CPU 96%
+            BlockingCount = 6, MaxBlockingWaitMs = 70000,
+            DeadlockCount = 2,
+            FailedCollectorCount = 1,
+        };
+
+        var reason = FleetRollup.BuildReason(s);
+
+        Assert.Contains("CPU 96%", reason, StringComparison.Ordinal);
+        Assert.Contains("Blocking 6", reason, StringComparison.Ordinal);
+        Assert.Contains("Deadlocks 2", reason, StringComparison.Ordinal);
+        Assert.Contains("1 collector failing", reason, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildReason_StaleOnly_SaysCollectionStale()
+    {
+        Assert.Equal("collection stale", FleetRollup.BuildReason(Stale("s", 1)));
+    }
+
+    [Fact]
+    public void RankedServer_LabelAndBrush_MatchTheBand()
+    {
+        var rollup = FleetRollup.Build(new[] { Critical("c1", 1), Offline("o1", 2), WarningCollectors("w1", 3) }, NoTotals);
+
+        var offline = rollup.WorstServers.Single(w => w.DisplayName == "o1");
+        var critical = rollup.WorstServers.Single(w => w.DisplayName == "c1");
+        var warning = rollup.WorstServers.Single(w => w.DisplayName == "w1");
+
+        Assert.Equal("Offline", offline.BandLabel);
+        Assert.Equal("#FF888888", offline.BandBrush.Color.ToString());   // grey (the card's Unknown palette)
+        Assert.Equal("Critical", critical.BandLabel);
+        Assert.Equal("#FFE57373", critical.BandBrush.Color.ToString());  // red
+        Assert.Equal("Warning", warning.BandLabel);
+        Assert.Equal("#FFFFB74D", warning.BandBrush.Color.ToString());   // amber
+    }
+
+    // ── Header / total display helpers (singular / plural) ──────────────────────────────────────────
+
+    [Fact]
+    public void DisplayHelpers_Pluralize()
+    {
+        var one = FleetRollup.Build(new[] { Healthy("h1", 1) }, NoTotals);
+        Assert.Equal("Monitoring 1 server", one.MonitoringText);
+        Assert.Equal("All 1 server healthy", one.AllHealthyText);
+
+        var many = FleetRollup.Build(new[]
+        {
+            Healthy("h1", 1),
+            new ServerSummaryItem { DisplayName = "w1", ServerId = 2, IsOnline = true, FailedCollectorCount = 1 },
+        }, NoTotals);
+        Assert.Equal("Monitoring 2 servers", many.MonitoringText);
+        Assert.Equal("1 server", many.CollectionFailuresText);
+
+        var twoFailing = FleetRollup.Build(new[]
+        {
+            new ServerSummaryItem { DisplayName = "w1", ServerId = 1, IsOnline = true, FailedCollectorCount = 1 },
+            new ServerSummaryItem { DisplayName = "w2", ServerId = 2, IsOnline = true, FailedCollectorCount = 2 },
+        }, NoTotals);
+        Assert.Equal("2 servers", twoFailing.CollectionFailuresText);
+    }
+}
+
+/// <summary>
+/// Gated (DARLING_TEST_PG) live round-trip for the Fleet-wide totals read against planted rows across
+/// MULTIPLE servers — the cross-server aggregate the Dashboard/Lite cannot run. Verifies the per-server
+/// XE→DMV blocking fallback is applied PER server before the fleet SUM (an XE server counts its XE rows; a
+/// DMV-only / RDS server counts its DMV rows) and that deadlocks total across servers. Uses a fixed
+/// historical sentinel window so only the planted rows fall inside it, making the fleet-wide (un-scoped)
+/// read deterministic regardless of any real data in the store; negative sentinel server_ids, cleaned up in
+/// finally. Shares the serialized "live-postgres" collection.
+/// </summary>
+[Collection("live-postgres")]
+public sealed class ViewerFleetRollupLivePostgresTests
+{
+    private const int XeServerId = -939301;   // has XE reports (XE preferred)
+    private const int DmvServerId = -939302;  // DMV snapshots only (fallback)
+    private const string ServerName = "viewer-fleet-e2e";
+
+    /* A fixed historical window no real collected row occupies, so the fleet-wide read sees only the
+       planted rows. */
+    private static readonly DateTime WindowAnchor = new(2001, 3, 14, 9, 0, 0, DateTimeKind.Unspecified);
+
+    [Fact]
+    public async Task FleetTotals_SumAcrossServers_WithPerServerXeDmvFallback_AgainstDevPostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the live fleet-totals test.");
+
+        using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await PgMigrations.MigrateAsync(connection, TestContext.Current.CancellationToken);
+        await DeleteFleetRowsAsync(connection);
+
+        await using var viewer = new ViewerDataService(connectionString!);
+
+        try
+        {
+            var at = WindowAnchor;
+
+            /* Server XE: two XE blocked-process reports + one DMV snapshot in the window → the fallback
+               prefers XE, so this server contributes 2 (the DMV row is ignored). One deadlock. */
+            await InsertBlockedProcessAsync(connection, XeServerId, at);
+            await InsertBlockedProcessAsync(connection, XeServerId, at.AddMinutes(1));
+            await InsertDmvBlockingAsync(connection, XeServerId, at);
+            await InsertDeadlockAsync(connection, XeServerId, at);
+
+            /* Server DMV: no XE reports, three DMV snapshots in the window → the fallback uses DMV, so this
+               server contributes 3. Two deadlocks. */
+            await InsertDmvBlockingAsync(connection, DmvServerId, at);
+            await InsertDmvBlockingAsync(connection, DmvServerId, at.AddMinutes(1));
+            await InsertDmvBlockingAsync(connection, DmvServerId, at.AddMinutes(2));
+            await InsertDeadlockAsync(connection, DmvServerId, at);
+            await InsertDeadlockAsync(connection, DmvServerId, at.AddMinutes(1));
+
+            var totals = await viewer.GetFleetTotalsAsync(at.AddMinutes(-5), at.AddMinutes(30));
+
+            /* Fleet blocking = 2 (XE server, XE-preferred) + 3 (DMV server, fallback) = 5. */
+            Assert.Equal(5, totals.TotalBlockingEvents);
+            /* Fleet deadlocks = 1 + 2 = 3. */
+            Assert.Equal(3, totals.TotalDeadlocks);
+        }
+        finally
+        {
+            await DeleteFleetRowsAsync(connection);
+        }
+    }
+
+    // ── planting helpers ─────────────────────────────────────────────────────────────
+
+    private static async Task InsertBlockedProcessAsync(NpgsqlConnection connection, int serverId, DateTime eventTime)
+    {
+        using var command = new NpgsqlCommand(
+            "INSERT INTO blocked_process_reports (blocked_report_id, collection_time, server_id, server_name, event_time) VALUES ($1, $2, $3, $4, $5)",
+            connection);
+        command.Parameters.AddWithValue(CollectionIdGenerator.Next());
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(eventTime, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(serverId);
+        command.Parameters.AddWithValue(ServerName);
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(eventTime, DateTimeKind.Unspecified));
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static async Task InsertDmvBlockingAsync(NpgsqlConnection connection, int serverId, DateTime eventTime)
+    {
+        using var command = new NpgsqlCommand(
+            "INSERT INTO dmv_blocking_snapshots (collection_id, collection_time, server_id, server_name, event_time) VALUES ($1, $2, $3, $4, $5)",
+            connection);
+        command.Parameters.AddWithValue(CollectionIdGenerator.Next());
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(eventTime, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(serverId);
+        command.Parameters.AddWithValue(ServerName);
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(eventTime, DateTimeKind.Unspecified));
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static async Task InsertDeadlockAsync(NpgsqlConnection connection, int serverId, DateTime deadlockTime)
+    {
+        using var command = new NpgsqlCommand(
+            "INSERT INTO deadlocks (deadlock_id, collection_time, server_id, server_name, deadlock_time) VALUES ($1, $2, $3, $4, $5)",
+            connection);
+        command.Parameters.AddWithValue(CollectionIdGenerator.Next());
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(deadlockTime, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(serverId);
+        command.Parameters.AddWithValue(ServerName);
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(deadlockTime, DateTimeKind.Unspecified));
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static async Task DeleteFleetRowsAsync(NpgsqlConnection connection)
+    {
+        foreach (var table in new[] { "blocked_process_reports", "dmv_blocking_snapshots", "deadlocks" })
+        {
+            using var cleanup = new NpgsqlCommand(
+                $"DELETE FROM {table} WHERE server_id IN ({XeServerId}, {DmvServerId});", connection);
+            await cleanup.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+        }
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
@@ -513,7 +513,131 @@
                      server's tab. Status is derived from collection freshness (see ServerSummaryItem),
                      not a live ping — the viewer has no live connection to the monitored servers. -->
                 <TabItem x:Name="OverviewTab" Header="Overview">
-                    <ScrollViewer VerticalScrollBarVisibility="Auto" Margin="0,8,0,0">
+                    <DockPanel Margin="0,8,0,0">
+                        <!-- Fleet-wide NOC roll-up (the signature capability Darling's single central
+                             store enables — the Dashboard/Lite each see one server's database and CANNOT
+                             rank/total servers against each other). Sits ABOVE the per-server cards, always
+                             visible. Three parts: (1) fleet health summary — total servers + counts by the
+                             SAME band #1426's cards compute (ServerSummaryItem.OverallMetricSeverity +
+                             freshness, reduced in FleetRollup.ClassifyBand); (2) fleet totals — the
+                             cross-server blocking / deadlock SQL aggregate (GetFleetTotalsAsync) + servers
+                             with collection failures; (3) the worst-first "Needs Attention" ranking, whose
+                             rows open that server's tab. DataContext (a FleetRollup) is set in code-behind
+                             after LoadOverviewAsync builds it. -->
+                        <Border x:Name="FleetRollupContainer" DockPanel.Dock="Top"
+                                Background="{DynamicResource BackgroundLightBrush}"
+                                BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" CornerRadius="6"
+                                Margin="6,0,6,10" Padding="16,12" Visibility="Collapsed">
+                            <StackPanel>
+                                <!-- Header -->
+                                <DockPanel Margin="0,0,0,10">
+                                    <TextBlock Text="Fleet Health" FontSize="16" FontWeight="SemiBold"
+                                               Foreground="{DynamicResource ForegroundBrush}"/>
+                                    <TextBlock Text="{Binding MonitoringText}" FontSize="11"
+                                               Foreground="{DynamicResource ForegroundMutedBrush}"
+                                               VerticalAlignment="Center" Margin="12,1,0,0"/>
+                                </DockPanel>
+
+                                <!-- (1) Health-band summary tiles: total + counts by band. Tile colours are
+                                     the card severity palette (green / amber / red / grey-for-offline). -->
+                                <WrapPanel Margin="0,0,0,12">
+                                    <Border Background="{DynamicResource BackgroundBrush}" BorderBrush="#3a3d45"
+                                            BorderThickness="1" CornerRadius="5" MinWidth="86" Margin="0,0,8,0" Padding="12,6">
+                                        <StackPanel>
+                                            <TextBlock Text="{Binding TotalServers}" FontSize="22" FontWeight="Bold"
+                                                       Foreground="{DynamicResource ForegroundBrush}" HorizontalAlignment="Center"/>
+                                            <TextBlock Text="Servers" FontSize="10" Foreground="{DynamicResource ForegroundMutedBrush}"
+                                                       HorizontalAlignment="Center"/>
+                                        </StackPanel>
+                                    </Border>
+                                    <Border Background="{DynamicResource BackgroundBrush}" BorderBrush="#81C784"
+                                            BorderThickness="1" CornerRadius="5" MinWidth="86" Margin="0,0,8,0" Padding="12,6">
+                                        <StackPanel>
+                                            <TextBlock Text="{Binding HealthyCount}" FontSize="22" FontWeight="Bold"
+                                                       Foreground="#81C784" HorizontalAlignment="Center"/>
+                                            <TextBlock Text="Healthy" FontSize="10" Foreground="{DynamicResource ForegroundMutedBrush}"
+                                                       HorizontalAlignment="Center"/>
+                                        </StackPanel>
+                                    </Border>
+                                    <Border Background="{DynamicResource BackgroundBrush}" BorderBrush="#FFB74D"
+                                            BorderThickness="1" CornerRadius="5" MinWidth="86" Margin="0,0,8,0" Padding="12,6">
+                                        <StackPanel>
+                                            <TextBlock Text="{Binding WarningCount}" FontSize="22" FontWeight="Bold"
+                                                       Foreground="#FFB74D" HorizontalAlignment="Center"/>
+                                            <TextBlock Text="Warning" FontSize="10" Foreground="{DynamicResource ForegroundMutedBrush}"
+                                                       HorizontalAlignment="Center"/>
+                                        </StackPanel>
+                                    </Border>
+                                    <Border Background="{DynamicResource BackgroundBrush}" BorderBrush="#E57373"
+                                            BorderThickness="1" CornerRadius="5" MinWidth="86" Margin="0,0,8,0" Padding="12,6">
+                                        <StackPanel>
+                                            <TextBlock Text="{Binding CriticalCount}" FontSize="22" FontWeight="Bold"
+                                                       Foreground="#E57373" HorizontalAlignment="Center"/>
+                                            <TextBlock Text="Critical" FontSize="10" Foreground="{DynamicResource ForegroundMutedBrush}"
+                                                       HorizontalAlignment="Center"/>
+                                        </StackPanel>
+                                    </Border>
+                                    <Border Background="{DynamicResource BackgroundBrush}" BorderBrush="#888888"
+                                            BorderThickness="1" CornerRadius="5" MinWidth="86" Margin="0,0,8,0" Padding="12,6">
+                                        <StackPanel>
+                                            <TextBlock Text="{Binding OfflineCount}" FontSize="22" FontWeight="Bold"
+                                                       Foreground="#AAAAAA" HorizontalAlignment="Center"/>
+                                            <TextBlock Text="Offline" FontSize="10" Foreground="{DynamicResource ForegroundMutedBrush}"
+                                                       HorizontalAlignment="Center"/>
+                                        </StackPanel>
+                                    </Border>
+                                </WrapPanel>
+
+                                <!-- (2) Fleet totals: the cross-server aggregate over the last hour (the
+                                     same window the per-server cards use, so these reconcile with the card
+                                     counts). -->
+                                <WrapPanel Margin="0,0,0,12">
+                                    <TextBlock Text="Last hour:" FontSize="11" FontWeight="SemiBold"
+                                               Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,0,10,0" VerticalAlignment="Center"/>
+                                    <TextBlock FontSize="11" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,16,0" VerticalAlignment="Center"
+                                               Text="{Binding TotalBlockingEvents, StringFormat='Blocking events: {0}'}"/>
+                                    <TextBlock FontSize="11" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,16,0" VerticalAlignment="Center"
+                                               Text="{Binding TotalDeadlocks, StringFormat='Deadlocks: {0}'}"/>
+                                    <TextBlock FontSize="11" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,16,0" VerticalAlignment="Center"
+                                               Text="{Binding CollectionFailuresText, StringFormat='Collection failures: {0}'}"/>
+                                </WrapPanel>
+
+                                <!-- (3) Worst-first "Needs Attention" ranking — problem servers only, opens
+                                     the server's tab on click. Hidden and replaced by the all-clear line
+                                     when the fleet is healthy (toggled in code-behind). -->
+                                <TextBlock Text="Needs Attention" FontSize="12" FontWeight="SemiBold"
+                                           Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
+                                <ItemsControl x:Name="FleetWorstServersList" ItemsSource="{Binding WorstServers}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate>
+                                            <Border Background="Transparent" Cursor="Hand" Padding="2,3" Margin="0,1"
+                                                    ToolTip="Open this server's tab"
+                                                    MouseLeftButtonUp="FleetWorstServer_Click">
+                                                <DockPanel LastChildFill="True">
+                                                    <Ellipse Width="9" Height="9" Fill="{Binding BandBrush}"
+                                                             VerticalAlignment="Center" Margin="0,0,8,0" DockPanel.Dock="Left"/>
+                                                    <TextBlock Text="{Binding BandLabel}" Foreground="{Binding BandBrush}"
+                                                               FontSize="11" FontWeight="SemiBold" Width="58"
+                                                               VerticalAlignment="Center" DockPanel.Dock="Left"/>
+                                                    <TextBlock Text="{Binding DisplayName}" Foreground="{DynamicResource ForegroundBrush}"
+                                                               FontSize="11" FontWeight="SemiBold" Width="160"
+                                                               VerticalAlignment="Center" TextTrimming="CharacterEllipsis" DockPanel.Dock="Left"/>
+                                                    <TextBlock Text="{Binding Reason}" Foreground="{DynamicResource ForegroundMutedBrush}"
+                                                               FontSize="11" VerticalAlignment="Center" TextTrimming="CharacterEllipsis"/>
+                                                </DockPanel>
+                                            </Border>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                                <TextBlock x:Name="FleetAdditionalProblemsText" Text="{Binding AdditionalProblemText}"
+                                           FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}"
+                                           Margin="17,2,0,0" Visibility="Collapsed"/>
+                                <TextBlock x:Name="FleetAllHealthyText" Text="{Binding AllHealthyText}"
+                                           FontSize="12" Foreground="#81C784" Margin="0,0,0,2" Visibility="Collapsed"/>
+                            </StackPanel>
+                        </Border>
+
+                        <ScrollViewer VerticalScrollBarVisibility="Auto">
                         <ItemsControl x:Name="OverviewItemsControl">
                             <ItemsControl.ItemsPanel>
                                 <ItemsPanelTemplate>
@@ -619,7 +743,8 @@
                                 </DataTemplate>
                             </ItemsControl.ItemTemplate>
                         </ItemsControl>
-                    </ScrollViewer>
+                        </ScrollViewer>
+                    </DockPanel>
                 </TabItem>
 
                 <!-- Recommendations: re-skinned to Lite's advise-only card design (W2b). Its OWN server

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
@@ -577,6 +577,7 @@ public partial class MainWindow : Window
         if (ServerList.ItemsSource is not IEnumerable<DarlingServer> servers)
         {
             OverviewItemsControl.ItemsSource = null;
+            FleetRollupContainer.Visibility = Visibility.Collapsed;
             return;
         }
 
@@ -584,6 +585,7 @@ public partial class MainWindow : Window
         if (list.Count == 0)
         {
             OverviewItemsControl.ItemsSource = null;
+            FleetRollupContainer.Visibility = Visibility.Collapsed;
             return;
         }
 
@@ -605,8 +607,44 @@ public partial class MainWindow : Window
             }
         }));
 
-        OverviewItemsControl.ItemsSource = summaries.OfType<ServerSummaryItem>().ToList();
+        var cards = summaries.OfType<ServerSummaryItem>().ToList();
+        OverviewItemsControl.ItemsSource = cards;
+
+        /* Fleet-wide NOC roll-up above the cards — the cross-server totals SQL aggregate (the read only
+           Darling's central store can serve) plus the band counts / worst-N ranking reduced from the
+           cards' own #1426 banding. The totals use the SAME one-hour window the per-server cards use, so
+           they reconcile with the sum of the card counts. A totals-read failure degrades to zero totals
+           rather than blanking the Overview — the band counts and ranking still render from the cards. */
+        FleetTotals totals;
+        try
+        {
+            totals = await service.GetFleetTotalsAsync(nowUtc.AddHours(-1), nowUtc);
+        }
+        catch
+        {
+            totals = new FleetTotals();
+        }
+
+        ApplyFleetRollup(FleetRollup.Build(cards, totals));
+
         StatusText.Text = $"overview — refreshed {DateTime.Now:HH:mm:ss}";
+    }
+
+    /// <summary>
+    /// Renders the fleet roll-up above the Overview cards: sets the FleetRollupContainer's DataContext and
+    /// toggles the worst-first "Needs Attention" ranking against the all-clear line (there is no
+    /// inverse-visibility converter, so the swap is done here). The container shows only when there are
+    /// servers to roll up.
+    /// </summary>
+    private void ApplyFleetRollup(FleetRollup rollup)
+    {
+        FleetRollupContainer.DataContext = rollup;
+        FleetRollupContainer.Visibility = rollup.TotalServers > 0 ? Visibility.Visible : Visibility.Collapsed;
+
+        FleetWorstServersList.Visibility = rollup.HasProblems ? Visibility.Visible : Visibility.Collapsed;
+        FleetAdditionalProblemsText.Visibility =
+            rollup.AdditionalProblemCount > 0 ? Visibility.Visible : Visibility.Collapsed;
+        FleetAllHealthyText.Visibility = rollup.HasProblems ? Visibility.Collapsed : Visibility.Visible;
     }
 
     /// <summary>Double-clicking an Overview card opens (or focuses) that server's tab (Lite's rule).</summary>
@@ -617,6 +655,24 @@ public partial class MainWindow : Window
             && ServerList.ItemsSource is IEnumerable<DarlingServer> servers)
         {
             var server = servers.FirstOrDefault(s => s.ServerId == summary.ServerId);
+            if (server is not null)
+            {
+                OpenServerTab(server);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Clicking a "Needs Attention" ranking row opens (or focuses) that server's tab — the same
+    /// server-id → sidebar-server → OpenServerTab hop the Overview cards use (#1427 made OpenServerTab
+    /// return the tab).
+    /// </summary>
+    private void FleetWorstServer_Click(object sender, MouseButtonEventArgs e)
+    {
+        if (sender is FrameworkElement { DataContext: FleetRankedServer ranked }
+            && ServerList.ItemsSource is IEnumerable<DarlingServer> servers)
+        {
+            var server = servers.FirstOrDefault(s => s.ServerId == ranked.ServerId);
             if (server is not null)
             {
                 OpenServerTab(server);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Fleet.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Fleet.cs
@@ -1,0 +1,448 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Media;
+using Npgsql;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The Fleet-wide NOC roll-up — the signature capability Darling's single central store enables that
+/// NEITHER the Dashboard nor Lite can do. Each of those monitors one server per PerformanceMonitor
+/// database, so they physically cannot rank or total servers against each other in SQL; Darling keys
+/// every server's rows by <c>server_id</c> in ONE Postgres store, so a single cross-server GROUP-BY /
+/// aggregate rolls the whole fleet up at once.
+///
+/// <para>This roll-up is deliberately split across two mechanisms so it can REUSE the per-server surface
+/// rather than re-derive it:</para>
+/// <list type="bullet">
+/// <item><b>Fleet totals</b> (<see cref="GetFleetTotalsAsync"/> / <see cref="FleetTotalsSql"/>) are a
+/// genuine single cross-server aggregate over the collector views — total blocking events and total
+/// deadlocks in the window. Blocking honors the SAME per-server XE→DMV fallback the Overview cards use
+/// (<c>ServerSummaryBlockingSql</c>): it counts per <c>server_id</c> from each source, takes the XE count
+/// when a server has any XE row this window else its DMV count, then SUMs across the fleet — so the fleet
+/// total reconciles with the sum of the per-server card counts. These are pure COUNT metrics with no C#
+/// banding, so they belong in SQL.</item>
+/// <item><b>Health-band counts, servers-with-collection-failures, and the worst-N ranking</b>
+/// (<see cref="FleetRollup.Build"/>) are a pure C# reduction over the <see cref="ServerSummaryItem"/>
+/// list the Overview already loads. They REUSE #1426's card banding verbatim: a server's fleet band comes
+/// from <see cref="ServerSummaryItem.OverallMetricSeverity"/> + its freshness status (which themselves
+/// reuse every per-metric band, including <see cref="CollectorHealthRow.HealthStatus"/> via the card's
+/// FailedCollectorCount). Reproducing that six-metric composite in SQL would be inventing a parallel
+/// banding, so the classification stays where the banding lives — in C#, over the already-read cards.</item>
+/// </list>
+///
+/// <para>The totals read is windowed (parameterized, naive-UTC per the store convention). The Overview tab
+/// has no per-tab toolbar; the caller passes the SAME one-hour window the per-server cards use, so the
+/// fleet totals and the cards describe the same span.</para>
+/// </summary>
+public sealed partial class ViewerDataService
+{
+    /// <summary>
+    /// The cross-server fleet totals over a window — the read only Darling's central store can serve.
+    /// <c>total_blocking_events</c> respects the Overview card's XE-preferred / DMV-fallback rule PER
+    /// server before summing: each source is counted per <c>server_id</c> (a GROUP BY), a FULL OUTER JOIN
+    /// lines the two sources up per server, and each server contributes its XE count when it has any XE row
+    /// this window else its DMV count (Lite's <c>COALESCE(NULLIF(xe,0), dmv)</c>, applied per server) — so
+    /// an AWS RDS server with only DMV snapshots still counts and a server with XE reports is never
+    /// double-counted. <c>total_deadlocks</c> is a plain cross-server COUNT. $1 window start, $2 window end
+    /// (both naive UTC).
+    /// </summary>
+    public const string FleetTotalsSql = @"
+SELECT
+    (
+        SELECT COALESCE(SUM(CASE WHEN per_server.xe_count > 0 THEN per_server.xe_count ELSE per_server.dmv_count END), 0)
+        FROM
+        (
+            SELECT
+                COALESCE(xe.server_id, dmv.server_id) AS server_id,
+                COALESCE(xe.cnt, 0) AS xe_count,
+                COALESCE(dmv.cnt, 0) AS dmv_count
+            FROM
+            (
+                SELECT server_id, COUNT(*) AS cnt
+                FROM v_blocked_process_reports
+                WHERE event_time >= $1
+                AND   event_time <= $2
+                GROUP BY server_id
+            ) AS xe
+            FULL OUTER JOIN
+            (
+                SELECT server_id, COUNT(*) AS cnt
+                FROM v_dmv_blocking_snapshots
+                WHERE event_time >= $1
+                AND   event_time <= $2
+                GROUP BY server_id
+            ) AS dmv ON xe.server_id = dmv.server_id
+        ) AS per_server
+    ) AS total_blocking_events,
+    (
+        SELECT COUNT(*)
+        FROM v_deadlocks
+        WHERE deadlock_time >= $1
+        AND   deadlock_time <= $2
+    ) AS total_deadlocks";
+
+    /// <summary>
+    /// Reads the fleet's cross-server blocking + deadlock totals over the window. The single query that
+    /// neither the Dashboard nor Lite can run (each sees one server's database). Window bounds are sent
+    /// Kind=Unspecified (the naive-UTC store convention).
+    /// </summary>
+    public async Task<FleetTotals> GetFleetTotalsAsync(DateTime startUtc, DateTime endUtc, CancellationToken cancellationToken = default)
+    {
+        await using var command = _dataSource.CreateCommand(FleetTotalsSql);
+        command.Parameters.Add(new NpgsqlParameter<DateTime>
+        {
+            TypedValue = DateTime.SpecifyKind(startUtc, DateTimeKind.Unspecified),
+        });
+        command.Parameters.Add(new NpgsqlParameter<DateTime>
+        {
+            TypedValue = DateTime.SpecifyKind(endUtc, DateTimeKind.Unspecified),
+        });
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        if (await reader.ReadAsync(cancellationToken))
+        {
+            return new FleetTotals
+            {
+                TotalBlockingEvents = reader.IsDBNull(0) ? 0 : Convert.ToInt64(reader.GetValue(0)),
+                TotalDeadlocks = reader.IsDBNull(1) ? 0 : Convert.ToInt64(reader.GetValue(1)),
+            };
+        }
+
+        return new FleetTotals();
+    }
+}
+
+/// <summary>The cross-server fleet totals over a window — pure SQL aggregates keyed by <c>server_id</c>.</summary>
+public sealed class FleetTotals
+{
+    /// <summary>Blocking events across the whole fleet this window (per-server XE→DMV fallback, then summed).</summary>
+    public long TotalBlockingEvents { get; set; }
+
+    /// <summary>Deadlocks across the whole fleet this window.</summary>
+    public long TotalDeadlocks { get; set; }
+}
+
+/// <summary>
+/// A server's fleet-health band — the SAME banding #1426's Overview cards compute, collapsed to one label
+/// per server. <see cref="FleetRollup.ClassifyBand"/> derives it from the card's
+/// <see cref="ServerSummaryItem.OverallMetricSeverity"/> + freshness, so it never invents a new band: it
+/// mirrors <see cref="ServerSummaryItem.CardBorderBrush"/> (offline / critical → red, warning / stale →
+/// amber, else calm).
+/// </summary>
+public enum FleetHealthBand
+{
+    Healthy,
+    Warning,
+    Critical,
+
+    /// <summary>The server's collection is long-dead / never happened (the card's red offline overlay).</summary>
+    Offline,
+}
+
+/// <summary>
+/// One entry in the fleet's worst-first "Needs attention" ranking — a problem server with its band, a
+/// short human reason (built from the card's own metric displays), and its composite score. Clicking the
+/// entry opens that server's tab (the caller maps <see cref="ServerId"/> back to the sidebar server and
+/// calls MainWindow's OpenServerTab). Every display is a pure format of the underlying
+/// <see cref="ServerSummaryItem"/>; the brushes reuse the card's severity palette.
+/// </summary>
+public sealed class FleetRankedServer
+{
+    private static readonly SolidColorBrush s_criticalBrush = MakeBrush("#E57373");
+    private static readonly SolidColorBrush s_warningBrush = MakeBrush("#FFB74D");
+    private static readonly SolidColorBrush s_healthyBrush = MakeBrush("#81C784");
+    private static readonly SolidColorBrush s_offlineBrush = MakeBrush("#888888");
+
+    public int ServerId { get; init; }
+    public string DisplayName { get; init; } = "";
+    public FleetHealthBand Band { get; init; }
+
+    /// <summary>The composite worst-first ordering score (band rank + severity magnitude + incident tiebreak).</summary>
+    public long Score { get; init; }
+
+    /// <summary>A short "why it needs attention" line, e.g. "CPU 97%, Blocking 6" or "Offline — no recent collection".</summary>
+    public string Reason { get; init; } = "";
+
+    public string BandLabel => Band switch
+    {
+        FleetHealthBand.Critical => "Critical",
+        FleetHealthBand.Warning => "Warning",
+        FleetHealthBand.Offline => "Offline",
+        _ => "Healthy",
+    };
+
+    /// <summary>The band's dot / label brush — the card's severity palette (offline = the Unknown grey).</summary>
+    public SolidColorBrush BandBrush => Band switch
+    {
+        FleetHealthBand.Critical => s_criticalBrush,
+        FleetHealthBand.Warning => s_warningBrush,
+        FleetHealthBand.Offline => s_offlineBrush,
+        _ => s_healthyBrush,
+    };
+
+    private static SolidColorBrush MakeBrush(string hex)
+    {
+        var brush = new SolidColorBrush((Color)ColorConverter.ConvertFromString(hex));
+        brush.Freeze();
+        return brush;
+    }
+}
+
+/// <summary>
+/// The fleet-wide roll-up view-model rendered above the Overview's per-server cards: the fleet health
+/// summary (total servers + counts by band), the fleet totals (cross-server blocking / deadlock sums +
+/// servers with collection failures), and the worst-first "Needs attention" ranking. Built by
+/// <see cref="Build"/> from the same <see cref="ServerSummaryItem"/> list the Overview loads plus the
+/// <see cref="FleetTotals"/> SQL read — REUSING #1426's card banding for every band decision.
+/// </summary>
+public sealed class FleetRollup
+{
+    /// <summary>The default depth of the worst-first ranking (the "Needs attention" list caps at this).</summary>
+    public const int DefaultWorstCount = 5;
+
+    /// <summary>An empty fleet (no servers registered) — every count zero, no ranking.</summary>
+    public static readonly FleetRollup Empty = new();
+
+    public int TotalServers { get; init; }
+    public int HealthyCount { get; init; }
+    public int WarningCount { get; init; }
+    public int CriticalCount { get; init; }
+    public int OfflineCount { get; init; }
+
+    /// <summary>Servers whose 7-day collection banding flags at least one FAILING collector (card reuse).</summary>
+    public int ServersWithCollectionFailures { get; init; }
+
+    /// <summary>Fleet-wide blocking events this window (from the cross-server SQL total).</summary>
+    public long TotalBlockingEvents { get; init; }
+
+    /// <summary>Fleet-wide deadlocks this window (from the cross-server SQL total).</summary>
+    public long TotalDeadlocks { get; init; }
+
+    /// <summary>The worst-first problem servers (band != Healthy), capped at the requested depth.</summary>
+    public IReadOnlyList<FleetRankedServer> WorstServers { get; init; } = Array.Empty<FleetRankedServer>();
+
+    /// <summary>Problem servers beyond the capped ranking — surfaced as a "+N more" affordance.</summary>
+    public int AdditionalProblemCount { get; init; }
+
+    /// <summary>Any server needs attention (band != Healthy) — drives the ranking list vs the all-clear line.</summary>
+    public bool HasProblems => WorstServers.Count > 0;
+
+    /// <summary>"+N more need attention" when the ranking overflows its cap, else empty.</summary>
+    public string AdditionalProblemText =>
+        AdditionalProblemCount > 0 ? $"+{AdditionalProblemCount} more need attention" : "";
+
+    /// <summary>The all-clear affirmation shown when nothing needs attention.</summary>
+    public string AllHealthyText => TotalServers == 1
+        ? "All 1 server healthy"
+        : $"All {TotalServers} servers healthy";
+
+    /// <summary>"Monitoring N servers" subtitle for the fleet header.</summary>
+    public string MonitoringText => TotalServers == 1
+        ? "Monitoring 1 server"
+        : $"Monitoring {TotalServers} servers";
+
+    /// <summary>"N server(s)" for the collection-failures total line.</summary>
+    public string CollectionFailuresText => ServersWithCollectionFailures == 1
+        ? "1 server"
+        : $"{ServersWithCollectionFailures} servers";
+
+    /// <summary>
+    /// Rolls the per-server Overview cards up into the fleet view-model. The band counts,
+    /// servers-with-failures, and worst-first ranking reduce the <paramref name="summaries"/> using #1426's
+    /// card banding (no new bands); the blocking / deadlock totals come from the cross-server
+    /// <paramref name="totals"/> SQL read. <paramref name="worstCount"/> caps the "Needs attention" list.
+    /// </summary>
+    public static FleetRollup Build(IReadOnlyList<ServerSummaryItem> summaries, FleetTotals totals, int worstCount = DefaultWorstCount)
+    {
+        if (summaries.Count == 0)
+        {
+            return new FleetRollup
+            {
+                TotalBlockingEvents = totals.TotalBlockingEvents,
+                TotalDeadlocks = totals.TotalDeadlocks,
+            };
+        }
+
+        var healthy = 0;
+        var warning = 0;
+        var critical = 0;
+        var offline = 0;
+        var failures = 0;
+
+        foreach (var s in summaries)
+        {
+            switch (ClassifyBand(s))
+            {
+                case FleetHealthBand.Offline: offline++; break;
+                case FleetHealthBand.Critical: critical++; break;
+                case FleetHealthBand.Warning: warning++; break;
+                default: healthy++; break;
+            }
+
+            /* Servers with collection failures — the card's own FAILING count (which reuses
+               CollectorHealthRow.HealthStatus), not a re-derived SQL band. */
+            if (s.FailedCollectorCount > 0)
+            {
+                failures++;
+            }
+        }
+
+        /* Worst-first ranking: problem servers only (band != Healthy), highest composite score first,
+           name as the stable tiebreak. The composite score keeps offline > critical > warning and, within
+           a band, ranks by how many metrics are bad — see FleetHealthScore. */
+        var problems = summaries
+            .Where(s => ClassifyBand(s) != FleetHealthBand.Healthy)
+            .OrderByDescending(FleetHealthScore)
+            .ThenBy(s => s.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var worst = problems
+            .Take(worstCount)
+            .Select(s => new FleetRankedServer
+            {
+                ServerId = s.ServerId,
+                DisplayName = s.DisplayName,
+                Band = ClassifyBand(s),
+                Score = FleetHealthScore(s),
+                Reason = BuildReason(s),
+            })
+            .ToList();
+
+        return new FleetRollup
+        {
+            TotalServers = summaries.Count,
+            HealthyCount = healthy,
+            WarningCount = warning,
+            CriticalCount = critical,
+            OfflineCount = offline,
+            ServersWithCollectionFailures = failures,
+            TotalBlockingEvents = totals.TotalBlockingEvents,
+            TotalDeadlocks = totals.TotalDeadlocks,
+            WorstServers = worst,
+            AdditionalProblemCount = Math.Max(0, problems.Count - worst.Count),
+        };
+    }
+
+    /// <summary>
+    /// Collapses a card's health to one fleet band — REUSING #1426's banding, mirroring
+    /// <see cref="ServerSummaryItem.CardBorderBrush"/>: offline collection → Offline; else the card's
+    /// worst metric band (<see cref="ServerSummaryItem.OverallMetricSeverity"/>) maps Critical → Critical,
+    /// Warning → Warning, and a stale collection (<see cref="ServerSummaryItem.HasCollectorErrors"/>) is
+    /// Warning too; otherwise Healthy. No new thresholds are introduced here.
+    /// </summary>
+    public static FleetHealthBand ClassifyBand(ServerSummaryItem s)
+    {
+        if (s.IsOnline == false)
+        {
+            return FleetHealthBand.Offline;
+        }
+
+        return s.OverallMetricSeverity switch
+        {
+            HealthSeverity.Critical => FleetHealthBand.Critical,
+            HealthSeverity.Warning => FleetHealthBand.Warning,
+            _ => s.HasCollectorErrors ? FleetHealthBand.Warning : FleetHealthBand.Healthy,
+        };
+    }
+
+    /// <summary>
+    /// The worst-first ordering score. Band rank dominates (Offline &gt; Critical &gt; Warning &gt;
+    /// Healthy) in steps of 1000; within a band, servers are ranked by how many of the six card metrics
+    /// are Critical (×100) or Warning (×10), with the blocking + deadlock counts (capped) as a final
+    /// tiebreak. The within-band terms are bounded well under 1000, so they never reorder bands. Reuses the
+    /// card's per-metric severities — no new signal.
+    /// </summary>
+    public static long FleetHealthScore(ServerSummaryItem s)
+    {
+        long bandRank = ClassifyBand(s) switch
+        {
+            FleetHealthBand.Offline => 4000,
+            FleetHealthBand.Critical => 3000,
+            FleetHealthBand.Warning => 2000,
+            _ => 0,
+        };
+
+        var criticals = 0;
+        var warnings = 0;
+        foreach (var sev in MetricSeverities(s))
+        {
+            if (sev == HealthSeverity.Critical) criticals++;
+            else if (sev == HealthSeverity.Warning) warnings++;
+        }
+
+        /* criticals + warnings <= 6, so magnitude <= 600; incidents <= 99 — the within-band total stays
+           under 1000 and can never cross a band boundary. */
+        long magnitude = (criticals * 100L) + (warnings * 10L);
+        long incidents = Math.Min(s.BlockingCount + s.DeadlockCount, 99);
+        return bandRank + magnitude + incidents;
+    }
+
+    /// <summary>The six per-metric card severities, in card row order — the reuse surface for scoring / reasons.</summary>
+    private static IEnumerable<HealthSeverity> MetricSeverities(ServerSummaryItem s)
+    {
+        yield return s.CpuSeverity;
+        yield return s.ThreadsSeverity;
+        yield return s.MemorySeverity;
+        yield return s.BlockingSeverity;
+        yield return s.DeadlockSeverity;
+        yield return s.CollectorSeverity;
+    }
+
+    /// <summary>
+    /// A short human reason for the ranking, built from the card's OWN metric displays so it never drifts
+    /// from what the card shows. Offline states say so; otherwise it names the metrics that are Warning or
+    /// Critical (CPU / Blocking / Deadlocks / Memory / Threads / Collectors), plus a stale-collection note.
+    /// </summary>
+    public static string BuildReason(ServerSummaryItem s)
+    {
+        if (s.IsOnline == false)
+        {
+            return "Offline — no recent collection";
+        }
+
+        var parts = new List<string>();
+
+        if (s.CpuSeverity >= HealthSeverity.Warning)
+        {
+            parts.Add($"CPU {s.CpuDisplay}");
+        }
+        if (s.ThreadsSeverity >= HealthSeverity.Warning)
+        {
+            parts.Add($"Threads {s.ThreadsDisplay}");
+        }
+        if (s.MemorySeverity >= HealthSeverity.Warning && s.HasMemoryPressure)
+        {
+            parts.Add($"Memory: {s.MemoryDetail}");
+        }
+        if (s.BlockingSeverity >= HealthSeverity.Warning && s.BlockingCount > 0)
+        {
+            parts.Add($"Blocking {s.BlockingCount}");
+        }
+        if (s.DeadlockSeverity >= HealthSeverity.Warning && s.DeadlockCount > 0)
+        {
+            parts.Add($"Deadlocks {s.DeadlockCount}");
+        }
+        if (s.CollectorSeverity >= HealthSeverity.Warning)
+        {
+            parts.Add($"{s.FailedCollectorCount} collector{(s.FailedCollectorCount == 1 ? "" : "s")} failing");
+        }
+        if (s.HasCollectorErrors)
+        {
+            parts.Add("collection stale");
+        }
+
+        return parts.Count > 0 ? string.Join(", ", parts) : "Needs attention";
+    }
+}


### PR DESCRIPTION
## Fleet-wide NOC roll-up

The signature capability Darling's single central store enables that **neither the Dashboard nor Lite can do**: each of those monitors one server per PerformanceMonitor database, so they physically cannot rank or total servers against each other in SQL. Darling keys every server's rows by `server_id` in ONE Postgres store, so a single cross-server GROUP-BY / aggregate rolls the whole fleet up at once.

### Placement — Overview enhancement (not a new tab)
A fleet roll-up section added **above** the existing per-server cards grid in the **Overview tab** (the natural home — it already loads a per-server `ServerSummaryItem` for every server). The per-server cards are unchanged. A new top-level tab wasn't needed; the Overview hosts it cleanly.

### The three parts
1. **Fleet health summary** — total servers + counts by band (**Healthy / Warning / Critical / Offline**) as colored tiles. The band per server REUSES #1426's card banding: `FleetRollup.ClassifyBand` mirrors `ServerSummaryItem.CardBorderBrush` (offline collection → Offline; else the card's `OverallMetricSeverity` → Critical/Warning, a stale collection → Warning; else Healthy). `OverallMetricSeverity` itself already reuses every per-metric band including `CollectorHealthRow.HealthStatus`. **No new bands invented.**
2. **Fleet totals** — a genuine cross-server SQL aggregate over the window (last hour): **total blocking events** + **total deadlocks**, plus **servers with collection failures**. Blocking honors the same per-server XE→DMV fallback the cards use (count per `server_id` from each source, `FULL OUTER JOIN`, take XE when present else DMV, then SUM), so the fleet total reconciles with the sum of the card counts.
3. **Worst-first "Needs Attention" ranking** — problem servers (band != Healthy) ranked by a composite health score (band rank dominates: Offline > Critical > Warning; within a band, by how many of the six card metrics are bad). Clicking a row **opens that server's tab** (reuses `OpenServerTab`, #1427). Caps at 5 with a "+N more" overflow; an all-clear line replaces the list when the fleet is healthy.

### The reads + verified columns
- **`ViewerDataService.Fleet.cs` / `FleetTotalsSql`** — the cross-server aggregate. Windowed on both bounds (`$1`/`$2`, naive-UTC), no per-server filter.
  - `v_blocked_process_reports` / `v_dmv_blocking_snapshots`: `event_time`, `server_id`
  - `v_deadlocks`: `deadlock_time`, `server_id`
  - All column names verified against the collector schema (`PgSchemaGenerator.CreateTable(...)`) and the migration views; `server_id` is the universal store key used by the existing (live-validated) Overview/CollectionHealth reads.
- **Band counts + servers-with-failures + ranking** — a pure C# reduction over the per-server `ServerSummaryItem` list the Overview already loads (`FleetRollup.Build`). This is deliberate: the health banding is deterministic C# CASE logic; re-deriving that six-metric composite in SQL would invent a parallel banding. So pure-COUNT metrics (blocking/deadlocks) live in the SQL aggregate; banding-dependent roll-ups reduce the cards.

### Window
The Overview tab has no per-tab toolbar; the fleet totals use the **same one-hour window the per-server cards use**, so the totals and cards describe the same span (and reconcile). A totals-read failure degrades to zero totals rather than blanking the Overview.

### Testing
`Darling.Tests/ViewerFleetRollupTests.cs`:
- **SQL pins** — source views, `GROUP BY server_id`, `FULL OUTER JOIN`, the XE→DMV fallback CASE, cross-server deadlock COUNT, two-sided window (2× each), Pg dialect (no `now(`/`N'`/`@`, positional params), no per-server filter.
- **Verified columns** against the generated source tables + migration views.
- **Pure banding/ranking** — ClassifyBand for every band, band counts, servers-with-failures, worst-first order (offline > critical > warning; within-band by metric count), cap + overflow, all-clear, totals passthrough, reason text, ranked-row label/brush, singular/plural helpers.
- **Gated live round-trip** (`DARLING_TEST_PG`) — plants blocking/deadlock rows across two servers in a historical sentinel window and asserts the fleet total = 5 blocking (2 XE-preferred + 3 DMV-fallback) + 3 deadlocks. **Verified passing against the live dev Postgres**, not just skipping.

Full suite: **1513 passed, 118 skipped (live-PG gated), 0 failed** (Release).

### For the reviewer (partly greenfield — visual review expected)
- The surface/layout (tiles + totals line + ranked list) is a **best-effort design** for your visual review; the build compiles the XAML but rendering hasn't been visually driven.
- **Design choice to confirm:** worst-first ranking puts **Offline above Critical** (an unreachable server = zero visibility = top NOC priority). The band-rank constants are trivial to flip if you'd rather rank active-Critical first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)