### PR TITLE
Restore Recommendations insufficient-data vs all-clear state in the Darling viewer

### DIFF
--- a/Darling/Darling.Tests/DarlingObservabilityTests.cs
+++ b/Darling/Darling.Tests/DarlingObservabilityTests.cs
@@ -32,9 +32,9 @@ public sealed class DarlingObservabilityTests
     private const int TestServerId = -424242;
 
     [Fact]
-    public void MigrationScripts_EighteenVersions_V17ConfigControlPlane_V18AlertDeliveryMode()
+    public void MigrationScripts_NineteenVersions_V18AlertDeliveryMode_V19AnalysisStateMarker()
     {
-        Assert.Equal(18, PgMigrations.Scripts.Count);
+        Assert.Equal(19, PgMigrations.Scripts.Count);
         Assert.Equal(1, PgMigrations.Scripts[0].Version);
         Assert.Equal(2, PgMigrations.Scripts[1].Version);
         Assert.Equal(3, PgMigrations.Scripts[2].Version);
@@ -53,7 +53,8 @@ public sealed class DarlingObservabilityTests
         Assert.Equal(16, PgMigrations.Scripts[15].Version);
         Assert.Equal(17, PgMigrations.Scripts[16].Version);
         Assert.Equal(18, PgMigrations.Scripts[17].Version);
-        Assert.Equal(18, StorageVersion.SchemaVersion);
+        Assert.Equal(19, PgMigrations.Scripts[18].Version);
+        Assert.Equal(19, StorageVersion.SchemaVersion);
 
         /* V5 completes the v_* twin of Lite's DuckDB view layer -- the copy-parity tail tabs
            (Running Jobs, Configuration, Daily Summary, Collection Health) read these five, so
@@ -278,6 +279,24 @@ public sealed class DarlingObservabilityTests
         /* Every V18 object is config.-qualified (a bare ALTER TABLE config_* would hit the wrong schema). */
         Assert.DoesNotContain("ALTER TABLE config_", v18, StringComparison.Ordinal);
 
+        /* V19 creates the per-server analysis-state marker (the "still collecting vs all-clear" signal the
+           viewer reads). It lives in collect (service-produced observed output read by the viewer, like
+           analysis_findings/collection_log) and is EXPLICITLY collect.-qualified — the opposite direction
+           from the config control plane. Single row per server (server_id PK) so the writer upserts; the
+           columns are exactly the marker's four (insufficient flag, engine message, analysis time). It has
+           NO v_* passthrough view (no Lite SQL ports through it), so the AllPassthroughViews cross-check
+           above is unaffected. */
+        var v19 = PgMigrations.Scripts[18].Sql;
+        Assert.Equal("analysis-state-marker", PgMigrations.Scripts[18].Name);
+        Assert.Contains("CREATE TABLE IF NOT EXISTS collect.analysis_state (", v19, StringComparison.Ordinal);
+        Assert.Contains("server_id integer NOT NULL PRIMARY KEY", v19, StringComparison.Ordinal);
+        Assert.Contains("insufficient_data boolean NOT NULL DEFAULT FALSE", v19, StringComparison.Ordinal);
+        Assert.Contains("message text", v19, StringComparison.Ordinal);
+        Assert.Contains("analysis_time timestamp NOT NULL", v19, StringComparison.Ordinal);
+        /* Observed-output tier -> collect, never the config control plane; and no passthrough view. */
+        Assert.DoesNotContain("config.analysis_state", v19, StringComparison.Ordinal);
+        Assert.DoesNotContain("CREATE OR REPLACE VIEW", v19, StringComparison.Ordinal);
+
         var v2 = PgMigrations.Scripts[1].Sql;
         Assert.Contains("CREATE TABLE IF NOT EXISTS servers (", v2, StringComparison.Ordinal);
         Assert.Contains("CREATE TABLE IF NOT EXISTS collection_log (", v2, StringComparison.Ordinal);
@@ -304,6 +323,24 @@ public sealed class DarlingObservabilityTests
         Assert.Contains("s.is_enabled IS DISTINCT FROM c.is_enabled", sql, StringComparison.Ordinal);
         Assert.Contains("s.monthly_cost_usd IS DISTINCT FROM c.monthly_cost_usd", sql, StringComparison.Ordinal);
         Assert.Contains(" OR ", sql, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The analysis-state marker write (V19) is an UPSERT on the natural server_id key over the four marker
+    /// columns, so a re-run for a server overwrites its prior determination rather than accumulating rows.
+    /// Bare <c>analysis_state</c> resolves through the collect/config search path to collect.analysis_state
+    /// (the observed-output schema). Pure SQL-shape pin (no store).
+    /// </summary>
+    [Fact]
+    public void WriteAnalysisStateSql_UpsertsTheFourMarkerColumnsOnServerId()
+    {
+        var sql = DarlingObservability.WriteAnalysisStateSql;
+
+        Assert.Contains("INSERT INTO analysis_state (server_id, insufficient_data, message, analysis_time)", sql, StringComparison.Ordinal);
+        Assert.Contains("ON CONFLICT (server_id) DO UPDATE SET", sql, StringComparison.Ordinal);
+        Assert.Contains("insufficient_data = EXCLUDED.insufficient_data", sql, StringComparison.Ordinal);
+        Assert.Contains("message = EXCLUDED.message", sql, StringComparison.Ordinal);
+        Assert.Contains("analysis_time = EXCLUDED.analysis_time", sql, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -491,6 +528,56 @@ public sealed class DarlingObservabilityTests
         await DeleteTestRowsAsync(connection);
     }
 
+    [Fact]
+    public async Task WriteAnalysisState_InsufficientThenSufficient_UpsertsTheMarker_AgainstDevPostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the analysis-state marker test.");
+
+        using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await PgMigrations.MigrateAsync(connection, TestContext.Current.CancellationToken);
+        await DeleteTestRowsAsync(connection);
+
+        await using var postgres = NpgsqlDataSource.Create(connectionString!);
+
+        /* Insufficient-data pass: the marker upserts insufficient_data = true with the engine's message. */
+        await DarlingObservability.WriteAnalysisStateAsync(
+            postgres, TestServerId, insufficientData: true, "Not enough data for reliable analysis. Need 1.0 days.",
+            null, TestContext.Current.CancellationToken);
+
+        var (insufficient1, message1) = await ReadAnalysisStateAsync(connection);
+        Assert.True(insufficient1);
+        Assert.Equal("Not enough data for reliable analysis. Need 1.0 days.", message1);
+
+        /* A real pass on enough data: the SAME row (server_id PK) flips to false and clears the message —
+           the upsert overwrites rather than inserting a second row. */
+        await DarlingObservability.WriteAnalysisStateAsync(
+            postgres, TestServerId, insufficientData: false, null, null, TestContext.Current.CancellationToken);
+
+        var (insufficient2, message2) = await ReadAnalysisStateAsync(connection);
+        Assert.False(insufficient2);
+        Assert.Null(message2);
+
+        using (var count = new NpgsqlCommand("SELECT COUNT(*) FROM analysis_state WHERE server_id = $1", connection))
+        {
+            count.Parameters.AddWithValue(TestServerId);
+            Assert.Equal(1L, await count.ExecuteScalarAsync(TestContext.Current.CancellationToken));
+        }
+
+        await DeleteTestRowsAsync(connection);
+    }
+
+    private static async Task<(bool Insufficient, string? Message)> ReadAnalysisStateAsync(NpgsqlConnection connection)
+    {
+        using var read = new NpgsqlCommand("SELECT insufficient_data, message FROM analysis_state WHERE server_id = $1", connection);
+        read.Parameters.AddWithValue(TestServerId);
+        using var reader = await read.ExecuteReaderAsync(TestContext.Current.CancellationToken);
+        Assert.True(await reader.ReadAsync(TestContext.Current.CancellationToken), "analysis_state row missing after write");
+        return (reader.GetBoolean(0), reader.IsDBNull(1) ? null : reader.GetString(1));
+    }
+
     private static async Task<bool> ReadObservedEnabledAsync(NpgsqlConnection connection)
     {
         using var read = new NpgsqlCommand("SELECT is_enabled FROM collect.servers WHERE server_id = $1", connection);
@@ -516,6 +603,7 @@ public sealed class DarlingObservabilityTests
     {
         using var cleanup = new NpgsqlCommand(
             $"DELETE FROM collection_log WHERE server_id = {TestServerId}; " +
+            $"DELETE FROM collect.analysis_state WHERE server_id = {TestServerId}; " +
             $"DELETE FROM collect.servers WHERE server_id = {TestServerId}; " +
             $"DELETE FROM config.config_monitored_servers WHERE server_id = {TestServerId};", connection);
         await cleanup.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);

--- a/Darling/Darling.Tests/ViewerRecommendationsTests.cs
+++ b/Darling/Darling.Tests/ViewerRecommendationsTests.cs
@@ -452,6 +452,64 @@ public sealed class ViewerRecommendationGroupingTests
         Assert.Equal(0, vm.TotalCount);
     }
 
+    // ── Insufficient-data vs all-clear state selection (V19 marker) ─────────────────────────────
+
+    [Fact]
+    public void FromFindings_ZeroFindings_NoInsufficientMarker_IsTheGenuineAllClear()
+    {
+        // data + zero findings -> Empty (the genuine all-clear); the message is empty.
+        var vm = RecommendationsViewModel.FromFindings(
+            Array.Empty<ViewerFindingRow>(), "SQL2022", utcOffsetMinutes: 0,
+            insufficientData: false, insufficientDataMessage: null);
+
+        Assert.Equal(RecommendationsState.Empty, vm.State);
+        Assert.Empty(vm.Sections);
+        Assert.Equal(string.Empty, vm.InsufficientDataMessage);
+    }
+
+    [Fact]
+    public void FromFindings_ZeroFindings_InsufficientMarker_ShowsStillCollecting_NotAllClear()
+    {
+        // insufficient + zero findings -> InsufficientData ("still collecting"), NOT a false all-clear.
+        var vm = RecommendationsViewModel.FromFindings(
+            Array.Empty<ViewerFindingRow>(), "SQL2022", utcOffsetMinutes: 0,
+            insufficientData: true,
+            insufficientDataMessage: "Not enough data for reliable analysis. Need 1.0 days, have 3.0 hours.");
+
+        Assert.Equal(RecommendationsState.InsufficientData, vm.State);
+        Assert.Empty(vm.Sections);
+        Assert.Equal("Not enough data for reliable analysis. Need 1.0 days, have 3.0 hours.", vm.InsufficientDataMessage);
+    }
+
+    [Fact]
+    public void FromFindings_InsufficientMarker_ButFindingsPresent_FindingsWin_Loaded()
+    {
+        // A server with findings shows them regardless of the marker (the marker only decides zero-finding).
+        var rows = new List<ViewerFindingRow> { Row(1.6, "CPU is on fire", incidentId: "a") };
+
+        var vm = RecommendationsViewModel.FromFindings(
+            rows, "SQL2022", utcOffsetMinutes: 0, insufficientData: true, insufficientDataMessage: "collecting");
+
+        Assert.Equal(RecommendationsState.Loaded, vm.State);
+        Assert.Single(vm.Sections);
+        Assert.Equal(string.Empty, vm.InsufficientDataMessage);
+    }
+
+    [Fact]
+    public void InsufficientData_UsesEngineMessageWhenPresent_ElseTheDefault()
+    {
+        Assert.Equal(
+            RecommendationsViewModel.DefaultInsufficientDataMessage,
+            RecommendationsViewModel.InsufficientData(null).InsufficientDataMessage);
+        Assert.Equal(
+            RecommendationsViewModel.DefaultInsufficientDataMessage,
+            RecommendationsViewModel.InsufficientData("   ").InsufficientDataMessage);
+        Assert.Equal(
+            "engine says 3.0 hours",
+            RecommendationsViewModel.InsufficientData("engine says 3.0 hours").InsufficientDataMessage);
+        Assert.Equal(RecommendationsState.InsufficientData, RecommendationsViewModel.InsufficientData(null).State);
+    }
+
     [Fact]
     public void FromFindings_GroupsByIncident_HeaderNamesPrimaryPlusCount()
     {

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingObservability.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingObservability.cs
@@ -63,6 +63,20 @@ WHERE s.server_id = c.server_id
 INSERT INTO collection_log (log_id, server_id, server_name, collector_name, collection_time, duration_ms, status, error_message, rows_collected, sql_duration_ms, duckdb_duration_ms)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11);";
 
+    /* The per-server analysis-state marker (V19): the analysis pass's insufficient-data determination,
+       persisted so the Viewer's Recommendations tab can tell "still collecting" (a young deployment under
+       the 24h data-span gate) apart from a genuine all-clear. One row per server, upserted after each
+       completed pass on the natural key (server_id). The bare name resolves through the collect/config
+       search path to collect.analysis_state — the observed-output schema, like servers/collection_log.
+       Internal so a pure test can pin the UPSERT shape. */
+    internal const string WriteAnalysisStateSql = @"
+INSERT INTO analysis_state (server_id, insufficient_data, message, analysis_time)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (server_id) DO UPDATE SET
+    insufficient_data = EXCLUDED.insufficient_data,
+    message = EXCLUDED.message,
+    analysis_time = EXCLUDED.analysis_time;";
+
     /// <summary>
     /// Registers (or refreshes) a connected server in the registry: created_date is written only on first
     /// insert, modified_date on every connect. is_enabled is set TRUE on first insert only and left
@@ -170,6 +184,43 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11);";
             /* Failure-isolated by design — an observability write must never break the collection loop. */
             logger?.LogDebug("Observability: collection_log write for '{Server}' / {Collector} failed: {Message}",
                 server.Config.DisplayName, collectorName, ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Upserts the per-server analysis-state marker (V19) after an analysis pass: <c>insufficient_data =
+    /// true</c> plus the engine's message when the pass hit the 24h data-span gate, or <c>false</c> + null
+    /// when a real pass completed on enough data. The engine ALREADY makes this determination
+    /// (<c>DarlingAnalysisService.InsufficientDataMessage</c>); this persists it so the Viewer's
+    /// Recommendations tab — which never calls the engine — shows "still collecting" instead of a false
+    /// all-clear on a young deployment's zero-finding read. One row per server, upserted on
+    /// <c>server_id</c>. Failure-isolated (Debug + no-op) like the other observability writes — an
+    /// analysis-state write must never break the collection loop.
+    /// </summary>
+    public static async Task WriteAnalysisStateAsync(
+        NpgsqlDataSource postgres,
+        int serverId,
+        bool insufficientData,
+        string? message,
+        ILogger? logger,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var connection = await postgres.OpenConnectionAsync(cancellationToken);
+            using var command = new NpgsqlCommand(WriteAnalysisStateSql, connection);
+            command.Parameters.AddWithValue(serverId);
+            command.Parameters.AddWithValue(insufficientData);
+            command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text, Value = (object?)message ?? DBNull.Value });
+            /* Naive-UTC storage: Npgsql 6+ rejects Kind=Utc against `timestamp` — see PgCollectorRowWriter. */
+            command.Parameters.AddWithValue(DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Unspecified));
+            await command.ExecuteNonQueryAsync(cancellationToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            /* Failure-isolated by design — an observability write must never break the collection loop. */
+            logger?.LogDebug("Observability: analysis-state write for server {ServerId} failed: {Message}",
+                serverId, ex.Message);
         }
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -1059,11 +1059,21 @@ LIMIT 1", connection);
                 await notificationService.NotifyAsync(findings);
             }
 
