### PR TITLE
Darling: per-server + per-event alert delivery mode (#1236/#1141)

### DIFF
--- a/Darling/Darling.Tests/DarlingConfigTests.cs
+++ b/Darling/Darling.Tests/DarlingConfigTests.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.Data.SqlClient;
 using PerformanceMonitor.Darling.Service;
+using PerformanceMonitor.Notifications;
 using Xunit;
 
 namespace Darling.Tests;
@@ -70,11 +71,40 @@ public sealed class DarlingConfigTests
         Assert.True(config.Alerts.Enabled);
         Assert.Equal(80, config.Alerts.CpuThresholdPercent);
         Assert.Equal("total", config.Alerts.CpuMode);
+        /* #1141/#1236: the sample documents the delivery-mode knobs (global default Summary / 5, and a
+           per-server override that inherits the global when null). */
+        Assert.Equal(AlertNotificationMode.Summary, config.Alerts.DeliveryMode);
+        Assert.Equal(5, config.Alerts.PerEventMax);
+        Assert.Null(config.Servers[0].AlertDeliveryModeOverride);
         Assert.Equal(587, config.Smtp.Port);
         Assert.Equal("", config.Smtp.Host);
         Assert.Equal("dba-team@example.com", config.Smtp.To);
         Assert.Equal("", config.Webhooks.TeamsUrl);
         Assert.Equal("", config.Webhooks.SlackUrl);
+    }
+
+    [Fact]
+    public void DeliveryMode_DefaultsSummary_ParsesEnumNames_AndPerServerOverride()
+    {
+        /* Defaults mirror the V18 DDL: global Summary / 5, per-server override null (inherit). */
+        var config = new DarlingConfig();
+        Assert.Equal(AlertNotificationMode.Summary, config.Alerts.DeliveryMode);
+        Assert.Equal(5, config.Alerts.PerEventMax);
+
+        /* darling.json carries the enum by NAME (JsonStringEnumConverter), and the per-server override
+           is nullable ("PerEvent" on one server, absent/null on another = inherit). */
+        var parsed = DarlingConfig.Parse(@"{
+            ""postgres"": { ""managed"": true },
+            ""servers"": [
+                { ""host"": ""noisy"", ""alertDeliveryModeOverride"": ""PerEvent"" },
+                { ""host"": ""quiet"" }
+            ],
+            ""alerts"": { ""deliveryMode"": ""PerEvent"", ""perEventMax"": 3 }
+        }");
+        Assert.Equal(AlertNotificationMode.PerEvent, parsed.Alerts.DeliveryMode);
+        Assert.Equal(3, parsed.Alerts.PerEventMax);
+        Assert.Equal(AlertNotificationMode.PerEvent, parsed.Servers[0].AlertDeliveryModeOverride);
+        Assert.Null(parsed.Servers[1].AlertDeliveryModeOverride);
     }
 
     [Fact]

