### PR TITLE
Darling viewer UI polish (verified visual-audit fixes)

### DIFF
--- a/Darling/Darling.Tests/ViewerFleetRollupTests.cs
+++ b/Darling/Darling.Tests/ViewerFleetRollupTests.cs
@@ -372,7 +372,7 @@ public sealed class ViewerFleetRollupBuilderTests
         Assert.Equal("Critical", critical.BandLabel);
         Assert.Equal("#FFE57373", critical.BandBrush.Color.ToString());  // red
         Assert.Equal("Warning", warning.BandLabel);
-        Assert.Equal("#FFFFB74D", warning.BandBrush.Color.ToString());   // amber
+        Assert.Equal("#FFFFD54F", warning.BandBrush.Color.ToString());   // amber
     }
 
     // ── Header / total display helpers (singular / plural) ──────────────────────────────────────────

--- a/Darling/Darling.Tests/ViewerW2aTests.cs
+++ b/Darling/Darling.Tests/ViewerW2aTests.cs
@@ -503,14 +503,14 @@ public sealed class ViewerServerSummaryDisplayTests
 
         var collectorsWarning = new ServerSummaryItem { FailedCollectorCount = 1, LastCollectionTime = Now };
         collectorsWarning.ApplyFreshness(Now);
-        Assert.Equal("#FFFFB74D", collectorsWarning.CardBorderBrush.Color.ToString());
+        Assert.Equal("#FFFFD54F", collectorsWarning.CardBorderBrush.Color.ToString());
     }
 
     [Fact]
     public void SeverityBrushes_MapBandsToDarkPalette()
     {
         Assert.Equal("#FF81C784", new ServerSummaryItem { CpuPercent = 10 }.CpuSeverityBrush.Color.ToString());  // Healthy green
-        Assert.Equal("#FFFFB74D", new ServerSummaryItem { CpuPercent = 85 }.CpuSeverityBrush.Color.ToString());  // Warning amber
+        Assert.Equal("#FFFFD54F", new ServerSummaryItem { CpuPercent = 85 }.CpuSeverityBrush.Color.ToString());  // Warning amber
         Assert.Equal("#FFE57373", new ServerSummaryItem { CpuPercent = 96 }.CpuSeverityBrush.Color.ToString());  // Critical red
         Assert.Equal("#FF888888", new ServerSummaryItem().ThreadsSeverityBrush.Color.ToString());                // Unknown gray
     }

--- a/Darling/PerformanceMonitor.Darling.Viewer/AddServerDialog.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/AddServerDialog.xaml
@@ -115,7 +115,7 @@
         <TextBlock Grid.Row="8" Text="Connection Options" FontWeight="Bold" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
         <StackPanel Grid.Row="9" Margin="0,0,0,12">
             <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
-                <TextBlock Text="Encryption:" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Width="80"/>
+                <TextBlock Text="Encryption:" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Width="110"/>
                 <ComboBox x:Name="EncryptModeComboBox" Width="150" SelectedIndex="1">
                     <ComboBoxItem Content="Optional"/>
                     <ComboBoxItem Content="Mandatory"/>
@@ -129,7 +129,7 @@
             <CheckBox x:Name="FavoriteCheckBox" Content="Mark as favorite (appears at top of list)"
                       Foreground="{DynamicResource ForegroundBrush}" Margin="0,6,0,0"/>
             <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
-                <TextBlock Text="Database:" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Width="80"/>
+                <TextBlock Text="Database:" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Width="110"/>
                 <TextBox x:Name="DatabaseNameBox" Width="250"
                          ToolTip="Required for Azure SQL Database. Leave empty for on-premises SQL Server."/>
             </StackPanel>

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
@@ -38,7 +38,7 @@
         </Style>
 
         <Style x:Key="EmptyHint" TargetType="TextBlock">
-            <Setter Property="Foreground" Value="#8B93A1"/>
+            <Setter Property="Foreground" Value="{DynamicResource ForegroundMutedBrush}"/>
             <Setter Property="HorizontalAlignment" Value="Center"/>
             <Setter Property="VerticalAlignment" Value="Center"/>
             <Setter Property="TextWrapping" Value="Wrap"/>
@@ -559,11 +559,11 @@
                                                        HorizontalAlignment="Center"/>
                                         </StackPanel>
                                     </Border>
-                                    <Border Background="{DynamicResource BackgroundBrush}" BorderBrush="#FFB74D"
+                                    <Border Background="{DynamicResource BackgroundBrush}" BorderBrush="#FFD54F"
                                             BorderThickness="1" CornerRadius="5" MinWidth="86" Margin="0,0,8,0" Padding="12,6">
                                         <StackPanel>
                                             <TextBlock Text="{Binding WarningCount}" FontSize="22" FontWeight="Bold"