+            /* Persist the pass's insufficient-data determination (V19 marker) so the Viewer's
+               Recommendations tab shows "still collecting" instead of a false all-clear on a young
+               deployment: true + the engine's message when the pass hit the 24h data-span gate, cleared
+               (false) when a real pass completed on enough data. Failure-isolated like the other
+               observability writes. Only the two REAL terminal states write it — a Skipped/TimedOut/Error
+               pass (handled above / in the catch) leaves the last known marker untouched. */
             if (analysisService.InsufficientDataMessage is string insufficient)
             {
+                await DarlingObservability.WriteAnalysisStateAsync(
+                    _postgres!, serverId, insufficientData: true, insufficient, _logger, stoppingToken);
                 return new AnalysisPassResult(AnalysisPassStatus.InsufficientData, 0, insufficient);
             }
 
+            await DarlingObservability.WriteAnalysisStateAsync(
+                _postgres!, serverId, insufficientData: false, null, _logger, stoppingToken);
             return new AnalysisPassResult(AnalysisPassStatus.Ran, findings.Count, null);
         }
         catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)

--- a/Darling/PerformanceMonitor.Darling.Storage/PgMigrations.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/PgMigrations.cs
@@ -62,6 +62,7 @@ public static class PgMigrations
         new Migration(16, "server-utc-offset", V16Sql),
         new Migration(17, "config-control-plane", V17Sql),
         new Migration(18, "alert-delivery-mode", V18Sql),
