### PR TITLE
Tune managed TimescaleDB for compact monitoring storage

### DIFF
--- a/Darling/PerformanceMonitor.Darling.Service/DarlingManagedPostgres.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingManagedPostgres.cs
@@ -187,6 +187,13 @@ public sealed class DarlingManagedPostgres
         builder.Append("shared_preload_libraries = 'timescaledb'\n");
         builder.Append("port = ").Append(port).Append('\n');
         builder.Append("listen_addresses = '127.0.0.1'\n");
+        /* LZ4 TOAST (PG14+; the bundled runtime is PG18): large text/XML values — query text, plan
+           XML, deadlock/blocked-process XML — auto-compress on write faster than the pglz default
+           and about as small, shrinking the ~1-day hot window before TimescaleDB's columnar
+           compression takes over. This is PostgreSQL's automatic equivalent of the SQL-Server
+           Dashboard's manual COMPRESS()/DECOMPRESS() on those columns — applied to every large
+           value, not hand-picked ones. Managed mode only; a BYO store uses its own server default. */
+        builder.Append("default_toast_compression = lz4\n");
         return builder.ToString();
     }
 

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -46,12 +46,26 @@ namespace PerformanceMonitor.Darling.Storage;
 public static class TimescaleSupport
 {
     /// <summary>
-    /// Compress chunks older than this many days — hardcoded (defaults over speculative
-    /// config). Compressed chunks remain fully queryable, just columnar and ~10-20x smaller:
-    /// this IS Darling's archival tier, the centralized-store answer to Lite's parquet archive,
-    /// keeping the full retention horizon cheap instead of splitting hot/cold stores.
+    /// Compress chunks older than this many days — hardcoded (defaults over speculative config).
+    /// Compressed chunks remain fully queryable, just columnar and ~10-20x smaller: this IS
+    /// Darling's archival tier, the centralized-store answer to Lite's parquet archive, keeping the
+    /// full retention horizon cheap instead of splitting hot/cold stores. Kept short (1 day) to
+    /// match <see cref="ChunkIntervalDays"/>: at the collectors' 1-minute cadence a longer lag left
+    /// the whole store uncompressed (a chunk cannot compress until it closes AND then ages past
+    /// this), so even a near-idle fleet grew ~1 GB in a couple of days of hot data. Collectors only
+    /// ever append current-time rows, so a day-old chunk never takes another write — safe to
+    /// compress. Measured on this data: perfmon ~16.7x, plan-XML-heavy query_stats ~6.4x.
     /// </summary>
-    public const int CompressAfterDays = 7;
+    public const int CompressAfterDays = 1;
+
+    /// <summary>
+    /// Hypertable chunk width in days. TimescaleDB's 7-day default is far too coarse for
+    /// 1-minute-cadence monitoring data: a chunk stays open (and uncompressible) for its whole
+    /// span, so 7-day chunks meant nothing compressed for ~2 weeks. 1-day chunks close daily and
+    /// become compressible within <see cref="CompressAfterDays"/>, keeping the store compact.
+    /// Applies at hypertable creation (fresh stores); existing chunks keep their original width.
+    /// </summary>
+    public const int ChunkIntervalDays = 1;
 
     /* The first conversion of a long-collected plain-PG store rewrites every row into chunks
        (migrate_data); Npgsql's default 30-second command timeout would abandon it halfway.
@@ -139,7 +153,7 @@ public static class TimescaleSupport
             throw new ArgumentNullException(nameof(schema));
         }
 
-        return $"SELECT create_hypertable('{schema.TargetTable}', by_range('{schema.PrefixTimeColumnName}'), if_not_exists => true, migrate_data => true)";
+        return $"SELECT create_hypertable('{schema.TargetTable}', by_range('{schema.PrefixTimeColumnName}', INTERVAL '{ChunkIntervalDays} days'), if_not_exists => true, migrate_data => true)";
     }
 
     /// <summary>

--- a/Darling/README.md
+++ b/Darling/README.md
@@ -207,7 +207,7 @@ Two mutually exclusive modes — setting both `managed: true` and `connectionStr
 
 | Key | Default | Notes |
 |---|---|---|
-| `capturePlans` | `true` | Capture execution plans into `query_stats.query_plan_xml` and `query_store_stats.query_plan_text`. PostgreSQL TOAST compresses the plan text transparently (pglz) and TimescaleDB chunk compression squeezes it further, so plans are cheap to keep — unlike Lite, which stores to DuckDB/Parquet and deliberately never captures them. Set `false` to skip plan capture (e.g. to shave storage across a very large fleet). |
+| `capturePlans` | `true` | Capture execution plans into `query_stats.query_plan_xml` and `query_store_stats.query_plan_text`. PostgreSQL TOAST compresses the plan text transparently (LZ4 on the managed store) and TimescaleDB chunk compression squeezes it further, so plans are cheap to keep — unlike Lite, which stores to DuckDB/Parquet and deliberately never captures them. Set `false` to skip plan capture (e.g. to shave storage across a very large fleet). |
 
 ### alerts
 
@@ -354,7 +354,7 @@ All timestamps in the store are **naive-UTC** `timestamp` columns — the produc
 
 At startup, right after migration, the service attempts `CREATE EXTENSION IF NOT EXISTS timescaledb` and checks `pg_extension`:
 
-- **Present** — every collector table is converted to a hypertable (partitioned on its own time column, existing rows migrated) and gets a compression policy: chunks older than **7 days** compress automatically (segmented by `server_id`). Compressed chunks stay fully queryable — this is Darling's archival tier, the centralized-store answer to Lite's Parquet archive. Everything is idempotent and re-converges on every service start; a table that fails conversion stays a plain table and keeps working.
+- **Present** — every collector table is converted to a hypertable (partitioned on its own time column into **1-day chunks**, existing rows migrated) and gets a compression policy: chunks older than **1 day** compress automatically (segmented by `server_id`). The short intervals matter at the 1-minute collection cadence — a chunk cannot compress until it closes and then ages, so TimescaleDB's 7-day default left the store fully uncompressed for ~2 weeks (a near-idle 5-server fleet still reached ~1 GB in a couple of days); 1-day chunks + 1-day compress keep it compact (measured ~16.7x on perfmon, ~6.4x on the plan-XML-heavy query_stats). Compressed chunks stay fully queryable — this is Darling's archival tier, the centralized-store answer to Lite's Parquet archive. Everything is idempotent and re-converges on every service start; a table that fails conversion stays a plain table and keeps working.
 - **Absent** — the service logs one Information line and runs in plain-PostgreSQL mode, which is a fully supported configuration, not a degraded one.
 
 `IF NOT EXISTS` short-circuits before privilege checks, so a store whose administrator pre-created the extension works for a service login that could never create it.
@@ -370,7 +370,7 @@ A purge runs on the first sweep after startup and then daily, driven by the same
 | 90 days | `database_size_stats`, `index_object_stats` |
 | 365 days | `server_properties` |
 
-On plain PostgreSQL the purge is DELETE-based. With TimescaleDB it switches to `drop_chunks` — a metadata-only detach of whole expired chunks (rows inside a partially-expired chunk survive until the whole chunk ages out; up to ~7 days of grace at the default chunk width), with a per-table DELETE fallback for any table that is not a hypertable. Failure-isolated per table: one stuck purge is logged and retried the next day without stopping the sweep.
+On plain PostgreSQL the purge is DELETE-based. With TimescaleDB it switches to `drop_chunks` — a metadata-only detach of whole expired chunks (rows inside a partially-expired chunk survive until the whole chunk ages out; up to ~1 day of grace at the 1-day chunk width), with a per-table DELETE fallback for any table that is not a hypertable. Failure-isolated per table: one stuck purge is logged and retried the next day without stopping the sweep.
 
 ### Logs
 


### PR DESCRIPTION
## Problem
A near-idle 5-server managed store reached **~1 GB in ~2.4 days**, entirely uncompressed. TimescaleDB's defaults are the cause: **7-day chunk interval + 7-day compress_after**. A chunk can't compress until it *closes* (a full 7 days) and then *ages* past compress_after (another 7 days), so at a 1-minute collection cadence nothing compresses for ~2 weeks. WAL was a non-issue (33 MB); the 1.1 GB was hot chunks (`perfmon_stats` 319 MB, `query_stats` 274 MB, `spinlock_stats` 125 MB, …).

## Fix
- **Chunk interval 7d → 1d** (`create_hypertable` `by_range` interval) and **`compress_after` 7d → 1d**. Chunks close daily and compress within a day. Safe: collectors only append current-time rows, so a day-old chunk never takes another write.
- **`default_toast_compression = lz4`** on the managed store (PG14+; bundled runtime is PG18). Large text/XML — query text, plan XML, deadlock/BPR XML — auto-compress on write. This is PostgreSQL's automatic equivalent of the SQL-Server Dashboard's manual `COMPRESS()`/`DECOMPRESS()`, applied to *every* large column rather than hand-picked ones.

## Evidence
Measured compression on the actual data: **`perfmon_stats` 16.7×**, **plan-XML-heavy `query_stats` 6.4×** — so ~1.1 GB of hot data → **~100–150 MB**. Chunk interval applies to fresh stores. Validated live on **PG18 / TimescaleDB 2.28.1**: `by_range('t', INTERVAL '1 days')` yields `time_interval = 1 day`, and `SET default_toast_compression = lz4` is accepted.

Found during release-prep investigation of managed-store growth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)