### PR TITLE
Performance Calendar: rich day-detail panel with drill-in

### DIFF
--- a/Darling/Darling.Tests/DailyHealthBandTests.cs
+++ b/Darling/Darling.Tests/DailyHealthBandTests.cs
@@ -6,6 +6,7 @@
  * Licensed under the MIT License. See LICENSE file in the project root for full license information.
  */
 
+using System;
 using PerformanceMonitor.Common;
 using Xunit;
 
@@ -131,5 +132,99 @@ public class DailyHealthBandTests
         Assert.Contains("1 severe memory-pressure event", described);
         Assert.Contains("2 memory-pressure events", described);
         Assert.DoesNotContain("3 memory-pressure events", described);
+    }
+
+    // ── Day-detail panel logic (the click-a-day panel's reasons / drills / window / metrics line) ──
+
+    [Fact]
+    public void BuildReasons_TerminalMessages_ForNoData_AndQuietDay()
+    {
+        // No-Data uses the day-detail phrasing (distinct from the tooltip's "No data collected.").
+        Assert.Equal(new[] { "No collection this day." }, DailyHealthBandCalculator.BuildReasons(Signals(hasData: false)));
+        Assert.Equal(new[] { "No issues detected." }, DailyHealthBandCalculator.BuildReasons(Signals()));
+    }
+
+    [Fact]
+    public void BuildReasons_ListsEachNonZeroSignal()
+    {
+        var reasons = DailyHealthBandCalculator.BuildReasons(
+            Signals(deadlocks: 2, collectionErrors: 1, highCpu: 4, blocking: 3, memPressure: 5, memCritical: 2, alerts: 1));
+        Assert.Contains("2 deadlocks", reasons);
+        Assert.Contains("1 collection error", reasons);
+        Assert.Contains("4 high-CPU samples", reasons);
+        Assert.Contains("3 blocking events", reasons);
+        Assert.Contains("2 severe memory-pressure events", reasons);
+        Assert.Contains("3 memory-pressure events", reasons); // 5 total - 2 severe, not double-counted
+        Assert.Contains("1 alert", reasons);
+    }
+
+    [Theory]
+    [InlineData(800, "4 blocking events (peak block 800 ms)")]
+    [InlineData(12500, "4 blocking events (peak block 12.5 s)")]
+    [InlineData(150000, "4 blocking events (peak block 2.5 min)")]
+    public void BuildReasons_BlockingLine_CarriesPeakBlock_WhenProvided(long peakMs, string expected)
+    {
+        Assert.Contains(expected, DailyHealthBandCalculator.BuildReasons(Signals(blocking: 4), peakMs));
+    }
+
+    [Fact]
+    public void BuildReasons_BlockingLine_OmitsPeak_WhenZero()
+    {
+        var reasons = DailyHealthBandCalculator.BuildReasons(Signals(blocking: 4), peakBlockMs: 0);
+        Assert.Contains("4 blocking events", reasons);
+        Assert.DoesNotContain(reasons, r => r.Contains("peak block", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void AvailableDrills_NoData_OffersNothing()
+    {
+        Assert.Empty(DailyHealthBandCalculator.AvailableDrills(Signals(hasData: false)));
+    }
+
+    [Fact]
+    public void AvailableDrills_CollectedDay_AlwaysOffersExpensiveQueries()
+    {
+        Assert.Equal(new[] { DayDrillTarget.ExpensiveQueries }, DailyHealthBandCalculator.AvailableDrills(Signals()));
+    }
+
+    [Fact]
+    public void AvailableDrills_AddsDeadlocks_And_Blocking_OnlyWhenPresent_InPanelOrder()
+    {
+        Assert.Equal(
+            new[] { DayDrillTarget.Deadlocks, DayDrillTarget.Blocking, DayDrillTarget.ExpensiveQueries },
+            DailyHealthBandCalculator.AvailableDrills(Signals(deadlocks: 1, blocking: 2)));
+        Assert.Equal(
+            new[] { DayDrillTarget.Deadlocks, DayDrillTarget.ExpensiveQueries },
+            DailyHealthBandCalculator.AvailableDrills(Signals(deadlocks: 3)));
+        Assert.Equal(
+            new[] { DayDrillTarget.Blocking, DayDrillTarget.ExpensiveQueries },
+            DailyHealthBandCalculator.AvailableDrills(Signals(blocking: 7)));
+    }
+
+    [Fact]
+    public void DayWindowUtc_IsClickedDay_MidnightToNextMidnight()
+    {
+        var (start, end) = DailyHealthBandCalculator.DayWindowUtc(new DateTime(2026, 7, 8, 14, 37, 12));
+        Assert.Equal(new DateTime(2026, 7, 8), start); // time component dropped
+        Assert.Equal(new DateTime(2026, 7, 9), end);
+        Assert.Equal(TimeSpan.FromDays(1), end - start);
+    }
+
+    [Fact]
+    public void BuildKeyMetricsLine_RendersRollup()
+    {
+        var line = DailyHealthBandCalculator.BuildKeyMetricsLine("CXPACKET", 4, 150m, 87);
+        Assert.Contains("Top wait: CXPACKET", line);
+        Assert.Contains("High-CPU samples: 4", line);
+        Assert.Contains("Total wait: 150.0 s", line);
+        Assert.Contains("Unique queries: 87", line);
+    }
+
+    [Fact]
+    public void BuildKeyMetricsLine_NoWait_ShowsNone_And_LargeWaitInMinutes()
+    {
+        var line = DailyHealthBandCalculator.BuildKeyMetricsLine(null, 0, 1200m, 0);
+        Assert.Contains("Top wait: none", line);
+        Assert.Contains("Total wait: 20.0 min", line); // 1200s / 60
     }
 }

--- a/Darling/Darling.Tests/ViewerDailyHealthTests.cs
+++ b/Darling/Darling.Tests/ViewerDailyHealthTests.cs
@@ -53,6 +53,11 @@ public sealed class ViewerDailySummarySqlTests
         Assert.Contains("FROM v_blocked_process_reports", sql, StringComparison.Ordinal);
         Assert.Contains("FROM v_dmv_blocking_snapshots", sql, StringComparison.Ordinal);
 
+        /* Peak block wait (ms) for the day-detail blocking reason: MAX(wait_time_ms) per source, taken from
+           the SAME source the count came from (BPR preferred, DMV fallback) so it reconciles with the count. */
+        Assert.Contains("MAX(wait_time_ms) AS max_wait_ms", sql, StringComparison.Ordinal);
+        Assert.Contains("CASE WHEN COALESCE(b.c, 0) > 0 THEN b.max_wait_ms ELSE dm.max_wait_ms END", sql, StringComparison.Ordinal);
+
         /* High-CPU count uses total host CPU = SQL + other-process (Linux NULL → 0), threshold 80, via FILTER. */
         Assert.Contains("(sqlserver_cpu_utilization + COALESCE(other_process_cpu_utilization, 0)) >= 80", sql, StringComparison.Ordinal);
         Assert.Contains("FROM v_cpu_utilization_stats", sql, StringComparison.Ordinal);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.DailySummary.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.DailySummary.cs
@@ -72,13 +72,13 @@ public sealed partial class ViewerDataService
             GROUP BY 1
         ),
         bpr AS (
-            SELECT date_trunc('day', collection_time) AS d, COUNT(*) AS c
+            SELECT date_trunc('day', collection_time) AS d, COUNT(*) AS c, MAX(wait_time_ms) AS max_wait_ms
             FROM v_blocked_process_reports
             WHERE server_id = $1 AND collection_time >= $2 AND collection_time < $3
             GROUP BY 1
         ),
         dmv AS (
-            SELECT date_trunc('day', collection_time) AS d, COUNT(*) AS c
+            SELECT date_trunc('day', collection_time) AS d, COUNT(*) AS c, MAX(wait_time_ms) AS max_wait_ms
             FROM v_dmv_blocking_snapshots
             WHERE server_id = $1 AND collection_time >= $2 AND collection_time < $3
             GROUP BY 1
@@ -144,7 +144,11 @@ public sealed partial class ViewerDataService
             COALESCE(cl.errs, 0) AS collection_errors,
             COALESCE(m.pressure, 0) AS memory_pressure_events,
             COALESCE(m.critical, 0) AS memory_critical_events,
-            COALESCE(al.c, 0) AS alert_count
+            COALESCE(al.c, 0) AS alert_count,
+            /* Peak block wait (ms) from the SAME source the blocking count came from (BPR preferred, DMV-snapshot
+               fallback), so the day-detail blocking reason ('N blocking events (peak block X)') reconciles with
+               the count. 0 when the blocking came from a source without a wait time. */
+            COALESCE(CASE WHEN COALESCE(b.c, 0) > 0 THEN b.max_wait_ms ELSE dm.max_wait_ms END, 0) AS peak_block_wait_ms
         FROM day_spine s
         LEFT JOIN waits w ON w.d = s.d
         LEFT JOIN queries q ON q.d = s.d
@@ -209,6 +213,7 @@ public sealed partial class ViewerDataService
             MemoryPressureEvents = reader.IsDBNull(8) ? 0L : Convert.ToInt64(reader.GetValue(8)),
             MemoryCriticalEvents = reader.IsDBNull(9) ? 0L : Convert.ToInt64(reader.GetValue(9)),
             AlertCount = reader.IsDBNull(10) ? 0L : Convert.ToInt64(reader.GetValue(10)),
+            MaxBlockDurationMs = reader.IsDBNull(11) ? 0L : Convert.ToInt64(reader.GetValue(11)),
             HasData = true,
         };
         row.HealthBand = DailyHealthBandCalculator.Classify(row.ToSignals());
@@ -233,6 +238,10 @@ public class DailySummaryRow
     public long MemoryCriticalEvents { get; set; }
     public long CollectionErrors { get; set; }
     public long AlertCount { get; set; }
+
+    /// <summary>The day's peak/max block wait in ms (0 when no blocking, or blocking from a source without a
+    /// wait time). Surfaced on the day-detail panel's blocking reason.</summary>
+    public long MaxBlockDurationMs { get; set; }
 
     /// <summary>True when the day had any collection. False renders the calendar cell as No-Data (grey).</summary>
     public bool HasData { get; set; }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.DailySummary.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.DailySummary.cs
@@ -7,11 +7,10 @@
  */
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Controls;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Ui;
 
 namespace PerformanceMonitor.Darling.Viewer;
@@ -19,14 +18,14 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// <summary>
 /// The Daily Summary inner tab — a COPY of Lite's Performance Calendar wiring, reads rewired to Postgres.
 /// A month heatmap of composite daily health (the shared <see cref="PerformanceCalendar"/>); clicking a day
-/// drills into its single-day roll-up. The tab-refresh loop (auto-refresh timer / tab switch, via
-/// <see cref="LoadDailySummaryAsync"/>) reloads the currently displayed month.
+/// opens the shared day-detail panel (band header, "why this day is &lt;band&gt;" reasons, key metrics, and
+/// drill buttons). The tab-refresh loop (auto-refresh timer / tab switch, via <see cref="LoadDailySummaryAsync"/>)
+/// reloads the currently displayed month; the panel re-shows itself for the selected day when it stays in view.
+/// Clicking a drill button (<see cref="DailyCalendar_DayDrillRequested"/>) scopes the toolbar to that day and
+/// jumps to the target grid, reusing the same mechanism as the per-chart "Show Active Queries at This Time" drill.
 /// </summary>
 public partial class ViewerServerTab
 {
-    /// <summary>The currently loaded month's rows, keyed by date, for O(1) day-click drill-in.</summary>
-    private Dictionary<DateTime, DailySummaryRow> _calendarRowsByDate = new();
-
     /// <summary>
     /// Entry point from LoadInnerTabAsync (index 14) and the auto-refresh loop: (re)load the calendar's
     /// currently displayed month. LoadInnerTabAsync owns this path's try/catch.
@@ -38,7 +37,9 @@ public partial class ViewerServerTab
 
     /// <summary>
     /// Loads a month's daily summaries into the Performance Calendar. One banded cell per collected day;
-    /// days with no collection are absent (the calendar renders them No-Data grey).
+    /// days with no collection are absent (the calendar renders them No-Data grey). Each day carries its
+    /// signals + key metrics so the shared day-detail panel can explain the day and offer the right drills.
+    /// The calendar re-shows the day-detail panel for the selected day itself when it stays in view.
     /// </summary>
     private async Task LoadCalendarMonthAsync(DateTime month)
     {
@@ -47,19 +48,17 @@ public partial class ViewerServerTab
 
         var rows = await _dataService.GetDailySummaryRangeAsync(_server.ServerId, start, end);
 
-        _calendarRowsByDate = rows.ToDictionary(r => r.SummaryDate.Date);
         DailyCalendar.Days = rows.Select(r => new PerformanceCalendarDay
         {
             Date = r.SummaryDate.Date,
             Band = r.HealthBand,
             Tooltip = $"{r.SummaryDate:MMM d, yyyy} - {r.OverallHealth}{Environment.NewLine}{r.SignalsTooltip}",
+            Signals = r.ToSignals(),
+            TopWaitType = r.TopWaitType,
+            TotalWaitSeconds = r.TotalWaitTimeSec,
+            UniqueQueries = r.UniqueQueries,
+            PeakBlockMs = r.MaxBlockDurationMs,
         }).ToList();
-
-        // Preserve the drilled-in day if it's still in view; otherwise clear the detail pane.
-        if (DailyCalendar.SelectedDate is DateTime sel && sel.Year == start.Year && sel.Month == start.Month)
-            ShowDayDetail(sel);
-        else
-            HideDayDetail();
     }
 
     private async void DailyCalendar_MonthChanged(object? sender, PerformanceCalendarMonthEventArgs e)
@@ -74,9 +73,6 @@ public partial class ViewerServerTab
         }
     }
 
