### PR TITLE
Fix the last zero-warning holdout: xUnit2031 in the AG evaluator tests

### DIFF
--- a/Lite.Tests/AgAlertEvaluatorTests.cs
+++ b/Lite.Tests/AgAlertEvaluatorTests.cs
@@ -222,7 +222,7 @@ public class AgAlertEvaluatorTests
 
         /* This server catches up. Its snapshot says nothing about the other server, whose alert must stand. */
         var recovered = e.EvaluateDatabases(ServerId, new[] { Database(lagSeconds: 0) }, 300, 0, Cooldown);
-        Assert.Single(recovered.Where(a => a.MetricName == "AG Sync Recovered"));
+        Assert.Single(recovered, a => a.MetricName == "AG Sync Recovered");
 
         /* The other server is still inside its cooldown, so it stays quiet rather than re-firing fresh. */
         Assert.Empty(e.EvaluateDatabases(otherServerId, new[] { Database(lagSeconds: 600) }, 300, 0, Cooldown));


### PR DESCRIPTION
The remainder after #1753. One line, no overlap.

#1753 fixed the `CS8604` in `AlertFiringLog` and the `CS8602` in Lite's AG evaluation — both of which my now-closed #1754 also covered, so I closed that as superseded rather than leave two PRs carrying the same fix.

**This one warning was not in #1753 and was still live on dev**, so the zero-warning build was not yet restored:

```
Lite.Tests/AgAlertEvaluatorTests.cs(225,9): warning xUnit2031
```

`Assert.Single(x.Where(p))` → `Assert.Single(x, p)`. Mine, from #1696.

The analyzer is right that the overload is better, and not only stylistically: the filtering form reports *"the collection contained 0 items"* on failure, having already discarded everything that didn't match, while the overload reports what **was** there. That's the difference between a useful failure message and a puzzle.

Scoped to this single line deliberately.

## Verification

Full solution on `-t:Rebuild`: **0 Warning(s), 0 Error(s)**. Lite suite: **1580 passed**.

(The `-t:Rebuild` matters here — an incremental build reports zero warnings for projects it didn't recompile, which is exactly how this one stayed hidden behind the other two.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
