### PR TITLE
Darling: harden retention/maintenance (run-record, 2x log horizon, batched purge, disk-pressure self-alert)

### DIFF
--- a/Darling/Darling.Tests/DarlingRetentionTests.cs
+++ b/Darling/Darling.Tests/DarlingRetentionTests.cs
@@ -57,14 +57,40 @@ public sealed class DarlingRetentionTests
     }
 
     [Fact]
-    public void DeleteSql_TargetsEachDefinitionsOwnTimeColumn()
+    public void DeleteSql_BatchesOnEachDefinitionsOwnTimeColumn()
     {
         var byName = CollectorCatalog.All.ToDictionary(d => d.Name, StringComparer.OrdinalIgnoreCase);
 
-        Assert.Equal("DELETE FROM wait_stats WHERE collection_time < $1",
+        /* The Postgres twin of the Dashboard's DELETE TOP(10000): batched via ctid IN (SELECT ... LIMIT
+           10000), with the time predicate REPEATED in the outer delete so a TimescaleDB hypertable's
+           per-chunk ctid can never delete a fresh row in another chunk. $1 is bound once and referenced by
+           both positions. */
+        Assert.Equal(
+            "DELETE FROM wait_stats WHERE collection_time < $1 AND ctid IN (SELECT ctid FROM wait_stats WHERE collection_time < $1 LIMIT 10000)",
             DarlingRetention.DeleteSqlFor(byName["wait_stats"]));
-        Assert.Equal("DELETE FROM trace_flags WHERE capture_time < $1",
+
+        /* The config snapshots batch on their capture_time, not collection_time. */
+        Assert.Equal(
+            "DELETE FROM trace_flags WHERE capture_time < $1 AND ctid IN (SELECT ctid FROM trace_flags WHERE capture_time < $1 LIMIT 10000)",
             DarlingRetention.DeleteSqlFor(byName["trace_flags"]));
+
+        /* collection_log runs through the same batched builder (never a hypertable, but one uniform path). */
+        Assert.Equal(
+            "DELETE FROM collection_log WHERE collection_time < $1 AND ctid IN (SELECT ctid FROM collection_log WHERE collection_time < $1 LIMIT 10000)",
+            DarlingRetention.BatchedDeleteSql("collection_log", "collection_time"));
+    }
+
+    [Fact]
+    public void CollectionLogRetention_IsTwiceTheBaseWindow()
+    {
+        /* collection_log is kept 2x the base data-retention window (the Dashboard's retention_date x2) so a
+           run-record outlives the metric rows it explains: 60 days vs the dominant 30-day collector horizon. */
+        Assert.Equal(30, DarlingRetention.DataRetentionBaseDays);
+        Assert.Equal(60, DarlingRetention.CollectionLogRetentionDays);
+        Assert.Equal(DarlingRetention.DataRetentionBaseDays * 2, DarlingRetention.CollectionLogRetentionDays);
+
+        /* The base mirrors the dominant collector horizon it is derived from. */
+        Assert.Equal(DarlingRetention.DataRetentionBaseDays, CollectorScheduleDefaults.All["wait_stats"].RetentionDays);
     }
 
     /// <summary>
@@ -133,7 +159,9 @@ public sealed class DarlingRetentionTests
                 await insert.ExecuteNonQueryAsync(ct);
             }
 
-            /* collection_log purges on its own 30-day horizon. */
+            /* collection_log purges on its own 2x horizon (60 days) so a run-record outlives the metric rows
+               it explains: a 70-day row is past the horizon and goes, a 45-day row is inside the 60-day
+               window (but past the 30-day data window) and SURVIVES — proving the 2x extension. */
             using (var insert = new NpgsqlCommand(
                 "INSERT INTO collection_log (log_id, server_id, server_name, collector_name, collection_time, status) VALUES ($1, $2, $3, $4, $5, $6)", connection))
             {
@@ -141,7 +169,19 @@ public sealed class DarlingRetentionTests
                 insert.Parameters.AddWithValue(TestServerId);
                 insert.Parameters.AddWithValue("retention-e2e");
                 insert.Parameters.AddWithValue("wait_stats");
-                insert.Parameters.AddWithValue(utcNow.AddDays(-40));
+                insert.Parameters.AddWithValue(utcNow.AddDays(-70));
+                insert.Parameters.AddWithValue("SUCCESS");
+                await insert.ExecuteNonQueryAsync(ct);
+            }
+
+            using (var insert = new NpgsqlCommand(
+                "INSERT INTO collection_log (log_id, server_id, server_name, collector_name, collection_time, status) VALUES ($1, $2, $3, $4, $5, $6)", connection))
+            {
+                insert.Parameters.AddWithValue(2L);
+                insert.Parameters.AddWithValue(TestServerId);
+                insert.Parameters.AddWithValue("retention-e2e");
+                insert.Parameters.AddWithValue("wait_stats");
+                insert.Parameters.AddWithValue(utcNow.AddDays(-45));
                 insert.Parameters.AddWithValue("SUCCESS");
                 await insert.ExecuteNonQueryAsync(ct);
             }
@@ -165,10 +205,24 @@ public sealed class DarlingRetentionTests
             }
 
             using (var read = new NpgsqlCommand(
-                "SELECT COUNT(*) FROM collection_log WHERE server_id = $1", connection))
+                "SELECT collection_time FROM collection_log WHERE server_id = $1 ORDER BY collection_time DESC", connection))
             {
                 read.Parameters.AddWithValue(TestServerId);
-                Assert.Equal(0L, await read.ExecuteScalarAsync(ct));
+                using var reader = await read.ExecuteReaderAsync(ct);
+                Assert.True(await reader.ReadAsync(ct), "the 45-day collection_log row (inside the 60-day 2x horizon) did not survive the purge");
+                var survivor = reader.GetDateTime(0);
+                Assert.True(survivor < utcNow.AddDays(-44) && survivor > utcNow.AddDays(-46),
+                    $"the surviving log row should be the 45-day one, got {survivor:O}");
+                Assert.False(await reader.ReadAsync(ct), "the 70-day collection_log row survived past the 60-day horizon");
+            }
+
+            /* The purge writes ONE auditable run-record under the fleet sentinel server_id — SUCCESS here
+               (every table purged cleanly on this store). Never attributed to a real monitored server. */
+            using (var read = new NpgsqlCommand(
+                "SELECT status FROM collection_log WHERE server_id = $1 AND collector_name = 'data_retention' ORDER BY collection_time DESC LIMIT 1", connection))
+            {
+                read.Parameters.AddWithValue(DarlingObservability.FleetServerId);
+                Assert.Equal("SUCCESS", await read.ExecuteScalarAsync(ct));
             }
         }
         finally
@@ -179,8 +233,13 @@ public sealed class DarlingRetentionTests
 
     private static async Task DeleteTestRowsAsync(NpgsqlConnection connection)
     {
+        /* Also clears the fleet-sentinel data_retention run-record the purge writes, so the shared dev store
+           doesn't accumulate them and the run-record assertion always reads THIS run's row. */
         using var cleanup = new NpgsqlCommand(
-            $"DELETE FROM wait_stats WHERE server_id = {TestServerId}; DELETE FROM collection_log WHERE server_id = {TestServerId};", connection);
+            $"DELETE FROM wait_stats WHERE server_id = {TestServerId}; " +
+            $"DELETE FROM collection_log WHERE server_id = {TestServerId}; " +
+            $"DELETE FROM collection_log WHERE server_id = {DarlingObservability.FleetServerId} AND collector_name = 'data_retention';",
+            connection);
         await cleanup.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
     }
 }

--- a/Darling/Darling.Tests/DarlingRetentionTests.cs
+++ b/Darling/Darling.Tests/DarlingRetentionTests.cs
@@ -7,7 +7,9 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Npgsql;
 using PerformanceMonitor.Collectors;
@@ -91,6 +93,86 @@ public sealed class DarlingRetentionTests
 
         /* The base mirrors the dominant collector horizon it is derived from. */
         Assert.Equal(DarlingRetention.DataRetentionBaseDays, CollectorScheduleDefaults.All["wait_stats"].RetentionDays);
