### PR TITLE
[THROWAWAY - do not merge] Validate the #1712 docs fast path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ community/*.sql
 
 # Test-run artifacts (dotnet test --logger trx)
 TestResults/
+# (throwaway) validating the docs fast path end-to-end - this branch never merges


### PR DESCRIPTION
Single root .gitignore comment - on the #1712 documentation allowlist but NOT markdown, so before #1712 this exact diff hit the '**' catch-all and paid the full six-project restore. Expected: build check ~1m45s with restore/setup skipped and a DOCS FAST PATH ENGAGED notice naming .gitignore; darling-pg reports its skip decision. This PR exists only to capture that evidence for the CI-intelligence PR and will be closed unmerged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)