--- a/Darling/Darling.Tests/DarlingDeliveryModeTests.cs
+++ b/Darling/Darling.Tests/DarlingDeliveryModeTests.cs
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using PerformanceMonitor.Alerting;
+using PerformanceMonitor.Darling.Service;
+using PerformanceMonitor.Darling.Storage;
+using PerformanceMonitor.Notifications;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Pins the per-server + per-event alert delivery mode (#1236 / #1141) the service now honors. The pure tests
+/// need no Postgres: <see cref="DarlingAlertSettings"/> exposes the global mode + per-event cap through the
+/// by-reference config seam (with the 1–100 clamp), and <see cref="DarlingAlertDeliverer"/> resolves a
+/// per-server override against the global mode and — in Per-event mode only — fans an incident-carrying alert
+/// out through the shared <see cref="PerEventNotification.Split"/> into one send+history-row per distinct
+/// incident (capped, "+N more"), with SMTP/webhooks unconfigured so every send records a "tray" row. The
+/// live test (gated on DARLING_TEST_PG) round-trips the two settings columns + the per-server override column
+/// through a real seed/read against an isolated scratch store.
+/// </summary>
+public sealed class DarlingDeliveryModeTests
+{
+    /* ---------------- pure: the settings seam ---------------- */
+
+    [Fact]
+    public void DarlingAlertSettings_ReadsDeliveryModeAndPerEventMax_ThroughTheByReferenceSeam()
+    {
+        var config = new DarlingConfig();
+        var settings = new DarlingAlertSettings(config);
+
+        /* Defaults mirror the V18 DDL: Summary / 5. */
+        Assert.Equal(AlertNotificationMode.Summary, settings.DeliveryMode);
+        Assert.Equal(5, settings.PerEventMax);
+
+        /* A store reload mutates the held config in place; the same adapter instance reflects it. */
+        config.Alerts.DeliveryMode = AlertNotificationMode.PerEvent;
+        config.Alerts.PerEventMax = 12;
+        Assert.Equal(AlertNotificationMode.PerEvent, settings.DeliveryMode);
+        Assert.Equal(12, settings.PerEventMax);
+    }
+
+    [Theory]
+    [InlineData(0, 1)]      // below floor -> 1
+    [InlineData(-4, 1)]     // negative -> 1
+    [InlineData(250, 100)]  // above ceiling -> 100
+    [InlineData(37, 37)]    // in range -> unchanged
+    public void DarlingAlertSettings_ClampsPerEventMax_1To100(int configured, int expected)
+    {
+        var config = new DarlingConfig();
+        config.Alerts.PerEventMax = configured;
+        Assert.Equal(expected, new DarlingAlertSettings(config).PerEventMax);
+    }
+
+    /* ---------------- pure: ApplyToConfig carries the new fields through the seam ---------------- */
+
+    [Fact]
+    public void ApplyToConfig_SwapsDeliveryModeAndPerEventMax_ReflectedThroughTheSettingsSeam()
+    {
+        var config = new DarlingConfig();
+        var settings = new DarlingAlertSettings(config);
+
+        StoreConfigProvider.ApplyToConfig(config, new StoreConfigView
+        {
+            Alerts = new AlertsConfig { DeliveryMode = AlertNotificationMode.PerEvent, PerEventMax = 9 },
+        });
+
+        Assert.Equal(AlertNotificationMode.PerEvent, settings.DeliveryMode);
+        Assert.Equal(9, settings.PerEventMax);
+    }
+
+    /* ---------------- pure: the deliverer Summary vs Per-event branch ---------------- */
+
+    [Fact]
+    public async Task Summary_WithIncidents_RecordsOneCombinedRow()
+    {
+        var config = new DarlingConfig(); // Summary default
+        var (deliverer, history) = BuildDeliverer(config);
+
+        await deliverer.DeliverAsync(OutcomeWithIncidents(3), TestContext.Current.CancellationToken);
+
+        /* One combined summary row, carrying the server-level numerics. */
+        var record = Assert.Single(history.Records);
+        Assert.Equal("Deadlocks Detected", record.MetricName);
+        Assert.Equal("tray", record.NotificationType); // no channel configured
+        Assert.Equal(3, record.NumericCurrentValue);
+    }
+
+    [Fact]
+    public async Task PerEvent_WithinCap_RecordsOneRowPerIncident_NoOverflow_NoServerNumerics()
+    {
+        var config = new DarlingConfig();
+        config.Alerts.DeliveryMode = AlertNotificationMode.PerEvent;
+        config.Alerts.PerEventMax = 5;
+        var (deliverer, history) = BuildDeliverer(config);
+
+        await deliverer.DeliverAsync(OutcomeWithIncidents(3), TestContext.Current.CancellationToken);
+
+        Assert.Equal(3, history.Records.Count);
+        /* Per-event cards carry the incident occurrence count, not the server-level numerics. */
+        Assert.All(history.Records, r => Assert.Null(r.NumericCurrentValue));
+        Assert.All(history.Records, r => Assert.Null(r.NumericThresholdValue));
+        Assert.DoesNotContain(history.Records, r => r.CurrentValueText.Contains("more", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task PerEvent_OverCap_CapsIndividualRows_AndBatchesOverflowWithPlusNMore()
+    {
+        var config = new DarlingConfig();
+        config.Alerts.DeliveryMode = AlertNotificationMode.PerEvent;
+        config.Alerts.PerEventMax = 2;
+        var (deliverer, history) = BuildDeliverer(config);
+
+        await deliverer.DeliverAsync(OutcomeWithIncidents(5), TestContext.Current.CancellationToken);
+
+        /* 2 individual + 1 overflow batch = 3 rows; the overflow row carries "+3 more". */
+        Assert.Equal(3, history.Records.Count);
+        Assert.Single(history.Records, r => r.CurrentValueText.Contains("+3 more", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task PerEvent_NoIncidents_FallsBackToTheSingleSummarySend()
+    {
+        var config = new DarlingConfig();
+        config.Alerts.DeliveryMode = AlertNotificationMode.PerEvent;
+        var (deliverer, history) = BuildDeliverer(config);
+
+        /* A CPU-style alert carries no incidents — even in Per-event mode it takes the single combined path. */
+        var outcome = new AlertOutcome("42", "srv", "High CPU", "92", "80",
+            Context: null, DetailText: "detail", NumericCurrentValue: 92, NumericThresholdValue: 80,
+            Muted: false, Severity: null);
+
+        await deliverer.DeliverAsync(outcome, TestContext.Current.CancellationToken);
+
+        var record = Assert.Single(history.Records);
+        Assert.Equal(92, record.NumericCurrentValue);
+    }
+
+    [Fact]
+    public async Task PerServerOverride_PerEvent_WinsOverGlobalSummary_AndSplits()
+    {
+        var config = new DarlingConfig(); // global Summary
+        var (deliverer, history) = BuildDeliverer(config, resolveOverride: _ => AlertNotificationMode.PerEvent);
+
+        await deliverer.DeliverAsync(OutcomeWithIncidents(3), TestContext.Current.CancellationToken);
+
+        Assert.Equal(3, history.Records.Count); // the override forced Per-event for this server
+    }
+
+    [Fact]
+    public async Task PerServerOverride_Summary_WinsOverGlobalPerEvent_AndDoesNotSplit()
+    {
+        var config = new DarlingConfig();
+        config.Alerts.DeliveryMode = AlertNotificationMode.PerEvent; // global Per-event
+        var (deliverer, history) = BuildDeliverer(config, resolveOverride: _ => AlertNotificationMode.Summary);
+
+        await deliverer.DeliverAsync(OutcomeWithIncidents(3), TestContext.Current.CancellationToken);
+
+        Assert.Single(history.Records); // the override forced Summary — one combined row
+    }
+
+    [Fact]
+    public async Task NullOverride_InheritsTheGlobalMode()
+    {
+        var config = new DarlingConfig();
+        config.Alerts.DeliveryMode = AlertNotificationMode.PerEvent;
+        var (deliverer, history) = BuildDeliverer(config, resolveOverride: _ => null); // null = inherit
+
+        await deliverer.DeliverAsync(OutcomeWithIncidents(4), TestContext.Current.CancellationToken);
+
+        Assert.Equal(4, history.Records.Count); // inherited the global Per-event
+    }
+
+    /* ---------------- live (DARLING_TEST_PG): seed -> read round-trip of the V18 columns ---------------- */
+
+    [Fact]
+    public async Task SeedAndRead_RoundTripsDeliveryMode_AndPerServerOverride_AgainstScratchPostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to an ISOLATED scratch Postgres (it seeds the singleton config rows) to run the seed/read round-trip.");
+
+        var ct = TestContext.Current.CancellationToken;
+
+        await using (var connection = new NpgsqlConnection(connectionString))
+        {
+            await connection.OpenAsync(ct);
+            await PgMigrations.MigrateAsync(connection, ct); // brings the scratch store to V18
+        }
+
+        await using var dataSource = NpgsqlDataSource.Create(connectionString!);
+        var provider = new StoreConfigProvider(dataSource);
+
+        var config = new DarlingConfig();
+        config.Alerts.DeliveryMode = AlertNotificationMode.PerEvent;
+        config.Alerts.PerEventMax = 7;
+        config.Servers.Add(new MonitoredServer
+        {
+            Name = "v18-override",
+            Host = "v18-scratch-host",
+            Auth = "integrated",
+            AlertDeliveryModeOverride = AlertNotificationMode.PerEvent,
+        });
+        config.Servers.Add(new MonitoredServer
+        {
+            Name = "v18-inherit",
+            Host = "v18-scratch-inherit",
+            Auth = "integrated",
+            /* no override -> null -> inherit global */
+        });
+
+        await provider.SeedIfEmptyAsync(config, ct);
+
+        var view = await provider.LoadViewAsync(new DarlingConfig(), ct);
+        Assert.NotNull(view);
+
+        /* The global settings columns round-tripped. */
+        Assert.Equal(AlertNotificationMode.PerEvent, view!.Alerts.DeliveryMode);
+        Assert.Equal(7, view.Alerts.PerEventMax);
+
+        /* The per-server override column round-tripped (set on one server, null on the other). */
+        var overridden = Assert.Single(view.EnabledServers, s => s.Host == "v18-scratch-host");
+        Assert.Equal(AlertNotificationMode.PerEvent, overridden.AlertDeliveryModeOverride);
+        var inherited = Assert.Single(view.EnabledServers, s => s.Host == "v18-scratch-inherit");
+        Assert.Null(inherited.AlertDeliveryModeOverride);
+    }
+
+    /* ---------------- helpers ---------------- */
+
+    private static (DarlingAlertDeliverer Deliverer, RecordingHistoryStore History) BuildDeliverer(
+        DarlingConfig config, Func<string, AlertNotificationMode?>? resolveOverride = null)
+    {
+        var settings = new DarlingAlertSettings(config);
+        var history = new RecordingHistoryStore();
+        /* SMTP + webhooks unconfigured (DarlingConfig defaults): no channel attempts, so each send records a
+           single "tray" row — isolating the Summary-vs-Per-event fan-out we assert on. */
+        var webhooks = new WebhookAlertService(
+            settings, DarlingAlertDeliverer.Branding, NullLogger<WebhookAlertService>.Instance, history);
+        var deliverer = new DarlingAlertDeliverer(settings, history, webhooks, NullLogger.Instance, resolveOverride);
+        return (deliverer, history);
+    }
+
+    private static AlertOutcome OutcomeWithIncidents(int n, string serverKey = "42")
+    {
+        var incidents = new List<AlertIncident>();
+        for (int i = 0; i < n; i++)
+        {
+            incidents.Add(new AlertIncident($"key{i}", new[] { $"db.dbo.T{i}" }, OccurrenceCount: i + 1));
+        }
+
+        var context = new AlertContext();
+        AlertIncidentRenderer.Apply(context, incidents);
+        return new AlertOutcome(
+            serverKey, "srv", "Deadlocks Detected", n.ToString(CultureInfo.InvariantCulture), "1",
+            context, "detail", NumericCurrentValue: n, NumericThresholdValue: 1, Muted: false, Severity: null);
+    }
+
+    private sealed class RecordingHistoryStore : IAlertHistoryStore
+    {
+        public List<AlertHistoryRecord> Records { get; } = new();
+
+        public Task RecordAlertAsync(AlertHistoryRecord record)
+        {
+            Records.Add(record);
+            return Task.CompletedTask;
+        }
+
+        public Task<DateTime?> GetLastEmailSentUtcAsync(string serverId, string metricName, string? dedupKey = null) =>
+            Task.FromResult<DateTime?>(null);
+
+        public Task<DateTime?> GetLastWebhookSentUtcAsync(string serverId, string metricName, string? dedupKey = null) =>
+            Task.FromResult<DateTime?>(null);
+
+        public Task<DateTime?> GetLastAlertTimeAsync(string serverId, string metricName) =>
+            Task.FromResult<DateTime?>(null);
+    }
+}

--- a/Darling/Darling.Tests/DarlingObservabilityTests.cs
+++ b/Darling/Darling.Tests/DarlingObservabilityTests.cs
@@ -32,9 +32,9 @@ public sealed class DarlingObservabilityTests
     private const int TestServerId = -424242;
 
     [Fact]
-    public void MigrationScripts_SeventeenVersions_V16ServerUtcOffset_V17ConfigControlPlane()
+    public void MigrationScripts_EighteenVersions_V17ConfigControlPlane_V18AlertDeliveryMode()
     {
-        Assert.Equal(17, PgMigrations.Scripts.Count);
+        Assert.Equal(18, PgMigrations.Scripts.Count);
         Assert.Equal(1, PgMigrations.Scripts[0].Version);
         Assert.Equal(2, PgMigrations.Scripts[1].Version);
         Assert.Equal(3, PgMigrations.Scripts[2].Version);
@@ -52,7 +52,8 @@ public sealed class DarlingObservabilityTests
         Assert.Equal(15, PgMigrations.Scripts[14].Version);
         Assert.Equal(16, PgMigrations.Scripts[15].Version);
         Assert.Equal(17, PgMigrations.Scripts[16].Version);
-        Assert.Equal(17, StorageVersion.SchemaVersion);
+        Assert.Equal(18, PgMigrations.Scripts[17].Version);
+        Assert.Equal(18, StorageVersion.SchemaVersion);
 
         /* V5 completes the v_* twin of Lite's DuckDB view layer -- the copy-parity tail tabs
            (Running Jobs, Configuration, Daily Summary, Collection Health) read these five, so
@@ -264,6 +265,18 @@ public sealed class DarlingObservabilityTests
         Assert.Contains("ON config.config_monitored_servers", v17, StringComparison.Ordinal);
         /* No unqualified CREATE TABLE may sneak in — every control-plane table is config.-qualified. */
         Assert.DoesNotContain("CREATE TABLE IF NOT EXISTS config_", v17, StringComparison.Ordinal);
+
+        /* V18 adds the per-server + per-event alert delivery mode (#1236/#1141): the two global columns on
+           config_alert_settings (delivery_mode text default Summary + per_event_max int default 5) and the
+           nullable per-server override on config_monitored_servers. CRITICAL: schema-qualified config.* like V17
+           (a bare ALTER would resolve to collect). Pin the qualification + the shipped defaults. */
+        var v18 = PgMigrations.Scripts[17].Sql;
+        Assert.Equal("alert-delivery-mode", PgMigrations.Scripts[17].Name);
+        Assert.Contains("ALTER TABLE config.config_alert_settings ADD COLUMN IF NOT EXISTS delivery_mode text NOT NULL DEFAULT 'Summary';", v18, StringComparison.Ordinal);
+        Assert.Contains("ALTER TABLE config.config_alert_settings ADD COLUMN IF NOT EXISTS per_event_max integer NOT NULL DEFAULT 5;", v18, StringComparison.Ordinal);
+        Assert.Contains("ALTER TABLE config.config_monitored_servers ADD COLUMN IF NOT EXISTS alert_delivery_mode_override text;", v18, StringComparison.Ordinal);
+        /* Every V18 object is config.-qualified (a bare ALTER TABLE config_* would hit the wrong schema). */
+        Assert.DoesNotContain("ALTER TABLE config_", v18, StringComparison.Ordinal);
 
         var v2 = PgMigrations.Scripts[1].Sql;
         Assert.Contains("CREATE TABLE IF NOT EXISTS servers (", v2, StringComparison.Ordinal);

--- a/Darling/Darling.Tests/DarlingWorkerTests.cs
+++ b/Darling/Darling.Tests/DarlingWorkerTests.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using Npgsql;
 using PerformanceMonitor.Collectors;
 using PerformanceMonitor.Darling.Service;
+using PerformanceMonitor.Notifications;
 using Xunit;
 
 namespace Darling.Tests;
@@ -112,6 +113,24 @@ public sealed class DarlingWorkerTests
 
         Assert.True(DarlingWorker.ServerDefinitionEquals(original, costChanged),
             "a cost-only change must compare equal (no reconnect) — cost is synced onto collect.servers without connection churn");
+    }
+
+    /// <summary>
+    /// #1236: a per-server alert-delivery override edit is likewise NON-connection — it must compare equal so
+    /// ReconcileServers does not tear down the connection. The deliverer reads the override live off the
+    /// refreshed state.Config, so the change still takes effect on the reload without connection churn.
+    /// </summary>
+    [Fact]
+    public void ServerDefinitionEquals_DeliveryOverrideDelta_IsEqual_SoNoReconnect()
+    {
+        var original = SampleServer();
+        original.AlertDeliveryModeOverride = null;
+
+        var overrideSet = SampleServer();
+        overrideSet.AlertDeliveryModeOverride = AlertNotificationMode.PerEvent;
+
+        Assert.True(DarlingWorker.ServerDefinitionEquals(original, overrideSet),
+            "an alert-delivery-override change must compare equal (no reconnect) — it is read live off state.Config, not a connection field");
     }
 
     /// <summary>

--- a/Darling/Darling.Tests/ViewerControlPlaneStage3bTests.cs
+++ b/Darling/Darling.Tests/ViewerControlPlaneStage3bTests.cs
@@ -27,7 +27,8 @@ namespace Darling.Tests;
 /// </summary>
 public sealed class ViewerAlertSettingsSqlTests
 {
-    /* The 27 AlertsConfig + AnalysisConfig columns the service reads (StoreConfigProvider.ReadAlertSettingsAsync). */
+    /* The 29 AlertsConfig + AnalysisConfig columns the service reads (StoreConfigProvider.ReadAlertSettingsAsync)
+       — delivery_mode/per_event_max appended in V18 (#1141/#1236). */
     private static readonly string[] Columns =
     {
         "enabled", "cpu_enabled", "cpu_threshold_percent", "cpu_mode", "blocking_enabled", "blocking_count_threshold",
@@ -36,7 +37,7 @@ public sealed class ViewerAlertSettingsSqlTests
         "tempdb_space_threshold_percent", "low_disk_enabled", "low_disk_threshold_percent", "low_disk_threshold_gb",
         "long_running_job_enabled", "long_running_job_multiplier", "failed_job_enabled", "failed_job_lookback_minutes",
         "cooldown_minutes", "excluded_databases", "analysis_enabled", "analysis_interval_minutes",
-        "analysis_notifications_enabled", "analysis_notify_severity",
+        "analysis_notifications_enabled", "analysis_notify_severity", "delivery_mode", "per_event_max",
     };
 
     [Fact]
@@ -51,7 +52,7 @@ public sealed class ViewerAlertSettingsSqlTests
             Assert.Contains(column, sql, StringComparison.Ordinal);
         }
 
-        for (var i = 1; i <= 27; i++)
+        for (var i = 1; i <= 29; i++)
         {
             Assert.Contains("$" + i.ToString(System.Globalization.CultureInfo.InvariantCulture), sql, StringComparison.Ordinal);
         }
@@ -446,6 +447,8 @@ public sealed class ViewerControlPlaneMigrationTests
             AlertExcludedDatabases = new List<string> { "msdb", "tempdb" },
             AnalysisIntervalMinutes = 45,
             AnalysisNotifySeverity = 1.2,
+            AlertDeliveryMode = "PerEvent",
+            AlertPerEventMaxPerCycle = 7,
         };
 
         var row = ViewerControlPlaneMigration.BuildAlertRow(settings);
@@ -456,6 +459,9 @@ public sealed class ViewerControlPlaneMigrationTests
         Assert.Equal(new[] { "msdb", "tempdb" }, row.ExcludedDatabases);
         Assert.Equal(45, row.AnalysisIntervalMinutes);
         Assert.Equal(1.2, row.AnalysisNotifySeverity, 3);
+        /* #1141/#1236: the delivery customization carries into the store row. */
+        Assert.Equal("PerEvent", row.DeliveryMode);
+        Assert.Equal(7, row.PerEventMax);
     }
 
     [Fact]

--- a/Darling/Darling.Tests/ViewerServerManagementTests.cs
+++ b/Darling/Darling.Tests/ViewerServerManagementTests.cs
@@ -29,11 +29,11 @@ public sealed class ViewerMonitoredServerSqlTests
     {
         "server_id", "name", "host", "database", "auth", "username", "encrypted_password", "encrypt_mode",
         "trust_server_certificate", "read_only_intent", "multi_subnet_failover", "excluded_databases",
-        "monthly_cost_usd", "capture_plans", "is_enabled",
+        "monthly_cost_usd", "capture_plans", "is_enabled", "alert_delivery_mode_override",
     };
 
     [Fact]
-    public void UpsertSql_WritesEveryV17Column_AsBoundParameters_OnConflictUpdate()
+    public void UpsertSql_WritesEveryStoreColumn_AsBoundParameters_OnConflictUpdate()
     {
         var sql = ViewerDataService.MonitoredServerUpsertSql;
 
@@ -43,8 +43,8 @@ public sealed class ViewerMonitoredServerSqlTests
             Assert.Contains(column, sql, StringComparison.Ordinal);
         }
 
-        /* Every value is a $N parameter (15 columns), never inlined. */
-        for (var i = 1; i <= 15; i++)
+        /* Every value is a $N parameter (16 columns incl. the V18 alert_delivery_mode_override), never inlined. */
+        for (var i = 1; i <= 16; i++)
         {
             Assert.Contains("$" + i.ToString(System.Globalization.CultureInfo.InvariantCulture), sql, StringComparison.Ordinal);
         }

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingAlertDeliverer.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingAlertDeliverer.cs
@@ -24,8 +24,14 @@ namespace PerformanceMonitor.Darling.Service;
 /// muted, channels skipped) and alerts with no channel configured at all (recorded as 'tray',
 /// Lite's taxonomy for delivered-without-email; the headless smoke asserts this row exists).
 /// Never throws — a dead SMTP server or Postgres store must not abort the engine's sweep.
-/// Delivery-mode fan-out (#1141 Per-event splitting, #1236 per-server override) is deliberately
-/// NOT implemented: Darling ships Lite's Summary default.
+///
+/// <para>Delivery-mode fan-out (Lite/Dashboard parity): the effective mode is the shared
+/// <see cref="AlertDeliveryModeResolver"/> of a per-server override (#1236,
+/// <see cref="MonitoredServer.AlertDeliveryModeOverride"/> via the injected resolver) against the global
+/// <see cref="DarlingAlertSettings.DeliveryMode"/>. In Per-event mode an alert carrying incidents is split by
+/// the shared <see cref="PerEventNotification.Split"/> into one send+row per distinct incident (capped at
+/// <see cref="DarlingAlertSettings.PerEventMax"/> with a trailing "+N more"); Summary mode — or any alert
+/// without incidents (CPU, low-disk, jobs) — takes the single combined send unchanged.</para>
 /// </summary>
 public sealed class DarlingAlertDeliverer : IAlertDeliverer
 {
@@ -40,15 +46,26 @@ public sealed class DarlingAlertDeliverer : IAlertDeliverer
     private readonly IAlertHistoryStore _historyStore;
     private readonly EmailSendCore _core;
     private readonly ILogger _logger;
+    private readonly DarlingAlertSettings _settings;
+    private readonly Func<string, AlertNotificationMode?> _resolveServerOverride;
 
+    /// <param name="resolveServerOverride">
+    /// Maps a fired alert's <see cref="AlertOutcome.ServerKey"/> to that server's
+    /// <see cref="MonitoredServer.AlertDeliveryModeOverride"/> (or null to inherit the global mode). Optional —
+    /// null (the default) means every server inherits the global <see cref="DarlingAlertSettings.DeliveryMode"/>,
+    /// which is also correct for incident-free self-alerts. The service passes a resolver over its live server set.
+    /// </param>
     public DarlingAlertDeliverer(
-        IAlertSettings settings,
+        DarlingAlertSettings settings,
         IAlertHistoryStore historyStore,
         WebhookAlertService webhookAlertService,
-        ILogger logger)
+        ILogger logger,
+        Func<string, AlertNotificationMode?>? resolveServerOverride = null)
     {
+        _settings = settings ?? throw new ArgumentNullException(nameof(settings));
         _historyStore = historyStore ?? throw new ArgumentNullException(nameof(historyStore));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _resolveServerOverride = resolveServerOverride ?? (_ => null);
         _core = new EmailSendCore(settings, historyStore, webhookAlertService, s_branding, logger);
     }
 
@@ -61,37 +78,28 @@ public sealed class DarlingAlertDeliverer : IAlertDeliverer
 
         try
         {
-            /* Lite's EmailAlertService.cs:65-66 — muted alerts skip both channels but still
-               record their history row below. */
-            var result = await _core.TrySendAsync(
-                outcome.MetricName, outcome.ServerName, outcome.CurrentValue, outcome.ThresholdValue,
-                outcome.ServerKey, outcome.Context, attemptChannels: !outcome.Muted);
-
-            /* Lite's single-row notification_type taxonomy (EmailAlertService.cs:68-80):
-               muted → "muted"; email attempted → "email"; webhook delivery upgrades to
-               "email+webhook"/"webhook"; otherwise "tray". */
-            var notificationType = outcome.Muted ? "muted" : "tray";
-            if (result.EmailAttempted)
+            /* #1236/#1141: a per-server override wins over the global mode; Per-event splits an
+               incident-carrying alert into one send+row per distinct incident (capped, "+N more"). */
+            var mode = AlertDeliveryModeResolver.Resolve(_resolveServerOverride(outcome.ServerKey), _settings.DeliveryMode);
+            if (mode == AlertNotificationMode.PerEvent && outcome.Context?.Incidents is { Count: > 0 })
             {
-                notificationType = "email";
+                foreach (var message in PerEventNotification.Split(outcome.Context, _settings.PerEventMax))
+                {
+                    /* Per-incident card: msg.CurrentValue is the incident's occurrence count; no server-level
+                       numerics (matching Lite/Dashboard's per-event sends), detail text rebuilt from the split context. */
+                    await SendAndRecordAsync(
+                        outcome, message.CurrentValue, message.Context,
+                        AlertContextBuilders.ContextToDetailText(message.Context),
+                        numericCurrentValue: null, numericThresholdValue: null);
+                }
+
+                return;
             }
 
-            var sent = result.EmailSent;
-            if (result.WebhookSent)
-            {
-                notificationType = notificationType == "email" ? "email+webhook" : "webhook";
-                sent = true;
-            }
-
-            /* Always log the alert, regardless of channel status (EmailAlertService.cs:82-94) —
-               the structured context persists as JSON alongside the flat detail_text. */
-            string? contextJson = outcome.Context is not null ? AlertContextSerializer.Serialize(outcome.Context) : null;
-            await _historyStore.RecordAlertAsync(new AlertHistoryRecord(
-                outcome.ServerKey, outcome.ServerName, outcome.MetricName,
-                outcome.CurrentValue, outcome.ThresholdValue,
-                outcome.NumericCurrentValue, outcome.NumericThresholdValue,
-                sent, notificationType, result.SendError,
-                outcome.Muted, outcome.DetailText, contextJson));
+            /* Summary mode, or an alert with no incidents (CPU/low-disk/jobs): one combined send+row, unchanged. */
+            await SendAndRecordAsync(
+                outcome, outcome.CurrentValue, outcome.Context, outcome.DetailText,
+                outcome.NumericCurrentValue, outcome.NumericThresholdValue);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -102,5 +110,47 @@ public sealed class DarlingAlertDeliverer : IAlertDeliverer
             _logger.LogError("Alert delivery failed for {Metric} on {Server}: {Message}",
                 outcome.MetricName, outcome.ServerName, ex.Message);
         }
+    }
+
+    /// <summary>
+    /// Sends one alert message (email + webhook fan-out via the shared core) and writes exactly one combined
+    /// <c>config_alert_log</c> row for it — Lite's record-and-send cadence. Called once for a Summary alert and
+    /// once per split incident in Per-event mode, so every send is paired with its own history row (the
+    /// structured context persists as JSON alongside the flat detail_text). Muted alerts skip both channels but
+    /// still record (flagged muted).
+    /// </summary>
+    private async Task SendAndRecordAsync(
+        AlertOutcome outcome, string currentValue, AlertContext? context, string? detailText,
+        double? numericCurrentValue, double? numericThresholdValue)
+    {
+        /* Lite's EmailAlertService.cs:65-66 — muted alerts skip both channels but still record below. */
+        var result = await _core.TrySendAsync(
+            outcome.MetricName, outcome.ServerName, currentValue, outcome.ThresholdValue,
+            outcome.ServerKey, context, attemptChannels: !outcome.Muted);
+
+        /* Lite's single-row notification_type taxonomy (EmailAlertService.cs:68-80):
+           muted → "muted"; email attempted → "email"; webhook delivery upgrades to
+           "email+webhook"/"webhook"; otherwise "tray". */
+        var notificationType = outcome.Muted ? "muted" : "tray";
+        if (result.EmailAttempted)
+        {
+            notificationType = "email";
+        }
+
+        var sent = result.EmailSent;
+        if (result.WebhookSent)
+        {
+            notificationType = notificationType == "email" ? "email+webhook" : "webhook";
+            sent = true;
+        }
+
+        /* Always log the alert, regardless of channel status (EmailAlertService.cs:82-94). */
+        string? contextJson = context is not null ? AlertContextSerializer.Serialize(context) : null;
+        await _historyStore.RecordAlertAsync(new AlertHistoryRecord(
+            outcome.ServerKey, outcome.ServerName, outcome.MetricName,
+            currentValue, outcome.ThresholdValue,
+            numericCurrentValue, numericThresholdValue,
+            sent, notificationType, result.SendError,
+            outcome.Muted, detailText, contextJson));
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingAlertSettings.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingAlertSettings.cs
@@ -61,6 +61,18 @@ public sealed class DarlingAlertSettings : IAlertEngineSettings, IAlertSettings
 
     public IReadOnlyList<string> ExcludedDatabases => _config.Alerts.ExcludedDatabases;
 
+    /// <summary>
+    /// The GLOBAL deadlock/blocking delivery mode (#1141), read live through the by-reference config seam so a
+    /// store reload reflects immediately. The deliverer resolves a per-server override against this via the
+    /// shared <c>AlertDeliveryModeResolver</c>. Not on the shared IAlertSettings surface — it is Darling's
+    /// delivery concern, consumed by <see cref="DarlingAlertDeliverer"/> off the concrete type.
+    /// </summary>
+    public AlertNotificationMode DeliveryMode => _config.Alerts.DeliveryMode;
+
+    /// <summary>Per-event mode's per-cycle incident cap before the "+N more" batch (#1141); clamped 1–100 like
+    /// Lite/the viewer so a hand-edited store value can't drive an unbounded fan-out.</summary>
+    public int PerEventMax => Math.Clamp(_config.Alerts.PerEventMax, 1, 100);
+
     /// <summary>"sql" → SqlProcess; anything else (incl. Lite's default "total") → TotalServer.</summary>
     public CpuAlertMode CpuAlertMode =>
         string.Equals(_config.Alerts.CpuMode, "sql", StringComparison.OrdinalIgnoreCase)

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingConfig.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingConfig.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using PerformanceMonitor.Notifications;
 
 namespace PerformanceMonitor.Darling.Service;
 
@@ -329,6 +330,23 @@ public sealed class AlertsConfig
     /// <summary>Databases excluded from blocking/deadlock/long-running-query alert evaluation.</summary>
     [JsonPropertyName("excludedDatabases")]
     public List<string> ExcludedDatabases { get; set; } = new();
+
+    /// <summary>
+    /// How deadlock/blocking alerts are delivered (#1141): <see cref="AlertNotificationMode.Summary"/>
+    /// (one batched card per cycle — the default, matching Lite) or <see cref="AlertNotificationMode.PerEvent"/>
+    /// (one notification per distinct incident, capped at <see cref="PerEventMax"/> with a trailing "+N more").
+    /// A per-server override (<see cref="MonitoredServer.AlertDeliveryModeOverride"/>) wins over this global
+    /// default via the shared <c>AlertDeliveryModeResolver</c>. Serialized as its name ("Summary"/"PerEvent")
+    /// in darling.json and stored as <c>config_alert_settings.delivery_mode</c>.
+    /// </summary>
+    [JsonPropertyName("deliveryMode")]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public AlertNotificationMode DeliveryMode { get; set; } = AlertNotificationMode.Summary;
+
+    /// <summary>Per-event mode's cap on incidents delivered individually per cycle before the trailing
+    /// "+N more" batch (#1141); clamped 1–100 when applied. Stored as <c>config_alert_settings.per_event_max</c>.</summary>
+    [JsonPropertyName("perEventMax")]
+    public int PerEventMax { get; set; } = 5;
 }
 
 /// <summary>
@@ -473,6 +491,17 @@ public sealed class MonitoredServer
     /// </summary>
     [JsonPropertyName("monthlyCostUsd")]
     public decimal MonthlyCostUsd { get; set; }
+
+    /// <summary>
+    /// Per-server override of the deadlock/blocking alert delivery mode (#1236); null (the default) inherits
+    /// the global <see cref="AlertsConfig.DeliveryMode"/>. Forces Summary or Per-event for THIS server only
+    /// (e.g. Per-event for one noisy prod box while the fleet default stays Summary). Populated from
+    /// <c>config_monitored_servers.alert_delivery_mode_override</c> at read time so the deliverer can resolve
+    /// it per fired alert via the shared <c>AlertDeliveryModeResolver</c>; serialized as its name in darling.json.
+    /// </summary>
+    [JsonPropertyName("alertDeliveryModeOverride")]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public AlertNotificationMode? AlertDeliveryModeOverride { get; set; }
 
     [JsonIgnore]
     public bool UsesSqlAuth => string.Equals(Auth, "sql", StringComparison.OrdinalIgnoreCase);

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -391,7 +391,25 @@ public sealed class DarlingWorker : BackgroundService
         /* The shared record-and-send deliverer — hoisted so BOTH the shared alert engine and the Stage 4
            service self-alerts (DarlingSelfAlertEvaluator) fire through the SAME instance: identical
            email/webhook delivery, per-fingerprint delivery cooldown, and history-seeded restart replay. */
-        var deliverer = new DarlingAlertDeliverer(alertSettings, historyStore, webhookAlertService, _logger);
+        var deliverer = new DarlingAlertDeliverer(
+            alertSettings, historyStore, webhookAlertService, _logger,
+            /* #1236: map a fired alert's ServerKey (the storage-name hash the engine keys on) back to the live
+               server's per-server delivery override, under the servers lock (mirrors FetchFailedJobsAsync). A
+               store reload swaps ServerLoopState.Config, so this always reads the current override. */
+            resolveServerOverride: serverKey =>
+            {
+                if (!int.TryParse(serverKey, NumberStyles.Integer, CultureInfo.InvariantCulture, out var id))
+                {
+                    return null;
+                }
+
+                lock (_serversLock)
+                {
+                    return servers
+                        .Find(s => ServerIdHelper.GetDeterministicHashCode(s.Config.StorageName) == id)
+                        ?.Config.AlertDeliveryModeOverride;
+                }
+            });
         var engine = BuildAlertEngine(config, servers, alertSettings, historyStore, muteRuleService, deliverer);
 
         /* Stage 4: the service self-alerts, over the SAME deliverer + history + mute check the engine uses.
@@ -673,9 +691,11 @@ public sealed class DarlingWorker : BackgroundService
     /// shared server_id. ADD: a new enabled server gets a disconnected state that connects on its next tick
     /// exactly like a startup server (via <see cref="TryConnectAsync"/> — no novel connection logic). REMOVE:
     /// a server no longer enabled/present is dropped; its runtime holds no persistent connection (the
-    /// collectors open per run), so dropping the state is a clean disconnect. STAY: an unchanged definition is
-    /// left untouched (connection + NextDue preserved); a changed one has its config replaced and its runtime
-    /// dropped so it reconnects with the new definition through the same startup path.
+    /// collectors open per run), so dropping the state is a clean disconnect. STAY: the held config is always
+    /// refreshed to the desired definition (so a non-connection edit — cost, the #1236 alert-delivery override
+    /// — goes live without churn), but the connection + NextDue are preserved unless a connection/collection
+    /// field changed (per <see cref="ServerDefinitionEquals"/>), in which case the runtime is dropped so it
+    /// reconnects with the new definition through the same startup path.
     /// </summary>
     private void ReconcileServers(List<ServerLoopState> servers, IReadOnlyList<MonitoredServer> desired)
     {
@@ -702,11 +722,16 @@ public sealed class DarlingWorker : BackgroundService
                 continue;
             }
 
-            if (!ServerDefinitionEquals(state.Config, desiredServer))
+            /* Always refresh the held definition so a NON-connection edit — the FinOps cost, or the #1236
+               alert-delivery override the deliverer's resolver reads live off state.Config — takes effect on
+               this reload without connection churn. Only a connection/collection-affecting change (per
+               ServerDefinitionEquals) drops the runtime to reconnect through the startup path. */
+            var connectionChanged = !ServerDefinitionEquals(state.Config, desiredServer);
+            state.Config = desiredServer;
+            if (connectionChanged)
             {
                 _logger.LogInformation(
                     "[{Server}] Definition changed — reconnecting with the new configuration", desiredServer.DisplayName);
-                state.Config = desiredServer;
                 state.Runtime = null;
                 state.NextConnectAttempt = DateTime.MinValue;
                 state.NextDue.Clear();

--- a/Darling/PerformanceMonitor.Darling.Service/StoreConfigProvider.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/StoreConfigProvider.cs
@@ -17,6 +17,7 @@ using Npgsql;
 using NpgsqlTypes;
 using PerformanceMonitor.Collectors;
 using PerformanceMonitor.Common;
+using PerformanceMonitor.Notifications;
 
 namespace PerformanceMonitor.Darling.Service;
 
@@ -157,9 +158,9 @@ INSERT INTO config_alert_settings (
     tempdb_space_threshold_percent, low_disk_enabled, low_disk_threshold_percent, low_disk_threshold_gb,
     long_running_job_enabled, long_running_job_multiplier, failed_job_enabled, failed_job_lookback_minutes,
     cooldown_minutes, excluded_databases, analysis_enabled, analysis_interval_minutes,
-    analysis_notifications_enabled, analysis_notify_severity, modified_at)
+    analysis_notifications_enabled, analysis_notify_severity, delivery_mode, per_event_max, modified_at)
 VALUES (1, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21,
-        $22, $23, $24, $25, $26, $27, $28)
+        $22, $23, $24, $25, $26, $27, $28, $29, $30)
 ON CONFLICT (id) DO NOTHING", connection);
         command.Parameters.AddWithValue(a.Enabled);
         command.Parameters.AddWithValue(a.CpuEnabled);
@@ -188,6 +189,9 @@ ON CONFLICT (id) DO NOTHING", connection);
         command.Parameters.AddWithValue(an.IntervalMinutes);
         command.Parameters.AddWithValue(an.NotificationsEnabled);
         command.Parameters.AddWithValue(an.NotifySeverity);
+        /* #1141 delivery mode: the enum name ("Summary"/"PerEvent") into the text column; the read parses it back. */
+        command.Parameters.AddWithValue(a.DeliveryMode.ToString());
+        command.Parameters.AddWithValue(a.PerEventMax);
         command.Parameters.AddWithValue(now);
         await command.ExecuteNonQueryAsync(ct);
     }
@@ -228,8 +232,8 @@ ON CONFLICT (id) DO NOTHING", connection);
 INSERT INTO config_monitored_servers (
     server_id, name, host, database, auth, username, encrypted_password, encrypt_mode,
     trust_server_certificate, read_only_intent, multi_subnet_failover, excluded_databases,
-    monthly_cost_usd, capture_plans, is_enabled, created_at, modified_at)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, NULL, TRUE, $14, $14)
+    monthly_cost_usd, capture_plans, alert_delivery_mode_override, is_enabled, created_at, modified_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, NULL, $14, TRUE, $15, $15)
 ON CONFLICT (server_id) DO NOTHING", connection);
             command.Parameters.AddWithValue(ServerIdHelper.GetDeterministicHashCode(server.StorageName));
             command.Parameters.AddWithValue(server.DisplayName);