+    }
+
+    /* ---------------- batched-drain loop (pure, injected executor) ---------------- */
+
+    [Fact]
+    public async Task DrainBatches_LoopsUntilBatchBelowCap_ThenStops()
+    {
+        /* [cap, cap, partial] -> 3 executions, summed; the partial batch (< cap) terminates the drain. */
+        var batches = new Queue<int>(new[] { 10000, 10000, 3 });
+        var calls = 0;
+        var total = await DarlingRetention.DrainBatchesAsync(
+            _ => { calls++; return Task.FromResult(batches.Dequeue()); }, batchSize: 10000, CancellationToken.None);
+
+        Assert.Equal(20003, total);
+        Assert.Equal(3, calls);
+    }
+
+    [Fact]
+    public async Task DrainBatches_SingleUnderCapBatch_StopsAfterOne()
+    {
+        var calls = 0;
+        var total = await DarlingRetention.DrainBatchesAsync(
+            _ => { calls++; return Task.FromResult(5); }, batchSize: 10000, CancellationToken.None);
+
+        Assert.Equal(5, total);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public async Task DrainBatches_ExactMultipleOfCap_TerminatesOnTheEmptyBatch()
+    {
+        /* Exactly cap, then 0: the full-cap batch forces another round; the empty batch terminates it. */
+        var batches = new Queue<int>(new[] { 10000, 0 });
+        var calls = 0;
+        var total = await DarlingRetention.DrainBatchesAsync(
+            _ => { calls++; return Task.FromResult(batches.Dequeue()); }, batchSize: 10000, CancellationToken.None);
+
+        Assert.Equal(10000, total);
+        Assert.Equal(2, calls);
+    }
+
+    /* ---------------- run-record status/message (pure) ---------------- */
+
+    [Fact]
+    public void BuildRunRecordSummary_AllTablesClean_IsSuccess()
+    {
+        var (status, message) = DarlingRetention.BuildRunRecordSummary(
+            tablesPurged: 33, totalRowsDeleted: 1200, totalChunksDropped: 42, tablesFailed: 0);
+
+        Assert.Equal("SUCCESS", status);
+        Assert.Contains("33 table(s)", message);
+        Assert.Contains("1200 row(s) deleted", message);
+        Assert.Contains("42 chunk(s) dropped", message);
+        Assert.DoesNotContain("failed", message);
+    }
+
+    [Fact]
+    public void BuildRunRecordSummary_SomeTablesFailed_IsWarning()
+    {
+        var (status, message) = DarlingRetention.BuildRunRecordSummary(
+            tablesPurged: 30, totalRowsDeleted: 500, totalChunksDropped: 0, tablesFailed: 3);
+
+        Assert.Equal("WARNING", status);
+        Assert.Contains("3 failed", message);
+    }
+
+    [Fact]
+    public async Task Purge_UnexpectedThrowInSweep_DoesNotPropagate_ReturnsPartialSummary()
+    {
+        /* The daily caller does NOT wrap PurgeAsync, so an unexpected throw inside the sweep would kill the
+           collection loop. Here a caller resolver throws on the first collector, driving the outer catch (the
+           ERROR path): PurgeAsync must swallow it and return a partial summary. The null data source is never
+           dereferenced before the throw, and the ERROR run-record write is itself failure-isolated, so this
+           stays a DB-free test. */
+        var summary = await DarlingRetention.PurgeAsync(
+            postgres: null!, timescaleAvailable: false, logger: null, TestContext.Current.CancellationToken,
+            retentionDaysFor: _ => throw new InvalidOperationException("resolver boom"));
+
+        Assert.Equal(0, summary.TablesPurged);
+        Assert.Equal(0, summary.TotalPurged);
     }
 
     /// <summary>
@@ -224,6 +306,41 @@ public sealed class DarlingRetentionTests
                 read.Parameters.AddWithValue(DarlingObservability.FleetServerId);
                 Assert.Equal("SUCCESS", await read.ExecuteScalarAsync(ct));
             }
+        }
+        finally
+        {
+            await DeleteTestRowsAsync(connection);
+        }
+    }
+
+    [Fact]
+    public async Task EndToEnd_PurgeResolverThrows_WritesErrorRunRecord_AgainstDevPostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the live ERROR run-record test.");
+
+        var ct = TestContext.Current.CancellationToken;
+
+        using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(ct);
+        await PgMigrations.MigrateAsync(connection, ct);
+        await DeleteTestRowsAsync(connection);
+
+        await using var postgres = NpgsqlDataSource.Create(connectionString!);
+        try
+        {
+            /* A resolver that throws drives PurgeAsync into its outer catch, which writes an ERROR run-record
+               to the store under the fleet sentinel — the failure is auditable, not a crashed loop. */
+            var summary = await DarlingRetention.PurgeAsync(
+                postgres, timescaleAvailable: false, null, ct,
+                retentionDaysFor: _ => throw new InvalidOperationException("resolver boom"));
+            Assert.Equal(0, summary.TablesPurged);
+
+            using var read = new NpgsqlCommand(
+                "SELECT status FROM collection_log WHERE server_id = $1 AND collector_name = 'data_retention' ORDER BY collection_time DESC LIMIT 1", connection);
+            read.Parameters.AddWithValue(DarlingObservability.FleetServerId);
+            Assert.Equal("ERROR", await read.ExecuteScalarAsync(ct));
         }
         finally
         {

--- a/Darling/Darling.Tests/DarlingSelfAlertTests.cs
+++ b/Darling/Darling.Tests/DarlingSelfAlertTests.cs
@@ -112,13 +112,19 @@ public sealed class DarlingSelfAlertTests
         public FakeHistoryStore History { get; } = new();
         public bool Muted { get; set; }
 
+        /// <summary>When set, the mute check throws — simulates a broken mute rule's Matches() to prove the
+        /// evaluation isolates it (a throw here must never propagate out and stop collection).</summary>
+        public bool MuteThrows { get; set; }
+
         /// <summary>The V20 connection-change notify gate, read live by the evaluator's connect edge (default on).</summary>
         public bool NotifyConnectionChanges { get; set; } = true;
 
         public DateTime Now { get; set; } = new(2026, 7, 1, 12, 0, 0, DateTimeKind.Utc);
 
         public DarlingSelfAlertEvaluator Build() => new(
-            Settings, Deliverer, History, _ => Muted, logger: null, utcNow: () => Now,
+            Settings, Deliverer, History,
+            _ => MuteThrows ? throw new InvalidOperationException("mute check boom") : Muted,
+            logger: null, utcNow: () => Now,
             notifyConnectionChanges: () => NotifyConnectionChanges);
     }
 
@@ -515,6 +521,28 @@ public sealed class DarlingSelfAlertTests
 
         await e.ApplyDiskPressureAsync(1 * Gib, 100 * Gib, null, Ct);
         Assert.Empty(h.Deliverer.Outcomes);
+    }
+
+    [Fact]
+    public async Task DiskPressure_ThrowingMuteCheck_IsIsolated_DoesNotPropagate()
+    {
+        /* MAJOR: the disk-pressure sweep-loop body has no catch-all of its own, and the pre-deliver mute check
+           (_isAlertMuted -> a mute rule's Matches()) is NOT internally isolated. EvaluateDiskPressureAsync must
+           swallow a throw there — otherwise a single broken mute rule stops collection for the whole fleet. */
+        var h = new Harness { MuteThrows = true };
+        var e = h.Build();
+
+        /* Must NOT throw (would propagate out of the un-guarded worker loop). */
+        await e.EvaluateDiskPressureAsync(5 * Gib, 100 * Gib, storeSizeBytes: 20 * Gib, Ct);
+
+        /* The throw happened in the mute check, before delivery — nothing was delivered, and we're still alive. */
+        Assert.Empty(h.Deliverer.Outcomes);
+
+        /* The isolation lives in the Evaluate wrapper (the worker's entry point), not the sibling-style
+           un-isolated Apply: a fresh evaluator's Apply lets the same throw propagate. */
+        var e2 = new Harness { MuteThrows = true }.Build();
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => e2.ApplyDiskPressureAsync(5 * Gib, 100 * Gib, null, Ct));
     }
 
     /* ---------------- master switch ---------------- */

--- a/Darling/Darling.Tests/DarlingSelfAlertTests.cs
+++ b/Darling/Darling.Tests/DarlingSelfAlertTests.cs
@@ -407,6 +407,116 @@ public sealed class DarlingSelfAlertTests
         Assert.Empty(h.Deliverer.Outcomes);
     }
 
