### PR TITLE
Add get_store_metrics to the Lite MCP ratchet allow-list

### DIFF
--- a/Lite.Tests/CrossAppMcpToolInventoryPinTests.cs
+++ b/Lite.Tests/CrossAppMcpToolInventoryPinTests.cs
@@ -55,6 +55,13 @@ public sealed class CrossAppMcpToolInventoryPinTests
     // system_health parser tools). A NEW Darling-only tool must be either ported to Lite or added here.
     private static readonly HashSet<string> KnownLiteMissingMcpTools = new(StringComparer.Ordinal)
     {
+        /* #2068: the store self-metrics read (get_store_metrics) over collect.store_metrics — the central
+           Postgres store measuring ITSELF (hypertable sizes/compression, payload dims, whole-store growth)
+           for capacity forecasting. Darling-ONLY by architecture, not a "not ported yet" item: Lite is a
+           single-instance app over local DuckDB with no central store to measure, no hypertables, and no
+           payload dimensions, so there is no Lite twin to port. */
+        "get_store_metrics",
+
         /* #1562: the pre-banded fleet-overview read born from the web dashboard's DarlingFleetReader.
            Lite twin = a DuckDB fleet reader over the SAME shared ServerHealthClassifier (Common) — tracked
            in #1573 alongside unifying Lite's own card banding onto that classifier; port it, then remove


### PR DESCRIPTION
Nightly-only failure: `Lite.Tests.CrossAppMcpToolInventoryPinTests.LiteMissingMcpTools_MatchTheRatchetAllowList` — #2070 added the Darling-only `get_store_metrics` tool (#2068) and its PR lane didn't run Lite tests, so the ratchet first fired on the nightly. The tool is Darling-only **by architecture** (Lite is single-instance over local DuckDB: no central store, hypertables, or payload dimensions to measure), so the fix is the allow-list entry with that rationale, same style as the Custom Views entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)