### PR TITLE
Yield-to-live stamps the Azure SQL DB arm too

### DIFF
--- a/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
@@ -322,6 +322,17 @@ public sealed class DarlingCollectorRunner
                        routine one-database miss. */
                     failed++;
                     firstFailure ??= ex;
+
+                    /* #2111: the yield-to-live stamp for the Azure SQL DB arm — query_store reaches
+                       THIS per-database loop there, not the enumeration path's onItemError, and
+                       without the stamp the backfill worker would never yield on an Azure target
+                       (the review catch on #2112). Same query_store-only guard as the hole
+                       recording above. */
+                    if (string.Equals(definition.Name, QueryStoreCollector.Instance.Name, StringComparison.Ordinal))
+                    {
+                        _lastQueryStoreItemFailureUtc[server.ServerId] = DateTime.UtcNow;
+                    }
+
                     _logger?.LogDebug("Skipping database '{Database}' for {Collector}: {Error}", databaseName, definition.Name, ex.Message);
                 }
             }

--- a/Lite/Services/RemoteCollectorService.DefinitionRunner.cs
+++ b/Lite/Services/RemoteCollectorService.DefinitionRunner.cs
@@ -250,6 +250,17 @@ public partial class RemoteCollectorService
                        routine one-database miss. */
                     failed++;
                     firstFailure ??= ex;
+
+                    /* #2111: the yield-to-live stamp for the Azure SQL DB arm — query_store reaches
+                       THIS per-database loop there, not the enumeration path's onItemError, and
+                       without the stamp the backfill worker would never yield on an Azure target
+                       (the review catch on #2112). Same query_store-only guard as the hole
+                       recording above. */
+                    if (string.Equals(definition.Name, QueryStoreCollector.Instance.Name, StringComparison.Ordinal))
+                    {
+                        _lastQueryStoreItemFailureUtc[serverId] = DateTime.UtcNow;
+                    }
+
                     _logger?.LogDebug("Skipping database '{Database}' for {Collector}: {Error}", databaseName, definition.Name, ex.Message);
                 }
             }


### PR DESCRIPTION
Follow-up to #2112 — the review robot's catch, and it was right in both SKUs: `QueryStoreCollector.RunsPerDatabase` routes query_store through the Azure SQL DB per-database loop, whose catch block never stamped `_lastQueryStoreItemFailureUtc`, so the #2111 yield-to-live signal could never be set for Azure targets — the backfill worker would hammer a struggling Azure replica exactly the way the mechanism exists to prevent. Both catch blocks now stamp under the same query_store-only guard the #2022 hole recording already uses three lines up. The on-box arm and the shared policy are unchanged.

(The robot's other note — the doc-comment placement in Lite's backfill partial — was already fixed on the #2112 branch before merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)