-    private void DailyCalendar_DayClicked(object? sender, PerformanceCalendarDayEventArgs e)
-        => ShowDayDetail(e.Date);
-
     private async void DailySummaryRefresh_Click(object sender, RoutedEventArgs e)
     {
         try
@@ -89,31 +85,67 @@ public partial class ViewerServerTab
         }
     }
 
-    /// <summary>Shows the single-day roll-up for the clicked date (reusing the existing detail grid).</summary>
-    private void ShowDayDetail(DateTime date)
+    /// <summary>
+    /// A day-detail drill button (View Deadlocks / Blocking / Expensive Queries): scope the toolbar to the
+    /// clicked day's [00:00, next-day 00:00) UTC window and jump to the target inner tab, then load that grid
+    /// over the day. This reuses the exact mechanism the per-chart drills use — set the toolbar's custom
+    /// window, switch the inner tab under <see cref="_suppressDrillDownAutoRefresh"/> (so the tab-switch
+    /// auto-refresh doesn't race the targeted read), then call the same loader the tab uses.
+    /// </summary>
+    private async void DailyCalendar_DayDrillRequested(object? sender, PerformanceCalendarDrillEventArgs e)
     {
-        DailyCalendar.SelectedDate = date.Date;
-
-        if (_calendarRowsByDate.TryGetValue(date.Date, out var row))
+        try
         {
-            DailySummaryGrid.ItemsSource = new List<DailySummaryRow> { row };
-            DailySummaryDetailHeader.Text = $"Detail for {date:dddd, MMMM d, yyyy} (UTC)";
-            DailySummaryDetailPanel.Visibility = Visibility.Visible;
-            DailySummaryNoData.Visibility = Visibility.Collapsed;
-        }
-        else
-        {
-            DailySummaryGrid.ItemsSource = null;
-            DailySummaryDetailPanel.Visibility = Visibility.Collapsed;
-            DailySummaryNoData.Text = $"No data collected for {date:MMMM d, yyyy}.";
-            DailySummaryNoData.Visibility = Visibility.Visible;
-        }
-    }
+            var (startUtc, endUtc) = DailyHealthBandCalculator.DayWindowUtc(e.Date);
 
-    private void HideDayDetail()
-    {
-        DailySummaryDetailPanel.Visibility = Visibility.Collapsed;
-        DailySummaryNoData.Visibility = Visibility.Collapsed;
-        DailySummaryGrid.ItemsSource = null;
+            // Server-mode picker conversion needs this server's offset applied (cached; a no-op once loaded).
+            await EnsureServerOffsetLoadedAsync();
+            ApplyServerOffsetToHelper();
+
+            // Scope the toolbar to the whole day so the grid the user lands on — and anywhere they navigate
+            // next — stays on that day. Suppressed so it drives no reload of its own; we load the target below.
+            SetToolbarWindowUtc(startUtc, endUtc);
+
+            _suppressDrillDownAutoRefresh = true;
+            try
+            {
+                switch (e.Target)
+                {
+                    case DayDrillTarget.Deadlocks:
+                        InnerTabs.SelectedIndex = BlockingInnerTabIndex;
+                        BlockingSubTabs.SelectedIndex = DeadlocksSubTabIndex;
+                        break;
+                    case DayDrillTarget.Blocking:
+                        InnerTabs.SelectedIndex = BlockingInnerTabIndex;
+                        BlockingSubTabs.SelectedIndex = BlockedProcessReportsSubTabIndex;
+                        break;
+                    case DayDrillTarget.ExpensiveQueries:
+                        InnerTabs.SelectedIndex = QueriesInnerTabIndex;
+                        QueriesSubTabControl.SelectedIndex = ExpensiveQueriesSubTabIndex;
+                        break;
+                }
+            }
+            finally
+            {
+                _suppressDrillDownAutoRefresh = false;
+            }
+
+            switch (e.Target)
+            {
+                case DayDrillTarget.Deadlocks:
+                    await LoadDeadlocksAsync(startUtc, endUtc);
+                    break;
+                case DayDrillTarget.Blocking:
+                    await LoadBlockedProcessReportsAsync(startUtc, endUtc);
+                    break;
+                case DayDrillTarget.ExpensiveQueries:
+                    await LoadExpensiveQueriesAsync(startUtc, endUtc);
+                    break;
+            }
+        }
+        catch (Exception ex)
+        {
+            StatusChanged?.Invoke($"day drill failed: {ex.Message}");
+        }
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.TimeRange.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.TimeRange.cs
@@ -517,6 +517,49 @@ public partial class ViewerServerTab
         _ = RefreshActiveInnerTabAsync();
     }
 
