### PR TITLE
Fix the --test WPF sync-over-async deadlock (#2005)

### DIFF
--- a/Darling/PerformanceMonitor.Darling.Viewer/App.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/App.xaml.cs
@@ -42,7 +42,13 @@ public partial class App : Application
            StartupUri from ever creating MainWindow (the second-instance pattern below). */
         if (HeadlessSelfTest.IsRequested(e.Args))
         {
-            var exitCode = HeadlessSelfTest.RunAsync(HeadlessSelfTest.ExplicitConfigPath(e.Args))
+            /* Task.Run is LOAD-BEARING, found the hard way on the first live SSM run: OnStartup executes on
+               the STA UI thread, which already carries WPF's DispatcherSynchronizationContext — so awaiting
+               RunAsync directly posts its continuations to a dispatcher this GetResult() is blocking, the
+               classic WPF sync-over-async deadlock (the process hung forever with exit code never written).
+               Task.Run hops the whole ladder onto the thread pool, where continuations resume freely. */
+            var exitCode = System.Threading.Tasks.Task.Run(
+                    () => HeadlessSelfTest.RunAsync(HeadlessSelfTest.ExplicitConfigPath(e.Args)))
                 .GetAwaiter().GetResult();
             Shutdown(exitCode);
             return;


### PR DESCRIPTION
## Summary

The first live `--test` run — over SSM on the monitor box, the exact scenario the flag exists for — hung forever. Root cause is the classic WPF sync-over-async deadlock: `OnStartup` runs on the STA thread, which already carries the `DispatcherSynchronizationContext`, so awaiting `HeadlessSelfTest.RunAsync` directly posts its continuations to a dispatcher the `GetAwaiter().GetResult()` was blocking. Unreachable on the dev Mac (the deferral's original reason the flag couldn't be locally tested), caught on the first real run.

## What changed

One line: `Task.Run` hops the whole ladder onto the thread pool, where continuations resume freely; the load-bearing comment explains why it must stay. The wedged process from the live run was killed and verified dead; the service was unaffected throughout.

## Testing

Viewer builds clean; the pure contracts are unchanged. Live revalidation over SSM rides the next box upgrade — same procedure that caught this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)