### PR TITLE
Darling viewer: gate Rec deep-link to incidents + "Last Collected" column (light theme surfaced as a gated blocker)

### DIFF
--- a/Darling/Darling.Tests/ViewerManageServersTests.cs
+++ b/Darling/Darling.Tests/ViewerManageServersTests.cs
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using PerformanceMonitor.Darling.Viewer;
+using PerformanceMonitor.Ui;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Pins the Manage Servers grid's new "Last Collected" column projection (<see cref="ManagedServerListItem"/>):
+/// the SERVICE's newest collection time (the MAX(collection_time) freshness signal the sidebar dots reuse) is
+/// rendered in the viewer's timestamp-display mode, and a server the service has not collected yet reads
+/// "Never" rather than a bogus epoch. The read itself (<see cref="ViewerDataService.GetServerFreshnessAsync"/>)
+/// is a single documented query already exercised by the sidebar; the CELL logic is what this change adds, and
+/// it is pure (given the display mode), so it is unit-testable without a live Postgres.
+/// </summary>
+public sealed class ViewerManageServersColumnTests
+{
+    private static ManagedServerListItem Item(DateTime? lastCollectedUtc) =>
+        new(new MonitoredServerRow { ServerId = 1, Host = "SQL2022", Name = "SQL2022" }, isFavorite: false)
+        {
+            LastCollectedUtc = lastCollectedUtc,
+        };
+
+    [Fact]
+    public void LastCollectedDisplay_ReadsNever_WhenTheServiceHasNotCollectedYet()
+    {
+        Assert.Equal("Never", Item(lastCollectedUtc: null).LastCollectedDisplay);
+    }
+
+    [Fact]
+    public void LastCollectedDisplay_FormatsTheNewestCollectionTime_InTheDisplayMode()
+    {
+        var savedMode = ViewerTimeHelper.CurrentDisplayMode;
+        try
+        {
+            // UTC mode is the identity conversion, so the naive-UTC collection time renders verbatim.
+            ViewerTimeHelper.CurrentDisplayMode = TimeDisplayMode.UTC;
+            var lastCollected = new DateTime(2026, 7, 1, 14, 30, 0, DateTimeKind.Unspecified);
+
+            Assert.Equal("2026-07-01 14:30", Item(lastCollected).LastCollectedDisplay);
+        }
+        finally
+        {
+            ViewerTimeHelper.CurrentDisplayMode = savedMode;
+        }
+    }
+}

--- a/Darling/Darling.Tests/ViewerRecommendationsTests.cs
+++ b/Darling/Darling.Tests/ViewerRecommendationsTests.cs
@@ -278,7 +278,8 @@ public sealed class ViewerRecommendationCardTests
         Assert.Equal(point.AddMinutes(ViewerServerTab.DrillDownHalfWindowMinutes), to);
     }
 
-    private static RecommendationCardViewModel Card(int serverId, DateTime? windowStart, DateTime? windowEnd)
+    private static RecommendationCardViewModel Card(
+        int serverId, DateTime? windowStart, DateTime? windowEnd, RemediationAction? remediation = null)
         => new(new RecommendationItem
         {
             Severity = RecommendationSeverity.Warning,
@@ -286,7 +287,68 @@ public sealed class ViewerRecommendationCardTests
             ServerId = serverId,
             WindowStartUtc = windowStart,
             WindowEndUtc = windowEnd,
+            Remediation = remediation,
         });
