### PR TITLE
Fix Memory + Query-Trend chart dead space: window-pin the remaining charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Viewer Memory and Query Performance Trends charts: the last of the trend-chart dead space is gone** ([#1487]) -- finishes the sweep started in [#1483]/[#1484]. The Memory Overview trend, both Memory Grants charts (sizing + activity), the Memory Clerks chart, and the four Query > Performance Trends charts (query / procedure / Query Store duration and execution count) were the remaining trend charts that never pinned the X-axis, so ScottPlot auto-fit with its default margin and left the same empty space at both edges. Each now pins to the selected window with `SetLimitsX` right after `DateTimeTicksBottomDateChange()`, exactly like the CPU/File I/O charts -- in both the populated and empty-data paths for the dense per-interval Memory charts, and in the populated path for the four Query-Trend charts (whose empty state keeps its existing "No Data" placeholder). `ViewerServerTab.Memory.cs` / `ViewerServerTab.QueryTrends.cs` (Darling) and `ServerTab.Charts.cs` / `ServerTab.Pickers.cs` (Lite -- the Memory Clerks chart lives in the picker file). Lite + Darling
+
 - **Viewer File I/O charts: the dead space at the chart edges is gone** ([#1484]) -- the four File I/O charts (read/write latency and read/write throughput, `ViewerServerTab.FileIo.cs` / `ServerTab.Charts.cs`) never pinned the X-axis, so ScottPlot auto-fit with its default margin and left empty space at both edges -- the same root cause as the CPU/tempdb charts in [#1483]. They now pin to the selected window like every other trend chart. Lite + Darling
 
 - **Viewer trend charts: the empty "dead space" at the tempdb, CPU, and Blocking Stats chart edges is gone** ([#1483]) -- the CPU and tempdb charts (`ServerTab.Charts.cs` / `ViewerServerTab.Charts.cs`, the one chart file copied from Lite) never pinned the X-axis, so ScottPlot auto-fit the range with its default margin and left symmetric empty space at both edges -- the only trend charts skipping the `SetLimitsX(rangeStart, rangeEnd)` every other viewer chart applies; they now pin to the selected window like the rest. Separately, the four Blocking-Stats charts (Darling) do pin the window but plot only the per-minute buckets that had a blocking/deadlock event, so when activity stops the connected line ends early while the axis runs on to the window's right edge; each series is now padded with a zero point at `rangeStart`/`rangeEnd` -- the same zero-baseline idiom the sibling Blocking/Deadlock Trend charts already use -- so the line spans the whole window (no activity = 0 ms). Lite + Darling (the Blocking-Stats severity sub-tab is Darling-only)
@@ -253,6 +255,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1481]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1481
 [#1483]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1483
 [#1484]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1484
+[#1487]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1487
 [#1478]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1478
 [#1477]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1477
 [#1476]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1476

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Memory.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Memory.cs
@@ -103,8 +103,8 @@ public partial class ViewerServerTab
         await Task.WhenAll(latestTask, trendTask, grantTrendTask, clerkTypesTask, grantChartTask, pressureTask);
 
         RenderMemorySummary(latestTask.Result);
-        RenderMemoryChart(trendTask.Result, grantTrendTask.Result);
-        RenderMemoryGrantCharts(grantChartTask.Result);
+        RenderMemoryChart(trendTask.Result, grantTrendTask.Result, startUtc, endUtc);
+        RenderMemoryGrantCharts(grantChartTask.Result, startUtc, endUtc);
         RenderMemoryPressureEventsChart(pressureTask.Result);
         PopulateMemoryClerkPicker(clerkTypesTask.Result);
         await UpdateMemoryClerksChartFromPickerAsync();
@@ -154,13 +154,23 @@ public partial class ViewerServerTab
     /// (dashed), Buffer Pool, and the Memory Grants overlay, all MB→GB. The grant overlay draws a flat
     /// zero line when no grant data exists. Times run through <see cref="ViewerTimeHelper.ForDisplay"/>.
     /// </summary>
-    private void RenderMemoryChart(List<MemoryTrendPoint> data, List<MemoryGrantTrendPoint> grantData)
+    private void RenderMemoryChart(List<MemoryTrendPoint> data, List<MemoryGrantTrendPoint> grantData, DateTime startUtc, DateTime endUtc)
     {
         ClearChart(MemoryChart);
         _memoryHover?.Clear();
         ApplyTheme(MemoryChart);
 
-        if (data.Count == 0) { MemoryChart.Refresh(); return; }
+        var rangeStart = ViewerTimeHelper.ForDisplay(startUtc).ToOADate();
+        var rangeEnd = ViewerTimeHelper.ForDisplay(endUtc).ToOADate();
+
+        if (data.Count == 0)
+        {
+            MemoryChart.Plot.Axes.DateTimeTicksBottomDateChange();
+            MemoryChart.Plot.Axes.SetLimitsX(rangeStart, rangeEnd);
+            ReapplyAxisColors(MemoryChart);
+            MemoryChart.Refresh();
+            return;
+        }
 
         var times = data.Select(d => ViewerTimeHelper.ForDisplay(d.CollectionTime).ToOADate()).ToArray();
         var totalMem = data.Select(d => d.TotalServerMemoryMb / 1024.0).ToArray();
@@ -206,6 +216,7 @@ public partial class ViewerServerTab
         _memoryHover?.Add(grantPlot, "Memory Grants");
 
         MemoryChart.Plot.Axes.DateTimeTicksBottomDateChange();
+        MemoryChart.Plot.Axes.SetLimitsX(rangeStart, rangeEnd);
         ReapplyAxisColors(MemoryChart);
         MemoryChart.Plot.YLabel("Memory (GB)");
 
@@ -222,7 +233,7 @@ public partial class ViewerServerTab
     /// pool, each pool×metric on a cycling <c>SeriesColors</c> color. Times run through
     /// <see cref="ViewerTimeHelper.ForDisplay"/>.
     /// </summary>
-    private void RenderMemoryGrantCharts(List<MemoryGrantChartPoint> data)
+    private void RenderMemoryGrantCharts(List<MemoryGrantChartPoint> data, DateTime startUtc, DateTime endUtc)
     {
         ClearChart(MemoryGrantSizingChart);
         ClearChart(MemoryGrantActivityChart);
@@ -231,10 +242,18 @@ public partial class ViewerServerTab
         ApplyTheme(MemoryGrantSizingChart);
         ApplyTheme(MemoryGrantActivityChart);
 
+        var rangeStart = ViewerTimeHelper.ForDisplay(startUtc).ToOADate();
+        var rangeEnd = ViewerTimeHelper.ForDisplay(endUtc).ToOADate();
+
         if (data.Count == 0)
         {
-            MemoryGrantSizingChart.Refresh();
-            MemoryGrantActivityChart.Refresh();
+            foreach (var c in new[] { MemoryGrantSizingChart, MemoryGrantActivityChart })
+            {
+                c.Plot.Axes.DateTimeTicksBottomDateChange();
+                c.Plot.Axes.SetLimitsX(rangeStart, rangeEnd);
+                ReapplyAxisColors(c);
+                c.Refresh();
+            }
             return;
         }
 
@@ -278,6 +297,7 @@ public partial class ViewerServerTab
         }
 
         MemoryGrantSizingChart.Plot.Axes.DateTimeTicksBottomDateChange();
+        MemoryGrantSizingChart.Plot.Axes.SetLimitsX(rangeStart, rangeEnd);
         ReapplyAxisColors(MemoryGrantSizingChart);
         MemoryGrantSizingChart.Plot.YLabel("Memory (MB)");
         SetChartYLimitsWithLegendPadding(MemoryGrantSizingChart, 0, sizingMax > 0 ? sizingMax : 100);
@@ -315,6 +335,7 @@ public partial class ViewerServerTab
         }
 
         MemoryGrantActivityChart.Plot.Axes.DateTimeTicksBottomDateChange();
+        MemoryGrantActivityChart.Plot.Axes.SetLimitsX(rangeStart, rangeEnd);
         ReapplyAxisColors(MemoryGrantActivityChart);
         MemoryGrantActivityChart.Plot.YLabel("Count");
         SetChartYLimitsWithLegendPadding(MemoryGrantActivityChart, 0, activityMax > 0 ? activityMax : 10);
@@ -529,15 +550,20 @@ public partial class ViewerServerTab
             ApplyTheme(MemoryClerksChart);
             _memoryClerksHover?.Clear();
 
+            var (startUtc, endUtc) = GetWindowUtc();
+            double xMin = ViewerTimeHelper.ForDisplay(startUtc).ToOADate();
+            double xMax = ViewerTimeHelper.ForDisplay(endUtc).ToOADate();
+
             if (selected.Count == 0)
             {
                 MemoryClerksTotalText.Text = "--";
                 MemoryClerksTopText.Text = "--";
+                MemoryClerksChart.Plot.Axes.DateTimeTicksBottomDateChange();
+                MemoryClerksChart.Plot.Axes.SetLimitsX(xMin, xMax);
+                ReapplyAxisColors(MemoryClerksChart);
                 MemoryClerksChart.Refresh();
                 return;
             }
-
-            var (startUtc, endUtc) = GetWindowUtc();
 
             double globalMax = 0;
             double nonBpTotal = 0;
@@ -578,6 +604,7 @@ public partial class ViewerServerTab
             }
 
             MemoryClerksChart.Plot.Axes.DateTimeTicksBottomDateChange();
+            MemoryClerksChart.Plot.Axes.SetLimitsX(xMin, xMax);
             ReapplyAxisColors(MemoryClerksChart);
             MemoryClerksChart.Plot.YLabel("Memory (MB)");
             SetChartYLimitsWithLegendPadding(MemoryClerksChart, 0, globalMax > 0 ? globalMax : 100);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.QueryTrends.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.QueryTrends.cs
@@ -73,19 +73,21 @@ public partial class ViewerServerTab
 
         await Task.WhenAll(queryDurationTask, procDurationTask, queryStoreDurationTask, executionCountTask);
 
-        UpdateQueryDurationTrendChart(queryDurationTask.Result);
-        UpdateProcDurationTrendChart(procDurationTask.Result);
-        UpdateQueryStoreDurationTrendChart(queryStoreDurationTask.Result);
-        UpdateExecutionCountTrendChart(executionCountTask.Result);
+        UpdateQueryDurationTrendChart(queryDurationTask.Result, startUtc, endUtc);
+        UpdateProcDurationTrendChart(procDurationTask.Result, startUtc, endUtc);
+        UpdateQueryStoreDurationTrendChart(queryStoreDurationTask.Result, startUtc, endUtc);
+        UpdateExecutionCountTrendChart(executionCountTask.Result, startUtc, endUtc);
     }
 
-    private void UpdateQueryDurationTrendChart(List<QueryTrendPoint> data)
+    private void UpdateQueryDurationTrendChart(List<QueryTrendPoint> data, DateTime startUtc, DateTime endUtc)
     {
         ClearChart(QueryDurationTrendChart);
         ApplyTheme(QueryDurationTrendChart);
 
         if (data.Count == 0) { RefreshEmptyChart(QueryDurationTrendChart, "Query Duration", "Duration (ms/sec)"); return; }
 
+        var rangeStart = ViewerTimeHelper.ForDisplay(startUtc).ToOADate();
+        var rangeEnd = ViewerTimeHelper.ForDisplay(endUtc).ToOADate();
         var times = data.Select(d => ViewerTimeHelper.ForDisplay(d.CollectionTime).ToOADate()).ToArray();
         var values = data.Select(d => d.Value).ToArray();
 
@@ -97,6 +99,7 @@ public partial class ViewerServerTab
         _queryDurationTrendHover?.Add(plot, "Query Duration");
 
         QueryDurationTrendChart.Plot.Axes.DateTimeTicksBottomDateChange();
+        QueryDurationTrendChart.Plot.Axes.SetLimitsX(rangeStart, rangeEnd);
         ReapplyAxisColors(QueryDurationTrendChart);
         QueryDurationTrendChart.Plot.YLabel("Duration (ms/sec)");
         SetChartYLimitsWithLegendPadding(QueryDurationTrendChart, 0, values.Max());
@@ -104,13 +107,15 @@ public partial class ViewerServerTab
         QueryDurationTrendChart.Refresh();
     }
 
-    private void UpdateProcDurationTrendChart(List<QueryTrendPoint> data)
+    private void UpdateProcDurationTrendChart(List<QueryTrendPoint> data, DateTime startUtc, DateTime endUtc)
     {
         ClearChart(ProcDurationTrendChart);
         ApplyTheme(ProcDurationTrendChart);
 
         if (data.Count == 0) { RefreshEmptyChart(ProcDurationTrendChart, "Procedure Duration", "Duration (ms/sec)"); return; }
 
+        var rangeStart = ViewerTimeHelper.ForDisplay(startUtc).ToOADate();
+        var rangeEnd = ViewerTimeHelper.ForDisplay(endUtc).ToOADate();
         var times = data.Select(d => ViewerTimeHelper.ForDisplay(d.CollectionTime).ToOADate()).ToArray();
         var values = data.Select(d => d.Value).ToArray();
 
@@ -122,6 +127,7 @@ public partial class ViewerServerTab
         _procDurationTrendHover?.Add(plot, "Procedure Duration");
 
         ProcDurationTrendChart.Plot.Axes.DateTimeTicksBottomDateChange();
+        ProcDurationTrendChart.Plot.Axes.SetLimitsX(rangeStart, rangeEnd);
         ReapplyAxisColors(ProcDurationTrendChart);
         ProcDurationTrendChart.Plot.YLabel("Duration (ms/sec)");
         SetChartYLimitsWithLegendPadding(ProcDurationTrendChart, 0, values.Max());
@@ -129,13 +135,15 @@ public partial class ViewerServerTab
         ProcDurationTrendChart.Refresh();
     }
 
-    private void UpdateQueryStoreDurationTrendChart(List<QueryTrendPoint> data)
+    private void UpdateQueryStoreDurationTrendChart(List<QueryTrendPoint> data, DateTime startUtc, DateTime endUtc)
     {
         ClearChart(QueryStoreDurationTrendChart);
         ApplyTheme(QueryStoreDurationTrendChart);
 
         if (data.Count == 0) { RefreshEmptyChart(QueryStoreDurationTrendChart, "Query Store Duration", "Duration (ms/sec)"); return; }
 
+        var rangeStart = ViewerTimeHelper.ForDisplay(startUtc).ToOADate();
+        var rangeEnd = ViewerTimeHelper.ForDisplay(endUtc).ToOADate();
         var times = data.Select(d => ViewerTimeHelper.ForDisplay(d.CollectionTime).ToOADate()).ToArray();
         var values = data.Select(d => d.Value).ToArray();
 
@@ -147,6 +155,7 @@ public partial class ViewerServerTab
         _queryStoreDurationTrendHover?.Add(plot, "Query Store Duration");
 
         QueryStoreDurationTrendChart.Plot.Axes.DateTimeTicksBottomDateChange();
+        QueryStoreDurationTrendChart.Plot.Axes.SetLimitsX(rangeStart, rangeEnd);
         ReapplyAxisColors(QueryStoreDurationTrendChart);
         QueryStoreDurationTrendChart.Plot.YLabel("Duration (ms/sec)");
         SetChartYLimitsWithLegendPadding(QueryStoreDurationTrendChart, 0, values.Max());
@@ -154,13 +163,15 @@ public partial class ViewerServerTab
         QueryStoreDurationTrendChart.Refresh();
     }
 
-    private void UpdateExecutionCountTrendChart(List<QueryTrendPoint> data)
+    private void UpdateExecutionCountTrendChart(List<QueryTrendPoint> data, DateTime startUtc, DateTime endUtc)
     {
         ClearChart(ExecutionCountTrendChart);
         ApplyTheme(ExecutionCountTrendChart);
 
         if (data.Count == 0) { RefreshEmptyChart(ExecutionCountTrendChart, "Executions", "Executions/sec"); return; }
 
+        var rangeStart = ViewerTimeHelper.ForDisplay(startUtc).ToOADate();
+        var rangeEnd = ViewerTimeHelper.ForDisplay(endUtc).ToOADate();
         var times = data.Select(d => ViewerTimeHelper.ForDisplay(d.CollectionTime).ToOADate()).ToArray();
         var values = data.Select(d => d.Value).ToArray();
 
@@ -172,6 +183,7 @@ public partial class ViewerServerTab
         _executionCountTrendHover?.Add(plot, "Executions");
 
         ExecutionCountTrendChart.Plot.Axes.DateTimeTicksBottomDateChange();
+        ExecutionCountTrendChart.Plot.Axes.SetLimitsX(rangeStart, rangeEnd);
         ReapplyAxisColors(ExecutionCountTrendChart);
         ExecutionCountTrendChart.Plot.YLabel("Executions/sec");
         SetChartYLimitsWithLegendPadding(ExecutionCountTrendChart, 0, values.Max());

--- a/Lite/Controls/ServerTab.Charts.cs
+++ b/Lite/Controls/ServerTab.Charts.cs
@@ -108,13 +108,25 @@ public partial class ServerTab : UserControl
         CpuChart.Refresh();
     }
 
-    private void UpdateMemoryChart(List<MemoryTrendPoint> data, List<MemoryTrendPoint> grantData)
+    private void UpdateMemoryChart(List<MemoryTrendPoint> data, List<MemoryTrendPoint> grantData, int hoursBack, DateTime? fromDate, DateTime? toDate)
     {
         ClearChart(MemoryChart);
         _memoryHover?.Clear();
         ApplyTheme(MemoryChart);
 
-        if (data.Count == 0) { MemoryChart.Refresh(); return; }
+        DateTime rangeEnd = toDate ?? DateTime.UtcNow.AddMinutes(UtcOffsetMinutes);
+        DateTime rangeStart = fromDate ?? rangeEnd.AddHours(-hoursBack);
+        double xMin = rangeStart.ToOADate();
+        double xMax = rangeEnd.ToOADate();
+
+        if (data.Count == 0)
+        {
+            MemoryChart.Plot.Axes.DateTimeTicksBottomDateChange();
+            MemoryChart.Plot.Axes.SetLimitsX(xMin, xMax);
+            ReapplyAxisColors(MemoryChart);
+            MemoryChart.Refresh();
+            return;
+        }
 
         var times = data.Select(d => d.CollectionTime.AddMinutes(UtcOffsetMinutes).ToOADate()).ToArray();
         var totalMem = data.Select(d => d.TotalServerMemoryMb / 1024.0).ToArray();
@@ -160,6 +172,7 @@ public partial class ServerTab : UserControl
         _memoryHover?.Add(grantPlot, "Memory Grants");
 
         MemoryChart.Plot.Axes.DateTimeTicksBottomDateChange();
+        MemoryChart.Plot.Axes.SetLimitsX(xMin, xMax);
         ReapplyAxisColors(MemoryChart);
         MemoryChart.Plot.YLabel("Memory (GB)");
 
@@ -170,7 +183,7 @@ public partial class ServerTab : UserControl
         MemoryChart.Refresh();
     }
 
-    private void UpdateMemoryGrantCharts(List<MemoryGrantChartPoint> data)
+    private void UpdateMemoryGrantCharts(List<MemoryGrantChartPoint> data, int hoursBack, DateTime? fromDate, DateTime? toDate)
     {
         ClearChart(MemoryGrantSizingChart);
         ClearChart(MemoryGrantActivityChart);
@@ -179,10 +192,20 @@ public partial class ServerTab : UserControl
         ApplyTheme(MemoryGrantSizingChart);
         ApplyTheme(MemoryGrantActivityChart);
 
+        DateTime rangeEnd = toDate ?? DateTime.UtcNow.AddMinutes(UtcOffsetMinutes);
+        DateTime rangeStart = fromDate ?? rangeEnd.AddHours(-hoursBack);
+        double xMin = rangeStart.ToOADate();
+        double xMax = rangeEnd.ToOADate();
+
         if (data.Count == 0)
         {
-            MemoryGrantSizingChart.Refresh();
-            MemoryGrantActivityChart.Refresh();
+            foreach (var c in new[] { MemoryGrantSizingChart, MemoryGrantActivityChart })
+            {
+                c.Plot.Axes.DateTimeTicksBottomDateChange();
+                c.Plot.Axes.SetLimitsX(xMin, xMax);
+                ReapplyAxisColors(c);
+                c.Refresh();
+            }
             return;
         }
 
@@ -218,6 +241,7 @@ public partial class ServerTab : UserControl
         }
 
         MemoryGrantSizingChart.Plot.Axes.DateTimeTicksBottomDateChange();
+        MemoryGrantSizingChart.Plot.Axes.SetLimitsX(xMin, xMax);
         ReapplyAxisColors(MemoryGrantSizingChart);
         MemoryGrantSizingChart.Plot.YLabel("Memory (MB)");
         SetChartYLimitsWithLegendPadding(MemoryGrantSizingChart, 0, sizingMax > 0 ? sizingMax : 100);
@@ -255,6 +279,7 @@ public partial class ServerTab : UserControl
         }
 
         MemoryGrantActivityChart.Plot.Axes.DateTimeTicksBottomDateChange();
+        MemoryGrantActivityChart.Plot.Axes.SetLimitsX(xMin, xMax);
         ReapplyAxisColors(MemoryGrantActivityChart);
         MemoryGrantActivityChart.Plot.YLabel("Count");
         SetChartYLimitsWithLegendPadding(MemoryGrantActivityChart, 0, activityMax > 0 ? activityMax : 10);
@@ -1076,12 +1101,17 @@ public partial class ServerTab : UserControl
 
     /* ========== Performance Trend Charts ========== */
 
-    private void UpdateQueryDurationTrendChart(List<QueryTrendPoint> data)
+    private void UpdateQueryDurationTrendChart(List<QueryTrendPoint> data, int hoursBack, DateTime? fromDate, DateTime? toDate)
     {
         ClearChart(QueryDurationTrendChart);
         ApplyTheme(QueryDurationTrendChart);
 
         if (data.Count == 0) { RefreshEmptyChart(QueryDurationTrendChart, "Query Duration", "Duration (ms/sec)"); return; }
+
+        DateTime rangeEnd = toDate ?? DateTime.UtcNow.AddMinutes(UtcOffsetMinutes);
+        DateTime rangeStart = fromDate ?? rangeEnd.AddHours(-hoursBack);
+        double xMin = rangeStart.ToOADate();
+        double xMax = rangeEnd.ToOADate();
 
         var times = data.Select(d => d.CollectionTime.AddMinutes(UtcOffsetMinutes).ToOADate()).ToArray();
         var values = data.Select(d => d.Value).ToArray();
@@ -1094,6 +1124,7 @@ public partial class ServerTab : UserControl
         _queryDurationTrendHover?.Add(plot, "Query Duration");
 
         QueryDurationTrendChart.Plot.Axes.DateTimeTicksBottomDateChange();
+        QueryDurationTrendChart.Plot.Axes.SetLimitsX(xMin, xMax);
         ReapplyAxisColors(QueryDurationTrendChart);
         QueryDurationTrendChart.Plot.YLabel("Duration (ms/sec)");
         SetChartYLimitsWithLegendPadding(QueryDurationTrendChart, 0, values.Max());
@@ -1101,12 +1132,17 @@ public partial class ServerTab : UserControl
         QueryDurationTrendChart.Refresh();
     }
 
-    private void UpdateProcDurationTrendChart(List<QueryTrendPoint> data)
+    private void UpdateProcDurationTrendChart(List<QueryTrendPoint> data, int hoursBack, DateTime? fromDate, DateTime? toDate)
     {
         ClearChart(ProcDurationTrendChart);
         ApplyTheme(ProcDurationTrendChart);
 
         if (data.Count == 0) { RefreshEmptyChart(ProcDurationTrendChart, "Procedure Duration", "Duration (ms/sec)"); return; }
+
+        DateTime rangeEnd = toDate ?? DateTime.UtcNow.AddMinutes(UtcOffsetMinutes);
+        DateTime rangeStart = fromDate ?? rangeEnd.AddHours(-hoursBack);
+        double xMin = rangeStart.ToOADate();
+        double xMax = rangeEnd.ToOADate();
 
         var times = data.Select(d => d.CollectionTime.AddMinutes(UtcOffsetMinutes).ToOADate()).ToArray();
         var values = data.Select(d => d.Value).ToArray();
@@ -1119,6 +1155,7 @@ public partial class ServerTab : UserControl
         _procDurationTrendHover?.Add(plot, "Procedure Duration");
 
         ProcDurationTrendChart.Plot.Axes.DateTimeTicksBottomDateChange();
+        ProcDurationTrendChart.Plot.Axes.SetLimitsX(xMin, xMax);
         ReapplyAxisColors(ProcDurationTrendChart);
         ProcDurationTrendChart.Plot.YLabel("Duration (ms/sec)");
         SetChartYLimitsWithLegendPadding(ProcDurationTrendChart, 0, values.Max());
@@ -1126,12 +1163,17 @@ public partial class ServerTab : UserControl
         ProcDurationTrendChart.Refresh();
     }
 
-    private void UpdateQueryStoreDurationTrendChart(List<QueryTrendPoint> data)
+    private void UpdateQueryStoreDurationTrendChart(List<QueryTrendPoint> data, int hoursBack, DateTime? fromDate, DateTime? toDate)
     {
         ClearChart(QueryStoreDurationTrendChart);
         ApplyTheme(QueryStoreDurationTrendChart);
 
         if (data.Count == 0) { RefreshEmptyChart(QueryStoreDurationTrendChart, "Query Store Duration", "Duration (ms/sec)"); return; }
+
+        DateTime rangeEnd = toDate ?? DateTime.UtcNow.AddMinutes(UtcOffsetMinutes);
+        DateTime rangeStart = fromDate ?? rangeEnd.AddHours(-hoursBack);
+        double xMin = rangeStart.ToOADate();
+        double xMax = rangeEnd.ToOADate();
 
         var times = data.Select(d => d.CollectionTime.AddMinutes(UtcOffsetMinutes).ToOADate()).ToArray();
         var values = data.Select(d => d.Value).ToArray();
@@ -1144,6 +1186,7 @@ public partial class ServerTab : UserControl
         _queryStoreDurationTrendHover?.Add(plot, "Query Store Duration");
 
         QueryStoreDurationTrendChart.Plot.Axes.DateTimeTicksBottomDateChange();
+        QueryStoreDurationTrendChart.Plot.Axes.SetLimitsX(xMin, xMax);
         ReapplyAxisColors(QueryStoreDurationTrendChart);
         QueryStoreDurationTrendChart.Plot.YLabel("Duration (ms/sec)");
         SetChartYLimitsWithLegendPadding(QueryStoreDurationTrendChart, 0, values.Max());
@@ -1151,12 +1194,17 @@ public partial class ServerTab : UserControl
         QueryStoreDurationTrendChart.Refresh();
     }
 
-    private void UpdateExecutionCountTrendChart(List<QueryTrendPoint> data)
+    private void UpdateExecutionCountTrendChart(List<QueryTrendPoint> data, int hoursBack, DateTime? fromDate, DateTime? toDate)
     {
         ClearChart(ExecutionCountTrendChart);
         ApplyTheme(ExecutionCountTrendChart);
 
         if (data.Count == 0) { RefreshEmptyChart(ExecutionCountTrendChart, "Executions", "Executions/sec"); return; }
+
+        DateTime rangeEnd = toDate ?? DateTime.UtcNow.AddMinutes(UtcOffsetMinutes);
+        DateTime rangeStart = fromDate ?? rangeEnd.AddHours(-hoursBack);
+        double xMin = rangeStart.ToOADate();
+        double xMax = rangeEnd.ToOADate();
 
         var times = data.Select(d => d.CollectionTime.AddMinutes(UtcOffsetMinutes).ToOADate()).ToArray();
         var values = data.Select(d => d.Value).ToArray();
@@ -1169,6 +1217,7 @@ public partial class ServerTab : UserControl
         _executionCountTrendHover?.Add(plot, "Executions");
 
         ExecutionCountTrendChart.Plot.Axes.DateTimeTicksBottomDateChange();
+        ExecutionCountTrendChart.Plot.Axes.SetLimitsX(xMin, xMax);
         ReapplyAxisColors(ExecutionCountTrendChart);
         ExecutionCountTrendChart.Plot.YLabel("Executions/sec");
         SetChartYLimitsWithLegendPadding(ExecutionCountTrendChart, 0, values.Max());

--- a/Lite/Controls/ServerTab.Pickers.cs
+++ b/Lite/Controls/ServerTab.Pickers.cs
@@ -307,14 +307,6 @@ public partial class ServerTab : UserControl
             ApplyTheme(MemoryClerksChart);
             _memoryClerksHover?.Clear();
 
-            if (selected.Count == 0)
-            {
-                MemoryClerksTotalText.Text = "--";
-                MemoryClerksTopText.Text = "--";
-                MemoryClerksChart.Refresh();
-                return;
-            }
-
             var hoursBack = GetHoursBack();
             DateTime? fromDate = null;
             DateTime? toDate = null;
@@ -327,6 +319,21 @@ public partial class ServerTab : UserControl
                     fromDate = ServerTimeHelper.DisplayTimeToServerTime(fromLocal.Value, ServerTimeHelper.CurrentDisplayMode);
                     toDate = ServerTimeHelper.DisplayTimeToServerTime(toLocal.Value, ServerTimeHelper.CurrentDisplayMode);
                 }
+            }
+            DateTime rangeEnd = toDate ?? DateTime.UtcNow.AddMinutes(UtcOffsetMinutes);
+            DateTime rangeStart = fromDate ?? rangeEnd.AddHours(-hoursBack);
+            double xMin = rangeStart.ToOADate();
+            double xMax = rangeEnd.ToOADate();
+
+            if (selected.Count == 0)
+            {
+                MemoryClerksTotalText.Text = "--";
+                MemoryClerksTopText.Text = "--";
+                MemoryClerksChart.Plot.Axes.DateTimeTicksBottomDateChange();
+                MemoryClerksChart.Plot.Axes.SetLimitsX(xMin, xMax);
+                ReapplyAxisColors(MemoryClerksChart);
+                MemoryClerksChart.Refresh();
+                return;
             }
 
             double globalMax = 0;
@@ -367,6 +374,7 @@ public partial class ServerTab : UserControl
             }
 
             MemoryClerksChart.Plot.Axes.DateTimeTicksBottomDateChange();
+            MemoryClerksChart.Plot.Axes.SetLimitsX(xMin, xMax);
             ReapplyAxisColors(MemoryClerksChart);
             MemoryClerksChart.Plot.YLabel("Memory (MB)");
             SetChartYLimitsWithLegendPadding(MemoryClerksChart, 0, globalMax > 0 ? globalMax : 100);

--- a/Lite/Controls/ServerTab.Refresh.cs
+++ b/Lite/Controls/ServerTab.Refresh.cs
@@ -163,10 +163,10 @@ public partial class ServerTab : UserControl
                         var qsdt = Helpers.MethodProfiler.TimeAsync("QueryPerformance.QsDurationTrends", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetQueryStoreDurationTrendAsync(_serverId, hoursBack, fromDate, toDate))));
                         var ect = Helpers.MethodProfiler.TimeAsync("QueryPerformance.ExecutionTrends", () => Task.Run(() => SafeQueryAsync(() => _dataService.GetExecutionCountTrendAsync(_serverId, hoursBack, fromDate, toDate))));
                         await System.Threading.Tasks.Task.WhenAll(qdt, pdt, qsdt, ect);
-                        UpdateQueryDurationTrendChart(qdt.Result);
-                        UpdateProcDurationTrendChart(pdt.Result);
-                        UpdateQueryStoreDurationTrendChart(qsdt.Result);
-                        UpdateExecutionCountTrendChart(ect.Result);
+                        UpdateQueryDurationTrendChart(qdt.Result, hoursBack, fromDate, toDate);
+                        UpdateProcDurationTrendChart(pdt.Result, hoursBack, fromDate, toDate);
+                        UpdateQueryStoreDurationTrendChart(qsdt.Result, hoursBack, fromDate, toDate);
+                        UpdateExecutionCountTrendChart(ect.Result, hoursBack, fromDate, toDate);
                         break;
                     case 1: // Active Queries
                         var snapshots = await Task.Run(() => _dataService.GetLatestQuerySnapshotsAsync(_serverId, hoursBack, fromDate, toDate));
@@ -267,10 +267,10 @@ public partial class ServerTab : UserControl
                 await RefreshQueryStoreComparisonAsync(cStart3, cEnd3);
             }
 
-            UpdateQueryDurationTrendChart(queryDurationTrendTask.Result);
-            UpdateProcDurationTrendChart(procDurationTrendTask.Result);
-            UpdateQueryStoreDurationTrendChart(queryStoreDurationTrendTask.Result);
-            UpdateExecutionCountTrendChart(executionCountTrendTask.Result);
+            UpdateQueryDurationTrendChart(queryDurationTrendTask.Result, hoursBack, fromDate, toDate);
+            UpdateProcDurationTrendChart(procDurationTrendTask.Result, hoursBack, fromDate, toDate);
+            UpdateQueryStoreDurationTrendChart(queryStoreDurationTrendTask.Result, hoursBack, fromDate, toDate);
+            UpdateExecutionCountTrendChart(executionCountTrendTask.Result, hoursBack, fromDate, toDate);
             UpdateQueryHeatmapChart(heatmapTask.Result);
         }
         catch (Exception ex)
@@ -323,7 +323,7 @@ public partial class ServerTab : UserControl
                         var memTrend = await Task.Run(() => _dataService.GetMemoryTrendAsync(_serverId, hoursBack, fromDate, toDate));
                         var memGrantTrend = await Task.Run(() => _dataService.GetMemoryGrantTrendAsync(_serverId, hoursBack, fromDate, toDate));
                         UpdateMemorySummary(memStats);
-                        UpdateMemoryChart(memTrend, memGrantTrend);
+                        UpdateMemoryChart(memTrend, memGrantTrend, hoursBack, fromDate, toDate);
                         break;
                     case 1: // Memory Clerks
                         var clerkTypes = await Task.Run(() => _dataService.GetDistinctMemoryClerkTypesAsync(_serverId, hoursBack, fromDate, toDate));
@@ -332,7 +332,7 @@ public partial class ServerTab : UserControl
                         break;
                     case 2: // Memory Grants
                         var grantChart = await Task.Run(() => _dataService.GetMemoryGrantChartDataAsync(_serverId, hoursBack, fromDate, toDate));
-                        UpdateMemoryGrantCharts(grantChart);
+                        UpdateMemoryGrantCharts(grantChart, hoursBack, fromDate, toDate);
                         break;
                     case 3: // Memory Pressure Events
                         var pressureEvents = await Task.Run(() => _dataService.GetMemoryPressureEventsAsync(_serverId, hoursBack, fromDate, toDate));
@@ -353,8 +353,8 @@ public partial class ServerTab : UserControl
             await System.Threading.Tasks.Task.WhenAll(memoryTask, memoryTrendTask, memoryClerkTypesTask, memoryGrantTrendTask, memoryGrantChartTask, memoryPressureEventsTask);
 
             UpdateMemorySummary(memoryTask.Result);
-            UpdateMemoryChart(memoryTrendTask.Result, memoryGrantTrendTask.Result);
-            UpdateMemoryGrantCharts(memoryGrantChartTask.Result);
+            UpdateMemoryChart(memoryTrendTask.Result, memoryGrantTrendTask.Result, hoursBack, fromDate, toDate);
+            UpdateMemoryGrantCharts(memoryGrantChartTask.Result, hoursBack, fromDate, toDate);
             UpdateMemoryPressureEventsChart(memoryPressureEventsTask.Result, hoursBack, fromDate, toDate);
             PopulateMemoryClerkPicker(memoryClerkTypesTask.Result);
             await UpdateMemoryClerksChartFromPickerAsync();


### PR DESCRIPTION
## Summary

Finishes the trend-chart dead-space sweep started in #1483 (CPU/tempdb) and #1484 (File I/O): window-pins the remaining Memory and Query Performance Trends charts that still auto-fit their X-axis, so ScottPlot no longer leaves default-margin dead space at the chart edges. Copies the exact `SetLimitsX(rangeStart, rangeEnd)`-after-`DateTimeTicksBottomDateChange()` idiom those PRs established.

### Charts pinned

**Darling** (`ViewerServerTab.Memory.cs`, `ViewerServerTab.QueryTrends.cs`)
- Memory Overview trend (`RenderMemoryChart`)
- Memory Grants sizing + activity (`RenderMemoryGrantCharts`)
- Memory Clerks (`UpdateMemoryClerksChartFromPickerAsync`)
- Query / Procedure / Query Store duration + Execution count trends

**Lite** (`ServerTab.Charts.cs`, `ServerTab.Pickers.cs`, `ServerTab.Refresh.cs`)
- The same eight charts, with `(hoursBack, fromDate, toDate)` threaded into the render methods and every call site in `RefreshMemoryAsync` / `RefreshQueriesAsync` updated.

### Notes
- The dense per-interval Memory charts pin in **both** the empty-data and populated paths (matching CPU/File I/O). The four Query-Trend charts pin the populated path and keep their existing `RefreshEmptyChart` "No Data" placeholder for the genuinely-empty case (no precedent in #1483/#1484 for replacing it, and it is the better empty-state UX).
- Charts that already pin X (Memory Pressure Events, Plan Cache) were left untouched. Heatmap/categorical charts skipped per scope.
- **Parity:** Lite's Memory Clerks chart lives in `ServerTab.Pickers.cs` (not `Charts.cs`), so it fell outside the originally-listed methods -- pinned here too so Lite and Darling stay in lockstep (same bug, same dense metric).

### Testing
- `dotnet build Darling/PerformanceMonitor.Darling.Viewer/PerformanceMonitor.Darling.Viewer.csproj -c Debug` -> **0 Error(s)**
- `dotnet build Lite/PerformanceMonitorLite.csproj -c Debug` -> **0 Error(s)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
