### PR TITLE
Darling: survive service accounts that are not the virtual account (#1823)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **CI: the version-bump check survives the deprecated/ layout transition** ([#1821]) - the check compares the PR's Dashboard.csproj version against MAIN's copy, but read main's copy only at the NEW deprecated/ path - which does not exist on main until the v3.3.0 promotion itself lands, so the release PR failed the check on a path error rather than a version verdict. The main-side read now falls back to the pre-move location; removable once main carries the new layout.
 
+### Fixed
+
+- **Darling installs re-homed to a domain account or gMSA survive upgrades and get correct remediation text** ([#1823], also [#1802]) - with `"auth": "integrated"` the service connects to monitored servers as its Log On account, and operators change that account for exactly that reason - but two paths still assumed the default virtual account. `install-darling.ps1`'s upgrade path preserves a custom Log On account, then rebuilt `darling.json`'s DACL around `NT SERVICE\PerformanceMonitor Darling` anyway, stripping the operator's grant and locking the re-homed service out of its own config on the next start; the hardening (and its printed `icacls` hint) now targets the account the service actually runs as. The service's own ACL-failure log lines had the same defect baked into their remediation - an `icacls /grant` naming the virtual account, which on a re-homed install is a fix that cannot work - and now name the running identity. The Darling README also gains the full account-switch runbook that previously lived only in an issue answer: Services.msc/`sc config` routes (gMSA included), the Windows-login grants, the one-time file re-grant that bites everyone who skips it, and the caveat that `--test-connection` runs as the console user, not the service account.
+
 ## [3.3.0] - 2026-07-29
 
 ### Important
@@ -1944,3 +1948,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1806]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1806
 [#1758]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/1758
 [#1807]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/1807
+[#1802]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/1802
+[#1823]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/1823

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingFileSecurity.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingFileSecurity.cs
@@ -66,6 +66,29 @@ public static class DarlingFileSecurity
             ?? throw new InvalidOperationException("Cannot resolve the current Windows identity for ACL hardening.");
 
     /// <summary>
+    /// The current identity as a display name for remediation log lines: <c>NT SERVICE\PerformanceMonitor
+    /// Darling</c> on a default install, <c>DOMAIN\svc-account</c> when an operator re-homed the service to a
+    /// domain account or gMSA for integrated auth (#1802, #1823). The <c>icacls /grant</c> a harden failure
+    /// prints must name the account the service RUNS AS — granting the virtual account on a re-homed install
+    /// is a fix that cannot work, handed to the one operator who needs it. Falls back to the default virtual
+    /// account name rather than throwing: a remediation string must never itself take the log line down.
+    /// </summary>
+    public static string ServiceAccountDisplayName
+    {
+        get
+        {
+            try
+            {
+                return WindowsIdentity.GetCurrent().Name;
+            }
+            catch (Exception)
+            {
+                return @"NT SERVICE\PerformanceMonitor Darling";
+            }
+        }
+    }
+
+    /// <summary>
     /// Locks a directory to SYSTEM + Administrators + the service account (full control, inherited by
     /// children), removing ALL inherited access so no Users / Authenticated Users read survives. When
     /// <paramref name="allowInteractiveTraverse"/> is set, INTERACTIVE gets traverse (not list) on THIS

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -564,10 +564,13 @@ public sealed class DarlingWorker : BackgroundService
                who can resolve this, so give them the three lines. */
             /* Built as ONE argument rather than repeating {Path}: a structured-logging template binds
                placeholders POSITIONALLY, so a repeated name silently consumes the next argument and the
-               tail of the message renders empty — in the one log line whose entire job is to be actionable. */
+               tail of the message renders empty — in the one log line whose entire job is to be actionable.
+               The /grant names the identity the service RUNS AS, not the default virtual account — on an
+               install re-homed to a domain account for integrated auth (#1823), granting the virtual
+               account would be a fix that cannot work. */
             var remediation =
                 $"icacls \"{path}\" /inheritance:d   then   icacls \"{path}\" /remove:g \"BUILTIN\\Users\"   " +
-                $"then   icacls \"{path}\" /grant \"NT SERVICE\\PerformanceMonitor Darling:(F)\"";
+                $"then   icacls \"{path}\" /grant \"{DarlingFileSecurity.ServiceAccountDisplayName}:(F)\"";
 
             _logger.LogError(
                 "Could not restrict the ACL on {Path}{Detail} ({Message}). If the owner is not this service, the " +
@@ -631,10 +634,11 @@ public sealed class DarlingWorker : BackgroundService
             catch (Exception ex)
             {
                 /* Same contract as the live file: best-effort, but the remediation is spelled out as
-                   runnable commands so an elevated human can finish the job the service cannot. */
+                   runnable commands so an elevated human can finish the job the service cannot — naming
+                   the identity the service runs as, which is not the virtual account on a re-homed install. */
                 var remediation =
                     $"icacls \"{backup}\" /inheritance:d   then   icacls \"{backup}\" /remove:g \"BUILTIN\\Users\"   " +
-                    $"then   icacls \"{backup}\" /grant \"NT SERVICE\\PerformanceMonitor Darling:(F)\"";
+                    $"then   icacls \"{backup}\" /grant \"{DarlingFileSecurity.ServiceAccountDisplayName}:(F)\"";
 
                 logger.LogError(
                     "Could not restrict the ACL on config backup {Path}{Detail} ({Message}). It carries the same " +

--- a/Darling/README.md
+++ b/Darling/README.md
@@ -77,7 +77,7 @@ Minimal working example — one server, integrated auth, bring-your-own PostgreS
 }
 ```
 
-**Integrated auth (recommended).** The service connects to monitored servers as the Windows account the service runs under. Grant that account the [permissions below](#permissions-on-monitored-servers).
+**Integrated auth (recommended).** The service connects to monitored servers as the Windows account the service runs under — there is no separate Windows credential to configure. Grant that account the [permissions below](#permissions-on-monitored-servers). The default install's virtual service account reaches *remote* servers as the collector machine's computer account (`DOMAIN\<machine>$`), so for integrated auth you will usually [run the service as a domain account or gMSA](#run-the-service-as-a-domain-account-or-gmsa) instead.
 
 **SQL auth.** Set `"auth": "sql"`, a `username`, and an `encryptedPassword` produced by the `--encrypt-password` verb:
 
@@ -98,6 +98,8 @@ PerformanceMonitor.Darling.Service.exe --test-connection
 ```
 
 (`--validate-config` is an alias.) It validates the file, then connects to and probes each server, printing a `[PASS]`/`[FAIL]` line per server (SQL major version, engine edition, and whether the account has msdb access for failed-job alerts). It exits `0` only when the file is valid **and** every server is reachable, so it doubles as a deployment gate. Add an explicit config path as a second argument if `darling.json` is not next to the exe and `DARLING_CONFIG` is not set. This is the same probe the Viewer's **Test Connection** button runs through the service.
+
+One identity caveat: the verb connects as **you**, the console user — not as the service account. For `"auth": "integrated"` servers a `[PASS]` proves the server is reachable and the config is well-formed, but the grants that matter at runtime are the *service account's*: the per-server connect lines in the service log are the real proof (see [Run the service as a domain account or gMSA](#run-the-service-as-a-domain-account-or-gmsa)).
 
 ### Run It — Console Mode
 
@@ -133,9 +135,41 @@ Also register the service's Windows event source once, from the same elevated sh
 powershell -NoProfile -Command "New-EventLog -LogName Application -Source 'PerformanceMonitor Darling' -ErrorAction SilentlyContinue"
 ```
 
-The `obj=` clause runs the service under a **virtual service account** (`NT SERVICE\<service name>` — password-less, per-service SID, unprivileged; the same convention SQL Server itself uses). That is the right account for SQL-auth monitoring, and with `postgres.managed = true` it is more than a preference: PostgreSQL refuses to execute with administrative privileges, so don't run the service as LocalSystem — a least-privilege account keeps the bundled store's initdb/start path on ground PostgreSQL supports. For integrated auth to monitored servers, set a domain account (or gMSA) holding the SQL-side grants below instead, via **Services.msc → Log On** or `sc config ... obj=`. Note the space after `binPath=`, `start=`, and `obj=` — `sc` requires it.
+The `obj=` clause runs the service under a **virtual service account** (`NT SERVICE\<service name>` — password-less, per-service SID, unprivileged; the same convention SQL Server itself uses). That is the right account for SQL-auth monitoring, and with `postgres.managed = true` it is more than a preference: PostgreSQL refuses to execute with administrative privileges, so don't run the service as LocalSystem — a least-privilege account keeps the bundled store's initdb/start path on ground PostgreSQL supports. For integrated auth to monitored servers, [run the service as a domain account or gMSA](#run-the-service-as-a-domain-account-or-gmsa) instead. Note the space after `binPath=`, `start=`, and `obj=` — `sc` requires it.
 
 One managed-mode handoff gotcha: if you test-drove the service from a console first, the bundled store's data directory belongs to *your* account, and the service account may not be able to write it. Point the service at a fresh `postgres.dataDirectory` (or delete the test directory) rather than fighting ACLs.
+
+#### Run the service as a domain account or gMSA
+
+With `"auth": "integrated"`, the monitoring identity **is** the service's Log On account — nothing in `darling.json` names a Windows account, and there is no separate credential to set. The default virtual account carries only the *machine* identity onto the network (remote servers see `DOMAIN\<collector-machine>$`), so for integrated auth against remote servers you almost always want a real AD service account or, better, a gMSA. Switching is a Windows-side change plus a SQL-side grant, with one file-permission step in the middle that bites everyone who skips it:
+
+1. **Change the Log On account.** Stop the service, then **Services.msc → PerformanceMonitor Darling → Log On → This account** — that route also grants the account the *Log on as a service* right automatically. Or from an elevated prompt (with `sc config` you grant *Log on as a service* yourself, via secpol.msc or GPO):
+
+   ```
+   sc config "PerformanceMonitor Darling" obj= "DOMAIN\svc-account" password= "ThePassword"
+   ```
+
+   A gMSA works the same way with an empty password: `obj= "DOMAIN\gmsa-name$" password= ""`. Keep the account **out of the local Administrators group**: with `postgres.managed = true` the bundled PostgreSQL refuses to run with administrative privileges, exactly as it refuses LocalSystem.
+
+2. **Grant the account on every monitored server** — a Windows login holding the same [permissions below](#permissions-on-monitored-servers) (the `GRANT`s there apply to a Windows login unchanged):
+
+   ```sql
+   USE [master];
+   CREATE LOGIN [DOMAIN\svc-account] FROM WINDOWS;
+   ```
+
+3. **Re-grant the service's own files — the step people miss.** The service deliberately locks its files down to SYSTEM, Administrators, and the account it was *running as*; the new account is on none of those ACLs, and the service will fail to read its config or write its store. One-time, from an elevated prompt, before starting the service:
+
+   ```
+   icacls "C:\ProgramData\PerformanceMonitorDarling" /grant "DOMAIN\svc-account:(OI)(CI)F"
+   icacls "C:\PerformanceMonitorDarling\darling.json" /grant "DOMAIN\svc-account:F"
+   ```
+
+   Adjust the second path to wherever `darling.json` sits beside the service exe; the first covers the logs and, in managed mode, the store's data directory. On its next start the service re-asserts the tight ACL itself — now including the new account — so this does not need repeating.
+
+4. **Start the service and verify from its log** (`%ProgramData%\PerformanceMonitorDarling\logs`): the per-server connect lines are the proof that the *service account's* grants work. `--test-connection` from your console runs as you, not the service account — see the [pre-flight note above](#validate-the-config-pre-flight).
+
+Nothing else moves: anything encrypted with `--encrypt-password` (SQL-auth server passwords, SMTP) survives the account change, because those blobs are DPAPI **machine**-scope, not account-scope — and collected data is untouched. Later `install-darling.ps1` upgrades preserve a custom Log On account and harden `darling.json` for the account the service actually runs as.
 
 ### What the Service Does on Monitored Servers
 

--- a/Darling/tools/install-darling.ps1
+++ b/Darling/tools/install-darling.ps1
@@ -129,6 +129,24 @@ else {
     Write-Host "Created service '$serviceName' (NT SERVICE virtual account, automatic start)."
 }
 
+# The account the service ACTUALLY logs on as - NOT assumed to be the virtual account. Operators using
+# integrated auth to monitored servers re-home the service to a domain account or gMSA (#1802, #1823),
+# and the upgrade path above deliberately preserves that (sc config touches binPath only). The 4b
+# hardening below must grant the account the service really runs as: rebuilding the DACL around the
+# virtual account on a re-homed install would strip the operator's grant and lock the service out of
+# its own config on the next start. Fresh installs resolve to the virtual account just created.
+$serviceAccount = "NT SERVICE\$serviceName"
+try {
+    $startName = (Get-CimInstance -ClassName Win32_Service -Filter "Name='$serviceName'" -ErrorAction Stop).StartName
+    if ($startName) {
+        if ($startName -eq 'LocalSystem') { $serviceAccount = 'NT AUTHORITY\SYSTEM' }
+        else { $serviceAccount = $startName -replace '^\.\\', "$env:COMPUTERNAME\" }
+    }
+}
+catch {
+    # Fall back to the virtual account the create path just used.
+}
+
 # -- 4b. Lock down darling.json (#1647) -----------------------------------------------------------
 # The config holds every monitored server's encryptedPassword plus the MCP bearer and web access tokens.
 # They are DPAPI LocalMachine scope with an entropy constant that ships in the open-source repo, so READ
@@ -162,7 +180,7 @@ foreach ($secretFile in @($configPath) + @(Get-ChildItem -Path $root -Filter 'da
         $systemSid      = New-Object System.Security.Principal.SecurityIdentifier($wk::LocalSystemSid, $null)
         $adminsSid      = New-Object System.Security.Principal.SecurityIdentifier($wk::BuiltinAdministratorsSid, $null)
         $interactiveSid = New-Object System.Security.Principal.SecurityIdentifier($wk::InteractiveSid, $null)
-        $serviceSid     = (New-Object System.Security.Principal.NTAccount("NT SERVICE\$serviceName")).Translate([System.Security.Principal.SecurityIdentifier])
+        $serviceSid     = (New-Object System.Security.Principal.NTAccount($serviceAccount)).Translate([System.Security.Principal.SecurityIdentifier])
 
         $acl = New-Object System.Security.AccessControl.FileSecurity
         # Protect the DACL and drop every inherited ACE: access is now EXACTLY the four rules below.
@@ -224,7 +242,7 @@ if ($failed.Count -gt 0) {
     Write-Host '  the file can recover all of it. Fix each one from an elevated prompt:' -ForegroundColor Red
     Write-Host "    icacls `"<file>`" /inheritance:d" -ForegroundColor Yellow
     Write-Host "    icacls `"<file>`" /remove:g `"BUILTIN\Users`"" -ForegroundColor Yellow
-    Write-Host "    icacls `"<file>`" /grant `"NT SERVICE\$serviceName`:(F)`"" -ForegroundColor Yellow
+    Write-Host "    icacls `"<file>`" /grant `"$serviceAccount`:(F)`"" -ForegroundColor Yellow
     Write-Host '  ...or move the install out of a world-readable folder such as one created directly under C:\.' -ForegroundColor Red
     Write-Host ''
 }


### PR DESCRIPTION
## Summary

#1823 (and #1802 before it) asked how the Darling service authenticates to monitored servers when it runs as the `NT SERVICE` virtual account, and how to use a custom AD service account instead. Investigating the answer surfaced two code paths that still assume the default virtual account after an operator re-homes the service:

- **`install-darling.ps1` upgrade lockout.** The upgrade path deliberately preserves a custom Log On account (`sc config` touches `binPath=` only), but section 4b then rebuilt `darling.json`'s DACL granting only `NT SERVICE\PerformanceMonitor Darling` — stripping the operator's grant and locking a re-homed service out of its own config on the next start. The hardening (and its printed `icacls` hint) now resolves the account the service actually runs as, via `Win32_Service.StartName` (with `.\` and `LocalSystem` normalization; unresolvable accounts fall through to the existing visible-failure path rather than silently ACLing the wrong principal).
- **Remediation log lines that name the wrong principal.** `DarlingWorker`'s two ACL-failure remediations hardcoded `icacls ... /grant "NT SERVICE\PerformanceMonitor Darling:(F)"` — on a re-homed install, a fix that cannot work, handed to the one operator who needs it. They now interpolate the running identity via a new `DarlingFileSecurity.ServiceAccountDisplayName` (falls back to the default name rather than throwing — a remediation string must never take the log line down).

Docs, so the question stops recurring:

- The Darling README gains **"Run the service as a domain account or gMSA"** — the full runbook from the #1802 answer: Services.msc / `sc config` routes (gMSA included), the *Log on as a service* note, keep-it-out-of-Administrators (managed PostgreSQL refuses admin privileges), the `FROM WINDOWS` login + pointer to the existing grants table, the one-time `icacls` re-grant that bites everyone who skips it, and DPAPI machine-scope blobs surviving the switch.
- The integrated-auth section now states that the default virtual account reaches *remote* servers as the collector machine's computer account (`DOMAIN\<machine>$`) — the direct answer to #1823's question.
- The pre-flight section documents that `--test-connection` connects as the console user, not the service account (the other half of #1823's question).

## Test plan

- [x] `Darling.Tests` build: 0 warnings, 0 errors
- [x] `DarlingFileSecurityTests` (drives the harden paths incl. `TryHardenConfigBackups`): 14/14 pass
- [x] `install-darling.ps1` passes the PowerShell language parser
- [x] No tests pin the remediation string content (grepped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)