+    /// <summary>
+    /// Scopes the toolbar to an explicit naive-UTC <c>[from, to)</c> window — the Performance Calendar day
+    /// drill's "set the time window to that day" step. Selects "Custom Range", reveals the pickers, and writes
+    /// them in the active display mode (<see cref="ViewerTimeHelper.ForDisplay(System.DateTime)"/> inverts the
+    /// naive-UTC bounds to the picker wall-clock, so <see cref="GetWindowUtc"/> round-trips back to the same
+    /// window). Runs under <see cref="_suppressRangeEvents"/> so it drives no reload of its own — the caller
+    /// (the day drill) loads the target inner tab itself. Mirrors <see cref="ApplyExternalTimeRange"/>'s picker
+    /// manipulation, but from UTC and without the reload.
+    /// </summary>
+    internal void SetToolbarWindowUtc(DateTime fromUtc, DateTime toUtc)
+    {
+        var fromDisplay = ViewerTimeHelper.ForDisplay(fromUtc);
+        var toDisplay = ViewerTimeHelper.ForDisplay(toUtc);
+
+        _suppressRangeEvents = true;
+        try
+        {
+            if (FromDatePicker != null)
+            {
+                FromDatePicker.Visibility = Visibility.Visible;
+                FromHourCombo.Visibility = Visibility.Visible;
+                FromMinuteCombo.Visibility = Visibility.Visible;
+                ToLabel.Visibility = Visibility.Visible;
+                ToDatePicker.Visibility = Visibility.Visible;
+                ToHourCombo.Visibility = Visibility.Visible;
+                ToMinuteCombo.Visibility = Visibility.Visible;
+
+                FromDatePicker.SelectedDate = fromDisplay.Date;
+                FromHourCombo.SelectedIndex = fromDisplay.Hour;
+                FromMinuteCombo.SelectedIndex = fromDisplay.Minute / 15;
+                ToDatePicker.SelectedDate = toDisplay.Date;
+                ToHourCombo.SelectedIndex = toDisplay.Hour;
+                ToMinuteCombo.SelectedIndex = toDisplay.Minute / 15;
+            }
+
+            TimeRangeCombo.SelectedIndex = CustomRangeIndex;
+        }
+        finally
+        {
+            _suppressRangeEvents = false;
+        }
+    }
+
     // ── Custom-range DatePicker calendar theming (viewer is fixed Dark) ───────────────
 
     private void DatePicker_CalendarOpened(object sender, RoutedEventArgs e)

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
@@ -2578,59 +2578,20 @@
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
-                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
 
                 <!-- Toolbar -->
                 <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,6">
                     <Button Content="Refresh" Click="DailySummaryRefresh_Click" Margin="0,0,10,0" Padding="8,4" MinWidth="60"/>
-                    <TextBlock x:Name="DailySummaryIndicator" Text="Composite daily health - click a day for detail (times in UTC)" VerticalAlignment="Center"
+                    <TextBlock x:Name="DailySummaryIndicator" Text="Composite daily health - click a day for detail and drill-in (times in UTC)" VerticalAlignment="Center"
                                FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                 </StackPanel>
 
-                <!-- Month heatmap -->
+                <!-- Month heatmap + the shared day-detail panel (click a day: band header, why-this-day
+                     reasons, key metrics, and drill buttons that scope to that day and jump to the grid). -->
                 <ui:PerformanceCalendar Grid.Row="1" x:Name="DailyCalendar"
-                                        MonthChanged="DailyCalendar_MonthChanged" DayClicked="DailyCalendar_DayClicked"/>
-
-                <!-- Clicked-day detail: the single-day roll-up, scoped to the clicked date -->
-                <StackPanel Grid.Row="2" x:Name="DailySummaryDetailPanel" Visibility="Collapsed" Margin="0,8,0,0">
-                    <TextBlock x:Name="DailySummaryDetailHeader" FontWeight="Bold" Margin="0,0,0,4" Foreground="{DynamicResource ForegroundBrush}"/>
-                    <DataGrid x:Name="DailySummaryGrid" Style="{StaticResource DarkGrid}">
-                        <DataGrid.Columns>
-                            <DataGridTextColumn Binding="{Binding SummaryDateFormatted}" Width="110">
-                                <DataGridTextColumn.Header><TextBlock Text="Date" FontWeight="Bold"/></DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding OverallHealth}" Width="120">
-                                <DataGridTextColumn.Header><TextBlock Text="Health" FontWeight="Bold"/></DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding TotalWaitFormatted}" ElementStyle="{StaticResource NumericCell}" Width="120" SortMemberPath="TotalWaitTimeSec">
-                                <DataGridTextColumn.Header><TextBlock Text="Total Wait" FontWeight="Bold"/></DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding TopWaitType}" Width="180">
-                                <DataGridTextColumn.Header><TextBlock Text="Top Wait Type" FontWeight="Bold"/></DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding UniqueQueries, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
-                                <DataGridTextColumn.Header><TextBlock Text="Unique Queries" FontWeight="Bold"/></DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding DeadlockCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                                <DataGridTextColumn.Header><TextBlock Text="Deadlocks" FontWeight="Bold"/></DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding BlockingEvents, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
-                                <DataGridTextColumn.Header><TextBlock Text="Blocking Events" FontWeight="Bold"/></DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding MemoryPressureEvents, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="130">
-                                <DataGridTextColumn.Header><TextBlock Text="Memory Pressure" FontWeight="Bold"/></DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding HighCpuEvents, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110">
-                                <DataGridTextColumn.Header><TextBlock Text="High CPU" FontWeight="Bold"/></DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                            <DataGridTextColumn Binding="{Binding CollectionErrors, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
-                                <DataGridTextColumn.Header><TextBlock Text="Collect Errors" FontWeight="Bold"/></DataGridTextColumn.Header>
-                            </DataGridTextColumn>
-                        </DataGrid.Columns>
-                    </DataGrid>
-                </StackPanel>
-                <TextBlock Grid.Row="2" x:Name="DailySummaryNoData" Style="{StaticResource NoDataMessage}" Visibility="Collapsed"/>
+                                        MonthChanged="DailyCalendar_MonthChanged"
+                                        DayDrillRequested="DailyCalendar_DayDrillRequested"/>
             </Grid>
         </TabItem>
 

--- a/Lite.Tests/DailyHealthBandTests.cs
+++ b/Lite.Tests/DailyHealthBandTests.cs
@@ -6,6 +6,7 @@
  * Licensed under the MIT License. See LICENSE file in the project root for full license information.
  */
 
+using System;
 using PerformanceMonitor.Common;
 using Xunit;
 
@@ -134,5 +135,99 @@ public class DailyHealthBandTests
         Assert.Contains("1 severe memory-pressure event", described);
         Assert.Contains("2 memory-pressure events", described);
         Assert.DoesNotContain("3 memory-pressure events", described);
