### PR TITLE
fix: fall back to base trace path when no rollover suffix (Linux)

### DIFF
--- a/Lite.Tests/DefaultTraceEventsCollectorDefinitionTests.cs
+++ b/Lite.Tests/DefaultTraceEventsCollectorDefinitionTests.cs
@@ -79,6 +79,19 @@ public sealed class DefaultTraceEventsCollectorDefinitionTests
     }
 
     [Fact]
+    public void BuildQuery_RolloverPathStrip_FallsBackToBasePath_WhenNoUnderscore()
+    {
+        /* SQL Server on Linux names the initial trace file without a rollover suffix (log.trc, not
+           log_1.trc). An unconditional strip finds no underscore, so LEFT takes the full path and
+           the re-appended extension doubles it (log.trc.trc), and fn_trace_gettable errors on the
+           nonexistent file. The CASE must fall back to the base t.path when CHARINDEX finds no underscore. */
+        var text = DefaultTraceEventsCollector.Instance.BuildQuery(MakeContext()).Text;
+
+        Assert.Contains("WHEN CHARINDEX(N'_', REVERSE(t.path)) > 0", text, StringComparison.Ordinal);
+        Assert.Contains("ELSE t.path", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void BuildQuery_CapturesTheCuratedEventSet()
     {
         var text = DefaultTraceEventsCollector.Instance.BuildQuery(MakeContext()).Text;

--- a/PerformanceMonitor.Collectors/DefaultTraceEventsCollector.cs
+++ b/PerformanceMonitor.Collectors/DefaultTraceEventsCollector.cs
@@ -114,9 +114,14 @@ public sealed class DefaultTraceEventsCollector : CollectorDefinitionBase<Defaul
 
     /* The curated, config-slice-free event set (see the class remarks). A {0} placeholder is spliced with
        the per-server excluded-database clause on ft.DatabaseName; the rollover-file base-path normalization
-       (strip _NN + re-append the extension) reads every retained file. READ UNCOMMITTED like every collector;
-       OPTION(RECOMPILE) because the cutoff selectivity varies wildly between the all-history first run and the
-       tiny steady-state windows. */
+       (strip _NN + re-append the extension) reads every retained file. The strip is guarded by a CHARINDEX
+       check: SQL Server on Linux names the initial trace file without a rollover suffix (log.trc, not
+       log_1.trc), so an unconditional strip finds no underscore, LEFT takes the full path unchanged, and
+       appending the extension back doubles it (log.trc.trc) - fn_trace_gettable then errors on the
+       nonexistent file (Msg 19049) and no events are collected. Falling back to t.path when CHARINDEX
+       returns 0 keeps the Windows behavior (which always has the _N suffix) unchanged. READ UNCOMMITTED
+       like every collector; OPTION(RECOMPILE) because the cutoff selectivity varies wildly between the
+       all-history first run and the tiny steady-state windows. */
     private const string QueryTemplate = @"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
@@ -145,8 +150,11 @@ SELECT
 FROM sys.traces AS t
 CROSS APPLY sys.fn_trace_gettable
 (
-    LEFT(t.path, LEN(t.path) - CHARINDEX(N'_', REVERSE(t.path))) +
-    RIGHT(t.path, 4),
+    CASE
+        WHEN CHARINDEX(N'_', REVERSE(t.path)) > 0
+        THEN LEFT(t.path, LEN(t.path) - CHARINDEX(N'_', REVERSE(t.path))) + RIGHT(t.path, 4)
+        ELSE t.path
+    END,
     t.max_files
 ) AS ft
 JOIN sys.trace_events AS te

--- a/install/29_collect_default_trace.sql
+++ b/install/29_collect_default_trace.sql
@@ -358,8 +358,19 @@ BEGIN
         FROM sys.traces AS st
         CROSS APPLY sys.fn_trace_gettable
         (
-            LEFT(st.path, LEN(st.path) - CHARINDEX('_', REVERSE(st.path))) + 
-            RIGHT(st.path, 4), 
+            /*
+            SQL Server on Linux names the initial trace file without a rollover suffix
+            (log.trc, not log_1.trc). An unconditional strip finds no underscore, LEFT
+            takes the full path unchanged, and appending the extension back doubles it
+            (log.trc.trc) - fn_trace_gettable then errors on the nonexistent file
+            (Msg 19049) and no events are collected. Fall back to st.path when
+            CHARINDEX returns 0.
+            */
+            CASE
+                WHEN CHARINDEX(N'_', REVERSE(st.path)) > 0
+                THEN LEFT(st.path, LEN(st.path) - CHARINDEX(N'_', REVERSE(st.path))) + RIGHT(st.path, 4)
+                ELSE st.path
+            END,
             st.max_files
         ) AS ft
         INNER JOIN sys.trace_events AS te


### PR DESCRIPTION
## What does this PR do?

Fixes #1632. The `default_trace_events` collector calls `sys.fn_trace_gettable` with an expression meant to strip the `_N` rollover suffix from `sys.traces.path` (e.g. `log_1.trc` -> `log.trc`) so all rollover files are read. On Windows the initial trace file always has that suffix, so the strip works. On Linux SQL Server the initial file has no suffix at all (`log.trc`), so `CHARINDEX` returns 0, `LEFT` takes the full path unchanged, and re-appending the extension doubles it (`log.trc.trc`). `fn_trace_gettable` then errors on the nonexistent file (Msg 19049), so no default trace events are ever collected on Linux.

Guards the strip with a `CASE` that falls back to the base path when `CHARINDEX` finds no underscore, applied to:

- `PerformanceMonitor.Collectors/DefaultTraceEventsCollector.cs` (shared definition used by
  Lite and Darling)
- `install/29_collect_default_trace.sql` (Full Dashboard's stored procedure)

## Which component(s) does this affect?

- [ ] Full Dashboard
- [x] Lite Dashboard
- [x] Lite Tests
- [x] SQL collection scripts
- [ ] CLI Installer
- [ ] Documentation

## How was this tested?

- Added `BuildQuery_RolloverPathStrip_FallsBackToBasePath_WhenNoUnderscore` to
  `Lite.Tests/DefaultTraceEventsCollectorDefinitionTests.cs`, asserting the generated query text contains the guarded `CASE` and the `ELSE t.path` fallback.
- `Build` and `SQL Validation` GitHub Actions workflows passed against this branch.
- Verified against a live `mcr.microsoft.com/mssql/server:2025-latest` container on Linux:
  - `sys.traces.path` confirmed as `/var/opt/mssql/log/log.trc` (no rollover suffix)
  - the unguarded expression produced `/var/opt/mssql/log/log.trc.trc`, and `sys.fn_trace_gettable` raised `Msg 19049` (file not found) against it
  - the guarded expression returned the correct `/var/opt/mssql/log/log.trc`, and `sys.fn_trace_gettable` returned rows (30) against it

SQL Server version(s) tested against: SQL Server 2025 (Linux, Docker, `:latest` tag)

## Checklist

- [x] I have read the [contributing guide](https://github.com/erikdarlingdata/PerformanceMonitor/blob/main/CONTRIBUTING.md)
- [ ] My code builds with zero warnings (`dotnet build -c Debug`)
- [x] I have tested my changes against at least one SQL Server version
- [x] I have not introduced any hardcoded credentials or server names