+    /* ---------------- store disk pressure (fleet-level, pure decision) ---------------- */
+
+    private const long Gib = 1024L * 1024 * 1024;
+
+    [Fact]
+    public void IsDiskPressure_BelowThreshold_Pressure()
+    {
+        /* 5% free (< the 10% warn threshold) reads as pressure; the reason names the percentage. */
+        Assert.True(DarlingSelfAlertEvaluator.IsDiskPressure(5 * Gib, 100 * Gib, out var reason));
+        Assert.Contains("5", reason);
+        Assert.Contains("%", reason);
+    }
+
+    [Fact]
+    public void IsDiskPressure_ExactlyAtThreshold_NotPressure()
+    {
+        /* Boundary: exactly 10% free is NOT pressure (strictly-less-than the threshold). */
+        Assert.False(DarlingSelfAlertEvaluator.IsDiskPressure(10 * Gib, 100 * Gib, out _));
+    }
+
+    [Fact]
+    public void IsDiskPressure_JustBelowThreshold_Pressure()
+    {
+        /* 9.9% free trips it — the threshold is a real edge, not a wide band. */
+        Assert.True(DarlingSelfAlertEvaluator.IsDiskPressure(99 * Gib, 1000 * Gib, out _));
+    }
+
+    [Fact]
+    public void IsDiskPressure_PlentyFree_NotPressure()
+    {
+        Assert.False(DarlingSelfAlertEvaluator.IsDiskPressure(50 * Gib, 100 * Gib, out _));
+    }
+
+    [Fact]
+    public void IsDiskPressure_NonPositiveTotal_NotPressure()
+    {
+        /* An undeterminable total ("can't tell") never reads as pressure. */
+        Assert.False(DarlingSelfAlertEvaluator.IsDiskPressure(0, 0, out _));
+    }
+
+    /* ---------------- store disk pressure edge ---------------- */
+
+    [Fact]
+    public async Task DiskPressure_FiresOnce_ThenCooldownSuppresses_ThenReFires()
+    {
+        var h = new Harness();
+        var e = h.Build();
+
+        await e.ApplyDiskPressureAsync(5 * Gib, 100 * Gib, storeSizeBytes: 20 * Gib, Ct);
+        var fired = Assert.Single(h.Deliverer.Outcomes);
+        Assert.Equal("Store Disk Pressure", fired.MetricName);
+        Assert.Equal(AlertSeverityLevel.Critical, fired.Severity);
+        Assert.Equal("store", fired.ServerKey);   /* the fleet sentinel key, not a real server_id */
+
+        /* Still low one minute later — inside the 5-minute cooldown, no re-fire (the EDGE: once, not every sweep). */
+        h.Now = h.Now.AddMinutes(1);
+        await e.ApplyDiskPressureAsync(5 * Gib, 100 * Gib, null, Ct);
+        Assert.Single(h.Deliverer.Outcomes);
+
+        /* After the cooldown the standing condition re-fires. */
+        h.Now = h.Now.AddMinutes(5);
+        await e.ApplyDiskPressureAsync(5 * Gib, 100 * Gib, null, Ct);
+        Assert.Equal(2, h.Deliverer.Outcomes.Count);
+    }
+
+    [Fact]
+    public async Task DiskPressure_Recovery_WritesOneResolvedHistoryRow()
+    {
+        var h = new Harness();
+        var e = h.Build();
+
+        await e.ApplyDiskPressureAsync(5 * Gib, 100 * Gib, null, Ct);   /* pressure */
+        Assert.Empty(h.History.Records);
+
+        /* Free space recovered: exactly one "Store Disk Pressure Resolved" audit row, no email/webhook. */
+        await e.ApplyDiskPressureAsync(50 * Gib, 100 * Gib, null, Ct);
+        var resolved = Assert.Single(h.History.Records);
+        Assert.Equal("Store Disk Pressure Resolved", resolved.MetricName);
+        Assert.True(resolved.AlertSent);
+        Assert.Equal("tray", resolved.NotificationType);
+        Assert.Single(h.Deliverer.Outcomes);   /* only the original fire went to the deliverer */
+
+        /* Still healthy on the next sweep — no duplicate resolved row (resolution is edge-triggered too). */
+        await e.ApplyDiskPressureAsync(50 * Gib, 100 * Gib, null, Ct);
+        Assert.Single(h.History.Records);
+    }
+
+    [Fact]
+    public async Task DiskPressure_UndeterminableFreeSpace_DoesNotFire()
+    {
+        /* A remote BYO store whose volume the service cannot see (null free/total) never alarms — even though
+           a store size is known, it is context only and never the trigger. */
+        var h = new Harness();
+        var e = h.Build();
+
+        await e.ApplyDiskPressureAsync(null, null, storeSizeBytes: 999 * Gib, Ct);
+        Assert.Empty(h.Deliverer.Outcomes);
+    }
+
+    [Fact]
+    public async Task DiskPressure_AlertsDisabled_DoesNotFire()
+    {
+        var h = new Harness();
+        h.Settings.AlertsEnabled = false;
+        var e = h.Build();
+
+        await e.ApplyDiskPressureAsync(1 * Gib, 100 * Gib, null, Ct);
+        Assert.Empty(h.Deliverer.Outcomes);
+    }
+
     /* ---------------- master switch ---------------- */
 
     [Fact]

--- a/Darling/Darling.Tests/ViewerServerChromeTests.cs
+++ b/Darling/Darling.Tests/ViewerServerChromeTests.cs
@@ -140,6 +140,9 @@ public sealed class ViewerServerChromeTests
         Assert.Contains("MAX(collection_time)", ViewerDataService.ServerFreshnessSql, StringComparison.Ordinal);
         Assert.Contains("FROM v_collection_log", ViewerDataService.ServerFreshnessSql, StringComparison.Ordinal);
         Assert.Contains("GROUP BY server_id", ViewerDataService.ServerFreshnessSql, StringComparison.Ordinal);
+        /* Excludes the fleet retention run-record sentinel (server_id 0) so it never appears as a phantom
+           server in the freshness dictionary. */
+        Assert.Contains("server_id <> 0", ViewerDataService.ServerFreshnessSql, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingObservability.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingObservability.cs
@@ -63,6 +63,21 @@ WHERE s.server_id = c.server_id
 INSERT INTO collection_log (log_id, server_id, server_name, collector_name, collection_time, duration_ms, status, error_message, rows_collected, sql_duration_ms, duckdb_duration_ms)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11);";
 
+    /* The fleet-sentinel server_id the daily retention purge writes its run-record under. collection_log's
+       server_id is NOT NULL and Collection Health reads per real server_id, but the purge is fleet-wide (per
+       shared table, not per server), so it has no real server to attribute to. This reserved id is never a
+       monitored server (server_ids are FNV-1a hashes of a storage name; it is also never registered in
+       config_monitored_servers / collect.servers), so the sentinel row is: (a) EXCLUDED from the fleet
+       Collection-Health aggregate — that read is scoped to server_id IN config_monitored_servers WHERE
+       is_enabled; (b) never matched by any per-server read (all WHERE server_id = $realId) or the self-alert
+       collection-signal reads; yet (c) fully auditable via v_collection_log (WHERE collector_name =
+       'data_retention'). Deliberately NOT a new fleet UI surface — just an auditable log row. */
+    internal const int FleetServerId = 0;
+    private const string FleetServerName = "(fleet)";
+
+    /* Matches the Dashboard's config.data_retention collector_name so the audit vocabulary twins across SKUs. */
+    private const string RetentionCollectorName = "data_retention";
+
     /* The per-server analysis-state marker (V19): the analysis pass's insufficient-data determination,
        persisted so the Viewer's Recommendations tab can tell "still collecting" (a young deployment under
        the 24h data-span gate) apart from a genuine all-clear. One row per server, upserted after each
@@ -184,6 +199,59 @@ ON CONFLICT (server_id) DO UPDATE SET
             /* Failure-isolated by design — an observability write must never break the collection loop. */
             logger?.LogDebug("Observability: collection_log write for '{Server}' / {Collector} failed: {Message}",
                 server.Config.DisplayName, collectorName, ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Records one daily retention-purge sweep in collection_log as an auditable <c>data_retention</c>
+    /// run-record (the Darling twin of the Dashboard's config.data_retention log rows). Fleet-wide, so it is
+    /// written under the reserved <see cref="FleetServerId"/> sentinel — never a real monitored server, and
+    /// excluded from every per-server and fleet Collection-Health read (see the constant's remarks). <paramref
+    /// name="status"/> is SUCCESS / WARNING (some tables failed) / ERROR; <paramref name="rowsPurged"/> is the
+    /// coarse rows-deleted-plus-chunks-dropped activity count; <paramref name="durationMs"/> is the whole-sweep
+    /// elapsed (recorded as both the total and the storage phase — a purge is all store-side work, no SQL-target
+    /// phase). Failure-isolated (Debug + no-op) like the other observability writes — an audit write must never
+    /// break the collection loop.
+    /// </summary>
+    public static async Task LogRetentionRunAsync(
+        NpgsqlDataSource postgres,
+        string status,
+        int rowsPurged,
+        long durationMs,
+        string? message,
+        ILogger? logger,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var text = message;
+            if (text is not null && text.Length > 4000)
+            {
+                text = text.Substring(0, 4000);
+            }
+
+            var elapsed = durationMs > int.MaxValue ? int.MaxValue : (int)durationMs;
+
+            await using var connection = await postgres.OpenConnectionAsync(cancellationToken);
+            using var command = new NpgsqlCommand(InsertCollectionLogSql, connection);
+            command.Parameters.AddWithValue(CollectionIdGenerator.Next());                                    // log_id
+            command.Parameters.AddWithValue(FleetServerId);                                                   // server_id (sentinel)
+            command.Parameters.AddWithValue(FleetServerName);                                                 // server_name
+            command.Parameters.AddWithValue(RetentionCollectorName);                                          // collector_name
+            /* Naive-UTC storage: Npgsql 6+ rejects Kind=Utc against `timestamp` — see PgCollectorRowWriter. */
+            command.Parameters.AddWithValue(DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Unspecified)); // collection_time
+            command.Parameters.AddWithValue(elapsed);                                                         // duration_ms
+            command.Parameters.AddWithValue(status);                                                          // status
+            command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text, Value = (object?)text ?? DBNull.Value }); // error_message
+            command.Parameters.AddWithValue(rowsPurged);                                                      // rows_collected
+            command.Parameters.AddWithValue(0);                                                               // sql_duration_ms (no SQL-target phase)
+            command.Parameters.AddWithValue(elapsed);                                                         // duckdb_duration_ms (storage phase = whole sweep)
+            await command.ExecuteNonQueryAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            /* Failure-isolated by design — an observability write must never break the collection loop. */
+            logger?.LogDebug("Observability: data_retention run-record write failed: {Message}", ex.Message);
         }
     }
 

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingRetention.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingRetention.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -30,22 +31,42 @@ namespace PerformanceMonitor.Darling.Service;
 /// purges without archiving — with Timescale, the compression policy on old chunks IS the
 /// archival tier (compressed chunks stay queryable), and the plain-PG story remains
 /// purge-without-archive for now.