+    }
+
+    // ── Day-detail panel logic (the click-a-day panel's reasons / drills / window / metrics line) ──
+
+    [Fact]
+    public void BuildReasons_TerminalMessages_ForNoData_AndQuietDay()
+    {
+        // No-Data uses the day-detail phrasing (distinct from the tooltip's "No data collected.").
+        Assert.Equal(new[] { "No collection this day." }, DailyHealthBandCalculator.BuildReasons(Signals(hasData: false)));
+        Assert.Equal(new[] { "No issues detected." }, DailyHealthBandCalculator.BuildReasons(Signals()));
+    }
+
+    [Fact]
+    public void BuildReasons_ListsEachNonZeroSignal()
+    {
+        var reasons = DailyHealthBandCalculator.BuildReasons(
+            Signals(deadlocks: 2, collectionErrors: 1, highCpu: 4, blocking: 3, memPressure: 5, memCritical: 2, alerts: 1));
+        Assert.Contains("2 deadlocks", reasons);
+        Assert.Contains("1 collection error", reasons);
+        Assert.Contains("4 high-CPU samples", reasons);
+        Assert.Contains("3 blocking events", reasons);
+        Assert.Contains("2 severe memory-pressure events", reasons);
+        Assert.Contains("3 memory-pressure events", reasons); // 5 total - 2 severe, not double-counted
+        Assert.Contains("1 alert", reasons);
+    }
+
+    [Theory]
+    [InlineData(800, "4 blocking events (peak block 800 ms)")]
+    [InlineData(12500, "4 blocking events (peak block 12.5 s)")]
+    [InlineData(150000, "4 blocking events (peak block 2.5 min)")]
+    public void BuildReasons_BlockingLine_CarriesPeakBlock_WhenProvided(long peakMs, string expected)
+    {
+        Assert.Contains(expected, DailyHealthBandCalculator.BuildReasons(Signals(blocking: 4), peakMs));
+    }
+
+    [Fact]
+    public void BuildReasons_BlockingLine_OmitsPeak_WhenZero()
+    {
+        var reasons = DailyHealthBandCalculator.BuildReasons(Signals(blocking: 4), peakBlockMs: 0);
+        Assert.Contains("4 blocking events", reasons);
+        Assert.DoesNotContain(reasons, r => r.Contains("peak block", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void AvailableDrills_NoData_OffersNothing()
+    {
+        Assert.Empty(DailyHealthBandCalculator.AvailableDrills(Signals(hasData: false)));
+    }
+
+    [Fact]
+    public void AvailableDrills_CollectedDay_AlwaysOffersExpensiveQueries()
+    {
+        Assert.Equal(new[] { DayDrillTarget.ExpensiveQueries }, DailyHealthBandCalculator.AvailableDrills(Signals()));
+    }
+
+    [Fact]
+    public void AvailableDrills_AddsDeadlocks_And_Blocking_OnlyWhenPresent_InPanelOrder()
+    {
+        Assert.Equal(
+            new[] { DayDrillTarget.Deadlocks, DayDrillTarget.Blocking, DayDrillTarget.ExpensiveQueries },
+            DailyHealthBandCalculator.AvailableDrills(Signals(deadlocks: 1, blocking: 2)));
+        Assert.Equal(
+            new[] { DayDrillTarget.Deadlocks, DayDrillTarget.ExpensiveQueries },
+            DailyHealthBandCalculator.AvailableDrills(Signals(deadlocks: 3)));
+        Assert.Equal(
+            new[] { DayDrillTarget.Blocking, DayDrillTarget.ExpensiveQueries },
+            DailyHealthBandCalculator.AvailableDrills(Signals(blocking: 7)));
+    }
+
+    [Fact]
+    public void DayWindowUtc_IsClickedDay_MidnightToNextMidnight()
+    {
+        var (start, end) = DailyHealthBandCalculator.DayWindowUtc(new DateTime(2026, 7, 8, 14, 37, 12));
+        Assert.Equal(new DateTime(2026, 7, 8), start); // time component dropped
+        Assert.Equal(new DateTime(2026, 7, 9), end);
+        Assert.Equal(TimeSpan.FromDays(1), end - start);
+    }
+
+    [Fact]
+    public void BuildKeyMetricsLine_RendersRollup()
+    {
+        var line = DailyHealthBandCalculator.BuildKeyMetricsLine("CXPACKET", 4, 150m, 87);
+        Assert.Contains("Top wait: CXPACKET", line);
+        Assert.Contains("High-CPU samples: 4", line);
+        Assert.Contains("Total wait: 150.0 s", line);
+        Assert.Contains("Unique queries: 87", line);
+    }
+
+    [Fact]
+    public void BuildKeyMetricsLine_NoWait_ShowsNone_And_LargeWaitInMinutes()
+    {
+        var line = DailyHealthBandCalculator.BuildKeyMetricsLine(null, 0, 1200m, 0);
+        Assert.Contains("Top wait: none", line);
+        Assert.Contains("Total wait: 20.0 min", line); // 1200s / 60
     }
 }

--- a/Lite.Tests/PerformanceCalendarDataTests.cs
+++ b/Lite.Tests/PerformanceCalendarDataTests.cs
@@ -88,6 +88,11 @@ public class PerformanceCalendarDataTests : IDisposable
             "INSERT INTO dmv_blocking_snapshots (collection_id, collection_time, server_id, server_name, monitor_loop) VALUES ($1,$2,$3,$4,1)",
             _nextId--, day.AddHours(1), ServerId, ServerName);
 
+    private Task SeedBprAsync(DateTime day, long waitTimeMs) =>
+        ExecAsync(
+            "INSERT INTO blocked_process_reports (blocked_report_id, collection_time, server_id, server_name, wait_time_ms) VALUES ($1,$2,$3,$4,$5)",
+            _nextId--, day.AddHours(1), ServerId, ServerName, waitTimeMs);
+
     private Task SeedMemoryAsync(DateTime day, int process, int system) =>
         ExecAsync(
             "INSERT INTO memory_pressure_events (collection_id, collection_time, server_id, server_name, sample_time, memory_notification, memory_indicators_process, memory_indicators_system) VALUES ($1,$2,$3,$4,$2,'RESOURCE_MEMPHYSICAL_LOW',$5,$6)",
@@ -179,6 +184,25 @@ public class PerformanceCalendarDataTests : IDisposable
         Assert.Equal(DailyHealthBand.Critical, byDate[Day(18)].HealthBand);
         Assert.Equal(1, byDate[Day(18)].MemoryCriticalEvents);
         Assert.Equal(1, byDate[Day(18)].MemoryPressureEvents);
+    }
+
+    [Fact]
+    public async Task GetDailySummaryRange_CarriesPeakBlockDuration_FromBlockedProcessReports()
+    {
+        await _duckDb.InitializeAsync();
+
+        // Two blocked-process reports on 07-14 with different wait times; the day's peak is the max, and the
+        // BPR-sourced count wins over any DMV fallback (there is none here). Feeds the day-detail blocking
+        // reason ("N blocking events (peak block X)").
+        await SeedCollectionRunAsync(Day(14));
+        await SeedBprAsync(Day(14), 4_200);
+        await SeedBprAsync(Day(14), 12_500);
+
+        var rows = await _dataService.GetDailySummaryRangeAsync(ServerId, MonthStart, MonthEnd);
+        var row = rows.Single(r => r.SummaryDate.Date == Day(14));
+
+        Assert.Equal(2, row.BlockingEvents);          // BPR-sourced count (preferred over DMV)
+        Assert.Equal(12_500, row.MaxBlockDurationMs); // peak = MAX(wait_time_ms)
     }
 
     [Fact]

--- a/Lite/Controls/ServerTab.DailySummary.cs
+++ b/Lite/Controls/ServerTab.DailySummary.cs
@@ -7,26 +7,25 @@
  */
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using PerformanceMonitorLite.Helpers;
 using PerformanceMonitorLite.Services;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Ui;
 
 namespace PerformanceMonitorLite.Controls;
 
 public partial class ServerTab : UserControl
 {
-    /// <summary>The currently loaded month's rows, keyed by date, for O(1) day-click drill-in.</summary>
-    private Dictionary<DateTime, DailySummaryRow> _calendarRowsByDate = new();
-
     /// <summary>
     /// Loads a month's daily summaries into the Performance Calendar. One banded cell per collected day;
-    /// days with no collection are simply absent (the calendar renders them No-Data grey). The heavy DuckDB
-    /// read runs off the UI thread.
+    /// days with no collection are simply absent (the calendar renders them No-Data grey). Each day carries
+    /// its signals + key metrics so the shared day-detail panel can explain the day and offer the right
+    /// drills. The heavy DuckDB read runs off the UI thread; the calendar re-shows its day-detail panel for
+    /// the selected day itself when it stays in view.
     /// </summary>
     private async Task LoadCalendarMonthAsync(DateTime month)
     {
@@ -37,19 +36,17 @@ public partial class ServerTab : UserControl
 
             var rows = await Task.Run(() => _dataService.GetDailySummaryRangeAsync(_serverId, start, end));
 
-            _calendarRowsByDate = rows.ToDictionary(r => r.SummaryDate.Date);
             DailyCalendar.Days = rows.Select(r => new PerformanceCalendarDay
             {
                 Date = r.SummaryDate.Date,
                 Band = r.HealthBand,
                 Tooltip = $"{r.SummaryDate:MMM d, yyyy} - {r.OverallHealth}{Environment.NewLine}{r.SignalsTooltip}",
+                Signals = r.ToSignals(),
+                TopWaitType = r.TopWaitType,
+                TotalWaitSeconds = r.TotalWaitTimeSec,
+                UniqueQueries = r.UniqueQueries,
+                PeakBlockMs = r.MaxBlockDurationMs,
             }).ToList();
-
-            // Preserve the drilled-in day if it's still in view; otherwise clear the detail pane.
-            if (DailyCalendar.SelectedDate is DateTime sel && sel.Year == start.Year && sel.Month == start.Month)
-                ShowDayDetail(sel);
-            else
-                HideDayDetail();
         }
         catch (Exception ex)
         {
@@ -60,37 +57,60 @@ public partial class ServerTab : UserControl
     private async void DailyCalendar_MonthChanged(object? sender, PerformanceCalendarMonthEventArgs e)
         => await LoadCalendarMonthAsync(e.Month);
 
-    private void DailyCalendar_DayClicked(object? sender, PerformanceCalendarDayEventArgs e)
-        => ShowDayDetail(e.Date);
-
     private async void DailySummaryRefresh_Click(object sender, RoutedEventArgs e)
         => await LoadCalendarMonthAsync(DailyCalendar.DisplayMonth);
 
-    /// <summary>Shows the single-day roll-up for the clicked date (reusing the existing detail grid).</summary>
-    private void ShowDayDetail(DateTime date)
+    /// <summary>
+    /// A day-detail drill button (View Deadlocks / Blocking / Expensive Queries): scope the toolbar to the
+    /// clicked day's [00:00, next-day 00:00) window and jump to the target tab, then load it over the day.
+    /// This reuses the exact mechanism the per-chart drills use — <see cref="SetDrillDownTimeRange"/> sets the
+    /// toolbar's custom window, the tab switches run under <see cref="_suppressActiveQueriesAutoRefresh"/> (so
+    /// the tab-switch auto-refresh doesn't race the targeted read), then the standard per-sub-tab refresh
+    /// loads that grid over the window. The calendar buckets days in UTC; the reads take server time, so the
+    /// UTC day is shifted by the server offset (mirroring <see cref="GetTimeRange"/>'s inverse).
+    /// </summary>
+    private async void DailyCalendar_DayDrillRequested(object? sender, PerformanceCalendarDrillEventArgs e)
     {
-        DailyCalendar.SelectedDate = date.Date;
-
-        if (_calendarRowsByDate.TryGetValue(date.Date, out var row))
+        try
         {
-            DailySummaryGrid.ItemsSource = new List<DailySummaryRow> { row };
-            DailySummaryDetailHeader.Text = $"Detail for {date:dddd, MMMM d, yyyy} (UTC)";
-            DailySummaryDetailPanel.Visibility = Visibility.Visible;
-            DailySummaryNoData.Visibility = Visibility.Collapsed;
-        }
-        else
-        {
-            DailySummaryGrid.ItemsSource = null;
-            DailySummaryDetailPanel.Visibility = Visibility.Collapsed;
-            DailySummaryNoData.Text = $"No data collected for {date:MMMM d, yyyy}.";
-            DailySummaryNoData.Visibility = Visibility.Visible;
-        }
-    }
+            var (startUtc, endUtc) = DailyHealthBandCalculator.DayWindowUtc(e.Date);
+            var fromServer = startUtc.AddMinutes(ServerTimeHelper.UtcOffsetMinutes);
+            var toServer = endUtc.AddMinutes(ServerTimeHelper.UtcOffsetMinutes);
 
-    private void HideDayDetail()
-    {
-        DailySummaryDetailPanel.Visibility = Visibility.Collapsed;
-        DailySummaryNoData.Visibility = Visibility.Collapsed;
-        DailySummaryGrid.ItemsSource = null;
+            // Scope the toolbar to the whole day so the grid the user lands on — and anywhere they navigate
+            // next — stays on that day (SetDrillDownTimeRange switches to Custom without triggering a reload).
+            SetDrillDownTimeRange(fromServer, toServer);
+
+            _suppressActiveQueriesAutoRefresh = true;
+            try
+            {
+                switch (e.Target)
+                {
+                    case DayDrillTarget.Deadlocks:
+                        MainTabControl.SelectedIndex = 8;        // Blocking
+                        BlockingSubTabControl.SelectedIndex = 3; // Deadlocks
+                        break;
+                    case DayDrillTarget.Blocking:
+                        MainTabControl.SelectedIndex = 8;        // Blocking
+                        BlockingSubTabControl.SelectedIndex = 2; // Blocked Process Reports
+                        break;
+                    case DayDrillTarget.ExpensiveQueries:
+                        MainTabControl.SelectedIndex = 2;        // Queries
+                        QueriesSubTabControl.SelectedIndex = 2;  // Top Queries by Duration
+                        break;
+                }
+            }
+            finally
+            {
+                _suppressActiveQueriesAutoRefresh = false;
+            }
+
+            // One targeted load of the tab we just switched to, over the day window (grid + slicer + comparison).
+            await RefreshVisibleTabAsync(GetHoursBack(), fromServer, toServer, subTabOnly: true);
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Info("ServerTab", $"[{_server.DisplayName}] DailyCalendar_DayDrillRequested failed: {ex.Message}");
+        }
     }
 }

--- a/Lite/Controls/ServerTab.xaml
+++ b/Lite/Controls/ServerTab.xaml
@@ -1948,62 +1948,20 @@
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
-                        <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
 
                     <!-- Toolbar -->
                     <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,6">
                         <Button Content="Refresh" Click="DailySummaryRefresh_Click" Margin="0,0,10,0" Padding="8,4" MinWidth="60"/>
-                        <TextBlock x:Name="DailySummaryIndicator" Text="Composite daily health - click a day for detail (times in UTC)" VerticalAlignment="Center"
+                        <TextBlock x:Name="DailySummaryIndicator" Text="Composite daily health - click a day for detail and drill-in (times in UTC)" VerticalAlignment="Center"
                                    FontStyle="Italic" Foreground="{DynamicResource AccentBrush}" FontWeight="SemiBold"/>
                     </StackPanel>
 
-                    <!-- Month heatmap -->
+                    <!-- Month heatmap + the shared day-detail panel (click a day: band header, why-this-day
+                         reasons, key metrics, and drill buttons that scope to that day and jump to the grid). -->
                     <ui:PerformanceCalendar Grid.Row="1" x:Name="DailyCalendar"
-                                            MonthChanged="DailyCalendar_MonthChanged" DayClicked="DailyCalendar_DayClicked"/>
-
-                    <!-- Clicked-day detail: the single-day roll-up, scoped to the clicked date -->
-                    <StackPanel Grid.Row="2" x:Name="DailySummaryDetailPanel" Visibility="Collapsed" Margin="0,8,0,0">
-                        <TextBlock x:Name="DailySummaryDetailHeader" FontWeight="Bold" Margin="0,0,0,4" Foreground="{DynamicResource ForegroundBrush}"/>
-                        <DataGrid x:Name="DailySummaryGrid"
-                                  AutoGenerateColumns="False" IsReadOnly="True"
-                                  RowStyle="{StaticResource GridRowStyle}"
-                                  HeadersVisibility="Column" GridLinesVisibility="Horizontal">
-                            <DataGrid.Columns>
-                                <DataGridTextColumn Binding="{Binding SummaryDateFormatted}" Width="110">
-                                    <DataGridTextColumn.Header><TextBlock Text="Date" FontWeight="Bold"/></DataGridTextColumn.Header>
-                                </DataGridTextColumn>
-                                <DataGridTextColumn Binding="{Binding OverallHealth}" Width="120">
-                                    <DataGridTextColumn.Header><TextBlock Text="Health" FontWeight="Bold"/></DataGridTextColumn.Header>
-                                </DataGridTextColumn>
-                                <DataGridTextColumn Binding="{Binding TotalWaitFormatted}" ElementStyle="{StaticResource NumericCell}" Width="120" SortMemberPath="TotalWaitTimeSec">
-                                    <DataGridTextColumn.Header><TextBlock Text="Total Wait" FontWeight="Bold"/></DataGridTextColumn.Header>
-                                </DataGridTextColumn>
-                                <DataGridTextColumn Binding="{Binding TopWaitType}" Width="180">
-                                    <DataGridTextColumn.Header><TextBlock Text="Top Wait Type" FontWeight="Bold"/></DataGridTextColumn.Header>
-                                </DataGridTextColumn>
-                                <DataGridTextColumn Binding="{Binding UniqueQueries, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
-                                    <DataGridTextColumn.Header><TextBlock Text="Unique Queries" FontWeight="Bold"/></DataGridTextColumn.Header>
-                                </DataGridTextColumn>
-                                <DataGridTextColumn Binding="{Binding DeadlockCount, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="100">
-                                    <DataGridTextColumn.Header><TextBlock Text="Deadlocks" FontWeight="Bold"/></DataGridTextColumn.Header>
-                                </DataGridTextColumn>
-                                <DataGridTextColumn Binding="{Binding BlockingEvents, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
-                                    <DataGridTextColumn.Header><TextBlock Text="Blocking Events" FontWeight="Bold"/></DataGridTextColumn.Header>
-                                </DataGridTextColumn>
-                                <DataGridTextColumn Binding="{Binding HighCpuEvents, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="110">
-                                    <DataGridTextColumn.Header><TextBlock Text="High CPU" FontWeight="Bold"/></DataGridTextColumn.Header>
-                                </DataGridTextColumn>
-                                <DataGridTextColumn Binding="{Binding MemoryPressureEvents, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
-                                    <DataGridTextColumn.Header><TextBlock Text="Memory Pressure" FontWeight="Bold"/></DataGridTextColumn.Header>
-                                </DataGridTextColumn>
-                                <DataGridTextColumn Binding="{Binding CollectionErrors, StringFormat=N0}" ElementStyle="{StaticResource NumericCell}" Width="120">
-                                    <DataGridTextColumn.Header><TextBlock Text="Collect Errors" FontWeight="Bold"/></DataGridTextColumn.Header>
-                                </DataGridTextColumn>
-                            </DataGrid.Columns>
-                        </DataGrid>
-                    </StackPanel>
-                    <TextBlock Grid.Row="2" x:Name="DailySummaryNoData" Style="{StaticResource NoDataMessage}" Visibility="Collapsed"/>
+                                            MonthChanged="DailyCalendar_MonthChanged"
+                                            DayDrillRequested="DailyCalendar_DayDrillRequested"/>
                 </Grid>
             </TabItem>
 

--- a/Lite/Services/LocalDataService.DailySummary.cs
+++ b/Lite/Services/LocalDataService.DailySummary.cs
@@ -51,13 +51,13 @@ deadlocks AS (
     GROUP BY 1
 ),
 bpr AS (
-    SELECT date_trunc('day', collection_time) AS d, COUNT(*) AS c
+    SELECT date_trunc('day', collection_time) AS d, COUNT(*) AS c, MAX(wait_time_ms) AS max_wait_ms
     FROM v_blocked_process_reports
     WHERE server_id = $1 AND collection_time >= $2 AND collection_time < $3
     GROUP BY 1
 ),
 dmv AS (
-    SELECT date_trunc('day', collection_time) AS d, COUNT(*) AS c
+    SELECT date_trunc('day', collection_time) AS d, COUNT(*) AS c, MAX(wait_time_ms) AS max_wait_ms
     FROM v_dmv_blocking_snapshots
     WHERE server_id = $1 AND collection_time >= $2 AND collection_time < $3
     GROUP BY 1
@@ -123,7 +123,11 @@ SELECT
     COALESCE(cl.errs, 0) AS collection_errors,
     COALESCE(m.pressure, 0) AS memory_pressure_events,
     COALESCE(m.critical, 0) AS memory_critical_events,
-    COALESCE(al.c, 0) AS alert_count
+    COALESCE(al.c, 0) AS alert_count,
+    /* Peak block wait (ms) from the SAME source the blocking count came from (BPR preferred, DMV-snapshot
+       fallback), so the day-detail blocking reason ('N blocking events (peak block X)') reconciles with the
+       count. 0 when the blocking came from a source without a wait time. */
+    COALESCE(CASE WHEN COALESCE(b.c, 0) > 0 THEN b.max_wait_ms ELSE dm.max_wait_ms END, 0) AS peak_block_wait_ms
 FROM day_spine s
 LEFT JOIN waits w ON w.d = s.d
 LEFT JOIN queries q ON q.d = s.d
@@ -190,6 +194,7 @@ ORDER BY s.d";
             MemoryPressureEvents = reader.IsDBNull(8) ? 0L : Convert.ToInt64(reader.GetValue(8)),
             MemoryCriticalEvents = reader.IsDBNull(9) ? 0L : Convert.ToInt64(reader.GetValue(9)),
             AlertCount = reader.IsDBNull(10) ? 0L : Convert.ToInt64(reader.GetValue(10)),
+            MaxBlockDurationMs = reader.IsDBNull(11) ? 0L : Convert.ToInt64(reader.GetValue(11)),
             HasData = true,
         };
         row.HealthBand = DailyHealthBandCalculator.Classify(row.ToSignals());
@@ -210,6 +215,10 @@ public class DailySummaryRow
     public long MemoryCriticalEvents { get; set; }
     public long CollectionErrors { get; set; }
     public long AlertCount { get; set; }
+
+    /// <summary>The day's peak/max block wait in ms (0 when no blocking, or blocking from a source without a
+    /// wait time). Surfaced on the day-detail panel's blocking reason.</summary>
+    public long MaxBlockDurationMs { get; set; }
 
     /// <summary>True when the day had any collection. False renders the calendar cell as No-Data (grey).</summary>
     public bool HasData { get; set; }

--- a/PerformanceMonitor.Common/DailyHealthBand.cs
+++ b/PerformanceMonitor.Common/DailyHealthBand.cs
@@ -35,6 +35,26 @@ namespace PerformanceMonitor.Common
     }
 
     /// <summary>