@@ -246,6 +250,8 @@ ON CONFLICT (server_id) DO NOTHING", connection);
             command.Parameters.AddWithValue(server.MultiSubnetFailover);
             AddTextArray(command, server.ExcludedDatabases);
             command.Parameters.AddWithValue(server.MonthlyCostUsd);
+            /* Per-server delivery override (#1236): the enum name or NULL = "inherit the global". */
+            AddNullableText(command, server.AlertDeliveryModeOverride?.ToString());
             command.Parameters.AddWithValue(now);
             await command.ExecuteNonQueryAsync(ct);
         }
@@ -322,7 +328,7 @@ SELECT enabled, cpu_enabled, cpu_threshold_percent, cpu_mode, blocking_enabled, 
        tempdb_space_threshold_percent, low_disk_enabled, low_disk_threshold_percent, low_disk_threshold_gb,
        long_running_job_enabled, long_running_job_multiplier, failed_job_enabled, failed_job_lookback_minutes,
        cooldown_minutes, excluded_databases, analysis_enabled, analysis_interval_minutes,
-       analysis_notifications_enabled, analysis_notify_severity
+       analysis_notifications_enabled, analysis_notify_severity, delivery_mode, per_event_max
 FROM config_alert_settings WHERE id = 1", connection);
         using var reader = await command.ExecuteReaderAsync(ct);
         if (!await reader.ReadAsync(ct))