+/// <para>Every sweep writes one AUDITABLE run-record to collection_log under a fleet-sentinel server_id
+/// (<see cref="DarlingObservability.FleetServerId"/>, never a real server) — SUCCESS, WARNING (some
+/// tables failed their statement, already logged + isolated), or ERROR — so a stalled or partial purge is
+/// visible in the collection log, not just the service log. The plain-PG DELETE path drains each table in
+/// <see cref="DeleteBatchSize"/>-row batches (the Dashboard's DELETE TOP idiom); collection_log is kept 2x
+/// the base data-retention window so a run-record outlives the metric rows it explains.</para>
 /// </summary>
 public static class DarlingRetention
 {
     /// <summary>
-    /// collection_log isn't a collector, so it has no <see cref="CollectorScheduleDefaults"/>
-    /// entry to carry its horizon — the constant lives here for now, until observability
-    /// retention grows a shared home. 30 days matches the dominant collector horizon.
+    /// The base data-retention window the collection_log horizon is a multiple of. 30 days matches the
+    /// dominant collector <see cref="CollectorScheduleDefaults"/> horizon and the Dashboard's
+    /// <c>@effective_retention_days</c> default (config.data_retention).
     /// </summary>
-    private const int CollectionLogRetentionDays = 30;
+    internal const int DataRetentionBaseDays = 30;
 
-    /* The first purge against a long backlog can delete a lot of rows; Npgsql's default
-       30-second command timeout would roll that DELETE back and the table would never catch up
-       (retried tomorrow with a day MORE to delete). Daily steady-state purges are far smaller. */
+    /// <summary>
+    /// collection_log isn't a collector, so it has no <see cref="CollectorScheduleDefaults"/> entry to carry
+    /// its horizon. It is kept at 2x the base window (mirrors the Dashboard's <c>retention_date x2</c> rule)
+    /// so a collector run-record survives long enough to diagnose WHY a collector failed AFTER its metric
+    /// rows have aged out — a 30-day metric row and its failure log would otherwise expire together, erasing
+    /// the evidence. Effectively 60 days.
+    /// </summary>
+    internal const int CollectionLogRetentionDays = DataRetentionBaseDays * 2;
+
+    /* The per-DELETE batch cap — the Postgres twin of the Dashboard's DELETE TOP(10000) idiom
+       (config.data_retention). A large first purge is drained in 10k-row batches instead of one giant
+       DELETE, bounding lock duration, WAL generation, and dead-tuple bloat. Steady-state daily purges are
+       far smaller and usually clear in a single batch. */
+    private const int DeleteBatchSize = 10000;
+
+    /* Each 10k-row batch is small and fast; the generous 300s per-batch command timeout (well above
+       Npgsql's 30s default) is belt-and-suspenders for a slow disk. Batching is also what keeps a large
+       first purge from ever hitting a timeout at all — the pre-batch single DELETE could roll back on a long
+       backlog and never catch up (retried tomorrow with a day MORE to delete). */
     private const int DeleteTimeoutSeconds = 300;
-
-    private const string CollectionLogDeleteSql = "DELETE FROM collection_log WHERE collection_time < $1";
 
     /// <summary>
     /// Purges every collector table past its shared <see cref="CollectorScheduleDefaults"/>
@@ -78,76 +99,137 @@ public static class DarlingRetention
         var tablesPurged = 0;
         var totalRowsDeleted = 0;
         var totalChunksDropped = 0;
+        var tablesFailed = 0;
 
         /* Naive-UTC storage: Npgsql 6+ rejects Kind=Utc against `timestamp` — see PgCollectorRowWriter. */
         var utcNow = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Unspecified);
 
-        foreach (var definition in CollectorCatalog.All)
+        try
         {
-            if (!CollectorScheduleDefaults.All.TryGetValue(definition.Name, out var schedule))
+            foreach (var definition in CollectorCatalog.All)
             {
-                /* Impossible while the retention coverage test holds — belt-and-suspenders so
-                   schedule drift degrades to a loud warning instead of killing the sweep. */
-                logger?.LogWarning("Retention purge: no schedule entry for '{Collector}' — {Table} was not purged",
-                    definition.Name, definition.TargetTable);
-                continue;
-            }
-
-            /* Clamp at the destructive sink (belt-and-suspenders with the resolver + the V17 CHECK): a
-               retention of 0/negative would flip the cutoff into the present/future and drop_chunks /
-               DELETE the entire table. Never purge with a horizon under 1 day. */
-            var retentionDays = Math.Max(1, retentionDaysFor?.Invoke(definition.Name) ?? schedule.RetentionDays);
-
-            if (timescaleAvailable)
-            {
-                var dropped = await DropChunksOneAsync(
-                    postgres, definition.TargetTable, DropChunksSqlFor(definition, retentionDays),
-                    logger, cancellationToken);
-                if (dropped is not null)
+                if (!CollectorScheduleDefaults.All.TryGetValue(definition.Name, out var schedule))
                 {
-                    tablesPurged++;
-                    totalChunksDropped += dropped.Value;
+                    /* Impossible while the retention coverage test holds — belt-and-suspenders so schedule
+                       drift degrades to a loud warning (and a WARNING run-record) instead of killing the sweep. */
+                    logger?.LogWarning("Retention purge: no schedule entry for '{Collector}' — {Table} was not purged",
+                        definition.Name, definition.TargetTable);
+                    tablesFailed++;
                     continue;
                 }
 
-                /* drop_chunks failed (warned) — most likely this one table failed hypertable
-                   conversion and is still plain. Fall back to the extension-free DELETE so the
-                   table still honors its horizon instead of growing unbounded. */
+                /* Clamp at the destructive sink (belt-and-suspenders with the resolver + the V17 CHECK): a
+                   retention of 0/negative would flip the cutoff into the present/future and drop_chunks /
+                   DELETE the entire table. Never purge with a horizon under 1 day. */
+                var retentionDays = Math.Max(1, retentionDaysFor?.Invoke(definition.Name) ?? schedule.RetentionDays);
+
+                if (timescaleAvailable)
+                {
+                    var dropped = await DropChunksOneAsync(
+                        postgres, definition.TargetTable, DropChunksSqlFor(definition, retentionDays),
+                        logger, cancellationToken);
+                    if (dropped is not null)
+                    {
+                        tablesPurged++;
+                        totalChunksDropped += dropped.Value;
+                        continue;
+                    }
+
+                    /* drop_chunks failed (warned) — most likely this one table failed hypertable
+                       conversion and is still plain. Fall back to the extension-free DELETE so the
+                       table still honors its horizon instead of growing unbounded. */
+                }
+
+                var deleted = await PurgeOneAsync(
+                    postgres, definition.TargetTable, DeleteSqlFor(definition),
+                    utcNow.AddDays(-retentionDays), logger, cancellationToken);
+                if (deleted is not null)
+                {
+                    tablesPurged++;
+                    totalRowsDeleted += deleted.Value;
+                }
+                else
+                {
+                    tablesFailed++;
+                }
             }
 
-            var deleted = await PurgeOneAsync(
-                postgres, definition.TargetTable, DeleteSqlFor(definition),
-                utcNow.AddDays(-retentionDays), logger, cancellationToken);
-            if (deleted is not null)
+            var logDeleted = await PurgeOneAsync(
+                postgres, "collection_log", BatchedDeleteSql("collection_log", "collection_time"),
+                utcNow.AddDays(-CollectionLogRetentionDays), logger, cancellationToken);
+            if (logDeleted is not null)
             {
                 tablesPurged++;
-                totalRowsDeleted += deleted.Value;
+                totalRowsDeleted += logDeleted.Value;
             }
-        }
+            else
+            {
+                tablesFailed++;
+            }
 
-        var logDeleted = await PurgeOneAsync(
-            postgres, "collection_log", CollectionLogDeleteSql,
-            utcNow.AddDays(-CollectionLogRetentionDays), logger, cancellationToken);
-        if (logDeleted is not null)
+            var summary = new PurgeSummary(tablesPurged, totalRowsDeleted, totalChunksDropped);
+            logger?.LogInformation(
+                "Retention purge: {Tables} table(s) purged, {Rows} row(s) deleted, {Chunks} chunk(s) dropped, {Failed} failed, {ElapsedMs}ms",
+                tablesPurged, totalRowsDeleted, totalChunksDropped, tablesFailed, sw.ElapsedMilliseconds);
+
+            /* Auditable run-record: a clean sweep writes SUCCESS, a sweep where one or more tables failed
+               their statement writes WARNING (the per-table failures were already logged + isolated above).
+               Fleet-wide, so it lands under the sentinel server_id (DarlingObservability.LogRetentionRunAsync),
+               which is failure-isolated and never breaks the loop. */
+            var status = tablesFailed == 0 ? "SUCCESS" : "WARNING";
+            var message = tablesFailed == 0
+                ? $"Purged {tablesPurged.ToString(CultureInfo.InvariantCulture)} table(s): {totalRowsDeleted.ToString(CultureInfo.InvariantCulture)} row(s) deleted, {totalChunksDropped.ToString(CultureInfo.InvariantCulture)} chunk(s) dropped"
+                : $"Purged {tablesPurged.ToString(CultureInfo.InvariantCulture)} table(s), {tablesFailed.ToString(CultureInfo.InvariantCulture)} failed (see prior warnings): {totalRowsDeleted.ToString(CultureInfo.InvariantCulture)} row(s) deleted, {totalChunksDropped.ToString(CultureInfo.InvariantCulture)} chunk(s) dropped";
+            await DarlingObservability.LogRetentionRunAsync(
+                postgres, status, summary.TotalPurged, sw.ElapsedMilliseconds, message, logger, cancellationToken);
+
+            return summary;
+        }
+        catch (OperationCanceledException)
         {
-            tablesPurged++;
-            totalRowsDeleted += logDeleted.Value;
+            /* Shutdown/cancellation — propagate exactly like the per-table helpers (no ERROR run-record; the
+               purge simply didn't finish and retries on the next daily tick). */
+            throw;
         }
