### PR TITLE
Darling: FinOps cost sync without reconnect + manual Purge Now command

### DIFF
--- a/Darling/Darling.Tests/DarlingCommandExecutorTests.cs
+++ b/Darling/Darling.Tests/DarlingCommandExecutorTests.cs
@@ -39,8 +39,36 @@ public sealed class DarlingCommandExecutorTests
         public Task<CommandOutcome> AnalyzeNowAsync(int serverId, CancellationToken cancellationToken)
             => throw new InvalidOperationException("host should not be called for this command");
 
+        public Task<CommandOutcome> PurgeNowAsync(int? customRetentionDays, CancellationToken cancellationToken)
+            => throw new InvalidOperationException("host should not be called for this command");
+
         public Task<CommandOutcome> FetchPlanAsync(int serverId, PlanFetchRequest request, CancellationToken cancellationToken)
             => throw new InvalidOperationException("host should not be called for this command");
+    }
+
+    /// <summary>Records the custom-retention argument a <c>purge_now</c> dispatch passed the host — for the
+    /// custom-N-vs-default parsing round-trip (no live store or SQL Server).</summary>
+    private sealed class PurgeRecordingHost : IDarlingCommandHost
+    {
+        public bool WasCalled { get; private set; }
+        public int? ReceivedCustomRetentionDays { get; private set; }
+
+        public Task<CommandOutcome> SnapshotNowAsync(int serverId, CancellationToken cancellationToken)
+            => throw new InvalidOperationException("not this command");
+
+        public Task<CommandOutcome> AnalyzeNowAsync(int serverId, CancellationToken cancellationToken)
+            => throw new InvalidOperationException("not this command");
+
+        public Task<CommandOutcome> PurgeNowAsync(int? customRetentionDays, CancellationToken cancellationToken)
+        {
+            WasCalled = true;
+            ReceivedCustomRetentionDays = customRetentionDays;
+            return Task.FromResult(new CommandOutcome(true, "purge complete",
+                "{\"success\":true,\"tablesPurged\":3,\"rowsPurged\":42}"));
+        }
+
+        public Task<CommandOutcome> FetchPlanAsync(int serverId, PlanFetchRequest request, CancellationToken cancellationToken)
+            => throw new InvalidOperationException("not this command");
     }
 
     /// <summary>A host that records the fetch_plan request it received and returns a canned plan — for the
@@ -54,6 +82,9 @@ public sealed class DarlingCommandExecutorTests
             => throw new InvalidOperationException("not this command");
 
         public Task<CommandOutcome> AnalyzeNowAsync(int serverId, CancellationToken cancellationToken)
+            => throw new InvalidOperationException("not this command");
+
+        public Task<CommandOutcome> PurgeNowAsync(int? customRetentionDays, CancellationToken cancellationToken)
             => throw new InvalidOperationException("not this command");
 
         public Task<CommandOutcome> FetchPlanAsync(int serverId, PlanFetchRequest request, CancellationToken cancellationToken)
@@ -201,6 +232,57 @@ public sealed class DarlingCommandExecutorTests
         Assert.Equal(CommandKind.Fail, DarlingCommandExecutor.ResolvePlan(Command("analyze_now")).Kind);
         Assert.Equal(CommandKind.Snapshot, DarlingCommandExecutor.ResolvePlan(Command("snapshot_now", target: 3)).Kind);
         Assert.Equal(CommandKind.Analyze, DarlingCommandExecutor.ResolvePlan(Command("analyze_now", target: 3)).Kind);
+    }
+
+    [Fact]
+    public void ResolvePlan_PurgeNow_ResolvesToPurge_WithNoTargetAndOptionalArgs()
+    {
+        /* Fleet-wide over the shared tables — NO target_server_id required (unlike snapshot_now/analyze_now). */
+        Assert.Equal(CommandKind.Purge, DarlingCommandExecutor.ResolvePlan(Command("purge_now")).Kind);
+
+        /* An optional custom-retention arg doesn't change the plan kind (it's read at execution time). */
+        Assert.Equal(CommandKind.Purge,
+            DarlingCommandExecutor.ResolvePlan(Command("purge_now", args: "{\"retention_days\":7}")).Kind);
+
+        /* Case-insensitive like every other command_type. */
+        Assert.Equal(CommandKind.Purge, DarlingCommandExecutor.ResolvePlan(Command("Purge_Now")).Kind);
+    }
+
+    [Fact]
+    public async Task ExecuteAndReport_PurgeNow_PassesCustomRetentionToHost_ElseNull()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the purge_now dispatch round-trip.");
+
+        var ct = TestContext.Current.CancellationToken;
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(ct);
+        await PgMigrations.MigrateAsync(connection, ct);
+
+        await using var postgres = NpgsqlDataSource.Create(connectionString!);
+
+        /* Custom-N days -> the host receives the parsed value. Build the args with the VIEWER's own builder so
+           this pins the two ends agree on the retention_days key, not just a hand-written literal. */
+        var customHost = new PurgeRecordingHost();
+        var customExecutor = new DarlingCommandExecutor(postgres, customHost, "test-instance", null);
+        await customExecutor.ExecuteAndReportAsync(
+            new ClaimedCommand(-1, "purge_now", null, PerformanceMonitor.Darling.Viewer.ViewerDataService.BuildPurgeNowArgs(7), "sentinel-test"), ct);
+        Assert.True(customHost.WasCalled);
+        Assert.Equal(7, customHost.ReceivedCustomRetentionDays);
+
+        /* No args -> the host receives null (the service falls back to the configured fleet horizons). */
+        var defaultHost = new PurgeRecordingHost();
+        var defaultExecutor = new DarlingCommandExecutor(postgres, defaultHost, "test-instance", null);
+        await defaultExecutor.ExecuteAndReportAsync(
+            new ClaimedCommand(-1, "purge_now", null, null, "sentinel-test"), ct);
+        Assert.True(defaultHost.WasCalled);
+        Assert.Null(defaultHost.ReceivedCustomRetentionDays);
+
+        using (var cleanup = new NpgsqlCommand("DELETE FROM config.config_command WHERE requested_by = 'sentinel-test'", connection))
+        {
+            await cleanup.ExecuteNonQueryAsync(ct);
+        }
     }
 
     [Fact]

