### PR TITLE
check-version: survive the deprecated/ layout transition on the main side

### DIFF
--- a/.github/workflows/check-version-bump.yml
+++ b/.github/workflows/check-version-bump.yml
@@ -61,9 +61,14 @@ jobs:
         id: main
         shell: pwsh
         run: |
-          $version = ([xml](Get-Content main-branch/deprecated/Dashboard/Dashboard.csproj)).Project.PropertyGroup.Version | Where-Object { $_ }
+          # main still carries the pre-deprecation layout until the v3.3.0 promotion lands;
+          # fall back to the old path so the release PR itself can pass. Removable once
+          # main has deprecated/Dashboard/.
+          $path = 'main-branch/deprecated/Dashboard/Dashboard.csproj'
+          if (-not (Test-Path $path)) { $path = 'main-branch/Dashboard/Dashboard.csproj' }
+          $version = ([xml](Get-Content $path)).Project.PropertyGroup.Version | Where-Object { $_ }
           echo "VERSION=$version" >> $env:GITHUB_OUTPUT
-          Write-Host "Main version: $version"
+          Write-Host "Main version: $version (from $path)"
 
       - name: Compare versions
         if: steps.changes.outputs.all_count != steps.changes.outputs.docs_count

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **CI: the version-bump check survives the deprecated/ layout transition** ([#1821]) - the check compares the PR's Dashboard.csproj version against MAIN's copy, but read main's copy only at the NEW deprecated/ path - which does not exist on main until the v3.3.0 promotion itself lands, so the release PR failed the check on a path error rather than a version verdict. The main-side read now falls back to the pre-move location; removable once main carries the new layout.
+
 ## [3.3.0] - 2026-07-29
 
 ### Important
@@ -1906,6 +1910,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1665]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/1665
 [#1799]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1799
 [#1798]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/1798
+[#1821]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1821
 [#1797]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1797
 [#1788]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1788
 [#1781]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1781


### PR DESCRIPTION
The version-bump check reads MAIN's Dashboard.csproj to compare against the PR's, but only at the new deprecated/ path — which doesn't exist on main until the v3.3.0 promotion itself merges. Release PR #1820 therefore failed check-version on a path error, not a version verdict. Falls back to the pre-move location; removable once main carries the new layout. (check-version is not a required context; this is correctness + optics for the release PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)