@@ -355,6 +361,10 @@ FROM config_alert_settings WHERE id = 1", connection);
             FailedJobLookbackMinutes = reader.GetInt32(20),
             CooldownMinutes = reader.GetInt32(21),
             ExcludedDatabases = ReadTextArray(reader, 22),
+            /* delivery_mode/per_event_max appended (V18) so ordinals 0–26 stay pinned; a store row from before
+               V18 can't reach here (the column is NOT NULL DEFAULT), but ParseDeliveryMode fails safe to Summary. */
+            DeliveryMode = ParseDeliveryMode(reader.IsDBNull(27) ? null : reader.GetString(27)),
+            PerEventMax = reader.GetInt32(28),
         };
         var analysis = new AnalysisConfig
         {
@@ -405,7 +415,7 @@ FROM config_notification WHERE id = 1", connection);
         var servers = new List<MonitoredServer>();
         using var command = new NpgsqlCommand(@"
 SELECT name, host, database, auth, username, encrypted_password, encrypt_mode, trust_server_certificate,
-       read_only_intent, multi_subnet_failover, excluded_databases, monthly_cost_usd
+       read_only_intent, multi_subnet_failover, excluded_databases, monthly_cost_usd, alert_delivery_mode_override
 FROM config_monitored_servers WHERE is_enabled = TRUE
 ORDER BY name", connection);
         using var reader = await command.ExecuteReaderAsync(ct);
@@ -443,6 +453,8 @@ ORDER BY name", connection);
             MultiSubnetFailover = reader.GetBoolean(9),
             ExcludedDatabases = ReadTextArray(reader, 10),
             MonthlyCostUsd = reader.GetDecimal(11),
+            /* #1236: the per-server delivery override (null = inherit the global), available at delivery time. */
+            AlertDeliveryModeOverride = ParseDeliveryOverride(reader.IsDBNull(12) ? null : reader.GetString(12)),
         };
 
         if (server.UsesSqlAuth && string.IsNullOrWhiteSpace(server.EncryptedPassword))
@@ -589,6 +601,15 @@ ORDER BY name", connection);
 
     /// <summary>Npgsql rejects Kind=Utc against `timestamp`; store all timestamps naive-UTC.</summary>
     private static DateTime Naive(DateTime value) => DateTime.SpecifyKind(value, DateTimeKind.Unspecified);
+
+    /// <summary>Parses the <c>delivery_mode</c>/<c>alert_delivery_mode_override</c> text ("Summary"/"PerEvent")
+    /// to the enum; an unknown or empty value fails safe to <see cref="AlertNotificationMode.Summary"/>.</summary>
+    private static AlertNotificationMode ParseDeliveryMode(string? value) =>
+        Enum.TryParse<AlertNotificationMode>(value, ignoreCase: true, out var mode) ? mode : AlertNotificationMode.Summary;
+
+    /// <summary>Parses a nullable per-server delivery override; null/empty = "inherit the global" (returns null).</summary>
+    private static AlertNotificationMode? ParseDeliveryOverride(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : ParseDeliveryMode(value);
 
     private static void AddNullableText(NpgsqlCommand command, string? value) =>
         command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text, Value = (object?)value ?? DBNull.Value });