-
-        logger?.LogInformation("Retention purge: {Tables} table(s) purged, {Rows} row(s) deleted, {Chunks} chunk(s) dropped, {ElapsedMs}ms",
-            tablesPurged, totalRowsDeleted, totalChunksDropped, sw.ElapsedMilliseconds);
-        return new PurgeSummary(tablesPurged, totalRowsDeleted, totalChunksDropped);
+        catch (Exception ex)
+        {
+            /* The per-table helpers isolate their own failures, so reaching here means something unexpected
+               escaped the loop. Record an ERROR run-record for the audit trail and return what we managed to
+               purge — PurgeAsync must never throw at the daily caller (it is not wrapped there), so a broken
+               purge surfaces as an auditable ERROR row, not a crashed collection loop. */
+            logger?.LogError("Retention purge failed: {Message}", ex.Message);
+            await DarlingObservability.LogRetentionRunAsync(
+                postgres, "ERROR", totalRowsDeleted + totalChunksDropped, sw.ElapsedMilliseconds, ex.Message, logger, cancellationToken);
+            return new PurgeSummary(tablesPurged, totalRowsDeleted, totalChunksDropped);
+        }
     }
 
     /// <summary>
-    /// The purge statement for one collector table — DELETE everything older than the cutoff on
-    /// the definition's own prefix time column ("collection_time" almost everywhere; the config
-    /// snapshots purge on "capture_time"). Table and column names come from the shared catalog
-    /// constants, never from user input, so interpolation is safe here — the same reasoning as
-    /// the runner's watermark read (DarlingCollectorRunner.GetLastCollectedTimeAsync).
+    /// The batched purge statement for one collector table — DELETE up to <see cref="DeleteBatchSize"/> rows
+    /// older than the cutoff on the definition's own prefix time column ("collection_time" almost everywhere;
+    /// the config snapshots purge on "capture_time"), executed in a loop until the table is drained
+    /// (<see cref="PurgeOneAsync"/>). Table and column names come from the shared catalog constants, never
+    /// from user input, so interpolation is safe here — the same reasoning as the runner's watermark read
+    /// (DarlingCollectorRunner.GetLastCollectedTimeAsync).
     /// </summary>
     internal static string DeleteSqlFor(ICollectorSchemaInfo schema)
-        => $"DELETE FROM {schema.TargetTable} WHERE {schema.PrefixTimeColumnName} < $1";
+        => BatchedDeleteSql(schema.TargetTable, schema.PrefixTimeColumnName);
+
+    /// <summary>
+    /// The Postgres twin of the Dashboard's <c>DELETE TOP(10000)</c> batched purge: delete up to
+    /// <see cref="DeleteBatchSize"/> expired rows per statement via a <c>ctid IN (SELECT … LIMIT N)</c>
+    /// subquery (Postgres has no <c>DELETE … LIMIT</c>). The time predicate is repeated in the OUTER delete —
+    /// <c>WHERE {col} &lt; $1 AND ctid IN (…)</c> — deliberately: on a plain table it is merely redundant, but
+    /// on a TimescaleDB hypertable a ctid is unique only WITHIN a chunk, so a bare <c>ctid IN (…)</c> could
+    /// match a same-ctid row in a DIFFERENT chunk; the outer <c>{col} &lt; $1</c> guarantees only
+    /// genuinely-expired rows are ever deleted, so a colliding fresh row is always safe. In production this
+    /// path only ever runs on plain tables anyway (hypertables purge via <c>drop_chunks</c>; collection_log is
+    /// never a hypertable), but the guard keeps the statement correct even against a store where a collector
+    /// table happens to be a hypertable. <c>$1</c> is bound once and referenced by both positions.
+    /// Table/column come from catalog constants (never user input), so interpolation is safe.
+    /// </summary>
+    internal static string BatchedDeleteSql(string table, string timeColumn)
+        => $"DELETE FROM {table} WHERE {timeColumn} < $1 AND ctid IN (SELECT ctid FROM {table} WHERE {timeColumn} < $1 LIMIT {DeleteBatchSize})";
 
     /// <summary>
     /// The Timescale purge statement for one collector table — <c>drop_chunks</c> detaches every
@@ -198,7 +280,14 @@ public static class DarlingRetention
         }
     }
 
-    /// <summary>One table's DELETE; null when it failed (warned, sweep continues).</summary>
+    /// <summary>
+    /// One table's batched DELETE: re-executes <paramref name="deleteSql"/> (a <see cref="BatchedDeleteSql"/>
+    /// statement capped at <see cref="DeleteBatchSize"/> rows) until a batch clears fewer rows than the cap —
+    /// i.e. the table is drained. Returns the total rows deleted across all batches, or null when it failed
+    /// (warned, sweep continues). Batching bounds lock/WAL/dead-tuple growth on a large first purge; a small
+    /// steady-state purge finishes in one batch. The connection and command (with its single bound cutoff
+    /// parameter) are reused across the loop.
+    /// </summary>
     private static async Task<int?> PurgeOneAsync(
         NpgsqlDataSource postgres,
         string tableName,
@@ -212,7 +301,22 @@ public static class DarlingRetention
             await using var connection = await postgres.OpenConnectionAsync(cancellationToken);
             using var command = new NpgsqlCommand(deleteSql, connection) { CommandTimeout = DeleteTimeoutSeconds };
             command.Parameters.AddWithValue(cutoff);
-            return await command.ExecuteNonQueryAsync(cancellationToken);
+
+            var totalDeleted = 0;
+            while (true)
+            {
+                var deleted = await command.ExecuteNonQueryAsync(cancellationToken);
+                totalDeleted += deleted;
+
+                /* A batch that clears fewer than the cap means no expired rows remain — the table is drained.
+                   A full-cap batch means there may be more, so go again. */
+                if (deleted < DeleteBatchSize)
+                {
+                    break;
+                }
+            }
+
+            return totalDeleted;
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingRetention.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingRetention.cs
@@ -176,10 +176,7 @@ public static class DarlingRetention
                their statement writes WARNING (the per-table failures were already logged + isolated above).
                Fleet-wide, so it lands under the sentinel server_id (DarlingObservability.LogRetentionRunAsync),
                which is failure-isolated and never breaks the loop. */
-            var status = tablesFailed == 0 ? "SUCCESS" : "WARNING";
-            var message = tablesFailed == 0
-                ? $"Purged {tablesPurged.ToString(CultureInfo.InvariantCulture)} table(s): {totalRowsDeleted.ToString(CultureInfo.InvariantCulture)} row(s) deleted, {totalChunksDropped.ToString(CultureInfo.InvariantCulture)} chunk(s) dropped"
-                : $"Purged {tablesPurged.ToString(CultureInfo.InvariantCulture)} table(s), {tablesFailed.ToString(CultureInfo.InvariantCulture)} failed (see prior warnings): {totalRowsDeleted.ToString(CultureInfo.InvariantCulture)} row(s) deleted, {totalChunksDropped.ToString(CultureInfo.InvariantCulture)} chunk(s) dropped";
+            var (status, message) = BuildRunRecordSummary(tablesPurged, totalRowsDeleted, totalChunksDropped, tablesFailed);
             await DarlingObservability.LogRetentionRunAsync(
                 postgres, status, summary.TotalPurged, sw.ElapsedMilliseconds, message, logger, cancellationToken);
 
@@ -202,6 +199,22 @@ public static class DarlingRetention
                 postgres, "ERROR", totalRowsDeleted + totalChunksDropped, sw.ElapsedMilliseconds, ex.Message, logger, cancellationToken);
             return new PurgeSummary(tablesPurged, totalRowsDeleted, totalChunksDropped);
         }