+        new Migration(19, "analysis-state-marker", V19Sql),
     };
 
     /// <summary>
@@ -572,6 +573,37 @@ CREATE TRIGGER trg_service_self_bump
 ALTER TABLE config.config_alert_settings ADD COLUMN IF NOT EXISTS delivery_mode text NOT NULL DEFAULT 'Summary';
 ALTER TABLE config.config_alert_settings ADD COLUMN IF NOT EXISTS per_event_max integer NOT NULL DEFAULT 5;
 ALTER TABLE config.config_monitored_servers ADD COLUMN IF NOT EXISTS alert_delivery_mode_override text;";
+
+    /// <summary>
+    /// V19 — the per-server ANALYSIS-STATE marker: the analysis pass's insufficient-data determination,
+    /// persisted so the Viewer's Recommendations tab can tell a young deployment ("still collecting —
+    /// need ~24h of history") apart from a genuine all-clear. The engine ALREADY computes this
+    /// (<c>DarlingAnalysisService.InsufficientDataMessage</c>, surfaced as the AN3 pass's
+    /// <c>InsufficientData</c> status when total history is under the 24h data-span gate); the Viewer
+    /// makes no engine call, so without a persisted marker a zero-finding read collapses to "All clear"
+    /// even when the engine only skipped for want of data. One row per server (<c>server_id</c> PRIMARY
+    /// KEY), upserted by the service after each completed pass and read by the Viewer.
+    ///
+    /// <para><b>Schema — <c>collect</c>, qualified.</b> This is service-produced OBSERVED analysis output
+    /// the Viewer READS, so it belongs in <c>collect</c> beside <c>analysis_findings</c> /
+    /// <c>collection_log</c> / <c>servers</c> — NOT the <c>config</c> control plane (which is the opposite
+    /// direction: the Viewer writes DESIRED state the service reads). The service connects as the owner
+    /// and writes it; the managed <c>admin</c>/<c>viewer</c> roles auto-inherit SELECT via
+    /// <c>ALTER DEFAULT PRIVILEGES … IN SCHEMA collect</c> (<see cref="!:DarlingManagedRoles"/>), so no
+    /// per-table grant is needed. Qualifying <c>collect.</c> is belt-and-suspenders — the migrate
+    /// session's <c>search_path = collect, config, public</c> already resolves a bare name to
+    /// <c>collect</c> — but it makes the intent explicit (the mirror of V17/V18's <c>config.</c>
+    /// qualification). <c>message</c> is nullable (null when a real pass cleared the gate);
+    /// <c>analysis_time</c> stores naive-UTC like the store-wide convention. No <c>v_*</c> passthrough
+    /// view: no Lite SQL ports through this Darling-specific marker.
+    /// </summary>
+    private const string V19Sql = @"
+CREATE TABLE IF NOT EXISTS collect.analysis_state (
+    server_id integer NOT NULL PRIMARY KEY,
+    insufficient_data boolean NOT NULL DEFAULT FALSE,
+    message text,
+    analysis_time timestamp NOT NULL
+);";
 
     private const string VersionTableSql = @"
 CREATE TABLE IF NOT EXISTS darling_schema_version (

--- a/Darling/PerformanceMonitor.Darling.Storage/StorageVersion.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/StorageVersion.cs
@@ -16,5 +16,5 @@ namespace PerformanceMonitor.Darling.Storage;
 /// </summary>
 public static class StorageVersion
 {
-    public const int SchemaVersion = 18;
+    public const int SchemaVersion = 19;
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
@@ -893,6 +893,13 @@
                                        Style="{StaticResource EmptyHint}"
                                        Text="All clear — no current recommendations."/>
 
+                            <!-- Insufficient data: the analysis pass has not cleared its 24h data-span
+                                 gate yet (the persisted V19 marker). Text is set from the view-model. -->
+                            <TextBlock x:Name="RecommendationsInsufficientText"
+                                       Style="{StaticResource EmptyHint}"
+                                       MaxWidth="520" TextWrapping="Wrap" TextAlignment="Center"
+                                       Visibility="Collapsed"/>
+
                             <TextBlock x:Name="RecommendationsLoadingText"
                                        Style="{StaticResource EmptyHint}"
                                        Text="Loading recommendations…"/>

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
@@ -683,11 +683,13 @@ public partial class MainWindow : Window
     // ── Recommendations tab (advise-only cards; own server selector, tab-activation refresh) ─────
 
     /// <summary>
-    /// Reads the latest analysis findings for the Recommendations tab's OWN selected server and renders
-    /// them as Lite's advise-only, incident-grouped cards. Advise-only: no Apply, and no mute (mute
-    /// lives on the Alert History surface per the re-skin). There is no "Generate now": the Darling
-    /// service runs analysis on its own 30-minute cadence (once 24h of history exists), so the viewer
-    /// cannot trigger it — the tab's status line surfaces the last analysis time instead.
+    /// Reads the latest analysis findings AND the per-server analysis-state marker (V19) for the
+    /// Recommendations tab's OWN selected server, and renders Lite's advise-only, incident-grouped cards.
+    /// Advise-only: no Apply, and no mute (mute lives on the Alert History surface per the re-skin). The
+    /// marker lets a zero-finding read on a young deployment show "still collecting" (the engine skipped
+    /// for its 24h data-span gate) instead of a false all-clear; a server with findings shows them, and a
+    /// server with enough data and zero findings shows the genuine all-clear. The tab's status line
+    /// surfaces the last analysis time; "Generate now" forces an immediate pass via the analyze_now command.
     /// </summary>
     private async Task LoadRecommendationsAsync()
     {
@@ -708,8 +710,17 @@ public partial class MainWindow : Window
 
         var rows = await _dataService.GetLatestFindingsAsync(server.ServerId);
 
+        /* Read the per-server analysis-state marker (V19) the Darling service persists after each pass, so
+           a zero-finding read on a young deployment renders "still collecting" (the engine skipped for its
+           24h data-span gate) instead of a false all-clear. The marker only decides the ZERO-finding case;
+           a server with findings shows them regardless. Null (no pass yet / pre-V19 store) = not insufficient. */
+        var analysisState = await _dataService.GetAnalysisStateAsync(server.ServerId);
+
         ApplyRecommendationsViewModel(
-            RecommendationsViewModel.FromFindings(rows, server.DisplayName, LocalUtcOffsetMinutes()));
+            RecommendationsViewModel.FromFindings(
+                rows, server.DisplayName, LocalUtcOffsetMinutes(),
+                insufficientData: analysisState?.InsufficientData == true,
+                insufficientDataMessage: analysisState?.Message));
 
         RecommendationsStatusText.Text = rows.Count > 0
             ? $"Last analyzed {rows[0].AnalysisTimeLocal:yyyy-MM-dd HH:mm:ss} (local)"
@@ -726,12 +737,23 @@ public partial class MainWindow : Window
                 RecommendationsLoadingText.Visibility = Visibility.Visible;
                 RecommendationsScroll.Visibility = Visibility.Collapsed;
                 RecommendationsEmptyText.Visibility = Visibility.Collapsed;
+                RecommendationsInsufficientText.Visibility = Visibility.Collapsed;
+                break;
+
+            case RecommendationsState.InsufficientData:
+                RecommendationsLoadingText.Visibility = Visibility.Collapsed;
+                RecommendationsSectionsList.ItemsSource = null;
+                RecommendationsScroll.Visibility = Visibility.Collapsed;
+                RecommendationsEmptyText.Visibility = Visibility.Collapsed;
+                RecommendationsInsufficientText.Text = vm.InsufficientDataMessage;
+                RecommendationsInsufficientText.Visibility = Visibility.Visible;
                 break;
 
             case RecommendationsState.Empty:
                 RecommendationsLoadingText.Visibility = Visibility.Collapsed;
                 RecommendationsSectionsList.ItemsSource = null;
                 RecommendationsScroll.Visibility = Visibility.Collapsed;
+                RecommendationsInsufficientText.Visibility = Visibility.Collapsed;
                 RecommendationsEmptyText.Visibility = Visibility.Visible;
                 break;
 
@@ -739,6 +761,7 @@ public partial class MainWindow : Window
             default:
                 RecommendationsLoadingText.Visibility = Visibility.Collapsed;
                 RecommendationsEmptyText.Visibility = Visibility.Collapsed;
+                RecommendationsInsufficientText.Visibility = Visibility.Collapsed;
                 RecommendationsSectionsList.ItemsSource = vm.Sections;
                 RecommendationsScroll.Visibility = Visibility.Visible;
                 break;

--- a/Darling/PerformanceMonitor.Darling.Viewer/RecommendationsViewModel.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/RecommendationsViewModel.cs
@@ -32,17 +32,25 @@ public enum RecommendationSeverity
 
 /// <summary>
 /// Which top-level state the Recommendations surface is in. The tab swaps a single visible region
-/// per state. Mirrors Lite's <c>LiteRecommendationsState</c> minus <c>InsufficientData</c>: that
-/// state is reachable in Lite ONLY through its in-app "Generate now" (which calls the engine and
-/// reads back its insufficient-data determination). The Darling service runs analysis on its own
-/// 30-minute cadence, so the viewer has no engine call and cannot distinguish "collecting" from
-/// "all clear" — a read with zero findings is simply <see cref="Empty"/>. See the header comment on
-/// the Recommendations tab in MainWindow for the Generate-now -> cadence-note deviation.
+/// per state. Mirrors Lite's <c>LiteRecommendationsState</c>, including <see cref="InsufficientData"/>:
+/// Lite reaches that state through its in-app engine call (which reads back the insufficient-data
+/// determination), whereas the Darling service runs analysis on its own cadence and PERSISTS the
+/// determination to the V19 <c>analysis_state</c> marker (<c>DarlingObservability.WriteAnalysisStateAsync</c>).
+/// The viewer reads that marker alongside the findings, so a zero-finding read on a young deployment
+/// (the engine skipped for want of its 24h history) renders <see cref="InsufficientData"/> — "still
+/// collecting" — instead of a false <see cref="Empty"/> all-clear.
 /// </summary>
 public enum RecommendationsState
 {
     /// <summary>A read is in flight.</summary>
     Loading,
+
+    /// <summary>
+    /// The read produced zero recommendations AND the persisted analysis-state marker says the engine
+    /// has not yet cleared its minimum-history window (the 24h data-span gate) — recommendations are not
+    /// meaningful yet, so "still collecting" is shown rather than a false all-clear.
+    /// </summary>
+    InsufficientData,
 
     /// <summary>The read completed and produced zero recommendations — the all-clear.</summary>
     Empty,
@@ -363,32 +371,68 @@ public sealed class RecommendationsViewModel
     /// <summary>The selected top-level state.</summary>
     public RecommendationsState State { get; }
 
+    /// <summary>
+    /// The message shown in the <see cref="RecommendationsState.InsufficientData"/> state — the engine's
+    /// own persisted message, or <see cref="DefaultInsufficientDataMessage"/> when it supplied none. Empty
+    /// in every other state.
+    /// </summary>
+    public string InsufficientDataMessage { get; }
+
     /// <summary>Total card count across all sections.</summary>
     public int TotalCount => Sections.Sum(s => s.Count);
 
-    private RecommendationsViewModel(IReadOnlyList<RecommendationSectionViewModel> sections, RecommendationsState state)
+    private RecommendationsViewModel(
+        IReadOnlyList<RecommendationSectionViewModel> sections, RecommendationsState state, string insufficientDataMessage)
     {
         Sections = sections;
         State = state;
+        InsufficientDataMessage = insufficientDataMessage;
     }
+
+    /// <summary>The default insufficient-data prose when the engine supplied no message (mirrors Lite's).</summary>
+    public const string DefaultInsufficientDataMessage =
+        "Still collecting — the engine needs about 24 hours of history before recommendations are " +
+        "meaningful. Keep the collector running and check back later.";
 
     /// <summary>Builds the loading-state view-model (no data yet, read in flight).</summary>
     public static RecommendationsViewModel Loading() =>
-        new(Array.Empty<RecommendationSectionViewModel>(), RecommendationsState.Loading);
+        new(Array.Empty<RecommendationSectionViewModel>(), RecommendationsState.Loading, string.Empty);
 
     /// <summary>
-    /// Builds a loaded/empty view-model from the persisted finding rows. Maps each row to an
-    /// advise-only item, appends the co-fired cross-reference, and groups by incident. The state is
-    /// <see cref="RecommendationsState.Empty"/> when there are no rows, else
-    /// <see cref="RecommendationsState.Loaded"/>. <paramref name="utcOffsetMinutes"/> is carried onto
-    /// each card for the Ask-AI prompt's window. The rows arrive pre-sorted (severity band desc, raw
-    /// desc, database, title) from the read, and grouping preserves that order.
+    /// Builds the insufficient-data-state view-model from the persisted analysis-state marker's message
+    /// (or the default when it is null/blank) — the viewer's mirror of Lite's
+    /// <c>LiteRecommendationsViewModel.InsufficientData</c>, sourced from the V19 marker the Darling
+    /// service writes rather than a live engine call.
+    /// </summary>
+    public static RecommendationsViewModel InsufficientData(string? message) =>
+        new(
+            Array.Empty<RecommendationSectionViewModel>(),
+            RecommendationsState.InsufficientData,
+            string.IsNullOrWhiteSpace(message) ? DefaultInsufficientDataMessage : message!);
+
+    /// <summary>
+    /// Builds a loaded/empty/insufficient-data view-model from the persisted finding rows and the
+    /// per-server analysis-state marker. Maps each row to an advise-only item, appends the co-fired
+    /// cross-reference, and groups by incident. State selection:
+    /// <list type="bullet">
+    /// <item>one or more findings -> <see cref="RecommendationsState.Loaded"/> (findings always win);</item>
+    /// <item>zero findings AND <paramref name="insufficientData"/> (the persisted marker says the engine
+    /// has not cleared its 24h data-span gate) -> <see cref="RecommendationsState.InsufficientData"/>
+    /// ("still collecting");</item>
+    /// <item>zero findings and no insufficient-data marker -> <see cref="RecommendationsState.Empty"/>
+    /// (the genuine all-clear — enough data, nothing to report).</item>
+    /// </list>
+    /// <paramref name="utcOffsetMinutes"/> is carried onto each card for the Ask-AI prompt's window. The
+    /// rows arrive pre-sorted (severity band desc, raw desc, database, title) from the read, and grouping
+    /// preserves that order. <paramref name="insufficientData"/> defaults false so the callers that carry
+    /// no marker keep the prior loaded/empty behavior.
     /// </summary>
     public static RecommendationsViewModel FromFindings(
-        IReadOnlyList<ViewerFindingRow> rows, string serverName, int utcOffsetMinutes = 0)
+        IReadOnlyList<ViewerFindingRow> rows, string serverName, int utcOffsetMinutes = 0,
+        bool insufficientData = false, string? insufficientDataMessage = null)
     {
         if (rows is null || rows.Count == 0)
-            return new(Array.Empty<RecommendationSectionViewModel>(), RecommendationsState.Empty);
+            return ZeroFindingState(insufficientData, insufficientDataMessage);
 
         var items = new List<RecommendationItem>(rows.Count);
         foreach (var row in rows)
@@ -399,11 +443,22 @@ public sealed class RecommendationsViewModel
         }
 
         if (items.Count == 0)
-            return new(Array.Empty<RecommendationSectionViewModel>(), RecommendationsState.Empty);
+            return ZeroFindingState(insufficientData, insufficientDataMessage);
 
         AppendCoFired(items);
-        return new(GroupByIncident(items, utcOffsetMinutes), RecommendationsState.Loaded);
+        return new(GroupByIncident(items, utcOffsetMinutes), RecommendationsState.Loaded, string.Empty);
     }
+
+    /// <summary>
+    /// Picks the state for a zero-finding read: <see cref="RecommendationsState.InsufficientData"/> when
+    /// the persisted marker says the analysis pass has not cleared the 24h data-span gate (so the tab
+    /// shows "still collecting" rather than a false all-clear), else <see cref="RecommendationsState.Empty"/>
+    /// (a genuine all-clear).
+    /// </summary>
+    private static RecommendationsViewModel ZeroFindingState(bool insufficientData, string? message) =>
+        insufficientData
+            ? InsufficientData(message)
+            : new(Array.Empty<RecommendationSectionViewModel>(), RecommendationsState.Empty, string.Empty);
 
     /// <summary>
     /// Maps one persisted finding row to an advise-only <see cref="RecommendationItem"/>. Reuses the

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Findings.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Findings.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Npgsql;
 using PerformanceMonitor.Analysis;
 using PerformanceMonitor.Darling.Analysis;
 using PerformanceMonitor.Notifications;
@@ -56,11 +57,63 @@ public sealed class ViewerFindingRow
     public string MutedLabel => IsMuted ? "Muted" : "";
 }
 
