### PR TITLE
Darling viewer: fleet-usability conveniences (timeout, silence, bulk reset, refresh knob)

### DIFF
--- a/Darling/Darling.Tests/ViewerAppSettingsStoreTests.cs
+++ b/Darling/Darling.Tests/ViewerAppSettingsStoreTests.cs
@@ -47,6 +47,7 @@ public sealed class ViewerAppSettingsStoreTests : IDisposable
         Assert.False(settings.McpEnabled);
         Assert.Equal(5152, settings.McpPort);
         Assert.Equal(5, settings.ConnectionTimeoutSeconds);
+        Assert.Equal(30, settings.NocRefreshIntervalSeconds);
         Assert.Equal("ServerTime", settings.TimeDisplayMode);
         Assert.True(settings.AlertsEnabled);
         Assert.Equal(80, settings.AlertCpuThreshold);
@@ -70,6 +71,7 @@ public sealed class ViewerAppSettingsStoreTests : IDisposable
             McpEnabled = true,
             McpPort = 5200,
             ConnectionTimeoutSeconds = 30,
+            NocRefreshIntervalSeconds = 120,
             CsvSeparator = ";",
             TimeDisplayMode = "UTC",
             AlertsEnabled = false,
@@ -106,6 +108,7 @@ public sealed class ViewerAppSettingsStoreTests : IDisposable
         Assert.True(reloaded.McpEnabled);
         Assert.Equal(5200, reloaded.McpPort);
         Assert.Equal(30, reloaded.ConnectionTimeoutSeconds);
+        Assert.Equal(120, reloaded.NocRefreshIntervalSeconds);
         Assert.Equal(";", reloaded.CsvSeparator);
         Assert.Equal("UTC", reloaded.TimeDisplayMode);
         Assert.False(reloaded.AlertsEnabled);
@@ -147,6 +150,7 @@ public sealed class ViewerAppSettingsStoreTests : IDisposable
             {
               "McpPort": 0,
               "ConnectionTimeoutSeconds": 1,
+              "NocRefreshIntervalSeconds": 9999,
               "AlertCpuThreshold": 999,
               "AlertCpuMode": "Bogus",
               "AlertLongRunningQueryMaxResults": 99999,
@@ -164,6 +168,7 @@ public sealed class ViewerAppSettingsStoreTests : IDisposable
 
         Assert.Equal(5152, settings.McpPort);                 // 0 (unset) -> Darling default
         Assert.Equal(5, settings.ConnectionTimeoutSeconds);   // below min 5 -> 5
+        Assert.Equal(600, settings.NocRefreshIntervalSeconds); // above max 600 -> 600
         Assert.Equal(100, settings.AlertCpuThreshold);        // above max 100 -> 100
         Assert.Equal("Total", settings.AlertCpuMode);         // unknown -> Total
         Assert.Equal(1000, settings.AlertLongRunningQueryMaxResults); // above max 1000 -> 1000

--- a/Darling/Darling.Tests/ViewerControlPlaneStage3bTests.cs
+++ b/Darling/Darling.Tests/ViewerControlPlaneStage3bTests.cs
@@ -250,6 +250,16 @@ public sealed class ViewerCollectorSchedulesSqlTests
         Assert.Contains("DELETE FROM config_collector_schedules WHERE server_id = $1",
             ViewerDataService.CollectorScheduleDeleteServerScopeSql, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void DeleteAllServerScopesSql_ClearsEveryPerServerOverride_ButNotTheFleetDefault()
+    {
+        /* The "Apply Default to All" bulk reset deletes every per-server row (server_id IS NOT NULL) in one
+           statement and must leave the fleet-wide default (server_id IS NULL) untouched. */
+        var sql = ViewerDataService.CollectorScheduleDeleteAllServerScopesSql;
+        Assert.Contains("DELETE FROM config_collector_schedules WHERE server_id IS NOT NULL", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("server_id IS NULL", sql, StringComparison.Ordinal);
+    }
 }
 
 /// <summary>The pure store↔editor overlay + the preset table (ported from Lite, frequency-only).</summary>

--- a/Darling/Darling.Tests/ViewerDataServiceTests.cs
+++ b/Darling/Darling.Tests/ViewerDataServiceTests.cs
@@ -546,3 +546,57 @@ public sealed class ViewerReadOnlyDegradationTests
                 () => Task.FromResult<ServiceConfigRow?>(new ServiceConfigRow())));
     }
 }
+
+/// <summary>
+/// Pins the connection-timeout application (the formerly-dead <c>ConnectionTimeoutSeconds</c> knob): the viewer's
+/// preference is applied to the store connection string as Npgsql's connect <c>Timeout</c> — set on the
+/// managed-derived string (which carries none) and appended to a BYO string only when the operator did not
+/// already specify one. Pure string logic (no live Postgres), the same discipline as the SQL-const pins.
+/// </summary>
+public sealed class ViewerConnectionTimeoutTests
+{
+    [Fact]
+    public void ApplyConnectionTimeout_ManagedStyleStringWithoutTimeout_SetsThePreference()
+    {
+        /* The managed-derived shape (DarlingManagedPostgres): no Timeout key, so the preference is applied. */
+        const string managed =
+            "Host=127.0.0.1;Port=5641;Username=admin;Password=secret;Database=darling;Search Path=collect,config,public";
+
+        var result = ViewerDataService.ApplyConnectionTimeout(managed, 42);
+
+        var builder = new NpgsqlConnectionStringBuilder(result);
+        Assert.Equal(42, builder.Timeout);
+        /* Every other setting is preserved. */
+        Assert.Equal("127.0.0.1", builder.Host);
+        Assert.Equal(5641, builder.Port);
+        Assert.Equal("darling", builder.Database);
+    }
+
+    [Fact]
+    public void ApplyConnectionTimeout_ByoStringWithoutTimeout_AppendsThePreference()
+    {
+        var result = ViewerDataService.ApplyConnectionTimeout("Host=db.corp;Port=5432;Database=darling", 30);
+
+        var builder = new NpgsqlConnectionStringBuilder(result);
+        Assert.Equal(30, builder.Timeout);
+        Assert.Equal("db.corp", builder.Host);
+    }
+
+    [Fact]
+    public void ApplyConnectionTimeout_ByoStringWithExplicitTimeout_LeavesTheOperatorsValue()
+    {
+        /* The operator's explicit Timeout in a BYO connection string wins — the preference must not override it. */
+        var result = ViewerDataService.ApplyConnectionTimeout("Host=db.corp;Database=darling;Timeout=25", 5);
+
+        Assert.Equal(25, new NpgsqlConnectionStringBuilder(result).Timeout);
+    }
+
+    [Fact]
+    public void ApplyConnectionTimeout_DetectsAnExistingTimeoutCaseInsensitively()
+    {
+        /* A lowercase keyword still counts as "already specified" (connection-string keys are case-insensitive). */
+        var result = ViewerDataService.ApplyConnectionTimeout("Host=db.corp;Database=darling;timeout=25", 5);
+
+        Assert.Equal(25, new NpgsqlConnectionStringBuilder(result).Timeout);
+    }
+}