+    }
+
+    /// <summary>
+    /// The status + human message for the auditable run-record of a completed sweep (not the exception path,
+    /// which writes a literal ERROR): SUCCESS when every table purged cleanly, WARNING when
+    /// <paramref name="tablesFailed"/> &gt; 0 (some table's statement failed — already logged + isolated).
+    /// Pure so the SUCCESS/WARNING branch and the message text are unit-testable without a live store.
+    /// </summary>
+    internal static (string Status, string Message) BuildRunRecordSummary(
+        int tablesPurged, int totalRowsDeleted, int totalChunksDropped, int tablesFailed)
+    {
+        var status = tablesFailed == 0 ? "SUCCESS" : "WARNING";
+        var message = tablesFailed == 0
+            ? $"Purged {tablesPurged.ToString(CultureInfo.InvariantCulture)} table(s): {totalRowsDeleted.ToString(CultureInfo.InvariantCulture)} row(s) deleted, {totalChunksDropped.ToString(CultureInfo.InvariantCulture)} chunk(s) dropped"
+            : $"Purged {tablesPurged.ToString(CultureInfo.InvariantCulture)} table(s), {tablesFailed.ToString(CultureInfo.InvariantCulture)} failed (see prior warnings): {totalRowsDeleted.ToString(CultureInfo.InvariantCulture)} row(s) deleted, {totalChunksDropped.ToString(CultureInfo.InvariantCulture)} chunk(s) dropped";
+        return (status, message);
     }
 
     /// <summary>
@@ -302,21 +315,7 @@ public static class DarlingRetention
             using var command = new NpgsqlCommand(deleteSql, connection) { CommandTimeout = DeleteTimeoutSeconds };
             command.Parameters.AddWithValue(cutoff);
 
-            var totalDeleted = 0;
-            while (true)
-            {
-                var deleted = await command.ExecuteNonQueryAsync(cancellationToken);
-                totalDeleted += deleted;
-
-                /* A batch that clears fewer than the cap means no expired rows remain — the table is drained.
-                   A full-cap batch means there may be more, so go again. */
-                if (deleted < DeleteBatchSize)
-                {
-                    break;
-                }
-            }
-
-            return totalDeleted;
+            return await DrainBatchesAsync(ct => command.ExecuteNonQueryAsync(ct), DeleteBatchSize, cancellationToken);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -324,6 +323,31 @@ public static class DarlingRetention
             logger?.LogWarning("Retention purge failed for {Table}: {Message}", tableName, ex.Message);
             return null;
         }
+    }
+
+    /// <summary>
+    /// Repeatedly runs <paramref name="executeBatch"/> (one capped batched-DELETE execution, returning its
+    /// rows-affected) and sums the total, stopping when a batch clears fewer than <paramref name="batchSize"/>
+    /// rows — i.e. no expired rows remain and the table is drained. A full-cap batch means there may be more,
+    /// so it goes again; an exact multiple of the cap terminates on the following empty batch. Pure over the
+    /// injected executor so the loop-again + termination is unit-testable without a live store.
+    /// </summary>
+    internal static async Task<int> DrainBatchesAsync(
+        Func<CancellationToken, Task<int>> executeBatch, int batchSize, CancellationToken cancellationToken)
+    {
+        var totalDeleted = 0;
+        while (true)
+        {
+            var deleted = await executeBatch(cancellationToken);
+            totalDeleted += deleted;
+
+            if (deleted < batchSize)
+            {
+                break;
+            }
+        }
+
+        return totalDeleted;
     }
 }
 

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingSelfAlertEvaluator.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingSelfAlertEvaluator.cs
@@ -401,15 +401,42 @@ internal sealed class DarlingSelfAlertEvaluator
     }
 
     /// <summary>
+    /// The isolating entry point the worker's disk-pressure sweep calls — the fleet-level twin of
+    /// <see cref="EvaluateStoreAlertsAsync"/> for the store-polled conditions. Wraps
+    /// <see cref="ApplyDiskPressureAsync"/> in the SAME failure isolation the sibling store-alerts use, so a
+    /// throwing seam — most notably the pre-deliver mute check (<c>_isAlertMuted</c> → a mute rule's
+    /// <c>Matches</c>), which unlike Deliver/RecordResolution is NOT internally isolated — can never propagate
+    /// out of the (otherwise un-guarded) collection sweep loop and stop collection for the whole fleet.
+    /// Cancellation still propagates.
+    /// </summary>
+    public async Task EvaluateDiskPressureAsync(
+        long? freeBytes, long? totalBytes, long? storeSizeBytes, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await ApplyDiskPressureAsync(freeBytes, totalBytes, storeSizeBytes, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError("Store disk-pressure self-alert failed: {Message}", ex.Message);
+        }
+    }
+
+    /// <summary>
     /// Edge-applies the fleet-level Store Disk Pressure condition from a store-volume sample: fire once on
     /// entry, re-fire only after the alert cooldown while it persists, and write ONE "Store Disk Pressure
     /// Resolved" history row on recovery (mirrors the per-server conditions' edge shape). Gated on the master
     /// alerts switch. NO-OPS when free/total are null — a remote BYO store whose volume the service can't see —
     /// so it never false-alarms; the managed store's own volume is what it exists to protect.
     /// <paramref name="storeSizeBytes"/> (pg_database_size) is context for the alert text only, never the
-    /// trigger. Testable directly with a recording deliverer + a controllable clock.
+    /// trigger. Internal (tested directly, like the sibling Apply methods); the worker calls the isolating
+    /// <see cref="EvaluateDiskPressureAsync"/>. Testable directly with a recording deliverer + a controllable clock.
     /// </summary>