--- a/Darling/Darling.Tests/DarlingObservabilityTests.cs
+++ b/Darling/Darling.Tests/DarlingObservabilityTests.cs
@@ -272,6 +272,27 @@ public sealed class DarlingObservabilityTests
             v2, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// Win 1: the reload sync mirrors BOTH the enable flag and the FinOps cost from the desired config onto the
+    /// observed registry, and fires when EITHER drifts — so a cost-only edit reaches collect.servers (which
+    /// FinOps reads) without a disconnect+reconnect. Pure SQL-shape pin (no store).
+    /// </summary>
+    [Fact]
+    public void SyncEnabledStatesSql_MirrorsEnabledAndCost_FiringOnEitherDelta()
+    {
+        var sql = DarlingObservability.SyncEnabledStatesSql;
+
+        /* Both the enable flag and the FinOps cost are mirrored desired -> observed. */
+        Assert.Contains("is_enabled = c.is_enabled", sql, StringComparison.Ordinal);
+        Assert.Contains("monthly_cost_usd = c.monthly_cost_usd", sql, StringComparison.Ordinal);
+
+        /* The WHERE fires when EITHER field drifts (so a cost-only edit is carried too), each via a NULL-safe
+           IS DISTINCT FROM (a pre-cost observed row still takes the config value). */
+        Assert.Contains("s.is_enabled IS DISTINCT FROM c.is_enabled", sql, StringComparison.Ordinal);
+        Assert.Contains("s.monthly_cost_usd IS DISTINCT FROM c.monthly_cost_usd", sql, StringComparison.Ordinal);
+        Assert.Contains(" OR ", sql, StringComparison.Ordinal);
+    }
+
     [Fact]
     public async Task EndToEnd_UpsertServerAndLogCollection_AgainstDevPostgres()
     {
@@ -390,6 +411,39 @@ public sealed class DarlingObservabilityTests
     }
 
     [Fact]
+    public async Task SyncServerEnabledStates_MirrorsCostOnlyDelta_OntoObservedRegistry_AgainstDevPostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the cost-sync test.");
+
+        using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await PgMigrations.MigrateAsync(connection, TestContext.Current.CancellationToken);
+        await DeleteTestRowsAsync(connection);
+
+        /* Desired cost 500, SAME enable state (TRUE) as observed — a COST-ONLY delta (the case Win 1 fixes:
+           before, the sync's WHERE only fired on an is_enabled delta, so a cost-only edit never reached the
+           observed row unless the server reconnected). Observed starts at 0. */
+        await ExecAsync(connection,
+            "INSERT INTO config.config_monitored_servers (server_id, name, host, is_enabled, monthly_cost_usd) VALUES ($1, 'cost-test', 'cost-host', TRUE, 500)");
+        await ExecAsync(connection,
+            "INSERT INTO collect.servers (server_id, server_name, is_enabled, monthly_cost_usd, created_date, modified_date) VALUES ($1, 'cost-host', TRUE, 0, now() AT TIME ZONE 'UTC', now() AT TIME ZONE 'UTC')");
+
+        await using var postgres = NpgsqlDataSource.Create(connectionString!);
+
+        await DarlingObservability.SyncServerEnabledStatesAsync(postgres, null, TestContext.Current.CancellationToken);
+        Assert.Equal(500m, await ReadObservedCostAsync(connection));
+
+        /* A later cost-only edit is carried too. */
+        await ExecAsync(connection, "UPDATE config.config_monitored_servers SET monthly_cost_usd = 750 WHERE server_id = $1");
+        await DarlingObservability.SyncServerEnabledStatesAsync(postgres, null, TestContext.Current.CancellationToken);
+        Assert.Equal(750m, await ReadObservedCostAsync(connection));
+
+        await DeleteTestRowsAsync(connection);
+    }
+
+    [Fact]
     public async Task UpsertServer_ReconnectDoesNotReEnableADisabledObservedRow_AgainstDevPostgres()
     {
         var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
@@ -429,6 +483,13 @@ public sealed class DarlingObservabilityTests
         using var read = new NpgsqlCommand("SELECT is_enabled FROM collect.servers WHERE server_id = $1", connection);
         read.Parameters.AddWithValue(TestServerId);
         return (bool)(await read.ExecuteScalarAsync(TestContext.Current.CancellationToken))!;
+    }
+
+    private static async Task<decimal> ReadObservedCostAsync(NpgsqlConnection connection)
+    {
+        using var read = new NpgsqlCommand("SELECT monthly_cost_usd FROM collect.servers WHERE server_id = $1", connection);
+        read.Parameters.AddWithValue(TestServerId);
+        return (decimal)(await read.ExecuteScalarAsync(TestContext.Current.CancellationToken))!;
     }
 
     private static async Task ExecAsync(NpgsqlConnection connection, string sql)

--- a/Darling/Darling.Tests/DarlingRetentionTests.cs
+++ b/Darling/Darling.Tests/DarlingRetentionTests.cs
@@ -36,6 +36,15 @@ public sealed class DarlingRetentionTests
     private const int TestServerId = -616161;
 
     [Fact]
