### PR TITLE
CI: Dependabot version updates + Claude auto-review workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+# Dependabot version updates (routine dependency bumps).
+# Security updates are enabled separately at the repo level and are not affected by this file.
+# NuGet projects use lockfiles (packages.lock.json); Dependabot regenerates them as part of each PR.
+version: 2
+updates:
+  # .NET packages across the solution (PerformanceMonitor.sln discovers all projects).
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    # One grouped PR for all NuGet bumps, to keep review noise down.
+    groups:
+      nuget:
+        patterns:
+          - "*"
+
+  # GitHub Actions used by the workflows in .github/workflows.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,7 +2,7 @@ name: Claude Auto Review
 
 # Reviews every pull request into dev or main when it is opened or updated. The review is
 # advisory (it posts comments) and is deliberately NOT a required status check, so it never
-# blocks a merge. It no-ops cleanly until the ANTHROPIC_API_KEY repo secret is set, and on
+# blocks a merge. It no-ops cleanly until the CLAUDE_CODE_OAUTH_TOKEN repo secret is set, and on
 # fork PRs (which do not receive secrets), so neither case shows a failed check.
 on:
   pull_request:
@@ -23,17 +23,17 @@ jobs:
       id-token: write
     env:
       # Mapped to env so the step guard below can skip cleanly when the secret is absent.
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
       - name: Claude review
-        if: ${{ env.ANTHROPIC_API_KEY != '' }}
+        if: ${{ env.CLAUDE_CODE_OAUTH_TOKEN != '' }}
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ env.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ env.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,57 @@
+name: Claude Auto Review
+
+# Reviews every pull request into dev or main when it is opened or updated. The review is
+# advisory (it posts comments) and is deliberately NOT a required status check, so it never
+# blocks a merge. It no-ops cleanly until the ANTHROPIC_API_KEY repo secret is set, and on
+# fork PRs (which do not receive secrets), so neither case shows a failed check.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [dev, main]
+
+# Cancel an in-flight review when new commits are pushed to the same PR.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    env:
+      # Mapped to env so the step guard below can skip cleanly when the secret is absent.
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Claude review
+        if: ${{ env.ANTHROPIC_API_KEY != '' }}
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ env.ANTHROPIC_API_KEY }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request. Follow the conventions in CLAUDE.md and the T-SQL style
+            guide it points to. This repository ships two apps that must stay in parity — Lite
+            and Darling — so flag any change made to one but not its counterpart. Focus on:
+            - Correctness: bugs, edge cases, null/error handling at system boundaries
+            - Lite/Darling parity drift
+            - Security: input handling, SQL injection, secrets, file/network/process use
+            - Performance regressions
+            Do NOT suggest SQL Server missing-index DMV recommendations — they are folklore in
+            this codebase and explicitly unwanted.
+
+            The PR branch is already checked out in the working directory.
+            Use `gh pr comment` for top-level feedback, and
+            `mcp__github_inline_comment__create_inline_comment` (with confirmed: true) for
+            specific line-level issues. Only post GitHub comments — do not emit review text as
+            plain messages.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
Adds the two automation pieces that were missing.

## `.github/dependabot.yml` — version updates
Repo-level Dependabot **security** updates were already on; this adds routine **version** bumps:
- **NuGet** and **GitHub Actions**, weekly (Mondays), each grouped into a single PR to keep noise down.
- NuGet uses lockfiles (`packages.lock.json` in 8 projects); Dependabot regenerates them per PR.

## `.github/workflows/claude-review.yml` — Claude auto-review
`anthropics/claude-code-action@v1` reviews PRs into `dev`/`main` on open/update, tuned to this repo (CLAUDE.md conventions, Lite/Darling parity, no missing-index folklore).

- **Advisory only** — deliberately NOT a required status check, so it never blocks a merge.
- **Authenticates with a Claude subscription** (not API billing): input `claude_code_oauth_token` / secret `CLAUDE_CODE_OAUTH_TOKEN`.
- **No-ops cleanly** until the secret is set, and on fork PRs — so no failed checks in the meantime.
- Uses `actions/checkout@v5` to match the other workflows.

### Action needed from you
1. In Claude Code, run `claude setup-token` (Pro/Max subscription) and copy the token.
2. Add it as repo secret **`CLAUDE_CODE_OAUTH_TOKEN`** (Settings → Secrets and variables → Actions).

Until then the review step skips silently.

No CHANGELOG entry — infra/CI only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)