### PR TITLE
Darling viewer per-server-tab audit fixes (15 findings)

### DIFF
--- a/Darling/Darling.Tests/ViewerConfigChangesTests.cs
+++ b/Darling/Darling.Tests/ViewerConfigChangesTests.cs
@@ -375,20 +375,37 @@ public sealed class ViewerConfigChangesDiffTests
 }
 
 /// <summary>
-/// Pins the inner-tab renumber: the Configuration Changes tab is inserted immediately after the latest-snapshot
-/// Configuration tab, so every tab after it shifts up by one. A stale constant would send LoadInnerTabAsync's
-/// switch to the wrong loader.
+/// Pins the reworked inner-tab order: the resource run (Overview … Configuration Changes) followed by a
+/// diagnostics tail — Daily Summary -> System Events -> Latches &amp; Spinlocks -> Collection Health. These
+/// constants are the source of truth for LoadInnerTabAsync's switch + the drill-down SelectedIndex navigation,
+/// so a stale constant would route to the wrong loader / tab. Must match the &lt;TabItem&gt; order in
+/// ViewerServerTab.xaml.
 /// </summary>
 public sealed class ViewerConfigChangesTabTests
 {
     [Fact]
-    public void InnerTabIndices_ConfigChangesInsertedAfterConfiguration_ShiftsRest()
+    public void InnerTabIndices_MatchTheReworkedDiagnosticsTailOrder()
     {
-        Assert.Equal(13, ViewerServerTab.ConfigurationInnerTabIndex);
-        Assert.Equal(14, ViewerServerTab.ConfigChangesInnerTabIndex);
-        Assert.Equal(15, ViewerServerTab.DailySummaryInnerTabIndex);
-        Assert.Equal(16, ViewerServerTab.HealthInnerTabIndex);
-        Assert.Equal(17, ViewerServerTab.SystemEventsInnerTabIndex);
+        /* Resource run. */
+        Assert.Equal(0, ViewerServerTab.OverviewInnerTabIndex);
+        Assert.Equal(1, ViewerServerTab.WaitStatsInnerTabIndex);
+        Assert.Equal(2, ViewerServerTab.QueriesInnerTabIndex);
+        Assert.Equal(3, ViewerServerTab.PlanViewerInnerTabIndex);
+        Assert.Equal(4, ViewerServerTab.CpuInnerTabIndex);
+        Assert.Equal(5, ViewerServerTab.MemoryInnerTabIndex);
+        Assert.Equal(6, ViewerServerTab.FileIoInnerTabIndex);
+        Assert.Equal(7, ViewerServerTab.TempDbInnerTabIndex);
+        Assert.Equal(8, ViewerServerTab.BlockingInnerTabIndex);
+        Assert.Equal(9, ViewerServerTab.PerfmonInnerTabIndex);
+        Assert.Equal(10, ViewerServerTab.SessionStatsInnerTabIndex);
+        Assert.Equal(11, ViewerServerTab.RunningJobsInnerTabIndex);
+        Assert.Equal(12, ViewerServerTab.ConfigurationInnerTabIndex);
+        Assert.Equal(13, ViewerServerTab.ConfigChangesInnerTabIndex);
+        /* Diagnostics tail: Daily Summary -> System Events -> Latches & Spinlocks -> Collection Health. */
+        Assert.Equal(14, ViewerServerTab.DailySummaryInnerTabIndex);
+        Assert.Equal(15, ViewerServerTab.SystemEventsInnerTabIndex);
+        Assert.Equal(16, ViewerServerTab.LatchSpinlockInnerTabIndex);
+        Assert.Equal(17, ViewerServerTab.HealthInnerTabIndex);
     }
 }
 

--- a/Darling/Darling.Tests/ViewerExpensiveQueriesTests.cs
+++ b/Darling/Darling.Tests/ViewerExpensiveQueriesTests.cs
@@ -126,6 +126,18 @@ public sealed class ViewerUnifiedExpensiveQueriesSqlTests
     }
 
     [Fact]
+    public void UnifiedSql_CarriesPlanHandle_OnStatementAndProcedureArms_NullForQueryStore()
+    {
+        /* "Fetch Live Plan" is keyed on plan_handle: the query_stats + procedure_stats arms carry
+           MAX(plan_handle) (mirroring their standalone reads), while the Query Store arm has none
+           (NULL::text) — so QS-sourced rows keep "Fetch Live Plan" correctly disabled. The UNION stays
+           column-aligned across all three branches. */
+        var sql = ViewerDataService.UnifiedExpensiveQueriesSql;
+        Assert.Equal(2, CountOccurrences(sql, "MAX(plan_handle) AS plan_handle"));
+        Assert.Contains("NULL::text AS plan_handle", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void UnifiedSql_IsPostgresDialect_FivePositionalParams_NoTsqlIsms()
     {
         var sql = ViewerDataService.UnifiedExpensiveQueriesSql;
@@ -183,6 +195,15 @@ public sealed class ViewerUnifiedExpensiveQueriesRowTests
         Assert.True(new ViewerExpensiveQueryRow { QueryPlanXml = "<ShowPlanXML/>" }.HasQueryPlan);
         Assert.False(new ViewerExpensiveQueryRow { QueryPlanXml = null }.HasQueryPlan);
         Assert.False(new ViewerExpensiveQueryRow { QueryPlanXml = "" }.HasQueryPlan);
+    }
+
+    [Fact]
+    public void HasLivePlanHandle_ReflectsThePlanHandlePresence()
+    {
+        /* Gates "Fetch Live Plan": the query_stats + procedure_stats sources carry a plan_handle; a Query
+           Store row (or any plan_handle-less row) leaves it empty and stays disabled. */
+        Assert.True(new ViewerExpensiveQueryRow { PlanHandle = "0x06000100AB" }.HasLivePlanHandle);
+        Assert.False(new ViewerExpensiveQueryRow { PlanHandle = "" }.HasLivePlanHandle);
     }
 
     [Fact]
@@ -307,18 +328,19 @@ public sealed class ViewerUnifiedExpensiveQueriesLivePostgresTests
 
         try
         {
-            /* Query Stats: highest avg worker. Two collections summed → exec 5, worker 500_000 us → avg 100 ms. */
+            /* Query Stats: highest avg worker. Two collections summed → exec 5, worker 500_000 us → avg 100 ms.
+               Same plan_handle in both collections so MAX(plan_handle) is deterministic. */
             await InsertQueryStatsAsync(connection, t1, "StackOverflow", "0xHOT",
                 deltaExec: 2, deltaWorker: 200_000, deltaElapsed: 400_000, deltaReads: 200,
-                maxGrantKb: 2048, queryText: "SELECT hot", planXml: "<ShowPlanXML>qs</ShowPlanXML>");
+                maxGrantKb: 2048, queryText: "SELECT hot", planXml: "<ShowPlanXML>qs</ShowPlanXML>", planHandle: "0x0500QSHANDLE");
             await InsertQueryStatsAsync(connection, t2, "StackOverflow", "0xHOT",
                 deltaExec: 3, deltaWorker: 300_000, deltaElapsed: 600_000, deltaReads: 300,
-                maxGrantKb: 2048, queryText: "SELECT hot", planXml: "<ShowPlanXML>qs</ShowPlanXML>");
+                maxGrantKb: 2048, queryText: "SELECT hot", planXml: "<ShowPlanXML>qs</ShowPlanXML>", planHandle: "0x0500QSHANDLE");
 
             /* Procedure: medium avg worker. exec 4, worker 200_000 us → avg 50 ms. No grant column. */
             await InsertProcedureStatsAsync(connection, t1, "StackOverflow", "dbo", "usp_Mid", "PROCEDURE",
                 deltaExec: 4, deltaWorker: 200_000, deltaElapsed: 400_000, deltaReads: 400,
-                planXml: "<ShowPlanXML>ps</ShowPlanXML>");
+                planXml: "<ShowPlanXML>ps</ShowPlanXML>", planHandle: "0x0500PSHANDLE");
 
             /* Query Store: lowest avg worker. exec 10, worker = avg 10_000 us * 10 → avg 10 ms. Grant 1024 pages. */
             await InsertQueryStoreAsync(connection, t1, "StackOverflow", queryId: 99, module: "dbo.usp_Qs",
@@ -338,17 +360,22 @@ public sealed class ViewerUnifiedExpensiveQueriesLivePostgresTests
             Assert.Equal(2.0, rows[0].MaxGrantMb!.Value, 3);        /* 2048 KB → 2 MB */
             Assert.Equal("SELECT hot", rows[0].QueryText);
             Assert.Equal("<ShowPlanXML>qs</ShowPlanXML>", rows[0].QueryPlanXml);
+            Assert.Equal("0x0500QSHANDLE", rows[0].PlanHandle);     /* MAX(plan_handle) across both collections */
+            Assert.True(rows[0].HasLivePlanHandle);
 
             Assert.Equal(ViewerDataService.ExpensiveSourceStoredProcedure, rows[1].Source);
             Assert.Equal("dbo.usp_Mid", rows[1].ObjectName);
             Assert.Equal(50.0, rows[1].AvgWorkerTimeMs, 3);
             Assert.Null(rows[1].MaxGrantMb);                        /* procedure DMVs carry no grant */
+            Assert.Equal("0x0500PSHANDLE", rows[1].PlanHandle);     /* the procedure arm carries plan_handle too */
 
             Assert.Equal(ViewerDataService.ExpensiveSourceQueryStore, rows[2].Source);
             Assert.Equal("dbo.usp_Qs", rows[2].ObjectName);
             Assert.Equal(10, rows[2].ExecutionCount);
             Assert.Equal(10.0, rows[2].AvgWorkerTimeMs, 3);
             Assert.Equal(8.0, rows[2].MaxGrantMb!.Value, 3);        /* 1024 pages * 8 KB / 1024 → 8 MB */
+            Assert.Equal("", rows[2].PlanHandle);                   /* Query Store has no plan_handle → disabled */
+            Assert.False(rows[2].HasLivePlanHandle);
         }
         finally
         {
@@ -362,7 +389,8 @@ public sealed class ViewerUnifiedExpensiveQueriesLivePostgresTests
 
     private static async Task InsertQueryStatsAsync(
         NpgsqlConnection connection, DateTime collectionTimeUtc, string databaseName, string queryHash,
-        long deltaExec, long deltaWorker, long deltaElapsed, long deltaReads, long maxGrantKb, string queryText, string planXml)
+        long deltaExec, long deltaWorker, long deltaElapsed, long deltaReads, long maxGrantKb, string queryText, string planXml,
+        string planHandle)
     {
         using var command = new NpgsqlCommand(@"
 INSERT INTO query_stats
@@ -370,8 +398,8 @@ INSERT INTO query_stats
      database_name, query_hash, creation_time, last_execution_time,
      delta_execution_count, delta_worker_time, delta_elapsed_time,
      delta_logical_reads, delta_logical_writes, delta_physical_reads,
-     max_grant_kb, query_text, query_plan_xml)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)", connection);
+     max_grant_kb, query_text, query_plan_xml, plan_handle)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)", connection);
         command.Parameters.AddWithValue(1L);
         command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTimeUtc, DateTimeKind.Unspecified));
         command.Parameters.AddWithValue(ServerId);
@@ -389,13 +417,14 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $
         command.Parameters.AddWithValue(maxGrantKb);
         command.Parameters.AddWithValue(queryText);
         command.Parameters.AddWithValue(planXml);
+        command.Parameters.AddWithValue(planHandle);
         await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
     }
 
     private static async Task InsertProcedureStatsAsync(
         NpgsqlConnection connection, DateTime collectionTimeUtc,
         string databaseName, string schemaName, string objectName, string objectType,
-        long deltaExec, long deltaWorker, long deltaElapsed, long deltaReads, string planXml)
+        long deltaExec, long deltaWorker, long deltaElapsed, long deltaReads, string planXml, string planHandle)
     {
         using var command = new NpgsqlCommand(@"
 INSERT INTO procedure_stats
@@ -403,8 +432,8 @@ INSERT INTO procedure_stats
      database_name, schema_name, object_name, object_type,
      cached_time, last_execution_time,
      delta_execution_count, delta_worker_time, delta_elapsed_time,
-     delta_logical_reads, delta_logical_writes, delta_physical_reads, query_plan_xml)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)", connection);
+     delta_logical_reads, delta_logical_writes, delta_physical_reads, query_plan_xml, plan_handle)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)", connection);
         command.Parameters.AddWithValue(1L);
         command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTimeUtc, DateTimeKind.Unspecified));
         command.Parameters.AddWithValue(ServerId);
@@ -422,6 +451,7 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $
         command.Parameters.AddWithValue(0L);
         command.Parameters.AddWithValue(0L);
         command.Parameters.AddWithValue(planXml);
+        command.Parameters.AddWithValue(planHandle);
         await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
     }
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/CorrelatedTimelineLanesControl.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/CorrelatedTimelineLanesControl.xaml.cs
@@ -27,7 +27,8 @@
  *     collection_time lanes on any server timezone; a UTC server is unchanged.
  * Deliberately dropped for v1 (noted in the PR): Lite's comparison-range ghost-line overlay (the whole
  * comparisonRange block, AddGhostLine, ComparisonLabel). The "Show Active Queries at This Time"
- * drill-down event is KEPT but left unwired — the viewer has no Active Queries surface yet.
+ * drill-down event is wired by the host ServerTab — ViewerServerTab.xaml.cs subscribes
+ * ShowActiveQueriesRequested to OnActiveQueriesDrillDown, which navigates to the Active Queries surface.
  */
 
 using System;
@@ -89,8 +90,8 @@ public partial class CorrelatedTimelineLanesControl : UserControl
 
     /// <summary>
     /// Raised when the user picks "Show Active Queries at This Time" on a lane. The argument is the
-    /// clicked time in the lanes' (viewer-local) X-axis space. Kept from Lite but currently unwired —
-    /// the viewer has no Active Queries surface yet (deferred).
+    /// clicked time in the lanes' (viewer-local) X-axis space. The host ServerTab subscribes this
+    /// (ViewerServerTab.xaml.cs) to OnActiveQueriesDrillDown, which navigates to the Active Queries surface.
     /// </summary>
     public event Action<DateTime>? ShowActiveQueriesRequested;
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ProcedureHistoryWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ProcedureHistoryWindow.xaml
@@ -42,6 +42,13 @@
                 <MenuItem Header="View Plan" Click="ViewPlan_Click">
                     <MenuItem.Icon><TextBlock Text="&#x1F50D;"/></MenuItem.Icon>
                 </MenuItem>
