### PR TITLE
Darling network endpoints Phase 1: config + store + roles foundation

### DIFF
--- a/Darling/Darling.Tests/DarlingConfigTests.cs
+++ b/Darling/Darling.Tests/DarlingConfigTests.cs
@@ -233,6 +233,83 @@ public sealed class DarlingConfigTests
     }
 
     [Fact]
+    public void Network_Sections_AbsentByDefault()
+    {
+        /* Omitting the network objects = the secure default (loopback-only); both parse to null. */
+        var config = DarlingConfig.Parse(@"{ ""postgres"": { ""managed"": true }, ""servers"": [ { ""host"": ""SQL2022"" } ] }");
+        Assert.Null(config.Postgres.Network);
+        Assert.Null(config.Mcp.Network);
+    }
+
+    [Fact]
+    public void Network_ParsesPostgresRoleAndMcpToken()
+    {
+        var config = DarlingConfig.Parse(@"{
+            ""postgres"": {
+                ""managed"": true,
+                ""network"": { ""listen"": ""192.168.1.205"", ""allowFrom"": ""192.168.1.0/24"", ""role"": ""admin"" }
+            },
+            ""mcp"": {
+                ""enabled"": true,
+                ""network"": { ""listen"": ""192.168.1.205"", ""allowFrom"": ""192.168.1.0/24"", ""token"": ""dev-token"" }
+            },
+            ""servers"": [ { ""host"": ""SQL2022"" } ]
+        }");
+
+        Assert.NotNull(config.Postgres.Network);
+        Assert.Equal("192.168.1.205", config.Postgres.Network!.Listen);
+        Assert.Equal("192.168.1.0/24", config.Postgres.Network.AllowFrom);
+        Assert.Equal("admin", config.Postgres.Network.Role);
+        Assert.True(config.Postgres.Network.IsConfigured);
+
+        Assert.NotNull(config.Mcp.Network);
+        Assert.Equal("192.168.1.205", config.Mcp.Network!.Listen);
+        Assert.Equal("dev-token", config.Mcp.Network.Token);
+        Assert.True(config.Mcp.Network.IsConfigured);
+    }
+
+    [Fact]
+    public void McpNetworkConfig_ResolveToken_PrefersEncrypted_FlagsPlaintext()
+    {
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "DPAPI requires Windows.");
+
+        /* Plaintext fallback flags usedPlaintext (so the MCP host caller warns). */
+        var plain = new McpNetworkConfig { Token = "dev-token" };
+        Assert.Equal("dev-token", plain.ResolveToken(out var usedPlaintext));
+        Assert.True(usedPlaintext);
+
+        /* encryptedToken preferred (DPAPI round-trip) over an also-present plaintext, and NOT flagged. */
+        var blob = DarlingSecrets.Protect("secret-token");
+        var encrypted = new McpNetworkConfig { EncryptedToken = blob, Token = "wrong-plaintext" };
+        Assert.Equal("secret-token", encrypted.ResolveToken(out usedPlaintext));
+        Assert.False(usedPlaintext);
+
+        /* Neither set -> null. */
+        Assert.Null(new McpNetworkConfig().ResolveToken(out usedPlaintext));
+        Assert.False(usedPlaintext);
+    }
+
+    [Fact]
+    public void Validate_IgnoresNetworkExposureConfig_NeverFatal()
+    {
+        /* D-validate: network-exposure rules are enforced at the point of use (degrade to loopback),
+           NEVER in the all-fatal Validate(). An EXPOSED-but-INVALID network (bad CIDR, bad role, MCP with
+           no token) must add NO problem — a typo in an optional, default-off endpoint can't kill collection. */
+        var config = new DarlingConfig
+        {
+            Postgres = new PostgresConfig
+            {
+                Managed = true,
+                Network = new PostgresNetworkConfig { Listen = "192.168.1.205", AllowFrom = "not-a-cidr", Role = "root" },
+            },
+            Mcp = new McpConfig { Enabled = true, Network = new McpNetworkConfig { Listen = "0.0.0.0" /* no token */ } },
+            Servers = { Server() },
+        };
+
+        Assert.Empty(config.Validate());
+    }
+
+    [Fact]
     public void Secrets_DpapiRoundTrip_BlobPreferredOverPlaintext()
     {
         Assert.SkipUnless(OperatingSystem.IsWindows(), "DPAPI requires Windows.");

--- a/Darling/Darling.Tests/DarlingManagedPostgresTests.cs
+++ b/Darling/Darling.Tests/DarlingManagedPostgresTests.cs
@@ -10,6 +10,8 @@ using System;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -205,6 +207,63 @@ public sealed class DarlingManagedPostgresTests
             Assert.Equal(password, parsed.Password);
             Assert.Equal("darling", parsed.Database);
             Assert.Equal("collect,config,public", parsed.SearchPath);
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CertificateSanCoversIp_TrueForItsIpSan_FalseForOthers()
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=test", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var san = new SubjectAlternativeNameBuilder();
+        san.AddIpAddress(IPAddress.Parse("192.168.1.205"));
+        san.AddDnsName("test-host");
+        request.CertificateExtensions.Add(san.Build());
+        using var cert = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(1));
+
+        Assert.True(DarlingManagedPostgres.CertificateSanCoversIp(cert, IPAddress.Parse("192.168.1.205")));
+        Assert.False(DarlingManagedPostgres.CertificateSanCoversIp(cert, IPAddress.Parse("192.168.1.206")));
+        Assert.False(DarlingManagedPostgres.CertificateSanCoversIp(cert, IPAddress.Parse("10.0.0.1")));
+    }
+
+    [Fact]
+    public void EnsureServerCertificate_ReusesWhenSanCoversIp_RegeneratesOnIpChange()
+    {
+        /* The key hardening (DarlingFileSecurity.HardenFile) is Windows-only. */
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "Cert key hardening is Windows-only.");
+
+        var root = Directory.CreateTempSubdirectory("darling-cert-");
+        try
+        {
+            var dataDirectory = Path.Combine(root.FullName, "pg");
+            Directory.CreateDirectory(dataDirectory);
+            var config = new PostgresConfig { Managed = true, Port = 5993, DataDirectory = dataDirectory };
+            var pg = new DarlingManagedPostgres(config, NullLogger.Instance);
+
+            /* The cert/key live beside the data directory, same convention as the credential files. */
+            var certPath = Path.Combine(root.FullName, DarlingManagedPostgres.ServerCertFileName);
+            var keyPath = Path.Combine(root.FullName, DarlingManagedPostgres.ServerKeyFileName);
+
+            /* First generation for IP A. */
+            pg.EnsureServerCertificate(IPAddress.Parse("192.168.1.205"), certPath, keyPath);
+            Assert.True(File.Exists(certPath) && File.Exists(keyPath));
+            var certA = File.ReadAllBytes(certPath);
+
+            /* Same IP -> reuse (SAN covers it), bytes unchanged. */
+            pg.EnsureServerCertificate(IPAddress.Parse("192.168.1.205"), certPath, keyPath);
+            Assert.Equal(certA, File.ReadAllBytes(certPath));
+
+            /* Different IP -> regenerate (stale SAN would break verify-full); the new cert covers B. */
+            pg.EnsureServerCertificate(IPAddress.Parse("192.168.1.206"), certPath, keyPath);
+            var certB = File.ReadAllBytes(certPath);
+            Assert.NotEqual(certA, certB);
+            using var reloaded = X509Certificate2.CreateFromPem(File.ReadAllText(certPath));
+            Assert.True(DarlingManagedPostgres.CertificateSanCoversIp(reloaded, IPAddress.Parse("192.168.1.206")));
+            Assert.False(DarlingManagedPostgres.CertificateSanCoversIp(reloaded, IPAddress.Parse("192.168.1.205")));
         }
         finally
         {

--- a/Darling/Darling.Tests/DarlingManagedPostgresTests.cs
+++ b/Darling/Darling.Tests/DarlingManagedPostgresTests.cs
@@ -38,7 +38,10 @@ public sealed class DarlingManagedPostgresTests
     {
         var parsed = new NpgsqlConnectionStringBuilder(DarlingManagedPostgres.BuildConnectionString(5641, "pw123"));
 
-        Assert.Equal("localhost", parsed.Host);
+        /* Explicit IPv4 loopback (not the name "localhost"): listen_addresses binds 127.0.0.1 (plus the
+           optional network IP when exposed), NOT ::1, so a host resolving "localhost" to IPv6 first could
+           otherwise miss the listener (darling-network-endpoints). */
+        Assert.Equal("127.0.0.1", parsed.Host);
         Assert.Equal(5641, parsed.Port);
         Assert.Equal("darling", parsed.Username);
         Assert.Equal("pw123", parsed.Password);
@@ -156,6 +159,52 @@ public sealed class DarlingManagedPostgresTests
             var parsed = new NpgsqlConnectionStringBuilder(derived);
             Assert.Equal(password, parsed.Password);
             Assert.Equal(5991, parsed.Port);
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void McpCredentialPath_BesideTheDataDirectory_AndDistinctFile()
+    {
+        /* The mcp role credential lives beside the data directory, same posture as owner/admin/viewer
+           (trailing separator tolerated) — a fourth distinct file (darling-network-endpoints, D3-role). */
+        Assert.Equal(@"D:\darling\pg-mcp-credential.dpapi", DarlingManagedPostgres.McpCredentialPathFor(@"D:\darling\pg"));
+        Assert.Equal(@"D:\darling\pg-mcp-credential.dpapi", DarlingManagedPostgres.McpCredentialPathFor(@"D:\darling\pg\"));
+        Assert.Equal("pg-mcp-credential.dpapi", DarlingManagedPostgres.McpCredentialFileName);
+        Assert.Equal("mcp", DarlingManagedPostgres.McpRoleName);
+    }
+
+    [Fact]
+    public void McpStoredCredential_DpapiRoundTrip_DerivesMcpConnectionString()
+    {
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "DPAPI requires Windows.");
+
+        var root = Directory.CreateTempSubdirectory("darling-mcpcred-");
+        try
+        {
+            var dataDirectory = Path.Combine(root.FullName, "pg");
+            var config = new PostgresConfig { Managed = true, Port = 5992, DataDirectory = dataDirectory };
+
+            /* No mcp credential yet → null (the MCP host polls for it after the worker provisions it). */
+            Assert.Null(DarlingManagedPostgres.TryBuildMcpConnectionStringFromStoredCredential(config));
+
+            var password = DarlingManagedPostgres.GeneratePassword();
+            File.WriteAllText(DarlingManagedPostgres.McpCredentialPathFor(dataDirectory), DarlingSecrets.Protect(password));
+
+            var derived = DarlingManagedPostgres.TryBuildMcpConnectionStringFromStoredCredential(config);
+            Assert.NotNull(derived);
+            var parsed = new NpgsqlConnectionStringBuilder(derived);
+
+            /* The mcp pool connects as the mcp role over the explicit IPv4 loopback, same search path. */
+            Assert.Equal("127.0.0.1", parsed.Host);
+            Assert.Equal(5992, parsed.Port);
+            Assert.Equal("mcp", parsed.Username);
+            Assert.Equal(password, parsed.Password);
+            Assert.Equal("darling", parsed.Database);
+            Assert.Equal("collect,config,public", parsed.SearchPath);
         }
         finally
         {

--- a/Darling/Darling.Tests/DarlingManagedRolesTests.cs
+++ b/Darling/Darling.Tests/DarlingManagedRolesTests.cs
@@ -27,7 +27,7 @@ public sealed class DarlingManagedRolesTests
     [Fact]
     public void BuildProvisioningSql_CreatesRolesIdempotently_LoginNoSuperuser()
     {
-        var sql = DarlingManagedRoles.BuildProvisioningSql("AdminPassword01", "ViewerPassword02");
+        var sql = DarlingManagedRoles.BuildProvisioningSql("AdminPassword01", "ViewerPassword02", "McpPassword03");
 
         /* DO-guarded CREATE ROLE (no IF NOT EXISTS on CREATE ROLE) + a password re-assert every start. */
         Assert.Contains("FROM pg_roles WHERE rolname = 'admin'", sql, StringComparison.Ordinal);
@@ -41,7 +41,7 @@ public sealed class DarlingManagedRolesTests
     [Fact]
     public void BuildProvisioningSql_StampsMarker_AndFailsLoudOnUnmarkedCollision()
     {
-        var sql = DarlingManagedRoles.BuildProvisioningSql("AdminPassword01", "ViewerPassword02");
+        var sql = DarlingManagedRoles.BuildProvisioningSql("AdminPassword01", "ViewerPassword02", "McpPassword03");
 
         Assert.Equal("darling-managed", DarlingManagedRoles.RoleMarker);
 
@@ -60,7 +60,7 @@ public sealed class DarlingManagedRolesTests
     [Fact]
     public void BuildProvisioningSql_GrantsReadBothSchemas_WritesConfigForAdminOnly()
     {
-        var sql = DarlingManagedRoles.BuildProvisioningSql("AdminPassword01", "ViewerPassword02");
+        var sql = DarlingManagedRoles.BuildProvisioningSql("AdminPassword01", "ViewerPassword02", "McpPassword03");
 
         Assert.Contains("GRANT USAGE ON SCHEMA collect, config TO admin, viewer;", sql, StringComparison.Ordinal);
         Assert.Contains("GRANT SELECT ON ALL TABLES IN SCHEMA collect TO admin, viewer;", sql, StringComparison.Ordinal);
@@ -70,14 +70,15 @@ public sealed class DarlingManagedRolesTests
         Assert.Contains("GRANT INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA config TO admin;", sql, StringComparison.Ordinal);
         Assert.DoesNotContain("INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA config TO admin, viewer", sql, StringComparison.Ordinal);
 
-        /* collect is read-only to everyone but the owner — no write grant on it at all. */
+        /* No BLANKET (schema-wide) collect write to anyone but the owner. mcp gets a single-table INSERT on
+           collect.analysis_findings (section 6, asserted separately), never a schema-wide collect write. */
         Assert.DoesNotContain("INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA collect", sql, StringComparison.Ordinal);
     }
 
     [Fact]
     public void BuildProvisioningSql_DefaultPrivileges_AutoGrantNewTables()
     {
-        var sql = DarlingManagedRoles.BuildProvisioningSql("AdminPassword01", "ViewerPassword02");
+        var sql = DarlingManagedRoles.BuildProvisioningSql("AdminPassword01", "ViewerPassword02", "McpPassword03");
 
         /* New collector tables (created bare into collect via search_path) auto-inherit SELECT. */
         Assert.Contains("ALTER DEFAULT PRIVILEGES FOR ROLE darling IN SCHEMA collect", sql, StringComparison.Ordinal);
@@ -92,7 +93,7 @@ public sealed class DarlingManagedRolesTests
     [Fact]
     public void BuildProvisioningSql_CarvesViewerSecretColumns_FailClosed()
     {
-        var sql = DarlingManagedRoles.BuildProvisioningSql("AdminPassword01", "ViewerPassword02");
+        var sql = DarlingManagedRoles.BuildProvisioningSql("AdminPassword01", "ViewerPassword02", "McpPassword03");
 
         /* The blanket config SELECT to viewer is still present (covers the non-secret config tables), but
            the three credential-bearing tables are then carved to column-level for viewer. */
@@ -167,7 +168,7 @@ public sealed class DarlingManagedRolesTests
     [Fact]
     public void BuildProvisioningSql_HardensPublic_ButKeepsAdminViewerConnect()
     {
-        var sql = DarlingManagedRoles.BuildProvisioningSql("AdminPassword01", "ViewerPassword02");
+        var sql = DarlingManagedRoles.BuildProvisioningSql("AdminPassword01", "ViewerPassword02", "McpPassword03");
 
         Assert.Contains("REVOKE CREATE ON SCHEMA public FROM PUBLIC;", sql, StringComparison.Ordinal);
         Assert.Contains("REVOKE ALL ON DATABASE darling FROM PUBLIC;", sql, StringComparison.Ordinal);
@@ -175,6 +176,73 @@ public sealed class DarlingManagedRolesTests
         /* REVOKE ALL drops PUBLIC's implicit CONNECT, so admin/viewer must be re-granted it, or the
            Viewer could no longer connect — the correctness fix over the design's literal DDL. */
         Assert.Contains("GRANT CONNECT ON DATABASE darling TO admin, viewer;", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildProvisioningSql_McpRole_CreatedAndGrantedReadPlusTwoInserts_NoAdp()
+    {
+        var sql = DarlingManagedRoles.BuildProvisioningSql("AdminPassword01", "ViewerPassword02", "McpPassword03");
+
+        /* The mcp role is created + stamped + re-asserted, guarded exactly like admin/viewer. */
+        Assert.Contains("FROM pg_roles WHERE rolname = 'mcp'", sql, StringComparison.Ordinal);
+        Assert.Contains("CREATE ROLE mcp LOGIN NOSUPERUSER PASSWORD 'McpPassword03';", sql, StringComparison.Ordinal);
+        Assert.Contains("COMMENT ON ROLE mcp IS 'darling-managed';", sql, StringComparison.Ordinal);
+        Assert.Contains("ALTER ROLE mcp    LOGIN NOSUPERUSER PASSWORD 'McpPassword03';", sql, StringComparison.Ordinal);
+        Assert.Contains("RAISE EXCEPTION 'Role \"mcp\" already exists and was not created by Darling", sql, StringComparison.Ordinal);
+
+        /* viewer's read surface, granted as SEPARATE 'TO mcp' statements — NOT appended to the pinned
+           'TO admin, viewer' grant lines (which stay verbatim). */
+        Assert.Contains("GRANT USAGE ON SCHEMA collect, config TO mcp;", sql, StringComparison.Ordinal);
+        Assert.Contains("GRANT SELECT ON ALL TABLES IN SCHEMA collect TO mcp;", sql, StringComparison.Ordinal);
+        Assert.Contains("GRANT SELECT ON ALL TABLES IN SCHEMA config  TO mcp;", sql, StringComparison.Ordinal);
+        Assert.Contains("GRANT CONNECT ON DATABASE darling TO mcp;", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("TO admin, viewer, mcp", sql, StringComparison.Ordinal);
+        Assert.Contains("GRANT SELECT ON ALL TABLES IN SCHEMA collect TO admin, viewer;", sql, StringComparison.Ordinal);
+
+        /* Exactly the two narrow analysis writes (Round 4 #1: INSERT-only). */
+        Assert.Contains("GRANT INSERT ON collect.analysis_findings TO mcp;", sql, StringComparison.Ordinal);
+        Assert.Contains("GRANT INSERT ON config.analysis_muted TO mcp;", sql, StringComparison.Ordinal);
+
+        /* No DELETE on analysis_muted (no MCP unmute tool) and no schema-wide write for mcp. */
+        Assert.DoesNotContain("DELETE ON config.analysis_muted TO mcp", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA config TO mcp", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA collect TO mcp", sql, StringComparison.Ordinal);
+
+        /* NO ALTER DEFAULT PRIVILEGES names mcp — ADP has no per-table form, so an ADP INSERT would broaden
+           mcp to ALL of collect. The narrow grants are explicit single-table statements. */
+        Assert.DoesNotContain("ON TABLES TO mcp", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("ON SEQUENCES TO mcp", sql, StringComparison.Ordinal);
+        foreach (var adpLine in sql.Split('\n').Where(l => l.Contains("ALTER DEFAULT PRIVILEGES", StringComparison.Ordinal)))
+        {
+            Assert.DoesNotContain("mcp", adpLine, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void BuildProvisioningSql_McpRole_CarvesSecretColumns_LikeViewer()
+    {
+        var sql = DarlingManagedRoles.BuildProvisioningSql("AdminPassword01", "ViewerPassword02", "McpPassword03");
+
+        /* The mcp role gets the SAME fail-closed secret-column carve as viewer (reusing
+           BuildViewerColumnAclSql(config, "mcp")), so a network-reachable token can never read the
+           credential columns. */
+        foreach (var acl in DarlingManagedRoles.ViewerRestrictedConfigTables)
+        {
+            Assert.Contains($"REVOKE SELECT ON config.{acl.Table} FROM mcp;", sql, StringComparison.Ordinal);
+            Assert.Contains($"GRANT SELECT ({string.Join(", ", acl.NonSecretColumns)}) ON config.{acl.Table} TO mcp;",
+                sql, StringComparison.Ordinal);
+        }
+
+        /* No secret column name appears in any GRANT SELECT (...) TO mcp line (belt over the per-table check). */
+        var mcpGrantLines = sql.Split('\n')
+            .Where(line => line.Contains("TO mcp", StringComparison.Ordinal) && line.Contains("GRANT SELECT (", StringComparison.Ordinal));
+        foreach (var secret in DarlingManagedRoles.ViewerRestrictedConfigTables.SelectMany(a => a.SecretColumns))
+        {
+            foreach (var line in mcpGrantLines)
+            {
+                Assert.DoesNotContain(secret, line, StringComparison.Ordinal);
+            }
+        }
     }
 
     [Theory]
@@ -186,9 +254,11 @@ public sealed class DarlingManagedRolesTests
     public void BuildProvisioningSql_RejectsNonAlphanumericPassword(string badPassword)
     {
         /* Passwords are interpolated into DDL literals; the alnum guard fails closed if the
-           generator's alphabet is ever widened without switching to quote_literal. */
-        Assert.Throws<ArgumentException>(() => DarlingManagedRoles.BuildProvisioningSql(badPassword, "ViewerPassword02"));
-        Assert.Throws<ArgumentException>(() => DarlingManagedRoles.BuildProvisioningSql("AdminPassword01", badPassword));
+           generator's alphabet is ever widened without switching to quote_literal. Guards all THREE
+           role passwords (admin/viewer/mcp). */
+        Assert.Throws<ArgumentException>(() => DarlingManagedRoles.BuildProvisioningSql(badPassword, "ViewerPassword02", "McpPassword03"));
+        Assert.Throws<ArgumentException>(() => DarlingManagedRoles.BuildProvisioningSql("AdminPassword01", badPassword, "McpPassword03"));
+        Assert.Throws<ArgumentException>(() => DarlingManagedRoles.BuildProvisioningSql("AdminPassword01", "ViewerPassword02", badPassword));
     }
 
     [Fact]
@@ -197,10 +267,12 @@ public sealed class DarlingManagedRolesTests
         /* The real generated passwords (32-char alnum) pass the guard and inject cleanly. */
         var admin = DarlingManagedPostgres.GeneratePassword();
         var viewer = DarlingManagedPostgres.GeneratePassword();
+        var mcp = DarlingManagedPostgres.GeneratePassword();
 
-        var sql = DarlingManagedRoles.BuildProvisioningSql(admin, viewer);
+        var sql = DarlingManagedRoles.BuildProvisioningSql(admin, viewer, mcp);
 
         Assert.Contains($"PASSWORD '{admin}'", sql, StringComparison.Ordinal);
         Assert.Contains($"PASSWORD '{viewer}'", sql, StringComparison.Ordinal);
+        Assert.Contains($"PASSWORD '{mcp}'", sql, StringComparison.Ordinal);
     }
 }

--- a/Darling/Darling.Tests/DarlingNetworkTests.cs
+++ b/Darling/Darling.Tests/DarlingNetworkTests.cs
@@ -102,18 +102,35 @@ public sealed class DarlingNetworkTests
         Assert.Contains("listen_addresses=127.0.0.1,192.168.1.205", opts, StringComparison.Ordinal);
     }
 
-    [Theory]
-    [InlineData("0.0.0.0")]
-    [InlineData("::")]
-    public void BuildServerRuntimeOptions_Wildcard_EmittedAlone_NoLoopbackPrefix(string wildcard)
+    [Fact]
+    public void BuildServerRuntimeOptions_Ipv4Wildcard_EmittedAlone_NoLoopbackPrefix()
     {
-        /* A wildcard binds every interface; on Windows PG cannot ALSO bind 127.0.0.1 on the same port
-           (WSAEADDRINUSE), so it must be emitted ALONE — never "127.0.0.1,<wildcard>". */
-        var opts = DarlingManagedPostgres.BuildServerRuntimeOptions(5641, wildcard, null, null);
-
-        Assert.Equal($"-p 5641 -c listen_addresses={wildcard}", opts);
-        Assert.DoesNotContain($"127.0.0.1,{wildcard}", opts, StringComparison.Ordinal);
+        /* 0.0.0.0 already covers 127.0.0.1 for the owner connection, and Windows PG cannot ALSO bind an
+           explicit 127.0.0.1 on the same port (overlapping IPv4 -> WSAEADDRINUSE), so it goes ALONE. */
+        var opts = DarlingManagedPostgres.BuildServerRuntimeOptions(5641, "0.0.0.0", null, null);
+        Assert.Equal("-p 5641 -c listen_addresses=0.0.0.0", opts);
+        Assert.DoesNotContain("127.0.0.1,0.0.0.0", opts, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void BuildServerRuntimeOptions_Ipv6Wildcard_KeepsLoopbackPrefix()
+    {
+        /* :: binds IPv6-ONLY on Windows, so it must KEEP the 127.0.0.1, prefix or the hardcoded-IPv4 owner
+           is stranded (different families -> no WSAEADDRINUSE). */
+        var opts = DarlingManagedPostgres.BuildServerRuntimeOptions(5641, "::", null, null);
+        Assert.Equal("-p 5641 -c listen_addresses=127.0.0.1,::", opts);
+    }
+
+    [Theory]
+    [InlineData(null, "127.0.0.1")]
+    [InlineData("", "127.0.0.1")]
+    [InlineData("   ", "127.0.0.1")]
+    [InlineData("0.0.0.0", "0.0.0.0")]                                  // IPv4 wildcard: alone
+    [InlineData("192.168.1.205", "127.0.0.1,192.168.1.205")]           // specific IPv4: prefixed
+    [InlineData("::", "127.0.0.1,::")]                                  // IPv6 wildcard: prefixed (IPv6-only bind)
+    [InlineData("2001:db8::5", "127.0.0.1,2001:db8::5")]               // specific IPv6: prefixed
+    public void BuildListenAddresses_Ipv4WildcardAlone_EverythingElseKeepsLoopback(string? listen, string expected)
+        => Assert.Equal(expected, DarlingManagedPostgres.BuildListenAddresses(listen));
 
     /* ---- pg_hba reconcile (DarlingManagedPostgres.ReconcilePgHba / BuildNetworkPgHbaLine) ---- */
 

--- a/Darling/Darling.Tests/DarlingNetworkTests.cs
+++ b/Darling/Darling.Tests/DarlingNetworkTests.cs
@@ -97,6 +97,22 @@ public sealed class DarlingNetworkTests
            space inside a value would make postgres re-split it, and backslashes must not survive. */
         Assert.DoesNotContain("'", opts, StringComparison.Ordinal);
         Assert.DoesNotContain("\\", opts, StringComparison.Ordinal);
+
+        /* A specific IP keeps the loopback prefix (the service connects over 127.0.0.1). */
+        Assert.Contains("listen_addresses=127.0.0.1,192.168.1.205", opts, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("0.0.0.0")]
+    [InlineData("::")]
+    public void BuildServerRuntimeOptions_Wildcard_EmittedAlone_NoLoopbackPrefix(string wildcard)
+    {
+        /* A wildcard binds every interface; on Windows PG cannot ALSO bind 127.0.0.1 on the same port
+           (WSAEADDRINUSE), so it must be emitted ALONE — never "127.0.0.1,<wildcard>". */
+        var opts = DarlingManagedPostgres.BuildServerRuntimeOptions(5641, wildcard, null, null);
+
+        Assert.Equal($"-p 5641 -c listen_addresses={wildcard}", opts);
+        Assert.DoesNotContain($"127.0.0.1,{wildcard}", opts, StringComparison.Ordinal);
     }
 
     /* ---- pg_hba reconcile (DarlingManagedPostgres.ReconcilePgHba / BuildNetworkPgHbaLine) ---- */
@@ -188,6 +204,22 @@ public sealed class DarlingNetworkTests
         Assert.Equal(disabledOnce, disabledTwice);
         Assert.Contains("hostssl otherdb reporting 10.9.0.0/16 scram-sha-256", disabledOnce, StringComparison.Ordinal);
         Assert.DoesNotContain("darling viewer", disabledOnce, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NeedsPgHbaReconcile_SkipsUntouchedStore_ReconcilesDisableEdgeAndExposure()
+    {
+        /* Never-exposed store, not exposing now -> NO reconcile (don't rewrite an untouched operator file). */
+        Assert.False(DarlingManagedPostgres.NeedsPgHbaReconcile(SampleHba, null));
+
+        /* A disable edge: the managed block is still present -> reconcile (to remove it), even with desired=null. */
+        var withBlock = DarlingManagedPostgres.ReconcilePgHba(
+            SampleHba, DarlingManagedPostgres.BuildNetworkPgHbaLine("viewer", "192.168.1.0/24"));
+        Assert.True(DarlingManagedPostgres.NeedsPgHbaReconcile(withBlock, null));
+
+        /* Exposing (a rule to apply) -> always reconcile, even with no prior block. */
+        Assert.True(DarlingManagedPostgres.NeedsPgHbaReconcile(
+            SampleHba, DarlingManagedPostgres.BuildNetworkPgHbaLine("viewer", "192.168.1.0/24")));
     }
 
     /* ---- firewall command builders (idempotent named shape) ---- */

--- a/Darling/Darling.Tests/DarlingNetworkTests.cs
+++ b/Darling/Darling.Tests/DarlingNetworkTests.cs
@@ -1,0 +1,333 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using PerformanceMonitor.Darling.Service;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// The opt-in network-endpoint primitives (darling-network-endpoints), all PURE + ungated: the
+/// non-loopback classifier, the role normalizer, the pg_ctl <c>-o</c> arg-gen (listen/ssl), the
+/// <c>ReconcilePgHba</c> marked-block reconcile, the firewall command builders, and the store
+/// loopback-degrade decision (<c>ResolveNetworkExposure</c>). The live round-trips (an exposed
+/// cluster actually accepts a TLS verify-full client, an off-CIDR client is refused, the mcp role is
+/// denied the secret columns) are validated on DARLING01 and in the gated
+/// <see cref="DarlingSecuritySplitLiveTests"/>.
+/// </summary>
+public sealed class DarlingNetworkTests
+{
+    /* ---- non-loopback classifier (DarlingNetwork.IsExposedListenAddress) ---- */
+
+    [Theory]
+    [InlineData("192.168.1.205", true)]  // a real LAN IP
+    [InlineData("10.0.0.5", true)]
+    [InlineData("0.0.0.0", true)]         // all interfaces
+    [InlineData("::", true)]              // IPv6 all interfaces
+    [InlineData("::1", true)]             // IPv6 loopback — the store's loopback handling is IPv4-127 only
+    [InlineData("*", true)]               // not an IP -> exposed (store bind will degrade)
+    [InlineData("localhost", true)]       // a name, not an IP -> exposed
+    [InlineData("db.lan", true)]          // a hostname -> exposed
+    [InlineData("127.0.0.1", false)]      // the canonical loopback = NOT exposed
+    [InlineData("127.0.0.5", false)]      // anywhere in 127.0.0.0/8 = NOT exposed
+    [InlineData("", false)]               // absent = the default loopback-only store
+    [InlineData("   ", false)]
+    [InlineData(null, false)]
+    public void IsExposedListenAddress_TreatsAnythingButIpv4Loopback_AsExposed(string? listen, bool expected)
+        => Assert.Equal(expected, DarlingNetwork.IsExposedListenAddress(listen));
+
+    /* ---- role normalizer (DarlingNetwork.NormalizeNetworkRole) ---- */
+
+    [Theory]
+    [InlineData(null, "viewer")]   // absent -> the secure read-only default (D7)
+    [InlineData("", "viewer")]
+    [InlineData("   ", "viewer")]
+    [InlineData("viewer", "viewer")]
+    [InlineData("VIEWER", "viewer")]
+    [InlineData(" Admin ", "admin")]
+    [InlineData("admin", "admin")]
+    public void NormalizeNetworkRole_DefaultsViewer_AcceptsAdminCaseInsensitively(string? role, string expected)
+        => Assert.Equal(expected, DarlingNetwork.NormalizeNetworkRole(role));
+
+    [Theory]
+    [InlineData("darling")]     // NEVER the superuser
+    [InlineData("postgres")]
+    [InlineData("superuser")]
+    [InlineData("root")]
+    public void NormalizeNetworkRole_RejectsAnythingElse_ToNull(string role)
+        => Assert.Null(DarlingNetwork.NormalizeNetworkRole(role));
+
+    /* ---- listen/ssl -o arg-gen (DarlingManagedPostgres.BuildServerRuntimeOptions) ---- */
+
+    [Fact]
+    public void BuildServerRuntimeOptions_LoopbackOnly_WhenNoNetworkIp()
+    {
+        var opts = DarlingManagedPostgres.BuildServerRuntimeOptions(5641, null, null, null);
+
+        /* Always the port + loopback listen; NO ssl, NO single quotes (Windows CRT arg hazard). */
+        Assert.Equal("-p 5641 -c listen_addresses=127.0.0.1", opts);
+        Assert.DoesNotContain("ssl", opts, StringComparison.Ordinal);
+        Assert.DoesNotContain("'", opts, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildServerRuntimeOptions_Exposed_AddsNetworkIpAndSslTrio_ForwardSlashed_NoQuotes()
+    {
+        var opts = DarlingManagedPostgres.BuildServerRuntimeOptions(
+            5641,
+            "192.168.1.205",
+            @"C:\ProgramData\PerformanceMonitorDarling\server.crt",
+            @"C:\ProgramData\PerformanceMonitorDarling\server.key");
+
+        /* Loopback FIRST, then the network IP appended (no space in the value). */
+        Assert.Contains("-c listen_addresses=127.0.0.1,192.168.1.205", opts, StringComparison.Ordinal);
+
+        /* The ssl trio, cert paths forward-slashed. */
+        Assert.Contains("-c ssl=on", opts, StringComparison.Ordinal);
+        Assert.Contains("-c ssl_cert_file=C:/ProgramData/PerformanceMonitorDarling/server.crt", opts, StringComparison.Ordinal);
+        Assert.Contains("-c ssl_key_file=C:/ProgramData/PerformanceMonitorDarling/server.key", opts, StringComparison.Ordinal);
+
+        /* Windows CRT hazards: only double quotes are metacharacters (single quotes corrupt a GUC), a
+           space inside a value would make postgres re-split it, and backslashes must not survive. */
+        Assert.DoesNotContain("'", opts, StringComparison.Ordinal);
+        Assert.DoesNotContain("\\", opts, StringComparison.Ordinal);
+    }
+
+    /* ---- pg_hba reconcile (DarlingManagedPostgres.ReconcilePgHba / BuildNetworkPgHbaLine) ---- */
+
+    private const string SampleHba =
+        "# TYPE  DATABASE  USER  ADDRESS  METHOD\n" +
+        "host  all  all  127.0.0.1/32  scram-sha-256\n" +
+        "host  all  all  ::1/128  scram-sha-256\n";
+
+    [Fact]
+    public void BuildNetworkPgHbaLine_IsHostssl_DarlingDb_ExactRole_NeverAllOrSuperuser()
+    {
+        Assert.Equal("hostssl darling viewer 192.168.1.0/24 scram-sha-256",
+            DarlingManagedPostgres.BuildNetworkPgHbaLine("viewer", "192.168.1.0/24"));
+        Assert.Equal("hostssl darling admin 10.0.0.0/8 scram-sha-256",
+            DarlingManagedPostgres.BuildNetworkPgHbaLine("admin", "10.0.0.0/8"));
+
+        var line = DarlingManagedPostgres.BuildNetworkPgHbaLine("viewer", "192.168.1.0/24");
+        Assert.StartsWith("hostssl ", line, StringComparison.Ordinal);   // TLS-required, never plain host
+        Assert.DoesNotContain(" all ", line, StringComparison.Ordinal);   // never database=all / user=all
+    }
+
+    [Fact]
+    public void ReconcilePgHba_AppendsBlock_WhenAbsent_PreservingExistingLines()
+    {
+        var result = DarlingManagedPostgres.ReconcilePgHba(
+            SampleHba, DarlingManagedPostgres.BuildNetworkPgHbaLine("viewer", "192.168.1.0/24"));
+
+        /* The initdb loopback rules are preserved verbatim. */
+        Assert.Contains("host  all  all  127.0.0.1/32  scram-sha-256", result, StringComparison.Ordinal);
+        Assert.Contains("host  all  all  ::1/128  scram-sha-256", result, StringComparison.Ordinal);
+
+        /* The marked block carries exactly the hostssl rule. */
+        Assert.Contains(DarlingManagedPostgres.PgHbaBeginMarker, result, StringComparison.Ordinal);
+        Assert.Contains(DarlingManagedPostgres.PgHbaEndMarker, result, StringComparison.Ordinal);
+        Assert.Contains("hostssl darling viewer 192.168.1.0/24 scram-sha-256", result, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ReconcilePgHba_NarrowingReplacesTheBlock_NotAppends()
+    {
+        var wide = DarlingManagedPostgres.ReconcilePgHba(
+            SampleHba, DarlingManagedPostgres.BuildNetworkPgHbaLine("viewer", "192.168.0.0/16"));
+        var narrowed = DarlingManagedPostgres.ReconcilePgHba(
+            wide, DarlingManagedPostgres.BuildNetworkPgHbaLine("viewer", "192.168.1.0/24"));
+
+        Assert.Contains("hostssl darling viewer 192.168.1.0/24 scram-sha-256", narrowed, StringComparison.Ordinal);
+        Assert.DoesNotContain("192.168.0.0/16", narrowed, StringComparison.Ordinal);
+
+        /* Exactly ONE managed block after narrowing — replaced, not accumulated. */
+        Assert.Equal(1, CountOccurrences(narrowed, DarlingManagedPostgres.PgHbaBeginMarker));
+        Assert.Equal(1, CountOccurrences(narrowed, DarlingManagedPostgres.PgHbaEndMarker));
+    }
+
+    [Fact]
+    public void ReconcilePgHba_RemovesBlock_WhenDisabled_PreservingNonMarkedLines()
+    {
+        var withBlock = DarlingManagedPostgres.ReconcilePgHba(
+            SampleHba, DarlingManagedPostgres.BuildNetworkPgHbaLine("admin", "10.0.0.0/8"));
+        var disabled = DarlingManagedPostgres.ReconcilePgHba(withBlock, null);
+
+        /* The managed block (and its hostssl rule) is gone; the operator's own lines survive. */
+        Assert.DoesNotContain(DarlingManagedPostgres.PgHbaBeginMarker, disabled, StringComparison.Ordinal);
+        Assert.DoesNotContain("hostssl", disabled, StringComparison.Ordinal);
+        Assert.Contains("host  all  all  127.0.0.1/32  scram-sha-256", disabled, StringComparison.Ordinal);
+        Assert.Contains("host  all  all  ::1/128  scram-sha-256", disabled, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ReconcilePgHba_Idempotent_SameDesiredYieldsSameText()
+    {
+        var line = DarlingManagedPostgres.BuildNetworkPgHbaLine("viewer", "192.168.1.0/24");
+        var once = DarlingManagedPostgres.ReconcilePgHba(SampleHba, line);
+        var twice = DarlingManagedPostgres.ReconcilePgHba(once, line);
+        Assert.Equal(once, twice);
+    }
+
+    [Fact]
+    public void ReconcilePgHba_DisableIsIdempotent_AndPreservesAManuallyAddedNonMarkedLine()
+    {
+        /* An operator's own hostssl rule OUTSIDE the marked block must survive a disable. */
+        var operatorLine = "hostssl otherdb reporting 10.9.0.0/16 scram-sha-256\n";
+        var withBoth = DarlingManagedPostgres.ReconcilePgHba(
+            SampleHba + operatorLine, DarlingManagedPostgres.BuildNetworkPgHbaLine("viewer", "192.168.1.0/24"));
+
+        var disabledOnce = DarlingManagedPostgres.ReconcilePgHba(withBoth, null);
+        var disabledTwice = DarlingManagedPostgres.ReconcilePgHba(disabledOnce, null);
+
+        Assert.Equal(disabledOnce, disabledTwice);
+        Assert.Contains("hostssl otherdb reporting 10.9.0.0/16 scram-sha-256", disabledOnce, StringComparison.Ordinal);
+        Assert.DoesNotContain("darling viewer", disabledOnce, StringComparison.Ordinal);
+    }
+
+    /* ---- firewall command builders (idempotent named shape) ---- */
+
+    [Fact]
+    public void BuildFirewallEnableCommand_RemovesThenAdds_ScopedToPortAndCidr()
+    {
+        const string ruleName = "PerformanceMonitor Darling store (port 5641)";
+        var cmd = DarlingManagedPostgres.BuildFirewallEnableCommand(ruleName, 5641, "192.168.1.0/24");
+
+        var removeIdx = cmd.IndexOf("Remove-NetFirewallRule", StringComparison.Ordinal);
+        var newIdx = cmd.IndexOf("New-NetFirewallRule", StringComparison.Ordinal);
+        Assert.True(removeIdx >= 0 && newIdx > removeIdx, "enable must remove-by-name (idempotent) then add");
+
+        Assert.Contains($"-DisplayName '{ruleName}'", cmd, StringComparison.Ordinal);
+        Assert.Contains("-Direction Inbound", cmd, StringComparison.Ordinal);
+        Assert.Contains("-Action Allow", cmd, StringComparison.Ordinal);
+        Assert.Contains("-Protocol TCP", cmd, StringComparison.Ordinal);
+        Assert.Contains("-LocalPort 5641", cmd, StringComparison.Ordinal);
+        Assert.Contains("-RemoteAddress 192.168.1.0/24", cmd, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildFirewallDisableCommand_RemovesByName_Only()
+    {
+        const string ruleName = "PerformanceMonitor Darling store (port 5641)";
+        var cmd = DarlingManagedPostgres.BuildFirewallDisableCommand(ruleName);
+
+        Assert.Contains($"Remove-NetFirewallRule -DisplayName '{ruleName}'", cmd, StringComparison.Ordinal);
+        Assert.DoesNotContain("New-NetFirewallRule", cmd, StringComparison.Ordinal);
+    }
+
+    /* ---- store loopback-degrade decision (DarlingManagedPostgres.ResolveNetworkExposure) ---- */
+
+    private const string CertPath = @"C:\ProgramData\PerformanceMonitorDarling\server.crt";
+    private const string KeyPath = @"C:\ProgramData\PerformanceMonitorDarling\server.key";
+
+    [Fact]
+    public void ResolveNetworkExposure_NoNetwork_IsLoopbackByDefault_NoDegradeReason()
+    {
+        var decision = DarlingManagedPostgres.ResolveNetworkExposure(null, CertPath, KeyPath);
+        Assert.False(decision.Exposed);
+        Assert.Null(decision.DegradeReason);
+    }
+
+    [Fact]
+    public void ResolveNetworkExposure_LoopbackListen_IsNotExposed()
+    {
+        var decision = DarlingManagedPostgres.ResolveNetworkExposure(
+            new PostgresNetworkConfig { Listen = "127.0.0.1", AllowFrom = "192.168.1.0/24", Role = "viewer" }, CertPath, KeyPath);
+        Assert.False(decision.Exposed);
+        Assert.Null(decision.DegradeReason);
+    }
+
+    [Fact]
+    public void ResolveNetworkExposure_ValidExposure_IsExposed_WithCanonicalCidrAndRole()
+    {
+        var decision = DarlingManagedPostgres.ResolveNetworkExposure(
+            new PostgresNetworkConfig { Listen = "192.168.1.205", AllowFrom = "192.168.1.0/24", Role = "admin" }, CertPath, KeyPath);
+
+        Assert.True(decision.Exposed);
+        Assert.Equal("192.168.1.205", decision.ListenIp);
+        Assert.Equal("192.168.1.0/24", decision.Cidr);
+        Assert.Equal("admin", decision.Role);
+        Assert.Null(decision.DegradeReason);
+    }
+
+    [Fact]
+    public void ResolveNetworkExposure_DefaultsRoleToViewer_WhenOmitted()
+    {
+        var decision = DarlingManagedPostgres.ResolveNetworkExposure(
+            new PostgresNetworkConfig { Listen = "192.168.1.205", AllowFrom = "192.168.1.0/24" }, CertPath, KeyPath);
+        Assert.True(decision.Exposed);
+        Assert.Equal("viewer", decision.Role);
+    }
+
+    [Fact]
+    public void ResolveNetworkExposure_Degrades_WhenAllowFromMissing()
+        => AssertDegraded(new PostgresNetworkConfig { Listen = "192.168.1.205", Role = "viewer" });
+
+    [Fact]
+    public void ResolveNetworkExposure_Degrades_WhenAllowFromInvalidCidr()
+        => AssertDegraded(new PostgresNetworkConfig { Listen = "192.168.1.205", AllowFrom = "not-a-cidr", Role = "viewer" });
+
+    [Fact]
+    public void ResolveNetworkExposure_Degrades_WhenAddressFamilyMismatch()
+        => AssertDegraded(new PostgresNetworkConfig { Listen = "192.168.1.205", AllowFrom = "2001:db8::/32", Role = "viewer" });
+
+    [Fact]
+    public void ResolveNetworkExposure_Degrades_WhenRoleInvalid()
+        => AssertDegraded(new PostgresNetworkConfig { Listen = "192.168.1.205", AllowFrom = "192.168.1.0/24", Role = "darling" });
+
+    [Fact]
+    public void ResolveNetworkExposure_Degrades_WhenListenNotAnIp()
+        => AssertDegraded(new PostgresNetworkConfig { Listen = "db.lan", AllowFrom = "192.168.1.0/24", Role = "viewer" });
+
+    [Fact]
+    public void ResolveNetworkExposure_Degrades_WhenCertPathHasWhitespace()
+    {
+        var decision = DarlingManagedPostgres.ResolveNetworkExposure(
+            new PostgresNetworkConfig { Listen = "192.168.1.205", AllowFrom = "192.168.1.0/24", Role = "viewer" },
+            @"C:\Program Files\PM\server.crt", @"C:\Program Files\PM\server.key");
+
+        Assert.False(decision.Exposed);
+        Assert.NotNull(decision.DegradeReason);
+        Assert.Contains("whitespace", decision.DegradeReason!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DegradedExposure_ProducesLoopbackOnlyRuntimeOptions_NoSsl()
+    {
+        /* Ties the pieces together: an invalid exposure degrades, and a degraded plan binds loopback-only
+           with no ssl — the FULL disable posture, never ssl=off while exposed. */
+        var decision = DarlingManagedPostgres.ResolveNetworkExposure(
+            new PostgresNetworkConfig { Listen = "192.168.1.205", Role = "viewer" /* no allowFrom */ }, CertPath, KeyPath);
+        Assert.False(decision.Exposed);
+
+        var opts = DarlingManagedPostgres.BuildServerRuntimeOptions(5641, decision.Exposed ? decision.ListenIp : null, null, null);
+        Assert.Equal("-p 5641 -c listen_addresses=127.0.0.1", opts);
+    }
+
+    private static void AssertDegraded(PostgresNetworkConfig network)
+    {
+        var decision = DarlingManagedPostgres.ResolveNetworkExposure(network, CertPath, KeyPath);
+        Assert.False(decision.Exposed);          // never bound to the network
+        Assert.NotNull(decision.DegradeReason);  // and it says WHY (logged critical, not a fatal Validate)
+        Assert.Null(decision.ListenIp);
+        Assert.Null(decision.Cidr);
+    }
+
+    private static int CountOccurrences(string text, string value)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = text.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += value.Length;
+        }
+
+        return count;
+    }
+}

--- a/Darling/Darling.Tests/DarlingSecuritySplitLiveTests.cs
+++ b/Darling/Darling.Tests/DarlingSecuritySplitLiveTests.cs
@@ -37,6 +37,7 @@ public sealed class DarlingSecuritySplitLiveTests
 {
     private const string AdminRole = "sec_admin_test";
     private const string ViewerRole = "sec_viewer_test";
+    private const string McpRole = "sec_mcp_test";
     private const string RolePassword = "SecSplitTestPw0123456789abcdef01"; // alnum, like the real generator
 
     private static string RequireLivePostgres()
@@ -209,6 +210,52 @@ public sealed class DarlingSecuritySplitLiveTests
     }
 
     [Fact]
+    public async Task McpRole_DeniedSecretColumns_ButGrantedExactlyTheTwoNarrowInserts()
+    {
+        var connectionString = RequireLivePostgres();
+        var ct = TestContext.Current.CancellationToken;
+
+        await using var owner = new NpgsqlConnection(connectionString);
+        await owner.OpenAsync(ct);
+        /* Applies V17 (creates the credential-bearing config tables + analysis_muted); the carve targets them. */
+        await PgMigrations.MigrateAsync(owner, ct);
+
+        await CreateTestRolesAndGrantsAsync(owner, ct);
+        try
+        {
+            await using var mcp = new NpgsqlConnection(RoleConnectionString(connectionString, McpRole));
+            await mcp.OpenAsync(ct);
+
+            /* Same read surface as viewer: every non-secret column readable, every secret column DENIED
+               (42501). Guards against a future refactor dropping BuildViewerColumnAclSql(config, "mcp") and
+               silently exposing the credential columns over the network MCP surface (Round 4 #5). */
+            foreach (var acl in DarlingManagedRoles.ViewerRestrictedConfigTables)
+            {
+                await ExecAsync(mcp, $"SELECT {string.Join(", ", acl.NonSecretColumns)} FROM config.{acl.Table} LIMIT 1", ct);
+                foreach (var secret in acl.SecretColumns)
+                {
+                    var denied = await Assert.ThrowsAsync<PostgresException>(async () =>
+                        await ExecAsync(mcp, $"SELECT {secret} FROM config.{acl.Table} LIMIT 1", ct));
+                    Assert.Equal("42501", denied.SqlState);
+                }
+            }
+
+            /* Exactly the two narrow analysis INSERTs are granted (has_table_privilege avoids needing the
+               tables' column shapes) — and NOTHING wider: no config_command write (the service-credential
+               pivot), no analysis_muted DELETE (no MCP unmute tool), no analysis_findings UPDATE. */
+            Assert.True(await HasPrivAsync(mcp, "collect.analysis_findings", "INSERT", ct));
+            Assert.True(await HasPrivAsync(mcp, "config.analysis_muted", "INSERT", ct));
+            Assert.False(await HasPrivAsync(mcp, "config.config_command", "INSERT", ct));
+            Assert.False(await HasPrivAsync(mcp, "config.analysis_muted", "DELETE", ct));
+            Assert.False(await HasPrivAsync(mcp, "collect.analysis_findings", "UPDATE", ct));
+        }
+        finally
+        {
+            await DropTestRolesAsync(owner, ct);
+        }
+    }
+
+    [Fact]
     public async Task CompressedHypertable_SetSchema_StaysReadableByLeastPrivilegeRole()
     {
         var connectionString = RequireLivePostgres();
@@ -319,13 +366,26 @@ BEGIN
    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{ViewerRole}') THEN
       CREATE ROLE {ViewerRole} LOGIN NOSUPERUSER PASSWORD '{RolePassword}';
    END IF;
+   IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{McpRole}') THEN
+      CREATE ROLE {McpRole} LOGIN NOSUPERUSER PASSWORD '{RolePassword}';
+   END IF;
 END $do$;
 GRANT USAGE ON SCHEMA collect, config TO {AdminRole}, {ViewerRole};
 GRANT SELECT ON ALL TABLES IN SCHEMA collect TO {AdminRole}, {ViewerRole};
 GRANT SELECT ON ALL TABLES IN SCHEMA config  TO {AdminRole}, {ViewerRole};
 GRANT INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA config TO {AdminRole};
 {DarlingManagedRoles.BuildViewerColumnAclSql("config", ViewerRole)}
-ALTER DEFAULT PRIVILEGES FOR ROLE {OwnerRoleOf(owner)} IN SCHEMA collect GRANT SELECT ON TABLES TO {AdminRole}, {ViewerRole};";
+ALTER DEFAULT PRIVILEGES FOR ROLE {OwnerRoleOf(owner)} IN SCHEMA collect GRANT SELECT ON TABLES TO {AdminRole}, {ViewerRole};
+
+-- The mcp-role analog (darling-network-endpoints, D3-role): viewer's read surface + the same secret-column
+-- carve + exactly the two narrow analysis INSERTs, mirroring DarlingManagedRoles.BuildProvisioningSql's
+-- section 6. Distinct disposable role so the shared store is never touched.
+GRANT USAGE ON SCHEMA collect, config TO {McpRole};
+GRANT SELECT ON ALL TABLES IN SCHEMA collect TO {McpRole};
+GRANT SELECT ON ALL TABLES IN SCHEMA config  TO {McpRole};
+{DarlingManagedRoles.BuildViewerColumnAclSql("config", McpRole)}
+GRANT INSERT ON collect.analysis_findings TO {McpRole};
+GRANT INSERT ON config.analysis_muted TO {McpRole};";
         await ExecAsync(owner, ddl, ct);
     }
 
@@ -342,9 +402,10 @@ ALTER DEFAULT PRIVILEGES FOR ROLE {OwnerRoleOf(owner)} IN SCHEMA collect GRANT S
         try
         {
             await ExecAsync(owner, $@"
-DROP OWNED BY {AdminRole}, {ViewerRole};
+DROP OWNED BY {AdminRole}, {ViewerRole}, {McpRole};
 DROP ROLE IF EXISTS {AdminRole};
-DROP ROLE IF EXISTS {ViewerRole};", ct);
+DROP ROLE IF EXISTS {ViewerRole};
+DROP ROLE IF EXISTS {McpRole};", ct);
         }
         catch (PostgresException)
         {
@@ -395,5 +456,17 @@ DROP ROLE IF EXISTS {ViewerRole};", ct);
     {
         using var command = new NpgsqlCommand(sql, connection);
         return await command.ExecuteScalarAsync(ct);
+    }
+
+    /// <summary>Whether the CONNECTED role has <paramref name="privilege"/> on <paramref name="table"/>
+    /// (the 2-arg <c>has_table_privilege</c> checks current_user) — proves grant shape without needing the
+    /// table's columns.</summary>
+    private static async Task<bool> HasPrivAsync(
+        NpgsqlConnection connection, string table, string privilege, System.Threading.CancellationToken ct)
+    {
+        using var command = new NpgsqlCommand("SELECT has_table_privilege($1, $2)", connection);
+        command.Parameters.AddWithValue(table);
+        command.Parameters.AddWithValue(privilege);
+        return (bool)(await command.ExecuteScalarAsync(ct))!;
     }
 }

--- a/Darling/Darling.Tests/DarlingWorkerTests.cs
+++ b/Darling/Darling.Tests/DarlingWorkerTests.cs
@@ -154,6 +154,83 @@ public sealed class DarlingWorkerTests
         Assert.True(DarlingWorker.ServerDefinitionEquals(original, SampleServer()));
     }
 
+    /// <summary>
+    /// D-BYO: managed=false with any network.* set warns per section that the fields are ignored (the
+    /// operator's own PostgreSQL governs exposure). Asserted against the pure function's returned strings,
+    /// NOT a live logger and NOT Validate().
+    /// </summary>
+    [Fact]
+    public void GetNetworkStartupWarnings_ByoWithNetwork_WarnsBothSectionsIgnored()
+    {
+        var config = new DarlingConfig
+        {
+            Postgres = new PostgresConfig
+            {
+                Managed = false,
+                ConnectionString = "Host=pg;Database=darling",
+                Network = new PostgresNetworkConfig { Listen = "192.168.1.205" },
+            },
+            Mcp = new McpConfig { Network = new McpNetworkConfig { Listen = "192.168.1.205" } },
+        };
+
+        var warnings = DarlingWorker.GetNetworkStartupWarnings(config);
+        Assert.Contains(warnings, w => w.Contains("postgres.network", StringComparison.Ordinal) && w.Contains("bring-your-own", StringComparison.Ordinal));
+        Assert.Contains(warnings, w => w.Contains("mcp.network", StringComparison.Ordinal) && w.Contains("managed-mode only", StringComparison.Ordinal));
+        /* BYO never emits the admin-pivot warning — the network config is ignored anyway. */
+        Assert.DoesNotContain(warnings, w => w.Contains("pivot", StringComparison.OrdinalIgnoreCase) || w.Contains("config_command", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// D7: managed mode + an EXPOSED store whose network role is admin warns about the config-write /
+    /// service-credential pivot a remote admin connection can reach.
+    /// </summary>
+    [Fact]
+    public void GetNetworkStartupWarnings_ManagedExposedAdminRole_WarnsPivot()
+    {
+        var config = new DarlingConfig
+        {
+            Postgres = new PostgresConfig
+            {
+                Managed = true,
+                Network = new PostgresNetworkConfig { Listen = "192.168.1.205", AllowFrom = "192.168.1.0/24", Role = "admin" },
+            },
+        };
+
+        var warnings = DarlingWorker.GetNetworkStartupWarnings(config);
+        Assert.Contains(warnings, w => w.Contains("network.role is 'admin'", StringComparison.Ordinal) && w.Contains("config_command", StringComparison.Ordinal));
+        /* Managed mode does not emit the BYO "ignored" notices. */
+        Assert.DoesNotContain(warnings, w => w.Contains("IGNORED", StringComparison.Ordinal));
+    }
+
+    /// <summary>The secure defaults are silent: managed + viewer role, managed + no network, and managed +
+    /// admin role that is NOT exposed (loopback listen) all produce zero warnings.</summary>
+    [Fact]
+    public void GetNetworkStartupWarnings_ManagedViewerOrLoopback_IsSilent()
+    {
+        var viewerExposed = new DarlingConfig
+        {
+            Postgres = new PostgresConfig
+            {
+                Managed = true,
+                Network = new PostgresNetworkConfig { Listen = "192.168.1.205", AllowFrom = "192.168.1.0/24", Role = "viewer" },
+            },
+        };
+        Assert.Empty(DarlingWorker.GetNetworkStartupWarnings(viewerExposed));
+
+        Assert.Empty(DarlingWorker.GetNetworkStartupWarnings(new DarlingConfig { Postgres = new PostgresConfig { Managed = true } }));
+
+        /* admin role but bound to loopback = not exposed => no pivot warning (nothing is reachable). */
+        var adminButLoopback = new DarlingConfig
+        {
+            Postgres = new PostgresConfig
+            {
+                Managed = true,
+                Network = new PostgresNetworkConfig { Listen = "127.0.0.1", AllowFrom = "192.168.1.0/24", Role = "admin" },
+            },
+        };
+        Assert.Empty(DarlingWorker.GetNetworkStartupWarnings(adminButLoopback));
+    }
+
     /// <summary>A fully-populated server definition the equality tests perturb a single field of.</summary>
     private static MonitoredServer SampleServer() => new()
     {

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingConfig.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingConfig.cs
@@ -9,6 +9,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
+using System.Net.Sockets;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using PerformanceMonitor.Notifications;
@@ -86,10 +88,12 @@ public sealed class DarlingConfig
     public AnalysisConfig Analysis { get; set; } = new();
 
     /// <summary>
-    /// The embedded MCP server (analysis slice AN4): the six analysis tools — the same tool
-    /// surface Lite and the Dashboard expose — over Streamable HTTP on localhost. Default OFF:
-    /// a headless service should not open a local port unless the operator asks for it (both
-    /// apps default their MCP servers off too). Optional — omit the section entirely.
+    /// The embedded MCP server (analysis slice AN4): the same analysis + data-read tool surface Lite
+    /// and the Dashboard expose (the analysis class plus the plan-analysis and ~60 STORED data-read
+    /// tools), over Streamable HTTP. Default OFF: a headless service should not open a port unless the
+    /// operator asks for it (both apps default their MCP servers off too). Loopback-only and tokenless
+    /// by default; an opt-in <see cref="McpConfig.Network"/> block exposes it on the LAN behind a
+    /// required bearer token + an in-app CIDR check (managed-mode only). Optional — omit the section entirely.
     /// </summary>
     [JsonPropertyName("mcp")]
     public McpConfig Mcp { get; set; } = new();
@@ -245,6 +249,17 @@ public sealed class PostgresConfig
     /// </summary>
     [JsonPropertyName("connectAs")]
     public string ConnectAs { get; set; } = "admin";
+
+    /// <summary>
+    /// Opt-in network exposure for the managed store (darling-network-endpoints). Omit for the secure
+    /// default = loopback-only (byte-for-byte today's behavior). Managed-mode only; ignored in BYO with
+    /// a caller warning (the operator's own PostgreSQL governs BYO exposure). Any invalid/incomplete
+    /// field degrades the store to loopback + LogCritical rather than failing validation — the exposure
+    /// rules live at the point of use, NEVER in the all-fatal <see cref="DarlingConfig.Validate"/>
+    /// (D-validate). See <see cref="PostgresNetworkConfig"/>.
+    /// </summary>
+    [JsonPropertyName("network")]
+    public PostgresNetworkConfig? Network { get; set; }
 }
 
 /// <summary>
@@ -449,7 +464,9 @@ public sealed class SmtpConfig
 
 /// <summary>
 /// The embedded MCP server's config. Port 5152 keeps the product's local MCP family
-/// non-colliding on one machine (Dashboard 5150, Lite 5151, Darling 5152).
+/// non-colliding on one machine (Dashboard 5150, Lite 5151, Darling 5152). Loopback-only and
+/// tokenless by default; the optional <see cref="Network"/> block opts into LAN exposure behind a
+/// required bearer token + an in-app CIDR check (darling-network-endpoints, managed-mode only).
 /// </summary>
 public sealed class McpConfig
 {
@@ -459,6 +476,213 @@ public sealed class McpConfig
 
     [JsonPropertyName("port")]
     public int Port { get; set; } = 5152;
+
+    /// <summary>
+    /// Opt-in network exposure for the MCP server (darling-network-endpoints). Omit for the secure
+    /// default = loopback-only, tokenless HTTP (today's behavior). Managed-mode only; ignored in BYO
+    /// with a caller warning. Any missing precondition (token / valid allowFrom / managed) keeps MCP
+    /// loopback-only + LogCritical — enforced in the MCP host, NEVER in the all-fatal
+    /// <see cref="DarlingConfig.Validate"/> (D-validate). See <see cref="McpNetworkConfig"/>.
+    /// </summary>
+    [JsonPropertyName("network")]
+    public McpNetworkConfig? Network { get; set; }
+}
+
+/// <summary>
+/// Opt-in NETWORK exposure for the managed store (darling-network-endpoints). Omit the whole
+/// <c>network</c> object for the secure default = today's loopback-only behavior (no pg_hba network
+/// rule, no firewall rule, ssl=off). When present with a non-loopback <see cref="Listen"/>, the
+/// service reconciles it on every start (managed mode only): listen_addresses gains the bind IP, a
+/// self-signed TLS cert is generated for verify-full, a marked
+/// <c>hostssl darling &lt;role&gt; &lt;allowFrom&gt; scram-sha-256</c> pg_hba block is written +
+/// reloaded, and a best-effort firewall rule is added. Reconciliation is symmetric (removing the
+/// block closes the box) and fail-closed: any invalid/incomplete field degrades the store to
+/// loopback + LogCritical, never exposed. These rules are enforced at the point of use, NOT in the
+/// all-fatal <see cref="DarlingConfig.Validate"/> (D-validate).
+/// </summary>
+public sealed class PostgresNetworkConfig
+{
+    /// <summary>
+    /// Bind IP for the store's network listener and the generated cert's iPAddress SAN. A specific IP
+    /// (e.g. <c>192.168.1.205</c>) is preferred; <c>0.0.0.0</c> = all interfaces (connect by a cert SAN
+    /// name under verify-full). Absent or an IPv4 loopback (<c>127.0.0.0/8</c>) = the default
+    /// loopback-only store.
+    /// </summary>
+    [JsonPropertyName("listen")]
+    public string? Listen { get; set; }
+
+    /// <summary>
+    /// The CIDR the pg_hba rule and firewall rule allow (e.g. <c>192.168.1.0/24</c>); its address family
+    /// must match <see cref="Listen"/>. Required when exposed — a missing/invalid CIDR degrades the store
+    /// to loopback.
+    /// </summary>
+    [JsonPropertyName("allowFrom")]
+    public string? AllowFrom { get; set; }
+
+    /// <summary>
+    /// The least-privilege login role the network pg_hba rule names: <c>viewer</c> (default, read-only
+    /// remote — the secure default) or <c>admin</c> (full remote writes; the caller warns because admin
+    /// holds the <c>config_command</c>/<c>config_monitored_servers</c>/<c>config_notification</c>
+    /// service-credential pivot). Never the superuser <c>darling</c>. Distinct from the local-loopback
+    /// <see cref="PostgresConfig.ConnectAs"/> (default admin) — the sample/README document the difference.
+    /// An unknown value degrades the store to loopback.
+    /// </summary>
+    [JsonPropertyName("role")]
+    public string? Role { get; set; }
+
+    /// <summary>
+    /// True when any field is set — used only for the BYO "network.* is ignored" caller warning (D-BYO).
+    /// It does NOT mean "exposed"; use <see cref="DarlingNetwork.IsExposedListenAddress"/> for that.
+    /// </summary>
+    [JsonIgnore]
+    public bool IsConfigured =>
+        !string.IsNullOrWhiteSpace(Listen)
+        || !string.IsNullOrWhiteSpace(AllowFrom)
+        || !string.IsNullOrWhiteSpace(Role);
+}
+
+/// <summary>
+/// Opt-in NETWORK exposure for the embedded MCP server (darling-network-endpoints). Omit the whole
+/// <c>network</c> object for the secure default = today's loopback-only, tokenless HTTP. When present
+/// with a non-loopback <see cref="Listen"/> AND managed mode AND a token AND a valid
+/// <see cref="AllowFrom"/>, the MCP host binds the network interface behind a required bearer token +
+/// an in-app CIDR check (D3); any missing precondition keeps MCP loopback-only + LogCritical
+/// (fail-closed, enforced in the MCP host). No TLS on MCP (a self-signed cert breaks real clients; the
+/// named MITM control is a TLS reverse proxy in front of the endpoint).
+/// </summary>
+public sealed class McpNetworkConfig
+{
+    /// <summary>
+    /// Bind IP for the MCP network listener (a specific IP preferred; <c>0.0.0.0</c> = all interfaces).
+    /// Absent or an IPv4 loopback = the default loopback-only MCP server.
+    /// </summary>
+    [JsonPropertyName("listen")]
+    public string? Listen { get; set; }
+
+    /// <summary>
+    /// The CIDR the in-app <c>RemoteIpAddress</c> check and the firewall rule allow (e.g.
+    /// <c>192.168.1.0/24</c>); loopback is always allowed regardless. Required when exposed.
+    /// </summary>
+    [JsonPropertyName("allowFrom")]
+    public string? AllowFrom { get; set; }
+
+    /// <summary>
+    /// DPAPI-LocalMachine-protected bearer token, base64 — produced by <c>--encrypt-password</c>
+    /// (preferred over the plaintext <see cref="Token"/>). Read via <see cref="ResolveToken"/>.
+    /// </summary>
+    [JsonPropertyName("encryptedToken")]
+    public string? EncryptedToken { get; set; }
+
+    /// <summary>
+    /// Plaintext bearer token — dev convenience only; the caller warns when it is used. Prefer
+    /// <see cref="EncryptedToken"/>.
+    /// </summary>
+    [JsonPropertyName("token")]
+    public string? Token { get; set; }
+
+    /// <summary>
+    /// True when any field is set — used only for the BYO "network.* is ignored" caller warning (D-BYO);
+    /// NOT the same as "exposed".
+    /// </summary>
+    [JsonIgnore]
+    public bool IsConfigured =>
+        !string.IsNullOrWhiteSpace(Listen)
+        || !string.IsNullOrWhiteSpace(AllowFrom)
+        || !string.IsNullOrWhiteSpace(EncryptedToken)
+        || !string.IsNullOrWhiteSpace(Token);
+
+    /// <summary>
+    /// The bearer token, preferring <see cref="EncryptedToken"/> (DPAPI-decrypted; Windows-only) over
+    /// the plaintext <see cref="Token"/>. <paramref name="usedPlaintext"/> is true when the plaintext
+    /// fallback is used, so the caller can warn — the same shape as
+    /// <see cref="DarlingSecrets.ResolvePassword"/>. Returns null when neither is set.
+    /// </summary>
+    public string? ResolveToken(out bool usedPlaintext)
+    {
+        usedPlaintext = false;
+
+        if (!string.IsNullOrWhiteSpace(EncryptedToken))
+        {
+            /* DarlingSecrets.Unprotect is DPAPI (Windows-only). The network path is managed-mode-only,
+               which is itself Windows-gated, so this only runs on Windows; the guard keeps the analyzer
+               (CA1416) honest and gives a clear failure if someone points a non-Windows BYO client here. */
+            if (!OperatingSystem.IsWindows())
+            {
+                throw new PlatformNotSupportedException(
+                    "mcp.network.encryptedToken requires Windows (DPAPI); use the plaintext \"token\" on other platforms.");
+            }
+
+            return DarlingSecrets.Unprotect(EncryptedToken);
+        }
+
+        if (!string.IsNullOrWhiteSpace(Token))
+        {
+            usedPlaintext = true;
+            return Token;
+        }
+
+        return null;
+    }
+}
+
+/// <summary>
+/// Shared network-exposure helpers for the opt-in store/MCP endpoints (darling-network-endpoints).
+/// These pure functions are the single source of truth for "is this listen value a network bind?"
+/// and "what pg_hba role?" — used by the store bootstrap (<see cref="DarlingManagedPostgres"/>), the
+/// worker's startup warnings (<see cref="DarlingWorker"/>), and the MCP host's bind resolution. Kept
+/// deliberately OUT of the all-fatal <see cref="DarlingConfig.Validate"/> (one entry there kills
+/// collection): a typo in an optional, default-off endpoint must degrade to loopback + LogCritical
+/// and keep collecting (D-validate).
+/// </summary>
+public static class DarlingNetwork
+{
+    /// <summary>
+    /// Is <paramref name="listen"/> a NETWORK (non-loopback) bind — i.e. anything other than the safe
+    /// IPv4 loopback range <c>127.0.0.0/8</c>? Absent/blank is NOT exposed (the default = today's
+    /// loopback-only behavior). Everything else is treated as exposed, and therefore subject to the full
+    /// exposure validation: a real IP; <c>0.0.0.0</c>/<c>::</c> (all interfaces); the IPv6 loopback
+    /// <c>::1</c> (the store's loopback handling is IPv4-<c>127</c> only); and any value that is not even
+    /// an IP — <c>localhost</c>, <c>*</c>, a hostname — which the store bind (it needs
+    /// <see cref="IPAddress.Parse"/>) then rejects by degrading to loopback. Fail-safe: unknown ⇒
+    /// exposed ⇒ validated, never silently bound.
+    /// </summary>
+    public static bool IsExposedListenAddress(string? listen)
+    {
+        if (string.IsNullOrWhiteSpace(listen))
+        {
+            return false;
+        }
+
+        if (IPAddress.TryParse(listen.Trim(), out var ip))
+        {
+            /* The ONLY non-exposed value is an IPv4 address in 127.0.0.0/8 (canonical loopback). */
+            return !(ip.AddressFamily == AddressFamily.InterNetwork && ip.GetAddressBytes()[0] == 127);
+        }
+
+        /* Not an IP at all (localhost / hostname / "*") — treat as exposed; the store bind degrades to
+           loopback because it cannot IPAddress.Parse it. */
+        return true;
+    }
+
+    /// <summary>
+    /// Normalizes <c>postgres.network.role</c> to the pg_hba login role: absent/blank ⇒ the secure
+    /// default <c>viewer</c> (read-only remote, D7); <c>viewer</c>/<c>admin</c> pass through
+    /// (case-insensitively); anything else ⇒ null (invalid — the store degrades to loopback). NEVER
+    /// returns <c>darling</c> (the superuser/owner is service-only).
+    /// </summary>
+    public static string? NormalizeNetworkRole(string? role)
+    {
+        /* Literals rather than DarlingManagedPostgres.ViewerRoleName/AdminRoleName: that type is
+           [SupportedOSPlatform("windows")] and this classifier is platform-neutral, so referencing its
+           consts would raise CA1416 here. The names mirror those consts (pinned equal by test). */
+        if (string.IsNullOrWhiteSpace(role))
+        {
+            return "viewer";
+        }
+
+        var normalized = role.Trim().ToLowerInvariant();
+        return normalized is "viewer" or "admin" ? normalized : null;
+    }
 }
 
 /// <summary>Teams/Slack incoming-webhook alert delivery; a channel is enabled by a non-empty URL.</summary>

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingManagedPostgres.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingManagedPostgres.cs
@@ -7,11 +7,15 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
+using System.Net;
+using System.Net.Sockets;
 using System.Runtime.Versioning;
 using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -26,8 +30,9 @@ namespace PerformanceMonitor.Darling.Service;
 /// calls <see cref="EnsureRunningAsync"/> BEFORE touching the store, and this class unpacks the
 /// runtime shipped beside the service (<c>pg-runtime\pgsql\</c>, self-healing from
 /// <c>pg-runtime.zip</c>), initializes a cluster on first run (initdb), starts the server when
-/// it is not already running (pg_ctl, loopback only), creates the <c>darling</c> database, and
-/// returns the derived connection string. On service shutdown the worker calls
+/// it is not already running (pg_ctl, loopback by default; an opt-in <c>postgres.network</c> block
+/// exposes it on the LAN behind TLS + pg_hba — see the posture note below), creates the
+/// <c>darling</c> database, and returns the derived connection string. On service shutdown the worker calls
 /// <see cref="StopIfStartedByThisProcessAsync"/> — the flag matters: a server this process did
 /// NOT start (an operator's own pg_ctl, a previous service crash's surviving postmaster) is
 /// adopted for connections but never stopped, because stopping someone else's server is not
@@ -43,9 +48,19 @@ namespace PerformanceMonitor.Darling.Service;
 /// wire, failed attempts are auditable, and access is confined to what can read the
 /// DPAPI-LocalMachine-protected credential file (<c>pg-credential.dpapi</c> beside the data
 /// directory — the same machine-bound posture as darling.json's <c>encryptedPassword</c>, so
-/// the interactive Viewer on the same machine can derive the connection string too). Defense in
-/// depth on top: <c>listen_addresses = '127.0.0.1'</c>, so the server is never reachable off
-/// the machine.</para>
+/// the interactive Viewer on the same machine can derive the connection string too).</para>
+///
+/// <para><b>Network exposure — off by default, secure by default (darling-network-endpoints):</b>
+/// with no <c>postgres.network</c> block the store binds <c>listen_addresses = '127.0.0.1'</c>
+/// (forced every start via the <c>-o</c> runtime override, so it holds even against a hand-edited
+/// <c>ALTER SYSTEM</c>), has no pg_hba network rule, no firewall rule, and <c>ssl=off</c> — byte-for-byte
+/// today's loopback-only behavior. An opt-in <c>network</c> block (managed mode only) adds the bind IP to
+/// listen_addresses, generates a self-signed cert for TLS <c>verify-full</c>, writes a marked
+/// <c>hostssl darling &lt;role&gt; &lt;allowFrom&gt; scram-sha-256</c> pg_hba block (loopback rules stay
+/// plain <c>host</c>), reloads, and best-effort adds a scoped firewall rule. Every layer is reconciled
+/// each start, symmetric (removing the block closes the box), and fail-closed: any invalid/incomplete
+/// exposure config degrades the store to loopback (the full disable-reconcile) + LogCritical — never
+/// <c>ssl=off</c> while exposed, never a stale pg_hba rule left open.</para>
 ///
 /// <para>Every step throws with an actionable message; the worker turns a bootstrap failure
 /// into LogCritical + clean service exit (the existing no-store behavior). All idempotent:
@@ -75,9 +90,21 @@ public sealed class DarlingManagedPostgres
     public const string AdminCredentialFileName = "pg-admin-credential.dpapi";
     public const string ViewerCredentialFileName = "pg-viewer-credential.dpapi";
 
-    /// <summary>The least-privilege login role names provisioned into the managed cluster (V8 hardening).</summary>
+    /// <summary>
+    /// DPAPI-LocalMachine blob holding the generated password for the dedicated least-privilege
+    /// <c>mcp</c> login role (darling-network-endpoints, D3-role) — the store pool identity the
+    /// (optionally network-exposed) MCP host connects as. Same location/posture as the admin/viewer
+    /// credentials, but hardened NON-interactive (<see cref="DarlingFileSecurity.HardenFile"/> with
+    /// <c>allowInteractiveRead: false</c>): it is consumed only by the in-service MCP host, never an
+    /// interactive Viewer, so it mirrors the superuser credential's ACL, not the admin/viewer one.
+    /// </summary>
+    public const string McpCredentialFileName = "pg-mcp-credential.dpapi";
+
+    /// <summary>The least-privilege login role names provisioned into the managed cluster (V8 hardening;
+    /// <c>mcp</c> added for the network endpoints, D3-role).</summary>
     public const string AdminRoleName = "admin";
     public const string ViewerRoleName = "viewer";
+    public const string McpRoleName = "mcp";
 
     /// <summary>
     /// The search path (schemas in resolution order) the managed connection strings carry, so pooled
@@ -101,6 +128,24 @@ public sealed class DarlingManagedPostgres
     /// marker-present-but-different-block conf is never rewritten in place.
     /// </summary>
     public const string ConfMarkerV2 = "# Managed by PerformanceMonitor Darling (v2 worker sizing) -- do not remove this block";
+
+    /// <summary>
+    /// Markers delimiting the Darling-managed network access block in pg_hba.conf
+    /// (darling-network-endpoints, D5). <see cref="ReconcilePgHba"/> replaces exactly the lines
+    /// between them and preserves every non-marked line, so the opt-in <c>hostssl</c> rule is
+    /// symmetric — appended when exposed, removed when disabled — without disturbing the operator's
+    /// own entries or initdb's loopback defaults.
+    /// </summary>
+    public const string PgHbaBeginMarker = "# BEGIN PerformanceMonitor Darling network access -- managed block, do not edit";
+    public const string PgHbaEndMarker = "# END PerformanceMonitor Darling network access";
+
+    /// <summary>The self-signed store TLS cert + key (PEM), generated beside the data directory for
+    /// verify-full when exposed (darling-network-endpoints, D6). Delete both to rotate.</summary>
+    public const string ServerCertFileName = "server.crt";
+    public const string ServerKeyFileName = "server.key";
+
+    /// <summary>~10-year self-signed validity (D6): a home-lab cert the operator pins; delete-to-rotate.</summary>
+    private const int ServerCertValidityYears = 10;
 
     private const string PasswordAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
     private const int PasswordLength = 32;
@@ -164,6 +209,10 @@ public sealed class DarlingManagedPostgres
     public static string ViewerCredentialPathFor(string dataDirectory)
         => Path.Combine(ParentOf(dataDirectory), ViewerCredentialFileName);
 
+    /// <summary>Path to the <c>mcp</c> role's DPAPI credential, beside the data directory (darling-network-endpoints).</summary>
+    public static string McpCredentialPathFor(string dataDirectory)
+        => Path.Combine(ParentOf(dataDirectory), McpCredentialFileName);
+
     /// <summary>
     /// 32 characters from [A-Za-z0-9] via the crypto RNG (~190 bits) — deliberately alphanumeric
     /// only, so the password survives initdb's --pwfile line, the connection string, and any
@@ -221,17 +270,29 @@ public sealed class DarlingManagedPostgres
     }
 
     /// <summary>
-    /// The derived managed-mode connection string: localhost + port + darling/darling + the generated
-    /// password, carrying the collect/config <see cref="SearchPath"/> so every pooled connection
-    /// resolves the bare table names to the V8 schemas regardless of the database default.
+    /// The derived managed-mode connection string: <c>127.0.0.1</c> + port + darling/darling + the
+    /// generated password, carrying the collect/config <see cref="SearchPath"/> so every pooled connection
+    /// resolves the bare table names to the V8 schemas regardless of the database default. Uses the explicit
+    /// IPv4 loopback rather than the name "localhost": listen_addresses binds IPv4 <c>127.0.0.1</c> (plus the
+    /// optional network IP when exposed), NOT <c>::1</c>, so a host that resolves "localhost" to IPv6 first
+    /// could otherwise miss the listener. (darling-network-endpoints)
     /// </summary>
     public static string BuildConnectionString(int port, string password)
+        => BuildRoleConnectionString(port, UserName, password);
+
+    /// <summary>
+    /// Builds a managed loopback connection string for a specific login role — shared by
+    /// <see cref="BuildConnectionString"/> (the owner) and
+    /// <see cref="TryBuildMcpConnectionStringFromStoredCredential"/> (the <c>mcp</c> role). Same
+    /// <c>127.0.0.1</c> + port + <see cref="SearchPath"/> shape; only the username/password differ.
+    /// </summary>
+    private static string BuildRoleConnectionString(int port, string username, string password)
     {
         var builder = new NpgsqlConnectionStringBuilder
         {
-            Host = "localhost",
+            Host = "127.0.0.1",
             Port = port,
-            Username = UserName,
+            Username = username,
             Password = password,
             Database = DatabaseName,
             SearchPath = SearchPath,
@@ -253,6 +314,25 @@ public sealed class DarlingManagedPostgres
         }
 
         return BuildConnectionString(config.Port, DarlingSecrets.Unprotect(File.ReadAllText(credentialPath).Trim()));
+    }
+
+    /// <summary>
+    /// Derives the MCP store connection string from the stored <c>mcp</c>-role credential WITHOUT touching
+    /// the server (darling-network-endpoints, D3-role) — the least-privilege pool the MCP host connects as
+    /// instead of the owner. Same <c>127.0.0.1</c> + port + <see cref="SearchPath"/> shape as the owner
+    /// string, but <c>Username = mcp</c>. Null until <see cref="DarlingManagedRoles.EnsureProvisionedAsync"/>
+    /// has written the credential — which happens AFTER migration, later than the owner credential, so the
+    /// MCP host's first-boot poll budget must tolerate the delay.
+    /// </summary>
+    public static string? TryBuildMcpConnectionStringFromStoredCredential(PostgresConfig config)
+    {
+        var credentialPath = McpCredentialPathFor(ResolveDataDirectory(config));
+        if (!File.Exists(credentialPath))
+        {
+            return null;
+        }
+
+        return BuildRoleConnectionString(config.Port, McpRoleName, DarlingSecrets.Unprotect(File.ReadAllText(credentialPath).Trim()));
     }
 
     /// <summary>
@@ -284,6 +364,22 @@ public sealed class DarlingManagedPostgres
 
         var password = ReadStoredPassword();
 
+        /* Resolve the opt-in network exposure (darling-network-endpoints) BEFORE start so listen_addresses
+           and the ssl trio can ride the -o runtime override. Fail-closed: an invalid/incomplete exposure
+           config (or a cert-gen failure) returns a LOOPBACK plan carrying the degrade reason, logged
+           critical here; the reconcile below then runs the FULL disable-reconcile (loopback listen + pg_hba
+           block removed + reload + verify), so a previously-exposed cluster actually closes. The whole
+           network path is caught internally (BuildNetworkPlan swallows cert-gen failure into a degrade;
+           ReconcileNetworkAsync never throws) because EnsureRunningAsync's contract is throw => service-exit,
+           and a typo in an optional, default-off endpoint must NEVER take collection down (Round 4 #3). */
+        var networkPlan = BuildNetworkPlan();
+        if (networkPlan.DegradeReason is not null)
+        {
+            _logger.LogCritical(
+                "Store network exposure DISABLED (degraded to loopback-only): {Reason}. Fix postgres.network and restart to expose the store.",
+                networkPlan.DegradeReason);
+        }
+
         if (await IsRunningAsync(binDirectory, cancellationToken))
         {
             /* Already running — a previous service crash's surviving postmaster, or an operator
@@ -294,12 +390,18 @@ public sealed class DarlingManagedPostgres
         }
         else
         {
-            await StartServerAsync(binDirectory, cancellationToken);
+            await StartServerAsync(binDirectory, networkPlan, cancellationToken);
             _startedByThisProcess = true;
         }
 
         var connectionString = BuildConnectionString(_config.Port, password);
         await EnsureDatabaseAsync(connectionString, cancellationToken);
+
+        /* Reconcile pg_hba + reload + verify, the adopted-listener guard, and the firewall against the LIVE
+           server — symmetric (present when exposed, absent when loopback/degraded). Never throws (Round 4 #3):
+           a network reconcile failure logs + degrades, it does not abort the bootstrap. */
+        await ReconcileNetworkAsync(binDirectory, networkPlan, connectionString, cancellationToken);
+
         return connectionString;
     }
 
@@ -483,19 +585,32 @@ public sealed class DarlingManagedPostgres
     }
 
     /// <summary>
-    /// pg_ctl start, windowed (-w): returns only when the server accepts connections. -o "-p"
-    /// makes darling.json's port authoritative over the conf line. pg_ctl itself handles a
-    /// stale postmaster.pid from a crash (the new postmaster validates and replaces it); when
-    /// start still fails, the server log tail is surfaced in the error because that is where
-    /// Postgres explains itself.
+    /// pg_ctl start, windowed (-w): returns only when the server accepts connections. The <c>-o</c>
+    /// runtime override carries the port (authoritative over the conf line), listen_addresses (always
+    /// <c>127.0.0.1</c>, plus the network IP when exposed — <c>-c</c> outranks postgresql.auto.conf, so
+    /// this forces loopback even against a hand-edited <c>ALTER SYSTEM</c>), and the ssl trio when exposed
+    /// (darling-network-endpoints, D2/D6). pg_ctl itself handles a stale postmaster.pid from a crash (the
+    /// new postmaster validates and replaces it); when start still fails, the server log tail is surfaced
+    /// in the error because that is where Postgres explains itself.
     /// </summary>
-    private async Task StartServerAsync(string binDirectory, CancellationToken cancellationToken)
+    private async Task StartServerAsync(string binDirectory, NetworkPlan networkPlan, CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Starting managed Postgres on 127.0.0.1:{Port} (log: {Log})", _config.Port, _serverLogPath);
+        var exposed = networkPlan.Mode == NetworkMode.Exposed;
+        var runtimeOptions = BuildServerRuntimeOptions(
+            _config.Port,
+            exposed ? networkPlan.ListenIp : null,
+            exposed ? networkPlan.CertPath : null,
+            exposed ? networkPlan.KeyPath : null);
+
+        _logger.LogInformation(
+            "Starting managed Postgres (listen_addresses={Listen}, ssl={Ssl}, port {Port}, log: {Log})",
+            exposed ? $"127.0.0.1,{networkPlan.ListenIp}" : "127.0.0.1",
+            exposed ? "on" : "off",
+            _config.Port, _serverLogPath);
 
         var exitCode = await RunDetachingToolAsync(
             Path.Combine(binDirectory, "pg_ctl.exe"),
-            $"-D \"{_dataDirectory}\" -o \"-p {_config.Port}\" -l \"{_serverLogPath}\" -w -t {PgCtlWaitSeconds} start",
+            $"-D \"{_dataDirectory}\" -o \"{runtimeOptions}\" -l \"{_serverLogPath}\" -w -t {PgCtlWaitSeconds} start",
             s_pgCtlTimeout,
             cancellationToken);
 
@@ -628,6 +743,658 @@ public sealed class DarlingManagedPostgres
         }
 
         return parent;
+    }
+
+    /* ================= Opt-in network exposure (darling-network-endpoints) ================= */
+
+    /// <summary>The store's effective bind: loopback-only (the default / a fail-closed degrade) or network-exposed.</summary>
+    private enum NetworkMode
+    {
+        Loopback,
+        Exposed,
+    }
+
+    /// <summary>
+    /// The resolved network state for one start. <see cref="Mode"/> = Exposed carries the validated bind
+    /// IP, canonical CIDR, pg_hba role, and generated cert/key paths; Loopback carries a non-null
+    /// <see cref="DegradeReason"/> only when it is a FAIL-CLOSED degrade from an INTENDED exposure (null
+    /// when the store is simply loopback-by-default). Resolved before start so listen/ssl ride the -o
+    /// override and the reconcile can run the disable path for a degrade.
+    /// </summary>
+    private sealed record NetworkPlan(
+        NetworkMode Mode,
+        string? ListenIp,
+        string? Cidr,
+        string? Role,
+        string? CertPath,
+        string? KeyPath,
+        string? DegradeReason)
+    {
+        public static NetworkPlan Loopback(string? degradeReason = null)
+            => new(NetworkMode.Loopback, null, null, null, null, null, degradeReason);
+
+        public static NetworkPlan Exposed(string listenIp, string cidr, string role, string certPath, string keyPath)
+            => new(NetworkMode.Exposed, listenIp, cidr, role, certPath, keyPath, null);
+    }
+
+    /// <summary>
+    /// The store's exposure decision after PURE validation (no I/O, no cert gen). <see cref="Exposed"/>=false
+    /// with a non-null <see cref="DegradeReason"/> is a FAIL-CLOSED degrade from an intended exposure;
+    /// Exposed=false with a null reason is loopback-by-default; Exposed=true carries the validated
+    /// ListenIp/Cidr/Role.
+    /// </summary>
+    internal sealed record NetworkExposureDecision(
+        bool Exposed, string? ListenIp, string? Cidr, string? Role, string? DegradeReason);
+
+    /// <summary>
+    /// PURE validation of postgres.network into a <see cref="NetworkExposureDecision"/> — NO I/O and NO cert
+    /// generation (the caller does that on a valid decision), so it is unit-testable without a live server.
+    /// Degrades to loopback WITH a reason on: a listen value that is not a parseable IP; a missing/invalid
+    /// allowFrom CIDR or an address-family mismatch; a role outside {viewer, admin}; or a cert path
+    /// (<paramref name="certPath"/>/<paramref name="keyPath"/>) that contains whitespace (the -o string
+    /// cannot nest-quote a space -> PG fail-DEAD). Never a fatal Validate() (D-validate).
+    /// </summary>
+    internal static NetworkExposureDecision ResolveNetworkExposure(PostgresNetworkConfig? network, string certPath, string keyPath)
+    {
+        if (network is null || !DarlingNetwork.IsExposedListenAddress(network.Listen))
+        {
+            /* Loopback by default (no reason) — the byte-for-byte-today path. */
+            return new NetworkExposureDecision(false, null, null, null, null);
+        }
+
+        var listenRaw = network.Listen!.Trim();
+        if (!IPAddress.TryParse(listenRaw, out var listenIp))
+        {
+            return Degrade(
+                $"postgres.network.listen '{network.Listen}' is not a valid IP address (use a specific IP, e.g. 192.168.1.205, or 0.0.0.0 for all interfaces)");
+        }
+
+        if (string.IsNullOrWhiteSpace(network.AllowFrom) || !IPNetwork.TryParse(network.AllowFrom.Trim(), out var cidr))
+        {
+            return Degrade(
+                $"postgres.network.allowFrom '{network.AllowFrom}' is not a valid CIDR (e.g. 192.168.1.0/24, with host bits zeroed)");
+        }
+
+        if (cidr.BaseAddress.AddressFamily != listenIp.AddressFamily)
+        {
+            return Degrade(
+                $"postgres.network.allowFrom '{network.AllowFrom}' address family does not match listen '{listenRaw}'");
+        }
+
+        var role = DarlingNetwork.NormalizeNetworkRole(network.Role);
+        if (role is null)
+        {
+            return Degrade(
+                $"postgres.network.role '{network.Role}' must be 'viewer' or 'admin' (never the superuser)");
+        }
+
+        /* The cert path rides the -o string, which cannot nest-quote a space -> a spaced path fail-DEADS
+           the postmaster. Gate on it (D6) and degrade rather than ever start ssl=on with a broken path. */
+        if (ContainsWhitespace(certPath) || ContainsWhitespace(keyPath))
+        {
+            return Degrade(
+                $"the TLS cert path '{certPath}' contains whitespace, which the pg_ctl -o override cannot pass to postgres; " +
+                "move postgres.dataDirectory to a space-free path to expose the store over TLS");
+        }
+
+        /* Canonical base/prefix form (IPNetwork requires zeroed host bits) for the pg_hba line + firewall. */
+        return new NetworkExposureDecision(true, listenIp.ToString(), $"{cidr.BaseAddress}/{cidr.PrefixLength}", role, null);
+
+        static NetworkExposureDecision Degrade(string reason) => new(false, null, null, null, reason);
+    }
+
+    /// <summary>
+    /// Validates postgres.network (via <see cref="ResolveNetworkExposure"/>) and, on a valid exposure,
+    /// generates the TLS cert — returning the effective <see cref="NetworkPlan"/>. NEVER throws: a cert-gen
+    /// failure degrades to loopback with a reason (D6/D-validate).
+    /// </summary>
+    private NetworkPlan BuildNetworkPlan()
+    {
+        var certPath = Path.Combine(ParentOf(_dataDirectory), ServerCertFileName);
+        var keyPath = Path.Combine(ParentOf(_dataDirectory), ServerKeyFileName);
+
+        var decision = ResolveNetworkExposure(_config.Network, certPath, keyPath);
+        if (!decision.Exposed)
+        {
+            return NetworkPlan.Loopback(decision.DegradeReason);
+        }
+
+        try
+        {
+            EnsureServerCertificate(IPAddress.Parse(decision.ListenIp!), certPath, keyPath);
+        }
+        catch (Exception ex)
+        {
+            /* Any cert-gen/write failure degrades to loopback — the network path must never throw out of
+               EnsureRunningAsync (its contract is throw => service-exit), Round 4 #3. */
+            return NetworkPlan.Loopback($"could not generate/read the store TLS cert ({ex.Message})");
+        }
+
+        return NetworkPlan.Exposed(decision.ListenIp!, decision.Cidr!, decision.Role!, certPath, keyPath);
+    }
+
+    private static bool ContainsWhitespace(string value)
+    {
+        foreach (var c in value)
+        {
+            if (char.IsWhiteSpace(c))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Idempotent self-signed server cert for store TLS verify-full (D6): reuse the existing PEM pair
+    /// (delete both to rotate), else generate a ~10-year cert with BOTH an iPAddress SAN (the listen IP,
+    /// for verify-full by IP) AND a dnsName SAN (the machine hostname, so the operator can connect by name
+    /// if IP-SAN validation ever disappoints, or when listen=0.0.0.0). The private key is written
+    /// unencrypted PKCS#8 PEM (what postgres reads) and hardened NON-interactive (SYSTEM + Administrators +
+    /// service account only) — the postmaster reads it, never an interactive user.
+    /// </summary>
+    private void EnsureServerCertificate(IPAddress listenIp, string certPath, string keyPath)
+    {
+        if (File.Exists(certPath) && File.Exists(keyPath))
+        {
+            /* Reuse (delete-to-rotate). Re-harden the key every start (self-healing), same discipline as the
+               credential files. */
+            TryHardenCredentialFile(keyPath, allowInteractiveRead: false);
+            return;
+        }
+
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest(
+            $"CN={Environment.MachineName}", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+
+        var sanBuilder = new SubjectAlternativeNameBuilder();
+        sanBuilder.AddIpAddress(listenIp);
+        sanBuilder.AddDnsName(Environment.MachineName);
+        request.CertificateExtensions.Add(sanBuilder.Build());
+        request.CertificateExtensions.Add(new X509BasicConstraintsExtension(false, false, 0, true));
+        request.CertificateExtensions.Add(
+            new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment, true));
+        request.CertificateExtensions.Add(
+            new X509EnhancedKeyUsageExtension(new OidCollection { new Oid("1.3.6.1.5.5.7.3.1") /* serverAuth */ }, false));
+
+        var notBefore = DateTimeOffset.UtcNow.AddDays(-1);
+        var notAfter = notBefore.AddYears(ServerCertValidityYears);
+        using var certificate = request.CreateSelfSigned(notBefore, notAfter);
+
+        File.WriteAllText(certPath, certificate.ExportCertificatePem());
+        File.WriteAllText(keyPath, rsa.ExportPkcs8PrivateKeyPem());
+        TryHardenCredentialFile(keyPath, allowInteractiveRead: false);
+
+        _logger.LogInformation(
+            "Generated a self-signed store TLS cert (CN/DNS SAN {Host}, IP SAN {Ip}, ~{Years}yr) at {Cert}",
+            Environment.MachineName, listenIp, ServerCertValidityYears, certPath);
+    }
+
+    /// <summary>
+    /// Builds the pg_ctl <c>-o</c> runtime-override payload (the INNER string, no wrapping quotes):
+    /// always <c>-p {port} -c listen_addresses=127.0.0.1</c> (loopback FIRST, forced every start — <c>-c</c>
+    /// outranks postgresql.auto.conf), the network IP appended when exposed, and the ssl trio
+    /// (<c>ssl=on</c> + cert/key) when a cert is present. NO single quotes and NO spaces inside any value
+    /// (Windows CRT arg parsing treats only double quotes as metacharacters, and postgres re-splits the
+    /// -o payload on interior spaces); cert paths are forward-slashed here and space-free-gated by the
+    /// caller. Pure + testable (D2/D6).
+    /// </summary>
+    internal static string BuildServerRuntimeOptions(int port, string? networkListenIp, string? sslCertFile, string? sslKeyFile)
+    {
+        var builder = new StringBuilder();
+        builder.Append("-p ").Append(port);
+
+        builder.Append(" -c listen_addresses=127.0.0.1");
+        if (!string.IsNullOrWhiteSpace(networkListenIp))
+        {
+            builder.Append(',').Append(networkListenIp.Trim());
+        }
+
+        if (!string.IsNullOrWhiteSpace(sslCertFile) && !string.IsNullOrWhiteSpace(sslKeyFile))
+        {
+            builder.Append(" -c ssl=on");
+            builder.Append(" -c ssl_cert_file=").Append(ToForwardSlashes(sslCertFile));
+            builder.Append(" -c ssl_key_file=").Append(ToForwardSlashes(sslKeyFile));
+        }
+
+        return builder.ToString();
+    }
+
+    private static string ToForwardSlashes(string path) => path.Replace('\\', '/');
+
+    /// <summary>
+    /// The Darling-managed pg_hba network rule: <c>hostssl darling &lt;role&gt; &lt;cidr&gt; scram-sha-256</c>
+    /// — TLS-required (hostssl rejects a non-TLS network client), scoped to the darling database and exactly
+    /// the given login role and CIDR; never <c>all</c>, never the superuser (D5/D6). Pure + testable.
+    /// </summary>
+    internal static string BuildNetworkPgHbaLine(string role, string cidr)
+        => $"hostssl {DatabaseName} {role} {cidr} scram-sha-256";
+
+    /// <summary>
+    /// Pure marked-block reconcile for pg_hba.conf (D5): returns <paramref name="existing"/> with the
+    /// Darling-managed block (between <see cref="PgHbaBeginMarker"/> and <see cref="PgHbaEndMarker"/>) set
+    /// to a single <paramref name="desiredRuleLine"/> when non-empty, or REMOVED when null/empty (disable).
+    /// Every non-marked line is preserved verbatim; a narrowing CIDR REPLACES the block (old removed, new
+    /// appended); idempotent (re-running with the same desired yields identical text).
+    /// </summary>
+    public static string ReconcilePgHba(string existing, string? desiredRuleLine)
+    {
+        existing ??= string.Empty;
+        var normalized = existing.Replace("\r\n", "\n", StringComparison.Ordinal).Replace('\r', '\n');
+        var lines = normalized.Split('\n');
+
+        var kept = new List<string>(lines.Length);
+        var insideBlock = false;
+        foreach (var line in lines)
+        {
+            var trimmed = line.Trim();
+            if (string.Equals(trimmed, PgHbaBeginMarker, StringComparison.Ordinal))
+            {
+                insideBlock = true;
+                continue;
+            }
+
+            if (string.Equals(trimmed, PgHbaEndMarker, StringComparison.Ordinal))
+            {
+                insideBlock = false;
+                continue;
+            }
+
+            if (!insideBlock)
+            {
+                kept.Add(line);
+            }
+        }
+
+        /* Drop trailing blank lines so re-runs don't accumulate whitespace (idempotency). */
+        while (kept.Count > 0 && string.IsNullOrWhiteSpace(kept[^1]))
+        {
+            kept.RemoveAt(kept.Count - 1);
+        }
+
+        var result = new StringBuilder();
+        foreach (var line in kept)
+        {
+            result.Append(line).Append('\n');
+        }
+
+        if (!string.IsNullOrWhiteSpace(desiredRuleLine))
+        {
+            result.Append('\n');
+            result.Append(PgHbaBeginMarker).Append('\n');
+            result.Append(desiredRuleLine!.Trim()).Append('\n');
+            result.Append(PgHbaEndMarker).Append('\n');
+        }
+
+        return result.ToString();
+    }
+
+    /// <summary>
+    /// Reconciles the LIVE server's network access to <paramref name="plan"/> (D5), symmetric and
+    /// fail-closed. Rewrites the pg_hba marked block (add the hostssl rule when exposed, remove it when
+    /// loopback/degraded), reloads (exit-checked), verifies the intended rule really took via
+    /// <c>pg_hba_file_rules</c> (a reload returns 0 for mere SIGHUP delivery even if a malformed file is
+    /// rejected), guards an ADOPTED server whose live listen_addresses cannot be changed without a restart
+    /// the service will not perform, and best-effort (dis)installs the firewall rule. NEVER throws
+    /// (Round 4 #3): its whole body is caught so a reconcile failure logs + degrades, it does not abort the
+    /// bootstrap (whose contract is throw => service-exit).
+    /// </summary>
+    private async Task ReconcileNetworkAsync(
+        string binDirectory, NetworkPlan plan, string ownerConnectionString, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var exposed = plan.Mode == NetworkMode.Exposed;
+            var desiredLine = exposed ? BuildNetworkPgHbaLine(plan.Role!, plan.Cidr!) : null;
+
+            var hbaPath = Path.Combine(_dataDirectory, "pg_hba.conf");
+            var changed = false;
+            if (File.Exists(hbaPath))
+            {
+                var current = await File.ReadAllTextAsync(hbaPath, cancellationToken);
+                var updated = ReconcilePgHba(current, desiredLine);
+                if (!string.Equals(current, updated, StringComparison.Ordinal))
+                {
+                    await File.WriteAllTextAsync(hbaPath, updated, cancellationToken);
+                    changed = true;
+                    var (reloadCode, reloadOutput) = await RunToolAsync(
+                        Path.Combine(binDirectory, "pg_ctl.exe"),
+                        $"reload -D \"{_dataDirectory}\"",
+                        s_statusTimeout,
+                        cancellationToken);
+                    if (reloadCode != 0)
+                    {
+                        _logger.LogCritical(
+                            "pg_ctl reload failed (exit {ExitCode}) after updating pg_hba.conf — the network access change may not be live: {Output}",
+                            reloadCode, reloadOutput);
+                    }
+                }
+            }
+            else if (exposed)
+            {
+                _logger.LogWarning("pg_hba.conf not found at {Path} — cannot apply the network access rule", hbaPath);
+            }
+
+            /* Byte-for-byte today's behavior for a store that was never exposed and stays loopback-only: no
+               managed block existed, none was written, so skip the live verify / adopted guard / firewall
+               churn entirely. The disable-reconcile (removing a stale block on an exposed->disabled edge)
+               DID set changed=true, so a previously-exposed cluster still runs the full close below. */
+            if (!exposed && !changed)
+            {
+                return;
+            }
+
+            /* Verify the live rules match intent (reload can report success on a rejected malformed file). */
+            await VerifyPgHbaAsync(ownerConnectionString, plan, changed, cancellationToken);
+
+            /* Adopted server: we did not start it, so the -o listen_addresses/ssl override never applied.
+               If its live listener cannot satisfy the desired exposure, say so loud and do not claim exposed. */
+            if (!_startedByThisProcess)
+            {
+                await GuardAdoptedListenAsync(ownerConnectionString, plan, cancellationToken);
+            }
+
+            /* Defense-in-depth firewall rule (the boundary is pg_hba + TLS). Best-effort, never fatal. Enable
+               when exposed; on a disable EDGE (we just removed the block) also remove the rule. A store that
+               was never exposed touches the firewall not at all (the early return above). */
+            if (exposed)
+            {
+                await TryConfigureStoreFirewallAsync(enable: true, plan.Cidr!, cancellationToken);
+            }
+            else
+            {
+                await TryConfigureStoreFirewallAsync(enable: false, cidr: null, cancellationToken);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            /* Shutdown mid-reconcile — the store still runs loopback-safe; nothing to clean up. */
+        }
+        catch (Exception ex)
+        {
+            /* Round 4 #3: never let a network reconcile failure abort the bootstrap. */
+            _logger.LogCritical(
+                "Store network reconcile failed ({Message}) — the store keeps running; verify pg_hba.conf / listen_addresses by hand.",
+                ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Confirms the live pg_hba rules match intent via <c>pg_hba_file_rules</c>: no rule has a parse error,
+    /// and the Darling hostssl rule for the network role is PRESENT when exposed / ABSENT when
+    /// loopback. A mismatch is logged critical (a reload delivers a SIGHUP that Postgres may then reject).
+    /// Best-effort — a query failure degrades to a warning, not a throw.
+    /// </summary>
+    private async Task VerifyPgHbaAsync(string ownerConnectionString, NetworkPlan plan, bool reloaded, CancellationToken cancellationToken)
+    {
+        var exposed = plan.Mode == NetworkMode.Exposed;
+        try
+        {
+            await using var connection = new NpgsqlConnection(ownerConnectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            await using (var errors = new NpgsqlCommand(
+                "SELECT count(*) FROM pg_hba_file_rules WHERE error IS NOT NULL", connection))
+            {
+                var errorCount = Convert.ToInt64(await errors.ExecuteScalarAsync(cancellationToken) ?? 0L);
+                if (errorCount > 0)
+                {
+                    _logger.LogCritical(
+                        "pg_hba.conf has {Count} rule(s) Postgres could not parse (pg_hba_file_rules.error) — the live network access may not match intent; check {Path}",
+                        errorCount, Path.Combine(_dataDirectory, "pg_hba.conf"));
+                    return;
+                }
+            }
+
+            long present;
+            if (exposed)
+            {
+                await using var command = new NpgsqlCommand(
+                    "SELECT count(*) FROM pg_hba_file_rules WHERE type = 'hostssl' AND $1 = ANY(database) AND $2 = ANY(user_name)",
+                    connection);
+                command.Parameters.AddWithValue(DatabaseName);
+                command.Parameters.AddWithValue(plan.Role!);
+                present = Convert.ToInt64(await command.ExecuteScalarAsync(cancellationToken) ?? 0L);
+
+                if (present == 0)
+                {
+                    _logger.LogCritical(
+                        "pg_hba verification: the expected 'hostssl {Db} {Role} {Cidr} scram-sha-256' rule is NOT live after reload — the store is not accepting network clients as intended",
+                        DatabaseName, plan.Role, plan.Cidr);
+                    return;
+                }
+
+                _logger.LogInformation(
+                    "Store network access reconciled: exposed to {Cidr} as '{Role}' over TLS (pg_hba {Verb}).",
+                    plan.Cidr, plan.Role, reloaded ? "reloaded + verified" : "already current");
+            }
+            else
+            {
+                /* Disable: no Darling-managed hostssl rule (darling database, viewer/admin) should remain. */
+                await using var command = new NpgsqlCommand(
+                    "SELECT count(*) FROM pg_hba_file_rules WHERE type = 'hostssl' AND $1 = ANY(database) AND (user_name && ARRAY['viewer','admin'])",
+                    connection);
+                command.Parameters.AddWithValue(DatabaseName);
+                present = Convert.ToInt64(await command.ExecuteScalarAsync(cancellationToken) ?? 0L);
+
+                if (present > 0)
+                {
+                    _logger.LogCritical(
+                        "pg_hba verification: a Darling hostssl rule is STILL live after the disable reconcile — network auth may not be closed; check {Path}",
+                        Path.Combine(_dataDirectory, "pg_hba.conf"));
+                    return;
+                }
+
+                _logger.LogInformation(
+                    "Store network access reconciled: loopback-only (pg_hba {Verb}).",
+                    reloaded ? "reloaded + verified" : "already current");
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("Could not verify pg_hba via pg_hba_file_rules ({Message}) — assuming the file write took", ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// For an ADOPTED (not-started-by-us) server the -o listen_addresses override never applied, so its live
+    /// binding is whatever its operator started it with. Compares <c>SHOW listen_addresses</c> to intent: an
+    /// exposed plan needs the network IP live (else LogCritical — the pg_hba rule is in place but the port is
+    /// not bound; the operator must restart their postmaster); a disable on a still-wide adopted listener is
+    /// a warning (auth closed, but the port stays bound until the operator restarts — the documented residual).
+    /// </summary>
+    private async Task GuardAdoptedListenAsync(string ownerConnectionString, NetworkPlan plan, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var connection = new NpgsqlConnection(ownerConnectionString);
+            await connection.OpenAsync(cancellationToken);
+            await using var command = new NpgsqlCommand("SHOW listen_addresses", connection);
+            var liveListen = await command.ExecuteScalarAsync(cancellationToken) as string ?? string.Empty;
+
+            if (plan.Mode == NetworkMode.Exposed)
+            {
+                if (!LiveListenIncludes(liveListen, plan.ListenIp!))
+                {
+                    _logger.LogCritical(
+                        "Adopted Postgres listen_addresses is '{Live}', which does not include the requested {Ip}. This service will not restart a server it did not start, so the network listener is NOT active — the pg_hba rule is in place but the port is not bound. Restart your postmaster to apply, or let the service own the cluster.",
+                        liveListen, plan.ListenIp);
+                }
+            }
+            else if (LiveListenHasNonLoopback(liveListen))
+            {
+                _logger.LogWarning(
+                    "Adopted Postgres listen_addresses is '{Live}' (wider than loopback). The network AUTH path is closed (pg_hba rule removed), but the TCP port stays bound until you restart your postmaster.",
+                    liveListen);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("Could not read the adopted server's listen_addresses ({Message})", ex.Message);
+        }
+    }
+
+    private static bool LiveListenIncludes(string liveListenAddresses, string ip)
+    {
+        foreach (var token in liveListenAddresses.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (string.Equals(token, ip, StringComparison.Ordinal)
+                || string.Equals(token, "*", StringComparison.Ordinal)
+                || string.Equals(token, "0.0.0.0", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool LiveListenHasNonLoopback(string liveListenAddresses)
+    {
+        foreach (var token in liveListenAddresses.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var isLoopback =
+                string.Equals(token, "localhost", StringComparison.OrdinalIgnoreCase)
+                || (IPAddress.TryParse(token, out var ip)
+                    && ip.AddressFamily == AddressFamily.InterNetwork
+                    && ip.GetAddressBytes()[0] == 127);
+            if (!isLoopback)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>The scoped store firewall rule name (idempotent by DisplayName), port-specific.</summary>
+    private string StoreFirewallRuleName => $"PerformanceMonitor Darling store (port {_config.Port})";
+
+    /// <summary>Idempotent-named enable command (remove-by-name then add) — the exact scoped command the docs
+    /// lead with (D1). Pure + testable.</summary>
+    internal static string BuildFirewallEnableCommand(string ruleName, int port, string remoteCidr)
+        => $"Remove-NetFirewallRule -DisplayName '{ruleName}' -ErrorAction SilentlyContinue; " +
+           $"New-NetFirewallRule -DisplayName '{ruleName}' -Direction Inbound -Action Allow -Protocol TCP -LocalPort {port} -RemoteAddress {remoteCidr} | Out-Null";
+
+    /// <summary>Idempotent-named disable command (remove-by-name). Pure + testable.</summary>
+    internal static string BuildFirewallDisableCommand(string ruleName)
+        => $"Remove-NetFirewallRule -DisplayName '{ruleName}' -ErrorAction SilentlyContinue";
+
+    /// <summary>
+    /// Best-effort firewall reconcile (D1): add/remove the scoped, idempotent-named inbound rule via
+    /// PowerShell. The firewall is defense-in-depth, NOT the boundary (pg_hba + TLS are), so a failure (no
+    /// elevation, PowerShell missing) logs the exact scoped command for the operator to run by hand and
+    /// NEVER fails startup.
+    /// </summary>
+    private async Task TryConfigureStoreFirewallAsync(bool enable, string? cidr, CancellationToken cancellationToken)
+    {
+        var ruleName = StoreFirewallRuleName;
+        var command = enable
+            ? BuildFirewallEnableCommand(ruleName, _config.Port, cidr!)
+            : BuildFirewallDisableCommand(ruleName);
+
+        try
+        {
+            var (exitCode, output) = await RunPowerShellAsync(command, cancellationToken);
+            if (exitCode == 0)
+            {
+                _logger.LogInformation("Firewall rule '{Rule}' {Verb}.", ruleName, enable ? "ensured" : "removed");
+            }
+            else if (enable)
+            {
+                _logger.LogWarning(
+                    "Could not configure the firewall automatically (exit {ExitCode}: {Output}). Run this in an elevated PowerShell:\n{Command}",
+                    exitCode, output, command);
+            }
+            else
+            {
+                _logger.LogWarning("Could not remove the firewall rule automatically (exit {ExitCode}: {Output}).", exitCode, output);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            if (enable)
+            {
+                _logger.LogWarning(
+                    "Could not configure the firewall automatically ({Message}). Run this in an elevated PowerShell:\n{Command}",
+                    ex.Message, command);
+            }
+            else
+            {
+                _logger.LogWarning("Could not remove the firewall rule automatically ({Message}).", ex.Message);
+            }
+        }
+    }
+
+    private static async Task<(int ExitCode, string Output)> RunPowerShellAsync(string command, CancellationToken cancellationToken)
+    {
+        using var process = new Process();
+        process.StartInfo = new ProcessStartInfo
+        {
+            FileName = "powershell.exe",
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+        process.StartInfo.ArgumentList.Add("-NoProfile");
+        process.StartInfo.ArgumentList.Add("-NonInteractive");
+        process.StartInfo.ArgumentList.Add("-Command");
+        process.StartInfo.ArgumentList.Add(command);
+
+        var output = new StringBuilder();
+        var outputLock = new object();
+        process.OutputDataReceived += (_, e) => { if (e.Data is not null) { lock (outputLock) { output.AppendLine(e.Data); } } };
+        process.ErrorDataReceived += (_, e) => { if (e.Data is not null) { lock (outputLock) { output.AppendLine(e.Data); } } };
+
+        if (!process.Start())
+        {
+            return (-1, "could not start powershell.exe");
+        }
+
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        using var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutSource.CancelAfter(s_statusTimeout);
+        try
+        {
+            await process.WaitForExitAsync(timeoutSource.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            try
+            {
+                process.Kill(entireProcessTree: true);
+            }
+            catch (InvalidOperationException)
+            {
+                /* Exited between the timeout and the kill. */
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            string soFar;
+            lock (outputLock) { soFar = output.ToString().Trim(); }
+            return (-1, $"timed out: {soFar}");
+        }
+
+        lock (outputLock)
+        {
+            return (process.ExitCode, output.ToString().Trim());
+        }
     }
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingManagedPostgres.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingManagedPostgres.cs
@@ -604,7 +604,7 @@ public sealed class DarlingManagedPostgres
 
         _logger.LogInformation(
             "Starting managed Postgres (listen_addresses={Listen}, ssl={Ssl}, port {Port}, log: {Log})",
-            exposed ? $"127.0.0.1,{networkPlan.ListenIp}" : "127.0.0.1",
+            BuildListenAddresses(exposed ? networkPlan.ListenIp : null),
             exposed ? "on" : "off",
             _config.Port, _serverLogPath);
 
@@ -1004,26 +1004,7 @@ public sealed class DarlingManagedPostgres
     {
         var builder = new StringBuilder();
         builder.Append("-p ").Append(port);
-
-        var listen = networkListenIp?.Trim();
-        if (string.IsNullOrEmpty(listen))
-        {
-            /* Disabled / none: loopback only. */
-            builder.Append(" -c listen_addresses=127.0.0.1");
-        }
-        else if (string.Equals(listen, "0.0.0.0", StringComparison.Ordinal) || string.Equals(listen, "::", StringComparison.Ordinal))
-        {
-            /* A wildcard binds EVERY interface; on Windows PG cannot ALSO bind 127.0.0.1 on the same port
-               (no SO_REUSEADDR -> WSAEADDRINUSE, then it silently falls back to loopback-only while we log
-               "exposed"). Emit the wildcard ALONE — 0.0.0.0 already covers IPv4 loopback for the service's
-               own connection. */
-            builder.Append(" -c listen_addresses=").Append(listen);
-        }
-        else
-        {
-            /* A specific IP: bind loopback (the service's own connection) FIRST, then the network IP. */
-            builder.Append(" -c listen_addresses=127.0.0.1,").Append(listen);
-        }
+        builder.Append(" -c listen_addresses=").Append(BuildListenAddresses(networkListenIp));
 
         if (!string.IsNullOrWhiteSpace(sslCertFile) && !string.IsNullOrWhiteSpace(sslKeyFile))
         {
@@ -1033,6 +1014,32 @@ public sealed class DarlingManagedPostgres
         }
 
         return builder.ToString();
+    }
+
+    /// <summary>
+    /// The effective <c>listen_addresses</c> value for a given network bind — the SINGLE source of truth so
+    /// the <c>-o</c> override and the start-log can never drift. Null/empty ⇒ <c>127.0.0.1</c> (loopback
+    /// only). Exactly <c>0.0.0.0</c> ⇒ <c>0.0.0.0</c> ALONE: the IPv4 wildcard already covers 127.0.0.1 for
+    /// the service's own owner connection, and Windows PG cannot ALSO bind an explicit 127.0.0.1 on the same
+    /// port (overlapping IPv4 -> WSAEADDRINUSE). Everything else — a specific IPv4, a specific IPv6, OR the
+    /// IPv6 wildcard <c>::</c> — keeps the <c>127.0.0.1,</c> prefix so the hardcoded-IPv4 owner ALWAYS
+    /// connects (different families / non-overlapping IPv4 = no WSAEADDRINUSE; <c>::</c> binds IPv6-only on
+    /// Windows and would otherwise strand the owner). Pure + testable.
+    /// </summary>
+    internal static string BuildListenAddresses(string? networkListenIp)
+    {
+        var listen = networkListenIp?.Trim();
+        if (string.IsNullOrEmpty(listen))
+        {
+            return "127.0.0.1";
+        }
+
+        if (string.Equals(listen, "0.0.0.0", StringComparison.Ordinal))
+        {
+            return "0.0.0.0";
+        }
+
+        return $"127.0.0.1,{listen}";
     }
 
     private static string ToForwardSlashes(string path) => path.Replace('\\', '/');

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingManagedPostgres.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingManagedPostgres.cs
@@ -887,21 +887,43 @@ public sealed class DarlingManagedPostgres
     }
 
     /// <summary>
-    /// Idempotent self-signed server cert for store TLS verify-full (D6): reuse the existing PEM pair
-    /// (delete both to rotate), else generate a ~10-year cert with BOTH an iPAddress SAN (the listen IP,
-    /// for verify-full by IP) AND a dnsName SAN (the machine hostname, so the operator can connect by name
-    /// if IP-SAN validation ever disappoints, or when listen=0.0.0.0). The private key is written
-    /// unencrypted PKCS#8 PEM (what postgres reads) and hardened NON-interactive (SYSTEM + Administrators +
-    /// service account only) — the postmaster reads it, never an interactive user.
+    /// Idempotent self-signed server cert for store TLS verify-full (D6): reuse the existing PEM pair ONLY if
+    /// it loads AND its SAN still covers the current <paramref name="listenIp"/> (delete both to rotate),
+    /// else generate a ~10-year cert with BOTH an iPAddress SAN (the listen IP, for verify-full by IP) AND a
+    /// dnsName SAN (the machine hostname, so the operator can connect by name if IP-SAN validation ever
+    /// disappoints, or when listen=0.0.0.0). Regenerating on an UNREADABLE cert avoids fail-DEADing an
+    /// <c>ssl=on</c> start (exposure-adjacent, Round 4 #3); regenerating on a SAN/IP change keeps verify-full
+    /// working after a bind-IP change. The private key is written unencrypted PKCS#8 PEM (what postgres reads)
+    /// and hardened NON-interactive (SYSTEM + Administrators + service account only) — the postmaster reads
+    /// it, never an interactive user.
     /// </summary>
-    private void EnsureServerCertificate(IPAddress listenIp, string certPath, string keyPath)
+    internal void EnsureServerCertificate(IPAddress listenIp, string certPath, string keyPath)
     {
         if (File.Exists(certPath) && File.Exists(keyPath))
         {
-            /* Reuse (delete-to-rotate). Re-harden the key every start (self-healing), same discipline as the
-               credential files. */
-            TryHardenCredentialFile(keyPath, allowInteractiveRead: false);
-            return;
+            try
+            {
+                using var existing = X509Certificate2.CreateFromPem(File.ReadAllText(certPath));
+                if (CertificateSanCoversIp(existing, listenIp))
+                {
+                    /* Present + loads + the SAN covers this listen IP -> reuse (delete-to-rotate). Re-harden
+                       the key every start (self-healing), same discipline as the credential files. */
+                    TryHardenCredentialFile(keyPath, allowInteractiveRead: false);
+                    return;
+                }
+
+                _logger.LogInformation(
+                    "Regenerating the store TLS cert: the existing cert's SAN does not cover the current listen IP {Ip} (a listen change needs a fresh cert for verify-full).",
+                    listenIp);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    "Regenerating the store TLS cert: the existing {Cert} could not be read ({Message}) — an unreadable cert would fail-dead an ssl=on start.",
+                    certPath, ex.Message);
+            }
+
+            /* Fall through to regenerate — overwrites both files (the service account owns them). */
         }
 
         using var rsa = RSA.Create(2048);
@@ -932,6 +954,44 @@ public sealed class DarlingManagedPostgres
     }
 
     /// <summary>
+    /// Whether <paramref name="certificate"/> carries an iPAddress SAN equal to <paramref name="listenIp"/>
+    /// — the reuse gate for the store TLS cert (verify-full pins the IP SAN). Reads the SAN extension
+    /// (OID 2.5.29.17) via <see cref="X509SubjectAlternativeNameExtension.EnumerateIPAddresses"/>. Pure.
+    /// </summary>
+    internal static bool CertificateSanCoversIp(X509Certificate2 certificate, IPAddress listenIp)
+    {
+        X509SubjectAlternativeNameExtension? san = null;
+        foreach (var extension in certificate.Extensions)
+        {
+            if (!string.Equals(extension.Oid?.Value, "2.5.29.17", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            /* cert.Extensions may hand back a generic X509Extension for the SAN; re-materialize the typed
+               view from its raw DER when so, so EnumerateIPAddresses is always available. */
+            san = extension as X509SubjectAlternativeNameExtension
+                ?? new X509SubjectAlternativeNameExtension(extension.RawData);
+            break;
+        }
+
+        if (san is null)
+        {
+            return false;
+        }
+
+        foreach (var ip in san.EnumerateIPAddresses())
+        {
+            if (ip.Equals(listenIp))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Builds the pg_ctl <c>-o</c> runtime-override payload (the INNER string, no wrapping quotes):
     /// always <c>-p {port} -c listen_addresses=127.0.0.1</c> (loopback FIRST, forced every start — <c>-c</c>
     /// outranks postgresql.auto.conf), the network IP appended when exposed, and the ssl trio
@@ -945,10 +1005,24 @@ public sealed class DarlingManagedPostgres
         var builder = new StringBuilder();
         builder.Append("-p ").Append(port);
 
-        builder.Append(" -c listen_addresses=127.0.0.1");
-        if (!string.IsNullOrWhiteSpace(networkListenIp))
+        var listen = networkListenIp?.Trim();
+        if (string.IsNullOrEmpty(listen))
         {
-            builder.Append(',').Append(networkListenIp.Trim());
+            /* Disabled / none: loopback only. */
+            builder.Append(" -c listen_addresses=127.0.0.1");
+        }
+        else if (string.Equals(listen, "0.0.0.0", StringComparison.Ordinal) || string.Equals(listen, "::", StringComparison.Ordinal))
+        {
+            /* A wildcard binds EVERY interface; on Windows PG cannot ALSO bind 127.0.0.1 on the same port
+               (no SO_REUSEADDR -> WSAEADDRINUSE, then it silently falls back to loopback-only while we log
+               "exposed"). Emit the wildcard ALONE — 0.0.0.0 already covers IPv4 loopback for the service's
+               own connection. */
+            builder.Append(" -c listen_addresses=").Append(listen);
+        }
+        else
+        {
+            /* A specific IP: bind loopback (the service's own connection) FIRST, then the network IP. */
+            builder.Append(" -c listen_addresses=127.0.0.1,").Append(listen);
         }
 
         if (!string.IsNullOrWhiteSpace(sslCertFile) && !string.IsNullOrWhiteSpace(sslKeyFile))
@@ -970,6 +1044,18 @@ public sealed class DarlingManagedPostgres
     /// </summary>
     internal static string BuildNetworkPgHbaLine(string role, string cidr)
         => $"hostssl {DatabaseName} {role} {cidr} scram-sha-256";
+
+    /// <summary>
+    /// Whether the live pg_hba.conf needs reconciling (darling-network-endpoints): true when there is a rule
+    /// to apply (<paramref name="desiredLine"/> non-null = exposing) OR the file still carries a Darling
+    /// managed block to remove (<see cref="PgHbaBeginMarker"/> present = a disable edge). FALSE for a store
+    /// that was never exposed and is not being exposed — so the reconcile skips reading-normalizing-rewriting
+    /// an untouched operator pg_hba (<see cref="ReconcilePgHba"/> normalizes CRLF and trims trailing blanks,
+    /// which would otherwise be a spurious write + reload + firewall spawn on a store never opted in). Pure.
+    /// </summary>
+    public static bool NeedsPgHbaReconcile(string current, string? desiredLine)
+        => desiredLine is not null
+        || (current is not null && current.Contains(PgHbaBeginMarker, StringComparison.Ordinal));
 
     /// <summary>
     /// Pure marked-block reconcile for pg_hba.conf (D5): returns <paramref name="existing"/> with the
@@ -1049,40 +1135,44 @@ public sealed class DarlingManagedPostgres
             var desiredLine = exposed ? BuildNetworkPgHbaLine(plan.Role!, plan.Cidr!) : null;
 
             var hbaPath = Path.Combine(_dataDirectory, "pg_hba.conf");
-            var changed = false;
-            if (File.Exists(hbaPath))
+            if (!File.Exists(hbaPath))
             {
-                var current = await File.ReadAllTextAsync(hbaPath, cancellationToken);
-                var updated = ReconcilePgHba(current, desiredLine);
-                if (!string.Equals(current, updated, StringComparison.Ordinal))
+                if (exposed)
                 {
-                    await File.WriteAllTextAsync(hbaPath, updated, cancellationToken);
-                    changed = true;
-                    var (reloadCode, reloadOutput) = await RunToolAsync(
-                        Path.Combine(binDirectory, "pg_ctl.exe"),
-                        $"reload -D \"{_dataDirectory}\"",
-                        s_statusTimeout,
-                        cancellationToken);
-                    if (reloadCode != 0)
-                    {
-                        _logger.LogCritical(
-                            "pg_ctl reload failed (exit {ExitCode}) after updating pg_hba.conf — the network access change may not be live: {Output}",
-                            reloadCode, reloadOutput);
-                    }
+                    _logger.LogWarning("pg_hba.conf not found at {Path} — cannot apply the network access rule", hbaPath);
                 }
-            }
-            else if (exposed)
-            {
-                _logger.LogWarning("pg_hba.conf not found at {Path} — cannot apply the network access rule", hbaPath);
+
+                return;
             }
 
-            /* Byte-for-byte today's behavior for a store that was never exposed and stays loopback-only: no
-               managed block existed, none was written, so skip the live verify / adopted guard / firewall
-               churn entirely. The disable-reconcile (removing a stale block on an exposed->disabled edge)
-               DID set changed=true, so a previously-exposed cluster still runs the full close below. */
-            if (!exposed && !changed)
+            var current = await File.ReadAllTextAsync(hbaPath, cancellationToken);
+
+            /* Byte-for-byte today's behavior: a never-exposed store (no managed block) that is not being
+               exposed needs NO reconcile — do not even normalize/rewrite pg_hba (ReconcilePgHba would trim
+               CRLF + trailing blanks and trigger a spurious write + reload + verify + firewall spawn on a
+               store the operator never opted into). A disable EDGE (marker still present) or an exposure to
+               apply (desiredLine non-null) both return true and run the full reconcile below. */
+            if (!NeedsPgHbaReconcile(current, desiredLine))
             {
                 return;
+            }
+
+            var updated = ReconcilePgHba(current, desiredLine);
+            var changed = !string.Equals(current, updated, StringComparison.Ordinal);
+            if (changed)
+            {
+                await File.WriteAllTextAsync(hbaPath, updated, cancellationToken);
+                var (reloadCode, reloadOutput) = await RunToolAsync(
+                    Path.Combine(binDirectory, "pg_ctl.exe"),
+                    $"reload -D \"{_dataDirectory}\"",
+                    s_statusTimeout,
+                    cancellationToken);
+                if (reloadCode != 0)
+                {
+                    _logger.LogCritical(
+                        "pg_ctl reload failed (exit {ExitCode}) after updating pg_hba.conf — the network access change may not be live: {Output}",
+                        reloadCode, reloadOutput);
+                }
             }
 
             /* Verify the live rules match intent (reload can report success on a rejected malformed file). */
@@ -1341,10 +1431,15 @@ public sealed class DarlingManagedPostgres
 
     private static async Task<(int ExitCode, string Output)> RunPowerShellAsync(string command, CancellationToken cancellationToken)
     {
+        /* Full path (not the bare name) — avoid a PATH/CWD hijack of "powershell.exe", matching the house
+           style of full-pathing every PG tool. */
+        var powershellPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.System), "WindowsPowerShell", "v1.0", "powershell.exe");
+
         using var process = new Process();
         process.StartInfo = new ProcessStartInfo
         {
-            FileName = "powershell.exe",
+            FileName = powershellPath,
             UseShellExecute = false,
             CreateNoWindow = true,
             RedirectStandardOutput = true,

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingManagedRoles.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingManagedRoles.cs
@@ -23,14 +23,23 @@ namespace PerformanceMonitor.Darling.Service;
 /// Least-privilege role provisioning for the managed store (V8 security hardening, #1262) — the
 /// conf-append discipline of <see cref="DarlingManagedPostgres"/> applied to roles and credentials.
 /// The service connects as the bootstrap superuser <c>darling</c> (it does DDL: migrations,
-/// hypertable conversion, retention), and it provisions two least-privilege LOGIN roles the
-/// interactive Viewer connects as instead of the superuser:
+/// hypertable conversion, retention), and it provisions three least-privilege LOGIN roles that
+/// connect instead of the superuser:
 /// <list type="bullet">
 /// <item><b><c>admin</c></b> — SELECT on both schemas + INSERT/UPDATE/DELETE on <c>config</c> only.
 /// The Viewer's default identity: it owns the alert-dismiss, mute-rule, and analysis-mute writes but
 /// can never DROP, alter schema, touch <c>collect</c> data, or create objects.</item>
 /// <item><b><c>viewer</c></b> — SELECT on both schemas, no writes anywhere. A locked-down
 /// deployment points the Viewer at this ("look but don't touch").</item>
+/// <item><b><c>mcp</c></b> — the (optionally network-exposed) MCP host's store identity
+/// (darling-network-endpoints, D3-role): the SAME read surface as <c>viewer</c> (SELECT on
+/// <c>collect</c> + <c>config</c>-minus-the-secret-columns) PLUS exactly two narrow writes — INSERT
+/// on <c>collect.analysis_findings</c> and <c>config.analysis_muted</c> (what <c>analyze_server</c>
+/// persists + the <c>mute</c> tool need, and nothing else). Deliberately NOT <c>admin</c>: a
+/// token-holder reachable over the network must never get the <c>config_command</c> service-credential
+/// pivot or the secret columns. Its INSERT grants are EXPLICIT single-table statements with NO
+/// <c>ALTER DEFAULT PRIVILEGES</c> (ADP has no per-table form -> it would broaden <c>mcp</c> to all of
+/// <c>collect</c>); a dropped/recreated table re-grants because provisioning re-runs every start.</item>
 /// </list>
 ///
 /// <para>On every managed startup (after migration, before TimescaleDB conversion), for each role:
@@ -129,11 +138,14 @@ public static class DarlingManagedRoles
             $"GRANT SELECT ({string.Join(", ", acl.NonSecretColumns)}) ON {configSchema}.{acl.Table} TO {viewerRole};"));
 
     /// <summary>
-    /// Ensures the <c>admin</c>/<c>viewer</c> roles, their DPAPI credentials, and the collect/config
-    /// grants exist and match — idempotent and self-healing. Opens one connection from the
+    /// Ensures the <c>admin</c>/<c>viewer</c>/<c>mcp</c> roles, their DPAPI credentials, and the
+    /// collect/config grants exist and match — idempotent and self-healing. Opens one connection from the
     /// owner-<c>darling</c> data source (ALTER DEFAULT PRIVILEGES FOR ROLE darling only governs objects
-    /// darling creates, which is all of them). Throws on a hard failure; the caller degrades (the
-    /// Viewer cannot connect as admin/viewer until a later start succeeds) but keeps collecting.
+    /// darling creates, which is all of them). MUST run AFTER migration: the <c>mcp</c> role's per-table
+    /// INSERT grants name <c>collect.analysis_findings</c> / <c>config.analysis_muted</c> by qualified
+    /// name, which the one-shot batch requires to already exist (they do — the worker migrates before it
+    /// calls this). Throws on a hard failure; the caller degrades (the Viewer/MCP cannot connect as their
+    /// roles until a later start succeeds) but keeps collecting.
     /// </summary>
     public static async Task EnsureProvisionedAsync(
         NpgsqlDataSource dataSource, string dataDirectory, ILogger logger, CancellationToken cancellationToken = default)
@@ -148,17 +160,25 @@ public static class DarlingManagedRoles
             throw new ArgumentException("Data directory is required.", nameof(dataDirectory));
         }
 
+        /* admin/viewer credentials are read by the interactive Viewer -> INTERACTIVE-readable ACL. */
         var adminPassword = EnsureRoleCredential(
-            DarlingManagedPostgres.AdminCredentialPathFor(dataDirectory), DarlingManagedPostgres.AdminRoleName, logger);
+            DarlingManagedPostgres.AdminCredentialPathFor(dataDirectory), DarlingManagedPostgres.AdminRoleName,
+            allowInteractiveRead: true, logger);
         var viewerPassword = EnsureRoleCredential(
-            DarlingManagedPostgres.ViewerCredentialPathFor(dataDirectory), DarlingManagedPostgres.ViewerRoleName, logger);
+            DarlingManagedPostgres.ViewerCredentialPathFor(dataDirectory), DarlingManagedPostgres.ViewerRoleName,
+            allowInteractiveRead: true, logger);
+        /* The mcp credential is consumed only by the in-service MCP host, never an interactive Viewer, so it
+           is hardened NON-interactive (mirrors the superuser posture, not admin/viewer's) — Round 4 #4. */
+        var mcpPassword = EnsureRoleCredential(
+            DarlingManagedPostgres.McpCredentialPathFor(dataDirectory), DarlingManagedPostgres.McpRoleName,
+            allowInteractiveRead: false, logger);
 
         await using var connection = await dataSource.OpenConnectionAsync(cancellationToken);
-        await using var command = new NpgsqlCommand(BuildProvisioningSql(adminPassword, viewerPassword), connection);
+        await using var command = new NpgsqlCommand(BuildProvisioningSql(adminPassword, viewerPassword, mcpPassword), connection);
         await command.ExecuteNonQueryAsync(cancellationToken);
 
         logger.LogInformation(
-            "Least-privilege roles ready (admin: read both schemas + write config; viewer: read-only) — the Viewer no longer connects as the superuser");
+            "Least-privilege roles ready (admin: read both schemas + write config; viewer: read-only; mcp: viewer's reads + INSERT on analysis_findings/analysis_muted) — the Viewer and MCP host no longer connect as the superuser");
     }
 
     /// <summary>
@@ -168,7 +188,7 @@ public static class DarlingManagedRoles
     /// always be re-asserted (<c>ALTER ROLE … PASSWORD</c>), so an untrusted-owned (possibly pre-planted)
     /// file is discarded and regenerated rather than trusted.
     /// </summary>
-    private static string EnsureRoleCredential(string credentialPath, string roleName, ILogger logger)
+    private static string EnsureRoleCredential(string credentialPath, string roleName, bool allowInteractiveRead, ILogger logger)
     {
         string password;
         if (File.Exists(credentialPath) && DarlingFileSecurity.IsTrustedOwner(credentialPath))
@@ -193,18 +213,19 @@ public static class DarlingManagedRoles
                 "Generated the managed '{Role}' role credential ({File})", roleName, Path.GetFileName(credentialPath));
         }
 
-        /* Re-harden every start (self-healing): the admin/viewer credentials are readable by SYSTEM +
-           Administrators + the service account + the interactive operator (whose Viewer reads them). */
-        TryHardenRoleCredential(credentialPath, logger);
+        /* Re-harden every start (self-healing): admin/viewer are additionally readable by the interactive
+           operator (whose Viewer reads them); mcp is NOT (SYSTEM + Administrators + service account only —
+           the in-service MCP host reads it, never an interactive user). */
+        TryHardenRoleCredential(credentialPath, allowInteractiveRead, logger);
         return password;
     }
 
     /// <summary>Best-effort restrictive ACL on a role credential; a failure is logged loud, not fatal.</summary>
-    private static void TryHardenRoleCredential(string path, ILogger logger)
+    private static void TryHardenRoleCredential(string path, bool allowInteractiveRead, ILogger logger)
     {
         try
         {
-            DarlingFileSecurity.HardenFile(path, allowInteractiveRead: true);
+            DarlingFileSecurity.HardenFile(path, allowInteractiveRead);
         }
         catch (Exception ex)
         {
@@ -232,18 +253,23 @@ public static class DarlingManagedRoles
     /// The idempotent, self-healing provisioning DDL with the role passwords injected. Passwords are
     /// alnum-only (<see cref="DarlingManagedPostgres.GeneratePassword"/>), verified here before the
     /// interpolation, so string-building the <c>PASSWORD '…'</c> literals is escaping-safe — the same
-    /// reasoning <see cref="DarlingManagedPostgres"/> relies on for <c>--pwfile</c>. Public + parameter-free
-    /// so a test can pin the shape without a live Postgres; shared with nothing else.
+    /// reasoning <see cref="DarlingManagedPostgres"/> relies on for <c>--pwfile</c>. Public + shape-pinnable
+    /// so a test can assert it without a live Postgres. The <c>mcp</c>-role INSERT grants reference
+    /// <c>collect.analysis_findings</c> / <c>config.analysis_muted</c> by qualified name, so the one-shot
+    /// batch requires those tables to already exist — safe because provisioning runs AFTER migration (see
+    /// <see cref="EnsureProvisionedAsync"/>); a dropped/recreated table re-grants on the next start.
     /// </summary>
-    public static string BuildProvisioningSql(string adminPassword, string viewerPassword)
+    public static string BuildProvisioningSql(string adminPassword, string viewerPassword, string mcpPassword)
     {
         RequireAlphanumeric(adminPassword, nameof(adminPassword));
         RequireAlphanumeric(viewerPassword, nameof(viewerPassword));
+        RequireAlphanumeric(mcpPassword, nameof(mcpPassword));
 
         const string owner = DarlingManagedPostgres.UserName;      // darling (owner/superuser)
         const string database = DarlingManagedPostgres.DatabaseName; // darling
         const string admin = DarlingManagedPostgres.AdminRoleName;
         const string viewer = DarlingManagedPostgres.ViewerRoleName;
+        const string mcp = DarlingManagedPostgres.McpRoleName;
         const string collect = PgSchemaGenerator.CollectSchema;
         const string config = PgSchemaGenerator.ConfigSchema;
         const string marker = RoleMarker;
@@ -252,6 +278,11 @@ public static class DarlingManagedRoles
            ViewerRestrictedConfigTables). Runs AFTER the blanket config GRANT below, so it strips
            viewer's table-wide SELECT on those tables and re-grants only the non-secret columns. */
         var viewerColumnAcl = BuildViewerColumnAclSql(config, viewer);
+
+        /* The SAME fail-closed carve for the mcp role — it gets viewer's read surface, so it must be
+           denied the identical secret columns. Reusing BuildViewerColumnAclSql(config, mcp) means the
+           mcp carve can never drift from viewer's (Round 4 #5 guards this with a live denial test). */
+        var mcpColumnAcl = BuildViewerColumnAclSql(config, mcp);
 
         return $@"
 /* Least-privilege roles for the Darling security split (#1262). Idempotent + self-healing:
@@ -275,12 +306,20 @@ BEGIN
    ELSIF shobj_description((SELECT oid FROM pg_roles WHERE rolname = '{viewer}'), 'pg_authid') IS DISTINCT FROM '{marker}' THEN
       RAISE EXCEPTION 'Role ""{viewer}"" already exists and was not created by Darling (missing the ''{marker}'' marker comment). Rename or drop it before provisioning so Darling does not repurpose an unrelated login.';
    END IF;
+
+   IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{mcp}') THEN
+      CREATE ROLE {mcp} LOGIN NOSUPERUSER PASSWORD '{mcpPassword}';
+      COMMENT ON ROLE {mcp} IS '{marker}';
+   ELSIF shobj_description((SELECT oid FROM pg_roles WHERE rolname = '{mcp}'), 'pg_authid') IS DISTINCT FROM '{marker}' THEN
+      RAISE EXCEPTION 'Role ""{mcp}"" already exists and was not created by Darling (missing the ''{marker}'' marker comment). Rename or drop it before provisioning so Darling does not repurpose an unrelated login.';
+   END IF;
 END $do$;
 
 -- 1b. Re-assert password + attributes every start (the credential file is the source of truth).
 --     Only reached when the guard above passed (fresh + marked, or already Darling-marked).
 ALTER ROLE {admin}  LOGIN NOSUPERUSER PASSWORD '{adminPassword}';
 ALTER ROLE {viewer} LOGIN NOSUPERUSER PASSWORD '{viewerPassword}';
+ALTER ROLE {mcp}    LOGIN NOSUPERUSER PASSWORD '{mcpPassword}';
 
 -- 2. Schema usage + SELECT everywhere (ALL TABLES covers tables AND views). collect holds no secrets,
 --    so admin+viewer read all of it. config: admin (the writer, and the Settings window's identity) reads
@@ -300,7 +339,8 @@ GRANT SELECT ON ALL TABLES IN SCHEMA {config}  TO {admin}, {viewer};
 --     PRIVILEGES already landed on these tables when they were created.
 {viewerColumnAcl}
 
--- 3. config writes -- admin only.
+-- 3. config writes -- admin gets the whole schema. (mcp gets ONLY a narrow config.analysis_muted INSERT
+--    in section 6, never the config_command/monitored_servers/notification pivot tables; viewer: none.)
 GRANT INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA {config} TO {admin};
 
 -- 4. Default privileges so NEW tables/views auto-inherit (no per-table-grant foot-gun).
@@ -321,6 +361,24 @@ ALTER DEFAULT PRIVILEGES FOR ROLE {owner} IN SCHEMA {config}
 REVOKE CREATE ON SCHEMA public FROM PUBLIC;
 REVOKE ALL ON DATABASE {database} FROM PUBLIC;
 GRANT CONNECT ON DATABASE {database} TO {admin}, {viewer};
+
+-- 6. The mcp role (darling-network-endpoints, D3-role): the ONLY credential reachable (via the bearer
+--    token) from the optional network MCP surface, so it is deliberately NOT admin. It gets viewer's exact
+--    READ surface (SELECT on collect + config-minus-secret-columns) as SEPARATE 'TO mcp' statements -- the
+--    'TO admin, viewer' grant lines above are pinned verbatim by tests, so mcp is never appended to them --
+--    PLUS exactly two narrow INSERTs: what analyze_server persists (collect.analysis_findings) and what the
+--    mute tool writes (config.analysis_muted). No UPDATE/DELETE (no MCP unmute tool exists; DELETE/unmute is
+--    viewer/admin only). EXPLICIT single-table grants with NO ALTER DEFAULT PRIVILEGES: ADP has no per-table
+--    form, so an ADP INSERT would broaden mcp to ALL of collect -- provisioning re-runs every start, so a
+--    recreated table re-grants (self-heal) without ADP. The two INSERT targets must already exist here, so
+--    provisioning runs AFTER migration (EnsureProvisionedAsync).
+GRANT USAGE ON SCHEMA {collect}, {config} TO {mcp};
+GRANT SELECT ON ALL TABLES IN SCHEMA {collect} TO {mcp};
+GRANT SELECT ON ALL TABLES IN SCHEMA {config}  TO {mcp};
+{mcpColumnAcl}
+GRANT INSERT ON {collect}.analysis_findings TO {mcp};
+GRANT INSERT ON {config}.analysis_muted TO {mcp};
+GRANT CONNECT ON DATABASE {database} TO {mcp};
 ";
     }
 

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingManagedRoles.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingManagedRoles.cs
@@ -53,8 +53,10 @@ namespace PerformanceMonitor.Darling.Service;
 /// checks drive it exactly as <see cref="DarlingManagedPostgres.EnsureConfAppended"/> uses its conf
 /// marker.</para>
 ///
-/// <para>Windows-only (the DPAPI credential files), like every DPAPI surface here. Bring-your-own
-/// Postgres provisions the same roles out-of-band via <c>Darling/tools/provision-roles.sql</c>.</para>
+/// <para>Windows-only (the DPAPI credential files), like every DPAPI surface here. Managed mode provisions
+/// all three roles (admin/viewer/mcp); bring-your-own Postgres provisions admin + viewer out-of-band via
+/// <c>Darling/tools/provision-roles.sql</c> and correctly has NO <c>mcp</c> role — the network MCP endpoint
+/// is managed-mode-only, so a BYO operator's own PostgreSQL governs any MCP-role exposure it wants.</para>
 /// </summary>
 [SupportedOSPlatform("windows")]
 public static class DarlingManagedRoles
@@ -378,6 +380,9 @@ GRANT SELECT ON ALL TABLES IN SCHEMA {config}  TO {mcp};
 {mcpColumnAcl}
 GRANT INSERT ON {collect}.analysis_findings TO {mcp};
 GRANT INSERT ON {config}.analysis_muted TO {mcp};
+-- NOT granted (Round 4 #9): collect.analysis_state. MCP analyze_server calls AnalyzeAsync directly and never
+-- writes the analysis_state marker -- only the worker's RunAnalysisPassAsync wrapper does, as the owner
+-- (the Analysis project cannot reference the Service-project observability writer), so mcp needs no grant on it.
 GRANT CONNECT ON DATABASE {database} TO {mcp};
 ";
     }

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -88,6 +88,54 @@ public sealed class DarlingWorker : BackgroundService
     /// </summary>
     internal static bool ShouldRunCollection(bool paused) => !paused;
 
+    /// <summary>
+    /// The network-endpoint startup warnings the worker emits AFTER <see cref="DarlingConfig.Validate"/>
+    /// passes (darling-network-endpoints) — NEVER inside Validate(), which is all-fatal, so an optional,
+    /// default-off endpoint note can never abort collection (D-BYO / D-validate):
+    /// <list type="bullet">
+    /// <item>BYO mode (<c>managed=false</c>) with any <c>postgres.network.*</c> or <c>mcp.network.*</c>
+    /// set — the fields are IGNORED; the operator's own PostgreSQL governs exposure.</item>
+    /// <item>Managed mode with an EXPOSED store whose <c>network.role</c> is <c>admin</c> — names the
+    /// <c>config_command</c> / <c>config_monitored_servers</c> / <c>config_notification</c>
+    /// service-credential pivot a remote admin connection can reach (D7 — the operator's informed opt-in).</item>
+    /// </list>
+    /// Pure so a unit test asserts the returned strings without driving the loop or a live logger.
+    /// </summary>
+    internal static IReadOnlyList<string> GetNetworkStartupWarnings(DarlingConfig config)
+    {
+        var warnings = new List<string>();
+
+        if (!config.Postgres.Managed)
+        {
+            /* BYO: network.* is managed-mode only. Warn per section that is set (D-BYO). */
+            if (config.Postgres.Network?.IsConfigured == true)
+            {
+                warnings.Add(
+                    "postgres.network.* is set but postgres.managed is false — it is IGNORED in bring-your-own mode; your own PostgreSQL governs its network exposure (pg_hba / listen_addresses / TLS).");
+            }
+
+            if (config.Mcp.Network?.IsConfigured == true)
+            {
+                warnings.Add(
+                    "mcp.network.* is set but postgres.managed is false — the MCP network endpoint is managed-mode only, so it is IGNORED; the MCP server stays loopback-only.");
+            }
+
+            return warnings;
+        }
+
+        /* Managed + the store is genuinely exposed + the network role resolves to admin (D7 pivot warning). */
+        var network = config.Postgres.Network;
+        if (network is not null
+            && DarlingNetwork.IsExposedListenAddress(network.Listen)
+            && string.Equals(DarlingNetwork.NormalizeNetworkRole(network.Role), "admin", StringComparison.Ordinal))
+        {
+            warnings.Add(
+                "postgres.network.role is 'admin' — a REMOTE admin connection can write config_command (the test_connect service-credential pivot), config_monitored_servers, and config_notification (webhook exfil). This is an explicit opt-in; the secure default is 'viewer' (read-only). Only expose admin on a trusted network.");
+        }
+
+        return warnings;
+    }
+
     private readonly ILogger<DarlingWorker> _logger;
     private readonly ILoggerFactory _loggerFactory;
 
@@ -193,6 +241,14 @@ public sealed class DarlingWorker : BackgroundService
                 _logger.LogCritical("Configuration problem: {Problem}", problem);
             }
             return;
+        }
+
+        /* Network-endpoint caller warnings (darling-network-endpoints, D-BYO / D7) — emitted AFTER
+           Validate() passes and NEVER inside it (Validate is all-fatal; an optional-endpoint note must not
+           abort startup). Covers BYO-mode network.* being ignored and the network.role=admin pivot risk. */
+        foreach (var warning in GetNetworkStartupWarnings(config))
+        {
+            _logger.LogWarning("{Warning}", warning);
         }
 
         /* Bundled-Postgres bootstrap (the shipped zero-admin default): in managed mode the


### PR DESCRIPTION
## Darling opt-in network endpoints — Phase 1 (coupled core: config + store + roles)

Implements **Phase 1** of the LOCKED plan `darling-network-endpoints.md` — the dependency-sequenced foundation that touches the shared core (`DarlingConfig.cs` / `DarlingManagedPostgres.cs` / `DarlingManagedRoles.cs` / `DarlingWorker.cs`). Phases 2 (MCP host) and 3 (verb + viewer + docs) are disjoint files and land after this per the plan's build split.

**Default = byte-for-byte today's behavior**: with no `postgres.network` / `mcp.network` block, the store binds loopback-only, no pg_hba network rule, no firewall rule, `ssl=off`. Every exposure layer is fail-closed (invalid/incomplete config degrades to loopback + `LogCritical`, never exposes) and symmetric (removing the config closes the box).

### What's implemented (scope → files → tests)

**1. `DarlingConfig.cs`** (scope item 1)
- `PostgresNetworkConfig` (listen/allowFrom/role) + `McpNetworkConfig` (listen/allowFrom/encryptedToken+token), nested on `PostgresConfig`/`McpConfig`.
- `McpNetworkConfig.ResolveToken(out usedPlaintext)` — prefers `encryptedToken` (DPAPI `Unprotect`), falls back to plaintext `token` and flags it so the caller warns.
- Shared `DarlingNetwork.IsExposedListenAddress` (only IPv4 `127/8` is non-exposed; `0.0.0.0`/`::`/`::1`/`*`/`localhost`/hostnames all "exposed") + `NormalizeNetworkRole` (default `viewer`; `viewer`/`admin` only; never superuser).
- Network rules kept **out of** the all-fatal `Validate()` (D-validate). Fixed the stale `:88-92` "six tools / localhost" mcp doc.
- Tests: `DarlingConfigTests` (parse both sections present/absent, `ResolveToken` encrypted-vs-plaintext, `Validate` stays empty on exposed-but-invalid), `DarlingNetworkTests` (classifier + role-normalizer matrices).

**2. `DarlingManagedPostgres.cs`** (scope item 2)
- listen/ssl via the `-o` runtime override (`BuildServerRuntimeOptions`): always `-c listen_addresses=127.0.0.1` (loopback-first, unquoted, no value spaces), network IP + `ssl=on`/cert/key appended when exposed.
- Self-signed cert (`EnsureServerCertificate`): `CertificateRequest` → PEM `server.crt`/`server.key` beside the data dir, **both** an iPAddress SAN (listen IP) and a dnsName SAN (hostname), ~10yr, idempotent reuse; `server.key` hardened `allowInteractiveRead:false`. `ssl=on` gated on cert-present **and** a space-free data dir, else degrade to loopback + `LogCritical` (never `ssl=off` while exposed, never `ssl=on` with a broken path).
- Pure `ReconcilePgHba(existing, desired)` (marked-block append/replace/remove, `hostssl darling <role> <cidr> scram-sha-256`, preserves non-marked lines) + `pg_ctl reload` (exit-checked) + `pg_hba_file_rules` verify + adopted-server `SHOW listen_addresses` guard.
- Best-effort idempotent named firewall helper (`New-NetFirewallRule`, remove-then-add); logs the exact scoped command on failure; never fails startup; only touches the firewall when exposed or on a disable-edge.
- Store **degrade-to-loopback is caught internally in `EnsureRunningAsync`** (never thrown — its contract is throw⇒service-exit) and runs the **full** disable-reconcile (loopback listen + pg_hba block removed + reload + verify) — Round 4 #3.
- `Host` `localhost`→`127.0.0.1` in `BuildConnectionString`; `McpCredentialPathFor` + `TryBuildMcpConnectionStringFromStoredCredential` (Username=`mcp`, same search path) for Phase 2. Rewrote the `:36-48`/`:29`/`:487` posture doc + start log.
- Tests: `DarlingNetworkTests` (`-o` arg-gen, `ReconcilePgHba` append/replace/remove/idempotent + non-marked preservation, `BuildNetworkPgHbaLine` shape, firewall builders, `ResolveNetworkExposure` degrade matrix: missing/invalid CIDR, family mismatch, bad role, listen-not-IP, spaced cert path); `DarlingManagedPostgresTests` (mcp credential round-trip, Host=`127.0.0.1` pin updated; `:80`/`:203` conf pins stay green — `BuildConfAppend` still writes `127.0.0.1`).

**3. `DarlingManagedRoles.cs`** (scope item 3)
- Third managed login role `mcp` (marker-guarded CREATE + `pg-mcp-credential.dpapi` hardened `allowInteractiveRead:false`, Round 4 #4): `viewer`'s read surface as **separate** `TO mcp` statements (the pinned `TO admin, viewer` lines are untouched) + `BuildViewerColumnAclSql(config,"mcp")` secret-column carve + `GRANT INSERT ON collect.analysis_findings TO mcp` + `GRANT INSERT ON config.analysis_muted TO mcp` — INSERT-only (Round 4 #1), explicit single-table, **no `ALTER DEFAULT PRIVILEGES`**. Verified both tables use app-generated `bigint` ids (no serial ⇒ no sequence grant needed). Migrate-before-provision ordering documented at the grant site.
- Updated the stale `:26`/`:28-34`/`:29-31`/`:160-161`/`:303` comments + log.
- Tests: `DarlingManagedRolesTests` (mcp created/granted read+two INSERTs, DoesNotContain any ADP-to-mcp or `DELETE … analysis_muted TO mcp`, mcp secret-column carve; existing admin/viewer read+write pins still hold); `DarlingSecuritySplitLiveTests` (gated live: mcp DENIED each secret column (42501), granted exactly the two INSERTs via `has_table_privilege`, denied config_command INSERT / analysis_muted DELETE / analysis_findings UPDATE).

**4. `DarlingWorker.cs`** (scope item 4)
- Pure `GetNetworkStartupWarnings(config)` + caller `LogWarning`s emitted **after** `Validate()` passes (none in `Validate()`): D-BYO (`managed=false` + any `network.*` set, per section) and the `network.role=admin` pivot (naming `config_command`/`config_monitored_servers`/`config_notification`).
- Tests: `DarlingWorkerTests` (BYO warns both sections; managed+exposed+admin warns pivot; managed+viewer / no-network / admin-but-loopback are silent).

### Build + test results (actual)
- `dotnet build PerformanceMonitor.Darling.Service` → **Build succeeded** (0 errors).
- `dotnet build PerformanceMonitor.Darling.Viewer` → **Build succeeded** (unaffected; its `DeriveManagedConnectionString` localhost→127.0.0.1 is Phase 3).
- Affected classes (`DarlingNetworkTests`, `DarlingManagedRolesTests`, `DarlingManagedPostgresTests`, `DarlingConfigTests`, `DarlingWorkerTests`): **94 passed, 1 skipped** (the DARLING_TEST_PGRUNTIME-gated bootstrap E2E), 0 failed.
- Full `Darling.Tests`: **1723 passed, 127 skipped (gated live), 2 failed** — see flag below.

### FLAGS (not silently dropped)

1. **The 2 full-suite failures are PRE-EXISTING on `origin/dev`, unrelated to this PR.** `TimescaleSupportTests.{CreateHypertableSql_…, CompressionSql_…}` assert `INTERVAL '7 days'` / `by_range('collection_time')`, but `TimescaleSupport.cs` on dev (from the #1458 merge) ships `CompressAfterDays = 1` / `ChunkIntervalDays = 1`. My branch touches **neither** file (`git diff origin/dev` is empty for both) and they reproduce on a clean `origin/dev`. There's a genuine **1-vs-7-day design ambiguity** (the code + its doc comment say 1-day for the 1-minute cadence; the plan calls #1458 "7-day compaction"), so I did **not** reconcile another PR's subsystem here — please decide the intended horizon and sync the test (or the constant) separately.

2. **Phase boundaries are the plan's build split, not a scope-down.** Deferred to Phase 2/3 (disjoint files, depend on this): the MCP host wiring (`ResolveMcpBind`, token + in-app-CIDR middleware, `mcp`-role pool, 300s poll, real-bind/precheck, host D-BYO warning), the `--print-viewer-connection` verb, the viewer read-only Settings/Edit degradation, and `darling.sample.json` / `README` / the remaining stale-doc fixes (`DarlingMcpTools.cs:652`, `DarlingMcpInstructions.cs:13/30`, `DarlingMcpHostService.cs:27`). This PR provides all the Phase-1 seams they consume (the `mcp` role + credential, `McpCredentialPathFor`, `TryBuildMcpConnectionStringFromStoredCredential`, `McpNetworkConfig.ResolveToken`, the shared classifier).

3. **Cert rotation = delete-to-rotate (per D6).** `EnsureServerCertificate` reuses an existing `server.crt`/`server.key` pair and does **not** auto-regenerate if `network.listen` changes — an IP change needs the operator to delete the pair (verify-full would otherwise fail on the stale iPAddress SAN). This matches the locked plan; noting it because it's a sharp edge for the README (Phase 3).

4. **`allowFrom` must be a network address.** `System.Net.IPNetwork.TryParse` requires zeroed host bits, so `192.168.1.0/24` is accepted but `192.168.1.5/24` degrades to loopback. Reasonable (pg_hba wants the same), worth a README note (Phase 3).

5. **`postgres.network.role` vs `postgres.connectAs`** deliberately have opposite defaults (`viewer` for the network role, `admin` for the local loopback role). Documented in the config XML docs; the sample/README note is Phase 3.

### STOP before merging
Per the plan, this awaits your thorough review + DARLING01 live-validation (enable/disable/off-CIDR/TLS verify-full) before any merge. Not merged; `dev`/`main` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
