### PR TITLE
Fix spinlock_stats InvalidCast on SQL 2016/2017 (backoffs int->bigint)

### DIFF
--- a/Lite.Tests/SpinlockStatsCollectorDefinitionTests.cs
+++ b/Lite.Tests/SpinlockStatsCollectorDefinitionTests.cs
@@ -32,7 +32,11 @@ SELECT
     spins = ss.spins,
     spins_per_collision = ss.spins_per_collision,
     sleep_time = ss.sleep_time,
-    backoffs = ss.backoffs
+    /* backoffs is int in sys.dm_os_spinlock_stats on SQL 2016/2017 and was widened to bigint on
+       2019+. CONVERT so the wire type is always bigint and ReadAsync's GetInt64 doesn't throw an
+       Int32->Int64 InvalidCast on the older versions (collisions/spins/sleep_time are bigint on
+       every supported version, so they need no cast). */
+    backoffs = CONVERT(bigint, ss.backoffs)
 FROM sys.dm_os_spinlock_stats AS ss
 WHERE ss.collisions > 0
 OR    ss.spins > 0

--- a/PerformanceMonitor.Collectors/SpinlockStatsCollector.cs
+++ b/PerformanceMonitor.Collectors/SpinlockStatsCollector.cs
@@ -45,7 +45,11 @@ SELECT
     spins = ss.spins,
     spins_per_collision = ss.spins_per_collision,
     sleep_time = ss.sleep_time,
-    backoffs = ss.backoffs
+    /* backoffs is int in sys.dm_os_spinlock_stats on SQL 2016/2017 and was widened to bigint on
+       2019+. CONVERT so the wire type is always bigint and ReadAsync's GetInt64 doesn't throw an
+       Int32->Int64 InvalidCast on the older versions (collisions/spins/sleep_time are bigint on
+       every supported version, so they need no cast). */
+    backoffs = CONVERT(bigint, ss.backoffs)
 FROM sys.dm_os_spinlock_stats AS ss
 WHERE ss.collisions > 0
 OR    ss.spins > 0


### PR DESCRIPTION
**Found via post-campaign functional validation.** `spinlock_stats` was failing every cycle on SQL2016 + SQL2017 (14 ERRORs/15min each) while 2019/2022/2025 were clean. Root cause: `sys.dm_os_spinlock_stats.backoffs` is `int` on 2016/2017 and `bigint` on 2019+ (confirmed against live SQL2016 vs SQL2022), but `ReadAsync` reads it with `GetInt64` -> `Unable to cast Int32 to Int64`, failing the whole collector on the older SKUs (so their Latches & Spinlocks tab is empty).

Fix: `CONVERT(bigint, ss.backoffs)` in the query so the wire type is deterministic. Shared collector, so this fixes **both Lite and Darling**. Verbatim-pin test updated; spinlock tests green in both suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)