--- a/Darling/Darling.Tests/ViewerDataServiceTests.cs
+++ b/Darling/Darling.Tests/ViewerDataServiceTests.cs
@@ -570,6 +570,11 @@ public sealed class ViewerConnectionTimeoutTests
         Assert.Equal("127.0.0.1", builder.Host);
         Assert.Equal(5641, builder.Port);
         Assert.Equal("darling", builder.Database);
+        /* Search Path is the load-bearing one: it resolves the bare table names to the collect/config schemas
+           on every connection, so if the base DbConnectionStringBuilder round-trip ever mangled it, every
+           managed-path query would silently break. Pin that it survives verbatim (the reason we detect + emit
+           via the base builder rather than NpgsqlConnectionStringBuilder). */
+        Assert.Equal("collect,config,public", builder.SearchPath);
     }
 
     [Fact]

--- a/Darling/Darling.Tests/ViewerServerSilenceTests.cs
+++ b/Darling/Darling.Tests/ViewerServerSilenceTests.cs
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using PerformanceMonitor.Darling.Viewer;
+using PerformanceMonitor.Notifications;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Pins the one-click "Silence This Server" / "Unsilence" logic (the sidebar shortcut over the multi-step
+/// Manage Mute Rules dialog): the whole-server silence rule it writes and the predicate "Unsilence" uses to find
+/// the rule(s) to remove. Pure domain logic (no WPF, no live Postgres) — the same discipline as the SQL pins.
+/// The rule is keyed on the server's DISPLAY name because that's what the alert engine's mute context and the
+/// alert rows carry (so the rule actually suppresses the alerts, matching the existing "Mute This Server").
+/// </summary>
+public sealed class ViewerServerSilenceTests
+{
+    [Fact]
+    public void BuildServerSilenceRule_ScopesToServer_WithNoNarrowingPatterns_AndNoExpiry()
+    {
+        var rule = ViewerDataService.BuildServerSilenceRule("Prod SQL 1");
+
+        Assert.Equal("Prod SQL 1", rule.ServerName);
+        Assert.True(rule.Enabled);
+        Assert.Null(rule.ExpiresAtUtc); /* indefinite — stays until Unsilence, mirroring Lite's per-server silence */
+        Assert.Equal(ViewerDataService.ServerSilenceReason, rule.Reason);
+
+        /* Every other pattern is null so the rule matches EVERY alert for the server. */
+        Assert.Null(rule.MetricName);
+        Assert.Null(rule.DatabasePattern);
+        Assert.Null(rule.QueryTextPattern);
+        Assert.Null(rule.WaitTypePattern);
+        Assert.Null(rule.JobNamePattern);
+    }
+
+    [Fact]
+    public void BuildServerSilenceRule_MatchesEveryAlertForThatServer_ButNotOtherServers()
+    {
+        var rule = ViewerDataService.BuildServerSilenceRule("Prod SQL 1");
+
+        Assert.True(rule.Matches(new AlertMuteContext { ServerName = "Prod SQL 1", MetricName = "High CPU" }));
+        Assert.True(rule.Matches(new AlertMuteContext { ServerName = "Prod SQL 1", MetricName = "Deadlocks Detected" }));
+        Assert.False(rule.Matches(new AlertMuteContext { ServerName = "Prod SQL 2", MetricName = "High CPU" }));
+    }
+
+    [Fact]
+    public void IsWholeServerSilence_TrueForABlanketServerRule_CaseInsensitiveOnTheName()
+    {
+        var rule = ViewerDataService.BuildServerSilenceRule("Prod SQL 1");
+
+        Assert.True(ViewerDataService.IsWholeServerSilence(rule, "Prod SQL 1"));
+        Assert.True(ViewerDataService.IsWholeServerSilence(rule, "prod sql 1")); /* name compare is case-insensitive */
+    }
+
+    [Fact]
+    public void IsWholeServerSilence_FalseForADifferentServer()
+    {
+        var rule = ViewerDataService.BuildServerSilenceRule("Prod SQL 1");
+
+        Assert.False(ViewerDataService.IsWholeServerSilence(rule, "Prod SQL 2"));
+    }
+
+    [Fact]
+    public void IsWholeServerSilence_FalseForANarrowedRule_SoUnsilenceLeavesSpecificMutesAlone()
+    {
+        /* A rule the operator authored to mute only ONE metric on the server is NOT a whole-server silence, so
+           "Unsilence" must not remove it. */
+        var narrowed = new MuteRule { ServerName = "Prod SQL 1", MetricName = "High CPU" };
+
+        Assert.False(ViewerDataService.IsWholeServerSilence(narrowed, "Prod SQL 1"));
+    }
+
+    [Fact]
+    public void IsWholeServerSilence_FalseForAMetricOnlyRule_WithNoServerScope()
+    {
+        /* A metric-only (all-servers) mute has no ServerName, so it's never a per-server silence. */
+        var metricOnly = new MuteRule { MetricName = "High CPU" };
+
+        Assert.False(ViewerDataService.IsWholeServerSilence(metricOnly, "Prod SQL 1"));
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/CollectorScheduleEditorWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/CollectorScheduleEditorWindow.xaml
@@ -90,9 +90,17 @@
         <TextBlock Grid.Row="5" Margin="0,8,0,0" FontSize="11" Foreground="{StaticResource DimTextBrush}" TextWrapping="Wrap"
                    Text="Every (min): 0 collects once on server load. Keep (days) must be at least 1. Changes apply on the service's next reload."/>
 
-        <StackPanel Grid.Row="6" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
-            <Button x:Name="SaveButton" Content="Save" Click="SaveButton_Click" Margin="0,0,8,0" MinWidth="80"/>
-            <Button Content="Cancel" Click="CancelButton_Click" MinWidth="80"/>
-        </StackPanel>
+        <DockPanel Grid.Row="6" Margin="0,12,0,0" LastChildFill="False">
+            <!-- Fleet-scale bulk reset: clears every server's per-server override in one write so they all fall
+                 back to the fleet-wide default (the shortcut over reverting servers one at a time). Confirmed +
+                 applied immediately, separate from the per-scope Save. -->
+            <Button x:Name="ApplyDefaultToAllButton" DockPanel.Dock="Left" Content="Apply Default to All Servers"
+                    Click="ApplyDefaultToAll_Click" MinWidth="80"
+                    ToolTip="Remove every server's custom schedule so they all follow the fleet-wide default"/>
+            <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
+                <Button x:Name="SaveButton" Content="Save" Click="SaveButton_Click" Margin="0,0,8,0" MinWidth="80"/>
+                <Button Content="Cancel" Click="CancelButton_Click" MinWidth="80"/>
+            </StackPanel>
+        </DockPanel>
     </Grid>
 </Window>

--- a/Darling/PerformanceMonitor.Darling.Viewer/CollectorScheduleEditorWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/CollectorScheduleEditorWindow.xaml.cs
@@ -57,6 +57,7 @@ public partial class CollectorScheduleEditorWindow : Window
         {
             ReadOnlyBanner.Visibility = Visibility.Visible;
             SaveButton.IsEnabled = false;
+            ApplyDefaultToAllButton.IsEnabled = false;
         }
 
         PopulateScopeCombos();
@@ -352,6 +353,64 @@ public partial class CollectorScheduleEditorWindow : Window
 
         error = "";
         return true;
+    }
+
+    /// <summary>
+    /// "Apply Default to All Servers" — the fleet-scale bulk reset: removes EVERY server's per-server schedule
+    /// override in one write (<see cref="ViewerDataService.ResetAllServerSchedulesAsync"/>) so they all fall back
+    /// to the fleet-wide default, the shortcut over reverting each server one at a time. The fleet-wide default
+    /// itself is untouched. Confirmed first (it clears every server's customization), then the editor re-reads so
+    /// the current scope reflects the reset.
+    /// </summary>
+    private async void ApplyDefaultToAll_Click(object sender, RoutedEventArgs e)
+    {
+        if (_dataService.IsReadOnly)
+        {
+            return;
+        }
+
+        var result = MessageBox.Show(
+            "Reset EVERY server to the fleet-wide default schedule?\n\n" +
+            "This removes all per-server schedule overrides; the fleet-wide default schedule is not changed. " +
+            "This can't be undone.",
+            "Apply Default to All Servers", MessageBoxButton.YesNo, MessageBoxImage.Warning);
+
+        if (result != MessageBoxResult.Yes)
+        {
+            return;
+        }
+
+        ApplyDefaultToAllButton.IsEnabled = false;
+        try
+        {
+            var removed = await _dataService.ResetAllServerSchedulesAsync();
+            Saved = true;
+
+            /* Re-read the overrides so the editor reflects the reset (every per-server row is now gone) and
+               reload the current scope's grid + preset detection. */
+            _allOverrides = await _dataService.GetCollectorSchedulesAsync();
+            LoadScopeSchedule();
+
+            StatusText.Text = removed > 0
+                ? $"Reset {removed} per-server schedule override(s) — every server now follows the fleet default."
+                : "No per-server overrides to reset — every server already follows the fleet default.";
+        }
+        catch (ViewerReadOnlyException ex)
+        {
+            MessageBox.Show(ex.Message, "Read-only connection", MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
+        catch (ViewerSchemaSkewException ex)
+        {
+            MessageBox.Show(ex.Message, "Store out of date", MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"Could not reset the schedules:\n\n{ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+        finally
+        {
+            ApplyDefaultToAllButton.IsEnabled = !_dataService.IsReadOnly;
+        }
     }
 
     private void CancelButton_Click(object sender, RoutedEventArgs e) => Close();

--- a/Darling/PerformanceMonitor.Darling.Viewer/FinOpsTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/FinOpsTab.xaml
@@ -12,7 +12,7 @@
         cross-server and lives ONCE here (no longer duplicated inside every server tab). The sub-tab content is
         the copy-parity FinOps surface relocated verbatim out of the per-server ViewerServerTab; only the
         server-selector header is new. The grids keep the hardcoded Dark styling (pure relocation); Only the
-        ACTIVE sub-tab loads (Lite's visible-only rule) and the shell's 60-second timer refreshes it.
+        ACTIVE sub-tab loads (Lite's visible-only rule) and the shell's fleet-refresh timer refreshes it.
     -->
     <UserControl.Resources>
         <Style x:Key="EmptyHint" TargetType="TextBlock">

--- a/Darling/PerformanceMonitor.Darling.Viewer/FinOpsTab.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/FinOpsTab.xaml.cs
@@ -133,7 +133,7 @@ public partial class FinOpsTab : UserControl
 
     /// <summary>
     /// Loads the ACTIVE FinOps sub-tab, with the overlap guard mirroring the per-server tab's
-    /// <c>RefreshActiveInnerTabAsync</c>. The shell calls this on tab activation and on its 60-second timer;
+    /// <c>RefreshActiveInnerTabAsync</c>. The shell calls this on tab activation and on its fleet-refresh timer;
     /// the sub-tab switch handler and the server selector call it too. If the sub-tab (or server) switches
     /// mid-load, the triggering event bounces off the guard and the running loop reloads once more, leaving no
     /// sub-tab stranded.

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.ServerManagement.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.ServerManagement.cs
@@ -344,6 +344,99 @@ public partial class MainWindow
         }
     }
 
+    // ── Server-row silence (one-click whole-server alert mute via a server-scoped MuteRule) ─────
+
+    /// <summary>
+    /// "Silence This Server" — writes a whole-server mute rule (see
+    /// <see cref="ViewerDataService.BuildServerSilenceRule"/>) the running Darling service honors on its next
+    /// config reload: every future alert for this server is flagged muted (channels skipped for email/Teams/Slack)
+    /// and so never toasts. The Darling shortcut over the multi-step Manage Mute Rules dialog, mirroring Lite's
+    /// one-click "Silence This Server". Idempotent: an existing active silence is reported, not duplicated. Keyed
+    /// on the server's DISPLAY name (what the alert engine's mute context + the alert rows carry). A read-only
+    /// seat / schema-skew / failure degrades to the friendly status message like the other server-row writes.
+    /// </summary>
+    private async void ServerContextMenu_Silence_Click(object sender, RoutedEventArgs e)
+    {
+        var server = GetServerFromContextMenu(sender);
+        if (server is null || _dataService is null)
+        {
+            return;
+        }
+
+        try
+        {
+            var rules = await _dataService.GetMuteRulesAsync();
+            if (rules.Any(r => ViewerDataService.IsWholeServerSilence(r, server.DisplayName) && r.Enabled && !r.IsExpired))
+            {
+                StatusText.Text = $"'{server.DisplayName}' is already silenced.";
+                return;
+            }
+
+            await _dataService.InsertMuteRuleAsync(ViewerDataService.BuildServerSilenceRule(server.DisplayName));
+            StatusText.Text = $"Silenced all alerts for '{server.DisplayName}'. Right-click → Unsilence to restore.";
+        }
+        catch (ViewerReadOnlyException ex)
+        {
+            StatusText.Text = ex.Message;
+        }
+        catch (ViewerSchemaSkewException ex)
+        {
+            StatusText.Text = ex.Message;
+        }
+        catch (Exception ex)
+        {
+            ViewerLogger.Error("ServerManagement", "Failed to silence the server", ex);
+            StatusText.Text = $"Could not silence the server: {ex.Message}";
+        }
+    }
+
+    /// <summary>
+    /// "Unsilence" — removes every whole-server silence rule for this server (the counter-action to
+    /// <see cref="ServerContextMenu_Silence_Click"/>), so the service resumes delivering its alerts on the next
+    /// reload. Only blanket silences match (see <see cref="ViewerDataService.IsWholeServerSilence"/>), so a
+    /// specific metric/query mute the operator authored for the server is left alone. Reports when the server was
+    /// not silenced.
+    /// </summary>
+    private async void ServerContextMenu_Unsilence_Click(object sender, RoutedEventArgs e)
+    {
+        var server = GetServerFromContextMenu(sender);
+        if (server is null || _dataService is null)
+        {
+            return;
+        }
+
+        try
+        {
+            var rules = await _dataService.GetMuteRulesAsync();
+            var silences = rules.Where(r => ViewerDataService.IsWholeServerSilence(r, server.DisplayName)).ToList();
+            if (silences.Count == 0)
+            {
+                StatusText.Text = $"'{server.DisplayName}' is not silenced.";
+                return;
+            }
+
+            foreach (var rule in silences)
+            {
+                await _dataService.DeleteMuteRuleAsync(rule.Id);
+            }
+
+            StatusText.Text = $"Unsilenced '{server.DisplayName}'.";
+        }
+        catch (ViewerReadOnlyException ex)
+        {
+            StatusText.Text = ex.Message;
+        }
+        catch (ViewerSchemaSkewException ex)
+        {
+            StatusText.Text = ex.Message;
+        }
+        catch (Exception ex)
+        {
+            ViewerLogger.Error("ServerManagement", "Failed to unsilence the server", ex);
+            StatusText.Text = $"Could not unsilence the server: {ex.Message}";
+        }
+    }
+
     // ── Footer buttons (Add / Manage / Import Settings / View Log / Open Log Folder) ─────
 
     private async void AddServerButton_Click(object sender, RoutedEventArgs e)

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
@@ -28,9 +28,9 @@
         servers (Overview is the server-cards grid; Alert History is the all-servers history, filterable
         by server); FinOps and Recommendations are server-scoped, their own pickers synced to the sidebar
         selection. Single-click a server drives the server-scoped aggregate tabs to it; double-click a
-        server row (or an Overview card) opens (or focuses) that server's ViewerServerTab. The 60-second
-        timer refreshes the visible tab (an aggregate tab or the visible server tab's active inner tab);
-        the Overview has its own faster 30-second timer (Lite's Overview cadence).
+        server row (or an Overview card) opens (or focuses) that server's ViewerServerTab. The fleet-refresh
+        timer (the configurable NocRefreshIntervalSeconds) refreshes the visible tab (an aggregate tab or the
+        visible server tab's active inner tab); the Overview has its own timer at the same interval.
     -->
     <Window.Resources>
         <local:StatusToBrushConverter x:Key="StatusToBrush"/>
@@ -429,6 +429,18 @@
                                         <MenuItem Header="Remove" Click="ServerContextMenu_Remove_Click">
                                             <MenuItem.Icon><TextBlock Text="&#x1F5D1;"/></MenuItem.Icon>
                                         </MenuItem>
+                                        <Separator/>
+                                        <!-- One-click whole-server alert silence: writes/removes a server-scoped
+                                             mute rule the running service honors (email/Teams/Slack + in-app toasts),
+                                             the shortcut over the multi-step Manage Mute Rules dialog. -->
+                                        <MenuItem Header="Silence This Server" Click="ServerContextMenu_Silence_Click"
+                                                  ToolTip="Mute every alert for this server until you Unsilence it">
+                                            <MenuItem.Icon><TextBlock Text="&#x1F507;"/></MenuItem.Icon>
+                                        </MenuItem>
+                                        <MenuItem Header="Unsilence" Click="ServerContextMenu_Unsilence_Click"
+                                                  ToolTip="Remove this server's whole-server alert silence">
+                                            <MenuItem.Icon><TextBlock Text="&#x1F514;"/></MenuItem.Icon>
+                                        </MenuItem>
                                     </ContextMenu>
                                 </Border.ContextMenu>
                                 <Grid>
@@ -503,8 +515,8 @@
 
             <!-- Right: the top tab strip. Fixed aggregate tabs (Overview, Recommendations, Alerts) plus
                  the dynamically-added closable per-server tabs (appended in code). Only the visible tab
-                 loads (Lite's visible-only rule); the 60-second timer re-reads the visible aggregate tab
-                 (Overview on its own 30-second timer), while per-server tabs self-refresh on their own
+                 loads (Lite's visible-only rule); the fleet-refresh timer re-reads the visible aggregate tab
+                 (Overview on its own timer at the same interval), while per-server tabs self-refresh on their own
                  toolbar auto-refresh timer. -->
             <TabControl x:Name="MainTabs"
                         Grid.Column="1"
@@ -779,7 +791,7 @@
                      mirroring the Recommendations tab, and independently changeable while the tab is open)
                      drives the eleven per-server sub-tabs; Server Inventory stays cross-server and now lives
                      ONCE here. The control owns its own load (server selector + sub-tab activation + the
-                     shell's 60-second timer). "View Plan" on its query grids raises PlanRequested, which the
+                     shell's fleet-refresh timer). "View Plan" on its query grids raises PlanRequested, which the
                      shell routes into the standalone Plan Viewer surface. -->
                 <TabItem x:Name="FinOpsTab" Header="FinOps">
                     <local:FinOpsTab x:Name="FinOpsContent" Margin="0,8,0,0"/>
@@ -795,7 +807,7 @@
                      app-merged Dark theme. "Generate now" asks the Darling service to run an immediate
                      analysis pass for the selected server (analyze_now) and then refreshes; the status line
                      also surfaces the last analysis time. A read-only seat can't command the service, so the
-                     button is disabled. NOT on the 60-second timer (tab-activation refresh only,
+                     button is disabled. NOT on the fleet-refresh timer (tab-activation refresh only,
                      matching Lite). -->
                 <TabItem x:Name="RecommendationsTab" Header="Recommendations">
                     <TabItem.Resources>

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
@@ -32,17 +32,26 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// <see cref="ViewerServerTab"/>,
 /// whose inner tabs (Overview charts, Queries, Blocking, Collection Health) hold the per-server surfaces.
 /// All reads go straight to Postgres via <see cref="ViewerDataService"/>. Loads are lazy per visible
-/// tab (Lite's visible-only rule): the 60-second timer refreshes only the visible tab — an aggregate
+/// tab (Lite's visible-only rule): the fleet-refresh timer (the configurable
+/// <see cref="ViewerAppSettings.NocRefreshIntervalSeconds"/>) refreshes only the visible tab — an aggregate
 /// tab for the selected server, or the visible server tab's active inner tab. Every data load is async.
 /// </summary>
 [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1001:Types that own disposable fields should be disposable",
     Justification = "WPF windows are never disposed by the framework; the data service is disposed in OnClosed.")]
 public partial class MainWindow : Window
 {
-    private static readonly TimeSpan s_refreshInterval = TimeSpan.FromSeconds(60);
+    /// <summary>
+    /// The fleet auto-refresh cadence for the Overview and the aggregate tabs — the single operator knob
+    /// (<see cref="ViewerAppSettings.NocRefreshIntervalSeconds"/>) that replaced the two hardcoded cadences
+    /// (60s aggregate / 30s Overview), mirroring the Dashboard's one NocRefreshIntervalSeconds. Both fleet-scope
+    /// timers run at this interval so an operator can dial the store-query load back at 500-server scale. Seeded
+    /// in the constructor; re-applied to the live timers when the Settings window closes.
+    /// </summary>
+    private TimeSpan _refreshInterval;
 
-    /// <summary>The Overview tab's own faster cadence (Lite's Overview refresh interval).</summary>
-    private static readonly TimeSpan s_overviewRefreshInterval = TimeSpan.FromSeconds(30);
+    /// <summary>The viewer's connect-timeout preference, applied to the store connection string when the data
+    /// service is created (see <see cref="ViewerDataService(string, int?)"/>). Seeded in the constructor.</summary>
+    private readonly int _connectionTimeoutSeconds;
 
     private ViewerDataService? _dataService;
     private DispatcherTimer? _refreshTimer;
@@ -129,6 +138,10 @@ public partial class MainWindow : Window
         _minimizeToTray = appSettings.MinimizeToTray;
         _alertsEnabled = appSettings.AlertsEnabled;
         _alertCooldownMinutes = appSettings.AlertCooldownMinutes;
+        /* Seed the connect-timeout applied to the store connection (at ViewerDataService creation, on connect)
+           and the single fleet-refresh cadence both shell timers run at. */
+        _connectionTimeoutSeconds = appSettings.ConnectionTimeoutSeconds;
+        _refreshInterval = TimeSpan.FromSeconds(appSettings.NocRefreshIntervalSeconds);
         ApplyTimeDisplayMode(appSettings.TimeDisplayMode);
         Loaded += OnLoaded;
         Closed += OnClosed;
@@ -155,7 +168,7 @@ public partial class MainWindow : Window
             return;
         }
 
-        _dataService = new ViewerDataService(settings.ConnectionString);
+        _dataService = new ViewerDataService(settings.ConnectionString, _connectionTimeoutSeconds);
 
         try
         {
@@ -269,13 +282,13 @@ public partial class MainWindow : Window
             ViewerLogger.Warn("AlertToasts", $"Priming the alert-toast watermark failed: {ex.Message}");
         }
 
-        _refreshTimer = new DispatcherTimer { Interval = s_refreshInterval };
+        _refreshTimer = new DispatcherTimer { Interval = _refreshInterval };
         _refreshTimer.Tick += OnRefreshTimerTick;
         _refreshTimer.Start();
 
-        /* The Overview tab refreshes on its own faster (30s) cadence, mirroring Lite; the 60s timer
-           skips it so the two don't double-refresh the same grid. */
-        _overviewTimer = new DispatcherTimer { Interval = s_overviewRefreshInterval };
+        /* The Overview keeps its own timer so it refreshes when it is the visible tab and the aggregate timer
+           skips it (they never double-refresh the same grid); both run at the one configurable fleet interval. */
+        _overviewTimer = new DispatcherTimer { Interval = _refreshInterval };
         _overviewTimer.Tick += OnOverviewTimerTick;
         _overviewTimer.Start();
     }
@@ -327,11 +340,11 @@ public partial class MainWindow : Window
            headless stand-in for Lite's in-process alert-engine toast). */
         _ = PollAlertToastsAsync();
 
-        /* Two tabs opt out of the 60s auto-refresh: Recommendations refreshes on tab-activation only
-           (matching Lite — analysis findings change on the service's 30-minute cadence, so a 60-second
-           auto-refresh is pointless churn and would reset the incident expanders' state under the
-           reader), and the Overview has its own faster 30s timer, so the 60s timer skips it too (they'd
-           otherwise double-refresh the same grid). Every other aggregate tab still auto-refreshes. */
+        /* Two tabs opt out of this timer: Recommendations refreshes on tab-activation only (matching Lite —
+           analysis findings change on the service's 30-minute cadence, so an interval auto-refresh is pointless
+           churn and would reset the incident expanders' state under the reader), and the Overview has its OWN
+           timer, so this one skips it (they'd otherwise double-refresh the same grid). Every other aggregate tab
+           still auto-refreshes. */
         if (ReferenceEquals(MainTabs.SelectedItem, RecommendationsTab)
             || ReferenceEquals(MainTabs.SelectedItem, OverviewTab))
         {
@@ -339,7 +352,7 @@ public partial class MainWindow : Window
         }
 
         /* Per-server tabs now self-refresh on their own toolbar auto-refresh timer (at the user's chosen
-           interval / on/off), so the global 60s timer skips them — otherwise both would fire and the
+           interval / on/off), so the global fleet-refresh timer skips them — otherwise both would fire and the
            user's interval choice wouldn't stick. */
         if (MainTabs.SelectedItem is TabItem { Content: ViewerServerTab })
         {
@@ -353,7 +366,7 @@ public partial class MainWindow : Window
     {
         if (ReferenceEquals(MainTabs.SelectedItem, OverviewTab))
         {
-            /* Refresh the sidebar dots on the snappier Overview cadence too, so they track the cards. */
+            /* Refresh the sidebar dots on the Overview cadence too, so they track the cards. */
             _ = RefreshServerStatusAsync();
             await RefreshVisibleAsync();
         }
@@ -576,7 +589,7 @@ public partial class MainWindow : Window
         await RefreshVisibleAsync();
         /* The status bar's collector-health scope flips with the active tab (a per-server tab shows that
            server; an aggregate tab shows the fleet-cumulative total), so refresh it now rather than waiting
-           up to 60s for the status timer. */
+           for the next fleet-refresh tick. */
         await UpdateCollectorHealthTextAsync();
     }
 
@@ -868,7 +881,7 @@ public partial class MainWindow : Window
             Enum.TryParse<TimeDisplayMode>(modeText, ignoreCase: true, out var mode) ? mode : TimeDisplayMode.ServerTime;
     }
 
-    // ── Overview tab (all-servers server cards; refreshes on its own 30s timer) ──────
+    // ── Overview tab (all-servers server cards; refreshes on its own timer at the fleet interval) ──────
 
     /// <summary>
     /// Loads a summary card for every registered server (Lite's RefreshOverviewAsync), reading each
@@ -1265,6 +1278,17 @@ public partial class MainWindow : Window
            "Tray notification cooldown" the window just wrote to the STORE are re-read from there. */
         _minimizeToTray = reloaded.MinimizeToTray;
         _ = RefreshAlertToastSettingsFromStoreAsync();
+        /* Re-apply the fleet refresh interval to the live shell timers so a change takes effect immediately
+           (the connection timeout is a connect-time setting and applies on the next viewer launch). */
+        _refreshInterval = TimeSpan.FromSeconds(reloaded.NocRefreshIntervalSeconds);
+        if (_refreshTimer is not null)
+        {
+            _refreshTimer.Interval = _refreshInterval;
+        }
+        if (_overviewTimer is not null)
+        {
+            _overviewTimer.Interval = _refreshInterval;
+        }
         var previousMode = ViewerTimeHelper.CurrentDisplayMode;
         ApplyTimeDisplayMode(reloaded.TimeDisplayMode);
         if (ViewerTimeHelper.CurrentDisplayMode != previousMode)

--- a/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml
@@ -136,6 +136,20 @@
                         <ComboBoxItem Content="5 minutes"/>
                     </ComboBox>
                 </StackPanel>
+                <!-- The shell's fleet cadence: one knob over what were two hardcoded timers (60s aggregate / 30s
+                     Overview). Raise it to cut store-query load at fleet scale. -->
+                <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                    <TextBlock Text="Fleet refresh interval:" VerticalAlignment="Center"
+                               Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,8,0"/>
+                    <ComboBox x:Name="NocRefreshIntervalCombo" Width="140" VerticalAlignment="Center"
+                              ToolTip="How often the Overview and aggregate tabs refresh from the store. Raise it to cut store load when monitoring many servers.">
+                        <ComboBoxItem Content="10 seconds" Tag="10"/>
+                        <ComboBoxItem Content="30 seconds" Tag="30"/>
+                        <ComboBoxItem Content="1 minute" Tag="60"/>
+                        <ComboBoxItem Content="2 minutes" Tag="120"/>
+                        <ComboBoxItem Content="5 minutes" Tag="300"/>
+                    </ComboBox>
+                </StackPanel>
                 <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
                     <TextBlock Text="Connection timeout:" VerticalAlignment="Center"
                                Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,8,0"/>

--- a/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml.cs
@@ -106,6 +106,7 @@ public partial class SettingsWindow : Window
         LoadMcpSettings();
         UpdateMcpStatus();
         LoadConnectionTimeout();
+        LoadNocRefreshInterval();
         LoadCsvSeparator();
         LoadTimeDisplayMode();
         LoadColorTheme();
@@ -447,6 +448,36 @@ public partial class SettingsWindow : Window
         if (int.TryParse(ConnectionTimeoutBox.Text, out var timeout) && timeout is >= 5 and <= 60)
         {
             _appSettings.ConnectionTimeoutSeconds = timeout;
+        }
+    }
+
+    /// <summary>Selects the combo row whose Tag matches the persisted fleet-refresh interval; falls back to the
+    /// 30-second default when the stored value isn't one of the presets.</summary>
+    private void LoadNocRefreshInterval()
+    {
+        foreach (ComboBoxItem item in NocRefreshIntervalCombo.Items)
+        {
+            if (item.Tag is string tag
+                && int.TryParse(tag, NumberStyles.Integer, CultureInfo.InvariantCulture, out var seconds)
+                && seconds == _appSettings.NocRefreshIntervalSeconds)
+            {
+                NocRefreshIntervalCombo.SelectedItem = item;
+                break;
+            }
+        }
+
+        if (NocRefreshIntervalCombo.SelectedItem == null)
+        {
+            NocRefreshIntervalCombo.SelectedIndex = 1; // 30 seconds (the default)
+        }
+    }
+
+    private void SaveNocRefreshInterval()
+    {
+        if (NocRefreshIntervalCombo.SelectedItem is ComboBoxItem { Tag: string tag }
+            && int.TryParse(tag, NumberStyles.Integer, CultureInfo.InvariantCulture, out var seconds))
+        {
+            _appSettings.NocRefreshIntervalSeconds = seconds;
         }
     }
 
@@ -1077,6 +1108,7 @@ public partial class SettingsWindow : Window
         /* Persist the viewer-LOCAL preferences immediately (valid values applied above), and capture the
            edited viewer preferences for MainWindow to save + re-seed tabs from. */
         SaveConnectionTimeout();
+        SaveNocRefreshInterval();
         SaveCsvSeparator();
         SaveTimeDisplayMode();
         SaveColorTheme();

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerAppSettings.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerAppSettings.cs
@@ -66,6 +66,15 @@ public sealed class ViewerAppSettings
     /// <summary>Connection timeout in seconds for the viewer's store reads (5-60).</summary>
     public int ConnectionTimeoutSeconds { get; set; } = 5;
 
+    /// <summary>
+    /// How often (seconds) the shell auto-refreshes the fleet Overview and the aggregate tabs — the single
+    /// operator knob over what were two hardcoded cadences (60s aggregate / 30s Overview), mirroring the
+    /// Dashboard's one <c>NocRefreshIntervalSeconds</c>. Both fleet-scope timers run at this interval so an
+    /// operator can dial the store-query load back at 500-server scale. Default 30 (the Dashboard's default and
+    /// the former Overview cadence). Clamped to 10–600.
+    /// </summary>
+    public int NocRefreshIntervalSeconds { get; set; } = 30;
+
     /// <summary>CSV export separator: "," ";" or a tab. Auto-detected from locale on first run.</summary>
     public string CsvSeparator { get; set; } = DefaultCsvSeparator();
 
@@ -179,6 +188,7 @@ public sealed class ViewerAppSettings
     {
         McpPort = Clamp(McpPort, 1024, 65535, 5152);
         ConnectionTimeoutSeconds = Clamp(ConnectionTimeoutSeconds, 5, 60, 5);
+        NocRefreshIntervalSeconds = Clamp(NocRefreshIntervalSeconds, 10, 600, 30);
         CsvSeparator = (CsvSeparator == "," || CsvSeparator == ";" || CsvSeparator == "\t") ? CsvSeparator : DefaultCsvSeparator();
         TimeDisplayMode = (TimeDisplayMode is "ServerTime" or "LocalTime" or "UTC") ? TimeDisplayMode : "ServerTime";
         ColorTheme = (ColorTheme is "Dark" or "Light" or "CoolBreeze") ? ColorTheme : "Dark";
@@ -304,9 +314,10 @@ public sealed class ViewerAppSettingsStore
 /// separator, read by the grid copy/export handlers (they call <c>DataGridExport.ExportToCsv(..., separator)</c>).
 /// Held as a process-wide value that <see cref="MainWindow"/> seeds from the persisted settings on startup and
 /// re-applies whenever the Settings window closes, so a change takes effect on the next export without a
-/// restart — mirroring how Lite's export reads <c>App.CsvSeparator</c>. The other persisted settings
-/// (alerts/SMTP/webhooks/MCP/timestamp-display/connection-timeout) are the service's or a larger wiring
-/// concern and are not consumed here yet (see the PR body).
+/// restart — mirroring how Lite's export reads <c>App.CsvSeparator</c>. The connection timeout is honored at
+/// CONNECT (applied to the store connection string in the <see cref="ViewerDataService"/> constructor) and the
+/// fleet refresh interval drives the shell's aggregate/Overview timers; the remaining persisted settings
+/// (alerts/SMTP/webhooks/MCP/timestamp-display) are the service's or a larger wiring concern.
 /// </summary>
 public static class ViewerExportSettings
 {

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.CollectorSchedules.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.CollectorSchedules.cs
@@ -74,6 +74,11 @@ ON CONFLICT (server_id, collector_name) WHERE server_id IS NOT NULL DO UPDATE SE
     public const string CollectorScheduleDeleteServerScopeSql =
         "DELETE FROM config_collector_schedules WHERE server_id = $1";
 
+    /// <summary>Deletes EVERY per-server override row in one statement (the fleet-wide "Apply Default to All"
+    /// reset), leaving the fleet-wide defaults (<c>server_id IS NULL</c>) untouched.</summary>
+    public const string CollectorScheduleDeleteAllServerScopesSql =
+        "DELETE FROM config_collector_schedules WHERE server_id IS NOT NULL";
+
     /// <summary>All override rows in the store (both fleet + per-server), for the editor overlay.</summary>
     public async Task<List<CollectorScheduleRow>> GetCollectorSchedulesAsync(CancellationToken cancellationToken = default)
     {
@@ -108,6 +113,20 @@ ON CONFLICT (server_id, collector_name) WHERE server_id IS NOT NULL DO UPDATE SE
     /// </summary>
     public Task ReplaceServerSchedulesAsync(int serverId, IEnumerable<CollectorScheduleRow> rows, CancellationToken cancellationToken = default) =>
         ReplaceScheduleScopeAsync(serverId, rows, cancellationToken);
+
+    /// <summary>
+    /// Reverts EVERY server's per-server schedule override back to the fleet/default schedule in one statement
+    /// (the "Apply Default to All" bulk reset) — the fleet-scale shortcut over reverting one server at a time.
+    /// Deletes all per-server rows and leaves the fleet-wide (<c>server_id IS NULL</c>) overrides in place;
+    /// returns the number of override rows removed. The V17 <c>trg_bump_collector_schedules</c> trigger bumps
+    /// <c>config_version</c> on the DELETE, so the service re-resolves schedules on its next sweep (same reload
+    /// path as <see cref="ReplaceServerSchedulesAsync"/>). A read-only seat throws <see cref="ViewerReadOnlyException"/>.
+    /// </summary>
+    public async Task<int> ResetAllServerSchedulesAsync(CancellationToken cancellationToken = default)
+    {
+        await using var command = _dataSource.CreateCommand(CollectorScheduleDeleteAllServerScopesSql);
+        return await ExecuteWriteAsync(command, cancellationToken);
+    }
 
     private async Task ReplaceScheduleScopeAsync(int? serverId, IEnumerable<CollectorScheduleRow> rows, CancellationToken cancellationToken)
     {

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.MuteRules.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.MuteRules.cs
@@ -72,6 +72,48 @@ WHERE id = $1";
 
     public const string MuteRuleDeleteSql = "DELETE FROM config_mute_rules WHERE id = $1";
 
+    /// <summary>The <see cref="MuteRule.Reason"/> stamped on a whole-server silence created from the sidebar's
+    /// "Silence This Server" one-click, so it reads clearly in the Manage Mute Rules list.</summary>
+    public const string ServerSilenceReason = "Silenced from server list";
+
+    /// <summary>
+    /// Builds the whole-server silence rule the sidebar's "Silence This Server" writes: a <see cref="MuteRule"/>
+    /// scoped to <paramref name="serverName"/> with every pattern field left null, so it matches EVERY alert for
+    /// that server (<see cref="MuteRule.Matches"/> only filters on the fields that are set). No expiry — a silence
+    /// stays until "Unsilence" removes it, mirroring Lite's indefinite per-server silence.
+    ///
+    /// <para><paramref name="serverName"/> must be the server's DISPLAY name, not its host name: the service's
+    /// alert engine builds its mute context with <c>ServerName = snapshot.ServerName</c> (the monitored server's
+    /// display name), and the alert rows the viewer reads carry that same display name — so a rule keyed on the
+    /// display name is what actually suppresses the alerts (matching the existing "Mute This Server" action,
+    /// which mutes on the alert row's <c>ServerName</c>).</para>
+    /// </summary>
+    public static MuteRule BuildServerSilenceRule(string serverName) => new()
+    {
+        ServerName = serverName,
+        Reason = ServerSilenceReason,
+        Enabled = true,
+        ExpiresAtUtc = null,
+        /* MetricName/DatabasePattern/QueryTextPattern/WaitTypePattern/JobNamePattern stay null → matches all. */
+    };
+
+    /// <summary>
+    /// True when <paramref name="rule"/> is a WHOLE-SERVER silence for <paramref name="serverName"/> — scoped to
+    /// that server (case-insensitive) with no narrowing pattern on any other field. This is the shape
+    /// <see cref="BuildServerSilenceRule"/> writes, and the predicate "Unsilence" uses to find the rule(s) to
+    /// remove (so it targets only blanket silences, never a specific metric/query/db mute the operator authored
+    /// for that server). Enabled/expiry are intentionally not part of the match — Unsilence clears any lingering
+    /// blanket silence regardless.
+    /// </summary>
+    public static bool IsWholeServerSilence(MuteRule rule, string serverName) =>
+        rule is not null
+        && string.Equals(rule.ServerName, serverName, StringComparison.OrdinalIgnoreCase)
+        && rule.MetricName is null
+        && rule.DatabasePattern is null
+        && rule.QueryTextPattern is null
+        && rule.WaitTypePattern is null
+        && rule.JobNamePattern is null;
+
     /// <summary>All mute rules, newest first — the "Manage Mute Rules" list. Timestamps come back
     /// tagged Utc (stored naive), so <see cref="MuteRule.ExpiresDisplay"/> converts correctly.</summary>
     public async Task<List<MuteRule>> GetMuteRulesAsync(CancellationToken cancellationToken = default)

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql;
@@ -167,9 +168,42 @@ public sealed partial class ViewerDataService : IAsyncDisposable
 
     private readonly NpgsqlDataSource _dataSource;
 
-    public ViewerDataService(string connectionString)
+    /// <param name="connectionString">The Postgres connection string (managed-derived or BYO from darling.json).</param>
+    /// <param name="connectionTimeoutSeconds">
+    /// The viewer's "Connection timeout" preference (<see cref="ViewerAppSettings.ConnectionTimeoutSeconds"/>,
+    /// Lite's "increase for VPN/remote" knob). When supplied it is applied to the pooled store connections as
+    /// Npgsql's connect <c>Timeout</c> — set on the managed-derived string (which carries none) and appended to a
+    /// BYO string only when the operator did not already specify one (their explicit Timeout wins). Null leaves
+    /// the string untouched (Npgsql's 15s default). This restores the setting the Settings window has always
+    /// saved but nothing consumed.
+    /// </param>
+    public ViewerDataService(string connectionString, int? connectionTimeoutSeconds = null)
     {
-        _dataSource = NpgsqlDataSource.Create(connectionString);
+        var effectiveConnectionString = connectionTimeoutSeconds is int seconds
+            ? ApplyConnectionTimeout(connectionString, seconds)
+            : connectionString;
+        _dataSource = NpgsqlDataSource.Create(effectiveConnectionString);
+    }
+
+    /// <summary>
+    /// Applies the viewer's connect-timeout preference to a connection string, but ONLY when the string does not
+    /// already specify a <c>Timeout</c> — so an operator's explicit Timeout in a BYO <c>postgres.connectionString</c>
+    /// always wins, while the managed-derived string (which never sets one) and a BYO string that omits it both
+    /// pick up the preference. <paramref name="timeoutSeconds"/> is Npgsql's connect timeout in seconds (the
+    /// caller clamps it to 5–60). Pure + string-only, so it is unit-tested without a live Postgres. Detection
+    /// uses the base <see cref="DbConnectionStringBuilder"/>, whose <c>ContainsKey</c> reflects exactly the keys
+    /// present in the string (NpgsqlConnectionStringBuilder overrides ContainsKey to answer for every KNOWN
+    /// keyword, which can't tell "set" from "settable").
+    /// </summary>
+    internal static string ApplyConnectionTimeout(string connectionString, int timeoutSeconds)
+    {
+        var builder = new DbConnectionStringBuilder { ConnectionString = connectionString };
+        if (!builder.ContainsKey("Timeout"))
+        {
+            builder["Timeout"] = timeoutSeconds;
+        }
+
+        return builder.ConnectionString;
     }
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.TimeRange.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.TimeRange.cs
@@ -26,7 +26,7 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// (<see cref="ViewerTimeHelper.DisplayToNaiveUtc(System.DateTime)"/>). This replaces the old hardcoded
 /// 24-hour <c>s_dataWindow</c>: every inner-tab load reads <see cref="GetWindowUtc"/> (preset
 /// 1h/4h/12h/24h/7d or a custom From/To), the auto-refresh cadence comes from the toolbar instead of
-/// MainWindow's fixed 60-second timer, and the display-mode picker re-renders the visible tab so every
+/// MainWindow's fleet-refresh timer, and the display-mode picker re-renders the visible tab so every
 /// timestamp honors the chosen mode.
 /// </summary>
 public partial class ViewerServerTab


### PR DESCRIPTION
Four small, self-contained fleet-usability fixes for the Darling viewer (from the Dashboard-scout inventory: Tier-1 items 8, 11, 13 + the Tier-2 configurable refresh interval). Each keeps to the "viewer = faithful Lite copy" idiom where Lite has the equivalent.

## 1. Connection-timeout dead knob (correctness / finish-the-work)
`ViewerAppSettings.ConnectionTimeoutSeconds` was loaded/saved with Lite's "increase for VPN/remote" tooltip, but nothing applied it — `ViewerDataService` passed the connection string to `NpgsqlDataSource.Create` verbatim. Now the constructor takes the preference and `ApplyConnectionTimeout` sets Npgsql's connect `Timeout`: on the managed-derived string (which carries none) and appended to a BYO string **only when the operator did not already specify one** (their explicit `Timeout` wins). Applied at connect (data-source creation); a change takes effect on the next viewer launch.

- `ViewerDataService.cs` (helper + constructor overload), `MainWindow.xaml.cs` (seed + pass), stale "not consumed" comment fixed in `ViewerAppSettings.cs`.
- **Note:** this is a Darling-only gap — Lite's same knob **is** wired (`RemoteCollectorService`/`ServerManager` set `ConnectTimeout`), so this brings Darling to parity rather than fixing a shared bug.
- **Effective-default note (for the record):** honoring the knob makes the effective default connect timeout **5s** (was Npgsql's implicit 15s) for the managed path and any BYO string without an explicit `Timeout`. Intended — the Settings UI always displayed 5s over the dead knob — and operator-raisable (5–60); localhost-managed connects are unaffected in practice.

## 2. Silence This Server / Unsilence (context menu)
Two server-row context-menu items. "Silence This Server" writes a whole-server `MuteRule` (`InsertMuteRuleAsync`); "Unsilence" loads the rules and deletes the matching blanket silence(s). Idempotent with clear status feedback. The service honors it on its next config reload — email/Teams/Slack skipped and rows flagged `muted` so they never toast.

- **Correctness detail (verified, worth a look):** the rule is keyed on the server's **display name**, not host name. The service's alert engine builds its mute context with `ServerName = snapshot.ServerName` (= `runtime.Config.DisplayName`), and the alert rows carry that same display name — so a display-name rule is what actually suppresses the alerts, matching the existing "Mute This Server" action (`item.ServerName`). Keying on the host name would silently mute nothing when display_name != server_name.
- The two items are always enabled (a read-only seat gets the friendly read-only message on click, like Remove); I did not add Lite's dynamic enable/disable because that would need an async store read on every right-click — the idempotent handlers give equivalent UX without the per-open probe. Flagging in case you want the dynamic state.
- `MainWindow.xaml` (menu), `MainWindow.ServerManagement.cs` (handlers), `ViewerDataService.MuteRules.cs` (`BuildServerSilenceRule` + `IsWholeServerSilence`).

## 3. Apply Default to All Servers (bulk schedule reset)
A button in the collector-schedule editor + one `ResetAllServerSchedulesAsync` (`DELETE FROM config_collector_schedules WHERE server_id IS NOT NULL`) reverting every server's overrides to the fleet default in one write. Confirm dialog, read-only gated, editor re-reads after. The fleet-wide default (`server_id IS NULL`) is untouched; the existing `trg_bump_collector_schedules` trigger bumps `config_version` for the service reload.

- `CollectorScheduleEditorWindow.xaml/.cs`, `ViewerDataService.CollectorSchedules.cs`.

## 4. Configurable fleet refresh interval
One `NocRefreshIntervalSeconds` knob (default 30, mirroring the Dashboard's single knob and combo presets: 10/30/60/120/300s) replacing the two hardcoded `static readonly TimeSpan` cadences (60s aggregate / 30s Overview). Both fleet-scope timers run at the one interval so an operator can dial the store-query load back at 500-server scale; re-applied live when Settings closes.

- **Design choice:** collapsing two defaults into one knob changes the aggregate-tab cadence from 60s→30s by default (the Overview stays 30s). Chose default 30 to match the Dashboard and keep the most-watched view snappy; an operator raises the single knob to cut both. Easy to flip to 60 if you'd rather not speed up the aggregate default.
- `ViewerAppSettings.cs` (+ clamp), `SettingsWindow.xaml/.cs`, `MainWindow.xaml.cs`. Stale 60s/30s comments across the shell/FinOps updated.

## Tests
- `ViewerConnectionTimeoutTests` (4): managed set (incl. pinning `Search Path=collect,config,public` survives the base-builder round-trip), BYO append, operator's explicit Timeout preserved, case-insensitive detection.
- `ViewerServerSilenceTests` (6): silence-rule shape + `Matches` behavior, `IsWholeServerSilence` true/false (case-insensitive, narrowed rule, other server, metric-only).
- `ViewerControlPlaneStage3bTests` (+1): the reset DELETE targets per-server rows only, never the fleet default.
- `ViewerAppSettingsStoreTests` (+3 assertions): `NocRefreshIntervalSeconds` default / round-trip / clamp.

Build: Viewer + Darling.Tests succeed (0 errors). Full `Darling.Tests`: **1836 passed, 127 skipped (live-Postgres), 0 failed** (the known-flaky `ViewerWave2DisplayTests.BlockedRow_EventTimeLocal` did not fire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