+    public void PurgeSummary_TotalPurged_SumsDeletedRowsAndDroppedChunks()
+    {
+        /* The single headline count the daily log + the purge_now result_json ("rowsPurged") report. */
+        var summary = new PurgeSummary(TablesPurged: 31, RowsDeleted: 1200, ChunksDropped: 42);
+        Assert.Equal(1242, summary.TotalPurged);
+        Assert.Equal(0, new PurgeSummary(0, 0, 0).TotalPurged);
+    }
+
+    [Fact]
     public void EveryCatalogCollector_HasAPositiveSharedRetention()
     {
         foreach (var definition in CollectorCatalog.All)
@@ -141,8 +150,8 @@ public sealed class DarlingRetentionTests
                extension-free DELETE path on purpose (timescaleAvailable: false) — it must keep
                working even on a store whose tables ARE hypertables (DELETE is
                hypertable-agnostic); the drop_chunks branch is TimescaleSupportTests' job. */
-            var deleted = await DarlingRetention.PurgeAsync(postgres, timescaleAvailable: false, null, ct);
-            Assert.True(deleted >= 2, $"expected the purge to delete at least the two expired test rows, got {deleted}");
+            var summary = await DarlingRetention.PurgeAsync(postgres, timescaleAvailable: false, null, ct);
+            Assert.True(summary.TotalPurged >= 2, $"expected the purge to delete at least the two expired test rows, got {summary.TotalPurged}");
 
             using (var read = new NpgsqlCommand(
                 "SELECT collection_time FROM wait_stats WHERE server_id = $1", connection))

--- a/Darling/Darling.Tests/DarlingWorkerTests.cs
+++ b/Darling/Darling.Tests/DarlingWorkerTests.cs
@@ -7,6 +7,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Npgsql;
 using PerformanceMonitor.Collectors;
@@ -95,4 +96,60 @@ public sealed class DarlingWorkerTests
         var result = DarlingWorker.EnsureStoreSearchPath(custom);
         Assert.Equal("collect,config,reporting,public", new NpgsqlConnectionStringBuilder(result).SearchPath);
     }
+
+    /// <summary>
+    /// Win 1: a cost-only edit must NOT count as a server-definition change, so ReconcileServers does not tear
+    /// down and re-establish the connection for it. The reload's
+    /// <see cref="DarlingObservability.SyncServerEnabledStatesAsync"/> mirrors the new MonthlyCostUsd straight
+    /// onto collect.servers (which the FinOps display reads) with no connection churn.
+    /// </summary>
+    [Fact]
+    public void ServerDefinitionEquals_CostOnlyDelta_IsEqual_SoNoReconnect()
+    {
+        var original = SampleServer();
+        var costChanged = SampleServer();
+        costChanged.MonthlyCostUsd = original.MonthlyCostUsd + 250m;
+
+        Assert.True(DarlingWorker.ServerDefinitionEquals(original, costChanged),
+            "a cost-only change must compare equal (no reconnect) — cost is synced onto collect.servers without connection churn");
+    }
+
+    /// <summary>
+    /// The flip side: a genuine connection- or collection-affecting change (host, excluded databases) still
+    /// compares NOT equal, so ReconcileServers reconnects the server with the new definition.
+    /// </summary>
+    [Fact]
+    public void ServerDefinitionEquals_ConnectionOrDbDelta_IsNotEqual_SoReconnects()
+    {
+        var original = SampleServer();
+
+        var hostChanged = SampleServer();
+        hostChanged.Host = "other-host";
+        Assert.False(DarlingWorker.ServerDefinitionEquals(original, hostChanged), "a host change must reconnect");
+
+        var excludedChanged = SampleServer();
+        excludedChanged.ExcludedDatabases = new List<string> { "tempdb", "reporting" };
+        Assert.False(DarlingWorker.ServerDefinitionEquals(original, excludedChanged), "an excluded-databases change must reconnect");
+
+        /* Sanity: two identical definitions compare equal. */
+        Assert.True(DarlingWorker.ServerDefinitionEquals(original, SampleServer()));
+    }
+
+    /// <summary>A fully-populated server definition the equality tests perturb a single field of.</summary>
+    private static MonitoredServer SampleServer() => new()
+    {
+        Name = "prod-01",
+        Host = "prod-host",
+        Database = "AppDb",
+        Auth = "sql",
+        Username = "monitor",
+        EncryptedPassword = "AQAAblob==",
+        Password = null,
+        EncryptMode = "Mandatory",
+        TrustServerCertificate = true,
+        ReadOnlyIntent = false,
+        MultiSubnetFailover = false,
+        MonthlyCostUsd = 500m,
+        ExcludedDatabases = new List<string> { "tempdb" },
+    };
 }

--- a/Darling/Darling.Tests/TimescaleSupportTests.cs
+++ b/Darling/Darling.Tests/TimescaleSupportTests.cs
@@ -194,8 +194,8 @@ public sealed class TimescaleSupportTests
             /* The Timescale purge: at least the old wait_stats chunk drops and the old
                collection_log row DELETEs (the return mixes rows + chunks — a coarse activity
                count, see PurgeAsync remarks). */
-            var purged = await DarlingRetention.PurgeAsync(postgres, timescaleAvailable: true, null, ct);
-            Assert.True(purged >= 2, $"expected at least one dropped chunk and one deleted log row, got {purged}");
+            var summary = await DarlingRetention.PurgeAsync(postgres, timescaleAvailable: true, null, ct);
+            Assert.True(summary.TotalPurged >= 2, $"expected at least one dropped chunk and one deleted log row, got {summary.TotalPurged}");
 
             using (var read = new NpgsqlCommand(
                 "SELECT collection_time FROM wait_stats WHERE server_id = $1", connection))

--- a/Darling/Darling.Tests/ViewerControlPlaneStage3bTests.cs
+++ b/Darling/Darling.Tests/ViewerControlPlaneStage3bTests.cs
@@ -378,6 +378,17 @@ public sealed class ViewerControlCommandParityTests
     }
 
     [Fact]