-    public async Task ApplyDiskPressureAsync(
+    internal async Task ApplyDiskPressureAsync(
         long? freeBytes, long? totalBytes, long? storeSizeBytes, CancellationToken cancellationToken)
     {
         if (!_settings.AlertsEnabled)

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingSelfAlertEvaluator.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingSelfAlertEvaluator.cs
@@ -22,10 +22,11 @@ namespace PerformanceMonitor.Darling.Service;
 /// <summary>
 /// Stage 4 of the Darling control plane — the SERVICE's self-alerts: the "is my collection actually
 /// working" conditions that matter most for an unattended 24/7 headless service where nobody is
-/// watching a dashboard. Three conditions, each a reframe of a Dashboard health check onto Darling's
-/// own signals, all routed through the SAME <see cref="IAlertDeliverer"/> the shared alert engine
-/// uses (so they inherit its email/webhook delivery, per-fingerprint delivery cooldown, and restart
-/// replay) and the SAME <c>config_alert_log</c> history store:
+/// watching a dashboard. Four conditions — the first three reframe a Dashboard health check onto Darling's
+/// own signals; the fourth (Store Disk Pressure) is net-new and guards the service's OWN store — all routed
+/// through the SAME <see cref="IAlertDeliverer"/> the shared alert engine uses (so they inherit its
+/// email/webhook delivery, per-fingerprint delivery cooldown, and restart replay) and the SAME
+/// <c>config_alert_log</c> history store:
 /// <list type="number">
 /// <item><b>Collection Stopped / collector failure</b> — the server's <c>collection_log</c> shows no
 ///   SUCCESS within a staleness window OR the last N runs all failed (reframes the Dashboard's
@@ -39,15 +40,22 @@ namespace PerformanceMonitor.Darling.Service;
 /// <item><b>Capture Down</b> — a missing/denied blocking-deadlock XE session, surfaced from the
 ///   <c>SESSION_MISSING</c> collection_log status the tolerant XE readers now write (reframes the
 ///   Dashboard's #1086 "Capture Down", <c>NocHealth.GetMissingCaptureSessionsAsync</c>).</item>
+/// <item><b>Store Disk Pressure</b> — the volume hosting the Darling store is nearly full. Unlike the
+///   other three (per monitored server), this is a FLEET-level condition polled once per sweep from the
+///   store itself (<c>pg_database_size</c> for context) and the store volume's free space: when a headless
+///   service's disk fills, collection and every write stop for the WHOLE fleet, and nobody is watching. The
+///   flagship-appropriate maintenance backstop the daily time-based purge otherwise lacks — deliberately
+///   NOT Lite's 512MB archive-then-reset (Postgres has no single-file INSERT cliff, and a blanket reset
+///   would nuke every tenant of the shared store).</item>
 /// </list>
 /// Each condition is EDGE-TRIGGERED (in-memory active flag + the shared alert cooldown for the polled
 /// conditions; a per-server connection state machine for the connect edge) so it fires once on the
 /// transition, not every sweep — exactly the Dashboard's <c>_activeXAlert</c>/<c>_lastXAlert</c> shape.
-/// On recovery a "…Resumed"/"…Restored" row is written to alert history (closing the audit loop the
-/// same way the engine's resolution callback now does — see <see cref="BuildResolutionRecord"/>).
+/// On recovery a "…Resumed"/"…Restored"/"…Resolved" row is written to alert history (closing the audit loop
+/// the same way the engine's resolution callback now does — see <see cref="BuildResolutionRecord"/>).
 /// Gated on the master <c>alerts.enabled</c> switch — plus, for the connect edge, the V20
 /// <c>notify_connection_changes</c> toggle (Lite's <c>App.NotifyConnectionChanges</c> twin); the
-/// collection-stopped / capture-down thresholds stay sensible hardcoded defaults.
+/// collection-stopped / capture-down / disk-pressure thresholds stay sensible hardcoded defaults.
 /// </summary>
 internal sealed class DarlingSelfAlertEvaluator
 {
@@ -62,6 +70,15 @@ internal sealed class DarlingSelfAlertEvaluator
        faster than the staleness backstop when a connected server's collectors are erroring on every
        cycle. 10 spans a couple of minutes of total failure across the frequently-scheduled collectors. */
     internal const int ConsecutiveFailureThreshold = 10;
+
+    /* Store Disk Pressure fires when the store volume drops below this percent free — a percentage (not an
+       absolute floor) so it scales from a small managed box to a large fleet disk; 10% is the universal DBA
+       "act now" threshold for a database volume, and mirrors the shared engine's target-server low-disk
+       percent (LowDiskThresholdPercent). Percent-only by design (defaults over speculative config — a GB
+       floor is a trivial follow-up if an operator ever wants one). The condition no-ops when free space is
+       undeterminable (a remote BYO store), so it never false-alarms; the managed store's own volume is the
+       case it exists to protect. */
+    internal const double DiskFreeWarnPercent = 10.0;
 
     private readonly IAlertEngineSettings _settings;
     private readonly IAlertDeliverer _deliverer;
@@ -86,6 +103,16 @@ internal sealed class DarlingSelfAlertEvaluator
     private readonly ConcurrentDictionary<string, bool> _activeCaptureDown = new();
     private readonly ConcurrentDictionary<string, DateTime> _lastCaptureDownAlert = new();
     private readonly ConcurrentDictionary<string, ConnectionState> _connectionState = new();
+
+    /* Store Disk Pressure edge state. FLEET-level (one shared store, not per server), so it is keyed by a
+       single fixed sentinel (DiskKey) rather than a serverId — never dropped by Forget (that is per-server).
+       Dictionaries (not a plain bool) purely to reuse the same TryRemove-recovery + CooldownElapsed helpers
+       the per-server conditions use. */
+    private readonly ConcurrentDictionary<string, bool> _activeDiskPressure = new();
+    private readonly ConcurrentDictionary<string, DateTime> _lastDiskPressureAlert = new();
+
+    /// <summary>The fixed key for the fleet-level Store Disk Pressure edge (not a real server).</summary>
+    private const string DiskKey = "store";
 
     /* Whether the service has successfully connected to this server at least once THIS process-run. Guards
        collection-stopped: unlike the Dashboard (whose target-side collection_log keeps filling regardless of
@@ -346,6 +373,86 @@ internal sealed class DarlingSelfAlertEvaluator
         /* previous == Unknown → baseline only (no fire). */
     }
 
+    /* ---------------- store disk pressure (fleet-level, polled) ---------------- */
+
+    /// <summary>
+    /// Pure disk-pressure decision: the store volume is under pressure when its FREE space is below
+    /// <see cref="DiskFreeWarnPercent"/> of the volume total. No I/O, so it pins directly. A non-positive
+    /// total is treated as "can't tell" (false — the caller also guards this). The percentage scales across
+    /// disk sizes; see the constant for why it is percent-only.
+    /// </summary>
+    internal static bool IsDiskPressure(long freeBytes, long totalBytes, out string reason)
+    {
+        if (totalBytes <= 0)
+        {
+            reason = "";
+            return false;
+        }
+
+        double percentFree = (double)freeBytes / totalBytes * 100.0;
+        if (percentFree < DiskFreeWarnPercent)
+        {
+            reason = $"The monitor store's disk volume has only {percentFree.ToString("0.#", CultureInfo.InvariantCulture)}% free ({FormatGb(freeBytes)} of {FormatGb(totalBytes)}).";
+            return true;
+        }
+
+        reason = "";
+        return false;
+    }
+
+    /// <summary>
+    /// Edge-applies the fleet-level Store Disk Pressure condition from a store-volume sample: fire once on
+    /// entry, re-fire only after the alert cooldown while it persists, and write ONE "Store Disk Pressure
+    /// Resolved" history row on recovery (mirrors the per-server conditions' edge shape). Gated on the master
+    /// alerts switch. NO-OPS when free/total are null — a remote BYO store whose volume the service can't see —
+    /// so it never false-alarms; the managed store's own volume is what it exists to protect.
+    /// <paramref name="storeSizeBytes"/> (pg_database_size) is context for the alert text only, never the
+    /// trigger. Testable directly with a recording deliverer + a controllable clock.
+    /// </summary>
+    public async Task ApplyDiskPressureAsync(
+        long? freeBytes, long? totalBytes, long? storeSizeBytes, CancellationToken cancellationToken)
+    {
+        if (!_settings.AlertsEnabled)
+        {
+            return;
+        }
+
+        /* Can't determine the store volume's free space (remote BYO store, or the drive was not ready) — no
+           signal, so neither fire nor clear a standing alert. */
+        if (freeBytes is not long free || totalBytes is not long total || total <= 0)
+        {
+            return;
+        }
+
+        var now = _utcNow();
+        bool pressure = IsDiskPressure(free, total, out var reason);
+
+        if (pressure)
+        {
+            _activeDiskPressure[DiskKey] = true;
+            if (CooldownElapsed(_lastDiskPressureAlert, DiskKey, now))
+            {
+                _lastDiskPressureAlert[DiskKey] = now;
+                var storeText = storeSizeBytes is long size ? $" The store currently holds {FormatGb(size)}." : "";
+                await FireAsync(
+                    DiskKey, "Monitor Store", "Store Disk Pressure", reason,
+                    $"{DiskFreeWarnPercent.ToString("0.#", CultureInfo.InvariantCulture)}% free",
+                    detail: reason + storeText + " When the store volume fills, collection and every write stop " +
+                        "for the WHOLE fleet, and a headless service has no dashboard to warn you. Free space on the " +
+                        "store volume, shorten retention (config_collector_schedules), enable TimescaleDB compression, " +
+                        "or move the store to a larger disk.",
+                    severity: AlertSeverityLevel.Critical,
+                    shortMessage: reason, cancellationToken);
+            }
+        }
+        else if (_activeDiskPressure.TryRemove(DiskKey, out var was) && was)
+        {
+            await RecordResolutionAsync(new AlertResolution(
+                DiskKey, "Monitor Store", "Store Disk Pressure",
+                "Store Disk Pressure Resolved", "Monitor store volume free space recovered"), cancellationToken);
+        }
+    }
+
     /// <summary>Drops all edge state for a server removed from the monitored set (reconcile), so a later
     /// re-add starts fresh at the Unknown baseline rather than inheriting a stale connection/active flag.</summary>
     public void Forget(int serverId)
@@ -496,4 +603,8 @@ ORDER BY x.collector_name", connection);
         || now - last >= TimeSpan.FromMinutes(_settings.CooldownMinutes);
 
     private static string Key(int serverId) => serverId.ToString(CultureInfo.InvariantCulture);
+
+    /// <summary>Human-readable GiB for disk-pressure alert text (binary GiB, 2 dp).</summary>
+    private static string FormatGb(long bytes) =>
+        (bytes / 1024.0 / 1024.0 / 1024.0).ToString("0.##", CultureInfo.InvariantCulture) + " GB";
 }

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -11,6 +11,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Threading;
@@ -66,6 +67,11 @@ public sealed class DarlingWorker : BackgroundService
        (a test_connect against an unreachable host can block for the connect timeout) never starves
        collection — the two loops share a cancellation token and the guarded server set only. */
     private static readonly TimeSpan s_commandPollInterval = TimeSpan.FromSeconds(5);
+
+    /* The store disk-pressure self-alert's poll cadence (fleet-level, Stage 4). Disk fills slowly, and the
+       check is one pg_database_size + one DriveInfo syscall, so 5 minutes is ample and cheap — no need to
+       run it on the 30-second alert sweep. */
+    private static readonly TimeSpan s_diskCheckInterval = TimeSpan.FromMinutes(5);
 
     /* The analysis pipeline's per-run budget — Lite's App default hardcoded (AnalysisTimeoutSeconds
        120; not a control-plane knob). The CADENCE (interval), the enabled gate, and the notify gate
@@ -168,6 +174,10 @@ public sealed class DarlingWorker : BackgroundService
 
     /* MinValue = the first sweep after startup runs the retention purge, then daily. */
     private DateTime _nextPurgeUtc = DateTime.MinValue;
+
+    /* MinValue = the first sweep after startup evaluates the store disk-pressure self-alert, then every
+       s_diskCheckInterval. Fleet-level (one shared store), so it is a single field, not per-server. */
+    private DateTime _nextDiskCheckUtc = DateTime.MinValue;
 
     /* Set once at startup by the TimescaleSupport detection (cached per data source — the
        extension can't appear or vanish under a running service without a restart anyway);
@@ -625,6 +635,16 @@ public sealed class DarlingWorker : BackgroundService
                 await new PgFindingStore(postgres, _logger).CleanupOldFindingsAsync(retentionDays: 30);
             }
 
+            /* Stage 4 fleet-level self-alert: the store disk-pressure backstop. The daily purge is the ONLY
+               other maintenance cadence and it is purely time-based (no disk-free check), so on its own the
+               store can still fill between purges — this edge-fired condition is the flagship-appropriate
+               backstop. Own slow cadence; the master alerts gate + edge-trigger live inside the evaluator. */
+            if (DateTime.UtcNow >= _nextDiskCheckUtc)
+            {
+                _nextDiskCheckUtc = DateTime.UtcNow.Add(s_diskCheckInterval);
+                await EvaluateStoreDiskPressureAsync(config, stoppingToken);
+            }
+
             try
             {
                 await Task.Delay(s_sweepInterval, stoppingToken);
@@ -1017,6 +1037,68 @@ LIMIT 1", connection);
 
         double? totalCpu = sqlCpu.HasValue ? sqlCpu.Value + (otherCpu ?? 0) : null;
         return (sqlCpu, totalCpu);
+    }
+
+    /// <summary>
+    /// Gathers the store disk-pressure sample and hands it to the Stage 4 evaluator (fleet-level). The store
+    /// size (<c>pg_database_size</c>, context only) is always readable; the store volume's free/total space is
+    /// resolved from the MANAGED data directory's drive — the bundled store this service owns and must protect.
+    /// In bring-your-own mode the store can be a remote Postgres whose disk the service cannot see, so
+    /// free/total stay null and the evaluator no-ops (never a false alarm — the operator owns their own
+    /// PostgreSQL's disk monitoring, consistent with the BYO posture elsewhere). Failure-isolated: a bad
+    /// sample logs at Debug and skips this tick, never breaking the loop.
+    /// </summary>
+    private async Task EvaluateStoreDiskPressureAsync(DarlingConfig config, CancellationToken cancellationToken)
+    {
+        long? storeSizeBytes = await ReadStoreSizeBytesAsync(cancellationToken);
+
+        long? freeBytes = null;
+        long? totalBytes = null;
+        if (config.Postgres.Managed && OperatingSystem.IsWindows())
+        {
+            try
+            {
+                var dataDirectory = DarlingManagedPostgres.ResolveDataDirectory(config.Postgres);
+                var root = Path.GetPathRoot(Path.GetFullPath(dataDirectory));
+                if (!string.IsNullOrEmpty(root))
+                {
+                    var drive = new DriveInfo(root);
+                    if (drive.IsReady)
+                    {
+                        freeBytes = drive.TotalFreeSpace;
+                        totalBytes = drive.TotalSize;
+                    }
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                /* Best-effort: an unreadable drive just means no disk signal this tick. */
+                _logger.LogDebug("Store disk-pressure check: could not read the store volume free space: {Message}", ex.Message);
+            }
+        }
+
+        await _selfAlerts!.ApplyDiskPressureAsync(freeBytes, totalBytes, storeSizeBytes, cancellationToken);
+    }
+
+    /// <summary>
+    /// The store database's on-disk size in bytes (<c>pg_database_size</c>) — context for the disk-pressure
+    /// alert text, the same read the Viewer's status bar uses. Failure-isolated to null (Debug) so a transient
+    /// store hiccup never breaks the disk-pressure check.
+    /// </summary>
+    private async Task<long?> ReadStoreSizeBytesAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var connection = await _postgres!.OpenConnectionAsync(cancellationToken);
+            using var command = new NpgsqlCommand("SELECT pg_database_size(current_database())", connection);
+            var result = await command.ExecuteScalarAsync(cancellationToken);
+            return result is null || result == DBNull.Value ? null : Convert.ToInt64(result, CultureInfo.InvariantCulture);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogDebug("Store disk-pressure check: could not read pg_database_size: {Message}", ex.Message);
+            return null;
+        }
     }
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -1077,7 +1077,11 @@ LIMIT 1", connection);
             }
         }
 
