### PR TITLE
fix report.daily_summary_v2.worst_query_hash sql_variant garbling

### DIFF
--- a/install/47_create_reporting_views.sql
+++ b/install/47_create_reporting_views.sql
@@ -863,7 +863,7 @@ WITH
     SELECT
         sort_order = 70,
         metric_name = N'worst_query_hash',
-        metric_value = CONVERT(sql_variant, wq.query_hash)
+        metric_value = CONVERT(sql_variant, CONVERT(nvarchar(20), wq.query_hash, 1))
     FROM worst_query AS wq
 
     UNION ALL


### PR DESCRIPTION
## What does this PR do?

Fixes #1666. The view boxes the raw `binary(8)` `query_hash` column directly into the `sql_variant` pivot column: `CONVERT(sql_variant, wq.query_hash)`. Any caller that follows the view's own documented usage and converts `metric_value` straight to `nvarchar` gets the raw bytes reinterpreted as UTF-16 instead of a readable hash - every other row in the view is a scalar and converts cleanly; only this one row carries a binary payload.

## Which component(s) does this affect?

- [ ] Lite
- [ ] Darling
- [ ] Lite Tests
- [ ] Darling Tests
- [x] SQL collection scripts
- [ ] Documentation
- [ ] Full Dashboard (deprecated)
- [ ] CLI Installer (deprecated)

## How was this tested?

- Verified against a live `mcr.microsoft.com/mssql/server:2022-latest` container:
  - Boxed a literal `binary(8)` query hash into `sql_variant` the way the unfixed view does, then converted to `nvarchar` - produced garbled text (`稟띿坧謈`), reproducing the bug.
  - Applied the fix (`CONVERT(nvarchar(20), ..., 1)` before boxing) against the same literal - produced the correct hex string (`0x1F7A7FB76757088B`).
- `Build` and `SQL Validation` GitHub Actions workflows triggered against this branch via a fork-internal PR.

SQL Server version(s) tested against: SQL Server 2022 (Docker, `:latest` tag)

## Checklist

- [x] I have read the [contributing guide](https://github.com/erikdarlingdata/PerformanceMonitor/blob/main/CONTRIBUTING.md)
- [ ] My code builds with zero warnings (`dotnet build -c Debug`)
- [x] I have tested my changes against at least one SQL Server version
- [x] I have not introduced any hardcoded credentials or server names
