### PR TITLE
Performance Calendar: month heatmap replacing the single-day Daily Summary (Lite + Darling viewer)

### DIFF
--- a/Darling/Darling.Tests/DailyHealthBandTests.cs
+++ b/Darling/Darling.Tests/DailyHealthBandTests.cs
@@ -122,4 +122,14 @@ public class DailyHealthBandTests
         Assert.Contains("1 blocking event", described);
         Assert.Contains("3 alerts", described);
     }
+
+    [Fact]
+    public void Describe_MemoryPressure_DoesNotDoubleCountSevere()
+    {
+        // 3 pressure events, 1 severe -> "1 severe" + "2 (non-severe)", never "3 memory-pressure events".
+        var described = DailyHealthBandCalculator.Describe(Signals(memPressure: 3, memCritical: 1));
+        Assert.Contains("1 severe memory-pressure event", described);
+        Assert.Contains("2 memory-pressure events", described);
+        Assert.DoesNotContain("3 memory-pressure events", described);
+    }
 }

--- a/Darling/Darling.Tests/DailyHealthBandTests.cs
+++ b/Darling/Darling.Tests/DailyHealthBandTests.cs
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using PerformanceMonitor.Common;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Table-driven tests for the shared Performance Calendar day-banding (<see cref="DailyHealthBandCalculator"/>).
+/// This is the one classification both apps color their month heatmap by, so it is pinned here (Darling) and,
+/// identically, in Lite.Tests. Covers the no-data / healthy / warning / critical tiers, first-match-wins
+/// priority, the threshold boundaries, and the label / brush-key / tooltip mappings.
+/// </summary>
+public class DailyHealthBandTests
+{
+    private static DailyHealthSignals Signals(
+        bool hasData = true, long deadlocks = 0, long collectionErrors = 0, long highCpu = 0,
+        long blocking = 0, long memPressure = 0, long memCritical = 0, long alerts = 0) => new()
+    {
+        HasData = hasData,
+        Deadlocks = deadlocks,
+        CollectionErrors = collectionErrors,
+        HighCpuEvents = highCpu,
+        BlockingEvents = blocking,
+        MemoryPressureEvents = memPressure,
+        MemoryCriticalEvents = memCritical,
+        AlertCount = alerts,
+    };
+
+    [Fact]
+    public void NoCollection_IsNoData_RegardlessOfOtherCounts()
+    {
+        var s = Signals(hasData: false, deadlocks: 99, collectionErrors: 99, highCpu: 99, blocking: 99, memCritical: 99, alerts: 99);
+        Assert.Equal(DailyHealthBand.NoData, DailyHealthBandCalculator.Classify(s));
+    }
+
+    [Fact]
+    public void Collected_AndNothingElevated_IsHealthy()
+    {
+        Assert.Equal(DailyHealthBand.Healthy, DailyHealthBandCalculator.Classify(Signals()));
+    }
+
+    [Theory]
+    [InlineData("deadlock", 1, 0, 0, 0, 0, 0)]
+    [InlineData("collection-error", 0, 1, 0, 0, 0, 0)]
+    [InlineData("memory-critical", 0, 0, 0, 0, 1, 0)]
+    [InlineData("sustained-cpu", 0, 0, 6, 0, 0, 0)]
+    [InlineData("heavy-blocking", 0, 0, 0, 11, 0, 0)]
+    public void CriticalTriggers_EachAloneIsCritical(string _, long deadlocks, long collErrors, long highCpu, long blocking, long memCritical, long alerts)
+    {
+        var s = Signals(deadlocks: deadlocks, collectionErrors: collErrors, highCpu: highCpu, blocking: blocking, memCritical: memCritical, alerts: alerts);
+        Assert.Equal(DailyHealthBand.Critical, DailyHealthBandCalculator.Classify(s));
+    }
+
+    [Theory]
+    [InlineData("moderate-cpu", 3, 0, 0, 0)]
+    [InlineData("some-blocking", 0, 5, 0, 0)]
+    [InlineData("memory-pressure", 0, 0, 1, 0)]
+    [InlineData("alert", 0, 0, 0, 1)]
+    public void WarningTriggers_EachAloneIsWarning(string _, long highCpu, long blocking, long memPressure, long alerts)
+    {
+        var s = Signals(highCpu: highCpu, blocking: blocking, memPressure: memPressure, alerts: alerts);
+        Assert.Equal(DailyHealthBand.Warning, DailyHealthBandCalculator.Classify(s));
+    }
+
+    [Fact]
+    public void CriticalBeatsWarning_WhenBothPresent()
+    {
+        var s = Signals(deadlocks: 1, highCpu: 3, alerts: 4);
+        Assert.Equal(DailyHealthBand.Critical, DailyHealthBandCalculator.Classify(s));
+    }
+
+    [Theory]
+    [InlineData(5, DailyHealthBand.Warning)]
+    [InlineData(6, DailyHealthBand.Critical)]
+    public void HighCpu_CriticalThreshold_IsSixSamples(long highCpu, DailyHealthBand expected)
+    {
+        Assert.Equal(expected, DailyHealthBandCalculator.Classify(Signals(highCpu: highCpu)));
+    }
+
+    [Theory]
+    [InlineData(10, DailyHealthBand.Warning)]
+    [InlineData(11, DailyHealthBand.Critical)]
+    public void Blocking_CriticalThreshold_IsElevenEvents(long blocking, DailyHealthBand expected)
+    {
+        Assert.Equal(expected, DailyHealthBandCalculator.Classify(Signals(blocking: blocking)));
+    }
+
+    [Fact]
+    public void Thresholds_AreOverridable()
+    {
+        var strict = new DailyHealthThresholds { HighCpuCriticalSamples = 3 };
+        Assert.Equal(DailyHealthBand.Critical, DailyHealthBandCalculator.Classify(Signals(highCpu: 3), strict));
+        Assert.Equal(DailyHealthBand.Warning, DailyHealthBandCalculator.Classify(Signals(highCpu: 3)));
+    }
+
+    [Theory]
+    [InlineData(DailyHealthBand.NoData, "No Data", "ForegroundMutedBrush")]
+    [InlineData(DailyHealthBand.Healthy, "Healthy", "SuccessBrush")]
+    [InlineData(DailyHealthBand.Warning, "Warning", "WarningBrush")]
+    [InlineData(DailyHealthBand.Critical, "Critical", "ErrorBrush")]
+    public void Label_And_BrushKey_MapEachBand(DailyHealthBand band, string label, string brushKey)
+    {
+        Assert.Equal(label, DailyHealthBandCalculator.Label(band));
+        Assert.Equal(brushKey, DailyHealthBandCalculator.BrushKey(band));
+    }
+
+    [Fact]
+    public void Describe_NoData_And_NoIssues_And_MultiSignal()
+    {
+        Assert.Equal("No data collected.", DailyHealthBandCalculator.Describe(Signals(hasData: false)));
+        Assert.Equal("No issues detected.", DailyHealthBandCalculator.Describe(Signals()));
+
+        var described = DailyHealthBandCalculator.Describe(Signals(deadlocks: 2, blocking: 1, alerts: 3));
+        Assert.Contains("2 deadlocks", described);
+        Assert.Contains("1 blocking event", described);
+        Assert.Contains("3 alerts", described);
+    }
+}

--- a/Darling/Darling.Tests/ViewerDailyHealthTests.cs
+++ b/Darling/Darling.Tests/ViewerDailyHealthTests.cs
@@ -18,24 +18,29 @@ using Xunit;
 namespace Darling.Tests;
 
 /// <summary>