+    /// The drill targets a Performance Calendar day-detail panel can offer. Which targets are shown for a
+    /// given day is decided by <see cref="DailyHealthBandCalculator.AvailableDrills"/> (shared, testable);
+    /// how each one navigates — which inner tab, and scoping the toolbar to the clicked day's window — is
+    /// app-specific and handled by each host (Lite's <c>ServerTab</c>, the Darling <c>ViewerServerTab</c>),
+    /// reusing the same tab-switch + time-window mechanism as the per-chart "Show Active Queries at This
+    /// Time" drill.
+    /// </summary>
+    public enum DayDrillTarget
+    {
+        /// <summary>Jump to the Deadlocks grid scoped to the day — offered only when the day had deadlocks.</summary>
+        Deadlocks,
+
+        /// <summary>Jump to the Blocked Process Reports grid scoped to the day — offered only when the day had blocking.</summary>
+        Blocking,
+
+        /// <summary>Jump to the expensive / top-queries grid scoped to the day — offered on any collected day.</summary>
+        ExpensiveQueries,
+    }
+
+    /// <summary>
     /// The per-day signal counts that feed <see cref="DailyHealthBandCalculator.Classify"/>. Every field is
     /// a whole-day roll-up over the same source views the Daily Summary already aggregates. A day with no
     /// collection at all sets <see cref="HasData"/> = false (all other fields ignored → <see cref="DailyHealthBand.NoData"/>).
