### PR TITLE
Darling: fix stale ComposeCaggCatalog doc (QS daily CAGG exists after #1626)

### DIFF
--- a/Darling/PerformanceMonitor.Darling.Service/Compose/ComposeSourceRouter.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Compose/ComposeSourceRouter.cs
@@ -63,7 +63,8 @@ public sealed record ComposeCaggInfo(
 /// its dimensions are covered (see <see cref="ComposeCaggInfo.Covers"/>). query_stats' <c>object_name</c> is
 /// covered via the module_map join (the CAGG carries sql_handle; the compiler joins collect.module_map for it) —
 /// it stays a ViaModuleJoin dimension so the RAW path still uses the live #1568 procedure_stats CTE.
-/// query_store_stats has no daily CAGG yet (deferred until a writable-QS primary supplies real data).
+/// All three rolled tables (query_stats / procedure_stats / query_store_stats) now carry both an hourly and a
+/// daily CAGG, so every one tiers raw → hourly → daily.
 /// </summary>
 public static class ComposeCaggCatalog
 {


### PR DESCRIPTION
One-line documentation fix. The `ComposeCaggCatalog` class-level doc still read *"query_store_stats has no daily CAGG yet (deferred until a writable-QS primary supplies real data)"*, but #1626 added `query_store_stats_daily` — visible in the dictionary directly below the comment. Updated to state all three rolled tables (query_stats / procedure_stats / query_store_stats) now tier raw → hourly → daily.

The fix was authored during #1627 but missed its commit (the CHANGELOG and test commits staged only their own files). Comment-only — no behavior change, no CHANGELOG entry (nothing user-facing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)