### PR TITLE
Port Lite's system tray + in-app alert toasts to the Darling viewer

### DIFF
--- a/Darling/Darling.Tests/ViewerAlertToastCoordinatorTests.cs
+++ b/Darling/Darling.Tests/ViewerAlertToastCoordinatorTests.cs
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using PerformanceMonitor.Darling.Viewer;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Pins the two load-bearing seams of the viewer's headless in-app alert toasts — the "new since last-seen"
+/// watermark and the per-condition cooldown gate in <see cref="AlertToastCoordinator"/> — without WPF,
+/// Postgres, or a real clock. The tray rendering itself (Hardcodet balloons) is not unit-testable; this
+/// covers all the decision logic that decides IF and WHICH polled alert rows become toasts.
+/// </summary>
+public sealed class ViewerAlertToastCoordinatorTests
+{
+    private static readonly DateTime T0 = new(2026, 7, 7, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly TimeSpan Retention = TimeSpan.FromMinutes(20);
+    private static readonly TimeSpan Cooldown = TimeSpan.FromMinutes(5);
+
+    private static ViewerAlertRow Row(
+        DateTime alertTime, int serverId, string metric, bool muted = false, string? detail = null) => new()
+    {
+        AlertTime = alertTime,
+        ServerId = serverId,
+        ServerName = $"Server{serverId}",
+        MetricName = metric,
+        CurrentValue = 90,
+        ThresholdValue = 80,
+        AlertSent = true,
+        NotificationType = "tray",
+        Muted = muted,
+        DetailText = detail,
+    };
+
+    [Fact]
+    public void Ctor_RejectsNonPositiveRetention()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new AlertToastCoordinator(TimeSpan.Zero));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new AlertToastCoordinator(TimeSpan.FromMinutes(-1)));
+    }
+
+    [Fact]
+    public void Prime_SuppressesRowsThatExistedAtStartup()
+    {
+        var coordinator = new AlertToastCoordinator(Retention);
+        var existing = new[] { Row(T0, 1, "High CPU"), Row(T0.AddMinutes(1), 2, "Blocking Detected") };
+        coordinator.Prime(existing);
+
+        /* Re-polling the exact rows that were present at startup must produce no toasts. */
+        var toasts = coordinator.SelectToasts(existing, T0.AddMinutes(2), Cooldown);
+
+        Assert.Empty(toasts);
+    }
+
+    [Fact]
+    public void SelectToasts_NewRowAfterPrime_IsToasted()
+    {
+        var coordinator = new AlertToastCoordinator(Retention);
+        coordinator.Prime(new[] { Row(T0, 1, "High CPU") });
+
+        var fresh = Row(T0.AddMinutes(1), 2, "Deadlocks Detected");
+        var toasts = coordinator.SelectToasts(
+            new[] { Row(T0, 1, "High CPU"), fresh }, T0.AddMinutes(1), Cooldown);
+
+        Assert.Single(toasts);
+        Assert.Same(fresh, toasts[0]);
+    }
+
+    [Fact]
+    public void SelectToasts_SameRowAcrossTwoPolls_ToastsExactlyOnce()
+    {
+        var coordinator = new AlertToastCoordinator(Retention);
+        var row = Row(T0, 1, "High CPU");
+
+        var first = coordinator.SelectToasts(new[] { row }, T0, Cooldown);
+        var second = coordinator.SelectToasts(new[] { row }, T0.AddMinutes(1), Cooldown);
+
+        Assert.Single(first);
+        Assert.Empty(second);
+    }
+
+    [Fact]
+    public void SelectToasts_MutedRow_IsNeverToasted()
+    {
+        var coordinator = new AlertToastCoordinator(Retention);
+        var muted = Row(T0, 1, "High CPU", muted: true);
+
+        var toasts = coordinator.SelectToasts(new[] { muted }, T0, Cooldown);
+
+        Assert.Empty(toasts);
+    }
+
+    [Fact]
+    public void SelectToasts_MutedRow_IsMarkedSeen_SoAnUnmuteInTheStoreDoesNotReplay()
+    {
+        var coordinator = new AlertToastCoordinator(Retention);
+        var muted = Row(T0, 1, "High CPU", muted: true);
+        coordinator.SelectToasts(new[] { muted }, T0, Cooldown);
+
+        /* Same identity re-read later (even if it came back unmuted) stays suppressed — the row was
+           already considered. */
+        var unmutedSameIdentity = Row(T0, 1, "High CPU");
+        var toasts = coordinator.SelectToasts(new[] { unmutedSameIdentity }, T0.AddMinutes(1), Cooldown);
+
+        Assert.Empty(toasts);
+    }
+
+    [Fact]
+    public void SelectToasts_TwoDistinctRowsOfSameCondition_WithinCooldown_ToastsOnlyTheFirst()
+    {
+        var coordinator = new AlertToastCoordinator(Retention);
+        var earlier = Row(T0, 1, "High CPU");
+        var later = Row(T0.AddMinutes(1), 1, "High CPU"); /* distinct row, same server+metric */
+
+        var toasts = coordinator.SelectToasts(new[] { earlier, later }, T0.AddMinutes(1), Cooldown);
+
+        Assert.Single(toasts);
+        Assert.Same(earlier, toasts[0]); /* oldest-first: the earliest wins the cooldown slot */
+    }
+
+    [Fact]
+    public void SelectToasts_ProcessesOldestFirst_RegardlessOfInputOrder()
+    {
+        var coordinator = new AlertToastCoordinator(Retention);
+        var earlier = Row(T0, 1, "High CPU");
+        var later = Row(T0.AddMinutes(1), 1, "High CPU");
+
+        /* Newest-first input (the read's ORDER BY alert_time DESC) must still admit the OLDEST. */
+        var toasts = coordinator.SelectToasts(new[] { later, earlier }, T0.AddMinutes(1), Cooldown);
+
+        Assert.Single(toasts);
+        Assert.Same(earlier, toasts[0]);
+    }
+
+    [Fact]
+    public void SelectToasts_DifferentConditions_BothToastWithinCooldown()
+    {
+        var coordinator = new AlertToastCoordinator(Retention);
+        var cpuOnA = Row(T0, 1, "High CPU");
+        var cpuOnB = Row(T0, 2, "High CPU");             /* different server */
+        var blockingOnA = Row(T0, 1, "Blocking Detected"); /* different metric */
+
+        var toasts = coordinator.SelectToasts(new[] { cpuOnA, cpuOnB, blockingOnA }, T0, Cooldown);
+
+        Assert.Equal(3, toasts.Count);
+    }
+
+    [Fact]
+    public void SelectToasts_CooldownElapsed_ReToastsSameCondition()
+    {
+        var coordinator = new AlertToastCoordinator(Retention);
+        var first = coordinator.SelectToasts(new[] { Row(T0, 1, "High CPU") }, T0, Cooldown);
+
+        /* A distinct later row of the same condition, polled after the cooldown window, toasts again. */
+        var later = Row(T0.AddMinutes(6), 1, "High CPU");
+        var second = coordinator.SelectToasts(new[] { later }, T0.AddMinutes(6), Cooldown);
+
+        Assert.Single(first);
+        Assert.Single(second);
+        Assert.Same(later, second[0]);
+    }
+
+    [Fact]
+    public void SelectToasts_ZeroCooldown_AdmitsEveryNewRowOfAConditionInOnePoll()
+    {
+        var coordinator = new AlertToastCoordinator(Retention);
+        var a = Row(T0, 1, "High CPU");
+        var b = Row(T0.AddMinutes(1), 1, "High CPU");
+        var c = Row(T0.AddMinutes(2), 1, "High CPU");
+
+        var toasts = coordinator.SelectToasts(new[] { a, b, c }, T0.AddMinutes(2), TimeSpan.Zero);
+
+        Assert.Equal(3, toasts.Count);
+    }
+
+    [Fact]
+    public void SelectToasts_ResolvedRow_IsSeverityAgnostic_AndStillSelected()
+    {
+        /* The coordinator does not filter by severity — the MainWindow renders a resolved row as a green
+           styled card. A "Restored"/"Cleared"/"Resolved" row (unmuted) must be admitted. */
+        var coordinator = new AlertToastCoordinator(Retention);
+        var resolved = Row(T0, 1, "Server Restored");
+
+        var toasts = coordinator.SelectToasts(new[] { resolved }, T0, Cooldown);
+
+        Assert.Single(toasts);
+        Assert.True(toasts[0].IsResolved);
+    }
+
+    [Fact]
+    public void SelectToasts_PrimedRowWithinRetention_StaysSuppressed()
+    {
+        var coordinator = new AlertToastCoordinator(Retention);
+        coordinator.Prime(new[] { Row(T0, 1, "High CPU") });
+
+        /* Well inside the retention window: the primed row is still remembered, so it never toasts. */
+        var toasts = coordinator.SelectToasts(new[] { Row(T0, 1, "High CPU") }, T0.AddMinutes(10), Cooldown);
+
+        Assert.Empty(toasts);
+    }
+
+    [Fact]
+    public void SelectToasts_SeenRowBeyondRetention_IsPruned_ThenReToasts()
+    {
+        var coordinator = new AlertToastCoordinator(Retention);
+        coordinator.Prime(new[] { Row(T0, 1, "High CPU") });
+
+        /* A poll past the retention window prunes the stale seen key (an out-of-window row can never be
+           re-read, so remembering it forever would leak). */
+        coordinator.SelectToasts(Array.Empty<ViewerAlertRow>(), T0.AddMinutes(21), Cooldown);
+
+        /* If that identity somehow re-appears it is treated as new again (bounded: retention exceeds the
+           poll fetch window, so an in-window row is never pruned early). */
+        var toasts = coordinator.SelectToasts(new[] { Row(T0, 1, "High CPU") }, T0.AddMinutes(21), Cooldown);
+
+        Assert.Single(toasts);
+    }
+}

