### PR TITLE
Post-merge nits from the #2013 review: hash-proxy + fixture fidelity

### DIFF
--- a/Darling/Darling.Tests/DistinctTextsLiveTests.cs
+++ b/Darling/Darling.Tests/DistinctTextsLiveTests.cs
@@ -102,6 +102,13 @@ public sealed class DistinctTextsLiveTests
         NpgsqlConnection connection, CancellationToken ct, DateTime at,
         string queryHash, string queryText, byte[]? digest, long weight)
     {
+        /* DISTINCT per caller, mirroring reality: different INSERT...EXEC callers have different
+           sql_handles even when their statement texts are the same length — the remediation note's
+           whole premise ("attribute per-caller work via sql_handle") depends on it, and the first
+           cut of this fixture accidentally collided them (review catch). */
+        var sqlHandle = "0xSQLH" + Convert.ToHexString(
+            System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(queryText)))[..12];
+
         await DarlingMcpTestData.ExecAsync(connection, ct,
             @"INSERT INTO query_stats (collection_id, collection_time, server_id, server_name, database_name,
                                        query_hash, query_plan_hash, sql_handle, plan_handle, query_text,
@@ -109,7 +116,7 @@ public sealed class DistinctTextsLiveTests
                                        delta_elapsed_time, delta_logical_reads, min_dop, max_dop)
               VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17)",
             CollectionIdGenerator.Next(), at, ServerId, ServerName, Db,
-            queryHash, "0xPLANHASH", "0xSQLH" + queryText.Length, "0xPLANH", queryText,
+            queryHash, "0xPLANHASH", sqlHandle, "0xPLANH", queryText,
             (object?)digest ?? DBNull.Value, weight, weight * 1000L, weight * 2000L, weight * 10L, 1, 1);
     }
 

--- a/Lite/Services/LocalDataService.QueryStats.cs
+++ b/Lite/Services/LocalDataService.QueryStats.cs
@@ -143,8 +143,11 @@ WITH ranked AS (
         MAX(CAST(delta_worker_time AS DOUBLE PRECISION) / NULLIF(sample_interval_seconds, 0) / 1000.0) AS worker_time_per_second,
         /* #2012: distinct statement texts merged into this hash group. query_hash is a SHAPE hash -
            INSERT...EXEC statements naming DIFFERENT callee procs share one, and ad-hoc literal
-           variants collapse too - so > 1 means the representative text below labels a blend. */
-        COUNT(DISTINCT query_text) AS distinct_texts
+           variants collapse too - so > 1 means the representative text below labels a blend.
+           DuckDB's 64-bit hash() stands in for Darling's #1767 content digest: comparing fixed-size
+           hashes instead of arbitrarily long batch texts (a review note on the twin's asymmetry);
+           a same-group 64-bit collision is negligible for a display count. */
+        COUNT(DISTINCT hash(query_text)) AS distinct_texts
     FROM v_query_stats
     WHERE server_id = $1
     AND   collection_time >= $2


### PR DESCRIPTION
## What does this PR do?

The two nits the #2013 review posted on the rebased round, both taken:

- **Lite's `distinct_texts` counts `DISTINCT hash(query_text)`** (DuckDB's 64-bit hash) instead of distinct full batch texts — the fixed-size stand-in for Darling's #1767 content digest, per the twin-asymmetry perf note. A same-group 64-bit collision is negligible for a display count.
- **The live fixture's fake `sql_handle`s derive from text content, not length** — the two blended INSERT...EXEC texts are the same length, so the first cut collided the handles, contradicting the very remediation premise the feature prints ("attribute per-caller work via `sql_handle`").

## How was this tested?

Same suites that cover the originals: the Lite reader fact and MCP envelope test exercise the changed SQL; the Darling live test exercises the changed fixture. No behavior change intended on any surface.

## Which component(s) does this affect?

- [x] Lite
- [ ] Darling
- [ ] Lite Tests
- [x] Darling Tests
- [ ] SQL collection scripts
- [ ] Documentation
- [ ] Full Dashboard (deprecated)
- [ ] CLI Installer (deprecated)

## Checklist

- [x] I have read the [contributing guide](https://github.com/erikdarlingdata/PerformanceMonitor/blob/main/CONTRIBUTING.md)
- [x] My code builds with zero warnings (`dotnet build -c Debug`)
- [x] I have tested my changes against at least one SQL Server version
- [x] I have not introduced any hardcoded credentials or server names

🤖 Generated with [Claude Code](https://claude.com/claude-code)