### PR TITLE
CI: bump the four PR-proven action pins; hold upload-artifact for the signing path (#1653)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,10 @@ updates:
       github-actions:
         patterns:
           - "*"
+    ignore:
+      # upload-artifact majors are release-path sensitive: its artifact-id output feeds the
+      # SignPath signing steps, which only execute on release publish — a bad bump breaks
+      # signing at the worst possible moment. Bumped manually alongside a validated signing
+      # run instead (#1653).
+      - dependency-name: "actions/upload-artifact"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Detect changed paths
         id: filter
         if: github.event_name != 'release'
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           # On push events, compare against the previous commit on this branch
           # (github.event.before). Without this, the action defaults to comparing
@@ -93,7 +93,7 @@ jobs:
 
       - name: Setup .NET 10.0
         if: steps.filter.outputs.code != 'false'
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
           cache: true
@@ -189,7 +189,7 @@ jobs:
       - name: Cache Darling pg-runtime.zip
         if: github.event_name == 'release'
         id: cache-pg-runtime
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: Darling/artifacts/pg-runtime.zip
           key: pg-runtime-${{ runner.os }}-${{ hashFiles('Darling/tools/fetch-pg-runtime.ps1') }}
@@ -210,6 +210,11 @@ jobs:
           # users at Setup.exe (Velopack); this ZIP is the explicit fallback.
           Compress-Archive -Path 'publish/Lite/*' -DestinationPath "releases/PerformanceMonitorLite-$version.zip" -Force
 
+      # upload-artifact is deliberately HELD at v6 (#1653): every signing step below consumes
+      # `steps.upload-*.outputs.artifact-id`, and v7 changes artifact archiving semantics (the
+      # `archive` parameter). The signing path only executes on `release: [published]`, so a broken
+      # bump surfaces at release time — bump only alongside a validated real signing run.
+      # Dependabot is configured to skip this major (see .github/dependabot.yml).
       - name: Upload Lite for signing
         if: github.event_name == 'release'
         id: upload-lite
@@ -420,7 +425,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       # Only do the expensive TimescaleDB work when Darling code changed — or when THIS workflow
       # changed, so a change to the gate itself is exercised by the gate (this is what makes the PR
@@ -430,7 +435,7 @@ jobs:
       - name: Detect changed paths
         id: filter
         if: github.event_name != 'release'
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           # On push, compare against the previous commit on this branch (mirrors the build job);
           # on pull_request, an empty base makes the action diff against the PR base branch.
@@ -443,7 +448,7 @@ jobs:
 
       - name: Setup .NET 10.0
         if: steps.filter.outputs.darling == 'true'
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
           cache: true
@@ -454,7 +459,7 @@ jobs:
       - name: Cache Darling pg-runtime.zip
         if: steps.filter.outputs.darling == 'true'
         id: cache-pg-runtime
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: Darling/artifacts/pg-runtime.zip
           key: pg-runtime-${{ runner.os }}-${{ hashFiles('Darling/tools/fetch-pg-runtime.ps1') }}

--- a/.github/workflows/check-version-bump.yml
+++ b/.github/workflows/check-version-bump.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       # Documentation-only PRs (e.g. a CHANGELOG correction) do not bump the
       # version. The workflow still runs so the required check reports a result
@@ -19,7 +19,7 @@ jobs:
       # any non-*.md file changed.
       - name: Detect non-documentation changes
         id: changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             code:
@@ -37,7 +37,7 @@ jobs:
 
       - name: Checkout main
         if: steps.changes.outputs.code == 'true'
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ref: main
           path: main-branch

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -25,7 +25,7 @@ jobs:
       # Mapped to env so the step guard below can skip cleanly when the secret is absent.
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       has_changes: ${{ steps.check.outputs.has_changes }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           ref: dev
           fetch-depth: 0
@@ -38,12 +38,12 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           ref: dev
 
       - name: Setup .NET 10.0
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
           cache: true
@@ -89,7 +89,7 @@ jobs:
       # branch; nightly and release runs share the assembled zip whenever the cache is visible.
       - name: Cache Darling pg-runtime.zip
         id: cache-pg-runtime
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: Darling/artifacts/pg-runtime.zip
           key: pg-runtime-${{ runner.os }}-${{ hashFiles('Darling/tools/fetch-pg-runtime.ps1') }}
@@ -196,12 +196,12 @@ jobs:
       # would be main). A manual dispatch tests the DISPATCHED ref — the only way to validate a
       # branch's gated-pg test changes before merge; the artifact-publishing build job stays
       # pinned to dev either way, so a branch dispatch can never ship branch binaries.
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || 'dev' }}
 
       - name: Setup .NET 10.0
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
           cache: true
@@ -213,7 +213,7 @@ jobs:
       # release share one cache entry, so a warm cache means no download here.
       - name: Cache Darling pg-runtime.zip
         id: cache-pg-runtime
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: Darling/artifacts/pg-runtime.zip
           key: pg-runtime-${{ runner.os }}-${{ hashFiles('Darling/tools/fetch-pg-runtime.ps1') }}

--- a/.github/workflows/sql-validation.yml
+++ b/.github/workflows/sql-validation.yml
@@ -41,7 +41,7 @@ jobs:
           --health-retries 15
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install sqlcmd
         run: |


### PR DESCRIPTION
Implements #1653's own suggested split.

**Bumped (proved by this PR's CI run):** `actions/checkout` v5→v7 (9 sites), `actions/setup-dotnet` v5→v6 (4), `actions/cache` v6 (4 — covers the ~340MB pg-runtime cache), `dorny/paths-filter` v3→v4 (3). All run on every PR, so a break is visible right here.

**Held:** `actions/upload-artifact` stays v6 (6 sites). Its `artifact-id` output feeds all six SignPath signing steps, which only execute on `release: [published]` — v7's archiving changes (`archive` parameter) would surface at release time. Marked with a comment at the first upload step, and **a Dependabot `ignore` rule** so Monday's github-actions group can't propose the major blindly. The remaining scope of #1653 (validate v7 against a real signing run) stays tracked there — suggest leaving the issue open, scoped to that.

Note: `nightly.yml` bumps take effect from main's copy per the scheduled-workflow rule — validated when next promoted.

No CHANGELOG entry — CI infra only (same as #1644).

🤖 Generated with [Claude Code](https://claude.com/claude-code)