+    public void PurgeNow_IsRecognizedFleetWide_WithNoTargetRequired()
+    {
+        Assert.Equal("purge_now", ViewerDataService.CommandPurgeNow);
+
+        /* Fleet-wide over the shared tables — resolves to Purge with NO target (unlike snapshot_now/analyze_now,
+           which the viewer only ever sends with a server id). */
+        Assert.Equal(CommandKind.Purge, DarlingCommandExecutor.ResolvePlan(Command(ViewerDataService.CommandPurgeNow)).Kind);
+        Assert.Equal(CommandKind.Purge, DarlingCommandExecutor.ResolvePlan(Command(ViewerDataService.CommandPurgeNow, target: 1)).Kind);
+    }
+
+    [Fact]
     public void FetchPlan_IsRecognized_WithATargetAndAViewerBuiltHandleArgs()
     {
         Assert.Equal("fetch_plan", ViewerDataService.CommandFetchPlan);

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingCommandExecutor.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingCommandExecutor.cs
@@ -272,6 +272,15 @@ WHERE status = 'in_progress'
             case CommandKind.Analyze:
                 return await _host.AnalyzeNowAsync(command.TargetServerId!.Value, cancellationToken);
 
+            case CommandKind.Purge:
+            {
+                /* Fleet-wide over the shared tables (no target server). The optional custom retention comes
+                   from args_json (default = the configured fleet horizons); parse it here like the other
+                   host-delegated branches re-derive their args. */
+                var customRetentionDays = TryReadInt(command.ArgsJson, "retention_days", "retentionDays");
+                return await _host.PurgeNowAsync(customRetentionDays, cancellationToken);
+            }
+
             case CommandKind.FetchPlan:
             {
                 /* Re-parse args_json here (the pure dispatch already validated it parses) so the host receives
@@ -345,6 +354,13 @@ WHERE status = 'in_progress'
                 return command.TargetServerId is int
                     ? new CommandPlan(CommandKind.Analyze, null, null, "analysis complete", null)
                     : Fail("analyze_now requires target_server_id");
+
+            case "purge_now":
+                /* The daily retention purge on demand. Fleet-wide over the SHARED store tables, so — unlike
+                   snapshot_now/analyze_now — it needs NO target_server_id. An optional custom retention
+                   (args_json.retention_days) is read at execution time; absent = the configured fleet horizons.
+                   Always resolvable: there are no required arguments. */
+                return new CommandPlan(CommandKind.Purge, null, null, "purge complete", null);
 
             case "fetch_plan":
                 /* Worker-delegated like snapshot_now (needs the target's LIVE runtime connection to read its
@@ -546,6 +562,9 @@ public enum CommandKind
     /// <summary><c>analyze_now</c>: force an immediate analysis pass for a server now (via the host).</summary>
     Analyze,
 
+    /// <summary><c>purge_now</c>: run the retention purge across the shared store now (fleet-wide, via the host).</summary>
+    Purge,
+
     /// <summary><c>fetch_plan</c>: read a plan from a server's LIVE plan cache by plan_handle or sql_handle (via the host).</summary>
     FetchPlan,
 
@@ -567,6 +586,14 @@ public interface IDarlingCommandHost
     Task<CommandOutcome> SnapshotNowAsync(int serverId, CancellationToken cancellationToken);
 
     Task<CommandOutcome> AnalyzeNowAsync(int serverId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// <c>purge_now</c>: run the retention purge over the shared store immediately (the daily
+    /// <see cref="DarlingRetention.PurgeAsync"/> on demand). Fleet-wide over shared tables, so no target
+    /// server; <paramref name="customRetentionDays"/> (from args_json) purges every collector to that horizon
+    /// when set, else the configured fleet horizons apply.
+    /// </summary>
+    Task<CommandOutcome> PurgeNowAsync(int? customRetentionDays, CancellationToken cancellationToken);
 
     /// <summary>
     /// <c>fetch_plan</c>: read an execution plan from the target server's LIVE plan cache (by plan_handle or by

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingObservability.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingObservability.cs
@@ -42,17 +42,22 @@ ON CONFLICT (server_id) DO UPDATE SET
     modified_date = EXCLUDED.modified_date,
     monthly_cost_usd = EXCLUDED.monthly_cost_usd;";
 
-    /* Mirror the DESIRED enable state (config.config_monitored_servers.is_enabled) onto the OBSERVED
-       registry (collect.servers.is_enabled). A disabled server drops out of the collection loop and stops
-       upserting, so without this its observed row would keep its last (TRUE) value forever; the viewer /
-       FinOps read collect.servers, so the observed flag must track the desired one. Runs on every reload. */
-    private const string SyncEnabledStatesSql = @"
+    /* Mirror the DESIRED config (config.config_monitored_servers) onto the OBSERVED registry
+       (collect.servers) for the two fields the viewer/FinOps read straight off collect.servers: is_enabled
+       and monthly_cost_usd. A disabled server drops out of the collection loop and stops upserting, so without
+       this its observed row would keep its last (TRUE) value forever; likewise a cost-only edit reaches the
+       FinOps display (which reads collect.servers) through THIS sync, so a cost change needs no
+       disconnect+reconnect (see DarlingWorker.ServerDefinitionEquals, which deliberately no longer compares
+       cost). Fires when EITHER field drifts. Internal so a pure test can pin the SHAPE. Runs on every reload. */
+    internal const string SyncEnabledStatesSql = @"
 UPDATE collect.servers s
 SET is_enabled = c.is_enabled,
+    monthly_cost_usd = c.monthly_cost_usd,
     modified_date = (now() AT TIME ZONE 'UTC')
 FROM config.config_monitored_servers c
 WHERE s.server_id = c.server_id
-  AND s.is_enabled IS DISTINCT FROM c.is_enabled;";
+  AND (s.is_enabled IS DISTINCT FROM c.is_enabled
+       OR s.monthly_cost_usd IS DISTINCT FROM c.monthly_cost_usd);";
 
     private const string InsertCollectionLogSql = @"
 INSERT INTO collection_log (log_id, server_id, server_name, collector_name, collection_time, duration_ms, status, error_message, rows_collected, sql_duration_ms, duckdb_duration_ms)
@@ -92,11 +97,13 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11);";
     }
 
     /// <summary>
