### PR TITLE
Pin NuGet source to nuget.org (supply-chain hardening)

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Supply-chain hardening (security audit LOW-2): pin the ONLY package source to nuget.org and
+  map every package to it. This closes the dependency-substitution / dependency-confusion gap so
+  a restore can never silently pull a package (e.g. the tray dependency Hardcodet.NotifyIcon.Wpf)
+  from a machine-configured or injected feed. Combined with the committed packages.lock.json
+  (contentHash) + CI locked-mode restores, package identity is now pinned by both source and content.
+-->
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>


### PR DESCRIPTION
Security-audit LOW-2 hardening. Adds a repo-root `nuget.config` that clears inherited sources, pins the sole package source to nuget.org, and maps every package pattern to it (`packageSourceMapping`). Closes the theoretical dependency-substitution / dependency-confusion gap for the campaign's new dependency (Hardcodet.NotifyIcon.Wpf) and every other package. Config-only; verified a `--locked-mode` restore of the viewer dependency graph resolves cleanly under the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)