### PR TITLE
Query Store catch-up trickles in hour-sized chunks instead of one-shotting an unbounded window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Query Store catch-up can no longer spiral a big database into permanent timeout** ([#2102], found dogfooding the use1 migration) - the live path's incremental window was `(watermark, now)` with only a 24h clamp, and the watermark only advances when a cycle SUCCEEDS. The per-database query aggregates, window-functions, and sorts its WHOLE window before `TOP` or the client byte budget can bound anything - a row cap is not a cost cap - so one missed 60s cycle (a flush burst, a CPU blip, a migration cutover) widened the next window, which cost more and timed out again, growing without bound below a clamp that sat far above the tipping point. On the field evidence the big tenants wedged at 0.5-6.5h stale and re-ran the same doomed query every cycle forever while small databases on the same servers stayed current - and the backfill worker's slices had the same latent flaw one layer down, querying a hole's full remaining range in one statement. Catch-up now trickles the way it was always meant to: the clamp is one hour (the envelope the fleet proves every day under Query Store's 900s flush cadence - and it slides forward with now, so recovery is immediate no matter how stale the watermark got), the skipped range is recorded as a hole exactly as before, and every backfill slice windows at most one hour at a time, with an empty chunk SHRINKING the persisted ceiling past the quiet hour instead of wrongly declaring the range complete (a quiet chunk on a derived-boundary tail converts the remainder to a hole record, because MIN over stored rows cannot walk through quiet space). Both SKUs, both the SQL Server and Azure SQL DB arms.
+
 ## [3.4.0] - 2026-08-06
 
 ### Important
@@ -2598,3 +2602,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2090]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/2090
 [#2093]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/2093
 [#2097]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/2097
+[#2102]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/2102

--- a/Darling/Darling.Tests/QueryStoreBackfillTests.cs
+++ b/Darling/Darling.Tests/QueryStoreBackfillTests.cs
@@ -79,6 +79,29 @@ public sealed class QueryStoreBackfillTests
     }
 
     [Fact]
+    public void BoundSliceFloor_CapsWideRanges_AndPassesNarrowOnesThrough()
+    {
+        /* #2102: a slice queries at most the top MaxSliceSpan of its remaining range — the byte
+           budget bounds what ships, not what the query aggregates and sorts, so an unchunked wide
+           window on a big database re-times-out every tick and the range never drains. The caller
+           reads the verdict from the result: floor moved = chunk (an empty slice shrinks the
+           ceiling and keeps walking); floor unmoved = the whole remainder was asked (an empty
+           slice is terminal, the pre-chunking semantics). */
+        var ceiling = new DateTime(2026, 8, 7, 12, 0, 0, DateTimeKind.Utc);
+
+        var wideFloor = ceiling.AddHours(-23);
+        Assert.Equal(ceiling - QueryStoreBackfillState.MaxSliceSpan, QueryStoreBackfillState.BoundSliceFloor(wideFloor, ceiling));
+
+        var narrowFloor = ceiling.AddMinutes(-25);
+        Assert.Equal(narrowFloor, QueryStoreBackfillState.BoundSliceFloor(narrowFloor, ceiling));
+
+        /* Exactly MaxSliceSpan wide is narrow enough — one slice takes it whole, so its empty
+           verdict stays terminal rather than saving a zero-width hole. */
+        var exactFloor = ceiling - QueryStoreBackfillState.MaxSliceSpan;
+        Assert.Equal(exactFloor, QueryStoreBackfillState.BoundSliceFloor(exactFloor, ceiling));
+    }
+
+    [Fact]
     public void StateIdentity_IsTheWorkersOwn_NotTheDefinitions()
     {
         /* The worker owns its collector_state rows under its OWN name, so the query_store

--- a/Darling/PerformanceMonitor.Darling.Service/QueryStoreBackfill.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/QueryStoreBackfill.cs
@@ -23,8 +23,11 @@ namespace PerformanceMonitor.Darling.Service;
 /// #2022 — Query Store phase 2 (of #1960): the newest-first backfill worker for the history the
 /// live path never takes. Phase 1 made the LIVE path hole-free, but two bounded windows still
 /// discard history by design: first contact takes only the trailing 60 minutes of a ~30-day
-/// catalog, and post-outage catch-up is clamped to 24h (the #1556 incident fix) as a bounded,
-/// logged hole. One mechanism fills both:
+/// catalog, and post-outage catch-up is clamped to <see cref="WatermarkPolicy.MaxCatchup"/> (the
+/// #1556 incident fix, tightened to 1h by #2102) as a bounded, logged hole. One mechanism fills
+/// both, and every slice of it windows at most <see cref="QueryStoreBackfillState.MaxSliceSpan"/>
+/// at a time (#2102 — the query's cost grows with window width, so an unchunked wide range on a
+/// big database re-times-out forever instead of draining):
 ///
 /// <para><b>The tail (first contact).</b> The backfill ceiling is DERIVED, exactly like the live
 /// watermark: MIN(last_execution_time) over the rows already stored for a database. Everything at
@@ -178,6 +181,12 @@ public sealed class QueryStoreBackfill
     private async Task RunSliceAsync(
         ServerRuntime server, string databaseName, DateTime floorUtc, DateTime ceilingUtc, bool isHole, CancellationToken cancellationToken)
     {
+        /* #2102: one slice queries at most the top MaxSliceSpan of the remaining range. The byte
+           budget bounds what SHIPS, not what the query aggregates and sorts — an unchunked wide
+           window on a big database times out at the command timeout every tick and the range never
+           drains, the same row-cap-is-not-a-cost-cap flaw that wedged the live path. */
+        var sliceFloor = QueryStoreBackfillState.BoundSliceFloor(floorUtc, ceilingUtc);
+
         var definition = QueryStoreCollector.Instance;
         var context = new CollectorContext
         {
@@ -201,7 +210,7 @@ public sealed class QueryStoreBackfill
                needed; CurrentDatabaseName feeds ReadAsync's database attribution exactly as on
                the live Azure path. */
             context.CurrentDatabaseName = databaseName;
-            var azurePlan = definition.BuildBackfillQuery(context, floorUtc, ceilingUtc);
+            var azurePlan = definition.BuildBackfillQuery(context, sliceFloor, ceilingUtc);
             using var dbConnection = await _runner.OpenAzureDatabaseConnectionAsync(server, databaseName, cancellationToken);
             using var dbCommand = DarlingCollectorRunner.CreateCollectorCommand(azurePlan, dbConnection, timeout);
             using var dbReader = await dbCommand.ExecuteReaderAsync(cancellationToken);
@@ -233,7 +242,7 @@ public sealed class QueryStoreBackfill
                 }
             }
 
-            var plan = definition.BuildBackfillPerItemQuery(databaseName, context, floorUtc, ceilingUtc);
+            var plan = definition.BuildBackfillPerItemQuery(databaseName, context, sliceFloor, ceilingUtc);
             using var command = DarlingCollectorRunner.CreateCollectorCommand(plan, sqlConnection, timeout);
             using var reader = await command.ExecuteReaderAsync(cancellationToken);
             await definition.ReadItemAsync(databaseName, reader, rows, context, cancellationToken);
@@ -241,6 +250,27 @@ public sealed class QueryStoreBackfill
 
         if (rows.Count == 0)
         {
+            if (sliceFloor > floorUtc)
+            {
+                /* Only this CHUNK is quiet — the range below it is unexplored, so this is an
+                   advance, not a terminal verdict (#2102). The persisted hole ceiling shrinks past
+                   the quiet chunk; a derived-boundary tail converts its remainder to a hole record,
+                   because MIN over stored rows cannot walk through quiet space (an empty chunk
+                   ships nothing, so the derived ceiling would re-ask the same chunk forever). The
+                   tail marks done in the same breath — the hole owns the rest of the dig, and the
+                   scan services holes first. */
+                await SaveStateAsync(server.ServerId, QueryStoreBackfillState.HoleKeyPrefix + databaseName, QueryStoreBackfillState.EncodeHole(floorUtc, sliceFloor), cancellationToken);
+                if (!isHole)
+                {
+                    await SaveStateAsync(server.ServerId, QueryStoreBackfillState.DoneKeyPrefix + databaseName, DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture), cancellationToken);
+                }
+
+                _logger?.LogInformation(
+                    "query_store backfill on '{Server}' [{Database}]: quiet chunk {Floor:o}..{Ceiling:o}, continuing below ({Range}).",
+                    server.Config.DisplayName, databaseName, sliceFloor, ceilingUtc, isHole ? "hole" : "tail");
+                return;
+            }
+
             /* Query Store retains nothing inside the window — the monitored catalog is shorter
                than the horizon (or the hole's span was never persisted at the source). Terminal
                for this range, and cheaper to record than to re-ask every tick. */
@@ -266,7 +296,11 @@ public sealed class QueryStoreBackfill
         var boundary = context.PerItemShippedBoundary;
         if (isHole)
         {
-            if (boundary is null || boundary <= floorUtc)
+            /* A chunked slice's rows all sit at or above its own chunk floor, so a missing shipped
+               boundary falls back to the chunk floor rather than deleting (#2102) — deletion under
+               a bounded window would orphan the unexplored range below it. */
+            var shippedTo = boundary ?? sliceFloor;
+            if (shippedTo <= floorUtc)
             {
                 await _runner.DeleteCollectorStateKeyAsync(server.ServerId, StateCollectorName, QueryStoreBackfillState.HoleKeyPrefix + databaseName, cancellationToken);
             }
@@ -274,7 +308,7 @@ public sealed class QueryStoreBackfill
             {
                 /* Shrink the ceiling to the oldest shipped row; the from-side stays at the floor we
                    actually used (anything below it is horizon-expired either way). */
-                await SaveStateAsync(server.ServerId, QueryStoreBackfillState.HoleKeyPrefix + databaseName, QueryStoreBackfillState.EncodeHole(floorUtc, boundary.Value), cancellationToken);
+                await SaveStateAsync(server.ServerId, QueryStoreBackfillState.HoleKeyPrefix + databaseName, QueryStoreBackfillState.EncodeHole(floorUtc, shippedTo), cancellationToken);
             }
         }
         else if (boundary is not null && boundary <= floorUtc)

--- a/Lite.Tests/WatermarkPolicyTests.cs
+++ b/Lite.Tests/WatermarkPolicyTests.cs
@@ -13,10 +13,11 @@ using Xunit;
 namespace Lite.Tests;
 
 /// <summary>
-/// #1556: the 24h catch-up clamp boundaries. A stale query_store watermark (a service down for days) must
-/// not point its cutoff days into the past — that one cycle would try to pull the whole retained backlog and
-/// drive the commit-limit blowout. The clamp floors a &gt;24h-stale watermark to now-24h; a fresh watermark
-/// and a null watermark pass through untouched.
+/// #1556/#2102: the catch-up clamp boundaries. A stale query_store watermark must not point its cutoff
+/// far into the past — the per-database query's cost grows with window width, so a wide one-shot window
+/// either blows the commit limit (#1556, days-wide) or times out every cycle and wedges the database
+/// permanently (#2102, hours-wide). The clamp floors a stale watermark to now-MaxCatchup; a fresh
+/// watermark and a null watermark pass through untouched.
 /// </summary>
 public sealed class WatermarkPolicyTests
 {
@@ -32,9 +33,9 @@ public sealed class WatermarkPolicyTests
     [Fact]
     public void ClampCatchup_WithinHorizon_ReturnedUnchanged()
     {
-        /* A routine restart / brief outage: the watermark is minutes-to-hours old and never clamps. */
-        var oneHourAgo = Now.AddHours(-1);
-        Assert.Equal(oneHourAgo, WatermarkPolicy.ClampCatchup(oneHourAgo, Now));
+        /* A routine restart: the watermark is minutes old and never clamps. */
+        var tenMinutesAgo = Now.AddMinutes(-10);
+        Assert.Equal(tenMinutesAgo, WatermarkPolicy.ClampCatchup(tenMinutesAgo, Now));
 
         var justInside = Now - WatermarkPolicy.MaxCatchup + TimeSpan.FromSeconds(1);
         Assert.Equal(justInside, WatermarkPolicy.ClampCatchup(justInside, Now));
@@ -43,19 +44,21 @@ public sealed class WatermarkPolicyTests
     [Fact]
     public void ClampCatchup_ExactlyAtHorizon_NotClamped()
     {
-        /* The floor is strict (< floor clamps): a watermark exactly 24h old is at the horizon, not past it. */
+        /* The floor is strict (< floor clamps): a watermark exactly MaxCatchup old is at the horizon,
+           not past it. */
         var atHorizon = Now - WatermarkPolicy.MaxCatchup;
         Assert.Equal(atHorizon, WatermarkPolicy.ClampCatchup(atHorizon, Now));
     }
 
     [Fact]
-    public void ClampCatchup_StalerThanHorizon_FlooredToNowMinus24h()
+    public void ClampCatchup_StalerThanHorizon_FlooredToNowMinusMaxCatchup()
     {
-        /* The field incident: a multi-day-old watermark is floored to now-24h so catch-up is bounded. */
+        /* The field incidents: a stale watermark is floored to now-MaxCatchup so one cycle's window is
+           bounded; the skipped range is the backfill worker's job. */
         var floor = Now - WatermarkPolicy.MaxCatchup;
 
         Assert.Equal(floor, WatermarkPolicy.ClampCatchup(Now.AddDays(-3), Now));
-        Assert.Equal(floor, WatermarkPolicy.ClampCatchup(Now.AddHours(-30), Now));
+        Assert.Equal(floor, WatermarkPolicy.ClampCatchup(Now.AddHours(-6), Now));
 
         var justPast = Now - WatermarkPolicy.MaxCatchup - TimeSpan.FromSeconds(1);
         Assert.Equal(floor, WatermarkPolicy.ClampCatchup(justPast, Now));
@@ -70,10 +73,14 @@ public sealed class WatermarkPolicyTests
     }
 
     [Fact]
-    public void MaxCatchup_IsTwentyFourHours()
+    public void MaxCatchup_IsOneHour_AndMatchesTheBackfillSliceSpan()
     {
-        /* Drift tripwire: the horizon is a deliberate choice (routine outages never clamp; multi-day ones
-           survive with a bounded, logged hole). */
-        Assert.Equal(TimeSpan.FromHours(24), WatermarkPolicy.MaxCatchup);
+        /* Drift tripwire: one hour is the live path's one-query cost envelope — the width the fleet
+           proves every day under Query Store's 900s flush cadence. It was 24h until #2102 showed the
+           clamp sat far above the cost tipping point on big databases and never interrupted the
+           timeout spiral. The equality half is the design invariant: NO path, live or backfill, may
+           window wider than the other, or one of them re-becomes the wide-window casualty. */
+        Assert.Equal(TimeSpan.FromHours(1), WatermarkPolicy.MaxCatchup);
+        Assert.Equal(QueryStoreBackfillState.MaxSliceSpan, WatermarkPolicy.MaxCatchup);
     }
 }

--- a/Lite/Services/RemoteCollectorService.QueryStoreBackfill.cs
+++ b/Lite/Services/RemoteCollectorService.QueryStoreBackfill.cs
@@ -163,6 +163,12 @@ public partial class RemoteCollectorService
         ServerConnection server, int serverId, CollectorTargetInfo target, string databaseName,
         DateTime floorUtc, DateTime ceilingUtc, bool isHole, CancellationToken cancellationToken)
     {
+        /* #2102: one slice queries at most the top MaxSliceSpan of the remaining range. The byte
+           budget bounds what SHIPS, not what the query aggregates and sorts — an unchunked wide
+           window on a big database times out at the command timeout every tick and the range never
+           drains, the same row-cap-is-not-a-cost-cap flaw that wedged the live path. */
+        var sliceFloor = QueryStoreBackfillState.BoundSliceFloor(floorUtc, ceilingUtc);
+
         var definition = QueryStoreCollector.Instance;
         var context = new CollectorContext
         {
@@ -183,7 +189,7 @@ public partial class RemoteCollectorService
             /* Azure arm: the window travels as command parameters on a per-database connection —
                same contract as Darling's, same shared BuildBackfillQuery. */
             context.CurrentDatabaseName = databaseName;
-            var azurePlan = definition.BuildBackfillQuery(context, floorUtc, ceilingUtc);
+            var azurePlan = definition.BuildBackfillQuery(context, sliceFloor, ceilingUtc);
             using var dbConnection = await OpenAzureDatabaseConnectionAsync(server, databaseName, cancellationToken);
             using var dbCommand = new SqlCommand(azurePlan.Text, dbConnection) { CommandTimeout = timeout };
             AddCollectorParameters(dbCommand, azurePlan);
@@ -215,7 +221,7 @@ public partial class RemoteCollectorService
                 }
             }
 
-            var plan = definition.BuildBackfillPerItemQuery(databaseName, context, floorUtc, ceilingUtc);
+            var plan = definition.BuildBackfillPerItemQuery(databaseName, context, sliceFloor, ceilingUtc);
             using var command = new SqlCommand(plan.Text, sqlConnection) { CommandTimeout = timeout };
             AddCollectorParameters(command, plan);
             using var reader = await command.ExecuteReaderAsync(cancellationToken);
@@ -224,6 +230,32 @@ public partial class RemoteCollectorService
 
         if (rows.Count == 0)
         {
+            if (sliceFloor > floorUtc)
+            {
+                /* Only this CHUNK is quiet — the range below it is unexplored, so this is an
+                   advance, not a terminal verdict (#2102). The persisted hole ceiling shrinks past
+                   the quiet chunk; a derived-boundary tail converts its remainder to a hole record,
+                   because MIN over stored rows cannot walk through quiet space (an empty chunk
+                   ships nothing, so the derived ceiling would re-ask the same chunk forever). The
+                   tail marks done in the same breath — the hole owns the rest of the dig, and the
+                   scan services holes first. */
+                var advance = new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    [QueryStoreBackfillState.HoleKeyPrefix + databaseName] = QueryStoreBackfillState.EncodeHole(floorUtc, sliceFloor)
+                };
+                if (!isHole)
+                {
+                    advance[QueryStoreBackfillState.DoneKeyPrefix + databaseName] = DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture);
+                }
+
+                await SaveCollectorStateAsync(serverId, QueryStoreBackfillState.StateCollectorName, advance, cancellationToken);
+
+                _logger?.LogInformation(
+                    "query_store backfill on '{Server}' [{Database}]: quiet chunk {Floor:o}..{Ceiling:o}, continuing below ({Range}).",
+                    server.DisplayName, databaseName, sliceFloor, ceilingUtc, isHole ? "hole" : "tail");
+                return;
+            }
+
             if (isHole)
             {
                 await DeleteCollectorStateKeyAsync(serverId, QueryStoreBackfillState.StateCollectorName, QueryStoreBackfillState.HoleKeyPrefix + databaseName, cancellationToken);
@@ -255,7 +287,11 @@ public partial class RemoteCollectorService
         var boundary = context.PerItemShippedBoundary;
         if (isHole)
         {
-            if (boundary is null || boundary <= floorUtc)
+            /* A chunked slice's rows all sit at or above its own chunk floor, so a missing shipped
+               boundary falls back to the chunk floor rather than deleting (#2102) — deletion under
+               a bounded window would orphan the unexplored range below it. */
+            var shippedTo = boundary ?? sliceFloor;
+            if (shippedTo <= floorUtc)
             {
                 await DeleteCollectorStateKeyAsync(serverId, QueryStoreBackfillState.StateCollectorName, QueryStoreBackfillState.HoleKeyPrefix + databaseName, cancellationToken);
             }
@@ -264,7 +300,7 @@ public partial class RemoteCollectorService
                 await SaveCollectorStateAsync(serverId, QueryStoreBackfillState.StateCollectorName,
                     new Dictionary<string, string>(StringComparer.Ordinal)
                     {
-                        [QueryStoreBackfillState.HoleKeyPrefix + databaseName] = QueryStoreBackfillState.EncodeHole(floorUtc, boundary.Value)
+                        [QueryStoreBackfillState.HoleKeyPrefix + databaseName] = QueryStoreBackfillState.EncodeHole(floorUtc, shippedTo)
                     }, cancellationToken);
             }
         }

--- a/PerformanceMonitor.Collectors/QueryStoreBackfillState.cs
+++ b/PerformanceMonitor.Collectors/QueryStoreBackfillState.cs
@@ -37,6 +37,31 @@ public static class QueryStoreBackfillState
     /// <summary>State key prefix for a recorded clamp hole (value: <see cref="EncodeHole"/>).</summary>
     public const string HoleKeyPrefix = "hole:";
 
+    /// <summary>
+    /// The widest window a single backfill slice may hand the per-database query (#2102) — matched
+    /// to <see cref="WatermarkPolicy.MaxCatchup"/> so NO path, live or backfill, ever windows wider
+    /// than the steady state the fleet proves. The backfill query aggregates and sorts its whole
+    /// window before the byte budget can bound anything (the same row-cap-is-not-a-cost-cap flaw
+    /// that wedged the live path), so an unchunked wide hole on a big database re-times-out forever
+    /// instead of draining.
+    /// </summary>
+    public static readonly TimeSpan MaxSliceSpan = TimeSpan.FromHours(1);
+
+    /// <summary>
+    /// Bounds one newest-first slice to the top <see cref="MaxSliceSpan"/> of the remaining range:
+    /// returns the floor the slice should actually query, which is the requested floor once the
+    /// remainder is narrow enough. A pure function so the placement is pinnable in isolation, like
+    /// <see cref="WatermarkPolicy.ClampCatchup"/>. The caller distinguishes "chunk exhausted"
+    /// (result &gt; <paramref name="floorUtc"/>: an empty slice means only this CHUNK is quiet —
+    /// shrink the ceiling and keep walking) from "range exhausted" (result ==
+    /// <paramref name="floorUtc"/>: an empty slice is terminal, exactly the pre-chunking semantics).
+    /// </summary>
+    public static DateTime BoundSliceFloor(DateTime floorUtc, DateTime ceilingUtc)
+    {
+        var chunkFloor = ceilingUtc - MaxSliceSpan;
+        return chunkFloor > floorUtc ? chunkFloor : floorUtc;
+    }
+
     /// <summary>Encodes a hole range as <c>from|to</c> in round-trip format — deliberately not
     /// JSON, so the state row stays greppable and the codec dependency-free.</summary>
     public static string EncodeHole(DateTime fromUtc, DateTime toUtc)

--- a/PerformanceMonitor.Collectors/WatermarkPolicy.cs
+++ b/PerformanceMonitor.Collectors/WatermarkPolicy.cs
@@ -17,10 +17,17 @@ namespace PerformanceMonitor.Collectors;
 /// one cycle tried to pull the entire backlog at once and drove the 0→13GB commit-limit blowout.
 ///
 /// <para>
-/// <see cref="ClampCatchup"/> floors a stale watermark to <c>now - 24h</c>: a routine restart or a
-/// brief outage never clamps (its watermark is minutes old), a multi-day outage survives with a
-/// deliberate, logged, BOUNDED hole (the source still retains the older data; the viewer's windows
-/// are 24h anyway). This is deliberately NOT applied to every timestamp watermark — for a ring-buffer
+/// <see cref="ClampCatchup"/> floors a stale watermark to <c>now - 1h</c>: a routine restart never
+/// clamps (its watermark is minutes old), and anything longer survives as a deliberate, logged,
+/// BOUNDED hole that the backfill worker (#2022/#2058) trickles in afterwards. The horizon was 24h
+/// until the use1 migration wedge (#2102) proved a row cap is not a cost cap: the per-database query
+/// aggregates and sorts the WHOLE window before TOP or the byte budget can bound anything, so its
+/// cost grows with window width. A big database that missed one 60s cycle faced a wider window the
+/// next cycle, which cost more and timed out again — a self-sustaining spiral the 24h clamp sat far
+/// above and never interrupted. One hour is the envelope the fleet already proves every day (Query
+/// Store's 900s flush cadence makes 15–60min effective windows the routine steady state), and the
+/// clamp floor slides forward with <c>now</c>, so recovery is immediate no matter how stale the
+/// watermark got. This is deliberately NOT applied to every timestamp watermark — for a ring-buffer
 /// or rolling-trace source the clamp is a no-op at best and, on a quiet <c>default_trace</c> whose
 /// 100MB ring can span days, a WRONG truncation of legitimate catch-up. It is therefore scoped to
 /// exactly ONE collector: query_store's per-database cutoff (the only unbounded-persisted source among
@@ -40,13 +47,15 @@ namespace PerformanceMonitor.Collectors;
 public static class WatermarkPolicy
 {
     /// <summary>
-    /// The maximum catch-up horizon. 24h is chosen so routine outages never clamp while a multi-day
-    /// outage survives with a single logged, bounded hole. Exposed so a test pins the boundary.
+    /// The maximum catch-up horizon — the live path's one-query cost envelope, matched to
+    /// <see cref="QueryStoreBackfillState.MaxSliceSpan"/> so no path ever windows wider than the
+    /// steady state the fleet proves (#2102). Everything older is the backfill worker's job.
+    /// Exposed so a test pins the boundary.
     /// </summary>
-    public static readonly TimeSpan MaxCatchup = TimeSpan.FromHours(24);
+    public static readonly TimeSpan MaxCatchup = TimeSpan.FromHours(1);
 
     /// <summary>
-    /// Floors a &gt;24h-stale timestamp watermark to <c>now - 24h</c>; a null watermark (nothing
+    /// Floors a stale timestamp watermark to <c>now - <see cref="MaxCatchup"/></c>; a null watermark (nothing
     /// collected yet — the definition's documented first-run window applies) stays null, and a
     /// watermark within the horizon is returned unchanged. Compare the result to the input to tell
     /// whether a clamp fired (the runner logs a WARNING when it does).


### PR DESCRIPTION
Closes #2102.

## What

A row cap is not a cost cap. The live QS path windowed `(watermark, now)` with only a 24h clamp, and the per-database query aggregates, window-functions, and sorts the whole window before `TOP (50000) WITH TIES` or the client byte budget can bound anything. Since the watermark only advances on a successful cycle, one missed 60s cycle widened the next window — a self-sustaining timeout spiral that permanently wedged every big database on the migrated use1 servers (0.5–6.5h stale, ~120 WARNs/hr flat) while small databases on the same servers stayed current to the minute. The 24h clamp never fired once: the spiral lives entirely below it. The backfill worker had the same latent flaw one layer down — hole/tail slices query the full remaining range in one statement, so wide holes on big databases could never drain either (observed: `backfill slice on 'multi32' failed: Execution Timeout Expired` alongside healthy 64MB slices elsewhere).

## How

Catch-up now trickles the way the design always intended:

- **`WatermarkPolicy.MaxCatchup` 24h → 1h.** The one-query cost envelope the fleet already proves every day (QS's 900s flush cadence makes 15–60min effective windows routine). The clamp floor slides forward with `now`, so recovery is immediate regardless of staleness; the skipped range records as a hole at the existing clamp sites, unchanged.
- **`QueryStoreBackfillState.MaxSliceSpan`/`BoundSliceFloor`** (pure, pinned): every backfill slice windows at most the top hour of its remaining range — both SKUs, both the SQL Server and Azure SQL DB arms. Empty-chunk semantics change from terminal to advancing: a quiet chunk **shrinks** the persisted hole ceiling; a quiet chunk on a derived-boundary tail converts the remainder to a hole record (MIN over stored rows cannot walk through quiet space) and marks the tail done in the same breath, since the scan services holes first. A missing shipped boundary on a chunked hole slice falls back to the chunk floor rather than deleting, which would orphan the unexplored range below it.

Considered and rejected: raising the collector's 60s command timeout — it moves the wall while burning minutes of a monitored replica's CPU per cycle per wedged database.

## Tests

- `MaxCatchup_IsOneHour_AndMatchesTheBackfillSliceSpan` — pins both constants AND their equality (the design invariant: no path windows wider than the other).
- `BoundSliceFloor_CapsWideRanges_AndPassesNarrowOnesThrough` — wide range capped to the top hour, narrow passthrough, exactly-`MaxSliceSpan` stays terminal-on-empty.
- Existing clamp boundary tests updated to the policy-relative wording; all fixtures were already relative to `MaxCatchup`.

## Validation plan

Deploy the nightly to the prod monitor box, where nine servers currently carry wedged big databases — they should clamp to a 1h window on the first cycle, collect clean, and the recorded holes should drain hour-by-hour in the backfill log lines (`quiet chunk … continuing below` / `shipped … down to`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)