+
+    // ── Incident-vs-config-fix gate on the deep-link (fixes the #1427 "shows on every finding" bug) ──
+
+    [Fact]
+    public void Card_ShowOpenInActiveQueries_HiddenForConfigFixFindings_EvenWithAWindowAndServer()
+    {
+        var start = new DateTime(2026, 7, 1, 10, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2026, 7, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        // A safe DB_CONFIG standing fix (AUTO_SHRINK) is a config fix, not an incident -> deep-link hidden
+        // despite carrying a full window + a real server id.
+        var dbConfig = new RemediationAction(
+            "DB_CONFIG", "set", Array.Empty<ForcePlanTarget>(),
+            DbConfigTargets: new[] { new DbConfigTarget("StackOverflow", DbConfigSetting.AutoShrinkOff) });
+        var dbConfigCard = Card(serverId: 7, windowStart: start, windowEnd: end, remediation: dbConfig);
+        Assert.True(dbConfigCard.IsConfigFix);
+        Assert.False(dbConfigCard.IsIncident);
+        Assert.False(dbConfigCard.ShowOpenInActiveQueries);
+
+        // A DB_CONFIG action can carry ONLY per-db RCSI targets (no safe targets) — still a config fix.
+        var rcsiOnly = new RemediationAction(
+            "DB_CONFIG", "set", Array.Empty<ForcePlanTarget>(),
+            RcsiTargets: new[] { new RcsiTarget("StackOverflow", new RcsiInactionFigures(50, 2, 60)) });
+        Assert.False(Card(serverId: 7, windowStart: start, windowEnd: end, remediation: rcsiOnly).ShowOpenInActiveQueries);
+
+        // Percent-autogrowth (FILE_AUTOGROWTH_PERCENT) is a config fix.
+        var autogrowth = new RemediationAction(
+            "FILE_AUTOGROWTH_PERCENT", "set", Array.Empty<ForcePlanTarget>(),
+            FileGrowthTargets: new[] { new FileGrowthTarget("StackOverflow", "SO_data", 90000, 10, 1024) });
+        Assert.False(Card(serverId: 7, windowStart: start, windowEnd: end, remediation: autogrowth).ShowOpenInActiveQueries);
+
+        // Server-level config (MAXDOP) is a config fix.
+        var serverConfig = new RemediationAction(
+            "SERVER_CONFIG", "set", Array.Empty<ForcePlanTarget>(),
+            ServerConfigTargets: new[] { new ServerConfigTarget(ServerConfigSetting.Maxdop, 0, 8) });
+        Assert.False(Card(serverId: 7, windowStart: start, windowEnd: end, remediation: serverConfig).ShowOpenInActiveQueries);
+    }
+
+    [Fact]
+    public void Card_ShowOpenInActiveQueries_ShownForIncidentFindings_WithAWindowAndServer()
+    {
+        var start = new DateTime(2026, 7, 1, 10, 0, 0, DateTimeKind.Utc);
+        var end = new DateTime(2026, 7, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        // A pure incident (CPU/blocking/waits) reads back with no remediation action -> shown.
+        var bare = Card(serverId: 7, windowStart: start, windowEnd: end, remediation: null);
+        Assert.True(bare.IsIncident);
+        Assert.True(bare.ShowOpenInActiveQueries);
+
+        // Plan-regression (force-plan) is Apply-able but stays an INCIDENT (no structured config targets) -> shown.
+        var forcePlan = new RemediationAction(
+            "PLAN_REGRESSION", "force", new[] { new ForcePlanTarget("StackOverflow", QueryId: 42, PlanId: 7) });
+        Assert.True(Card(serverId: 7, windowStart: start, windowEnd: end, remediation: forcePlan).ShowOpenInActiveQueries);
+
+        // MISSING_INDEX is copy-paste-only but deliberately stays an incident (Dashboard parity) -> shown.
+        var missingIndex = new RemediationAction(
+            "MISSING_INDEX", "advise", Array.Empty<ForcePlanTarget>(),
+            MissingIndexTargets: new[] { new MissingIndexTarget("dbo.Posts", 92.5, "CREATE INDEX IX ON dbo.Posts (OwnerUserId);") });
+        Assert.True(Card(serverId: 7, windowStart: start, windowEnd: end, remediation: missingIndex).ShowOpenInActiveQueries);
+    }
 
     [Theory]
     [InlineData(RecommendationSeverity.Critical, "CRITICAL", "")]

--- a/Darling/PerformanceMonitor.Darling.Viewer/ManageServersWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ManageServersWindow.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Manage Servers"
-        Height="500" Width="830"
+        Height="500" Width="980"
         WindowStartupLocation="CenterOwner"
         Icon="EDD.ico"
         Background="{DynamicResource BackgroundBrush}">
@@ -66,8 +66,11 @@
                     </DataGridTextColumn.ElementStyle>
                 </DataGridTextColumn>
                 <!-- "Added" (creation time), not Lite's "Last Connected": the viewer never connects to a
-                     monitored server, so a last-connected time would be meaningless here. -->
+                     monitored server. -->
                 <DataGridTextColumn Header="Added" Binding="{Binding CreatedDate, StringFormat=yyyy-MM-dd HH:mm}" Width="140"/>
+                <!-- "Last Collected" (not "Last Connected"): the Darling SERVICE connects + collects, not the
+                     viewer. Reuses the sidebar dots' MAX(collection_time) freshness read; "Never" until first collect. -->
+                <DataGridTextColumn Header="Last Collected" Binding="{Binding LastCollectedDisplay}" Width="140"/>
             </DataGrid.Columns>
         </DataGrid>
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ManageServersWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ManageServersWindow.xaml.cs
@@ -58,10 +58,31 @@ public partial class ManageServersWindow : Window
 
             var rows = await _dataService.GetMonitoredServersAsync();
             var appVersion = GetAppVersion();
+
+            /* One collection-freshness read for the whole list — the same MAX(collection_time) per server the
+               sidebar dots + Overview cards derive freshness from — so the grid shows when the Darling SERVICE
+               last collected each server (the viewer never connects to a monitored server). Defensive: a
+               read-only seat or a transient failure just leaves the column showing "Never". */
+            Dictionary<int, DateTime> freshness;
+            try
+            {
+                freshness = await _dataService.GetServerFreshnessAsync();
+            }
+            catch (Exception ex)
+            {
+                ViewerLogger.Warn("ManageServersWindow", $"collection-freshness read failed: {ex.Message}");
+                freshness = new Dictionary<int, DateTime>();
+            }
+
             var items = new List<ManagedServerListItem>(rows.Count);
             foreach (var row in rows)
             {
-                items.Add(new ManagedServerListItem(row, _serverStore.IsFavorite(row.Host)) { InstalledVersion = appVersion });
+                var lastCollected = freshness.TryGetValue(row.ServerId, out var t) ? t : (DateTime?)null;
+                items.Add(new ManagedServerListItem(row, _serverStore.IsFavorite(row.Host))
+                {
+                    InstalledVersion = appVersion,
+                    LastCollectedUtc = lastCollected,
+                });
             }
 
             ServersGrid.ItemsSource = items;
@@ -284,4 +305,15 @@ public sealed class ManagedServerListItem
 
     /// <summary>The store's creation time (local, for the grid's "Added" column); falls back to now for a row read without it.</summary>
     public DateTime CreatedDate => (Row.CreatedAt ?? DateTime.UtcNow).ToLocalTime();
+
+    /// <summary>The store's naive-UTC newest collection time for this server (MAX(collection_time) across all
+    /// collectors), set once before binding; null when the Darling service has not collected this server yet.</summary>
+    public DateTime? LastCollectedUtc { get; set; }
+
+    /// <summary>The "Last Collected" cell: the newest collection time rendered in the viewer's timestamp-display
+    /// mode (Server/Local/UTC via <see cref="ViewerTimeHelper.ForDisplay"/>), or "Never" when the service has
+    /// not collected this server yet. Labeled "Last Collected" — the SERVICE connects and collects, the viewer
+    /// never does — so this reflects service activity, not a viewer connection.</summary>
+    public string LastCollectedDisplay =>
+        LastCollectedUtc is { } utc ? ViewerTimeHelper.ForDisplay(utc).ToString("yyyy-MM-dd HH:mm") : "Never";
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/RecommendationsViewModel.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/RecommendationsViewModel.cs
@@ -97,6 +97,17 @@ public sealed class RecommendationItem
     public string? CopyPasteSql { get; init; }
 
     /// <summary>
+    /// The finding's PERSISTED remediation action (or null) — the same object <see cref="CopyPasteSql"/>
+    /// is derived from. Carried so the card can reconstruct the incident-vs-config-fix distinction the
+    /// Dashboard draws from its RecommendationSetting taxonomy (<c>RecommendationsViewModel.IsIncident</c>).
+    /// The viewer reads only engine findings (there is no legacy critical_issues RecommendationSetting
+    /// store here), so a structured standing-config action — DB_CONFIG / RCSI / FILE_AUTOGROWTH_PERCENT /
+    /// SERVER_CONFIG — is the only signal that a finding is a config fix rather than a time-bound incident,
+    /// and it gates whether the "Open in Active Queries" deep-link is offered.
+    /// </summary>
+    public RemediationAction? Remediation { get; init; }
+
+    /// <summary>
     /// The finding's incident id — the group key the surface collapses cards under so related
     /// findings render as one report. Empty for findings analyzed before incident_id existed; the
     /// view-model treats an empty id as a standalone single-card incident.
@@ -202,15 +213,53 @@ public sealed class RecommendationCardViewModel
     public DateTime? WindowEndUtc => Item.WindowEndUtc;
 
     /// <summary>
-    /// Whether the "Open in Active Queries" deep-link is shown — an incident-type finding that carries
-    /// BOTH a time window (to scope the Active Queries read to when it fired) AND a server id (to open the
-    /// right per-server tab). This is the Dashboard's incident affordance (<c>ShowOpenInActiveQueries</c>)
-    /// ported to the viewer's advise-only model: the viewer has no RecommendationSetting/structured-fix
-    /// taxonomy, so the gate is simply "has a time anchor + a server" — a finding with no time window
-    /// (or no server id) hides it, because deep-linking to Active Queries needs both.
+    /// Whether this row carries a STRUCTURED standing config-fix action — a persisted
+    /// <see cref="RemediationAction"/> whose typed per-target lists map to a database- or server-level
+    /// configuration change: DB_CONFIG safe settings (<see cref="RemediationAction.DbConfigTargets"/>),
+    /// per-database RCSI (<see cref="RemediationAction.RcsiTargets"/> — a DB_CONFIG action can carry ONLY
+    /// these, so they must be checked), percent-autogrowth files
+    /// (<see cref="RemediationAction.FileGrowthTargets"/>), or server config MAXDOP/CTFP/memory
+    /// (<see cref="RemediationAction.ServerConfigTargets"/>). Mirrors the Dashboard card's
+    /// <c>HasStructuredFixAction</c>. Plan-regression (force-plan), clear-plan, and MISSING_INDEX actions
+    /// are deliberately NOT structured config fixes — their target lists are empty here — so they remain
+    /// incidents, matching the Dashboard (where MISSING_INDEX keeps the incident affordances).
+    /// </summary>
+    private bool HasStructuredFixAction =>
+        Item.Remediation is { } r &&
+        ((r.DbConfigTargets is { Count: > 0 }) ||
+         (r.RcsiTargets is { Count: > 0 }) ||
+         (r.FileGrowthTargets is { Count: > 0 }) ||
+         (r.ServerConfigTargets is { Count: > 0 }));
+
+    /// <summary>
+    /// Whether this is a standing CONFIG-FIX finding (a structured config action) rather than a time-bound
+    /// incident. The viewer reads only engine findings (no legacy critical_issues RecommendationSetting
+    /// store), so — unlike the Dashboard, which also flags a config fix via a non-None Setting — the
+    /// structured action is the only config-fix signal available here.
+    /// </summary>
+    public bool IsConfigFix => HasStructuredFixAction;
+
+    /// <summary>
+    /// Whether this is a time-bound INCIDENT finding (CPU/memory/blocking/waits/plan-regression/
+    /// missing-index) — anything that is NOT a structured standing config fix. Mirrors the Dashboard's
+    /// <c>IsIncident</c> (<c>Setting == None &amp;&amp; !HasStructuredFixAction</c>), reduced to the
+    /// <c>!HasStructuredFixAction</c> half the viewer can observe. Incidents get the deep-link to Active
+    /// Queries; config fixes do not.
+    /// </summary>
+    public bool IsIncident => !HasStructuredFixAction;
+
+    /// <summary>
+    /// Whether the "Open in Active Queries" deep-link is shown — an INCIDENT-type finding (not a standing
+    /// config fix) that ALSO carries BOTH a time window (to scope the Active Queries read to when it fired)
+    /// AND a server id (to open the right per-server tab). This is the Dashboard's incident affordance
+    /// (<c>ShowOpenInActiveQueries => IsIncident</c>) ported to the viewer's advise-only model: a config-fix
+    /// finding (e.g. AUTO_SHRINK, RCSI, autogrowth, MAXDOP) hides the deep-link even when it carries a
+    /// window+server, because sending the operator to Active Queries makes no sense for a standing
+    /// misconfiguration; a finding with no time window (or no server id) also hides it, because deep-linking
+    /// needs both.
     /// </summary>
     public bool ShowOpenInActiveQueries =>
-        Item.ServerId != 0 && Item.WindowStartUtc.HasValue && Item.WindowEndUtc.HasValue;
+        IsIncident && Item.ServerId != 0 && Item.WindowStartUtc.HasValue && Item.WindowEndUtc.HasValue;
 
     /// <summary>
     /// The UTC window the deep-link scopes Active Queries to: the finding's own window when it carries a
@@ -377,6 +426,7 @@ public sealed class RecommendationsViewModel
             Title = row.Title,
             AdviceText = ComposeAdvice(advice),
             CopyPasteSql = BuildCopyPasteSql(finding.Remediation),
+            Remediation = finding.Remediation,
             IncidentId = finding.IncidentId,
             ServerName = serverName ?? string.Empty,
             ServerId = finding.ServerId,


### PR DESCRIPTION
Three code-verified Darling viewer parity wins were scoped. **Two shipped here** (Wins 1 & 2, with tests). **Win 3 (light theme) is surfaced as a blocker** — the re-audit found its "mostly free" premise is contradicted by the code (the viewer shell is hardcoded dark), so a coherent light theme needs a dedicated, visual-review-gated pass rather than a small win. Evidence below.

## Win 1 — Rec-card "Open in Active Queries" no longer shows on config-fix findings

Fixes a real bug from #1427: the deep-link showed on **every** finding because the Darling viewer never reconstructed the Dashboard's incident-vs-config-fix distinction.

- The Dashboard gates the deep-link on `IsIncident` = (`Setting == None` AND no structured fix action) — `Dashboard/Controls/RecommendationsViewModel.cs:130,159`.
- The viewer has no `RecommendationSetting` taxonomy (engine-only reads), so the incident/config signal is reconstructed from the persisted `RemediationAction` carried on the shared `AnalysisFinding` (`PerformanceMonitor.Analysis/AnalysisModels.cs:158`).
- A **structured standing-config** action marks a config fix (not an incident): `DbConfigTargets`, `RcsiTargets` (a DB_CONFIG action can carry *only* RCSI targets — `FactRemediation.cs:79-82` — so it must be checked), `FileGrowthTargets`, or `ServerConfigTargets`. Plan-regression (force-plan), clear-plan, and **MISSING_INDEX stay incidents** (Dashboard parity — missing-index keeps the incident affordances).
- `RecommendationItem` now carries the action; `ShowOpenInActiveQueries` is gated on `IsIncident` (and still requires a time window + server id).

~35 lines, no schema/store change.

## Win 2 — "Last Collected" column in Manage Servers

`ManageServersWindow` showed only `created_at` as "Added" (`ManageServersWindow.xaml:70`). Added a **"Last Collected"** column (labeled that — the *service* connects, not the viewer).

- Reuses the existing per-server freshness read `ViewerDataService.GetServerFreshnessAsync` (`MAX(collection_time)` per `server_id` — `ViewerDataService.ServerStatus.cs:43`), the same signal the sidebar status dots use. No migration.
- Rendered in the viewer's timestamp-display mode via `ViewerTimeHelper.ForDisplay`; reads **"Never"** until the service's first collection. The read is defensive (a read-only seat / transient failure just shows "Never"). Window widened 830→980 so the column is visible.

## Tests

`Darling.Tests -c Release`: **1566 passed, 120 skipped** (gated live-Postgres, no `DARLING_TEST_PG`), **0 failed**.

- Win 1: config-fix findings (DB_CONFIG / RCSI-only / FILE_AUTOGROWTH_PERCENT / SERVER_CONFIG) hide the deep-link even with a window+server; incidents (bare / force-plan / MISSING_INDEX) show it.
- Win 2: `LastCollectedDisplay` formats the freshness time in the display mode and reads "Never" when uncollected.

## Win 3 — Light theme: NOT shipped; surfaced as a gated blocker (evidence)

The brief assumed the viewer was "needlessly dark-only" and a full theme was "mostly free" because `ThemeManager.Apply` already supports Dark/Light/CoolBreeze. The plumbing side is indeed easy — but a **code-verified re-audit shows the viewer shell + primary content are pervasively hardcoded dark**, so enabling a Light/CoolBreeze picker today renders a broken, partly-unreadable UI. Making it coherent is a large, visual-review-gated pass, not a small win. Rather than ship a broken picker (or unilaterally re-theme the shell that is gated for visual review — shell/chrome is a known gap in the NOTES-until-go viewer queue), this is reported for that queue:

- **~250 hardcoded dark hexes** across the shell/content, not `{DynamicResource}`: `MainWindow.xaml` (77), `FinOpsTab.xaml` (66, a mix of chrome + fixed data-viz), `ViewerServerTab.xaml` (29), + the secondary windows. These don't follow a theme swap.
- **10 secondary windows are hard-pinned to dark**: About / AlertDetail / CollectionLog / CollectorScheduleEditor / MuteRuleEdit / MuteRules / ProcedureHistory / QueryStatsHistory / QueryStoreHistory / WaitDrillDown each merge `ViewerDarkTheme.xaml` (a full 50-hex dark control dictionary) at the window level, which wins over any app-level theme.
- **Unreadable text under a light bg**: `MainWindow.xaml:10-11` sets window-level `Background="#22252b"` + `Foreground="#E4E6EB"` as literal hex — near-white text is inherited by child `TextBlock`s that don't set their own color, so a light background yields white-on-light.
- **Light/CoolBreeze are missing 10 `Slicer*` keys** that `DarkTheme.xaml` defines (inherited gap from Lite's themes) — slicer controls wouldn't resolve their brushes under a light theme.

The one thing that *would* theme for free is charts (`ChartStyle` reads `ThemeManager.CurrentTheme`), plus the few `{DynamicResource}`-only dialogs (Settings/ManageServers/AddServer). That isn't enough for a coherent app.

**Recommended follow-up (dedicated, visual-review-gated):** copy `LightTheme.xaml` + `CoolBreezeTheme.xaml` into the viewer's `Themes/`; backfill the 10 `Slicer*` keys into Light/CoolBreeze; convert the shell/content chrome hexes + `ViewerDarkTheme.xaml` to theme keys (keeping data-viz/semantic colors fixed); fix the window-level `Foreground`/`Background`; persist a normalized `ColorTheme` in `ViewerAppSettings` and apply it at startup + on change; then enable the (already-present, currently-disabled) Settings combo. Dark stays the default throughout, so it can be verified for zero regression as part of that pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
