### PR TITLE
Add aggregate blocking-severity (duration) stats to the Darling viewer

### DIFF
--- a/Darling/Darling.Tests/ViewerBlockingStatsTests.cs
+++ b/Darling/Darling.Tests/ViewerBlockingStatsTests.cs
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Npgsql;
+using PerformanceMonitor.Collectors;
+using PerformanceMonitor.Darling.Storage;
+using PerformanceMonitor.Darling.Viewer;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Pins the Blocking Stats sub-tab's blocking-duration aggregate read against the Darling store contract
+/// (no live Postgres). This is the SEVERITY companion to the blocking-incident COUNT trend: it buckets the
+/// raw blocked-process rows by minute and aggregates each block's <c>wait_time_ms</c> into total / max / avg
+/// duration. Critically it reuses the count trend's EXACT XE-preferred / DMV-fallback source selection
+/// (<c>WHERE NOT EXISTS (SELECT 1 FROM bpr)</c>) so the severity and count surfaces reconcile. Postgres
+/// dialect adaptations mirror the sibling reads: COUNT(*) / SUM are read as bigint (SUM CAST back from
+/// numeric), AVG CAST to double precision.
+/// </summary>
+public sealed class ViewerBlockingStatsSqlTests
+{
+    [Fact]
+    public void BlockingDurationStatsSql_XePreferred_DmvFallbackOnlyWhenNoXe()
+    {
+        Assert.Contains("FROM v_blocked_process_reports", ViewerDataService.BlockingDurationStatsSql, StringComparison.Ordinal);
+        Assert.Contains("FROM v_dmv_blocking_snapshots", ViewerDataService.BlockingDurationStatsSql, StringComparison.Ordinal);
+        /* The DMV branch contributes only when the XE source has no rows in the window — the SAME exclusion
+           as the blocking-incident count trend, so the two surfaces reconcile row-for-row. */
+        Assert.Contains("WHERE NOT EXISTS (SELECT 1 FROM bpr)", ViewerDataService.BlockingDurationStatsSql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BlockingDurationStatsSql_AggregatesWaitTimeMs_TotalMaxAvg()
+    {
+        /* The duration source is each blocked process's wait_time_ms (the verified block-duration column). */
+        Assert.Contains("SUM(wait_time_ms)", ViewerDataService.BlockingDurationStatsSql, StringComparison.Ordinal);
+        Assert.Contains("MAX(wait_time_ms)", ViewerDataService.BlockingDurationStatsSql, StringComparison.Ordinal);
+        Assert.Contains("AVG(wait_time_ms)", ViewerDataService.BlockingDurationStatsSql, StringComparison.Ordinal);
+        Assert.Contains("COUNT(*) AS event_count", ViewerDataService.BlockingDurationStatsSql, StringComparison.Ordinal);
+        /* SUM of a bigint column is numeric in Postgres → CAST back to bigint for the typed GetInt64 reader;
+           AVG is numeric → CAST to double precision for GetDouble (the sibling reads' exact adaptations). */
+        Assert.Contains("CAST(SUM(wait_time_ms) AS bigint)", ViewerDataService.BlockingDurationStatsSql, StringComparison.Ordinal);
+        Assert.Contains("CAST(AVG(wait_time_ms) AS double precision)", ViewerDataService.BlockingDurationStatsSql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BlockingDurationStatsSql_BucketsPerMinute_BothWindowBoundsOnEventTime()
+    {
+        /* Bucketed on event_time (when blocking happened), not collection_time — matching the count trend so
+           the buckets line up 1:1 across the severity and count charts. */
+        Assert.Contains("DATE_TRUNC('minute', event_time)", ViewerDataService.BlockingDurationStatsSql, StringComparison.Ordinal);
+        Assert.Contains("GROUP BY DATE_TRUNC('minute', event_time)", ViewerDataService.BlockingDurationStatsSql, StringComparison.Ordinal);
+        /* Both window bounds are applied (the XE and DMV CTEs each carry them). */
+        Assert.Contains("event_time >= $2 AND event_time <= $3", ViewerDataService.BlockingDurationStatsSql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BlockingDurationStatsSql_PgDialect_PositionalParams_NoBareNow_NoNLiterals()
+    {
+        var sql = ViewerDataService.BlockingDurationStatsSql;
+        Assert.DoesNotContain("now(", sql.ToLowerInvariant());
+        Assert.DoesNotContain("N'", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("@", sql, StringComparison.Ordinal);
+        Assert.Contains("$1", sql, StringComparison.Ordinal);
+        Assert.Contains("$2", sql, StringComparison.Ordinal);
+        Assert.Contains("$3", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BlockingDurationStats_ReadsWaitTimeMsColumnThatExistsInBothGeneratedTables()
+    {
+        /* The verified duration column — wait_time_ms — must exist in BOTH the XE-report table and the
+           DMV-snapshot fallback table (the read UNION-ALLs the two aggregates). */
+        Assert.Equal("blocked_process_reports", BlockedProcessReportCollector.Instance.TargetTable);
+        Assert.Equal("dmv_blocking_snapshots", DmvBlockingSnapshotCollector.Instance.TargetTable);
+
+        var bprDdl = PgSchemaGenerator.CreateTable(BlockedProcessReportCollector.Instance);
+        var dmvDdl = PgSchemaGenerator.CreateTable(DmvBlockingSnapshotCollector.Instance);
+        foreach (var column in new[] { "event_time", "wait_time_ms" })
+        {
+            Assert.Contains(column, bprDdl, StringComparison.Ordinal);
+            Assert.Contains(column, dmvDdl, StringComparison.Ordinal);
+        }
+    }
+}
+
+/// <summary>
+/// Gated (DARLING_TEST_PG) live round-trips for the blocking-duration aggregate: proves the per-minute
+/// bucketing, the total / max / avg wait_time_ms math, and the XE-preferred / DMV-fallback reconciliation
+/// (DMV excluded while any XE row exists in the window; contributes once the XE rows are gone). Shares the
+/// serialized "live-postgres" collection so the row churn can't race another class; uses a negative sentinel
+/// server_id and cleans up in finally.
+/// </summary>
+[Collection("live-postgres")]
+public sealed class ViewerBlockingStatsLivePostgresTests
+{
+    private const int StatsServerId = -972001;
+    private const string ServerName = "viewer-blocking-stats-e2e";
+
+    [Fact]
+    public async Task BlockingDurationStats_BucketsPerMinute_TotalMaxAvg_XePreferred_DmvFallback_AgainstDevPostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the live blocking-duration-stats test.");
+
+        using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await PgMigrations.MigrateAsync(connection, TestContext.Current.CancellationToken);
+        await DeleteRowsAsync(connection, "blocked_process_reports", StatsServerId);
+        await DeleteRowsAsync(connection, "dmv_blocking_snapshots", StatsServerId);
+
+        await using var viewer = new ViewerDataService(connectionString!);
+
+        try
+        {
+            var baseTime = TruncateToMinute(DateTime.UtcNow.AddMinutes(-10));
+            var minuteA = baseTime;
+            var minuteB = baseTime.AddMinutes(3);
+
+            /* minute A: two XE blocks (1000 ms + 3000 ms); minute B: one XE block (500 ms). Plus two DMV
+               rows in minute A (9999 ms) that must be EXCLUDED while any XE row exists in the window. */
+            await InsertBlockedProcessReportAsync(connection, StatsServerId, minuteA, minuteA.AddSeconds(5), 1000);
+            await InsertBlockedProcessReportAsync(connection, StatsServerId, minuteA, minuteA.AddSeconds(40), 3000);
+            await InsertBlockedProcessReportAsync(connection, StatsServerId, minuteB, minuteB.AddSeconds(10), 500);
+            await InsertDmvBlockingSnapshotAsync(connection, StatsServerId, minuteA, minuteA.AddSeconds(20), 9999);
+            await InsertDmvBlockingSnapshotAsync(connection, StatsServerId, minuteA, minuteA.AddSeconds(50), 9999);
+
+            var withXe = await viewer.GetBlockingDurationStatsAsync(StatsServerId, baseTime.AddMinutes(-1), baseTime.AddMinutes(10));
+
+            /* Only the XE buckets appear (DMV excluded by WHERE NOT EXISTS): A then B, ordered by bucket. */
+            Assert.Equal(2, withXe.Count);
+            Assert.True(withXe[0].Time < withXe[1].Time);
+
+            /* minute A: 2 events, total 4000, max 3000, avg 2000. */
+            Assert.Equal(2, withXe[0].EventCount);
+            Assert.Equal(4000, withXe[0].TotalDurationMs);
+            Assert.Equal(3000, withXe[0].MaxDurationMs);
+            Assert.Equal(2000.0, withXe[0].AvgDurationMs, precision: 3);
+
+            /* minute B: 1 event, total 500, max 500, avg 500. */
+            Assert.Equal(1, withXe[1].EventCount);
+            Assert.Equal(500, withXe[1].TotalDurationMs);
+            Assert.Equal(500, withXe[1].MaxDurationMs);
+            Assert.Equal(500.0, withXe[1].AvgDurationMs, precision: 3);
+
+            /* Remove the XE rows: now the DMV fallback contributes its two minute-A rows (9999 ms each). */
+            await DeleteRowsAsync(connection, "blocked_process_reports", StatsServerId);
+            var dmvOnly = await viewer.GetBlockingDurationStatsAsync(StatsServerId, baseTime.AddMinutes(-1), baseTime.AddMinutes(10));
+
+            Assert.Single(dmvOnly);
+            Assert.Equal(2, dmvOnly[0].EventCount);
+            Assert.Equal(19998, dmvOnly[0].TotalDurationMs);
+            Assert.Equal(9999, dmvOnly[0].MaxDurationMs);
+            Assert.Equal(9999.0, dmvOnly[0].AvgDurationMs, precision: 3);
+        }
+        finally
+        {
+            await DeleteRowsAsync(connection, "blocked_process_reports", StatsServerId);
+            await DeleteRowsAsync(connection, "dmv_blocking_snapshots", StatsServerId);
+        }
+    }
+
+    private static async Task InsertBlockedProcessReportAsync(
+        NpgsqlConnection connection, int serverId, DateTime collectionTimeUtc, DateTime eventTimeUtc, long waitTimeMs)
+    {
+        using var command = new NpgsqlCommand(@"
+INSERT INTO blocked_process_reports
+    (blocked_report_id, collection_time, server_id, server_name, event_time, database_name,
+     blocked_spid, blocking_spid, wait_time_ms, lock_mode, blocked_sql_text, blocking_sql_text,
+     blocked_process_report_xml, contentious_object)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)", connection);
+        command.Parameters.AddWithValue(1L);
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTimeUtc, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(serverId);
+        command.Parameters.AddWithValue(ServerName);
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(eventTimeUtc, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue("AppDb");
+        command.Parameters.AddWithValue(55);
+        command.Parameters.AddWithValue(60);
+        command.Parameters.AddWithValue(waitTimeMs);
+        command.Parameters.AddWithValue("X");
+        command.Parameters.AddWithValue("SELECT 1");
+        command.Parameters.AddWithValue("UPDATE t SET c = 1");
+        command.Parameters.AddWithValue("<blocked/>");
+        command.Parameters.AddWithValue("dbo.t");
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static async Task InsertDmvBlockingSnapshotAsync(
+        NpgsqlConnection connection, int serverId, DateTime collectionTimeUtc, DateTime eventTimeUtc, long waitTimeMs)
+    {
+        using var command = new NpgsqlCommand(@"
+INSERT INTO dmv_blocking_snapshots
+    (collection_id, collection_time, server_id, server_name, event_time, database_name,
+     blocked_spid, blocking_spid, wait_time_ms, lock_mode, blocked_sql_text, blocking_sql_text, contentious_object)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)", connection);
+        command.Parameters.AddWithValue(1L);
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTimeUtc, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(serverId);
+        command.Parameters.AddWithValue(ServerName);
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(eventTimeUtc, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue("AppDb");
+        command.Parameters.AddWithValue(155);
+        command.Parameters.AddWithValue(160);
+        command.Parameters.AddWithValue(waitTimeMs);
+        command.Parameters.AddWithValue("S");
+        command.Parameters.AddWithValue("SELECT 2");
+        command.Parameters.AddWithValue("UPDATE t SET c = 2");
+        command.Parameters.AddWithValue("dbo.t");
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    /* The duration aggregate buckets by DATE_TRUNC('minute', event_time), so the test anchors on a minute
+       boundary — otherwise added seconds could spill into the next minute and split a bucket. */
+    private static DateTime TruncateToMinute(DateTime value) =>
+        DateTime.SpecifyKind(new DateTime(value.Ticks - (value.Ticks % TimeSpan.TicksPerMinute)), DateTimeKind.Unspecified);
+
+    private static async Task DeleteRowsAsync(NpgsqlConnection connection, string table, int serverId)
+    {
+        using var cleanup = new NpgsqlCommand($"DELETE FROM {table} WHERE server_id = {serverId};", connection);
+        await cleanup.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.BlockingStats.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.BlockingStats.cs
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// One per-minute bucket of blocking SEVERITY (the Blocking Stats sub-tab): the count of blocked-process
+/// events in the bucket plus the total / max / avg blocking DURATION (ms) over them. The on-the-fly
+/// Darling equivalent of the Dashboard's pre-aggregated <c>collect.blocking_deadlock_stats</c>
+/// (blocking_event_count / total_blocking_duration_ms / max_blocking_duration_ms / avg_blocking_duration_ms)
+/// — computed from the raw <c>blocked_process_reports</c> rows the store already keeps, so no collector or
+/// schema change is needed. The duration source is each blocked process's <c>wait_time_ms</c> (bigint) —
+/// the same column the Blocked Process Reports grid and the alert path read as the block's wait time.
+/// </summary>
+public sealed record BlockingDurationStatsPoint(
+    DateTime Time, int EventCount, long TotalDurationMs, long MaxDurationMs, double AvgDurationMs);
+
+public sealed partial class ViewerDataService
+{
+    /// <summary>
+    /// Blocking-duration aggregate per minute — the SEVERITY companion to <see cref="BlockingTrendSql"/>'s
+    /// count-only trend, built on the SAME XE-preferred / DMV-fallback source selection so the two
+    /// reconcile exactly. XE blocked-process reports (<c>v_blocked_process_reports</c>) are the primary
+    /// source, bucketed on <c>event_time</c>; the always-on DMV snapshot (<c>v_dmv_blocking_snapshots</c>)
+    /// contributes only when the XE source has no rows in the window (<c>WHERE NOT EXISTS</c>), so a server
+    /// with both sources never double-counts (identical exclusion to the count trend). Each bucket carries
+    /// COUNT(*) events and the SUM / MAX / AVG of <c>wait_time_ms</c> (the per-blocked-process block
+    /// duration). Postgres dialect notes mirror the sibling reads: COUNT(*) is <c>bigint</c> (read via
+    /// GetInt64, narrowed to int); SUM of a bigint column is <c>numeric</c>, CAST back to <c>bigint</c> for
+    /// the typed GetInt64 reader (the same adaptation the waiting-task read makes); AVG is <c>numeric</c>,
+    /// CAST to <c>double precision</c> for GetDouble. $1 server_id, $2 window start, $3 window end (naive
+    /// UTC).
+    /// </summary>
+    public const string BlockingDurationStatsSql = """
+        WITH bpr AS (
+            SELECT
+                DATE_TRUNC('minute', event_time) AS bucket,
+                COUNT(*) AS event_count,
+                CAST(SUM(wait_time_ms) AS bigint) AS total_duration_ms,
+                MAX(wait_time_ms) AS max_duration_ms,
+                CAST(AVG(wait_time_ms) AS double precision) AS avg_duration_ms
+            FROM v_blocked_process_reports
+            WHERE server_id = $1 AND event_time >= $2 AND event_time <= $3
+            GROUP BY DATE_TRUNC('minute', event_time)
+        ),
+        dmv AS (
+            SELECT
+                DATE_TRUNC('minute', event_time) AS bucket,
+                COUNT(*) AS event_count,
+                CAST(SUM(wait_time_ms) AS bigint) AS total_duration_ms,
+                MAX(wait_time_ms) AS max_duration_ms,
+                CAST(AVG(wait_time_ms) AS double precision) AS avg_duration_ms
+            FROM v_dmv_blocking_snapshots
+            WHERE server_id = $1 AND event_time >= $2 AND event_time <= $3
+            GROUP BY DATE_TRUNC('minute', event_time)
+        )
+        SELECT bucket, event_count, total_duration_ms, max_duration_ms, avg_duration_ms FROM bpr
+        UNION ALL
+        SELECT bucket, event_count, total_duration_ms, max_duration_ms, avg_duration_ms FROM dmv WHERE NOT EXISTS (SELECT 1 FROM bpr)
+        ORDER BY bucket
+        """;
+
+    /// <summary>
+    /// Blocking-duration-severity buckets for one server over the window (Blocking Stats sub-tab): total
+    /// events and total / max / avg block duration per minute, XE-preferred with the DMV-snapshot fallback
+    /// so it reconciles with the blocking-incident count trend.
+    /// </summary>
+    public async Task<List<BlockingDurationStatsPoint>> GetBlockingDurationStatsAsync(
+        int serverId, DateTime startUtc, DateTime endUtc, CancellationToken cancellationToken = default)
+    {
+        var items = new List<BlockingDurationStatsPoint>();
+
+        await using var command = _dataSource.CreateCommand(BlockingDurationStatsSql);
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+        command.Parameters.Add(new NpgsqlParameter<DateTime>
+        {
+            TypedValue = DateTime.SpecifyKind(startUtc, DateTimeKind.Unspecified),
+        });
+        command.Parameters.Add(new NpgsqlParameter<DateTime>
+        {
+            TypedValue = DateTime.SpecifyKind(endUtc, DateTimeKind.Unspecified),
+        });
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            items.Add(new BlockingDurationStatsPoint(
+                reader.GetDateTime(0),
+                reader.IsDBNull(1) ? 0 : (int)reader.GetInt64(1),
+                reader.IsDBNull(2) ? 0 : reader.GetInt64(2),
+                reader.IsDBNull(3) ? 0 : reader.GetInt64(3),
+                reader.IsDBNull(4) ? 0 : reader.GetDouble(4)));
+        }
+
+        return items;
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Blocking.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Blocking.cs
@@ -37,16 +37,20 @@ public partial class ViewerServerTab
     private ChartHoverHelper? _lockWaitTrendHover;
     private ChartHoverHelper? _blockingTrendHover;
     private ChartHoverHelper? _deadlockTrendHover;
+    private ChartHoverHelper? _blockingDurationHover;
+    private ChartHoverHelper? _blockingTotalDurationHover;
     private ChartHoverHelper? _currentWaitsDurationHover;
     private ChartHoverHelper? _currentWaitsBlockedHover;
 
     /* Blocking sub-tab order (mirrors LoadBlockingAsync's switch + Lite's BlockingSubTabControl): Trends,
-       Current Waits, Blocked Process Reports, Deadlocks. Named so the chart drill-downs
-       (OnBlockingDrillDown / OnDeadlockDrillDown) target the right sub-tab without a magic literal. */
+       Blocking Stats, Current Waits, Blocked Process Reports, Deadlocks. Named so the chart drill-downs
+       (OnBlockingDrillDown / OnDeadlockDrillDown) target the right sub-tab without a magic literal; the
+       Blocking Stats severity sub-tab sits right after Trends (its count-only sibling). */
     private const int BlockingTrendsSubTabIndex = 0;
-    private const int BlockingCurrentWaitsSubTabIndex = 1;
-    private const int BlockedProcessReportsSubTabIndex = 2;
-    private const int DeadlocksSubTabIndex = 3;
+    private const int BlockingStatsSubTabIndex = 1;
+    private const int BlockingCurrentWaitsSubTabIndex = 2;
+    private const int BlockedProcessReportsSubTabIndex = 3;
+    private const int DeadlocksSubTabIndex = 4;
 
     /// <summary>
     /// Applies the shared chrome to the five Blocking trend charts and wires their hover tooltips
@@ -61,6 +65,10 @@ public partial class ViewerServerTab
         BlockingTrendChart.Refresh();
         ApplyTheme(DeadlockTrendChart);
         DeadlockTrendChart.Refresh();
+        ApplyTheme(BlockingDurationChart);
+        BlockingDurationChart.Refresh();
+        ApplyTheme(BlockingTotalDurationChart);
+        BlockingTotalDurationChart.Refresh();
         ApplyTheme(CurrentWaitsDurationChart);
         CurrentWaitsDurationChart.Refresh();
         ApplyTheme(CurrentWaitsBlockedChart);
@@ -69,6 +77,8 @@ public partial class ViewerServerTab
         _lockWaitTrendHover = new ChartHoverHelper(LockWaitTrendChart, "ms/sec");
         _blockingTrendHover = new ChartHoverHelper(BlockingTrendChart, "incidents");
         _deadlockTrendHover = new ChartHoverHelper(DeadlockTrendChart, "deadlocks");
+        _blockingDurationHover = new ChartHoverHelper(BlockingDurationChart, "ms");
+        _blockingTotalDurationHover = new ChartHoverHelper(BlockingTotalDurationChart, "ms");
         _currentWaitsDurationHover = new ChartHoverHelper(CurrentWaitsDurationChart, "ms");
         _currentWaitsBlockedHover = new ChartHoverHelper(CurrentWaitsBlockedChart, "sessions");
 
@@ -124,6 +134,18 @@ public partial class ViewerServerTab
                 RenderLockWaitTrendChart(lockWaits);
                 RenderBlockingTrendChart(blocking);
                 RenderDeadlockTrendChart(deadlocks);
+                break;
+            case BlockingStatsSubTabIndex:
+                /* Blocking SEVERITY: the duration aggregate reconciles with the count trend (same XE→DMV
+                   source selection); the deadlock COUNT is the cheap sibling of the Trends tab's deadlock
+                   trend, summed here for the summary strip (its per-minute buckets share this window). */
+                var durationStatsTask = _dataService.GetBlockingDurationStatsAsync(_server.ServerId, startUtc, endUtc);
+                var deadlockCountTask = _dataService.GetDeadlockTrendAsync(_server.ServerId, startUtc, endUtc);
+                var durationStats = await durationStatsTask;
+                var deadlockCounts = await deadlockCountTask;
+                RenderBlockingDurationChart(durationStats);
+                RenderBlockingTotalDurationChart(durationStats);
+                UpdateBlockingStatsSummary(durationStats, deadlockCounts);
                 break;
             case BlockingCurrentWaitsSubTabIndex:
                 var durationTask = _dataService.GetWaitingTaskTrendAsync(_server.ServerId, startUtc, endUtc);
@@ -485,6 +507,145 @@ public partial class ViewerServerTab
         DeadlockTrendChart.Refresh();
     }
 
+    /// <summary>
+    /// Max + Avg block duration (ms) per minute — the per-incident severity signal (how long an individual
+    /// block lasts). Two connected-scatter series on one shared ms axis (Max ≥ Avg, comparable magnitudes),
+    /// mirroring the Current Waits duration chart's render idiom. Total duration lands on its own chart
+    /// (<see cref="RenderBlockingTotalDurationChart"/>) because its aggregate magnitude dwarfs these.
+    /// </summary>
+    private void RenderBlockingDurationChart(List<BlockingDurationStatsPoint> data)
+    {
+        ClearChart(BlockingDurationChart);
+        ApplyTheme(BlockingDurationChart);
+
+        var (winStartUtc, winEndUtc) = GetWindowUtc();
+        var rangeStart = ViewerTimeHelper.ForDisplay(winStartUtc);
+        var rangeEnd = ViewerTimeHelper.ForDisplay(winEndUtc);
+
+        _blockingDurationHover?.Clear();
+        if (data.Count == 0)
+        {
+            var zeroLine = BlockingDurationChart.Plot.Add.Scatter(
+                new[] { rangeStart.ToOADate(), rangeEnd.ToOADate() },
+                new[] { 0.0, 0.0 });
+            zeroLine.LegendText = "Max Block Duration";
+            zeroLine.Color = ScottPlot.Color.FromHex(SeriesColors[0]);
+            zeroLine.MarkerSize = 0;
+            BlockingDurationChart.Plot.Axes.DateTimeTicksBottomDateChange();
+            BlockingDurationChart.Plot.Axes.SetLimitsX(rangeStart.ToOADate(), rangeEnd.ToOADate());
+            ReapplyAxisColors(BlockingDurationChart);
+            BlockingDurationChart.Plot.YLabel("Block Duration (ms)");
+            SetChartYLimitsWithLegendPadding(BlockingDurationChart, 0, 1);
+            ShowChartLegend(BlockingDurationChart);
+            BlockingDurationChart.Refresh();
+            return;
+        }
+
+        var ordered = data.OrderBy(d => d.Time).ToList();
+        var times = ordered.Select(d => ViewerTimeHelper.ForDisplay(d.Time).ToOADate()).ToArray();
+        var maxValues = ordered.Select(d => (double)d.MaxDurationMs).ToArray();
+        var avgValues = ordered.Select(d => d.AvgDurationMs).ToArray();
+
+        var maxPlot = BlockingDurationChart.Plot.Add.Scatter(times, maxValues);
+        maxPlot.LegendText = "Max Block Duration";
+        maxPlot.Color = ScottPlot.Color.FromHex(SeriesColors[0]);
+        ChartStyle.StyleScatter(maxPlot);
+        _blockingDurationHover?.Add(maxPlot, "Max Block Duration");
+
+        var avgPlot = BlockingDurationChart.Plot.Add.Scatter(times, avgValues);
+        avgPlot.LegendText = "Avg Block Duration";
+        avgPlot.Color = ScottPlot.Color.FromHex(SeriesColors[1]);
+        ChartStyle.StyleScatter(avgPlot);
+        _blockingDurationHover?.Add(avgPlot, "Avg Block Duration");
+
+        double globalMax = maxValues.Length > 0 ? maxValues.Max() : 0;
+
+        BlockingDurationChart.Plot.Axes.DateTimeTicksBottomDateChange();
+        BlockingDurationChart.Plot.Axes.SetLimitsX(rangeStart.ToOADate(), rangeEnd.ToOADate());
+        ReapplyAxisColors(BlockingDurationChart);
+        BlockingDurationChart.Plot.YLabel("Block Duration (ms)");
+        SetChartYLimitsWithLegendPadding(BlockingDurationChart, 0, globalMax > 0 ? globalMax : 1);
+        ShowChartLegend(BlockingDurationChart);
+        BlockingDurationChart.Refresh();
+    }
+
+    /// <summary>
+    /// Total block duration (ms) per minute — the aggregate volume×severity signal (the sum of every block's
+    /// wait time in the bucket). Single connected-scatter series on its own chart/axis so its magnitude
+    /// doesn't swamp the per-incident Max/Avg chart; colored with the blocking identity so it reads as a
+    /// sibling of the Trends tab's blocking-incident chart.
+    /// </summary>
+    private void RenderBlockingTotalDurationChart(List<BlockingDurationStatsPoint> data)
+    {
+        ClearChart(BlockingTotalDurationChart);
+        ApplyTheme(BlockingTotalDurationChart);
+
+        var (winStartUtc, winEndUtc) = GetWindowUtc();
+        var rangeStart = ViewerTimeHelper.ForDisplay(winStartUtc);
+        var rangeEnd = ViewerTimeHelper.ForDisplay(winEndUtc);
+
+        _blockingTotalDurationHover?.Clear();
+        if (data.Count == 0)
+        {
+            var zeroLine = BlockingTotalDurationChart.Plot.Add.Scatter(
+                new[] { rangeStart.ToOADate(), rangeEnd.ToOADate() },
+                new[] { 0.0, 0.0 });
+            zeroLine.LegendText = "Total Block Duration";
+            zeroLine.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("Blocking"));
+            zeroLine.MarkerSize = 0;
+            BlockingTotalDurationChart.Plot.Axes.DateTimeTicksBottomDateChange();
+            BlockingTotalDurationChart.Plot.Axes.SetLimitsX(rangeStart.ToOADate(), rangeEnd.ToOADate());
+            ReapplyAxisColors(BlockingTotalDurationChart);
+            BlockingTotalDurationChart.Plot.YLabel("Total Block Duration (ms)");
+            SetChartYLimitsWithLegendPadding(BlockingTotalDurationChart, 0, 1);
+            ShowChartLegend(BlockingTotalDurationChart);
+            BlockingTotalDurationChart.Refresh();
+            return;
+        }
+
+        var ordered = data.OrderBy(d => d.Time).ToList();
+        var times = ordered.Select(d => ViewerTimeHelper.ForDisplay(d.Time).ToOADate()).ToArray();
+        var totals = ordered.Select(d => (double)d.TotalDurationMs).ToArray();
+
+        var plot = BlockingTotalDurationChart.Plot.Add.Scatter(times, totals);
+        plot.LegendText = "Total Block Duration";
+        plot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("Blocking"));
+        ChartStyle.StyleScatter(plot);
+        _blockingTotalDurationHover?.Add(plot, "Total Block Duration");
+
+        double globalMax = totals.Length > 0 ? totals.Max() : 0;
+
+        BlockingTotalDurationChart.Plot.Axes.DateTimeTicksBottomDateChange();
+        BlockingTotalDurationChart.Plot.Axes.SetLimitsX(rangeStart.ToOADate(), rangeEnd.ToOADate());
+        ReapplyAxisColors(BlockingTotalDurationChart);
+        BlockingTotalDurationChart.Plot.YLabel("Total Block Duration (ms)");
+        SetChartYLimitsWithLegendPadding(BlockingTotalDurationChart, 0, globalMax > 0 ? globalMax : 1);
+        ShowChartLegend(BlockingTotalDurationChart);
+        BlockingTotalDurationChart.Refresh();
+    }
+
+    /// <summary>
+    /// Window-rollup summary strip for the Blocking Stats sub-tab: total blocking events, total / max / avg
+    /// block duration (the avg is EVENT-weighted — total ÷ events — not a mean of the per-minute averages),
+    /// and the deadlock COUNT over the window. The deadlock count is the cheap signal; the Dashboard's
+    /// victim_count / total_deadlock_wait_time_ms need deadlock-graph XML parsing (a collector port) and are
+    /// deferred. Durations render with the viewer's blocking wait-time format (ms under a second, else sec).
+    /// </summary>
+    private void UpdateBlockingStatsSummary(List<BlockingDurationStatsPoint> stats, List<BlockingTrendPoint> deadlocks)
+    {
+        long totalEvents = stats.Sum(s => (long)s.EventCount);
+        long totalDuration = stats.Sum(s => s.TotalDurationMs);
+        long maxDuration = stats.Count > 0 ? stats.Max(s => s.MaxDurationMs) : 0;
+        long totalDeadlocks = deadlocks.Sum(d => (long)d.Count);
+        long avgDuration = totalEvents > 0 ? (long)Math.Round((double)totalDuration / totalEvents) : 0;
+
+        BlockingStatsEventCountText.Text = totalEvents.ToString("N0");
+        BlockingStatsTotalDurationText.Text = totalEvents > 0 ? ViewerDataService.FormatWaitTime(totalDuration) : "--";
+        BlockingStatsMaxDurationText.Text = totalEvents > 0 ? ViewerDataService.FormatWaitTime(maxDuration) : "--";
+        BlockingStatsAvgDurationText.Text = totalEvents > 0 ? ViewerDataService.FormatWaitTime(avgDuration) : "--";
+        BlockingStatsDeadlockCountText.Text = totalDeadlocks.ToString("N0");
+    }
+
     private void RenderCurrentWaitsDurationChart(List<WaitingTaskTrendPoint> data)
     {
         ClearChart(CurrentWaitsDurationChart);
@@ -603,6 +764,8 @@ public partial class ViewerServerTab
         _lockWaitTrendHover?.Dispose();
         _blockingTrendHover?.Dispose();
         _deadlockTrendHover?.Dispose();
+        _blockingDurationHover?.Dispose();
+        _blockingTotalDurationHover?.Dispose();
         _currentWaitsDurationHover?.Dispose();
         _currentWaitsBlockedHover?.Dispose();
     }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.DrillDown.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.DrillDown.cs
@@ -85,6 +85,12 @@ public partial class ViewerServerTab
         AddChartDrillDownMenuItem(BlockingTrendChart, BuildChartContextMenu(BlockingTrendChart, "Blocking_Trends"), () => _blockingTrendHover, "Show Blocking at This Time", OnBlockingDrillDown);
         AddChartDrillDownMenuItem(DeadlockTrendChart, BuildChartContextMenu(DeadlockTrendChart, "Deadlock_Trends"), () => _deadlockTrendHover, "Show Deadlocks at This Time", OnDeadlockDrillDown);
 
+        /* Blocking Stats (this feature) — the severity duration charts drill to the same blocked-process
+           reports as their count-trend siblings, so right-clicking a duration spike opens the blocks at that
+           time ("Show Blocking at This Time" -> OnBlockingDrillDown). */
+        AddChartDrillDownMenuItem(BlockingDurationChart, BuildChartContextMenu(BlockingDurationChart, "Blocking_Duration"), () => _blockingDurationHover, "Show Blocking at This Time", OnBlockingDrillDown);
+        AddChartDrillDownMenuItem(BlockingTotalDurationChart, BuildChartContextMenu(BlockingTotalDurationChart, "Blocking_Total_Duration"), () => _blockingTotalDurationHover, "Show Blocking at This Time", OnBlockingDrillDown);
+
         /* File I/O (4) + Blocking > Current Waits (2) — the rest of Lite's "Show Active Queries at This Time"
            set (ServerTab.xaml.cs:340-363, in the same referenced block). Charts in this same viewer surface,
            same drill target; wired for faithful parity so no sibling chart is left without the drill-down. */

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
@@ -1886,6 +1886,45 @@
                             </Border>
                         </Grid>
                     </TabItem>
+                    <!-- Blocking Stats — the blocking-SEVERITY companion to the count-only "Trends" tab
+                         (the "are blocks getting LONGER, not just more frequent" signal). Computed ON-THE-FLY
+                         from the same blocked_process_reports (XE) rows the count trend uses, with the identical
+                         v_dmv_blocking_snapshots fallback (WHERE NOT EXISTS) so the two reconcile — the Darling
+                         equivalent of the Dashboard's pre-aggregated collect.blocking_deadlock_stats. Two charts
+                         split the magnitude scales: per-incident Max/Avg block duration on one, aggregate Total
+                         duration on the other (Total dwarfs per-incident on a shared linear axis). A window
+                         summary strip carries events / total / max / avg duration + the (cheap) deadlock COUNT.
+                         The Dashboard's victim_count / total_deadlock_wait_time_ms need deadlock-graph XML
+                         parsing (a collector port), so they are deferred, not shown here. -->
+                    <TabItem Header="Blocking Stats">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="*"/>
+                                <RowDefinition Height="*"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <Border Grid.Row="0" Margin="0,0,0,4">
+                                <scottplot:WpfPlot x:Name="BlockingDurationChart"/>
+                            </Border>
+                            <Border Grid.Row="1" Margin="0,4,0,4">
+                                <scottplot:WpfPlot x:Name="BlockingTotalDurationChart"/>
+                            </Border>
+                            <Border Grid.Row="2" Background="{DynamicResource BackgroundDarkBrush}" CornerRadius="4" Padding="12,8" Margin="0,4,0,0">
+                                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                    <TextBlock Text="Blocking Events:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                    <TextBlock x:Name="BlockingStatsEventCountText" Text="--" VerticalAlignment="Center" Margin="0,0,20,0"/>
+                                    <TextBlock Text="Total Duration:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                    <TextBlock x:Name="BlockingStatsTotalDurationText" Text="--" VerticalAlignment="Center" Margin="0,0,20,0"/>
+                                    <TextBlock Text="Max Duration:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                    <TextBlock x:Name="BlockingStatsMaxDurationText" Text="--" VerticalAlignment="Center" Margin="0,0,20,0"/>
+                                    <TextBlock Text="Avg Duration:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                    <TextBlock x:Name="BlockingStatsAvgDurationText" Text="--" VerticalAlignment="Center" Margin="0,0,20,0"/>
+                                    <TextBlock Text="Deadlocks:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                    <TextBlock x:Name="BlockingStatsDeadlockCountText" Text="--" VerticalAlignment="Center"/>
+                                </StackPanel>
+                            </Border>
+                        </Grid>
+                    </TabItem>
                     <TabItem Header="Current Waits">
                         <Grid>
                             <Grid.RowDefinitions>


### PR DESCRIPTION
## What & why

Darling already trends blocking-incident **COUNT** and deadlock **COUNT**, but not blocking **SEVERITY** — whether blocks are getting *longer*, not just more frequent. This adds a **"Blocking Stats"** sub-tab under **Blocking** (right after the count-only **Trends** tab) showing **total / max / avg blocking DURATION** over the window.

It's the Darling equivalent of the Dashboard's pre-aggregated `collect.blocking_deadlock_stats` collector, but computed **on-the-fly** from the raw `blocked_process_reports` rows Darling already stores — **no collector or schema change**.

## Placement

New `Blocking Stats` sub-tab, index 1 (right after `Trends`, its count-only sibling). The four named sub-tab index constants were renumbered (Current Waits / Blocked Process Reports / Deadlocks shift +1); every consumer already references the named constants, so the drill-down navigation is unaffected. No test pinned the sub-tab count.

## The read (`ViewerDataService.BlockingStats.cs`)

`BlockingDurationStatsSql` buckets by `DATE_TRUNC('minute', event_time)` and aggregates each blocked process's **`wait_time_ms`** into `COUNT(*)` events + `SUM` / `MAX` / `AVG` duration.

- **Verified duration column: `wait_time_ms`** — a physical `BigInt` in both `blocked_process_reports` (`BlockedProcessReportCollector`, the XE report's blocked-process wait time) and `dmv_blocking_snapshots` (`DmvBlockingSnapshotCollector`, sourced from `wt.wait_duration_ms`). It's the same column the Blocked Process Reports grid and the alert path already read as the block's wait time.
- **XE→DMV reconciliation:** reuses the blocking-incident count trend's *exact* source selection — XE `v_blocked_process_reports` preferred, `v_dmv_blocking_snapshots` contributes only `WHERE NOT EXISTS (SELECT 1 FROM bpr)` — so the severity and count surfaces reconcile row-for-row and never double-count.
- **Pg dialect** (mirrors the sibling reads): `CAST(SUM(wait_time_ms) AS bigint)` (numeric→bigint), `CAST(AVG(wait_time_ms) AS double precision)`, positional `$1/$2/$3`, both-sides window bound on `event_time`.

## The UI (`ViewerServerTab.Blocking.cs` / `.xaml` / `.DrillDown.cs`)

- **Two charts** split the magnitude scales — per-incident **Max/Avg** block duration on one, aggregate **Total** duration on the other (Total dwarfs per-incident on a shared linear axis, so one chart would flatten Max/Avg).
- **Window summary strip**: Blocking Events · Total Duration · Max Duration · Avg Duration (event-weighted = total ÷ events) · Deadlocks.
- Viewer chart pattern: ScottPlot + `ChartStyle` + hover + the #1419 copy/save/export **context menu**, plus the **"Show Blocking at This Time"** drill-down for parity with the count-trend siblings. Settable window + Apply-to-all via the existing `GetWindowUtc()` / `RefreshActiveInnerTabAsync` loader.
- **Deadlock COUNT** (cheap, from the existing deadlock-trend read, same per-minute buckets) is summed into the summary. It is not re-charted here because the sibling **Trends** tab already charts deadlock count over time (re-charting would be redundant and mixing count+ms axes would muddy the duration charts).

## Deferred enrichment (the one allowed deferral)

The Dashboard's **`victim_count`** and **`total_deadlock_wait_time_ms`** are **not** built here. They require parsing `deadlocks.deadlock_graph_xml` per event — a proper collector/parse pass (a separate cross-app `blocking_deadlock_stats` collector port), not a cheap on-the-fly compute. Two prior MCP passes (#1421, #1425) reached the same conclusion. Deadlock **COUNT** (cheap) is shown; victims/wait-time are left for the collector port.

## Tests (`ViewerBlockingStatsTests.cs`)

- **SQL pins** (no live PG): XE-preferred + DMV fallback (`WHERE NOT EXISTS`), `SUM/MAX/AVG(wait_time_ms)` + the two casts, per-minute bucket + both window bounds on `event_time`, Pg-dialect positional params (no bare `now(`, no `N'`, no `@`), and `wait_time_ms` exists in both generated tables.
- **`DARLING_TEST_PG`-gated live round-trip**: proves per-minute bucketing, the total/max/avg math, and the XE-preferred / DMV-fallback contribution (DMV excluded while XE exists; contributes once XE is gone).

Full `Darling.Tests -c Release`: **1518 passed, 0 failed, 119 skipped** (live-PG gated). Whole-solution build clean. Touches only the Viewer project + Darling.Tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)