@@ -176,19 +196,96 @@ namespace PerformanceMonitor.Common
             if (!signals.HasData)
                 return "No data collected.";
 
+            var lines = BuildSignalLines(signals, peakBlockMs: 0);
+            return lines.Count == 0 ? "No issues detected." : string.Join(Environment.NewLine, lines);
+        }
+
+        /// <summary>
+        /// The day-detail "Why this day is &lt;band&gt;" reasons: one line per non-zero signal that drove the
+        /// band, using the SAME per-signal wording as the calendar tooltip (<see cref="Describe"/>) so the two
+        /// can't drift, plus — when <paramref name="peakBlockMs"/> is supplied (&gt; 0) — the day's peak block
+        /// duration appended to the blocking line. A collected-but-quiet day returns a single "No issues
+        /// detected."; a day with no collection returns "No collection this day." (the day-detail phrasing,
+        /// distinct from the tooltip's "No data collected.").
+        /// </summary>
+        /// <param name="signals">The day's rolled-up signal counts.</param>
+        /// <param name="peakBlockMs">The day's peak/max block wait in ms (0 = unknown / not carried), shown on the blocking line.</param>
+        public static IReadOnlyList<string> BuildReasons(in DailyHealthSignals signals, long peakBlockMs = 0)
+        {
+            if (!signals.HasData)
+                return new[] { "No collection this day." };
+
+            var lines = BuildSignalLines(signals, peakBlockMs);
+            return lines.Count == 0 ? new List<string> { "No issues detected." } : lines;
+        }
+
+        /// <summary>
+        /// Which day-detail drill buttons to offer for a day, in panel order. A day with no collection offers
+        /// none (there is nothing to drill into). Otherwise Expensive Queries is always offered (you can always
+        /// inspect what ran), Deadlocks is offered only when the day had any deadlock, and Blocking only when it
+        /// had any blocking event. Pure + static so both hosts and the tests share one decision.
+        /// </summary>
+        public static IReadOnlyList<DayDrillTarget> AvailableDrills(in DailyHealthSignals signals)
+        {
+            var drills = new List<DayDrillTarget>();
+            if (!signals.HasData)
+                return drills;
+
+            if (signals.Deadlocks > 0)
+                drills.Add(DayDrillTarget.Deadlocks);
+            if (signals.BlockingEvents > 0)
+                drills.Add(DayDrillTarget.Blocking);
+            drills.Add(DayDrillTarget.ExpensiveQueries);
+            return drills;
+        }
+
+        /// <summary>
+        /// The [start, next-day-start) window for a clicked calendar day as naive-UTC bounds — the calendar
+        /// buckets days in UTC day-space (<c>date_trunc('day', collection_time)</c> over naive-UTC collection
+        /// times), so a day drill scopes to exactly that UTC day. Each host converts these bounds into its own
+        /// time space (Lite adds the server offset for its server-time reads; the viewer reads naive UTC
+        /// directly). Pure + static so the window computation is unit-testable.
+        /// </summary>
+        public static (DateTime StartUtc, DateTime EndUtc) DayWindowUtc(DateTime date)
+        {
+            var start = date.Date;
+            return (start, start.AddDays(1));
+        }
+
+        /// <summary>
+        /// The day-detail key-metrics one-liner from a day's roll-up: top wait type, high-CPU sample count,
+        /// total wait time, and unique query count. Formatting lives here (shared by both apps, unit-testable)
+        /// so the two hosts render the line identically.
+        /// </summary>
+        public static string BuildKeyMetricsLine(string? topWaitType, long highCpuEvents, decimal totalWaitSeconds, long uniqueQueries)
+        {
+            var wait = string.IsNullOrWhiteSpace(topWaitType) ? "none" : topWaitType;
+            var totalWait = totalWaitSeconds < 1000
+                ? totalWaitSeconds.ToString("N1", CultureInfo.InvariantCulture) + " s"
+                : (totalWaitSeconds / 60).ToString("N1", CultureInfo.InvariantCulture) + " min";
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                "Top wait: {0}     High-CPU samples: {1:N0}     Total wait: {2}     Unique queries: {3:N0}",
+                wait, highCpuEvents, totalWait, uniqueQueries);
+        }
+
+        /// <summary>The non-empty per-signal lines for a collected day (no terminal "quiet"/"no-data" handling —
+        /// callers add their own). The order matches the tooltip; the blocking line carries the peak block
+        /// duration when one is supplied.</summary>
+        private static List<string> BuildSignalLines(in DailyHealthSignals signals, long peakBlockMs)
+        {
             var lines = new List<string>();
             AppendCount(lines, signals.Deadlocks, "deadlock", "deadlocks");
             AppendCount(lines, signals.CollectionErrors, "collection error", "collection errors");
             AppendCount(lines, signals.HighCpuEvents, "high-CPU sample", "high-CPU samples");
-            AppendCount(lines, signals.BlockingEvents, "blocking event", "blocking events");
+            AppendBlocking(lines, signals.BlockingEvents, peakBlockMs);
             AppendCount(lines, signals.MemoryCriticalEvents, "severe memory-pressure event", "severe memory-pressure events");
             // MemoryPressureEvents is the full count (medium + severe); severe is a subset already listed
             // above, so only the non-severe remainder is shown here to avoid double-counting.
             var nonSevereMemory = Math.Max(0, signals.MemoryPressureEvents - signals.MemoryCriticalEvents);
             AppendCount(lines, nonSevereMemory, "memory-pressure event", "memory-pressure events");
             AppendCount(lines, signals.AlertCount, "alert", "alerts");
-
-            return lines.Count == 0 ? "No issues detected." : string.Join(Environment.NewLine, lines);
+            return lines;
         }
 
         private static void AppendCount(List<string> lines, long count, string singular, string plural)
@@ -198,6 +295,32 @@ namespace PerformanceMonitor.Common
 
             var noun = count == 1 ? singular : plural;
             lines.Add(count.ToString("N0", CultureInfo.InvariantCulture) + " " + noun);
+        }
+
+        /// <summary>The blocking line — like <see cref="AppendCount"/> but appends the day's peak block
+        /// duration when one is known (&gt; 0), e.g. "42 blocking events (peak block 12.5 s)".</summary>
+        private static void AppendBlocking(List<string> lines, long count, long peakBlockMs)
+        {
+            if (count <= 0)
+                return;
+
+            var noun = count == 1 ? "blocking event" : "blocking events";
+            var line = count.ToString("N0", CultureInfo.InvariantCulture) + " " + noun;
+            if (peakBlockMs > 0)
+                line += " (peak block " + FormatDurationMs(peakBlockMs) + ")";
+            lines.Add(line);
+        }
+
+        /// <summary>Formats a millisecond duration compactly ("800 ms" / "12.5 s" / "3.2 min").</summary>
+        internal static string FormatDurationMs(long ms)
+        {
+            if (ms < 1000)
+                return ms.ToString("N0", CultureInfo.InvariantCulture) + " ms";
+
+            var seconds = ms / 1000.0;
+            return seconds < 60
+                ? seconds.ToString("N1", CultureInfo.InvariantCulture) + " s"
+                : (seconds / 60).ToString("N1", CultureInfo.InvariantCulture) + " min";
         }
     }
 }

--- a/PerformanceMonitor.Ui/PerformanceCalendar.xaml
+++ b/PerformanceMonitor.Ui/PerformanceCalendar.xaml
@@ -5,9 +5,10 @@
     <!--
       A navigable month heatmap: 6 weeks x 7 days of cells, each washed with its composite daily
       health band (green / amber / red / muted-grey for no-data). Prev/next/Today navigate months