--- a/Darling/PerformanceMonitor.Darling.Service/darling.sample.json
+++ b/Darling/PerformanceMonitor.Darling.Service/darling.sample.json
@@ -60,6 +60,10 @@
       // figure is proportional math on this one number (a database's share = its size fraction x budget).
       // Omit or 0 (the default) to hide all cost columns/cards, exactly like Performance Monitor Lite.
       "monthlyCostUsd": 0,
+      // Optional per-server override of the global alerts.deliveryMode: "Summary" or "PerEvent" forces
+      // that mode for THIS server (e.g. Per-event for one noisy prod box while the fleet stays Summary);
+      // omit (or null) to inherit the global setting.
+      "alertDeliveryModeOverride": null,
       "excludedDatabases": []
     },
     {
@@ -92,6 +96,13 @@
     "enabled": true,
     "cpuThresholdPercent": 80,
     "cpuMode": "total", // "total" (SQL + other processes) or "sql" (SQL process only)
+    // How deadlock/blocking alerts are delivered: "Summary" (one batched card per cycle, the default)
+    // or "PerEvent" (one notification per distinct incident, so downstream automation can open one
+    // ticket per incident). A per-server "alertDeliveryModeOverride" (see servers[]) wins over this.
+    "deliveryMode": "Summary",
+    // Per-event mode's cap on incidents delivered individually per cycle before a trailing "+N more"
+    // batch (so no incident is ever silently dropped). Clamped 1-100.
+    "perEventMax": 5,
     "excludedDatabases": []
   },
 

--- a/Darling/PerformanceMonitor.Darling.Storage/PgMigrations.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/PgMigrations.cs
@@ -61,6 +61,7 @@ public static class PgMigrations
         new Migration(15, "index-metadata-columns", V15Sql),
         new Migration(16, "server-utc-offset", V16Sql),
         new Migration(17, "config-control-plane", V17Sql),
+        new Migration(18, "alert-delivery-mode", V18Sql),
     };
 
     /// <summary>
@@ -552,6 +553,25 @@ DROP TRIGGER IF EXISTS trg_service_self_bump ON config.config_service;
 CREATE TRIGGER trg_service_self_bump
     BEFORE UPDATE ON config.config_service
     FOR EACH ROW EXECUTE FUNCTION config.config_service_bump();";
