### PR TITLE
Fix truncated plan_handle/sql_handle in shared collectors (varchar 64 -> 130)

### DIFF
--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingStoredPlanReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingStoredPlanReader.cs
@@ -61,7 +61,7 @@ internal static class DarlingStoredPlanReader
     /// <summary>
     /// The latest captured procedure_stats plan for a procedure, keyed by (server, sql_handle) — the
     /// Dashboard's GetProcedurePlanXmlBySqlHandleAsync key. procedure_stats carries sql_handle as the
-    /// '0x...' hex string the collector stamps (CONVERT(varchar(64), ..., 1)), so the match is a direct
+    /// '0x...' hex string the collector stamps (CONVERT(varchar(130), ..., 1)), so the match is a direct
     /// text compare (no varbinary CONVERT the SQL-Server side needs). $1 server_id, $2 sql_handle.
     /// </summary>
     public const string ProcedurePlanXmlBySqlHandleSql = """

--- a/Lite.Tests/ProcedureStatsCollectorDefinitionTests.cs
+++ b/Lite.Tests/ProcedureStatsCollectorDefinitionTests.cs
@@ -77,6 +77,26 @@ public sealed class ProcedureStatsCollectorDefinitionTests
     }
 
     [Fact]
+    public void BuildQuery_HandlesConvertToVarchar130_NeverTruncated()
+    {
+        /* plan_handle/sql_handle are varbinary(64); style-1 hex is '0x' + 128 = 130 chars. The old
+           CONVERT(varchar(64), ...) truncated the handle to ~31 bytes, so dm_exec_query_plan rejected the
+           stored value and Fetch Live Plan failed for every procedure/trigger/function row. Guards every
+           UNION branch in the standard body and the single-proc Azure variant. */
+        foreach (var text in new[]
+        {
+            Collapse(ProcedureStatsCollector.Instance.BuildQuery(CollectorTestContext.Make(s_deltas)).Text),
+            Collapse(ProcedureStatsCollector.Instance.BuildQuery(CollectorTestContext.Make(s_deltas, isAzureSqlDb: true)).Text),
+        })
+        {
+            Assert.Contains("sql_handle=CONVERT(varchar(130),s.sql_handle,1)", text, StringComparison.Ordinal);
+            Assert.Contains("plan_handle=CONVERT(varchar(130),s.plan_handle,1)", text, StringComparison.Ordinal);
+            Assert.DoesNotContain("CONVERT(varchar(64),s.sql_handle,1)", text, StringComparison.Ordinal);
+            Assert.DoesNotContain("CONVERT(varchar(64),s.plan_handle,1)", text, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
     public void PayloadColumns_MatchSchema_35Columns()
     {
         var names = ProcedureStatsCollector.Instance.PayloadColumns.Select(c => c.Name).ToArray();

--- a/Lite.Tests/QueryStatsCollectorDefinitionTests.cs
+++ b/Lite.Tests/QueryStatsCollectorDefinitionTests.cs
@@ -150,6 +150,29 @@ public sealed class QueryStatsCollectorDefinitionTests
         };
 
     [Fact]
+    public void BuildQuery_HandlesConvertToVarchar130_HashesStayVarchar64()
+    {
+        /* plan_handle/sql_handle are varbinary(64); style-1 hex is '0x' + 128 = 130 chars. The old
+           CONVERT(varchar(64), ...) truncated the handle to ~31 bytes, so dm_exec_query_plan rejected the
+           stored value and Fetch Live Plan failed for every query-grid row (and the by-sql_handle path).
+           query_hash/query_plan_hash are binary(8) (18 chars) and correctly stay varchar(64). Both the
+           on-prem and Azure builds share SelectColumnsText, so this guards both. */
+        foreach (var text in new[]
+        {
+            Collapse(QueryStatsCollector.Instance.BuildQuery(MakeContext()).Text),
+            Collapse(QueryStatsCollector.Instance.BuildQuery(MakeContext(isAzureSqlDb: true)).Text),
+        })
+        {
+            Assert.Contains("sql_handle=CONVERT(varchar(130),qs.sql_handle,1)", text, StringComparison.Ordinal);
+            Assert.Contains("plan_handle=CONVERT(varchar(130),qs.plan_handle,1)", text, StringComparison.Ordinal);
+            Assert.DoesNotContain("CONVERT(varchar(64),qs.sql_handle,1)", text, StringComparison.Ordinal);
+            Assert.DoesNotContain("CONVERT(varchar(64),qs.plan_handle,1)", text, StringComparison.Ordinal);
+            Assert.Contains("query_hash=CONVERT(varchar(64),qs.query_hash,1)", text, StringComparison.Ordinal);
+            Assert.Contains("query_plan_hash=CONVERT(varchar(64),qs.query_plan_hash,1)", text, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
     public void PayloadColumns_MatchSchemaOrder_50Columns()
     {
         var names = QueryStatsCollector.Instance.PayloadColumns.Select(c => c.Name).ToArray();

--- a/PerformanceMonitor.Collectors/ProcedureStatsCollector.cs
+++ b/PerformanceMonitor.Collectors/ProcedureStatsCollector.cs
@@ -95,8 +95,8 @@ SELECT
     min_logical_writes = s.min_logical_writes,
     max_logical_writes = s.max_logical_writes,
     ' AS nvarchar(max)) + @spills_cols + N'
-    sql_handle = CONVERT(varchar(64), s.sql_handle, 1),
-    plan_handle = CONVERT(varchar(64), s.plan_handle, 1)/*PLAN_SELECT*/
+    sql_handle = CONVERT(varchar(130), s.sql_handle, 1),
+    plan_handle = CONVERT(varchar(130), s.plan_handle, 1)/*PLAN_SELECT*/
 FROM sys.dm_exec_procedure_stats AS s/*PLAN_APPLY*/
 CROSS APPLY
 (
@@ -150,8 +150,8 @@ SELECT
     min_logical_writes = s.min_logical_writes,
     max_logical_writes = s.max_logical_writes,
     ' + @spills_cols + CAST(N'
-    sql_handle = CONVERT(varchar(64), s.sql_handle, 1),
-    plan_handle = CONVERT(varchar(64), s.plan_handle, 1)/*PLAN_SELECT*/
+    sql_handle = CONVERT(varchar(130), s.sql_handle, 1),
+    plan_handle = CONVERT(varchar(130), s.plan_handle, 1)/*PLAN_SELECT*/
 FROM sys.dm_exec_trigger_stats AS s/*PLAN_APPLY*/
 CROSS APPLY sys.dm_exec_sql_text(s.sql_handle) AS st
 CROSS APPLY
@@ -194,8 +194,8 @@ SELECT
     min_logical_writes = s.min_logical_writes,
     max_logical_writes = s.max_logical_writes,
     ' AS nvarchar(max)) + @fn_spills_cols + CAST(N'
-    sql_handle = CONVERT(varchar(64), s.sql_handle, 1),
-    plan_handle = CONVERT(varchar(64), s.plan_handle, 1)/*PLAN_SELECT*/
+    sql_handle = CONVERT(varchar(130), s.sql_handle, 1),
+    plan_handle = CONVERT(varchar(130), s.plan_handle, 1)/*PLAN_SELECT*/
 FROM sys.dm_exec_function_stats AS s/*PLAN_APPLY*/
 CROSS APPLY
 (
@@ -245,8 +245,8 @@ SELECT /* PerformanceMonitorLite */ TOP (150)
     total_spills = ISNULL(s.total_spills, 0),
     min_spills = ISNULL(s.min_spills, 0),
     max_spills = ISNULL(s.max_spills, 0),
-    sql_handle = CONVERT(varchar(64), s.sql_handle, 1),
-    plan_handle = CONVERT(varchar(64), s.plan_handle, 1)/*PLAN_SELECT*/
+    sql_handle = CONVERT(varchar(130), s.sql_handle, 1),
+    plan_handle = CONVERT(varchar(130), s.plan_handle, 1)/*PLAN_SELECT*/
 FROM sys.dm_exec_procedure_stats AS s/*PLAN_APPLY*/
 WHERE s.database_id = DB_ID()
 AND   s.last_execution_time >= DATEADD(MINUTE, -10, GETDATE())

--- a/PerformanceMonitor.Collectors/QueryStatsCollector.cs
+++ b/PerformanceMonitor.Collectors/QueryStatsCollector.cs
@@ -117,8 +117,8 @@ public sealed class QueryStatsCollector : CollectorDefinitionBase<QueryStatsColl
     max_used_threads = qs.max_used_threads,
     min_spills = qs.min_spills,
     max_spills = qs.max_spills,
-    sql_handle = CONVERT(varchar(64), qs.sql_handle, 1),
-    plan_handle = CONVERT(varchar(64), qs.plan_handle, 1),
+    sql_handle = CONVERT(varchar(130), qs.sql_handle, 1),
+    plan_handle = CONVERT(varchar(130), qs.plan_handle, 1),
     query_text =
         CASE
             WHEN qs.statement_start_offset = 0


### PR DESCRIPTION
## The bug (live-caught)

"Fetch Live Plan" failed for **every** query because the captured `plan_handle` / `sql_handle` values were **truncated** at collection time.

`plan_handle` and `sql_handle` are SQL Server `varbinary(64)` (64 bytes). Converting one to a hex string with style `1` yields `0x` + 128 hex chars = **130 characters**. The shared collectors did `CONVERT(varchar(64), <handle>, 1)`, which silently truncates the 130-char handle to 64 chars (~31 bytes). The truncated string is then rejected downstream by `sys.dm_exec_query_plan` -- *"The handle that was passed to dm_exec_query_plan was invalid"* -- so the on-demand plan fetch failed for every row. Confirmed live: stored handles were exactly 64 chars.

The math: `130 = "0x" (2) + 64 bytes x 2 hex/byte (128)`. It is the exact maximum, and holds shorter handles fine.

## The fix

Widen the **10 handle conversions** from `varchar(64)` to `varchar(130)`:

- `PerformanceMonitor.Collectors/QueryStatsCollector.cs` -- `sql_handle` + `plan_handle` (the single `SelectColumnsText`, shared by the on-prem and Azure builds).
- `PerformanceMonitor.Collectors/ProcedureStatsCollector.cs` -- `sql_handle` + `plan_handle` in all **four** variants: procedure, trigger, function, and the Azure single-database query.

These collectors are **shared by Lite and Darling**, so this one change fixes Fetch Live Plan across the query grids in **both apps**, plus the by-`sql_handle` **deadlock** and **blocked-process** plan lookups.

The fetch side was already correct -- it does `CONVERT(varbinary(64), @plan_handle, 1)` to reconstruct the 64-byte binary handle for `dm_exec_query_plan`; it just needed the full 130-char string to reconstruct from. `130` is also the width the **Dashboard's own SQL already uses everywhere** it stringifies a handle (`DatabaseService.QueryPerformance.History.cs`, `SqlServerDrillDownCollector.*.cs`, `install/46_create_query_plan_views.sql`), so this brings the shared collectors in line with the proven-correct pattern.

## Deliberately NOT changed

Every other `varchar(64)` is a non-handle and was left alone:

- `query_hash` / `query_plan_hash` in `QueryStatsCollector` and `QueryStoreCollector` -- these are `binary(8)` (18 hex chars), no truncation.
- `FetchQueryPlanOnDemandAsync`'s `query_hash` compare in `LocalDataService.QueryStats.cs` -- also `query_hash`, not a handle.
- The fetch-side `CONVERT(varbinary(64), @plan_handle, 1)` -- correct as-is (a full handle is 64 bytes).
- Install-script column definitions (`finding_fact_key`, `lock_mode`, `incident_id`) -- unrelated `varchar(64)` columns.

Also corrected a now-stale doc comment in `DarlingStoredPlanReader.cs` that quoted the old `varchar(64)` width.

## Tests

No existing pin test asserted the handle-conversion width, so the fix had zero regression coverage. Added two pin tests in `Lite.Tests` that assert **every** handle converts with `varchar(130)` (guarding both apps' shared collectors, every branch + Azure) and that the `binary(8)` hashes correctly stay `varchar(64)`.

- **Lite.Tests (Release):** 940 passed, 0 failed.
- **Darling.Tests (Release):** 1657 passed, 0 failed, 126 skipped (live-Postgres integration tests).
- Lite app, Darling Viewer, and Darling Service all build clean in Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
