### PR TITLE
fix report.trace_flag_changes bit conversion error on toggle

### DIFF
--- a/install/47_create_reporting_views.sql
+++ b/install/47_create_reporting_views.sql
@@ -1133,9 +1133,9 @@ SELECT
         END,
     change_description =
         CASE
-            WHEN rc.previous_status = N'OFF' AND rc.status = N'ON'
+            WHEN rc.previous_status = 0 AND rc.status = 1
             THEN N'Trace flag ' + CONVERT(nvarchar(10), rc.trace_flag) + N' ENABLED'
-            WHEN rc.previous_status = N'ON' AND rc.status = N'OFF'
+            WHEN rc.previous_status = 1 AND rc.status = 0
             THEN N'Trace flag ' + CONVERT(nvarchar(10), rc.trace_flag) + N' DISABLED'
             ELSE N'Status unchanged'
         END,


### PR DESCRIPTION
## What does this PR do?

Fixes #1635. The view's `change_description` CASE compares the `bit` columns `previous_status`/`status` (from `config.trace_flags_history`) against the nvarchar literals `N'OFF'`/`N'ON'`. SQL Server implicitly converts the literal to `bit` to resolve the type mismatch.

## Which component(s) does this affect?

- [ ] Lite
- [ ] Darling
- [ ] Lite Tests
- [ ] Darling Tests
- [x] SQL collection scripts
- [ ] Documentation
- [ ] Full Dashboard (deprecated)
- [ ] CLI Installer (deprecated)

## How was this tested?

- Verified against a live `mcr.microsoft.com/mssql/server:2022-latest` container:
  - Built a minimal `#history` temp table matching `config.trace_flags_history`'s shape, with and initial capture (status 0) and a toggle (status 1).
  - The unfixed CASE expression raised `Msg 245: Conversion failed when converting the nvarchar value 'OFF' to data type bit.`
  - The fixed CASE expression (`0`/`1` comparisons) returned the correct row: `Trace flag 1222 ENABLED`.
- `Build` and `SQL Validation` GitHub Actions workflows passed against this branch.

SQL Server version(s) tested against: SQL Server 2022 (Docker, `:latest` tag)

## Checklist

- [x] I have read the [contributing guide](https://github.com/erikdarlingdata/PerformanceMonitor/blob/main/CONTRIBUTING.md)
- [ ] My code builds with zero warnings (`dotnet build -c Debug`)
- [x] I have tested my changes against at least one SQL Server version
- [x] I have not introduced any hardcoded credentials or server names