-                                                       Foreground="#FFB74D" HorizontalAlignment="Center"/>
+                                                       Foreground="#FFD54F" HorizontalAlignment="Center"/>
                                             <TextBlock Text="Warning" FontSize="10" Foreground="{DynamicResource ForegroundMutedBrush}"
                                                        HorizontalAlignment="Center"/>
                                         </StackPanel>
@@ -581,7 +581,7 @@
                                             BorderThickness="1" CornerRadius="5" MinWidth="86" Margin="0,0,8,0" Padding="12,6">
                                         <StackPanel>
                                             <TextBlock Text="{Binding OfflineCount}" FontSize="22" FontWeight="Bold"
-                                                       Foreground="#AAAAAA" HorizontalAlignment="Center"/>
+                                                       Foreground="#888888" HorizontalAlignment="Center"/>
                                             <TextBlock Text="Offline" FontSize="10" Foreground="{DynamicResource ForegroundMutedBrush}"
                                                        HorizontalAlignment="Center"/>
                                         </StackPanel>
@@ -610,9 +610,19 @@
                                 <ItemsControl x:Name="FleetWorstServersList" ItemsSource="{Binding WorstServers}">
                                     <ItemsControl.ItemTemplate>
                                         <DataTemplate>
-                                            <Border Background="Transparent" Cursor="Hand" Padding="2,3" Margin="0,1"
+                                            <Border Cursor="Hand" Padding="2,3" Margin="0,1"
                                                     ToolTip="Open this server's tab"
                                                     MouseLeftButtonUp="FleetWorstServer_Click">
+                                                <Border.Style>
+                                                    <Style TargetType="Border">
+                                                        <Setter Property="Background" Value="Transparent"/>
+                                                        <Style.Triggers>
+                                                            <Trigger Property="IsMouseOver" Value="True">
+                                                                <Setter Property="Background" Value="#1f232b"/>
+                                                            </Trigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Border.Style>
                                                 <DockPanel LastChildFill="True">
                                                     <Ellipse Width="9" Height="9" Fill="{Binding BandBrush}"
                                                              VerticalAlignment="Center" Margin="0,0,8,0" DockPanel.Dock="Left"/>