+/// <summary>
+/// The per-server analysis-state marker (V19) the Darling service writes after each analysis pass:
+/// whether the pass hit the 24h data-span gate (<see cref="InsufficientData"/> true, with the engine's
+/// <see cref="Message"/>) or completed on enough data (false). The Recommendations tab reads it so a
+/// zero-finding young deployment shows "still collecting" instead of a false all-clear. A read yields
+/// <c>null</c> when no pass has run for the server yet (no row), which the tab treats as "not
+/// insufficient" — an explicit marker is required to show the collecting state.
+/// </summary>
+public sealed record AnalysisStateMarker(bool InsufficientData, string? Message, DateTime AnalysisTimeUtc);
+
 public sealed partial class ViewerDataService
 {
     private PgFindingStore? _findingStore;
 
     private static readonly JsonSerializerOptions s_indentedJson = new() { WriteIndented = true };
+
+    /// <summary>
+    /// The per-server analysis-state marker (V19). Bare <c>analysis_state</c> resolves through the
+    /// database-default search path to <c>collect.analysis_state</c> (the same schema the viewer reads
+    /// <c>analysis_findings</c> from).
+    /// </summary>
+    public const string GetAnalysisStateSql = @"
+SELECT insufficient_data, message, analysis_time
+FROM analysis_state
+WHERE server_id = $1";
+
+    /// <summary>
+    /// Reads the per-server analysis-state marker the Darling service writes after each analysis pass
+    /// (<c>DarlingObservability.WriteAnalysisStateAsync</c>). Returns <c>null</c> when no pass has run for
+    /// the server yet (no row) — the tab then treats a zero-finding read as a genuine all-clear. Degrades
+    /// to <c>null</c> on any read error (a store not yet migrated to V19, a transient failure), never
+    /// throwing, matching the finding read's read-degrades discipline so the tab never crashes on it.
+    /// </summary>
+    public async Task<AnalysisStateMarker?> GetAnalysisStateAsync(int serverId)
+    {
+        try
+        {
+            await using var command = _dataSource.CreateCommand(GetAnalysisStateSql);
+            command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+
+            await using var reader = await command.ExecuteReaderAsync();
+            if (!await reader.ReadAsync())
+            {
+                return null;
+            }
+
+            var insufficient = !reader.IsDBNull(0) && reader.GetBoolean(0);
+            var message = reader.IsDBNull(1) ? null : reader.GetString(1);
+            /* Stored naive-UTC; tag Utc on read so the kind is explicit (the store-wide read discipline). */
+            var analysisTime = DateTime.SpecifyKind(reader.GetDateTime(2), DateTimeKind.Utc);
+            return new AnalysisStateMarker(insufficient, message, analysisTime);
+        }
+        catch
+        {
+            return null;
+        }
+    }
 
     /// <summary>
     /// The latest analysis run's findings for one server, mapped to display rows. Reads


### PR DESCRIPTION
## Problem

The analysis engine already determines warm-up state — `DarlingAnalysisService.InsufficientDataMessage` is set (and the AN3 pass returns `AnalysisPassStatus.InsufficientData`) when a server's total history is under the 24h data-span gate. But the viewer never **persisted or read** that determination, so a young deployment's zero-finding read collapsed to a false **"All clear."** This restores the distinct **InsufficientData** ("still collecting") state that Lite/Dashboard already have.

This is persistence + display + a small migration — the engine does the computing.

## Where the marker lives + why

New **`collect.analysis_state`** table (V19), one row per server: `server_id int PK, insufficient_data boolean, message text, analysis_time timestamp`.

- **`collect`, not `config`.** The marker is service-produced **observed analysis output the viewer reads** — the exact role of the `collect` schema (home of `analysis_findings`, `collection_log`, `servers`). `config` is the opposite direction (viewer-writes-desired-state the service reads: `config_monitored_servers`, `analysis_muted`). It's the sibling of `collect.analysis_findings`: same producer (the analysis pass), same consumer (the Recommendations tab).
- **Grants line up automatically.** The migration creates it as owner `darling`; `ALTER DEFAULT PRIVILEGES … IN SCHEMA collect GRANT SELECT … TO admin, viewer` (DarlingManagedRoles) gives both viewer identities read with no per-table grant, and the owner (the service) writes it. So it's service-writable + viewer-readable with the correct semantic direction.
- **Dedicated single-row table** (not columns on `collect.servers`) isolates the analysis writer from the connect-registry upsert (which must never clobber, cf. `is_enabled`) and gives a clean `ON CONFLICT (server_id) DO UPDATE`. Schema-qualified `collect.` (mirror of V17/V18's `config.`). No `v_*` passthrough view (no Lite SQL ports through it).

## Changes

**Storage** — `StorageVersion` 18→19; `PgMigrations` gains `Migration(19, "analysis-state-marker", V19Sql)`.

**Service** — `RunAnalysisPassAsync` writes the marker after each pass via new failure-isolated `DarlingObservability.WriteAnalysisStateAsync` (mirrors the other observability writes): `insufficient_data = true` + the engine's message when the pass hit the data-span gate, cleared (`false`) when a real pass completed. Only the two real terminal states write it; a Skipped/TimedOut/Error pass leaves the last marker untouched.

**Viewer** — `RecommendationsState` gains `InsufficientData`; `RecommendationsViewModel.FromFindings` accepts the marker and, on a zero-finding read with the marker set, returns the `InsufficientData` state (engine message or a default "still collecting — ~24h of history" prose) instead of `Empty`. Findings always win (a server with findings shows them). `ViewerDataService.GetAnalysisStateAsync` reads the marker (degrades to null on a pre-V19 store / error). `MainWindow` reads it alongside findings and renders a new message region.

## Testing

- **V19 migration shape** + count pin (18→19), schema placement (collect, not config), PK, no `v_*` view.
- **Service marker write** (gated live + ungated SQL-shape pin): insufficient→true+message, sufficient→false+null, single row (upsert overwrites).
- **Viewer state selection** (pure): insufficient+zero-findings → InsufficientData; data+zero → AllClear (Empty); findings present → Loaded; default-vs-engine message.
- Full `Darling.Tests -c Release`: **1592 passed, 124 skipped (live-PG gated), 0 failed.**
- **V19 live-validated** on an isolated scratch DB on :5641 via psql (create + migrate V1→V19 + verify table/columns/PK/schema + drop). The `darling` database and the running service were not touched.

No `install/*.sql` changes.