### PR TITLE
Service-driven live execution-plan fetch for Darling

### DIFF
--- a/Darling/Darling.Tests/DarlingCommandExecutorTests.cs
+++ b/Darling/Darling.Tests/DarlingCommandExecutorTests.cs
@@ -38,6 +38,30 @@ public sealed class DarlingCommandExecutorTests
 
         public Task<CommandOutcome> AnalyzeNowAsync(int serverId, CancellationToken cancellationToken)
             => throw new InvalidOperationException("host should not be called for this command");
+
+        public Task<CommandOutcome> FetchPlanAsync(int serverId, PlanFetchRequest request, CancellationToken cancellationToken)
+            => throw new InvalidOperationException("host should not be called for this command");
+    }
+
+    /// <summary>A host that records the fetch_plan request it received and returns a canned plan — for the
+    /// fetch_plan claim/execute/report round-trip (the store path, without a live SQL Server).</summary>
+    private sealed class PlanReturningHost : IDarlingCommandHost
+    {
+        public PlanFetchRequest? Received { get; private set; }
+        public int ReceivedServerId { get; private set; }
+
+        public Task<CommandOutcome> SnapshotNowAsync(int serverId, CancellationToken cancellationToken)
+            => throw new InvalidOperationException("not this command");
+
+        public Task<CommandOutcome> AnalyzeNowAsync(int serverId, CancellationToken cancellationToken)
+            => throw new InvalidOperationException("not this command");
+
+        public Task<CommandOutcome> FetchPlanAsync(int serverId, PlanFetchRequest request, CancellationToken cancellationToken)
+        {
+            Received = request;
+            ReceivedServerId = serverId;
+            return Task.FromResult(new CommandOutcome(true, "plan fetched", "{\"success\":true,\"planXml\":\"<ShowPlanXML/>\"}"));
+        }
     }
 
     private static ClaimedCommand Command(string type, int? target = null, string? args = null) =>
@@ -177,6 +201,34 @@ public sealed class DarlingCommandExecutorTests
         Assert.Equal(CommandKind.Fail, DarlingCommandExecutor.ResolvePlan(Command("analyze_now")).Kind);
         Assert.Equal(CommandKind.Snapshot, DarlingCommandExecutor.ResolvePlan(Command("snapshot_now", target: 3)).Kind);
         Assert.Equal(CommandKind.Analyze, DarlingCommandExecutor.ResolvePlan(Command("analyze_now", target: 3)).Kind);
+    }
+
+    [Fact]
+    public void ResolvePlan_FetchPlan_RequiresTargetAndAHandleInArgs()
+    {
+        /* No target -> fail (needs a server whose live cache to read). */
+        Assert.Equal(CommandKind.Fail, DarlingCommandExecutor.ResolvePlan(Command("fetch_plan")).Kind);
+        Assert.Equal(CommandKind.Fail, DarlingCommandExecutor.ResolvePlan(Command("fetch_plan", args: "{\"planHandle\":\"0x06\"}")).Kind);
+
+        /* Target but no args, or args without any handle -> fail (nothing to fetch). */
+        Assert.Equal(CommandKind.Fail, DarlingCommandExecutor.ResolvePlan(Command("fetch_plan", target: 7)).Kind);
+        Assert.Equal(CommandKind.Fail, DarlingCommandExecutor.ResolvePlan(Command("fetch_plan", target: 7, args: "{}")).Kind);
+        Assert.Equal(CommandKind.Fail, DarlingCommandExecutor.ResolvePlan(Command("fetch_plan", target: 7, args: "{\"databaseName\":\"tempdb\"}")).Kind);
+
+        /* Target + a plan_handle (query-grid path) -> FetchPlan. */
+        Assert.Equal(CommandKind.FetchPlan,
+            DarlingCommandExecutor.ResolvePlan(Command("fetch_plan", target: 7, args: "{\"planHandle\":\"0x06000100\"}")).Kind);
+
+        /* Target + a sql_handle (deadlock / blocked path) -> FetchPlan. */
+        Assert.Equal(CommandKind.FetchPlan,
+            DarlingCommandExecutor.ResolvePlan(Command("fetch_plan", target: 7, args: "{\"sqlHandle\":\"0x0200\",\"statementStartOffset\":0,\"statementEndOffset\":-1}")).Kind);
+    }
+
+    [Fact]
+    public void ResolvePlan_FetchPlan_IsCaseInsensitive()
+    {
+        Assert.Equal(CommandKind.FetchPlan,
+            DarlingCommandExecutor.ResolvePlan(Command("Fetch_Plan", target: 1, args: "{\"planHandle\":\"0x06\"}")).Kind);
     }
 
     [Theory]
@@ -439,6 +491,61 @@ public sealed class DarlingCommandExecutorTests
         }
 
         await tx.RollbackAsync(ct);
+    }
+
+    [Fact]
+    public async Task ExecuteAndReport_FetchPlan_RoundTrip_DispatchesToHost_ReportsPlanXml()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the fetch_plan command round-trip.");
+
+        var ct = TestContext.Current.CancellationToken;
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(ct);
+        await PgMigrations.MigrateAsync(connection, ct);
+        await CleanupSentinelAsync(connection, ct);
+
+        /* A real pending fetch_plan row carrying a plan_handle in args_json (the query-grid path). */
+        long commandId;
+        using (var insert = new NpgsqlCommand(
+            "INSERT INTO config.config_command (command_type, target_server_id, args_json, status) " +
+            "VALUES ('fetch_plan', $1, '{\"planHandle\":\"0x0600AB\",\"databaseName\":\"master\"}'::jsonb, 'pending') RETURNING command_id", connection))
+        {
+            insert.Parameters.AddWithValue(SentinelServerId);
+            commandId = Convert.ToInt64(await insert.ExecuteScalarAsync(ct));
+        }
+
+        await using var postgres = NpgsqlDataSource.Create(connectionString!);
+        var host = new PlanReturningHost();
+        var executor = new DarlingCommandExecutor(postgres, host, "test-instance", null);
+
+        var claimed = await executor.ClaimNextAsync(ct);
+        Assert.NotNull(claimed);
+        Assert.Equal("fetch_plan", claimed!.CommandType);
+        await executor.ExecuteAndReportAsync(claimed, ct);
+
+        /* The executor parsed args_json and dispatched the structured request to the host with the target id. */
+        Assert.Equal(SentinelServerId, host.ReceivedServerId);
+        Assert.NotNull(host.Received);
+        Assert.Equal("0x0600AB", host.Received!.PlanHandle);
+        Assert.Equal("master", host.Received.DatabaseName);
+        Assert.True(host.Received.UsePlanHandle);
+
+        /* The reported terminal outcome carries the plan XML; args_json is scrubbed on terminal state. */
+        using (var read = new NpgsqlCommand(
+            "SELECT status, result_status, result_json::text, args_json FROM config.config_command WHERE command_id = $1", connection))
+        {
+            read.Parameters.AddWithValue(commandId);
+            using var reader = await read.ExecuteReaderAsync(ct);
+            Assert.True(await reader.ReadAsync(ct));
+            Assert.Equal("succeeded", reader.GetString(0));
+            Assert.Equal("plan fetched", reader.GetString(1));
+            Assert.Contains("ShowPlanXML", reader.GetString(2), StringComparison.Ordinal);
+            Assert.True(reader.IsDBNull(3), "args_json must be nulled on terminal state");
+        }
+
+        await CleanupSentinelAsync(connection, ct);
     }
 
     [Fact]

