### PR TITLE
Darling: failure-isolate the connection-edge self-alert delivery

### DIFF
--- a/Darling/Darling.Tests/DarlingSelfAlertTests.cs
+++ b/Darling/Darling.Tests/DarlingSelfAlertTests.cs
@@ -413,6 +413,34 @@ public sealed class DarlingSelfAlertTests
         Assert.Empty(h.Deliverer.Outcomes);
     }
 
+    [Fact]
+    public async Task Connection_ThrowingMuteCheck_IsIsolated_AndStateStillAdvances()
+    {
+        /* The connection edge fires straight from the un-guarded sweep loop (TryConnectAsync), whose OWN catch
+           re-calls this with online:false — so a throwing mute-check here (a broken rule's Matches()) would
+           propagate out and stop collection for the whole fleet. The delivery portion must isolate it, and
+           because the state machine advances BEFORE the fire, the edge must still transition correctly. */
+        var h = new Harness();
+        var e = h.Build();
+
+        /* Online baseline (Unknown->Online is silent; no mute check reached). */
+        await e.ApplyConnectionOutcomeAsync(ServerId, Name, online: true, error: null, Ct);
+        Assert.Empty(h.Deliverer.Outcomes);
+
+        /* Now the mute check throws: Online->Offline WOULD fire "Server Unreachable" -> mute throws.
+           Must NOT propagate (would kill the loop), and nothing is delivered (throw precedes delivery). */
+        h.MuteThrows = true;
+        await e.ApplyConnectionOutcomeAsync(ServerId, Name, online: false, error: "boom", Ct);
+        Assert.Empty(h.Deliverer.Outcomes);
+
+        /* The state STILL advanced to Offline despite the throwing fire: with the mute check healthy again,
+           Offline->Online now fires "Server Restored" — it would NOT if the state were stuck at Online. */
+        h.MuteThrows = false;
+        await e.ApplyConnectionOutcomeAsync(ServerId, Name, online: true, error: null, Ct);
+        var restored = Assert.Single(h.Deliverer.Outcomes);
+        Assert.Equal("Server Restored", restored.MetricName);
+    }
+
     /* ---------------- store disk pressure (fleet-level, pure decision) ---------------- */
 
     private const long Gib = 1024L * 1024 * 1024;

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingSelfAlertEvaluator.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingSelfAlertEvaluator.cs
@@ -328,6 +328,8 @@ internal sealed class DarlingSelfAlertEvaluator
     /// restore is not a silent resolution). State is tracked even while alerts are disabled so re-enabling
     /// resumes from the correct baseline; only delivery is gated — on the master switch AND the V20
     /// connection-change notify toggle (<see cref="DarlingAlertSettings.NotifyConnectionChanges"/>).
+    /// The delivery portion is failure-isolated (a throwing mute-check can't propagate out of the un-guarded
+    /// sweep loop and stop the fleet); the state machine advances first, so isolation never corrupts the edge.
     /// </summary>
     public async Task ApplyConnectionOutcomeAsync(
         int serverId, string serverName, bool online, string? error, CancellationToken cancellationToken)
@@ -352,25 +354,43 @@ internal sealed class DarlingSelfAlertEvaluator
             return;
         }
 
-        if (online && previous == ConnectionState.Offline)
+        /* Isolate the DELIVERY portion (the state machine already advanced above, so wrapping only the fire can
+           never corrupt the edge). FireAsync's pre-deliver mute-check seam (_isAlertMuted → a mute rule's
+           Matches()) is NOT internally isolated, and this method is called straight from the un-guarded sweep
+           loop (DarlingWorker.TryConnectAsync) — whose OWN catch RE-CALLS this with online:false — so a throwing
+           mute-check here would propagate out of that catch and stop collection for the whole fleet. Same
+           isolation the sibling self-alerts use (EvaluateStoreAlertsAsync / EvaluateDiskPressureAsync).
+           Cancellation still propagates. */
+        try
         {
-            /* Severity null → the shared AlertSeverity map renders "Server Restored" green/RESOLVED. */
-            await FireAsync(
-                key, serverName, "Server Restored", "Online", "Online",
-                detail: $"{serverName}: connection restored",
-                severity: null,
-                shortMessage: "connection restored", cancellationToken);
+            if (online && previous == ConnectionState.Offline)
+            {
+                /* Severity null → the shared AlertSeverity map renders "Server Restored" green/RESOLVED. */
+                await FireAsync(
+                    key, serverName, "Server Restored", "Online", "Online",
+                    detail: $"{serverName}: connection restored",
+                    severity: null,
+                    shortMessage: "connection restored", cancellationToken);
+            }
+            else if (!online && previous == ConnectionState.Online)
+            {
+                var reason = string.IsNullOrWhiteSpace(error) ? "Connection failed" : error!;
+                await FireAsync(
+                    key, serverName, "Server Unreachable", reason, "Online",
+                    detail: reason,
+                    severity: AlertSeverityLevel.Critical,
+                    shortMessage: reason, cancellationToken);
+            }
+            /* previous == Unknown → baseline only (no fire). */
         }
