### PR TITLE
Darling: reshape QS + procedure_stats CAGGs to the composer's dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Full Dashboard and the CLI Installer are being retired.** They moved to a `deprecated/` folder and are no longer built into release artifacts; releases now ship Lite + Darling only, with Darling the flagship replacement for the Full Dashboard. The deprecated code still compiles and its tests run in CI. ([#1612])
 - **Darling Web: the custom-view panel grid is capped at two columns on wide screens** ([#1619]) - a dense view (e.g. four panels) no longer crams four-across on a wide monitor; the min column track is >=45% of the row so at most two columns ever fit, and a `span-2` (or lone) panel still takes the full width.
+- **Darling: the query_store_stats + procedure_stats continuous aggregates are reshaped to the composer's dimensions** ([#1624]) - the #1621/#1623 CAGGs grouped query_store_stats by Query Store's native query_id/plan_id (which the composer never uses - it reads QS by module_name/query_hash) and dropped procedure_stats' schema_name, so a composed panel over those dimensions could not route to the rollup, and the QS execution-weighted mean was unreconstructable (it stored avg-of-avgs). Regrouped query_store_stats_hourly to server/database_name/module_name/query_hash carrying execution-weighted sums (so the weighted mean composes exactly), and added schema_name to the procedure_stats hourly + daily CAGGs. Reshaped now while the CAGGs are empty (QS is read-only on the current replica) or a day or two old, via a guarded drop+recreate that detects the old shape structurally. Matters ahead of a writable-Query-Store primary; query_stats CAGGs are unchanged.
 
 ### Fixed
 
@@ -520,6 +521,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1620]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1620
 [#1622]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1622
 [#1623]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1623
+[#1624]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1624
 [#1617]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/1617
 [#1621]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1621
 [#1601]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1601

--- a/Darling/Darling.Tests/TimescaleContinuousAggregateTests.cs
+++ b/Darling/Darling.Tests/TimescaleContinuousAggregateTests.cs
@@ -52,14 +52,15 @@ public sealed class TimescaleContinuousAggregateTests
     }
 
     [Fact]
-    public void ProcedureStatsHourly_MirrorsQueryStats_GroupedByObjectName()
+    public void ProcedureStatsHourly_GroupedBySchemaAndObject()
     {
         var sql = TimescaleSupport.CreateProcedureStatsHourlySql;
 
         Assert.Contains("CREATE MATERIALIZED VIEW IF NOT EXISTS collect.procedure_stats_hourly", sql, StringComparison.Ordinal);
         Assert.Contains("WITH (timescaledb.continuous)", sql, StringComparison.Ordinal);
         Assert.Contains("FROM collect.procedure_stats", sql, StringComparison.Ordinal);
-        Assert.Contains("GROUP BY server_id, server_name, database_name, object_name, bucket", sql, StringComparison.Ordinal);
+        /* schema_name + object_name — both composer dimensions (a panel by schema_name alone re-aggregates). */
+        Assert.Contains("GROUP BY server_id, server_name, database_name, schema_name, object_name, bucket", sql, StringComparison.Ordinal);
         Assert.Contains("count(*) AS sample_count", sql, StringComparison.Ordinal);
         Assert.Contains("WITH NO DATA", sql, StringComparison.Ordinal);
     }
@@ -77,7 +78,7 @@ public sealed class TimescaleContinuousAggregateTests
     }
 
     [Fact]
-    public void QueryStoreStatsHourly_GroupedByQsIdentity_SumsCount_AveragesTheAvgColumns()
+    public void QueryStoreStatsHourly_GroupedByComposerDims_CarriesWeightedSums()
     {
         var sql = TimescaleSupport.CreateQueryStoreStatsHourlySql;
 
@@ -85,14 +86,20 @@ public sealed class TimescaleContinuousAggregateTests
         Assert.Contains("WITH (timescaledb.continuous)", sql, StringComparison.Ordinal);
         Assert.Contains("time_bucket('1 hour', collection_time) AS bucket", sql, StringComparison.Ordinal);
         Assert.Contains("FROM collect.query_store_stats", sql, StringComparison.Ordinal);
-        /* QS's own identity (query_id / plan_id), not a query_hash. */
-        Assert.Contains("GROUP BY server_id, server_name, database_name, query_id, plan_id, bucket", sql, StringComparison.Ordinal);
-        /* QS carries already-aggregated figures (not Darling deltas): SUM the count, MAX the max_*, avg-of-avgs on avg_*. */
+        /* The COMPOSER's QS dimensions (module_name / query_hash) so a composed QS panel can route here — NOT
+           Query Store's own query_id / plan_id, which the composer never exposes. */
+        Assert.Contains("GROUP BY server_id, server_name, database_name, module_name, query_hash, bucket", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("query_id", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("plan_id", sql, StringComparison.Ordinal);
+        /* Execution-WEIGHTED sums so the composer's weighted mean = duration_us_weighted_sum / execution_count_sum
+           composes EXACTLY (avg*count = the interval total, summed = the true total) — never an avg-of-avgs. */
         Assert.Contains("sum(execution_count) AS execution_count_sum", sql, StringComparison.Ordinal);
-        Assert.Contains("avg(avg_duration_us) AS avg_duration_us_avg", sql, StringComparison.Ordinal);
+        Assert.Contains("sum(avg_duration_us::double precision * execution_count) AS duration_us_weighted_sum", sql, StringComparison.Ordinal);
+        Assert.Contains("sum(avg_cpu_time_us::double precision * execution_count) AS cpu_us_weighted_sum", sql, StringComparison.Ordinal);
         Assert.Contains("max(max_duration_us) AS max_duration_us_max", sql, StringComparison.Ordinal);
-        Assert.Contains("avg(avg_cpu_time_us) AS avg_cpu_time_us_avg", sql, StringComparison.Ordinal);
         Assert.Contains("max(max_cpu_time_us) AS max_cpu_time_us_max", sql, StringComparison.Ordinal);
+        /* The imprecise avg-of-avgs shape is gone. */
+        Assert.DoesNotContain("avg(avg_duration_us)", sql, StringComparison.Ordinal);
         Assert.Contains("count(*) AS sample_count", sql, StringComparison.Ordinal);
         Assert.Contains("WITH NO DATA", sql, StringComparison.Ordinal);
     }
@@ -125,7 +132,7 @@ public sealed class TimescaleContinuousAggregateTests
 
         Assert.Contains("CREATE MATERIALIZED VIEW IF NOT EXISTS collect.procedure_stats_daily", sql, StringComparison.Ordinal);
         Assert.Contains("FROM collect.procedure_stats_hourly", sql, StringComparison.Ordinal);
-        Assert.Contains("GROUP BY server_id, server_name, database_name, object_name, time_bucket('1 day', bucket)", sql, StringComparison.Ordinal);
+        Assert.Contains("GROUP BY server_id, server_name, database_name, schema_name, object_name, time_bucket('1 day', bucket)", sql, StringComparison.Ordinal);
         Assert.Contains("sum(sample_count) AS sample_count", sql, StringComparison.Ordinal);
         Assert.Contains("WITH NO DATA", sql, StringComparison.Ordinal);
     }

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -589,6 +589,9 @@ public sealed class DarlingWorker : BackgroundService
                 await TimescaleSupport.ConvertToHypertablesAsync(timescaleConnection, _logger, stoppingToken);
                 await TimescaleSupport.ApplyCompressionPolicyAsync(timescaleConnection, _logger, stoppingToken);
                 await TimescaleSupport.EnsureCollectionLogHypertableAsync(timescaleConnection, _logger, stoppingToken);
+                // Reshape: drop stale old-shape QS / procedure_stats CAGGs FIRST so the ensure below rebuilds them
+                // in the composer-dimension shape (no-op once reshaped, and on a fresh store nothing matches).
+                await TimescaleSupport.DropStaleContinuousAggregatesAsync(timescaleConnection, _logger, stoppingToken);
                 await TimescaleSupport.EnsureContinuousAggregatesAsync(timescaleConnection, _logger, stoppingToken);
                 // AFTER the CAGGs exist: the tiered retention (raw 4d, hourly CAGGs 21d; daily kept indefinitely).
                 await TimescaleSupport.EnsureRetentionPoliciesAsync(timescaleConnection, _logger, stoppingToken);

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -291,14 +291,16 @@ GROUP BY server_id, server_name, database_name, query_hash, bucket
 WITH NO DATA";
 
     /// <summary>The procedure_stats hourly continuous aggregate — <see cref="CreateQueryStatsHourlySql"/>'s
-    /// sibling, grouped by <c>object_name</c> instead of <c>query_hash</c> (procedure_stats' composer
-    /// dimension). Same aggregation shape, same WITH NO DATA + IF NOT EXISTS discipline.</summary>
+    /// sibling, grouped by <c>schema_name</c> + <c>object_name</c> (procedure_stats' composer dimensions; a panel
+    /// grouping by schema_name alone re-aggregates over its objects). Same aggregation shape, same WITH NO DATA +
+    /// IF NOT EXISTS discipline.</summary>
     public const string CreateProcedureStatsHourlySql = @"CREATE MATERIALIZED VIEW IF NOT EXISTS collect.procedure_stats_hourly
 WITH (timescaledb.continuous) AS
 SELECT
     server_id,
     server_name,
     database_name,
+    schema_name,
     object_name,
     time_bucket('1 hour', collection_time) AS bucket,
     sum(delta_worker_time) AS worker_time_sum,
@@ -312,16 +314,18 @@ SELECT
     max(delta_execution_count) AS execution_count_max,
     count(*) AS sample_count
 FROM collect.procedure_stats
-GROUP BY server_id, server_name, database_name, object_name, bucket
+GROUP BY server_id, server_name, database_name, schema_name, object_name, bucket
 WITH NO DATA";
 
     /// <summary>
-    /// The query_store_stats hourly continuous aggregate. Grouped by QS's own identity dimensions
-    /// (server_id / server_name / database_name / query_id / plan_id) instead of a query_hash. query_store_stats
-    /// carries Query Store's already-aggregated per-collection figures (not Darling deltas), so this SUMs the
-    /// execution_count and takes MAX on the max_* columns; the avg_* columns are averaged (avg-of-avgs — QS does
-    /// not expose a total from which to weight, and QS is itself a sampled top-N, so the approximation is
-    /// acceptable). WITH NO DATA + IF NOT EXISTS, one statement, exactly like the delta-table hourly CAGGs.
+    /// The query_store_stats hourly continuous aggregate, grouped by the COMPOSER's Query Store dimensions
+    /// (server / database_name / module_name / query_hash) so a composed QS panel can route here — NOT Query
+    /// Store's own query_id/plan_id, which the composer never exposes. Carries the EXECUTION-WEIGHTED sums
+    /// (<c>sum(avg_* * execution_count)</c>) so the composer's weighted mean composes EXACTLY as
+    /// <c>duration_us_weighted_sum / execution_count_sum</c> across any window (avg*count = the interval's total,
+    /// summed = the true total) — never an avg-of-avgs. This matters the moment a writable-Query-Store primary is
+    /// added (the scenario this CAGG exists to be ready for); on the current read-only replica it is simply empty.
+    /// WITH NO DATA + IF NOT EXISTS, one statement.
     /// </summary>
     public const string CreateQueryStoreStatsHourlySql = @"CREATE MATERIALIZED VIEW IF NOT EXISTS collect.query_store_stats_hourly
 WITH (timescaledb.continuous) AS
@@ -329,17 +333,17 @@ SELECT
     server_id,
     server_name,
     database_name,
-    query_id,
-    plan_id,
+    module_name,
+    query_hash,
     time_bucket('1 hour', collection_time) AS bucket,
     sum(execution_count) AS execution_count_sum,
-    avg(avg_duration_us) AS avg_duration_us_avg,
+    sum(avg_duration_us::double precision * execution_count) AS duration_us_weighted_sum,
+    sum(avg_cpu_time_us::double precision * execution_count) AS cpu_us_weighted_sum,
     max(max_duration_us) AS max_duration_us_max,
-    avg(avg_cpu_time_us) AS avg_cpu_time_us_avg,
     max(max_cpu_time_us) AS max_cpu_time_us_max,
     count(*) AS sample_count
 FROM collect.query_store_stats
-GROUP BY server_id, server_name, database_name, query_id, plan_id, bucket
+GROUP BY server_id, server_name, database_name, module_name, query_hash, bucket
 WITH NO DATA";
 
     /// <summary>
@@ -374,14 +378,15 @@ GROUP BY server_id, server_name, database_name, query_hash, time_bucket('1 day',
 WITH NO DATA";
 
     /// <summary>The procedure_stats DAILY continuous aggregate — <see cref="CreateQueryStatsDailySql"/>'s sibling,
-    /// sourced from <see cref="ProcedureStatsHourlyView"/> and grouped by <c>object_name</c>. Same hierarchical
-    /// re-aggregation and same explicit-<c>time_bucket</c> GROUP BY discipline.</summary>
+    /// sourced from <see cref="ProcedureStatsHourlyView"/> and grouped by <c>schema_name</c> + <c>object_name</c>.
+    /// Same hierarchical re-aggregation and same explicit-<c>time_bucket</c> GROUP BY discipline.</summary>
     public const string CreateProcedureStatsDailySql = @"CREATE MATERIALIZED VIEW IF NOT EXISTS collect.procedure_stats_daily
 WITH (timescaledb.continuous) AS
 SELECT
     server_id,
     server_name,
     database_name,
+    schema_name,
     object_name,
     time_bucket('1 day', bucket) AS bucket,
     sum(worker_time_sum) AS worker_time_sum,
@@ -395,7 +400,7 @@ SELECT
     max(execution_count_max) AS execution_count_max,
     sum(sample_count) AS sample_count
 FROM collect.procedure_stats_hourly
-GROUP BY server_id, server_name, database_name, object_name, time_bucket('1 day', bucket)
+GROUP BY server_id, server_name, database_name, schema_name, object_name, time_bucket('1 day', bucket)
 WITH NO DATA";
 
     /// <summary>
@@ -408,6 +413,73 @@ WITH NO DATA";
     /// </summary>
     public static string AddContinuousAggregatePolicySql(string view, string endOffset = "1 hour", string scheduleInterval = "1 hour")
         => $"SELECT add_continuous_aggregate_policy('collect.{view}', start_offset => INTERVAL '3 days', end_offset => INTERVAL '{endOffset}', schedule_interval => INTERVAL '{scheduleInterval}', if_not_exists => true)";
+
+    /// <summary>
+    /// The composer-dimension reshape: the QS hourly CAGG regrouped query_id/plan_id → module_name/query_hash
+    /// (+ weighted sums), and the procedure_stats CAGGs gained schema_name. <c>CREATE ... IF NOT EXISTS</c> cannot
+    /// ALTER an existing CAGG, so a store that already built the OLD shape must DROP it first;
+    /// <see cref="EnsureContinuousAggregatesAsync"/> (run right after) recreates it in the new shape. Each affected
+    /// CAGG is empty (QS on a read-only replica) or only a day or two old, so the drop loses little and the refresh
+    /// backfills the recent window within the hour. Staleness is detected STRUCTURALLY — the OLD QS CAGG still has
+    /// a <c>query_id</c> column; the OLD procedure_stats CAGG lacks <c>schema_name</c> — so this is a strict no-op
+    /// once reshaped, and on a fresh store (no CAGG yet) nothing matches. Failure-isolated: a failed drop leaves the
+    /// old shape in place (logged), never kills startup. query_stats CAGGs are unchanged and untouched. CASCADE
+    /// drops the dependent daily CAGG, which the ensure sweep also recreates.
+    /// </summary>
+    public static async Task<int> DropStaleContinuousAggregatesAsync(NpgsqlConnection connection, ILogger? logger, CancellationToken cancellationToken = default)
+    {
+        if (connection is null)
+        {
+            throw new ArgumentNullException(nameof(connection));
+        }
+
+        var reshapes = new[]
+        {
+            /* OLD query_store_stats_hourly grouped by query_id/plan_id → stale iff it still has a query_id column. */
+            (View: "query_store_stats_hourly",
+             StaleCheck: "SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'collect' AND table_name = 'query_store_stats_hourly' AND column_name = 'query_id')"),
+            /* OLD procedure_stats_hourly lacked schema_name → stale iff the view EXISTS but has no schema_name
+               column. CASCADE also drops procedure_stats_daily, which the ensure sweep recreates. */
+            (View: "procedure_stats_hourly",
+             StaleCheck: "SELECT (EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'collect' AND table_name = 'procedure_stats_hourly') AND NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'collect' AND table_name = 'procedure_stats_hourly' AND column_name = 'schema_name'))"),
+        };
+
+        var dropped = 0;
+        foreach (var (view, staleCheck) in reshapes)
+        {
+            try
+            {
+                bool stale;
+                using (var check = new NpgsqlCommand(staleCheck, connection) { CommandTimeout = SetupTimeoutSeconds })
+                {
+                    stale = await check.ExecuteScalarAsync(cancellationToken) is true;
+                }
+
+                if (!stale)
+                {
+                    continue;
+                }
+
+                using (var drop = new NpgsqlCommand($"DROP MATERIALIZED VIEW IF EXISTS collect.{view} CASCADE", connection) { CommandTimeout = SetupTimeoutSeconds })
+                {
+                    await drop.ExecuteNonQueryAsync(cancellationToken);
+                }
+
+                dropped++;
+                logger?.LogInformation(
+                    "TimescaleDB: dropped stale continuous aggregate {View} (composer-dimension reshape) — recreated in the new shape this cycle.",
+                    view);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                logger?.LogWarning(
+                    "Reshape drop of {View} failed — it stays in the OLD shape until the next restart retries: {Message}",
+                    view, ex.Message);
+            }
+        }
+
+        return dropped;
+    }
 
     /// <summary>
     /// Creates the continuous aggregates and attaches each one's refresh policy


### PR DESCRIPTION
## What

Corrects the #1623 CAGG shapes so the composer can actually route to them (the read-routing follow-up depends on this). Done **now, while the CAGGs are still empty** (QS — read-only replica) or only a day or two old — reshaping later means dropping materialized data.

**query_store_stats_hourly — regrouped + weighted sums.** As #1623 built it, the QS CAGG was grouped by `query_id`/`plan_id` (Query Store's native identity), but the composer reads QS by `module_name`/`query_hash` — so it could not route *any* composer QS panel, and the execution-weighted mean was unreconstructable from `avg(avg_duration_us)`. Regrouped to the composer's dims and now carries `sum(avg_duration_us * execution_count) AS duration_us_weighted_sum` (+ cpu), so the weighted mean composes **exactly** as `duration_us_weighted_sum / execution_count_sum` — never an avg-of-avgs. This is the shape a **writable-Query-Store primary** needs (the scenario the CAGG exists to be ready for).

**procedure_stats hourly + daily — added `schema_name`.** It's a composer dimension that had been dropped from the CAGG, so schema_name-grouped panels couldn't route.

**`DropStaleContinuousAggregatesAsync`** (wired before the ensure sweep). `CREATE ... IF NOT EXISTS` cannot ALTER a CAGG, so an existing old-shape CAGG is dropped (CASCADE) and recreated in the new shape. Staleness is detected **structurally** — the old QS CAGG still has a `query_id` column; the old procedure_stats CAGG lacks `schema_name` — so it's a strict no-op once reshaped and on a fresh store nothing matches. Failure-isolated.

## Not in scope

`object_name`-on-query_stats routing (#1568). Covering it means carrying `sql_handle` on **both** the query_stats and procedure_stats CAGGs for a read-time join — which bloats the two biggest tables the CAGGs exist to shrink, for a secondary dimension. Deferred; revisit with a small retained `sql_handle→object_name` module map if it matters. query_stats CAGGs are untouched here.

## Validation

Pinned by `TimescaleContinuousAggregateTests` (updated for the new shapes; asserts the old query_id/plan_id + avg-of-avgs shape is gone). Live-validated on DARLING01 (which holds the old-shape CAGGs) — the guarded drop fires on the real old CAGGs and the ensure sweep recreates all five in the new shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)