### PR TITLE
Skip running_jobs collector on Azure SQL DB (no SQL Agent)

### DIFF
--- a/Lite.Tests/RunningJobsCollectorDefinitionTests.cs
+++ b/Lite.Tests/RunningJobsCollectorDefinitionTests.cs
@@ -34,6 +34,16 @@ public sealed class RunningJobsCollectorDefinitionTests
     }
 
     [Fact]
+    public void AppliesTo_SkipsAzureSqlDb_ButCollectsOnPremManagedInstanceAndRds()
+    {
+        /* Azure SQL DB has no SQL Agent (msdb unreachable) — skip rather than log a per-cycle ERROR. */
+        Assert.False(RunningJobsCollector.Instance.AppliesTo(new CollectorTargetInfo { IsAzureSqlDb = true }));
+        /* Managed Instance has Agent; on-prem and RDS (a non-Azure edition) collect too. */
+        Assert.True(RunningJobsCollector.Instance.AppliesTo(new CollectorTargetInfo { IsAzureManagedInstance = true }));
+        Assert.True(RunningJobsCollector.Instance.AppliesTo(new CollectorTargetInfo()));
+    }
+
+    [Fact]
     public void NamesColumnsAndQuery_MatchSchema()
     {
         Assert.Equal("running_jobs", RunningJobsCollector.Instance.Name);

--- a/PerformanceMonitor.Collectors/RunningJobsCollector.cs
+++ b/PerformanceMonitor.Collectors/RunningJobsCollector.cs
@@ -144,6 +144,16 @@ OPTION(RECOMPILE);";
     /// <summary>running_jobs is keyed by (collection_time, server) alone — no collection_id.</summary>
     public override bool IncludesCollectionId => false;
 
+    /// <summary>
+    /// Azure SQL Database has no SQL Agent — <c>msdb.dbo.sysjobactivity</c> is unreachable there
+    /// (the three-part msdb reference raises "not supported in this version of SQL Server"), so skip
+    /// the collector rather than log a per-cycle ERROR. Managed Instance (edition 8) DOES have Agent,
+    /// so it collects there; RDS/on-prem collect too (a login lacking msdb rights surfaces as a soft
+    /// PERMISSIONS status, not a skip). Mirrors the failed-jobs alert path, which already skips Azure
+    /// SQL DB before querying msdb (AppliesTo = !IsAzureSqlDb).
+    /// </summary>
+    public override bool AppliesTo(CollectorTargetInfo target) => !target.IsAzureSqlDb;
+
     public override CollectorQuery BuildQuery(CollectorContext context) => new(QueryText);
 
     public override IReadOnlyList<CollectorColumn> PayloadColumns { get; } = new[]


### PR DESCRIPTION
## Summary
Azure SQL DB has no SQL Agent, so the shared `running_jobs` collector's `msdb.dbo.sysjobactivity` query raises *"Reference to database and/or server name in 'msdb.dbo.sysjobactivity' is not supported in this version of SQL Server"* and logs a hard **ERROR** to `collection_log` every collection cycle.

Gate the collector with `AppliesTo => !target.IsAzureSqlDb`, mirroring the three other server-scoped collectors that already skip Azure SQL DB (`cpu_scheduler_stats`, `memory_pressure_events`, `system_health_events`) and the failed-jobs **alert** path, which already skips Azure SQL DB before touching msdb.

- **Azure SQL DB** (edition 5): skipped — logs a clean SUCCESS/0-rows `collection_log` row like its sibling gated collectors, no more per-cycle ERROR.
- **Azure Managed Instance** (edition 8, has Agent): still collects.
- **RDS / on-prem**: still collect; an RDS login lacking msdb rights continues to surface as a soft `PERMISSIONS` status (a real, grantable permission gap, not a skip).

Shared collector, so both **Lite** and **Darling** get the fix (Lite calls `RunningJobsCollector.Instance` directly).

## How it was found
Release-checklist section 5g cloud testing, against a live **Azure SQL DB** instance (Darling headless stack). Every other collector ran clean on Azure; `running_jobs` was the lone ungated msdb-dependent collector.

## Testing
- New unit test `AppliesTo_SkipsAzureSqlDb_ButCollectsOnPremManagedInstanceAndRds` (Lite.Tests) — 4/4 pass; service build clean.
- **Live-validated** against a real Azure SQL DB + AWS RDS: after deploying the fix, Azure `running_jobs` went ERROR -> SUCCESS (skipped); RDS `running_jobs` unchanged (`PERMISSIONS`); on-prem unchanged (runs). Zero hard ERRORs on either cloud server post-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)