### PR TITLE
Make the Darling viewer theme-able (Light/CoolBreeze) + fix Lite muted/Slicer (#1441)

### DIFF
--- a/Darling/Darling.Tests/ThemeCompletenessTests.cs
+++ b/Darling/Darling.Tests/ThemeCompletenessTests.cs
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Guards that the viewer is fully theme-able: the Dark, Light, and CoolBreeze dictionaries define the
+/// SAME set of resource keys, and every theme token the viewer XAML actually references resolves in ALL
+/// three. This is the automated backstop for "Light / CoolBreeze mode has no missing resources" — a token
+/// that exists only in Dark (the historical failure mode: the app looked right in Dark only) fails here
+/// instead of silently rendering a control unstyled after a theme switch.
+///
+/// Text-parses the XAML (no WPF apartment / pack-URI loading needed) and locates the Viewer project via
+/// <see cref="CallerFilePathAttribute"/> — the tests read source that sits next to this file in the repo.
+/// </summary>
+public sealed class ThemeCompletenessTests
+{
+    private static readonly string[] ThemeRelativePaths =
+    {
+        "Themes/DarkTheme.xaml",
+        "Themes/LightTheme.xaml",
+        "Themes/CoolBreezeTheme.xaml",
+    };
+
+    /// <summary>Matches a named resource definition: <c>x:Key="Name"</c> where Name is a plain identifier
+    /// (skips system keys like <c>x:Key="{x:Static SystemColors.HighlightBrushKey}"</c>).</summary>
+    private static readonly Regex KeyDefinition =
+        new("x:Key=\"([A-Za-z_][A-Za-z0-9_]*)\"", RegexOptions.Compiled);
+
+    /// <summary>Matches a simple resource reference: <c>{DynamicResource Name}</c> / <c>{StaticResource Name}</c>.
+    /// The identifier-only capture skips nested markup like <c>{StaticResource {x:Type Button}}</c>.</summary>
+    private static readonly Regex ResourceReference =
+        new(@"\{(?:Dynamic|Static)Resource\s+([A-Za-z_][A-Za-z0-9_]*)\s*\}", RegexOptions.Compiled);
+
+    [Fact]
+    public void Light_and_CoolBreeze_define_the_same_keys_as_Dark()
+    {
+        var dark = KeysIn(ThemeRelativePaths[0]);
+        var light = KeysIn(ThemeRelativePaths[1]);
+        var coolBreeze = KeysIn(ThemeRelativePaths[2]);
+
+        Assert.False(dark.Count == 0, "Parsed zero keys from DarkTheme.xaml — the test cannot find the theme files.");
+
+        var missingFromLight = dark.Except(light).OrderBy(k => k, StringComparer.Ordinal).ToList();
+        var extraInLight = light.Except(dark).OrderBy(k => k, StringComparer.Ordinal).ToList();
+        Assert.True(
+            missingFromLight.Count == 0 && extraInLight.Count == 0,
+            $"LightTheme.xaml key set differs from DarkTheme.xaml.\n" +
+            $"  Missing from Light (would render unstyled in Light): {Join(missingFromLight)}\n" +
+            $"  Extra in Light (not in Dark): {Join(extraInLight)}");
+
+        var missingFromCool = dark.Except(coolBreeze).OrderBy(k => k, StringComparer.Ordinal).ToList();
+        var extraInCool = coolBreeze.Except(dark).OrderBy(k => k, StringComparer.Ordinal).ToList();
+        Assert.True(
+            missingFromCool.Count == 0 && extraInCool.Count == 0,
+            $"CoolBreezeTheme.xaml key set differs from DarkTheme.xaml.\n" +
+            $"  Missing from CoolBreeze: {Join(missingFromCool)}\n" +
+            $"  Extra in CoolBreeze: {Join(extraInCool)}");
+    }
+
+    [Fact]
+    public void Every_theme_token_referenced_in_viewer_xaml_resolves_in_all_three_themes()
+    {
+        var viewerDir = ViewerDirectory();
+        var dark = KeysIn(ThemeRelativePaths[0]);
+        var light = KeysIn(ThemeRelativePaths[1]);
+        var coolBreeze = KeysIn(ThemeRelativePaths[2]);
+
+        /* Only consider references that ARE theme tokens (defined in Dark) — this ignores locally-defined
+           window styles, ViewerDarkTheme aliases, and WPF system keys, so a real "token in Dark but not
+           Light/CoolBreeze" is the only thing that can fail here. */
+        var offenders = new List<string>();
+        foreach (var xaml in Directory.EnumerateFiles(viewerDir, "*.xaml", SearchOption.AllDirectories))
+        {
+            if (xaml.Contains(Path.Combine("obj", ""), StringComparison.OrdinalIgnoreCase) ||
+                xaml.Contains(Path.Combine("bin", ""), StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var text = File.ReadAllText(xaml);
+            foreach (Match m in ResourceReference.Matches(text))
+            {
+                var key = m.Groups[1].Value;
+                if (!dark.Contains(key))
+                {
+                    continue; // not a theme token (local style / system / cross-assembly)
+                }
+
+                if (!light.Contains(key))
+                {
+                    offenders.Add($"{Path.GetFileName(xaml)} references '{key}', which is missing from LightTheme.xaml");
+                }
+                if (!coolBreeze.Contains(key))
+                {
+                    offenders.Add($"{Path.GetFileName(xaml)} references '{key}', which is missing from CoolBreezeTheme.xaml");
+                }
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            "Theme tokens referenced by the viewer XAML do not resolve in every theme:\n  " +
+            string.Join("\n  ", offenders.Distinct()));
+    }
+
+    private static HashSet<string> KeysIn(string relativePath)
+    {
+        var path = Path.Combine(ViewerDirectory(), relativePath.Replace('/', Path.DirectorySeparatorChar));
+        var text = File.ReadAllText(path);
+        return KeyDefinition.Matches(text).Select(m => m.Groups[1].Value).ToHashSet(StringComparer.Ordinal);
+    }
+
+    /// <summary>The Viewer project directory, resolved from this test file's compile-time path (it lives at
+    /// <c>Darling/Darling.Tests/</c>; the Viewer is the sibling <c>Darling/PerformanceMonitor.Darling.Viewer/</c>).</summary>
+    private static string ViewerDirectory([CallerFilePath] string thisFile = "")
+    {
+        var testDir = Path.GetDirectoryName(thisFile)!;
+        return Path.GetFullPath(Path.Combine(testDir, "..", "PerformanceMonitor.Darling.Viewer"));
+    }
+
+    private static string Join(IReadOnlyCollection<string> keys) =>
+        keys.Count == 0 ? "(none)" : string.Join(", ", keys);
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/AboutWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/AboutWindow.xaml
@@ -6,8 +6,8 @@
         WindowStartupLocation="CenterOwner"
         ResizeMode="NoResize"
         Icon="EDD.ico"
-        Background="#22252b"
-        Foreground="#E4E6EB">
+        Background="{DynamicResource BackgroundLightBrush}"
+        Foreground="{DynamicResource ForegroundBrush}">
     <!-- Mirrors Lite's AboutWindow (Lite/Windows/AboutWindow.xaml), dark-styled via the shared
          ViewerDarkTheme resource dictionary like the viewer's other dialogs (Manage Mute Rules).
          The viewer ships inside the Darling service release and is not independently Velopack-managed,
@@ -35,23 +35,23 @@
         </Grid.RowDefinitions>
 
         <TextBlock Grid.Row="0" Text="SQL Server Performance Monitor Darling"
-                   FontSize="18" FontWeight="Bold" Foreground="#E4E6EB"
+                   FontSize="18" FontWeight="Bold" Foreground="{DynamicResource ForegroundBrush}"
                    TextWrapping="Wrap" Margin="0,0,0,8"/>
 
         <TextBlock Grid.Row="1" x:Name="VersionText" Text="Version 3.1.0"
-                   Foreground="#8B93A1" Margin="0,0,0,16"/>
+                   Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,0,0,16"/>
 
-        <TextBlock Grid.Row="2" TextWrapping="Wrap" Foreground="#E4E6EB" Margin="0,0,0,8">
+        <TextBlock Grid.Row="2" TextWrapping="Wrap" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,8">
             The desktop viewer for the Performance Monitor Darling service. Connects to the central
             Postgres store to show per-server dashboards, recommendations, and alerts across every
             monitored SQL Server.
         </TextBlock>
 
         <StackPanel Grid.Row="3" Margin="0,0,0,8">
-            <TextBlock Foreground="#E4E6EB" FontSize="12">
+            <TextBlock Foreground="{DynamicResource ForegroundBrush}" FontSize="12">
                 © 2026 Erik Darling, Darling Data LLC
             </TextBlock>
-            <TextBlock Foreground="#8B93A1" FontSize="12">
+            <TextBlock Foreground="{DynamicResource ForegroundMutedBrush}" FontSize="12">
                 Licensed under the MIT License
             </TextBlock>
         </StackPanel>

--- a/Darling/PerformanceMonitor.Darling.Viewer/AlertDetailWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/AlertDetailWindow.xaml
@@ -6,8 +6,8 @@
         WindowStartupLocation="CenterOwner"
         Icon="EDD.ico"
         ResizeMode="NoResize"
-        Background="#22252b"
-        Foreground="#E4E6EB">
+        Background="{DynamicResource BackgroundLightBrush}"
+        Foreground="{DynamicResource ForegroundBrush}">
     <!-- Copied from Lite's AlertDetailWindow (Lite/Windows/AlertDetailWindow.xaml) for the W2a Alert
          History parity: the modal alert detail the grid opens on double-click / View Details, replacing
          the shell's inline detail pane (Lite has no inline pane, only this window). Dark-styled via the
@@ -32,7 +32,7 @@
 
         <!-- Header -->
         <TextBlock Grid.Row="0" Text="Alert Details" FontSize="16" FontWeight="SemiBold"
-                   Foreground="#E4E6EB" Margin="0,0,0,16"/>
+                   Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,16"/>
 
         <!-- Detail fields -->
         <Grid Grid.Row="1">
@@ -51,39 +51,39 @@
             </Grid.RowDefinitions>
 
             <TextBlock Grid.Row="0" Grid.Column="0" Text="Time:" FontWeight="SemiBold"
-                       Foreground="#E4E6EB" Margin="0,4"/>
+                       Foreground="{DynamicResource ForegroundBrush}" Margin="0,4"/>
             <TextBlock Grid.Row="0" Grid.Column="1" x:Name="TimeText"
-                       Foreground="#E4E6EB" Margin="0,4" TextWrapping="Wrap"/>
+                       Foreground="{DynamicResource ForegroundBrush}" Margin="0,4" TextWrapping="Wrap"/>
 
             <TextBlock Grid.Row="1" Grid.Column="0" Text="Server:" FontWeight="SemiBold"
-                       Foreground="#E4E6EB" Margin="0,4"/>
+                       Foreground="{DynamicResource ForegroundBrush}" Margin="0,4"/>
             <TextBlock Grid.Row="1" Grid.Column="1" x:Name="ServerText"
-                       Foreground="#E4E6EB" Margin="0,4" TextWrapping="Wrap"/>
+                       Foreground="{DynamicResource ForegroundBrush}" Margin="0,4" TextWrapping="Wrap"/>
 
             <TextBlock Grid.Row="2" Grid.Column="0" Text="Metric:" FontWeight="SemiBold"
-                       Foreground="#E4E6EB" Margin="0,4"/>
+                       Foreground="{DynamicResource ForegroundBrush}" Margin="0,4"/>
             <TextBlock Grid.Row="2" Grid.Column="1" x:Name="MetricText"
-                       Foreground="#E4E6EB" Margin="0,4" TextWrapping="Wrap"/>
+                       Foreground="{DynamicResource ForegroundBrush}" Margin="0,4" TextWrapping="Wrap"/>
 
             <TextBlock Grid.Row="3" Grid.Column="0" Text="Current Value:" FontWeight="SemiBold"
-                       Foreground="#E4E6EB" Margin="0,4"/>
+                       Foreground="{DynamicResource ForegroundBrush}" Margin="0,4"/>
             <TextBlock Grid.Row="3" Grid.Column="1" x:Name="CurrentValueText"
-                       Foreground="#E4E6EB" Margin="0,4" TextWrapping="Wrap"/>
+                       Foreground="{DynamicResource ForegroundBrush}" Margin="0,4" TextWrapping="Wrap"/>
 
             <TextBlock Grid.Row="4" Grid.Column="0" Text="Threshold:" FontWeight="SemiBold"
-                       Foreground="#E4E6EB" Margin="0,4"/>
+                       Foreground="{DynamicResource ForegroundBrush}" Margin="0,4"/>
             <TextBlock Grid.Row="4" Grid.Column="1" x:Name="ThresholdText"
-                       Foreground="#E4E6EB" Margin="0,4" TextWrapping="Wrap"/>
+                       Foreground="{DynamicResource ForegroundBrush}" Margin="0,4" TextWrapping="Wrap"/>
 
             <TextBlock Grid.Row="5" Grid.Column="0" Text="Notification:" FontWeight="SemiBold"
-                       Foreground="#E4E6EB" Margin="0,4"/>
+                       Foreground="{DynamicResource ForegroundBrush}" Margin="0,4"/>
             <TextBlock Grid.Row="5" Grid.Column="1" x:Name="NotificationText"
-                       Foreground="#E4E6EB" Margin="0,4" TextWrapping="Wrap"/>
+                       Foreground="{DynamicResource ForegroundBrush}" Margin="0,4" TextWrapping="Wrap"/>
 
             <TextBlock Grid.Row="6" Grid.Column="0" Text="Status:" FontWeight="SemiBold"
-                       Foreground="#E4E6EB" Margin="0,4"/>
+                       Foreground="{DynamicResource ForegroundBrush}" Margin="0,4"/>
             <TextBlock Grid.Row="6" Grid.Column="1" x:Name="StatusValueText"
-                       Foreground="#E4E6EB" Margin="0,4" TextWrapping="Wrap"/>
+                       Foreground="{DynamicResource ForegroundBrush}" Margin="0,4" TextWrapping="Wrap"/>
         </Grid>
 
         <!-- Muted indicator -->
@@ -91,16 +91,16 @@
                 Background="#33FFD54F"
                 CornerRadius="4" Padding="8" Margin="0,12,0,0">
             <TextBlock Text="&#x1F507; This alert was muted by a mute rule"
-                       Foreground="#E4E6EB" FontStyle="Italic"/>
+                       Foreground="{DynamicResource ForegroundBrush}" FontStyle="Italic"/>
         </Border>
 
         <!-- Context-specific details -->
         <Border Grid.Row="3" x:Name="DetailPanel" Visibility="Collapsed"
-                Background="#111217" BorderBrush="#2a2d35"
+                Background="{DynamicResource BackgroundDarkBrush}" BorderBrush="{DynamicResource BorderBrush}"
                 BorderThickness="1" CornerRadius="4" Padding="10" Margin="0,12,0,0">
             <StackPanel>
                 <TextBlock Text="Details" FontWeight="SemiBold" FontSize="13"
-                           Foreground="#E4E6EB" Margin="0,0,0,6"/>
+                           Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,6"/>
 
                 <!-- Structured detail items (advice prose, remediation T-SQL, drill-down).
                      Shown when the persisted context_json deserializes. -->
@@ -111,7 +111,7 @@
                             <DataTemplate>
                                 <StackPanel Margin="0,0,0,10">
                                     <TextBlock Text="{Binding Heading}" FontWeight="SemiBold"
-                                               Foreground="#E4E6EB" Margin="0,0,0,4"/>
+                                               Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,0,4"/>
 
                                     <!-- Remediation T-SQL: monospace, read-only, with Copy. -->
                                     <StackPanel Visibility="{Binding IsCodeBlock, Converter={StaticResource BoolToVis}}">
@@ -124,14 +124,14 @@
                                                  VerticalScrollBarVisibility="Auto"
                                                  HorizontalScrollBarVisibility="Auto"
                                                  Background="Transparent"
-                                                 Foreground="#E4E6EB"
-                                                 BorderBrush="#2a2d35" BorderThickness="1"/>
+                                                 Foreground="{DynamicResource ForegroundBrush}"
+                                                 BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"/>
                                     </StackPanel>
 
                                     <!-- Advice prose. -->
                                     <TextBlock Text="{Binding Body}" TextWrapping="Wrap"
                                                Visibility="{Binding IsProse, Converter={StaticResource BoolToVis}}"
-                                               Foreground="#E4E6EB"/>
+                                               Foreground="{DynamicResource ForegroundBrush}"/>
 
                                     <!-- Label/value field rows. -->
                                     <ItemsControl ItemsSource="{Binding Fields}"
@@ -144,10 +144,10 @@
                                                         <ColumnDefinition Width="*"/>
                                                     </Grid.ColumnDefinitions>
                                                     <TextBlock Grid.Column="0" Text="{Binding Label}"
-                                                               Foreground="#E4E6EB"
+                                                               Foreground="{DynamicResource ForegroundBrush}"
                                                                TextWrapping="Wrap"/>
                                                     <TextBlock Grid.Column="1" Text="{Binding Value}"
-                                                               Foreground="#E4E6EB"
+                                                               Foreground="{DynamicResource ForegroundBrush}"
                                                                FontFamily="Consolas" FontSize="12"
                                                                TextWrapping="Wrap"/>
                                                 </Grid>
@@ -164,7 +164,7 @@
                 <TextBox x:Name="DetailTextBox" IsReadOnly="True" TextWrapping="Wrap"
                          Visibility="Collapsed"
                          Background="Transparent" BorderThickness="0"
-                         Foreground="#E4E6EB" FontFamily="Consolas"
+                         Foreground="{DynamicResource ForegroundBrush}" FontFamily="Consolas"
                          FontSize="12" MaxHeight="300"
                          VerticalScrollBarVisibility="Auto"/>
             </StackPanel>

--- a/Darling/PerformanceMonitor.Darling.Viewer/App.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/App.xaml.cs
@@ -17,9 +17,10 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// <summary>
 /// The Darling viewer — a Postgres client of the central store. MainWindow owns data startup:
 /// it loads the viewer's sliver of darling.json (<see cref="ViewerSettings"/>) and connects
-/// on first render. App startup applies the shared Dark theme through <see cref="ThemeManager"/>
-/// so copied Lite XAML resolves its theme keys; the theme is fixed to Dark for v1 (no picker), and
-/// <see cref="ThemeManager.CurrentTheme"/> stays "Dark" so <c>ChartStyle</c> draws dark chrome.
+/// on first render. App startup applies the operator's saved color theme (Dark / Light / CoolBreeze)
+/// through <see cref="ThemeManager"/> so copied Lite XAML resolves its theme keys; the Settings window's
+/// theme selector live-previews and persists the choice to <see cref="ViewerAppSettings"/>, and
+/// <see cref="ThemeManager.CurrentTheme"/> drives whether <c>ChartStyle</c> draws dark or light chrome.
 /// Single-instance enforcement uses the shared <see cref="SingleInstanceCoordinator"/> (as Lite /
 /// Dashboard) so a second launch surfaces the existing window instead of opening a duplicate viewer,
 /// and a newer Velopack build launched over an older one takes over.
@@ -34,10 +35,19 @@ public partial class App : Application
 
     protected override void OnStartup(StartupEventArgs e)
     {
-        /* Re-apply through ThemeManager (App.xaml already merges the same dictionary) so
-           ThemeManager owns the app-level merged dictionary at runtime, before StartupUri
-           creates MainWindow. Dark is the default; naming it keeps the source of truth explicit. */
-        ThemeManager.Apply("Dark");
+        /* Apply the saved color theme through ThemeManager (App.xaml merges Dark as the design-time
+           default) so ThemeManager owns the app-level merged dictionary at runtime, before StartupUri
+           creates MainWindow. Reads the viewer-local settings directly (cheap JSON read) so the very
+           first paint is already in the operator's chosen theme — no flash of Dark. Falls back to Dark
+           on any error. Light / CoolBreeze are honored via the Settings window's theme selector. */
+        try
+        {
+            ThemeManager.Apply(new ViewerAppSettingsStore().Load().ColorTheme);
+        }
+        catch
+        {
+            ThemeManager.Apply("Dark");
+        }
 
         /* #1050 (companion to the ported tray's WindowResumeGuard): WPF's GPU render thread can zombie its
            surface across sleep/wake or RDP, leaving a live-but-blank window — now reachable in the viewer

--- a/Darling/PerformanceMonitor.Darling.Viewer/CollectionLogWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/CollectionLogWindow.xaml
@@ -4,8 +4,8 @@
         Title="Collection History" Height="600" Width="1100"
         WindowStartupLocation="CenterOwner"
         Icon="EDD.ico"
-        Background="#22252b"
-        Foreground="#E4E6EB">
+        Background="{DynamicResource BackgroundLightBrush}"
+        Foreground="{DynamicResource ForegroundBrush}">
     <!-- Copied from Lite's Windows/CollectionLogWindow.xaml for the W1i copy-parity port: the
          per-collector collection-history drill the Collection Health "Health Summary" grid opens on
          double-click. Purely data-driven; the one behavioral change is the data call is repointed to
@@ -49,7 +49,7 @@
         </Grid.RowDefinitions>
 
         <!-- Header -->
-        <Border Grid.Row="0" Background="#111217" Padding="10" Margin="10,10,10,0" CornerRadius="4">
+        <Border Grid.Row="0" Background="{DynamicResource BackgroundDarkBrush}" Padding="10" Margin="10,10,10,0" CornerRadius="4">
             <StackPanel>
                 <TextBlock x:Name="CollectorNameText" FontSize="16" FontWeight="Bold"/>
                 <TextBlock x:Name="SummaryText" Margin="0,5,0,0"/>
@@ -104,7 +104,7 @@
         </DataGrid>
 
         <!-- Footer -->
-        <Border Grid.Row="2" Background="#111217" Padding="10" Margin="10,0,10,10" CornerRadius="4">
+        <Border Grid.Row="2" Background="{DynamicResource BackgroundDarkBrush}" Padding="10" Margin="10,0,10,10" CornerRadius="4">
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
                 <Button Content="Close" Width="100" Height="30" Click="Close_Click"/>
             </StackPanel>

--- a/Darling/PerformanceMonitor.Darling.Viewer/CollectorScheduleEditorWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/CollectorScheduleEditorWindow.xaml
@@ -7,8 +7,8 @@
         WindowStartupLocation="CenterOwner"
         Icon="EDD.ico"
         ResizeMode="CanResizeWithGrip"
-        Background="#22252b"
-        Foreground="#E4E6EB">
+        Background="{DynamicResource BackgroundLightBrush}"
+        Foreground="{DynamicResource ForegroundBrush}">
     <!-- The Darling viewer's collector-schedule editor: a faithful port of Lite's CollectorScheduleEditorWindow,
          rewired to write the control-plane config.config_collector_schedules the running service honors (scope =
          All servers / a specific server; presets change frequencies only). Dark-styled via the shared
@@ -36,7 +36,7 @@
             <TextBlock x:Name="HeaderText" Text="Collector Schedules" FontSize="18" FontWeight="Bold"/>
             <TextBlock x:Name="SubHeaderText" FontSize="12" Foreground="{StaticResource DimTextBrush}" Margin="0,4,0,0" TextWrapping="Wrap"
                        Text="Override how often the Darling service collects each metric, and how long it keeps it. Blank overrides fall back to the built-in defaults."/>
-            <TextBlock x:Name="ReadOnlyBanner" FontSize="12" Foreground="#E0A030" Margin="0,6,0,0" TextWrapping="Wrap"
+            <TextBlock x:Name="ReadOnlyBanner" FontSize="12" Foreground="{DynamicResource WarningTextBrush}" Margin="0,6,0,0" TextWrapping="Wrap"
                        Visibility="Collapsed"
                        Text="This viewer is connected with a read-only role, so collector schedules can't be changed here."/>
         </StackPanel>

--- a/Darling/PerformanceMonitor.Darling.Viewer/FinOpsTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/FinOpsTab.xaml
@@ -16,7 +16,7 @@
     -->
     <UserControl.Resources>
         <Style x:Key="EmptyHint" TargetType="TextBlock">
-            <Setter Property="Foreground" Value="#8B93A1"/>
+            <Setter Property="Foreground" Value="{DynamicResource ForegroundMutedBrush}"/>
             <Setter Property="HorizontalAlignment" Value="Center"/>
             <Setter Property="VerticalAlignment" Value="Center"/>
             <Setter Property="TextWrapping" Value="Wrap"/>
@@ -29,9 +29,9 @@
         <!-- Dark grid chrome shared by the FinOps grids (copied from ViewerServerTab.xaml — same setters,
              zero visual change). -->
         <Style x:Key="DarkGridHeader" TargetType="DataGridColumnHeader">
-            <Setter Property="Background" Value="#262932"/>
-            <Setter Property="Foreground" Value="#E4E6EB"/>
-            <Setter Property="BorderBrush" Value="#2a2d35"/>
+            <Setter Property="Background" Value="{DynamicResource ViewerGridHeaderBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource BorderBrush}"/>
             <Setter Property="BorderThickness" Value="0,0,1,1"/>
             <Setter Property="Padding" Value="8,5"/>
             <Setter Property="FontWeight" Value="SemiBold"/>
@@ -41,7 +41,7 @@
             <Setter Property="Background" Value="Transparent"/>
             <Style.Triggers>
                 <Trigger Property="IsMouseOver" Value="True">
-                    <Setter Property="Background" Value="#1f232b"/>
+                    <Setter Property="Background" Value="{DynamicResource ViewerHoverBrush}"/>
                 </Trigger>
             </Style.Triggers>
         </Style>
@@ -49,11 +49,11 @@
         <Style x:Key="DarkGridCell" TargetType="DataGridCell">
             <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="Background" Value="Transparent"/>
-            <Setter Property="Foreground" Value="#E4E6EB"/>
+            <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
             <Style.Triggers>
                 <Trigger Property="IsSelected" Value="True">
-                    <Setter Property="Background" Value="#2f3542"/>
-                    <Setter Property="Foreground" Value="#E4E6EB"/>
+                    <Setter Property="Background" Value="{DynamicResource ViewerSelectionBrush}"/>
+                    <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
                 </Trigger>
             </Style.Triggers>
         </Style>
@@ -66,13 +66,13 @@
             <Setter Property="SelectionMode" Value="Single"/>
             <Setter Property="SelectionUnit" Value="FullRow"/>
             <Setter Property="GridLinesVisibility" Value="Horizontal"/>
-            <Setter Property="HorizontalGridLinesBrush" Value="#2a2d35"/>
-            <Setter Property="Background" Value="#111217"/>
-            <Setter Property="Foreground" Value="#E4E6EB"/>
-            <Setter Property="BorderBrush" Value="#2a2d35"/>
+            <Setter Property="HorizontalGridLinesBrush" Value="{DynamicResource BorderBrush}"/>
+            <Setter Property="Background" Value="{DynamicResource BackgroundDarkBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource BorderBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
-            <Setter Property="RowBackground" Value="#111217"/>
-            <Setter Property="AlternatingRowBackground" Value="#16181d"/>
+            <Setter Property="RowBackground" Value="{DynamicResource BackgroundDarkBrush}"/>
+            <Setter Property="AlternatingRowBackground" Value="{DynamicResource ViewerAltRowBrush}"/>
             <Setter Property="ColumnHeaderStyle" Value="{StaticResource DarkGridHeader}"/>
             <Setter Property="RowStyle" Value="{StaticResource DarkGridRow}"/>
             <Setter Property="CellStyle" Value="{StaticResource DarkGridCell}"/>
@@ -81,7 +81,7 @@
         <!-- Server-selector header chrome (copied from MainWindow.xaml's DarkCombo / DarkButton so the
              selector + Refresh match the Recommendations tab's own selector exactly). -->
         <Style x:Key="DarkComboItem" TargetType="ComboBoxItem">
-            <Setter Property="Foreground" Value="#E4E6EB"/>
+            <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
             <Setter Property="Background" Value="Transparent"/>
             <Setter Property="Padding" Value="6,4"/>
             <Setter Property="Template">
@@ -92,10 +92,10 @@
                         </Border>
                         <ControlTemplate.Triggers>
                             <Trigger Property="IsMouseOver" Value="True">
-                                <Setter TargetName="Bd" Property="Background" Value="#1f232b"/>
+                                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource ViewerHoverBrush}"/>
                             </Trigger>
                             <Trigger Property="IsHighlighted" Value="True">
-                                <Setter TargetName="Bd" Property="Background" Value="#2f3542"/>
+                                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource ViewerSelectionBrush}"/>
                             </Trigger>
                         </ControlTemplate.Triggers>
                     </ControlTemplate>
@@ -104,9 +104,9 @@
         </Style>
 
         <Style x:Key="DarkButton" TargetType="Button">
-            <Setter Property="Foreground" Value="#E4E6EB"/>
-            <Setter Property="Background" Value="#2f3542"/>
-            <Setter Property="BorderBrush" Value="#3a4150"/>
+            <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+            <Setter Property="Background" Value="{DynamicResource ViewerSelectionBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource ViewerButtonBorderBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="Cursor" Value="Hand"/>
             <Setter Property="Template">
@@ -119,11 +119,11 @@
                         </Border>
                         <ControlTemplate.Triggers>
                             <Trigger Property="IsMouseOver" Value="True">
-                                <Setter TargetName="Bd" Property="Background" Value="#3a4150"/>
+                                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource ViewerButtonBorderBrush}"/>
                             </Trigger>
                             <Trigger Property="IsEnabled" Value="False">
-                                <Setter TargetName="Bd" Property="Background" Value="#1b1e24"/>
-                                <Setter Property="Foreground" Value="#5c6472"/>
+                                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource ViewerDisabledBgBrush}"/>
+                                <Setter Property="Foreground" Value="{DynamicResource ViewerDisabledTextBrush}"/>
                             </Trigger>
                         </ControlTemplate.Triggers>
                     </ControlTemplate>
@@ -132,9 +132,9 @@
         </Style>
 
         <Style x:Key="DarkCombo" TargetType="ComboBox">
-            <Setter Property="Foreground" Value="#E4E6EB"/>
-            <Setter Property="Background" Value="#111217"/>
-            <Setter Property="BorderBrush" Value="#2a2d35"/>
+            <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+            <Setter Property="Background" Value="{DynamicResource BackgroundDarkBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource BorderBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="Padding" Value="6,4"/>
             <Setter Property="ItemContainerStyle" Value="{StaticResource DarkComboItem}"/>
@@ -147,14 +147,14 @@
                                           ClickMode="Press">
                                 <ToggleButton.Template>
                                     <ControlTemplate TargetType="ToggleButton">
-                                        <Border Background="#111217" BorderBrush="#2a2d35" BorderThickness="1" CornerRadius="3">
+                                        <Border Background="{DynamicResource BackgroundDarkBrush}" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" CornerRadius="3">
                                             <Grid>
                                                 <Grid.ColumnDefinitions>
                                                     <ColumnDefinition Width="*"/>
                                                     <ColumnDefinition Width="20"/>
                                                 </Grid.ColumnDefinitions>
                                                 <Path Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center"
-                                                      Data="M 0 0 L 4 4 L 8 0 Z" Fill="#8B93A1"/>
+                                                      Data="M 0 0 L 4 4 L 8 0 Z" Fill="{DynamicResource ForegroundMutedBrush}"/>
                                             </Grid>
                                         </Border>
                                     </ControlTemplate>
@@ -167,7 +167,7 @@
                                               VerticalAlignment="Center" HorizontalAlignment="Left"/>
                             <Popup x:Name="PART_Popup" Placement="Bottom" IsOpen="{TemplateBinding IsDropDownOpen}"
                                    AllowsTransparency="True" Focusable="False" PopupAnimation="Slide">
-                                <Border Background="#16181d" BorderBrush="#2a2d35" BorderThickness="1"
+                                <Border Background="{DynamicResource ViewerAltRowBrush}" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"
                                         MinWidth="{TemplateBinding ActualWidth}" MaxHeight="240">
                                     <ScrollViewer>
                                         <StackPanel IsItemsHost="True"/>
@@ -239,7 +239,7 @@
 
         <!-- Header bar: own server selector (independent of the sidebar, mirroring the Recommendations tab) + Refresh. -->
         <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,8">
-            <TextBlock Text="Server:" VerticalAlignment="Center" Foreground="#8B93A1" Margin="0,0,6,0"/>
+            <TextBlock Text="Server:" VerticalAlignment="Center" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,0,6,0"/>
             <ComboBox x:Name="ServerSelector" Width="260" VerticalAlignment="Center"
                       Style="{StaticResource DarkCombo}"
                       SelectionChanged="ServerSelector_SelectionChanged">
@@ -249,7 +249,7 @@
                     </DataTemplate>
                 </ComboBox.ItemTemplate>
             </ComboBox>
-            <Button Content="Refresh" Margin="10,0,0,0" Padding="12,4" Style="{StaticResource DarkButton}"
+            <Button Content="Refresh" Margin="10,0,0,0" Padding="12,4"
                     Click="FinOpsRefresh_Click"
                     ToolTip="Reload FinOps data for the selected server"/>
         </StackPanel>

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
@@ -10,14 +10,16 @@
         WindowState="Maximized"
         WindowStartupLocation="CenterScreen"
         Icon="EDD.ico"
-        Background="#22252b"
-        Foreground="#E4E6EB">
+        Background="{DynamicResource BackgroundLightBrush}"
+        Foreground="{DynamicResource ForegroundBrush}">
     <!--
-        Dark-only shell (headless plan). The window keeps its hardcoded Dark palette (#22252b chrome,
-        #111217 wells, #2a2d35 borders, #E4E6EB text); the shared theme dictionary is now merged
-        app-wide (App.xaml) so copied Lite XAML — the per-server ViewerServerTab and the later tab
-        ports — resolve their {DynamicResource} keys. This window's own controls keep their explicit
-        StaticResource styles + inline hex, so they render exactly as before.
+        Theme-aware shell (headless plan). The window's chrome colors now resolve from the shared
+        theme dictionary via {DynamicResource} (merged app-wide in App.xaml) — the same keys the
+        copied Lite XAML (the per-server ViewerServerTab and the later tab ports) already use — so
+        this window follows the active Dark/Light/CoolBreeze theme. Each token's Dark value equals
+        the hex it replaced (#22252b chrome, #111217 wells, #2a2d35 borders, #E4E6EB text), so Dark
+        renders exactly as before; only a few semantic/keep colors (offline grey, badge text, modal
+        scrim, favorite-star gold) stay inline.
 
         Navigation mirrors Lite's shape (headless-plan W0 IA inversion): a left sidebar server list,
         and ONE top tab strip holding the fixed aggregate tabs (Overview, Alert History, FinOps,
@@ -37,7 +39,7 @@
         <Style x:Key="SectionHeader" TargetType="TextBlock">
             <Setter Property="FontSize" Value="14"/>
             <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="Foreground" Value="#E4E6EB"/>
+            <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
             <Setter Property="Margin" Value="0,0,0,6"/>
         </Style>
 
@@ -55,9 +57,9 @@
         <!-- One dark grid chrome shared by the aggregate-tab data grids (hoisted from the wave-1
              HealthGrid inline styles — same setters, zero visual change). -->
         <Style x:Key="DarkGridHeader" TargetType="DataGridColumnHeader">
-            <Setter Property="Background" Value="#262932"/>
-            <Setter Property="Foreground" Value="#E4E6EB"/>
-            <Setter Property="BorderBrush" Value="#2a2d35"/>
+            <Setter Property="Background" Value="{DynamicResource ViewerGridHeaderBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource BorderBrush}"/>
             <Setter Property="BorderThickness" Value="0,0,1,1"/>
             <Setter Property="Padding" Value="8,5"/>
             <Setter Property="FontWeight" Value="SemiBold"/>
@@ -67,7 +69,7 @@
             <Setter Property="Background" Value="Transparent"/>
             <Style.Triggers>
                 <Trigger Property="IsMouseOver" Value="True">
-                    <Setter Property="Background" Value="#1f232b"/>
+                    <Setter Property="Background" Value="{DynamicResource ViewerHoverBrush}"/>
                 </Trigger>
             </Style.Triggers>
         </Style>
@@ -75,11 +77,11 @@
         <Style x:Key="DarkGridCell" TargetType="DataGridCell">
             <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="Background" Value="Transparent"/>
-            <Setter Property="Foreground" Value="#E4E6EB"/>
+            <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
             <Style.Triggers>
                 <Trigger Property="IsSelected" Value="True">
-                    <Setter Property="Background" Value="#2f3542"/>
-                    <Setter Property="Foreground" Value="#E4E6EB"/>
+                    <Setter Property="Background" Value="{DynamicResource ViewerSelectionBrush}"/>
+                    <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
                 </Trigger>
             </Style.Triggers>
         </Style>
@@ -92,20 +94,20 @@
             <Setter Property="SelectionMode" Value="Single"/>
             <Setter Property="SelectionUnit" Value="FullRow"/>
             <Setter Property="GridLinesVisibility" Value="Horizontal"/>
-            <Setter Property="HorizontalGridLinesBrush" Value="#2a2d35"/>
-            <Setter Property="Background" Value="#111217"/>
-            <Setter Property="Foreground" Value="#E4E6EB"/>
-            <Setter Property="BorderBrush" Value="#2a2d35"/>
+            <Setter Property="HorizontalGridLinesBrush" Value="{DynamicResource BorderBrush}"/>
+            <Setter Property="Background" Value="{DynamicResource BackgroundDarkBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource BorderBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
-            <Setter Property="RowBackground" Value="#111217"/>
-            <Setter Property="AlternatingRowBackground" Value="#16181d"/>
+            <Setter Property="RowBackground" Value="{DynamicResource BackgroundDarkBrush}"/>
+            <Setter Property="AlternatingRowBackground" Value="{DynamicResource ViewerAltRowBrush}"/>
             <Setter Property="ColumnHeaderStyle" Value="{StaticResource DarkGridHeader}"/>
             <Setter Property="RowStyle" Value="{StaticResource DarkGridRow}"/>
             <Setter Property="CellStyle" Value="{StaticResource DarkGridCell}"/>
         </Style>
 
         <Style x:Key="DarkTabItem" TargetType="TabItem">
-            <Setter Property="Foreground" Value="#E4E6EB"/>
+            <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="TabItem">
@@ -120,10 +122,10 @@
                         </Border>
                         <ControlTemplate.Triggers>
                             <Trigger Property="IsMouseOver" Value="True">
-                                <Setter TargetName="Bd" Property="Background" Value="#1f232b"/>
+                                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource ViewerHoverBrush}"/>
                             </Trigger>
                             <Trigger Property="IsSelected" Value="True">
-                                <Setter TargetName="Bd" Property="Background" Value="#2f3542"/>
+                                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource ViewerSelectionBrush}"/>
                             </Trigger>
                         </ControlTemplate.Triggers>
                     </ControlTemplate>
@@ -134,7 +136,7 @@
         <!-- Dark ComboBox / Button used by the Recommendations tab's own server selector + Refresh
              button (they match the hardcoded Dark palette instead of the default light WPF chrome). -->
         <Style x:Key="DarkComboItem" TargetType="ComboBoxItem">
-            <Setter Property="Foreground" Value="#E4E6EB"/>
+            <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
             <Setter Property="Background" Value="Transparent"/>
             <Setter Property="Padding" Value="6,4"/>
             <Setter Property="Template">
@@ -145,10 +147,10 @@
                         </Border>
                         <ControlTemplate.Triggers>
                             <Trigger Property="IsMouseOver" Value="True">
-                                <Setter TargetName="Bd" Property="Background" Value="#1f232b"/>
+                                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource ViewerHoverBrush}"/>
                             </Trigger>
                             <Trigger Property="IsHighlighted" Value="True">
-                                <Setter TargetName="Bd" Property="Background" Value="#2f3542"/>
+                                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource ViewerSelectionBrush}"/>
                             </Trigger>
                         </ControlTemplate.Triggers>
                     </ControlTemplate>
@@ -157,9 +159,9 @@
         </Style>
 
         <Style x:Key="DarkButton" TargetType="Button">
-            <Setter Property="Foreground" Value="#E4E6EB"/>
-            <Setter Property="Background" Value="#2f3542"/>
-            <Setter Property="BorderBrush" Value="#3a4150"/>
+            <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+            <Setter Property="Background" Value="{DynamicResource ViewerSelectionBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource ViewerButtonBorderBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="Cursor" Value="Hand"/>
             <Setter Property="Template">
@@ -172,11 +174,11 @@
                         </Border>
                         <ControlTemplate.Triggers>
                             <Trigger Property="IsMouseOver" Value="True">
-                                <Setter TargetName="Bd" Property="Background" Value="#3a4150"/>
+                                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource ViewerButtonBorderBrush}"/>
                             </Trigger>
                             <Trigger Property="IsEnabled" Value="False">
-                                <Setter TargetName="Bd" Property="Background" Value="#1b1e24"/>
-                                <Setter Property="Foreground" Value="#5c6472"/>
+                                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource ViewerDisabledBgBrush}"/>
+                                <Setter Property="Foreground" Value="{DynamicResource ViewerDisabledTextBrush}"/>
                             </Trigger>
                         </ControlTemplate.Triggers>
                     </ControlTemplate>
@@ -185,9 +187,9 @@
         </Style>
 
         <Style x:Key="DarkCombo" TargetType="ComboBox">
-            <Setter Property="Foreground" Value="#E4E6EB"/>
-            <Setter Property="Background" Value="#111217"/>
-            <Setter Property="BorderBrush" Value="#2a2d35"/>
+            <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+            <Setter Property="Background" Value="{DynamicResource BackgroundDarkBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource BorderBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="Padding" Value="6,4"/>
             <Setter Property="ItemContainerStyle" Value="{StaticResource DarkComboItem}"/>
@@ -200,14 +202,14 @@
                                           ClickMode="Press">
                                 <ToggleButton.Template>
                                     <ControlTemplate TargetType="ToggleButton">
-                                        <Border Background="#111217" BorderBrush="#2a2d35" BorderThickness="1" CornerRadius="3">
+                                        <Border Background="{DynamicResource BackgroundDarkBrush}" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" CornerRadius="3">
                                             <Grid>
                                                 <Grid.ColumnDefinitions>
                                                     <ColumnDefinition Width="*"/>
                                                     <ColumnDefinition Width="20"/>
                                                 </Grid.ColumnDefinitions>
                                                 <Path Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center"
-                                                      Data="M 0 0 L 4 4 L 8 0 Z" Fill="#8B93A1"/>
+                                                      Data="M 0 0 L 4 4 L 8 0 Z" Fill="{DynamicResource ForegroundMutedBrush}"/>
                                             </Grid>
                                         </Border>
                                     </ControlTemplate>
@@ -220,7 +222,7 @@
                                               VerticalAlignment="Center" HorizontalAlignment="Left"/>
                             <Popup x:Name="PART_Popup" Placement="Bottom" IsOpen="{TemplateBinding IsDropDownOpen}"
                                    AllowsTransparency="True" Focusable="False" PopupAnimation="Slide">
-                                <Border Background="#16181d" BorderBrush="#2a2d35" BorderThickness="1"
+                                <Border Background="{DynamicResource ViewerAltRowBrush}" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"
                                         MinWidth="{TemplateBinding ActualWidth}" MaxHeight="240">
                                     <ScrollViewer>
                                         <StackPanel IsItemsHost="True"/>
@@ -257,7 +259,7 @@
                     </Grid.ColumnDefinitions>
                     <StackPanel Grid.Column="0" x:Name="SidebarHeaderText">
                         <TextBlock Text="Servers" Style="{StaticResource SectionHeader}" Margin="0,0,0,2"/>
-                        <TextBlock Text="Double-click to open a server tab" Foreground="#8B93A1" FontSize="11" Margin="0,0,0,6"/>
+                        <TextBlock Text="Double-click to open a server tab" Foreground="{DynamicResource ForegroundMutedBrush}" FontSize="11" Margin="0,0,0,6"/>
                     </StackPanel>
                     <Button Grid.Column="1" x:Name="SidebarToggleButton" Content="«" Click="ToggleSidebar_Click"
                             Style="{StaticResource DarkButton}"
@@ -271,7 +273,7 @@
                      (Lite's DuckDB import) is omitted — it has no viewer meaning. Declared as the first
                      Bottom-docked child so it sits at the very bottom, below the no-servers hint. -->
                 <Border x:Name="SidebarFooter" DockPanel.Dock="Bottom"
-                        BorderBrush="#2a2d35" BorderThickness="0,1,0,0"
+                        BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,1,0,0"
                         Margin="0,8,0,0" Padding="0,8,0,0">
                     <StackPanel>
                         <Button Click="AddServerButton_Click"
@@ -367,21 +369,21 @@
                 <TextBlock x:Name="ServersHintText"
                            DockPanel.Dock="Bottom"
                            Text="no servers registered — is the Darling service running?"
-                           Foreground="#8B93A1"
+                           Foreground="{DynamicResource ForegroundMutedBrush}"
                            TextWrapping="Wrap"
                            Margin="2,8,2,0"
                            Visibility="Collapsed"/>
                 <ListBox x:Name="ServerList"
-                         Background="#111217"
-                         BorderBrush="#2a2d35"
+                         Background="{DynamicResource BackgroundDarkBrush}"
+                         BorderBrush="{DynamicResource BorderBrush}"
                          BorderThickness="1"
-                         Foreground="#E4E6EB"
+                         Foreground="{DynamicResource ForegroundBrush}"
                          SelectionChanged="ServerList_SelectionChanged"
                          MouseDoubleClick="ServerList_MouseDoubleClick">
                     <ListBox.ItemContainerStyle>
                         <Style TargetType="ListBoxItem">
                             <Setter Property="Background" Value="Transparent"/>
-                            <Setter Property="Foreground" Value="#E4E6EB"/>
+                            <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
                             <Setter Property="Padding" Value="8,5"/>
                             <Setter Property="Template">
                                 <Setter.Value>
@@ -395,10 +397,10 @@
                                         </Border>
                                         <ControlTemplate.Triggers>
                                             <Trigger Property="IsMouseOver" Value="True">
-                                                <Setter TargetName="Bd" Property="Background" Value="#1f232b"/>
+                                                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource ViewerHoverBrush}"/>
                                             </Trigger>
                                             <Trigger Property="IsSelected" Value="True">
-                                                <Setter TargetName="Bd" Property="Background" Value="#2f3542"/>
+                                                <Setter TargetName="Bd" Property="Background" Value="{DynamicResource ViewerSelectionBrush}"/>
                                             </Trigger>
                                         </ControlTemplate.Triggers>
                                     </ControlTemplate>
@@ -545,7 +547,7 @@
                                 <!-- (1) Health-band summary tiles: total + counts by band. Tile colours are
                                      the card severity palette (green / amber / red / grey-for-offline). -->
                                 <WrapPanel Margin="0,0,0,12">
-                                    <Border Background="{DynamicResource BackgroundBrush}" BorderBrush="#3a3d45"
+                                    <Border Background="{DynamicResource BackgroundBrush}" BorderBrush="{DynamicResource CardBorderBrush}"
                                             BorderThickness="1" CornerRadius="5" MinWidth="86" Margin="0,0,8,0" Padding="12,6">
                                         <StackPanel>
                                             <TextBlock Text="{Binding TotalServers}" FontSize="22" FontWeight="Bold"
@@ -554,29 +556,29 @@
                                                        HorizontalAlignment="Center"/>
                                         </StackPanel>
                                     </Border>
-                                    <Border Background="{DynamicResource BackgroundBrush}" BorderBrush="#81C784"
+                                    <Border Background="{DynamicResource BackgroundBrush}" BorderBrush="{DynamicResource SuccessBrush}"
                                             BorderThickness="1" CornerRadius="5" MinWidth="86" Margin="0,0,8,0" Padding="12,6">
                                         <StackPanel>
                                             <TextBlock Text="{Binding HealthyCount}" FontSize="22" FontWeight="Bold"
-                                                       Foreground="#81C784" HorizontalAlignment="Center"/>
+                                                       Foreground="{DynamicResource SuccessBrush}" HorizontalAlignment="Center"/>
                                             <TextBlock Text="Healthy" FontSize="10" Foreground="{DynamicResource ForegroundMutedBrush}"
                                                        HorizontalAlignment="Center"/>
                                         </StackPanel>
                                     </Border>
-                                    <Border Background="{DynamicResource BackgroundBrush}" BorderBrush="#FFD54F"
+                                    <Border Background="{DynamicResource BackgroundBrush}" BorderBrush="{DynamicResource WarningBrush}"
                                             BorderThickness="1" CornerRadius="5" MinWidth="86" Margin="0,0,8,0" Padding="12,6">
                                         <StackPanel>
                                             <TextBlock Text="{Binding WarningCount}" FontSize="22" FontWeight="Bold"
-                                                       Foreground="#FFD54F" HorizontalAlignment="Center"/>
+                                                       Foreground="{DynamicResource WarningBrush}" HorizontalAlignment="Center"/>
                                             <TextBlock Text="Warning" FontSize="10" Foreground="{DynamicResource ForegroundMutedBrush}"
                                                        HorizontalAlignment="Center"/>
                                         </StackPanel>
                                     </Border>
-                                    <Border Background="{DynamicResource BackgroundBrush}" BorderBrush="#E57373"
+                                    <Border Background="{DynamicResource BackgroundBrush}" BorderBrush="{DynamicResource ErrorBrush}"
                                             BorderThickness="1" CornerRadius="5" MinWidth="86" Margin="0,0,8,0" Padding="12,6">
                                         <StackPanel>
                                             <TextBlock Text="{Binding CriticalCount}" FontSize="22" FontWeight="Bold"
-                                                       Foreground="#E57373" HorizontalAlignment="Center"/>
+                                                       Foreground="{DynamicResource ErrorBrush}" HorizontalAlignment="Center"/>
                                             <TextBlock Text="Critical" FontSize="10" Foreground="{DynamicResource ForegroundMutedBrush}"
                                                        HorizontalAlignment="Center"/>
                                         </StackPanel>
@@ -622,7 +624,7 @@
                                                         <Setter Property="Background" Value="Transparent"/>
                                                         <Style.Triggers>
                                                             <Trigger Property="IsMouseOver" Value="True">
-                                                                <Setter Property="Background" Value="#1f232b"/>
+                                                                <Setter Property="Background" Value="{DynamicResource ViewerHoverBrush}"/>
                                                             </Trigger>
                                                         </Style.Triggers>
                                                     </Style>
@@ -647,7 +649,7 @@
                                            FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}"
                                            Margin="17,2,0,0" Visibility="Collapsed"/>
                                 <TextBlock x:Name="FleetAllHealthyText" Text="{Binding AllHealthyText}"
-                                           FontSize="12" Foreground="#81C784" Margin="0,0,0,2" Visibility="Collapsed"/>
+                                           FontSize="12" Foreground="{DynamicResource SuccessBrush}" Margin="0,0,0,2" Visibility="Collapsed"/>
                             </StackPanel>
                         </Border>
 
@@ -746,9 +748,9 @@
                                             <Border Background="#80000000" CornerRadius="6"
                                                     Visibility="{Binding IsOffline, Converter={StaticResource BoolToVisibility}}">
                                                 <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
-                                                    <TextBlock Text="&#x2717;" FontSize="28" Foreground="#E57373"
+                                                    <TextBlock Text="&#x2717;" FontSize="28" Foreground="{DynamicResource ErrorBrush}"
                                                                HorizontalAlignment="Center"/>
-                                                    <TextBlock Text="Offline" FontSize="13" Foreground="#E57373"
+                                                    <TextBlock Text="Offline" FontSize="13" Foreground="{DynamicResource ErrorBrush}"
                                                                FontWeight="SemiBold" HorizontalAlignment="Center" Margin="0,4,0,0"/>
                                                 </StackPanel>
                                             </Border>
@@ -897,7 +899,7 @@
 
                         <!-- Header bar: own server selector + Refresh + status (last-analysis time). -->
                         <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,8">
-                            <TextBlock Text="Server:" VerticalAlignment="Center" Foreground="#8B93A1" Margin="0,0,6,0"/>
+                            <TextBlock Text="Server:" VerticalAlignment="Center" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,0,6,0"/>
                             <ComboBox x:Name="RecommendationsServerSelector" Width="260" VerticalAlignment="Center"
                                       Style="{StaticResource DarkCombo}"
                                       SelectionChanged="RecommendationsServerSelector_SelectionChanged">
@@ -907,7 +909,7 @@
                                     </DataTemplate>
                                 </ComboBox.ItemTemplate>
                             </ComboBox>
-                            <Button Content="Refresh" Margin="10,0,0,0" Padding="12,4" Style="{StaticResource DarkButton}"
+                            <Button Content="Refresh" Margin="10,0,0,0" Padding="12,4"
                                     Click="RecommendationsRefresh_Click"
                                     ToolTip="Re-read recommendations for the selected server"/>
                             <Button x:Name="RecommendationsGenerateButton" Content="Generate now" Margin="8,0,0,0" Padding="12,4"
@@ -915,7 +917,7 @@
                                     Click="RecommendationsGenerateNow_Click"
                                     ToolTip="Ask the Darling service to run analysis for this server now, then refresh"/>
                             <TextBlock x:Name="RecommendationsStatusText" Margin="12,0,0,0" VerticalAlignment="Center"
-                                       FontStyle="Italic" Foreground="#8B93A1"/>
+                                       FontStyle="Italic" Foreground="{DynamicResource ForegroundMutedBrush}"/>
                         </StackPanel>
 
                         <!-- Content: exactly one region is visible per state. -->
@@ -982,9 +984,9 @@
                 <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
                     <TextBlock Text="No Servers Registered"
                                FontSize="24" FontWeight="Light"
-                               Foreground="#8B93A1" HorizontalAlignment="Center"/>
+                               Foreground="{DynamicResource ForegroundMutedBrush}" HorizontalAlignment="Center"/>
                     <TextBlock Text="Start the Darling service to populate the store, then double-click a server to open its dashboard."
-                               FontSize="14" Foreground="#8B93A1"
+                               FontSize="14" Foreground="{DynamicResource ForegroundMutedBrush}"
                                Margin="0,8,0,0" HorizontalAlignment="Center"
                                TextAlignment="Center" MaxWidth="480" TextWrapping="Wrap"/>
                 </StackPanel>
@@ -994,7 +996,7 @@
         <!-- Full-window message state: missing config / unreachable store -->
         <Border x:Name="MessageOverlay"
                 Grid.Row="0"
-                Background="#22252b"
+                Background="{DynamicResource BackgroundLightBrush}"
                 Visibility="Collapsed">
             <TextBlock x:Name="MessageText"
                        HorizontalAlignment="Center"
@@ -1003,7 +1005,7 @@
                        TextAlignment="Center"
                        MaxWidth="640"
                        FontSize="14"
-                       Foreground="#E4E6EB"/>
+                       Foreground="{DynamicResource ForegroundBrush}"/>
         </Border>
 
         <!-- Multi-field status bar (ported from Lite, adapted to what the viewer knows): general status,
@@ -1017,11 +1019,11 @@
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
-            <TextBlock Grid.Column="0" x:Name="StatusText" FontSize="12" Foreground="#8B93A1" VerticalAlignment="Center"/>
-            <TextBlock Grid.Column="1" x:Name="CollectorHealthText" FontSize="12" Foreground="#8B93A1" Margin="16,0" VerticalAlignment="Center"/>
-            <TextBlock Grid.Column="2" x:Name="DatabaseSizeText" Text="Database: --" FontSize="12" Foreground="#8B93A1" Margin="16,0" VerticalAlignment="Center"/>
-            <TextBlock Grid.Column="3" x:Name="CollectionStatusText" Text="Collection: --" FontSize="12" Foreground="#8B93A1" Margin="16,0" VerticalAlignment="Center"/>
-            <TextBlock Grid.Column="4" x:Name="ServerCountText" Text="Servers: 0" FontSize="12" Foreground="#8B93A1" VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="0" x:Name="StatusText" FontSize="12" Foreground="{DynamicResource ForegroundMutedBrush}" VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="1" x:Name="CollectorHealthText" FontSize="12" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="16,0" VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="2" x:Name="DatabaseSizeText" Text="Database: --" FontSize="12" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="16,0" VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="3" x:Name="CollectionStatusText" Text="Collection: --" FontSize="12" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="16,0" VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="4" x:Name="ServerCountText" Text="Servers: 0" FontSize="12" Foreground="{DynamicResource ForegroundMutedBrush}" VerticalAlignment="Center"/>
         </Grid>
     </Grid>
 </Window>

--- a/Darling/PerformanceMonitor.Darling.Viewer/MuteRuleEditDialog.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MuteRuleEditDialog.xaml
@@ -6,8 +6,8 @@
         WindowStartupLocation="CenterOwner"
         Icon="EDD.ico"
         ResizeMode="NoResize"
-        Background="#22252b"
-        Foreground="#E4E6EB">
+        Background="{DynamicResource BackgroundLightBrush}"
+        Foreground="{DynamicResource ForegroundBrush}">
     <!-- Mirrors Lite's MuteRuleDialog (Lite/Windows/MuteRuleDialog.xaml) field-for-field, dark-styled
          via the shared ViewerDarkTheme resource dictionary. -->
     <Window.Resources>
@@ -40,7 +40,7 @@
         <TextBlock Grid.Row="0" x:Name="HeaderText" Text="Create Mute Rule" FontSize="18" FontWeight="Bold"
                    HorizontalAlignment="Left" Margin="0,0,0,5"/>
         <TextBlock Grid.Row="1" Text="Alerts matching all specified fields will be suppressed from notifications."
-                   Foreground="#8B93A1" TextWrapping="Wrap" HorizontalAlignment="Left" Margin="0,0,0,15"/>
+                   Foreground="{DynamicResource ForegroundMutedBrush}" TextWrapping="Wrap" HorizontalAlignment="Left" Margin="0,0,0,15"/>
 
         <TextBlock Grid.Row="2" Text="Reason (optional)" FontWeight="Bold" HorizontalAlignment="Left" Margin="0,0,0,4"/>
         <TextBox Grid.Row="3" x:Name="ReasonBox" Margin="0,0,0,12"/>
@@ -53,11 +53,11 @@
             <ComboBoxItem Content="Never (permanent)"/>
         </ComboBox>
 
-        <Border Grid.Row="6" BorderThickness="0,0,0,1" BorderBrush="#2a2d35" Margin="0,0,0,12"/>
+        <Border Grid.Row="6" BorderThickness="0,0,0,1" BorderBrush="{DynamicResource BorderBrush}" Margin="0,0,0,12"/>
 
         <TextBlock Grid.Row="7" Text="Match Criteria" FontSize="14" FontWeight="SemiBold" HorizontalAlignment="Left" Margin="0,0,0,4"/>
         <TextBlock Grid.Row="8" Text="Leave fields blank to match any value. All filled fields must match (AND logic)."
-                   Foreground="#8B93A1" TextWrapping="Wrap" HorizontalAlignment="Left" Margin="0,0,0,12"/>
+                   Foreground="{DynamicResource ForegroundMutedBrush}" TextWrapping="Wrap" HorizontalAlignment="Left" Margin="0,0,0,12"/>
 
         <TextBlock Grid.Row="9" Text="Server Name (exact match)" HorizontalAlignment="Left" Margin="0,0,0,4"/>
         <TextBox Grid.Row="10" x:Name="ServerNameBox" Margin="0,0,0,8"/>

--- a/Darling/PerformanceMonitor.Darling.Viewer/MuteRulesWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MuteRulesWindow.xaml
@@ -6,8 +6,8 @@
         WindowStartupLocation="CenterOwner"
         Icon="EDD.ico"
         ResizeMode="CanResizeWithGrip"
-        Background="#22252b"
-        Foreground="#E4E6EB">
+        Background="{DynamicResource BackgroundLightBrush}"
+        Foreground="{DynamicResource ForegroundBrush}">
     <!-- Mirrors Lite's ManageMuteRulesWindow (Lite/Windows/ManageMuteRulesWindow.xaml), dark-styled
          via the shared ViewerDarkTheme resource dictionary. Persists straight to Postgres via
          ViewerDataService (no in-memory MuteRuleService cache — the running service re-reads). -->
@@ -29,7 +29,7 @@
 
         <TextBlock Grid.Row="0" Text="Mute Rules" FontSize="18" FontWeight="Bold" HorizontalAlignment="Left" Margin="0,0,0,4"/>
         <TextBlock Grid.Row="1" Text="Muted alerts are still collected and logged, but suppressed from alert delivery (email and webhooks). Changes are written to the shared store and take effect on the service's next mute-rule load."
-                   Foreground="#8B93A1" TextWrapping="Wrap" HorizontalAlignment="Left" Margin="0,0,0,12"/>
+                   Foreground="{DynamicResource ForegroundMutedBrush}" TextWrapping="Wrap" HorizontalAlignment="Left" Margin="0,0,0,12"/>
 
         <Grid Grid.Row="2">
             <DataGrid x:Name="RulesGrid"
@@ -55,7 +55,7 @@
             </DataGrid>
             <TextBlock x:Name="NoRulesMessage"
                        Text="No mute rules yet. Add one, or create one from an alert in the Alerts tab."
-                       Foreground="#8B93A1"
+                       Foreground="{DynamicResource ForegroundMutedBrush}"
                        HorizontalAlignment="Center" VerticalAlignment="Center"
                        TextWrapping="Wrap" TextAlignment="Center" MaxWidth="420"
                        Visibility="Collapsed"/>
@@ -69,7 +69,7 @@
             <Button Content="Purge Expired" Width="110" Height="28" Click="PurgeExpired_Click"/>
         </StackPanel>
         <TextBlock x:Name="ReadOnlyBanner" Grid.Row="3" HorizontalAlignment="Left" VerticalAlignment="Center"
-                   Margin="0,12,0,0" Foreground="#E0A030" TextWrapping="Wrap" MaxWidth="560" Visibility="Collapsed"
+                   Margin="0,12,0,0" Foreground="{DynamicResource WarningTextBrush}" TextWrapping="Wrap" MaxWidth="560" Visibility="Collapsed"
                    Text="Read-only connection (postgres.connectAs = &quot;viewer&quot;): mute rules can be viewed but not changed here. Set connectAs to &quot;admin&quot; and restart the viewer to edit them."/>
         <Button Grid.Row="3" Content="Close" Width="80" Height="28" Margin="0,12,0,0"
                 HorizontalAlignment="Right" Click="Close_Click" IsCancel="True"/>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ProcedureHistoryWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ProcedureHistoryWindow.xaml
@@ -7,8 +7,8 @@
         Icon="EDD.ico"
         TextOptions.TextFormattingMode="Display"
         UseLayoutRounding="True"
-        Background="#22252b"
-        Foreground="#E4E6EB">
+        Background="{DynamicResource BackgroundLightBrush}"
+        Foreground="{DynamicResource ForegroundBrush}">
     <!-- Ported from Lite's Windows/ProcedureHistoryWindow.xaml (the Top Procedures per-row double-click
          history window): the selected procedure's metric trend chart + a filterable grid of its per-collection
          snapshots. Data repointed to ViewerDataService Postgres reads; "View Plan" / the per-row Download
@@ -64,11 +64,11 @@
         <!-- Header -->
         <StackPanel Grid.Row="0" Margin="0,0,0,10">
             <TextBlock x:Name="ProcIdentifierText" FontSize="16" FontWeight="Bold"/>
-            <TextBlock x:Name="SummaryText" FontSize="12" Margin="0,4,0,0" Foreground="#B8BCC4"/>
+            <TextBlock x:Name="SummaryText" FontSize="12" Margin="0,4,0,0" Foreground="{DynamicResource ForegroundDimBrush}"/>
         </StackPanel>
 
         <!-- Chart -->
-        <Border Grid.Row="1" Background="#111217" BorderBrush="#2a2d35" BorderThickness="1" CornerRadius="3">
+        <Border Grid.Row="1" Background="{DynamicResource BackgroundDarkBrush}" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" CornerRadius="3">
             <Grid>
                 <ComboBox x:Name="MetricSelector" Width="180" Height="26"
                           VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0,6,10,0"

--- a/Darling/PerformanceMonitor.Darling.Viewer/QueryStatsHistoryWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/QueryStatsHistoryWindow.xaml
@@ -7,8 +7,8 @@
         Icon="EDD.ico"
         TextOptions.TextFormattingMode="Display"
         UseLayoutRounding="True"
-        Background="#22252b"
-        Foreground="#E4E6EB">
+        Background="{DynamicResource BackgroundLightBrush}"
+        Foreground="{DynamicResource ForegroundBrush}">
     <!-- Ported from Lite's Windows/QueryStatsHistoryWindow.xaml (the Top Queries per-row double-click
          history window): the selected query's metric trend chart + a filterable grid of its per-collection
          snapshots, delta columns and all. Data repointed to ViewerDataService Postgres reads; the one viewer
@@ -66,11 +66,11 @@
         <!-- Header -->
         <StackPanel Grid.Row="0" Margin="0,0,0,10">
             <TextBlock x:Name="QueryIdentifierText" FontSize="16" FontWeight="Bold"/>
-            <TextBlock x:Name="SummaryText" FontSize="12" Margin="0,4,0,0" Foreground="#B8BCC4"/>
+            <TextBlock x:Name="SummaryText" FontSize="12" Margin="0,4,0,0" Foreground="{DynamicResource ForegroundDimBrush}"/>
         </StackPanel>
 
         <!-- Chart -->
-        <Border Grid.Row="1" Background="#111217" BorderBrush="#2a2d35" BorderThickness="1" CornerRadius="3">
+        <Border Grid.Row="1" Background="{DynamicResource BackgroundDarkBrush}" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" CornerRadius="3">
             <Grid>
                 <ComboBox x:Name="MetricSelector" Width="180" Height="26"
                           VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0,6,10,0"

--- a/Darling/PerformanceMonitor.Darling.Viewer/QueryStoreHistoryWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/QueryStoreHistoryWindow.xaml
@@ -7,8 +7,8 @@
         Icon="EDD.ico"
         TextOptions.TextFormattingMode="Display"
         UseLayoutRounding="True"
-        Background="#22252b"
-        Foreground="#E4E6EB">
+        Background="{DynamicResource BackgroundLightBrush}"
+        Foreground="{DynamicResource ForegroundBrush}">
     <!-- Ported from Lite's Windows/QueryStoreHistoryWindow.xaml (the Query Store per-row double-click history
          window): the selected query's per-plan metric trend over the window (one chart series per plan_id, so
          plan switches / regressions are visible) plus a filterable grid of its per-collection snapshots. Data
@@ -57,11 +57,11 @@
         <!-- Header -->
         <StackPanel Grid.Row="0" Margin="0,0,0,10">
             <TextBlock x:Name="QueryIdentifierText" FontSize="16" FontWeight="Bold"/>
-            <TextBlock x:Name="SummaryText" FontSize="12" Margin="0,4,0,0" Foreground="#B8BCC4"/>
+            <TextBlock x:Name="SummaryText" FontSize="12" Margin="0,4,0,0" Foreground="{DynamicResource ForegroundDimBrush}"/>
         </StackPanel>
 
         <!-- Chart -->
-        <Border Grid.Row="1" Background="#111217" BorderBrush="#2a2d35" BorderThickness="1" CornerRadius="3">
+        <Border Grid.Row="1" Background="{DynamicResource BackgroundDarkBrush}" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" CornerRadius="3">
             <Grid>
                 <ComboBox x:Name="MetricSelector" Width="180" Height="26"
                           VerticalAlignment="Top" HorizontalAlignment="Right" Margin="0,6,10,0"

--- a/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml
@@ -73,7 +73,7 @@
                 <TextBlock Text="Store query and Query Store execution-plan XML across the fleet. Disable to shave storage on a very large fleet; a per-server override lives on each server's dialog."
                            FontSize="11" FontStyle="Italic" Foreground="{DynamicResource ForegroundMutedBrush}"
                            Margin="0,4,0,0" TextWrapping="Wrap"/>
-                <TextBlock x:Name="SettingsReadOnlyBanner" FontSize="12" Foreground="#E0A030" Margin="0,8,0,0" TextWrapping="Wrap"
+                <TextBlock x:Name="SettingsReadOnlyBanner" FontSize="12" Foreground="{DynamicResource WarningTextBrush}" Margin="0,8,0,0" TextWrapping="Wrap"
                            Visibility="Collapsed"
                            Text="This viewer is connected with a read-only role. Monitoring settings below are shown for reference but can't be changed from here."/>
             </StackPanel>
@@ -168,12 +168,12 @@
                 <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
                     <TextBlock Text="Color theme:" VerticalAlignment="Center"
                                Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,8,0"/>
-                    <ComboBox x:Name="ColorThemeCombo" Width="140" VerticalAlignment="Center" IsEnabled="False">
-                        <ComboBoxItem Content="Dark" IsSelected="True"/>
+                    <ComboBox x:Name="ColorThemeCombo" Width="140" VerticalAlignment="Center"
+                              SelectionChanged="ColorThemeCombo_SelectionChanged">
+                        <ComboBoxItem Content="Dark" Tag="Dark"/>
+                        <ComboBoxItem Content="Light" Tag="Light"/>
+                        <ComboBoxItem Content="Cool Breeze" Tag="CoolBreeze"/>
                     </ComboBox>
-                    <TextBlock Text="the Darling viewer is dark-only"
-                               FontSize="11" FontStyle="Italic" Foreground="{DynamicResource ForegroundMutedBrush}"
-                               VerticalAlignment="Center" Margin="6,0,0,0"/>
                 </StackPanel>
             </StackPanel>
         </Border>
@@ -537,7 +537,7 @@
                     <Run Foreground="#16A34A" FontWeight="Bold" Text="&#x25A0; Green" /> — Resolved (Server Restored)
                 </TextBlock>
                 <TextBlock TextWrapping="Wrap" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}">
-                    <Run Foreground="#2eaef1" FontWeight="Bold" Text="&#x25A0; Blue" /> — Info
+                    <Run Foreground="{DynamicResource InfoBrush}" FontWeight="Bold" Text="&#x25A0; Blue" /> — Info
                 </TextBlock>
             </StackPanel>
         </Border>

--- a/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml.cs
@@ -18,6 +18,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Navigation;
 using PerformanceMonitor.Notifications;
+using PerformanceMonitor.Ui;
 
 namespace PerformanceMonitor.Darling.Viewer;
 
@@ -55,6 +56,16 @@ public partial class SettingsWindow : Window
 
     /// <summary>The service's paused state as last read from <c>config_service</c>, reflected on the button.</summary>
     private bool _paused;
+
+    /// <summary>Guards the theme combo's SelectionChanged from firing an Apply while <see cref="LoadColorTheme"/>
+    /// is seeding the selection.</summary>
+    private bool _isLoadingTheme;
+
+    /// <summary>The theme active when the window opened, so a Cancel/close-without-save reverts the live preview.</summary>
+    private readonly string _originalTheme = ThemeManager.CurrentTheme;
+
+    /// <summary>Set once the operator saves, so the close handlers do not revert the (now persisted) theme.</summary>
+    private bool _themeSaved;
 
     /// <summary>
     /// True once the operator config was READ from the store without error. Save writes the store sections only
@@ -97,6 +108,7 @@ public partial class SettingsWindow : Window
         LoadConnectionTimeout();
         LoadCsvSeparator();
         LoadTimeDisplayMode();
+        LoadColorTheme();
         LoadViewerLocalAlertFields();
         SeedAlertControlsFrom(AlertSettingsRow.Defaults());
         SeedNotificationControlsFrom(NotificationRow.Defaults());
@@ -435,6 +447,51 @@ public partial class SettingsWindow : Window
         {
             _appSettings.TimeDisplayMode = mode;
         }
+    }
+
+    // ── Color theme (viewer-local; live-previewed via the shared ThemeManager, mirrors Lite) ──
+
+    /// <summary>Live-applies the picked theme so the operator sees Dark / Light / CoolBreeze immediately.
+    /// A Cancel/close-without-save reverts to <see cref="_originalTheme"/>; Save persists it.</summary>
+    private void ColorThemeCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_isLoadingTheme)
+        {
+            return;
+        }
+
+        if (ColorThemeCombo.SelectedItem is ComboBoxItem { Tag: string theme })
+        {
+            ThemeManager.Apply(theme);
+        }
+    }
+
+    private void LoadColorTheme()
+    {
+        _isLoadingTheme = true;
+        foreach (ComboBoxItem item in ColorThemeCombo.Items)
+        {
+            if (item.Tag?.ToString() == _appSettings.ColorTheme)
+            {
+                ColorThemeCombo.SelectedItem = item;
+                break;
+            }
+        }
+        if (ColorThemeCombo.SelectedItem == null)
+        {
+            ColorThemeCombo.SelectedIndex = 0;
+        }
+        _isLoadingTheme = false;
+    }
+
+    private void SaveColorTheme()
+    {
+        if (ColorThemeCombo.SelectedItem is ComboBoxItem { Tag: string theme })
+        {
+            _appSettings.ColorTheme = theme;
+            ThemeManager.Apply(theme);
+        }
+        _themeSaved = true;
     }
 
     // ── Notifications / alert thresholds ──
@@ -973,6 +1030,7 @@ public partial class SettingsWindow : Window
         SaveConnectionTimeout();
         SaveCsvSeparator();
         SaveTimeDisplayMode();
+        SaveColorTheme();
         _appSettingsStore.Save(_appSettings);
         Result = BuildViewerPreferences();
 
@@ -1035,7 +1093,25 @@ public partial class SettingsWindow : Window
         Close();
     }
 
-    private void CloseButton_Click(object sender, RoutedEventArgs e) => Close();
+    private void CloseButton_Click(object sender, RoutedEventArgs e)
+    {
+        /* Revert the live theme preview when closing without saving (the X button is handled in OnClosing). */
+        if (!_themeSaved)
+        {
+            ThemeManager.Apply(_originalTheme);
+        }
+        Close();
+    }
+
+    protected override void OnClosing(System.ComponentModel.CancelEventArgs e)
+    {
+        /* Catches the title-bar X / Esc: an unsaved theme preview reverts to what was active on open. */
+        if (!_themeSaved)
+        {
+            ThemeManager.Apply(_originalTheme);
+        }
+        base.OnClosing(e);
+    }
 
     /// <summary>
     /// A throwaway <see cref="IAlertSettings"/> built from the live SMTP/webhook controls, so "Send Test

--- a/Darling/PerformanceMonitor.Darling.Viewer/Themes/CoolBreezeTheme.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/Themes/CoolBreezeTheme.xaml
@@ -4,39 +4,39 @@
                     xmlns:helpers="clr-namespace:PerformanceMonitor.Ui;assembly=PerformanceMonitor.Ui">
 
     <!-- ============================================ -->
-    <!-- Darling Data Light Theme                      -->
+    <!-- Darling Data Cool Breeze Theme                      -->
     <!-- Flat/Minimal Design                          -->
     <!-- ============================================ -->
 
     <!-- Brand Colors -->
-    <Color x:Key="AccentColor">#2eaef1</Color>
-    <Color x:Key="AccentHoverColor">#5bc4f5</Color>
-    <Color x:Key="AccentPressedColor">#1a9ae0</Color>
+    <Color x:Key="AccentColor">#1E6FA8</Color>
+    <Color x:Key="AccentHoverColor">#2B87C8</Color>
+    <Color x:Key="AccentPressedColor">#155A8A</Color>
 
     <!-- Background Colors -->
-    <Color x:Key="BackgroundDarkColor">#F0F2F5</Color>
-    <Color x:Key="AlternatingRowColor">#EDF1F7</Color>
-    <Color x:Key="BackgroundColor">#F5F7FA</Color>
-    <Color x:Key="BackgroundLightColor">#FFFFFF</Color>
-    <Color x:Key="BackgroundLighterColor">#E8ECF0</Color>
+    <Color x:Key="BackgroundDarkColor">#CFDDE9</Color>
+    <Color x:Key="AlternatingRowColor">#C5D5E4</Color>
+    <Color x:Key="BackgroundColor">#DAE6F0</Color>
+    <Color x:Key="BackgroundLightColor">#EEF4FA</Color>
+    <Color x:Key="BackgroundLighterColor">#BDD0E1</Color>
 
     <!-- Text Colors (dark on light backgrounds) -->
-    <Color x:Key="ForegroundColor">#1A1D23</Color>
-    <Color x:Key="ForegroundDimColor">#1A1D23</Color>
-    <!-- Muted (tertiary) text. #1441: the old #718096 was only 3.38:1 on the light wells and
-         failed WCAG AA. #5A6472 is ~6:1 on #FFFFFF / ~5.6:1 on #F5F7FA — a readable secondary
-         tone that still reads quieter than primary, mirroring the Dark muted tier. -->
-    <Color x:Key="ForegroundMutedColor">#5A6472</Color>
+    <Color x:Key="ForegroundColor">#1A2A3A</Color>
+    <Color x:Key="ForegroundDimColor">#1A2A3A</Color>
+    <!-- Muted (tertiary) text. #1441: the old #5B7A90 was only 2.87:1 on the light-blue wells and
+         failed WCAG AA. #4A5D72 is ~6.5:1 on #EEF4FA — a readable secondary tone that keeps the
+         cool blue character while reading quieter than primary, mirroring the Dark muted tier. -->
+    <Color x:Key="ForegroundMutedColor">#4A5D72</Color>
 
     <!-- Border Colors (subtle, low-contrast) -->
-    <Color x:Key="BorderColor">#DEE2E6</Color>
-    <Color x:Key="BorderLightColor">#CED4DA</Color>
+    <Color x:Key="BorderColor">#A8BDD0</Color>
+    <Color x:Key="BorderLightColor">#8AACC4</Color>
 
     <!-- Status Colors (Material Design 700 — visible against light backgrounds) -->
     <Color x:Key="SuccessColor">#2E7D32</Color>
     <Color x:Key="WarningColor">#F57F17</Color>
     <Color x:Key="ErrorColor">#C62828</Color>
-    <Color x:Key="InfoColor">#2eaef1</Color>
+    <Color x:Key="InfoColor">#1E6FA8</Color>
 
     <!-- Spacing Scale -->
     <sys:Double x:Key="SpacingXS">2</sys:Double>
@@ -63,7 +63,7 @@
 
     <SolidColorBrush x:Key="ForegroundBrush" Color="{StaticResource ForegroundColor}"/>
     <SolidColorBrush x:Key="ForegroundDimBrush" Color="{StaticResource ForegroundDimColor}"/>
-    <!-- #1441: use the (now readable) muted color so Light has a real 3-tier text hierarchy
+    <!-- #1441: use the (now readable) muted color so CoolBreeze has a real 3-tier text hierarchy
          like Dark, instead of collapsing muted onto the primary foreground. -->
     <SolidColorBrush x:Key="ForegroundMutedBrush" Color="{StaticResource ForegroundMutedColor}"/>
 
@@ -82,7 +82,7 @@
     <!-- Deadlock victim node border + VICTIM badge fill, and the "waits for" edge/arrow. Tuned per theme
          so the victim red clears >=3:1 as a border on the light node card and the edge reads on the canvas. -->
     <SolidColorBrush x:Key="DeadlockVictimBrush" Color="#C62828"/>
-    <SolidColorBrush x:Key="DeadlockEdgeBrush" Color="#5A6270"/>
+    <SolidColorBrush x:Key="DeadlockEdgeBrush" Color="#455A6E"/>
     <SolidColorBrush x:Key="ErrorBrush" Color="{StaticResource ErrorColor}"/>
     <SolidColorBrush x:Key="InfoBrush" Color="{StaticResource InfoColor}"/>
 
@@ -113,7 +113,7 @@
     <!-- ============================================ -->
     <Style TargetType="Button">
         <Setter Property="Background" Value="{StaticResource BackgroundLightBrush}"/>
-        <Setter Property="Foreground" Value="#1A1D23"/>
+        <Setter Property="Foreground" Value="#1A2A3A"/>
         <Setter Property="BorderBrush" Value="{StaticResource BorderBrush}"/>
         <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="Padding" Value="12,6"/>
@@ -220,7 +220,7 @@
     <!-- ToggleButton Style (respects Background in all states) -->
     <Style TargetType="ToggleButton">
         <Setter Property="Background" Value="#E8ECF0"/>
-        <Setter Property="Foreground" Value="#1A1D23"/>
+        <Setter Property="Foreground" Value="#1A2A3A"/>
         <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="Padding" Value="12,5"/>
         <Setter Property="Template">
@@ -295,7 +295,7 @@
     <!-- Success Button Style (for Refresh) -->
     <Style x:Key="SuccessButton" TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
         <Setter Property="Background" Value="{StaticResource SuccessBrush}"/>
-        <Setter Property="Foreground" Value="#E4E6EB"/>
+        <Setter Property="Foreground" Value="#EEF4FA"/>
         <Setter Property="FontWeight" Value="SemiBold"/>
         <Setter Property="Template">
             <Setter.Value>
@@ -331,11 +331,11 @@
     <!-- Named style for filter TextBoxes in DataGrid column headers -->
     <Style x:Key="FilterTextBoxStyle" TargetType="TextBox">
         <Setter Property="Background" Value="{StaticResource BackgroundDarkBrush}"/>
-        <Setter Property="Foreground" Value="#1A1D23"/>
+        <Setter Property="Foreground" Value="#1A2A3A"/>
         <Setter Property="BorderBrush" Value="{StaticResource BorderBrush}"/>
         <Setter Property="BorderThickness" Value="1"/>
         <Setter Property="Padding" Value="4,2"/>
-        <Setter Property="CaretBrush" Value="#1A1D23"/>
+        <Setter Property="CaretBrush" Value="#1A2A3A"/>
         <Setter Property="SelectionBrush" Value="{StaticResource AccentBrush}"/>
     </Style>
 
@@ -593,7 +593,7 @@
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsSelected" Value="True">
                             <Setter TargetName="border" Property="Background" Value="{StaticResource AccentBrush}"/>
-                            <Setter Property="Foreground" Value="#E4E6EB"/>
+                            <Setter Property="Foreground" Value="#EEF4FA"/>
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter TargetName="border" Property="Background" Value="{StaticResource BackgroundLighterBrush}"/>
@@ -749,18 +749,18 @@
     <!-- Column header style when filter is active - subtle blue highlight -->
     <Style x:Key="FilteredColumnHeaderStyle" TargetType="DataGridColumnHeader"
            BasedOn="{StaticResource {x:Type DataGridColumnHeader}}">
-        <Setter Property="Background" Value="#BBDEFB"/>
+        <Setter Property="Background" Value="#9DBFD9"/>
     </Style>
 
-    <!-- Foreground to use on selected rows (dark text on the light accent background) -->
-    <SolidColorBrush x:Key="GridSelectionForegroundBrush" Color="#1A1D23"/>
+    <!-- Foreground to use on selected rows (white text on the cool-breeze accent background) -->
+    <SolidColorBrush x:Key="GridSelectionForegroundBrush" Color="#FFFFFF"/>
 
     <!-- Override WPF system selection brushes so all controls (DataGrid, ListBox, etc.)
          use the theme accent and the matching readable text color. -->
     <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}"                    Color="{StaticResource AccentColor}"/>
-    <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey}"                Color="#1A1D23"/>
+    <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey}"                Color="#FFFFFF"/>
     <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightBrushKey}"   Color="{StaticResource AccentColor}"/>
-    <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightTextBrushKey}" Color="#1A1D23"/>
+    <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightTextBrushKey}" Color="#FFFFFF"/>
 
     <!-- Named base style for DataGridTextColumn ElementStyles that must set an explicit
          Foreground.  BasedOn this style; keep the unselected Foreground setter in the
