### PR TITLE
Derive managed-PG worker sizing from the hypertable count

### DIFF
--- a/Darling/Darling.Tests/DarlingManagedPostgresTests.cs
+++ b/Darling/Darling.Tests/DarlingManagedPostgresTests.cs
@@ -16,6 +16,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
 using Npgsql;
+using PerformanceMonitor.Darling.Storage;
 using PerformanceMonitor.Darling.Service;
 using Xunit;
 
@@ -90,19 +91,21 @@ public sealed class DarlingManagedPostgresTests
     }
 
     /// <summary>
-    /// PostgreSQL's default max_worker_processes = 8 cannot launch the 26 per-hypertable
-    /// compression policy jobs (live smoke: "failed to start a background worker" storms,
-    /// 21 failed vs 7 successful policy runs). Pins the TimescaleDB-guidance sizing:
-    /// background workers = jobs + 2 = 28; max_worker_processes = 3 + 28 + 8 parallel = 39 -> 40.
+    /// PostgreSQL's default max_worker_processes = 8 cannot launch the per-hypertable compression
+    /// policy jobs (live smoke: "failed to start a background worker" storms). Pins the
+    /// TimescaleDB-guidance sizing, DERIVED from the hypertable count so it never goes stale as
+    /// collectors are added: background workers = hypertables + 2; max_worker_processes = 3 + that + 8.
     /// </summary>
     [Fact]
     public void WorkerSizingConfAppend_PinsV2MarkerAndSizing()
     {
         var block = DarlingManagedPostgres.BuildWorkerSizingConfAppend();
+        var expectedBackgroundWorkers = TimescaleSupport.HypertableTables.Count + 2;
+        var expectedWorkerProcesses = 3 + expectedBackgroundWorkers + 8;
 
         Assert.Contains(DarlingManagedPostgres.ConfMarkerV2, block, StringComparison.Ordinal);
-        Assert.Contains("timescaledb.max_background_workers = 28", block, StringComparison.Ordinal);
-        Assert.Contains("max_worker_processes = 40", block, StringComparison.Ordinal);
+        Assert.Contains($"timescaledb.max_background_workers = {expectedBackgroundWorkers}", block, StringComparison.Ordinal);
+        Assert.Contains($"max_worker_processes = {expectedWorkerProcesses}", block, StringComparison.Ordinal);
 
         /* v2 must not restate v1 settings — the blocks compose, they don't compete. */
         Assert.DoesNotContain("shared_preload_libraries", block, StringComparison.Ordinal);
@@ -309,7 +312,7 @@ public sealed class DarlingManagedPostgresTests
             var conf = File.ReadAllText(Path.Combine(dataDirectory, "postgresql.conf"));
             Assert.Contains("shared_preload_libraries = 'timescaledb'", conf, StringComparison.Ordinal);
             Assert.Contains("listen_addresses = '127.0.0.1'", conf, StringComparison.Ordinal);
-            Assert.Contains("max_worker_processes = 40", conf, StringComparison.Ordinal);
+            Assert.Contains($"max_worker_processes = {3 + (TimescaleSupport.HypertableTables.Count + 2) + 8}", conf, StringComparison.Ordinal);
 
             /* The derived credential really authenticates (scram, not trust) into the darling
                database — and the server started with our appended conf, so the timescaledb

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingManagedPostgres.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingManagedPostgres.cs
@@ -21,6 +21,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Npgsql;
+using PerformanceMonitor.Darling.Storage;
 
 namespace PerformanceMonitor.Darling.Service;
 
@@ -253,19 +254,25 @@ public sealed class DarlingManagedPostgres
     /// fail (caught live: 21 failures vs 7 successes in timescaledb_information.job_stats on a
     /// fresh managed instance). Sizing follows the TimescaleDB guidance
     /// (max_worker_processes = 3 + timescaledb.max_background_workers + max_parallel_workers,
-    /// background workers sized to total jobs + 2): 26 policy jobs + scheduler + slack = 28, and
-    /// 3 + 28 + 8 (default max_parallel_workers) = 39, rounded to 40. Idle background workers
+    /// background workers sized to hypertables + 2): DERIVED from the live hypertable count so it
+    /// never goes stale as collectors are added (26 hypertables -> 28/40, 32 -> 34/45). Idle background workers
     /// cost a few MB each and no CPU. Both settings need a PostgreSQL restart, so an existing
     /// cluster picks this up on its next service-owned start — an adopted (not-started-by-us)
     /// server heals the conf now and applies it whenever its operator next restarts it.
     /// </summary>
     public static string BuildWorkerSizingConfAppend()
     {
+        /* Derived from the live hypertable count (never stale when a collector is added): one
+           background worker per per-hypertable compression policy that can run concurrently + the
+           scheduler + slack; max_worker_processes = 3 (other bg workers) + bg workers + 8 (default
+           max_parallel_workers). Historical fixed pair was 28/40 at 26 hypertables. */
+        var maxBackgroundWorkers = TimescaleSupport.HypertableTables.Count + 2;
+        var maxWorkerProcesses = 3 + maxBackgroundWorkers + 8;
         var builder = new StringBuilder();
         builder.Append('\n');
         builder.Append(ConfMarkerV2).Append('\n');
-        builder.Append("timescaledb.max_background_workers = 28\n");
-        builder.Append("max_worker_processes = 40\n");
+        builder.Append("timescaledb.max_background_workers = ").Append(maxBackgroundWorkers).Append('\n');
+        builder.Append("max_worker_processes = ").Append(maxWorkerProcesses).Append('\n');
         return builder.ToString();
     }
 
@@ -562,7 +569,7 @@ public sealed class DarlingManagedPostgres
         if (!conf.Contains(ConfMarkerV2, StringComparison.Ordinal))
         {
             File.AppendAllText(confPath, BuildWorkerSizingConfAppend());
-            _logger.LogInformation("Appended v2 worker sizing to postgresql.conf (timescaledb.max_background_workers 28, max_worker_processes 40; effective from the next PostgreSQL restart)");
+            _logger.LogInformation("Appended v2 worker sizing to postgresql.conf (derived from {Hypertables} hypertables; effective from the next PostgreSQL restart)", TimescaleSupport.HypertableTables.Count);
         }
     }
 


### PR DESCRIPTION
## What
`BuildWorkerSizingConfAppend` hardcoded `timescaledb.max_background_workers=28` / `max_worker_processes=40` — derived once for 26 hypertables. The collector catalog is now **32** hypertables. Measured live on DARLING01: 32 compression jobs vs only 28 background workers, so not all can run concurrently (the deferred concern).

## Fix
Derive both from `TimescaleSupport.HypertableTables.Count` (which tracks `CollectorCatalog.All`):
- `max_background_workers = hypertables + 2` (one per per-hypertable compression policy + scheduler + slack)
- `max_worker_processes = 3 + max_background_workers + 8` (TimescaleDB guidance)

For 32 hypertables that's 34 / 45, and it **auto-scales** so it never goes stale again when a collector is added. Tests assert the derived formula rather than a fixed pair.

## Verify
Full `Darling.Tests`: 1825 passed, 0 failed, 127 gated-skipped.

Note: existing managed clusters keep their v2-marker block value until re-provisioned (same conf-append behavior as always); fresh installs get the derived value. DARLING01 measured 32 hypertables / 34 total jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)