+                <!-- Live plan fetch for the RIGHT-CLICKED snapshot by its plan_handle (headless-safe cached read,
+                     no re-exec) — distinct from the stored "View Plan". Gated on the current row's
+                     HasLivePlanHandle so a snapshot without a plan_handle shows it disabled. -->
+                <MenuItem Header="Fetch Live Plan" Click="FetchLivePlan_Click"
+                          IsEnabled="{Binding CurrentItem.HasLivePlanHandle, ElementName=HistoryDataGrid, FallbackValue=False}">
+                    <MenuItem.Icon><TextBlock Text="&#x1F310;"/></MenuItem.Icon>
+                </MenuItem>
             </ContextMenu>
         </ResourceDictionary>
     </Window.Resources>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ProcedureHistoryWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ProcedureHistoryWindow.xaml.cs
@@ -244,6 +244,68 @@ public partial class ProcedureHistoryWindow : Window
         window.Closed += (_, _) => viewer.Cleanup();
     }
 
+    /// <summary>"Fetch Live Plan" — asks the service to read the RIGHT-CLICKED snapshot's plan from the target's
+    /// LIVE cache by its plan_handle (headless-safe: a cached read via the fetch_plan command, no re-execution),
+    /// mirroring the parent grid's FetchLiveQueryPlan_Click. Distinct from "View Plan" (the stored plan XML).
+    /// Gated per row on HasLivePlanHandle; the same plan_handle-bearing row gets it on the parent Top Procedures grid.</summary>
+    private async void FetchLivePlan_Click(object sender, RoutedEventArgs e)
+    {
+        if (HistoryDataGrid.CurrentItem is not ViewerProcedureStatsHistoryRow row || string.IsNullOrEmpty(row.PlanHandle))
+            return;
+
+        var fullName = string.IsNullOrEmpty(_schemaName) ? _objectName : $"{_schemaName}.{_objectName}";
+        var label = $"Live Plan - {fullName}";
+        var argsJson = ViewerDataService.BuildPlanFetchArgsByPlanHandle(row.PlanHandle, _databaseName);
+        await FetchAndShowLivePlanAsync(argsJson, label, queryText: null);
+    }
+
+    /// <summary>Runs a fetch_plan round-trip and shows the plan in a shared PlanViewerControl floated above this
+    /// window (a read-only seat / not-in-cache / failure surfaces the service's message). Mirrors
+    /// ViewerServerTab.FetchAndOpenLivePlanAsync, adapted to this window's GraphViewerWindow plan host.</summary>
+    private async Task FetchAndShowLivePlanAsync(string argsJson, string label, string? queryText)
+    {
+        LivePlanFetchResult result;
+        try
+        {
+            result = await _dataService.FetchLivePlanAsync(_serverId, argsJson);
+        }
+        catch (ViewerReadOnlyException)
+        {
+            MessageBox.Show(this, "This is a read-only viewer seat, which cannot ask the service to fetch a live plan.",
+                "Read-Only", MessageBoxButton.OK, MessageBoxImage.Information);
+            return;
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show(this, $"Failed to fetch the live plan: {ex.Message}", "Live Plan Error",
+                MessageBoxButton.OK, MessageBoxImage.Error);
+            return;
+        }
+
+        if (result.Status != LivePlanFetchStatus.Fetched || string.IsNullOrEmpty(result.PlanXml))
+        {
+            MessageBox.Show(this, result.Message ?? "The live plan could not be fetched.",
+                "Live Plan", MessageBoxButton.OK, MessageBoxImage.Information);
+            return;
+        }
+
+        var viewer = new PlanViewerControl();
+        try
+        {
+            await viewer.LoadPlan(result.PlanXml, label, queryText);
+        }
+        catch (Exception ex)
+        {
+            viewer.Cleanup();
+            MessageBox.Show(this, $"Failed to load the execution plan:\n\n{ex.Message}",
+                "Plan Load Error", MessageBoxButton.OK, MessageBoxImage.Warning);
+            return;
+        }
+
+        var window = GraphViewerWindow.ShowGraph(this, viewer, label);
+        window.Closed += (_, _) => viewer.Cleanup();
+    }
+
     // ── Column Filter Popup (mirrors WaitDrillDownWindow / ViewerServerTab.Filters.cs) ──
 
     private void EnsureFilterPopup()

--- a/Darling/PerformanceMonitor.Darling.Viewer/QueryStatsHistoryWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/QueryStatsHistoryWindow.xaml
@@ -44,6 +44,13 @@
                 <MenuItem Header="View Plan" Click="ViewPlan_Click">
                     <MenuItem.Icon><TextBlock Text="&#x1F50D;"/></MenuItem.Icon>
                 </MenuItem>
+                <!-- Live plan fetch for the RIGHT-CLICKED snapshot by its plan_handle (headless-safe cached read,
+                     no re-exec) — distinct from the stored "View Plan". Gated on the current row's
+                     HasLivePlanHandle so a snapshot without a plan_handle shows it disabled. -->
+                <MenuItem Header="Fetch Live Plan" Click="FetchLivePlan_Click"
+                          IsEnabled="{Binding CurrentItem.HasLivePlanHandle, ElementName=HistoryDataGrid, FallbackValue=False}">
+                    <MenuItem.Icon><TextBlock Text="&#x1F310;"/></MenuItem.Icon>
+                </MenuItem>
             </ContextMenu>
         </ResourceDictionary>
     </Window.Resources>

--- a/Darling/PerformanceMonitor.Darling.Viewer/QueryStatsHistoryWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/QueryStatsHistoryWindow.xaml.cs
@@ -242,6 +242,67 @@ public partial class QueryStatsHistoryWindow : Window
         window.Closed += (_, _) => viewer.Cleanup();
     }
 
+    /// <summary>"Fetch Live Plan" — asks the service to read the RIGHT-CLICKED snapshot's plan from the target's
+    /// LIVE cache by its plan_handle (headless-safe: a cached read via the fetch_plan command, no re-execution),
+    /// mirroring the parent grid's FetchLiveQueryPlan_Click. Distinct from "View Plan" (the stored plan XML).
+    /// Gated per row on HasLivePlanHandle; the same plan_handle-bearing row gets it on the parent Top Queries grid.</summary>
+    private async void FetchLivePlan_Click(object sender, RoutedEventArgs e)
+    {
+        if (HistoryDataGrid.CurrentItem is not ViewerQueryStatsHistoryRow row || string.IsNullOrEmpty(row.PlanHandle))
+            return;
+
+        var label = $"Live Plan - {_queryHash}";
+        var argsJson = ViewerDataService.BuildPlanFetchArgsByPlanHandle(row.PlanHandle, _databaseName);
+        await FetchAndShowLivePlanAsync(argsJson, label, _queryText);
+    }
+
+    /// <summary>Runs a fetch_plan round-trip and shows the plan in a shared PlanViewerControl floated above this
+    /// window (a read-only seat / not-in-cache / failure surfaces the service's message). Mirrors
+    /// ViewerServerTab.FetchAndOpenLivePlanAsync, adapted to this window's GraphViewerWindow plan host.</summary>
+    private async Task FetchAndShowLivePlanAsync(string argsJson, string label, string? queryText)
+    {
+        LivePlanFetchResult result;
+        try
+        {
+            result = await _dataService.FetchLivePlanAsync(_serverId, argsJson);
+        }
+        catch (ViewerReadOnlyException)
+        {
+            MessageBox.Show(this, "This is a read-only viewer seat, which cannot ask the service to fetch a live plan.",
+                "Read-Only", MessageBoxButton.OK, MessageBoxImage.Information);
+            return;
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show(this, $"Failed to fetch the live plan: {ex.Message}", "Live Plan Error",
+                MessageBoxButton.OK, MessageBoxImage.Error);
+            return;
+        }
+
+        if (result.Status != LivePlanFetchStatus.Fetched || string.IsNullOrEmpty(result.PlanXml))
+        {
+            MessageBox.Show(this, result.Message ?? "The live plan could not be fetched.",
+                "Live Plan", MessageBoxButton.OK, MessageBoxImage.Information);
+            return;
+        }
+
+        var viewer = new PlanViewerControl();
+        try
+        {
+            await viewer.LoadPlan(result.PlanXml, label, queryText);
+        }
+        catch (Exception ex)
+        {
+            viewer.Cleanup();
+            MessageBox.Show(this, $"Failed to load the execution plan:\n\n{ex.Message}",
+                "Plan Load Error", MessageBoxButton.OK, MessageBoxImage.Warning);
+            return;
+        }
+
+        var window = GraphViewerWindow.ShowGraph(this, viewer, label);
+        window.Closed += (_, _) => viewer.Cleanup();
+    }
+
     // ── Column Filter Popup (mirrors WaitDrillDownWindow / ViewerServerTab.Filters.cs) ──
 
     private void EnsureFilterPopup()

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Blocking.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Blocking.cs
@@ -183,7 +183,10 @@ public sealed partial class ViewerDataService
             blocked_client_app,
             blocked_last_tran_started,
             blocking_last_tran_started,
-            monitor_loop
+            monitor_loop,
+            blocking_login_name,
+            blocking_host_name,
+            blocking_client_app
         FROM v_dmv_blocking_snapshots
         WHERE server_id = $1
         AND   collection_time >= $2
@@ -322,6 +325,11 @@ public sealed partial class ViewerDataService
                 BlockedLastTranStarted = reader.IsDBNull(16) ? null : reader.GetDateTime(16),
                 BlockingLastTranStarted = reader.IsDBNull(17) ? null : reader.GetDateTime(17),
                 MonitorLoop = reader.IsDBNull(18) ? null : reader.GetInt32(18),
+                /* Blocking-side identity — the DMV snapshot is the only blocking source on AWS RDS / when the
+                   BPR threshold is unset, so surface it here too (the XE path already sets these). */
+                BlockingLoginName = reader.IsDBNull(19) ? "" : reader.GetString(19),
+                BlockingHostName = reader.IsDBNull(20) ? "" : reader.GetString(20),
+                BlockingClientApp = reader.IsDBNull(21) ? "" : reader.GetString(21),
                 Source = BlockedProcessAlertRow.DmvSnapshotSource,
             });
         }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Deadlock.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Deadlock.cs
@@ -69,11 +69,19 @@ public sealed class DeadlockProcessDetail
     /// <summary>
     /// The BEST-EFFORT victim plan for this deadlock (deadlocks.victim_query_plan_xml, #1368 / V7) — one
     /// plan per deadlock, copied onto every process row parsed from the same graph. The "View Victim Plan"
-    /// context item is gated per row on <see cref="HasVictimQueryPlan"/> so a plan-less deadlock (NULL, the
+    /// context item is gated per row on <see cref="CanViewVictimPlan"/> so a plan-less deadlock (NULL, the
     /// common case, and always so under Lite) shows it disabled rather than shown-and-failed.
     /// </summary>
     public string? VictimQueryPlanXml { get; set; }
     public bool HasVictimQueryPlan => !string.IsNullOrEmpty(VictimQueryPlanXml);
+
+    /// <summary>
+    /// Whether "View Victim Plan" should be active for THIS row. The victim plan is a single per-deadlock plan
+    /// copied onto every process row, so gating only on <see cref="HasVictimQueryPlan"/> lit it up on the
+    /// deadlocker rows too (where it reads as "this process's plan", which it isn't). Requires the row to be the
+    /// victim AND to carry a plan, so the item is active only on the victim row.
+    /// </summary>
+    public bool CanViewVictimPlan => IsVictim && HasVictimQueryPlan;
 
     /* New fields from sp_BlitzLock analysis */
     public string DeadlockType { get; set; } = "";

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ExpensiveQueries.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ExpensiveQueries.cs
@@ -60,6 +60,13 @@ public sealed class ViewerExpensiveQueryRow
     /// <summary>The collector's STORED plan XML for the row, carried in-row so "View Plan" / "Copy Repro
     /// Script" need no extra read; null when no plan was captured (best-effort, or aged out of retention).</summary>
     public string? QueryPlanXml { get; set; }
+
+    /// <summary>The row's plan_handle for the LIVE-cache fetch ("Fetch Live Plan"), distinct from the stored
+    /// <see cref="QueryPlanXml"/> that "View Plan" opens. The query_stats + procedure_stats arms carry it
+    /// (MAX(plan_handle) per group); the Query Store arm has no plan_handle, so its rows leave this empty and
+    /// keep "Fetch Live Plan" correctly disabled.</summary>
+    public string PlanHandle { get; set; } = "";
+
     public DateTime? FirstExecutionTime { get; set; }
     public DateTime? LastExecutionTime { get; set; }
 
@@ -75,6 +82,10 @@ public sealed class ViewerExpensiveQueryRow
     /// <summary>Whether a stored plan rode back for this row — gates the "View Plan" context item so a
     /// plan-less row shows it disabled instead of shown-and-failed.</summary>
     public bool HasQueryPlan => !string.IsNullOrEmpty(QueryPlanXml);
+
+    /// <summary>Whether this row carries a plan_handle — gates the "Fetch Live Plan" context item (the
+    /// live-cache fetch is keyed on plan_handle). Query Store rows have none and stay disabled.</summary>
+    public bool HasLivePlanHandle => !string.IsNullOrEmpty(PlanHandle);
 
     /// <summary>
     /// True when <see cref="QueryText"/> holds a RUNNABLE statement (the Query Stats / Query Store
@@ -166,6 +177,7 @@ public sealed partial class ViewerDataService
                 r.max_grant_mb,
                 COALESCE(t.query_text, '') AS query_text_sample,
                 t.query_plan_xml,