+
+    /// <summary>
+    /// V18 — the per-server + per-event alert delivery mode (#1236 / #1141) the Viewer writes and the
+    /// service honors at delivery time. The GLOBAL default lives on <c>config_alert_settings</c>
+    /// (<c>delivery_mode</c> = Summary/PerEvent, <c>per_event_max</c> = the "+N more" cap the shared
+    /// <c>PerEventNotification.Split</c> applies); a PER-SERVER override lives on
+    /// <c>config_monitored_servers</c> (<c>alert_delivery_mode_override</c>, nullable = "use the global"),
+    /// resolved through the shared <c>AlertDeliveryModeResolver</c>. Additive ALTERs, schema-qualified
+    /// <c>config.*</c> exactly like V17 (the migrate session's <c>search_path = collect, config, public</c>
+    /// resolves a bare name to <c>collect</c> — the wrong schema/ACL); <c>IF NOT EXISTS</c> matches the
+    /// file's ALTER idiom (V7/V9/V15/V16) so a re-run is a harmless no-op. The two settings columns are
+    /// NOT NULL with the shipped defaults (Summary / 5) so the single seeded row comes up honoring Summary;
+    /// the per-server column is nullable so an un-overridden server inherits the global. Neither table has a
+    /// <c>v_*</c> passthrough view, so nothing to refresh.
+    /// </summary>
+    private const string V18Sql = @"
+ALTER TABLE config.config_alert_settings ADD COLUMN IF NOT EXISTS delivery_mode text NOT NULL DEFAULT 'Summary';
+ALTER TABLE config.config_alert_settings ADD COLUMN IF NOT EXISTS per_event_max integer NOT NULL DEFAULT 5;
+ALTER TABLE config.config_monitored_servers ADD COLUMN IF NOT EXISTS alert_delivery_mode_override text;";
 
     private const string VersionTableSql = @"
 CREATE TABLE IF NOT EXISTS darling_schema_version (

--- a/Darling/PerformanceMonitor.Darling.Storage/StorageVersion.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/StorageVersion.cs
@@ -16,5 +16,5 @@ namespace PerformanceMonitor.Darling.Storage;
 /// </summary>
 public static class StorageVersion
 {
-    public const int SchemaVersion = 17;
+    public const int SchemaVersion = 18;
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/AddServerDialog.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/AddServerDialog.xaml
@@ -144,6 +144,15 @@
                 <TextBox x:Name="MonthlyCostBox" Width="100" TextAlignment="Right" Text="0"
                          ToolTip="What this server costs per month (license, compute, storage combined). Used for FinOps cost attribution. Leave 0 to hide cost columns."/>
             </StackPanel>
+            <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+                <TextBlock Text="Alert delivery:" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Width="110"/>
+                <ComboBox x:Name="AlertDeliveryOverrideBox" Width="240" SelectedIndex="0"
+                          ToolTip="How deadlock/blocking alerts for THIS server are delivered. 'Use global setting' follows the app-wide Alerts setting; override to force Summary or Per-event for just this server.">
+                    <ComboBoxItem Content="Use global setting"/>
+                    <ComboBoxItem Content="Summary — one card per cycle"/>
+                    <ComboBoxItem Content="Per-event — one notification per incident"/>
+                </ComboBox>
+            </StackPanel>
         </StackPanel>
 
         <!-- Status -->

--- a/Darling/PerformanceMonitor.Darling.Viewer/AddServerDialog.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/AddServerDialog.xaml.cs
@@ -12,6 +12,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using System.Windows;
 using PerformanceMonitor.Common;
+using PerformanceMonitor.Notifications;
 
 namespace PerformanceMonitor.Darling.Viewer;
 
@@ -98,6 +99,13 @@ public partial class AddServerDialog : Window
         ReadOnlyIntentCheckBox.IsChecked = existing.ReadOnlyIntent;
         MultiSubnetFailoverCheckBox.IsChecked = existing.MultiSubnetFailover;
         MonthlyCostBox.Text = existing.MonthlyCostUsd.ToString(CultureInfo.InvariantCulture);
+        /* #1236: prefill the per-server delivery override (null = "Use global setting"). */
+        AlertDeliveryOverrideBox.SelectedIndex = existing.AlertDeliveryModeOverride switch
+        {
+            AlertNotificationMode.Summary => 1,
+            AlertNotificationMode.PerEvent => 2,
+            _ => 0
+        };
         FavoriteCheckBox.IsChecked = isFavorite;
 
         EncryptModeComboBox.SelectedIndex = existing.EncryptMode switch
@@ -354,9 +362,19 @@ public partial class AddServerDialog : Window
             ExcludedDatabases = _existing?.ExcludedDatabases ?? new System.Collections.Generic.List<string>(),
             MonthlyCostUsd = monthlyCost,
             CapturePlans = _existing?.CapturePlans,
+            AlertDeliveryModeOverride = GetSelectedDeliveryOverride(),
             IsEnabled = EnabledCheckBox.IsChecked == true,
         };
     }
+
+    /// <summary>The per-server delivery override the combo encodes: index 0 = inherit the global (null),
+    /// 1 = force Summary, 2 = force Per-event (#1236).</summary>
+    private AlertNotificationMode? GetSelectedDeliveryOverride() => AlertDeliveryOverrideBox.SelectedIndex switch
+    {
+        1 => AlertNotificationMode.Summary,
+        2 => AlertNotificationMode.PerEvent,
+        _ => null
+    };
 
     private async void SaveButton_Click(object sender, RoutedEventArgs e)
     {

--- a/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml.cs
@@ -447,8 +447,8 @@ public partial class SettingsWindow : Window
         LrqExcludeBackupsCheckBox.IsChecked = _appSettings.AlertLongRunningQueryExcludeBackups;
         LrqExcludeMiscWaitsCheckBox.IsChecked = _appSettings.AlertLongRunningQueryExcludeMiscWaits;
         LrqExcludeCdcCheckBox.IsChecked = _appSettings.AlertLongRunningQueryExcludeCdc;
-        AlertDeliveryModeBox.SelectedIndex = _appSettings.AlertDeliveryMode == "PerEvent" ? 1 : 0;
-        AlertPerEventMaxBox.Text = _appSettings.AlertPerEventMaxPerCycle.ToString(CultureInfo.InvariantCulture);
+        /* AlertDeliveryMode/PerEventMax moved to the STORE-backed controls (SeedAlertControlsFrom /
+           BuildAlertRowFromControls) now that the service honors them (#1141/#1236); no longer viewer-local. */
         MuteRuleDefaultExpirationCombo.SelectedIndex = _appSettings.MuteRuleDefaultExpiration switch
         {
             "1 hour" => 0,
@@ -490,6 +490,10 @@ public partial class SettingsWindow : Window
         AnalysisIntervalBox.Text = r.AnalysisIntervalMinutes.ToString(CultureInfo.InvariantCulture);
         AnalysisNotificationsCheckBox.IsChecked = r.AnalysisNotificationsEnabled;
         AnalysisNotifySeverityBox.Text = r.AnalysisNotifySeverity.ToString("0.0", CultureInfo.InvariantCulture);
+        /* #1141/#1236: the delivery mode + per-event cap are now STORE-backed (the service honors them),
+           seeded from the row like every other alert-engine control. */
+        AlertDeliveryModeBox.SelectedIndex = r.DeliveryMode == "PerEvent" ? 1 : 0;
+        AlertPerEventMaxBox.Text = r.PerEventMax.ToString(CultureInfo.InvariantCulture);
         UpdateAlertControlStates();
     }
 
@@ -556,6 +560,13 @@ public partial class SettingsWindow : Window
         else
             errors.Add("Analysis notify severity must be between 0.0 and 2.0.");
 
+        /* #1141/#1236: delivery mode + per-event cap (store-backed). */
+        row.DeliveryMode = AlertDeliveryModeBox.SelectedIndex == 1 ? "PerEvent" : "Summary";
+        if (int.TryParse(AlertPerEventMaxBox.Text, out var perEventMax) && perEventMax is >= 1 and <= 100)
+            row.PerEventMax = perEventMax;
+        else
+            errors.Add("Per-event max-per-cycle must be between 1 and 100.");
+
         return row;
     }
 
@@ -571,11 +582,7 @@ public partial class SettingsWindow : Window
         _appSettings.AlertLongRunningQueryExcludeBackups = LrqExcludeBackupsCheckBox.IsChecked == true;
         _appSettings.AlertLongRunningQueryExcludeMiscWaits = LrqExcludeMiscWaitsCheckBox.IsChecked == true;
         _appSettings.AlertLongRunningQueryExcludeCdc = LrqExcludeCdcCheckBox.IsChecked == true;
-        _appSettings.AlertDeliveryMode = AlertDeliveryModeBox.SelectedIndex == 1 ? "PerEvent" : "Summary";
-        if (int.TryParse(AlertPerEventMaxBox.Text, out var perEventMax) && perEventMax is >= 1 and <= 100)
-            _appSettings.AlertPerEventMaxPerCycle = perEventMax;
-        else
-            errors.Add("Per-event max-per-cycle must be between 1 and 100.");
+        /* AlertDeliveryMode/PerEventMax are STORE-backed now (BuildAlertRowFromControls writes them); not here. */
         _appSettings.MuteRuleDefaultExpiration = (MuteRuleDefaultExpirationCombo.SelectedItem as ComboBoxItem)?.Content?.ToString() ?? "24 hours";
         _appSettings.LogAlertDismissals = LogAlertDismissalsCheckBox.IsChecked == true;
     }
@@ -598,7 +605,7 @@ public partial class SettingsWindow : Window
         AlertCooldownBox.Text = "5";
         EmailCooldownBox.Text = "15";
         AlertDeliveryModeBox.SelectedIndex = 0;
-        AlertPerEventMaxBox.Text = "10";
+        AlertPerEventMaxBox.Text = "5";
         AnalysisIntervalBox.Text = "30";
         AnalysisNotifySeverityBox.Text = "1.5";
         AlertExcludedDatabasesBox.Text = "";

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerAppSettings.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerAppSettings.cs
@@ -114,9 +114,11 @@ public sealed class ViewerAppSettings
     public int AlertCooldownMinutes { get; set; } = 5;
     public int EmailCooldownMinutes { get; set; } = 15;
 
-    /// <summary>Deadlock/blocking notification delivery: "Summary" (one card per cycle) or "PerEvent".</summary>
+    /// <summary>Deadlock/blocking notification delivery: "Summary" (one card per cycle) or "PerEvent".
+    /// Store-backed since V18 (the service honors it); retained here only as the pre-3b migrate-in source, so its
+    /// defaults match <see cref="AlertSettingsRow.Defaults"/> (Summary / 5) — a fresh viewer imports nothing.</summary>
     public string AlertDeliveryMode { get; set; } = "Summary";
-    public int AlertPerEventMaxPerCycle { get; set; } = 10;
+    public int AlertPerEventMaxPerCycle { get; set; } = 5;
 
     /// <summary>Default expiration for new mute rules: "1 hour", "24 hours", "7 days", or "Never".</summary>
     public string MuteRuleDefaultExpiration { get; set; } = "24 hours";