--- a/Darling/Darling.Tests/packages.lock.json
+++ b/Darling/Darling.Tests/packages.lock.json
@@ -32,6 +32,11 @@
         "resolved": "1.0.2",
         "contentHash": "VkP04/jFXaxT3TkcRhzETYtOrznQxRmQ2J1XJdbXz47Bir7hIzPR7mFZk4GJQ4An4gozW+vonpf+iqTHomAkQw=="
       },
+      "Hardcodet.NotifyIcon.Wpf": {
+        "type": "Transitive",
+        "resolved": "2.0.1",
+        "contentHash": "dtxmeZXzV2GzSm91aZ3hqzgoeVoARSkDPVCYfhVUNyyKBWYxMgNC0EcLiSYxD4Uc4alq/2qb3SmV8DgAENLRLQ=="
+      },
       "HarfBuzzSharp": {
         "type": "Transitive",
         "resolved": "8.3.1.1",
@@ -877,6 +882,7 @@
       "performancemonitor.darling.viewer": {
         "type": "Project",
         "dependencies": {
+          "Hardcodet.NotifyIcon.Wpf": "[2.0.1, )",
           "PerformanceMonitor.Alerting": "[1.0.0, )",
           "PerformanceMonitor.Analysis": "[1.0.0, )",
           "PerformanceMonitor.Common": "[1.0.0, )",

--- a/Darling/PerformanceMonitor.Darling.Viewer/AlertToastCoordinator.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/AlertToastCoordinator.cs
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// Decides which polled alert-history rows become in-app tray toasts — the headless viewer's stand-in for
+/// Lite's in-process alert engine, which fires a toast at the moment it detects a condition. The viewer has
+/// no engine: alerts already fired SERVICE-side (written to <c>config_alert_log</c> and delivered by
+/// email/Teams/Slack), so the MainWindow re-reads recent history on a timer and this coordinator turns that
+/// stream into non-duplicated, non-spammy toasts. Pure and clock-injected so the two load-bearing seams —
+/// the "new since last-seen" watermark and the per-condition cooldown gate — are unit-testable without WPF,
+/// Postgres, or a real clock.
+///
+/// <para>Two-stage gate, per polled row:</para>
+/// <list type="number">
+/// <item><b>Seen-once watermark.</b> Each distinct alert row is identified by the same triple the dismiss
+/// path keys on — (alert_time, server_id, metric_name) — so a row that has already been offered as a toast
+/// (or was present at startup, via <see cref="Prime"/>) is never re-toasted, even though the poll re-reads
+/// an overlapping window each cycle.</item>
+/// <item><b>Per-condition cooldown.</b> A genuinely-new row still toasts only if the same condition —
+/// (server_id, metric_name) — has not toasted within the cooldown window, so a recurring condition the
+/// service logs every cycle (e.g. High CPU) nudges at most once per cooldown instead of storming the tray.
+/// Mirrors the spirit of the shared <c>IncidentCooldown</c> keyed on a fingerprint.</item>
+/// </list>
+/// <para>Muted rows never toast (Lite parity: the service still logs a muted row, flagged, with channels
+/// skipped). Bookkeeping is pruned each call so neither map grows without bound over a long-lived viewer.</para>
+/// </summary>
+public sealed class AlertToastCoordinator
+{
+    /// <summary>How long a seen-row key is retained. Must be at least the poll fetch window so a row still
+    /// inside that window is never pruned early and re-toasted.</summary>
+    private readonly TimeSpan _seenRetention;
+
+    /// <summary>rowKey (alert_time|server_id|metric) → the row's alert_time, for seen-once + pruning.</summary>
+    private readonly Dictionary<string, DateTime> _seen = new(StringComparer.Ordinal);
+
+    /// <summary>condKey (server_id|metric) → the last toast's nowUtc, for the cooldown gate + pruning.</summary>
+    private readonly Dictionary<string, DateTime> _lastToast = new(StringComparer.Ordinal);
+
+    /// <param name="seenRetention">
+    /// How long to remember a row so the overlapping poll window doesn't re-toast it. Pass at least the
+    /// poll fetch window (the MainWindow passes fetch-window + a margin).
+    /// </param>
+    public AlertToastCoordinator(TimeSpan seenRetention)
+    {
+        if (seenRetention <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(seenRetention), "Retention must be positive.");
+        }
+
+        _seenRetention = seenRetention;
+    }
+
+    /// <summary>The distinct-row identity (matches the dismiss key: alert_time + server_id + metric_name).</summary>
+    private static string RowKey(ViewerAlertRow row) =>
+        string.Concat(row.AlertTime.Ticks.ToString(System.Globalization.CultureInfo.InvariantCulture), "|",
+            row.ServerId.ToString(System.Globalization.CultureInfo.InvariantCulture), "|", row.MetricName);
+
+    /// <summary>The condition identity the cooldown throttles (server + metric).</summary>
+    private static string ConditionKey(ViewerAlertRow row) =>
+        string.Concat(row.ServerId.ToString(System.Globalization.CultureInfo.InvariantCulture), "|", row.MetricName);
+
+    /// <summary>
+    /// Seeds the seen-set from rows that already existed when the viewer opened, so startup does NOT replay
+    /// the whole alert history as a toast storm — only alerts that arrive AFTER priming can toast. Does not
+    /// arm the cooldown (a post-startup recurrence of a primed condition is free to toast once).
+    /// </summary>
+    public void Prime(IEnumerable<ViewerAlertRow> existingRows)
+    {
+        ArgumentNullException.ThrowIfNull(existingRows);
+
+        foreach (var row in existingRows)
+        {
+            _seen[RowKey(row)] = row.AlertTime;
+        }
+    }
+
+    /// <summary>
+    /// Filters a freshly-polled batch to the rows that should toast now, updating the seen-set and cooldown
+    /// state. Rows are considered oldest-first so, within a burst that shares a condition, the EARLIEST row
+    /// wins the cooldown slot (the rest are suppressed until the window elapses). A row is emitted only when
+    /// it is new (not seen/primed), not muted, and its condition is outside the cooldown window; every
+    /// processed row is marked seen regardless of outcome so it is considered exactly once.
+    /// </summary>
+    /// <param name="polledRows">The latest read of recent, non-dismissed alert rows (any order).</param>
+    /// <param name="nowUtc">The current time (injected for testability).</param>
+    /// <param name="cooldown">
+    /// The per-condition cooldown window (the "Tray notification cooldown" setting). <see cref="TimeSpan.Zero"/>
+    /// or negative disables the cooldown so every new, unmuted row toasts.
+    /// </param>
+    public IReadOnlyList<ViewerAlertRow> SelectToasts(
+        IEnumerable<ViewerAlertRow> polledRows, DateTime nowUtc, TimeSpan cooldown)
+    {
+        ArgumentNullException.ThrowIfNull(polledRows);
+
+        var toasts = new List<ViewerAlertRow>();
+
+        foreach (var row in polledRows.OrderBy(r => r.AlertTime))
+        {
+            var rowKey = RowKey(row);
+            if (_seen.ContainsKey(rowKey))
+            {
+                continue; /* already offered (or primed at startup) — never re-toast */
+            }
+
+            _seen[rowKey] = row.AlertTime; /* processed exactly once, whatever we decide below */
+
+            if (row.Muted)
+            {
+                continue; /* Lite parity: a muted row is logged but never toasted */
+            }
+
+            var conditionKey = ConditionKey(row);
+            if (cooldown > TimeSpan.Zero
+                && _lastToast.TryGetValue(conditionKey, out var last)
+                && nowUtc - last < cooldown)
+            {
+                continue; /* same condition toasted too recently */
+            }
+
+            _lastToast[conditionKey] = nowUtc;
+            toasts.Add(row);
+        }
+
+        Prune(nowUtc, cooldown);
+        return toasts;
+    }
+
+    /// <summary>
+    /// Drops bookkeeping that can no longer affect a decision: a seen row older than the retention window
+    /// (the poll can never re-read it) and a cooldown entry older than the effective cooldown window.
+    /// </summary>
+    private void Prune(DateTime nowUtc, TimeSpan cooldown)
+    {
+        var seenCutoff = nowUtc - _seenRetention;
+        foreach (var key in _seen.Where(kv => kv.Value < seenCutoff).Select(kv => kv.Key).ToList())
+        {
+            _seen.Remove(key);
+        }
+
+        /* Keep a cooldown entry until it can no longer block anything — retain for the longer of the
+           cooldown window and the seen-retention so a slow poll can't forget an active cooldown early. */
+        var cooldownWindow = cooldown > _seenRetention ? cooldown : _seenRetention;
+        var toastCutoff = nowUtc - cooldownWindow;
+        foreach (var key in _lastToast.Where(kv => kv.Value < toastCutoff).Select(kv => kv.Key).ToList())
+        {
+            _lastToast.Remove(key);
+        }
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/App.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/App.xaml.cs
@@ -39,6 +39,13 @@ public partial class App : Application
            creates MainWindow. Dark is the default; naming it keeps the source of truth explicit. */
         ThemeManager.Apply("Dark");
 
+        /* #1050 (companion to the ported tray's WindowResumeGuard): WPF's GPU render thread can zombie its
+           surface across sleep/wake or RDP, leaving a live-but-blank window — now reachable in the viewer
+           because minimize-to-tray can hide it. Software rendering removes the GPU dependency entirely; charts
+           are unaffected (ScottPlot renders via SkiaSharp/CPU into a bitmap, not WPF's GPU path). Matches Lite. */
+        System.Windows.Media.RenderOptions.ProcessRenderMode =
+            System.Windows.Interop.RenderMode.SoftwareOnly;
+
         /* Minimal file logging (ported from Lite's AppLogger) so the sidebar's View Log / Open Log
            Folder buttons have a real target and operator bug reports carry viewer diagnostics. */
         ViewerLogger.Initialize();
@@ -85,7 +92,8 @@ public partial class App : Application
     /// <summary>
     /// Invoked on <see cref="SingleInstanceSignal"/>'s background thread when a second launch asks us to
     /// surface the window. Marshals to the UI thread and brings the existing window to the front via WPF's
-    /// own path (the viewer has no tray, so this simply restores/activates it).
+    /// own path — the shared <see cref="MainWindow.SurfaceWindow"/> the tray Restore also uses, so a
+    /// tray-hidden window is un-hidden consistently.
     /// </summary>
     private void OnSurfaceWindowRequested()
     {

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
@@ -17,6 +17,7 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Threading;
 using PerformanceMonitor.Common;
+using PerformanceMonitor.Notifications;
 using PerformanceMonitor.Ui;
 
 namespace PerformanceMonitor.Darling.Viewer;
@@ -74,6 +75,37 @@ public partial class MainWindow : Window
     /// </summary>
     private readonly ViewerAppSettingsStore _appSettingsStore = new();
 
+    /// <summary>
+    /// The system-tray icon + minimize-to-tray behavior (ported from Lite's SystemTrayService, adapted for
+    /// the headless viewer). Null until <see cref="OnLoaded"/> initializes it once the store connects.
+    /// </summary>
+    private SystemTrayService? _trayService;
+
+    /// <summary>
+    /// Turns polled alert-history rows into non-duplicated, cooldown-gated tray toasts — the headless
+    /// stand-in for Lite's in-process alert-engine toast. Primed at startup so history isn't replayed.
+    /// </summary>
+    private AlertToastCoordinator? _toastCoordinator;
+    private bool _alertPollInFlight;
+
+    /// <summary>
+    /// Restores the window from the tray if a sleep-/lock-driven minimize hid it (Lite #1050). Reachable now
+    /// that minimize-to-tray can hide the viewer; paired with the App-startup SoftwareOnly render mode.
+    /// </summary>
+    private WindowResumeGuard? _resumeGuard;
+
+    /* Live copies of the three ViewerAppSettings values the tray/toast path honors at runtime: seeded in
+       the constructor and refreshed when the Settings window closes (mirroring ViewerExportSettings). */
+    private bool _minimizeToTray;
+    private bool _alertsEnabled;
+    private int _alertCooldownMinutes;
+
+    /// <summary>How far back each toast poll reads alert history; the coordinator dedupes the overlap.</summary>
+    private static readonly TimeSpan s_alertPollWindow = TimeSpan.FromMinutes(15);
+
+    /// <summary>Seen-row retention (poll window + margin) so a row still inside the window is never pruned early.</summary>
+    private static readonly TimeSpan s_alertSeenRetention = TimeSpan.FromMinutes(20);
+
     public MainWindow()
     {
         InitializeComponent();
@@ -89,6 +121,14 @@ public partial class MainWindow : Window
            dismiss/mute action-logging opt-in the Alerts tab honors. */
         MuteRuleEditDialog.DefaultExpiration = appSettings.MuteRuleDefaultExpiration;
         AlertsHistoryTab.LogDismissals = appSettings.LogAlertDismissals;
+        /* Seed the runtime tray/toast knobs. Minimize-to-tray is genuinely viewer-local (ViewerAppSettings).
+           The alerts-master and the "Tray notification cooldown" are STORE-backed (AlertSettingsRow.Enabled /
+           .CooldownMinutes — the same fields the Settings window's "Enable notifications" + cooldown drive and
+           the service honors); these ViewerAppSettings copies are only a pre-connect fallback, overwritten by
+           RefreshAlertToastSettingsFromStoreAsync once the store connects and again on Settings close. */
+        _minimizeToTray = appSettings.MinimizeToTray;
+        _alertsEnabled = appSettings.AlertsEnabled;
+        _alertCooldownMinutes = appSettings.AlertCooldownMinutes;
         ApplyTimeDisplayMode(appSettings.TimeDisplayMode);
         Loaded += OnLoaded;
         Closed += OnClosed;
@@ -200,6 +240,35 @@ public partial class MainWindow : Window
             }
         }
 
+        /* System tray + in-app alert toasts (the ported Lite tray, adapted for headless). The tray icon lives
+           for the process; restore shares the single-instance SurfaceWindow path so the tray Restore and a
+           second-launch surface behave identically. Minimize-to-tray reads the live _minimizeToTray value. */
+        _trayService = new SystemTrayService(this, SurfaceWindow, () => _minimizeToTray);
+        _trayService.Initialize();
+
+        /* #1050: restore the window from the tray on resume/unlock if a sleep- or lock-driven minimize hid it.
+           ??= so a repeated Loaded can't double-subscribe (static SystemEvents). Shares the SurfaceWindow path. */
+        _resumeGuard ??= new WindowResumeGuard(this, SurfaceWindow);
+
+        /* Pull the store-authoritative alerts-master + toast cooldown (AlertSettingsRow) so the toast path
+           honors the same "Enable notifications" + "Tray notification cooldown" the service does. */
+        await RefreshAlertToastSettingsFromStoreAsync();
+
+        /* Prime the toast watermark with the rows already present so startup doesn't replay history as a
+           toast storm — only alerts that arrive after this point can toast. Best-effort: a failed prime just
+           means the first poll may toast up to one card per condition in the window (bounded by the cooldown). */
+        _toastCoordinator = new AlertToastCoordinator(s_alertSeenRetention);
+        try
+        {
+            var existing = await _dataService.GetAlertHistoryAsync(
+                DateTime.UtcNow - s_alertPollWindow, serverId: null, limit: 500);
+            _toastCoordinator.Prime(existing);
+        }
+        catch (Exception ex)
+        {
+            ViewerLogger.Warn("AlertToasts", $"Priming the alert-toast watermark failed: {ex.Message}");
+        }
+
         _refreshTimer = new DispatcherTimer { Interval = s_refreshInterval };
         _refreshTimer.Tick += OnRefreshTimerTick;
         _refreshTimer.Start();
@@ -254,6 +323,10 @@ public partial class MainWindow : Window
         _ = RefreshServerStatusAsync();
         _ = RefreshStoreSizeAsync();
 
+        /* Poll alert history for new rows to surface as tray toasts, regardless of the visible tab (the
+           headless stand-in for Lite's in-process alert-engine toast). */
+        _ = PollAlertToastsAsync();
+
         /* Two tabs opt out of the 60s auto-refresh: Recommendations refreshes on tab-activation only
            (matching Lite — analysis findings change on the service's 30-minute cadence, so a 60-second
            auto-refresh is pointless churn and would reset the incident expanders' state under the
@@ -285,6 +358,158 @@ public partial class MainWindow : Window
             await RefreshVisibleAsync();
         }
     }
+
+    // ── In-app alert toasts (headless poll of alert history) ─────────────────────────────
+
+    /// <summary>
+    /// Refreshes the two store-authoritative toast knobs — the alerts master (<see cref="AlertSettingsRow.Enabled"/>,
+    /// the Settings window's "Enable notifications") and the per-condition cooldown
+    /// (<see cref="AlertSettingsRow.CooldownMinutes"/>, the "Tray notification cooldown") — from the store, so
+    /// the viewer's toasts honor exactly what the Settings window drives + the service applies. Best-effort:
+    /// a null row (store not seeded yet) or a read failure leaves the pre-connect fallback values in place.
+    /// </summary>
+    private async Task RefreshAlertToastSettingsFromStoreAsync()
+    {
+        if (_dataService is null)
+        {
+            return;
+        }
+
+        try
+        {
+            var row = await _dataService.GetAlertSettingsAsync();
+            if (row is not null)
+            {
+                _alertsEnabled = row.Enabled;
+                _alertCooldownMinutes = row.CooldownMinutes;
+            }
+        }
+        catch (Exception ex)
+        {
+            ViewerLogger.Warn("AlertToasts", $"Reading alert settings for toasts failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Polls recent, non-dismissed alert history and surfaces genuinely-new rows as tray toasts — the
+    /// headless viewer's substitute for Lite's in-process alert-engine toast (the service already delivered
+    /// them via email/Teams/Slack; this is the supplementary in-app nudge). Duplicate-suppression and the
+    /// per-condition "Tray notification cooldown" gate live in <see cref="AlertToastCoordinator"/>; this only
+    /// does the read + render. Skips when notifications are disabled and never throws (a broken poll must not
+    /// disturb the refresh loop).
+    /// </summary>
+    private async Task PollAlertToastsAsync()
+    {
+        if (_dataService is null || _trayService is null || _toastCoordinator is null)
+        {
+            return;
+        }
+
+        if (!_alertsEnabled || _alertPollInFlight)
+        {
+            return;
+        }
+
+        _alertPollInFlight = true;
+        try
+        {
+            var rows = await _dataService.GetAlertHistoryAsync(
+                DateTime.UtcNow - s_alertPollWindow, serverId: null, limit: 500);
+
+            var cooldown = TimeSpan.FromMinutes(Math.Max(0, _alertCooldownMinutes));
+            foreach (var row in _toastCoordinator.SelectToasts(rows, DateTime.UtcNow, cooldown))
+            {
+                ShowAlertToast(row);
+            }
+        }
+        catch (Exception ex)
+        {
+            ViewerLogger.Warn("AlertToasts", $"Alert-toast poll failed: {ex.Message}");
+        }
+        finally
+        {
+            _alertPollInFlight = false;
+        }
+    }
+
+    /// <summary>
+    /// Renders one polled alert row as a tray toast: a green "resolved" styled card for resolution notices
+    /// (Cleared/Resolved/Restored), otherwise an interactive snoozable card (Error accent for
+    /// deadlock/poison, Warning otherwise) whose Snooze writes a scoped mute rule to the store.
+    /// </summary>
+    private void ShowAlertToast(ViewerAlertRow row)
+    {
+        if (_trayService is null)
+        {
+            return;
+        }
+
+        var body = $"{row.ServerName}: {ToastBody(row)}";
+
+        if (row.IsResolved)
+        {
+            _trayService.ShowStyledNotification(row.MetricName, body, ToastSeverity.Success);
+            return;
+        }
+
+        var icon = row.IsCritical
+            ? Hardcodet.Wpf.TaskbarNotification.BalloonIcon.Error
+            : Hardcodet.Wpf.TaskbarNotification.BalloonIcon.Warning;
+
+        /* Capture the identity so the snooze callback scopes the mute rule to THIS alert's server + metric. */
+        var serverName = row.ServerName;
+        var metricName = row.MetricName;
+        _trayService.ShowSnoozableNotification(
+            row.MetricName, body, icon, duration => SnoozeAlertAsync(serverName, metricName, duration));
+    }
+
+    /// <summary>
+    /// The toast one-liner: the first meaningful line of the stored detail (the richest summary, the analog
+    /// of Lite's per-metric ShortMessage), falling back to the formatted current value.
+    /// </summary>
+    private static string ToastBody(ViewerAlertRow row)
+    {
+        if (!string.IsNullOrEmpty(row.DetailText))
+        {
+            foreach (var line in row.DetailText.Split('\n'))
+            {
+                var trimmed = line.Trim();
+                if (!string.IsNullOrEmpty(trimmed))
+                {
+                    return trimmed;
+                }
+            }
+        }
+
+        return row.CurrentValueDisplay;
+    }
+
+    /// <summary>
+    /// Persists a snooze from a tray toast: a temporary mute rule scoped to the alert's server + metric
+    /// (Lite's SnoozeBalloon semantics), written straight to <c>config_mute_rules</c>. The running Darling
+    /// service re-reads it on its next config load, so the condition stops re-alerting until it expires.
+    /// </summary>
+    private async Task SnoozeAlertAsync(string serverName, string metricName, TimeSpan duration)
+    {
+        if (_dataService is null)
+        {
+            return;
+        }
+
+        var rule = new MuteRule
+        {
+            ServerName = string.IsNullOrEmpty(serverName) ? null : serverName,
+            MetricName = metricName,
+            ExpiresAtUtc = DateTime.UtcNow + duration,
+            Reason = $"Snoozed from tray ({FormatSnoozeDuration(duration)})",
+        };
+
+        await _dataService.InsertMuteRuleAsync(rule);
+        StatusText.Text = $"Snoozed {metricName} on {serverName} for {FormatSnoozeDuration(duration)} — {DateTime.Now:HH:mm:ss}";
+    }
+
+    private static string FormatSnoozeDuration(TimeSpan d) =>
+        d.TotalHours >= 1 ? $"{(int)d.TotalHours}h" : $"{(int)d.TotalMinutes}m";
 
     /// <summary>
     /// Single-clicking a sidebar server drives the server-scoped aggregate tabs to it: it syncs the
@@ -1031,6 +1256,11 @@ public partial class MainWindow : Window
         /* Re-seed the new-mute-rule default expiration + dismiss/mute logging opt-in in case the operator changed them. */
         MuteRuleEditDialog.DefaultExpiration = reloaded.MuteRuleDefaultExpiration;
         AlertsHistoryTab.LogDismissals = reloaded.LogAlertDismissals;
+        /* Re-seed the runtime tray/toast knobs so a change takes effect immediately (the tray reads
+           _minimizeToTray live). Minimize-to-tray is viewer-local (the reloaded file); the alerts-master +
+           "Tray notification cooldown" the window just wrote to the STORE are re-read from there. */
+        _minimizeToTray = reloaded.MinimizeToTray;
+        _ = RefreshAlertToastSettingsFromStoreAsync();
         var previousMode = ViewerTimeHelper.CurrentDisplayMode;
         ApplyTimeDisplayMode(reloaded.TimeDisplayMode);
         if (ViewerTimeHelper.CurrentDisplayMode != previousMode)
@@ -1050,10 +1280,12 @@ public partial class MainWindow : Window
     }
 
     /// <summary>
-    /// Brings the viewer window to the foreground when a second launch is folded into this instance (the
-    /// shared single-instance surface path). Restores a minimized window to Maximized — the viewer's startup
-    /// state — and activates it through WPF's own Show()/Activate() path. The viewer has no tray, so there is
-    /// no hidden-Visibility state to reconcile.
+    /// The one true window-restore path, shared by the tray (Show Window / double-click), minimize-to-tray
+    /// restore, and the single-instance second-launch surface, so the window can never be left hidden-but-blank.
+    /// Reconciles a tray-hidden window — minimize-to-tray calls <see cref="Window.Hide"/>, which sets
+    /// Visibility=Hidden; only <see cref="Window.Show"/> re-runs layout/render (a raw Win32 ShowWindow would
+    /// leave it blank, Lite #1050) — and restores a minimized window to the viewer's Maximized startup state.
+    /// Must run on the UI thread.
     /// </summary>
     public void SurfaceWindow()
     {
@@ -1063,6 +1295,7 @@ public partial class MainWindow : Window
         }
 
         Show();
+        ShowInTaskbar = true;
         Activate();
         /* Nudge to the top without pinning topmost. */
         Topmost = true;
@@ -1080,6 +1313,8 @@ public partial class MainWindow : Window
     {
         _refreshTimer?.Stop();
         _overviewTimer?.Stop();
+        _resumeGuard?.Dispose();
+        _trayService?.Dispose();
 
         if (_dataService is not null)
         {

--- a/Darling/PerformanceMonitor.Darling.Viewer/PerformanceMonitor.Darling.Viewer.csproj
+++ b/Darling/PerformanceMonitor.Darling.Viewer/PerformanceMonitor.Darling.Viewer.csproj
@@ -27,6 +27,9 @@
   <ItemGroup>
     <!-- Same package + version as Lite, so both chart hosts pin one ScottPlot. -->
     <PackageReference Include="ScottPlot.WPF" Version="5.1.58" />
+    <!-- System tray icon + balloon toasts (ported from Lite's SystemTrayService). Same package + version
+         as Lite so both WPF front ends pin one Hardcodet.NotifyIcon.Wpf. -->
+    <PackageReference Include="Hardcodet.NotifyIcon.Wpf" Version="2.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Darling/PerformanceMonitor.Darling.Viewer/SnoozeBalloon.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/SnoozeBalloon.xaml
@@ -1,0 +1,63 @@
+<UserControl x:Class="PerformanceMonitor.Darling.Viewer.SnoozeBalloon"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             Width="360"
+             FontFamily="Segoe UI">
+    <!-- Interactive tray toast with Snooze/Dismiss. Ported verbatim from Lite's SnoozeBalloon
+         (adapted only in namespace + a snooze callback in the code-behind, since the viewer writes the
+         mute rule straight to Postgres rather than through Lite's in-process MuteRuleService). -->
+    <Border Background="{DynamicResource BackgroundBrush}"
+            BorderBrush="{DynamicResource BorderBrush}"
+            BorderThickness="1"
+            CornerRadius="6"
+            TextElement.FontFamily="Segoe UI">
+        <StackPanel Margin="14,12,14,12">
+            <DockPanel Margin="0,0,0,4">
+                <TextBlock x:Name="SeverityIcon"
+                           Text="!"
+                           FontSize="16"
+                           FontWeight="Bold"
+                           VerticalAlignment="Center"
+                           Margin="0,0,8,0"
+                           Foreground="{DynamicResource ForegroundBrush}"/>
+                <TextBlock x:Name="TitleText"
+                           Text="Alert"
+                           FontWeight="SemiBold"
+                           FontSize="13"
+                           Foreground="{DynamicResource ForegroundBrush}"
+                           VerticalAlignment="Center"/>
+            </DockPanel>
+
+            <TextBlock x:Name="MessageText"
+                       Text=""
+                       TextWrapping="Wrap"
+                       FontSize="12"
+                       Foreground="{DynamicResource ForegroundBrush}"
+                       Margin="0,0,0,10"/>
+
+            <DockPanel>
+                <Button x:Name="DismissButton"
+                        Content="Dismiss"
+                        DockPanel.Dock="Right"
+                        Padding="10,4"
+                        Click="DismissButton_Click"/>
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Left">
+                    <Button x:Name="Snooze15Button"
+                            Content="Snooze 15m"
+                            Padding="8,4"
+                            Margin="0,0,4,0"
+                            Click="Snooze15Button_Click"/>
+                    <Button x:Name="Snooze1hButton"
+                            Content="Snooze 1h"
+                            Padding="8,4"
+                            Margin="0,0,4,0"
+                            Click="Snooze1hButton_Click"/>
+                    <Button x:Name="Snooze4hButton"
+                            Content="Snooze 4h"
+                            Padding="8,4"
+                            Click="Snooze4hButton_Click"/>
+                </StackPanel>
+            </DockPanel>
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/Darling/PerformanceMonitor.Darling.Viewer/SnoozeBalloon.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/SnoozeBalloon.xaml.cs
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using Hardcodet.Wpf.TaskbarNotification;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// An interactive tray toast with Snooze (15m / 1h / 4h) and Dismiss, ported from Lite's SnoozeBalloon.
+/// The one adaptation for the headless viewer: instead of holding Lite's in-process
+/// <c>MuteRuleService</c> + a server/metric pair, it takes an <paramref name="onSnooze"/> callback the
+/// caller supplies. The viewer's callback writes a temporary <c>config_mute_rules</c> row straight to
+/// Postgres (scoped to the alert's server + metric), which the running Darling service re-reads on its
+/// next config load — the store is the coordination point, so there is no IPC to the service.
+/// </summary>
+public partial class SnoozeBalloon : UserControl
+{
+    private readonly Func<TimeSpan, Task> _onSnooze;
+    private readonly Action _closePopup;
+    private bool _closed;
+
+    /// <param name="onSnooze">Persists a snooze of the given duration (writes the scoped mute rule).</param>
+    /// <param name="closePopup">Tears the popup down — call <c>TaskbarIcon.CloseBalloon()</c>.</param>
+    public SnoozeBalloon(
+        string title,
+        string message,
+        BalloonIcon icon,
+        Func<TimeSpan, Task> onSnooze,
+        Action closePopup)
+    {
+        InitializeComponent();
+
+        _onSnooze = onSnooze ?? throw new ArgumentNullException(nameof(onSnooze));
+        _closePopup = closePopup ?? throw new ArgumentNullException(nameof(closePopup));
+
+        TitleText.Text = title;
+        MessageText.Text = message;
+        ApplySeverity(icon);
+    }
+
+    private void ApplySeverity(BalloonIcon icon)
+    {
+        switch (icon)
+        {
+            case BalloonIcon.Error:
+                SeverityIcon.Text = "⚠"; /* warning sign */
+                SeverityIcon.Foreground = new SolidColorBrush(Color.FromRgb(0xDC, 0x26, 0x26));
+                break;
+            case BalloonIcon.Warning:
+                SeverityIcon.Text = "⚠";
+                SeverityIcon.Foreground = new SolidColorBrush(Color.FromRgb(0xF5, 0x9E, 0x0B));
+                break;
+            default:
+                SeverityIcon.Text = "ℹ"; /* info */
+                SeverityIcon.Foreground = new SolidColorBrush(Color.FromRgb(0x3B, 0x82, 0xF6));
+                break;
+        }
+    }
+
+    private void Snooze15Button_Click(object sender, RoutedEventArgs e) => Snooze(TimeSpan.FromMinutes(15));
+    private void Snooze1hButton_Click(object sender, RoutedEventArgs e) => Snooze(TimeSpan.FromHours(1));
+    private void Snooze4hButton_Click(object sender, RoutedEventArgs e) => Snooze(TimeSpan.FromHours(4));
+
+    private async void Snooze(TimeSpan duration)
+    {
+        if (_closed) return;
+        _closed = true;
+
+        try
+        {
+            await _onSnooze(duration);
+        }
+        catch (Exception ex)
+        {
+            ViewerLogger.Warn("SnoozeBalloon", $"Failed to add snooze rule: {ex.Message}");
+        }
+
+        CloseBalloon();
+    }
+
+    private void DismissButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (_closed) return;
+        _closed = true;
+        CloseBalloon();
+    }
+
+    private void CloseBalloon()
+    {
+        /* Hardcodet's BalloonClosingEvent is emitted BY the library when it closes; it has no
+           listener that translates a balloon-initiated raise back into a close. To actually
+           tear the popup down we have to call TaskbarIcon.CloseBalloon() directly. */
+        _closePopup();
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/StyledBalloon.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/StyledBalloon.xaml
@@ -1,0 +1,39 @@
+<UserControl x:Class="PerformanceMonitor.Darling.Viewer.StyledBalloon"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             Width="360"
+             FontFamily="Segoe UI">
+    <!-- Button-less themed card for resolved/cleared (and other informational) tray notifications.
+         Ported verbatim from Lite's StyledBalloon; mirrors SnoozeBalloon's chrome so an "all clear" toast
+         matches the snoozable condition cards instead of rendering as a plain, unthemed Windows balloon. -->
+    <Border Background="{DynamicResource BackgroundBrush}"
+            BorderBrush="{DynamicResource BorderBrush}"
+            BorderThickness="1"
+            CornerRadius="6"
+            TextElement.FontFamily="Segoe UI">
+        <StackPanel Margin="14,12,14,12">
+            <DockPanel Margin="0,0,0,4">
+                <TextBlock x:Name="SeverityIcon"
+                           Text="!"
+                           FontSize="16"
+                           FontWeight="Bold"
+                           VerticalAlignment="Center"
+                           Margin="0,0,8,0"
+                           Foreground="{DynamicResource ForegroundBrush}"/>
+                <TextBlock x:Name="TitleText"
+                           Text="Alert"
+                           FontWeight="SemiBold"
+                           FontSize="13"
+                           Foreground="{DynamicResource ForegroundBrush}"
+                           VerticalAlignment="Center"/>
+            </DockPanel>
+
+            <TextBlock x:Name="MessageText"
+                       Text=""
+                       TextWrapping="Wrap"
+                       FontSize="12"
+                       Foreground="{DynamicResource ForegroundBrush}"
+                       Margin="0"/>
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/Darling/PerformanceMonitor.Darling.Viewer/StyledBalloon.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/StyledBalloon.xaml.cs
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System.Windows.Controls;
+using System.Windows.Media;
+using PerformanceMonitor.Notifications;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// A themed, button-less tray balloon for resolved/cleared (and other informational) notifications.
+/// Ported from Lite's StyledBalloon (adapted only in namespace) so the two front ends render the same
+/// card. Shares <see cref="SnoozeBalloon"/>'s card chrome (background/border/severity icon) so a "Cleared"
+/// or "Resolved" toast looks like the snoozable condition cards rather than a plain Windows balloon.
+/// </summary>
+public partial class StyledBalloon : UserControl
+{
+    public StyledBalloon(string title, string message, ToastSeverity severity)
+    {
+        InitializeComponent();
+
+        TitleText.Text = title;
+        MessageText.Text = message;
+        ApplySeverity(severity);
+    }
+
+    /* Mirrors SnoozeBalloon.ApplySeverity (identical Warning/Error/Info glyphs + colors) and adds the
+       Success case — a green check (#16A34A), the same green the email/webhook "RESOLVED" badge uses —
+       for cleared/resolved conditions. */
+    private void ApplySeverity(ToastSeverity severity)
+    {
+        switch (severity)
+        {
+            case ToastSeverity.Error:
+                SeverityIcon.Text = "⚠"; /* warning sign */
+                SeverityIcon.Foreground = new SolidColorBrush(Color.FromRgb(0xDC, 0x26, 0x26));
+                break;
+            case ToastSeverity.Warning:
+                SeverityIcon.Text = "⚠";
+                SeverityIcon.Foreground = new SolidColorBrush(Color.FromRgb(0xF5, 0x9E, 0x0B));
+                break;
+            case ToastSeverity.Success:
+                SeverityIcon.Text = "✓"; /* check mark */
+                SeverityIcon.Foreground = new SolidColorBrush(Color.FromRgb(0x16, 0xA3, 0x4A));
+                break;
+            default:
+                SeverityIcon.Text = "ℹ"; /* info */
+                SeverityIcon.Foreground = new SolidColorBrush(Color.FromRgb(0x3B, 0x82, 0xF6));
+                break;
+        }
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/SystemTrayService.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/SystemTrayService.cs
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using Hardcodet.Wpf.TaskbarNotification;
+using PerformanceMonitor.Notifications;
+using PerformanceMonitor.Ui;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The viewer's system-tray icon + minimize-to-tray behavior, ported from Lite's SystemTrayService and
+/// adapted for the headless viewer:
+/// <list type="bullet">
+/// <item>there is no in-process collector to pause, so the context menu is just Show Window / Exit (Lite's
+/// Pause/Resume item is dropped) — collection is the separate Darling service's job;</item>
+/// <item>minimize-to-tray reads a caller-supplied <c>Func&lt;bool&gt;</c> (the live
+/// <see cref="ViewerAppSettings.MinimizeToTray"/> value) instead of Lite's <c>App.MinimizeToTray</c> static;</item>
+/// <item>the snoozable toast takes a persist-snooze callback (the viewer writes the mute rule straight to
+/// Postgres) instead of Lite's in-process <c>MuteRuleService</c>.</item>
+/// </list>
+/// The tray icon is created once and lives for the process lifetime; toasts are surfaced by the
+/// MainWindow's alert-history poll (there is no in-process alert engine in the viewer).
+/// </summary>
+public sealed class SystemTrayService : IDisposable
+{
+    private const string TooltipText = "Performance Monitor Darling Viewer";
+
+    private TaskbarIcon? _trayIcon;
+    private readonly Window _mainWindow;
+    private readonly Action _restoreWindow;
+    private readonly Func<bool> _minimizeToTrayEnabled;
+    private bool _disposed;
+    private TextBlock? _tooltipText;
+
+    /// <param name="mainWindow">The window whose minimize is intercepted and hidden to the tray.</param>
+    /// <param name="restoreWindow">
+    /// The window's own WPF restore (the viewer's <c>MainWindow.SurfaceWindow</c>, shared with the
+    /// single-instance surface path). The tray must restore through WPF's <see cref="Window.Show"/> path,
+    /// never a raw Win32 ShowWindow, or a tray-hidden window comes back blank (Lite #1050).
+    /// </param>
+    /// <param name="minimizeToTrayEnabled">Reads the live Minimize-to-tray setting each time the window minimizes.</param>
+    public SystemTrayService(Window mainWindow, Action restoreWindow, Func<bool> minimizeToTrayEnabled)
+    {
+        _mainWindow = mainWindow ?? throw new ArgumentNullException(nameof(mainWindow));
+        _restoreWindow = restoreWindow ?? throw new ArgumentNullException(nameof(restoreWindow));
+        _minimizeToTrayEnabled = minimizeToTrayEnabled ?? throw new ArgumentNullException(nameof(minimizeToTrayEnabled));
+        ThemeManager.ThemeChanged += OnThemeChanged;
+    }
+
+    /// <summary>
+    /// Initializes the system tray icon with its context menu. Safe to call again (theme change): it
+    /// disposes the old icon and re-subscribes the StateChanged handler exactly once.
+    /// </summary>
+    public void Initialize()
+    {
+        _trayIcon?.Dispose();
+
+        _trayIcon = new TaskbarIcon();
+
+        bool hasLightBackground = ThemeManager.HasLightBackground;
+
+        /* Custom tooltip styled to match current theme.
+           Note: Hardcodet TrayToolTip can rarely trigger a race condition in Popup.CreateWindow
+           that throws "The root Visual of a VisualTarget cannot have a parent." (issue #422).
+           The DispatcherUnhandledException handler silently logs this specific crash. */
+        _tooltipText = new TextBlock
+        {
+            Text = TooltipText,
+            Foreground = new SolidColorBrush(hasLightBackground
+                ? (Color)ColorConverter.ConvertFromString("#1A1D23")
+                : (Color)ColorConverter.ConvertFromString("#E4E6EB")),
+            FontSize = 12
+        };
+        _trayIcon.TrayToolTip = new Border
+        {
+            Background = new SolidColorBrush(hasLightBackground
+                ? (Color)ColorConverter.ConvertFromString("#FFFFFF")
+                : (Color)ColorConverter.ConvertFromString("#22252b")),
+            BorderBrush = new SolidColorBrush(hasLightBackground
+                ? (Color)ColorConverter.ConvertFromString("#DEE2E6")
+                : (Color)ColorConverter.ConvertFromString("#33363e")),
+            BorderThickness = new Thickness(1),
+            Padding = new Thickness(10, 8, 10, 8),
+            CornerRadius = new CornerRadius(4),
+            Child = _tooltipText
+        };
+
+        /* Load icon */
+        try
+        {
+            var iconUri = new Uri("pack://application:,,,/EDD.ico", UriKind.Absolute);
+            _trayIcon.IconSource = new BitmapImage(iconUri);
+        }
+        catch
+        {
+            /* Icon loading failed - tray icon will be blank but functional */
+        }
+
+        /* Build context menu — Show Window / Exit. The viewer has no in-process collection to pause. */
+        var contextMenu = new ContextMenu();
+
+        var showItem = new MenuItem { Header = "Show Window", Icon = new TextBlock { Text = "📊", Background = Brushes.Transparent } };
+        showItem.Click += (s, e) => _restoreWindow();
+        contextMenu.Items.Add(showItem);
+
+        contextMenu.Items.Add(new Separator());
+
+        var exitItem = new MenuItem { Header = "Exit", Icon = new TextBlock { Text = "✕", Background = Brushes.Transparent } };
+        exitItem.Click += (s, e) => ExitApplication();
+        contextMenu.Items.Add(exitItem);
+
+        _trayIcon.ContextMenu = contextMenu;
+
+        /* Double-click to show window */
+        _trayIcon.TrayMouseDoubleClick += (s, e) => _restoreWindow();
+
+        /* Handle minimize to tray. Unsubscribe first: Initialize re-runs on theme change, so a
+           plain += would stack a duplicate StateChanged handler on the app-lifetime window each time. */
+        _mainWindow.StateChanged -= MainWindow_StateChanged;
+        _mainWindow.StateChanged += MainWindow_StateChanged;
+    }
+
+    private void MainWindow_StateChanged(object? sender, EventArgs e)
+    {
+        if (_mainWindow.WindowState == WindowState.Minimized && _minimizeToTrayEnabled())
+        {
+            _mainWindow.Hide();
+        }
+    }
+
+    private static void ExitApplication()
+    {
+        Application.Current.Shutdown();
+    }
+
+    /// <summary>
+    /// Shows a plain balloon notification from the system tray icon. No-op if the tray icon hasn't been
+    /// initialized.
+    /// </summary>
+    public void ShowNotification(string title, string message, BalloonIcon icon)
+    {
+        _trayIcon?.ShowBalloonTip(title, message, icon);
+    }
+
+    /// <summary>
+    /// Shows a themed, button-less balloon (the same card chrome as the snoozable condition cards)
+    /// for resolved/cleared conditions, so an "all clear" toast no longer renders as a plain, unthemed
+    /// Windows balloon. Pass <see cref="ToastSeverity.Success"/> for a green-check "resolved" accent.
+    /// No-op if the tray icon hasn't been initialized.
+    /// </summary>
+    public void ShowStyledNotification(string title, string message, ToastSeverity severity)
+    {
+        if (_trayIcon == null)
+        {
+            return;
+        }
+
+        var balloon = new StyledBalloon(title, message, severity);
+        _trayIcon.ShowCustomBalloon(balloon, System.Windows.Controls.Primitives.PopupAnimation.Slide, 10000);
+    }
+
+    /// <summary>
+    /// Shows a custom interactive balloon with snooze buttons. The <paramref name="onSnooze"/> callback
+    /// persists a temporary mute rule scoped to the alert's server + metric (the viewer writes it straight
+    /// to <c>config_mute_rules</c>). No-op if the tray icon hasn't been initialized.
+    /// </summary>
+    public void ShowSnoozableNotification(
+        string title,
+        string message,
+        BalloonIcon icon,
+        Func<TimeSpan, Task> onSnooze)
+    {
+        if (_trayIcon == null)
+        {
+            return;
+        }
+
+        var trayIcon = _trayIcon;
+        var balloon = new SnoozeBalloon(title, message, icon, onSnooze, () => trayIcon.CloseBalloon());
+        _trayIcon.ShowCustomBalloon(balloon, System.Windows.Controls.Primitives.PopupAnimation.Slide, 15000);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        ThemeManager.ThemeChanged -= OnThemeChanged;
+        _mainWindow.StateChanged -= MainWindow_StateChanged;
+
+        if (_trayIcon != null)
+        {
+            _trayIcon.Visibility = Visibility.Collapsed;
+            _trayIcon.Dispose();
+            _trayIcon = null;
+        }
+
+        _disposed = true;
+    }
+
+    private void OnThemeChanged(string _)
+    {
+        _mainWindow.Dispatcher.InvokeAsync(Initialize);
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerAppSettings.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerAppSettings.cs
@@ -38,7 +38,10 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// state survives a restart — making the running service honor a change is a separate wiring concern
 /// (the service reads darling.json, not this file). The controls that DO act inside the viewer today —
 /// Manage Mute Rules (writes Postgres), Send Test Email / Send Test Notification (the shared, connection-
-/// independent renderers), and the viewer preferences folded in — work immediately.
+/// independent renderers), the viewer preferences folded in, <see cref="MinimizeToTray"/> (hides the window
+/// to the system tray on minimize), and the in-app alert toasts (the MainWindow polls alert history and
+/// surfaces new rows through the ported tray, honoring the store-backed "Tray notification cooldown") —
+/// work immediately.
 /// </para>
 ///
 /// <para>

--- a/Darling/PerformanceMonitor.Darling.Viewer/packages.lock.json
+++ b/Darling/PerformanceMonitor.Darling.Viewer/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 1,
   "dependencies": {
     "net10.0-windows7.0": {
+      "Hardcodet.NotifyIcon.Wpf": {
+        "type": "Direct",
+        "requested": "[2.0.1, )",
+        "resolved": "2.0.1",
+        "contentHash": "dtxmeZXzV2GzSm91aZ3hqzgoeVoARSkDPVCYfhVUNyyKBWYxMgNC0EcLiSYxD4Uc4alq/2qb3SmV8DgAENLRLQ=="
+      },
       "ScottPlot.WPF": {
         "type": "Direct",
         "requested": "[5.1.58, )",


### PR DESCRIPTION
Closes the audit finding *"System tray icon, minimize-to-tray, and in-app alert toasts entirely absent; MinimizeToTray checkbox + 'Tray notification cooldown' label are dead/misleading."* Takes **option (a) — port the tray so the dead controls become real** (not option b, delete them).

## What this does
- **System tray icon** (`SystemTrayService`): a Hardcodet `TaskbarIcon` with a **Show Window / Exit** context menu, double-click restore, and a `MainWindow.StateChanged` handler that **hides the window to the tray** when the (previously inert) `MinimizeToTray` setting is on.
- **Minimize-to-tray is now real**: the Settings checkbox drives actual behavior; the tray reads the value live and it re-applies when Settings closes.
- **In-app alert toasts**, headlessly: the viewer polls **alert history** and surfaces genuinely-new rows as themed toasts — **snoozable** cards for actionable alerts (Error accent for deadlock/poison, Warning otherwise) and a green **styled "resolved"** card for Cleared/Resolved/Restored notices.
- **"Tray notification cooldown" is now truthful**: it gates these toasts for real.
- **Single-instance coordination (#1442)**: the tray Restore and the second-launch surface both route through the shared `SurfaceWindow`, which now also reconciles a tray-*hidden* window — one restore path, not a duplicate.
- **#1050 companions** (now reachable because the window can be hidden): wires the shared `WindowResumeGuard` + `RenderOptions.ProcessRenderMode = SoftwareOnly`, matching Lite.

## Ported vs adapted (headless)
| Piece | Lite | Darling viewer |
|---|---|---|
| `StyledBalloon` | verbatim | verbatim (namespace only) |
| `SnoozeBalloon` | holds `MuteRuleService` + server/metric | takes a **persist-snooze callback**; the viewer writes the mute rule straight to `config_mute_rules` |
| `SystemTrayService` | Pause/Resume item, `App.MinimizeToTray` static, `MuteRuleService` | **no Pause/Resume** (collection is the separate service), `Func<bool>` for the live setting, callback snooze |
| Toast source | in-process alert **engine** fires on detection | **poll of `config_alert_log`** (the engine lives in the service) |

## How alerts are polled headlessly
The viewer has no in-process alert engine — the **service** evaluates alerts, writes `config_alert_log`, and delivers email/Teams/Slack. The tray toast is a supplementary in-app nudge:
1. On the existing 60s refresh timer, read recent non-dismissed alert rows via `ViewerDataService.GetAlertHistoryAsync` (the same read the Alerts tab uses — **no live SQL to the monitored server**).
2. `AlertToastCoordinator` (pure, clock-injected) decides which rows toast:
   - **New-since-last-seen watermark** keyed on the dismiss triple `(alert_time, server_id, metric_name)`, so the overlapping poll window never re-toasts a row. **Primed at startup** so history isn't replayed.
   - **Per-condition cooldown** on `(server_id, metric_name)` = the store-backed **"Tray notification cooldown"**, so a recurring condition nudges at most once per window.
   - **Muted rows never toast** (Lite parity); bookkeeping is pruned so neither map grows unbounded.
3. **Snooze** writes a temporary scoped mute rule to the store (service re-reads on its next config load); **Dismiss** just closes.

Because the alerts-master and cooldown are store-backed (`AlertSettingsRow.Enabled` / `.CooldownMinutes` — the same fields the Settings window writes and the service honors), the toast path reads them **from the store**, refreshed on connect + on Settings close (Minimize-to-tray stays viewer-local).

## Tests
- **Build**: `PerformanceMonitor.Darling.Viewer` `-c Release` — succeeded, 0 errors.
- **Suite**: `Darling.Tests` `-c Release` — **1640 passed, 126 skipped, 0 failed**.
- **New**: 14 xUnit tests on `AlertToastCoordinator` (watermark dedupe, cooldown gate, muted suppression, resolved severity-agnostic, retention pruning). The WPF tray UI itself isn't unit-testable; the decision logic is fully covered.

## For Erik's visual review
- Right-click the tray icon → **Show Window / Exit**; **double-click** to restore.
- With **Minimize to system tray** checked, minimizing hides to the tray; restore comes back non-blank.
- When a new alert lands, a **snoozable** toast appears (Snooze 15m/1h/4h writes a mute rule; Dismiss closes); a **Server Restored** row shows the green resolved card.
- Toast body uses the first line of the stored detail (falling back to the formatted value) — worth a glance for wording.

STOP — not merging; opening for review + your visual pass.