### PR TITLE
Fix muted/dim secondary-text hierarchy in the shared dark theme

### DIFF
--- a/Darling/PerformanceMonitor.Darling.Viewer/Themes/DarkTheme.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/Themes/DarkTheme.xaml
@@ -20,10 +20,14 @@
     <Color x:Key="BackgroundLightColor">#22252b</Color>
     <Color x:Key="BackgroundLighterColor">#2a2d35</Color>
 
-    <!-- Text Colors (off-white to reduce eye strain) -->
+    <!-- Text Colors: 3-tier readable hierarchy, all >= 4.5:1 on the dark backgrounds
+         (Foreground ~11-14:1, Dim ~8.5:1, Muted ~6:1). Foreground = primary values/headers;
+         Dim = secondary captions/labels (dimmed a step off primary); Muted = the quietest tier
+         for empty-state/placeholder text. Dim stays brighter than Muted. NOTE: no truly-dim tone
+         here on purpose; every tier must remain comfortably readable. -->
     <Color x:Key="ForegroundColor">#E4E6EB</Color>
-    <Color x:Key="ForegroundDimColor">#E4E6EB</Color>
-    <Color x:Key="ForegroundMutedColor">#6B7280</Color>
+    <Color x:Key="ForegroundDimColor">#C7CBD4</Color>
+    <Color x:Key="ForegroundMutedColor">#A8AEBA</Color>
 
     <!-- Border Colors (subtle, low-contrast) -->
     <Color x:Key="BorderColor">#2a2d35</Color>
@@ -60,7 +64,7 @@
 
     <SolidColorBrush x:Key="ForegroundBrush" Color="{StaticResource ForegroundColor}"/>
     <SolidColorBrush x:Key="ForegroundDimBrush" Color="{StaticResource ForegroundDimColor}"/>
-    <SolidColorBrush x:Key="ForegroundMutedBrush" Color="{StaticResource ForegroundColor}"/>
+    <SolidColorBrush x:Key="ForegroundMutedBrush" Color="{StaticResource ForegroundMutedColor}"/>
 
     <SolidColorBrush x:Key="BorderBrush" Color="{StaticResource BorderColor}"/>
     <SolidColorBrush x:Key="BorderLightBrush" Color="{StaticResource BorderLightColor}"/>

--- a/Lite/Themes/DarkTheme.xaml
+++ b/Lite/Themes/DarkTheme.xaml
@@ -20,10 +20,14 @@
     <Color x:Key="BackgroundLightColor">#22252b</Color>
     <Color x:Key="BackgroundLighterColor">#2a2d35</Color>
 
-    <!-- Text Colors (off-white to reduce eye strain) -->
+    <!-- Text Colors: 3-tier readable hierarchy, all >= 4.5:1 on the dark backgrounds
+         (Foreground ~11-14:1, Dim ~8.5:1, Muted ~6:1). Foreground = primary values/headers;
+         Dim = secondary captions/labels (dimmed a step off primary); Muted = the quietest tier
+         for empty-state/placeholder text. Dim stays brighter than Muted. NOTE: no truly-dim tone
+         here on purpose; every tier must remain comfortably readable. -->
     <Color x:Key="ForegroundColor">#E4E6EB</Color>
-    <Color x:Key="ForegroundDimColor">#E4E6EB</Color>
-    <Color x:Key="ForegroundMutedColor">#6B7280</Color>
+    <Color x:Key="ForegroundDimColor">#C7CBD4</Color>
+    <Color x:Key="ForegroundMutedColor">#A8AEBA</Color>
 
     <!-- Border Colors (subtle, low-contrast) -->
     <Color x:Key="BorderColor">#2a2d35</Color>
@@ -60,7 +64,7 @@
 
     <SolidColorBrush x:Key="ForegroundBrush" Color="{StaticResource ForegroundColor}"/>
     <SolidColorBrush x:Key="ForegroundDimBrush" Color="{StaticResource ForegroundDimColor}"/>