@@ -180,7 +182,7 @@ public sealed class ViewerAppSettings
         AlertCooldownMinutes = Clamp(AlertCooldownMinutes, 1, 120, 5);
         EmailCooldownMinutes = Clamp(EmailCooldownMinutes, 1, 120, 15);
         AlertDeliveryMode = (AlertDeliveryMode is "Summary" or "PerEvent") ? AlertDeliveryMode : "Summary";
-        AlertPerEventMaxPerCycle = Clamp(AlertPerEventMaxPerCycle, 1, 100, 10);
+        AlertPerEventMaxPerCycle = Clamp(AlertPerEventMaxPerCycle, 1, 100, 5);
         MuteRuleDefaultExpiration = (MuteRuleDefaultExpiration is "1 hour" or "24 hours" or "7 days" or "Never")
             ? MuteRuleDefaultExpiration : "24 hours";
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerControlPlaneMigration.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerControlPlaneMigration.cs
@@ -166,6 +166,10 @@ public sealed class ViewerControlPlaneMigration
             AnalysisIntervalMinutes = s.AnalysisIntervalMinutes,
             AnalysisNotificationsEnabled = s.AnalysisNotificationsEnabled,
             AnalysisNotifySeverity = s.AnalysisNotifySeverity,
+            /* #1141/#1236: carry a pre-3b viewer's delivery customization into the store now that the service
+               honors it (was a dead knob before V18). Fresh-viewer defaults match Defaults() → nothing imported. */
+            DeliveryMode = (s.AlertDeliveryMode is "Summary" or "PerEvent") ? s.AlertDeliveryMode : "Summary",
+            PerEventMax = s.AlertPerEventMaxPerCycle,
         };
     }
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.AlertSettings.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.AlertSettings.cs
@@ -39,8 +39,9 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// </summary>
 public sealed partial class ViewerDataService
 {
-    /* The 27 AlertsConfig + AnalysisConfig columns in the SAME order the service reads them
-       (StoreConfigProvider.ReadAlertSettingsAsync), so the parity test pins one list against both ends. */
+    /* The 29 AlertsConfig + AnalysisConfig columns in the SAME order the service reads them
+       (StoreConfigProvider.ReadAlertSettingsAsync), so the parity test pins one list against both ends.
+       delivery_mode/per_event_max (V18, #1141) are appended so the existing ordinals stay pinned. */
     private const string AlertSettingsColumns =
         "enabled, cpu_enabled, cpu_threshold_percent, cpu_mode, blocking_enabled, blocking_count_threshold, " +
         "deadlock_enabled, deadlock_count_threshold, poison_wait_enabled, poison_wait_threshold_ms, " +
@@ -48,7 +49,7 @@ public sealed partial class ViewerDataService
         "tempdb_space_threshold_percent, low_disk_enabled, low_disk_threshold_percent, low_disk_threshold_gb, " +
         "long_running_job_enabled, long_running_job_multiplier, failed_job_enabled, failed_job_lookback_minutes, " +
         "cooldown_minutes, excluded_databases, analysis_enabled, analysis_interval_minutes, " +
-        "analysis_notifications_enabled, analysis_notify_severity";
+        "analysis_notifications_enabled, analysis_notify_severity, delivery_mode, per_event_max";
 
     /// <summary>The single global alert-settings row (id=1), for the Settings window prefill + the migrate-in
     /// defaults check. Column order matches <see cref="AlertSettingsColumns"/>.</summary>
@@ -57,11 +58,11 @@ public sealed partial class ViewerDataService
 
     /// <summary>Upserts the single global alert-settings row (Settings window Save). ON CONFLICT rewrites every
     /// column and bumps <c>modified_at</c> (and, via the V17 statement trigger, <c>config_version</c> — the
-    /// service reloads on its next sweep). $1..$27 bind the columns in <see cref="AlertSettingsColumns"/> order.</summary>
+    /// service reloads on its next sweep). $1..$29 bind the columns in <see cref="AlertSettingsColumns"/> order.</summary>
     public const string AlertSettingsUpsertSql = @"
 INSERT INTO config_alert_settings (id, " + AlertSettingsColumns + @", modified_at)
 VALUES (1, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22,
-        $23, $24, $25, $26, $27, (now() AT TIME ZONE 'UTC'))
+        $23, $24, $25, $26, $27, $28, $29, (now() AT TIME ZONE 'UTC'))
 ON CONFLICT (id) DO UPDATE SET
     enabled = EXCLUDED.enabled,
     cpu_enabled = EXCLUDED.cpu_enabled,
@@ -90,6 +91,8 @@ ON CONFLICT (id) DO UPDATE SET
     analysis_interval_minutes = EXCLUDED.analysis_interval_minutes,
     analysis_notifications_enabled = EXCLUDED.analysis_notifications_enabled,
     analysis_notify_severity = EXCLUDED.analysis_notify_severity,
+    delivery_mode = EXCLUDED.delivery_mode,
+    per_event_max = EXCLUDED.per_event_max,
     modified_at = (now() AT TIME ZONE 'UTC')";
 
     /// <summary>The two <c>cpu_mode</c> values the service honors (it compares case-insensitively against
@@ -146,6 +149,8 @@ ON CONFLICT (id) DO UPDATE SET
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = r.AnalysisIntervalMinutes });           // $25
         command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = r.AnalysisNotificationsEnabled });     // $26
         command.Parameters.Add(new NpgsqlParameter<double> { TypedValue = r.AnalysisNotifySeverity });         // $27
+        command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = r.DeliveryMode });                   // $28
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = r.PerEventMax });                       // $29
     }
 
     private static AlertSettingsRow ReadAlertSettingsRow(NpgsqlDataReader reader) => new()
@@ -177,6 +182,8 @@ ON CONFLICT (id) DO UPDATE SET
         AnalysisIntervalMinutes = reader.GetInt32(24),
         AnalysisNotificationsEnabled = reader.GetBoolean(25),
         AnalysisNotifySeverity = reader.GetDouble(26),
+        DeliveryMode = reader.GetString(27),
+        PerEventMax = reader.GetInt32(28),
     };
 
     /// <summary>Maps the Settings window's CPU-mode combo tag ("Total"/"SqlOnly") to the store value.</summary>
@@ -191,11 +198,12 @@ ON CONFLICT (id) DO UPDATE SET
 /// <summary>
 /// A <c>config.config_alert_settings</c> row (the single id=1 global row) as the viewer authors + reads it —
 /// the desired-state twin of the service's <c>AlertsConfig</c> + <c>AnalysisConfig</c> the store hot-swaps in.
-/// Carries ONLY the columns the store (and hence the service) has: the viewer-only alert fields the Settings
-/// window also edits (tray minimize, connection-change notify, LRQ max-results + the five noise filters,
-/// Summary/Per-event delivery, mute-rule default expiration, dismissal logging, analysis re-notify cooldown)
-/// are NOT service-honored config and stay viewer-local in <see cref="ViewerAppSettings"/>. Defaults mirror
-/// the V17 DDL (and Lite's <c>App.*</c>) member-for-member so <see cref="Defaults"/> equals a freshly-seeded row.
+/// Carries ONLY the columns the store (and hence the service) has, now INCLUDING the Summary/Per-event delivery
+/// mode + per-event cap (#1141/#1236, V18 — the service honors them at delivery time). The remaining viewer-only
+/// alert fields the Settings window also edits (tray minimize, connection-change notify, LRQ max-results + the
+/// five noise filters, mute-rule default expiration, dismissal logging, analysis re-notify cooldown) are NOT
+/// service-honored config and stay viewer-local in <see cref="ViewerAppSettings"/>. Defaults mirror the V17/V18
+/// DDL (and Lite's <c>App.*</c>) member-for-member so <see cref="Defaults"/> equals a freshly-seeded row.
 /// </summary>
 public sealed class AlertSettingsRow
 {
@@ -232,7 +240,14 @@ public sealed class AlertSettingsRow
     public bool AnalysisNotificationsEnabled { get; set; } = true;
     public double AnalysisNotifySeverity { get; set; } = 1.5;
 
-    /// <summary>A row equal to the V17 seed defaults — the migrate-in "is the service section still at defaults?" baseline.</summary>
+    /// <summary>Deadlock/blocking delivery mode: "Summary" (one card per cycle) or "PerEvent" (#1141) — the store's
+    /// <c>delivery_mode</c> text, matching the service's <c>AlertNotificationMode</c> names. Default "Summary" (V18 DDL).</summary>
+    public string DeliveryMode { get; set; } = "Summary";
+
+    /// <summary>Per-event mode's per-cycle incident cap before the "+N more" batch. Default 5 (V18 DDL); clamped 1–100.</summary>
+    public int PerEventMax { get; set; } = 5;
+
+    /// <summary>A row equal to the V17/V18 seed defaults — the migrate-in "is the service section still at defaults?" baseline.</summary>
     public static AlertSettingsRow Defaults() => new();
 
     /// <summary>Value-equality against another row (sequence-comparing the excluded-databases list) — the
@@ -266,6 +281,8 @@ public sealed class AlertSettingsRow
             && AnalysisEnabled == other.AnalysisEnabled
             && AnalysisIntervalMinutes == other.AnalysisIntervalMinutes
             && AnalysisNotificationsEnabled == other.AnalysisNotificationsEnabled
-            && Math.Abs(AnalysisNotifySeverity - other.AnalysisNotifySeverity) < 0.0001;
+            && Math.Abs(AnalysisNotifySeverity - other.AnalysisNotifySeverity) < 0.0001
+            && string.Equals(DeliveryMode, other.DeliveryMode, StringComparison.OrdinalIgnoreCase)
+            && PerEventMax == other.PerEventMax;
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.MonitoredServers.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.MonitoredServers.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using Npgsql;
 using NpgsqlTypes;
 using PerformanceMonitor.Common;
+using PerformanceMonitor.Notifications;
 
 namespace PerformanceMonitor.Darling.Viewer;
 
@@ -46,10 +47,10 @@ public sealed partial class ViewerDataService
     private const string MonitoredServerColumns =
         "server_id, name, host, database, auth, username, encrypted_password, encrypt_mode, " +
         "trust_server_certificate, read_only_intent, multi_subnet_failover, excluded_databases, " +
-        "monthly_cost_usd, capture_plans, is_enabled";
+        "monthly_cost_usd, capture_plans, is_enabled, alert_delivery_mode_override";
 
     private const string MonitoredServerValues =
-        "$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, " +
+        "$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, " +
         "(now() AT TIME ZONE 'UTC'), (now() AT TIME ZONE 'UTC')";
 
     /// <summary>Upsert by <c>server_id</c> — the Add/Edit save. ON CONFLICT rewrites every field but
@@ -72,6 +73,7 @@ ON CONFLICT (server_id) DO UPDATE SET
     monthly_cost_usd = EXCLUDED.monthly_cost_usd,
     capture_plans = EXCLUDED.capture_plans,
     is_enabled = EXCLUDED.is_enabled,
+    alert_delivery_mode_override = EXCLUDED.alert_delivery_mode_override,
     modified_at = (now() AT TIME ZONE 'UTC')";
 
     /// <summary>Insert only when the <c>server_id</c> is absent — the one-time <c>viewer-servers.json</c>
@@ -103,7 +105,7 @@ ON CONFLICT (server_id) DO NOTHING";
     public const string MonitoredServersSelectSql = @"
 SELECT server_id, name, host, database, auth, username, encrypt_mode,
        trust_server_certificate, read_only_intent, multi_subnet_failover, excluded_databases,
-       monthly_cost_usd, capture_plans, is_enabled, created_at
+       monthly_cost_usd, capture_plans, is_enabled, created_at, alert_delivery_mode_override
 FROM config_monitored_servers
 ORDER BY name";
 
@@ -111,7 +113,7 @@ ORDER BY name";
     public const string MonitoredServerByIdSql = @"
 SELECT server_id, name, host, database, auth, username, encrypted_password, encrypt_mode,
        trust_server_certificate, read_only_intent, multi_subnet_failover, excluded_databases,
-       monthly_cost_usd, capture_plans, is_enabled, created_at
+       monthly_cost_usd, capture_plans, is_enabled, created_at, alert_delivery_mode_override
 FROM config_monitored_servers
 WHERE server_id = $1";
 
@@ -315,6 +317,8 @@ ORDER BY COALESCE(s.display_name, c.name)";
         command.Parameters.Add(new NpgsqlParameter<decimal> { TypedValue = row.MonthlyCostUsd });       // $13
         AddNullableBool(command, row.CapturePlans);                                                      // $14
         command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = row.IsEnabled });               // $15
