### PR TITLE
Lite's get_pvs_stats carries the as_of stamp Darling's does (#2029 follow-up)

### DIFF
--- a/Lite/Mcp/McpPvsTools.cs
+++ b/Lite/Mcp/McpPvsTools.cs
@@ -92,6 +92,7 @@ public sealed class McpPvsTools
             return JsonSerializer.Serialize(new
             {
                 server = resolved.ServerName,
+                as_of = rows[0].CollectionTime.ToString("o"),
                 databases,
                 trend_hours_back = trend_hours_back > 0 ? trend_hours_back : (int?)null,
                 trend,

--- a/Lite/Services/LocalDataService.FinOps.Pvs.cs
+++ b/Lite/Services/LocalDataService.FinOps.Pvs.cs
@@ -150,7 +150,8 @@ SELECT
     offrow_version_cleaner_end_time,
     pvs_off_row_page_skipped_low_water_mark,
     pvs_off_row_page_skipped_min_useful_xts,
-    pvs_off_row_page_skipped_oldest_aborted_xdesid
+    pvs_off_row_page_skipped_oldest_aborted_xdesid,
+    collection_time
 FROM v_pvs_stats
 WHERE server_id = $1
 AND   collection_time = (
@@ -182,7 +183,8 @@ ORDER BY persistent_version_store_size_mb DESC NULLS LAST, database_name";
                 OffrowCleanerEndTime = reader.IsDBNull(11) ? null : reader.GetDateTime(11),
                 SkippedLowWaterMark = reader.IsDBNull(12) ? null : Convert.ToInt64(reader.GetValue(12)),
                 SkippedMinUsefulXts = reader.IsDBNull(13) ? null : Convert.ToInt64(reader.GetValue(13)),
-                SkippedOldestAborted = reader.IsDBNull(14) ? null : Convert.ToInt64(reader.GetValue(14))
+                SkippedOldestAborted = reader.IsDBNull(14) ? null : Convert.ToInt64(reader.GetValue(14)),
+                CollectionTime = reader.GetDateTime(15)
             });
         }
 
@@ -213,6 +215,7 @@ public class PvsStatsRow
     public long? SkippedLowWaterMark { get; set; }
     public long? SkippedMinUsefulXts { get; set; }
     public long? SkippedOldestAborted { get; set; }
+    public DateTime CollectionTime { get; set; }
 
     public string AdrDisplay => IsAdrOn switch
     {


### PR DESCRIPTION
## Summary

The #2042 review bot caught a Lite/Darling parity drift in the new `get_pvs_stats`: Darling's payload stamps a top-level `as_of` from the snapshot's collection time; Lite's `PvsStatsRow` never carried `collection_time` at all, so its payload silently omitted the field the twins convention says must match.

## What changed

Additive only: `collection_time` appended to Lite's snapshot read (ordinal 15), a `CollectionTime` property on `PvsStatsRow`, and the `as_of` stamp in the tool payload — now byte-shape-identical to Darling's. The FinOps grid binds by property name and is unaffected.

## Testing

Lite builds clean under EnableWindowsTargeting; the tool payload shape is exercised by the same CI that ran #2042.

🤖 Generated with [Claude Code](https://claude.com/claude-code)