-    /// Mirrors the DESIRED enable state (<c>config.config_monitored_servers.is_enabled</c>) onto the
-    /// OBSERVED registry (<c>collect.servers.is_enabled</c>) for every server present in both — so a
-    /// control-plane <c>disable_server</c> flips the observed row to FALSE even though the disabled server
-    /// stops upserting, and a later <c>enable_server</c> flips it back. Runs on each control-plane reload.
-    /// Failure-isolated (Debug + no-op) like the other observability writes.
+    /// Mirrors the DESIRED config (<c>config.config_monitored_servers</c>) onto the OBSERVED registry
+    /// (<c>collect.servers</c>) for the two fields the viewer/FinOps read straight off <c>collect.servers</c>:
+    /// <c>is_enabled</c> and <c>monthly_cost_usd</c>. So a control-plane <c>disable_server</c> flips the
+    /// observed row to FALSE even though the disabled server stops upserting (a later <c>enable_server</c>
+    /// flips it back), and a cost-only edit reaches the FinOps display through this reload sync with NO
+    /// disconnect+reconnect. Runs on each control-plane reload. Failure-isolated (Debug + no-op) like the
+    /// other observability writes.
     /// </summary>
     public static async Task SyncServerEnabledStatesAsync(NpgsqlDataSource postgres, ILogger? logger, CancellationToken cancellationToken)
     {
@@ -107,7 +114,7 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11);";
             var changed = await command.ExecuteNonQueryAsync(cancellationToken);
             if (changed > 0)
             {
-                logger?.LogInformation("Synced observed enable-state for {Count} server(s) from the desired config", changed);
+                logger?.LogInformation("Synced observed enable-state/cost for {Count} server(s) from the desired config", changed);
             }
         }
         catch (Exception ex) when (ex is not OperationCanceledException)

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingRetention.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingRetention.cs
@@ -64,8 +64,13 @@ public static class DarlingRetention
     /// Optional resolver for a collector's effective retention horizon (control-plane fleet-wide overrides
     /// layered on <see cref="CollectorScheduleDefaults"/>). Null (or a value it does not override) uses the
     /// shared default. A per-server override cannot apply here — the purge is per shared table, not per server.
+    /// The on-demand <c>purge_now</c> command passes a <c>_ =&gt; customDays</c> resolver for its custom-N mode.
     /// </param>
-    public static async Task<int> PurgeAsync(
+    /// <returns>
+    /// A <see cref="PurgeSummary"/>: how many tables were touched and the coarse activity count (DELETE rows
+    /// plus dropped chunks). The daily caller discards it; the on-demand <c>purge_now</c> command reports it.
+    /// </returns>
+    public static async Task<PurgeSummary> PurgeAsync(
         NpgsqlDataSource postgres, bool timescaleAvailable, ILogger? logger, CancellationToken cancellationToken,
         Func<string, int>? retentionDaysFor = null)
     {
@@ -131,7 +136,7 @@ public static class DarlingRetention
 
         logger?.LogInformation("Retention purge: {Tables} table(s) purged, {Rows} row(s) deleted, {Chunks} chunk(s) dropped, {ElapsedMs}ms",
             tablesPurged, totalRowsDeleted, totalChunksDropped, sw.ElapsedMilliseconds);
-        return totalRowsDeleted + totalChunksDropped;
+        return new PurgeSummary(tablesPurged, totalRowsDeleted, totalChunksDropped);
     }
 
     /// <summary>
@@ -216,4 +221,17 @@ public static class DarlingRetention
             return null;
         }
     }
+}
+
+/// <summary>
+/// The outcome of one <see cref="DarlingRetention.PurgeAsync"/> sweep: how many tables were touched
+/// (<paramref name="TablesPurged"/>) and the coarse activity count split into DELETE rows
+/// (<paramref name="RowsDeleted"/>) and dropped Timescale chunks (<paramref name="ChunksDropped"/> —
+/// drop_chunks doesn't report per-row counts). <see cref="TotalPurged"/> is the single headline number the
+/// daily log and the on-demand <c>purge_now</c> result report.
+/// </summary>
+public readonly record struct PurgeSummary(int TablesPurged, int RowsDeleted, int ChunksDropped)
+{
+    /// <summary>Rows deleted plus whole chunks dropped — the coarse "how much did this purge remove" count.</summary>
+    public int TotalPurged => RowsDeleted + ChunksDropped;
 }

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -760,10 +760,14 @@ public sealed class DarlingWorker : BackgroundService
 
     /// <summary>
     /// Whether two server definitions are identical for the collection loop — the connection-relevant fields
-    /// plus the collection-affecting ones (excluded databases, cost, display name). A difference triggers a
-    /// reconnect on reconcile so the new definition takes effect.
+    /// plus the collection-affecting excluded databases. A difference triggers a reconnect on reconcile so the
+    /// new definition takes effect. <c>MonthlyCostUsd</c> is deliberately NOT compared: it does not affect
+    /// collection at all, and the reload's <see cref="DarlingObservability.SyncServerEnabledStatesAsync"/>
+    /// mirrors a cost change straight onto <c>collect.servers</c> (which the FinOps display reads) with no
+    /// connection churn — so a cost-only edit must NOT trigger a disconnect+reconnect. Internal so a unit test
+    /// can pin exactly that.
     /// </summary>