-      (raising MonthChanged so the host can fetch that month's data); clicking an in-month day raises
-      DayClicked so the host can drill into that day's detail. All colors are theme DynamicResources
-      resolved from the host app — this control ships no theme of its own.
+      (raising MonthChanged so the host can fetch that month's data); clicking an in-month day opens
+      the built-in day-detail panel, whose drill buttons raise DayDrillRequested so the host can scope
+      and navigate. All colors are theme DynamicResources resolved from the host app — this control
+      ships no theme of its own.
     -->
     <Grid Margin="4">
         <Grid.RowDefinitions>

--- a/PerformanceMonitor.Ui/PerformanceCalendar.xaml
+++ b/PerformanceMonitor.Ui/PerformanceCalendar.xaml
@@ -14,6 +14,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
         <!-- Row 0: month navigation + legend -->
@@ -157,5 +158,49 @@
                 </DataTemplate>
             </ItemsControl.ItemTemplate>
         </ItemsControl>
+
+        <!--
+          Row 3: the day-detail panel. Shown when a day is clicked (replacing the old one-row Daily Summary
+          popup): a band-colored header, the "why this day is <band>" reasons that drove the band, a
+          key-metrics line, and drill buttons that jump to that day's Deadlocks / Blocking / Expensive Queries.
+          The reasons / metrics / which buttons appear are all computed by the shared DailyHealthBandCalculator;
+          clicking a drill button raises DayDrillRequested for the host to scope + navigate. All colors are
+          theme DynamicResources so the panel themes with its host.
+        -->
+        <Border Grid.Row="3" x:Name="DayDetailPanel" Visibility="Collapsed" Margin="2,10,2,2"
+                CornerRadius="6" BorderThickness="1"
+                BorderBrush="{DynamicResource BorderBrush}"
+                Background="{DynamicResource BackgroundLighterBrush}">
+            <StackPanel Margin="14,10">
+                <!-- Header: "<Weekday, Mon D> — <BAND>" (band-colored via SetResourceReference in code-behind). -->
+                <TextBlock x:Name="DayDetailHeader" FontSize="15" FontWeight="SemiBold" Margin="0,0,0,8"/>
+
+                <!-- Why this day is <band> -->
+                <TextBlock x:Name="DayDetailWhyLabel" FontSize="12" FontWeight="SemiBold" Margin="0,0,0,3"
+                           Foreground="{DynamicResource ForegroundDimBrush}"/>
+                <ItemsControl x:Name="DayDetailReasons" Margin="0,0,0,10">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding}" Margin="8,1,0,1" FontSize="12" TextWrapping="Wrap"
+                                       Foreground="{DynamicResource ForegroundBrush}"/>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+
+                <!-- Key metrics line -->
+                <TextBlock x:Name="DayDetailMetrics" FontSize="12" Margin="0,0,0,10" TextWrapping="Wrap"
+                           Foreground="{DynamicResource ForegroundDimBrush}"/>
+
+                <!-- Drill buttons (each shown only when it makes sense for the day). -->
+                <StackPanel Orientation="Horizontal">
+                    <Button x:Name="DeadlocksDrillButton" Content="View Deadlocks" Margin="0,0,8,0" Padding="12,4"
+                            Visibility="Collapsed" Click="DeadlocksDrillButton_Click"/>
+                    <Button x:Name="BlockingDrillButton" Content="View Blocking" Margin="0,0,8,0" Padding="12,4"
+                            Visibility="Collapsed" Click="BlockingDrillButton_Click"/>
+                    <Button x:Name="ExpensiveQueriesDrillButton" Content="View Expensive Queries" Margin="0,0,8,0" Padding="12,4"
+                            Visibility="Collapsed" Click="ExpensiveQueriesDrillButton_Click"/>
+                </StackPanel>
+            </StackPanel>
+        </Border>
     </Grid>
 </UserControl>

--- a/PerformanceMonitor.Ui/PerformanceCalendar.xaml.cs
+++ b/PerformanceMonitor.Ui/PerformanceCalendar.xaml.cs
@@ -23,8 +23,8 @@ namespace PerformanceMonitor.Ui
     /// the Performance Calendar can't drift between them. The host supplies <see cref="Days"/> (one banded
     /// <see cref="PerformanceCalendarDay"/> per collected day) and the displayed month; the control lays out
     /// a 6x7 grid, washes each in-month cell with its band color, and raises <see cref="MonthChanged"/> when
-    /// the user navigates (so the host can fetch that month) and <see cref="DayClicked"/> when a day is
-    /// clicked (so the host can drill into that day's detail).
+    /// the user navigates (so the host can fetch that month). Clicking a day opens the built-in day-detail
+    /// panel; its drill buttons raise <see cref="DayDrillRequested"/> so the host can scope + navigate.
     /// </summary>
     public partial class PerformanceCalendar : UserControl
     {
@@ -68,9 +68,6 @@ namespace PerformanceMonitor.Ui
             get => (DateTime?)GetValue(SelectedDateProperty);
             set => SetValue(SelectedDateProperty, value);
         }
-
-        /// <summary>Raised when a user clicks an in-month day cell.</summary>
-        public event EventHandler<PerformanceCalendarDayEventArgs>? DayClicked;
 
         /// <summary>Raised when the user navigates to a different month (prev / next / Today), carrying the new month's first day.</summary>
         public event EventHandler<PerformanceCalendarMonthEventArgs>? MonthChanged;
@@ -192,7 +189,6 @@ namespace PerformanceMonitor.Ui
                 // Setting SelectedDate reframes the accent ring and (via the DP callback -> RebuildCells ->
                 // UpdateDayDetailPanel) shows the day-detail panel for this day.
                 SelectedDate = cell.Date;
-                DayClicked?.Invoke(this, new PerformanceCalendarDayEventArgs(cell.Date));
             }
         }
 

--- a/PerformanceMonitor.Ui/PerformanceCalendar.xaml.cs
+++ b/PerformanceMonitor.Ui/PerformanceCalendar.xaml.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -74,11 +75,23 @@ namespace PerformanceMonitor.Ui
         /// <summary>Raised when the user navigates to a different month (prev / next / Today), carrying the new month's first day.</summary>
         public event EventHandler<PerformanceCalendarMonthEventArgs>? MonthChanged;
 
+        /// <summary>Raised when the user clicks a drill button in the day-detail panel (View Deadlocks /
+        /// Blocking / Expensive Queries), carrying the day + which grid to jump to. The host scopes its
+        /// toolbar to that day's window and switches to the target tab.</summary>
+        public event EventHandler<PerformanceCalendarDrillEventArgs>? DayDrillRequested;
+
         /// <summary>The weekday column headers in the current culture's week order.</summary>
         public ObservableCollection<string> WeekdayHeaders { get; } = new();
 
         /// <summary>The 42 rendered day cells (6 weeks x 7 days).</summary>
         public ObservableCollection<PerformanceCalendarCell> Cells { get; } = new();
+
+        /// <summary>The supplied days indexed by date, for O(1) day-detail-panel lookup on click. Rebuilt
+        /// alongside the cells whenever <see cref="Days"/> changes.</summary>
+        private Dictionary<DateTime, PerformanceCalendarDay> _daysByDate = new();
+
+        /// <summary>The date the day-detail panel is currently showing (drives the drill buttons). Null when hidden.</summary>
+        private DateTime? _detailDate;
 
         private static DateTime FirstOfMonth(DateTime value) => new(value.Year, value.Month, 1);
 
@@ -108,7 +121,7 @@ namespace PerformanceMonitor.Ui
                 MonthLabel.Text = month.ToString("MMMM yyyy", CultureInfo.CurrentCulture);
             }
 
-            // Index the supplied days by date for O(1) lookup.
+            // Index the supplied days by date for O(1) lookup (cells + day-detail panel).
             var byDate = new Dictionary<DateTime, PerformanceCalendarDay>();
             if (Days != null)
             {
@@ -117,6 +130,7 @@ namespace PerformanceMonitor.Ui
                     byDate[day.Date.Date] = day;
                 }
             }
+            _daysByDate = byDate;
 
             var today = DateTime.UtcNow.Date; // calendar days are UTC-bucketed; highlight the UTC "today"
             var selected = SelectedDate?.Date;
@@ -152,6 +166,8 @@ namespace PerformanceMonitor.Ui
                     band,
                     tooltip));
             }
+
+            UpdateDayDetailPanel();
         }
 
         private void PrevMonthButton_Click(object sender, RoutedEventArgs e) =>
@@ -173,7 +189,83 @@ namespace PerformanceMonitor.Ui
         {
             if (sender is FrameworkElement { DataContext: PerformanceCalendarCell cell } && cell.IsInDisplayMonth)
             {
+                // Setting SelectedDate reframes the accent ring and (via the DP callback -> RebuildCells ->
+                // UpdateDayDetailPanel) shows the day-detail panel for this day.
+                SelectedDate = cell.Date;
                 DayClicked?.Invoke(this, new PerformanceCalendarDayEventArgs(cell.Date));
+            }
+        }
+
+        /// <summary>
+        /// (Re)populates the day-detail panel for <see cref="SelectedDate"/>: a band-colored header, the
+        /// "why this day is &lt;band&gt;" reasons, a key-metrics line, and the drill buttons that make sense for
+        /// the day — all from the shared <see cref="DailyHealthBandCalculator"/>. Hidden when no day is selected
+        /// or the selection isn't in the displayed month (e.g. after navigating to another month). A selected
+        /// day that had no collection (absent from <see cref="Days"/>) still shows a No-Data panel.
+        /// </summary>
+        private void UpdateDayDetailPanel()
+        {
+            if (DayDetailPanel == null)
+            {
+                return; // template not applied yet (early construction)
+            }
+
+            var selected = SelectedDate?.Date;
+            var month = FirstOfMonth(DisplayMonth);
+            var inMonth = selected.HasValue && selected.Value.Year == month.Year && selected.Value.Month == month.Month;
+            if (!inMonth)
+            {
+                DayDetailPanel.Visibility = Visibility.Collapsed;
+                _detailDate = null;
+                return;
+            }
+
+            _detailDate = selected!.Value;
+
+            // A day absent from the supplied set had no collection -> render it as a No-Data day.
+            _daysByDate.TryGetValue(selected.Value, out var day);
+            var band = day?.Band ?? DailyHealthBand.NoData;
+            var signals = day?.Signals ?? default; // default => HasData == false
+            var hasData = signals.HasData;
+            var bandLabel = DailyHealthBandCalculator.Label(band);
+
+            DayDetailHeader.Text = $"{selected.Value:dddd, MMM d} — {bandLabel}";
+            DayDetailHeader.SetResourceReference(TextBlock.ForegroundProperty, DailyHealthBandCalculator.BrushKey(band));
+
+            DayDetailWhyLabel.Text = $"Why this day is {bandLabel}:";
+            DayDetailReasons.ItemsSource = DailyHealthBandCalculator.BuildReasons(signals, day?.PeakBlockMs ?? 0);
+
+            // Key metrics only make sense for a collected day.
+            if (hasData)
+            {
+                DayDetailMetrics.Text = DailyHealthBandCalculator.BuildKeyMetricsLine(
+                    day!.TopWaitType, signals.HighCpuEvents, day.TotalWaitSeconds, day.UniqueQueries);
+                DayDetailMetrics.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                DayDetailMetrics.Visibility = Visibility.Collapsed;
+            }
+
+            var drills = DailyHealthBandCalculator.AvailableDrills(signals);
+            DeadlocksDrillButton.Visibility = drills.Contains(DayDrillTarget.Deadlocks) ? Visibility.Visible : Visibility.Collapsed;
+            BlockingDrillButton.Visibility = drills.Contains(DayDrillTarget.Blocking) ? Visibility.Visible : Visibility.Collapsed;
+            ExpensiveQueriesDrillButton.Visibility = drills.Contains(DayDrillTarget.ExpensiveQueries) ? Visibility.Visible : Visibility.Collapsed;
+
+            DayDetailPanel.Visibility = Visibility.Visible;
+        }
+
+        private void DeadlocksDrillButton_Click(object sender, RoutedEventArgs e) => RaiseDrill(DayDrillTarget.Deadlocks);
+
+        private void BlockingDrillButton_Click(object sender, RoutedEventArgs e) => RaiseDrill(DayDrillTarget.Blocking);
+
+        private void ExpensiveQueriesDrillButton_Click(object sender, RoutedEventArgs e) => RaiseDrill(DayDrillTarget.ExpensiveQueries);
+
+        private void RaiseDrill(DayDrillTarget target)
+        {
+            if (_detailDate is DateTime date)
+            {
+                DayDrillRequested?.Invoke(this, new PerformanceCalendarDrillEventArgs(date, target));
             }
         }
     }