+                r.plan_handle,
                 r.first_execution_time,
                 r.last_execution_time
             FROM (
@@ -179,6 +191,7 @@ public sealed partial class ViewerDataService
                     CAST(SUM(delta_logical_writes) AS bigint) AS total_logical_writes,
                     CAST(SUM(delta_physical_reads) AS bigint) AS total_physical_reads,
                     (MAX(max_grant_kb) / 1024.0)::double precision AS max_grant_mb,
+                    MAX(plan_handle) AS plan_handle,
                     MIN(creation_time) AS first_execution_time,
                     MAX(last_execution_time) AS last_execution_time
                 FROM query_stats
@@ -224,6 +237,7 @@ public sealed partial class ViewerDataService
                 NULL::double precision AS max_grant_mb,
                 r.database_name || '.' || r.schema_name || '.' || r.object_name AS query_text_sample,
                 p.query_plan_xml,
+                r.plan_handle,
                 r.first_execution_time,
                 r.last_execution_time
             FROM (
@@ -238,6 +252,7 @@ public sealed partial class ViewerDataService
                     CAST(SUM(delta_logical_reads) AS bigint) AS total_logical_reads,
                     CAST(SUM(delta_logical_writes) AS bigint) AS total_logical_writes,
                     CAST(SUM(delta_physical_reads) AS bigint) AS total_physical_reads,
+                    MAX(plan_handle) AS plan_handle,
                     MIN(cached_time) AS first_execution_time,
                     MAX(last_execution_time) AS last_execution_time
                 FROM procedure_stats
@@ -280,6 +295,7 @@ public sealed partial class ViewerDataService
                 r.max_grant_mb,
                 COALESCE(t.query_text, '') AS query_text_sample,
                 t.query_plan_text AS query_plan_xml,
+                NULL::text AS plan_handle,
                 r.first_execution_time,
                 r.last_execution_time
             FROM (
@@ -335,7 +351,8 @@ public sealed partial class ViewerDataService
             query_text_sample,
             query_plan_xml,
             first_execution_time,
-            last_execution_time
+            last_execution_time,
+            plan_handle
         FROM all_sources
         ORDER BY avg_worker_ms DESC NULLS LAST
         LIMIT $5
@@ -382,6 +399,7 @@ public sealed partial class ViewerDataService
                 QueryPlanXml = reader.IsDBNull(16) ? null : reader.GetString(16),
                 FirstExecutionTime = reader.IsDBNull(17) ? null : reader.GetDateTime(17),
                 LastExecutionTime = reader.IsDBNull(18) ? null : reader.GetDateTime(18),
+                PlanHandle = reader.IsDBNull(19) ? "" : reader.GetString(19),
             });
         }
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerHistoryRows.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerHistoryRows.cs
@@ -98,6 +98,10 @@ public sealed class ViewerQueryStatsHistoryRow
     public string CollectionTimeLocal => HistoryTime.CollectionLocal(CollectionTime);
     public string CreationTimeLocal => ViewerDataService.FormatServerClock(CreationTime);
     public string LastExecutionTimeLocal => ViewerDataService.FormatServerClock(LastExecutionTime);
+
+    /// <summary>Whether this snapshot carries a plan_handle — gates the history grid's "Fetch Live Plan" item
+    /// (the live-cache fetch is keyed on plan_handle, distinct from the stored plan "View Plan" opens).</summary>
+    public bool HasLivePlanHandle => !string.IsNullOrEmpty(PlanHandle);
 }
 
 /// <summary>One collected procedure_stats snapshot for a single (database, schema, object) — Lite's
@@ -154,6 +158,10 @@ public sealed class ViewerProcedureStatsHistoryRow
     public string CollectionTimeLocal => HistoryTime.CollectionLocal(CollectionTime);
     public string CachedTimeLocal => ViewerDataService.FormatServerClock(CachedTime);
     public string LastExecutionTimeLocal => ViewerDataService.FormatServerClock(LastExecutionTime);
+
+    /// <summary>Whether this snapshot carries a plan_handle — gates the history grid's "Fetch Live Plan" item
+    /// (the live-cache fetch is keyed on plan_handle, distinct from the stored plan "View Plan" opens).</summary>
+    public bool HasLivePlanHandle => !string.IsNullOrEmpty(PlanHandle);
 }
 
 /// <summary>One collected query_store_stats snapshot for a single (database, query_id) plan — Lite's

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.ActiveQueries.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.ActiveQueries.cs
@@ -195,18 +195,48 @@ public partial class ViewerServerTab
         }
     }
 
-    /// <summary>Opens the snapshot's stored ESTIMATED plan in the Plan Viewer (gated on HasQueryPlan).</summary>
+    /// <summary>Opens the snapshot's stored ESTIMATED plan in the Plan Viewer (gated on HasQueryPlan). Wired to
+    /// the in-row "Estimated" button (DataContext is the row).</summary>
     private void OpenSnapshotEstimatedPlan_Click(object sender, RoutedEventArgs e)
     {
-        if (sender is not Button btn || btn.DataContext is not ViewerQuerySnapshotRow row) return;
+        if (sender is FrameworkElement { DataContext: ViewerQuerySnapshotRow row })
+            OpenSnapshotEstimatedPlan(row);
+    }
+
+    /// <summary>Opens the snapshot's stored ACTUAL (live) plan in the Plan Viewer (gated on HasLiveQueryPlan).
+    /// Wired to the in-row "Actual" button (DataContext is the row).</summary>
+    private void OpenSnapshotActualPlan_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is FrameworkElement { DataContext: ViewerQuerySnapshotRow row })
+            OpenSnapshotActualPlan(row);
+    }
+
+    /// <summary>Right-click "View Estimated Plan" on the snapshot grid — resolves the right-clicked row from the
+    /// grid (menu items are outside the visual tree, so DataContext doesn't flow) and opens its stored plan,
+    /// mirroring the in-row button (Lite parity).</summary>
+    private void ViewSnapshotEstimatedPlan_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is MenuItem menuItem && FindParentDataGrid(menuItem)?.CurrentItem is ViewerQuerySnapshotRow row)
+            OpenSnapshotEstimatedPlan(row);
+    }
+
+    /// <summary>Right-click "View Actual Plan" on the snapshot grid (see <see cref="ViewSnapshotEstimatedPlan_Click"/>).</summary>
+    private void ViewSnapshotActualPlan_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is MenuItem menuItem && FindParentDataGrid(menuItem)?.CurrentItem is ViewerQuerySnapshotRow row)
+            OpenSnapshotActualPlan(row);
+    }
+
+    /// <summary>Opens the snapshot row's stored estimated plan (shared by the button + context-menu handlers).</summary>
+    private void OpenSnapshotEstimatedPlan(ViewerQuerySnapshotRow row)
+    {
         if (string.IsNullOrEmpty(row.QueryPlan)) return;
         OpenPlanTab(row.QueryPlan, $"Estimated Plan — Session {row.SessionId}", row.QueryText);
     }
 
-    /// <summary>Opens the snapshot's stored ACTUAL (live) plan in the Plan Viewer (gated on HasLiveQueryPlan).</summary>
-    private void OpenSnapshotActualPlan_Click(object sender, RoutedEventArgs e)
+    /// <summary>Opens the snapshot row's stored actual plan (shared by the button + context-menu handlers).</summary>
+    private void OpenSnapshotActualPlan(ViewerQuerySnapshotRow row)
     {
-        if (sender is not Button btn || btn.DataContext is not ViewerQuerySnapshotRow row) return;
         if (string.IsNullOrEmpty(row.LiveQueryPlan)) return;
         OpenPlanTab(row.LiveQueryPlan, $"Actual Plan — Session {row.SessionId}", row.QueryText);
     }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.ChartContextMenu.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.ChartContextMenu.cs
@@ -32,9 +32,8 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// <see cref="ContextMenu"/> = [drill-down item] + [separator] + [these copy/save/export items], exactly like
 /// Lite: <see cref="BuildChartContextMenu"/> builds the copy/export items and takes over right-click (via the
 /// shared <c>AttachChartContextMenu</c> in ViewerServerTab.DrillDown.cs), then the drill-down wiring