--- a/Darling/Darling.Tests/DarlingLivePlanFetchTests.cs
+++ b/Darling/Darling.Tests/DarlingLivePlanFetchTests.cs
@@ -1,0 +1,318 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using PerformanceMonitor.Darling.Analysis;
+using PerformanceMonitor.Darling.Service;
+using PerformanceMonitor.Darling.Viewer;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// The <c>fetch_plan</c> command — the service-driven LIVE plan-cache fetch. Pure, no-store pins:
+/// <list type="bullet">
+///   <item>the args model round-trips through the viewer's builders and the service's parser (the two ends must
+///   agree on the wire shape);</item>
+///   <item>the fetch SQL is the read-only DMV shape (the by-plan_handle and by-sql_handle keys) — reused from
+///   <see cref="PgPlanFetcher"/>, not duplicated;</item>
+///   <item>the viewer's result parser maps the polled outcome to the right status;</item>
+///   <item>the frame extractor pulls the (sql_handle, offsets) out of a real deadlock graph / blocked-process
+///   report and skips the dynamic-SQL zero sentinel.</item>
+/// </list>
+/// </summary>
+public sealed class PlanFetchRequestTests
+{
+    [Fact]
+    public void TryParse_PlanHandleMode_ReadsTheHandleAndDatabase()
+    {
+        Assert.True(PlanFetchRequest.TryParse("{\"planHandle\":\"0x06000100\",\"databaseName\":\"AdventureWorks\"}", out var req));
+        Assert.Equal("0x06000100", req.PlanHandle);
+        Assert.Null(req.SqlHandle);
+        Assert.True(req.UsePlanHandle);
+        Assert.Equal("AdventureWorks", req.DatabaseName);
+    }
+
+    [Fact]
+    public void TryParse_SqlHandleMode_ReadsTheHandleOffsetsAndDatabase()
+    {
+        Assert.True(PlanFetchRequest.TryParse(
+            "{\"sqlHandle\":\"0x0200AA\",\"statementStartOffset\":40,\"statementEndOffset\":120,\"databaseName\":\"tempdb\"}", out var req));
+        Assert.Equal("0x0200AA", req.SqlHandle);
+        Assert.Null(req.PlanHandle);
+        Assert.False(req.UsePlanHandle);
+        Assert.Equal(40, req.StatementStartOffset);
+        Assert.Equal(120, req.StatementEndOffset);
+        Assert.Equal("tempdb", req.DatabaseName);
+    }
+
+    [Fact]
+    public void TryParse_SqlHandle_DefaultsOffsetsToWholeStatement_WhenAbsent()
+    {
+        Assert.True(PlanFetchRequest.TryParse("{\"sqlHandle\":\"0x0200\"}", out var req));
+        Assert.Equal(0, req.StatementStartOffset);
+        Assert.Equal(-1, req.StatementEndOffset);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("{}")]
+    [InlineData("{\"databaseName\":\"tempdb\"}")]      /* neither handle */
+    [InlineData("{\"planHandle\":\"   \"}")]           /* blank handle */
+    [InlineData("not json at all")]
+    public void TryParse_RejectsMissingHandleOrMalformed(string? argsJson)
+    {
+        Assert.False(PlanFetchRequest.TryParse(argsJson, out _));
+    }
+
+    [Fact]
+    public void ViewerBuilders_RoundTripThroughTheServiceParser()
+    {
+        /* The two ends of the command channel must agree on the wire shape — build with the viewer, parse with
+           the service. */
+        var byPlan = ViewerDataService.BuildPlanFetchArgsByPlanHandle("0x06AA", "master");
+        Assert.True(PlanFetchRequest.TryParse(byPlan, out var planReq));
+        Assert.Equal("0x06AA", planReq.PlanHandle);
+        Assert.Equal("master", planReq.DatabaseName);
+        Assert.True(planReq.UsePlanHandle);
+
+        var bySql = ViewerDataService.BuildPlanFetchArgsBySqlHandle("0x0200BB", 8, 200, "AdventureWorks");
+        Assert.True(PlanFetchRequest.TryParse(bySql, out var sqlReq));
+        Assert.Equal("0x0200BB", sqlReq.SqlHandle);
+        Assert.Equal(8, sqlReq.StatementStartOffset);
+        Assert.Equal(200, sqlReq.StatementEndOffset);
+        Assert.Equal("AdventureWorks", sqlReq.DatabaseName);
+        Assert.False(sqlReq.UsePlanHandle);
+    }
+
+    [Fact]
+    public void ViewerBuilder_OmitsBlankDatabase()
+    {
+        /* A null/blank database must not serialize as an empty string the service would try to QUOTENAME. */
+        Assert.True(PlanFetchRequest.TryParse(ViewerDataService.BuildPlanFetchArgsByPlanHandle("0x06", null), out var req));
+        Assert.Null(req.DatabaseName);
+    }
+}
+
+/// <summary>The live-cache fetch SQL — reused from <see cref="PgPlanFetcher"/> (not a duplicate fetcher), pinned
+/// read-only + DMV-shaped for both keys.</summary>
+public sealed class PgPlanFetcherSqlTests
+{
+    [Fact]
+    public void PlanHandleQuery_IsTheReadOnlyDmvFetchByPlanHandle()
+    {
+        var sql = PgPlanFetcher.PlanQuery;
+        Assert.Contains("sys.dm_exec_query_plan", sql, StringComparison.Ordinal);
+        Assert.Contains("CONVERT(varbinary(64), @plan_handle, 1)", sql, StringComparison.Ordinal);
+        AssertReadOnly(sql);
+    }
+
+    [Fact]
+    public void SqlHandleInnerQuery_IsTheReadOnlyDmvFetchBySqlHandleAndOffsets()
+    {
+        var sql = PgPlanFetcher.SqlHandlePlanInnerSql;
+        Assert.Contains("sys.dm_exec_query_stats", sql, StringComparison.Ordinal);
+        Assert.Contains("sys.dm_exec_text_query_plan", sql, StringComparison.Ordinal);
+        Assert.Contains("qs.sql_handle = @h", sql, StringComparison.Ordinal);
+        Assert.Contains("qs.statement_start_offset = @stmt_start", sql, StringComparison.Ordinal);
+        Assert.Contains("qs.statement_end_offset = @stmt_end", sql, StringComparison.Ordinal);
+        AssertReadOnly(sql);
+    }
+
+    [Fact]
+    public void ValidateDatabaseSql_QuotesTheNameFromSysDatabases()
+    {
+        var sql = PgPlanFetcher.ValidateDatabaseSql;
+        Assert.Contains("QUOTENAME(d.name)", sql, StringComparison.Ordinal);
+        Assert.Contains("sys.databases", sql, StringComparison.Ordinal);
+        Assert.Contains("@database_name", sql, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("0x0102", new byte[] { 0x01, 0x02 })]
+    [InlineData("0102", new byte[] { 0x01, 0x02 })]            /* bare, no 0x prefix */
+    [InlineData("0xDEADBEEF", new byte[] { 0xDE, 0xAD, 0xBE, 0xEF })]
+    public void HexStringToBytes_ParsesValidHandles(string hex, byte[] expected)
+    {
+        Assert.Equal(expected, PgPlanFetcher.HexStringToBytes(hex));
+    }
+
+    [Theory]
+    [InlineData("0x")]        /* empty after prefix */
+    [InlineData("0x012")]     /* odd length */
+    [InlineData("0xZZ")]      /* non-hex */
+    [InlineData("")]
+    public void HexStringToBytes_RejectsMalformed(string hex)
+    {
+        Assert.Null(PgPlanFetcher.HexStringToBytes(hex));
+    }
+
+    private static void AssertReadOnly(string sql)
+    {
+        /* A plan read is a SELECT (a leading SET NOCOUNT is a session setting, not a mutation) with no
+           data-modifying statement anywhere. */
+        Assert.Contains("SELECT", sql, StringComparison.OrdinalIgnoreCase);
+        foreach (var forbidden in new[] { "INSERT", "UPDATE ", "DELETE", "DROP", "ALTER", "MERGE", "TRUNCATE" })
+        {
+            Assert.DoesNotContain(forbidden, sql, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}
+
+/// <summary>The viewer's mapping of a polled command result to the plan-fetch outcome the handlers switch on.</summary>
+public sealed class ViewerPlanFetchResultTests
+{
+    [Fact]
+    public void Parse_NullPoll_IsTimedOut()
+    {
+        var result = ViewerDataService.ParsePlanFetchResult(null);
+        Assert.Equal(LivePlanFetchStatus.TimedOut, result.Status);
+        Assert.Null(result.PlanXml);
+    }
+
+    [Fact]
+    public void Parse_Succeeded_WithPlanXml_IsFetched()
+    {
+        var result = ViewerDataService.ParsePlanFetchResult(
+            new CommandResult(ViewerDataService.StatusSucceeded, "plan fetched",
+                "{\"success\": true, \"planXml\": \"<ShowPlanXML/>\"}"));
+        Assert.Equal(LivePlanFetchStatus.Fetched, result.Status);
+        Assert.Equal("<ShowPlanXML/>", result.PlanXml);
+    }
+
+    [Fact]
+    public void Parse_Succeeded_WithNullPlanXml_IsNotInCache()
+    {
+        var result = ViewerDataService.ParsePlanFetchResult(
+            new CommandResult(ViewerDataService.StatusSucceeded, "not in cache",
+                "{\"success\": true, \"planXml\": null}"));
+        Assert.Equal(LivePlanFetchStatus.NotInCache, result.Status);
+        Assert.Null(result.PlanXml);
+    }
+
+    [Fact]
+    public void Parse_Failed_CarriesTheServiceError()
+    {
+        var result = ViewerDataService.ParsePlanFetchResult(
+            new CommandResult(ViewerDataService.StatusFailed, "server not connected",
+                "{\"success\": false, \"error\": \"server 'SQL01' is not currently connected\"}"));
+        Assert.Equal(LivePlanFetchStatus.Failed, result.Status);
+        Assert.Contains("not currently connected", result.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Parse_Failed_FallsBackToResultStatus_WhenNoErrorJson()
+    {
+        var result = ViewerDataService.ParsePlanFetchResult(
+            new CommandResult(ViewerDataService.StatusFailed, "server not monitored", null));
+        Assert.Equal(LivePlanFetchStatus.Failed, result.Status);
+        Assert.Equal("server not monitored", result.Message);
+    }
+}
+
+/// <summary>The pure frame extractor that resolves a process's sql_handle out of the raw XML the store rows
+/// carry (the shared DeadlockGraphParser drops it) — the key the deadlock / blocked live fetch enqueues.</summary>
+public sealed class PlanFrameExtractorTests
+{
+    /* A minimal deadlock graph: one process with a process-level sqlhandle AND an executionStack frame handle,
+       plus a second process carrying only the all-zero dynamic-SQL sentinel (built from the extractor's own
+       constant so the zero-length is exact). */
+    private static readonly string DeadlockGraph = $@"
+<deadlock>
+  <process-list>
+    <process id='process111' spid='55' sqlhandle='0x0200AAAA' stmtstart='40' stmtend='120'>
+      <executionStack>
+        <frame procname='adhoc' sqlhandle='0x0200BBBB' stmtstart='0' stmtend='-1'/>
+      </executionStack>
+      <inputbuf>SELECT 1</inputbuf>
+    </process>
+    <process id='process222' spid='56' sqlhandle='{PlanFrameExtractor.ZeroSqlHandle}'>
+      <executionStack><frame sqlhandle='{PlanFrameExtractor.ZeroSqlHandle}'/></executionStack>
+    </process>
+  </process-list>
+</deadlock>";
+
+    [Fact]
+    public void DeadlockFrames_ReturnsProcessHandleFirst_ThenFrameHandles()
+    {
+        var frames = PlanFrameExtractor.ExtractDeadlockProcessFrames(DeadlockGraph, "process111");
+        Assert.Equal(2, frames.Count);
+
+        Assert.Equal("0x0200AAAA", frames[0].SqlHandle); /* process-level first */
+        Assert.Equal(40, frames[0].StmtStart);
+        Assert.Equal(120, frames[0].StmtEnd);
+
+        Assert.Equal("0x0200BBBB", frames[1].SqlHandle); /* then the executionStack frame */
+        Assert.Equal(0, frames[1].StmtStart);
+        Assert.Equal(-1, frames[1].StmtEnd);
+    }
+
+    [Fact]
+    public void DeadlockFrames_SkipsTheZeroHandleProcess()
+    {
+        /* process222 carries only the all-zero dynamic-SQL sentinel -> nothing resolvable. */
+        Assert.Empty(PlanFrameExtractor.ExtractDeadlockProcessFrames(DeadlockGraph, "process222"));
+    }
+
+    [Fact]
+    public void DeadlockFrames_UnknownProcessOrBlankInput_IsEmpty()
+    {
+        Assert.Empty(PlanFrameExtractor.ExtractDeadlockProcessFrames(DeadlockGraph, "processZZZ"));
+        Assert.Empty(PlanFrameExtractor.ExtractDeadlockProcessFrames("", "process111"));
+        Assert.Empty(PlanFrameExtractor.ExtractDeadlockProcessFrames("<not-a-graph/>", "process111"));
+    }
+
+    private const string BlockedProcessReport = @"
+<blocked-process-report>
+  <blocked-process>
+    <process id='pblocked' spid='60'>
+      <executionStack>
+        <frame line='1' sqlhandle='0x0200CCCC' stmtstart='10' stmtend='90'/>
+      </executionStack>
+      <inputbuf>UPDATE t SET x = 1</inputbuf>
+    </process>
+  </blocked-process>
+  <blocking-process>
+    <process id='pblocking' spid='61'>
+      <executionStack>
+        <frame line='1' sqlhandle='0x0200DDDD' stmtstart='0' stmtend='-1'/>
+      </executionStack>
+      <inputbuf>WAITFOR DELAY '00:01:00'</inputbuf>
+    </process>
+  </blocking-process>
+</blocked-process-report>";
+
+    [Fact]
+    public void BlockedProcessFrames_ReadsTheBlockedSide()
+    {
+        var frames = PlanFrameExtractor.ExtractBlockedProcessFrames(BlockedProcessReport, blockingSide: false);
+        var frame = Assert.Single(frames);
+        Assert.Equal("0x0200CCCC", frame.SqlHandle);
+        Assert.Equal(10, frame.StmtStart);
+        Assert.Equal(90, frame.StmtEnd);
+    }
+
+    [Fact]
+    public void BlockedProcessFrames_ReadsTheBlockingSide()
+    {
+        var frames = PlanFrameExtractor.ExtractBlockedProcessFrames(BlockedProcessReport, blockingSide: true);
+        var frame = Assert.Single(frames);
+        Assert.Equal("0x0200DDDD", frame.SqlHandle);
+    }
+
+    [Fact]
+    public void BlockedProcessFrames_BlankOrHandleless_IsEmpty()
+    {
+        Assert.Empty(PlanFrameExtractor.ExtractBlockedProcessFrames("", blockingSide: false));
+        Assert.Empty(PlanFrameExtractor.ExtractBlockedProcessFrames(
+            "<blocked-process-report><blocked-process><process><executionStack/></process></blocked-process></blocked-process-report>",
+            blockingSide: false));
+    }
+}

--- a/Darling/Darling.Tests/ViewerControlPlaneStage3bTests.cs
+++ b/Darling/Darling.Tests/ViewerControlPlaneStage3bTests.cs
@@ -376,6 +376,21 @@ public sealed class ViewerControlCommandParityTests
         Assert.Equal(CommandKind.Fail, DarlingCommandExecutor.ResolvePlan(Command(ViewerDataService.CommandSnapshotNow)).Kind);
         Assert.Equal(CommandKind.Fail, DarlingCommandExecutor.ResolvePlan(Command(ViewerDataService.CommandAnalyzeNow)).Kind);
     }
+
+    [Fact]
+    public void FetchPlan_IsRecognized_WithATargetAndAViewerBuiltHandleArgs()
+    {
+        Assert.Equal("fetch_plan", ViewerDataService.CommandFetchPlan);
+
+        /* The viewer builds the args; the executor must recognize them as a live-plan fetch. */
+        var args = ViewerDataService.BuildPlanFetchArgsByPlanHandle("0x0600AA", "master");
+        var command = new ClaimedCommand(1, ViewerDataService.CommandFetchPlan, 5, args, "viewer");
+        Assert.Equal(CommandKind.FetchPlan, DarlingCommandExecutor.ResolvePlan(command).Kind);
+
+        /* Without a target it fails — the viewer only ever sends it with a server id. */
+        Assert.Equal(CommandKind.Fail,
+            DarlingCommandExecutor.ResolvePlan(new ClaimedCommand(1, ViewerDataService.CommandFetchPlan, null, args, "viewer")).Kind);
+    }
 }
 
 /// <summary>The one-time operational migrate-in: the defaults-only import decision + the projection, with no

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgPlanFetcher.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgPlanFetcher.cs
@@ -7,6 +7,9 @@
  */
 
 using System;
+using System.Data;
+using System.Globalization;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
@@ -98,5 +101,144 @@ FROM sys.dm_exec_query_plan(CONVERT(varbinary(64), @plan_handle, 1));";
             _logger?.LogError("[PgPlanFetcher] Failed to fetch plan for handle {PlanHandle}: {Message}", planHandle, ex.Message);
             return null;
         }
+    }
+
+    /// <summary>
+    /// The database-name → QUOTENAME validation (Lite's <c>GetValidatedDatabaseNameAsync</c>): resolves the
+    /// caller-supplied database name to its safely-quoted form via <c>sys.databases</c>, so the by-sql_handle
+    /// fetch's three-part <c>[db].sys.sp_executesql</c> can never be a SQL-injection vector. Public const so a
+    /// test can pin the shape.
+    /// </summary>
+    public const string ValidateDatabaseSql = @"
+SELECT
+    quoted_name = QUOTENAME(d.name)
+FROM sys.databases AS d
+WHERE d.name = @database_name;";
+
+    /// <summary>
+    /// The by-sql_handle plan fetch's inner statement (Lite's <c>FetchPlanBySqlHandleAsync</c> body): the stored
+    /// statement's plan by sql_handle + the exact statement offsets, newest execution first. This is the key a
+    /// deadlock-graph process / blocked-process-report frame carries (no plan_handle), so it is what closes the
+    /// "fetch ANY process's live plan" gap. Public const so a test can pin the DMV shape + read-only-ness.
+    /// </summary>
+    public const string SqlHandlePlanInnerSql = @"
+SELECT TOP (1)
+    query_plan_text = tqp.query_plan
+FROM sys.dm_exec_query_stats AS qs
+OUTER APPLY sys.dm_exec_text_query_plan(qs.plan_handle, qs.statement_start_offset, qs.statement_end_offset) AS tqp
+WHERE qs.sql_handle = @h
+AND   qs.statement_start_offset = @stmt_start
+AND   qs.statement_end_offset = @stmt_end
+AND   tqp.query_plan IS NOT NULL
+ORDER BY
+    qs.last_execution_time DESC
+OPTION(RECOMPILE);";
+
+    /// <summary>
+    /// Fetches a cached plan BY SQL_HANDLE + statement offsets — the second live-cache key
+    /// <see cref="FetchPlanXmlAsync"/>'s plan_handle path cannot serve, needed for a deadlock-graph process or a
+    /// blocked-process-report frame (those XE payloads carry only a sql_handle). Same seam + degrade semantics
+    /// as <see cref="FetchPlanXmlAsync"/>: resolves <paramref name="serverId"/> to the connected runtime's
+    /// connection string (null for unknown/disconnected → null), validates the database name to QUOTENAME
+    /// (falls back to <c>[master]</c> like Lite), and returns null (never throws) for a plan no longer in cache
+    /// or any error — a plan fetch can never fail its caller.
+    /// </summary>
+    public async Task<string?> FetchPlanBySqlHandleAsync(
+        int serverId, string? databaseName, string sqlHandleHex,
+        int statementStartOffset, int statementEndOffset, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(sqlHandleHex))
+        {
+            return null;
+        }
+
+        var handleBytes = HexStringToBytes(sqlHandleHex);
+        if (handleBytes is null || handleBytes.Length == 0)
+        {
+            return null;
+        }
+
+        try
+        {
+            var connectionString = _connectionStringResolver(serverId);
+            if (string.IsNullOrEmpty(connectionString))
+            {
+                return null;
+            }
+
+            var builder = new SqlConnectionStringBuilder(connectionString)
+            {
+                ConnectTimeout = 10,
+                CommandTimeout = 30,
+            };
+
+            await using var connection = new SqlConnection(builder.ConnectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            var quotedDbName = await GetValidatedDatabaseNameAsync(connection, databaseName, cancellationToken) ?? "[master]";
+
+            var query = $@"
+EXECUTE {quotedDbName}.sys.sp_executesql
+    N'{SqlHandlePlanInnerSql}',
+    N'@h varbinary(64), @stmt_start int, @stmt_end int',
+    @h, @stmt_start, @stmt_end;";
+
+            await using var command = new SqlCommand(query, connection) { CommandTimeout = 30 };
+            command.Parameters.Add(new SqlParameter("@h", SqlDbType.VarBinary, 64) { Value = handleBytes });
+            command.Parameters.Add(new SqlParameter("@stmt_start", SqlDbType.Int) { Value = statementStartOffset });
+            command.Parameters.Add(new SqlParameter("@stmt_end", SqlDbType.Int) { Value = statementEndOffset });
+
+            var result = await command.ExecuteScalarAsync(cancellationToken);
+            return result is null or DBNull ? null : result.ToString();
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger?.LogError("[PgPlanFetcher] Failed to fetch plan for sql_handle {SqlHandle}: {Message}", sqlHandleHex, ex.Message);
+            return null;
+        }
+    }
+
+    /// <summary>Resolves a database name to its QUOTENAME'd form (null when unknown) — the injection guard for
+    /// the three-part <c>sp_executesql</c>. A null/blank name short-circuits to null (caller uses <c>[master]</c>).</summary>
+    private static async Task<string?> GetValidatedDatabaseNameAsync(
+        SqlConnection connection, string? databaseName, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(databaseName))
+        {
+            return null;
+        }
+
+        await using var command = new SqlCommand(ValidateDatabaseSql, connection) { CommandTimeout = 30 };
+        command.Parameters.Add(new SqlParameter("@database_name", SqlDbType.NVarChar, 128) { Value = databaseName });
+        var result = await command.ExecuteScalarAsync(cancellationToken);
+        return result as string;
+    }
+
+    /// <summary>Parses a '0x…' (or bare) hex handle to bytes; null for a malformed / odd-length string (Lite's
+    /// <c>HexStringToBytes</c> verbatim).</summary>
+    internal static byte[]? HexStringToBytes(string hex)
+    {
+        if (string.IsNullOrEmpty(hex))
+        {
+            return null;
+        }
+
+        var start = hex.StartsWith("0x", StringComparison.OrdinalIgnoreCase) ? 2 : 0;
+        var len = hex.Length - start;
+        if (len <= 0 || (len % 2) != 0)
+        {
+            return null;
+        }
+
+        var bytes = new byte[len / 2];
+        for (int i = 0; i < bytes.Length; i++)
+        {
+            if (!byte.TryParse(hex.AsSpan(start + i * 2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out bytes[i]))
+            {
+                return null;
+            }
+        }
+
+        return bytes;
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingCommandExecutor.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingCommandExecutor.cs
@@ -272,6 +272,19 @@ WHERE status = 'in_progress'
             case CommandKind.Analyze:
                 return await _host.AnalyzeNowAsync(command.TargetServerId!.Value, cancellationToken);
 
+            case CommandKind.FetchPlan:
+            {
+                /* Re-parse args_json here (the pure dispatch already validated it parses) so the host receives
+                   the structured request — mirrors the Probe branch re-deriving its MonitoredServer. */
+                if (!PlanFetchRequest.TryParse(command.ArgsJson, out var fetchRequest))
+                {
+                    return new CommandOutcome(false, "invalid args_json",
+                        ErrorJson("fetch_plan args_json did not carry a plan_handle or sql_handle"));
+                }
+
+                return await _host.FetchPlanAsync(command.TargetServerId!.Value, fetchRequest, cancellationToken);
+            }
+
             default:
                 return new CommandOutcome(false, "unknown command_type", ErrorJson("unknown command_type"));
         }
@@ -332,6 +345,18 @@ WHERE status = 'in_progress'
                 return command.TargetServerId is int
                     ? new CommandPlan(CommandKind.Analyze, null, null, "analysis complete", null)
                     : Fail("analyze_now requires target_server_id");
+
+            case "fetch_plan":
+                /* Worker-delegated like snapshot_now (needs the target's LIVE runtime connection to read its
+                   plan cache). Requires a target server AND args_json carrying a plan_handle or sql_handle. */
+                if (command.TargetServerId is null)
+                {
+                    return Fail("fetch_plan requires target_server_id");
+                }
+
+                return PlanFetchRequest.TryParse(command.ArgsJson, out _)
+                    ? new CommandPlan(CommandKind.FetchPlan, null, null, "plan fetched", null)
+                    : Fail("fetch_plan requires args_json with a plan_handle or sql_handle");
 
             default:
                 return Fail("unknown command_type");
@@ -521,6 +546,9 @@ public enum CommandKind
     /// <summary><c>analyze_now</c>: force an immediate analysis pass for a server now (via the host).</summary>
     Analyze,
 
+    /// <summary><c>fetch_plan</c>: read a plan from a server's LIVE plan cache by plan_handle or sql_handle (via the host).</summary>
+    FetchPlan,
+
     /// <summary>Bad arguments or an unknown command_type — report failed without touching the store.</summary>
     Fail,
 }
@@ -539,4 +567,12 @@ public interface IDarlingCommandHost
     Task<CommandOutcome> SnapshotNowAsync(int serverId, CancellationToken cancellationToken);
 
     Task<CommandOutcome> AnalyzeNowAsync(int serverId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// <c>fetch_plan</c>: read an execution plan from the target server's LIVE plan cache (by plan_handle or by
+    /// sql_handle + offsets — see <see cref="PlanFetchRequest"/>) on the server's runtime connection, and return
+    /// the plan XML (or a "not in cache" / "not connected" outcome). Read-only, like the other worker-delegated
+    /// commands but reaching the target SQL Server rather than the store.
+    /// </summary>
+    Task<CommandOutcome> FetchPlanAsync(int serverId, PlanFetchRequest request, CancellationToken cancellationToken);
 }

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -1130,6 +1130,9 @@ LIMIT 1", connection);
 
         public Task<CommandOutcome> AnalyzeNowAsync(int serverId, CancellationToken cancellationToken)
             => _worker.RunAnalyzeNowAsync(_servers, _planFetcher, _notificationService, _config, serverId, cancellationToken);
+
+        public Task<CommandOutcome> FetchPlanAsync(int serverId, PlanFetchRequest request, CancellationToken cancellationToken)
+            => _worker.RunFetchPlanAsync(_servers, _planFetcher, serverId, request, cancellationToken);
     }
 
     /// <summary>