+        /* #1236: per-server delivery override as its enum name, or NULL = "inherit the global". */
+        AddNullableText(command, row.AlertDeliveryModeOverride?.ToString());                             // $16
     }
 
     private static MonitoredServerRow ReadMonitoredServerRow(NpgsqlDataReader reader) => new()
@@ -335,6 +339,7 @@ ORDER BY COALESCE(s.display_name, c.name)";
         CapturePlans = reader.IsDBNull(13) ? null : reader.GetBoolean(13),
         IsEnabled = reader.GetBoolean(14),
         CreatedAt = reader.IsDBNull(15) ? null : DateTime.SpecifyKind(reader.GetDateTime(15), DateTimeKind.Utc),
+        AlertDeliveryModeOverride = ParseDeliveryOverride(reader.IsDBNull(16) ? null : reader.GetString(16)),
     };
 
     /// <summary>
@@ -363,6 +368,7 @@ ORDER BY COALESCE(s.display_name, c.name)";
         CapturePlans = reader.IsDBNull(12) ? null : reader.GetBoolean(12),
         IsEnabled = reader.GetBoolean(13),
         CreatedAt = reader.IsDBNull(14) ? null : DateTime.SpecifyKind(reader.GetDateTime(14), DateTimeKind.Utc),
+        AlertDeliveryModeOverride = ParseDeliveryOverride(reader.IsDBNull(15) ? null : reader.GetString(15)),
     };
 
     private static void AddTextArray(NpgsqlCommand command, IEnumerable<string>? values) =>
@@ -378,15 +384,21 @@ ORDER BY COALESCE(s.display_name, c.name)";
             NpgsqlDbType = NpgsqlDbType.Boolean,
             Value = value.HasValue ? value.Value : DBNull.Value,
         });
+
+    /// <summary>Parses the nullable <c>alert_delivery_mode_override</c> text ("Summary"/"PerEvent") to the enum;
+    /// null/empty/unknown = null = "inherit the global delivery mode". Mirrors the service's read parse.</summary>
+    private static AlertNotificationMode? ParseDeliveryOverride(string? value) =>
+        Enum.TryParse<AlertNotificationMode>(value, ignoreCase: true, out var mode) ? mode : null;
 }
 
 /// <summary>
 /// A <c>config.config_monitored_servers</c> row as the viewer authors + reads it — the connection definition
 /// the Darling service reconstructs a <c>MonitoredServer</c> from. Deliberately carries only the columns the
-/// store (and hence the service) has; the viewer-only cosmetics some Lite fields kept (description, utility
-/// DB, per-server alert-delivery override, the Azure client ids) are NOT part of the service-honored server
-/// model and stay out of the store. <see cref="EncryptedPassword"/> is a DPAPI-LocalMachine blob, never
-/// plaintext. Favorites remain viewer-local (<see cref="ViewerServerStore"/>).
+/// store (and hence the service) has — now INCLUDING the per-server alert-delivery override (#1236, V18, the
+/// service honors it at delivery time); the remaining viewer-only cosmetics some Lite fields kept (description,
+/// utility DB, the Azure client ids) are NOT part of the service-honored server model and stay out of the store.
+/// <see cref="EncryptedPassword"/> is a DPAPI-LocalMachine blob, never plaintext. Favorites remain viewer-local
+/// (<see cref="ViewerServerStore"/>).
 /// </summary>
 public sealed class MonitoredServerRow
 {
@@ -412,6 +424,10 @@ public sealed class MonitoredServerRow
 
     /// <summary>Per-server plan-capture override; null = follow the global <c>config_service.capture_plans</c>.</summary>
     public bool? CapturePlans { get; set; }
+
+    /// <summary>Per-server deadlock/blocking delivery-mode override (#1236); null = inherit the global
+    /// <c>config_alert_settings.delivery_mode</c>. Stored as the enum name in <c>alert_delivery_mode_override</c>.</summary>
+    public AlertNotificationMode? AlertDeliveryModeOverride { get; set; }
 
     public bool IsEnabled { get; set; } = true;
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerMigration.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerMigration.cs
@@ -203,6 +203,8 @@ public sealed class ViewerServerMigration
         MultiSubnetFailover = entry.MultiSubnetFailover,
         ExcludedDatabases = entry.ExcludedDatabases ?? new List<string>(),
         MonthlyCostUsd = entry.MonthlyCostUsd,
+        /* #1236: carry the per-server delivery override into the store (was viewer-local / dead pre-V18). */
+        AlertDeliveryModeOverride = entry.AlertDeliveryModeOverride,
         IsEnabled = entry.IsEnabled,
     };
 


### PR DESCRIPTION
## What

Wires up **per-server + per-event alert delivery mode** for the Darling service. Darling shipped Lite's Summary-only default and did NOT fan out; the viewer's global delivery combo and the per-server override were dead knobs the service ignored. The hard parts (`AlertDeliveryModeResolver`, `PerEventNotification.Split`) were already shared + tested — this is the wiring + a small migration.

## Changes

**Storage — V18 migration** (`StorageVersion` 17 → 18, `alert-delivery-mode`)
- `config.config_alert_settings` += `delivery_mode text NOT NULL DEFAULT 'Summary'`, `per_event_max integer NOT NULL DEFAULT 5`
- `config.config_monitored_servers` += `alert_delivery_mode_override text` (nullable = inherit global)
- Additive, schema-qualified `config.*` exactly like V17 (`IF NOT EXISTS`, no new tables)

**Service (config plumbing + deliverer)**
- `AlertsConfig.DeliveryMode` (the `AlertNotificationMode` enum) + `PerEventMax`; `MonitoredServer.AlertDeliveryModeOverride`; both are darling.json knobs (documented in `darling.sample.json`)
- `DarlingAlertSettings` exposes `DeliveryMode` + clamped (1–100) `PerEventMax` over the by-reference config seam
- `StoreConfigProvider` seeds + reads back both settings columns and the per-server override
- `DarlingAlertDeliverer`: effective mode = `AlertDeliveryModeResolver.Resolve(server override, global)`; in **PerEvent** mode an incident-carrying alert is split via `PerEventNotification.Split(context, PerEventMax)` into one send + `config_alert_log` row per distinct incident (capped, trailing "+N more"); **Summary** — or any alert without incidents (CPU/low-disk/jobs) — is the single combined send, unchanged. The "deliberately NOT implemented" comment is gone.
- `ReconcileServers` now always refreshes `state.Config` so a per-server override edit goes live on the reload beacon **without a reconnect** (mirrors the existing cost-edit rule; the override is a non-connection field)

**Viewer**
- The existing global delivery combo in Settings is now **store-backed** — it writes `config_alert_settings.delivery_mode`/`per_event_max` via the Stage-3b AlertSettings write partial and reads it back (moved off the dead viewer-local `_appSettings`)
- Add/Edit Server gains an **"Alert delivery"** override control writing `config_monitored_servers.alert_delivery_mode_override` (null = inherit global) — reviving the knob #1415 removed as dead
- Control-plane + server migrations carry a pre-3b viewer's delivery customization into the store

## Testing

- **`Darling.Tests -c Release` green: 1587 passed, 0 failed, 123 skipped** (live-PG gated)
- New/updated pins: V18 migration shape + `Scripts.Count`/`StorageVersion` 17→18; deliverer Summary-vs-PerEvent branch + per-server override precedence + the "+N more" cap; `DarlingAlertSettings` clamp; `ApplyToConfig` seam; live-gated seed/read round-trip; viewer write-partial column parity (viewer ↔ service, 29 alert cols / 16 server cols); `darling.sample.json` + darling.json enum round-trip
- **V18 live-validated** against an isolated scratch DB on `:5641` (psql): columns + defaults confirmed (`delivery_mode`/`Summary`, `per_event_max`/`5`, nullable override), full V1→V18 migrate + seed/read round-trip (PerEvent / 7 / per-server override) verified, scratch DB dropped, `darling` database untouched.

## Note for review

The V18 store default for `per_event_max` is **5** (as specified for the migration). Lite's `App.AlertPerEventMaxPerCycle` default is 10 — I aligned Darling's store/service/viewer/migration defaults to 5 consistently and set `ViewerAppSettings` to match so a fresh viewer imports nothing. Say the word if you'd rather Darling mirror Lite's 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)