-/// <c>Insert</c>s its item at the top of the SAME menu. Charts that have no drill-down (latch/spinlock,
-/// CPU scheduler, plan cache, collector duration, System Events) get this menu on its own via
-/// <see cref="WireChartContextMenus"/>.</para>
+/// <c>Insert</c>s its item at the top of the SAME menu. The only chart with no drill-down (collector duration,
+/// which Lite also leaves drill-less) gets this menu on its own via <see cref="WireChartContextMenus"/>.</para>
 /// </summary>
 public partial class ViewerServerTab
 {
@@ -179,24 +178,12 @@ public partial class ViewerServerTab
     /// </summary>
     private void WireChartContextMenus()
     {
-        /* Darling-only collectors Lite lacks (latch/spinlock, CPU scheduler, plan cache) + the collector
-           duration chart Lite also leaves drill-less. */
-        BuildChartContextMenu(LatchStatsChart, "Latch_Stats");
-        BuildChartContextMenu(SpinlockStatsChart, "Spinlock_Stats");
-        BuildChartContextMenu(SessionStatsChart, "Session_Stats");
-        BuildChartContextMenu(CpuSchedulerChart, "CPU_Scheduler");
-        BuildChartContextMenu(PlanCacheChart, "Plan_Cache");
+        /* Only the collector-duration chart is menu-only here — Lite leaves its collector-duration chart
+           drill-less too. The other Darling-only charts (latch/spinlock, CPU scheduler, plan cache, session
+           counts, the eight System Events charts) now carry a "Show Active Queries at This Time" drill-down,
+           so they get their copy/export menu from WireChartDrillDowns instead (one menu per chart — no
+           double-menuing). */
         BuildChartContextMenu(CollectorDurationChart, "Collector_Duration");
-
-        /* System Events (system_health XE) charts. */
-        BuildChartContextMenu(BadPagesChart, "Bad_Pages");
-        BuildChartContextMenu(DumpRequestsChart, "Dump_Requests");
-        BuildChartContextMenu(AccessViolationsChart, "Access_Violations");
-        BuildChartContextMenu(WriteAccessViolationsChart, "Write_Access_Violations");
-        BuildChartContextMenu(NonYieldingTasksChart, "Non_Yielding_Tasks");
-        BuildChartContextMenu(LatchWarningsChart, "Latch_Warnings");
-        BuildChartContextMenu(SickSpinlocksChart, "Sick_Spinlocks");
-        BuildChartContextMenu(CpuComparisonChart, "CPU_Comparison");
     }
 
     private static void CopyChartImage(WpfPlot chart)

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.DrillDown.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.DrillDown.cs
@@ -104,6 +104,27 @@ public partial class ViewerServerTab
         AddChartDrillDownMenuItem(FileIoWriteThroughputChart, BuildChartContextMenu(FileIoWriteThroughputChart, "File_IO_Write_Throughput"), () => _fileIoWriteThroughputHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
         AddChartDrillDownMenuItem(CurrentWaitsDurationChart, BuildChartContextMenu(CurrentWaitsDurationChart, "Current_Waits_Duration"), () => _currentWaitsDurationHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
         AddChartDrillDownMenuItem(CurrentWaitsBlockedChart, BuildChartContextMenu(CurrentWaitsBlockedChart, "Current_Waits_Blocked"), () => _currentWaitsBlockedHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+
+        /* Darling-only time-series charts Lite lacks — CPU Scheduler, Latch/Spinlock contention, Plan Cache,
+           Session Counts, and the eight System Events (system_health XE) counter charts. All plot display-time
+           on X, so "Show Active Queries at This Time" navigates to the correlated +/-30-minute active-queries
+           window exactly like their sibling resource/trend charts. Peer-consistency (these previously had only
+           the copy/export menu); no per-latch/per-spinlock-type drill (no correlation data captured). Only
+           CollectorDuration stays menu-only, matching Lite's drill-less collector-duration chart. */
+        AddChartDrillDownMenuItem(CpuSchedulerChart, BuildChartContextMenu(CpuSchedulerChart, "CPU_Scheduler"), () => _cpuSchedulerHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        AddChartDrillDownMenuItem(LatchStatsChart, BuildChartContextMenu(LatchStatsChart, "Latch_Stats"), () => _latchStatsHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        AddChartDrillDownMenuItem(SpinlockStatsChart, BuildChartContextMenu(SpinlockStatsChart, "Spinlock_Stats"), () => _spinlockStatsHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        AddChartDrillDownMenuItem(SessionStatsChart, BuildChartContextMenu(SessionStatsChart, "Session_Stats"), () => _sessionStatsHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        AddChartDrillDownMenuItem(PlanCacheChart, BuildChartContextMenu(PlanCacheChart, "Plan_Cache"), () => _planCacheHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+
+        AddChartDrillDownMenuItem(BadPagesChart, BuildChartContextMenu(BadPagesChart, "Bad_Pages"), () => _badPagesHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        AddChartDrillDownMenuItem(DumpRequestsChart, BuildChartContextMenu(DumpRequestsChart, "Dump_Requests"), () => _dumpRequestsHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        AddChartDrillDownMenuItem(AccessViolationsChart, BuildChartContextMenu(AccessViolationsChart, "Access_Violations"), () => _accessViolationsHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        AddChartDrillDownMenuItem(WriteAccessViolationsChart, BuildChartContextMenu(WriteAccessViolationsChart, "Write_Access_Violations"), () => _writeAccessViolationsHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        AddChartDrillDownMenuItem(NonYieldingTasksChart, BuildChartContextMenu(NonYieldingTasksChart, "Non_Yielding_Tasks"), () => _nonYieldingTasksHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        AddChartDrillDownMenuItem(LatchWarningsChart, BuildChartContextMenu(LatchWarningsChart, "Latch_Warnings"), () => _latchWarningsHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        AddChartDrillDownMenuItem(SickSpinlocksChart, BuildChartContextMenu(SickSpinlocksChart, "Sick_Spinlocks"), () => _sickSpinlocksHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
+        AddChartDrillDownMenuItem(CpuComparisonChart, BuildChartContextMenu(CpuComparisonChart, "CPU_Comparison"), () => _cpuComparisonHover, "Show Active Queries at This Time", OnActiveQueriesDrillDown);
     }
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.LivePlan.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.LivePlan.cs
@@ -71,6 +71,15 @@ public partial class ViewerServerTab
                 label = $"Live Plan - {proc.FullName}";
                 queryText = null; /* the procedure grid carries no statement text; the plan XML holds its own */
                 break;
+            case ViewerExpensiveQueryRow expensive when !string.IsNullOrEmpty(expensive.PlanHandle):
+                /* Unified Expensive Queries: the query_stats + procedure_stats arms carry a plan_handle; the
+                   Query Store arm has none (its rows stay disabled). Statement text only for the statement
+                   sources; the procedure sources carry the object name, whose plan XML holds its own text. */
+                planHandle = expensive.PlanHandle;
+                databaseName = expensive.DatabaseName;
+                label = $"Live Plan - {expensive.Source}: {expensive.ObjectName}";
+                queryText = expensive.IsStatementSource ? expensive.QueryText : null;
+                break;
             default:
                 return;
         }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.SystemHealthCharts.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.SystemHealthCharts.cs
@@ -132,7 +132,9 @@ public partial class ViewerServerTab
         chart.Plot.Axes.DateTimeTicksBottomDateChange();
         ReapplyAxisColors(chart);
         chart.Plot.Axes.SetLimitsX(xMin, xMax);
-        chart.Plot.YLabel("Count");
+        /* The tiles are borderless (no in-panel title), so the descriptive Y-axis label is the chart's
+           identifier — the same convention the File I/O charts use ("Read Latency (ms)"). */
+        chart.Plot.YLabel(label);
         chart.Plot.Axes.SetLimitsY(0, max > 0 ? max * 1.15 : 1);
         chart.Refresh();
     }
@@ -190,7 +192,7 @@ public partial class ViewerServerTab
         SickSpinlocksChart.Plot.Axes.DateTimeTicksBottomDateChange();
         ReapplyAxisColors(SickSpinlocksChart);
         SickSpinlocksChart.Plot.Axes.SetLimitsX(xMin, xMax);
-        SickSpinlocksChart.Plot.YLabel("Backoffs");
+        SickSpinlocksChart.Plot.YLabel("Sick Spinlocks (backoffs)");
         SetChartYLimitsWithLegendPadding(SickSpinlocksChart, 0, max);
         SickSpinlocksChart.Refresh();
     }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
@@ -2289,7 +2289,7 @@
                 <TextBlock Grid.Row="0" Text="Currently Running SQL Agent Jobs" Style="{StaticResource SectionHeader}"/>
                 <TextBlock Grid.Row="1" x:Name="RunningJobsMsdbWarning"
                            Text="Running Jobs requires msdb access. Grant the login access to msdb to enable this feature."
-                           Foreground="#FFD700" FontSize="12" Margin="0,0,0,8" Visibility="Collapsed"
+                           Foreground="{DynamicResource WarningTextBrush}" FontSize="12" Margin="0,0,0,8" Visibility="Collapsed"
                            TextWrapping="Wrap"/>
                 <DataGrid Grid.Row="2" x:Name="RunningJobsGrid" Style="{StaticResource DarkGrid}">
                     <DataGrid.RowStyle>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
@@ -439,56 +439,6 @@
             </Grid>
         </TabItem>
 
-        <!-- Latches & Spinlocks Tab — the Dashboard-parity port of ResourceMetricsContent's Latch Stats /
-             Spinlock Stats sub-tabs. Two sub-tabs, each a per-second trend chart (top 5 by delta) over the
-             settable window + a latest-snapshot grid. Placed BETWEEN Wait Stats and Queries (the
-             contention-stats grouping). Both sub-tabs load on parent-tab activation, so this sub-TabControl
-             needs no SelectionChanged handler (mirrors the Memory tab). -->
-        <TabItem Header="Latches &amp; Spinlocks">
-            <TabControl x:Name="LatchSpinlockSubTabControl" Background="Transparent" BorderThickness="0" ItemContainerStyle="{DynamicResource SubTabItemStyle}">
-                <TabItem Header="Latch Stats">
-                    <Grid Margin="8">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="2*"/>
-                            <RowDefinition Height="*"/>
-                        </Grid.RowDefinitions>
-                        <scottplot:WpfPlot Grid.Row="0" x:Name="LatchStatsChart"/>
-                        <DataGrid Grid.Row="1" x:Name="LatchStatsGrid" Style="{StaticResource DarkGrid}" Margin="0,8,0,0">
-                            <DataGrid.Columns>
-                                <DataGridTextColumn Header="Latch Class" Binding="{Binding LatchClass}" Width="*"/>
-                                <DataGridTextColumn Header="Δ Wait (ms)" Binding="{Binding DeltaWaitTimeMs, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
-                                <DataGridTextColumn Header="Δ Waiting Reqs" Binding="{Binding DeltaWaitingRequestsCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
-                                <DataGridTextColumn Header="Wait Time (ms)" Binding="{Binding WaitTimeMs, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
-                                <DataGridTextColumn Header="Max Wait (ms)" Binding="{Binding MaxWaitTimeMs, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
-                                <DataGridTextColumn Header="Waiting Reqs (total)" Binding="{Binding WaitingRequestsCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="140"/>
-                            </DataGrid.Columns>
-                        </DataGrid>
-                    </Grid>
-                </TabItem>
-                <TabItem Header="Spinlock Stats">
-                    <Grid Margin="8">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="2*"/>
-                            <RowDefinition Height="*"/>
-                        </Grid.RowDefinitions>
-                        <scottplot:WpfPlot Grid.Row="0" x:Name="SpinlockStatsChart"/>
-                        <DataGrid Grid.Row="1" x:Name="SpinlockStatsGrid" Style="{StaticResource DarkGrid}" Margin="0,8,0,0">
-                            <DataGrid.Columns>
-                                <DataGridTextColumn Header="Spinlock" Binding="{Binding SpinlockName}" Width="*"/>
-                                <DataGridTextColumn Header="Δ Collisions" Binding="{Binding DeltaCollisions, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
-                                <DataGridTextColumn Header="Δ Spins" Binding="{Binding DeltaSpins, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
-                                <DataGridTextColumn Header="Spins/Collision" Binding="{Binding SpinsPerCollision, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
-                                <DataGridTextColumn Header="Collisions (total)" Binding="{Binding Collisions, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="130"/>
-                                <DataGridTextColumn Header="Spins (total)" Binding="{Binding Spins, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
-                                <DataGridTextColumn Header="Sleep Time" Binding="{Binding SleepTime, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
-                                <DataGridTextColumn Header="Backoffs" Binding="{Binding Backoffs, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
-                            </DataGrid.Columns>
-                        </DataGrid>
-                    </Grid>
-                </TabItem>
-            </TabControl>
-        </TabItem>
-
         <!-- Queries Tab — the full six-sub-tab group matching Lite's ServerTab.xaml QueriesSubTabControl
              exactly: Performance Trends, Active Queries (W1f-2), Top Queries / Top Procedures / Query
              Store by Duration (W1f-1), Query Heatmap (W1f-2). A shared "Compare:" combo above the
@@ -2566,8 +2516,8 @@
              (Today / an explicit date, UTC) driving a single-row daily roll-up — total wait, top wait
              type, unique queries, deadlocks, blocking events, high-CPU count, collect errors — with the
              health band. Reads rewired to Postgres (GetDailySummaryAsync); grid keeps the viewer's
-             DarkGrid chrome + the shared Accent/Success buttons + NoDataMessage. Sits between
-             Configuration and Collection Health, matching Lite's own tab order. The DatePicker + its
+             DarkGrid chrome + the shared Accent/Success buttons + NoDataMessage. Leads the diagnostics tail
+             (Daily Summary -> System Events -> Latches & Spinlocks -> Collection Health). The DatePicker + its
              calendar dropdown theme declaratively from DarkTheme.xaml, so Lite's imperative
              CalendarOpened re-theming handler is not ported (the viewer is fixed-Dark). -->
         <TabItem Header="Daily Summary">
@@ -2623,113 +2573,6 @@
                     </DataGrid.Columns>
                 </DataGrid>
                 <TextBlock Grid.Row="1" x:Name="DailySummaryNoData" Style="{StaticResource NoDataMessage}"/>
-            </Grid>
-        </TabItem>
-
-        <!-- Collection Health Tab — upgraded from the shell's single latest-run grid to Lite's rich
-             3-sub-tab shape (copied from Lite's ServerTab.xaml Collection Health tab). Reads rewired to
-             Postgres; grids keep the viewer's DarkGrid chrome + Lite's ColumnFilterButtonStyle headers.
-             Health Summary = the 7-day per-collector aggregate with the HealthStatus band (double-click
-             opens the per-collector CollectionLogWindow drill). Collection Log = the recent run log.
-             Duration Trends = the per-collector success-duration scatter. Two deviations from Lite: the
-             HealthStatus cell is plain text (Lite doesn't color it — the shell's StatusToBrush stays on
-             the Findings grid only), and Lite's "Open Log File" button is dropped (it opens Lite's local
-             log file, which the viewer has no equivalent of). -->
-        <TabItem Header="Collection Health">
-            <Grid Margin="8">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="*"/>
-                </Grid.RowDefinitions>
-                <!-- Fleet-wide "Purge Now": runs the daily retention purge on demand via the purge_now
-                     control command. Placed on Collection Health (the store-health tab) rather than a
-                     per-server toolbar because the purge is fleet-wide over the shared store tables. A
-                     read-only viewer seat can't enqueue commands, so the handler shows an explanation. -->
-                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,8">
-                    <Button x:Name="PurgeNowButton" Content="Purge Now..." Click="PurgeNow_Click"
-                            Padding="12,4" Margin="0,0,8,0" VerticalAlignment="Center"/>
-                    <TextBlock x:Name="PurgeNowIndicator" Text="" FontSize="12"
-                               Foreground="DarkGoldenrod" FontWeight="SemiBold" VerticalAlignment="Center"/>
-                </StackPanel>
-                <TabControl Grid.Row="1" Background="Transparent" BorderThickness="0" ItemContainerStyle="{DynamicResource SubTabItemStyle}">
-                    <TabItem Header="Health Summary">
-                        <DataGrid x:Name="CollectionHealthGrid" Style="{StaticResource DarkGrid}"
-                                  MouseDoubleClick="CollectionHealthGrid_MouseDoubleClick">
-                            <DataGrid.Columns>
-                                <DataGridTextColumn Binding="{Binding CollectorName}" Width="180">
-                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CollectorName" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Collector" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
-                                </DataGridTextColumn>
-                                <DataGridTextColumn Binding="{Binding HealthStatus}" Width="90">
-                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="HealthStatus" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Status" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
-                                </DataGridTextColumn>
-                                <DataGridTextColumn Binding="{Binding TotalRuns, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80">
-                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalRuns" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Runs" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
-                                </DataGridTextColumn>
-                                <DataGridTextColumn Binding="{Binding SuccessCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80">
-                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SuccessCount" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Success" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
-                                </DataGridTextColumn>
-                                <DataGridTextColumn Binding="{Binding ErrorCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80">
-                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ErrorCount" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Errors" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
-                                </DataGridTextColumn>
-                                <DataGridTextColumn Binding="{Binding FailureRatePercent, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="85">
-                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="FailureRatePercent" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Fail %" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
-                                </DataGridTextColumn>
-                                <DataGridTextColumn Binding="{Binding AvgDurationFormatted}" Width="120" SortMemberPath="AvgDurationMs">
-                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgDurationFormatted" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Avg Duration" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
-                                </DataGridTextColumn>
-                                <DataGridTextColumn Binding="{Binding LastSuccessFormatted}" Width="140">
-                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastSuccessFormatted" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Last Success" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
-                                </DataGridTextColumn>
-                                <DataGridTextColumn Binding="{Binding LastRunFormatted}" Width="140">
-                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastRunFormatted" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Last Run" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
-                                </DataGridTextColumn>
-                                <DataGridTextColumn Binding="{Binding LastErrorFormatted}" Width="140">
-                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastErrorFormatted" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Last Error At" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
-                                </DataGridTextColumn>
-                                <DataGridTextColumn Binding="{Binding LastError}" Width="*">
-                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastError" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Last Error" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
-                                </DataGridTextColumn>
-                            </DataGrid.Columns>
-                        </DataGrid>
-                    </TabItem>
-                    <TabItem Header="Collection Log">
-                        <!-- Lite's "Open Log File" button dropped (it opens Lite's local log file; the
-                             viewer has no equivalent), so the grid fills the whole sub-tab. -->
-                        <DataGrid x:Name="CollectionLogGrid" Style="{StaticResource DarkGrid}">
-                            <DataGrid.Columns>
-                                <DataGridTextColumn Binding="{Binding CollectionTimeFormatted}" Width="130">
-                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CollectionTimeFormatted" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Time" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
-                                </DataGridTextColumn>
-                                <DataGridTextColumn Binding="{Binding CollectorName}" Width="180">
-                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CollectorName" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Collector" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
-                                </DataGridTextColumn>
-                                <DataGridTextColumn Binding="{Binding Status}" Width="80">
-                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Status" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Status" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
-                                </DataGridTextColumn>
-                                <DataGridTextColumn Binding="{Binding DurationFormatted}" Width="90" SortMemberPath="DurationMs">
-                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DurationFormatted" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Duration" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
-                                </DataGridTextColumn>
-                                <DataGridTextColumn Binding="{Binding SqlDurationFormatted}" Width="90" SortMemberPath="SqlDurationMs">
-                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SqlDurationFormatted" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="SQL (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
-                                </DataGridTextColumn>
-                                <!-- Store phase: the store column is duckdb_duration_ms, but on the Darling
-                                     side it records the Postgres write time — labelled "Store (ms)". -->
-                                <DataGridTextColumn Binding="{Binding DuckDbDurationFormatted}" Width="120" SortMemberPath="DuckDbDurationMs">
-                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DuckDbDurationFormatted" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Store (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
-                                </DataGridTextColumn>
-                                <DataGridTextColumn Binding="{Binding RowsCollected, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80">
-                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="RowsCollected" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Rows" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
-                                </DataGridTextColumn>
-                                <DataGridTextColumn Binding="{Binding ErrorMessage}" Width="*">
-                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ErrorMessage" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Error" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
-                                </DataGridTextColumn>
-                            </DataGrid.Columns>
-                        </DataGrid>
-                    </TabItem>
-                    <TabItem Header="Duration Trends">
-                        <scottplot:WpfPlot x:Name="CollectorDurationChart" Margin="4"/>
-                    </TabItem>
-                </TabControl>
             </Grid>
         </TabItem>
 
@@ -3077,6 +2920,163 @@
                     </Grid>
                 </TabItem>
             </TabControl>
+        </TabItem>
+
+        <!-- Latches & Spinlocks Tab — the Dashboard-parity port of ResourceMetricsContent's Latch Stats /
+             Spinlock Stats sub-tabs. Two sub-tabs, each a per-second trend chart (top 5 by delta) over the
+             settable window + a latest-snapshot grid. Grouped into the diagnostics tail (after System Events,
+             before Collection Health) rather than the main resource run. Both sub-tabs load on parent-tab
+             activation, so this sub-TabControl needs no SelectionChanged handler (mirrors the Memory tab). -->
+        <TabItem Header="Latches &amp; Spinlocks">
+            <TabControl x:Name="LatchSpinlockSubTabControl" Background="Transparent" BorderThickness="0" ItemContainerStyle="{DynamicResource SubTabItemStyle}">
+                <TabItem Header="Latch Stats">
+                    <Grid Margin="8">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="2*"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <scottplot:WpfPlot Grid.Row="0" x:Name="LatchStatsChart"/>
+                        <DataGrid Grid.Row="1" x:Name="LatchStatsGrid" Style="{StaticResource DarkGrid}" Margin="0,8,0,0">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Header="Latch Class" Binding="{Binding LatchClass}" Width="*"/>
+                                <DataGridTextColumn Header="Δ Wait (ms)" Binding="{Binding DeltaWaitTimeMs, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                                <DataGridTextColumn Header="Δ Waiting Reqs" Binding="{Binding DeltaWaitingRequestsCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                                <DataGridTextColumn Header="Wait Time (ms)" Binding="{Binding WaitTimeMs, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                                <DataGridTextColumn Header="Max Wait (ms)" Binding="{Binding MaxWaitTimeMs, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                                <DataGridTextColumn Header="Waiting Reqs (total)" Binding="{Binding WaitingRequestsCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="140"/>
+                            </DataGrid.Columns>
+                        </DataGrid>
+                    </Grid>
+                </TabItem>
+                <TabItem Header="Spinlock Stats">
+                    <Grid Margin="8">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="2*"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+                        <scottplot:WpfPlot Grid.Row="0" x:Name="SpinlockStatsChart"/>
+                        <DataGrid Grid.Row="1" x:Name="SpinlockStatsGrid" Style="{StaticResource DarkGrid}" Margin="0,8,0,0">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Header="Spinlock" Binding="{Binding SpinlockName}" Width="*"/>
+                                <DataGridTextColumn Header="Δ Collisions" Binding="{Binding DeltaCollisions, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110"/>
+                                <DataGridTextColumn Header="Δ Spins" Binding="{Binding DeltaSpins, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                                <DataGridTextColumn Header="Spins/Collision" Binding="{Binding SpinsPerCollision, StringFormat=N2}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                                <DataGridTextColumn Header="Collisions (total)" Binding="{Binding Collisions, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="130"/>
+                                <DataGridTextColumn Header="Spins (total)" Binding="{Binding Spins, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120"/>
+                                <DataGridTextColumn Header="Sleep Time" Binding="{Binding SleepTime, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                                <DataGridTextColumn Header="Backoffs" Binding="{Binding Backoffs, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100"/>
+                            </DataGrid.Columns>
+                        </DataGrid>
+                    </Grid>
+                </TabItem>
+            </TabControl>
+        </TabItem>
+
+        <!-- Collection Health Tab — upgraded from the shell's single latest-run grid to Lite's rich
+             3-sub-tab shape (copied from Lite's ServerTab.xaml Collection Health tab). Reads rewired to
+             Postgres; grids keep the viewer's DarkGrid chrome + Lite's ColumnFilterButtonStyle headers.
+             Health Summary = the 7-day per-collector aggregate with the HealthStatus band (double-click
+             opens the per-collector CollectionLogWindow drill). Collection Log = the recent run log.
+             Duration Trends = the per-collector success-duration scatter. Two deviations from Lite: the
+             HealthStatus cell is plain text (Lite doesn't color it — the shell's StatusToBrush stays on
+             the Findings grid only), and Lite's "Open Log File" button is dropped (it opens Lite's local
+             log file, which the viewer has no equivalent of). -->
+        <TabItem Header="Collection Health">
+            <Grid Margin="8">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <!-- Fleet-wide "Purge Now": runs the daily retention purge on demand via the purge_now
+                     control command. Placed on Collection Health (the store-health tab) rather than a
+                     per-server toolbar because the purge is fleet-wide over the shared store tables. A
+                     read-only viewer seat can't enqueue commands, so the handler shows an explanation. -->
+                <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,8">
+                    <Button x:Name="PurgeNowButton" Content="Purge Now..." Click="PurgeNow_Click"
+                            Padding="12,4" Margin="0,0,8,0" VerticalAlignment="Center"/>
+                    <TextBlock x:Name="PurgeNowIndicator" Text="" FontSize="12"
+                               Foreground="DarkGoldenrod" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                </StackPanel>
+                <TabControl Grid.Row="1" Background="Transparent" BorderThickness="0" ItemContainerStyle="{DynamicResource SubTabItemStyle}">
+                    <TabItem Header="Health Summary">
+                        <DataGrid x:Name="CollectionHealthGrid" Style="{StaticResource DarkGrid}"
+                                  MouseDoubleClick="CollectionHealthGrid_MouseDoubleClick">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Binding="{Binding CollectorName}" Width="180">
+                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CollectorName" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Collector" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                </DataGridTextColumn>
+                                <DataGridTextColumn Binding="{Binding HealthStatus}" Width="90">
+                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="HealthStatus" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Status" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                </DataGridTextColumn>
+                                <DataGridTextColumn Binding="{Binding TotalRuns, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80">
+                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="TotalRuns" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Runs" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                </DataGridTextColumn>
+                                <DataGridTextColumn Binding="{Binding SuccessCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80">
+                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SuccessCount" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Success" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                </DataGridTextColumn>
+                                <DataGridTextColumn Binding="{Binding ErrorCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80">
+                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ErrorCount" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Errors" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                </DataGridTextColumn>
+                                <DataGridTextColumn Binding="{Binding FailureRatePercent, StringFormat=N1}" ElementStyle="{StaticResource NumericCell}" Width="85">
+                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="FailureRatePercent" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Fail %" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                </DataGridTextColumn>
+                                <DataGridTextColumn Binding="{Binding AvgDurationFormatted}" Width="120" SortMemberPath="AvgDurationMs">
+                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="AvgDurationFormatted" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Avg Duration" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                </DataGridTextColumn>
+                                <DataGridTextColumn Binding="{Binding LastSuccessFormatted}" Width="140">
+                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastSuccessFormatted" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Last Success" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                </DataGridTextColumn>
+                                <DataGridTextColumn Binding="{Binding LastRunFormatted}" Width="140">
+                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastRunFormatted" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Last Run" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                </DataGridTextColumn>
+                                <DataGridTextColumn Binding="{Binding LastErrorFormatted}" Width="140">
+                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastErrorFormatted" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Last Error At" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                </DataGridTextColumn>
+                                <DataGridTextColumn Binding="{Binding LastError}" Width="*">
+                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="LastError" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Last Error" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                </DataGridTextColumn>
+                            </DataGrid.Columns>
+                        </DataGrid>
+                    </TabItem>
+                    <TabItem Header="Collection Log">
+                        <!-- Lite's "Open Log File" button dropped (it opens Lite's local log file; the
+                             viewer has no equivalent), so the grid fills the whole sub-tab. -->
+                        <DataGrid x:Name="CollectionLogGrid" Style="{StaticResource DarkGrid}">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Binding="{Binding CollectionTimeFormatted}" Width="130">
+                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CollectionTimeFormatted" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Time" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                </DataGridTextColumn>
+                                <DataGridTextColumn Binding="{Binding CollectorName}" Width="180">
+                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="CollectorName" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Collector" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                </DataGridTextColumn>
+                                <DataGridTextColumn Binding="{Binding Status}" Width="80">
+                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="Status" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Status" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                </DataGridTextColumn>
+                                <DataGridTextColumn Binding="{Binding DurationFormatted}" Width="90" SortMemberPath="DurationMs">
+                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DurationFormatted" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Duration" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                </DataGridTextColumn>
+                                <DataGridTextColumn Binding="{Binding SqlDurationFormatted}" Width="90" SortMemberPath="SqlDurationMs">
+                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="SqlDurationFormatted" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="SQL (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                </DataGridTextColumn>
+                                <!-- Store phase: the store column is duckdb_duration_ms, but on the Darling
+                                     side it records the Postgres write time — labelled "Store (ms)". -->
+                                <DataGridTextColumn Binding="{Binding DuckDbDurationFormatted}" Width="120" SortMemberPath="DuckDbDurationMs">
+                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="DuckDbDurationFormatted" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Store (ms)" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                </DataGridTextColumn>
+                                <DataGridTextColumn Binding="{Binding RowsCollected, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="80">
+                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="RowsCollected" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Rows" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                </DataGridTextColumn>
+                                <DataGridTextColumn Binding="{Binding ErrorMessage}" Width="*">
+                                    <DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="ErrorMessage" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Error" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header>
+                                </DataGridTextColumn>
+                            </DataGrid.Columns>
+                        </DataGrid>
+                    </TabItem>
+                    <TabItem Header="Duration Trends">
+                        <scottplot:WpfPlot x:Name="CollectorDurationChart" Margin="4"/>
+                    </TabItem>
+                </TabControl>
+            </Grid>
         </TabItem>
     </TabControl>
     </Grid>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
@@ -509,7 +509,7 @@
                             </Grid.RowDefinitions>
                             <local:TimeRangeSlicerControl x:Name="ActiveQueriesSlicer" Grid.Row="0"/>
                             <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,0,0,8">
-                                <TextBlock Text="Currently Running Queries" FontSize="14" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                <TextBlock Text="Currently Running Queries" Style="{StaticResource SectionHeader}" VerticalAlignment="Center" Margin="0"/>
                                 <Button x:Name="LatestSnapshotButton" Content="Latest Snapshot"
                                         Click="LatestSnapshot_Click" Padding="12,4" Margin="16,0,8,0"
                                         VerticalAlignment="Center"/>
@@ -2209,7 +2209,7 @@
                     <RowDefinition Height="*"/>
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
-                <TextBlock Grid.Row="0" Text="Session Counts Over Time" FontWeight="Bold" HorizontalAlignment="Center" Margin="0,0,0,4"/>
+                <TextBlock Grid.Row="0" Text="Session Counts Over Time" Style="{StaticResource SectionHeader}"/>
                 <scottplot:WpfPlot Grid.Row="1" x:Name="SessionStatsChart"/>
                 <Border Grid.Row="2" Background="{DynamicResource BackgroundDarkBrush}" CornerRadius="4" Padding="12,8" Margin="0,4,0,0">
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
@@ -2592,7 +2592,7 @@
                     <Grid>
                         <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
                         <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
-                            <TextBlock Text="Corruption Events (bad pages, dump requests, access violations)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
+                            <TextBlock Text="Corruption Events (bad pages, dump requests, access violations)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="SemiBold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
                             <Button Content="Refresh" Click="SystemEventsRefresh_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
                         </StackPanel>
                         <Grid Grid.Row="1" Margin="8,0,8,8">
@@ -2623,7 +2623,7 @@
                     <Grid>
                         <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
                         <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
-                            <TextBlock Text="Contention Events (non-yielding tasks, latches, spinlocks, CPU)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
+                            <TextBlock Text="Contention Events (non-yielding tasks, latches, spinlocks, CPU)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="SemiBold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
                             <Button Content="Refresh" Click="SystemEventsRefresh_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
                         </StackPanel>
                         <Grid Grid.Row="1" Margin="8,0,8,8">
@@ -2653,7 +2653,7 @@
                     <Grid>
                         <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
                         <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
-                            <TextBlock Text="Scheduler Issues" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
+                            <TextBlock Text="Scheduler Issues" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="SemiBold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
                             <Button Content="Refresh" Click="SystemEventsRefresh_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
                             <TextBlock x:Name="SchedulerIssuesCountIndicator" Text="" Margin="12,0,0,0" VerticalAlignment="Center" FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                         </StackPanel>
@@ -2681,7 +2681,7 @@
                     <Grid>
                         <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
                         <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
-                            <TextBlock Text="Severe Errors (severity ≥ 19)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
+                            <TextBlock Text="Severe Errors (severity ≥ 19)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="SemiBold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
                             <Button Content="Refresh" Click="SystemEventsRefresh_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
                             <TextBlock x:Name="SevereErrorsCountIndicator" Text="" Margin="12,0,0,0" VerticalAlignment="Center" FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                         </StackPanel>
@@ -2710,7 +2710,7 @@
                     <Grid>
                         <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
                         <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
-                            <TextBlock Text="Memory Conditions (low physical memory)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
+                            <TextBlock Text="Memory Conditions (low physical memory)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="SemiBold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
                             <Button Content="Refresh" Click="SystemEventsRefresh_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
                             <TextBlock x:Name="MemoryConditionsCountIndicator" Text="" Margin="12,0,0,0" VerticalAlignment="Center" FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                         </StackPanel>
@@ -2761,7 +2761,7 @@
                     <Grid>
                         <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
                         <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
-                            <TextBlock Text="Memory Broker (low physical memory)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
+                            <TextBlock Text="Memory Broker (low physical memory)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="SemiBold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
                             <Button Content="Refresh" Click="SystemEventsRefresh_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
                             <TextBlock x:Name="MemoryBrokerCountIndicator" Text="" Margin="12,0,0,0" VerticalAlignment="Center" FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                         </StackPanel>
@@ -2793,7 +2793,7 @@
                     <Grid>
                         <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
                         <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
-                            <TextBlock Text="Memory Node OOM" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
+                            <TextBlock Text="Memory Node OOM" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="SemiBold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
                             <Button Content="Refresh" Click="SystemEventsRefresh_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
                             <TextBlock x:Name="MemoryNodeOomCountIndicator" Text="" Margin="12,0,0,0" VerticalAlignment="Center" FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                         </StackPanel>
@@ -2840,7 +2840,7 @@
                     <Grid>
                         <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
                         <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
-                            <TextBlock Text="Significant Waits (duration ≥ 500 ms)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
+                            <TextBlock Text="Significant Waits (duration ≥ 500 ms)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="SemiBold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
                             <Button Content="Refresh" Click="SystemEventsRefresh_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
                             <TextBlock x:Name="SignificantWaitsCountIndicator" Text="" Margin="12,0,0,0" VerticalAlignment="Center" FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                         </StackPanel>
@@ -2869,7 +2869,7 @@
                     <Grid>
                         <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
                         <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
-                            <TextBlock Text="CPU Tasks (WARNING with 10+ pending tasks)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
+                            <TextBlock Text="CPU Tasks (WARNING with 10+ pending tasks)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="SemiBold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
                             <Button Content="Refresh" Click="SystemEventsRefresh_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
                             <TextBlock x:Name="CpuTasksCountIndicator" Text="" Margin="12,0,0,0" VerticalAlignment="Center" FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                         </StackPanel>
@@ -2899,7 +2899,7 @@
                     <Grid>
                         <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
                         <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
-                            <TextBlock Text="I/O Issues (WARNING with pending I/O)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
+                            <TextBlock Text="I/O Issues (WARNING with pending I/O)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="SemiBold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
                             <Button Content="Refresh" Click="SystemEventsRefresh_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
                             <TextBlock x:Name="IoIssuesCountIndicator" Text="" Margin="12,0,0,0" VerticalAlignment="Center" FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                         </StackPanel>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
@@ -1748,13 +1748,13 @@
 
                 <!-- Memory Grants Sub-Tab -->
                 <TabItem Header="Memory Grants">
-                    <Grid>
+                    <Grid Margin="8">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="*"/>
                             <RowDefinition Height="*"/>
                         </Grid.RowDefinitions>
-                        <scottplot:WpfPlot Grid.Row="0" x:Name="MemoryGrantSizingChart" Margin="5,5,5,2"/>
-                        <scottplot:WpfPlot Grid.Row="1" x:Name="MemoryGrantActivityChart" Margin="5,2,5,5"/>
+                        <scottplot:WpfPlot Grid.Row="0" x:Name="MemoryGrantSizingChart" Margin="0,0,0,4"/>
+                        <scottplot:WpfPlot Grid.Row="1" x:Name="MemoryGrantActivityChart" Margin="0,4,0,0"/>
                     </Grid>
                 </TabItem>
 
@@ -1802,8 +1802,8 @@
 
                 <!-- Memory Pressure Events Sub-Tab -->
                 <TabItem Header="Memory Pressure Events">
-                    <Grid>
-                        <scottplot:WpfPlot x:Name="MemoryPressureEventsChart" Margin="5"/>
+                    <Grid Margin="8">
+                        <scottplot:WpfPlot x:Name="MemoryPressureEventsChart"/>
                     </Grid>
                 </TabItem>
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
@@ -2838,7 +2838,7 @@
                     <Grid>
                         <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
                         <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
-                            <TextBlock Text="Scheduler Issues (last 24h)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
+                            <TextBlock Text="Scheduler Issues" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
                             <Button Content="Refresh" Click="SystemEventsRefresh_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
                             <TextBlock x:Name="SchedulerIssuesCountIndicator" Text="" Margin="12,0,0,0" VerticalAlignment="Center" FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                         </StackPanel>
@@ -2866,7 +2866,7 @@
                     <Grid>
                         <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
                         <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
-                            <TextBlock Text="Severe Errors (last 24h, severity ≥ 19)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
+                            <TextBlock Text="Severe Errors (severity ≥ 19)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
                             <Button Content="Refresh" Click="SystemEventsRefresh_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
                             <TextBlock x:Name="SevereErrorsCountIndicator" Text="" Margin="12,0,0,0" VerticalAlignment="Center" FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                         </StackPanel>
@@ -2895,7 +2895,7 @@
                     <Grid>
                         <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
                         <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
-                            <TextBlock Text="Memory Conditions (last 24h, low physical memory)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
+                            <TextBlock Text="Memory Conditions (low physical memory)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
                             <Button Content="Refresh" Click="SystemEventsRefresh_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
                             <TextBlock x:Name="MemoryConditionsCountIndicator" Text="" Margin="12,0,0,0" VerticalAlignment="Center" FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                         </StackPanel>
@@ -2946,7 +2946,7 @@
                     <Grid>
                         <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
                         <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
-                            <TextBlock Text="Memory Broker (last 24h, low physical memory)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
+                            <TextBlock Text="Memory Broker (low physical memory)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
                             <Button Content="Refresh" Click="SystemEventsRefresh_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
                             <TextBlock x:Name="MemoryBrokerCountIndicator" Text="" Margin="12,0,0,0" VerticalAlignment="Center" FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                         </StackPanel>
@@ -2978,7 +2978,7 @@
                     <Grid>
                         <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
                         <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
-                            <TextBlock Text="Memory Node OOM (last 24h)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
+                            <TextBlock Text="Memory Node OOM" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
                             <Button Content="Refresh" Click="SystemEventsRefresh_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
                             <TextBlock x:Name="MemoryNodeOomCountIndicator" Text="" Margin="12,0,0,0" VerticalAlignment="Center" FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                         </StackPanel>
@@ -3025,7 +3025,7 @@
                     <Grid>
                         <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
                         <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
-                            <TextBlock Text="Significant Waits (last 24h, duration ≥ 500 ms)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
+                            <TextBlock Text="Significant Waits (duration ≥ 500 ms)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
                             <Button Content="Refresh" Click="SystemEventsRefresh_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
                             <TextBlock x:Name="SignificantWaitsCountIndicator" Text="" Margin="12,0,0,0" VerticalAlignment="Center" FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                         </StackPanel>
@@ -3054,7 +3054,7 @@
                     <Grid>
                         <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
                         <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
-                            <TextBlock Text="CPU Tasks (last 24h, WARNING with 10+ pending tasks)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
+                            <TextBlock Text="CPU Tasks (WARNING with 10+ pending tasks)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
                             <Button Content="Refresh" Click="SystemEventsRefresh_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
                             <TextBlock x:Name="CpuTasksCountIndicator" Text="" Margin="12,0,0,0" VerticalAlignment="Center" FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                         </StackPanel>
@@ -3084,7 +3084,7 @@
                     <Grid>
                         <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
                         <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
-                            <TextBlock Text="I/O Issues (last 24h, WARNING with pending I/O)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
+                            <TextBlock Text="I/O Issues (WARNING with pending I/O)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="Bold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
                             <Button Content="Refresh" Click="SystemEventsRefresh_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
                             <TextBlock x:Name="IoIssuesCountIndicator" Text="" Margin="12,0,0,0" VerticalAlignment="Center" FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                         </StackPanel>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
@@ -288,6 +288,44 @@
             <Setter Property="ContextMenu" Value="{StaticResource QueryPlanGridContextMenu}"/>
         </Style>
 
+        <!-- PLAN variant for the Active Queries snapshot grid: its plans are the snapshot's OWN captured XML
+             (estimated always; actual only when the snapshot caught a live plan), opened via the OpenSnapshot*
+             handlers — a different mechanism from the plan_handle live-fetch the aggregate grids use, so it
+             gets its own menu rather than reusing QueryPlanGridContextMenu. Mirrors the in-row Estimated/Actual
+             buttons so plan access is available by right-click too (Lite parity). Each item is gated on the
+             row's HasQueryPlan / HasLiveQueryPlan exactly like the buttons. -->
+        <ContextMenu x:Key="QuerySnapshotGridContextMenu">
+            <MenuItem Header="Copy Cell" Click="CopyCell_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4CB;"/></MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Header="Copy Row" Click="CopyRow_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4C4;"/></MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Header="Copy All Rows" Click="CopyAllRows_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4D1;"/></MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Header="Copy Repro Script" Click="CopyReproScript_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4DD;"/></MenuItem.Icon>
+            </MenuItem>
+            <Separator/>
+            <MenuItem Header="Export to CSV..." Click="ExportToCsv_Click">
+                <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
+            </MenuItem>
+            <Separator/>
+            <MenuItem Header="View Estimated Plan" Click="ViewSnapshotEstimatedPlan_Click"
+                      IsEnabled="{Binding PlacementTarget.DataContext.HasQueryPlan, RelativeSource={RelativeSource AncestorType=ContextMenu}, FallbackValue=False}">
+                <MenuItem.Icon><TextBlock Text="&#x1F50D;"/></MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Header="View Actual Plan" Click="ViewSnapshotActualPlan_Click"
+                      IsEnabled="{Binding PlacementTarget.DataContext.HasLiveQueryPlan, RelativeSource={RelativeSource AncestorType=ContextMenu}, FallbackValue=False}">
+                <MenuItem.Icon><TextBlock Text="&#x1F310;"/></MenuItem.Icon>
+            </MenuItem>
+        </ContextMenu>
+
+        <Style x:Key="QuerySnapshotGridRowStyle" TargetType="DataGridRow" BasedOn="{StaticResource DarkGridRow}">
+            <Setter Property="ContextMenu" Value="{StaticResource QuerySnapshotGridContextMenu}"/>
+        </Style>
+
     </UserControl.Resources>
 
     <Grid>
@@ -529,7 +567,7 @@
                                            Foreground="DarkGoldenrod" FontWeight="SemiBold" VerticalAlignment="Center"/>
                             </StackPanel>
                             <DataGrid Grid.Row="2" x:Name="QuerySnapshotsGrid" Style="{StaticResource DarkGrid}"
-                                      RowStyle="{StaticResource QueryGridRowStyle}"
+                                      RowStyle="{StaticResource QuerySnapshotGridRowStyle}"
                                       HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto"
                                       Sorting="QuerySnapshotsGrid_Sorting">
                                 <DataGrid.Columns>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
@@ -178,17 +178,22 @@
                 <MenuItem.Icon><TextBlock Text="&#x1F4CA;"/></MenuItem.Icon>
             </MenuItem>
             <Separator/>
-            <!-- Stored victim query plan (#1368 / V7), gated per row on HasVictimQueryPlan via the
-                 ContextMenu's PlacementTarget so a plan-less deadlock (best-effort NULL, the common case)
-                 shows the item disabled instead of shown-and-failed. -->
+            <!-- Stored victim query plan (#1368 / V7), gated per row on CanViewVictimPlan (IsVictim AND a plan)
+                 via the ContextMenu's PlacementTarget. The single per-deadlock victim plan is copied onto every
+                 process row, so gating on IsVictim keeps the item from reading as active on the deadlocker rows
+                 (where it is NOT that process's plan); a plan-less deadlock (best-effort NULL, the common case)
+                 still shows it disabled. -->
             <MenuItem Header="View Victim Plan" Click="ViewVictimQueryPlan_Click"
-                      IsEnabled="{Binding PlacementTarget.DataContext.HasVictimQueryPlan, RelativeSource={RelativeSource AncestorType=ContextMenu}, FallbackValue=False}">
+                      IsEnabled="{Binding PlacementTarget.DataContext.CanViewVictimPlan, RelativeSource={RelativeSource AncestorType=ContextMenu}, FallbackValue=False}">
                 <MenuItem.Icon><TextBlock Text="&#x1F50D;"/></MenuItem.Icon>
             </MenuItem>
             <!-- Live plan fetch for ANY process in the graph (headless-plan live-plan wave): asks the service to
                  read the right-clicked process's plan from the target's LIVE cache by the sql_handle in the
-                 deadlock graph — not limited to the single best-effort victim plan the collector stashed. -->
-            <MenuItem Header="Fetch Live Plan (This Process)" Click="FetchDeadlockProcessLivePlan_Click">
+                 deadlock graph — not limited to the single best-effort victim plan the collector stashed. Gated
+                 on HasDeadlockXml (the graph is where the sql_handle is resolved from) for consistency with the
+                 query-grid + blocked-process Fetch items, which disable rather than error when there's no source. -->
+            <MenuItem Header="Fetch Live Plan (This Process)" Click="FetchDeadlockProcessLivePlan_Click"
+                      IsEnabled="{Binding PlacementTarget.DataContext.HasDeadlockXml, RelativeSource={RelativeSource AncestorType=ContextMenu}, FallbackValue=False}">
                 <MenuItem.Icon><TextBlock Text="&#x1F310;"/></MenuItem.Icon>
             </MenuItem>
             <MenuItem Header="View Deadlock Graph" Click="ViewDeadlockGraph_Click">

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
@@ -305,6 +305,18 @@
              works because the server's UTC offset is collected in server_properties.utc_offset_minutes. -->
         <Border Grid.Row="0" Background="{DynamicResource BackgroundDarkBrush}" Padding="12,8">
             <WrapPanel Orientation="Horizontal">
+                <!-- Leading identity + freshness readout (Lite's header shows the server name + a live status;
+                     the headless-appropriate equivalent is the display name + the newest collection time, since
+                     the SERVICE collects and the viewer only reads). Populated from the shared MAX(collection_time)
+                     freshness read, rendered in the toolbar's Server/Local/UTC display mode. -->
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,10,4">
+                    <TextBlock x:Name="ServerNameText" FontSize="14" FontWeight="SemiBold" VerticalAlignment="Center"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBlock x:Name="ServerFreshnessText" FontSize="12" VerticalAlignment="Center" Margin="8,0,0,0"
+                               Foreground="{DynamicResource ForegroundMutedBrush}"
+                               ToolTip="Newest collection time across all collectors — the service collects, the viewer reads"/>
+                </StackPanel>
+                <Separator Style="{StaticResource {x:Static ToolBar.SeparatorStyleKey}}" Margin="8,2"/>
                 <ComboBox x:Name="TimeRangeCombo" SelectedIndex="3" Width="120" Margin="0,0,8,4"
                           SelectionChanged="TimeRangeCombo_SelectionChanged"
                           ToolTip="Time window every inner tab reads">

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
@@ -380,7 +380,7 @@
             <!-- Correlated timeline lanes (copied from Lite's Overview): five stacked, X-axis-synced
                  lanes — CPU %, total wait ms/sec, blocking + deadlocking, buffer pool MB, and file-I/O
                  latency — with baseline bands + anomaly markers and a shared correlated crosshair. -->
-            <local:CorrelatedTimelineLanesControl x:Name="OverviewLanes" Margin="0,8,0,0"/>
+            <local:CorrelatedTimelineLanesControl x:Name="OverviewLanes" Margin="8"/>
         </TabItem>
 
         <!-- Wait Stats Tab — copied from Lite's ServerTab.xaml (the 220px wait-type picker + metric
@@ -465,7 +465,7 @@
         <TabItem Header="Queries">
             <!-- The shared "Compare:" baseline combo lives in the per-server header now (it drives the
                  whole tab's window, not just Queries); this tab is just the sub-tab group. -->
-            <Grid Margin="0,8,0,0">
+            <Grid Margin="8">
                 <TabControl x:Name="QueriesSubTabControl"
                             Background="Transparent" BorderThickness="0"
                             ItemContainerStyle="{DynamicResource SubTabItemStyle}"
@@ -2591,7 +2591,7 @@
                 <TabItem Header="Corruption Events">
                     <Grid>
                         <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
-                        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
+                        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="8,8" Height="36">
                             <TextBlock Text="Corruption Events (bad pages, dump requests, access violations)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="SemiBold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
                             <Button Content="Refresh" Click="SystemEventsRefresh_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
                         </StackPanel>
@@ -2622,7 +2622,7 @@
                 <TabItem Header="Contention Events">
                     <Grid>
                         <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
-                        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
+                        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="8,8" Height="36">
                             <TextBlock Text="Contention Events (non-yielding tasks, latches, spinlocks, CPU)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="SemiBold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
                             <Button Content="Refresh" Click="SystemEventsRefresh_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
                         </StackPanel>
@@ -2652,12 +2652,12 @@
                 <TabItem Header="Scheduler Issues">
                     <Grid>
                         <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
-                        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
+                        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="8,8" Height="36">
                             <TextBlock Text="Scheduler Issues" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="SemiBold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
                             <Button Content="Refresh" Click="SystemEventsRefresh_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
                             <TextBlock x:Name="SchedulerIssuesCountIndicator" Text="" Margin="12,0,0,0" VerticalAlignment="Center" FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                         </StackPanel>
-                        <Grid Grid.Row="1" Margin="10,0,10,10">
+                        <Grid Grid.Row="1" Margin="8,0,8,8">
                             <DataGrid x:Name="SchedulerIssuesGrid" Style="{StaticResource DarkGrid}" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" IsReadOnly="True" AutoGenerateColumns="False">
                                 <DataGrid.Columns>
                                     <DataGridTextColumn Binding="{Binding EventTimeLocal}" Width="145"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="EventTimeLocal" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Event Time" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
@@ -2680,12 +2680,12 @@
                 <TabItem Header="Severe Errors">
                     <Grid>
                         <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
-                        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
+                        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="8,8" Height="36">
                             <TextBlock Text="Severe Errors (severity ≥ 19)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="SemiBold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
                             <Button Content="Refresh" Click="SystemEventsRefresh_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
                             <TextBlock x:Name="SevereErrorsCountIndicator" Text="" Margin="12,0,0,0" VerticalAlignment="Center" FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                         </StackPanel>
-                        <Grid Grid.Row="1" Margin="10,0,10,10">
+                        <Grid Grid.Row="1" Margin="8,0,8,8">
                             <DataGrid x:Name="SevereErrorsGrid" Style="{StaticResource DarkGrid}" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" IsReadOnly="True" AutoGenerateColumns="False">
                                 <DataGrid.Columns>
                                     <DataGridTextColumn Binding="{Binding EventTimeLocal}" Width="145"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="EventTimeLocal" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Event Time" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
@@ -2709,12 +2709,12 @@
                 <TabItem Header="Memory Conditions">
                     <Grid>
                         <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
-                        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
+                        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="8,8" Height="36">
                             <TextBlock Text="Memory Conditions (low physical memory)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="SemiBold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
                             <Button Content="Refresh" Click="SystemEventsRefresh_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
                             <TextBlock x:Name="MemoryConditionsCountIndicator" Text="" Margin="12,0,0,0" VerticalAlignment="Center" FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                         </StackPanel>
-                        <Grid Grid.Row="1" Margin="10,0,10,10">
+                        <Grid Grid.Row="1" Margin="8,0,8,8">
                             <DataGrid x:Name="MemoryConditionsGrid" Style="{StaticResource DarkGrid}" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" IsReadOnly="True" AutoGenerateColumns="False">
                                 <DataGrid.Columns>
                                     <DataGridTextColumn Binding="{Binding EventTimeLocal}" Width="145"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="EventTimeLocal" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Event Time" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
@@ -2760,12 +2760,12 @@
                 <TabItem Header="Memory Broker">
                     <Grid>
                         <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
-                        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
+                        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="8,8" Height="36">
                             <TextBlock Text="Memory Broker (low physical memory)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="SemiBold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
                             <Button Content="Refresh" Click="SystemEventsRefresh_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
                             <TextBlock x:Name="MemoryBrokerCountIndicator" Text="" Margin="12,0,0,0" VerticalAlignment="Center" FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                         </StackPanel>
-                        <Grid Grid.Row="1" Margin="10,0,10,10">
+                        <Grid Grid.Row="1" Margin="8,0,8,8">
                             <DataGrid x:Name="MemoryBrokerGrid" Style="{StaticResource DarkGrid}" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" IsReadOnly="True" AutoGenerateColumns="False">
                                 <DataGrid.Columns>
                                     <DataGridTextColumn Binding="{Binding EventTimeLocal}" Width="145"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="EventTimeLocal" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Event Time" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
@@ -2792,12 +2792,12 @@
                 <TabItem Header="Memory Node OOM">
                     <Grid>
                         <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
-                        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
+                        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="8,8" Height="36">
                             <TextBlock Text="Memory Node OOM" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="SemiBold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
                             <Button Content="Refresh" Click="SystemEventsRefresh_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
                             <TextBlock x:Name="MemoryNodeOomCountIndicator" Text="" Margin="12,0,0,0" VerticalAlignment="Center" FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                         </StackPanel>
-                        <Grid Grid.Row="1" Margin="10,0,10,10">
+                        <Grid Grid.Row="1" Margin="8,0,8,8">
                             <DataGrid x:Name="MemoryNodeOomGrid" Style="{StaticResource DarkGrid}" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" IsReadOnly="True" AutoGenerateColumns="False">
                                 <DataGrid.Columns>
                                     <DataGridTextColumn Binding="{Binding EventTimeLocal}" Width="145"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="EventTimeLocal" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Event Time" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
@@ -2839,12 +2839,12 @@
                 <TabItem Header="Significant Waits">
                     <Grid>
                         <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
-                        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
+                        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="8,8" Height="36">
                             <TextBlock Text="Significant Waits (duration ≥ 500 ms)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="SemiBold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
                             <Button Content="Refresh" Click="SystemEventsRefresh_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
                             <TextBlock x:Name="SignificantWaitsCountIndicator" Text="" Margin="12,0,0,0" VerticalAlignment="Center" FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                         </StackPanel>
-                        <Grid Grid.Row="1" Margin="10,0,10,10">
+                        <Grid Grid.Row="1" Margin="8,0,8,8">
                             <DataGrid x:Name="SignificantWaitsGrid" Style="{StaticResource DarkGrid}" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" IsReadOnly="True" AutoGenerateColumns="False">
                                 <DataGrid.Columns>
                                     <DataGridTextColumn Binding="{Binding EventTimeLocal}" Width="145"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="EventTimeLocal" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Event Time" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
@@ -2868,12 +2868,12 @@
                 <TabItem Header="CPU Tasks">
                     <Grid>
                         <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
-                        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
+                        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="8,8" Height="36">
                             <TextBlock Text="CPU Tasks (WARNING with 10+ pending tasks)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="SemiBold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
                             <Button Content="Refresh" Click="SystemEventsRefresh_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
                             <TextBlock x:Name="CpuTasksCountIndicator" Text="" Margin="12,0,0,0" VerticalAlignment="Center" FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                         </StackPanel>
-                        <Grid Grid.Row="1" Margin="10,0,10,10">
+                        <Grid Grid.Row="1" Margin="8,0,8,8">
                             <DataGrid x:Name="CpuTasksGrid" Style="{StaticResource DarkGrid}" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" IsReadOnly="True" AutoGenerateColumns="False">
                                 <DataGrid.Columns>
                                     <DataGridTextColumn Binding="{Binding EventTimeLocal}" Width="145"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="EventTimeLocal" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Event Time" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>
@@ -2898,12 +2898,12 @@
                 <TabItem Header="I/O Issues">
                     <Grid>
                         <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
-                        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10,8" Height="36">
+                        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="8,8" Height="36">
                             <TextBlock Text="I/O Issues (WARNING with pending I/O)" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="SemiBold" FontSize="14" Foreground="{DynamicResource ForegroundBrush}"/>
                             <Button Content="Refresh" Click="SystemEventsRefresh_Click" Margin="12,0,0,0" Padding="10,4" MinWidth="70"/>
                             <TextBlock x:Name="IoIssuesCountIndicator" Text="" Margin="12,0,0,0" VerticalAlignment="Center" FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                         </StackPanel>
-                        <Grid Grid.Row="1" Margin="10,0,10,10">
+                        <Grid Grid.Row="1" Margin="8,0,8,8">
                             <DataGrid x:Name="IoIssuesGrid" Style="{StaticResource DarkGrid}" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" IsReadOnly="True" AutoGenerateColumns="False">
                                 <DataGrid.Columns>
                                     <DataGridTextColumn Binding="{Binding EventTimeLocal}" Width="145"><DataGridTextColumn.Header><StackPanel Orientation="Horizontal"><Button Style="{DynamicResource ColumnFilterButtonStyle}" Tag="EventTimeLocal" Click="FilterButton_Click" Margin="0,0,4,0"/><TextBlock Text="Event Time" FontWeight="Bold" VerticalAlignment="Center"/></StackPanel></DataGridTextColumn.Header></DataGridTextColumn>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
@@ -2756,33 +2756,19 @@
                             <Grid.RowDefinitions><RowDefinition Height="*"/><RowDefinition Height="*"/></Grid.RowDefinitions>
                             <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="*"/></Grid.ColumnDefinitions>
 
-                            <Border Grid.Row="0" Grid.Column="0" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" Margin="2">
-                                <Grid>
-                                    <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
-                                    <TextBlock Text="Bad Pages Detected" FontWeight="Bold" Margin="5,3" FontSize="11" Foreground="{DynamicResource ForegroundBrush}"/>
-                                    <scottplot:WpfPlot Grid.Row="1" x:Name="BadPagesChart"/>
-                                </Grid>
+                            <!-- Borderless tiles matching every other chart tab; each chart identifies itself
+                                 via its descriptive Y-axis label (like File I/O's "Read Latency (ms)"). -->
+                            <Border Grid.Row="0" Grid.Column="0" Margin="2">
+                                <scottplot:WpfPlot x:Name="BadPagesChart"/>
                             </Border>
-                            <Border Grid.Row="0" Grid.Column="1" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" Margin="2">
-                                <Grid>
-                                    <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
-                                    <TextBlock Text="Interval Dump Requests" FontWeight="Bold" Margin="5,3" FontSize="11" Foreground="{DynamicResource ForegroundBrush}"/>
-                                    <scottplot:WpfPlot Grid.Row="1" x:Name="DumpRequestsChart"/>
-                                </Grid>
+                            <Border Grid.Row="0" Grid.Column="1" Margin="2">
+                                <scottplot:WpfPlot x:Name="DumpRequestsChart"/>
                             </Border>
-                            <Border Grid.Row="1" Grid.Column="0" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" Margin="2">
-                                <Grid>
-                                    <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
-                                    <TextBlock Text="Access Violations Occurred" FontWeight="Bold" Margin="5,3" FontSize="11" Foreground="{DynamicResource ForegroundBrush}"/>
-                                    <scottplot:WpfPlot Grid.Row="1" x:Name="AccessViolationsChart"/>
-                                </Grid>
+                            <Border Grid.Row="1" Grid.Column="0" Margin="2">
+                                <scottplot:WpfPlot x:Name="AccessViolationsChart"/>
                             </Border>
-                            <Border Grid.Row="1" Grid.Column="1" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" Margin="2">
-                                <Grid>
-                                    <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
-                                    <TextBlock Text="Write Access Violation Count" FontWeight="Bold" Margin="5,3" FontSize="11" Foreground="{DynamicResource ForegroundBrush}"/>
-                                    <scottplot:WpfPlot Grid.Row="1" x:Name="WriteAccessViolationsChart"/>
-                                </Grid>
+                            <Border Grid.Row="1" Grid.Column="1" Margin="2">
+                                <scottplot:WpfPlot x:Name="WriteAccessViolationsChart"/>
                             </Border>
                         </Grid>
                     </Grid>
@@ -2801,33 +2787,19 @@
                             <Grid.RowDefinitions><RowDefinition Height="*"/><RowDefinition Height="*"/></Grid.RowDefinitions>
                             <Grid.ColumnDefinitions><ColumnDefinition Width="*"/><ColumnDefinition Width="*"/></Grid.ColumnDefinitions>
 
-                            <Border Grid.Row="0" Grid.Column="0" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" Margin="2">
-                                <Grid>
-                                    <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
-                                    <TextBlock Text="Non-Yielding Tasks Reported" FontWeight="Bold" Margin="5,3" FontSize="11" Foreground="{DynamicResource ForegroundBrush}"/>
-                                    <scottplot:WpfPlot Grid.Row="1" x:Name="NonYieldingTasksChart"/>
-                                </Grid>
+                            <!-- Borderless tiles matching every other chart tab; each chart identifies itself
+                                 via its descriptive Y-axis label / legend (like File I/O's "Read Latency (ms)"). -->
+                            <Border Grid.Row="0" Grid.Column="0" Margin="2">
+                                <scottplot:WpfPlot x:Name="NonYieldingTasksChart"/>
                             </Border>
-                            <Border Grid.Row="0" Grid.Column="1" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" Margin="2">
-                                <Grid>
-                                    <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
-                                    <TextBlock Text="Latch Warnings" FontWeight="Bold" Margin="5,3" FontSize="11" Foreground="{DynamicResource ForegroundBrush}"/>
-                                    <scottplot:WpfPlot Grid.Row="1" x:Name="LatchWarningsChart"/>
-                                </Grid>
+                            <Border Grid.Row="0" Grid.Column="1" Margin="2">
+                                <scottplot:WpfPlot x:Name="LatchWarningsChart"/>
                             </Border>
-                            <Border Grid.Row="1" Grid.Column="0" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" Margin="2">
-                                <Grid>
-                                    <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
-                                    <TextBlock Text="Sick Spinlocks by Type" FontWeight="Bold" Margin="5,3" FontSize="11" Foreground="{DynamicResource ForegroundBrush}"/>
-                                    <scottplot:WpfPlot Grid.Row="1" x:Name="SickSpinlocksChart"/>
-                                </Grid>
+                            <Border Grid.Row="1" Grid.Column="0" Margin="2">
+                                <scottplot:WpfPlot x:Name="SickSpinlocksChart"/>
                             </Border>
-                            <Border Grid.Row="1" Grid.Column="1" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" Margin="2">
-                                <Grid>
-                                    <Grid.RowDefinitions><RowDefinition Height="Auto"/><RowDefinition Height="*"/></Grid.RowDefinitions>
-                                    <TextBlock Text="SQL CPU vs System CPU" FontWeight="Bold" Margin="5,3" FontSize="11" Foreground="{DynamicResource ForegroundBrush}"/>
-                                    <scottplot:WpfPlot Grid.Row="1" x:Name="CpuComparisonChart"/>
-                                </Grid>
+                            <Border Grid.Row="1" Grid.Column="1" Margin="2">
+                                <scottplot:WpfPlot x:Name="CpuComparisonChart"/>
                             </Border>
                         </Grid>
                     </Grid>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml.cs
@@ -86,6 +86,11 @@ public partial class ViewerServerTab : UserControl
         _server = server;
         InitializeComponent();
 
+        /* Per-server toolbar identity label: the display name is static (it also heads the tab), while the
+           freshness readout to its right is filled on the first (and every) refresh from the shared
+           collection-time read (UpdateServerFreshnessLabelAsync). */
+        ServerNameText.Text = _server.DisplayName;
+
         /* Column-filter managers for the Configuration sub-grids (copied from Lite's ServerTab filter
            wiring) — after InitializeComponent so the named grids exist. */
         InitializeFilterManagers();
@@ -229,6 +234,10 @@ public partial class ViewerServerTab : UserControl
             await EnsureServerOffsetLoadedAsync();
             ApplyServerOffsetToHelper();
 
+            /* Refresh the toolbar freshness readout in the same pass (after the offset is applied so it renders
+               in the active display mode). Non-critical chrome — its own try/catch keeps it off the load path. */
+            await UpdateServerFreshnessLabelAsync();
+
             do
             {
                 _refreshRequested = false;
@@ -246,6 +255,28 @@ public partial class ViewerServerTab : UserControl
         finally
         {
             _refreshInFlight = false;
+        }
+    }
+
+    /// <summary>
+    /// Fills the toolbar's freshness readout with this server's newest collection time (the shared
+    /// MAX(collection_time) read the sidebar dots use), rendered in the active Server/Local/UTC display mode
+    /// exactly like the Manage Servers "Last Collected" column. A server the service hasn't collected yet is
+    /// absent from the freshness map, shown as "no data collected yet". Best-effort chrome: a read failure
+    /// blanks the readout rather than disturbing the tab load.
+    /// </summary>
+    private async Task UpdateServerFreshnessLabelAsync()
+    {
+        try
+        {
+            var freshness = await _dataService.GetServerFreshnessAsync();
+            ServerFreshnessText.Text = freshness.TryGetValue(_server.ServerId, out var lastUtc)
+                ? $"collected {ViewerTimeHelper.ForDisplay(lastUtc):yyyy-MM-dd HH:mm}"
+                : "no data collected yet";
+        }
+        catch
+        {
+            ServerFreshnessText.Text = string.Empty;
         }
     }
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml.cs
@@ -34,50 +34,36 @@ public partial class ViewerServerTab : UserControl
        time-range dropdown / custom From-To (see ViewerServerTab.TimeRange.cs). Every inner-tab load
        reads GetWindowUtc() / GetWindowHoursBack() instead of the removed s_dataWindow. */
 
-    /* Inner-tab order mirrors Lite's ServerTab relative order (Overview, Wait Stats, Queries,
-       Plan Viewer, CPU, Memory, File I/O, tempdb, Blocking, Perfmon, Running Jobs, Configuration, Daily
-       Summary, Collection Health) — ported tabs slot into Lite's positions as they arrive (Plan
-       Viewer sits BETWEEN Queries and CPU, Memory sits BETWEEN CPU and File I/O, File I/O sits BEFORE
-       tempdb, Perfmon/Running Jobs sit between Blocking and Configuration, and Daily Summary sits between
-       Configuration and Collection Health, matching Lite's own order), so the constants renumber when a
-       wave lands between existing tabs. */
+    /* Inner-tab order: the main resource run mirrors Lite's ServerTab relative order (Overview, Wait Stats,
+       Queries, Plan Viewer, CPU, Memory, File I/O, tempdb, Blocking, Perfmon, Session Stats, Running Jobs,
+       Configuration, Configuration Changes), followed by a Darling-specific DIAGNOSTICS TAIL:
+       Daily Summary -> System Events -> Latches & Spinlocks -> Collection Health. Latches & Spinlocks and
+       System Events are Darling-only tabs grouped into that tail rather than the resource run. These index
+       constants are the source of truth for SelectedIndex navigation (drill-downs), so they MUST match the
+       <TabItem> order in ViewerServerTab.xaml. */
     internal const int OverviewInnerTabIndex = 0;
     internal const int WaitStatsInnerTabIndex = 1;
+    internal const int QueriesInnerTabIndex = 2;
+    internal const int PlanViewerInnerTabIndex = 3;
+    internal const int CpuInnerTabIndex = 4;
+    internal const int MemoryInnerTabIndex = 5;
+    internal const int FileIoInnerTabIndex = 6;
+    internal const int TempDbInnerTabIndex = 7;
+    internal const int BlockingInnerTabIndex = 8;
+    internal const int PerfmonInnerTabIndex = 9;
+    internal const int SessionStatsInnerTabIndex = 10;
+    internal const int RunningJobsInnerTabIndex = 11;
+    internal const int ConfigurationInnerTabIndex = 12;
+    internal const int ConfigChangesInnerTabIndex = 13;
 
-    /* Latches & Spinlocks sits BETWEEN Wait Stats and Queries — the contention-stats grouping mirroring
-       the Dashboard (its Latch/Spinlock sub-tabs live alongside waits in ResourceMetrics). A new top-level
-       tab holding two sub-tabs (Latch Stats + Spinlock Stats); everything after it renumbers by one. */
-    internal const int LatchSpinlockInnerTabIndex = 2;
-    internal const int QueriesInnerTabIndex = 3;
-    internal const int PlanViewerInnerTabIndex = 4;
-    internal const int CpuInnerTabIndex = 5;
-    internal const int MemoryInnerTabIndex = 6;
-    internal const int FileIoInnerTabIndex = 7;
-    internal const int TempDbInnerTabIndex = 8;
-    internal const int BlockingInnerTabIndex = 9;
-    internal const int PerfmonInnerTabIndex = 10;
-
-    /* Session Stats sits BETWEEN Perfmon and Running Jobs — the Dashboard-parity port of
-       ResourceMetricsContent's Session Stats sub-tab (which the Dashboard places right after Perfmon). Not a
-       Lite ServerTab tab (it is Dashboard-only), so it has no Lite position to mirror; a new top-level tab,
-       and everything after it renumbers by one. */
-    internal const int SessionStatsInnerTabIndex = 11;
-    internal const int RunningJobsInnerTabIndex = 12;
-    internal const int ConfigurationInnerTabIndex = 13;
-
-    /* Configuration Changes sits immediately AFTER Configuration (the latest-snapshot tab): the Dashboard's
-       dedicated ConfigChangesContent ported as its own tab — three grids diffing the append-only config
-       snapshots into server-config / database-config / trace-flag DRIFT over the window. A new top-level tab,
-       so everything after it renumbers by one. */
-    internal const int ConfigChangesInnerTabIndex = 14;
-    internal const int DailySummaryInnerTabIndex = 15;
-    internal const int HealthInnerTabIndex = 16;
-
-    /* System Events is appended AFTER Collection Health (system_health parity, Stage 2b): six parse-on-read
-       sub-tabs, one per unique system_health warning category. FinOps used to sit between them as a per-server
-       inner tab, but it was promoted to a top-level cross-server aggregate tab (FinOpsTab, in MainWindow's
-       MainTabs), so System Events now takes Collection Health's next slot. */
-    internal const int SystemEventsInnerTabIndex = 17;
+    /* Diagnostics tail (Daily Summary -> System Events -> Latches & Spinlocks -> Collection Health): the
+       reworked per-server tab order groups the two Darling-only diagnostic tabs (System Events, Latches &
+       Spinlocks) with Daily Summary and Collection Health at the end, instead of scattering them through the
+       resource run (Latches & Spinlocks was formerly at position 3, System Events dead last). */
+    internal const int DailySummaryInnerTabIndex = 14;
+    internal const int SystemEventsInnerTabIndex = 15;
+    internal const int LatchSpinlockInnerTabIndex = 16;
+    internal const int HealthInnerTabIndex = 17;
 
     private readonly ViewerDataService _dataService;
     private readonly DarlingServer _server;

--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -1349,20 +1349,20 @@
 
                     <!-- Memory Grants Sub-Tab -->
                     <TabItem Header="Memory Grants">
-                        <Grid>
+                        <Grid Margin="8">
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="*"/>
                                 <RowDefinition Height="*"/>
                             </Grid.RowDefinitions>
-                            <ScottPlot:WpfPlot Grid.Row="0" x:Name="MemoryGrantSizingChart" Margin="5,5,5,2"/>
-                            <ScottPlot:WpfPlot Grid.Row="1" x:Name="MemoryGrantActivityChart" Margin="5,2,5,5"/>
+                            <ScottPlot:WpfPlot Grid.Row="0" x:Name="MemoryGrantSizingChart" Margin="0,0,0,4"/>
+                            <ScottPlot:WpfPlot Grid.Row="1" x:Name="MemoryGrantActivityChart" Margin="0,4,0,0"/>
                         </Grid>
                     </TabItem>
 
                     <!-- Memory Pressure Events Sub-Tab -->
                     <TabItem Header="Memory Pressure Events">
-                        <Grid>
-                            <ScottPlot:WpfPlot x:Name="MemoryPressureEventsChart" Margin="5"/>
+                        <Grid Margin="8">
+                            <ScottPlot:WpfPlot x:Name="MemoryPressureEventsChart"/>
                         </Grid>
                     </TabItem>
 

--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -1730,7 +1730,7 @@
                     <TextBlock Grid.Row="0" Text="Currently Running SQL Agent Jobs" FontSize="14" FontWeight="SemiBold" Margin="0,0,0,8"/>
                     <TextBlock Grid.Row="1" x:Name="RunningJobsMsdbWarning"
                                Text="Running Jobs requires msdb access. Grant the login access to msdb to enable this feature."
-                               Foreground="#FFD700" FontSize="12" Margin="0,0,0,8" Visibility="Collapsed"
+                               Foreground="{DynamicResource WarningTextBrush}" FontSize="12" Margin="0,0,0,8" Visibility="Collapsed"
                                TextWrapping="Wrap"/>
                     <DataGrid Grid.Row="2" x:Name="RunningJobsGrid"
                               AutoGenerateColumns="False" IsReadOnly="True"

--- a/Lite/Services/LocalDataService.Blocking.cs
+++ b/Lite/Services/LocalDataService.Blocking.cs
@@ -389,7 +389,8 @@ SELECT
     wait_time_ms, lock_mode, blocking_status, contentious_object,
     blocked_sql_text, blocking_sql_text,
     blocked_login_name, blocked_host_name, blocked_client_app,
-    blocked_last_tran_started, blocking_last_tran_started, monitor_loop
+    blocked_last_tran_started, blocking_last_tran_started, monitor_loop,
+    blocking_login_name, blocking_host_name, blocking_client_app
 FROM v_dmv_blocking_snapshots
 WHERE server_id = $1 AND collection_time >= $2 AND collection_time <= $3
 ORDER BY event_time DESC
@@ -422,6 +423,11 @@ LIMIT 200";
                     BlockedLastTranStarted = reader.IsDBNull(16) ? null : reader.GetDateTime(16),
                     BlockingLastTranStarted = reader.IsDBNull(17) ? null : reader.GetDateTime(17),
                     MonitorLoop = reader.IsDBNull(18) ? (int?)null : reader.GetInt32(18),
+                    /* Blocking-side identity — the DMV snapshot is the only blocking source on AWS RDS / when the
+                       BPR threshold is unset, so surface it here too (the XE path already sets these). */
+                    BlockingLoginName = reader.IsDBNull(19) ? "" : reader.GetString(19),
+                    BlockingHostName = reader.IsDBNull(20) ? "" : reader.GetString(20),
+                    BlockingClientApp = reader.IsDBNull(21) ? "" : reader.GetString(21),
                     Source = BlockedProcessAlertRow.DmvSnapshotSource
                 });
             }


### PR DESCRIPTION
Implements a cluster of 15 verified audit findings on the Darling viewer's per-server-tab surfaces (plus cross-app Lite mirrors where the defect is shared). Each finding is its own commit for review. Every fix follows the exact evidence + prescribed fix from the viewer-vs-Lite audit inventory; #1439's already-landed visual fixes were left intact.

## Findings (one commit each)

**Chrome / IA**
- **Per-server tab order rework** — Latches & Spinlocks was at position 3 and System Events dead last; reordered into a resource run + diagnostics tail (Daily Summary -> System Events -> Latches & Spinlocks -> Collection Health). Renumbered the `*InnerTabIndex` constants (source of truth for drill-down `SelectedIndex` routing) + updated the pinning test.
- **Per-server toolbar** now shows the server DisplayName + newest-collection freshness (reuses `GetServerFreshnessAsync`, rendered in the active Server/Local/UTC mode like Manage Servers' "Last Collected").

**Plan access**
- **Expensive Queries "Fetch Live Plan"** was permanently greyed (model lacked `HasLivePlanHandle`) — added `MAX(plan_handle)` to the query_stats + procedure_stats UNION arms, `NULL::text` to the query_store arm, `PlanHandle`/`HasLivePlanHandle` to the row, and a `ViewerExpensiveQueryRow` case to `FetchLiveQueryPlan_Click`. QS rows stay correctly disabled. +tests.
- **Top Queries / Top Procedures history windows** gained a gated "Fetch Live Plan" (was stored "View Plan" only) via the headless-safe `fetch_plan` command; Query Store history correctly stays View-Plan-only.
- **Deadlocks** — "View Victim Plan" gated on `CanViewVictimPlan` (IsVictim + a plan) so it no longer reads active on deadlocker rows; "Fetch Live Plan (This Process)" gated on `HasDeadlockXml` for consistency.
- **Active Queries snapshot grid** — added right-click "View Estimated/Actual Plan" (mirrors the in-row buttons); Get Actual Plan re-execution stays the deliberate headless omission.

**Charts & drill-downs**
- **13 Darling-only charts** (CPU Scheduler, Latch/Spinlock, Plan Cache, Session Counts, 8 System Events) gained the peer "Show Active Queries at This Time" drill (moved from menu-only to `WireChartDrillDowns`; CollectorDuration stays menu-only like Lite).
- Fixed the stale "unwired" comments on `CorrelatedTimelineLanesControl` (the drill event is in fact wired).

**Data completeness**
- **DMV blocked-process rows** now surface Blocking Login/Host/App (the only blocking source on AWS RDS / unset BPR threshold). Mirrored in Lite.

**Visual consistency**
- System Events grid titles drop the misleading "(last 24h)" (grids query the settable window).
- In-tab section titles standardized on the SectionHeader style (Session Stats outlier fixed; 10 System Events strips Bold->SemiBold).
- Per-tab outer inset standardized at 8px (Overview/Queries `0,8,0,0`->`8`; System Events 10px->8px).
- System Events Corruption/Contention chart tiles made borderless like every other chart tab (identity now via descriptive Y-axis label).
- Memory Grants / Pressure Events insets standardized (mirror Lite).
- Running Jobs msdb warning uses the `WarningTextBrush` theme token instead of hardcoded `#FFD700` (mirror Lite).

## Validation
- Darling viewer + Lite build clean (`-c Release`).
- **Darling.Tests: 1609 passed, 0 failed, 125 gated-skip.**
- **Lite.Tests: 911 passed, 0 failed.**
- Live-Postgres round-trips are gated (DARLING_TEST_PG unset here); the Expensive Queries live test was extended to plant + assert `plan_handle` end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