@@ -797,7 +797,7 @@
         <Style.Triggers>
             <Trigger Property="IsSelected" Value="True">
                 <Setter Property="Background" Value="{StaticResource AccentBrush}"/>
-                <Setter Property="Foreground" Value="#1A1D23"/>
+                <Setter Property="Foreground" Value="#FFFFFF"/>
             </Trigger>
         </Style.Triggers>
     </Style>
@@ -1282,12 +1282,22 @@
     </Style>
 
 
-    <!-- Time Range Slicer (light values; #1441 completeness — these 10 keys existed only in Dark) -->
+    <!-- Viewer secondary-window surfaces (write-back windows that merge ViewerDarkTheme.xaml). Cool-breeze values. -->
+    <SolidColorBrush x:Key="CardBorderBrush" Color="{StaticResource BorderLightColor}"/>
+    <SolidColorBrush x:Key="ViewerSelectionBrush" Color="#B7CEE2"/>
+    <SolidColorBrush x:Key="ViewerHoverBrush" Color="{StaticResource BackgroundLighterColor}"/>
+    <SolidColorBrush x:Key="ViewerGridHeaderBrush" Color="{StaticResource BackgroundLighterColor}"/>
+    <SolidColorBrush x:Key="ViewerAltRowBrush" Color="{StaticResource AlternatingRowColor}"/>
+    <SolidColorBrush x:Key="ViewerButtonBorderBrush" Color="{StaticResource BorderLightColor}"/>
+    <SolidColorBrush x:Key="ViewerDisabledBgBrush" Color="{StaticResource BackgroundLighterColor}"/>
+    <SolidColorBrush x:Key="ViewerDisabledTextBrush" Color="#8CA0B2"/>
+
+    <!-- Time Range Slicer (cool-breeze values; #1441 completeness — these 10 keys existed only in Dark) -->
     <SolidColorBrush x:Key="SlicerBackgroundBrush" Color="{StaticResource BackgroundDarkColor}"/>
     <SolidColorBrush x:Key="SlicerChartLineBrush" Color="{StaticResource AccentColor}"/>
-    <SolidColorBrush x:Key="SlicerChartFillBrush" Color="#332EAEF1"/>
+    <SolidColorBrush x:Key="SlicerChartFillBrush" Color="#331E6FA8"/>
     <SolidColorBrush x:Key="SlicerOverlayBrush" Color="#40000000"/>
-    <SolidColorBrush x:Key="SlicerSelectedBrush" Color="#222EAEF1"/>
+    <SolidColorBrush x:Key="SlicerSelectedBrush" Color="#221E6FA8"/>
     <SolidColorBrush x:Key="SlicerHandleBrush" Color="{StaticResource ForegroundColor}"/>
     <SolidColorBrush x:Key="SlicerHandleHoverBrush" Color="{StaticResource AccentColor}"/>
     <SolidColorBrush x:Key="SlicerBorderBrush" Color="{StaticResource BorderColor}"/>
@@ -1297,16 +1307,18 @@
     <!-- ============================================ -->
     <!-- Plan Viewer Resources                        -->
     <!-- ============================================ -->
-    <SolidColorBrush x:Key="PlanTooltipBgBrush" Color="#FFFFFF"/>
+    <SolidColorBrush x:Key="PlanTooltipBgBrush" Color="{StaticResource BackgroundLightColor}"/>
     <SolidColorBrush x:Key="PlanTooltipBorderBrush" Color="{StaticResource BorderColor}"/>
     <SolidColorBrush x:Key="PlanPanelTextBrush" Color="{StaticResource ForegroundColor}"/>
     <SolidColorBrush x:Key="PlanPanelMutedBrush" Color="{StaticResource ForegroundMutedColor}"/>
     <SolidColorBrush x:Key="PlanSectionHeaderBrush" Color="{StaticResource AccentPressedColor}"/>
     <SolidColorBrush x:Key="PlanPropSeparatorBrush" Color="{StaticResource BorderColor}"/>
-    <SolidColorBrush x:Key="PlanMissingIndexBgBrush" Color="#FFF8E1"/>
-    <SolidColorBrush x:Key="PlanMissingIndexBorderBrush" Color="#FFD54F"/>
-    <SolidColorBrush x:Key="PlanMissingIndexHeaderBrush" Color="#E65100"/>
-    <SolidColorBrush x:Key="PlanWaitStatsBgBrush" Color="#E3F2FD"/>
-    <SolidColorBrush x:Key="PlanWaitStatsHeaderBrush" Color="#1565C0"/>
+    <SolidColorBrush x:Key="PlanMissingIndexBgBrush" Color="#FFF3C8"/>
+    <SolidColorBrush x:Key="PlanMissingIndexBorderBrush" Color="#EEB800"/>
+    <SolidColorBrush x:Key="PlanMissingIndexHeaderBrush" Color="#BF4700"/>
+    <SolidColorBrush x:Key="PlanWaitStatsBgBrush" Color="#D5E9F5"/>
+    <SolidColorBrush x:Key="PlanWaitStatsHeaderBrush" Color="#0D47A1"/>
 
 </ResourceDictionary>
+
+

--- a/Darling/PerformanceMonitor.Darling.Viewer/Themes/DarkTheme.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/Themes/DarkTheme.xaml
@@ -1280,6 +1280,18 @@
         <Setter Property="Padding" Value="10,8"/>
     </Style>
 
+    <!-- Viewer secondary-window surfaces (the read-only write-back windows that merge
+         ViewerDarkTheme.xaml). Dark values equal the literals they replace so dark is pixel-identical;
+         Light/CoolBreeze give them themed values. -->
+    <SolidColorBrush x:Key="CardBorderBrush" Color="#3A3D45"/>
+    <SolidColorBrush x:Key="ViewerSelectionBrush" Color="#2F3542"/>
+    <SolidColorBrush x:Key="ViewerHoverBrush" Color="#1F232B"/>
+    <SolidColorBrush x:Key="ViewerGridHeaderBrush" Color="#262932"/>
+    <SolidColorBrush x:Key="ViewerAltRowBrush" Color="#16181D"/>
+    <SolidColorBrush x:Key="ViewerButtonBorderBrush" Color="#3A4150"/>
+    <SolidColorBrush x:Key="ViewerDisabledBgBrush" Color="#1B1E24"/>
+    <SolidColorBrush x:Key="ViewerDisabledTextBrush" Color="#5C6472"/>
+
     <!-- Time Range Slicer -->
     <SolidColorBrush x:Key="SlicerBackgroundBrush" Color="#15171C"/>
     <SolidColorBrush x:Key="SlicerChartLineBrush" Color="#2EAEF1"/>

--- a/Darling/PerformanceMonitor.Darling.Viewer/Themes/LightTheme.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/Themes/LightTheme.xaml
@@ -1282,6 +1282,16 @@
     </Style>
 
 
+    <!-- Viewer secondary-window surfaces (write-back windows that merge ViewerDarkTheme.xaml). Light values. -->
+    <SolidColorBrush x:Key="CardBorderBrush" Color="{StaticResource BorderLightColor}"/>
+    <SolidColorBrush x:Key="ViewerSelectionBrush" Color="#D6E4F5"/>
+    <SolidColorBrush x:Key="ViewerHoverBrush" Color="{StaticResource BackgroundLighterColor}"/>
+    <SolidColorBrush x:Key="ViewerGridHeaderBrush" Color="{StaticResource BackgroundLighterColor}"/>
+    <SolidColorBrush x:Key="ViewerAltRowBrush" Color="{StaticResource AlternatingRowColor}"/>
+    <SolidColorBrush x:Key="ViewerButtonBorderBrush" Color="{StaticResource BorderLightColor}"/>
+    <SolidColorBrush x:Key="ViewerDisabledBgBrush" Color="{StaticResource BackgroundLighterColor}"/>
+    <SolidColorBrush x:Key="ViewerDisabledTextBrush" Color="#A0A8B4"/>
+
     <!-- Time Range Slicer (light values; #1441 completeness — these 10 keys existed only in Dark) -->
     <SolidColorBrush x:Key="SlicerBackgroundBrush" Color="{StaticResource BackgroundDarkColor}"/>
     <SolidColorBrush x:Key="SlicerChartLineBrush" Color="{StaticResource AccentColor}"/>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerAppSettings.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerAppSettings.cs
@@ -72,6 +72,10 @@ public sealed class ViewerAppSettings
     /// <summary>Timestamp display mode: "ServerTime", "LocalTime", or "UTC".</summary>
     public string TimeDisplayMode { get; set; } = "ServerTime";
 
+    /// <summary>Color theme: "Dark" (default), "Light", or "CoolBreeze". Mirrors Lite's <c>App.ColorTheme</c>;
+    /// applied at startup and live-previewed from the Settings window via the shared <c>ThemeManager</c>.</summary>
+    public string ColorTheme { get; set; } = "Dark";
+
     /* ---------------- Notifications / alert thresholds (mirrors Lite App.*) ---------------- */
 
     public bool MinimizeToTray { get; set; } = true;
@@ -177,6 +181,7 @@ public sealed class ViewerAppSettings
         ConnectionTimeoutSeconds = Clamp(ConnectionTimeoutSeconds, 5, 60, 5);
         CsvSeparator = (CsvSeparator == "," || CsvSeparator == ";" || CsvSeparator == "\t") ? CsvSeparator : DefaultCsvSeparator();
         TimeDisplayMode = (TimeDisplayMode is "ServerTime" or "LocalTime" or "UTC") ? TimeDisplayMode : "ServerTime";
+        ColorTheme = (ColorTheme is "Dark" or "Light" or "CoolBreeze") ? ColorTheme : "Dark";
 
         AlertCpuThreshold = Clamp(AlertCpuThreshold, 1, 100, 80);
         AlertCpuMode = (AlertCpuMode is "Total" or "SqlOnly") ? AlertCpuMode : "Total";

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDarkTheme.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDarkTheme.xaml
@@ -1,30 +1,33 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <!--
-        Shared dark control styles for the viewer's write-back windows (Manage Mute Rules + the
-        Mute Rule editor), matching MainWindow's hardcoded Dark palette (#22252b chrome, #111217
-        wells, #2a2d35 borders, #E4E6EB text, #2f3542 selection). Implicit (keyless) styles so a
-        merged window's controls theme automatically — MainWindow keeps its own inline copies.
+        Shared control styles for the viewer's read-only write-back / dialog windows (Manage Mute
+        Rules, the Mute Rule editor, history popups, collection log, etc.). Merged locally by those
+        windows so their controls pick up a consistent look.
+
+        THEME-AWARE: every color is a {DynamicResource} into the app-wide theme dictionary that
+        ThemeManager swaps at runtime, so these windows follow Dark / Light / CoolBreeze like the
+        main window. The token dark values are unchanged, so Dark is pixel-identical to the previous
+        hardcoded palette (#22252b chrome, #111217 wells, #2a2d35 borders, #E4E6EB text,
+        #2f3542 selection). Implicit (keyless) styles so a merged window's controls theme
+        automatically — MainWindow keeps its own inline copies.
+        (File name kept for the windows that reference it; it is no longer "dark-only".)
     -->
 
-    <SolidColorBrush x:Key="WindowBg" Color="#22252b"/>
-    <SolidColorBrush x:Key="WellBg" Color="#111217"/>
-    <SolidColorBrush x:Key="BorderColorBrush" Color="#2a2d35"/>
-    <SolidColorBrush x:Key="TextBrush" Color="#E4E6EB"/>
-    <SolidColorBrush x:Key="DimTextBrush" Color="#8B93A1"/>
-    <SolidColorBrush x:Key="SelectionBg" Color="#2f3542"/>
-    <SolidColorBrush x:Key="HoverBg" Color="#1f232b"/>
+    <!-- DimTextBrush: the only by-key color reference from the windows (3 uses). Theme-aware alias
+         to the readable muted tier (#1441 — replaces the old #8B93A1). -->
+    <SolidColorBrush x:Key="DimTextBrush" Color="{DynamicResource ForegroundMutedColor}"/>
 
     <Style TargetType="TextBlock">
-        <Setter Property="Foreground" Value="#E4E6EB"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
         <Setter Property="VerticalAlignment" Value="Center"/>
     </Style>
 
     <Style TargetType="TextBox">
-        <Setter Property="Background" Value="#111217"/>
-        <Setter Property="Foreground" Value="#E4E6EB"/>
-        <Setter Property="CaretBrush" Value="#E4E6EB"/>
-        <Setter Property="BorderBrush" Value="#2a2d35"/>
+        <Setter Property="Background" Value="{DynamicResource BackgroundDarkBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="CaretBrush" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrush}"/>
         <Setter Property="BorderThickness" Value="1"/>
         <Setter Property="Padding" Value="6,4"/>
         <Setter Property="Template">
@@ -42,14 +45,14 @@
     </Style>
 
     <Style TargetType="CheckBox">
-        <Setter Property="Foreground" Value="#E4E6EB"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
         <Setter Property="VerticalAlignment" Value="Center"/>
     </Style>
 
     <Style x:Key="ViewerButton" TargetType="Button">
-        <Setter Property="Foreground" Value="#E4E6EB"/>
-        <Setter Property="Background" Value="#2f3542"/>
-        <Setter Property="BorderBrush" Value="#3a4150"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="Background" Value="{DynamicResource ViewerSelectionBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource ViewerButtonBorderBrush}"/>
         <Setter Property="BorderThickness" Value="1"/>
         <Setter Property="Padding" Value="12,5"/>
         <Setter Property="Cursor" Value="Hand"/>
@@ -66,11 +69,11 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="Bd" Property="Background" Value="#3a4150"/>
+                            <Setter TargetName="Bd" Property="Background" Value="{DynamicResource ViewerButtonBorderBrush}"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
-                            <Setter TargetName="Bd" Property="Background" Value="#1b1e24"/>
-                            <Setter Property="Foreground" Value="#5c6472"/>
+                            <Setter TargetName="Bd" Property="Background" Value="{DynamicResource ViewerDisabledBgBrush}"/>
+                            <Setter Property="Foreground" Value="{DynamicResource ViewerDisabledTextBrush}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -80,9 +83,9 @@
 
     <Style TargetType="Button" BasedOn="{StaticResource ViewerButton}"/>
 
-    <!-- ComboBox: compact dark re-template (toggle + dark popup). -->
+    <!-- ComboBox: compact re-template (toggle + popup), theme-aware. -->
     <Style TargetType="ComboBoxItem">
-        <Setter Property="Foreground" Value="#E4E6EB"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="Padding" Value="6,4"/>
         <Setter Property="Template">
@@ -93,10 +96,10 @@
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="Bd" Property="Background" Value="#1f232b"/>
+                            <Setter TargetName="Bd" Property="Background" Value="{DynamicResource ViewerHoverBrush}"/>
                         </Trigger>
                         <Trigger Property="IsHighlighted" Value="True">
-                            <Setter TargetName="Bd" Property="Background" Value="#2f3542"/>
+                            <Setter TargetName="Bd" Property="Background" Value="{DynamicResource ViewerSelectionBrush}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -105,9 +108,9 @@
     </Style>
 
     <Style TargetType="ComboBox">
-        <Setter Property="Foreground" Value="#E4E6EB"/>
-        <Setter Property="Background" Value="#111217"/>
-        <Setter Property="BorderBrush" Value="#2a2d35"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="Background" Value="{DynamicResource BackgroundDarkBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrush}"/>
         <Setter Property="BorderThickness" Value="1"/>
         <Setter Property="Padding" Value="6,4"/>
         <Setter Property="Template">
@@ -120,8 +123,8 @@
                                       ClickMode="Press">
                             <ToggleButton.Template>
                                 <ControlTemplate TargetType="ToggleButton">
-                                    <Border Background="#111217"
-                                            BorderBrush="#2a2d35"
+                                    <Border Background="{DynamicResource BackgroundDarkBrush}"
+                                            BorderBrush="{DynamicResource BorderBrush}"
                                             BorderThickness="1"
                                             CornerRadius="3">
                                         <Grid>
@@ -131,7 +134,7 @@
                                             </Grid.ColumnDefinitions>
                                             <Path Grid.Column="1"
                                                   HorizontalAlignment="Center" VerticalAlignment="Center"
-                                                  Data="M 0 0 L 4 4 L 8 0 Z" Fill="#8B93A1"/>
+                                                  Data="M 0 0 L 4 4 L 8 0 Z" Fill="{DynamicResource ForegroundMutedBrush}"/>
                                         </Grid>
                                     </Border>
                                 </ControlTemplate>
@@ -147,7 +150,7 @@
                         <Popup x:Name="PART_Popup" Placement="Bottom"
                                IsOpen="{TemplateBinding IsDropDownOpen}"
                                AllowsTransparency="True" Focusable="False" PopupAnimation="Slide">
-                            <Border Background="#16181d" BorderBrush="#2a2d35" BorderThickness="1"
+                            <Border Background="{DynamicResource ViewerAltRowBrush}" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1"
                                     MinWidth="{TemplateBinding ActualWidth}" MaxHeight="240">
                                 <ScrollViewer>
                                     <StackPanel IsItemsHost="True"/>
@@ -157,7 +160,7 @@
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsEnabled" Value="False">
-                            <Setter Property="Foreground" Value="#5c6472"/>
+                            <Setter Property="Foreground" Value="{DynamicResource ViewerDisabledTextBrush}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -165,11 +168,11 @@
         </Setter>
     </Style>
 
-    <!-- DataGrid chrome, matching MainWindow's DarkGrid family. -->
+    <!-- DataGrid chrome, matching MainWindow's DarkGrid family (theme-aware). -->
     <Style x:Key="DarkGridHeader" TargetType="DataGridColumnHeader">
-        <Setter Property="Background" Value="#262932"/>
-        <Setter Property="Foreground" Value="#E4E6EB"/>
-        <Setter Property="BorderBrush" Value="#2a2d35"/>
+        <Setter Property="Background" Value="{DynamicResource ViewerGridHeaderBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrush}"/>
         <Setter Property="BorderThickness" Value="0,0,1,1"/>
         <Setter Property="Padding" Value="8,5"/>
         <Setter Property="FontWeight" Value="SemiBold"/>
@@ -177,10 +180,10 @@
 
     <Style x:Key="DarkGridRow" TargetType="DataGridRow">
         <Setter Property="Background" Value="Transparent"/>
-        <Setter Property="Foreground" Value="#E4E6EB"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
-                <Setter Property="Background" Value="#1f232b"/>
+                <Setter Property="Background" Value="{DynamicResource ViewerHoverBrush}"/>
             </Trigger>
         </Style.Triggers>
     </Style>
@@ -188,11 +191,11 @@
     <Style x:Key="DarkGridCell" TargetType="DataGridCell">
         <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="Background" Value="Transparent"/>
-        <Setter Property="Foreground" Value="#E4E6EB"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
         <Style.Triggers>
             <Trigger Property="IsSelected" Value="True">
-                <Setter Property="Background" Value="#2f3542"/>
-                <Setter Property="Foreground" Value="#E4E6EB"/>
+                <Setter Property="Background" Value="{DynamicResource ViewerSelectionBrush}"/>
+                <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
             </Trigger>
         </Style.Triggers>
     </Style>
@@ -205,13 +208,13 @@
         <Setter Property="SelectionMode" Value="Single"/>
         <Setter Property="SelectionUnit" Value="FullRow"/>
         <Setter Property="GridLinesVisibility" Value="Horizontal"/>
-        <Setter Property="HorizontalGridLinesBrush" Value="#2a2d35"/>
-        <Setter Property="Background" Value="#111217"/>
-        <Setter Property="Foreground" Value="#E4E6EB"/>
-        <Setter Property="BorderBrush" Value="#2a2d35"/>
+        <Setter Property="HorizontalGridLinesBrush" Value="{DynamicResource BorderBrush}"/>
+        <Setter Property="Background" Value="{DynamicResource BackgroundDarkBrush}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrush}"/>
         <Setter Property="BorderThickness" Value="1"/>
-        <Setter Property="RowBackground" Value="#111217"/>
-        <Setter Property="AlternatingRowBackground" Value="#16181d"/>
+        <Setter Property="RowBackground" Value="{DynamicResource BackgroundDarkBrush}"/>
+        <Setter Property="AlternatingRowBackground" Value="{DynamicResource ViewerAltRowBrush}"/>
         <Setter Property="ColumnHeaderStyle" Value="{StaticResource DarkGridHeader}"/>
         <Setter Property="RowStyle" Value="{StaticResource DarkGridRow}"/>
         <Setter Property="CellStyle" Value="{StaticResource DarkGridCell}"/>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
@@ -20,7 +20,7 @@
         <Style x:Key="SectionHeader" TargetType="TextBlock">
             <Setter Property="FontSize" Value="14"/>
             <Setter Property="FontWeight" Value="SemiBold"/>
-            <Setter Property="Foreground" Value="#E4E6EB"/>
+            <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
             <Setter Property="Margin" Value="0,0,0,6"/>
         </Style>
 
@@ -38,9 +38,9 @@
         <!-- Dark grid chrome shared by the per-server grids (relocated from MainWindow's
              Window.Resources — same setters, zero visual change). -->
         <Style x:Key="DarkGridHeader" TargetType="DataGridColumnHeader">
-            <Setter Property="Background" Value="#262932"/>
-            <Setter Property="Foreground" Value="#E4E6EB"/>
-            <Setter Property="BorderBrush" Value="#2a2d35"/>
+            <Setter Property="Background" Value="{DynamicResource ViewerGridHeaderBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource BorderBrush}"/>
             <Setter Property="BorderThickness" Value="0,0,1,1"/>
             <Setter Property="Padding" Value="8,5"/>
             <Setter Property="FontWeight" Value="SemiBold"/>
@@ -74,7 +74,7 @@
             <Setter Property="ContextMenu" Value="{StaticResource DataGridContextMenu}"/>
             <Style.Triggers>
                 <Trigger Property="IsMouseOver" Value="True">
-                    <Setter Property="Background" Value="#1f232b"/>
+                    <Setter Property="Background" Value="{DynamicResource ViewerHoverBrush}"/>
                 </Trigger>
             </Style.Triggers>
         </Style>
@@ -82,11 +82,11 @@
         <Style x:Key="DarkGridCell" TargetType="DataGridCell">
             <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="Background" Value="Transparent"/>
-            <Setter Property="Foreground" Value="#E4E6EB"/>
+            <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
             <Style.Triggers>
                 <Trigger Property="IsSelected" Value="True">
-                    <Setter Property="Background" Value="#2f3542"/>
-                    <Setter Property="Foreground" Value="#E4E6EB"/>
+                    <Setter Property="Background" Value="{DynamicResource ViewerSelectionBrush}"/>
+                    <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
                 </Trigger>
             </Style.Triggers>
         </Style>
@@ -99,13 +99,13 @@
             <Setter Property="SelectionMode" Value="Single"/>
             <Setter Property="SelectionUnit" Value="FullRow"/>
             <Setter Property="GridLinesVisibility" Value="Horizontal"/>
-            <Setter Property="HorizontalGridLinesBrush" Value="#2a2d35"/>
-            <Setter Property="Background" Value="#111217"/>
-            <Setter Property="Foreground" Value="#E4E6EB"/>
-            <Setter Property="BorderBrush" Value="#2a2d35"/>
+            <Setter Property="HorizontalGridLinesBrush" Value="{DynamicResource BorderBrush}"/>
+            <Setter Property="Background" Value="{DynamicResource BackgroundDarkBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource ForegroundBrush}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource BorderBrush}"/>
             <Setter Property="BorderThickness" Value="1"/>
-            <Setter Property="RowBackground" Value="#111217"/>
-            <Setter Property="AlternatingRowBackground" Value="#16181d"/>
+            <Setter Property="RowBackground" Value="{DynamicResource BackgroundDarkBrush}"/>
+            <Setter Property="AlternatingRowBackground" Value="{DynamicResource ViewerAltRowBrush}"/>
             <Setter Property="ColumnHeaderStyle" Value="{StaticResource DarkGridHeader}"/>
             <Setter Property="RowStyle" Value="{StaticResource DarkGridRow}"/>
             <Setter Property="CellStyle" Value="{StaticResource DarkGridCell}"/>
@@ -2583,7 +2583,7 @@
 
                 <!-- Toolbar -->
                 <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,6">
-                    <Button Content="Refresh" Click="DailySummaryRefresh_Click" Margin="0,0,10,0" Padding="8,4" MinWidth="60" Style="{StaticResource SuccessButton}"/>
+                    <Button Content="Refresh" Click="DailySummaryRefresh_Click" Margin="0,0,10,0" Padding="8,4" MinWidth="60"/>
                     <TextBlock x:Name="DailySummaryIndicator" Text="Composite daily health - click a day for detail (times in UTC)" VerticalAlignment="Center"
                                FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                 </StackPanel>

--- a/Darling/PerformanceMonitor.Darling.Viewer/WaitDrillDownWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/WaitDrillDownWindow.xaml
@@ -4,8 +4,8 @@
         Title="Wait Drill-Down" Width="1400" Height="700"
         WindowStartupLocation="CenterOwner"
         Icon="EDD.ico"
-        Background="#22252b"
-        Foreground="#E4E6EB">
+        Background="{DynamicResource BackgroundLightBrush}"
+        Foreground="{DynamicResource ForegroundBrush}">
     <!-- Ported from Lite's Windows/WaitDrillDownWindow.xaml (the Wait Stats "Show Queries With <wait>"
          drill-down). Same three classified views (correlated / uncapturable / chain / filtered) driving the
          shared PerformanceMonitor.Ui WaitDrillDownHelper + blocking-chain walker; the read is repointed to
@@ -57,7 +57,7 @@
         <!-- Header -->
         <StackPanel Grid.Row="0" Margin="0,0,0,6">
             <TextBlock x:Name="HeaderText" FontSize="16" FontWeight="Bold"/>
-            <TextBlock x:Name="SummaryText" FontSize="12" Margin="0,4,0,0" Foreground="#B8BCC4"/>
+            <TextBlock x:Name="SummaryText" FontSize="12" Margin="0,4,0,0" Foreground="{DynamicResource ForegroundDimBrush}"/>
         </StackPanel>
 
         <!-- Warning banner (hidden by default) -->

--- a/Lite.Tests/ThemeCompletenessTests.cs
+++ b/Lite.Tests/ThemeCompletenessTests.cs
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// Guards that Lite stays fully theme-able: the Dark, Light, and CoolBreeze dictionaries define the SAME
+/// set of resource keys, and every theme token the Lite XAML references resolves in ALL three. This is the
+/// automated backstop for "Light / CoolBreeze mode has no missing resources" — e.g. the Slicer keys that
+/// once lived only in Dark (#1441) would fail here. Text-parses the XAML (no WPF apartment needed) and
+/// locates the Lite project via <see cref="CallerFilePathAttribute"/>.
+/// </summary>
+public sealed class ThemeCompletenessTests
+{
+    private static readonly string[] ThemeRelativePaths =
+    {
+        "Themes/DarkTheme.xaml",
+        "Themes/LightTheme.xaml",
+        "Themes/CoolBreezeTheme.xaml",
+    };
+
+    private static readonly Regex KeyDefinition =
+        new("x:Key=\"([A-Za-z_][A-Za-z0-9_]*)\"", RegexOptions.Compiled);
+
+    private static readonly Regex ResourceReference =
+        new(@"\{(?:Dynamic|Static)Resource\s+([A-Za-z_][A-Za-z0-9_]*)\s*\}", RegexOptions.Compiled);
+
+    [Fact]
+    public void Light_and_CoolBreeze_define_the_same_keys_as_Dark()
+    {
+        var dark = KeysIn(ThemeRelativePaths[0]);
+        var light = KeysIn(ThemeRelativePaths[1]);
+        var coolBreeze = KeysIn(ThemeRelativePaths[2]);
+
+        Assert.False(dark.Count == 0, "Parsed zero keys from DarkTheme.xaml — the test cannot find the theme files.");
+
+        var missingFromLight = dark.Except(light).OrderBy(k => k, StringComparer.Ordinal).ToList();
+        var extraInLight = light.Except(dark).OrderBy(k => k, StringComparer.Ordinal).ToList();
+        Assert.True(
+            missingFromLight.Count == 0 && extraInLight.Count == 0,
+            $"LightTheme.xaml key set differs from DarkTheme.xaml.\n" +
+            $"  Missing from Light (would render unstyled in Light): {Join(missingFromLight)}\n" +
+            $"  Extra in Light (not in Dark): {Join(extraInLight)}");
+
+        var missingFromCool = dark.Except(coolBreeze).OrderBy(k => k, StringComparer.Ordinal).ToList();
+        var extraInCool = coolBreeze.Except(dark).OrderBy(k => k, StringComparer.Ordinal).ToList();
+        Assert.True(
+            missingFromCool.Count == 0 && extraInCool.Count == 0,
+            $"CoolBreezeTheme.xaml key set differs from DarkTheme.xaml.\n" +
+            $"  Missing from CoolBreeze: {Join(missingFromCool)}\n" +
+            $"  Extra in CoolBreeze: {Join(extraInCool)}");
+    }
+
+    [Fact]
+    public void Every_theme_token_referenced_in_lite_xaml_resolves_in_all_three_themes()
+    {
+        var liteDir = LiteDirectory();
+        var dark = KeysIn(ThemeRelativePaths[0]);
+        var light = KeysIn(ThemeRelativePaths[1]);
+        var coolBreeze = KeysIn(ThemeRelativePaths[2]);
+
+        var offenders = new List<string>();
+        foreach (var xaml in Directory.EnumerateFiles(liteDir, "*.xaml", SearchOption.AllDirectories))
+        {
+            if (xaml.Contains(Path.Combine("obj", ""), StringComparison.OrdinalIgnoreCase) ||
+                xaml.Contains(Path.Combine("bin", ""), StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var text = File.ReadAllText(xaml);
+            foreach (Match m in ResourceReference.Matches(text))
+            {
+                var key = m.Groups[1].Value;
+                if (!dark.Contains(key))
+                {
+                    continue; // not a theme token (local style / system / cross-assembly)
+                }
+
+                if (!light.Contains(key))
+                {
+                    offenders.Add($"{Path.GetFileName(xaml)} references '{key}', which is missing from LightTheme.xaml");
+                }
+                if (!coolBreeze.Contains(key))
+                {
+                    offenders.Add($"{Path.GetFileName(xaml)} references '{key}', which is missing from CoolBreezeTheme.xaml");
+                }
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            "Theme tokens referenced by the Lite XAML do not resolve in every theme:\n  " +
+            string.Join("\n  ", offenders.Distinct()));
+    }
+
+    private static HashSet<string> KeysIn(string relativePath)
+    {
+        var path = Path.Combine(LiteDirectory(), relativePath.Replace('/', Path.DirectorySeparatorChar));
+        var text = File.ReadAllText(path);
+        return KeyDefinition.Matches(text).Select(m => m.Groups[1].Value).ToHashSet(StringComparer.Ordinal);
+    }
+
+    /// <summary>The Lite project directory, resolved from this test file's compile-time path (Lite.Tests is a
+    /// sibling of the Lite project).</summary>
+    private static string LiteDirectory([CallerFilePath] string thisFile = "")
+    {
+        var testDir = Path.GetDirectoryName(thisFile)!;
+        return Path.GetFullPath(Path.Combine(testDir, "..", "Lite"));
+    }
+
+    private static string Join(IReadOnlyCollection<string> keys) =>
+        keys.Count == 0 ? "(none)" : string.Join(", ", keys);
+}

--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -1953,7 +1953,7 @@
 
                     <!-- Toolbar -->
                     <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,6">
-                        <Button Content="Refresh" Click="DailySummaryRefresh_Click" Margin="0,0,10,0" Padding="8,4" MinWidth="60" Style="{StaticResource SuccessButton}"/>
+                        <Button Content="Refresh" Click="DailySummaryRefresh_Click" Margin="0,0,10,0" Padding="8,4" MinWidth="60"/>
                         <TextBlock x:Name="DailySummaryIndicator" Text="Composite daily health - click a day for detail (times in UTC)" VerticalAlignment="Center"
                                    FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                     </StackPanel>

--- a/Lite/MainWindow.xaml
+++ b/Lite/MainWindow.xaml
@@ -293,9 +293,9 @@
                                                 <Border Background="#80000000" CornerRadius="6"
                                                         Visibility="{Binding IsOffline, Converter={StaticResource BoolToVisibility}}">
                                                     <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
-                                                        <TextBlock Text="&#x2717;" FontSize="28" Foreground="#E57373"
+                                                        <TextBlock Text="&#x2717;" FontSize="28" Foreground="{DynamicResource ErrorBrush}"
                                                                    HorizontalAlignment="Center"/>
-                                                        <TextBlock Text="Offline" FontSize="13" Foreground="#E57373"
+                                                        <TextBlock Text="Offline" FontSize="13" Foreground="{DynamicResource ErrorBrush}"
                                                                    FontWeight="SemiBold" HorizontalAlignment="Center" Margin="0,4,0,0"/>
                                                     </StackPanel>
                                                 </Border>

--- a/Lite/Themes/CoolBreezeTheme.xaml
+++ b/Lite/Themes/CoolBreezeTheme.xaml
@@ -23,7 +23,10 @@
     <!-- Text Colors (dark on light backgrounds) -->
     <Color x:Key="ForegroundColor">#1A2A3A</Color>
     <Color x:Key="ForegroundDimColor">#1A2A3A</Color>
-    <Color x:Key="ForegroundMutedColor">#5B7A90</Color>
+    <!-- Muted (tertiary) text. #1441: the old #5B7A90 was only 2.87:1 on the light-blue wells and
+         failed WCAG AA. #4A5D72 is ~6.5:1 on #EEF4FA — a readable secondary tone that keeps the
+         cool blue character while reading quieter than primary, mirroring the Dark muted tier. -->
+    <Color x:Key="ForegroundMutedColor">#4A5D72</Color>
 
     <!-- Border Colors (subtle, low-contrast) -->
     <Color x:Key="BorderColor">#A8BDD0</Color>
@@ -60,7 +63,9 @@
 
     <SolidColorBrush x:Key="ForegroundBrush" Color="{StaticResource ForegroundColor}"/>
     <SolidColorBrush x:Key="ForegroundDimBrush" Color="{StaticResource ForegroundDimColor}"/>
-    <SolidColorBrush x:Key="ForegroundMutedBrush" Color="{StaticResource ForegroundColor}"/>
+    <!-- #1441: use the (now readable) muted color so CoolBreeze has a real 3-tier text hierarchy
+         like Dark, instead of collapsing muted onto the primary foreground. -->
+    <SolidColorBrush x:Key="ForegroundMutedBrush" Color="{StaticResource ForegroundMutedColor}"/>
 
     <SolidColorBrush x:Key="BorderBrush" Color="{StaticResource BorderColor}"/>
     <SolidColorBrush x:Key="BorderLightBrush" Color="{StaticResource BorderLightColor}"/>
@@ -1276,6 +1281,18 @@
         <Setter Property="Padding" Value="10,8"/>
     </Style>
 
+
+    <!-- Time Range Slicer (cool-breeze values; #1441 completeness — these 10 keys existed only in Dark) -->
+    <SolidColorBrush x:Key="SlicerBackgroundBrush" Color="{StaticResource BackgroundDarkColor}"/>
+    <SolidColorBrush x:Key="SlicerChartLineBrush" Color="{StaticResource AccentColor}"/>
+    <SolidColorBrush x:Key="SlicerChartFillBrush" Color="#331E6FA8"/>
+    <SolidColorBrush x:Key="SlicerOverlayBrush" Color="#40000000"/>
+    <SolidColorBrush x:Key="SlicerSelectedBrush" Color="#221E6FA8"/>
+    <SolidColorBrush x:Key="SlicerHandleBrush" Color="{StaticResource ForegroundColor}"/>
+    <SolidColorBrush x:Key="SlicerHandleHoverBrush" Color="{StaticResource AccentColor}"/>
+    <SolidColorBrush x:Key="SlicerBorderBrush" Color="{StaticResource BorderColor}"/>
+    <SolidColorBrush x:Key="SlicerLabelBrush" Color="{StaticResource ForegroundColor}"/>
+    <SolidColorBrush x:Key="SlicerToggleBrush" Color="{StaticResource ForegroundColor}"/>
 
     <!-- ============================================ -->
     <!-- Plan Viewer Resources                        -->

--- a/Lite/Windows/SettingsWindow.xaml
+++ b/Lite/Windows/SettingsWindow.xaml
@@ -500,7 +500,7 @@
                     <Run Foreground="#16A34A" FontWeight="Bold" Text="&#x25A0; Green" /> — Resolved (Server Restored)
                 </TextBlock>
                 <TextBlock TextWrapping="Wrap" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}">
-                    <Run Foreground="#2eaef1" FontWeight="Bold" Text="&#x25A0; Blue" /> — Info
+                    <Run Foreground="{DynamicResource InfoBrush}" FontWeight="Bold" Text="&#x25A0; Blue" /> — Info
                 </TextBlock>
             </StackPanel>
         </Border>


### PR DESCRIPTION
## Summary

Makes the Darling viewer fully theme-able. It previously only looked right in **Dark** because ~200 hardcoded dark hexes across the XAML didn't respond to the theme, the write-back windows pulled in a hardcoded-dark dictionary, and the theme selector was a disabled dark-only placeholder. This converts chrome hexes to theme tokens, adds the viewer's Light + CoolBreeze dictionaries, wires a real theme selector, and folds in the three consistency items. Cross-app changes are mirrored in **Lite**; the deprecated Dashboard is untouched.

## The invariant held

For every hex replaced with `{DynamicResource X}`, token X's **dark** value equals the removed hex, so **Dark is pixel-identical**. Verified by grep against `Themes/DarkTheme.xaml` and by the new completeness tests. The only *deliberate* dark changes (all requested / consistency-driven, called out for your visual pass):

- **`#8B93A1` -> `ForegroundMutedBrush` (dark `#A8AEBA`)** — the #1441 readability fix (item 4b). Affects dim labels app-wide + `DimTextBrush` + combo arrows.
- **`#B8BCC4` -> `ForegroundDimBrush` (dark `#C7CBD4`)** — 4 history-window `SummaryText` sub-headers. Stray hardcode; Lite's equivalent already uses `ForegroundDimBrush`, so this restores parity and makes it theme-aware.
- **`#E0A030` -> `WarningTextBrush` (dark `#FFB347`)** — the 3 read-only banners. Uses the purpose-built legible-warning token so the banner is readable in Light too.

## What changed (6 reviewable commits)

1. **Theme dicts** — new viewer `LightTheme.xaml` + `CoolBreezeTheme.xaml` (seeded from Lite's, which share the byte-identical Dark dict); 8 new chrome tokens for the secondary write-back surfaces (`CardBorderBrush`, `ViewerSelectionBrush`, `ViewerHoverBrush`, `ViewerGridHeaderBrush`, `ViewerAltRowBrush`, `ViewerButtonBorderBrush`, `ViewerDisabledBgBrush`, `ViewerDisabledTextBrush`); **#1441** muted-tone fix (Light `#718096`=3.38:1, CoolBreeze `#5B7A90`=2.87:1 -> `#5A6472` / `#4A5D72`, both >=4.5:1) + un-collapsed `ForegroundMutedBrush` for a real 3-tier hierarchy in Light/CoolBreeze; added the 10 `Slicer*` keys that existed only in Dark. All three viewer dicts now define identical 97-key sets.
2. **ViewerDarkTheme.xaml theme-aware** — the 11 write-back/dialog windows merged this hardcoded-dark dict (not swapped by ThemeManager = the root cause of their staying dark). Rewrote its styles to `{DynamicResource}` the app-wide tokens (as Lite themes its equivalents). `DarkGrid*` + `ViewerButton` names unchanged (60+ by-key refs intact); dropped 6 unused local aliases.
3. **Theme selector** — `ViewerAppSettings.ColorTheme` + startup apply (no flash of Dark); enabled Dark/Light/CoolBreeze combo in Settings with live preview, Save-persists, Cancel/close reverts.
4. **Viewer chrome hex -> token conversions** (~180 across MainWindow, ViewerServerTab, FinOpsTab, AlertDetailWindow, and the dialogs/history/mute/log windows) **+ Refresh unification**.
5. **Lite parity** — offline indicator -> `ErrorBrush`, Info legend swatch -> `InfoBrush`, Daily Summary Refresh de-styled.
6. **Theme-completeness tests** (viewer + Lite).

**Rough counts:** ~180 chrome hexes tokenized in viewer XAML + ~30 in ViewerDarkTheme (~210 total); 8 new tokens added (+10 Slicer keys back-filled into Light/CoolBreeze); ~90 hexes deliberately kept as data-viz/semantic.

## Refresh button — chosen style

Unified every `"Refresh"` button to the **theme default `Button`** (was a mix of gray-default / green `SuccessButton` / bordered `DarkButton`). Refresh now reads as the neutral utility action everywhere; `Accent`/`Success` stay reserved for genuinely distinct primary actions. Applied in both apps.

## Deliberately LEFT hardcoded (data-viz / semantic identity; Lite keeps these too)

- FinOps cost palette `#27AE60` / `#E74C3C` / `#F39C12` / `#3498DB`, and the `#1AFFFFFF` bar-track overlay.
- Neutral offline-band gray `#888888`; dark-on-bright badge text `#1A1A1A`; alert-badge fills `#D97706` / `#DC2626`; filter-active gold `#FFD700`; modal scrim `#80000000`.
- All translucent 8-digit ARGB overlays (`#33FF6B6B`, `#2244AAFF`, `#33DC2626`, ...).
- Severity legend swatches in Settings that *document* the constant badge colors (kept, except the "Info" swatch which uses the themed `InfoBrush`).
- FinOps status badges set from code-behind (`Background="Gray"` / `Foreground="White"`) — named colors, out of scope.

## Verification

- **Build both apps `-c Release` — 0 errors** (viewer + Lite).
- **Darling.Tests** green (1656 passed; one unrelated flake re-ran green). **Lite.Tests** green (936 passed).
- **New completeness tests (2 per app) pass**: (a) Dark/Light/CoolBreeze define identical key sets; (b) every theme token referenced in the app XAML resolves in all three themes. This is the automated guard that Light has no missing resources.

## For your visual pass (couldn't screenshot-verify)

- Overall **Light + CoolBreeze** look across all tabs, and the **write-back windows** (mute rules, history popups, collection log) now that they theme.
- The **8 new chrome tokens'** Light/CoolBreeze *values* I picked, and the new **Slicer** control values.
- The **muted-tier** change: Light/CoolBreeze secondary text is now the readable muted tone (was collapsed onto primary) — confirm the hierarchy reads well.
- **Charts** on Light/CoolBreeze and on a live theme switch (ChartStyle reads `CurrentTheme`; ThemeChanged repaints) — confirm chart chrome flips and ScottPlot series still read on light backgrounds.
- The three small dark shifts listed under "the invariant held".
- Kept data-viz colors (`#888888`, the saturated FinOps palette) on light backgrounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