-/// Pins the Daily Summary tab's single-row aggregate (W1i, copied from Lite's
-/// LocalDataService.DailySummary.cs) against the Darling store contract — no live Postgres. The SQL is
-/// byte-portable between DuckDB and Postgres, so the pins are the load-bearing clauses: the per-source
-/// subqueries, the top-wait ranking, the blocking XE→DMV fallback, and the total-host-CPU ≥ 80 rule.
+/// Pins the Performance Calendar / Daily Summary per-day-range aggregate (<c>DailySummaryRangeSql</c>)
+/// against the Darling store contract — no live Postgres. The pins are the load-bearing clauses: per-day
+/// bucketing, the day spine, the per-source CTEs, the top-wait ranking, the blocking XE→DMV fallback, the
+/// total-host-CPU ≥ 80 rule, the memory tiers, and the actionable-alert filter.
 /// </summary>
 public sealed class ViewerDailySummarySqlTests
 {
     [Fact]
-    public void DailySummarySql_RollsUpEverySource_OverTheHalfOpenDayWindow()
+    public void DailySummaryRangeSql_RollsUpEverySource_GroupedPerDay()
     {
-        var sql = ViewerDataService.DailySummarySql;
+        var sql = ViewerDataService.DailySummaryRangeSql;
 
-        /* Total wait seconds + top wait type off v_wait_stats, positive deltas only. */
+        /* Per-day bucketing + a day spine so a quiet-but-collected day still appears. */
+        Assert.Contains("date_trunc('day', collection_time)", sql, StringComparison.Ordinal);
+        Assert.Contains("day_spine AS (", sql, StringComparison.Ordinal);
+        Assert.Contains("UNION SELECT d FROM", sql, StringComparison.Ordinal);
+
+        /* Total wait seconds + per-day top wait type off v_wait_stats, positive deltas only. */
         Assert.Contains("FROM v_wait_stats", sql, StringComparison.Ordinal);
-        Assert.Contains("SUM(delta_wait_time_ms) / 1000.0", sql, StringComparison.Ordinal);
+        Assert.Contains("SUM(ms) / 1000.0", sql, StringComparison.Ordinal);
         Assert.Contains("delta_wait_time_ms > 0", sql, StringComparison.Ordinal);
-        Assert.Contains("ORDER BY SUM(delta_wait_time_ms) DESC", sql, StringComparison.Ordinal);
-        Assert.Contains("LIMIT 1", sql, StringComparison.Ordinal);
+        Assert.Contains("DISTINCT ON (d)", sql, StringComparison.Ordinal);
+        Assert.Contains("ORDER BY d, ms DESC", sql, StringComparison.Ordinal);
 
         /* Distinct query count, deadlock count. */
         Assert.Contains("COUNT(DISTINCT query_hash)", sql, StringComparison.Ordinal);
@@ -44,30 +49,36 @@ public sealed class ViewerDailySummarySqlTests
 
         /* Blocking events: XE blocked-process reports, falling back to the DMV snapshot count when the
            XE count is zero (NULLIF → COALESCE). */
-        Assert.Contains("NULLIF(", sql, StringComparison.Ordinal);
+        Assert.Contains("COALESCE(NULLIF(b.c, 0), dm.c, 0)", sql, StringComparison.Ordinal);
         Assert.Contains("FROM v_blocked_process_reports", sql, StringComparison.Ordinal);
         Assert.Contains("FROM v_dmv_blocking_snapshots", sql, StringComparison.Ordinal);
 
-        /* High-CPU count uses total host CPU = SQL + other-process (Linux NULL → 0), threshold 80. */
+        /* High-CPU count uses total host CPU = SQL + other-process (Linux NULL → 0), threshold 80, via FILTER. */
         Assert.Contains("(sqlserver_cpu_utilization + COALESCE(other_process_cpu_utilization, 0)) >= 80", sql, StringComparison.Ordinal);
         Assert.Contains("FROM v_cpu_utilization_stats", sql, StringComparison.Ordinal);
+        Assert.Contains("FILTER (WHERE", sql, StringComparison.Ordinal);
 
-        /* Collect errors off the collection_log ERROR rows. */
+        /* Collect errors off the collection_log ERROR rows; all-status runs mark the day collected. */
         Assert.Contains("status = 'ERROR'", sql, StringComparison.Ordinal);
         Assert.Contains("FROM v_collection_log", sql, StringComparison.Ordinal);
 
-        /* Memory pressure: the displayed count (process OR system indicator >= 2) and the MEMORY_CRITICAL
-           escalation source (process indicator >= 3), both off v_memory_pressure_events (Dashboard parity). */
+        /* Memory pressure (process OR system indicator >= 2) and the severe escalation (process >= 3). */
         Assert.Contains("FROM v_memory_pressure_events", sql, StringComparison.Ordinal);
-        Assert.Contains("(memory_indicators_process >= 2 OR memory_indicators_system >= 2)", sql, StringComparison.Ordinal);
+        Assert.Contains("memory_indicators_process >= 2 OR memory_indicators_system >= 2", sql, StringComparison.Ordinal);
         Assert.Contains("memory_indicators_process >= 3", sql, StringComparison.Ordinal);
 
-        /* Every subquery windows on the half-open [dayStart, dayEnd) range. */
+        /* Actionable alerts: non-dismissed, excluding resolution notices, off config_alert_log. */
+        Assert.Contains("FROM config_alert_log", sql, StringComparison.Ordinal);
+        Assert.Contains("dismissed = FALSE", sql, StringComparison.Ordinal);
+        Assert.Contains("NOT LIKE '%Cleared%'", sql, StringComparison.Ordinal);
+
+        /* Every subquery windows on the half-open [rangeStart, rangeEnd) range. */
         Assert.Contains("collection_time >= $2 AND collection_time < $3", sql, StringComparison.Ordinal);
+        Assert.Contains("alert_time >= $2 AND alert_time < $3", sql, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void DailySummarySql_MemoryPressureColumns_ExistInTheGeneratedSourceTable()
+    public void DailySummaryRangeSql_MemoryPressureColumns_ExistInTheGeneratedSourceTable()
     {
         var ddl = PgSchemaGenerator.CreateTable(MemoryPressureEventsCollector.Instance);
         Assert.Contains("memory_indicators_process", ddl, StringComparison.Ordinal);
@@ -76,9 +87,9 @@ public sealed class ViewerDailySummarySqlTests
     }
 
     [Fact]
-    public void DailySummarySql_IsPgDialect_PositionalParams_NoBareNow_NoNLiterals()
+    public void DailySummaryRangeSql_IsPgDialect_PositionalParams_NoBareNow_NoNLiterals()
     {
-        var sql = ViewerDataService.DailySummarySql;
+        var sql = ViewerDataService.DailySummaryRangeSql;
         Assert.DoesNotContain("now(", sql.ToLowerInvariant());
         Assert.DoesNotContain("N'", sql, StringComparison.Ordinal);
         Assert.DoesNotContain("@", sql, StringComparison.Ordinal);
@@ -88,7 +99,7 @@ public sealed class ViewerDailySummarySqlTests
     }
 
     [Fact]
-    public void DailySummarySql_ReadsColumnsThatExistInTheGeneratedSourceTables()
+    public void DailySummaryRangeSql_ReadsColumnsThatExistInTheGeneratedSourceTables()
     {
         Assert.Contains("delta_wait_time_ms", PgSchemaGenerator.CreateTable(WaitStatsCollector.Instance), StringComparison.Ordinal);
         Assert.Contains("wait_type", PgSchemaGenerator.CreateTable(WaitStatsCollector.Instance), StringComparison.Ordinal);
@@ -103,12 +114,13 @@ public sealed class ViewerDailySummarySqlTests
     public void PassthroughViews_ForEverySource_ExistInTheMigrations()
     {
         /* The daily-summary sources read the v_* passthrough views; they are created across the
-           migration set (the aggregate sources in one, v_collection_log in another). */
+           migration set. The alert signal reads the config_alert_log base table directly. */
         var allMigrationSql = string.Concat(PgMigrations.Scripts.Select(m => m.Sql));
         foreach (var view in new[]
         {
             "v_wait_stats", "v_query_stats", "v_deadlocks", "v_blocked_process_reports",
             "v_dmv_blocking_snapshots", "v_cpu_utilization_stats", "v_collection_log",
+            "v_memory_pressure_events", "config_alert_log",
         })
         {
             Assert.Contains(view, allMigrationSql, StringComparison.Ordinal);
@@ -230,42 +242,9 @@ public sealed class ViewerDailyHealthRowTests
         Assert.Equal("2026-07-03", row.SummaryDateFormatted);
     }
 
-    [Fact]
-    public void ClassifyDailyHealth_Normal_WhenNothingBreaches()
-        => Assert.Equal("NORMAL", ViewerDataService.ClassifyDailyHealth(deadlocks: 0, highCpuEvents: 0, memoryCriticalEvents: 0, blockingEvents: 0));
-
-    [Fact]
-    public void ClassifyDailyHealth_Deadlocks_WinAllOtherBands()
-        => Assert.Equal("DEADLOCKS", ViewerDataService.ClassifyDailyHealth(deadlocks: 1, highCpuEvents: 99, memoryCriticalEvents: 99, blockingEvents: 99));
-
-    [Fact]
-    public void ClassifyDailyHealth_CpuCritical_WhenMoreThanFiveHighCpuAndNoDeadlocks()
-        => Assert.Equal("CPU_CRITICAL", ViewerDataService.ClassifyDailyHealth(deadlocks: 0, highCpuEvents: 6, memoryCriticalEvents: 99, blockingEvents: 99));
-
-    [Fact]
-    public void ClassifyDailyHealth_MemoryCritical_WhenSevereMemoryPressure_AndNoDeadlockOrCpu()
-    {
-        /* Item 5: the escalation the viewer dropped — a severe memory-pressure day (process indicator >= 3,
-           memoryCriticalEvents > 0) bands MEMORY_CRITICAL, ranking ahead of BLOCKING. */
-        Assert.Equal("MEMORY_CRITICAL",
-            ViewerDataService.ClassifyDailyHealth(deadlocks: 0, highCpuEvents: 5, memoryCriticalEvents: 1, blockingEvents: 99));
-    }
-
-    [Fact]
-    public void ClassifyDailyHealth_Blocking_WhenOverTenBlockingAndNoHigherBand()
-        => Assert.Equal("BLOCKING", ViewerDataService.ClassifyDailyHealth(deadlocks: 0, highCpuEvents: 0, memoryCriticalEvents: 0, blockingEvents: 11));
-
-    [Theory]
-    [InlineData(5, "NORMAL")]     // exactly 5 is NOT > 5
-    [InlineData(6, "CPU_CRITICAL")]
-    public void ClassifyDailyHealth_HighCpuThreshold_IsStrictlyGreaterThanFive(long highCpu, string expected)
-        => Assert.Equal(expected, ViewerDataService.ClassifyDailyHealth(0, highCpu, 0, 0));
-
-    [Theory]
-    [InlineData(10, "NORMAL")]    // exactly 10 is NOT > 10
-    [InlineData(11, "BLOCKING")]
-    public void ClassifyDailyHealth_BlockingThreshold_IsStrictlyGreaterThanTen(long blocking, string expected)
-        => Assert.Equal(expected, ViewerDataService.ClassifyDailyHealth(0, 0, 0, blocking));
+    // The Daily Summary health banding moved to the shared, app-agnostic DailyHealthBandCalculator
+    // (composite No-Data / Healthy / Warning / Critical for the Performance Calendar) and is pinned by
+    // DailyHealthBandTests here in Darling.Tests and, identically, in Lite.Tests.
 
     [Fact]
     public void CollectorHealthRow_NeverRun_WhenNoRuns()
@@ -486,7 +465,7 @@ public sealed class ViewerDailyHealthLivePostgresTests
             Assert.Equal(1, summary.BlockingEvents);               // XE report count (fallback not used)
             Assert.Equal(1, summary.HighCpuEvents);                // only the 90% sample
             Assert.Equal(1, summary.CollectionErrors);
-            Assert.Equal("DEADLOCKS", summary.OverallHealth);      // deadlocks > 0 wins the banding
+            Assert.Equal("Critical", summary.OverallHealth);       // deadlocks -> Critical composite band
         }
         finally
         {
@@ -514,7 +493,8 @@ public sealed class ViewerDailyHealthLivePostgresTests
             var inDay = day.AddHours(9);
 
             /* No XE blocked-process reports; two DMV snapshots → the COALESCE(NULLIF(...)) falls back to
-               the DMV count. No deadlocks / high CPU / >10 blocking → NORMAL. */
+               the DMV count. No deadlocks / sustained CPU / heavy blocking, but 2 blocking events is
+               "some blocking" → the composite band is Warning. */
             await InsertDmvBlockingAsync(connection, SummaryServerId, inDay);
             await InsertDmvBlockingAsync(connection, SummaryServerId, inDay);
 
@@ -523,7 +503,7 @@ public sealed class ViewerDailyHealthLivePostgresTests
             Assert.NotNull(summary);
             Assert.Equal(2, summary!.BlockingEvents);
             Assert.Equal(0, summary.DeadlockCount);
-            Assert.Equal("NORMAL", summary.OverallHealth);
+            Assert.Equal("Warning", summary.OverallHealth);
         }
         finally
         {

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.DailySummary.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.DailySummary.cs
@@ -131,6 +131,7 @@ public sealed partial class ViewerDataService
             UNION SELECT d FROM cpu
             UNION SELECT d FROM coll
             UNION SELECT d FROM mem
+            UNION SELECT d FROM alerts
         )
         SELECT
             s.d AS day,

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.DailySummary.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.DailySummary.cs
@@ -7,175 +7,217 @@
  */
 
 using System;
+using System.Collections.Generic;
+using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql;
+using PerformanceMonitor.Common;
 
 namespace PerformanceMonitor.Darling.Viewer;
 
 /// <summary>
-/// The Daily Summary tab's single-row aggregate (W1i), copied from Lite's
-/// <c>LocalDataService.DailySummary.cs</c> and run on the <c>v_wait_stats</c> / <c>v_query_stats</c> /
-/// <c>v_deadlocks</c> / <c>v_blocked_process_reports</c> (with the <c>v_dmv_blocking_snapshots</c>
-/// fallback) / <c>v_cpu_utilization_stats</c> / <c>v_collection_log</c> passthrough views. The whole day
-/// rolls up in one scalar-subquery SELECT: total wait seconds, the top wait type, distinct query count,
-/// deadlock / blocking-event / high-CPU / collect-error counts, with the health string computed in C#.
-/// The SQL is byte-portable between DuckDB and Postgres (positional <c>$1/$2/$3</c> referenced across
-/// every subquery, COALESCE/NULLIF, no dialect functions), so only the parameter binding differs: the
-/// naive day-boundary <see cref="DateTime"/>s go in with <c>DateTimeKind.Unspecified</c> (the store's
-/// naive-UTC convention — a Kind=Utc value would bind as timestamptz and throw against the naive columns).
+/// The Performance Calendar / Daily Summary aggregate, grouped one row per day over a half-open
+/// [fromDate, toDate) window and run on the <c>v_wait_stats</c> / <c>v_query_stats</c> / <c>v_deadlocks</c> /
+/// <c>v_blocked_process_reports</c> (with the <c>v_dmv_blocking_snapshots</c> fallback) /
+/// <c>v_cpu_utilization_stats</c> / <c>v_collection_log</c> / <c>v_memory_pressure_events</c> passthrough
+/// views plus <c>config_alert_log</c>. One row is returned for every day that had any collection; days with
+/// none are absent (the calendar renders them No-Data). Each row's composite band is computed by the shared
+/// <see cref="DailyHealthBandCalculator"/> so it bands identically to Lite. This is the single source of
+/// truth for the daily aggregate; <see cref="GetDailySummaryAsync"/> (one day) delegates here.
 /// </summary>
 public sealed partial class ViewerDataService
 {
     /// <summary>
-    /// Lite's daily-summary aggregate verbatim. $1 server_id, $2 day start, $3 day end (naive UTC,
-    /// half-open <c>[start, end)</c>). The high-CPU rule (total host CPU = SQL + other-process ≥ 80,
-    /// with the Linux NULL-other-process fallback) mirrors the alert engine, the Overview headline, and
-    /// Dashboard's report.daily_summary — see the inline note.
+    /// Grouped per-day daily-summary aggregate. $1 server_id, $2 range start, $3 range end (naive UTC,
+    /// half-open <c>[start, end)</c>). Postgres dialect: <c>date_trunc('day', ...)</c> day bucketing,
+    /// <c>(array_agg(wait_type ORDER BY ...))[1]</c> for the per-day top wait, <c>FILTER</c> conditional
+    /// counts, and a day spine (UNION of every source's days) LEFT JOINed so a quiet-but-collected day still
+    /// appears (Healthy, not No-Data). The high-CPU rule (total host CPU = SQL + other-process ≥ 80, Linux
+    /// NULL-other-process fallback) mirrors the alert engine and the Overview headline.
     /// </summary>
-    public const string DailySummarySql = """
+    public const string DailySummaryRangeSql = """
+        WITH wait_per_type AS (
+            SELECT date_trunc('day', collection_time) AS d, wait_type, SUM(delta_wait_time_ms) AS ms
+            FROM v_wait_stats
+            WHERE server_id = $1 AND collection_time >= $2 AND collection_time < $3 AND delta_wait_time_ms > 0
+            GROUP BY 1, 2
+        ),
+        wait_totals AS (
+            SELECT d, SUM(ms) / 1000.0 AS total_wait_sec
+            FROM wait_per_type
+            GROUP BY d
+        ),
+        wait_top AS (
+            /* Per-day top wait type = the wait with the most delta time that day (Postgres DISTINCT ON). */
+            SELECT DISTINCT ON (d) d, wait_type AS top_wait_type
+            FROM wait_per_type
+            ORDER BY d, ms DESC
+        ),
+        waits AS (
+            SELECT t.d, t.total_wait_sec, tp.top_wait_type
+            FROM wait_totals t
+            LEFT JOIN wait_top tp ON tp.d = t.d
+        ),
+        queries AS (
+            SELECT date_trunc('day', collection_time) AS d, COUNT(DISTINCT query_hash) AS c
+            FROM v_query_stats
+            WHERE server_id = $1 AND collection_time >= $2 AND collection_time < $3
+            GROUP BY 1
+        ),
+        deadlocks AS (
+            SELECT date_trunc('day', collection_time) AS d, COUNT(*) AS c
+            FROM v_deadlocks
+            WHERE server_id = $1 AND collection_time >= $2 AND collection_time < $3
+            GROUP BY 1
+        ),
+        bpr AS (
+            SELECT date_trunc('day', collection_time) AS d, COUNT(*) AS c
+            FROM v_blocked_process_reports
+            WHERE server_id = $1 AND collection_time >= $2 AND collection_time < $3
+            GROUP BY 1
+        ),
+        dmv AS (
+            SELECT date_trunc('day', collection_time) AS d, COUNT(*) AS c
+            FROM v_dmv_blocking_snapshots
+            WHERE server_id = $1 AND collection_time >= $2 AND collection_time < $3
+            GROUP BY 1
+        ),
+        cpu AS (
+            /* Total host CPU = SQL + other-process (NULL on Linux -> 0), matching the alert engine and the
+               Overview headline; sustained >= 80 samples drive the day's band. */
+            SELECT date_trunc('day', collection_time) AS d,
+                   COUNT(*) FILTER (WHERE (sqlserver_cpu_utilization + COALESCE(other_process_cpu_utilization, 0)) >= 80) AS c
+            FROM v_cpu_utilization_stats
+            WHERE server_id = $1 AND collection_time >= $2 AND collection_time < $3
+            GROUP BY 1
+        ),
+        coll AS (
+            /* Any run (all statuses) marks the day as collected -> it appears even if every metric is quiet
+               (a quiet monitored day is Healthy/green, not No-Data/grey). errs feeds the Critical band. */
+            SELECT date_trunc('day', collection_time) AS d,
+                   COUNT(*) AS runs,
+                   COUNT(*) FILTER (WHERE status = 'ERROR') AS errs
+            FROM v_collection_log
+            WHERE server_id = $1 AND collection_time >= $2 AND collection_time < $3
+            GROUP BY 1
+        ),
+        mem AS (
+            SELECT date_trunc('day', collection_time) AS d,
+                   COUNT(*) FILTER (WHERE memory_indicators_process >= 2 OR memory_indicators_system >= 2) AS pressure,
+                   COUNT(*) FILTER (WHERE memory_indicators_process >= 3) AS critical
+            FROM v_memory_pressure_events
+            WHERE server_id = $1 AND collection_time >= $2 AND collection_time < $3
+            GROUP BY 1
+        ),
+        alerts AS (
+            /* Actionable alerts only: exclude dismissed rows and resolution/good-news notices (Cleared /
+               Resolved / Restored), mirroring AlertMetricClassifier.IsResolution. */
+            SELECT date_trunc('day', alert_time) AS d, COUNT(*) AS c
+            FROM config_alert_log
+            WHERE server_id = $1 AND alert_time >= $2 AND alert_time < $3
+              AND dismissed = FALSE
+              AND metric_name NOT LIKE '%Cleared%'
+              AND metric_name NOT LIKE '%Resolved%'
+              AND metric_name NOT LIKE '%Restored%'
+            GROUP BY 1
+        ),
+        day_spine AS (
+            SELECT d FROM waits
+            UNION SELECT d FROM queries
+            UNION SELECT d FROM deadlocks
+            UNION SELECT d FROM bpr
+            UNION SELECT d FROM dmv
+            UNION SELECT d FROM cpu
+            UNION SELECT d FROM coll
+            UNION SELECT d FROM mem
+        )
         SELECT
-            COALESCE(
-                (SELECT SUM(delta_wait_time_ms) / 1000.0
-                 FROM v_wait_stats
-                 WHERE server_id = $1
-                 AND   collection_time >= $2 AND collection_time < $3
-                 AND   delta_wait_time_ms > 0), 0
-            ) AS total_wait_sec,
-            (SELECT wait_type
-             FROM v_wait_stats
-             WHERE server_id = $1
-             AND   collection_time >= $2 AND collection_time < $3
-             AND   delta_wait_time_ms > 0
-             GROUP BY wait_type
-             ORDER BY SUM(delta_wait_time_ms) DESC
-             LIMIT 1
-            ) AS top_wait_type,
-            COALESCE(
-                (SELECT COUNT(DISTINCT query_hash)
-                 FROM v_query_stats
-                 WHERE server_id = $1
-                 AND   collection_time >= $2 AND collection_time < $3), 0
-            ) AS unique_queries,
-            COALESCE(
-                (SELECT COUNT(*)
-                 FROM v_deadlocks
-                 WHERE server_id = $1
-                 AND   collection_time >= $2 AND collection_time < $3), 0
-            ) AS deadlock_count,
-            COALESCE(
-                NULLIF((SELECT COUNT(*)
-                 FROM v_blocked_process_reports
-                 WHERE server_id = $1
-                 AND   collection_time >= $2 AND collection_time < $3), 0),
-                (SELECT COUNT(*)
-                 FROM v_dmv_blocking_snapshots
-                 WHERE server_id = $1
-                 AND   collection_time >= $2 AND collection_time < $3), 0
-            ) AS blocking_events,
-            COALESCE(
-                (SELECT COUNT(*)
-                 FROM v_cpu_utilization_stats
-                 WHERE server_id = $1
-                 /* Total host CPU = SQL + other-process, matching the alert engine (CpuAlertMode.Total),
-                    the Overview headline (TotalCpuPercent = sqlserver + (other_process ?? 0)), and
-                    Dashboard's report.daily_summary (#1004). other_process_cpu_utilization is NULL on SQL
-                    Server on Linux (host CPU not derivable, #1048), so COALESCE(.,0) collapses this to the
-                    SQL-only figure there -- the same fallback as Dashboard's ISNULL(total, sqlserver). */
-                 AND   (sqlserver_cpu_utilization + COALESCE(other_process_cpu_utilization, 0)) >= 80
-                 AND   collection_time >= $2 AND collection_time < $3), 0
-            ) AS high_cpu_events,
-            COALESCE(
-                (SELECT COUNT(*)
-                 FROM v_collection_log
-                 WHERE server_id = $1
-                 AND   status = 'ERROR'
-                 AND   collection_time >= $2 AND collection_time < $3), 0
-            ) AS collection_errors,
-            /* Memory-pressure events for the day (Dashboard's report.daily_summary parity,
-               DatabaseService.Overview.cs:105-113): a RING_BUFFER_RESOURCE_MONITOR sample counts as pressure
-               when the process OR system indicator reached medium (>= 2). Windowed on collection_time (the
-               prefix time, matching the Dashboard) — not the payload sample_time the chart uses. */
-            COALESCE(
-                (SELECT COUNT(*)
-                 FROM v_memory_pressure_events
-                 WHERE server_id = $1
-                 AND   collection_time >= $2 AND collection_time < $3
-                 AND   (memory_indicators_process >= 2 OR memory_indicators_system >= 2)), 0
-            ) AS memory_pressure_events,
-            /* MEMORY_CRITICAL escalation source: any process indicator that reached severe (>= 3) in the day
-               (Dashboard's overall_health branch, DatabaseService.Overview.cs:151-160). Not displayed as a
-               column — it only decides the health band. */
-            COALESCE(
-                (SELECT COUNT(*)
-                 FROM v_memory_pressure_events
-                 WHERE server_id = $1
-                 AND   collection_time >= $2 AND collection_time < $3
-                 AND   memory_indicators_process >= 3), 0
-            ) AS memory_critical_events
+            s.d AS day,
+            COALESCE(w.total_wait_sec, 0) AS total_wait_sec,
+            w.top_wait_type,
+            COALESCE(q.c, 0) AS unique_queries,
+            COALESCE(dl.c, 0) AS deadlock_count,
+            COALESCE(NULLIF(b.c, 0), dm.c, 0) AS blocking_events,
+            COALESCE(cp.c, 0) AS high_cpu_events,
+            COALESCE(cl.errs, 0) AS collection_errors,
+            COALESCE(m.pressure, 0) AS memory_pressure_events,
+            COALESCE(m.critical, 0) AS memory_critical_events,
+            COALESCE(al.c, 0) AS alert_count
+        FROM day_spine s
+        LEFT JOIN waits w ON w.d = s.d
+        LEFT JOIN queries q ON q.d = s.d
+        LEFT JOIN deadlocks dl ON dl.d = s.d
+        LEFT JOIN bpr b ON b.d = s.d
+        LEFT JOIN dmv dm ON dm.d = s.d
+        LEFT JOIN cpu cp ON cp.d = s.d
+        LEFT JOIN coll cl ON cl.d = s.d
+        LEFT JOIN mem m ON m.d = s.d
+        LEFT JOIN alerts al ON al.d = s.d
+        ORDER BY s.d
         """;
 
     /// <summary>
+    /// Returns one <see cref="DailySummaryRow"/> per collected day in the half-open [fromDate, toDate)
+    /// window. Powers the Performance Calendar month grid.
+    /// </summary>
+    public async Task<List<DailySummaryRow>> GetDailySummaryRangeAsync(
+        int serverId, DateTime fromDate, DateTime toDate, CancellationToken cancellationToken = default)
+    {
+        await using var command = _dataSource.CreateCommand(DailySummaryRangeSql);
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+        command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = DateTime.SpecifyKind(fromDate.Date, DateTimeKind.Unspecified) });
+        command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = DateTime.SpecifyKind(toDate.Date, DateTimeKind.Unspecified) });
+
+        var results = new List<DailySummaryRow>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            results.Add(ReadDailySummaryRow(reader));
+        }
+
+        return results;
+    }
+
+    /// <summary>
     /// Daily summary for one server on a specific date (or today, UTC, when <paramref name="summaryDate"/>
-    /// is null). Copied from Lite's <c>GetDailySummaryAsync</c> — same half-open day window, same health
-    /// banding computed on the read.
+    /// is null). Delegates to the range query for a single day; returns a No-Data row when the day had no
+    /// collection.
     /// </summary>
     public async Task<DailySummaryRow?> GetDailySummaryAsync(int serverId, DateTime? summaryDate = null, CancellationToken cancellationToken = default)
     {
         var targetDate = summaryDate?.Date ?? DateTime.UtcNow.Date;
-        var dayStart = targetDate;
-        var dayEnd = targetDate.AddDays(1);
-
-        await using var command = _dataSource.CreateCommand(DailySummarySql);
-        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
-        command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = DateTime.SpecifyKind(dayStart, DateTimeKind.Unspecified) });
-        command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = DateTime.SpecifyKind(dayEnd, DateTimeKind.Unspecified) });
-
-        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
-        if (!await reader.ReadAsync(cancellationToken)) return null;
-
-        var deadlocks = reader.IsDBNull(3) ? 0L : Convert.ToInt64(reader.GetValue(3));
-        var blocking = reader.IsDBNull(4) ? 0L : Convert.ToInt64(reader.GetValue(4));
-        var highCpu = reader.IsDBNull(5) ? 0L : Convert.ToInt64(reader.GetValue(5));
-        var memoryPressure = reader.IsDBNull(7) ? 0L : Convert.ToInt64(reader.GetValue(7));
-        var memoryCritical = reader.IsDBNull(8) ? 0L : Convert.ToInt64(reader.GetValue(8));
-
-        return new DailySummaryRow
-        {
-            SummaryDate = targetDate,
-            TotalWaitTimeSec = reader.IsDBNull(0) ? 0m : Convert.ToDecimal(reader.GetValue(0)),
-            TopWaitType = reader.IsDBNull(1) ? "" : reader.GetString(1),
-            UniqueQueries = reader.IsDBNull(2) ? 0L : Convert.ToInt64(reader.GetValue(2)),
-            DeadlockCount = deadlocks,
-            BlockingEvents = blocking,
-            HighCpuEvents = highCpu,
-            MemoryPressureEvents = memoryPressure,
-            CollectionErrors = reader.IsDBNull(6) ? 0L : Convert.ToInt64(reader.GetValue(6)),
-            OverallHealth = ClassifyDailyHealth(deadlocks, highCpu, memoryCritical, blocking)
-        };
+        var rows = await GetDailySummaryRangeAsync(serverId, targetDate, targetDate.AddDays(1), cancellationToken);
+        return rows.Count > 0
+            ? rows[0]
+            : new DailySummaryRow { SummaryDate = targetDate, HasData = false, HealthBand = DailyHealthBand.NoData };
     }
 
-    /// <summary>
-    /// The Daily Summary health band, computed on the read (Lite's <c>LocalDataService.DailySummary.cs</c>
-    /// bands NORMAL / DEADLOCKS / CPU_CRITICAL / BLOCKING) plus the Dashboard's MEMORY_CRITICAL escalation
-    /// (report.daily_summary / DatabaseService.Overview.cs:151-160): a severe memory-pressure day
-    /// (<paramref name="memoryCriticalEvents"/> &gt; 0, from a process indicator &gt;= 3) ranks with the other
-    /// critical bands, ahead of BLOCKING. Severity order: deadlocks &gt; high-CPU &gt; memory-critical &gt;
-    /// blocking. Static + internal so the banding is unit-testable without Postgres.
-    /// </summary>
-    internal static string ClassifyDailyHealth(long deadlocks, long highCpuEvents, long memoryCriticalEvents, long blockingEvents)
+    private static DailySummaryRow ReadDailySummaryRow(DbDataReader reader)
     {
-        if (deadlocks > 0) return "DEADLOCKS";
-        if (highCpuEvents > 5) return "CPU_CRITICAL";
-        if (memoryCriticalEvents > 0) return "MEMORY_CRITICAL";
-        if (blockingEvents > 10) return "BLOCKING";
-        return "NORMAL";
+        var row = new DailySummaryRow
+        {
+            SummaryDate = reader.IsDBNull(0) ? DateTime.MinValue : Convert.ToDateTime(reader.GetValue(0)),
+            TotalWaitTimeSec = reader.IsDBNull(1) ? 0m : Convert.ToDecimal(reader.GetValue(1)),
+            TopWaitType = reader.IsDBNull(2) ? "" : reader.GetString(2),
+            UniqueQueries = reader.IsDBNull(3) ? 0L : Convert.ToInt64(reader.GetValue(3)),
+            DeadlockCount = reader.IsDBNull(4) ? 0L : Convert.ToInt64(reader.GetValue(4)),
+            BlockingEvents = reader.IsDBNull(5) ? 0L : Convert.ToInt64(reader.GetValue(5)),
+            HighCpuEvents = reader.IsDBNull(6) ? 0L : Convert.ToInt64(reader.GetValue(6)),
+            CollectionErrors = reader.IsDBNull(7) ? 0L : Convert.ToInt64(reader.GetValue(7)),
+            MemoryPressureEvents = reader.IsDBNull(8) ? 0L : Convert.ToInt64(reader.GetValue(8)),
+            MemoryCriticalEvents = reader.IsDBNull(9) ? 0L : Convert.ToInt64(reader.GetValue(9)),
+            AlertCount = reader.IsDBNull(10) ? 0L : Convert.ToInt64(reader.GetValue(10)),
+            HasData = true,
+        };
+        row.HealthBand = DailyHealthBandCalculator.Classify(row.ToSignals());
+        return row;
     }
 }
 
 /// <summary>
-/// The single Daily Summary grid row. Copied VERBATIM from Lite's <c>DailySummaryRow</c>
-/// (LocalDataService.DailySummary.cs): the two display properties are pure formats of stored values.
+/// The Daily Summary grid row, structurally identical to Lite's <c>DailySummaryRow</c>. The composite
+/// <see cref="HealthBand"/> is computed by the shared <see cref="DailyHealthBandCalculator"/>.
 /// </summary>
 public class DailySummaryRow
 {
@@ -187,11 +229,37 @@ public class DailySummaryRow
     public long BlockingEvents { get; set; }
     public long HighCpuEvents { get; set; }
     public long MemoryPressureEvents { get; set; }
+    public long MemoryCriticalEvents { get; set; }
     public long CollectionErrors { get; set; }
-    public string OverallHealth { get; set; } = "";
+    public long AlertCount { get; set; }
+
+    /// <summary>True when the day had any collection. False renders the calendar cell as No-Data (grey).</summary>
+    public bool HasData { get; set; }
+
+    /// <summary>The composite health band that colors this day's calendar cell.</summary>
+    public DailyHealthBand HealthBand { get; set; } = DailyHealthBand.NoData;
+
+    /// <summary>Human label for the band ("Healthy" / "Warning" / "Critical" / "No Data"), shown in the day detail.</summary>
+    public string OverallHealth => DailyHealthBandCalculator.Label(HealthBand);
 
     public string SummaryDateFormatted => SummaryDate.ToString("yyyy-MM-dd");
     public string TotalWaitFormatted => TotalWaitTimeSec < 1000
         ? $"{TotalWaitTimeSec:N1} s"
         : $"{TotalWaitTimeSec / 60:N1} min";
+
+    /// <summary>Multi-line hover text summarizing the day's signals, for the calendar cell tooltip.</summary>
+    public string SignalsTooltip => DailyHealthBandCalculator.Describe(ToSignals());
+
+    /// <summary>Projects this row's counts into the shared banding input.</summary>
+    public DailyHealthSignals ToSignals() => new()
+    {
+        HasData = HasData,
+        Deadlocks = DeadlockCount,
+        CollectionErrors = CollectionErrors,
+        HighCpuEvents = HighCpuEvents,
+        BlockingEvents = BlockingEvents,
+        MemoryPressureEvents = MemoryPressureEvents,
+        MemoryCriticalEvents = MemoryCriticalEvents,
+        AlertCount = AlertCount,
+    };
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.DailySummary.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.DailySummary.cs
@@ -8,60 +8,80 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using PerformanceMonitor.Ui;
 
 namespace PerformanceMonitor.Darling.Viewer;
 
 /// <summary>
-/// The Daily Summary inner tab — a COPY of Lite's Daily Summary tab (ServerTab.xaml + the
-/// <c>DailySummaryToday_Click</c> / <c>DailySummaryDate_Changed</c> / <c>DailySummaryRefresh_Click</c>
-/// handlers and the <c>RefreshDailySummaryAsync</c> load), reads rewired to Postgres. The date picker
-/// drives a single-row daily roll-up over the selected UTC day (default today). Matching Lite exactly,
-/// changing the date only updates the indicator — the load fires on the Today button or Refresh. The
-/// tab-refresh loop (the per-server toolbar's auto-refresh timer, via <see cref="LoadDailySummaryAsync"/>)
-/// reloads whatever date is selected; this tab is date-picker-driven, so the toolbar's time-range window
-/// does not apply to it.
+/// The Daily Summary inner tab — a COPY of Lite's Performance Calendar wiring, reads rewired to Postgres.
+/// A month heatmap of composite daily health (the shared <see cref="PerformanceCalendar"/>); clicking a day
+/// drills into its single-day roll-up. The tab-refresh loop (auto-refresh timer / tab switch, via
+/// <see cref="LoadDailySummaryAsync"/>) reloads the currently displayed month.
 /// </summary>
 public partial class ViewerServerTab
 {
-    /// <summary>The selected summary day (null = today, UTC). Mirrors Lite's <c>_dailySummaryDate</c>.</summary>
-    private DateTime? _dailySummaryDate;
+    /// <summary>The currently loaded month's rows, keyed by date, for O(1) day-click drill-in.</summary>
+    private Dictionary<DateTime, DailySummaryRow> _calendarRowsByDate = new();
 
-    private async void DailySummaryToday_Click(object sender, RoutedEventArgs e)
+    /// <summary>
+    /// Entry point from LoadInnerTabAsync (index 14) and the auto-refresh loop: (re)load the calendar's
+    /// currently displayed month. LoadInnerTabAsync owns this path's try/catch.
+    /// </summary>
+    private async Task LoadDailySummaryAsync()
     {
-        _dailySummaryDate = null;
-        DailySummaryDatePicker.SelectedDate = null;
-        DailySummaryTodayButton.FontWeight = FontWeights.Bold;
-        DailySummaryIndicator.Text = "Showing: Today (UTC)";
-        await ReloadDailySummaryAsync();
-    }
-
-    private void DailySummaryDate_Changed(object sender, SelectionChangedEventArgs e)
-    {
-        if (DailySummaryDatePicker.SelectedDate.HasValue)
-        {
-            _dailySummaryDate = DailySummaryDatePicker.SelectedDate.Value.Date;
-            DailySummaryTodayButton.FontWeight = FontWeights.Normal;
-            DailySummaryIndicator.Text = $"Showing: {_dailySummaryDate.Value:MMM d, yyyy}";
-        }
-    }
-
-    private async void DailySummaryRefresh_Click(object sender, RoutedEventArgs e)
-    {
-        await ReloadDailySummaryAsync();
+        await LoadCalendarMonthAsync(DailyCalendar.DisplayMonth);
     }
 
     /// <summary>
-    /// Button-path reload with its own error surfacing. The timer / tab-switch path calls
-    /// <see cref="LoadDailySummaryAsync"/> through LoadInnerTabAsync, which owns that path's try/catch.
+    /// Loads a month's daily summaries into the Performance Calendar. One banded cell per collected day;
+    /// days with no collection are absent (the calendar renders them No-Data grey).
     /// </summary>
-    private async Task ReloadDailySummaryAsync()
+    private async Task LoadCalendarMonthAsync(DateTime month)
+    {
+        var start = new DateTime(month.Year, month.Month, 1);
+        var end = start.AddMonths(1);
+
+        var rows = await _dataService.GetDailySummaryRangeAsync(_server.ServerId, start, end);
+
+        _calendarRowsByDate = rows.ToDictionary(r => r.SummaryDate.Date);
+        DailyCalendar.Days = rows.Select(r => new PerformanceCalendarDay
+        {
+            Date = r.SummaryDate.Date,
+            Band = r.HealthBand,
+            Tooltip = $"{r.SummaryDate:MMM d, yyyy} - {r.OverallHealth}{Environment.NewLine}{r.SignalsTooltip}",
+        }).ToList();
+
+        // Preserve the drilled-in day if it's still in view; otherwise clear the detail pane.
+        if (DailyCalendar.SelectedDate is DateTime sel && sel.Year == start.Year && sel.Month == start.Month)
+            ShowDayDetail(sel);
+        else
+            HideDayDetail();
+    }
+
+    private async void DailyCalendar_MonthChanged(object? sender, PerformanceCalendarMonthEventArgs e)
     {
         try
         {
-            await LoadDailySummaryAsync();
+            await LoadCalendarMonthAsync(e.Month);
+        }
+        catch (Exception ex)
+        {
+            StatusChanged?.Invoke($"Daily Summary load failed: {ex.Message}");
+        }
+    }
+
+    private void DailyCalendar_DayClicked(object? sender, PerformanceCalendarDayEventArgs e)
+        => ShowDayDetail(e.Date);
+
+    private async void DailySummaryRefresh_Click(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            await LoadCalendarMonthAsync(DailyCalendar.DisplayMonth);
         }
         catch (Exception ex)
         {
@@ -69,18 +89,31 @@ public partial class ViewerServerTab
         }
     }
 
-    /// <summary>
-    /// Daily Summary load: the single-row aggregate for the selected day. Copied from Lite's
-    /// <c>RefreshDailySummaryAsync</c> — the read is genuinely async (Npgsql), so no Task.Run wrap.
-    /// A null result shows the no-data message; in practice the aggregate always returns a (possibly
-    /// all-zero) row, so the message is the same parity-only fallback Lite carries.
-    /// </summary>
-    private async Task LoadDailySummaryAsync()
+    /// <summary>Shows the single-day roll-up for the clicked date (reusing the existing detail grid).</summary>
+    private void ShowDayDetail(DateTime date)
     {
-        var result = await _dataService.GetDailySummaryAsync(_server.ServerId, _dailySummaryDate);
-        DailySummaryGrid.ItemsSource = result != null
-            ? new List<DailySummaryRow> { result }
-            : null;
-        DailySummaryNoData.Visibility = result == null ? Visibility.Visible : Visibility.Collapsed;
+        DailyCalendar.SelectedDate = date.Date;
+
+        if (_calendarRowsByDate.TryGetValue(date.Date, out var row))
+        {
+            DailySummaryGrid.ItemsSource = new List<DailySummaryRow> { row };
+            DailySummaryDetailHeader.Text = $"Detail for {date:dddd, MMMM d, yyyy} (UTC)";
+            DailySummaryDetailPanel.Visibility = Visibility.Visible;
+            DailySummaryNoData.Visibility = Visibility.Collapsed;
+        }
+        else
+        {
+            DailySummaryGrid.ItemsSource = null;
+            DailySummaryDetailPanel.Visibility = Visibility.Collapsed;
+            DailySummaryNoData.Text = $"No data collected for {date:MMMM d, yyyy}.";
+            DailySummaryNoData.Visibility = Visibility.Visible;
+        }
+    }
+
+    private void HideDayDetail()
+    {
+        DailySummaryDetailPanel.Visibility = Visibility.Collapsed;
+        DailySummaryNoData.Visibility = Visibility.Collapsed;
+        DailySummaryGrid.ItemsSource = null;
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
@@ -2567,67 +2567,70 @@
             </Grid>
         </TabItem>
 
-        <!-- Daily Summary Tab — copied from Lite's ServerTab.xaml Daily Summary tab: a date picker
-             (Today / an explicit date, UTC) driving a single-row daily roll-up — total wait, top wait
-             type, unique queries, deadlocks, blocking events, high-CPU count, collect errors — with the
-             health band. Reads rewired to Postgres (GetDailySummaryAsync); grid keeps the viewer's
-             DarkGrid chrome + the shared Accent/Success buttons + NoDataMessage. Leads the diagnostics tail
-             (Daily Summary -> System Events -> Latches & Spinlocks -> Collection Health). The DatePicker + its
-             calendar dropdown theme declaratively from DarkTheme.xaml, so Lite's imperative
-             CalendarOpened re-theming handler is not ported (the viewer is fixed-Dark). -->
+        <!-- Daily Summary Tab: a month heatmap of composite daily health (the shared PerformanceCalendar,
+             identical to Lite's), replacing the old single-day date-picker roll-up. Each cell is banded by
+             the shared DailyHealthBandCalculator over that day's Postgres aggregate (GetDailySummaryRangeAsync);
+             clicking a day drills into its single-day roll-up in the detail grid below (the viewer's DarkGrid
+             chrome, keeping the Memory Pressure column). Leads the diagnostics tail (Daily Summary -> System
+             Events -> Latches & Spinlocks -> Collection Health). -->
         <TabItem Header="Daily Summary">
             <Grid Margin="8">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
+                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
 
-                <!-- Date Selection -->
+                <!-- Toolbar -->
                 <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,6">
-                    <TextBlock Text="Summary Date:" VerticalAlignment="Center" Margin="0,0,6,0" FontWeight="Bold"/>
-                    <Button x:Name="DailySummaryTodayButton" Content="Today" Click="DailySummaryToday_Click" Margin="0,0,6,0" Padding="8,4" MinWidth="60" Style="{StaticResource AccentButton}"/>
-                    <DatePicker x:Name="DailySummaryDatePicker" Width="120" Margin="0,0,6,0" SelectedDateChanged="DailySummaryDate_Changed"/>
-                    <Button Content="Refresh" Click="DailySummaryRefresh_Click" Margin="0,0,6,0" Padding="8,4" MinWidth="60" Style="{StaticResource SuccessButton}"/>
-                    <TextBlock x:Name="DailySummaryIndicator" Text="Showing: Today (UTC)" VerticalAlignment="Center"
+                    <Button Content="Refresh" Click="DailySummaryRefresh_Click" Margin="0,0,10,0" Padding="8,4" MinWidth="60" Style="{StaticResource SuccessButton}"/>
+                    <TextBlock x:Name="DailySummaryIndicator" Text="Composite daily health - click a day for detail (times in UTC)" VerticalAlignment="Center"
                                FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                 </StackPanel>
 
-                <!-- Summary Grid -->
-                <DataGrid Grid.Row="1" x:Name="DailySummaryGrid" Style="{StaticResource DarkGrid}">
-                    <DataGrid.Columns>
-                        <DataGridTextColumn Binding="{Binding SummaryDateFormatted}" Width="110">
-                            <DataGridTextColumn.Header><TextBlock Text="Date" FontWeight="Bold"/></DataGridTextColumn.Header>
-                        </DataGridTextColumn>
-                        <DataGridTextColumn Binding="{Binding OverallHealth}" Width="120">
-                            <DataGridTextColumn.Header><TextBlock Text="Health" FontWeight="Bold"/></DataGridTextColumn.Header>
-                        </DataGridTextColumn>
-                        <DataGridTextColumn Binding="{Binding TotalWaitFormatted}" ElementStyle="{StaticResource NumericCell}" Width="120" SortMemberPath="TotalWaitTimeSec">
-                            <DataGridTextColumn.Header><TextBlock Text="Total Wait" FontWeight="Bold"/></DataGridTextColumn.Header>
-                        </DataGridTextColumn>
-                        <DataGridTextColumn Binding="{Binding TopWaitType}" Width="180">
-                            <DataGridTextColumn.Header><TextBlock Text="Top Wait Type" FontWeight="Bold"/></DataGridTextColumn.Header>
-                        </DataGridTextColumn>
-                        <DataGridTextColumn Binding="{Binding UniqueQueries, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
-                            <DataGridTextColumn.Header><TextBlock Text="Unique Queries" FontWeight="Bold"/></DataGridTextColumn.Header>
-                        </DataGridTextColumn>
-                        <DataGridTextColumn Binding="{Binding DeadlockCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                            <DataGridTextColumn.Header><TextBlock Text="Deadlocks" FontWeight="Bold"/></DataGridTextColumn.Header>
-                        </DataGridTextColumn>
-                        <DataGridTextColumn Binding="{Binding BlockingEvents, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
-                            <DataGridTextColumn.Header><TextBlock Text="Blocking Events" FontWeight="Bold"/></DataGridTextColumn.Header>
-                        </DataGridTextColumn>
-                        <DataGridTextColumn Binding="{Binding MemoryPressureEvents, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="130">
-                            <DataGridTextColumn.Header><TextBlock Text="Memory Pressure" FontWeight="Bold"/></DataGridTextColumn.Header>
-                        </DataGridTextColumn>
-                        <DataGridTextColumn Binding="{Binding HighCpuEvents, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110">
-                            <DataGridTextColumn.Header><TextBlock Text="High CPU" FontWeight="Bold"/></DataGridTextColumn.Header>
-                        </DataGridTextColumn>
-                        <DataGridTextColumn Binding="{Binding CollectionErrors, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
-                            <DataGridTextColumn.Header><TextBlock Text="Collect Errors" FontWeight="Bold"/></DataGridTextColumn.Header>
-                        </DataGridTextColumn>
-                    </DataGrid.Columns>
-                </DataGrid>
-                <TextBlock Grid.Row="1" x:Name="DailySummaryNoData" Style="{StaticResource NoDataMessage}"/>
+                <!-- Month heatmap -->
+                <ui:PerformanceCalendar Grid.Row="1" x:Name="DailyCalendar"
+                                        MonthChanged="DailyCalendar_MonthChanged" DayClicked="DailyCalendar_DayClicked"/>
+
+                <!-- Clicked-day detail: the single-day roll-up, scoped to the clicked date -->
+                <StackPanel Grid.Row="2" x:Name="DailySummaryDetailPanel" Visibility="Collapsed" Margin="0,8,0,0">
+                    <TextBlock x:Name="DailySummaryDetailHeader" FontWeight="Bold" Margin="0,0,0,4" Foreground="{DynamicResource ForegroundBrush}"/>
+                    <DataGrid x:Name="DailySummaryGrid" Style="{StaticResource DarkGrid}">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Binding="{Binding SummaryDateFormatted}" Width="110">
+                                <DataGridTextColumn.Header><TextBlock Text="Date" FontWeight="Bold"/></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding OverallHealth}" Width="120">
+                                <DataGridTextColumn.Header><TextBlock Text="Health" FontWeight="Bold"/></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding TotalWaitFormatted}" ElementStyle="{StaticResource NumericCell}" Width="120" SortMemberPath="TotalWaitTimeSec">
+                                <DataGridTextColumn.Header><TextBlock Text="Total Wait" FontWeight="Bold"/></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding TopWaitType}" Width="180">
+                                <DataGridTextColumn.Header><TextBlock Text="Top Wait Type" FontWeight="Bold"/></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding UniqueQueries, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
+                                <DataGridTextColumn.Header><TextBlock Text="Unique Queries" FontWeight="Bold"/></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding DeadlockCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                                <DataGridTextColumn.Header><TextBlock Text="Deadlocks" FontWeight="Bold"/></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding BlockingEvents, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
+                                <DataGridTextColumn.Header><TextBlock Text="Blocking Events" FontWeight="Bold"/></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding MemoryPressureEvents, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="130">
+                                <DataGridTextColumn.Header><TextBlock Text="Memory Pressure" FontWeight="Bold"/></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding HighCpuEvents, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                                <DataGridTextColumn.Header><TextBlock Text="High CPU" FontWeight="Bold"/></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                            <DataGridTextColumn Binding="{Binding CollectionErrors, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
+                                <DataGridTextColumn.Header><TextBlock Text="Collect Errors" FontWeight="Bold"/></DataGridTextColumn.Header>
+                            </DataGridTextColumn>
+                        </DataGrid.Columns>
+                    </DataGrid>
+                </StackPanel>
+                <TextBlock Grid.Row="2" x:Name="DailySummaryNoData" Style="{StaticResource NoDataMessage}" Visibility="Collapsed"/>
             </Grid>
         </TabItem>
 

--- a/Lite.Tests/DailyHealthBandTests.cs
+++ b/Lite.Tests/DailyHealthBandTests.cs
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using PerformanceMonitor.Common;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// Table-driven tests for the shared Performance Calendar day-banding (<see cref="DailyHealthBandCalculator"/>).
+/// This is the one classification both apps color their month heatmap by, so it is pinned here (Lite) and,
+/// identically, in Darling.Tests. Covers the no-data / healthy / warning / critical tiers, first-match-wins
+/// priority, the threshold boundaries, and the label / brush-key / tooltip mappings.
+/// </summary>
+public class DailyHealthBandTests
+{
+    private static DailyHealthSignals Signals(
+        bool hasData = true, long deadlocks = 0, long collectionErrors = 0, long highCpu = 0,
+        long blocking = 0, long memPressure = 0, long memCritical = 0, long alerts = 0) => new()
+    {
+        HasData = hasData,
+        Deadlocks = deadlocks,
+        CollectionErrors = collectionErrors,
+        HighCpuEvents = highCpu,
+        BlockingEvents = blocking,
+        MemoryPressureEvents = memPressure,
+        MemoryCriticalEvents = memCritical,
+        AlertCount = alerts,
+    };
+
+    [Fact]
+    public void NoCollection_IsNoData_RegardlessOfOtherCounts()
+    {
+        // Even absurd counts can't override "we didn't collect that day".
+        var s = Signals(hasData: false, deadlocks: 99, collectionErrors: 99, highCpu: 99, blocking: 99, memCritical: 99, alerts: 99);
+        Assert.Equal(DailyHealthBand.NoData, DailyHealthBandCalculator.Classify(s));
+    }
+
+    [Fact]
+    public void Collected_AndNothingElevated_IsHealthy()
+    {
+        Assert.Equal(DailyHealthBand.Healthy, DailyHealthBandCalculator.Classify(Signals()));
+    }
+
+    [Theory]
+    [InlineData("deadlock", 1, 0, 0, 0, 0, 0)]
+    [InlineData("collection-error", 0, 1, 0, 0, 0, 0)]
+    [InlineData("memory-critical", 0, 0, 0, 0, 1, 0)]
+    [InlineData("sustained-cpu", 0, 0, 6, 0, 0, 0)]
+    [InlineData("heavy-blocking", 0, 0, 0, 11, 0, 0)]
+    public void CriticalTriggers_EachAloneIsCritical(string _, long deadlocks, long collErrors, long highCpu, long blocking, long memCritical, long alerts)
+    {
+        var s = Signals(deadlocks: deadlocks, collectionErrors: collErrors, highCpu: highCpu, blocking: blocking, memCritical: memCritical, alerts: alerts);
+        Assert.Equal(DailyHealthBand.Critical, DailyHealthBandCalculator.Classify(s));
+    }
+
+    [Theory]
+    [InlineData("moderate-cpu", 3, 0, 0, 0)]
+    [InlineData("some-blocking", 0, 5, 0, 0)]
+    [InlineData("memory-pressure", 0, 0, 1, 0)]
+    [InlineData("alert", 0, 0, 0, 1)]
+    public void WarningTriggers_EachAloneIsWarning(string _, long highCpu, long blocking, long memPressure, long alerts)
+    {
+        var s = Signals(highCpu: highCpu, blocking: blocking, memPressure: memPressure, alerts: alerts);
+        Assert.Equal(DailyHealthBand.Warning, DailyHealthBandCalculator.Classify(s));
+    }
+
+    [Fact]
+    public void CriticalBeatsWarning_WhenBothPresent()
+    {
+        // A deadlock (critical) plus moderate CPU + alerts (warning) still bands Critical.
+        var s = Signals(deadlocks: 1, highCpu: 3, alerts: 4);
+        Assert.Equal(DailyHealthBand.Critical, DailyHealthBandCalculator.Classify(s));
+    }
+
+    [Theory]
+    [InlineData(5, DailyHealthBand.Warning)]   // 5 high-CPU samples = moderate
+    [InlineData(6, DailyHealthBand.Critical)]  // 6 = sustained (default threshold)
+    public void HighCpu_CriticalThreshold_IsSixSamples(long highCpu, DailyHealthBand expected)
+    {
+        Assert.Equal(expected, DailyHealthBandCalculator.Classify(Signals(highCpu: highCpu)));
+    }
+
+    [Theory]
+    [InlineData(10, DailyHealthBand.Warning)]  // 10 blocking events = some
+    [InlineData(11, DailyHealthBand.Critical)] // 11 = heavy (default threshold)
+    public void Blocking_CriticalThreshold_IsElevenEvents(long blocking, DailyHealthBand expected)
+    {
+        Assert.Equal(expected, DailyHealthBandCalculator.Classify(Signals(blocking: blocking)));
+    }
+
+    [Fact]
+    public void Thresholds_AreOverridable()
+    {
+        // Same day, stricter warning thresholds: 3 high-CPU samples now clears the Critical bar.
+        var strict = new DailyHealthThresholds { HighCpuCriticalSamples = 3 };
+        Assert.Equal(DailyHealthBand.Critical, DailyHealthBandCalculator.Classify(Signals(highCpu: 3), strict));
+        Assert.Equal(DailyHealthBand.Warning, DailyHealthBandCalculator.Classify(Signals(highCpu: 3)));
+    }
+
+    [Theory]
+    [InlineData(DailyHealthBand.NoData, "No Data", "ForegroundMutedBrush")]
+    [InlineData(DailyHealthBand.Healthy, "Healthy", "SuccessBrush")]
+    [InlineData(DailyHealthBand.Warning, "Warning", "WarningBrush")]
+    [InlineData(DailyHealthBand.Critical, "Critical", "ErrorBrush")]
+    public void Label_And_BrushKey_MapEachBand(DailyHealthBand band, string label, string brushKey)
+    {
+        Assert.Equal(label, DailyHealthBandCalculator.Label(band));
+        Assert.Equal(brushKey, DailyHealthBandCalculator.BrushKey(band));
+    }
+
+    [Fact]
+    public void Describe_NoData_And_NoIssues_And_MultiSignal()
+    {
+        Assert.Equal("No data collected.", DailyHealthBandCalculator.Describe(Signals(hasData: false)));
+        Assert.Equal("No issues detected.", DailyHealthBandCalculator.Describe(Signals()));
+
+        var described = DailyHealthBandCalculator.Describe(Signals(deadlocks: 2, blocking: 1, alerts: 3));
+        Assert.Contains("2 deadlocks", described);
+        Assert.Contains("1 blocking event", described);   // singular
+        Assert.Contains("3 alerts", described);
+    }
+}

--- a/Lite.Tests/DailyHealthBandTests.cs
+++ b/Lite.Tests/DailyHealthBandTests.cs
@@ -125,4 +125,14 @@ public class DailyHealthBandTests
         Assert.Contains("1 blocking event", described);   // singular
         Assert.Contains("3 alerts", described);
     }
+
+    [Fact]
+    public void Describe_MemoryPressure_DoesNotDoubleCountSevere()
+    {
+        // 3 pressure events, 1 severe -> "1 severe" + "2 (non-severe)", never "3 memory-pressure events".
+        var described = DailyHealthBandCalculator.Describe(Signals(memPressure: 3, memCritical: 1));
+        Assert.Contains("1 severe memory-pressure event", described);
+        Assert.Contains("2 memory-pressure events", described);
+        Assert.DoesNotContain("3 memory-pressure events", described);
+    }
 }

--- a/Lite.Tests/PerformanceCalendarDataTests.cs
+++ b/Lite.Tests/PerformanceCalendarDataTests.cs
@@ -141,12 +141,19 @@ public class PerformanceCalendarDataTests : IDisposable
         await SeedCollectionRunAsync(Day(18));
         await SeedMemoryAsync(Day(18), process: 3, system: 1);
 
+        // 07-22 Warning via an alert alone (no collection-log run that day) -- the day must still appear
+        // (alerts are part of the day spine), banded Warning, not dropped as No-Data.
+        await SeedAlertAsync(Day(22), "Blocking Detected", dismissed: false);
+
         var rows = await _dataService.GetDailySummaryRangeAsync(ServerId, MonthStart, MonthEnd);
         var byDate = rows.ToDictionary(r => r.SummaryDate.Date);
 
-        // Exactly the seven seeded days appear; unseeded days are absent (calendar renders them No-Data).
-        Assert.Equal(7, rows.Count);
+        // Exactly the eight seeded days appear; unseeded days are absent (calendar renders them No-Data).
+        Assert.Equal(8, rows.Count);
         Assert.False(byDate.ContainsKey(Day(20)));
+
+        Assert.Equal(DailyHealthBand.Warning, byDate[Day(22)].HealthBand);
+        Assert.Equal(1, byDate[Day(22)].AlertCount);
 
         Assert.Equal(DailyHealthBand.Critical, byDate[Day(2)].HealthBand);
         Assert.Equal(1, byDate[Day(2)].DeadlockCount);

--- a/Lite.Tests/PerformanceCalendarDataTests.cs
+++ b/Lite.Tests/PerformanceCalendarDataTests.cs
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using DuckDB.NET.Data;
+using PerformanceMonitor.Common;
+using PerformanceMonitorLite.Database;
+using PerformanceMonitorLite.Services;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// End-to-end validation of the Performance Calendar's per-day-range aggregate against a real DuckDB:
+/// that the grouped range SQL (day spine + per-source CTEs, arg_max top wait, FILTER counts, the
+/// blocked-process-report -> DMV-snapshot blocking fallback, the actionable-alert filter) buckets each
+/// seeded day correctly and that each day's composite band matches the shared calculator.
+/// </summary>
+public class PerformanceCalendarDataTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly DuckDbInitializer _duckDb;
+    private readonly LocalDataService _dataService;
+    private const int ServerId = -779;
+    private const string ServerName = "CalTestServer";
+    private long _nextId = -1;
+
+    private static readonly DateTime MonthStart = new(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime MonthEnd = new(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    public PerformanceCalendarDataTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "CalTests_" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+        _duckDb = new DuckDbInitializer(Path.Combine(_tempDir, "test.duckdb"));
+        _dataService = new LocalDataService(_duckDb);
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_tempDir)) Directory.Delete(_tempDir, recursive: true); }
+        catch { }
+        GC.SuppressFinalize(this);
+    }
+
+    private async Task ExecAsync(string sql, params object?[] values)
+    {
+        using var readLock = _duckDb.AcquireReadLock();
+        using var conn = _duckDb.CreateConnection();
+        await conn.OpenAsync();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        foreach (var v in values)
+            cmd.Parameters.Add(new DuckDBParameter { Value = v ?? DBNull.Value });
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private Task SeedCollectionRunAsync(DateTime day, string status = "SUCCESS") =>
+        ExecAsync(
+            "INSERT INTO collection_log (log_id, server_id, server_name, collector_name, collection_time, status) VALUES ($1,$2,$3,'wait_stats',$4,$5)",
+            _nextId--, ServerId, ServerName, day.AddHours(1), status);
+
+    private Task SeedWaitAsync(DateTime day, string waitType, long deltaMs) =>
+        ExecAsync(
+            "INSERT INTO wait_stats (collection_id, collection_time, server_id, server_name, wait_type, delta_wait_time_ms) VALUES ($1,$2,$3,$4,$5,$6)",
+            _nextId--, day.AddHours(1), ServerId, ServerName, waitType, deltaMs);
+
+    private Task SeedCpuAsync(DateTime day, int sqlCpu, int otherCpu) =>
+        ExecAsync(
+            "INSERT INTO cpu_utilization_stats (collection_id, collection_time, server_id, server_name, sample_time, sqlserver_cpu_utilization, other_process_cpu_utilization) VALUES ($1,$2,$3,$4,$2,$5,$6)",
+            _nextId--, day.AddHours(1), ServerId, ServerName, sqlCpu, otherCpu);
+
+    private Task SeedDeadlockAsync(DateTime day) =>
+        ExecAsync(
+            "INSERT INTO deadlocks (deadlock_id, collection_time, server_id, server_name) VALUES ($1,$2,$3,$4)",
+            _nextId--, day.AddHours(1), ServerId, ServerName);
+
+    private Task SeedDmvBlockingAsync(DateTime day) =>
+        ExecAsync(
+            "INSERT INTO dmv_blocking_snapshots (collection_id, collection_time, server_id, server_name, monitor_loop) VALUES ($1,$2,$3,$4,1)",
+            _nextId--, day.AddHours(1), ServerId, ServerName);
+
+    private Task SeedMemoryAsync(DateTime day, int process, int system) =>
+        ExecAsync(
+            "INSERT INTO memory_pressure_events (collection_id, collection_time, server_id, server_name, sample_time, memory_notification, memory_indicators_process, memory_indicators_system) VALUES ($1,$2,$3,$4,$2,'RESOURCE_MEMPHYSICAL_LOW',$5,$6)",
+            _nextId--, day.AddHours(1), ServerId, ServerName, process, system);
+
+    private Task SeedAlertAsync(DateTime day, string metric, bool dismissed) =>
+        ExecAsync(
+            "INSERT INTO config_alert_log (alert_time, server_id, server_name, metric_name, current_value, threshold_value, dismissed) VALUES ($1,$2,$3,$4,1.0,1.0,$5)",
+            day.AddHours(1), ServerId, ServerName, metric, dismissed);
+
+    private static DateTime Day(int d) => new(2026, 7, d, 0, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task GetDailySummaryRange_BucketsEachDay_AndBandsViaSharedCalculator()
+    {
+        await _duckDb.InitializeAsync();
+
+        // 07-02 Critical: a deadlock, plus waits (CXPACKET should win the top-wait ranking).
+        await SeedCollectionRunAsync(Day(2));
+        await SeedWaitAsync(Day(2), "CXPACKET", 100_000);
+        await SeedWaitAsync(Day(2), "PAGEIOLATCH_SH", 50_000);
+        await SeedDeadlockAsync(Day(2));
+
+        // 07-05 Critical: 6 sustained high-CPU samples (>= threshold).
+        await SeedCollectionRunAsync(Day(5));
+        for (var i = 0; i < 6; i++)
+            await SeedCpuAsync(Day(5), 70, 20); // 90 total >= 80
+
+        // 07-08 Warning: no BPR but 3 DMV blocking snapshots (fallback) + 2 moderate high-CPU samples.
+        await SeedCollectionRunAsync(Day(8));
+        await SeedDmvBlockingAsync(Day(8));
+        await SeedDmvBlockingAsync(Day(8));
+        await SeedDmvBlockingAsync(Day(8));
+        await SeedCpuAsync(Day(8), 85, 0);
+        await SeedCpuAsync(Day(8), 82, 0);
+
+        // 07-10 Warning: one actionable alert; a dismissed alert and a resolution notice must NOT count.
+        await SeedCollectionRunAsync(Day(10));
+        await SeedAlertAsync(Day(10), "High CPU", dismissed: false);
+        await SeedAlertAsync(Day(10), "Blocking Detected", dismissed: true);
+        await SeedAlertAsync(Day(10), "CPU Resolved", dismissed: false);
+
+        // 07-12 Healthy: collected, quiet.
+        await SeedCollectionRunAsync(Day(12));
+
+        // 07-15 Critical: a collection ERROR (monitoring blind spot).
+        await SeedCollectionRunAsync(Day(15), status: "SUCCESS");
+        await SeedCollectionRunAsync(Day(15), status: "ERROR");
+
+        // 07-18 Critical: severe memory pressure (process indicator >= 3).
+        await SeedCollectionRunAsync(Day(18));
+        await SeedMemoryAsync(Day(18), process: 3, system: 1);
+
+        var rows = await _dataService.GetDailySummaryRangeAsync(ServerId, MonthStart, MonthEnd);
+        var byDate = rows.ToDictionary(r => r.SummaryDate.Date);
+
+        // Exactly the seven seeded days appear; unseeded days are absent (calendar renders them No-Data).
+        Assert.Equal(7, rows.Count);
+        Assert.False(byDate.ContainsKey(Day(20)));
+
+        Assert.Equal(DailyHealthBand.Critical, byDate[Day(2)].HealthBand);
+        Assert.Equal(1, byDate[Day(2)].DeadlockCount);
+        Assert.Equal("CXPACKET", byDate[Day(2)].TopWaitType);
+        Assert.Equal(150m, byDate[Day(2)].TotalWaitTimeSec);
+
+        Assert.Equal(DailyHealthBand.Critical, byDate[Day(5)].HealthBand);
+        Assert.Equal(6, byDate[Day(5)].HighCpuEvents);
+
+        Assert.Equal(DailyHealthBand.Warning, byDate[Day(8)].HealthBand);
+        Assert.Equal(3, byDate[Day(8)].BlockingEvents);   // DMV fallback (0 BPR)
+        Assert.Equal(2, byDate[Day(8)].HighCpuEvents);
+
+        Assert.Equal(DailyHealthBand.Warning, byDate[Day(10)].HealthBand);
+        Assert.Equal(1, byDate[Day(10)].AlertCount);       // dismissed + resolution excluded
+
+        Assert.Equal(DailyHealthBand.Healthy, byDate[Day(12)].HealthBand);
+        Assert.True(byDate[Day(12)].HasData);
+
+        Assert.Equal(DailyHealthBand.Critical, byDate[Day(15)].HealthBand);
+        Assert.Equal(1, byDate[Day(15)].CollectionErrors);
+
+        Assert.Equal(DailyHealthBand.Critical, byDate[Day(18)].HealthBand);
+        Assert.Equal(1, byDate[Day(18)].MemoryCriticalEvents);
+        Assert.Equal(1, byDate[Day(18)].MemoryPressureEvents);
+    }
+
+    [Fact]
+    public async Task GetDailySummary_SingleDay_DelegatesToRange_AndReturnsNoDataRowWhenEmpty()
+    {
+        await _duckDb.InitializeAsync();
+
+        await SeedCollectionRunAsync(Day(2));
+        await SeedDeadlockAsync(Day(2));
+
+        var seeded = await _dataService.GetDailySummaryAsync(ServerId, Day(2));
+        Assert.NotNull(seeded);
+        Assert.True(seeded!.HasData);
+        Assert.Equal(DailyHealthBand.Critical, seeded.HealthBand);
+        Assert.Equal("Critical", seeded.OverallHealth);
+
+        var empty = await _dataService.GetDailySummaryAsync(ServerId, Day(25));
+        Assert.NotNull(empty);
+        Assert.False(empty!.HasData);
+        Assert.Equal(DailyHealthBand.NoData, empty.HealthBand);
+        Assert.Equal("No Data", empty.OverallHealth);
+    }
+}

--- a/Lite/Controls/ServerTab.DailySummary.cs
+++ b/Lite/Controls/ServerTab.DailySummary.cs
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using PerformanceMonitorLite.Helpers;
+using PerformanceMonitorLite.Services;
+using PerformanceMonitor.Ui;
+
+namespace PerformanceMonitorLite.Controls;
+
+public partial class ServerTab : UserControl
+{
+    /// <summary>The currently loaded month's rows, keyed by date, for O(1) day-click drill-in.</summary>
+    private Dictionary<DateTime, DailySummaryRow> _calendarRowsByDate = new();
+
+    /// <summary>
+    /// Loads a month's daily summaries into the Performance Calendar. One banded cell per collected day;
+    /// days with no collection are simply absent (the calendar renders them No-Data grey). The heavy DuckDB
+    /// read runs off the UI thread.
+    /// </summary>
+    private async Task LoadCalendarMonthAsync(DateTime month)
+    {
+        try
+        {
+            var start = new DateTime(month.Year, month.Month, 1);
+            var end = start.AddMonths(1);
+
+            var rows = await Task.Run(() => _dataService.GetDailySummaryRangeAsync(_serverId, start, end));
+
+            _calendarRowsByDate = rows.ToDictionary(r => r.SummaryDate.Date);
+            DailyCalendar.Days = rows.Select(r => new PerformanceCalendarDay
+            {
+                Date = r.SummaryDate.Date,
+                Band = r.HealthBand,
+                Tooltip = $"{r.SummaryDate:MMM d, yyyy} - {r.OverallHealth}{Environment.NewLine}{r.SignalsTooltip}",
+            }).ToList();
+
+            // Preserve the drilled-in day if it's still in view; otherwise clear the detail pane.
+            if (DailyCalendar.SelectedDate is DateTime sel && sel.Year == start.Year && sel.Month == start.Month)
+                ShowDayDetail(sel);
+            else
+                HideDayDetail();
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Info("ServerTab", $"[{_server.DisplayName}] LoadCalendarMonthAsync failed: {ex.Message}");
+        }
+    }
+
+    private async void DailyCalendar_MonthChanged(object? sender, PerformanceCalendarMonthEventArgs e)
+        => await LoadCalendarMonthAsync(e.Month);
+
+    private void DailyCalendar_DayClicked(object? sender, PerformanceCalendarDayEventArgs e)
+        => ShowDayDetail(e.Date);
+
+    private async void DailySummaryRefresh_Click(object sender, RoutedEventArgs e)
+        => await LoadCalendarMonthAsync(DailyCalendar.DisplayMonth);
+
+    /// <summary>Shows the single-day roll-up for the clicked date (reusing the existing detail grid).</summary>
+    private void ShowDayDetail(DateTime date)
+    {
+        DailyCalendar.SelectedDate = date.Date;
+
+        if (_calendarRowsByDate.TryGetValue(date.Date, out var row))
+        {
+            DailySummaryGrid.ItemsSource = new List<DailySummaryRow> { row };
+            DailySummaryDetailHeader.Text = $"Detail for {date:dddd, MMMM d, yyyy} (UTC)";
+            DailySummaryDetailPanel.Visibility = Visibility.Visible;
+            DailySummaryNoData.Visibility = Visibility.Collapsed;
+        }
+        else
+        {
+            DailySummaryGrid.ItemsSource = null;
+            DailySummaryDetailPanel.Visibility = Visibility.Collapsed;
+            DailySummaryNoData.Text = $"No data collected for {date:MMMM d, yyyy}.";
+            DailySummaryNoData.Visibility = Visibility.Visible;
+        }
+    }
+
+    private void HideDayDetail()
+    {
+        DailySummaryDetailPanel.Visibility = Visibility.Collapsed;
+        DailySummaryNoData.Visibility = Visibility.Collapsed;
+        DailySummaryGrid.ItemsSource = null;
+    }
+}

--- a/Lite/Controls/ServerTab.Refresh.cs
+++ b/Lite/Controls/ServerTab.Refresh.cs
@@ -623,22 +623,10 @@ public partial class ServerTab : UserControl
         }
     }
 
-    /// <summary>Tab 11 — Daily Summary</summary>
+    /// <summary>Tab 11 — Daily Summary (Performance Calendar month heatmap).</summary>
     private async System.Threading.Tasks.Task RefreshDailySummaryAsync(int hoursBack, DateTime? fromDate, DateTime? toDate)
     {
-        try
-        {
-            var dailySummaryTask = Task.Run(() => _dataService.GetDailySummaryAsync(_serverId, _dailySummaryDate));
-            var dailySummary = await dailySummaryTask;
-            DailySummaryGrid.ItemsSource = dailySummary != null
-                ? new List<DailySummaryRow> { dailySummary } : null;
-            DailySummaryNoData.Visibility = dailySummary == null
-                ? System.Windows.Visibility.Visible : System.Windows.Visibility.Collapsed;
-        }
-        catch (Exception ex)
-        {
-            AppLogger.Info("ServerTab", $"[{_server.DisplayName}] RefreshDailySummaryAsync failed: {ex.Message}");
-        }
+        await LoadCalendarMonthAsync(DailyCalendar.DisplayMonth);
     }
 
     /// <summary>Tab 12 — Collection Health</summary>

--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -1942,60 +1942,68 @@
                 </Grid>
             </TabItem>
 
-            <!-- Daily Summary Tab -->
+            <!-- Daily Summary Tab: a month heatmap of composite daily health; click a day for its roll-up -->
             <TabItem Header="Daily Summary">
                 <Grid Margin="8">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
+                        <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
 
-                    <!-- Date Selection -->
+                    <!-- Toolbar -->
                     <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,6">
-                        <TextBlock Text="Summary Date:" VerticalAlignment="Center" Margin="0,0,6,0" FontWeight="Bold"/>
-                        <Button x:Name="DailySummaryTodayButton" Content="Today" Click="DailySummaryToday_Click" Margin="0,0,6,0" Padding="8,4" MinWidth="60" Style="{StaticResource AccentButton}"/>
-                        <DatePicker x:Name="DailySummaryDatePicker" Width="120" Margin="0,0,6,0" SelectedDateChanged="DailySummaryDate_Changed" CalendarOpened="DatePicker_CalendarOpened"/>
-                        <Button Content="Refresh" Click="DailySummaryRefresh_Click" Margin="0,0,6,0" Padding="8,4" MinWidth="60" Style="{StaticResource SuccessButton}"/>
-                        <TextBlock x:Name="DailySummaryIndicator" Text="Showing: Today (UTC)" VerticalAlignment="Center"
+                        <Button Content="Refresh" Click="DailySummaryRefresh_Click" Margin="0,0,10,0" Padding="8,4" MinWidth="60" Style="{StaticResource SuccessButton}"/>
+                        <TextBlock x:Name="DailySummaryIndicator" Text="Composite daily health - click a day for detail (times in UTC)" VerticalAlignment="Center"
                                    FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                     </StackPanel>
 
-                    <!-- Summary Grid -->
-                    <DataGrid Grid.Row="1" x:Name="DailySummaryGrid"
-                              AutoGenerateColumns="False" IsReadOnly="True"
-                              RowStyle="{StaticResource GridRowStyle}"
-                              HeadersVisibility="Column" GridLinesVisibility="Horizontal">
-                        <DataGrid.Columns>
-                            <DataGridTextColumn Binding="{Binding SummaryDateFormatted}" Width="110">
-                                <DataGridTextColumn.Header><TextBlock Text="Date" FontWeight="Bold"/></DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding OverallHealth}" Width="120">
-                                <DataGridTextColumn.Header><TextBlock Text="Health" FontWeight="Bold"/></DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding TotalWaitFormatted}" ElementStyle="{StaticResource NumericCell}" Width="120" SortMemberPath="TotalWaitTimeSec">
-                                <DataGridTextColumn.Header><TextBlock Text="Total Wait" FontWeight="Bold"/></DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding TopWaitType}" Width="180">
-                                <DataGridTextColumn.Header><TextBlock Text="Top Wait Type" FontWeight="Bold"/></DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding UniqueQueries, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
-                                <DataGridTextColumn.Header><TextBlock Text="Unique Queries" FontWeight="Bold"/></DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding DeadlockCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                                <DataGridTextColumn.Header><TextBlock Text="Deadlocks" FontWeight="Bold"/></DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding BlockingEvents, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
-                                <DataGridTextColumn.Header><TextBlock Text="Blocking Events" FontWeight="Bold"/></DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding HighCpuEvents, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110">
-                                <DataGridTextColumn.Header><TextBlock Text="High CPU" FontWeight="Bold"/></DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding CollectionErrors, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
-                                <DataGridTextColumn.Header><TextBlock Text="Collect Errors" FontWeight="Bold"/></DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                        </DataGrid.Columns>
-                    </DataGrid>
-                    <TextBlock Grid.Row="1" x:Name="DailySummaryNoData" Style="{StaticResource NoDataMessage}"/>
+                    <!-- Month heatmap -->
+                    <ui:PerformanceCalendar Grid.Row="1" x:Name="DailyCalendar"
+                                            MonthChanged="DailyCalendar_MonthChanged" DayClicked="DailyCalendar_DayClicked"/>
+
+                    <!-- Clicked-day detail: the single-day roll-up, scoped to the clicked date -->
+                    <StackPanel Grid.Row="2" x:Name="DailySummaryDetailPanel" Visibility="Collapsed" Margin="0,8,0,0">
+                        <TextBlock x:Name="DailySummaryDetailHeader" FontWeight="Bold" Margin="0,0,0,4" Foreground="{DynamicResource ForegroundBrush}"/>
+                        <DataGrid x:Name="DailySummaryGrid"
+                                  AutoGenerateColumns="False" IsReadOnly="True"
+                                  RowStyle="{StaticResource GridRowStyle}"
+                                  HeadersVisibility="Column" GridLinesVisibility="Horizontal">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Binding="{Binding SummaryDateFormatted}" Width="110">
+                                    <DataGridTextColumn.Header><TextBlock Text="Date" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                </DataGridTextColumn>
+                                <DataGridTextColumn Binding="{Binding OverallHealth}" Width="120">
+                                    <DataGridTextColumn.Header><TextBlock Text="Health" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                </DataGridTextColumn>
+                                <DataGridTextColumn Binding="{Binding TotalWaitFormatted}" ElementStyle="{StaticResource NumericCell}" Width="120" SortMemberPath="TotalWaitTimeSec">
+                                    <DataGridTextColumn.Header><TextBlock Text="Total Wait" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                </DataGridTextColumn>
+                                <DataGridTextColumn Binding="{Binding TopWaitType}" Width="180">
+                                    <DataGridTextColumn.Header><TextBlock Text="Top Wait Type" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                </DataGridTextColumn>
+                                <DataGridTextColumn Binding="{Binding UniqueQueries, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
+                                    <DataGridTextColumn.Header><TextBlock Text="Unique Queries" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                </DataGridTextColumn>
+                                <DataGridTextColumn Binding="{Binding DeadlockCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100">
+                                    <DataGridTextColumn.Header><TextBlock Text="Deadlocks" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                </DataGridTextColumn>
+                                <DataGridTextColumn Binding="{Binding BlockingEvents, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
+                                    <DataGridTextColumn.Header><TextBlock Text="Blocking Events" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                </DataGridTextColumn>
+                                <DataGridTextColumn Binding="{Binding HighCpuEvents, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110">
+                                    <DataGridTextColumn.Header><TextBlock Text="High CPU" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                </DataGridTextColumn>
+                                <DataGridTextColumn Binding="{Binding MemoryPressureEvents, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
+                                    <DataGridTextColumn.Header><TextBlock Text="Memory Pressure" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                </DataGridTextColumn>
+                                <DataGridTextColumn Binding="{Binding CollectionErrors, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
+                                    <DataGridTextColumn.Header><TextBlock Text="Collect Errors" FontWeight="Bold"/></DataGridTextColumn.Header>
+                                </DataGridTextColumn>
+                            </DataGrid.Columns>
+                        </DataGrid>
+                    </StackPanel>
+                    <TextBlock Grid.Row="2" x:Name="DailySummaryNoData" Style="{StaticResource NoDataMessage}" Visibility="Collapsed"/>
                 </Grid>
             </TabItem>
 

--- a/Lite/Controls/ServerTab.xaml.cs
+++ b/Lite/Controls/ServerTab.xaml.cs
@@ -105,7 +105,6 @@ public partial class ServerTab : UserControl
     private DataGridFilterManager<TraceFlagRow>? _traceFlagsFilterMgr;
     private DataGridFilterManager<CollectorHealthRow>? _collectionHealthFilterMgr;
     private DataGridFilterManager<CollectionLogRow>? _collectionLogFilterMgr;
-    private DateTime? _dailySummaryDate; // null = today
     private CancellationTokenSource? _actualPlanCts;
 
     public int UtcOffsetMinutes { get; }
@@ -445,41 +444,6 @@ public partial class ServerTab : UserControl
             : $"TabNav-tab{MainTabControl.SelectedIndex}";
         using var _navTimer = Helpers.MethodProfiler.StartTiming(navContext);
         await RefreshVisibleTabAsync(hoursBack, fromDate, toDate, subTabOnly: true);
-    }
-
-    private void DailySummaryToday_Click(object sender, RoutedEventArgs e)
-    {
-        _dailySummaryDate = null;
-        DailySummaryDatePicker.SelectedDate = null;
-        DailySummaryTodayButton.FontWeight = FontWeights.Bold;
-        DailySummaryIndicator.Text = "Showing: Today (UTC)";
-        DailySummaryRefresh_Click(sender, e);
-    }
-
-    private void DailySummaryDate_Changed(object sender, SelectionChangedEventArgs e)
-    {
-        if (DailySummaryDatePicker.SelectedDate.HasValue)
-        {
-            _dailySummaryDate = DailySummaryDatePicker.SelectedDate.Value.Date;
-            DailySummaryTodayButton.FontWeight = FontWeights.Normal;
-            DailySummaryIndicator.Text = $"Showing: {_dailySummaryDate.Value:MMM d, yyyy}";
-        }
-    }
-
-    private async void DailySummaryRefresh_Click(object sender, RoutedEventArgs e)
-    {
-        try
-        {
-            var result = await Task.Run(() => _dataService.GetDailySummaryAsync(_serverId, _dailySummaryDate));
-            DailySummaryGrid.ItemsSource = result != null
-                ? new List<DailySummaryRow> { result } : null;
-            DailySummaryNoData.Visibility = result == null
-                ? Visibility.Visible : Visibility.Collapsed;
-        }
-        catch (Exception ex)
-        {
-            AppLogger.Error("DailySummary", $"Error refreshing: {ex.Message}");
-        }
     }
 
     private async void LiveSnapshot_Click(object sender, RoutedEventArgs e)

--- a/Lite/Services/LocalDataService.DailySummary.cs
+++ b/Lite/Services/LocalDataService.DailySummary.cs
@@ -10,112 +10,189 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using DuckDB.NET.Data;
+using PerformanceMonitor.Common;
 
 namespace PerformanceMonitorLite.Services;
 
 public partial class LocalDataService
 {
     /// <summary>
-    /// Gets daily summary for a specific date (or today if null).
+    /// The Performance Calendar / Daily Summary aggregate, grouped one row per day over a half-open
+    /// [fromDate, toDate) window. One row is returned for every day that had ANY collection (present in
+    /// the collection log or any source view); days with no collection are simply absent, which the
+    /// calendar renders as <see cref="DailyHealthBand.NoData"/>. Each row's composite band is computed by
+    /// the shared <see cref="DailyHealthBandCalculator"/> so it bands identically to the Darling viewer.
+    ///
+    /// This is the single source of truth for the daily aggregate; <see cref="GetDailySummaryAsync"/>
+    /// (single day) delegates here so the calendar cell and the drilled-in day can never disagree.
     /// </summary>
-    public async Task<DailySummaryRow?> GetDailySummaryAsync(int serverId, DateTime? summaryDate = null)
+    private const string DailySummaryRangeSql = @"
+WITH wait_per_type AS (
+    SELECT date_trunc('day', collection_time) AS d, wait_type, SUM(delta_wait_time_ms) AS ms
+    FROM v_wait_stats
+    WHERE server_id = $1 AND collection_time >= $2 AND collection_time < $3 AND delta_wait_time_ms > 0
+    GROUP BY 1, 2
+),
+waits AS (
+    SELECT d, SUM(ms) / 1000.0 AS total_wait_sec, arg_max(wait_type, ms) AS top_wait_type
+    FROM wait_per_type
+    GROUP BY d
+),
+queries AS (
+    SELECT date_trunc('day', collection_time) AS d, COUNT(DISTINCT query_hash) AS c
+    FROM v_query_stats
+    WHERE server_id = $1 AND collection_time >= $2 AND collection_time < $3
+    GROUP BY 1
+),
+deadlocks AS (
+    SELECT date_trunc('day', collection_time) AS d, COUNT(*) AS c
+    FROM v_deadlocks
+    WHERE server_id = $1 AND collection_time >= $2 AND collection_time < $3
+    GROUP BY 1
+),
+bpr AS (
+    SELECT date_trunc('day', collection_time) AS d, COUNT(*) AS c
+    FROM v_blocked_process_reports
+    WHERE server_id = $1 AND collection_time >= $2 AND collection_time < $3
+    GROUP BY 1
+),
+dmv AS (
+    SELECT date_trunc('day', collection_time) AS d, COUNT(*) AS c
+    FROM v_dmv_blocking_snapshots
+    WHERE server_id = $1 AND collection_time >= $2 AND collection_time < $3
+    GROUP BY 1
+),
+cpu AS (
+    /* Total host CPU = SQL + other-process (NULL on Linux -> 0), matching the alert engine and the
+       Overview headline; sustained >= 80 samples drive the day's band. */
+    SELECT date_trunc('day', collection_time) AS d,
+           COUNT(*) FILTER (WHERE (sqlserver_cpu_utilization + COALESCE(other_process_cpu_utilization, 0)) >= 80) AS c
+    FROM v_cpu_utilization_stats
+    WHERE server_id = $1 AND collection_time >= $2 AND collection_time < $3
+    GROUP BY 1
+),
+coll AS (
+    /* Any run (all statuses) marks the day as collected -> it appears even if every metric is quiet
+       (a quiet monitored day is Healthy/green, not No-Data/grey). errs feeds the Critical band. */
+    SELECT date_trunc('day', collection_time) AS d,
+           COUNT(*) AS runs,
+           COUNT(*) FILTER (WHERE status = 'ERROR') AS errs
+    FROM v_collection_log
+    WHERE server_id = $1 AND collection_time >= $2 AND collection_time < $3
+    GROUP BY 1
+),
+mem AS (
+    SELECT date_trunc('day', collection_time) AS d,
+           COUNT(*) FILTER (WHERE memory_indicators_process >= 2 OR memory_indicators_system >= 2) AS pressure,
+           COUNT(*) FILTER (WHERE memory_indicators_process >= 3) AS critical
+    FROM v_memory_pressure_events
+    WHERE server_id = $1 AND collection_time >= $2 AND collection_time < $3
+    GROUP BY 1
+),
+alerts AS (
+    /* Actionable alerts only: exclude dismissed rows and resolution/good-news notices (Cleared /
+       Resolved / Restored), mirroring AlertMetricClassifier.IsResolution. */
+    SELECT date_trunc('day', alert_time) AS d, COUNT(*) AS c
+    FROM v_config_alert_log
+    WHERE server_id = $1 AND alert_time >= $2 AND alert_time < $3
+      AND dismissed = false
+      AND metric_name NOT LIKE '%Cleared%'
+      AND metric_name NOT LIKE '%Resolved%'
+      AND metric_name NOT LIKE '%Restored%'
+    GROUP BY 1
+),
+day_spine AS (
+    SELECT d FROM waits
+    UNION SELECT d FROM queries
+    UNION SELECT d FROM deadlocks
+    UNION SELECT d FROM bpr
+    UNION SELECT d FROM dmv
+    UNION SELECT d FROM cpu
+    UNION SELECT d FROM coll
+    UNION SELECT d FROM mem
+)
+SELECT
+    s.d AS day,
+    COALESCE(w.total_wait_sec, 0) AS total_wait_sec,
+    w.top_wait_type,
+    COALESCE(q.c, 0) AS unique_queries,
+    COALESCE(dl.c, 0) AS deadlock_count,
+    COALESCE(NULLIF(b.c, 0), dm.c, 0) AS blocking_events,
+    COALESCE(cp.c, 0) AS high_cpu_events,
+    COALESCE(cl.errs, 0) AS collection_errors,
+    COALESCE(m.pressure, 0) AS memory_pressure_events,
+    COALESCE(m.critical, 0) AS memory_critical_events,
+    COALESCE(al.c, 0) AS alert_count
+FROM day_spine s
+LEFT JOIN waits w ON w.d = s.d
+LEFT JOIN queries q ON q.d = s.d
+LEFT JOIN deadlocks dl ON dl.d = s.d
+LEFT JOIN bpr b ON b.d = s.d
+LEFT JOIN dmv dm ON dm.d = s.d
+LEFT JOIN cpu cp ON cp.d = s.d
+LEFT JOIN coll cl ON cl.d = s.d
+LEFT JOIN mem m ON m.d = s.d
+LEFT JOIN alerts al ON al.d = s.d
+ORDER BY s.d";
+
+    /// <summary>
+    /// Returns one <see cref="DailySummaryRow"/> per collected day in the half-open [fromDate, toDate)
+    /// window (dates normalized to their date component). Powers the Performance Calendar month grid.
+    /// </summary>
+    public async Task<List<DailySummaryRow>> GetDailySummaryRangeAsync(int serverId, DateTime fromDate, DateTime toDate)
     {
-        using var _q = TimeQuery("GetDailySummaryAsync", "daily summary aggregation");
+        using var _q = TimeQuery("GetDailySummaryRangeAsync", "daily summary range aggregation");
         using var connection = await OpenConnectionAsync();
         using var command = connection.CreateCommand();
 
-        var targetDate = summaryDate?.Date ?? DateTime.UtcNow.Date;
-        var dayStart = targetDate;
-        var dayEnd = targetDate.AddDays(1);
-
-        command.CommandText = @"
-SELECT
-    COALESCE(
-        (SELECT SUM(delta_wait_time_ms) / 1000.0
-         FROM v_wait_stats
-         WHERE server_id = $1
-         AND   collection_time >= $2 AND collection_time < $3
-         AND   delta_wait_time_ms > 0), 0
-    ) AS total_wait_sec,
-    (SELECT wait_type
-     FROM v_wait_stats
-     WHERE server_id = $1
-     AND   collection_time >= $2 AND collection_time < $3
-     AND   delta_wait_time_ms > 0
-     GROUP BY wait_type
-     ORDER BY SUM(delta_wait_time_ms) DESC
-     LIMIT 1
-    ) AS top_wait_type,
-    COALESCE(
-        (SELECT COUNT(DISTINCT query_hash)
-         FROM v_query_stats
-         WHERE server_id = $1
-         AND   collection_time >= $2 AND collection_time < $3), 0
-    ) AS unique_queries,
-    COALESCE(
-        (SELECT COUNT(*)
-         FROM v_deadlocks
-         WHERE server_id = $1
-         AND   collection_time >= $2 AND collection_time < $3), 0
-    ) AS deadlock_count,
-    COALESCE(
-        NULLIF((SELECT COUNT(*)
-         FROM v_blocked_process_reports
-         WHERE server_id = $1
-         AND   collection_time >= $2 AND collection_time < $3), 0),
-        (SELECT COUNT(*)
-         FROM v_dmv_blocking_snapshots
-         WHERE server_id = $1
-         AND   collection_time >= $2 AND collection_time < $3), 0
-    ) AS blocking_events,
-    COALESCE(
-        (SELECT COUNT(*)
-         FROM v_cpu_utilization_stats
-         WHERE server_id = $1
-         /* Total host CPU = SQL + other-process, matching the alert engine (CpuAlertMode.Total),
-            the Overview headline (TotalCpuPercent = sqlserver + (other_process ?? 0)), and
-            Dashboard's report.daily_summary (#1004). other_process_cpu_utilization is NULL on SQL
-            Server on Linux (host CPU not derivable, #1048), so COALESCE(.,0) collapses this to the
-            SQL-only figure there -- the same fallback as Dashboard's ISNULL(total, sqlserver). */
-         AND   (sqlserver_cpu_utilization + COALESCE(other_process_cpu_utilization, 0)) >= 80
-         AND   collection_time >= $2 AND collection_time < $3), 0
-    ) AS high_cpu_events,
-    COALESCE(
-        (SELECT COUNT(*)
-         FROM v_collection_log
-         WHERE server_id = $1
-         AND   status = 'ERROR'
-         AND   collection_time >= $2 AND collection_time < $3), 0
-    ) AS collection_errors";
-
+        command.CommandText = DailySummaryRangeSql;
         command.Parameters.Add(new DuckDBParameter { Value = serverId });
-        command.Parameters.Add(new DuckDBParameter { Value = dayStart });
-        command.Parameters.Add(new DuckDBParameter { Value = dayEnd });
+        command.Parameters.Add(new DuckDBParameter { Value = fromDate.Date });
+        command.Parameters.Add(new DuckDBParameter { Value = toDate.Date });
 
+        var results = new List<DailySummaryRow>();
         using var reader = await command.ExecuteReaderAsync();
-        if (!await reader.ReadAsync()) return null;
-
-        var deadlocks = reader.IsDBNull(3) ? 0L : Convert.ToInt64(reader.GetValue(3));
-        var blocking = reader.IsDBNull(4) ? 0L : Convert.ToInt64(reader.GetValue(4));
-        var highCpu = reader.IsDBNull(5) ? 0L : Convert.ToInt64(reader.GetValue(5));
-
-        var health = "NORMAL";
-        if (deadlocks > 0) health = "DEADLOCKS";
-        else if (highCpu > 5) health = "CPU_CRITICAL";
-        else if (blocking > 10) health = "BLOCKING";
-
-        return new DailySummaryRow
+        while (await reader.ReadAsync())
         {
-            SummaryDate = targetDate,
-            TotalWaitTimeSec = reader.IsDBNull(0) ? 0m : Convert.ToDecimal(reader.GetValue(0)),
-            TopWaitType = reader.IsDBNull(1) ? "" : reader.GetString(1),
-            UniqueQueries = reader.IsDBNull(2) ? 0L : Convert.ToInt64(reader.GetValue(2)),
-            DeadlockCount = deadlocks,
-            BlockingEvents = blocking,
-            HighCpuEvents = highCpu,
-            CollectionErrors = reader.IsDBNull(6) ? 0L : Convert.ToInt64(reader.GetValue(6)),
-            OverallHealth = health
+            results.Add(ReadDailySummaryRow(reader));
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Gets the daily summary for a specific date (or today if null). Delegates to the range query for a
+    /// single day so the single-day contract shares the one aggregate; returns a No-Data row when the day
+    /// had no collection.
+    /// </summary>
+    public async Task<DailySummaryRow?> GetDailySummaryAsync(int serverId, DateTime? summaryDate = null)
+    {
+        var targetDate = summaryDate?.Date ?? DateTime.UtcNow.Date;
+        var rows = await GetDailySummaryRangeAsync(serverId, targetDate, targetDate.AddDays(1));
+        return rows.Count > 0
+            ? rows[0]
+            : new DailySummaryRow { SummaryDate = targetDate, HasData = false, HealthBand = DailyHealthBand.NoData };
+    }
+
+    private static DailySummaryRow ReadDailySummaryRow(System.Data.Common.DbDataReader reader)
+    {
+        var row = new DailySummaryRow
+        {
+            SummaryDate = reader.IsDBNull(0) ? DateTime.MinValue : Convert.ToDateTime(reader.GetValue(0)),
+            TotalWaitTimeSec = reader.IsDBNull(1) ? 0m : Convert.ToDecimal(reader.GetValue(1)),
+            TopWaitType = reader.IsDBNull(2) ? "" : reader.GetString(2),
+            UniqueQueries = reader.IsDBNull(3) ? 0L : Convert.ToInt64(reader.GetValue(3)),
+            DeadlockCount = reader.IsDBNull(4) ? 0L : Convert.ToInt64(reader.GetValue(4)),
+            BlockingEvents = reader.IsDBNull(5) ? 0L : Convert.ToInt64(reader.GetValue(5)),
+            HighCpuEvents = reader.IsDBNull(6) ? 0L : Convert.ToInt64(reader.GetValue(6)),
+            CollectionErrors = reader.IsDBNull(7) ? 0L : Convert.ToInt64(reader.GetValue(7)),
+            MemoryPressureEvents = reader.IsDBNull(8) ? 0L : Convert.ToInt64(reader.GetValue(8)),
+            MemoryCriticalEvents = reader.IsDBNull(9) ? 0L : Convert.ToInt64(reader.GetValue(9)),
+            AlertCount = reader.IsDBNull(10) ? 0L : Convert.ToInt64(reader.GetValue(10)),
+            HasData = true,
         };
+        row.HealthBand = DailyHealthBandCalculator.Classify(row.ToSignals());
+        return row;
     }
 }
 
@@ -128,11 +205,38 @@ public class DailySummaryRow
     public long DeadlockCount { get; set; }
     public long BlockingEvents { get; set; }
     public long HighCpuEvents { get; set; }
+    public long MemoryPressureEvents { get; set; }
+    public long MemoryCriticalEvents { get; set; }
     public long CollectionErrors { get; set; }
-    public string OverallHealth { get; set; } = "";
+    public long AlertCount { get; set; }
+
+    /// <summary>True when the day had any collection. False renders the calendar cell as No-Data (grey).</summary>
+    public bool HasData { get; set; }
+
+    /// <summary>The composite health band that colors this day's calendar cell.</summary>
+    public DailyHealthBand HealthBand { get; set; } = DailyHealthBand.NoData;
+
+    /// <summary>Human label for the band ("Healthy" / "Warning" / "Critical" / "No Data"), shown in the day detail.</summary>
+    public string OverallHealth => DailyHealthBandCalculator.Label(HealthBand);
 
     public string SummaryDateFormatted => SummaryDate.ToString("yyyy-MM-dd");
     public string TotalWaitFormatted => TotalWaitTimeSec < 1000
         ? $"{TotalWaitTimeSec:N1} s"
         : $"{TotalWaitTimeSec / 60:N1} min";
+
+    /// <summary>Multi-line hover text summarizing the day's signals, for the calendar cell tooltip.</summary>
+    public string SignalsTooltip => DailyHealthBandCalculator.Describe(ToSignals());
+
+    /// <summary>Projects this row's counts into the shared banding input.</summary>
+    public DailyHealthSignals ToSignals() => new()
+    {
+        HasData = HasData,
+        Deadlocks = DeadlockCount,
+        CollectionErrors = CollectionErrors,
+        HighCpuEvents = HighCpuEvents,
+        BlockingEvents = BlockingEvents,
+        MemoryPressureEvents = MemoryPressureEvents,
+        MemoryCriticalEvents = MemoryCriticalEvents,
+        AlertCount = AlertCount,
+    };
 }

--- a/Lite/Services/LocalDataService.DailySummary.cs
+++ b/Lite/Services/LocalDataService.DailySummary.cs
@@ -110,6 +110,7 @@ day_spine AS (
     UNION SELECT d FROM cpu
     UNION SELECT d FROM coll
     UNION SELECT d FROM mem
+    UNION SELECT d FROM alerts
 )
 SELECT
     s.d AS day,

--- a/PerformanceMonitor.Common/DailyHealthBand.cs
+++ b/PerformanceMonitor.Common/DailyHealthBand.cs
@@ -182,7 +182,10 @@ namespace PerformanceMonitor.Common
             AppendCount(lines, signals.HighCpuEvents, "high-CPU sample", "high-CPU samples");
             AppendCount(lines, signals.BlockingEvents, "blocking event", "blocking events");
             AppendCount(lines, signals.MemoryCriticalEvents, "severe memory-pressure event", "severe memory-pressure events");
-            AppendCount(lines, signals.MemoryPressureEvents, "memory-pressure event", "memory-pressure events");
+            // MemoryPressureEvents is the full count (medium + severe); severe is a subset already listed
+            // above, so only the non-severe remainder is shown here to avoid double-counting.
+            var nonSevereMemory = Math.Max(0, signals.MemoryPressureEvents - signals.MemoryCriticalEvents);
+            AppendCount(lines, nonSevereMemory, "memory-pressure event", "memory-pressure events");
             AppendCount(lines, signals.AlertCount, "alert", "alerts");
 
             return lines.Count == 0 ? "No issues detected." : string.Join(Environment.NewLine, lines);

--- a/PerformanceMonitor.Common/DailyHealthBand.cs
+++ b/PerformanceMonitor.Common/DailyHealthBand.cs
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace PerformanceMonitor.Common
+{
+    /// <summary>
+    /// The composite health tier for a single day, used to color a Performance Calendar day cell at a
+    /// glance. This is deliberately a <b>composite</b> band (folding deadlocks, collection failures, CPU,
+    /// blocking, memory pressure and alerts into one verdict) rather than any single metric, so a month of
+    /// cells reads as green / amber / red days.
+    /// </summary>
+    public enum DailyHealthBand
+    {
+        /// <summary>No collection happened that day — rendered neutral grey (the muted theme tier).</summary>
+        NoData = 0,
+
+        /// <summary>Collected, nothing elevated — green.</summary>
+        Healthy = 1,
+
+        /// <summary>Elevated but not critical (moderate CPU, some blocking, memory pressure, or alerts) — amber.</summary>
+        Warning = 2,
+
+        /// <summary>A serious day (deadlocks, collection failures, sustained high CPU, heavy blocking, or
+        /// severe memory pressure) — red.</summary>
+        Critical = 3,
+    }
+
+    /// <summary>
+    /// The per-day signal counts that feed <see cref="DailyHealthBandCalculator.Classify"/>. Every field is
+    /// a whole-day roll-up over the same source views the Daily Summary already aggregates. A day with no
+    /// collection at all sets <see cref="HasData"/> = false (all other fields ignored → <see cref="DailyHealthBand.NoData"/>).
+    /// </summary>
+    public readonly record struct DailyHealthSignals
+    {
+        /// <summary>True when any collection ran that day. When false the band is always <see cref="DailyHealthBand.NoData"/>.</summary>
+        public bool HasData { get; init; }
+
+        /// <summary>Deadlocks captured that day. Any (&gt; 0) is Critical.</summary>
+        public long Deadlocks { get; init; }
+
+        /// <summary>Collector runs that ended in ERROR that day. Any (&gt; 0) is Critical — a monitoring blind spot is itself serious.</summary>
+        public long CollectionErrors { get; init; }
+
+        /// <summary>CPU samples where total host CPU (SQL + other-process) was ≥ 80%. Sustained (see
+        /// <see cref="DailyHealthThresholds.HighCpuCriticalSamples"/>) is Critical; a few is Warning.</summary>
+        public long HighCpuEvents { get; init; }
+
+        /// <summary>Blocking events that day (blocked-process reports, falling back to DMV blocking snapshots).
+        /// Past <see cref="DailyHealthThresholds.BlockingCriticalEvents"/> is Critical; some is Warning.</summary>
+        public long BlockingEvents { get; init; }
+
+        /// <summary>Memory-pressure events (a process or system indicator ≥ 2) that were not severe. Any is Warning.</summary>
+        public long MemoryPressureEvents { get; init; }
+
+        /// <summary>Severe memory-pressure events (a process indicator ≥ 3) that day. Any (&gt; 0) is Critical.</summary>
+        public long MemoryCriticalEvents { get; init; }
+
+        /// <summary>Actionable (non-resolution) alerts raised that day. At/over
+        /// <see cref="DailyHealthThresholds.AlertWarningCount"/> is Warning.</summary>
+        public long AlertCount { get; init; }
+    }
+
+    /// <summary>
+    /// The one, documented, tunable place for the Performance Calendar's day-banding thresholds. If a month
+    /// of cells reads too red or too green in practice, adjust these — nothing else needs to change. The
+    /// defaults are chosen to be continuous with the Daily Summary's long-standing single-day banding
+    /// (high-CPU &gt; 5 and blocking &gt; 10 were the original Critical triggers).
+    /// </summary>
+    public sealed record DailyHealthThresholds
+    {
+        /// <summary>High-CPU samples (≥ 80% total host) at or above which the day is Critical ("sustained high CPU").
+        /// Default 6 preserves the original "high_cpu_events &gt; 5" Critical rule.</summary>
+        public int HighCpuCriticalSamples { get; init; } = 6;
+
+        /// <summary>High-CPU samples at or above which the day is at least Warning ("moderate CPU"). Default 1:
+        /// any 80%+ total-host-CPU moment is worth a second look, short of the sustained (Critical) count.</summary>
+        public int HighCpuWarningSamples { get; init; } = 1;
+
+        /// <summary>Blocking events at or above which the day is Critical. Default 11 preserves the original
+        /// "blocking_events &gt; 10" Critical rule.</summary>
+        public int BlockingCriticalEvents { get; init; } = 11;
+
+        /// <summary>Blocking events at or above which the day is at least Warning ("some blocking"). Default 1.</summary>
+        public int BlockingWarningEvents { get; init; } = 1;
+
+        /// <summary>Actionable alerts at or above which the day is at least Warning. Default 1 (any alert).</summary>
+        public int AlertWarningCount { get; init; } = 1;
+
+        /// <summary>The shipped defaults. Use this everywhere unless a caller has an explicit reason to override.</summary>
+        public static DailyHealthThresholds Default { get; } = new();
+    }
+
+    /// <summary>
+    /// The single, app-agnostic source of truth for the Performance Calendar's per-day composite health band.
+    /// Both apps (Lite over DuckDB, the Darling viewer over Postgres) roll each day's signals into a
+    /// <see cref="DailyHealthSignals"/> and call <see cref="Classify"/>, so the month heatmap bands identically
+    /// no matter which store fed it — replacing the previously twinned-and-drifted single-day "OverallHealth"
+    /// string logic (Lite's inline copy lacked the memory-critical escalation the viewer had).
+    /// </summary>
+    public static class DailyHealthBandCalculator
+    {
+        /// <summary>
+        /// Folds a day's signals into a single <see cref="DailyHealthBand"/>. Severity is first-match-wins:
+        /// no-data → critical checks → warning checks → healthy.
+        /// </summary>
+        /// <param name="signals">The day's rolled-up signal counts.</param>
+        /// <param name="thresholds">Banding thresholds; <see cref="DailyHealthThresholds.Default"/> when null.</param>
+        public static DailyHealthBand Classify(in DailyHealthSignals signals, DailyHealthThresholds? thresholds = null)
+        {
+            if (!signals.HasData)
+                return DailyHealthBand.NoData;
+
+            var t = thresholds ?? DailyHealthThresholds.Default;
+
+            // Critical: anything that makes the day genuinely serious. Deadlocks, a monitoring gap
+            // (collection errors), severe memory pressure, sustained high CPU, or heavy blocking.
+            if (signals.Deadlocks > 0
+                || signals.CollectionErrors > 0
+                || signals.MemoryCriticalEvents > 0
+                || signals.HighCpuEvents >= t.HighCpuCriticalSamples
+                || signals.BlockingEvents >= t.BlockingCriticalEvents)
+            {
+                return DailyHealthBand.Critical;
+            }
+
+            // Warning: elevated but not critical — moderate CPU, some blocking, (non-severe) memory
+            // pressure, or any actionable alert fired that day.
+            if (signals.HighCpuEvents >= t.HighCpuWarningSamples
+                || signals.BlockingEvents >= t.BlockingWarningEvents
+                || signals.MemoryPressureEvents > 0
+                || signals.AlertCount >= t.AlertWarningCount)
+            {
+                return DailyHealthBand.Warning;
+            }
+
+            return DailyHealthBand.Healthy;
+        }
+
+        /// <summary>A short human label for the band ("No Data" / "Healthy" / "Warning" / "Critical").</summary>
+        public static string Label(DailyHealthBand band) => band switch
+        {
+            DailyHealthBand.Healthy => "Healthy",
+            DailyHealthBand.Warning => "Warning",
+            DailyHealthBand.Critical => "Critical",
+            _ => "No Data",
+        };
+
+        /// <summary>
+        /// The theme resource key for the band's fill brush. Resolved by each app's theme via
+        /// <c>DynamicResource</c> — the shared calendar control has no theme of its own. The muted tier
+        /// (<c>ForegroundMutedBrush</c>) is the neutral grey used for days with no collection.
+        /// </summary>
+        public static string BrushKey(DailyHealthBand band) => band switch
+        {
+            DailyHealthBand.Healthy => "SuccessBrush",
+            DailyHealthBand.Warning => "WarningBrush",
+            DailyHealthBand.Critical => "ErrorBrush",
+            _ => "ForegroundMutedBrush",
+        };
+
+        /// <summary>
+        /// Builds a multi-line tooltip summarizing the day's signals — one line per non-zero signal, or a
+        /// terse "No data collected." / "No issues detected." when appropriate. Suitable for a cell ToolTip.
+        /// </summary>
+        public static string Describe(in DailyHealthSignals signals)
+        {
+            if (!signals.HasData)
+                return "No data collected.";
+
+            var lines = new List<string>();
+            AppendCount(lines, signals.Deadlocks, "deadlock", "deadlocks");
+            AppendCount(lines, signals.CollectionErrors, "collection error", "collection errors");
+            AppendCount(lines, signals.HighCpuEvents, "high-CPU sample", "high-CPU samples");
+            AppendCount(lines, signals.BlockingEvents, "blocking event", "blocking events");
+            AppendCount(lines, signals.MemoryCriticalEvents, "severe memory-pressure event", "severe memory-pressure events");
+            AppendCount(lines, signals.MemoryPressureEvents, "memory-pressure event", "memory-pressure events");
+            AppendCount(lines, signals.AlertCount, "alert", "alerts");
+
+            return lines.Count == 0 ? "No issues detected." : string.Join(Environment.NewLine, lines);
+        }
+
+        private static void AppendCount(List<string> lines, long count, string singular, string plural)
+        {
+            if (count <= 0)
+                return;
+
+            var noun = count == 1 ? singular : plural;
+            lines.Add(count.ToString("N0", CultureInfo.InvariantCulture) + " " + noun);
+        }
+    }
+}

--- a/PerformanceMonitor.Ui/PerformanceCalendar.xaml
+++ b/PerformanceMonitor.Ui/PerformanceCalendar.xaml
@@ -1,0 +1,161 @@
+<UserControl x:Class="PerformanceMonitor.Ui.PerformanceCalendar"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Name="Root">
+    <!--
+      A navigable month heatmap: 6 weeks x 7 days of cells, each washed with its composite daily
+      health band (green / amber / red / muted-grey for no-data). Prev/next/Today navigate months
+      (raising MonthChanged so the host can fetch that month's data); clicking an in-month day raises
+      DayClicked so the host can drill into that day's detail. All colors are theme DynamicResources
+      resolved from the host app — this control ships no theme of its own.
+    -->
+    <Grid Margin="4">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <!-- Row 0: month navigation + legend -->
+        <Grid Grid.Row="0" Margin="2,2,2,8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+
+            <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
+                <Button x:Name="PrevMonthButton" Content="&#9664;" Width="30" Padding="0" ToolTip="Previous month"
+                        Click="PrevMonthButton_Click"/>
+                <TextBlock x:Name="MonthLabel" MinWidth="150" Margin="10,0" FontSize="15" FontWeight="SemiBold"
+                           VerticalAlignment="Center" HorizontalAlignment="Center"
+                           Foreground="{DynamicResource ForegroundBrush}"/>
+                <Button x:Name="NextMonthButton" Content="&#9654;" Width="30" Padding="0" ToolTip="Next month"
+                        Click="NextMonthButton_Click"/>
+                <Button x:Name="TodayButton" Content="Today" Margin="12,0,0,0" Padding="10,2"
+                        Click="TodayButton_Click"/>
+            </StackPanel>
+
+            <!-- Legend -->
+            <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center">
+                <Rectangle Width="12" Height="12" RadiusX="2" RadiusY="2" Fill="{DynamicResource SuccessBrush}"/>
+                <TextBlock Text="Healthy" Margin="4,0,12,0" VerticalAlignment="Center" FontSize="11"
+                           Foreground="{DynamicResource ForegroundDimBrush}"/>
+                <Rectangle Width="12" Height="12" RadiusX="2" RadiusY="2" Fill="{DynamicResource WarningBrush}"/>
+                <TextBlock Text="Warning" Margin="4,0,12,0" VerticalAlignment="Center" FontSize="11"
+                           Foreground="{DynamicResource ForegroundDimBrush}"/>
+                <Rectangle Width="12" Height="12" RadiusX="2" RadiusY="2" Fill="{DynamicResource ErrorBrush}"/>
+                <TextBlock Text="Critical" Margin="4,0,12,0" VerticalAlignment="Center" FontSize="11"
+                           Foreground="{DynamicResource ForegroundDimBrush}"/>
+                <Rectangle Width="12" Height="12" RadiusX="2" RadiusY="2" Fill="{DynamicResource ForegroundMutedBrush}" Opacity="0.4"/>
+                <TextBlock Text="No data" Margin="4,0,0,0" VerticalAlignment="Center" FontSize="11"
+                           Foreground="{DynamicResource ForegroundDimBrush}"/>
+            </StackPanel>
+        </Grid>
+
+        <!-- Row 1: weekday headers -->
+        <ItemsControl Grid.Row="1" ItemsSource="{Binding WeekdayHeaders, ElementName=Root}">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <UniformGrid Columns="7"/>
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock Text="{Binding}" HorizontalAlignment="Center" Margin="0,0,0,4"
+                               FontSize="11" FontWeight="SemiBold"
+                               Foreground="{DynamicResource ForegroundDimBrush}"/>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+
+        <!-- Row 2: day cells -->
+        <ItemsControl Grid.Row="2" ItemsSource="{Binding Cells, ElementName=Root}">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <UniformGrid Columns="7" Rows="6"/>
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <!-- Cell chrome. Transparent background makes the whole cell hit-testable. -->
+                    <Border Margin="2" CornerRadius="4" Background="Transparent"
+                            MouseLeftButtonUp="Cell_MouseLeftButtonUp"
+                            ToolTip="{Binding Tooltip}">
+                        <Border.Style>
+                            <Style TargetType="Border">
+                                <Setter Property="BorderBrush" Value="{DynamicResource BorderBrush}"/>
+                                <Setter Property="BorderThickness" Value="1"/>
+                                <Setter Property="Cursor" Value="Hand"/>
+                                <Style.Triggers>
+                                    <!-- Out-of-month days are not interactive. -->
+                                    <DataTrigger Binding="{Binding IsInDisplayMonth}" Value="False">
+                                        <Setter Property="Cursor" Value="Arrow"/>
+                                        <Setter Property="BorderThickness" Value="0"/>
+                                        <Setter Property="ToolTip" Value="{x:Null}"/>
+                                    </DataTrigger>
+                                    <!-- Selected day: accent ring. -->
+                                    <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                                        <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+                                        <Setter Property="BorderThickness" Value="2"/>
+                                    </DataTrigger>
+                                    <!-- Today: accent ring (overrides selected so today is always framed). -->
+                                    <DataTrigger Binding="{Binding IsToday}" Value="True">
+                                        <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+                                        <Setter Property="BorderThickness" Value="2"/>
+                                    </DataTrigger>
+                                    <Trigger Property="IsMouseOver" Value="True">
+                                        <Setter Property="BorderBrush" Value="{DynamicResource AccentHoverBrush}"/>
+                                    </Trigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+
+                        <Grid MinHeight="44" MinWidth="44">
+                            <!-- Band wash. Fill is the band brush; opacity conveys presence/severity. -->
+                            <Rectangle RadiusX="3" RadiusY="3" Opacity="{Binding WashOpacity}">
+                                <Rectangle.Style>
+                                    <Style TargetType="Rectangle">
+                                        <Setter Property="Fill" Value="{DynamicResource ForegroundMutedBrush}"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding Band}" Value="Healthy">
+                                                <Setter Property="Fill" Value="{DynamicResource SuccessBrush}"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding Band}" Value="Warning">
+                                                <Setter Property="Fill" Value="{DynamicResource WarningBrush}"/>
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding Band}" Value="Critical">
+                                                <Setter Property="Fill" Value="{DynamicResource ErrorBrush}"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Rectangle.Style>
+                            </Rectangle>
+
+                            <!-- Day number, top-left. -->
+                            <TextBlock Text="{Binding DayNumber}" Margin="6,4,0,0"
+                                       HorizontalAlignment="Left" VerticalAlignment="Top" FontSize="12"
+                                       Opacity="{Binding NumberOpacity}">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock">
+                                        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding IsInDisplayMonth}" Value="False">
+                                                <Setter Property="Foreground" Value="{DynamicResource ForegroundMutedBrush}"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
+
+                            <!-- Band label, bottom-right, only for in-month days with data. -->
+                            <TextBlock Text="{Binding BandLabel}" Margin="0,0,6,4"
+                                       HorizontalAlignment="Right" VerticalAlignment="Bottom" FontSize="10"
+                                       Foreground="{DynamicResource ForegroundDimBrush}"/>
+                        </Grid>
+                    </Border>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+    </Grid>
+</UserControl>

--- a/PerformanceMonitor.Ui/PerformanceCalendar.xaml.cs
+++ b/PerformanceMonitor.Ui/PerformanceCalendar.xaml.cs
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using PerformanceMonitor.Common;
+
+namespace PerformanceMonitor.Ui
+{
+    /// <summary>
+    /// A navigable month heatmap of composite daily health bands, shared by Lite and the Darling viewer so
+    /// the Performance Calendar can't drift between them. The host supplies <see cref="Days"/> (one banded
+    /// <see cref="PerformanceCalendarDay"/> per collected day) and the displayed month; the control lays out
+    /// a 6x7 grid, washes each in-month cell with its band color, and raises <see cref="MonthChanged"/> when
+    /// the user navigates (so the host can fetch that month) and <see cref="DayClicked"/> when a day is
+    /// clicked (so the host can drill into that day's detail).
+    /// </summary>
+    public partial class PerformanceCalendar : UserControl
+    {
+        private const int WeeksShown = 6;
+        private const int DaysPerWeek = 7;
+
+        public PerformanceCalendar()
+        {
+            InitializeComponent();
+            BuildWeekdayHeaders();
+            RebuildCells();
+        }
+
+        /// <summary>The banded days to render (one per collected day in the displayed month).</summary>
+        public static readonly DependencyProperty DaysProperty = DependencyProperty.Register(
+            nameof(Days), typeof(IEnumerable<PerformanceCalendarDay>), typeof(PerformanceCalendar),
+            new PropertyMetadata(null, OnVisualInputChanged));
+        public IEnumerable<PerformanceCalendarDay>? Days
+        {
+            get => (IEnumerable<PerformanceCalendarDay>?)GetValue(DaysProperty);
+            set => SetValue(DaysProperty, value);
+        }
+
+        /// <summary>The month to display (any day within it; normalized to the first). Defaults to the current
+        /// UTC month — the calendar operates in UTC day-space to match the collected data (naive-UTC collection times).</summary>
+        public static readonly DependencyProperty DisplayMonthProperty = DependencyProperty.Register(
+            nameof(DisplayMonth), typeof(DateTime), typeof(PerformanceCalendar),
+            new PropertyMetadata(FirstOfMonth(DateTime.UtcNow), OnVisualInputChanged));
+        public DateTime DisplayMonth
+        {
+            get => (DateTime)GetValue(DisplayMonthProperty);
+            set => SetValue(DisplayMonthProperty, value);
+        }
+
+        /// <summary>The currently selected/drilled day, framed with an accent ring. Null when none.</summary>
+        public static readonly DependencyProperty SelectedDateProperty = DependencyProperty.Register(
+            nameof(SelectedDate), typeof(DateTime?), typeof(PerformanceCalendar),
+            new PropertyMetadata(null, OnVisualInputChanged));
+        public DateTime? SelectedDate
+        {
+            get => (DateTime?)GetValue(SelectedDateProperty);
+            set => SetValue(SelectedDateProperty, value);
+        }
+
+        /// <summary>Raised when a user clicks an in-month day cell.</summary>
+        public event EventHandler<PerformanceCalendarDayEventArgs>? DayClicked;
+
+        /// <summary>Raised when the user navigates to a different month (prev / next / Today), carrying the new month's first day.</summary>
+        public event EventHandler<PerformanceCalendarMonthEventArgs>? MonthChanged;
+
+        /// <summary>The weekday column headers in the current culture's week order.</summary>
+        public ObservableCollection<string> WeekdayHeaders { get; } = new();
+
+        /// <summary>The 42 rendered day cells (6 weeks x 7 days).</summary>
+        public ObservableCollection<PerformanceCalendarCell> Cells { get; } = new();
+
+        private static DateTime FirstOfMonth(DateTime value) => new(value.Year, value.Month, 1);
+
+        private static void OnVisualInputChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            ((PerformanceCalendar)d).RebuildCells();
+        }
+
+        private void BuildWeekdayHeaders()
+        {
+            WeekdayHeaders.Clear();
+            var culture = CultureInfo.CurrentCulture;
+            var firstDay = (int)culture.DateTimeFormat.FirstDayOfWeek;
+            var names = culture.DateTimeFormat.AbbreviatedDayNames; // index 0 = Sunday
+            for (var i = 0; i < DaysPerWeek; i++)
+            {
+                WeekdayHeaders.Add(names[(firstDay + i) % DaysPerWeek]);
+            }
+        }
+
+        private void RebuildCells()
+        {
+            // MonthLabel/Cells may be referenced before the template is applied during construction.
+            var month = FirstOfMonth(DisplayMonth);
+            if (MonthLabel != null)
+            {
+                MonthLabel.Text = month.ToString("MMMM yyyy", CultureInfo.CurrentCulture);
+            }
+
+            // Index the supplied days by date for O(1) lookup.
+            var byDate = new Dictionary<DateTime, PerformanceCalendarDay>();
+            if (Days != null)
+            {
+                foreach (var day in Days)
+                {
+                    byDate[day.Date.Date] = day;
+                }
+            }
+
+            var today = DateTime.UtcNow.Date; // calendar days are UTC-bucketed; highlight the UTC "today"
+            var selected = SelectedDate?.Date;
+
+            // The grid starts on the first day-of-week on or before the 1st of the month.
+            var firstDayOfWeek = (int)CultureInfo.CurrentCulture.DateTimeFormat.FirstDayOfWeek;
+            var offset = ((int)month.DayOfWeek - firstDayOfWeek + DaysPerWeek) % DaysPerWeek;
+            var gridStart = month.AddDays(-offset);
+
+            Cells.Clear();
+            for (var i = 0; i < WeeksShown * DaysPerWeek; i++)
+            {
+                var date = gridStart.AddDays(i);
+                var inMonth = date.Year == month.Year && date.Month == month.Month;
+
+                var band = DailyHealthBand.NoData;
+                var tooltip = string.Empty;
+                if (inMonth && byDate.TryGetValue(date, out var day))
+                {
+                    band = day.Band;
+                    tooltip = day.Tooltip;
+                }
+                else if (inMonth)
+                {
+                    tooltip = "No data collected.";
+                }
+
+                Cells.Add(new PerformanceCalendarCell(
+                    date,
+                    inMonth,
+                    isToday: date == today,
+                    isSelected: selected.HasValue && date == selected.Value,
+                    band,
+                    tooltip));
+            }
+        }
+
+        private void PrevMonthButton_Click(object sender, RoutedEventArgs e) =>
+            NavigateToMonth(FirstOfMonth(DisplayMonth).AddMonths(-1));
+
+        private void NextMonthButton_Click(object sender, RoutedEventArgs e) =>
+            NavigateToMonth(FirstOfMonth(DisplayMonth).AddMonths(1));
+
+        private void TodayButton_Click(object sender, RoutedEventArgs e) =>
+            NavigateToMonth(FirstOfMonth(DateTime.UtcNow));
+
+        private void NavigateToMonth(DateTime month)
+        {
+            DisplayMonth = month; // triggers RebuildCells via the DP callback
+            MonthChanged?.Invoke(this, new PerformanceCalendarMonthEventArgs(month));
+        }
+
+        private void Cell_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is FrameworkElement { DataContext: PerformanceCalendarCell cell } && cell.IsInDisplayMonth)
+            {
+                DayClicked?.Invoke(this, new PerformanceCalendarDayEventArgs(cell.Date));
+            }
+        }
+    }
+
+    /// <summary>
+    /// The render model for one calendar cell. Immutable; the control rebuilds the whole set on any change,
+    /// so no change notification is needed. The presentation opacities/label are derived from the band here
+    /// (rather than in XAML) so the cell template stays declarative.
+    /// </summary>
+    public sealed class PerformanceCalendarCell
+    {
+        public PerformanceCalendarCell(
+            DateTime date, bool isInDisplayMonth, bool isToday, bool isSelected,
+            DailyHealthBand band, string tooltip)
+        {
+            Date = date;
+            IsInDisplayMonth = isInDisplayMonth;
+            IsToday = isToday;
+            IsSelected = isSelected;
+            Band = band;
+            Tooltip = tooltip;
+            DayNumber = date.Day.ToString(CultureInfo.CurrentCulture);
+
+            if (!isInDisplayMonth)
+            {
+                WashOpacity = 0.0;
+                NumberOpacity = 0.45;
+            }
+            else if (band == DailyHealthBand.NoData)
+            {
+                WashOpacity = 0.14;
+                NumberOpacity = 0.55;
+            }
+            else
+            {
+                WashOpacity = 0.55;
+                NumberOpacity = 1.0;
+            }
+
+            // A textual band label on non-healthy in-month days aids at-a-glance scanning and color-blind
+            // legibility; healthy / no-data cells stay uncluttered (color and emptiness carry the meaning).
+            BandLabel = isInDisplayMonth && (band == DailyHealthBand.Warning || band == DailyHealthBand.Critical)
+                ? DailyHealthBandCalculator.Label(band)
+                : string.Empty;
+        }
+
+        public DateTime Date { get; }
+        public bool IsInDisplayMonth { get; }
+        public bool IsToday { get; }
+        public bool IsSelected { get; }
+        public DailyHealthBand Band { get; }
+        public string Tooltip { get; }
+        public string DayNumber { get; }
+        public string BandLabel { get; }
+        public double WashOpacity { get; }
+        public double NumberOpacity { get; }
+    }
+}

--- a/PerformanceMonitor.Ui/PerformanceCalendarDay.cs
+++ b/PerformanceMonitor.Ui/PerformanceCalendarDay.cs
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using PerformanceMonitor.Common;
+
+namespace PerformanceMonitor.Ui
+{
+    /// <summary>
+    /// One day's worth of banded data supplied to <see cref="PerformanceCalendar"/>. Apps build one of
+    /// these per day that had any collection (from their own <c>DailySummaryRow</c> range read), setting the
+    /// <see cref="Band"/> they already computed via <see cref="DailyHealthBandCalculator"/> and a hover
+    /// <see cref="Tooltip"/>. Days absent from the supplied set render as <see cref="DailyHealthBand.NoData"/>.
+    /// </summary>
+    public sealed class PerformanceCalendarDay
+    {
+        /// <summary>The calendar date (date component only; time ignored).</summary>
+        public DateTime Date { get; init; }
+
+        /// <summary>The composite health band that colors the cell.</summary>
+        public DailyHealthBand Band { get; init; }
+
+        /// <summary>Multi-line hover text summarizing the day's signals (see <see cref="DailyHealthBandCalculator.Describe"/>).</summary>
+        public string Tooltip { get; init; } = string.Empty;
+    }
+
+    /// <summary>Event args carrying the day a user clicked on the calendar.</summary>
+    public sealed class PerformanceCalendarDayEventArgs : EventArgs
+    {
+        public PerformanceCalendarDayEventArgs(DateTime date)
+        {
+            Date = date;
+        }
+
+        /// <summary>The clicked date (date component only).</summary>
+        public DateTime Date { get; }
+    }
+
+    /// <summary>Event args carrying the month the calendar wants data for (its first day, at midnight).</summary>
+    public sealed class PerformanceCalendarMonthEventArgs : EventArgs
+    {
+        public PerformanceCalendarMonthEventArgs(DateTime month)
+        {
+            Month = month;
+        }
+
+        /// <summary>The first day of the month now being displayed.</summary>
+        public DateTime Month { get; }
+    }
+}


### PR DESCRIPTION
## Performance Calendar — month heatmap replacing the single-day Daily Summary

Replaces the single-day "Daily Summary" tab in Lite (DuckDB) and the Darling viewer (Postgres) with a navigable month heatmap: each day cell is colored by a composite daily health band, prev/next/Today navigate months, clicking a day drills into that day's single-day roll-up below the grid. Scope = Lite + Darling viewer only (Dashboard is being deprecated; band logic + control are shared so it is easy to add later).

### Composite band (cell color) — DailyHealthBandCalculator in PerformanceMonitor.Common
First-match-wins:
- NoData -> no collection that day (muted grey / ForegroundMutedBrush)
- Critical -> deadlocks>0 OR collectionErrors>0 OR memoryCritical>0 OR highCpuSamples>=6 OR blockingEvents>=11 (red / ErrorBrush)
- Warning -> highCpuSamples>=1 OR blockingEvents>=1 OR memoryPressure>0 OR actionableAlerts>=1 (amber / WarningBrush)
- Healthy -> collected, none of the above (green / SuccessBrush)

Thresholds live in one tunable place, DailyHealthThresholds.Default: HighCpuCritical=6 (preserves old >5), HighCpuWarning=1, BlockingCritical=11 (preserves old >10), BlockingWarning=1, AlertWarning=1; deadlocks/collectionErrors/severe-memory(process>=3) always Critical when >0. New inputs vs the old band: collection failures now drive Critical; actionable alerts (config_alert_log, non-dismissed, excluding Cleared/Resolved/Restored) drive Warning. Each cell has a signal-summary tooltip.

### Shared vs twinned
Shared: Common/DailyHealthBand.cs (enum+calculator+thresholds, both apps feed identical inputs — also fixes the pre-existing drift where Lite's band lacked the viewer's memory-critical escalation); Ui/PerformanceCalendar control + PerformanceCalendarDay (colors via DynamicResource theme keys). Twinned per-store (mirrors existing pattern): the grouped per-day-range SQL — DuckDB (arg_max) in LocalDataService, Postgres (DISTINCT ON) in ViewerDataService. The range query is now the single source of truth per store; single-day GetDailySummaryAsync delegates to it so cell and drill-in can't disagree.

### Tests
DailyHealthBandTests (table-driven) added to BOTH suites; PerformanceCalendarDataTests (Lite DuckDB e2e). ViewerDailySummarySqlTests rewritten for the new range SQL; old ClassifyDailyHealth tests replaced by the shared band tests; 2 gated live asserts updated. Both suites green (Lite 935; Darling 1639 + 126 gated-skip). All apps build -c Release.

### For visual review
Postgres range query validated by structure-parity with the passing DuckDB test + standard-construct analysis, NOT executed live (avoided touching the running :5641 stack). Click the viewer Daily Summary tab or run gated ViewerDailyHealthLivePostgresTests with DARLING_TEST_PG. Wash opacity/threshold defaults are first-pass and all tunable in DailyHealthThresholds.Default.