-    private static bool ServerDefinitionEquals(MonitoredServer a, MonitoredServer b)
+    internal static bool ServerDefinitionEquals(MonitoredServer a, MonitoredServer b)
         => string.Equals(a.Name, b.Name, StringComparison.Ordinal)
         && string.Equals(a.Host, b.Host, StringComparison.OrdinalIgnoreCase)
         && string.Equals(a.Database, b.Database, StringComparison.OrdinalIgnoreCase)
@@ -775,7 +779,6 @@ public sealed class DarlingWorker : BackgroundService
         && a.TrustServerCertificate == b.TrustServerCertificate
         && a.ReadOnlyIntent == b.ReadOnlyIntent
         && a.MultiSubnetFailover == b.MultiSubnetFailover
-        && a.MonthlyCostUsd == b.MonthlyCostUsd
         && a.ExcludedDatabases.SequenceEqual(b.ExcludedDatabases, StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
@@ -1098,6 +1101,46 @@ LIMIT 1", connection);
     private static string JsonError(string error) => JsonSerializer.Serialize(new { success = false, error });
 
     /// <summary>
+    /// The <c>purge_now</c> command handler (the daily retention purge on demand): runs
+    /// <see cref="DarlingRetention.PurgeAsync"/> over the shared store immediately and reports the tables +
+    /// rows purged. Fleet-wide over the SHARED tables (no target server). When
+    /// <paramref name="customRetentionDays"/> is set it purges every collector to that horizon (a
+    /// <c>_ =&gt; customDays</c> resolver — PurgeAsync clamps a sub-1-day horizon at its destructive sink, so a
+    /// bad custom-N can never wipe a table); otherwise it uses the SAME fleet resolver the scheduled daily
+    /// purge uses (<see cref="StoreConfigProvider.ResolveFleetRetentionDays"/> over the live overrides). Takes
+    /// NO collection gate: unlike snapshot_now a purge writes no collector state and races no delta baseline,
+    /// and PurgeAsync is idempotent + failure-isolated per table, so it may safely overlap the daily sweep.
+    /// </summary>
+    private async Task<CommandOutcome> RunPurgeNowAsync(int? customRetentionDays, CancellationToken cancellationToken)
+    {
+        /* Reference read of the live overrides, matching the daily purge caller (never held under a lock —
+           the reload swaps the whole list atomically). */
+        var overrides = _scheduleOverrides;
+        Func<string, int> resolver = customRetentionDays is int days
+            ? _ => days
+            : name => StoreConfigProvider.ResolveFleetRetentionDays(name, overrides);
+
+        var summary = await DarlingRetention.PurgeAsync(
+            _postgres!, _timescaleAvailable, _logger, cancellationToken, resolver);
+
+        _logger.LogInformation(
+            "purge_now purged {Tables} table(s), {Rows} row(s)/chunk(s){Custom}",
+            summary.TablesPurged, summary.TotalPurged,
+            customRetentionDays is int cd ? $" (custom retention {cd}d)" : string.Empty);
+
+        var json = JsonSerializer.Serialize(new
+        {
+            success = true,
+            tablesPurged = summary.TablesPurged,
+            rowsPurged = summary.TotalPurged,
+            rowsDeleted = summary.RowsDeleted,
+            chunksDropped = summary.ChunksDropped,
+            customRetentionDays,
+        });
+        return new CommandOutcome(true, "purge complete", json);
+    }
+
+    /// <summary>
     /// The worker's <see cref="IDarlingCommandHost"/> adapter (Stage 2): lets the command executor reach the
     /// two imperative commands that need the LIVE loop (snapshot_now / analyze_now) without the executor
     /// holding the worker's mutable loop state. Captures the running server set + collector runner + analysis
@@ -1130,6 +1173,9 @@ LIMIT 1", connection);
 
         public Task<CommandOutcome> AnalyzeNowAsync(int serverId, CancellationToken cancellationToken)
             => _worker.RunAnalyzeNowAsync(_servers, _planFetcher, _notificationService, _config, serverId, cancellationToken);
+
+        public Task<CommandOutcome> PurgeNowAsync(int? customRetentionDays, CancellationToken cancellationToken)
+            => _worker.RunPurgeNowAsync(customRetentionDays, cancellationToken);
 
         public Task<CommandOutcome> FetchPlanAsync(int serverId, PlanFetchRequest request, CancellationToken cancellationToken)
             => _worker.RunFetchPlanAsync(_servers, _planFetcher, serverId, request, cancellationToken);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ControlCommands.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ControlCommands.cs
@@ -7,6 +7,7 @@
  */
 
 using System;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -16,7 +17,8 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// The viewer's typed wrappers over the Stage-2 command plane (<see cref="EnqueueCommandAsync"/> /
 /// <see cref="RunCommandAsync"/>) for the operator's imperative actions: <c>pause</c>/<c>resume</c> the whole
 /// service (the Settings window's Data Collection toggle), <c>snapshot_now</c> for one server (the "Latest
-/// Snapshot" button), and <c>analyze_now</c> for one server (the Recommendations "Generate now" button). The
+/// Snapshot" button), <c>analyze_now</c> for one server (the Recommendations "Generate now" button), and
+/// <c>purge_now</c> fleet-wide (the Collection Health "Purge Now" button). The
 /// command TYPES match <c>DarlingCommandExecutor.ResolvePlan</c> exactly so the two ends agree; Darling.Tests
 /// pin the constants against the executor's cases.
 ///
@@ -30,11 +32,12 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// </summary>
 public sealed partial class ViewerDataService
 {
-    /// <summary>The four control-command types the viewer enqueues (must match the service executor's cases).</summary>
+    /// <summary>The control-command types the viewer enqueues (must match the service executor's cases).</summary>
     public const string CommandPause = "pause";
     public const string CommandResume = "resume";
     public const string CommandSnapshotNow = "snapshot_now";
     public const string CommandAnalyzeNow = "analyze_now";
+    public const string CommandPurgeNow = "purge_now";
 
     /// <summary>A full-server snapshot or analysis pass can take longer than a config write's <see
     /// cref="DefaultCommandTimeout"/>, so the imperative per-server commands wait up to three minutes for the
@@ -59,6 +62,24 @@ public sealed partial class ViewerDataService
     /// terminal result. Returns null on timeout.</summary>
     public Task<CommandResult?> RequestAnalyzeNowAsync(int serverId, CancellationToken cancellationToken = default) =>
         RunCommandAsync(CommandAnalyzeNow, serverId, argsJson: null, RequestedBy(), ImperativeCommandTimeout, cancellationToken);
+
+    /// <summary>Enqueues a <c>purge_now</c> (run the retention purge over the shared store now) and waits for
+    /// the terminal result. Fleet-wide over the shared tables, so NO server id. <paramref
+    /// name="customRetentionDays"/> (when set) purges every collector to that horizon instead of the configured
+    /// fleet retention; null = the configured horizons. Returns null on timeout. Read-only seats throw
+    /// <see cref="ViewerReadOnlyException"/> (a purge is a config-write command, like Pause).</summary>
+    public Task<CommandResult?> RequestPurgeNowAsync(int? customRetentionDays = null, CancellationToken cancellationToken = default)
+    {
+        var argsJson = customRetentionDays is int days ? BuildPurgeNowArgs(days) : null;
+        return RunCommandAsync(CommandPurgeNow, targetServerId: null, argsJson, RequestedBy(), ImperativeCommandTimeout, cancellationToken);
+    }
+
+    /// <summary>
+    /// Builds the <c>purge_now</c> <c>args_json</c> carrying a custom retention horizon; the service executor
+    /// reads the <c>retention_days</c> key, so the two ends must agree on it. Pure; pinned by Darling.Tests.
+    /// </summary>
+    public static string BuildPurgeNowArgs(int customRetentionDays) =>
+        JsonSerializer.Serialize(new { retention_days = customRetentionDays });
 
     /// <summary>The audit label stamped on <c>config_command.requested_by</c> — the interactive user + a viewer tag.</summary>
     private static string RequestedBy()

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.CollectionHealth.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.CollectionHealth.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
@@ -67,6 +68,97 @@ public partial class ViewerServerTab
         _collectionHealthFilterMgr!.UpdateData(healthTask.Result);
         _collectionLogFilterMgr!.UpdateData(logTask.Result);
         RenderCollectorDurationChart(logTask.Result);
+    }
+
+    /// <summary>
+    /// "Purge Now" (Collection Health): runs the daily retention purge on demand via the fleet-wide
+    /// <c>purge_now</c> control command, after a confirm — it permanently deletes collected data older than the
+    /// configured retention horizons across ALL monitored servers (the purge is fleet-wide over the shared
+    /// store). A read-only viewer seat can't enqueue commands, so it shows an explanation instead (same rule as
+    /// Pause / live-plan fetch). On success it shows the purged summary and reloads the tab so the grids/chart
+    /// reflect the purge.
+    /// </summary>
+    private async void PurgeNow_Click(object sender, RoutedEventArgs e)
+    {
+        if (_dataService.IsReadOnly)
+        {
+            MessageBox.Show(
+                "Purging asks the service to run the retention purge, which it does by running a command — a " +
+                "read-only viewer seat can't enqueue commands. Reconnect with a read-write profile to purge.",
+                "Read-Only Viewer", MessageBoxButton.OK, MessageBoxImage.Information);
+            return;
+        }
+
+        var confirm = MessageBox.Show(
+            "Run the retention purge now?\n\n" +
+            "This permanently deletes collected data older than the configured retention horizons across ALL " +
+            "monitored servers (the purge is fleet-wide over the shared store). It is exactly what the service " +
+            "does automatically once a day — running it now just does it immediately. This cannot be undone.",
+            "Purge Now", MessageBoxButton.YesNo, MessageBoxImage.Warning);
+        if (confirm != MessageBoxResult.Yes)
+        {
+            return;
+        }
+
+        PurgeNowButton.IsEnabled = false;
+        PurgeNowIndicator.Text = "Purging...";
+        try
+        {
+            var result = await _dataService.RequestPurgeNowAsync();
+            if (result is null)
+            {
+                PurgeNowIndicator.Text = "Purge still running — re-open Collection Health to see the result";
+            }
+            else if (result.Status != ViewerDataService.StatusSucceeded)
+            {
+                PurgeNowIndicator.Text = $"Purge failed: {result.ResultStatus ?? "unknown error"}";
+            }
+            else
+            {
+                PurgeNowIndicator.Text = FormatPurgeSummary(result.ResultJson);
+                /* Reflect the purge in the grids + duration chart. */
+                await LoadHealthAsync();
+            }
+        }
+        catch (ViewerReadOnlyException)
+        {
+            /* Grants changed under us (the enqueue already threw). */
+            PurgeNowIndicator.Text = "Read-only viewer — cannot purge";
+        }
+        catch (Exception ex)
+        {
+            PurgeNowIndicator.Text = "";
+            StatusChanged?.Invoke($"purge failed: {ex.Message}");
+        }
+        finally
+        {
+            PurgeNowButton.IsEnabled = true;
+        }
+    }
+
+    /// <summary>
+    /// Formats the <c>purge_now</c> result_json (<c>{ tablesPurged, rowsPurged, ... }</c>) into the one-line
+    /// summary the indicator shows. Degrades to a plain "Purge complete" if the JSON is missing/unparseable.
+    /// </summary>
+    private static string FormatPurgeSummary(string? resultJson)
+    {
+        if (string.IsNullOrWhiteSpace(resultJson))
+        {
+            return "Purge complete";
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(resultJson);
+            var root = doc.RootElement;
+            var tables = root.TryGetProperty("tablesPurged", out var t) && t.TryGetInt32(out var ti) ? ti : 0;
+            var rows = root.TryGetProperty("rowsPurged", out var r) && r.TryGetInt32(out var ri) ? ri : 0;
+            return $"Purged {rows:N0} row(s)/chunk(s) across {tables:N0} table(s)";
+        }
+        catch (JsonException)
+        {
+            return "Purge complete";
+        }
     }
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
@@ -2616,7 +2616,21 @@
              log file, which the viewer has no equivalent of). -->
         <TabItem Header="Collection Health">
             <Grid Margin="8">