-        await _selfAlerts!.ApplyDiskPressureAsync(freeBytes, totalBytes, storeSizeBytes, cancellationToken);
+        /* EvaluateDiskPressureAsync (not ApplyDiskPressureAsync) so a throwing seam — e.g. a mute rule's
+           Matches() in the pre-deliver mute check — is isolated inside the evaluator, exactly like the
+           per-server EvaluateStoreAlertsAsync. This sweep-loop body has no catch-all of its own, so an
+           un-isolated throw here would stop collection for the whole fleet. */
+        await _selfAlerts!.EvaluateDiskPressureAsync(freeBytes, totalBytes, storeSizeBytes, cancellationToken);
     }
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ServerStatus.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ServerStatus.cs
@@ -27,10 +27,14 @@ public sealed partial class ViewerDataService
     /// Newest collection time per server across all collectors, in one pass — the sidebar dots and the
     /// status bar's collection field derive freshness from this (the same <c>MAX(collection_time)</c> the
     /// Overview cards use per server, so a dot and its card agree). Timestamps are the store's naive UTC.
+    /// Excludes <c>server_id = 0</c>, the fleet-level retention run-record sentinel
+    /// (<c>DarlingObservability.FleetServerId</c>) — it is not a real server, so it must not appear as a
+    /// phantom key a future key-iterating consumer could render as "server 0".
     /// </summary>
     public const string ServerFreshnessSql = @"
 SELECT server_id, MAX(collection_time)
 FROM v_collection_log
+WHERE server_id <> 0
 GROUP BY server_id";
 
     /// <summary>The store's on-disk size in bytes (status-bar Database field). No parameters.</summary>


### PR DESCRIPTION
Small fleet-hardening fixes from the Darling scout **maintenance/retention** batch (Tier-1 items 9, 10, 12 + the Tier-2 disk-pressure backstop). No new collection, no schema migration, no new UI surface.

## What changed

### 1. Retention purge writes an auditable `collection_log` run-record
`PurgeAsync` was invisible — it logged only to `ILogger` and its return was discarded, so a stalled purge was caught only when *inserts* started failing. It now writes one `data_retention` run-record per sweep (Dashboard parity) with status **SUCCESS / WARNING** (some tables failed their statement, already logged + isolated) **/ ERROR** (unexpected throw).

- **Sentinel caveat handled:** `collection_log.server_id` is `NOT NULL` and Collection Health reads per real `server_id`, but the purge is fleet-wide. The row is written under a reserved `DarlingObservability.FleetServerId = 0` — never a real server (server_ids are FNV-1a hashes; also never in `config_monitored_servers`). It is therefore **excluded** from the fleet aggregate (`server_id IN config_monitored_servers WHERE is_enabled`), never matched by any per-server read, yet fully **auditable** via `v_collection_log WHERE collector_name = 'data_retention'`. No new UI surface.
- `PurgeAsync` is now wrapped so an unexpected throw records an ERROR row and returns — it must never throw at the daily caller (which is unwrapped), so a broken purge is an auditable row, not a crashed loop. Cancellation still propagates.

### 2. `collection_log` kept at 2× the base window (30 → 60 days)
Mirrors the Dashboard's `retention_date x2`, so a run-record outlives the metric rows it explains — you can still diagnose *why* a collector failed after its data ages out.

### 3. Batched plain-PG purge
The single unbatched `DELETE` becomes a `ctid IN (SELECT ... LIMIT 10000)` loop (the Postgres twin of the Dashboard's `DELETE TOP(10000)`), bounding lock/WAL/dead-tuple growth on a large first purge. **Hypertable-safe:** the time predicate is repeated in the OUTER delete (`WHERE col < $1 AND ctid IN (...)`) so a hypertable's per-chunk ctid can never delete a fresh row in another chunk. In production this path only runs on plain tables anyway (hypertables purge via `drop_chunks`; `collection_log` is never a hypertable). *(Flag below.)*

### 4. Store disk-pressure self-alert backstop
Darling's only maintenance cadence was the daily *time-based* purge with **no disk check**, so the shared store could still fill between purges. A new **fleet-level, edge-fired** condition in the existing `DarlingSelfAlertEvaluator` polls the managed store volume's free space (`pg_database_size` for context) every 5 min and fires **Critical below 10% free**, clearing on recovery — same edge/cooldown/resolution shape as the other self-alerts. **No-ops when free space is undeterminable** (remote BYO store) so it never false-alarms; BYO operators own their own Postgres disk monitoring (consistent with the BYO posture elsewhere). Deliberately **not** Lite's 512MB archive-then-reset (Postgres has no single-file INSERT cliff; a blanket reset would nuke every tenant of the shared store).

## Tests
Pure logic as required: retention-day math (`CollectionLogRetention_IsTwiceTheBaseWindow`), batched-delete SQL shape (`DeleteSql_BatchesOnEachDefinitionsOwnTimeColumn`), disk-pressure threshold (`IsDiskPressure_*`). Plus disk-pressure edge behavior (fire-once/cooldown/re-fire, recovery resolution row, undeterminable→no-fire, disabled→no-fire) and the gated e2e updated for the 60-day horizon + a run-record assertion.

**Full `Darling.Tests` suite: 1835 passed, 0 failed, 127 skipped** (gated live tests). Service + test projects build with 0 errors.

## Flag (design decision, not a defect)
The batched delete uses `ctid`, which is only unique *within* a chunk on a TimescaleDB hypertable — a bare `ctid IN (...)` could cross-collide chunks and delete fresh rows. `TimescaleSupportTests` converts `wait_stats` to a hypertable in the shared dev store and never reverts it, so the gated retention e2e could exercise this. Resolved by repeating the `col < $1` guard in the outer delete (safe on plain tables and hypertables; correct in production regardless). Called out in case a future reader wonders why the predicate is doubled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)