### PR TITLE
Darling: strip embedded NULs before Postgres COPY (#1614)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Full Dashboard and the CLI Installer are being retired.** They moved to a `deprecated/` folder and are no longer built into release artifacts; releases now ship Lite + Darling only, with Darling the flagship replacement for the Full Dashboard. The deprecated code still compiles and its tests run in CI. ([#1612])
 
+### Fixed
+
+- **Darling: collectors no longer fail with `22021: invalid byte sequence for encoding "UTF8": 0x00`** ([#1614]) - SQL Server NVARCHAR allows embedded NUL characters and query text from `sys.dm_exec_sql_text` sometimes carries them, but Postgres `text` columns reject the byte, so one NUL-laden cached query failed the entire `query_stats` COPY batch every cycle (`DBCC FREEPROCCACHE` never helped because the app re-caches the same query). The Postgres row writer now strips NULs from every collected string - query text, plan XML, deadlock and blocked-process XML included - at the single COPY choke point.
+
 ## [3.2.0] - 2026-07-21
 
 ### Added
@@ -499,6 +503,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1608]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1608
 [#1609]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1609
 [#1612]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1612
+[#1614]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/1614
 [#1601]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1601
 [#1604]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1604
 [#1602]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1602

--- a/Darling/Darling.Tests/PgCopyWriterTests.cs
+++ b/Darling/Darling.Tests/PgCopyWriterTests.cs
@@ -83,6 +83,16 @@ public sealed class PgCopyWriterTests
     }
 
     [Fact]
+    public void StripEmbeddedNuls_RemovesNulsPostgresRejects_LeavesCleanTextAlone()
+    {
+        /* SQL Server NVARCHAR allows embedded NUL; Postgres text rejects it with 22021 (#1614). */
+        Assert.Equal("SELECT 1;", PgCollectorRowWriter.StripEmbeddedNuls("SELECT 1;"));
+        Assert.Equal("SELECT 1;", PgCollectorRowWriter.StripEmbeddedNuls("SELECT\0 1;\0"));
+        Assert.Equal(string.Empty, PgCollectorRowWriter.StripEmbeddedNuls("\0\0"));
+        Assert.Equal(string.Empty, PgCollectorRowWriter.StripEmbeddedNuls(string.Empty));
+    }
+
+    [Fact]
     public async Task EndToEnd_MigrateCopyReadBack_AgainstDevPostgres()
     {
         var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
@@ -96,13 +106,15 @@ public sealed class PgCopyWriterTests
         await PgMigrations.MigrateAsync(connection, TestContext.Current.CancellationToken);
         Assert.Equal(0, await PgMigrations.MigrateAsync(connection, TestContext.Current.CancellationToken));
 
-        /* COPY one deadlocks row through the definition's own WritePayload. */
+        /* COPY one deadlocks row through the definition's own WritePayload. The victim text
+           carries an embedded NUL — the #1614 repro: SQL Server NVARCHAR allows it, Postgres
+           rejects the raw byte with 22021, and the writer must strip it or this COPY fails. */
         var collectionTime = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Unspecified);
         var row = new DeadlocksCollector.Row
         {
             DeadlockTime = collectionTime,
             VictimProcessId = "process-e2e",
-            VictimSqlText = "UPDATE t SET x = 1;",
+            VictimSqlText = "UPDATE t SET x = 1;\0",
             GraphXml = "<deadlock/>",
         };
 

--- a/Darling/PerformanceMonitor.Darling.Storage/PgCollectorRowWriter.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/PgCollectorRowWriter.cs
@@ -85,9 +85,18 @@ public sealed class PgCollectorRowWriter : ICollectorRowWriter
     /// <summary>Naive-UTC storage: strip the Kind so Npgsql accepts the value for `timestamp`.</summary>
     private static DateTime Naive(DateTime value) => DateTime.SpecifyKind(value, DateTimeKind.Unspecified);
 
+    /// <summary>
+    /// Postgres `text` cannot hold NUL (0x00), which SQL Server NVARCHAR allows — one NUL-laden
+    /// query text from dm_exec_sql_text fails the whole COPY batch with 22021 "invalid byte
+    /// sequence for encoding UTF8: 0x00" (#1614). Every collector string funnels through
+    /// <see cref="Value(string?)"/>, so stripping here covers all of them. String.Replace returns
+    /// the original instance when nothing matches, so clean strings (the vast majority) don't allocate.
+    /// </summary>
+    public static string StripEmbeddedNuls(string value) => value.Replace("\0", string.Empty);
+
     public ICollectorRowWriter Value(string? value)
     {
-        if (value is null) { Target.WriteNull(); } else { Target.Write(value, NpgsqlDbType.Text); }
+        if (value is null) { Target.WriteNull(); } else { Target.Write(StripEmbeddedNuls(value), NpgsqlDbType.Text); }
         return this;
     }
 


### PR DESCRIPTION
## Summary

Fixes #1614 — the `query_stats` collector (and any other collector whose text hits the same data) failing every cycle with `22021: invalid byte sequence for encoding "UTF8": 0x00` on Darling 3.2.0.

**Root cause:** SQL Server NVARCHAR allows embedded NUL (`0x00`) characters, and query text from `sys.dm_exec_sql_text` sometimes carries them (apps sending SQL with NUL-laden literals). Postgres `text` columns reject the byte outright, so one such cached query failed the entire COPY batch every cycle. `DBCC FREEPROCCACHE` never helped because the offending app re-caches the same query immediately. 3.1.0 Full never hit this because SQL Server storage accepts NULs; Postgres is the new constraint.

**Fix:** every collector string funnels through `PgCollectorRowWriter.Value(string?)` — the single COPY choke point — so NULs are stripped there, covering query text, plan XML, deadlock and blocked-process XML, and every other collected string. Same adapt-at-the-storage-boundary pattern as the existing DateTime Kind handling in that file. `String.Replace` returns the original instance when nothing matches, so clean strings (the vast majority) do not allocate.

Other Postgres write surfaces (alert log, findings, config) get their text from Postgres reads (downstream of COPY) or service/user-generated strings, so this one site covers the product.

## Test plan

- New unit test pins `StripEmbeddedNuls` (clean text untouched, NULs removed, all-NUL collapses to empty).
- The live E2E COPY test (`DARLING_TEST_PG`-gated, runs in the darling-pg CI job) now writes victim SQL text carrying an embedded NUL and asserts it reads back stripped.
- Negative proof against a live dev Postgres: with the strip call reverted, that E2E fails with the exact reported error (`Npgsql.PostgresException : 22021: invalid byte sequence for encoding "UTF8": 0x00`); with the fix, 5/5 pass including the live round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)