--- a/Darling/PerformanceMonitor.Darling.Viewer/StatusToBrushConverter.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/StatusToBrushConverter.cs
@@ -25,7 +25,7 @@ namespace PerformanceMonitor.Darling.Viewer;
 public sealed class StatusToBrushConverter : IValueConverter
 {
     private static readonly SolidColorBrush s_success = Frozen("#81C784");
-    private static readonly SolidColorBrush s_permissions = Frozen("#FFB74D");
+    private static readonly SolidColorBrush s_permissions = Frozen("#FFD54F");
     private static readonly SolidColorBrush s_error = Frozen("#E57373");
     private static readonly SolidColorBrush s_info = Frozen("#4FC3F7");
     private static readonly SolidColorBrush s_default = Frozen("#E4E6EB");

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Fleet.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Fleet.cs
@@ -161,7 +161,7 @@ public enum FleetHealthBand
 public sealed class FleetRankedServer
 {
     private static readonly SolidColorBrush s_criticalBrush = MakeBrush("#E57373");
-    private static readonly SolidColorBrush s_warningBrush = MakeBrush("#FFB74D");
+    private static readonly SolidColorBrush s_warningBrush = MakeBrush("#FFD54F");
     private static readonly SolidColorBrush s_healthyBrush = MakeBrush("#81C784");
     private static readonly SolidColorBrush s_offlineBrush = MakeBrush("#888888");
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Overview.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Overview.cs
@@ -399,7 +399,7 @@ public sealed class ServerSummaryItem
 
     /* Per-severity dot / value brushes, frozen once (the viewer's dark-theme palette). */
     private static readonly SolidColorBrush s_criticalBrush = MakeBrush("#E57373");
-    private static readonly SolidColorBrush s_warningBrush = MakeBrush("#FFB74D");
+    private static readonly SolidColorBrush s_warningBrush = MakeBrush("#FFD54F");
     private static readonly SolidColorBrush s_healthyBrush = MakeBrush("#81C784");
     private static readonly SolidColorBrush s_unknownBrush = MakeBrush("#888888");
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
@@ -25,7 +25,7 @@
         </Style>
 
         <Style x:Key="EmptyHint" TargetType="TextBlock">
-            <Setter Property="Foreground" Value="#8B93A1"/>
+            <Setter Property="Foreground" Value="{DynamicResource ForegroundMutedBrush}"/>
             <Setter Property="HorizontalAlignment" Value="Center"/>
             <Setter Property="VerticalAlignment" Value="Center"/>
             <Setter Property="TextWrapping" Value="Wrap"/>
@@ -1925,27 +1925,33 @@
                          max / avg block duration, the deadlock COUNT, and the deadlock victim count + total
                          deadlock wait (the Dashboard's victim_count / total_deadlock_wait_time_ms). -->
                     <TabItem Header="Blocking Stats">
+                        <!-- 2x2 grid (matching the Performance Trends layout): the charts are natural pairs —
+                             row 0 = blocking Max/Avg | blocking Total, row 1 = deadlock Max/Avg | deadlock Total —
+                             so a 2x2 reads better AND keeps each plot area tall enough that the X-axis time labels
+                             don't collide on a short (768px) laptop. The summary strip spans both columns below. -->
                         <Grid>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="*"/>
                                 <RowDefinition Height="*"/>
-                                <RowDefinition Height="*"/>
-                                <RowDefinition Height="*"/>
                                 <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
-                            <Border Grid.Row="0" Margin="0,0,0,4">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Border Grid.Row="0" Grid.Column="0" Margin="0,0,4,4">
                                 <scottplot:WpfPlot x:Name="BlockingDurationChart"/>
                             </Border>
-                            <Border Grid.Row="1" Margin="0,4,0,4">
+                            <Border Grid.Row="0" Grid.Column="1" Margin="4,0,0,4">
                                 <scottplot:WpfPlot x:Name="BlockingTotalDurationChart"/>
                             </Border>
-                            <Border Grid.Row="2" Margin="0,4,0,4">
+                            <Border Grid.Row="1" Grid.Column="0" Margin="0,4,4,0">
                                 <scottplot:WpfPlot x:Name="DeadlockWaitChart"/>
                             </Border>
-                            <Border Grid.Row="3" Margin="0,4,0,4">
+                            <Border Grid.Row="1" Grid.Column="1" Margin="4,4,0,0">
                                 <scottplot:WpfPlot x:Name="DeadlockTotalWaitChart"/>
                             </Border>
-                            <Border Grid.Row="4" Background="{DynamicResource BackgroundDarkBrush}" CornerRadius="4" Padding="12,8" Margin="0,4,0,0">
+                            <Border Grid.Row="2" Grid.ColumnSpan="2" Background="{DynamicResource BackgroundDarkBrush}" CornerRadius="4" Padding="12,8" Margin="0,4,0,0">
                                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                                     <TextBlock Text="Blocking Events:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
                                     <TextBlock x:Name="BlockingStatsEventCountText" Text="--" VerticalAlignment="Center" Margin="0,0,20,0"/>
@@ -2255,8 +2261,7 @@
                 </Grid.RowDefinitions>
                 <TextBlock Grid.Row="0" Text="Session Counts Over Time" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,0,0,4"/>
                 <scottplot:WpfPlot Grid.Row="1" x:Name="SessionStatsChart"/>
-                <Border Grid.Row="2" Background="{DynamicResource BackgroundDarkBrush}" BorderBrush="{DynamicResource BorderBrush}"
-                        BorderThickness="0,1,0,0" Padding="10,8" Margin="0,8,0,0" CornerRadius="0,0,4,4">
+                <Border Grid.Row="2" Background="{DynamicResource BackgroundDarkBrush}" CornerRadius="4" Padding="12,8" Margin="0,4,0,0">
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                         <TextBlock Text="Top Application:" FontWeight="SemiBold" Foreground="{DynamicResource ForegroundDimBrush}" VerticalAlignment="Center" Margin="0,0,5,0"/>
                         <TextBlock x:Name="SessionStatsTopAppText" Text="N/A" Foreground="{DynamicResource ForegroundBrush}" VerticalAlignment="Center" Margin="0,0,20,0"/>
@@ -2499,7 +2504,7 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
-                <TextBlock Grid.Row="0" Margin="2,0,2,8" TextWrapping="Wrap" Foreground="#8B93A1" FontSize="12"
+                <TextBlock Grid.Row="0" Margin="2,0,2,8" TextWrapping="Wrap" Foreground="{DynamicResource ForegroundMutedBrush}" FontSize="12"
                            Text="Configuration is captured on connect/restart (the config collectors run on connect, not on a timer), so these histories reflect that cadence — a setting appears here only when at least two captures bracket the change within the selected time window."/>
                 <TabControl Grid.Row="1" Background="Transparent" BorderThickness="0" ItemContainerStyle="{DynamicResource SubTabItemStyle}">
                     <TabItem Header="Server Config Changes">


### PR DESCRIPTION
Seven UI polish fixes to the Darling viewer, each from a code-reviewed visual audit (carries a file:line). Scope is **Viewer project + Darling.Tests only** — no Service/Storage/Config/Migrations touched.

## Should-fix

**1. Blocking Stats — 2×2 chart relayout** (`ViewerServerTab.xaml`)
Went **2×2** (not ScrollViewer). The 4 charts were stacked equal-height in a `*,*,*,*,Auto` grid with no scroll, so on a 768px laptop each plot area dropped to ~65px and the X-axis time labels collided. Relaid out to a 2×2 grid: row 0 = blocking Max/Avg | blocking Total, row 1 = deadlock Max/Avg | deadlock Total, summary strip spans a third `Auto` row (both columns). The charts are natural pairs so 2×2 reads better **and** fixes the density. Matched the existing **Performance Trends** 2×2 idiom already in this file (`*,*` rows/cols, symmetric 4px-gutter margins). All chart `x:Name`s and their hover / context-menu / drill-down wiring are unchanged — only the layout container changed.

**2. Dim muted text → readable** (no-dim-text rule)
- (a) Config Changes intro paragraph: hardcoded `#8B93A1` → `{DynamicResource ForegroundMutedBrush}`, matching the sibling Expensive Queries description on the same tab group.
- (b) Shared `EmptyHint` style (`MainWindow.xaml` + `ViewerServerTab.xaml`): `#8B93A1` → `ForegroundMutedBrush`. In the Darling theme `ForegroundMutedBrush` resolves to `#E4E6EB` (the readable muted the rest of the app uses; `#B0B6C0` does not exist anywhere in the repo). Fixed once per style definition.

## Polish

**3. Fleet "Needs Attention" rows — hover feedback** (`MainWindow.xaml`)
Rows were `Cursor="Hand"` + clickable but had no hover. Added an `IsMouseOver` trigger (`#1f232b`) via a `Border.Style`, mirroring the `DarkGridRow` / sidebar hover idiom. The inline `Background="Transparent"` was moved into the style's default setter so the trigger actually wins (a local value would override a style trigger).

**4. Unify the two "offline" greys** (`MainWindow.xaml`)
Offline count `#AAAAAA` → `#888888` to match the offline band brush (`ViewerDataService.Fleet.cs`).

**5. Unify the two summary strips** (`ViewerServerTab.xaml`)
Session Stats strip was an attached-footer (`BorderThickness="0,1,0,0"`, `CornerRadius="0,0,4,4"`) while the sibling Blocking Stats strip is a detached pill (`CornerRadius="4"`). Picked the **detached pill** (reads cleaner) and applied it to the Session Stats strip too.

**6. AddServerDialog label alignment** (`AddServerDialog.xaml`)
Connection-Options labels used mixed widths (80 for Encryption/Database vs 110 for Monthly-Cost/Alert-delivery), so inputs started at two x-offsets. Unified all four to `Width="110"`.

**7. Unify the warning color** (`MainWindow.xaml`, `ViewerDataService.Fleet.cs`, `ViewerDataService.Overview.cs`, `StatusToBrushConverter.cs`)
Health/severity warning bands used `#FFB74D` (orange) while `WarningBrush` and the card collector-error border (`ViewerDataService.Overview.cs`) use `#FFD54F` (theme `WarningColor`). Unified the bands to the theme value `#FFD54F`: the MainWindow warning tile, `FleetRankedServer` + `ServerSummaryItem` `s_warningBrush`, and the `StatusToBrushConverter` WARNING/PERMISSIONS band (documented as "shared with WARNING"). Their sibling brushes already mirror the theme (`#E57373`=ErrorColor, `#81C784`=SuccessColor), so this makes warning consistent too — and the card warning band now matches the collector-error border on the same card. Left the correlated-timeline wait-lane `#FFB74D` alone (that's a chart series-identity color, not a health band).

## Scope guardrails
Did **not** do a broad hardcoded-hex → DynamicResource conversion (the deferred light-theme pass owns that) — only the specific named inconsistencies (the two greys, the one warning color).

## Testing
- `PerformanceMonitor.Darling.Viewer` builds `-c Release` — **0 errors**; WPF XAML markup-compile passes.
- Whole Darling stack (Viewer, Service, + test deps) builds `-c Release` clean.
- `Darling.Tests -c Release`: **Failed: 0, Passed: 1607, Skipped: 125** (skips are the live-Postgres/SQL tests that need a dev environment). 3 tests pinned the old warning hex `#FFFFB74D` and were updated to `#FFFFD54F`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)