-                <TabControl Background="Transparent" BorderThickness="0" ItemContainerStyle="{DynamicResource SubTabItemStyle}">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <!-- Fleet-wide "Purge Now": runs the daily retention purge on demand via the purge_now
+                     control command. Placed on Collection Health (the store-health tab) rather than a
+                     per-server toolbar because the purge is fleet-wide over the shared store tables. A
+                     read-only viewer seat can't enqueue commands, so the handler shows an explanation. -->
+                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,8">
+                    <Button x:Name="PurgeNowButton" Content="Purge Now..." Click="PurgeNow_Click"
+                            Padding="12,4" Margin="0,0,8,0" VerticalAlignment="Center"/>
+                    <TextBlock x:Name="PurgeNowIndicator" Text="" FontSize="12"
+                               Foreground="DarkGoldenrod" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                </StackPanel>
+                <TabControl Grid.Row="1" Background="Transparent" BorderThickness="0" ItemContainerStyle="{DynamicResource SubTabItemStyle}">
                     <TabItem Header="Health Summary">
                         <DataGrid x:Name="CollectionHealthGrid" Style="{StaticResource DarkGrid}"
                                   MouseDoubleClick="CollectionHealthGrid_MouseDoubleClick">


### PR DESCRIPTION
Two small, code-verified control-plane wins for Darling.