--- a/PerformanceMonitor.Ui/PerformanceCalendarDay.cs
+++ b/PerformanceMonitor.Ui/PerformanceCalendarDay.cs
@@ -47,18 +47,6 @@ namespace PerformanceMonitor.Ui
         public long PeakBlockMs { get; init; }
     }
 
-    /// <summary>Event args carrying the day a user clicked on the calendar.</summary>
-    public sealed class PerformanceCalendarDayEventArgs : EventArgs
-    {
-        public PerformanceCalendarDayEventArgs(DateTime date)
-        {
-            Date = date;
-        }
-
-        /// <summary>The clicked date (date component only).</summary>
-        public DateTime Date { get; }
-    }
-
     /// <summary>Event args carrying a day-detail drill request: the clicked day plus which grid to jump to.
     /// The shared panel raises this; each host scopes its toolbar to the day and switches to the target tab.</summary>
     public sealed class PerformanceCalendarDrillEventArgs : EventArgs

--- a/PerformanceMonitor.Ui/PerformanceCalendarDay.cs
+++ b/PerformanceMonitor.Ui/PerformanceCalendarDay.cs
@@ -14,8 +14,9 @@ namespace PerformanceMonitor.Ui
     /// <summary>
     /// One day's worth of banded data supplied to <see cref="PerformanceCalendar"/>. Apps build one of
     /// these per day that had any collection (from their own <c>DailySummaryRow</c> range read), setting the
-    /// <see cref="Band"/> they already computed via <see cref="DailyHealthBandCalculator"/> and a hover
-    /// <see cref="Tooltip"/>. Days absent from the supplied set render as <see cref="DailyHealthBand.NoData"/>.
+    /// <see cref="Band"/> they already computed via <see cref="DailyHealthBandCalculator"/>, a hover
+    /// <see cref="Tooltip"/>, and the <see cref="Signals"/> + key metrics the shared day-detail panel renders
+    /// on click. Days absent from the supplied set render as <see cref="DailyHealthBand.NoData"/> (no panel).
     /// </summary>
     public sealed class PerformanceCalendarDay
     {
@@ -27,6 +28,23 @@ namespace PerformanceMonitor.Ui
 
         /// <summary>Multi-line hover text summarizing the day's signals (see <see cref="DailyHealthBandCalculator.Describe"/>).</summary>
         public string Tooltip { get; init; } = string.Empty;
+
+        /// <summary>The day's rolled-up signal counts — drives the day-detail panel's "why this day is
+        /// &lt;band&gt;" reasons and which drill buttons it offers (<see cref="DailyHealthBandCalculator.BuildReasons"/> /
+        /// <see cref="DailyHealthBandCalculator.AvailableDrills"/>).</summary>
+        public DailyHealthSignals Signals { get; init; }
+
+        /// <summary>The day's top wait type (for the panel's key-metrics line).</summary>
+        public string TopWaitType { get; init; } = string.Empty;
+
+        /// <summary>The day's total wait, in seconds (for the panel's key-metrics line).</summary>
+        public decimal TotalWaitSeconds { get; init; }
+
+        /// <summary>The day's distinct-query count (for the panel's key-metrics line).</summary>
+        public long UniqueQueries { get; init; }
+
+        /// <summary>The day's peak/max block wait in ms (0 when unknown), shown on the panel's blocking reason.</summary>
+        public long PeakBlockMs { get; init; }
     }
 
     /// <summary>Event args carrying the day a user clicked on the calendar.</summary>
@@ -39,6 +57,23 @@ namespace PerformanceMonitor.Ui
 
         /// <summary>The clicked date (date component only).</summary>
         public DateTime Date { get; }
+    }
+
+    /// <summary>Event args carrying a day-detail drill request: the clicked day plus which grid to jump to.
+    /// The shared panel raises this; each host scopes its toolbar to the day and switches to the target tab.</summary>
+    public sealed class PerformanceCalendarDrillEventArgs : EventArgs
+    {
+        public PerformanceCalendarDrillEventArgs(DateTime date, DayDrillTarget target)
+        {
+            Date = date;
+            Target = target;
+        }
+
+        /// <summary>The day to scope the drill to (date component only).</summary>
+        public DateTime Date { get; }
+
+        /// <summary>Which grid the user asked to jump to for that day.</summary>
+        public DayDrillTarget Target { get; }
     }
 
     /// <summary>Event args carrying the month the calendar wants data for (its first day, at midnight).</summary>


### PR DESCRIPTION
## What

Replaces the Performance Calendar's day-click behavior. Clicking a day used to show a one-row Daily Summary grid; it now opens a rich **day-detail panel** built into the shared calendar control, with a drill-in.

The panel (shown under the month grid):
1. **Header** — `<Weekday, Mon D> — <BAND>`, colored by the band's theme brush (`DailyHealthBandCalculator.BrushKey` via `SetResourceReference`, so it themes).
2. **"Why this day is `<band>`:"** — one line per non-zero signal that drove the band (deadlocks, collection errors, high-CPU samples, blocking events *with peak block duration*, severe / non-severe memory-pressure, alerts), reusing the same per-signal wording as the calendar tooltip. Healthy -> "No issues detected."; No-Data -> "No collection this day."
3. **Key-metrics line** — top wait type, high-CPU sample count, total wait (s), unique queries.
4. **Drill buttons** — `View Deadlocks` (only if the day had deadlocks), `View Blocking` (only if blocking > 0), `View Expensive Queries` (any collected day).

## Drill navigation (reuses the existing chart-drill mechanism)

Clicking a drill button **scopes the per-server tab's time window to that day** (00:00 -> next 00:00) **and switches to the target inner tab**, mirroring the per-chart "Show Active Queries at This Time" drill:

- **Lite** reuses `SetDrillDownTimeRange` to put the toolbar on a Custom range for the day, switches `MainTabControl`/sub-tab under `_suppressActiveQueriesAutoRefresh`, then runs the standard per-sub-tab refresh over the day window.
- **Viewer** adds `SetToolbarWindowUtc` (mirroring `ApplyExternalTimeRange`'s picker manipulation, from UTC, without a reload), switches `InnerTabs`/sub-tab under `_suppressDrillDownAutoRefresh`, then calls the same loader the chart drills use.

Targets: Deadlocks -> Blocking / Deadlocks; Blocking -> Blocking / Blocked Process Reports; Expensive Queries -> viewer's Queries / Expensive Queries, Lite's Queries / Top Queries by Duration.

The calendar buckets days in UTC; Lite converts the UTC day to server time for its reads, the viewer passes naive UTC through and converts only for the display-mode pickers.

## Shared vs. per-app

- **Shared (Common)** — `DailyHealthBandCalculator.BuildReasons` / `AvailableDrills` / `DayWindowUtc` / `BuildKeyMetricsLine` + `DayDrillTarget`. Pure, unit-tested.
- **Shared (Ui)** — the panel lives in `PerformanceCalendar` (control + `PerformanceCalendarDay` enriched with signals/metrics). Colors are theme `DynamicResource`s; the control raises `DayDrillRequested(date, target)`.
- **Per-app** — each host handles `DayDrillRequested` with its own toolbar-window + inner-tab mechanism.

Also added a **peak block duration** column (`MAX(wait_time_ms)`, BPR-preferred / DMV-fallback) to both `DailySummaryRangeSql` queries + `DailySummaryRow` classes.

## Tests

- `DailyHealthBandTests` (Lite + Darling): BuildReasons terminals/lines/peak-block, AvailableDrills gating+order, DayWindowUtc, BuildKeyMetricsLine.
- `PerformanceCalendarDataTests` (Lite): seeds BPR rows -> asserts `MaxBlockDurationMs`.
- `ViewerDailySummarySqlTests` (Darling): asserts the peak-block clause in the Postgres SQL.
- Both apps build `-c Release`; full suites green (Lite 953, Darling 1669 pass / 126 skipped live-DB).

## For visual review (WPF rendering isn't unit-tested)

- Panel layout/spacing and the band-colored header.
- The three drill targets and their scoped landing tabs.
- Key-metrics shows the high-CPU **sample count** (chose the count over a peak-%, which is what the banding uses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
