### PR TITLE
Darling network endpoints Phase 3: --print-viewer-connection verb + viewer read-only degradation + docs

### DIFF
--- a/Darling/Darling.Tests/DarlingCliCommandsTests.cs
+++ b/Darling/Darling.Tests/DarlingCliCommandsTests.cs
@@ -7,6 +7,10 @@
  */
 
 using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 using PerformanceMonitor.Darling.Service;
 using Xunit;
 
@@ -95,5 +99,189 @@ public sealed class DarlingCliCommandsTests
         Assert.Equal("Azure SQL Database", DarlingServerConnector.DescribeEngineEdition(5));
         Assert.Equal("Azure SQL Managed Instance", DarlingServerConnector.DescribeEngineEdition(8));
         Assert.Contains("Unknown", DarlingServerConnector.DescribeEngineEdition(999), StringComparison.Ordinal);
+    }
+}
+
+/// <summary>
+/// The <c>--print-viewer-connection</c> verb (darling-network-endpoints D8): the pure connection-string /
+/// host builders (unit-testable without DPAPI or a store), plus a Windows-gated end-to-end that decrypts a
+/// temp <c>viewer</c> credential + emits the cert, asserting the paste-ready shape and the live-secret warning.
+/// </summary>
+public sealed class DarlingPrintViewerConnectionTests
+{
+    [Theory]
+    [InlineData("--print-viewer-connection", true)]
+    [InlineData("--PRINT-VIEWER-CONNECTION", true)]
+    [InlineData("--validate-config", false)]
+    [InlineData("--encrypt-password", false)]
+    [InlineData("--nonsense", false)]
+    public void IsPrintViewerConnectionVerb_RecognizesTheVerb_CaseInsensitive(string arg, bool expected)
+    {
+        Assert.Equal(expected, DarlingCliCommands.IsPrintViewerConnectionVerb(arg));
+    }
+
+    [Fact]
+    public void BuildViewerConnectionString_CarriesSearchPath_VerifyFull_RootCert_Role_HostAndPort()
+    {
+        var cs = DarlingCliCommands.BuildViewerConnectionString(
+            "192.168.1.205", 5641, "viewer", "s3cretPW", "server.crt");
+
+        Assert.Contains("Host=192.168.1.205", cs, StringComparison.Ordinal);
+        Assert.Contains("Port=5641", cs, StringComparison.Ordinal);
+        Assert.Contains("Username=viewer", cs, StringComparison.Ordinal);
+        Assert.Contains("Password=s3cretPW", cs, StringComparison.Ordinal);
+        Assert.Contains("Database=darling", cs, StringComparison.Ordinal);
+        Assert.Contains("Search Path=collect,config,public", cs, StringComparison.Ordinal);
+        Assert.Contains("SSL Mode=VerifyFull", cs, StringComparison.Ordinal);
+        Assert.Contains("Root Certificate=server.crt", cs, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildViewerConnectionString_NamesTheSelectedRole()
+    {
+        /* role:admin flows through to Username= so the admin opt-in prints an admin connection. */
+        var cs = DarlingCliCommands.BuildViewerConnectionString("host", 1, "admin", "pw", "c.crt");
+        Assert.Contains("Username=admin", cs, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ResolveViewerHost_ConcreteIp_ReturnsTheIp()
+    {
+        /* A concrete bind IP is used verbatim — verify-full validates it against the cert's iPAddress SAN. */
+        Assert.Equal("192.168.1.205", DarlingCliCommands.ResolveViewerHost("192.168.1.205"));
+        Assert.Equal("10.0.0.7", DarlingCliCommands.ResolveViewerHost("  10.0.0.7  "));
+    }
+
+    [Theory]
+    [InlineData("0.0.0.0")]     // IPv4 wildcard — can't be dialed
+    [InlineData("::")]          // IPv6 wildcard
+    [InlineData("127.0.0.1")]   // loopback
+    [InlineData("localhost")]   // not an IP
+    [InlineData("")]            // unset
+    [InlineData(null)]
+    public void ResolveViewerHost_WildcardLoopbackOrHostname_FallsBackToTheMachineDnsSan(string? listen)
+    {
+        /* The fallback is the machine hostname, which the cert carries as a dnsName SAN. */
+        Assert.Equal(Environment.MachineName, DarlingCliCommands.ResolveViewerHost(listen));
+    }
+
+    [Fact]
+    public async Task PrintViewerConnectionAsync_ByoMode_ReturnsError_WithoutTouchingDpapi()
+    {
+        var root = Directory.CreateTempSubdirectory("darling-printconn-byo-");
+        try
+        {
+            var configPath = Path.Combine(root.FullName, "darling.json");
+            await File.WriteAllTextAsync(configPath,
+                """{ "postgres": { "connectionString": "Host=localhost;Database=darling" } }""");
+
+            var output = new StringWriter();
+            var error = new StringWriter();
+            var exit = await DarlingCliCommands.PrintViewerConnectionAsync(configPath, output, error, CancellationToken.None);
+
+            Assert.Equal(1, exit);
+            Assert.Contains("bring-your-own", error.ToString(), StringComparison.OrdinalIgnoreCase);
+            Assert.Equal("", output.ToString());
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task PrintViewerConnectionAsync_InvalidRole_ReturnsError()
+    {
+        var root = Directory.CreateTempSubdirectory("darling-printconn-role-");
+        try
+        {
+            var dataDirectory = Path.Combine(root.FullName, "pg");
+            var configPath = Path.Combine(root.FullName, "darling.json");
+            var json = $$"""
+                {
+                  "postgres": {
+                    "managed": true,
+                    "port": 5641,
+                    "dataDirectory": {{JsonSerializer.Serialize(dataDirectory)}},
+                    "network": { "listen": "192.168.1.205", "allowFrom": "192.168.1.0/24", "role": "superadmin" }
+                  }
+                }
+                """;
+            await File.WriteAllTextAsync(configPath, json);
+
+            var output = new StringWriter();
+            var error = new StringWriter();
+            var exit = await DarlingCliCommands.PrintViewerConnectionAsync(configPath, output, error, CancellationToken.None);
+
+            Assert.Equal(1, exit);
+            Assert.Contains("role", error.ToString(), StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task PrintViewerConnectionAsync_ManagedViewer_PrintsConnection_Cert_AndSecretWarning()
+    {
+        Assert.SkipUnless(OperatingSystem.IsWindows(), "DPAPI requires Windows.");
+
+        var root = Directory.CreateTempSubdirectory("darling-printconn-");
+        try
+        {
+            /* Lay down the managed layout the verb reads on the store host: the viewer role's DPAPI credential
+               and the generated server cert, both beside the data directory. */
+            var dataDirectory = Path.Combine(root.FullName, "pg");
+            var viewerCredential = PerformanceMonitor.Darling.Service.DarlingManagedPostgres.ViewerCredentialPathFor(dataDirectory);
+            File.WriteAllText(viewerCredential, PerformanceMonitor.Darling.Service.DarlingSecrets.Protect("viewer-secret-pw"));
+
+            var certPath = Path.Combine(
+                Path.GetDirectoryName(viewerCredential)!,
+                PerformanceMonitor.Darling.Service.DarlingManagedPostgres.ServerCertFileName);
+            const string pem = "-----BEGIN CERTIFICATE-----\nMIIBTESTCERTPEM\n-----END CERTIFICATE-----";
+            File.WriteAllText(certPath, pem);
+
+            var configPath = Path.Combine(root.FullName, "darling.json");
+            var json = $$"""
+                {
+                  "postgres": {
+                    "managed": true,
+                    "port": 5641,
+                    "dataDirectory": {{JsonSerializer.Serialize(dataDirectory)}},
+                    "network": { "listen": "192.168.1.205", "allowFrom": "192.168.1.0/24", "role": "viewer" }
+                  },
+                  "servers": [ { "name": "SQL2022", "host": "SQL2022" } ]
+                }
+                """;
+            await File.WriteAllTextAsync(configPath, json);
+
+            var output = new StringWriter();
+            var error = new StringWriter();
+            var exit = await DarlingCliCommands.PrintViewerConnectionAsync(configPath, output, error, CancellationToken.None);
+            var stdout = output.ToString();
+            var stderr = error.ToString();
+
+            Assert.Equal(0, exit);
+
+            /* The paste-ready connection string on STDOUT: verify-full, the search path, the client cert path,
+               the viewer role, the decrypted password, and Host=the IP (Round 4 #12). */
+            Assert.Contains("Host=192.168.1.205", stdout, StringComparison.Ordinal);
+            Assert.Contains("Username=viewer", stdout, StringComparison.Ordinal);
+            Assert.Contains("Password=viewer-secret-pw", stdout, StringComparison.Ordinal);
+            Assert.Contains("Search Path=collect,config,public", stdout, StringComparison.Ordinal);
+            Assert.Contains("SSL Mode=VerifyFull", stdout, StringComparison.Ordinal);
+            Assert.Contains("Root Certificate=server.crt", stdout, StringComparison.Ordinal);
+
+            /* The server cert PEM is emitted so the operator can place it on the client. */
+            Assert.Contains(pem, stdout, StringComparison.Ordinal);
+
+            /* The live-secret warning is printed (to STDERR, so a STDOUT redirect keeps it visible). */
+            Assert.Contains("LIVE database password", stderr, StringComparison.Ordinal);
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
     }
 }

--- a/Darling/Darling.Tests/ViewerDataServiceTests.cs
+++ b/Darling/Darling.Tests/ViewerDataServiceTests.cs
@@ -10,6 +10,7 @@ using System;
 using System.Globalization;
 using System.IO;
 using System.Text.Json;
+using System.Threading.Tasks;
 using System.Windows.Media;
 using Npgsql;
 using PerformanceMonitor.Darling.Storage;
@@ -103,7 +104,9 @@ public sealed class ViewerSettingsTests
 
             var settings = ViewerSettings.Parse(json);
             var parsed = new NpgsqlConnectionStringBuilder(settings.ConnectionString);
-            Assert.Equal("localhost", parsed.Host);
+            /* 127.0.0.1, not "localhost" — the viewer half of the managed-Host parity pair with the
+               service's DarlingManagedPostgres.BuildConnectionString (darling-network-endpoints). */
+            Assert.Equal("127.0.0.1", parsed.Host);
             Assert.Equal(5991, parsed.Port);
             Assert.Equal("admin", parsed.Username);
             Assert.Equal("admin-pw", parsed.Password);
@@ -444,5 +447,102 @@ public sealed class ViewerStoreUnreachableTests
 
         /* An unrelated exception is not a connection failure either. */
         Assert.False(ViewerDataService.IsConnectionFailure(new InvalidOperationException()));
+    }
+}
+
+/// <summary>
+/// The read-only viewer's per-section Settings degradation (darling-network-endpoints D7): a read-only
+/// <c>viewer</c> role is column-denied the secret columns of <c>config_notification</c> and
+/// <c>config_monitored_servers</c>, so those reads fall back to secret-free projections, and the Settings load
+/// reads each section independently so one 42501 never blanks the rest.
+/// </summary>
+public sealed class ViewerReadOnlyDegradationTests
+{
+    [Fact]
+    public void NotificationSelectNoSecretSql_OmitsTheCarvedSecrets_KeepsTheNonSecretColumns()
+    {
+        var noSecret = ViewerDataService.NotificationSelectNoSecretSql;
+
+        /* The four carved secret columns the viewer role loses SELECT on (#1262). */
+        Assert.DoesNotContain("smtp_encrypted_password", noSecret, StringComparison.Ordinal);
+        Assert.DoesNotContain("smtp_username", noSecret, StringComparison.Ordinal);
+        Assert.DoesNotContain("teams_url", noSecret, StringComparison.Ordinal);
+        Assert.DoesNotContain("slack_url", noSecret, StringComparison.Ordinal);
+
+        /* The non-secret fields the read-only Settings window still prefills. */
+        Assert.Contains("smtp_host", noSecret, StringComparison.Ordinal);
+        Assert.Contains("smtp_from_address", noSecret, StringComparison.Ordinal);
+        Assert.Contains("teams_proxy", noSecret, StringComparison.Ordinal);
+        Assert.Contains("slack_proxy", noSecret, StringComparison.Ordinal);
+        Assert.Contains("FROM config_notification WHERE id = 1", noSecret, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NotificationSelectSql_FullProjection_StillCarriesTheSecrets_ForAWritableSeat()
+    {
+        /* The admin/owner seat still reads the secrets to prefill the SMTP password + webhook URLs. */
+        var full = ViewerDataService.NotificationSelectSql;
+        Assert.Contains("smtp_encrypted_password", full, StringComparison.Ordinal);
+        Assert.Contains("smtp_username", full, StringComparison.Ordinal);
+        Assert.Contains("teams_url", full, StringComparison.Ordinal);
+        Assert.Contains("slack_url", full, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MonitoredServerByIdNoSecretSql_OmitsEncryptedPassword_ButKeepsTheByIdFilter()
+    {
+        var noSecret = ViewerDataService.MonitoredServerByIdNoSecretSql;
+        Assert.DoesNotContain("encrypted_password", noSecret, StringComparison.Ordinal);
+        Assert.Contains("WHERE server_id = $1", noSecret, StringComparison.Ordinal);
+
+        /* The full by-id read (an admin action) still selects the DPAPI blob for the password box. */
+        Assert.Contains("encrypted_password", ViewerDataService.MonitoredServerByIdSql, StringComparison.Ordinal);
+        Assert.Contains("WHERE server_id = $1", ViewerDataService.MonitoredServerByIdSql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ReadStoreSectionsAsync_NotificationThrows42501_DoesNotBlankTheOtherSections()
+    {
+        var alert = AlertSettingsRow.Defaults();
+        var service = new ServiceConfigRow();
+
+        var sections = await SettingsWindow.ReadStoreSectionsAsync(
+            () => Task.FromResult<AlertSettingsRow?>(alert),
+            () => Task.FromException<NotificationRow?>(
+                new PostgresException("permission denied for table config_notification", "ERROR", "ERROR", "42501")),
+            () => Task.FromResult<ServiceConfigRow?>(service));
+
+        /* The notification section degrades to null (its defaults stand); the OTHER two survive intact. */
+        Assert.Same(alert, sections.Alert);
+        Assert.Null(sections.Notification);
+        Assert.Same(service, sections.Service);
+    }
+
+    [Fact]
+    public async Task ReadStoreSectionsAsync_AllSucceed_ReturnsAllThreeSections()
+    {
+        var alert = AlertSettingsRow.Defaults();
+        var notify = NotificationRow.Defaults();
+        var service = new ServiceConfigRow();
+
+        var sections = await SettingsWindow.ReadStoreSectionsAsync(
+            () => Task.FromResult<AlertSettingsRow?>(alert),
+            () => Task.FromResult<NotificationRow?>(notify),
+            () => Task.FromResult<ServiceConfigRow?>(service));
+
+        Assert.Same(alert, sections.Alert);
+        Assert.Same(notify, sections.Notification);
+        Assert.Same(service, sections.Service);
+    }
+
+    [Fact]
+    public async Task ReadStoreSectionsAsync_Cancellation_Propagates()
+    {
+        /* A genuine cancellation is NOT swallowed as a degraded section — it propagates. */
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            SettingsWindow.ReadStoreSectionsAsync(
+                () => Task.FromResult<AlertSettingsRow?>(AlertSettingsRow.Defaults()),
+                () => Task.FromException<NotificationRow?>(new OperationCanceledException()),
+                () => Task.FromResult<ServiceConfigRow?>(new ServiceConfigRow())));
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingCliCommands.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingCliCommands.cs
@@ -8,6 +8,9 @@
 
 using System;
 using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -27,6 +30,10 @@ public static class DarlingCliCommands
     public static bool IsValidateConfigVerb(string arg) =>
         string.Equals(arg, "--test-connection", StringComparison.OrdinalIgnoreCase)
         || string.Equals(arg, "--validate-config", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>The verb <see cref="PrintViewerConnectionAsync"/> handles (darling-network-endpoints D8).</summary>
+    public static bool IsPrintViewerConnectionVerb(string arg) =>
+        string.Equals(arg, "--print-viewer-connection", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Loads + validates darling.json, then probes every server. Prints one PASS/FAIL line per server and a
@@ -93,4 +100,191 @@ public static class DarlingCliCommands
         var msdb = probe.HasMsdbAccess ? "msdb access: yes" : "msdb access: NO (failed-job alerts unavailable)";
         return $"  [PASS] {serverName}: SQL major version {probe.MajorVersion}, {edition}, {msdb}";
     }
+
+    /// <summary>
+    /// Prints a paste-ready remote-viewer connection string and the server TLS certificate for the opt-in store
+    /// network endpoint (darling-network-endpoints D8). It DPAPI-decrypts the credential of the role
+    /// <c>postgres.network.role</c> names (default <c>viewer</c>, read-only) and reads the generated
+    /// <c>server.crt</c>, so it must run ON the managed store's host under an account that can decrypt them —
+    /// hence Windows-only (the caller is <c>OperatingSystem.IsWindows()</c>-guarded, mirroring
+    /// <c>--encrypt-password</c>). The operator pastes the string into the VIEWER machine's darling.json
+    /// (<c>postgres.managed = false</c>, into <c>postgres.connectionString</c>, consumed verbatim — no viewer
+    /// code change) and saves the emitted PEM where <c>Root Certificate</c> points. Returns 0 on success; 1 on a
+    /// mode/role/credential error. Managed-mode only (BYO governs its own exposure, D-BYO); network config lives
+    /// out of the all-fatal <see cref="DarlingConfig.Validate"/>, so this verb never calls it.
+    /// <para><b>STDOUT carries a LIVE SECRET</b> (the role password) — the verb warns (on STDERR) to redirect it
+    /// to an ACL'd file or the clipboard, never scrollback / CI / a screenshare.</para>
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    public static async Task<int> PrintViewerConnectionAsync(
+        string? configPath, TextWriter output, TextWriter error, CancellationToken cancellationToken)
+    {
+        DarlingConfig config;
+        try
+        {
+            config = DarlingConfig.Load(configPath);
+        }
+        catch (Exception ex)
+        {
+            error.WriteLine($"Could not load configuration: {ex.Message}");
+            return 1;
+        }
+
+        var postgres = config.Postgres;
+        if (postgres is null)
+        {
+            error.WriteLine("postgres section is required.");
+            return 1;
+        }
+
+        /* Managed-mode only: the DPAPI credential files + the generated TLS cert this verb reads exist only in
+           managed mode. In BYO the operator's own PostgreSQL governs exposure + credentials (D-BYO). */
+        if (!postgres.Managed)
+        {
+            error.WriteLine(
+                "--print-viewer-connection is for the managed store only. In bring-your-own mode " +
+                "(postgres.connectionString), your own PostgreSQL governs network exposure and credentials — " +
+                "build the remote viewer's connection string from your own role + TLS setup.");
+            return 1;
+        }
+
+        /* The pg_hba login role the network exposure names — default viewer (read-only, the secure default).
+           An explicitly-invalid value is a hard error: the store degrades to loopback for it, so no remote
+           connection exists to print. */
+        var network = postgres.Network;
+        var role = DarlingNetwork.NormalizeNetworkRole(network?.Role);
+        if (role is null)
+        {
+            error.WriteLine(
+                $"postgres.network.role '{network?.Role}' is invalid — it must be \"viewer\" (default, read-only) " +
+                "or \"admin\". The store degrades to loopback for an unknown role, so there is no remote connection to print.");
+            return 1;
+        }
+
+        /* Warn (not fail) when the store is not actually network-exposed: the operator still gets a template,
+           but the endpoint will not accept it until postgres.network.listen is set and the service restarted. */
+        if (!DarlingNetwork.IsExposedListenAddress(network?.Listen))
+        {
+            error.WriteLine(
+                "WARNING: postgres.network.listen is not a network address, so the managed store is loopback-only " +
+                "right now. Set postgres.network (listen + allowFrom) and restart the service to expose it (which " +
+                "also generates the TLS cert), then re-run this command.");
+        }
+
+        var host = ResolveViewerHost(network?.Listen);
+
+        /* Decrypt the role's DPAPI-LocalMachine credential (Windows-only; the caller is IsWindows-guarded).
+           The cert lives in the same directory as the credential (ParentOf(dataDirectory)). */
+        var dataDirectory = DarlingManagedPostgres.ResolveDataDirectory(postgres);
+        var credentialPath = string.Equals(role, "admin", StringComparison.Ordinal)
+            ? DarlingManagedPostgres.AdminCredentialPathFor(dataDirectory)
+            : DarlingManagedPostgres.ViewerCredentialPathFor(dataDirectory);
+
+        if (!File.Exists(credentialPath))
+        {
+            error.WriteLine(
+                $"The '{role}' role credential ({credentialPath}) does not exist yet. Start the PerformanceMonitor " +
+                "Darling service once so its first run provisions the least-privilege roles and their credentials, " +
+                "then re-run this command.");
+            return 1;
+        }
+
+        string password;
+        try
+        {
+            password = DarlingSecrets.Unprotect((await File.ReadAllTextAsync(credentialPath, cancellationToken)).Trim());
+        }
+        catch (Exception ex)
+        {
+            error.WriteLine(
+                $"Could not decrypt the '{role}' credential at {credentialPath}: {ex.Message} (DPAPI-LocalMachine — " +
+                "run this on the same machine as the service, under an account that can read the credential).");
+            return 1;
+        }
+
+        /* The client-side Root Certificate placeholder: the operator saves the PEM below at this path on the
+           VIEWER machine (a bare filename resolves beside the viewer's working directory; an absolute path
+           also works). Kept as a literal so the printed string is paste-ready. */
+        const string clientCertificatePath = "server.crt";
+        var connectionString = BuildViewerConnectionString(host, postgres.Port, role, password, clientCertificatePath);
+
+        /* Guidance + the live-secret warning go to STDERR, so redirecting STDOUT to a file or the clipboard
+           captures the connection string + cert WITHOUT swallowing the warning (D8). */
+        error.WriteLine();
+        error.WriteLine(
+            $"WARNING: the connection string below contains a LIVE database password (the '{role}' role), written " +
+            "to STDOUT. Redirect it to an ACL'd file or pipe it to the clipboard; do not leave it in shell " +
+            "scrollback, CI logs, or a screenshare.");
+        error.WriteLine("  Example (file):      PerformanceMonitor.Darling.Service.exe --print-viewer-connection > viewer-connection.txt");
+        error.WriteLine("  Example (clipboard): PerformanceMonitor.Darling.Service.exe --print-viewer-connection | clip");
+        if (string.Equals(role, "admin", StringComparison.Ordinal))
+        {
+            error.WriteLine(
+                "  NOTE: 'admin' is a WRITE credential holding the config-table pivot surface. Prefer the default " +
+                "'viewer' (read-only) for a remote seat; if you must use 'admin', NTFS-ACL the laptop file too.");
+        }
+
+        error.WriteLine(
+            $"Save the certificate block below as '{clientCertificatePath}' on the viewer machine (beside its " +
+            "darling.json) and point \"Root Certificate\" at it — the store uses SSL Mode=VerifyFull, so the cert must match.");
+        error.WriteLine();
+
+        output.WriteLine(
+            "# Paste into the viewer machine's darling.json -> postgres.connectionString (with postgres.managed = false):");
+        output.WriteLine(connectionString);
+        output.WriteLine();
+
+        /* Emit the server cert PEM so the operator can copy it to the viewer machine. */
+        var certificatePath = Path.Combine(
+            Path.GetDirectoryName(credentialPath)!, DarlingManagedPostgres.ServerCertFileName);
+        if (File.Exists(certificatePath))
+        {
+            output.WriteLine($"# Server TLS certificate ({DarlingManagedPostgres.ServerCertFileName}) — save as '{clientCertificatePath}' on the viewer machine:");
+            output.WriteLine((await File.ReadAllTextAsync(certificatePath, cancellationToken)).Trim());
+        }
+        else
+        {
+            error.WriteLine(
+                $"NOTE: the server TLS certificate ({certificatePath}) does not exist yet — the service generates it " +
+                "on its first managed start with postgres.network exposed. Enable postgres.network, restart the " +
+                "service, then re-run this command to emit the cert for verify-full.");
+        }
+
+        return 0;
+    }
+
+    /// <summary>
+    /// The <c>Host=</c> value for the remote viewer connection (D8 / Round 4 #12): the bind IP itself when
+    /// <paramref name="listen"/> is a concrete IP (not IPv4 loopback, not a <c>0.0.0.0</c>/<c>::</c> wildcard) —
+    /// verify-full then validates it against the cert's iPAddress SAN — otherwise the machine's hostname, which
+    /// the cert also carries as a dnsName SAN (the fallback for a wildcard bind, a hostname listen, or an unset
+    /// listen). Pure — unit-testable.
+    /// </summary>
+    public static string ResolveViewerHost(string? listen)
+    {
+        var trimmed = listen?.Trim();
+        if (!string.IsNullOrEmpty(trimmed)
+            && IPAddress.TryParse(trimmed, out var ip)
+            && !(ip.AddressFamily == AddressFamily.InterNetwork && ip.GetAddressBytes()[0] == 127)
+            && !ip.Equals(IPAddress.Any)
+            && !ip.Equals(IPAddress.IPv6Any))
+        {
+            return trimmed;
+        }
+
+        return Environment.MachineName;
+    }
+
+    /// <summary>
+    /// The remote viewer's paste-ready Npgsql connection string (D8): the resolved host, the network role,
+    /// verify-full TLS against the pinned server cert, the <c>darling</c> database, and the collect/config
+    /// search path — the exact string the operator drops into the viewer machine's darling.json
+    /// <c>postgres.connectionString</c> (<c>managed = false</c>, consumed verbatim). The managed role password
+    /// is service-generated alphanumeric (no connection-string metacharacters), so a hand-built string is safe
+    /// and yields the exact documented shape. Pure — unit-testable.
+    /// </summary>
+    public static string BuildViewerConnectionString(
+        string host, int port, string role, string password, string rootCertificatePath) =>
+        $"Host={host};Port={port};Username={role};Password={password};Database=darling;" +
+        $"Search Path=collect,config,public;SSL Mode=VerifyFull;Root Certificate={rootCertificatePath}";
 }

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpInstructions.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpInstructions.cs
@@ -10,8 +10,9 @@ namespace PerformanceMonitor.Darling.Service.Mcp;
 
 /// <summary>
 /// Server instructions sent to MCP clients during initialization — Lite's McpInstructions
-/// framing (read-only posture, collection-freshness notes, tool reference) scoped to the six
-/// diagnostic-analysis tools this headless service exposes.
+/// framing (read-only posture, collection-freshness notes, tool reference) scoped to the ~60
+/// analysis + plan-analysis + data-read tools this headless service exposes (the <see cref="Text"/>
+/// body enumerates them).
 /// </summary>
 internal static class DarlingMcpInstructions
 {
@@ -27,7 +28,7 @@ internal static class DarlingMcpInstructions
         - Modify, insert, or delete any collected data
         - Run any ad-hoc diagnostics beyond what the collectors have already captured
 
-        The only write this server performs is mute_analysis_finding, which records a mute rule in the MONITORING store — it never touches a monitored SQL Server.
+        The only writes this server performs are to the MONITORING store: mute_analysis_finding records a mute rule, and analyze_server persists its findings. Neither ever touches a monitored SQL Server.
 
         ## How Data Is Collected
 

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpTools.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpTools.cs
@@ -649,9 +649,9 @@ public sealed class DarlingMcpTools
 /// Maps fact keys to recommended MCP tools for further investigation.
 /// Used by analyze_server to tell the AI client what to call next.
 /// Verbatim per-app copy of Lite's table (the Dashboard carries one too): the named tools are
-/// the PRODUCT's data-tool surface — Darling's own MCP server exposes only the six analysis
-/// tools, so these recommendations point the client at the companion Lite/Dashboard server
-/// (or serve as investigation hints), exactly as documented in DarlingMcpInstructions.
+/// the PRODUCT's data-tool surface — and Darling's own MCP server now hosts them itself (the
+/// analysis, plan-analysis, and ~60 stored data-read tools), so these recommendations point the
+/// client at tools on THIS server, exactly as documented in DarlingMcpInstructions.
 /// </summary>
 internal static class ToolRecommendations
 {

--- a/Darling/PerformanceMonitor.Darling.Service/Program.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Program.cs
@@ -45,6 +45,21 @@ if (args.Length > 0 && DarlingCliCommands.IsValidateConfigVerb(args[0]))
     return await DarlingCliCommands.ValidateConfigAsync(configPath, Console.Out, Console.Error, CancellationToken.None);
 }
 
+/* CLI verb: print a paste-ready remote-viewer connection string + the server TLS cert for the opt-in store
+   network endpoint (darling-network-endpoints D8). It DPAPI-decrypts the network role's credential, so it is
+   Windows-only (same guard shape as --encrypt-password). Optional second arg = an explicit config path. */
+if (args.Length > 0 && DarlingCliCommands.IsPrintViewerConnectionVerb(args[0]))
+{
+    if (!OperatingSystem.IsWindows())
+    {
+        Console.Error.WriteLine("--print-viewer-connection requires Windows (DPAPI).");
+        return 1;
+    }
+
+    var configPath = args.Length > 1 ? args[1] : null;
+    return await DarlingCliCommands.PrintViewerConnectionAsync(configPath, Console.Out, Console.Error, CancellationToken.None);
+}
+
 var builder = Host.CreateApplicationBuilder(args);
 
 /* Windows-service lifetime is a no-op when run from a console, so the same exe

--- a/Darling/PerformanceMonitor.Darling.Service/darling.sample.json
+++ b/Darling/PerformanceMonitor.Darling.Service/darling.sample.json
@@ -16,7 +16,8 @@
   //    PostgreSQL 17 + TimescaleDB — on first run it unpacks pg-runtime.zip (shipped beside
   //    the binary), initializes a cluster with scram-sha-256 auth and a generated password
   //    (DPAPI-protected in pg-credential.dpapi beside the data directory; never trust auth,
-  //    even on localhost), preloads TimescaleDB, and starts the server on 127.0.0.1 only.
+  //    even on localhost), preloads TimescaleDB, and starts the server on 127.0.0.1 by default
+  //    (see the opt-in "network" block below to reach the store from the LAN over TLS).
   //    The connection string is DERIVED — do NOT also set connectionString (validation error).
   //    "port" 5641 is deliberately uncommon so the bundled instance coexists with any
   //    PostgreSQL (5432) already on the machine. "dataDirectory" null means
@@ -45,10 +46,32 @@
     "managed": true,
     "port": 5641,
     "dataDirectory": null,
-    // Which least-privilege role the Viewer connects as (managed mode): "admin" (default —
-    // can dismiss alerts and manage mute rules) or "viewer" (read-only; those actions are
-    // hidden/disabled). Ignored in bring-your-own mode (the connectionString picks the role).
-    "connectAs": "admin"
+    // Which least-privilege role the Viewer connects as OVER LOOPBACK (managed mode): "admin"
+    // (default — can dismiss alerts and manage mute rules) or "viewer" (read-only; those actions
+    // are hidden/disabled). Ignored in bring-your-own mode (the connectionString picks the role).
+    // This is the LOCAL VM viewer's role; it is INDEPENDENT of network.role below (the REMOTE
+    // pg_hba role, default "viewer") — note the opposite defaults.
+    "connectAs": "admin",
+
+    // OPT-IN NETWORK EXPOSURE for the store (managed mode only) — omit this whole block for the
+    // secure default (loopback-only, byte-for-byte today's behavior: no pg_hba network rule, no
+    // firewall rule, ssl=off). When present with a non-loopback "listen", the service reconciles it
+    // on every start: it adds the bind IP to listen_addresses, generates a self-signed TLS cert for
+    // verify-full, writes a marked `hostssl darling <role> <allowFrom> scram-sha-256` pg_hba rule +
+    // reloads, and best-effort adds a firewall rule (also add the exact scoped rule yourself; see
+    // Darling/README.md). Reconciliation is symmetric (delete the block to close the box) and
+    // fail-closed: any invalid/incomplete field degrades the store to loopback + a critical log line,
+    // never exposed. Get the remote viewer's paste-ready connection string + the server cert with:
+    //   PerformanceMonitor.Darling.Service.exe --print-viewer-connection
+    // Uncomment (a comma already follows connectAs above):
+    // "network": {
+    //   "listen": "192.168.1.205",      // the specific bind IP (preferred; = the cert's iPAddress SAN).
+    //                                    // "0.0.0.0" = all interfaces (then connect by a cert SAN name).
+    //   "allowFrom": "192.168.1.0/24",  // pg_hba + firewall CIDR (its address family must match "listen").
+    //   "role": "viewer"                // "viewer" (default, read-only remote — the secure default) or
+    //                                    // "admin" (full remote WRITES; the service warns, because admin
+    //                                    // holds the config-table service-credential pivot). Never the superuser.
+    // }
   },
   "servers": [
     {
@@ -148,13 +171,32 @@
     "slackUrl": ""
   },
 
-  // Embedded MCP server (optional): the six analysis tools (analyze_server, get_analysis_facts,
-  // compare_analysis, audit_config, get_analysis_findings, mute_analysis_finding) — the same
-  // analysis surface Lite and the Dashboard expose — over Streamable HTTP at
-  // http://localhost:{port}. Default OFF; port 5152 avoids the Dashboard (5150) and Lite (5151)
-  // defaults so all three can run on one machine.
+  // Embedded MCP server (optional): the SAME ~60-tool surface Lite and the Dashboard expose — the
+  // six analysis tools (analyze_server, get_analysis_facts, compare_analysis, audit_config,
+  // get_analysis_findings, mute_analysis_finding) PLUS the plan-analysis tools and the ~60 STORED
+  // data-read tools (every read is served from the collected store, never a live query against a
+  // monitored server). Over Streamable HTTP at http://localhost:{port}; see Darling/README.md for the
+  // full tool list. Default OFF; port 5152 avoids the Dashboard (5150) and Lite (5151) defaults so all
+  // three can run on one machine.
+  //
+  // OPT-IN NETWORK EXPOSURE for MCP (managed mode only) — omit "network" for the secure default
+  // (loopback-only, tokenless HTTP, today's behavior). When present with a non-loopback "listen", the
+  // MCP host binds the LAN interface behind a REQUIRED bearer token + an in-app CIDR check, fail-closed
+  // (any missing precondition — token / valid allowFrom / managed mode — keeps it loopback-only).
+  // THREAT MODEL: the token gates the whole read surface AND analyze_server, which opens LIVE outbound
+  // connections to your monitored SQL Servers — so this is a trusted-LAN opt-in, NEVER internet-exposed.
+  // There is deliberately NO TLS on MCP (a self-signed cert breaks real MCP clients), so the token
+  // travels cleartext on-segment: the MITM control is a TLS REVERSE PROXY in front of the endpoint
+  // (the in-app CIDR only bounds WHO can route to it, not the wire).
   "mcp": {
     "enabled": false,
-    "port": 5152
+    "port": 5152,
+
+    // Uncomment to expose MCP on the LAN (a comma already follows "port" above):
+    // "network": {
+    //   "listen": "192.168.1.205",                     // specific bind IP preferred; "0.0.0.0" = all interfaces.
+    //   "allowFrom": "192.168.1.0/24",                 // in-app RemoteIpAddress check + firewall CIDR (loopback always allowed).
+    //   "encryptedToken": "<output of --encrypt-password>"  // REQUIRED to expose; or a plaintext "token" (dev only, warned).
+    // }
   }
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml.cs
@@ -134,41 +134,41 @@ public partial class SettingsWindow : Window
     {
         if (_dataService is not null)
         {
-            try
+            /* Read the three store-backed sections INDEPENDENTLY (D7): a read-only viewer role is column-denied
+               the config_notification secrets, so selecting them 42501s — and in a single shared try-block one
+               such throw blanks every LATER section. GetNotificationAsync already falls back to a secret-free
+               projection for a read-only seat, and this per-section isolation is the belt-and-suspenders that
+               keeps any other single-section failure from blanking the rest. */
+            var sections = await ReadStoreSectionsAsync(
+                () => _dataService.GetAlertSettingsAsync(),
+                () => _dataService.GetNotificationAsync(),
+                () => _dataService.GetServiceConfigAsync());
+
+            if (sections.Alert is not null)
             {
-                var alert = await _dataService.GetAlertSettingsAsync();
-                if (alert is not null)
-                {
-                    SeedAlertControlsFrom(alert);
-                }
-
-                var notify = await _dataService.GetNotificationAsync();
-                if (notify is not null)
-                {
-                    SeedNotificationControlsFrom(notify);
-                }
-
-                var service = await _dataService.GetServiceConfigAsync();
-                if (service is not null)
-                {
-                    CapturePlansCheckBox.IsChecked = service.CapturePlans;
-                    McpEnabledCheckBox.IsChecked = service.McpEnabled;
-                    McpPortTextBox.Text = service.McpPort.ToString(CultureInfo.InvariantCulture);
-                    _paused = service.Paused;
-                }
-
-                /* Save may write the store sections only when it is SEEDED — config_service is written LAST by
-                   the service (its presence marks the seed complete), so a non-null row here guarantees the
-                   alert/notification sections read real rows too. On a reachable-but-UNSEEDED store every read
-                   returns null and the controls hold on-screen defaults; upserting those would INSERT id=1
-                   defaults and make the service SKIP seeding those sections from darling.json (COUNT != 0),
-                   silently shadowing operator-tuned config. Leaving this false makes Save decline + say so. */
-                _storeLoaded = service is not null;
+                SeedAlertControlsFrom(sections.Alert);
             }
-            catch (Exception ex)
+
+            if (sections.Notification is not null)
             {
-                Debug.WriteLine($"SettingsWindow: could not read the control-plane store, showing defaults: {ex.Message}");
+                SeedNotificationControlsFrom(sections.Notification);
             }
+
+            if (sections.Service is not null)
+            {
+                CapturePlansCheckBox.IsChecked = sections.Service.CapturePlans;
+                McpEnabledCheckBox.IsChecked = sections.Service.McpEnabled;
+                McpPortTextBox.Text = sections.Service.McpPort.ToString(CultureInfo.InvariantCulture);
+                _paused = sections.Service.Paused;
+            }
+
+            /* Save may write the store sections only when ALL THREE loaded. config_service is written LAST by
+               the service (its presence marks the seed complete), and on a seeded store the alert/notification
+               rows are present too — so requiring all three preserves the original anti-clobber guard while
+               tolerating a per-section read failure: any missing section leaves this false so Save declines
+               rather than overwriting a section it could not read with the on-screen defaults. (On a
+               reachable-but-UNSEEDED store every read returns null → false, exactly as before.) */
+            _storeLoaded = sections.Alert is not null && sections.Notification is not null && sections.Service is not null;
         }
 
         ApplyReadOnlyGating();
@@ -179,6 +179,55 @@ public partial class SettingsWindow : Window
         UpdateTeamsControlStates();
         UpdateSlackControlStates();
     }
+
+    /// <summary>
+    /// Reads the three control-plane Settings sections (alert engine, notification, service flags)
+    /// INDEPENDENTLY, so one section's failure — most importantly a read-only <c>viewer</c> seat's SQLSTATE
+    /// 42501 on the secret-bearing <c>config_notification</c> columns — degrades only THAT section to its
+    /// on-screen defaults instead of aborting a shared read and blanking the rest (D7). Each getter runs in its
+    /// own try/catch; a thrown or null result leaves that section null and its synchronous defaults stand.
+    /// Pure of WPF (the caller applies the results to controls), so it is unit-testable without a live store or
+    /// an STA window.
+    /// </summary>
+    internal static async Task<StoreSections> ReadStoreSectionsAsync(
+        Func<Task<AlertSettingsRow?>> getAlert,
+        Func<Task<NotificationRow?>> getNotification,
+        Func<Task<ServiceConfigRow?>> getService)
+    {
+        ArgumentNullException.ThrowIfNull(getAlert);
+        ArgumentNullException.ThrowIfNull(getNotification);
+        ArgumentNullException.ThrowIfNull(getService);
+
+        return new StoreSections(
+            await TryReadSectionAsync(getAlert),
+            await TryReadSectionAsync(getNotification),
+            await TryReadSectionAsync(getService));
+    }
+
+    /// <summary>Runs one section read, degrading any non-cancellation failure (a read-only 42501, a transient
+    /// blip) to <c>null</c> so that section keeps its on-screen defaults; cancellation propagates.</summary>
+    private static async Task<T?> TryReadSectionAsync<T>(Func<Task<T?>> read) where T : class
+    {
+        try
+        {
+            return await read();
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"SettingsWindow: a control-plane section could not be read, keeping its defaults: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>The three independently-loaded Settings store sections; a null member means that section could
+    /// not be read (an unseeded store, or a per-section failure such as a read-only 42501) and its on-screen
+    /// defaults stand.</summary>
+    internal readonly record struct StoreSections(
+        AlertSettingsRow? Alert, NotificationRow? Notification, ServiceConfigRow? Service);
 
     /// <summary>Reflects a read-only seat: a banner + the operator-action buttons disabled. The threshold
     /// inputs stay visible for reference; a Save attempt surfaces the friendly read-only message.</summary>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.MonitoredServers.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.MonitoredServers.cs
@@ -109,9 +109,23 @@ SELECT server_id, name, host, database, auth, username, encrypt_mode,
 FROM config_monitored_servers
 ORDER BY name";
 
-    /// <summary>One configured server by id (the Edit prefill, incl. the DPAPI blob for the password box). $1 server_id.</summary>
+    /// <summary>One configured server by id (the Edit prefill, incl. the DPAPI blob for the password box). $1 server_id.
+    /// An <c>admin</c>-role action — the read-only <c>viewer</c> role is column-denied <c>encrypted_password</c>
+    /// (#1416), so a viewer seat uses <see cref="MonitoredServerByIdNoSecretSql"/> instead.</summary>
     public const string MonitoredServerByIdSql = @"
 SELECT server_id, name, host, database, auth, username, encrypted_password, encrypt_mode,
+       trust_server_certificate, read_only_intent, multi_subnet_failover, excluded_databases,
+       monthly_cost_usd, capture_plans, is_enabled, created_at, alert_delivery_mode_override
+FROM config_monitored_servers
+WHERE server_id = $1";
+
+    /// <summary>One configured server by id WITHOUT the <c>encrypted_password</c> secret — the read-only
+    /// <c>viewer</c> Edit prefill (D7). The viewer role lost SELECT on that column (#1416), so the full
+    /// <see cref="MonitoredServerByIdSql"/> would 42501 for a read-only seat; this projection matches the
+    /// secret-free LIST columns (so <see cref="ReadMonitoredServerRowNoSecret"/> reads it), leaving the
+    /// password box empty (the read-only seat can't save an edit anyway). $1 server_id.</summary>
+    public const string MonitoredServerByIdNoSecretSql = @"
+SELECT server_id, name, host, database, auth, username, encrypt_mode,
        trust_server_certificate, read_only_intent, multi_subnet_failover, excluded_databases,
        monthly_cost_usd, capture_plans, is_enabled, created_at, alert_delivery_mode_override
 FROM config_monitored_servers
@@ -228,9 +242,20 @@ ORDER BY COALESCE(s.display_name, c.name)";
         return servers;
     }
 
-    /// <summary>One configured server by id, or null when it is not in the store (the Edit prefill).</summary>
+    /// <summary>One configured server by id, or null when it is not in the store (the Edit prefill). A read-only
+    /// <c>viewer</c> seat is column-denied <c>encrypted_password</c> (#1416), so it degrades to the secret-free
+    /// <see cref="MonitoredServerByIdNoSecretSql"/> projection (D7) — leaving the password box empty — instead
+    /// of failing the prefill with 42501.</summary>
     public async Task<MonitoredServerRow?> GetMonitoredServerAsync(int serverId, CancellationToken cancellationToken = default)
     {
+        if (IsReadOnly)
+        {
+            await using var noSecretCommand = _dataSource.CreateCommand(MonitoredServerByIdNoSecretSql);
+            noSecretCommand.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
+            await using var noSecretReader = await noSecretCommand.ExecuteReaderAsync(cancellationToken);
+            return await noSecretReader.ReadAsync(cancellationToken) ? ReadMonitoredServerRowNoSecret(noSecretReader) : null;
+        }
+
         await using var command = _dataSource.CreateCommand(MonitoredServerByIdSql);
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Notification.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Notification.cs
@@ -47,6 +47,21 @@ public sealed partial class ViewerDataService
     public const string NotificationSelectSql =
         "SELECT " + NotificationColumns + " FROM config_notification WHERE id = 1";
 
+    /* The non-secret subset of NotificationColumns a read-only viewer role CAN read. The four secret
+       columns (smtp_encrypted_password, smtp_username, teams_url, slack_url — a webhook URL is a bearer
+       secret) are column-REVOKEd from the viewer role (#1262 /
+       DarlingManagedRoles.ViewerRestrictedConfigTables), so selecting them raises SQLSTATE 42501 for a
+       read-only seat and — in the Settings load — one such throw would blank every later section. */
+    private const string NotificationNonSecretColumns =
+        "smtp_host, smtp_port, smtp_use_ssl, smtp_from_address, smtp_recipients, " +
+        "email_cooldown_minutes, teams_proxy, slack_proxy";
+
+    /// <summary>The secret-free notification projection a read-only <c>viewer</c> seat reads (D7 degradation):
+    /// the four carved secret columns are omitted, so it never 42501s for a viewer. The secret fields come back
+    /// null/empty (the viewer can't author them anyway); the non-secret fields prefill the Settings window.</summary>
+    public const string NotificationSelectNoSecretSql =
+        "SELECT " + NotificationNonSecretColumns + " FROM config_notification WHERE id = 1";
+
     /// <summary>Upserts the single global notification row (Settings window Save). ON CONFLICT rewrites every
     /// column and bumps <c>config_version</c> via the V17 trigger. $1..$12 in <see cref="NotificationColumns"/> order.</summary>
     public const string NotificationUpsertSql = @"
@@ -67,9 +82,19 @@ ON CONFLICT (id) DO UPDATE SET
     slack_proxy = EXCLUDED.slack_proxy,
     modified_at = (now() AT TIME ZONE 'UTC')";
 
-    /// <summary>Reads the single global notification row, or null when the store has not seeded it yet.</summary>
+    /// <summary>Reads the single global notification row, or null when the store has not seeded it yet. A
+    /// read-only <c>viewer</c> seat is column-denied the four secret columns, so it degrades to the secret-free
+    /// <see cref="NotificationSelectNoSecretSql"/> projection (D7) instead of failing the read with 42501 —
+    /// which, in the Settings load, would otherwise blank the later sections.</summary>
     public async Task<NotificationRow?> GetNotificationAsync(CancellationToken cancellationToken = default)
     {
+        if (IsReadOnly)
+        {
+            await using var noSecretCommand = _dataSource.CreateCommand(NotificationSelectNoSecretSql);
+            await using var noSecretReader = await noSecretCommand.ExecuteReaderAsync(cancellationToken);
+            return await noSecretReader.ReadAsync(cancellationToken) ? ReadNotificationRowNoSecret(noSecretReader) : null;
+        }
+
         await using var command = _dataSource.CreateCommand(NotificationSelectSql);
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         return await reader.ReadAsync(cancellationToken) ? ReadNotificationRow(reader) : null;
@@ -111,6 +136,30 @@ ON CONFLICT (id) DO UPDATE SET
         TeamsProxy = reader.GetString(9),
         SlackUrl = reader.GetString(10),
         SlackProxy = reader.GetString(11),
+    };
+
+    /// <summary>
+    /// Reads a <see cref="NotificationRow"/> from the secret-free projection
+    /// (<see cref="NotificationSelectNoSecretSql"/>) a read-only <c>viewer</c> seat uses (D7): identical to
+    /// <see cref="ReadNotificationRow"/> but the four carved secret columns (<c>smtp_username</c>,
+    /// <c>smtp_encrypted_password</c>, <c>teams_url</c>, <c>slack_url</c>) are not selected, so they stay
+    /// null/empty and every column after each shifts ordinal. The viewer can't author those secrets on a
+    /// read-only seat anyway, so the empty values are harmless — the non-secret fields still prefill.
+    /// </summary>
+    private static NotificationRow ReadNotificationRowNoSecret(NpgsqlDataReader reader) => new()
+    {
+        SmtpHost = reader.GetString(0),
+        SmtpPort = reader.GetInt32(1),
+        SmtpUseSsl = reader.GetBoolean(2),
+        SmtpUsername = null,          /* carved — not selected for a read-only viewer (#1262) */
+        SmtpEncryptedPassword = null, /* carved */
+        SmtpFromAddress = reader.GetString(3),
+        SmtpRecipients = reader.GetString(4),
+        EmailCooldownMinutes = reader.GetInt32(5),
+        TeamsUrl = "",                /* carved */
+        TeamsProxy = reader.GetString(6),
+        SlackUrl = "",                /* carved */
+        SlackProxy = reader.GetString(7),
     };
 }
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerSettings.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerSettings.cs
@@ -29,7 +29,7 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// allowed, property names are case-insensitive.
 /// Managed mode (<c>postgres.managed = true</c>, the shipped default): the SERVICE bootstraps
 /// and owns the bundled Postgres; the viewer only derives the same connection string —
-/// localhost + port + the darling user with the password the service generated on first run,
+/// 127.0.0.1 + port + the darling user with the password the service generated on first run,
 /// unprotected from the DPAPI-LocalMachine credential file beside the data directory. The
 /// derivation constants (user/database name, credential path convention, DPAPI entropy) are
 /// the service's <c>DarlingManagedPostgres</c>/<c>DarlingSecrets</c> values, duplicated under
@@ -142,7 +142,7 @@ public sealed class ViewerSettings
 
     /// <summary>
     /// The managed-mode derivation, mirroring the service: data directory = configured or
-    /// %ProgramData%\PerformanceMonitorDarling\pg, and connection = localhost + port + the
+    /// %ProgramData%\PerformanceMonitorDarling\pg, and connection = 127.0.0.1 + port + the
     /// least-privilege role <c>postgres.connectAs</c> selects (admin by default, or viewer),
     /// authenticated with that role's DPAPI credential file beside the data directory and carrying
     /// the collect/config search path. The Viewer never connects as the superuser <c>darling</c> —
@@ -181,7 +181,10 @@ public sealed class ViewerSettings
 
         var builder = new NpgsqlConnectionStringBuilder
         {
-            Host = "localhost",
+            /* 127.0.0.1, not "localhost", mirroring the service's DarlingManagedPostgres.BuildConnectionString
+               (the parity half of the same pair): a literal IPv4 loopback avoids a localhost->::1 resolution
+               that would miss the IPv4-only pg_hba loopback rule the managed cluster ships. */
+            Host = "127.0.0.1",
             Port = postgres.Port,
             Username = role,
             Password = password,

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerSettings.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerSettings.cs
@@ -183,7 +183,8 @@ public sealed class ViewerSettings
         {
             /* 127.0.0.1, not "localhost", mirroring the service's DarlingManagedPostgres.BuildConnectionString
                (the parity half of the same pair): a literal IPv4 loopback avoids a localhost->::1 resolution
-               that would miss the IPv4-only pg_hba loopback rule the managed cluster ships. */
+               that would miss the managed cluster's IPv4-only listen_addresses (it binds 127.0.0.1, not ::1;
+               initdb's pg_hba ships a ::1 rule but there is no ::1 listener). */
             Host = "127.0.0.1",
             Port = postgres.Port,
             Username = role,

--- a/Darling/README.md
+++ b/Darling/README.md
@@ -269,7 +269,7 @@ A channel is enabled by a non-empty URL.
 
 ### mcp
 
-The embedded MCP server, over Streamable HTTP bound to `localhost` only. It exposes the same tool names Lite and the Dashboard expose:
+The embedded MCP server, over Streamable HTTP bound to `localhost` by default (see [Opt-in Network Endpoints (LAN)](#opt-in-network-endpoints-lan) to reach it — and the store — from the LAN). It exposes the same tool names Lite and the Dashboard expose:
 
 - **Six diagnostic-analysis tools** — `analyze_server`, `get_analysis_facts`, `compare_analysis`, `audit_config`, `get_analysis_findings`, `mute_analysis_finding`.
 - **Five plan-analysis tools** — `analyze_query_plan` (by `query_hash`), `analyze_procedure_plan` (by `sql_handle`), `analyze_query_store_plan` (by `database_name` + `query_id`), `analyze_plan_xml` (raw showplan XML, no fetch), and `get_plan_xml` (raw stored plan XML by `query_hash`). These run the shared execution-plan analyzer over the plan XML the collectors already captured into the store — a stored-plan read, never a live query against the monitored server. `analyze_query_plan`/`get_plan_xml` accept an optional `database_name`, and `analyze_query_store_plan` an optional `plan_id`, to pin the exact stored plan when the caller knows it.
@@ -454,7 +454,7 @@ A monitored server that is down is retried every 60 seconds forever; a collector
 
 **"TimescaleDB setup failed — continuing in plain-PostgreSQL mode"** (warning) — the extension exists but conversion hit a problem. Everything still works (DELETE-based retention, plain tables); conversion is retried on the next service start.
 
-**MCP client cannot connect** — `mcp.enabled` defaults to `false`; set it to `true` and restart. If the log says `Port 5152 is already in use — MCP server not started`, change `mcp.port`. The MCP server binds to `localhost` only and does not accept remote connections.
+**MCP client cannot connect** — `mcp.enabled` defaults to `false`; set it to `true` and restart. If the log says `Port 5152 is already in use — MCP server not started`, change `mcp.port`. The MCP server binds to `localhost` only unless you opt into a LAN endpoint (see [Opt-in Network Endpoints (LAN)](#opt-in-network-endpoints-lan)); a remote client that gets 401 is missing or mismatching the required bearer token, and one that is refused before any response is outside the configured `allowFrom` CIDR.
 
 **Recommendations tab says no findings** — analysis runs every 30 minutes per server but only once the store holds at least 24 hours of collected data for that server; a fresh install simply has not earned findings yet.
 
@@ -490,7 +490,7 @@ With `postgres.managed = true` (the sample's default), the service runs its own 
 
 **What first run does.** The service looks for `pg-runtime\pgsql\` beside its binary, extracting it from `pg-runtime.zip` when only the zip is present (deleting the extracted directory is therefore always safe — it self-heals). If the data directory has no cluster, it generates a 32-character random password, protects it with DPAPI LocalMachine into `pg-credential.dpapi` beside the data directory (credential first, so a crash mid-initdb never strands a cluster nobody can log into), then runs `initdb` with `scram-sha-256` auth, data checksums, and UTF8/C locale. A marker-guarded block appended to `postgresql.conf` preloads TimescaleDB, sets the port, and restricts listening to `127.0.0.1`; a second versioned block sizes background workers up for the per-hypertable compression jobs (`timescaledb.max_background_workers = 28`, `max_worker_processes = 40` — PostgreSQL's default of 8 workers cannot launch them). Both appends are re-checked on every start, so a crash between initdb and the append heals itself instead of silently degrading — and clusters initialized before the worker sizing existed gain it on their next start (effective at the next PostgreSQL restart). Then `pg_ctl start`, `CREATE DATABASE darling`, and the normal startup path (migrations, TimescaleDB adoption — you should see `32/32 collector table(s) are hypertables`) continues exactly as in bring-your-own mode. The connection string is derived from the stored credential; the Viewer and the MCP host on the same machine derive it the same way, so nothing needs configuring there either.
 
-**Why scram and not trust, even loopback-only.** Trust auth would hand superuser to any local code that can open a loopback socket — every other local user, and network-capable-but-not-filesystem-capable attack primitives like SSRF from a co-hosted app. With scram the credential travels on the wire, failed attempts are auditable, and access is confined to what can read the DPAPI-protected credential file. `listen_addresses = '127.0.0.1'` keeps the server unreachable off the machine on top.
+**Why scram and not trust, even loopback-only.** Trust auth would hand superuser to any local code that can open a loopback socket — every other local user, and network-capable-but-not-filesystem-capable attack primitives like SSRF from a co-hosted app. With scram the credential travels on the wire, failed attempts are auditable, and access is confined to what can read the DPAPI-protected credential file. `listen_addresses = '127.0.0.1'` keeps the server unreachable off the machine on top — unless you deliberately opt into a LAN endpoint (see [Opt-in Network Endpoints (LAN)](#opt-in-network-endpoints-lan)), which reconciles `listen_addresses`, a `hostssl` pg_hba rule, and TLS on every start and is otherwise off.
 
 **Lifecycle.** On shutdown the service stops the server (`pg_ctl stop -m fast`) **only when it started it**. A server that was already running — an operator's own `pg_ctl`, or a postmaster that survived a service crash — is adopted for connections but never stopped: you'll see `already running … will not stop it` in the log, and the service keeps collecting into it.
 
@@ -507,33 +507,112 @@ The store is split into two schemas so that no consumer connects with more privi
 
 Table names are unchanged — only their schema moved — and the shared SQL keeps using the bare, unqualified names, resolved through `search_path = collect, config, public` (set as the database default and carried on the managed connection strings). This is deliberate: Darling's SQL is byte-identical to Lite's DuckDB SQL, and re-qualifying it would fork that twin.
 
-**Three roles.** The service still owns the store as the `darling` superuser (it does the DDL — migrations, hypertable conversion, retention). On top of that it provisions two least-privilege **login** roles the Viewer connects as instead:
+**The roles.** The service still owns the store as the `darling` superuser (it does the DDL — migrations, hypertable conversion, retention). On top of that, **managed mode provisions three least-privilege login roles** (BYO provisions two — see below):
 
 | Role | Privileges | Used by |
 |---|---|---|
 | `darling` | superuser / owner | the service (collection, migration, provisioning) |
 | `admin` | SELECT on both schemas + INSERT/UPDATE/DELETE on `config` only | the Viewer, by default (`connectAs: "admin"`) |
 | `viewer` | SELECT on both schemas, no writes | a locked-down Viewer (`connectAs: "viewer"`) |
+| `mcp` | `viewer`'s exact read surface + INSERT on `collect.analysis_findings` / `config.analysis_muted` only | the store identity the opt-in MCP **network** endpoint connects as (managed only); dormant until MCP is exposed on the LAN |
 
-`admin` cannot `DROP`, alter schema, touch `collect` data, or create objects — it can only do what the Viewer's mute-rule / alert-dismiss surfaces need. `ALTER DEFAULT PRIVILEGES` means new collector tables auto-inherit SELECT, so the model never drifts as collectors are added.
+`admin` cannot `DROP`, alter schema, touch `collect` data, or create objects — it can only do what the Viewer's mute-rule / alert-dismiss surfaces need. The `mcp` role is narrower still: it reads exactly what `viewer` reads (the secret config columns are carved out identically) and its only writes are the two analysis tables `analyze_server` + `mute_analysis_finding` persist — so a token-holder on the network MCP endpoint can never reach the `config`-table service-credential pivot or the secret columns. `ALTER DEFAULT PRIVILEGES` means new collector tables auto-inherit SELECT for `admin`/`viewer`, so the model never drifts as collectors are added (the `mcp` role's two INSERTs are explicit single-table grants, deliberately not schema-wide).
 
-**Managed mode** provisions all of this automatically on every start (idempotent and self-healing), generating a per-role DPAPI-LocalMachine credential — `pg-admin-credential.dpapi` and `pg-viewer-credential.dpapi` beside the data directory, same posture as the owner's `pg-credential.dpapi`. Nothing to configure beyond `connectAs`.
+**Managed mode** provisions all of this automatically on every start (idempotent and self-healing), generating a per-role DPAPI-LocalMachine credential — `pg-admin-credential.dpapi`, `pg-viewer-credential.dpapi`, and `pg-mcp-credential.dpapi` beside the data directory, same posture as the owner's `pg-credential.dpapi`. Nothing to configure beyond `connectAs`.
 
 **Credential file protection.** DPAPI LocalMachine scope is deliberate (the service writes the credential, a *different* interactive user's Viewer reads it), which means the machine-bound blob is decryptable by anything that can *read* the file. So the credential files are locked down with an NTFS ACL that strips the inherited world-read `%ProgramData%` would give them:
 
 | File(s) | Readable by |
 |---|---|
-| `pg-credential.dpapi` (superuser) + the transient init pwfile | SYSTEM, Administrators, the service account — **not** interactive users |
+| `pg-credential.dpapi` (superuser), `pg-mcp-credential.dpapi` (the network MCP role) + the transient init pwfile | SYSTEM, Administrators, the service account — **not** interactive users |
 | `pg-admin-credential.dpapi`, `pg-viewer-credential.dpapi` | the above **+ `NT AUTHORITY\INTERACTIVE`** (the operator's Viewer) |
+
+`pg-mcp-credential.dpapi` sits with the superuser (non-interactive) rather than with the Viewer's credentials because only the in-service MCP host reads it — never an interactive Viewer.
 
 The principal model assumes the **single-operator VM** this edition targets: `INTERACTIVE` == the operator, so the admin/viewer credentials are readable by the Viewer with zero configuration, while non-interactive local code (other services, sandboxed/SSRF socket primitives, scheduled tasks) and the superuser credential are excluded outright. On a shared machine where untrusted users log on interactively, tighten those two files to the specific operator account by hand. The service also refuses to trust a credential file that isn't owned by SYSTEM/Administrators/itself (closing a pre-plant attack), and regenerates an untrusted role credential.
 
 **A read-only (`viewer`) Viewer degrades gracefully.** It probes its own privileges on connect (`has_table_privilege`), so the mute-rule Add/Edit/Toggle/Delete/Purge buttons and the alert Dismiss / Dismiss All buttons are hidden or disabled, and any write that still slips through returns a clear "read-only connection" message instead of an error.
 
-**Bring-your-own PostgreSQL.** The schema split runs everywhere (it's a migration — the service applies it on startup and best-effort sets the database `search_path`; if your collection login can't `ALTER DATABASE`, run that one statement yourself as the owner). Role provisioning is managed-only, so for BYO you create the two roles yourself, once, with the shipped script:
+**Bring-your-own PostgreSQL.** The schema split runs everywhere (it's a migration — the service applies it on startup and best-effort sets the database `search_path`; if your collection login can't `ALTER DATABASE`, run that one statement yourself as the owner). Role provisioning is managed-only, so for BYO you create the roles yourself, once, with the shipped script:
 
 ```
 psql -h <host> -U <owner> -d darling -f Darling/tools/provision-roles.sql
 ```
 
-Edit the two password placeholders (and the database/owner names if yours differ) first. Then point a read-only Viewer's `connectionString` at the `viewer` role.
+Edit the two password placeholders (and the database/owner names if yours differ) first. Then point a read-only Viewer's `connectionString` at the `viewer` role. **`provision-roles.sql` creates two login roles — `admin` and `viewer`** — the two the Viewer connects as. Managed mode creates a third, `mcp`, but BYO deliberately does not: the MCP **network** endpoint (the only consumer of the `mcp` role) is managed-mode-only, and a BYO operator governs their own PostgreSQL's network exposure. If you expose MCP through your own reverse proxy against a BYO store, point it at whichever least-privilege role you choose (the `viewer` role covers the read tools; `analyze_server`'s finding persistence and `mute_analysis_finding` need INSERT on `collect.analysis_findings` / `config.analysis_muted`).
+
+## Opt-in Network Endpoints (LAN)
+
+By default both network surfaces bind **loopback only** — the store to `127.0.0.1`, the MCP server to `localhost` — exactly as they always have. Two optional, independent opt-ins let a remote viewer or MCP client on your **trusted LAN** reach them. This is a home-lab / trusted-subnet feature: **never expose either endpoint to the internet.** Both are **managed-mode only** (in bring-your-own mode your own PostgreSQL / reverse proxy governs exposure, and the config is ignored with a warning), and both are **fail-closed** — any invalid or incomplete field degrades that endpoint back to loopback and logs a critical line rather than exposing it. Removing the config on the next restart closes the box again.
+
+### Store endpoint (viewer over the LAN)
+
+Add a `network` block to `postgres` (managed mode):
+
+```json
+"postgres": {
+  "managed": true,
+  "port": 5641,
+  "network": {
+    "listen": "192.168.1.205",
+    "allowFrom": "192.168.1.0/24",
+    "role": "viewer"
+  }
+}
+```
+
+On every start the service reconciles this against the live cluster: it adds the bind IP to `listen_addresses`, generates a self-signed TLS certificate (`server.crt` / `server.key` beside the data directory, with both an IP SAN for `listen` and a DNS SAN for the machine hostname), writes a marked `hostssl darling <role> <allowFrom> scram-sha-256` rule into `pg_hba.conf` and reloads, and best-effort adds a firewall rule.
+
+- **`role`** — the pg_hba login role the rule names: `"viewer"` (default, **read-only** — the secure default, covering a laptop reading every dashboard, chart, and finding) or `"admin"` (full remote **writes**; the service logs a warning because `admin` holds the `config_command` / `config_monitored_servers` / `config_notification` service-credential pivot). Never the superuser. This is **distinct from `postgres.connectAs`** (the *local* VM viewer's loopback role, default `admin`): `network.role` is the *remote* role and defaults to `viewer`, so the two have opposite defaults — the local seat is writable, the remote seat is read-only, unless you say otherwise.
+- **TLS is verify-full, not `require`.** Because Darling generates the cert, the client can pin it, so the connection string below uses `SSL Mode=VerifyFull` — which actually defends against an on-path MITM (`require` verifies nothing). The store's network pg_hba line is `hostssl`, so a non-TLS network client is refused.
+- **The firewall is defense-in-depth, and you should set the scoped rule yourself** (the service's best-effort rule is a convenience). The store's real boundary is pg_hba + TLS:
+
+  ```
+  New-NetFirewallRule -DisplayName "Darling store (Postgres)" -Direction Inbound -Action Allow -Protocol TCP -LocalPort 5641 -RemoteAddress 192.168.1.0/24
+  ```
+
+**Remote-viewer handoff.** On the **service host**, run:
+
+```
+PerformanceMonitor.Darling.Service.exe --print-viewer-connection
+```
+
+It decrypts the `network.role` credential and prints a paste-ready connection string plus the server certificate PEM. It prints a **live database password to STDOUT** — redirect it to an ACL'd file or pipe it to the clipboard (`... --print-viewer-connection | clip`); do not leave it in shell scrollback, CI logs, or a screenshare. On the **viewer machine**, set a minimal `darling.json` to bring-your-own mode and paste the string in verbatim (no viewer code path changes — the string is consumed as-is), then save the emitted PEM where `Root Certificate` points:
+
+```json
+{
+  "postgres": {
+    "managed": false,
+    "connectionString": "Host=192.168.1.205;Port=5641;Username=viewer;Password=...;Database=darling;Search Path=collect,config,public;SSL Mode=VerifyFull;Root Certificate=server.crt"
+  }
+}
+```
+
+- **Certificate placement + rotation.** Save the emitted PEM at the `Root Certificate` path on the viewer machine (a bare `server.crt` resolves beside the viewer's working directory; an absolute path also works). The cert **auto-regenerates if the bind IP changes** (so verify-full keeps working after a `listen` change) — when that happens, clients must re-run `--print-viewer-connection` and replace their saved cert. To rotate on demand, **delete `server.crt` and `server.key`** beside the data directory; the service regenerates the pair on its next start.
+- **Plaintext at rest on the viewer machine.** The pasted connection string holds the role password in cleartext in the laptop's `darling.json` (there is no client-side secret store yet). That is acceptable for the read-only `viewer` credential on a single-operator, ACL'd profile; if you use `role: "admin"`, treat that file as a secret and NTFS-ACL it to your account. DPAPI-encrypting the viewer's BYO connection string is future hardening, out of scope today.
+
+### MCP endpoint (assistant over the LAN)
+
+Add a `network` block to `mcp` (managed mode; `mcp.enabled` must be `true`):
+
+```json
+"mcp": {
+  "enabled": true,
+  "port": 5152,
+  "network": {
+    "listen": "192.168.1.205",
+    "allowFrom": "192.168.1.0/24",
+    "encryptedToken": "<output of --encrypt-password>"
+  }
+}
+```
+
+When `listen` is a network address **and** a token is present **and** `allowFrom` is a valid CIDR, the MCP host binds that interface behind two gates: a **required bearer token** (checked first, constant-time, no loopback exemption) and an **in-app CIDR check** on the remote address (loopback is always allowed, so local clients keep working). Any missing precondition keeps MCP loopback-only. Prefer `encryptedToken` (a DPAPI blob from `--encrypt-password`); a plaintext `token` works for dev but is warned. Set the same scoped firewall rule for the MCP port:
+
+```
+New-NetFirewallRule -DisplayName "Darling MCP" -Direction Inbound -Action Allow -Protocol TCP -LocalPort 5152 -RemoteAddress 192.168.1.0/24
+```
+
+**Blast radius, stated honestly.** The token gates the entire ~60-tool read surface *and* `analyze_server`, which opens **live outbound connections to your monitored SQL Servers** (the plan-fetcher). Treat the token as a high-value secret. The store-side identity is the least-privilege `mcp` role (read + only the two analysis-table INSERTs), so a token-holder can never reach the config pivot or the secret columns — but they can read everything collected and trigger analysis.
+
+**MCP has no TLS — the MITM control is a TLS reverse proxy.** A self-signed cert breaks real MCP clients, so the MCP endpoint is plain HTTP and the bearer token travels **cleartext on the segment**; an active on-path attacker (ARP spoof, rogue DHCP, compromised switch) could capture and replay it. The in-app CIDR bounds *who can route to* the port; it does **not** protect the wire. If your segment is not fully trusted, put a **TLS-terminating reverse proxy** in front of the MCP port and point clients at that — the named MITM control for this endpoint. (The store endpoint needs no such proxy: it has verify-full TLS built in.)

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ claude mcp add --transport http --scope user sql-monitor http://localhost:5151/
 | Plan Analysis | `analyze_query_plan`, `analyze_procedure_plan`, `analyze_query_store_plan`, `analyze_plan_xml`, `get_plan_xml` |
 | Diagnostic Analysis | `analyze_server`, `get_analysis_facts`, `compare_analysis`, `audit_config`, `get_analysis_findings`, `mute_analysis_finding` |
 
-Most tools accept optional `server_name` and `hours_back` parameters. If only one server is configured, `server_name` is auto-resolved. The MCP server binds to `localhost` only and does not accept remote connections. (Darling adds latch/spinlock, plan-cache, CPU-scheduler, health-parser, and windowed-trend tools — see [Darling/README.md](Darling/README.md).)
+Most tools accept optional `server_name` and `hours_back` parameters. If only one server is configured, `server_name` is auto-resolved. The MCP server binds to `localhost` only and does not accept remote connections. (Darling adds latch/spinlock, plan-cache, CPU-scheduler, health-parser, and windowed-trend tools, and supports an opt-in LAN endpoint — see [Darling/README.md](Darling/README.md).)
 
 ---
 


### PR DESCRIPTION
Phase 3 of the opt-in Darling network endpoints feature (store + MCP). Phase 1 (config/store/roles foundation) is merged to `dev`; this branch builds off it and touches files disjoint from Phase 2 (the MCP host). **Do not merge before Phase 1; Phase 2 and 3 are parallel.**

## Scope -> files -> tests

### 1. `--print-viewer-connection` verb (D8, Round 4 #12)
- `Program.cs` — dispatch after the `--validate-config` block, `OperatingSystem.IsWindows()`-guarded (mirrors `--encrypt-password`).
- `DarlingCliCommands.cs` — `PrintViewerConnectionAsync` (mirrors `ValidateConfigAsync`'s signature): managed-mode only; reads `postgres.network.role` (default `viewer`), DPAPI-decrypts that role's credential, prints a paste-ready Npgsql string + the server-cert PEM, and warns (stderr) that a live secret hits stdout. Pure `BuildViewerConnectionString` / `ResolveViewerHost` split out for tests. `Host` = the IP when `listen` is an IP, else the machine (DNS-SAN) hostname.
- Tests: format pins (Search Path + `SSL Mode=VerifyFull` + `Root Certificate` + role), `ResolveViewerHost` IP-vs-fallback, BYO/invalid-role errors, and a Windows-gated end-to-end that decrypts a temp credential + emits the cert.

### 2. Viewer read-only Settings/Edit degradation (D7)
- `ViewerDataService.Notification.cs` — `GetNotificationAsync` degrades to a secret-free projection (`NotificationSelectNoSecretSql`) for a read-only `viewer` role (column-denied `smtp_encrypted_password`/`smtp_username`/`teams_url`/`slack_url`).
- `ViewerDataService.MonitoredServers.cs` — the Edit-server by-id read degrades to `MonitoredServerByIdNoSecretSql` (omits `encrypted_password`) for a read-only seat.
- `SettingsWindow.xaml.cs` — `LoadFromStoreAsync` now reads the three control-plane sections independently via a testable `ReadStoreSectionsAsync` helper, so one 42501 (on `config_notification`) degrades only that section instead of blanking the rest; the Save anti-clobber guard now requires all three sections to have loaded (strictly safer than the old `service is not null`).
- Data tabs read `collect` + non-secret `config` — confirmed unaffected.
- Tests: secret-free SQL pins (both), and `ReadStoreSectionsAsync` proving a simulated 42501 on notification does NOT blank alert/service.

### 3. Viewer `Host` mirror (parity)
- `ViewerSettings.DeriveManagedConnectionString` -> `Host=127.0.0.1` (the viewer half of the pair Phase 1 flipped service-side). Pinned test `ViewerDataServiceTests.cs:106` updated; the `managed=false` verbatim `Host=localhost` pin at ~:214 correctly stays.

### 4. Docs (D9, Darling-scoped only — root README untouched)
- `darling.sample.json` — commented+off `postgres.network` and `mcp.network` blocks (uncomment-ready via trailing commas), the true ~60-tool MCP surface, the LAN threat model, and the `network.role` vs `connectAs` local-vs-network note; fixed the "six analysis tools" claim and the loopback-only line.
- `Darling/README.md` — new **Opt-in Network Endpoints (LAN)** section (scoped `New-NetFirewallRule`, `--print-viewer-connection` + laptop `managed=false` handoff, verify-full + cert placement + auto-regenerate-on-IP-change + delete-to-rotate, the `network.role` tradeoff, plaintext-at-rest, MCP token + TLS-reverse-proxy MITM control); added the `mcp` role to the security table + `pg-mcp-credential.dpapi` to the ACL table; `provision-roles.sql` BYO=2-roles vs managed=3-roles clarification; fixed the `:272`/troubleshooting/`:493` "localhost only" spots.
- Stale MCP-surface fixes: `DarlingMcpInstructions.cs` (class summary + the false "only write is mute_analysis_finding" — `analyze_server` persists findings) and `DarlingMcpTools.cs` `ToolRecommendations` inverted rationale. Left `DarlingMcpTools.cs:24` (the analysis class genuinely has 6).

## Build + test
- `dotnet build` Service + Viewer: **Build succeeded, 0 errors** (warnings all pre-existing CS8629/CA1416/CA18xx).
- `dotnet test Darling/Darling.Tests`: **1760 passed, 0 failed, 127 skipped** (skips are live-Postgres/live-SQL integration, no store here).
- Also drove the built exe end-to-end: `--encrypt-password` -> credential file -> `--print-viewer-connection` prints the decrypted `viewer` connection (Host=the IP, verify-full) + cert PEM + secret warning, rc=0.

## Flags / notes
- **Docs describe the MCP network endpoint (token, in-app CIDR, TLS-reverse-proxy control) whose host-side binding lands in Phase 2**, per the plan's explicit D9 Phase-3 assignment. On this branch (off Phase-1 `dev`) the `mcp.network` block parses but is not yet bound until Phase 2 merges — flagging so the merge order is intentional (both phases are reviewed + live-validated before merge).
- The read-only degradation branches on `ViewerDataService.IsReadOnly` (set at connect by `DetectReadOnlyAsync`); for a writable/admin seat the reads are byte-identical to before, so the migrate-in and Edit flows are unchanged for admin and strictly better for a read-only seat.
- Pre-existing flaky `ViewerWave2DisplayTests.BlockedRow_EventTimeLocal_...` did not flake here; not touched.

**STOP before merging** — awaiting your review + DARLING01 live-validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)