### PR TITLE
Add deadlock victim + wait-time aggregate to Darling viewer Blocking Stats (#1429)

### DIFF
--- a/Darling/Darling.Tests/ViewerDeadlockSeverityStatsTests.cs
+++ b/Darling/Darling.Tests/ViewerDeadlockSeverityStatsTests.cs
@@ -1,0 +1,357 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Npgsql;
+using PerformanceMonitor.Collectors;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.Darling.Storage;
+using PerformanceMonitor.Darling.Viewer;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Pins the Blocking Stats sub-tab's deadlock-SEVERITY aggregate — the on-the-fly Darling equivalent of the
+/// Dashboard's <c>collect.blocking_deadlock_stats</c> victim_count / total_deadlock_wait_time_ms, computed by
+/// parsing the stored <c>deadlock_graph_xml</c> (no collector, no migration). Two halves: (1) the read SQL,
+/// which hands back raw (deadlock_time, xml) rows over the SAME <c>v_deadlocks</c> / <c>collection_time</c>
+/// window as the deadlock COUNT trend so the two reconcile in period; (2) the pure parse→aggregate logic that
+/// buckets by minute and sums the shared <see cref="DeadlockGraphParser"/>'s per-process IsVictim / WaitTimeMs.
+/// No live Postgres (the live round-trip is the gated sibling class below).
+/// </summary>
+public sealed class ViewerDeadlockSeverityStatsSqlTests
+{
+    [Fact]
+    public void DeadlockSeverityGraphsSql_ReadsGraphAndTime_FromDeadlocksView()
+    {
+        /* The read pulls only what the C# aggregate needs: the bucket key (deadlock_time) and the payload
+           the shared parser reads (deadlock_graph_xml) — nothing is aggregated in SQL. */
+        Assert.Contains("FROM v_deadlocks", ViewerDataService.DeadlockSeverityGraphsSql, StringComparison.Ordinal);
+        Assert.Contains("deadlock_time", ViewerDataService.DeadlockSeverityGraphsSql, StringComparison.Ordinal);
+        Assert.Contains("deadlock_graph_xml", ViewerDataService.DeadlockSeverityGraphsSql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DeadlockSeverityGraphsSql_WindowsOnCollectionTime_ReconcilesWithCountTrend()
+    {
+        /* Reconciliation: the deadlock COUNT trend windows on collection_time (NOT deadlock_time). To draw from
+           the identical row set — so the count on the summary strip and the victim/wait aggregate agree in
+           period — this read must window on collection_time too. */
+        Assert.Contains("collection_time >= $2", ViewerDataService.DeadlockSeverityGraphsSql, StringComparison.Ordinal);
+        Assert.Contains("collection_time <= $3", ViewerDataService.DeadlockSeverityGraphsSql, StringComparison.Ordinal);
+        Assert.Contains("collection_time >= $2", ViewerDataService.DeadlockTrendSql, StringComparison.Ordinal);
+        Assert.Contains("collection_time <= $3", ViewerDataService.DeadlockTrendSql, StringComparison.Ordinal);
+        /* The window is NOT applied on deadlock_time (that column is only the SELECT'd bucket key + ORDER BY). */
+        Assert.DoesNotContain("deadlock_time >=", ViewerDataService.DeadlockSeverityGraphsSql, StringComparison.Ordinal);
+        Assert.DoesNotContain("deadlock_time <=", ViewerDataService.DeadlockSeverityGraphsSql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DeadlockSeverityGraphsSql_HasNoCap_SoItCannotDropRowsTheCountTrendKeeps()
+    {
+        /* No LIMIT: deadlocks are rare (low volume), and any cap would silently drop rows the un-capped count
+           trend keeps, breaking reconciliation. If a cap is ever needed it must be surfaced, not silent. */
+        Assert.DoesNotContain("LIMIT", ViewerDataService.DeadlockSeverityGraphsSql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DeadlockSeverityGraphsSql_PgDialect_PositionalParams_NoBareNow_NoNLiterals()
+    {
+        var sql = ViewerDataService.DeadlockSeverityGraphsSql;
+        Assert.DoesNotContain("now(", sql.ToLowerInvariant());
+        Assert.DoesNotContain("N'", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("@", sql, StringComparison.Ordinal);
+        Assert.Contains("$1", sql, StringComparison.Ordinal);
+        Assert.Contains("$2", sql, StringComparison.Ordinal);
+        Assert.Contains("$3", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DeadlockSeverityGraphXml_IsAnOriginalDeadlocksColumn_SoTheViewExposesIt()
+    {
+        /* Unlike victim_query_plan_xml (V7, why RecentDeadlocksSql reads the base table), deadlock_graph_xml is
+           an original deadlocks column, so the SELECT * view (v_deadlocks) projects it. The generated DDL pins
+           that the column exists; the gated live test proves the view actually returns it. */
+        var ddl = PgSchemaGenerator.CreateTable(DeadlocksCollector.Instance);
+        Assert.Contains("deadlock_graph_xml", ddl, StringComparison.Ordinal);
+        Assert.Contains("deadlock_time", ddl, StringComparison.Ordinal);
+    }
+}
+
+/// <summary>
+/// Pins the pure parse→aggregate core (<see cref="ViewerDataService.AggregateDeadlockSeverity"/>): buckets the
+/// deadlock graphs by minute and sums the shared parser's per-process IsVictim / WaitTimeMs into victim_count
+/// and total / max / avg deadlock wait — the Dashboard analyzer's exact semantics
+/// (26_blocking_deadlock_analyzer.sql: victim_count = SUM(IsVictim); total = SUM(every process's wait)).
+/// Driven by the REAL sql2025 deadlock fixtures (documented victim counts) plus synthetic graphs with known
+/// wait times for exact total/max/avg. No database, no WPF.
+/// </summary>
+public sealed class DeadlockSeverityAggregationTests
+{
+    /// <summary>Builds a bare &lt;deadlock&gt; graph (what the store keeps) from known processes, so a test can
+    /// assert exact victim_count / total / max / avg without depending on a captured fixture's wait times.</summary>
+    private static string BuildGraph(params (string Id, int Spid, long WaitTime, bool IsVictim)[] processes)
+    {
+        var sb = new StringBuilder();
+        sb.Append("<deadlock><victim-list>");
+        foreach (var p in processes.Where(p => p.IsVictim))
+            sb.Append($"<victimProcess id=\"{p.Id}\"/>");
+        sb.Append("</victim-list><process-list>");
+        foreach (var p in processes)
+            sb.Append($"<process id=\"{p.Id}\" spid=\"{p.Spid}\" waittime=\"{p.WaitTime}\"><inputbuf>x</inputbuf></process>");
+        sb.Append("</process-list></deadlock>");
+        return sb.ToString();
+    }
+
+    private static readonly DateTime MinuteA = new(2026, 6, 21, 6, 51, 0, DateTimeKind.Unspecified);
+    private static readonly DateTime MinuteB = new(2026, 6, 21, 6, 53, 0, DateTimeKind.Unspecified);
+
+    [Fact]
+    public void SingleGraph_SumsVictimsAndWaits_AvgIsProcessWeighted()
+    {
+        var graph = BuildGraph(
+            ("p1", 55, 1000, true),
+            ("p2", 66, 3000, false));
+
+        var points = ViewerDataService.AggregateDeadlockSeverity(
+            new (DateTime?, string?)[] { (MinuteA.AddSeconds(30), graph) });
+
+        var point = Assert.Single(points);
+        Assert.Equal(MinuteA, point.Time);               // bucketed to the minute
+        Assert.Equal(1, point.VictimCount);              // p1 only
+        Assert.Equal(4000, point.TotalWaitMs);           // 1000 + 3000
+        Assert.Equal(3000, point.MaxWaitMs);             // max process wait
+        Assert.Equal(2000.0, point.AvgWaitMs, precision: 3); // 4000 / 2 processes
+    }
+
+    [Fact]
+    public void MultipleGraphs_SameMinute_CollapseIntoOneBucket()
+    {
+        /* Two deadlocks in the same minute → one bucket summing victims + waits across BOTH graphs. */
+        var graphs = new (DateTime?, string?)[]
+        {
+            (MinuteA.AddSeconds(10), BuildGraph(("a1", 55, 1000, true), ("a2", 66, 3000, false))),
+            (MinuteA.AddSeconds(50), BuildGraph(("b1", 77, 2000, true))),
+        };
+
+        var point = Assert.Single(ViewerDataService.AggregateDeadlockSeverity(graphs));
+        Assert.Equal(MinuteA, point.Time);
+        Assert.Equal(2, point.VictimCount);              // one victim per graph
+        Assert.Equal(6000, point.TotalWaitMs);           // 1000 + 3000 + 2000
+        Assert.Equal(3000, point.MaxWaitMs);
+        Assert.Equal(2000.0, point.AvgWaitMs, precision: 3); // 6000 / 3 processes
+    }
+
+    [Fact]
+    public void MultipleGraphs_DifferentMinutes_ProduceOrderedBuckets()
+    {
+        /* Fed out of order; the aggregate must return buckets ordered by time (parity with the SQL ORDER BY). */
+        var graphs = new (DateTime?, string?)[]
+        {
+            (MinuteB.AddSeconds(5), BuildGraph(("b1", 77, 500, true), ("b2", 88, 700, false))),
+            (MinuteA.AddSeconds(5), BuildGraph(("a1", 55, 1000, true))),
+        };
+
+        var points = ViewerDataService.AggregateDeadlockSeverity(graphs);
+        Assert.Equal(2, points.Count);
+        Assert.Equal(MinuteA, points[0].Time);
+        Assert.Equal(MinuteB, points[1].Time);
+        Assert.Equal(1, points[0].VictimCount);
+        Assert.Equal(1200, points[1].TotalWaitMs);       // 500 + 700
+        Assert.Equal(700, points[1].MaxWaitMs);
+    }
+
+    [Fact]
+    public void NullDeadlockTime_IsSkipped_CannotBeBucketed()
+    {
+        var graphs = new (DateTime?, string?)[]
+        {
+            (null, BuildGraph(("p1", 55, 1000, true))),
+            (MinuteA.AddSeconds(5), BuildGraph(("p2", 66, 2000, true))),
+        };
+
+        var point = Assert.Single(ViewerDataService.AggregateDeadlockSeverity(graphs));
+        Assert.Equal(MinuteA, point.Time);
+        Assert.Equal(2000, point.TotalWaitMs);           // only the placeable graph
+    }
+
+    [Fact]
+    public void EmptyOrMalformedXml_ContributesNothing()
+    {
+        var graphs = new (DateTime?, string?)[]
+        {
+            (MinuteA.AddSeconds(1), null),
+            (MinuteA.AddSeconds(2), ""),
+            (MinuteA.AddSeconds(3), "<not-a-deadlock/>"),
+            (MinuteA.AddSeconds(4), "<deadlock><oops"),   // unparseable
+        };
+
+        Assert.Empty(ViewerDataService.AggregateDeadlockSeverity(graphs));
+    }
+
+    [Fact]
+    public void Real2ProcFixture_OneVictim_ExactWaitSums()
+    {
+        /* deadlock_2proc_real_sql2025.xml: spid 103 (VICTIM, waittime 630) + spid 85 (waittime 626). */
+        var xml = DeadlockGraphParserTests.LoadFixture("deadlock_2proc_real_sql2025.xml");
+        var point = Assert.Single(ViewerDataService.AggregateDeadlockSeverity(
+            new (DateTime?, string?)[] { (MinuteA.AddSeconds(30), xml) }));
+
+        Assert.Equal(1, point.VictimCount);
+        Assert.Equal(1256, point.TotalWaitMs);           // 630 + 626
+        Assert.Equal(630, point.MaxWaitMs);
+        Assert.Equal(628.0, point.AvgWaitMs, precision: 3); // 1256 / 2
+    }
+
+    [Theory]
+    [InlineData("deadlock_2proc_real_sql2025.xml", 1)]
+    [InlineData("deadlock_5proc_real_sql2025.xml", 2)]
+    [InlineData("deadlock_8proc_multivictim_real_sql2025.xml", 4)]
+    public void RealFixtures_VictimCountAndWaitSum_MatchTheSharedParser(string fixture, int expectedVictims)
+    {
+        /* The documented victim counts (README) are absolute ground truth; the wait sums are cross-checked
+           against the shared parser so this pins that the aggregate faithfully SUMS what the parser produces
+           (the parser itself is covered by DeadlockGraphParserTests). */
+        var xml = DeadlockGraphParserTests.LoadFixture(fixture);
+        var model = DeadlockGraphParser.Parse(xml);
+        long expectedTotal = model.Processes.Sum(p => p.WaitTimeMs);
+        long expectedMax = model.Processes.Max(p => p.WaitTimeMs);
+
+        var point = Assert.Single(ViewerDataService.AggregateDeadlockSeverity(
+            new (DateTime?, string?)[] { (MinuteA.AddSeconds(15), xml) }));
+
+        Assert.Equal(expectedVictims, point.VictimCount);
+        Assert.Equal(expectedTotal, point.TotalWaitMs);
+        Assert.Equal(expectedMax, point.MaxWaitMs);
+    }
+
+    [Fact]
+    public void BucketVictimCount_NeverExceedsProcesses_ButAtLeastOnePerRealDeadlock()
+    {
+        /* Reconciliation sanity: each real deadlock contributes >= 1 victim to its bucket, so the summed
+           victim_count is a coherent companion to the deadlock COUNT drawn from the same window. */
+        var xml = DeadlockGraphParserTests.LoadFixture("deadlock_5proc_real_sql2025.xml");
+        var point = Assert.Single(ViewerDataService.AggregateDeadlockSeverity(
+            new (DateTime?, string?)[] { (MinuteA.AddSeconds(15), xml) }));
+
+        Assert.True(point.VictimCount >= 1);
+        Assert.True(point.VictimCount <= DeadlockGraphParser.Parse(xml).Processes.Count);
+    }
+}
+
+/// <summary>
+/// Gated (DARLING_TEST_PG) live round-trip for the deadlock-severity aggregate: proves the read executes
+/// against the real migrated schema (in particular that <c>v_deadlocks</c> exposes <c>deadlock_graph_xml</c>),
+/// windows on collection_time, and that the C# parse→bucket produces the right per-minute victim / total /
+/// max / avg. Shares the serialized "live-postgres" collection; uses a negative sentinel server_id + finally
+/// cleanup so it can't race or leak.
+/// </summary>
+[Collection("live-postgres")]
+public sealed class ViewerDeadlockSeverityLivePostgresTests
+{
+    private const int SeverityServerId = -972101;
+    private const string ServerName = "viewer-deadlock-severity-e2e";
+
+    [Fact]
+    public async Task DeadlockSeverity_BucketsPerMinute_VictimTotalMaxAvg_AgainstDevPostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the live deadlock-severity-stats test.");
+
+        using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await PgMigrations.MigrateAsync(connection, TestContext.Current.CancellationToken);
+        await DeleteRowsAsync(connection, SeverityServerId);
+
+        await using var viewer = new ViewerDataService(connectionString!);
+
+        try
+        {
+            var baseTime = TruncateToMinute(DateTime.UtcNow.AddMinutes(-10));
+            var minuteA = baseTime;
+            var minuteB = baseTime.AddMinutes(3);
+
+            /* minute A: two deadlocks (2 victims total, waits 1000+3000 then 2000 → total 6000, max 3000,
+               3 processes → avg 2000); minute B: one deadlock (1 victim, waits 500+700 → total 1200, max 700,
+               2 processes → avg 600). */
+            await InsertDeadlockAsync(connection, minuteA, minuteA.AddSeconds(10),
+                BuildGraph(("a1", 55, 1000, true), ("a2", 66, 3000, false)));
+            await InsertDeadlockAsync(connection, minuteA, minuteA.AddSeconds(40),
+                BuildGraph(("b1", 77, 2000, true)));
+            await InsertDeadlockAsync(connection, minuteB, minuteB.AddSeconds(10),
+                BuildGraph(("c1", 88, 500, true), ("c2", 99, 700, false)));
+
+            var points = await viewer.GetDeadlockSeverityStatsAsync(
+                SeverityServerId, baseTime.AddMinutes(-1), baseTime.AddMinutes(10));
+
+            Assert.Equal(2, points.Count);
+            Assert.True(points[0].Time < points[1].Time);
+
+            Assert.Equal(2, points[0].VictimCount);
+            Assert.Equal(6000, points[0].TotalWaitMs);
+            Assert.Equal(3000, points[0].MaxWaitMs);
+            Assert.Equal(2000.0, points[0].AvgWaitMs, precision: 3);
+
+            Assert.Equal(1, points[1].VictimCount);
+            Assert.Equal(1200, points[1].TotalWaitMs);
+            Assert.Equal(700, points[1].MaxWaitMs);
+            Assert.Equal(600.0, points[1].AvgWaitMs, precision: 3);
+        }
+        finally
+        {
+            await DeleteRowsAsync(connection, SeverityServerId);
+        }
+    }
+
+    private static string BuildGraph(params (string Id, int Spid, long WaitTime, bool IsVictim)[] processes)
+    {
+        var sb = new StringBuilder();
+        sb.Append("<deadlock><victim-list>");
+        foreach (var p in processes.Where(p => p.IsVictim))
+            sb.Append($"<victimProcess id=\"{p.Id}\"/>");
+        sb.Append("</victim-list><process-list>");
+        foreach (var p in processes)
+            sb.Append($"<process id=\"{p.Id}\" spid=\"{p.Spid}\" waittime=\"{p.WaitTime}\"><inputbuf>x</inputbuf></process>");
+        sb.Append("</process-list></deadlock>");
+        return sb.ToString();
+    }
+
+    private static async Task InsertDeadlockAsync(
+        NpgsqlConnection connection, DateTime collectionTimeUtc, DateTime deadlockTimeUtc, string graphXml)
+    {
+        using var command = new NpgsqlCommand(@"
+INSERT INTO deadlocks
+    (deadlock_id, collection_time, server_id, server_name, deadlock_time,
+     victim_process_id, victim_sql_text, deadlock_graph_xml)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)", connection);
+        command.Parameters.AddWithValue(1L);
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTimeUtc, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(SeverityServerId);
+        command.Parameters.AddWithValue(ServerName);
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(deadlockTimeUtc, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue("a1");
+        command.Parameters.AddWithValue("UPDATE t SET c = 1");
+        command.Parameters.AddWithValue(graphXml);
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static DateTime TruncateToMinute(DateTime value) =>
+        DateTime.SpecifyKind(new DateTime(value.Ticks - (value.Ticks % TimeSpan.TicksPerMinute)), DateTimeKind.Unspecified);
+
+    private static async Task DeleteRowsAsync(NpgsqlConnection connection, int serverId)
+    {
+        using var cleanup = new NpgsqlCommand($"DELETE FROM deadlocks WHERE server_id = {serverId};", connection);
+        await cleanup.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.BlockingStats.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.BlockingStats.cs
@@ -8,9 +8,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql;
+using PerformanceMonitor.Common;
 
 namespace PerformanceMonitor.Darling.Viewer;
 
@@ -25,6 +27,22 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// </summary>
 public sealed record BlockingDurationStatsPoint(
     DateTime Time, int EventCount, long TotalDurationMs, long MaxDurationMs, double AvgDurationMs);
+
+/// <summary>
+/// One per-minute bucket of deadlock SEVERITY (the Blocking Stats sub-tab's deadlock companion to
+/// <see cref="BlockingDurationStatsPoint"/>): the count of deadlock VICTIM processes in the bucket plus the
+/// total / max / avg deadlock <c>wait_time_ms</c> over EVERY process in the bucket's graphs. The on-the-fly
+/// Darling equivalent of the Dashboard's pre-aggregated <c>collect.blocking_deadlock_stats</c>
+/// (<c>victim_count</c> / <c>total_deadlock_wait_time_ms</c>) — computed by parsing the
+/// <c>deadlock_graph_xml</c> the store already keeps, so (like the blocking-duration aggregate) it needs no
+/// collector and no schema change. Matches the Dashboard analyzer's exact semantics
+/// (<c>26_blocking_deadlock_analyzer.sql</c>: <c>victim_count = SUM(CASE WHEN … VICTIM)</c>,
+/// <c>total_deadlock_wait_time_ms = SUM(every process's wait_time)</c>) via the shared
+/// <see cref="DeadlockGraphParser"/>'s per-process <see cref="DeadlockProcessNode.IsVictim"/> /
+/// <see cref="DeadlockProcessNode.WaitTimeMs"/>.
+/// </summary>
+public sealed record DeadlockSeverityStatsPoint(
+    DateTime Time, int VictimCount, long TotalWaitMs, long MaxWaitMs, double AvgWaitMs);
 
 public sealed partial class ViewerDataService
 {
@@ -104,4 +122,128 @@ public sealed partial class ViewerDataService
 
         return items;
     }
+
+    /// <summary>
+    /// The deadlock graphs in the window, for the deadlock-severity aggregate. Deliberately parses NOTHING in
+    /// SQL: the victim / wait-time signal lives inside <c>deadlock_graph_xml</c>, which only the shared
+    /// <see cref="DeadlockGraphParser"/> can read, so this read hands back just the raw
+    /// (<c>deadlock_time</c>, <c>deadlock_graph_xml</c>) pairs and the C# aggregate does the parse + bucket.
+    ///
+    /// <para>Windows on <c>collection_time</c> (NOT <c>deadlock_time</c>) and reads <c>v_deadlocks</c> — the
+    /// IDENTICAL row-selection predicate the deadlock COUNT trend (<see cref="DeadlockTrendSql"/>) uses — so
+    /// the count already shown on this tab's summary strip and the new victim_count / wait aggregate are drawn
+    /// from the exact same set of deadlock rows and reconcile in period. Bucketing (on <c>deadlock_time</c>,
+    /// matching the count trend's <c>DATE_TRUNC('minute', deadlock_time)</c>) happens C#-side after the parse,
+    /// so it is not expressed here. <c>deadlock_graph_xml</c> is an original deadlocks column (predates the V7
+    /// <c>victim_query_plan_xml</c>), so unlike <see cref="RecentDeadlocksSql"/> the view exposes it.
+    /// No LIMIT: deadlocks are rare, and a cap would drop rows the count trend keeps (breaking reconciliation).
+    /// $1 server_id, $2 window start, $3 window end (naive UTC).</para>
+    /// </summary>
+    public const string DeadlockSeverityGraphsSql = """
+        SELECT
+            deadlock_time,
+            deadlock_graph_xml
+        FROM v_deadlocks
+        WHERE server_id = $1
+        AND   collection_time >= $2
+        AND   collection_time <= $3
+        ORDER BY deadlock_time
+        """;
+
+    /// <summary>
+    /// Deadlock-severity buckets for one server over the window (Blocking Stats sub-tab): victim count and
+    /// total / max / avg deadlock wait per minute. Reads the raw graphs (async I/O), then parses + aggregates
+    /// them OFF the UI thread (<see cref="Task.Run"/>) — the graph walk is CPU-bound XML work, the same reason
+    /// the Deadlocks grid parses off-thread. Reconciles in period with the deadlock COUNT trend (same
+    /// <c>v_deadlocks</c> / <c>collection_time</c> window).
+    /// </summary>
+    public async Task<List<DeadlockSeverityStatsPoint>> GetDeadlockSeverityStatsAsync(
+        int serverId, DateTime startUtc, DateTime endUtc, CancellationToken cancellationToken = default)
+    {
+        var graphs = new List<(DateTime? DeadlockTime, string? Xml)>();
+
+        await using var command = _dataSource.CreateCommand(DeadlockSeverityGraphsSql);
+        AddBlockingParameters(command, serverId, startUtc, endUtc);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            graphs.Add((
+                reader.IsDBNull(0) ? null : reader.GetDateTime(0),
+                reader.IsDBNull(1) ? null : reader.GetString(1)));
+        }
+
+        /* Parse each graph + aggregate on the thread pool (Lite's #1193 discipline): deadlocks are low-volume,
+           but the sp_BlitzLock-style walk is still CPU-bound, so it never runs on the dispatcher. */
+        return await Task.Run(() => AggregateDeadlockSeverity(graphs), cancellationToken);
+    }
+
+    /// <summary>
+    /// Parses each deadlock graph via the shared <see cref="DeadlockGraphParser"/> and rolls the processes up
+    /// into per-minute severity buckets (bucketed on <c>deadlock_time</c> truncated to the minute, matching the
+    /// count trend's <c>DATE_TRUNC('minute', deadlock_time)</c>). Per bucket: <c>victim_count</c> = SUM of
+    /// <see cref="DeadlockProcessNode.IsVictim"/>, and total / max / avg deadlock wait over EVERY process's
+    /// <see cref="DeadlockProcessNode.WaitTimeMs"/> (avg is process-weighted = total ÷ process count) — the
+    /// Dashboard <c>collect.blocking_deadlock_stats</c> semantics. A graph with no parseable process (empty /
+    /// malformed XML) or a null <c>deadlock_time</c> (unplaceable on the time axis) contributes nothing.
+    /// Pure + off-WPF so Darling.Tests pin it without a live store; the ORDER BY is re-applied here because the
+    /// dictionary rollup does not preserve the read order.
+    /// </summary>
+    internal static List<DeadlockSeverityStatsPoint> AggregateDeadlockSeverity(
+        IReadOnlyList<(DateTime? DeadlockTime, string? Xml)> graphs)
+    {
+        var buckets = new Dictionary<DateTime, DeadlockSeverityAccumulator>();
+
+        foreach (var (deadlockTime, xml) in graphs)
+        {
+            if (deadlockTime is not { } dt)
+                continue;
+
+            var model = DeadlockGraphParser.Parse(xml);
+            if (model.IsEmpty)
+                continue;
+
+            var bucket = TruncateToMinute(dt);
+            if (!buckets.TryGetValue(bucket, out var acc))
+            {
+                acc = new DeadlockSeverityAccumulator();
+                buckets[bucket] = acc;
+            }
+
+            foreach (var process in model.Processes)
+            {
+                if (process.IsVictim)
+                    acc.VictimCount++;
+                acc.TotalWaitMs += process.WaitTimeMs;
+                if (process.WaitTimeMs > acc.MaxWaitMs)
+                    acc.MaxWaitMs = process.WaitTimeMs;
+                acc.ProcessCount++;
+            }
+        }
+
+        return buckets
+            .OrderBy(kvp => kvp.Key)
+            .Select(kvp => new DeadlockSeverityStatsPoint(
+                kvp.Key,
+                kvp.Value.VictimCount,
+                kvp.Value.TotalWaitMs,
+                kvp.Value.MaxWaitMs,
+                kvp.Value.ProcessCount > 0 ? (double)kvp.Value.TotalWaitMs / kvp.Value.ProcessCount : 0.0))
+            .ToList();
+    }
+
+    /// <summary>Mutable per-bucket accumulator for <see cref="AggregateDeadlockSeverity"/> (a reference type so
+    /// the <c>TryGetValue</c> handle mutates the stored instance in place — one alloc per populated minute,
+    /// which is negligible at deadlock volumes).</summary>
+    private sealed class DeadlockSeverityAccumulator
+    {
+        public int VictimCount;
+        public long TotalWaitMs;
+        public long MaxWaitMs;
+        public int ProcessCount;
+    }
+
+    /// <summary>Truncates to the minute to match Postgres <c>DATE_TRUNC('minute', …)</c> (the count trend's
+    /// bucketing), preserving the value's <see cref="DateTimeKind"/> (naive UTC from the store).</summary>
+    private static DateTime TruncateToMinute(DateTime value) =>
+        new(value.Ticks - (value.Ticks % TimeSpan.TicksPerMinute), value.Kind);
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Blocking.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Blocking.cs
@@ -39,6 +39,8 @@ public partial class ViewerServerTab
     private ChartHoverHelper? _deadlockTrendHover;
     private ChartHoverHelper? _blockingDurationHover;
     private ChartHoverHelper? _blockingTotalDurationHover;
+    private ChartHoverHelper? _deadlockWaitHover;
+    private ChartHoverHelper? _deadlockTotalWaitHover;
     private ChartHoverHelper? _currentWaitsDurationHover;
     private ChartHoverHelper? _currentWaitsBlockedHover;
 
@@ -69,6 +71,10 @@ public partial class ViewerServerTab
         BlockingDurationChart.Refresh();
         ApplyTheme(BlockingTotalDurationChart);
         BlockingTotalDurationChart.Refresh();
+        ApplyTheme(DeadlockWaitChart);
+        DeadlockWaitChart.Refresh();
+        ApplyTheme(DeadlockTotalWaitChart);
+        DeadlockTotalWaitChart.Refresh();
         ApplyTheme(CurrentWaitsDurationChart);
         CurrentWaitsDurationChart.Refresh();
         ApplyTheme(CurrentWaitsBlockedChart);
@@ -79,6 +85,8 @@ public partial class ViewerServerTab
         _deadlockTrendHover = new ChartHoverHelper(DeadlockTrendChart, "deadlocks");
         _blockingDurationHover = new ChartHoverHelper(BlockingDurationChart, "ms");
         _blockingTotalDurationHover = new ChartHoverHelper(BlockingTotalDurationChart, "ms");
+        _deadlockWaitHover = new ChartHoverHelper(DeadlockWaitChart, "ms");
+        _deadlockTotalWaitHover = new ChartHoverHelper(DeadlockTotalWaitChart, "ms");
         _currentWaitsDurationHover = new ChartHoverHelper(CurrentWaitsDurationChart, "ms");
         _currentWaitsBlockedHover = new ChartHoverHelper(CurrentWaitsBlockedChart, "sessions");
 
@@ -138,14 +146,20 @@ public partial class ViewerServerTab
             case BlockingStatsSubTabIndex:
                 /* Blocking SEVERITY: the duration aggregate reconciles with the count trend (same XE→DMV
                    source selection); the deadlock COUNT is the cheap sibling of the Trends tab's deadlock
-                   trend, summed here for the summary strip (its per-minute buckets share this window). */
+                   trend, summed here for the summary strip. The deadlock SEVERITY aggregate (victim_count +
+                   total/max/avg wait, parsed on-the-fly from deadlock_graph_xml) is drawn from the SAME
+                   v_deadlocks/collection_time window as the count, so the two reconcile in period. */
                 var durationStatsTask = _dataService.GetBlockingDurationStatsAsync(_server.ServerId, startUtc, endUtc);
                 var deadlockCountTask = _dataService.GetDeadlockTrendAsync(_server.ServerId, startUtc, endUtc);
+                var deadlockSeverityTask = _dataService.GetDeadlockSeverityStatsAsync(_server.ServerId, startUtc, endUtc);
                 var durationStats = await durationStatsTask;
                 var deadlockCounts = await deadlockCountTask;
+                var deadlockSeverity = await deadlockSeverityTask;
                 RenderBlockingDurationChart(durationStats);
                 RenderBlockingTotalDurationChart(durationStats);
-                UpdateBlockingStatsSummary(durationStats, deadlockCounts);
+                RenderDeadlockWaitChart(deadlockSeverity);
+                RenderDeadlockTotalWaitChart(deadlockSeverity);
+                UpdateBlockingStatsSummary(durationStats, deadlockCounts, deadlockSeverity);
                 break;
             case BlockingCurrentWaitsSubTabIndex:
                 var durationTask = _dataService.GetWaitingTaskTrendAsync(_server.ServerId, startUtc, endUtc);
@@ -625,25 +639,152 @@ public partial class ViewerServerTab
     }
 
     /// <summary>
+    /// Max + Avg deadlock wait (ms) per minute — the per-process deadlock severity signal (how long the
+    /// deadlocked processes had waited before the monitor broke the cycle). Two connected-scatter series on one
+    /// shared ms axis (Max ≥ Avg, comparable magnitudes), the deadlock analog of
+    /// <see cref="RenderBlockingDurationChart"/>. Total deadlock wait lands on its own chart
+    /// (<see cref="RenderDeadlockTotalWaitChart"/>) because its aggregate magnitude dwarfs these.
+    /// </summary>
+    private void RenderDeadlockWaitChart(List<DeadlockSeverityStatsPoint> data)
+    {
+        ClearChart(DeadlockWaitChart);
+        ApplyTheme(DeadlockWaitChart);
+
+        var (winStartUtc, winEndUtc) = GetWindowUtc();
+        var rangeStart = ViewerTimeHelper.ForDisplay(winStartUtc);
+        var rangeEnd = ViewerTimeHelper.ForDisplay(winEndUtc);
+
+        _deadlockWaitHover?.Clear();
+        if (data.Count == 0)
+        {
+            var zeroLine = DeadlockWaitChart.Plot.Add.Scatter(
+                new[] { rangeStart.ToOADate(), rangeEnd.ToOADate() },
+                new[] { 0.0, 0.0 });
+            zeroLine.LegendText = "Max Deadlock Wait";
+            zeroLine.Color = ScottPlot.Color.FromHex(SeriesColors[0]);
+            zeroLine.MarkerSize = 0;
+            DeadlockWaitChart.Plot.Axes.DateTimeTicksBottomDateChange();
+            DeadlockWaitChart.Plot.Axes.SetLimitsX(rangeStart.ToOADate(), rangeEnd.ToOADate());
+            ReapplyAxisColors(DeadlockWaitChart);
+            DeadlockWaitChart.Plot.YLabel("Deadlock Wait (ms)");
+            SetChartYLimitsWithLegendPadding(DeadlockWaitChart, 0, 1);
+            ShowChartLegend(DeadlockWaitChart);
+            DeadlockWaitChart.Refresh();
+            return;
+        }
+
+        var ordered = data.OrderBy(d => d.Time).ToList();
+        var times = ordered.Select(d => ViewerTimeHelper.ForDisplay(d.Time).ToOADate()).ToArray();
+        var maxValues = ordered.Select(d => (double)d.MaxWaitMs).ToArray();
+        var avgValues = ordered.Select(d => d.AvgWaitMs).ToArray();
+
+        var maxPlot = DeadlockWaitChart.Plot.Add.Scatter(times, maxValues);
+        maxPlot.LegendText = "Max Deadlock Wait";
+        maxPlot.Color = ScottPlot.Color.FromHex(SeriesColors[0]);
+        ChartStyle.StyleScatter(maxPlot);
+        _deadlockWaitHover?.Add(maxPlot, "Max Deadlock Wait");
+
+        var avgPlot = DeadlockWaitChart.Plot.Add.Scatter(times, avgValues);
+        avgPlot.LegendText = "Avg Deadlock Wait";
+        avgPlot.Color = ScottPlot.Color.FromHex(SeriesColors[1]);
+        ChartStyle.StyleScatter(avgPlot);
+        _deadlockWaitHover?.Add(avgPlot, "Avg Deadlock Wait");
+
+        double globalMax = maxValues.Length > 0 ? maxValues.Max() : 0;
+
+        DeadlockWaitChart.Plot.Axes.DateTimeTicksBottomDateChange();
+        DeadlockWaitChart.Plot.Axes.SetLimitsX(rangeStart.ToOADate(), rangeEnd.ToOADate());
+        ReapplyAxisColors(DeadlockWaitChart);
+        DeadlockWaitChart.Plot.YLabel("Deadlock Wait (ms)");
+        SetChartYLimitsWithLegendPadding(DeadlockWaitChart, 0, globalMax > 0 ? globalMax : 1);
+        ShowChartLegend(DeadlockWaitChart);
+        DeadlockWaitChart.Refresh();
+    }
+
+    /// <summary>
+    /// Total deadlock wait (ms) per minute — the aggregate signal (the sum of every deadlocked process's wait
+    /// time in the bucket). Single connected-scatter series on its own chart/axis so its magnitude doesn't
+    /// swamp the per-process Max/Avg chart; colored with the Deadlocks identity so it reads as a sibling of the
+    /// Trends tab's deadlock-count chart. The deadlock analog of <see cref="RenderBlockingTotalDurationChart"/>.
+    /// </summary>
+    private void RenderDeadlockTotalWaitChart(List<DeadlockSeverityStatsPoint> data)
+    {
+        ClearChart(DeadlockTotalWaitChart);
+        ApplyTheme(DeadlockTotalWaitChart);
+
+        var (winStartUtc, winEndUtc) = GetWindowUtc();
+        var rangeStart = ViewerTimeHelper.ForDisplay(winStartUtc);
+        var rangeEnd = ViewerTimeHelper.ForDisplay(winEndUtc);
+
+        _deadlockTotalWaitHover?.Clear();
+        if (data.Count == 0)
+        {
+            var zeroLine = DeadlockTotalWaitChart.Plot.Add.Scatter(
+                new[] { rangeStart.ToOADate(), rangeEnd.ToOADate() },
+                new[] { 0.0, 0.0 });
+            zeroLine.LegendText = "Total Deadlock Wait";
+            zeroLine.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("Deadlocks"));
+            zeroLine.MarkerSize = 0;
+            DeadlockTotalWaitChart.Plot.Axes.DateTimeTicksBottomDateChange();
+            DeadlockTotalWaitChart.Plot.Axes.SetLimitsX(rangeStart.ToOADate(), rangeEnd.ToOADate());
+            ReapplyAxisColors(DeadlockTotalWaitChart);
+            DeadlockTotalWaitChart.Plot.YLabel("Total Deadlock Wait (ms)");
+            SetChartYLimitsWithLegendPadding(DeadlockTotalWaitChart, 0, 1);
+            ShowChartLegend(DeadlockTotalWaitChart);
+            DeadlockTotalWaitChart.Refresh();
+            return;
+        }
+
+        var ordered = data.OrderBy(d => d.Time).ToList();
+        var times = ordered.Select(d => ViewerTimeHelper.ForDisplay(d.Time).ToOADate()).ToArray();
+        var totals = ordered.Select(d => (double)d.TotalWaitMs).ToArray();
+
+        var plot = DeadlockTotalWaitChart.Plot.Add.Scatter(times, totals);
+        plot.LegendText = "Total Deadlock Wait";
+        plot.Color = ScottPlot.Color.FromHex(ChartPalette.SeriesColor("Deadlocks"));
+        ChartStyle.StyleScatter(plot);
+        _deadlockTotalWaitHover?.Add(plot, "Total Deadlock Wait");
+
+        double globalMax = totals.Length > 0 ? totals.Max() : 0;
+
+        DeadlockTotalWaitChart.Plot.Axes.DateTimeTicksBottomDateChange();
+        DeadlockTotalWaitChart.Plot.Axes.SetLimitsX(rangeStart.ToOADate(), rangeEnd.ToOADate());
+        ReapplyAxisColors(DeadlockTotalWaitChart);
+        DeadlockTotalWaitChart.Plot.YLabel("Total Deadlock Wait (ms)");
+        SetChartYLimitsWithLegendPadding(DeadlockTotalWaitChart, 0, globalMax > 0 ? globalMax : 1);
+        ShowChartLegend(DeadlockTotalWaitChart);
+        DeadlockTotalWaitChart.Refresh();
+    }
+
+    /// <summary>
     /// Window-rollup summary strip for the Blocking Stats sub-tab: total blocking events, total / max / avg
     /// block duration (the avg is EVENT-weighted — total ÷ events — not a mean of the per-minute averages),
-    /// and the deadlock COUNT over the window. The deadlock count is the cheap signal; the Dashboard's
-    /// victim_count / total_deadlock_wait_time_ms need deadlock-graph XML parsing (a collector port) and are
-    /// deferred. Durations render with the viewer's blocking wait-time format (ms under a second, else sec).
+    /// the deadlock COUNT, and the deadlock SEVERITY rollup (total victim processes + total deadlock wait) over
+    /// the window. The deadlock count is the cheap incident signal; the victim_count / total-deadlock-wait are
+    /// parsed on-the-fly from <c>deadlock_graph_xml</c> over the SAME v_deadlocks window (so they reconcile in
+    /// period), the Darling equivalent of the Dashboard's <c>victim_count</c> / <c>total_deadlock_wait_time_ms</c>.
+    /// Durations render with the viewer's blocking wait-time format (ms under a second, else sec).
     /// </summary>
-    private void UpdateBlockingStatsSummary(List<BlockingDurationStatsPoint> stats, List<BlockingTrendPoint> deadlocks)
+    private void UpdateBlockingStatsSummary(
+        List<BlockingDurationStatsPoint> stats,
+        List<BlockingTrendPoint> deadlocks,
+        List<DeadlockSeverityStatsPoint> deadlockSeverity)
     {
         long totalEvents = stats.Sum(s => (long)s.EventCount);
         long totalDuration = stats.Sum(s => s.TotalDurationMs);
         long maxDuration = stats.Count > 0 ? stats.Max(s => s.MaxDurationMs) : 0;
         long totalDeadlocks = deadlocks.Sum(d => (long)d.Count);
         long avgDuration = totalEvents > 0 ? (long)Math.Round((double)totalDuration / totalEvents) : 0;
+        long totalVictims = deadlockSeverity.Sum(d => (long)d.VictimCount);
+        long totalDeadlockWait = deadlockSeverity.Sum(d => d.TotalWaitMs);
 
         BlockingStatsEventCountText.Text = totalEvents.ToString("N0");
         BlockingStatsTotalDurationText.Text = totalEvents > 0 ? ViewerDataService.FormatWaitTime(totalDuration) : "--";
         BlockingStatsMaxDurationText.Text = totalEvents > 0 ? ViewerDataService.FormatWaitTime(maxDuration) : "--";
         BlockingStatsAvgDurationText.Text = totalEvents > 0 ? ViewerDataService.FormatWaitTime(avgDuration) : "--";
         BlockingStatsDeadlockCountText.Text = totalDeadlocks.ToString("N0");
+        BlockingStatsDeadlockVictimsText.Text = totalVictims.ToString("N0");
+        BlockingStatsDeadlockWaitText.Text = totalDeadlocks > 0 ? ViewerDataService.FormatWaitTime(totalDeadlockWait) : "--";
     }
 
     private void RenderCurrentWaitsDurationChart(List<WaitingTaskTrendPoint> data)
@@ -766,6 +907,8 @@ public partial class ViewerServerTab
         _deadlockTrendHover?.Dispose();
         _blockingDurationHover?.Dispose();
         _blockingTotalDurationHover?.Dispose();
+        _deadlockWaitHover?.Dispose();
+        _deadlockTotalWaitHover?.Dispose();
         _currentWaitsDurationHover?.Dispose();
         _currentWaitsBlockedHover?.Dispose();
     }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.DrillDown.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.DrillDown.cs
@@ -87,9 +87,13 @@ public partial class ViewerServerTab
 
         /* Blocking Stats (this feature) — the severity duration charts drill to the same blocked-process
            reports as their count-trend siblings, so right-clicking a duration spike opens the blocks at that
-           time ("Show Blocking at This Time" -> OnBlockingDrillDown). */
+           time ("Show Blocking at This Time" -> OnBlockingDrillDown). The deadlock-severity charts drill to
+           the Deadlocks grid instead ("Show Deadlocks at This Time" -> OnDeadlockDrillDown), matching the
+           Trends tab's deadlock-count chart. */
         AddChartDrillDownMenuItem(BlockingDurationChart, BuildChartContextMenu(BlockingDurationChart, "Blocking_Duration"), () => _blockingDurationHover, "Show Blocking at This Time", OnBlockingDrillDown);
         AddChartDrillDownMenuItem(BlockingTotalDurationChart, BuildChartContextMenu(BlockingTotalDurationChart, "Blocking_Total_Duration"), () => _blockingTotalDurationHover, "Show Blocking at This Time", OnBlockingDrillDown);
+        AddChartDrillDownMenuItem(DeadlockWaitChart, BuildChartContextMenu(DeadlockWaitChart, "Deadlock_Wait"), () => _deadlockWaitHover, "Show Deadlocks at This Time", OnDeadlockDrillDown);
+        AddChartDrillDownMenuItem(DeadlockTotalWaitChart, BuildChartContextMenu(DeadlockTotalWaitChart, "Deadlock_Total_Wait"), () => _deadlockTotalWaitHover, "Show Deadlocks at This Time", OnDeadlockDrillDown);
 
         /* File I/O (4) + Blocking > Current Waits (2) — the rest of Lite's "Show Active Queries at This Time"
            set (ServerTab.xaml.cs:340-363, in the same referenced block). Charts in this same viewer surface,

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
@@ -1910,19 +1910,25 @@
                             </Border>
                         </Grid>
                     </TabItem>
-                    <!-- Blocking Stats — the blocking-SEVERITY companion to the count-only "Trends" tab
-                         (the "are blocks getting LONGER, not just more frequent" signal). Computed ON-THE-FLY
-                         from the same blocked_process_reports (XE) rows the count trend uses, with the identical
-                         v_dmv_blocking_snapshots fallback (WHERE NOT EXISTS) so the two reconcile — the Darling
-                         equivalent of the Dashboard's pre-aggregated collect.blocking_deadlock_stats. Two charts
-                         split the magnitude scales: per-incident Max/Avg block duration on one, aggregate Total
-                         duration on the other (Total dwarfs per-incident on a shared linear axis). A window
-                         summary strip carries events / total / max / avg duration + the (cheap) deadlock COUNT.
-                         The Dashboard's victim_count / total_deadlock_wait_time_ms need deadlock-graph XML
-                         parsing (a collector port), so they are deferred, not shown here. -->
+                    <!-- Blocking Stats — the blocking- AND deadlock-SEVERITY companion to the count-only
+                         "Trends" tab (the "are blocks/deadlocks getting WORSE, not just more frequent" signal).
+                         Everything is computed ON-THE-FLY from rows the store already keeps, so there is no
+                         collector or migration — the Darling equivalent of the Dashboard's pre-aggregated
+                         collect.blocking_deadlock_stats. Blocking severity comes from the same
+                         blocked_process_reports (XE) rows the count trend uses, with the identical
+                         v_dmv_blocking_snapshots fallback (WHERE NOT EXISTS) so the two reconcile. Deadlock
+                         severity is parsed from deadlock_graph_xml over the SAME v_deadlocks window as the
+                         deadlock count (so those reconcile too), via the shared DeadlockGraphParser
+                         (IsVictim / WaitTimeMs). Four charts, each splitting Total from per-incident Max/Avg so
+                         the aggregate magnitude doesn't swamp the per-incident axis: block Max/Avg + block Total,
+                         then deadlock Max/Avg + deadlock Total. A window summary strip carries events / total /
+                         max / avg block duration, the deadlock COUNT, and the deadlock victim count + total
+                         deadlock wait (the Dashboard's victim_count / total_deadlock_wait_time_ms). -->
                     <TabItem Header="Blocking Stats">
                         <Grid>
                             <Grid.RowDefinitions>
+                                <RowDefinition Height="*"/>
+                                <RowDefinition Height="*"/>
                                 <RowDefinition Height="*"/>
                                 <RowDefinition Height="*"/>
                                 <RowDefinition Height="Auto"/>
@@ -1933,7 +1939,13 @@
                             <Border Grid.Row="1" Margin="0,4,0,4">
                                 <scottplot:WpfPlot x:Name="BlockingTotalDurationChart"/>
                             </Border>
-                            <Border Grid.Row="2" Background="{DynamicResource BackgroundDarkBrush}" CornerRadius="4" Padding="12,8" Margin="0,4,0,0">
+                            <Border Grid.Row="2" Margin="0,4,0,4">
+                                <scottplot:WpfPlot x:Name="DeadlockWaitChart"/>
+                            </Border>
+                            <Border Grid.Row="3" Margin="0,4,0,4">
+                                <scottplot:WpfPlot x:Name="DeadlockTotalWaitChart"/>
+                            </Border>
+                            <Border Grid.Row="4" Background="{DynamicResource BackgroundDarkBrush}" CornerRadius="4" Padding="12,8" Margin="0,4,0,0">
                                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                                     <TextBlock Text="Blocking Events:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
                                     <TextBlock x:Name="BlockingStatsEventCountText" Text="--" VerticalAlignment="Center" Margin="0,0,20,0"/>
@@ -1944,7 +1956,11 @@
                                     <TextBlock Text="Avg Duration:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
                                     <TextBlock x:Name="BlockingStatsAvgDurationText" Text="--" VerticalAlignment="Center" Margin="0,0,20,0"/>
                                     <TextBlock Text="Deadlocks:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                                    <TextBlock x:Name="BlockingStatsDeadlockCountText" Text="--" VerticalAlignment="Center"/>
+                                    <TextBlock x:Name="BlockingStatsDeadlockCountText" Text="--" VerticalAlignment="Center" Margin="0,0,20,0"/>
+                                    <TextBlock Text="Deadlock Victims:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                    <TextBlock x:Name="BlockingStatsDeadlockVictimsText" Text="--" VerticalAlignment="Center" Margin="0,0,20,0"/>
+                                    <TextBlock Text="Deadlock Wait:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
+                                    <TextBlock x:Name="BlockingStatsDeadlockWaitText" Text="--" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Border>
                         </Grid>


### PR DESCRIPTION
## What

Completes the Darling viewer's **Blocking Stats** tab (#1429) by adding the **deadlock victim + wait-time aggregate over time** — the piece #1429 explicitly deferred. It is the on-the-fly Darling equivalent of the Dashboard's pre-aggregated `collect.blocking_deadlock_stats` (`victim_count` / `total_deadlock_wait_time_ms`).

**No collector, no migration.** A code-verified re-audit confirmed this is computable from already-stored data: the deadlock rows already carry `deadlock_graph_xml`, and the shared `PerformanceMonitor.Common/DeadlockGraphParser` already exposes per-process `IsVictim` + `WaitTimeMs`. This PR just reads those graphs and aggregates them.

## How

- **`ViewerDataService.BlockingStats.cs`** — new `DeadlockSeverityStatsPoint` record + `DeadlockSeverityGraphsSql` (raw `deadlock_time`/`deadlock_graph_xml` rows from `v_deadlocks`) + `GetDeadlockSeverityStatsAsync` (reads async, then parses + buckets **off the UI thread** via `Task.Run`, mirroring the Deadlocks grid's `#1193` discipline) + the pure `AggregateDeadlockSeverity` (buckets by `DATE_TRUNC('minute', deadlock_time)` in C#, sums the parser's `IsVictim` and `WaitTimeMs` into victim_count + total/max/avg wait — the Dashboard analyzer's exact semantics).
- **`ViewerServerTab.Blocking.cs` / `.xaml`** — two deadlock wait charts (Max/Avg on one axis, Total on its own, split exactly like #1429 split blocking Total from Max/Avg) + the summary strip extended with **Deadlock Victims** and **Deadlock Wait**. The existing blocking-duration charts and deadlock-count summary are unchanged.
- **`ViewerServerTab.DrillDown.cs`** — the two new charts get the #1419 chart context menu + hover + a "Show Deadlocks at This Time" drill-down to the Deadlocks grid (matching the Trends tab's deadlock-count chart).

## Reconciliation

The read windows on **`collection_time`** and reads **`v_deadlocks`** — the identical row-selection the existing deadlock COUNT trend (`DeadlockTrendSql`) uses — so the count already on the summary strip and the new victim/wait aggregate are drawn from the same set of deadlock rows and agree in period. **No `LIMIT`**: deadlocks are rare, and a cap would drop rows the un-capped count trend keeps (I did not cap graph volume).

## Testing

`Darling.Tests -c Release` green: **1607 passed, 0 failed, 125 skipped** (all skips are the gated `DARLING_TEST_PG` live-postgres tests). New coverage:
- The read SQL: `v_deadlocks`, `collection_time` window (reconciles with `DeadlockTrendSql`), no cap, pg dialect / positional params.
- The parse→aggregate logic: synthetic graphs with known wait times for exact victim_count + total/max/avg per bucket (same-minute collapse, cross-minute ordering, null/malformed skip), plus the real sql2025 fixtures for the documented victim counts (1 / 2 / 4).
- A gated live-Postgres round-trip proving the read executes against the real schema (incl. that `v_deadlocks` exposes `deadlock_graph_xml`).

Scope: Viewer + Darling.Tests only — no Service/Storage/Config/Migrations/install touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)