### PR TITLE
Fix io_latency baseline decimal overflow (ratio -> double)

### DIFF
--- a/Darling/Darling.Tests/DarlingAnomalyBaselineTests.cs
+++ b/Darling/Darling.Tests/DarlingAnomalyBaselineTests.cs
@@ -96,6 +96,17 @@ public sealed class DarlingAnomalyBaselineTests
     private static IEnumerable<string> AllAnalysisSql =>
         AllDetectorSql.Concat(AllMetricNames.Select(m => PgBaselineProvider.GetBaselineQuery(m)!));
 
+    [Fact]
+    public void IoLatencyBaseline_CastsRatioToDoublePrecision_NotNumeric()
+    {
+        /* The stall/reads ratio must be DOUBLE PRECISION, not numeric (`* 1.0`): STDDEV_SAMP of a
+           spurious-large ratio yields a numeric that overflows System.Decimal when Npgsql materializes
+           the aggregate, silently failing the io_latency baseline (found live via the error monitor). */
+        var sql = PgBaselineProvider.GetBaselineQuery(MetricNames.IoLatency)!;
+        Assert.Contains("delta_stall_read_ms::DOUBLE PRECISION", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("delta_stall_read_ms * 1.0", sql, StringComparison.Ordinal);
+    }
+
     /* ---------------- ungated: method-surface pins vs Lite ---------------- */
 
     [Fact]

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgBaselineProvider.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgBaselineProvider.cs
@@ -394,12 +394,15 @@ FROM with_lag
 WHERE NOT (total_elapsed = 0 AND prior_total_elapsed > 100000)
 GROUP BY hour_of_day, day_of_week",
 
-            // Point-in-time metric — no restart exclusion needed
+            // Point-in-time metric — no restart exclusion needed. The stall/reads ratio is cast to
+            // DOUBLE PRECISION (as the memory / wait-rate metrics are) so a spurious large delta can't
+            // make STDDEV_SAMP produce a numeric that overflows System.Decimal when Npgsql materializes
+            // the aggregate (it does with `* 1.0`, which yields numeric, not float8).
             MetricNames.IoLatency => @"
 SELECT EXTRACT(HOUR FROM collection_time)::INT AS hour_of_day,
        EXTRACT(DOW FROM collection_time)::INT AS day_of_week,
-       AVG(delta_stall_read_ms * 1.0 / NULLIF(delta_reads, 0)) AS mean_val,
-       STDDEV_SAMP(delta_stall_read_ms * 1.0 / NULLIF(delta_reads, 0)) AS stddev_val,
+       AVG(delta_stall_read_ms::DOUBLE PRECISION / NULLIF(delta_reads, 0)) AS mean_val,
+       STDDEV_SAMP(delta_stall_read_ms::DOUBLE PRECISION / NULLIF(delta_reads, 0)) AS stddev_val,
        COUNT(*) AS sample_count
 FROM v_file_io_stats
 WHERE server_id = $1 AND collection_time >= $2 AND collection_time < $3


### PR DESCRIPTION
**Found live via the error monitor** (not a green-collection_log surface). Each analysis pass logged `[PgBaselineProvider] Failed to compute baselines for io_latency: Numeric value does not fit in a System.Decimal`, so io_latency anomaly baselining was silently failing.

Root cause: the io_latency baseline computed `AVG/STDDEV_SAMP(delta_stall_read_ms * 1.0 / NULLIF(delta_reads,0))` as Postgres `numeric`; `STDDEV_SAMP` squares deviations, so a spurious-large stall/reads ratio exceeds .NET `decimal` range when Npgsql materializes it. Every sibling ratio/rate metric (memory, wait-rate, blocking) already casts to `::DOUBLE PRECISION`; io_latency was the lone hold-out. Cast it to double (float8, no decimal path). Regression pin added; baseline tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)