## Win 1 — FinOps cost sync WITHOUT a reconnect
Today a cost-only server edit forces a full disconnect+reconnect because `DarlingWorker.ServerDefinitionEquals` compares `MonthlyCostUsd`; cost only reached the FinOps display via the connect-time `collect.servers` upsert.

- `DarlingObservability.SyncEnabledStatesSql` (the UPDATE that already mirrors `config_monitored_servers.is_enabled → collect.servers.is_enabled` on every reload) now **also** `SET monthly_cost_usd = c.monthly_cost_usd`, and its WHERE fires when **either** `is_enabled` **or** `monthly_cost_usd` drifts (NULL-safe `IS DISTINCT FROM`).
- Removed the `MonthlyCostUsd` comparison from `ServerDefinitionEquals`, so a cost-only edit no longer triggers a reconnect — the reload's sync carries the new cost straight to `collect.servers` (which FinOps reads) with no connection churn.

Net: a 2-line SQL change + one deleted comparison line.

## Win 2 — manual "Purge Now" via the control-plane command channel
The service runs `DarlingRetention.PurgeAsync` daily; there was no on-demand purge. Added one through the Stage-2 command plane (mirrors `snapshot_now`, but simpler — the purge is fleet-wide over shared tables, so **no** `target_server_id`).

- **Service:** `CommandKind.Purge` + a `purge_now` case in `ResolvePlan`, delegated to the worker via `IDarlingCommandHost.PurgeNowAsync`. `DarlingWorker.RunPurgeNowAsync` wraps the existing `DarlingRetention.PurgeAsync(...)` call. Custom-N days is supported cheaply by passing a `_ => customDays` retention resolver (`args_json.retention_days`; default = the configured fleet retention). `PurgeAsync` now returns a `PurgeSummary` (tables + rows/chunks) reported in `result_json`. No collection gate — a purge writes no collector state and `PurgeAsync` is idempotent + per-table failure-isolated, so it may safely overlap the daily sweep.
- **Viewer:** a "Purge Now" button on the **Collection Health** tab (`ViewerServerTab.CollectionHealth.cs`/`.xaml`) enqueues `purge_now` via a new `ViewerDataService.ControlCommands` wrapper and polls the terminal result (reuses the Stage-3a enqueue/poll). `IsReadOnly`-gated (enqueue is a config write, like Pause), confirms before purging (it's destructive to old data), then shows the purged summary and refreshes the tab.

## Files touched
- Service: `DarlingObservability.cs`, `DarlingWorker.cs`, `DarlingCommandExecutor.cs`, `DarlingRetention.cs`
- Viewer (only these 3): `ViewerServerTab.CollectionHealth.cs`, `ViewerServerTab.xaml`, `ViewerDataService.ControlCommands.cs`
- Tests: `DarlingObservabilityTests`, `DarlingWorkerTests`, `DarlingCommandExecutorTests`, `DarlingRetentionTests`, `TimescaleSupportTests`, `ViewerControlPlaneStage3bTests`

No `install/*.sql` changes.

## Testing
- `dotnet build` the whole Darling solution `-c Release`: succeeds (0 errors); Viewer XAML markup compile clean.
- `Darling.Tests -c Release`: **1568 passed, 0 failed, 122 skipped** (the skips are all `DARLING_TEST_PG`-gated live round-trips — not set in this env).
- New pure tests: cost-sync SQL shape (enabled + cost, fires on either delta); `ServerDefinitionEquals` cost-only delta compares equal (no reconnect) while host/excluded-db deltas still reconnect; `purge_now` dispatch (Purge kind, no target, case-insensitive); `PurgeSummary.TotalPurged` contract; viewer↔executor `purge_now` constant agreement.
- New live round-trips (gated on `DARLING_TEST_PG`): cost-only sync mirrors onto `collect.servers`; `purge_now` execute/report passes custom-N (built with the viewer's `BuildPurgeNowArgs`) vs null to the host.
