### PR TITLE
Bugfix/issue - #1629 cpu other linux oversuppression

### DIFF
--- a/Lite.Tests/CpuUtilizationCollectorDefinitionTests.cs
+++ b/Lite.Tests/CpuUtilizationCollectorDefinitionTests.cs
@@ -37,6 +37,19 @@ public sealed class CpuUtilizationCollectorDefinitionTests
     }
 
     [Fact]
+    public void BuildQuery_RingBuffer_SuppressesOtherCpu_OnlyWhenSystemIdleIsZero()
+    {
+        /* Some Linux/SQL Server version combos report a non-zero SystemIdle, so
+           unconditionally nulling other-process CPU on @is_linux = 1 over-suppressed a
+           derivable value. The guard must require BOTH @is_linux = 1 AND system_idle = 0. */
+        var plan = CpuUtilizationCollector.Instance.BuildQuery(
+            CollectorTestContext.Make(s_deltas, isAzureSqlDb: false));
+
+        Assert.Contains("WHEN @is_linux = 1 AND x.system_idle = 0", plan.Text, StringComparison.Ordinal);
+        Assert.DoesNotContain("WHEN @is_linux = 1\n", plan.Text, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void BuildQuery_Azure_NoWatermark_UsesTop60()
     {
         var plan = CpuUtilizationCollector.Instance.BuildQuery(

--- a/PerformanceMonitor.Collectors/CpuUtilizationCollector.cs
+++ b/PerformanceMonitor.Collectors/CpuUtilizationCollector.cs
@@ -17,8 +17,8 @@ namespace PerformanceMonitor.Collectors;
 /// <summary>
 /// CPU utilization — ring buffer (on-prem, MI, RDS) or sys.dm_db_resource_stats (Azure SQL DB).
 /// Extracted verbatim from Lite's RemoteCollectorService.Cpu.cs, including the platform rules
-/// that are the parity contract: Linux stores NULL other-process CPU because SystemIdle is
-/// always 0 there (#1048); incomplete SystemHealth ring-buffer records are skipped (#989);
+/// that are the parity contract: Linux stores NULL other-process CPU when SystemIdle reports
+/// 0 there (#1048); incomplete SystemHealth ring-buffer records are skipped (#989);
 /// Azure filters server-side on the watermark while the ring buffer dedups client-side
 /// (its sample_time is computed and cannot be filtered in SQL).
 /// </summary>
@@ -70,11 +70,14 @@ SELECT
     @start_time = dosi.sqlserver_start_time
 FROM sys.dm_os_sys_info AS dosi;
 
-/* Detect SQL Server on Linux. SystemIdle is always 0 in the SCHEDULER_MONITOR
-   ring buffer on Linux, so 100 - SystemIdle - ProcessUtilization fabricates a
-   host figure that pins total CPU at 100% (Issue #1048). No DMV exposes true host
-   CPU on Linux, so other_process is stored as NULL there. sys.dm_os_host_info is
-   2017+; referenced via sp_executesql so SQL 2016 never binds it (@is_linux = 0). */
+/* Detect SQL Server on Linux. SystemIdle reports 0 in the SCHEDULER_MONITOR
+   ring buffer on some Linux/SQL Server version combos, so 100 - SystemIdle - ProcessUtilization
+   fabricates a host figure that pins total CPU at 100% (Issue #1048). Prior to SQL Server
+   2025 CU1 no DMV exposes true host CPU when that happens, so other_process is stored as NULL
+   there. sys.dm_os_linux_cpu_stats (2025 CU1+) exposes real host CPU jiffies but is a cumulative
+   counter requiring a two-sample delta, not a point-in-time snapshot like SCHEDULER_MONITOR, so
+   it isn't used here. sys.dm_os_host_info is 2017+; referenced via sp_executesql so SQL 2016
+   never binds it (@is_linux = 0). */
 IF OBJECT_ID(N'sys.dm_os_host_info', N'V') IS NOT NULL
     EXEC sys.sp_executesql
         N'SELECT @linux = CASE WHEN hi.host_platform = N''Linux'' THEN 1 ELSE 0 END FROM sys.dm_os_host_info AS hi;',
@@ -85,7 +88,7 @@ SELECT TOP (60)
     sqlserver_cpu_utilization = x.process_utilization,
     other_process_cpu_utilization =
         CASE
-            WHEN @is_linux = 1
+            WHEN @is_linux = 1 AND x.system_idle = 0
             THEN NULL
             WHEN (100 - x.system_idle - x.process_utilization) < 0
             THEN 0
@@ -161,7 +164,7 @@ OPTION(RECOMPILE);";
             rows.Add(new Row(
                 sampleTime,
                 reader.IsDBNull(1) ? 0 : reader.GetInt32(1),
-                /* NULL = host/other CPU not derivable (SQL on Linux, Issue #1048) */
+                /* NULL = host/other CPU not derivable (SystemIdle reported 0, Issue #1048) */
                 reader.IsDBNull(2) ? (int?)null : reader.GetInt32(2)));
         }
 

--- a/deprecated/Dashboard/Services/DatabaseService.NocHealth.cs
+++ b/deprecated/Dashboard/Services/DatabaseService.NocHealth.cs
@@ -475,12 +475,16 @@ namespace PerformanceMonitorDashboard.Services
 
                 DECLARE @is_linux bit = 0;
 
-                /* SystemIdle is always 0 in the SCHEDULER_MONITOR ring buffer on SQL Server
-                   on Linux, so 100 - SystemIdle - ProcessUtilization fabricates a host figure
-                   that pins total CPU at 100% forever (Issue #1048). No DMV exposes true host
-                   CPU on Linux, so report other/host CPU as NULL there and let the alert engine
-                   fall back to the SQL-only figure. sys.dm_os_host_info is 2017+; referenced via
-                   sp_executesql so SQL 2016 (no Linux build) never binds it (@is_linux stays 0). */
+                /* SystemIdle reports 0 in the SCHEDULER_MONITOR ring buffer on some Linux/SQL
+                   Server version combos, so 100 - SystemIdle - ProcessUtilization fabricates a
+                   host figure that pins total CPU at 100% forever (Issue #1048). Prior to SQL
+                   Server 2025 CU1 no DMV exposes true host CPU when that happens, so report
+                   other/host CPU as NULL and let the alert engine fall back to the SQL-only
+                   figure. sys.dm_os_linux_cpu_stats (2025 CU1+) exposes real host CPU jiffies
+                   but is a cumulative counter requiring a two-sample delta, not a point-in-time
+                   snapshot like SCHEDULER_MONITOR, so it isn't used here. sys.dm_os_host_info is
+                   2017+; referenced via sp_executesql so SQL 2016 (no Linux build) never binds it
+                   (@is_linux stays 0). */
                 IF OBJECT_ID(N'sys.dm_os_host_info', N'V') IS NOT NULL
                 BEGIN
                     EXEC sys.sp_executesql
@@ -499,6 +503,11 @@ namespace PerformanceMonitorDashboard.Services
                     other_cpu_percent =
                         CASE
                             WHEN @is_linux = 1
+                                 AND x.rb.value
+                                 (
+                                     '(./Record/SchedulerMonitorEvent/SystemHealth/SystemIdle)[1]',
+                                     'integer'
+                                 ) = 0
                             THEN NULL
                             ELSE 100
                                  - x.rb.value

--- a/install/02_create_tables.sql
+++ b/install/02_create_tables.sql
@@ -942,10 +942,11 @@ BEGIN
         sample_time datetime2(7) NOT NULL,
         sqlserver_cpu_utilization integer NOT NULL,
         /*
-        Nullable: NULL means host/other-process CPU is not derivable. On SQL Server
-        on Linux the SCHEDULER_MONITOR ring buffer reports SystemIdle = 0, so the
-        collector cannot compute a real host figure and stores NULL here rather than
-        a false 100% (Issue #1048). NULL propagates to total_cpu_utilization below.
+        Nullable: NULL means host/other-process CPU is not derivable. On some
+        Linux/SQL Server version combos the SCHEDULER_MONITOR ring buffer reports
+        SystemIdle = 0, so the collector cannot compute a real host figure and
+        stores NULL here rather than a false 100% (Issue #1048). NULL propagates
+        to total_cpu_utilization below.
         */
         other_process_cpu_utilization integer NULL,
         total_cpu_utilization AS (sqlserver_cpu_utilization + other_process_cpu_utilization) PERSISTED,

--- a/install/18_collect_cpu_utilization_stats.sql
+++ b/install/18_collect_cpu_utilization_stats.sql
@@ -56,11 +56,15 @@ BEGIN
         @error_message nvarchar(4000);
 
     /*
-    Detect SQL Server on Linux. On Linux the SCHEDULER_MONITOR ring buffer
-    reports SystemIdle = 0, so 100 - SystemIdle - ProcessUtilization fabricates
-    a host figure that pins total CPU at 100% forever (Issue #1048). There is no
-    DMV that exposes true host CPU on Linux, so on Linux we store NULL for
-    other_process_cpu_utilization instead of a false value.
+    Detect SQL Server on Linux. On some Linux/SQL Server version combos the
+    SCHEDULER_MONITOR ring buffer reports SystemIdle = 0, so 100 - SystemIdle -
+    ProcessUtilization fabricates a host figure that pins total CPU at 100%
+    forever (Issue #1048). Prior to SQL Server 2025 CU1 there is no DMV that
+    exposes true host CPU when that happens, so we store NULL for
+    other_process_cpu_utilization instead of a false value. sys.dm_os_linux_cpu_stats
+    (2025 CU1+) exposes real host CPU jiffies but is a cumulative counter
+    requiring a two-sample delta, not a point-in-time snapshot like
+    SCHEDULER_MONITOR, so it isn't used here.
 
     sys.dm_os_host_info exists only on SQL Server 2017+. It is referenced through
     sp_executesql so SQL Server 2016 (which has no Linux build) never binds it and
@@ -154,8 +158,8 @@ BEGIN
                 x.process_utilization,
             other_process_cpu_utilization =
                 CASE
-                    WHEN @is_linux = 1
-                    THEN NULL /*SystemIdle is always 0 on Linux; host CPU is not derivable (Issue #1048)*/
+                    WHEN @is_linux = 1 AND x.system_idle = 0
+                    THEN NULL /*SystemIdle reports 0 on some Linux/SQL Server version combos; host CPU is not derivable when that happens (Issue #1048)*/
                     WHEN (100 - x.system_idle - x.process_utilization) < 0
                     THEN 0
                     ELSE 100 - x.system_idle - x.process_utilization


### PR DESCRIPTION
## What does this PR do?

Fixes #1629. The Linux CPU guard added for #1048 blanket-suppressed `other_process_cpu_utilization` on every Linux host (`WHEN @is_linux = 1 THEN NULL`), to work around `SystemIdle` always reporting 0 in the SCHEDULER_MONITOR ring buffer on SQL Server 2022 and older on Linux.

SQL Server 2025 on Linux reports real `SystemIdle` values again, so the blanket guard now discards a derivable figure on any Linux host running 2025 - `other_process_cpu_utilization` comes back permanently NULL even though the data is available.

Narrows the guard to `WHEN @is_linux = 1 AND system_idle = 0 THEN NULL`, so suppression only happens when the value is actually non-derivable, matching the real condition instead of the platform. Applied consistently to:

- `PerformanceMonitor.Collectors/CpuUtilizationCollector.cs`
- `install/18_collect_cpu_utilization_stats.sql`
- `install/02_create_tables.sql` (table comment)
- `Dashboard/Services/DatabaseService.NocHealth.cs`

## Which component(s) does this affect?

- [ ] Full Dashboard
- [x] Lite Dashboard
- [x] Lite Tests
- [x] SQL collection scripts
- [ ] CLI Installer
- [ ] Documentation

## How was this tested?

- Added `BuildQuery_RingBuffer_SuppressesOtherCpu_OnlyWhenSystemIdleIsZero` to
  `Lite.Tests/CpuUtilizationCollectorDefinitionTests.cs`, asserting the generated query text uses
  the narrowed guard and no longer contains the old unconditional `WHEN @is_linux = 1` branch.
- `Build` and `SQL Validation` GitHub Actions workflows passed against this branch.
- Verified the guard algebraically against the two scenarios from the bug report:
  - SQL 2022 Linux (`system_idle = 0`, `process_util = 2`) -> stays NULL (not derivable)
  - SQL 2025 Linux (`system_idle = 95`, `process_util = 3`) -> returns `2` (`100 - 95 - 3`)

<!-- Fill in if you ran this against a live instance, e.g. the SQL 2025 docker repro from the issue:
SQL Server version(s) tested against:
Steps to verify the change works:
-->

## Checklist

- [x] I have read the [contributing guide](https://github.com/erikdarlingdata/PerformanceMonitor/blob/main/CONTRIBUTING.md)
- [ ] My code builds with zero warnings (`dotnet build -c Debug`)
- [ ] I have tested my changes against at least one SQL Server version
- [x] I have not introduced any hardcoded credentials or server names