-    <SolidColorBrush x:Key="ForegroundMutedBrush" Color="{StaticResource ForegroundColor}"/>
+    <SolidColorBrush x:Key="ForegroundMutedBrush" Color="{StaticResource ForegroundMutedColor}"/>
 
     <SolidColorBrush x:Key="BorderBrush" Color="{StaticResource BorderColor}"/>
     <SolidColorBrush x:Key="BorderLightBrush" Color="{StaticResource BorderLightColor}"/>


### PR DESCRIPTION
## Problem

Audit finding (Visual consistency, Med): *"Muted/dim secondary text has no visual hierarchy; MutedBrush/DimBrush both resolve to full-brightness, and equivalent empty-states render at different brightness."*

In the shared dark theme:
- `ForegroundMutedBrush` was aliased to full-bright `ForegroundColor` (#E4E6EB) instead of `ForegroundMutedColor`.
- `ForegroundDimColor` equalled `ForegroundColor` (#E4E6EB), so `ForegroundDimBrush` was also full-bright.
- `ForegroundMutedColor` (#6B7280) was defined but referenced nowhere — and at **2.85:1** it is unreadably dim anyway.

Net effect: captions/labels (DimBrush) rendered identical to their values, and empty-state text (EmptyHint / NoDataMessage / inline "No X"), already routed to MutedBrush by #1439, rendered full-bright — no hierarchy.

## Fix — a 3-tier readable hierarchy

Every tier stays **>= 4.5:1** on the dark backgrounds (no truly-dim text, per the standing readability rule):

| Token | Before | After | Role | Worst-case contrast |
|---|---|---|---|---|
| `ForegroundColor` | #E4E6EB | #E4E6EB | primary values/headers | ~11–14:1 |
| `ForegroundDimColor` | #E4E6EB | **#C7CBD4** | secondary captions/labels | ~8.5:1 |
| `ForegroundMutedColor` | #6B7280 | **#A8AEBA** | quietest empty-state/placeholder tier | ~6:1 |
| `ForegroundMutedBrush` | → `ForegroundColor` | → **`ForegroundMutedColor`** | — | — |

Contrast measured (WCAG) against every dark surface (#111217 / #181b1f / #22252b / #2a2d35 / #1c1f25); worst case is #2a2d35: Dim **8.47:1**, Muted **6.18:1**. `#A8AEBA` is the dimmer end of the intended readable-secondary range; `#C7CBD4` is the distinct "mid" value for Dim so captions read a clear step below their values while staying crisp.

## What this standardizes

Empty-state text was already unified onto `ForegroundMutedBrush` by #1439 (EmptyHint, NoDataMessage, FinOps inline "No X" at FinOpsTab, AlertsHistoryTab "No alerts recorded"). Making Muted a readable-secondary tone is the intended completion — all those states now render consistently muted. DimBrush captions (memory-tile labels, "Total Plans:", "Blocking Events:", "Top Application:", etc.) now sit a readable step below their primary-brush values.

## Cross-app parity

The dark theme is byte-identical between the Darling viewer and Lite, so the change is mirrored exactly — both files hash to `782327db…` after the edit.

## Out of scope (flagged, not silently dropped)

- **Lite Light / CoolBreeze themes** carry the identical alias defect, but their pre-defined `ForegroundMutedColor` values (#718096 = 3.38:1, #5B7A90 = 2.87:1) **fail 4.5:1**, so fixing them needs *new* color choices (a design decision + visual review), not a brush re-point. Left as-is renders full-strength/readable — no regression.
- **Dashboard** (Dark/Light/CoolBreeze) has the byte-identical defect, but it is the app being deprecated, sits outside this task's build/test gate, and re-pointing its shared brush restyles a large unverified surface — a separate reviewable change.

## Build & test

- `dotnet build -c Release`: Darling viewer ✅, Lite ✅
- `dotnet test -c Release`: Darling.Tests **1607 passed / 0 failed** (125 skipped), Lite.Tests **911 passed / 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)