### PR TITLE
Wire ClearServerTagsForServerAsync into the remove-server path (#2020 2b-i follow-up)

### DIFF
--- a/Lite/MainWindow.xaml.cs
+++ b/Lite/MainWindow.xaml.cs
@@ -1637,7 +1637,7 @@ public partial class MainWindow : Window
         }
     }
 
-    private void ServerContextMenu_Remove_Click(object sender, RoutedEventArgs e)
+    private async void ServerContextMenu_Remove_Click(object sender, RoutedEventArgs e)
     {
         var server = GetServerFromContextMenu(sender);
         if (server == null) return;
@@ -1658,6 +1658,20 @@ public partial class MainWindow : Window
                sighting against the OLD role and page a phantom failover. The storage name hashes
                deterministically, so a re-added server really does get the same id back. */
             _agAlertEvaluator.Forget(removedServerId);
+            /* #2020 2b-i: drop the removed server's tag assignments for the same reason as the AG forget
+               above — the id hashes deterministically, so a removed-then-re-added server would silently
+               resurrect its old tags. */
+            if (_dataService != null)
+            {
+                try
+                {
+                    await _dataService.ClearServerTagsForServerAsync(removedServerId);
+                }
+                catch (Exception ex)
+                {
+                    AppLogger.Info("Tags", $"Failed to clear tags for removed server: {ex.Message}");
+                }
+            }
             _serverManager.DeleteServer(server.Id);
             RefreshServerList();
             StatusText.Text = $"Removed server: {server.DisplayNameWithIntent}";


### PR DESCRIPTION
## Summary

The one functional gap from the #2026 review: `ClearServerTagsForServerAsync` shipped with a store implementation and a test, but no call site — the doc's 'called when a server is removed' was aspiration. A removed-then-re-added server would silently resurrect its old tags, because the server id is a deterministic hash of the storage name (the exact scenario the method exists to prevent, and the same rationale as the #1696 AG forget sitting two lines above the new call).

## What changed

`ServerContextMenu_Remove_Click` (the one remove site that does deep cleanup) now awaits the tag clear beside the health and AG forgets, guarded with the file's AppLogger idiom so a store hiccup can't crash the async void handler or block the removal itself.

Maintainer-edit push to the contributor's fork wasn't possible (fine-grained PAT is scoped to this org), hence the follow-up PR instead of a commit on #2026.

## Testing

The store method's behavior is covered by `LiteServerTagsStoreTests` from #2026; this PR is the one-call wire-up plus Lite building clean locally under EnableWindowsTargeting.

Part of #2020 (stage 2b-i).

🤖 Generated with [Claude Code](https://claude.com/claude-code)