@@ -1388,6 +1391,68 @@ LIMIT 1", connection);
         {
             server.CollectionGate.Release();
         }
+    }
+
+    /// <summary>
+    /// The <c>fetch_plan</c> command handler (headless-plan live-plan wave): reads an execution plan from one
+    /// monitored server's LIVE plan cache and returns the plan XML — the mechanism the viewer uses to fetch a
+    /// plan for ANY process in a deadlock graph / blocked-process report (by its sql_handle) or the
+    /// currently-cached plan for a query-grid row (by its plan_handle), neither of which the store holds. The
+    /// actual cache read is delegated to the SAME <see cref="PgPlanFetcher"/> the analysis pipeline already uses
+    /// (it resolves the serverId to the connected runtime's connection string) — the plan_handle path is its
+    /// existing <see cref="PgPlanFetcher.FetchPlanXmlAsync"/>, the sql_handle path its
+    /// <see cref="PgPlanFetcher.FetchPlanBySqlHandleAsync"/>. Unlike snapshot_now it takes NO collection gate: a
+    /// DMV plan read touches no collector state and writes nothing, so it can run concurrently with a scheduled
+    /// sweep. The up-front lookup gives a precise "not monitored" / "not connected" outcome (mirroring
+    /// RunSnapshotAsync); a plan that has aged out of the cache — or any fetch error the fetcher swallows to null
+    /// per its analysis-safe contract — is reported as a clean "not in cache" (the command itself succeeded).
+    /// </summary>
+    private async Task<CommandOutcome> RunFetchPlanAsync(
+        List<ServerLoopState> servers, PgPlanFetcher planFetcher, int serverId,
+        PlanFetchRequest request, CancellationToken cancellationToken)
+    {
+        /* Lookup under the lock (the command loop reconciles the list concurrently); the fetcher re-resolves the
+           serverId to the runtime connection string itself, so this only gates the precise not-monitored /
+           not-connected outcomes. Held only for the microsecond lookup. */
+        ServerLoopState? server;
+        bool connected;
+        string displayName;
+        lock (_serversLock)
+        {
+            server = servers.Find(s => ServerIdHelper.GetDeterministicHashCode(s.Config.StorageName) == serverId);
+            connected = server?.Runtime is not null;
+            displayName = server?.Config.DisplayName ?? serverId.ToString(CultureInfo.InvariantCulture);
+        }
+
+        if (server is null)
+        {
+            return new CommandOutcome(false, "server not monitored", JsonError($"no monitored server with server_id {serverId}"));
+        }
+
+        if (!connected)
+        {
+            return new CommandOutcome(false, "server not connected",
+                JsonError($"server '{displayName}' is not currently connected — the live plan cache can only be read from a connected server"));
+        }
+
+        var planXml = request.UsePlanHandle
+            ? await planFetcher.FetchPlanXmlAsync(serverId, request.PlanHandle!)
+            : await planFetcher.FetchPlanBySqlHandleAsync(
+                serverId, request.DatabaseName, request.SqlHandle!,
+                request.StatementStartOffset, request.StatementEndOffset, cancellationToken);
+
+        if (string.IsNullOrEmpty(planXml))
+        {
+            _logger.LogInformation("[{Server}] fetch_plan: the requested plan is not in the cache", displayName);
+            /* Succeeded (the fetch ran) but the plan is gone — the viewer shows a "not in cache" info, distinct
+               from a failure. planXml is null so the viewer's parse hits the not-in-cache branch. */
+            return new CommandOutcome(true, "not in cache",
+                JsonSerializer.Serialize(new { success = true, planXml = (string?)null }));
+        }
+
+        _logger.LogInformation("[{Server}] fetch_plan returned a {Length}-char plan", displayName, planXml.Length);
+        return new CommandOutcome(true, "plan fetched",
+            JsonSerializer.Serialize(new { success = true, planXml }));
     }
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Service/PlanFetchRequest.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/PlanFetchRequest.cs
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System.Text.Json;
+
+namespace PerformanceMonitor.Darling.Service;
+
+/// <summary>
+/// The parsed <c>fetch_plan</c> command payload an <c>args_json</c> carries (the viewer builds it, the service
+/// parses it). Exactly one of the two handle modes is populated: <see cref="PlanHandle"/> for the query-grid
+/// fetch (the currently-cached plan by plan_handle, via <c>PgPlanFetcher.FetchPlanXmlAsync</c>) or
+/// <see cref="SqlHandle"/> + the statement offsets for the deadlock-graph / blocked-process fetch (those XE
+/// payloads carry only a sql_handle per executionStack frame — no plan_handle — so they need the by-sql_handle
+/// path, <c>PgPlanFetcher.FetchPlanBySqlHandleAsync</c>). Property names are camelCase to match the viewer's
+/// serialization (parsed case-insensitively). This is a pure args model + validation
+/// (<see cref="TryParse"/>) — the actual cache read is <c>PgPlanFetcher</c>'s, not duplicated here.
+/// </summary>
+public sealed record PlanFetchRequest(
+    string? PlanHandle,
+    string? SqlHandle,
+    int StatementStartOffset,
+    int StatementEndOffset,
+    string? DatabaseName)
+{
+    /// <summary>True when at least one usable handle is present — the dispatch fails a request with neither.</summary>
+    public bool HasHandle => !string.IsNullOrWhiteSpace(PlanHandle) || !string.IsNullOrWhiteSpace(SqlHandle);
+
+    /// <summary>True when the plan_handle mode should run (it takes precedence when both are somehow present).</summary>
+    public bool UsePlanHandle => !string.IsNullOrWhiteSpace(PlanHandle);
+
+    private static readonly JsonSerializerOptions s_options = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true,
+    };
+
+    /// <summary>
+    /// Parses <c>args_json</c> into a request, returning false for null/blank/malformed JSON or a request that
+    /// carries neither handle. Statement offsets default to whole-statement (0 / -1) when absent. Never throws.
+    /// </summary>
+    public static bool TryParse(string? argsJson, out PlanFetchRequest request)
+    {
+        request = new PlanFetchRequest(null, null, 0, -1, null);
+        if (string.IsNullOrWhiteSpace(argsJson))
+        {
+            return false;
+        }
+
+        Dto? dto;
+        try
+        {
+            dto = JsonSerializer.Deserialize<Dto>(argsJson, s_options);
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+
+        if (dto is null)
+        {
+            return false;
+        }
+
+        var parsed = new PlanFetchRequest(
+            NullIfBlank(dto.PlanHandle),
+            NullIfBlank(dto.SqlHandle),
+            dto.StatementStartOffset ?? 0,
+            dto.StatementEndOffset ?? -1,
+            NullIfBlank(dto.DatabaseName));
+
+        if (!parsed.HasHandle)
+        {
+            return false;
+        }
+
+        request = parsed;
+        return true;
+    }
+
+    private static string? NullIfBlank(string? value) => string.IsNullOrWhiteSpace(value) ? null : value;
+
+    /// <summary>The wire shape of <c>args_json</c> — offsets nullable so an absent pair defaults to whole-statement.</summary>
+    private sealed class Dto
+    {
+        public string? PlanHandle { get; set; }
+        public string? SqlHandle { get; set; }
+        public int? StatementStartOffset { get; set; }
+        public int? StatementEndOffset { get; set; }
+        public string? DatabaseName { get; set; }
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/PlanFrameExtractor.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/PlanFrameExtractor.cs
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// Pulls the (sql_handle, statement-start, statement-end) frames out of a deadlock graph's process node or a
+/// blocked-process report's blocked/blocking side — the keys the <c>fetch_plan</c> command needs to read a
+/// process's plan from the live cache. The shared <see cref="PerformanceMonitor.Common.DeadlockGraphParser"/>
+/// deliberately drops the raw <c>sqlhandle</c> (it exposes the parsed SqlText / SPID / procname for display),
+/// so this walks the raw XML the store rows carry directly — Lite's <c>ServerTab.Plans.cs</c> frame-walk lifted
+/// to a pure, testable helper (no UI coupling). The all-zero dynamic-SQL / system-context handle is skipped
+/// (SQL Server records it when there is no persistent sql_handle, and no plan can be recovered from it).
+/// </summary>
+public static class PlanFrameExtractor
+{
+    /// <summary>SQL Server's 42-byte all-zero sql_handle sentinel for dynamic SQL / system contexts (no plan).</summary>
+    public static readonly string ZeroSqlHandle = "0x" + new string('0', 84);
+
+    /// <summary>
+    /// The candidate frames for ONE deadlock-graph process (matched by its graph node id): the process-level
+    /// sqlhandle first (deadlock graphs frequently put it on <c>&lt;process&gt;</c>), then the executionStack
+    /// <c>&lt;frame&gt;</c> handles top-down. Empty when the graph / id is blank, the process is not found, or
+    /// every handle is the zero sentinel.
+    /// </summary>
+    public static IReadOnlyList<(string SqlHandle, int StmtStart, int StmtEnd)> ExtractDeadlockProcessFrames(
+        string graphXml, string processId)
+    {
+        var empty = Array.Empty<(string, int, int)>();
+        if (string.IsNullOrWhiteSpace(graphXml) || string.IsNullOrWhiteSpace(processId)) return empty;
+        try
+        {
+            var doc = XElement.Parse(graphXml);
+            var process = doc.Descendants("process")
+                .FirstOrDefault(p => string.Equals(p.Attribute("id")?.Value, processId, StringComparison.OrdinalIgnoreCase));
+            if (process == null) return empty;
+
+            var frames = new List<(string, int, int)>();
+
+            var procHandle = process.Attribute("sqlhandle")?.Value;
+            if (!string.IsNullOrWhiteSpace(procHandle) &&
+                !string.Equals(procHandle, ZeroSqlHandle, StringComparison.OrdinalIgnoreCase))
+            {
+                int ps = 0, pe = -1;
+                int.TryParse(process.Attribute("stmtstart")?.Value, out ps);
+                if (int.TryParse(process.Attribute("stmtend")?.Value, out var peParsed)) pe = peParsed;
+                frames.Add((procHandle!, ps, pe));
+            }
+
+            var stack = process.Element("executionStack");
+            if (stack != null)
+            {
+                foreach (var frame in stack.Elements("frame"))
+                {
+                    var handle = frame.Attribute("sqlhandle")?.Value;
+                    if (string.IsNullOrWhiteSpace(handle)) continue;
+                    if (string.Equals(handle, ZeroSqlHandle, StringComparison.OrdinalIgnoreCase)) continue;
+
+                    int fs = 0, fe = -1;
+                    int.TryParse(frame.Attribute("stmtstart")?.Value, out fs);
+                    if (int.TryParse(frame.Attribute("stmtend")?.Value, out var feParsed)) fe = feParsed;
+                    frames.Add((handle!, fs, fe));
+                }
+            }
+
+            return frames;
+        }
+        catch
+        {
+            return empty;
+        }
+    }
+
+    /// <summary>
+    /// The candidate frames for the blocked OR blocking side of a blocked-process report — the executionStack
+    /// <c>&lt;frame&gt;</c> handles, zero sentinel skipped. Searches by descendant (matching the Dashboard) so
+    /// it works regardless of how deep the process node sits. Empty when the XML is blank / has no matching
+    /// executionStack, or every handle is the zero sentinel.
+    /// </summary>
+    public static IReadOnlyList<(string SqlHandle, int StmtStart, int StmtEnd)> ExtractBlockedProcessFrames(
+        string bprXml, bool blockingSide)
+    {
+        var empty = Array.Empty<(string, int, int)>();
+        if (string.IsNullOrWhiteSpace(bprXml)) return empty;
+        try
+        {
+            var doc = XElement.Parse(bprXml);
+            var processContainer = doc
+                .Descendants(blockingSide ? "blocking-process" : "blocked-process")
+                .FirstOrDefault();
+            var stack = processContainer?.Descendants("executionStack").FirstOrDefault();
+            if (stack == null) return empty;
+
+            var frames = new List<(string, int, int)>();
+            foreach (var frame in stack.Elements("frame"))
+            {
+                var handle = frame.Attribute("sqlhandle")?.Value;
+                if (string.IsNullOrWhiteSpace(handle)) continue;
+                if (string.Equals(handle, ZeroSqlHandle, StringComparison.OrdinalIgnoreCase)) continue;
+
+                int stmtStart = 0;
+                int stmtEnd = -1;
+                int.TryParse(frame.Attribute("stmtstart")?.Value, out stmtStart);
+                if (int.TryParse(frame.Attribute("stmtend")?.Value, out var se)) stmtEnd = se;
+
+                frames.Add((handle!, stmtStart, stmtEnd));
+            }
+            return frames;
+        }
+        catch
+        {
+            return empty;
+        }
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Blocking.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Blocking.cs
@@ -83,6 +83,11 @@ public sealed class ViewerBlockedProcessRow : BlockedProcessAlertRow
     public string? BlockingQueryPlanXml { get; set; }
     public bool HasBlockedQueryPlan => !string.IsNullOrEmpty(BlockedQueryPlanXml);
     public bool HasBlockingQueryPlan => !string.IsNullOrEmpty(BlockingQueryPlanXml);
+
+    /// <summary>True when this row carries the blocked-process-report XML (the XE rows; the DMV-snapshot fallback
+    /// rows have none). The report XML's executionStack frames carry the sql_handle the "Fetch Live Plan" items
+    /// key on, so those items are gated on this — a DMV-snapshot row shows them disabled.</summary>
+    public bool HasReportXml => !string.IsNullOrEmpty(BlockedProcessReportXml);
 }
 
 public sealed partial class ViewerDataService

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.LivePlan.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.LivePlan.cs
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The viewer's typed wrapper over the Stage-2 <c>fetch_plan</c> command — the missing live-plan path. The
+/// viewer holds no SqlClient connection to a monitored server, but the SERVICE keeps a live runtime connection
+/// to every one, so a "fetch this process's plan from the live cache" request rides the SAME command channel
+/// <c>test_connect</c> / <c>snapshot_now</c> use: the viewer enqueues a <c>fetch_plan</c> row carrying the
+/// handle to fetch (a plan_handle for a query-grid row, or a sql_handle + statement offsets for a deadlock-graph
+/// / blocked-process process), the service reads the plan off the target server's plan cache, and the viewer
+/// polls for the plan XML in <c>result_json</c>.
+///
+/// <para>Like every other command it is a WRITE (enqueue), so a read-only <c>viewer</c> seat throws
+/// <see cref="ViewerReadOnlyException"/> — correct, and consistent with Pause / Snapshot: enqueuing a command is
+/// a config write a read-only seat cannot make. The command row is DELETED after its terminal result is read
+/// (like <c>test_connect</c>): the plan XML in <c>result_json</c> can be large and there is no reason to retain
+/// it in <c>config_command</c> once the viewer has it.</para>
+/// </summary>
+public sealed partial class ViewerDataService
+{
+    /// <summary>The command type the viewer enqueues for a live plan fetch (must match the service executor's case).</summary>
+    public const string CommandFetchPlan = "fetch_plan";
+
+    private static readonly JsonSerializerOptions s_planFetchArgsOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private static readonly JsonSerializerOptions s_planFetchResultOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    /// <summary>
+    /// Builds the <c>args_json</c> for a fetch BY PLAN_HANDLE (the query-grids path — the currently-cached plan
+    /// for a query/procedure row, distinct from the stored one). Pure — pinned by Darling.Tests against the
+    /// service's <c>PlanFetchRequest.TryParse</c>.
+    /// </summary>
+    public static string BuildPlanFetchArgsByPlanHandle(string planHandle, string? databaseName)
+        => JsonSerializer.Serialize(
+            new PlanFetchArgs { PlanHandle = planHandle, DatabaseName = NullIfBlank(databaseName) },
+            s_planFetchArgsOptions);
+
+    /// <summary>
+    /// Builds the <c>args_json</c> for a fetch BY SQL_HANDLE + statement offsets (the deadlock-graph /
+    /// blocked-process path — the plan for a process whose only key is a sql_handle from an executionStack
+    /// frame). Pure — pinned by Darling.Tests against the service's <c>PlanFetchRequest.TryParse</c>.
+    /// </summary>
+    public static string BuildPlanFetchArgsBySqlHandle(
+        string sqlHandle, int statementStartOffset, int statementEndOffset, string? databaseName)
+        => JsonSerializer.Serialize(
+            new PlanFetchArgs
+            {
+                SqlHandle = sqlHandle,
+                StatementStartOffset = statementStartOffset,
+                StatementEndOffset = statementEndOffset,
+                DatabaseName = NullIfBlank(databaseName),
+            },
+            s_planFetchArgsOptions);
+
+    /// <summary>
+    /// Enqueues a <c>fetch_plan</c> with the given <paramref name="argsJson"/> (built by one of the Build*
+    /// helpers), polls for its terminal result, deletes the (possibly large) command row, and maps the outcome
+    /// to a <see cref="LivePlanFetchResult"/>. A read-only seat throws <see cref="ViewerReadOnlyException"/> from
+    /// the enqueue (a read-only seat cannot command the service). Returns <see cref="LivePlanFetchStatus.TimedOut"/>
+    /// when the service does not report within the budget (the caller shows "still fetching / try again").
+    /// </summary>
+    public async Task<LivePlanFetchResult> FetchLivePlanAsync(
+        int serverId, string argsJson, CancellationToken cancellationToken = default)
+    {
+        var commandId = await EnqueueCommandAsync(CommandFetchPlan, serverId, argsJson, RequestedBy(), cancellationToken);
+        var result = await PollCommandResultAsync(commandId, DefaultCommandTimeout, cancellationToken);
+
+        if (result is not null)
+        {
+            try
+            {
+                await DeleteCommandAsync(commandId, cancellationToken);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                /* The plan-bearing row could not be cleaned up now; the service-side reaper is the backstop.
+                   Never let cleanup hide the plan the user is waiting on. */
+            }
+        }
+
+        return ParsePlanFetchResult(result);
+    }
+
+    /// <summary>
+    /// Maps a polled command result to a <see cref="LivePlanFetchResult"/> (pure — pinned by Darling.Tests):
+    /// a null poll → <see cref="LivePlanFetchStatus.TimedOut"/>; a <c>succeeded</c> row → the plan XML from
+    /// <c>result_json</c> (or <see cref="LivePlanFetchStatus.NotInCache"/> when it is null); a <c>failed</c> row →
+    /// <see cref="LivePlanFetchStatus.Failed"/> with the service's error / status message.
+    /// </summary>
+    public static LivePlanFetchResult ParsePlanFetchResult(CommandResult? result)
+    {
+        if (result is null)
+        {
+            return new LivePlanFetchResult(LivePlanFetchStatus.TimedOut, null,
+                "The service did not return the plan in time. It may still be fetching — try again.");
+        }
+
+        if (result.Status == StatusSucceeded)
+        {
+            var planXml = ReadStringField(result.ResultJson, "planXml");
+            return string.IsNullOrEmpty(planXml)
+                ? new LivePlanFetchResult(LivePlanFetchStatus.NotInCache, null,
+                    "The plan is no longer in the server's plan cache (it was evicted or recompiled since it was captured).")
+                : new LivePlanFetchResult(LivePlanFetchStatus.Fetched, planXml, null);
+        }
+
+        var error = ReadStringField(result.ResultJson, "error");
+        return new LivePlanFetchResult(LivePlanFetchStatus.Failed, null,
+            !string.IsNullOrEmpty(error) ? error
+            : !string.IsNullOrEmpty(result.ResultStatus) ? result.ResultStatus
+            : "The service could not fetch the plan.");
+    }
+
+    private static string? ReadStringField(string? json, string field)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            if (document.RootElement.ValueKind == JsonValueKind.Object
+                && document.RootElement.TryGetProperty(field, out var element)
+                && element.ValueKind == JsonValueKind.String)
+            {
+                return element.GetString();
+            }
+        }
+        catch (JsonException)
+        {
+            /* Malformed result_json — degrade to null. */
+        }
+
+        return null;
+    }
+
+    private static string? NullIfBlank(string? value) => string.IsNullOrWhiteSpace(value) ? null : value;
+
+    /// <summary>The wire shape of a <c>fetch_plan</c> <c>args_json</c> (camelCase to match the service's parser).</summary>
+    private sealed class PlanFetchArgs
+    {
+        public string? PlanHandle { get; set; }
+        public string? SqlHandle { get; set; }
+        public int? StatementStartOffset { get; set; }
+        public int? StatementEndOffset { get; set; }
+        public string? DatabaseName { get; set; }
+    }
+}
+
+/// <summary>The terminal state of a live plan fetch — the viewer's plan handlers switch on it.</summary>
+public enum LivePlanFetchStatus
+{
+    /// <summary>The plan XML was read from the live cache.</summary>
+    Fetched,
+
+    /// <summary>The fetch ran but the plan is no longer cached (evicted / recompiled).</summary>
+    NotInCache,
+
+    /// <summary>The service reported a failure (server not connected, connect / SQL error).</summary>
+    Failed,
+
+    /// <summary>The service did not report a terminal result within the poll budget.</summary>
+    TimedOut,
+}
+
+/// <summary>A live plan fetch's outcome: the plan XML on success, else a message to surface.</summary>
+public sealed record LivePlanFetchResult(LivePlanFetchStatus Status, string? PlanXml, string? Message);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ProcedureStats.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ProcedureStats.cs
@@ -56,6 +56,9 @@ public sealed class ViewerProcedureStatsRow
     /// <summary>Whether the collector stored an execution plan for this object in the window — gates the
     /// grid's per-row "Query Plan" Download button (mirrors Lite's Top Procedures HasQueryPlan gating).</summary>
     public bool HasQueryPlan { get; set; }
+
+    /// <summary>True when this row carries a plan_handle — gates the grid's "Fetch Live Plan" context item.</summary>
+    public bool HasLivePlanHandle => !string.IsNullOrEmpty(PlanHandle);
     public string FullName => string.IsNullOrEmpty(SchemaName) ? ObjectName : $"{SchemaName}.{ObjectName}";
     public double TotalCpuMs => TotalCpuUs / 1000.0;
     public double TotalElapsedMs => TotalElapsedUs / 1000.0;

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStats.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStats.cs
@@ -76,6 +76,10 @@ public sealed class ViewerQueryStatsRow
     /// <summary>True when the collector captured a query_plan_xml for this (database, query_hash) —
     /// gates the grid's Query Plan column (the full plan is fetched on demand, not carried here).</summary>
     public bool HasQueryPlan { get; set; }
+
+    /// <summary>True when this row carries a plan_handle — gates the grid's "Fetch Live Plan" context item (the
+    /// live-cache fetch is keyed on plan_handle, distinct from the stored query_plan_xml "View Plan" opens).</summary>
+    public bool HasLivePlanHandle => !string.IsNullOrEmpty(PlanHandle);
     public double TotalCpuMs => TotalCpuUs / 1000.0;
     public double TotalElapsedMs => TotalElapsedUs / 1000.0;
     public double AvgCpuMs => TotalExecutions > 0 ? TotalCpuMs / TotalExecutions : 0;

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.LivePlan.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.LivePlan.cs
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The "Fetch Live Plan" surfaces (headless-plan live-plan wave): the piece Darling's stored-plan-only viewer
+/// had to drop when it lost Lite's direct SqlClient path. The viewer never touches SQL Server, but the SERVICE
+/// holds a live runtime connection to every monitored server, so these hand a handle to the service over the
+/// Stage-2 command channel (<see cref="ViewerDataService.FetchLivePlanAsync"/> → a <c>fetch_plan</c> command)
+/// and display the plan the service reads back from the target's live plan cache in the SAME
+/// <see cref="OpenPlanTab"/> host the stored plans use. Two keys, matching what the store rows carry:
+/// <list type="bullet">
+///   <item>the query / procedure grids' <c>plan_handle</c> — the currently-cached plan for a row, DISTINCT from
+///   the (possibly older) plan the collector stored;</item>
+///   <item>a deadlock-graph process's or a blocked-process-report frame's <c>sql_handle</c> + statement offsets
+///   — this is what lets a user open the plan for ANY process in the graph (the deadlocker, a blocker), not
+///   just the one best-effort victim plan the collector happened to stash.</item>
+/// </list>
+///
+/// <para>Each fetch enqueues a command, which is a config write, so a read-only <c>viewer</c> seat cannot do it
+/// (consistent with Pause / Snapshot) — the handlers short-circuit with an explanation, and the enqueue's
+/// <see cref="ViewerReadOnlyException"/> is the belt-and-braces backstop. A spinner ("Fetching live plan…") runs
+/// in the Plan Viewer while the command is polled; the loading overlay's Cancel button cancels the poll. The
+/// "get the ACTUAL plan by re-executing the query" (SET STATISTICS XML) variant is deliberately NOT here — it
+/// has side effects and belongs behind Apply Fix's informed-consent gate.</para>
+/// </summary>
+public partial class ViewerServerTab
+{
+    // ── Query / Procedure grids: fetch the currently-cached plan by plan_handle ──
+
+    /// <summary>
+    /// "Fetch Live Plan" on a Top Queries / Top Procedures row — fetches the plan CURRENTLY in the server's plan
+    /// cache by the row's plan_handle (distinct from the collector's stored plan, which "View Plan" opens). Gated
+    /// in XAML on the row's <c>HasLivePlanHandle</c>, so it only fires for a row that carries a plan_handle.
+    /// </summary>
+    private async void FetchLiveQueryPlan_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not MenuItem menuItem) return;
+        var grid = FindParentDataGrid(menuItem);
+        if (grid?.CurrentItem is null) return;
+
+        string planHandle;
+        string? databaseName;
+        string label;
+        string? queryText;
+
+        switch (grid.CurrentItem)
+        {
+            case ViewerQueryStatsRow stats when !string.IsNullOrEmpty(stats.PlanHandle):
+                planHandle = stats.PlanHandle;
+                databaseName = stats.DatabaseName;
+                label = $"Live Plan - {stats.QueryHash}";
+                queryText = stats.QueryText;
+                break;
+            case ViewerProcedureStatsRow proc when !string.IsNullOrEmpty(proc.PlanHandle):
+                planHandle = proc.PlanHandle;
+                databaseName = proc.DatabaseName;
+                label = $"Live Plan - {proc.FullName}";
+                queryText = null; /* the procedure grid carries no statement text; the plan XML holds its own */
+                break;
+            default:
+                return;
+        }
+
+        var argsJson = ViewerDataService.BuildPlanFetchArgsByPlanHandle(planHandle, databaseName);
+        await FetchAndOpenLivePlanAsync(argsJson, label, queryText);
+    }
+
+    // ── Deadlock grid: fetch the live plan for THIS process (any process in the graph) by its sql_handle ──
+
+    /// <summary>
+    /// "Fetch Live Plan (This Process)" on a deadlock row — fetches the live plan for the RIGHT-CLICKED process
+    /// (victim OR deadlocker) by the sql_handle in its deadlock-graph executionStack, closing Lite's "any
+    /// process, not just the stored victim" gap. Tries the process-level handle then each frame top-down (Lite's
+    /// order), first cached plan wins.
+    /// </summary>
+    private async void FetchDeadlockProcessLivePlan_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not MenuItem menuItem) return;
+        var grid = FindParentDataGrid(menuItem);
+        if (grid?.CurrentItem is not DeadlockProcessDetail row) return;
+
+        var sideLabel = row.IsVictim ? "Victim" : "Deadlocker";
+        var frames = PlanFrameExtractor.ExtractDeadlockProcessFrames(row.DeadlockGraphXml, row.ProcessId);
+        if (frames.Count == 0)
+        {
+            ShowNoResolvableHandle(sideLabel.ToLowerInvariant() + " process");
+            return;
+        }
+
+        await FetchAndOpenBySqlHandleFramesAsync(frames, row.DatabaseName, $"Live Plan - {sideLabel} SPID {row.Spid}", row.SqlText);
+    }
+
+    // ── Blocked Process Reports grid: fetch the live plan for the blocked / blocking process by its sql_handle ──
+
+    private async void FetchBlockedSideLivePlan_Click(object sender, RoutedEventArgs e)
+        => await FetchBlockedProcessLivePlanAsync(sender, blockingSide: false);
+
+    private async void FetchBlockingSideLivePlan_Click(object sender, RoutedEventArgs e)
+        => await FetchBlockedProcessLivePlanAsync(sender, blockingSide: true);
+
+    /// <summary>
+    /// "Fetch Blocked/Blocking Live Plan" on a blocked-process-report row — fetches the live plan for the blocked
+    /// or blocking process by the sql_handle in its executionStack frames. Gated in XAML on the row's
+    /// <c>HasReportXml</c>, so a DMV-snapshot fallback row (no report XML → no sql_handle) shows the items
+    /// disabled rather than shown-and-empty.
+    /// </summary>
+    private async Task FetchBlockedProcessLivePlanAsync(object sender, bool blockingSide)
+    {
+        if (sender is not MenuItem menuItem) return;
+        var grid = FindParentDataGrid(menuItem);
+        if (grid?.CurrentItem is not ViewerBlockedProcessRow row) return;
+
+        var sideLabel = blockingSide ? "Blocking" : "Blocked";
+        var spid = blockingSide ? row.BlockingSpid : row.BlockedSpid;
+        var queryText = blockingSide ? row.BlockingSqlText : row.BlockedSqlText;
+
+        var frames = PlanFrameExtractor.ExtractBlockedProcessFrames(row.BlockedProcessReportXml, blockingSide);
+        if (frames.Count == 0)
+        {
+            ShowNoResolvableHandle(sideLabel.ToLowerInvariant() + " process");
+            return;
+        }
+
+        await FetchAndOpenBySqlHandleFramesAsync(frames, row.DatabaseName, $"Live Plan - {sideLabel} SPID {spid}", queryText);
+    }
+
+    // ── Shared fetch/display flow ──
+
+    /// <summary>
+    /// Fetches ONE plan by plan_handle and opens it. Gates read-only, shows the "Fetching live plan…" spinner,
+    /// polls the command (cancelable via the overlay's Cancel button), and either opens the plan or shows the
+    /// service's not-in-cache / failure / timeout message.
+    /// </summary>
+    private async Task FetchAndOpenLivePlanAsync(string argsJson, string label, string? queryText)
+    {
+        if (BlockedByReadOnlySeat()) return;
+
+        BeginLivePlanFetch(label);
+        try
+        {
+            var result = await _dataService.FetchLivePlanAsync(_server.ServerId, argsJson, _planLoadCts!.Token);
+            if (result.Status == LivePlanFetchStatus.Fetched)
+            {
+                OpenPlanTab(result.PlanXml!, label, queryText); /* HidePlanLoading runs inside OpenPlanTab */
+            }
+            else
+            {
+                HidePlanLoading();
+                ShowLivePlanOutcome(result);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            HidePlanLoading();
+        }
+        catch (ViewerReadOnlyException)
+        {
+            HidePlanLoading();
+            BlockedByReadOnlySeat(force: true);
+        }
+        catch (Exception ex)
+        {
+            HidePlanLoading();
+            MessageBox.Show($"Failed to fetch the live plan:\n\n{ex.Message}", "Live Plan Error",
+                MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+    }
+
+    /// <summary>
+    /// Fetches by sql_handle across a process's candidate frames (process-level handle, then executionStack
+    /// frames top-down), opening the FIRST that is still cached — mirroring Lite's per-frame walk, but each
+    /// frame is one <c>fetch_plan</c> command round-trip. A "not connected" hard failure stops the walk; an
+    /// evicted frame moves on to the next.
+    /// </summary>
+    private async Task FetchAndOpenBySqlHandleFramesAsync(
+        IReadOnlyList<(string SqlHandle, int StmtStart, int StmtEnd)> frames,
+        string databaseName, string label, string? queryText)
+    {
+        if (BlockedByReadOnlySeat()) return;
+
+        BeginLivePlanFetch(label);
+        try
+        {
+            LivePlanFetchResult? last = null;
+            foreach (var frame in frames)
+            {
+                _planLoadCts!.Token.ThrowIfCancellationRequested();
+
+                var argsJson = ViewerDataService.BuildPlanFetchArgsBySqlHandle(
+                    frame.SqlHandle, frame.StmtStart, frame.StmtEnd, databaseName);
+                var result = await _dataService.FetchLivePlanAsync(_server.ServerId, argsJson, _planLoadCts.Token);
+                last = result;
+
+                if (result.Status == LivePlanFetchStatus.Fetched)
+                {
+                    OpenPlanTab(result.PlanXml!, label, queryText); /* HidePlanLoading runs inside OpenPlanTab */
+                    return;
+                }
+
+                /* A hard failure (server not connected) won't improve on the next frame — stop and report it.
+                   An evicted plan (NotInCache) might be a different frame's, so keep walking. */
+                if (result.Status is LivePlanFetchStatus.Failed or LivePlanFetchStatus.TimedOut)
+                {
+                    break;
+                }
+            }
+
+            HidePlanLoading();
+            if (last is not null && last.Status != LivePlanFetchStatus.NotInCache)
+            {
+                ShowLivePlanOutcome(last);
+            }
+            else
+            {
+                MessageBox.Show(
+                    $"The plan for this process is no longer in the plan cache on {_server.DisplayName}. " +
+                    "A deadlock graph / blocked-process report only carries a sql_handle — if that plan has been " +
+                    "evicted or recompiled, it can't be recovered.",
+                    "Plan Not In Cache", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            HidePlanLoading();
+        }
+        catch (ViewerReadOnlyException)
+        {
+            HidePlanLoading();
+            BlockedByReadOnlySeat(force: true);
+        }
+        catch (Exception ex)
+        {
+            HidePlanLoading();
+            MessageBox.Show($"Failed to fetch the live plan:\n\n{ex.Message}", "Live Plan Error",
+                MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+    }
+
+    /// <summary>Shows the Plan Viewer's loading overlay with a fetch-specific label + a fresh cancellation source.</summary>
+    private void BeginLivePlanFetch(string label)
+    {
+        ShowPlanLoading(label);
+        PlanLoadingLabel.Text = $"Fetching live plan: {label}";
+        _planLoadCts?.Dispose();
+        _planLoadCts = new CancellationTokenSource();
+    }
+
+    /// <summary>Surfaces a non-fetched outcome (not-in-cache info, or a failure/timeout warning).</summary>
+    private void ShowLivePlanOutcome(LivePlanFetchResult result)
+    {
+        var (caption, icon) = result.Status == LivePlanFetchStatus.NotInCache
+            ? ("Plan Not In Cache", MessageBoxImage.Information)
+            : ("Live Plan Fetch Failed", MessageBoxImage.Warning);
+        MessageBox.Show(result.Message ?? "The plan could not be fetched.", caption, MessageBoxButton.OK, icon);
+    }
+
+    private void ShowNoResolvableHandle(string what)
+        => MessageBox.Show(
+            $"The {what} has no resolvable sql_handle in its captured XML. This usually means the query ran as " +
+            "dynamic SQL or a system context — SQL Server records a zero handle there and the plan can't be recovered.",
+            "No Plan Available", MessageBoxButton.OK, MessageBoxImage.Information);
+
+    /// <summary>
+    /// True (and shows an explanation) when the current seat is read-only: fetching a live plan enqueues a
+    /// command, which a read-only <c>viewer</c> seat cannot do (same rule as Pause / per-server toggles).
+    /// <paramref name="force"/> shows the message even if IsReadOnly went stale (the enqueue already threw).
+    /// </summary>
+    private bool BlockedByReadOnlySeat(bool force = false)
+    {
+        if (!force && !_dataService.IsReadOnly) return false;
+        MessageBox.Show(
+            "Fetching a live plan asks the service to read the target server's plan cache, which it does by " +
+            "running a command — a read-only viewer seat can't enqueue commands. Reconnect with a read-write " +
+            "profile to fetch live plans.",
+            "Read-Only Viewer", MessageBoxButton.OK, MessageBoxImage.Information);
+        return true;
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
@@ -147,6 +147,17 @@
                       IsEnabled="{Binding PlacementTarget.DataContext.HasBlockingQueryPlan, RelativeSource={RelativeSource AncestorType=ContextMenu}, FallbackValue=False}">
                 <MenuItem.Icon><TextBlock Text="&#x1F50D;"/></MenuItem.Icon>
             </MenuItem>
+            <!-- Live plan fetch (headless-plan live-plan wave): asks the service to read the process's plan from
+                 the target's LIVE cache by the sql_handle in its report XML — works for a process whose plan the
+                 collector never stashed. Gated on HasReportXml so a DMV-snapshot fallback row (no XML) disables it. -->
+            <MenuItem Header="Fetch Blocked Live Plan" Click="FetchBlockedSideLivePlan_Click"
+                      IsEnabled="{Binding PlacementTarget.DataContext.HasReportXml, RelativeSource={RelativeSource AncestorType=ContextMenu}, FallbackValue=False}">
+                <MenuItem.Icon><TextBlock Text="&#x1F310;"/></MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Header="Fetch Blocking Live Plan" Click="FetchBlockingSideLivePlan_Click"
+                      IsEnabled="{Binding PlacementTarget.DataContext.HasReportXml, RelativeSource={RelativeSource AncestorType=ContextMenu}, FallbackValue=False}">
+                <MenuItem.Icon><TextBlock Text="&#x1F310;"/></MenuItem.Icon>
+            </MenuItem>
             <MenuItem Header="View Block Chain" Click="ViewBlockChain_Click">
                 <MenuItem.Icon><TextBlock Text="&#x1F517;"/></MenuItem.Icon>
             </MenuItem>
@@ -173,6 +184,12 @@
             <MenuItem Header="View Victim Plan" Click="ViewVictimQueryPlan_Click"
                       IsEnabled="{Binding PlacementTarget.DataContext.HasVictimQueryPlan, RelativeSource={RelativeSource AncestorType=ContextMenu}, FallbackValue=False}">
                 <MenuItem.Icon><TextBlock Text="&#x1F50D;"/></MenuItem.Icon>
+            </MenuItem>
+            <!-- Live plan fetch for ANY process in the graph (headless-plan live-plan wave): asks the service to
+                 read the right-clicked process's plan from the target's LIVE cache by the sql_handle in the
+                 deadlock graph — not limited to the single best-effort victim plan the collector stashed. -->
+            <MenuItem Header="Fetch Live Plan (This Process)" Click="FetchDeadlockProcessLivePlan_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F310;"/></MenuItem.Icon>
             </MenuItem>
             <MenuItem Header="View Deadlock Graph" Click="ViewDeadlockGraph_Click">
                 <MenuItem.Icon><TextBlock Text="&#x1F578;"/></MenuItem.Icon>
@@ -251,6 +268,13 @@
             <Separator/>
             <MenuItem Header="View Plan" Click="ViewPlan_Click">
                 <MenuItem.Icon><TextBlock Text="&#x1F50D;"/></MenuItem.Icon>
+            </MenuItem>
+            <!-- Live plan fetch (headless-plan live-plan wave): asks the service to read the plan CURRENTLY in
+                 the target's cache by this row's plan_handle — distinct from the stored plan "View Plan" opens.
+                 Gated on HasLivePlanHandle so rows without a plan_handle (Query Store / Expensive Queries) disable it. -->
+            <MenuItem Header="Fetch Live Plan" Click="FetchLiveQueryPlan_Click"
+                      IsEnabled="{Binding PlacementTarget.DataContext.HasLivePlanHandle, RelativeSource={RelativeSource AncestorType=ContextMenu}, FallbackValue=False}">
+                <MenuItem.Icon><TextBlock Text="&#x1F310;"/></MenuItem.Icon>
             </MenuItem>
         </ContextMenu>
 


### PR DESCRIPTION
## What this does

Restores the live / any-process execution-plan fetch that Darling's stored-plan-only viewer had to drop, correcting the wrong classification that *"the viewer can't fetch live/any-process plans."* The viewer can't open SqlClient, but the **service** holds a live runtime connection to every monitored server — so the viewer now asks the service to fetch a plan from a server's live plan cache over the **Stage-2 `config_command` channel** (the same channel `test_connect` / `snapshot_now` use) and streams the XML back.

## Service — the new `fetch_plan` command
- **Worker-delegated** (like `snapshot_now`) so it runs on the target server's LIVE runtime connection. `args_json` carries a `plan_handle` (query-grid path) or a `sql_handle` + statement offsets (deadlock / blocked-process path); the worker reads the plan and returns the XML in `result_json`, or a clean `not in cache` / `server not connected` / `server not monitored`. Read-only (SELECT against DMVs — no side effects).
- **Reuses the existing `PgPlanFetcher`** rather than a new fetcher (per review steer): its `FetchPlanXmlAsync` already serves the by-`plan_handle` key (`sys.dm_exec_query_plan(CONVERT(varbinary(64), @plan_handle, 1))`). A **minimal `FetchPlanBySqlHandleAsync`** is added for the by-`sql_handle` key — deadlock-graph / blocked-process frames carry only a `sql_handle`, which the plan_handle DMV can't serve (`dm_exec_query_stats` → `dm_exec_text_query_plan`, db-validated `sp_executesql`, Lite's shape).
- `PlanFetchRequest` is the pure, testable args model; registered in the executor dispatch + the worker host.

## Viewer — the plan menus wired to it
- **Deadlock View-Plan** → "Fetch Live Plan (This Process)" for **any** process in the graph (the deadlocker, not just the stored victim) by its `sql_handle`.
- **Blocked/Blocking View-Plan** → "Fetch Blocked/Blocking Live Plan" for a process whose plan wasn't collected.
- **Top Queries / Top Procedures grids** → "Fetch Live Plan" (the currently-cached plan by `plan_handle`, distinct from the stored one).
- All enqueue `fetch_plan` via `ViewerDataService.Commands`, display in the existing plan viewer with a **"Fetching live plan…" spinner** (the loading overlay's Cancel button cancels the poll). The `sql_handle` is resolved from the raw graph / report XML by a pure `PlanFrameExtractor` (the shared `DeadlockGraphParser` drops the raw handle).
- **Read-only gating:** enqueuing a command is a config write, so a read-only `viewer` seat can't (consistent with Pause) — the handlers short-circuit with an explanation and the enqueue's `ViewerReadOnlyException` is the backstop. Per-row gates hide the action where no handle exists (DMV-snapshot blocking rows; Query Store / Expensive Queries rows).

## Store-row handle availability (verified)
- Top Queries / Top Procedures rows **carry `plan_handle`** (and `sql_handle`) — the query-grid fetch works directly.
- Deadlock rows carry the **graph XML**; the `sql_handle` is extracted from it (no dedicated column, and the shared parser drops it).
- Blocked-process rows carry the **report XML** for the XE rows; the always-on **DMV-snapshot fallback rows carry no XML → no handle**, so the live items are correctly disabled for them.

## Deferred (the only one)
"Get **Actual** Plan" in the SET-STATISTICS-XML sense **re-executes** the query (side effects — unsafe for non-SELECT). That belongs behind **Apply Fix**'s informed-consent gate (a separate lead-owned item). This PR builds only the READ-ONLY cache fetch, which fully covers the deadlock/blocked "any-process live plan" gap.

## Tests
`Darling.Tests` (Release): 1554 passed / 119 skipped / 0 failed. New coverage — `fetch_plan` dispatch + args validation, the viewer args-builder ↔ service parser round-trip, the read-only fetch SQL shape (pinned), `HexStringToBytes`, the deadlock/BPR frame extraction (incl. the zero-handle sentinel skip), and the viewer result mapping; plus a live `fetch_plan` store round-trip gated on `DARLING_TEST_PG`.

No Installer.Tests, no `install/*.sql` edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)