-        else if (!online && previous == ConnectionState.Online)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            var reason = string.IsNullOrWhiteSpace(error) ? "Connection failed" : error!;
-            await FireAsync(
-                key, serverName, "Server Unreachable", reason, "Online",
-                detail: reason,
-                severity: AlertSeverityLevel.Critical,
-                shortMessage: reason, cancellationToken);
+            throw;
         }
-        /* previous == Unknown → baseline only (no fire). */
+        catch (Exception ex)
+        {
+            _logger?.LogError("[{Server}] Connection-change self-alert delivery failed: {Message}", serverName, ex.Message);
+        }
     }
 
     /* ---------------- store disk pressure (fleet-level, polled) ---------------- */


### PR DESCRIPTION
Follow-up to #1464 (which isolated the disk-pressure self-alert). The connection-edge self-alert had the **same un-isolated `FireAsync`/mute-check fleet-death exposure**, which I flagged on that PR.

## The bug
`ApplyConnectionOutcomeAsync` fires straight from the **un-guarded** sweep loop (`DarlingWorker.TryConnectAsync`), and `FireAsync`'s pre-deliver mute-check seam (`_isAlertMuted` → `MuteRuleService.IsAlertMuted` → a mute rule's `Matches()`) is **not** internally isolated.

It's worse than the double-fault I originally described — a **single** broken mute rule plus an ordinary connection loss is enough:
1. `ConnectAsync` throws (server unreachable) → caught by `TryConnectAsync`'s own `catch`
2. that catch re-calls `ApplyConnectionOutcomeAsync(online: false)` → `Online→Offline` → fires **"Server Unreachable"** → `Matches()` throws
3. the throw propagates **out of that catch, out of the sweep loop → collection stops for the whole fleet** (unattended service death)

## The fix
Wrap the **delivery portion** of `ApplyConnectionOutcomeAsync` in the identical isolation the sibling self-alerts use (`EvaluateStoreAlertsAsync` / `EvaluateDiskPressureAsync`): `catch (OperationCanceledException) when (cancelled) { throw; }` + `catch (Exception ex) { LogError }`. The **state machine advances before** the fire, so isolating only the delivery never corrupts the edge (verified by the test below).

## Finishing the class (scan)
Scanned every `FireAsync`/`Apply*` call in the sweep-loop path:
- `ApplyCollectionStoppedAsync` + `ApplyCaptureDownAsync` → isolated by their caller `EvaluateStoreAlertsAsync` ✓
- `ApplyDiskPressureAsync` → isolated by `EvaluateDiskPressureAsync` (#1464) ✓
- `engine.EvaluateServerAsync` → wrapped by the worker's `EvaluateAlertsAsync` try/catch ✓
- `ApplyConnectionOutcomeAsync` → **this was the last un-isolated instance** ← fixed here

No third instance remains. #1467's default-trace work added a collector, not an alert path.

## Test
`Connection_ThrowingMuteCheck_IsIsolated_AndStateStillAdvances` (mirrors `DiskPressure_ThrowingMuteCheck_IsIsolated_DoesNotPropagate`): a throwing mute-check on `Online→Offline` is swallowed (no propagation, nothing delivered) **and** the state still advanced — a subsequent healthy `Offline→Online` fires "Server Restored", which it could not if the edge were stuck at Online.

Full `Darling.Tests` suite green (**1917 passed, 0 failed, 132 skipped**). Service + test projects build with 0 errors. Two files changed (evaluator + its test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)