### PR TITLE
Remove a second stale stacked summary, on QuiesceTimescaleServerOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **A second stale doc comment describing behaviour that no longer exists** ([#1744]) - `QuiesceTimescaleServerOptions` carried two stacked `<summary>` elements, the first left by an earlier edit. XML docs take the LAST summary, so tooling rendered the correct one and only a human reading the file was misled - invisible to the build, the tests and the analyzers, which is why it survived several re-reads and was found by pattern-matching the file instead. Same defect as [#1739]'s, in a second place. The surviving summary keeps both rationales that matter: the timescale/timescaledb#1593 `template0` deadlock behind quiescing the scheduler for the upgrade window, and the IPv4/IPv6 loopback trap behind restoring `listen_addresses=localhost` for it.
 - Darling README: added a "verify it's actually reachable" recipe for the opt-in LAN MCP/web endpoints — confirm the listener is on the LAN address (not loopback), the scoped firewall rule covers the client, and the client connects to the box IP rather than `localhost` — plus what to re-run after a reinstall. Enabling an endpoint is not the same as reaching it. ([#1616])
 
 ## [3.2.0] - 2026-07-21
@@ -1733,6 +1734,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1725]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1725
 [#1730]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1730
 [#1739]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1739
+[#1744]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1744
 [#1727]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1727
 [#1690]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1690
 [#1693]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1693

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingStoreUpgrade.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingStoreUpgrade.cs
@@ -368,18 +368,6 @@ internal sealed class DarlingStoreUpgrade
     }
 
     /// <summary>
-    /// Server options pg_upgrade passes to BOTH clusters it starts, quiescing TimescaleDB for the duration
-    /// of the binary upgrade.
-    ///
-    /// <para>This is not tuning, it is a deadlock avoidance. TimescaleDB's scheduler background worker
-    /// connects to databases and takes locks on its own schedule — including on <c>template0</c>, which
-    /// timescale/timescaledb#1593 documents deadlocking against a restore that needs the same lock, in a
-    /// cycle PostgreSQL's deadlock detector does not break. pg_upgrade is exactly that kind of workload: it
-    /// starts each cluster and connects database by database. Nothing the scheduler could do during an
-    /// upgrade window is wanted anyway — the jobs it would run operate on data being copied out from under
-    /// them — so it is turned off for the duration and comes back with the normal start afterwards.</para>
-    /// </summary>
-    /// <summary>
     /// Server options pg_upgrade passes to BOTH clusters it starts, for the upgrade window only. The
     /// store's own postgresql.conf is never edited; <c>-c</c> on the command line simply outranks it, the
     /// same mechanism <see cref="DarlingManagedPostgres.BuildServerRuntimeOptions"/> already uses to force


### PR DESCRIPTION
Stranded for the second time: pushed to `feature/1706-pg-upgrade` after #1739 merged, so it is not in dev. Opening it rather than let a real cleanup die on a merged branch.

**Comment-only.** A second stale stacked `<summary>` on `QuiesceTimescaleServerOptions`, left by an earlier edit — the same defect #1739 fixed on `BuildLibpqCredentialEnvironment`, in a second place nobody had looked.

**Verified before opening, because "comment-only" is exactly the claim worth checking:**

```
git diff 725cbb44..16e01f79            ->  1 file, 12 deletions
non-comment changed lines              ->  none
"1593" occurrences at 725cbb44         ->  2
"1593" occurrences at 16e01f79         ->  1   (survivor, line 378)
```

So the deleted block was a genuine duplicate, and the surviving summary keeps both rationales that matter: the timescale/timescaledb#1593 `template0` deadlock (why the scheduler is quiesced for the upgrade window) and the IPv4/IPv6 loopback trap (why `listen_addresses=localhost` rides `-o`/`-O`). No load-bearing documentation was lost.

**Why this class keeps escaping review**: XML doc comments take the LAST `<summary>`, so tooling renders the correct one and only a human reading the file is misled. Invisible to the build, the tests, and the analyzers. The author found it by pattern-matching the file rather than re-reading it — after re-reading had already missed it several times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
