### PR TITLE
Every previously-hardcoded alert threshold is a real setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Every previously-hardcoded alert threshold is now a real setting** ([#2107], the split-out from gotqn's #2101 - "it was fine to hardcode these for development but any serious monitoring allows configuring of alert thresholds") - six new knobs ride the store control plane (V55), the Viewer's Settings window, and `get_alert_settings`/`update_alert_settings`, clamped on read like their siblings: the monitor store volume's self-alert warning percent (was 10), the Collection Stopped staleness window (was 30 minutes) and consecutive-failure fast path (was 10), the low-disk CRITICAL severity tier's percent and GB floors (were 3% / 2 GB - these grade the target-volume alert in BOTH apps, and Lite reads its pair from `settings.json` as `alert_disk_critical_free_percent` / `alert_disk_critical_free_gb`), and the analysis notification cooldown (was a hardcoded 360 in Darling while Lite always honored a configured value - the parity gap closed). MCP shape: `low_disk.critical_free_percent` / `low_disk.critical_free_gb`, a new `self_alerts` group, and `analysis.notify_cooldown_minutes`.
+
 ### Fixed
 
 - **Query Store catch-up can no longer spiral a big database into permanent timeout** ([#2102], found dogfooding the use1 migration) - the live path's incremental window was `(watermark, now)` with only a 24h clamp, and the watermark only advances when a cycle SUCCEEDS. The per-database query aggregates, window-functions, and sorts its WHOLE window before `TOP` or the client byte budget can bound anything - a row cap is not a cost cap - so one missed 60s cycle (a flush burst, a CPU blip, a migration cutover) widened the next window, which cost more and timed out again, growing without bound below a clamp that sat far above the tipping point. On the field evidence the big tenants wedged at 0.5-6.5h stale and re-ran the same doomed query every cycle forever while small databases on the same servers stayed current - and the backfill worker's slices had the same latent flaw one layer down, querying a hole's full remaining range in one statement. Catch-up now trickles the way it was always meant to: the clamp is one hour (the envelope the fleet proves every day under Query Store's 900s flush cadence - and it slides forward with now, so recovery is immediate no matter how stale the watermark got), the skipped range is recorded as a hole exactly as before, and every backfill slice windows at most one hour at a time, with an empty chunk SHRINKING the persisted ceiling past the quiet hour instead of wrongly declaring the range complete (a quiet chunk on a derived-boundary tail converts the remainder to a hole record, because MIN over stored rows cannot walk through quiet space). Both SKUs, both the SQL Server and Azure SQL DB arms.
@@ -2610,6 +2614,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2093]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/2093
 [#2097]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/2097
 [#2101]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/2101
+[#2107]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/2107
 [#2102]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/2102
 [#2108]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/2108
 [#2109]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/2109

--- a/Darling/Darling.Tests/AlertEngineTests.cs
+++ b/Darling/Darling.Tests/AlertEngineTests.cs
@@ -62,6 +62,12 @@ public sealed class AlertEngineTests
         public int TempDbSpaceThresholdPercent { get; set; } = 80;
         public int LowDiskThresholdPercent { get; set; } = 10;
         public int LowDiskThresholdGb { get; set; } = 5;
+        /* #2107: the previously-hardcoded knobs, at their shipped defaults. */
+        public int DiskCriticalFreePercent { get; set; } = 3;
+        public int DiskCriticalFreeGb { get; set; } = 2;
+        public int SelfDiskFreeWarnPercent { get; set; } = 10;
+        public int CollectionStaleMinutes { get; set; } = 30;
+        public int CollectionFailureThreshold { get; set; } = 10;
         /* #1984: DarlingConfig defaults (40% / 1 GB); enable stays the class's opt-in OFF. */
         public int PvsThresholdPercent { get; set; } = 40;
         public int PvsFloorGb { get; set; } = 1;

--- a/Darling/Darling.Tests/AlertStoredValueTests.cs
+++ b/Darling/Darling.Tests/AlertStoredValueTests.cs
@@ -86,6 +86,12 @@ public sealed class AlertStoredValueTests
         public int TempDbSpaceThresholdPercent { get; set; } = 80;
         public int LowDiskThresholdPercent { get; set; } = 10;
         public int LowDiskThresholdGb { get; set; } = 5;
+        /* #2107: the previously-hardcoded knobs, at their shipped defaults. */
+        public int DiskCriticalFreePercent { get; set; } = 3;
+        public int DiskCriticalFreeGb { get; set; } = 2;
+        public int SelfDiskFreeWarnPercent { get; set; } = 10;
+        public int CollectionStaleMinutes { get; set; } = 30;
+        public int CollectionFailureThreshold { get; set; } = 10;
         public int PvsThresholdPercent { get; set; } = 40;
         public int PvsFloorGb { get; set; } = 1;
         public int LongRunningJobMultiplier { get; set; } = 3;

--- a/Darling/Darling.Tests/DarlingAlertTuningKnobsTests.cs
+++ b/Darling/Darling.Tests/DarlingAlertTuningKnobsTests.cs
@@ -30,6 +30,41 @@ namespace Darling.Tests;
    out; this comment is here so the next sweep does not "fix" it. */
 public sealed class DarlingAlertTuningKnobsTests
 {
+    /* ---------------- #2107: the previously-hardcoded thresholds through the settings seam ---------------- */
+
+    [Fact]
+    public void SelfAlertKnobs_DefaultsAreTheConstantsTheyReplaced_AndReadsClampLikeSiblings()
+    {
+        var config = new DarlingConfig();
+        var settings = new DarlingAlertSettings(config);
+
+        /* Defaults mirror the V55 DDL — the compile-time constants these knobs replaced. */
+        Assert.Equal(10, settings.SelfDiskFreeWarnPercent);
+        Assert.Equal(30, settings.CollectionStaleMinutes);
+        Assert.Equal(10, settings.CollectionFailureThreshold);
+        Assert.Equal(3, settings.DiskCriticalFreePercent);
+        Assert.Equal(2, settings.DiskCriticalFreeGb);
+        Assert.Equal(360, settings.AnalysisNotifyCooldownMinutes);
+
+        /* Live reload through the by-reference seam, clamped on read — a hand-edited store value
+           can't drive a nonsense threshold: a 0-minute staleness window would fire every sweep, a
+           0 failure threshold on the fast path would fire on any single failure, and the analysis
+           cooldown keeps the shared engine's documented [30, 10080]. */
+        config.Alerts.SelfDiskFreeWarnPercent = 150;
+        config.Alerts.CollectionStaleMinutes = 0;
+        config.Alerts.CollectionFailureThreshold = 0;
+        config.Alerts.DiskCriticalFreePercent = -5;
+        config.Alerts.DiskCriticalFreeGb = -1;
+        config.Alerts.AnalysisNotifyCooldownMinutes = 99999;
+
+        Assert.Equal(100, settings.SelfDiskFreeWarnPercent);
+        Assert.Equal(5, settings.CollectionStaleMinutes);
+        Assert.Equal(1, settings.CollectionFailureThreshold);
+        Assert.Equal(0, settings.DiskCriticalFreePercent);
+        Assert.Equal(0, settings.DiskCriticalFreeGb);
+        Assert.Equal(10080, settings.AnalysisNotifyCooldownMinutes);
+    }
+
     /* ---------------- pure: the long-running-query read shape through the settings seam ---------------- */
 
     [Fact]

--- a/Darling/Darling.Tests/DarlingObservabilityTests.cs
+++ b/Darling/Darling.Tests/DarlingObservabilityTests.cs
@@ -76,8 +76,8 @@ public sealed class DarlingObservabilityTests
         Assert.Equal(33, PgMigrations.Scripts[32].Version);
         /* The newest migration is asserted by identity rather than by ordinal: this ladder is walked by every
            stacked branch at once, and a positional pin turns each addition into a conflict for the next. */
-        Assert.Equal(54, PgMigrations.Scripts[^1].Version);
-        Assert.Equal(54, StorageVersion.SchemaVersion);
+        Assert.Equal(55, PgMigrations.Scripts[^1].Version);
+        Assert.Equal(55, StorageVersion.SchemaVersion);
 
         /* V34 (#991) creates the two Availability Group collector tables. Schema-qualified collect.* and
            CREATE TABLE IF NOT EXISTS, per the file's additive-create idiom (V29): a no-op on a fresh store

--- a/Darling/Darling.Tests/DarlingPlanCorrectionLiveMigrationTests.cs
+++ b/Darling/Darling.Tests/DarlingPlanCorrectionLiveMigrationTests.cs
@@ -93,12 +93,13 @@ public sealed class DarlingPlanCorrectionLiveMigrationTests
 
         var applied = await PgMigrations.MigrateAsync(connection, cancellationToken);
 
-        /* Exactly the eight scripts above 44 ran — V46, V47, V48 (#1984), V49 (#1986 database-state alert),
+        /* Exactly the scripts above 44 ran — V46, V47, V48 (#1984), V49 (#1986 database-state alert),
            V50 (#2008 2a server-tag colour), V51 (#2012 stage 2 query-stats host object), V52 (#2060
-           persisted finding drill-down), and V53 (#2068 store self-metrics). If the applier had stumbled
-           over the permanent V45 gap it would either re-run everything above 1 or nothing at all, and both
-           show up right here. */
-        Assert.Equal(9, applied);
+           persisted finding drill-down), V53 (#2068 store self-metrics), V54 (#2069 plan-dim gzip), and
+           V55 (#2107 self-alert knobs). If the applier had stumbled over the permanent V45 gap it would
+           either re-run everything above 1 or nothing at all, and both show up right here. Version-agnostic
+           on purpose: the ladder-top pin lives in ScaffoldTests, and this count just tracks it. */
+        Assert.Equal(PgMigrations.Scripts.Count(m => m.Version > 44), applied);
         Assert.Equal(StorageVersion.SchemaVersion, await CurrentVersionAsync(connection, cancellationToken));
 
         var fromMigration = await ReadColumnsAsync(connection, cancellationToken);

--- a/Darling/Darling.Tests/DarlingSelfAlertTests.cs
+++ b/Darling/Darling.Tests/DarlingSelfAlertTests.cs
@@ -70,6 +70,12 @@ public sealed class DarlingSelfAlertTests
         public int TempDbSpaceThresholdPercent { get; set; } = 80;
         public int LowDiskThresholdPercent { get; set; } = 10;
         public int LowDiskThresholdGb { get; set; } = 5;
+        /* #2107: the previously-hardcoded knobs, at their shipped defaults. */
+        public int DiskCriticalFreePercent { get; set; } = 3;
+        public int DiskCriticalFreeGb { get; set; } = 2;
+        public int SelfDiskFreeWarnPercent { get; set; } = 10;
+        public int CollectionStaleMinutes { get; set; } = 30;
+        public int CollectionFailureThreshold { get; set; } = 10;
         public int PvsThresholdPercent { get; set; } = 40;
         public int PvsFloorGb { get; set; } = 1;
         public int LongRunningJobMultiplier { get; set; } = 3;

--- a/Darling/Darling.Tests/PvsStatsStoreTests.cs
+++ b/Darling/Darling.Tests/PvsStatsStoreTests.cs
@@ -45,8 +45,8 @@ public sealed class PvsStatsStoreTests
            (#2060, the persisted finding drill-down), then V53 (#2068, the store self-metrics table) followed
            this migration — the newest-rung pins track the newest, the V47 identity pins below are
            unchanged. */
-        Assert.Equal(54, PgMigrations.Scripts[^1].Version);
-        Assert.Equal(54, StorageVersion.SchemaVersion);
+        Assert.Equal(55, PgMigrations.Scripts[^1].Version);
+        Assert.Equal(55, StorageVersion.SchemaVersion);
 
         /* collect.-qualified like V44 and V34, and idempotent so a re-run is a no-op. */
         Assert.Contains("CREATE TABLE IF NOT EXISTS collect.pvs_stats (", v47.Sql, StringComparison.Ordinal);
@@ -87,7 +87,7 @@ public sealed class PvsStatsStoreTests
            migration reports every healthy store as skewed and refuses to open it — permanently.
            (53 since #2068's store self-metrics table; the full-sentinel pin lives in
            ViewerDataServiceTests.) */
-        Assert.Equal(54, ViewerDataService.RequiredStoreSchemaVersion);
+        Assert.Equal(55, ViewerDataService.RequiredStoreSchemaVersion);
         Assert.Contains("table_name = 'pvs_stats'", ViewerDataService.StoreSchemaProbeSql, StringComparison.Ordinal);
 
         /* The V47 arm: pvs_stats present (and nothing newer) maps to exactly 47. */

--- a/Darling/Darling.Tests/StoreSelfMetricsTests.cs
+++ b/Darling/Darling.Tests/StoreSelfMetricsTests.cs
@@ -29,8 +29,8 @@ public sealed class StoreSelfMetricsTests
         var v53 = PgMigrations.Scripts.Single(m => m.Version == 53);
 
         Assert.Equal("store-self-metrics", v53.Name);
-        Assert.Equal(54, PgMigrations.Scripts[^1].Version);
-        Assert.Equal(54, StorageVersion.SchemaVersion);
+        Assert.Equal(55, PgMigrations.Scripts[^1].Version);
+        Assert.Equal(55, StorageVersion.SchemaVersion);
 
         /* collect.-qualified like V44/V47/V49, and idempotent so a re-run is a no-op. */
         Assert.Contains("CREATE TABLE IF NOT EXISTS collect.store_metrics (", v53.Sql, StringComparison.Ordinal);
@@ -70,7 +70,7 @@ public sealed class StoreSelfMetricsTests
     {
         /* The trap a StorageVersion bump sets: a probe that cannot SEE the newest migration maps every
            healthy store below RequiredStoreSchemaVersion and the connect-time gate refuses it permanently. */
-        Assert.Equal(54, ViewerDataService.RequiredStoreSchemaVersion);
+        Assert.Equal(55, ViewerDataService.RequiredStoreSchemaVersion);
         Assert.Contains("table_name = 'store_metrics'", ViewerDataService.StoreSchemaProbeSql, StringComparison.Ordinal);
 
         /* The V53 arm: store_metrics present (and everything below it, but NOT V54's gz column —

--- a/Darling/Darling.Tests/ViewerDataServiceTests.cs
+++ b/Darling/Darling.Tests/ViewerDataServiceTests.cs
@@ -546,7 +546,7 @@ public sealed class ViewerSchemaVersionGateTests
            the connect-time gate refuse to open the viewer against a perfectly healthy store. */
         Assert.Equal(
             ViewerDataService.RequiredStoreSchemaVersion,
-            ViewerDataService.MapProbedSchemaVersion(true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true));
+            ViewerDataService.MapProbedSchemaVersion(true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true));
     }
 }
 

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingAlertSettings.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingAlertSettings.cs
@@ -62,6 +62,16 @@ public sealed class DarlingAlertSettings : IAlertEngineSettings, IAlertSettings
     public int LowDiskThresholdPercent => Math.Clamp(_config.Alerts.LowDiskThresholdPercent, 0, 100);
     public int LowDiskThresholdGb => Math.Max(0, _config.Alerts.LowDiskThresholdGb);
 
+    /* #2107: the previously-hardcoded thresholds, clamped on read like their siblings so a
+       hand-edited store value can't drive a nonsense threshold. The critical floors keep low-disk's
+       0-100 percent clamp and 0-floor GB shape; the staleness window and failure fast-path get
+       floors that keep the self-alerts meaningful (a 0-minute window would fire on every sweep). */
+    public int DiskCriticalFreePercent => Math.Clamp(_config.Alerts.DiskCriticalFreePercent, 0, 100);
+    public int DiskCriticalFreeGb => Math.Max(0, _config.Alerts.DiskCriticalFreeGb);
+    public int SelfDiskFreeWarnPercent => Math.Clamp(_config.Alerts.SelfDiskFreeWarnPercent, 0, 100);
+    public int CollectionStaleMinutes => Math.Clamp(_config.Alerts.CollectionStaleMinutes, 5, 1440);
+    public int CollectionFailureThreshold => Math.Clamp(_config.Alerts.CollectionFailureThreshold, 1, 1000);
+
     /* #1984: percent clamped like low-disk's (0 = off); the GB floor merely floored at 0 — unlike
        the percent it has no meaningful upper bound. */
     public int PvsThresholdPercent => Math.Clamp(_config.Alerts.PvsThresholdPercent, 0, 100);
@@ -209,5 +219,7 @@ public sealed class DarlingAlertSettings : IAlertEngineSettings, IAlertSettings
        1) read through the by-reference config seam — a store reload reflects it immediately; clamped
        0–2 like Lite/Dashboard. The re-notify cooldown stays Lite's hardcoded default (not a knob). */
     public double AnalysisNotifySeverity => Math.Clamp(_config.Analysis.NotifySeverity, 0.0, 2.0);
-    public int AnalysisNotifyCooldownMinutes => 360;
+    /* #2107: was a hardcoded 360 while the shared engine accepts a clamped [30, 10080] value and
+       Lite always passed a configured one through — the Darling parity gap gotqn called out. */
+    public int AnalysisNotifyCooldownMinutes => Math.Clamp(_config.Alerts.AnalysisNotifyCooldownMinutes, 30, 10080);
 }

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingConfig.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingConfig.cs
@@ -434,6 +434,35 @@ public sealed class AlertsConfig
     [JsonPropertyName("pvsFloorGb")]
     public int PvsFloorGb { get; set; } = 1;
 
+    /// <summary>#2107: the store volume's self-alert warning percent (was a compile-time 10.0;
+    /// 0 disables the check — percent is its only trigger).</summary>
+    [JsonPropertyName("selfDiskFreeWarnPercent")]
+    public int SelfDiskFreeWarnPercent { get; set; } = 10;
+
+    /// <summary>#2107: how long collection may go quiet before Collection Stopped / Agent Not
+    /// Running fire (was a compile-time 30 minutes).</summary>
+    [JsonPropertyName("collectionStaleMinutes")]
+    public int CollectionStaleMinutes { get; set; } = 30;
+
+    /// <summary>#2107: the Collection Stopped fast path — consecutive failures with zero successes
+    /// that fire without waiting out the staleness window (was a compile-time 10).</summary>
+    [JsonPropertyName("collectionFailureThreshold")]
+    public int CollectionFailureThreshold { get; set; } = 10;
+
+    /// <summary>#2107: the low-disk CRITICAL severity tier's percent floor (#1136 — grades the
+    /// target-volume alert; was a compile-time 3.0).</summary>
+    [JsonPropertyName("diskCriticalFreePercent")]
+    public int DiskCriticalFreePercent { get; set; } = 3;
+
+    /// <summary>#2107: the low-disk CRITICAL severity tier's GB floor (was a compile-time 2.0).</summary>
+    [JsonPropertyName("diskCriticalFreeGb")]
+    public int DiskCriticalFreeGb { get; set; } = 2;
+
+    /// <summary>#2107: the analysis notification cooldown — the shared engine clamps [30, 10080]
+    /// and Lite always passed a configured value through; Darling hardcoded 360.</summary>
+    [JsonPropertyName("analysisNotifyCooldownMinutes")]
+    public int AnalysisNotifyCooldownMinutes { get; set; } = 360;
+
     [JsonPropertyName("longRunningJobEnabled")]
     public bool LongRunningJobEnabled { get; set; } = true;
 

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingSelfAlertEvaluator.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingSelfAlertEvaluator.cs
@@ -303,9 +303,13 @@ internal sealed class DarlingSelfAlertEvaluator
         {
             try
             {
+                /* #2107: store-backed window/threshold (clamped on read); the constants remain
+                   only as the shipped defaults. */
                 var (lastSuccess, recentRuns, recentSuccess) =
-                    await ReadCollectionSignalsAsync(postgres, serverId, ConsecutiveFailureThreshold, cancellationToken);
-                bool stopped = IsCollectionStopped(lastSuccess, recentRuns, recentSuccess, _utcNow(), out var reason);
+                    await ReadCollectionSignalsAsync(postgres, serverId, _settings.CollectionFailureThreshold, cancellationToken);
+                bool stopped = IsCollectionStopped(
+                    lastSuccess, recentRuns, recentSuccess, _utcNow(),
+                    SettingsStaleWindow, _settings.CollectionFailureThreshold, out var reason);
                 await ApplyCollectionStoppedAsync(serverId, serverName, stopped, reason, cancellationToken);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -345,7 +349,7 @@ internal sealed class DarlingSelfAlertEvaluator
             var (agentCollectionTimeUtc, agentRunning) = await ReadLatestAgentStatusAsync(postgres, serverId, cancellationToken);
             bool? freshRunning = agentRunning.HasValue
                 && agentCollectionTimeUtc.HasValue
-                && _utcNow() - agentCollectionTimeUtc.Value < StaleWindow
+                && _utcNow() - agentCollectionTimeUtc.Value < SettingsStaleWindow
                     ? agentRunning
                     : null;
 
@@ -417,8 +421,12 @@ internal sealed class DarlingSelfAlertEvaluator
         /* A snapshot only judges while it is fresh; a missing one (no AGs, or the collector has never run) and
            a stale one are both "no signal", exactly as agent_status is treated above. */
         bool IsFresh(DateTime? snapshotUtc) =>
-            snapshotUtc.HasValue && _utcNow() - snapshotUtc.Value < StaleWindow;
+            snapshotUtc.HasValue && _utcNow() - snapshotUtc.Value < SettingsStaleWindow;
     }
+
+    /// <summary>#2107: the staleness window the sweep actually uses — store-backed, clamped on
+    /// read; <see cref="StaleWindow"/> remains only as the shipped default.</summary>
+    private TimeSpan SettingsStaleWindow => TimeSpan.FromMinutes(_settings.CollectionStaleMinutes);
 
     /// <summary>
     /// Pure collection-stopped decision from the three store signals — no I/O, so it pins directly.
@@ -429,16 +437,23 @@ internal sealed class DarlingSelfAlertEvaluator
     /// </summary>
     internal static bool IsCollectionStopped(
         DateTime? lastSuccessUtc, int recentRunCount, int recentSuccessCount, DateTime nowUtc, out string reason)
+        => IsCollectionStopped(lastSuccessUtc, recentRunCount, recentSuccessCount, nowUtc, StaleWindow, ConsecutiveFailureThreshold, out reason);
+
+    /// <summary>#2107: the configurable form — the sweep passes the store-backed window and
+    /// threshold; the constant overload keeps the shipped defaults for the tests pinning them.</summary>
+    internal static bool IsCollectionStopped(
+        DateTime? lastSuccessUtc, int recentRunCount, int recentSuccessCount, DateTime nowUtc,
+        TimeSpan staleWindow, int consecutiveFailureThreshold, out string reason)
     {
         /* Fast path: the most-recent N runs all failed. */
-        if (recentRunCount >= ConsecutiveFailureThreshold && recentSuccessCount == 0)
+        if (recentRunCount >= consecutiveFailureThreshold && recentSuccessCount == 0)
         {
             reason = $"The last {recentRunCount.ToString(CultureInfo.InvariantCulture)} collector runs all failed — no data is landing.";
             return true;
         }
 
         /* Backstop: a server that HAS collected before but hasn't succeeded within the staleness window. */
-        if (lastSuccessUtc.HasValue && nowUtc - lastSuccessUtc.Value >= StaleWindow)
+        if (lastSuccessUtc.HasValue && nowUtc - lastSuccessUtc.Value >= staleWindow)
         {
             int minutes = (int)(nowUtc - lastSuccessUtc.Value).TotalMinutes;
             reason = $"No successful collection in {minutes.ToString(CultureInfo.InvariantCulture)} minutes — the collectors are failing or the server is unreachable.";
@@ -1073,6 +1088,12 @@ internal sealed class DarlingSelfAlertEvaluator
     /// the one dangerous ambiguity this metric must never have back into the signature.</para>
     /// </summary>
     internal static bool IsDiskPressure(long freeBytes, long totalBytes, out string reason, out double percentFree)
+        => IsDiskPressure(freeBytes, totalBytes, DiskFreeWarnPercent, out reason, out percentFree);
+
+    /// <summary>#2107: the configurable form — the sweep passes the store-backed
+    /// <c>SelfDiskFreeWarnPercent</c>; the constant-threshold overload keeps the shipped default
+    /// for the tests pinning it.</summary>
+    internal static bool IsDiskPressure(long freeBytes, long totalBytes, double warnPercent, out string reason, out double percentFree)
     {
         if (totalBytes <= 0)
         {
@@ -1082,7 +1103,7 @@ internal sealed class DarlingSelfAlertEvaluator
         }
 
         percentFree = (double)freeBytes / totalBytes * 100.0;
-        if (percentFree < DiskFreeWarnPercent)
+        if (percentFree < warnPercent)
         {
             reason = $"The monitor store's disk volume has only {percentFree.ToString("0.#", CultureInfo.InvariantCulture)}% free ({FormatGb(freeBytes)} of {FormatGb(totalBytes)}).";
             return true;
@@ -1144,7 +1165,10 @@ internal sealed class DarlingSelfAlertEvaluator
         }
 
         var now = _utcNow();
-        bool pressure = IsDiskPressure(free, total, out var reason, out var percentFree);
+        /* #2107: store-backed threshold (clamped on read); the constant remains only as the
+           shipped default. */
+        double warnPercent = _settings.SelfDiskFreeWarnPercent;
+        bool pressure = IsDiskPressure(free, total, warnPercent, out var reason, out var percentFree);
 
         if (pressure)
         {
@@ -1168,7 +1192,7 @@ internal sealed class DarlingSelfAlertEvaluator
                 var storeText = storeSizeBytes is long size ? $" The store currently holds {FormatGb(size)}." : "";
                 await FireAsync(
                     DiskKey, "Monitor Store", "Store Disk Pressure", reason,
-                    $"{DiskFreeWarnPercent.ToString("0.#", CultureInfo.InvariantCulture)}% free",
+                    $"{warnPercent.ToString("0.#", CultureInfo.InvariantCulture)}% free",
                     detail: reason + storeText + " When the store volume fills, collection and every write stop " +
                         "for the WHOLE fleet, and a headless service has no dashboard to warn you. Free space on the " +
                         "store volume, shorten retention (config_collector_schedules), enable TimescaleDB compression, " +
@@ -1182,7 +1206,7 @@ internal sealed class DarlingSelfAlertEvaluator
                        explicitly means an operator's volume path ("D2:\\") can no longer get there first,
                        and the stored value stops depending on prose word order. The threshold is a real
                        bound too, which is what separates this metric from every sibling above. */
-                    numericCurrentValue: percentFree, numericThresholdValue: DiskFreeWarnPercent,
+                    numericCurrentValue: percentFree, numericThresholdValue: warnPercent,
                     cancellationToken);
             }
         }

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingAlertReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingAlertReader.cs
@@ -137,7 +137,13 @@ LIMIT $2";
         bool PvsEnabled,
         int PvsThresholdPercent,
         int PvsFloorGb,
-        bool DatabaseStateEnabled);
+        bool DatabaseStateEnabled,
+        int SelfDiskFreeWarnPercent,
+        int CollectionStaleMinutes,
+        int CollectionFailureThreshold,
+        int DiskCriticalFreePercent,
+        int DiskCriticalFreeGb,
+        int AnalysisNotifyCooldownMinutes);
 
     /// <summary>The single global alert-settings row (id=1) — the viewer's <c>AlertSettingsSelectSql</c>. The
     /// 47 columns are read in the SAME order the service reads them (<c>StoreConfigProvider</c>). This had
@@ -157,7 +163,9 @@ SELECT enabled, cpu_enabled, cpu_threshold_percent, cpu_mode, blocking_enabled, 
        notify_connection_down_at_startup, connection_refire_minutes,
        notify_ag_health, ag_lag_alert_seconds, ag_redo_queue_alert_kb,
        ag_disconnect_refire_minutes, blocking_wait_seconds_threshold, pvs_enabled, pvs_threshold_percent,
-       pvs_floor_gb, database_state_enabled
+       pvs_floor_gb, database_state_enabled,
+       self_disk_free_warn_percent, collection_stale_minutes, collection_failure_threshold,
+       disk_critical_free_percent, disk_critical_free_gb, analysis_notify_cooldown_minutes
 FROM config_alert_settings
 WHERE id = 1";
 
@@ -191,6 +199,9 @@ WHERE id = 1";
             reader.GetInt32(41),
             reader.GetInt32(42),
             reader.GetBoolean(43), reader.GetInt32(44), reader.GetInt32(45),
-            reader.GetBoolean(46));
+            reader.GetBoolean(46),
+            /* #2107 threshold knobs (V55) at 47–52. */
+            reader.GetInt32(47), reader.GetInt32(48), reader.GetInt32(49),
+            reader.GetInt32(50), reader.GetInt32(51), reader.GetInt32(52));
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpAlertTools.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpAlertTools.cs
@@ -171,7 +171,23 @@ public sealed class DarlingMcpAlertTools
             exclude_cdc = s.LongRunningQueryExcludeCdc
         },
         tempdb_space = new { enabled = s.TempDbSpaceEnabled, threshold_percent = s.TempDbSpaceThresholdPercent },
-        low_disk = new { enabled = s.LowDiskEnabled, threshold_percent = s.LowDiskThresholdPercent, threshold_gb = s.LowDiskThresholdGb },
+        low_disk = new
+        {
+            enabled = s.LowDiskEnabled,
+            threshold_percent = s.LowDiskThresholdPercent,
+            threshold_gb = s.LowDiskThresholdGb,
+            /* #2107: the CRITICAL severity tier's floors (#1136) — previously compile-time. */
+            critical_free_percent = s.DiskCriticalFreePercent,
+            critical_free_gb = s.DiskCriticalFreeGb
+        },
+        /* #2107: the monitor's own self-alerts (store volume, collection health) — previously
+           compile-time constants. */
+        self_alerts = new
+        {
+            disk_free_warn_percent = s.SelfDiskFreeWarnPercent,
+            collection_stale_minutes = s.CollectionStaleMinutes,
+            collection_failure_threshold = s.CollectionFailureThreshold
+        },
         pvs = new { enabled = s.PvsEnabled, threshold_percent = s.PvsThresholdPercent, floor_gb = s.PvsFloorGb },
         long_running_job = new { enabled = s.LongRunningJobEnabled, multiplier = s.LongRunningJobMultiplier },
         failed_job = new { enabled = s.FailedJobEnabled, lookback_minutes = s.FailedJobLookbackMinutes },
@@ -184,7 +200,9 @@ public sealed class DarlingMcpAlertTools
             enabled = s.AnalysisEnabled,
             interval_minutes = s.AnalysisIntervalMinutes,
             notifications_enabled = s.AnalysisNotificationsEnabled,
-            notify_severity = s.AnalysisNotifySeverity
+            notify_severity = s.AnalysisNotifySeverity,
+            /* #2107: was a hardcoded 360 in Darling while Lite passed a configured value through. */
+            notify_cooldown_minutes = s.AnalysisNotifyCooldownMinutes
         }
     };
 
@@ -617,7 +635,26 @@ public sealed class DarlingMcpAlertTools
                             case "enabled": AddBool("low_disk_enabled", n, "low_disk.enabled"); break;
                             case "threshold_percent": AddInt("low_disk_threshold_percent", n, "low_disk.threshold_percent", 0, 100); break;
                             case "threshold_gb": AddInt("low_disk_threshold_gb", n, "low_disk.threshold_gb", 0, int.MaxValue); break;
+                            /* #2107: the CRITICAL tier floors, clamped like the warning thresholds. */
+                            case "critical_free_percent": AddInt("disk_critical_free_percent", n, "low_disk.critical_free_percent", 0, 100); break;
+                            case "critical_free_gb": AddInt("disk_critical_free_gb", n, "low_disk.critical_free_gb", 0, int.MaxValue); break;
                             default: error = $"Unknown field 'low_disk.{k}'."; break;
+                        }
+                    });
+                    break;
+
+                case "self_alerts":
+                    /* #2107: the monitor's own store-volume and collection-health thresholds. The
+                       clamps match DarlingAlertSettings' read-side clamps, so a value stored here is
+                       the value the sweep uses. */
+                    Group(prop.Value, "self_alerts", (k, n) =>
+                    {
+                        switch (k)
+                        {
+                            case "disk_free_warn_percent": AddInt("self_disk_free_warn_percent", n, "self_alerts.disk_free_warn_percent", 0, 100); break;
+                            case "collection_stale_minutes": AddInt("collection_stale_minutes", n, "self_alerts.collection_stale_minutes", 5, 1440); break;
+                            case "collection_failure_threshold": AddInt("collection_failure_threshold", n, "self_alerts.collection_failure_threshold", 1, 1000); break;
+                            default: error = $"Unknown field 'self_alerts.{k}'."; break;
                         }
                     });
                     break;
@@ -691,6 +728,8 @@ public sealed class DarlingMcpAlertTools
                             case "interval_minutes": AddInt("analysis_interval_minutes", n, "analysis.interval_minutes", 5, 360); break;
                             case "notifications_enabled": AddBool("analysis_notifications_enabled", n, "analysis.notifications_enabled"); break;
                             case "notify_severity": AddDouble("analysis_notify_severity", n, "analysis.notify_severity", 0.0, 2.0); break;
+                            /* #2107: the clamp matches the shared engine's documented [30, 10080]. */
+                            case "notify_cooldown_minutes": AddInt("analysis_notify_cooldown_minutes", n, "analysis.notify_cooldown_minutes", 30, 10080); break;
                             default: error = $"Unknown field 'analysis.{k}'."; break;
                         }
                     });

--- a/Darling/PerformanceMonitor.Darling.Service/StoreConfigProvider.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/StoreConfigProvider.cs
@@ -167,10 +167,12 @@ INSERT INTO config_alert_settings (
     notify_connection_down_at_startup, connection_refire_minutes,
     notify_ag_health, ag_lag_alert_seconds, ag_redo_queue_alert_kb,
     ag_disconnect_refire_minutes, blocking_wait_seconds_threshold, pvs_enabled, pvs_threshold_percent,
-    pvs_floor_gb, modified_at, database_state_enabled)
+    pvs_floor_gb, modified_at, database_state_enabled,
+    self_disk_free_warn_percent, collection_stale_minutes, collection_failure_threshold,
+    disk_critical_free_percent, disk_critical_free_gb, analysis_notify_cooldown_minutes)
 VALUES (1, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21,
         $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42,
-        $43, $44, $45, $46, $47, $48)
+        $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54)
 ON CONFLICT (id) DO NOTHING", connection);
         command.Parameters.AddWithValue(a.Enabled);
         command.Parameters.AddWithValue(a.CpuEnabled);
@@ -229,6 +231,13 @@ ON CONFLICT (id) DO NOTHING", connection);
         command.Parameters.AddWithValue(now);
         /* V49 database-state alert master switch (appended last, matching the ALTER's physical order). */
         command.Parameters.AddWithValue(a.DatabaseStateEnabled);
+        /* V55 #2107: the previously-hardcoded threshold knobs, appended in the ALTER's order. */
+        command.Parameters.AddWithValue(a.SelfDiskFreeWarnPercent);
+        command.Parameters.AddWithValue(a.CollectionStaleMinutes);
+        command.Parameters.AddWithValue(a.CollectionFailureThreshold);
+        command.Parameters.AddWithValue(a.DiskCriticalFreePercent);
+        command.Parameters.AddWithValue(a.DiskCriticalFreeGb);
+        command.Parameters.AddWithValue(a.AnalysisNotifyCooldownMinutes);
         await command.ExecuteNonQueryAsync(ct);
     }
 
@@ -374,7 +383,9 @@ SELECT enabled, cpu_enabled, cpu_threshold_percent, cpu_mode, blocking_enabled, 
        notify_connection_down_at_startup, connection_refire_minutes,
        notify_ag_health, ag_lag_alert_seconds, ag_redo_queue_alert_kb,
        ag_disconnect_refire_minutes, blocking_wait_seconds_threshold, pvs_enabled, pvs_threshold_percent,
-       pvs_floor_gb, database_state_enabled
+       pvs_floor_gb, database_state_enabled,
+       self_disk_free_warn_percent, collection_stale_minutes, collection_failure_threshold,
+       disk_critical_free_percent, disk_critical_free_gb, analysis_notify_cooldown_minutes
 FROM config_alert_settings WHERE id = 1", connection);
         using var reader = await command.ExecuteReaderAsync(ct);
         if (!await reader.ReadAsync(ct))
@@ -447,6 +458,15 @@ FROM config_alert_settings WHERE id = 1", connection);
             /* database-state alert master switch appended (V49) at ordinal 46; NOT NULL DEFAULT true so a
                pre-V49 row can't reach here without the column present. */
             DatabaseStateEnabled = reader.GetBoolean(46),
+            /* #2107 threshold knobs appended (V55) at ordinals 47–52; NOT NULL DEFAULTs are the
+               constants they replace, so a pre-V55 row can't reach here without the columns present
+               and the wholesale ApplyToConfig replacement never resets a knob. */
+            SelfDiskFreeWarnPercent = reader.GetInt32(47),
+            CollectionStaleMinutes = reader.GetInt32(48),
+            CollectionFailureThreshold = reader.GetInt32(49),
+            DiskCriticalFreePercent = reader.GetInt32(50),
+            DiskCriticalFreeGb = reader.GetInt32(51),
+            AnalysisNotifyCooldownMinutes = reader.GetInt32(52),
         };
         var analysis = new AnalysisConfig
         {

--- a/Darling/PerformanceMonitor.Darling.Storage/PgMigrations.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/PgMigrations.cs
@@ -111,6 +111,7 @@ public static class PgMigrations
         new Migration(52, "finding-drilldown-json", V52Sql),
         new Migration(53, "store-self-metrics", V53Sql),
         new Migration(54, "plan-dim-gzip", V54Sql + "\n" + PgSchemaGenerator.GenerateQueryStatsResolvingView()),
+        new Migration(55, "self-alert-knobs", V55Sql),
     };
 
     /// <summary>
@@ -1066,6 +1067,28 @@ ALTER TABLE query_plan_dim
     ADD COLUMN IF NOT EXISTS query_plan_gz bytea;
 ALTER TABLE query_plan_dim
     ALTER COLUMN query_plan_xml DROP NOT NULL;";
+
+    /// <summary>
+    /// V55 — the #2107 alert-threshold knobs, all previously compile-time constants: the store
+    /// volume's self-alert warning percent, the Collection Stopped staleness window and
+    /// consecutive-failure fast path, the low-disk CRITICAL severity tier's two floors (#1136 —
+    /// these grade the shared target-volume alert, not just the self-alert), and the analysis
+    /// notification cooldown Lite already passed through while Darling hardcoded 360. Defaults are
+    /// the constants they replace, NOT NULL so pre-V55 rows read cleanly at the appended ordinals.
+    /// </summary>
+    private const string V55Sql = @"
+ALTER TABLE config.config_alert_settings
+    ADD COLUMN IF NOT EXISTS self_disk_free_warn_percent integer NOT NULL DEFAULT 10;
+ALTER TABLE config.config_alert_settings
+    ADD COLUMN IF NOT EXISTS collection_stale_minutes integer NOT NULL DEFAULT 30;
+ALTER TABLE config.config_alert_settings
+    ADD COLUMN IF NOT EXISTS collection_failure_threshold integer NOT NULL DEFAULT 10;
+ALTER TABLE config.config_alert_settings
+    ADD COLUMN IF NOT EXISTS disk_critical_free_percent integer NOT NULL DEFAULT 3;
+ALTER TABLE config.config_alert_settings
+    ADD COLUMN IF NOT EXISTS disk_critical_free_gb integer NOT NULL DEFAULT 2;
+ALTER TABLE config.config_alert_settings
+    ADD COLUMN IF NOT EXISTS analysis_notify_cooldown_minutes integer NOT NULL DEFAULT 360;";
 
     /// <summary>
     /// V9 — the FinOps copy-parity fields that were user-input config or previously live-only:

--- a/Darling/PerformanceMonitor.Darling.Storage/StorageVersion.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/StorageVersion.cs
@@ -16,5 +16,5 @@ namespace PerformanceMonitor.Darling.Storage;
 /// </summary>
 public static class StorageVersion
 {
-    public const int SchemaVersion = 54;
+    public const int SchemaVersion = 55;
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml
@@ -373,6 +373,31 @@
                     <TextBlock Text="GB free (Azure SQL DB excluded)" VerticalAlignment="Center" Margin="2,0,0,0"
                                Foreground="{DynamicResource ForegroundBrush}"/>
                 </StackPanel>
+                <!-- #2107: the CRITICAL severity tier's floors (#1136) — previously compile-time. -->
+                <StackPanel Orientation="Horizontal" Margin="40,4,0,0">
+                    <TextBlock Text="grade CRITICAL at" VerticalAlignment="Center"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AlertDiskCriticalPercentBox" Width="45" Text="3" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="% or" VerticalAlignment="Center" Margin="2,0,0,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AlertDiskCriticalGbBox" Width="45" Text="2" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="GB free" VerticalAlignment="Center" Margin="2,0,0,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                </StackPanel>
+                <!-- #2107: the monitor's own self-alerts — store volume + collection health. -->
+                <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
+                    <TextBlock Text="Monitor self-alerts: store volume under" VerticalAlignment="Center"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AlertSelfDiskWarnPercentBox" Width="45" Text="10" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="% free; collection quiet" VerticalAlignment="Center" Margin="2,0,0,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AlertCollectionStaleMinutesBox" Width="45" Text="30" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="min or" VerticalAlignment="Center" Margin="2,0,0,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AlertCollectionFailureThresholdBox" Width="45" Text="10" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="straight failures" VerticalAlignment="Center" Margin="2,0,0,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                </StackPanel>
                 <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
                     <CheckBox x:Name="AlertPvsCheckBox" Content="Version store (PVS) over" VerticalAlignment="Center"
                               Foreground="{DynamicResource ForegroundBrush}"/>
@@ -487,6 +512,14 @@
                                Foreground="{DynamicResource ForegroundBrush}"/>
                     <TextBox x:Name="AnalysisNotifySeverityBox" Width="45" TextAlignment="Center" VerticalAlignment="Center"/>
                     <TextBlock Text="(0.0 - 2.0)" VerticalAlignment="Center" Margin="4,0,0,0"
+                               Foreground="{DynamicResource ForegroundMutedBrush}"/>
+                </StackPanel>
+                <!-- #2107: was a hardcoded 360 while Lite always honored a configured value. -->
+                <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
+                    <TextBlock Text="Re-notify an unchanged finding after" VerticalAlignment="Center" Margin="0,0,8,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AnalysisNotifyCooldownBox" Width="55" TextAlignment="Center" VerticalAlignment="Center"/>
+                    <TextBlock Text="minutes (30 - 10080)" VerticalAlignment="Center" Margin="4,0,0,0"
                                Foreground="{DynamicResource ForegroundMutedBrush}"/>
                 </StackPanel>
                 <TextBlock Text="Requires SMTP or a webhook configured below for delivery; findings are recorded in the Alerts tab either way."

--- a/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml.cs
@@ -833,10 +833,13 @@ public partial class SettingsWindow : Window
         if (double.TryParse(AnalysisNotifySeverityBox.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var analysisSeverity)
             && analysisSeverity is >= 0.0 and <= 2.0)
             row.AnalysisNotifySeverity = analysisSeverity;
+        else
+            errors.Add("Analysis notify severity must be between 0.0 and 2.0.");
+
         if (int.TryParse(AnalysisNotifyCooldownBox.Text, out var analysisCooldown) && analysisCooldown is >= 30 and <= 10080)
             row.AnalysisNotifyCooldownMinutes = analysisCooldown;
         else
-            errors.Add("Analysis notify severity must be between 0.0 and 2.0.");
+            errors.Add("Analysis re-notify cooldown must be between 30 and 10080 minutes.");
 
         /* #1141/#1236: delivery mode + per-event cap (store-backed). */
         row.DeliveryMode = AlertDeliveryModeBox.SelectedIndex == 1 ? "PerEvent" : "Summary";

--- a/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml.cs
@@ -703,6 +703,11 @@ public partial class SettingsWindow : Window
         AlertLowDiskCheckBox.IsChecked = r.LowDiskEnabled;
         AlertLowDiskThresholdPercentBox.Text = r.LowDiskThresholdPercent.ToString(CultureInfo.InvariantCulture);
         AlertLowDiskThresholdGbBox.Text = r.LowDiskThresholdGb.ToString(CultureInfo.InvariantCulture);
+        AlertDiskCriticalPercentBox.Text = r.DiskCriticalFreePercent.ToString(CultureInfo.InvariantCulture);
+        AlertDiskCriticalGbBox.Text = r.DiskCriticalFreeGb.ToString(CultureInfo.InvariantCulture);
+        AlertSelfDiskWarnPercentBox.Text = r.SelfDiskFreeWarnPercent.ToString(CultureInfo.InvariantCulture);
+        AlertCollectionStaleMinutesBox.Text = r.CollectionStaleMinutes.ToString(CultureInfo.InvariantCulture);
+        AlertCollectionFailureThresholdBox.Text = r.CollectionFailureThreshold.ToString(CultureInfo.InvariantCulture);
         AlertPvsCheckBox.IsChecked = r.PvsEnabled;
         AlertPvsThresholdPercentBox.Text = r.PvsThresholdPercent.ToString(CultureInfo.InvariantCulture);
         AlertPvsFloorGbBox.Text = r.PvsFloorGb.ToString(CultureInfo.InvariantCulture);
@@ -716,6 +721,7 @@ public partial class SettingsWindow : Window
         AnalysisIntervalBox.Text = r.AnalysisIntervalMinutes.ToString(CultureInfo.InvariantCulture);
         AnalysisNotificationsCheckBox.IsChecked = r.AnalysisNotificationsEnabled;
         AnalysisNotifySeverityBox.Text = r.AnalysisNotifySeverity.ToString("0.0", CultureInfo.InvariantCulture);
+        AnalysisNotifyCooldownBox.Text = r.AnalysisNotifyCooldownMinutes.ToString(CultureInfo.InvariantCulture);
         /* #1141/#1236: the delivery mode + per-event cap are now STORE-backed (the service honors them),
            seeded from the row like every other alert-engine control. */
         AlertDeliveryModeBox.SelectedIndex = r.DeliveryMode == "PerEvent" ? 1 : 0;
@@ -794,6 +800,17 @@ public partial class SettingsWindow : Window
             row.LowDiskThresholdPercent = lowDiskPct;
         if (int.TryParse(AlertLowDiskThresholdGbBox.Text, out var lowDiskGb) && lowDiskGb >= 0)
             row.LowDiskThresholdGb = lowDiskGb;
+        /* #2107: the previously-hardcoded knobs, validated to the same ranges the service clamps. */
+        if (int.TryParse(AlertDiskCriticalPercentBox.Text, out var critPct) && critPct is >= 0 and <= 100)
+            row.DiskCriticalFreePercent = critPct;
+        if (int.TryParse(AlertDiskCriticalGbBox.Text, out var critGb) && critGb >= 0)
+            row.DiskCriticalFreeGb = critGb;
+        if (int.TryParse(AlertSelfDiskWarnPercentBox.Text, out var selfDiskPct) && selfDiskPct is >= 0 and <= 100)
+            row.SelfDiskFreeWarnPercent = selfDiskPct;
+        if (int.TryParse(AlertCollectionStaleMinutesBox.Text, out var staleMin) && staleMin is >= 5 and <= 1440)
+            row.CollectionStaleMinutes = staleMin;
+        if (int.TryParse(AlertCollectionFailureThresholdBox.Text, out var failThresh) && failThresh is >= 1 and <= 1000)
+            row.CollectionFailureThreshold = failThresh;
         if (int.TryParse(AlertPvsThresholdPercentBox.Text, out var pvsPct) && pvsPct is >= 0 and <= 100)
             row.PvsThresholdPercent = pvsPct;
         if (int.TryParse(AlertPvsFloorGbBox.Text, out var pvsFloor) && pvsFloor >= 0)
@@ -816,6 +833,8 @@ public partial class SettingsWindow : Window
         if (double.TryParse(AnalysisNotifySeverityBox.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var analysisSeverity)
             && analysisSeverity is >= 0.0 and <= 2.0)
             row.AnalysisNotifySeverity = analysisSeverity;
+        if (int.TryParse(AnalysisNotifyCooldownBox.Text, out var analysisCooldown) && analysisCooldown is >= 30 and <= 10080)
+            row.AnalysisNotifyCooldownMinutes = analysisCooldown;
         else
             errors.Add("Analysis notify severity must be between 0.0 and 2.0.");
 
@@ -860,6 +879,13 @@ public partial class SettingsWindow : Window
         AlertTempDbSpaceThresholdBox.Text = "80";
         AlertLowDiskThresholdPercentBox.Text = "10";
         AlertLowDiskThresholdGbBox.Text = "5";
+        /* #2107: the previously-hardcoded knobs reset to the constants they replaced. */
+        AlertDiskCriticalPercentBox.Text = "3";
+        AlertDiskCriticalGbBox.Text = "2";
+        AlertSelfDiskWarnPercentBox.Text = "10";
+        AlertCollectionStaleMinutesBox.Text = "30";
+        AlertCollectionFailureThresholdBox.Text = "10";
+        AnalysisNotifyCooldownBox.Text = "360";
         AlertPvsThresholdPercentBox.Text = "40";
         AlertPvsFloorGbBox.Text = "1";
         AlertLongRunningJobMultiplierBox.Text = "3";

--- a/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml.cs
@@ -987,6 +987,12 @@ public partial class SettingsWindow : Window
         AlertPvsThresholdPercentBox.IsEnabled = enabled;
         AlertPvsFloorGbBox.IsEnabled = enabled;
         AlertLowDiskThresholdGbBox.IsEnabled = enabled;
+        /* #2107: the new threshold boxes follow the master switch like every sibling. */
+        AlertDiskCriticalPercentBox.IsEnabled = enabled;
+        AlertDiskCriticalGbBox.IsEnabled = enabled;
+        AlertSelfDiskWarnPercentBox.IsEnabled = enabled;
+        AlertCollectionStaleMinutesBox.IsEnabled = enabled;
+        AlertCollectionFailureThresholdBox.IsEnabled = enabled;
         AlertLongRunningJobCheckBox.IsEnabled = enabled;
         AlertLongRunningJobMultiplierBox.IsEnabled = enabled;
         AlertFailedJobCheckBox.IsEnabled = enabled;

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.AlertSettings.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.AlertSettings.cs
@@ -57,7 +57,9 @@ public sealed partial class ViewerDataService
         "notify_connection_down_at_startup, connection_refire_minutes, " +
         "notify_ag_health, ag_lag_alert_seconds, ag_redo_queue_alert_kb, " +
         "ag_disconnect_refire_minutes, blocking_wait_seconds_threshold, " +
-        "pvs_enabled, pvs_threshold_percent, pvs_floor_gb, database_state_enabled";
+        "pvs_enabled, pvs_threshold_percent, pvs_floor_gb, database_state_enabled, " +
+        "self_disk_free_warn_percent, collection_stale_minutes, collection_failure_threshold, " +
+        "disk_critical_free_percent, disk_critical_free_gb, analysis_notify_cooldown_minutes";
 
     /// <summary>The single global alert-settings row (id=1), for the Settings window prefill + the migrate-in
     /// defaults check. Column order matches <see cref="AlertSettingsColumns"/>.</summary>
@@ -71,7 +73,7 @@ public sealed partial class ViewerDataService
 INSERT INTO config_alert_settings (id, " + AlertSettingsColumns + @", modified_at)
 VALUES (1, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22,
         $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43,
-        $44, $45, $46, $47,
+        $44, $45, $46, $47, $48, $49, $50, $51, $52, $53,
         (now() AT TIME ZONE 'UTC'))
 ON CONFLICT (id) DO UPDATE SET
     enabled = EXCLUDED.enabled,
@@ -121,6 +123,12 @@ ON CONFLICT (id) DO UPDATE SET
     pvs_threshold_percent = EXCLUDED.pvs_threshold_percent,
     pvs_floor_gb = EXCLUDED.pvs_floor_gb,
     database_state_enabled = EXCLUDED.database_state_enabled,
+    self_disk_free_warn_percent = EXCLUDED.self_disk_free_warn_percent,
+    collection_stale_minutes = EXCLUDED.collection_stale_minutes,
+    collection_failure_threshold = EXCLUDED.collection_failure_threshold,
+    disk_critical_free_percent = EXCLUDED.disk_critical_free_percent,
+    disk_critical_free_gb = EXCLUDED.disk_critical_free_gb,
+    analysis_notify_cooldown_minutes = EXCLUDED.analysis_notify_cooldown_minutes,
     modified_at = (now() AT TIME ZONE 'UTC')";
 
     /// <summary>The two <c>cpu_mode</c> values the service honors (it compares case-insensitively against
@@ -197,6 +205,12 @@ ON CONFLICT (id) DO UPDATE SET
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = r.PvsThresholdPercent });             // $45 (#1984, V48)
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = r.PvsFloorGb });                      // $46 (#1984, V48)
         command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = r.DatabaseStateEnabled });            // $47 (database-state alert, V49)
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = r.SelfDiskFreeWarnPercent });          // $48 (#2107, V55)
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = r.CollectionStaleMinutes });           // $49 (#2107, V55)
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = r.CollectionFailureThreshold });       // $50 (#2107, V55)
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = r.DiskCriticalFreePercent });          // $51 (#2107, V55)
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = r.DiskCriticalFreeGb });               // $52 (#2107, V55)
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = r.AnalysisNotifyCooldownMinutes });    // $53 (#2107, V55)
     }
 
     private static AlertSettingsRow ReadAlertSettingsRow(NpgsqlDataReader reader) => new()
@@ -254,6 +268,13 @@ ON CONFLICT (id) DO UPDATE SET
         PvsFloorGb = reader.GetInt32(45),
         /* database-state alert master switch appended (V49) at ordinal 46. */
         DatabaseStateEnabled = reader.GetBoolean(46),
+        /* #2107 threshold knobs appended (V55) at ordinals 47–52. */
+        SelfDiskFreeWarnPercent = reader.GetInt32(47),
+        CollectionStaleMinutes = reader.GetInt32(48),
+        CollectionFailureThreshold = reader.GetInt32(49),
+        DiskCriticalFreePercent = reader.GetInt32(50),
+        DiskCriticalFreeGb = reader.GetInt32(51),
+        AnalysisNotifyCooldownMinutes = reader.GetInt32(52),
     };
 
     /// <summary>Maps the Settings window's CPU-mode combo tag ("Total"/"SqlOnly") to the store value.</summary>
@@ -304,6 +325,14 @@ public sealed class AlertSettingsRow
 
     /// <summary>Master switch for the baseline-deviation database-state alert (V40 DDL default true).</summary>
     public bool DatabaseStateEnabled { get; set; } = true;
+
+    /* #2107 (V55): the previously-hardcoded thresholds; defaults are the constants they replaced. */
+    public int SelfDiskFreeWarnPercent { get; set; } = 10;
+    public int CollectionStaleMinutes { get; set; } = 30;
+    public int CollectionFailureThreshold { get; set; } = 10;
+    public int DiskCriticalFreePercent { get; set; } = 3;
+    public int DiskCriticalFreeGb { get; set; } = 2;
+    public int AnalysisNotifyCooldownMinutes { get; set; } = 360;
 
     public bool CpuEnabled { get; set; } = true;
     public int CpuThresholdPercent { get; set; } = 80;
@@ -394,6 +423,12 @@ public sealed class AlertSettingsRow
             && AgRedoQueueAlertKb == other.AgRedoQueueAlertKb
             && AgDisconnectRefireMinutes == other.AgDisconnectRefireMinutes
             && DatabaseStateEnabled == other.DatabaseStateEnabled
+            && SelfDiskFreeWarnPercent == other.SelfDiskFreeWarnPercent
+            && CollectionStaleMinutes == other.CollectionStaleMinutes
+            && CollectionFailureThreshold == other.CollectionFailureThreshold
+            && DiskCriticalFreePercent == other.DiskCriticalFreePercent
+            && DiskCriticalFreeGb == other.DiskCriticalFreeGb
+            && AnalysisNotifyCooldownMinutes == other.AnalysisNotifyCooldownMinutes
             && CpuEnabled == other.CpuEnabled
             && CpuThresholdPercent == other.CpuThresholdPercent
             && string.Equals(CpuMode, other.CpuMode, StringComparison.OrdinalIgnoreCase)

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.cs
@@ -436,7 +436,8 @@ SELECT
     EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'query_stats' AND column_name = 'host_object_name'),
     EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'analysis_findings' AND column_name = 'drill_down_json'),
     EXISTS (SELECT 1 FROM information_schema.tables  WHERE table_name = 'store_metrics'),
-    EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'query_plan_dim' AND column_name = 'query_plan_gz')";
+    EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'query_plan_dim' AND column_name = 'query_plan_gz'),
+    EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'config_alert_settings' AND column_name = 'self_disk_free_warn_percent')";
 
     /// <summary>The store schema version this viewer build requires — the highest migration it knows
     /// (<see cref="StorageVersion.SchemaVersion"/>). The connect-time gate blocks a store below this.</summary>
@@ -457,7 +458,7 @@ SELECT
             await using var reader = await command.ExecuteReaderAsync(cancellationToken);
             if (await reader.ReadAsync(cancellationToken))
             {
-                return MapProbedSchemaVersion(reader.GetBoolean(0), reader.GetBoolean(1), reader.GetBoolean(2), reader.GetBoolean(3), reader.GetBoolean(4), reader.GetBoolean(5), reader.GetBoolean(6), reader.GetBoolean(7), reader.GetBoolean(8), reader.GetBoolean(9), reader.GetBoolean(10), reader.GetBoolean(11), reader.GetBoolean(12), reader.GetBoolean(13), reader.GetBoolean(14), reader.GetBoolean(15), reader.GetBoolean(16), reader.GetBoolean(17), reader.GetBoolean(18), reader.GetBoolean(19), reader.GetBoolean(20), reader.GetBoolean(21), reader.GetBoolean(22), reader.GetBoolean(23), reader.GetBoolean(24), reader.GetBoolean(25), reader.GetBoolean(26), reader.GetBoolean(27), reader.GetBoolean(28), reader.GetBoolean(29), reader.GetBoolean(30), reader.GetBoolean(31), reader.GetBoolean(32), reader.GetBoolean(33), reader.GetBoolean(34), reader.GetBoolean(35), reader.GetBoolean(36));
+                return MapProbedSchemaVersion(reader.GetBoolean(0), reader.GetBoolean(1), reader.GetBoolean(2), reader.GetBoolean(3), reader.GetBoolean(4), reader.GetBoolean(5), reader.GetBoolean(6), reader.GetBoolean(7), reader.GetBoolean(8), reader.GetBoolean(9), reader.GetBoolean(10), reader.GetBoolean(11), reader.GetBoolean(12), reader.GetBoolean(13), reader.GetBoolean(14), reader.GetBoolean(15), reader.GetBoolean(16), reader.GetBoolean(17), reader.GetBoolean(18), reader.GetBoolean(19), reader.GetBoolean(20), reader.GetBoolean(21), reader.GetBoolean(22), reader.GetBoolean(23), reader.GetBoolean(24), reader.GetBoolean(25), reader.GetBoolean(26), reader.GetBoolean(27), reader.GetBoolean(28), reader.GetBoolean(29), reader.GetBoolean(30), reader.GetBoolean(31), reader.GetBoolean(32), reader.GetBoolean(33), reader.GetBoolean(34), reader.GetBoolean(35), reader.GetBoolean(36), reader.GetBoolean(37));
             }
 
             return null;
@@ -482,8 +483,18 @@ SELECT
     /// is unit-tested without a live store; any schema bump past the newest arm trips the pinning test that keeps
     /// this in step with <see cref="StorageVersion.SchemaVersion"/>.
     /// </summary>
-    internal static int MapProbedSchemaVersion(bool hasConfigControlPlane, bool hasAlertDeliveryOverride, bool hasAnalysisState, bool hasAlertTuningKnobs, bool hasDefaultTraceEvents, bool hasIndexObjectStatsLatestIndex, bool hasCollectionLogHypertableOrPlainPg, bool hasJobHistory, bool hasAgentStatus, bool hasGenericWebhook, bool hasDeadlocksDatabaseName, bool hasQueryStoreReplicaRole, bool hasLongQueryCompletions, bool hasWebDashboardConfig, bool hasCustomViews, bool hasServerTags, bool hasConnectionRefireKnobs = false, bool hasAgCollectors = false, bool hasAgAlertKnobs = false, bool hasAgLatencyColumns = false, bool hasAgDisconnectRefire = false, bool hasPayloadDimensions = false, bool hasDimFloorIndexes = false, bool hasBlockingWaitThreshold = false, bool hasQueryStoreIntervalIdentity = false, bool hasPagerDutyWebhook = false, bool hasPagerDutyProxy = false, bool hasCollectorState = false, bool hasPlanCorrection = false, bool hasPvsStats = false, bool hasPvsPressureKnobs = false, bool hasDatabaseStateAlert = false, bool hasServerTagColour = false, bool hasQueryStatsHostObject = false, bool hasFindingDrillDown = false, bool hasStoreMetrics = false, bool hasPlanDimGzip = false)
+    internal static int MapProbedSchemaVersion(bool hasConfigControlPlane, bool hasAlertDeliveryOverride, bool hasAnalysisState, bool hasAlertTuningKnobs, bool hasDefaultTraceEvents, bool hasIndexObjectStatsLatestIndex, bool hasCollectionLogHypertableOrPlainPg, bool hasJobHistory, bool hasAgentStatus, bool hasGenericWebhook, bool hasDeadlocksDatabaseName, bool hasQueryStoreReplicaRole, bool hasLongQueryCompletions, bool hasWebDashboardConfig, bool hasCustomViews, bool hasServerTags, bool hasConnectionRefireKnobs = false, bool hasAgCollectors = false, bool hasAgAlertKnobs = false, bool hasAgLatencyColumns = false, bool hasAgDisconnectRefire = false, bool hasPayloadDimensions = false, bool hasDimFloorIndexes = false, bool hasBlockingWaitThreshold = false, bool hasQueryStoreIntervalIdentity = false, bool hasPagerDutyWebhook = false, bool hasPagerDutyProxy = false, bool hasCollectorState = false, bool hasPlanCorrection = false, bool hasPvsStats = false, bool hasPvsPressureKnobs = false, bool hasDatabaseStateAlert = false, bool hasServerTagColour = false, bool hasQueryStatsHostObject = false, bool hasFindingDrillDown = false, bool hasStoreMetrics = false, bool hasPlanDimGzip = false, bool hasSelfAlertKnobs = false)
     {
+        /* V55 (self-alert threshold knobs, #2107): column-existence sentinel, newest-first arm.
+           config_alert_settings.self_disk_free_warn_percent exists only at V55 or later. The viewer
+           NAMES the V55 columns in AlertSettingsSelectSql/Upsert, so against a V54 store the
+           Settings read would fail 42703 — the gate must refuse it, and a fully-migrated V55 store
+           must map to exactly RequiredStoreSchemaVersion. */
+        if (hasSelfAlertKnobs)
+        {
+            return 55;
+        }
+
         /* V54 (gzip plan-dim content, #2069): column-existence sentinel, newest-first arm.
            query_plan_dim.query_plan_gz exists only at V54 or later. The viewer NAMES the column in
            its plan-fetch reads (gz-else-text coalesce), so against a V53 store those reads would

--- a/Lite/App.xaml.cs
+++ b/Lite/App.xaml.cs
@@ -150,6 +150,8 @@ public partial class App : Application
     public static bool AlertLowDiskEnabled { get; set; } = true;
     public static int AlertLowDiskThresholdPercent { get; set; } = 10; // Alert when a volume's free space < X% (0 disables this check)
     public static int AlertLowDiskThresholdGb { get; set; } = 5;        // Alert when a volume's free space < X GB (0 disables this check)
+    public static int AlertDiskCriticalFreePercent { get; set; } = 3;   // #2107: at/below this % free the low-disk alert grades CRITICAL (#1136 tier)
+    public static int AlertDiskCriticalFreeGb { get; set; } = 2;        // #2107: at/below this many GB free is CRITICAL on any volume (OR-ed with the %)
     public static bool AlertPvsEnabled { get; set; } = true;            // #1984 ADR persistent version store pressure
     public static int AlertPvsThresholdPercent { get; set; } = 40;      // Alert when an ADR database's PVS >= X% of its data files (0 disables this check)
     public static int AlertPvsFloorGb { get; set; } = 1;                // AND-qualifier: the PVS must also be >= X GB (0 removes the floor)
@@ -650,6 +652,9 @@ public partial class App : Application
             if (root.TryGetProperty("alert_low_disk_enabled", out v)) AlertLowDiskEnabled = v.GetBoolean();
             if (root.TryGetProperty("alert_low_disk_threshold_percent", out v)) AlertLowDiskThresholdPercent = (int)Math.Clamp(v.GetInt64(), 0, 100);
             if (root.TryGetProperty("alert_low_disk_threshold_gb", out v)) AlertLowDiskThresholdGb = (int)Math.Max(0, v.GetInt64());
+            /* #2107: the CRITICAL tier floors, clamped like the WARNING thresholds above. */
+            if (root.TryGetProperty("alert_disk_critical_free_percent", out v)) AlertDiskCriticalFreePercent = Math.Clamp(v.GetInt32(), 0, 100);
+            if (root.TryGetProperty("alert_disk_critical_free_gb", out v)) AlertDiskCriticalFreeGb = (int)Math.Max(0, v.GetInt64());
             if (root.TryGetProperty("alert_pvs_enabled", out v)) AlertPvsEnabled = v.GetBoolean();
             if (root.TryGetProperty("alert_pvs_threshold_percent", out v)) AlertPvsThresholdPercent = (int)Math.Clamp(v.GetInt64(), 0, 100);
             if (root.TryGetProperty("alert_pvs_floor_gb", out v)) AlertPvsFloorGb = (int)Math.Max(0, v.GetInt64());

--- a/Lite/Services/AppAlertEngineSettings.cs
+++ b/Lite/Services/AppAlertEngineSettings.cs
@@ -63,6 +63,16 @@ public sealed class AppAlertEngineSettings : IAlertEngineSettings
     public int TempDbSpaceThresholdPercent => App.AlertTempDbSpaceThresholdPercent;
     public int LowDiskThresholdPercent => App.AlertLowDiskThresholdPercent;
     public int LowDiskThresholdGb => App.AlertLowDiskThresholdGb;
+
+    /* #2107: the low-disk CRITICAL tier floors — settings.json-backed like their WARNING-tier
+       siblings above. The three Darling self-monitoring knobs below them return the shipped
+       defaults: Lite has no headless store volume or fleet collection loop to self-monitor, and
+       the members exist so the two apps' settings objects stay one shape (the PVS precedent). */
+    public int DiskCriticalFreePercent => App.AlertDiskCriticalFreePercent;
+    public int DiskCriticalFreeGb => App.AlertDiskCriticalFreeGb;
+    public int SelfDiskFreeWarnPercent => 10;
+    public int CollectionStaleMinutes => 30;
+    public int CollectionFailureThreshold => 10;
     public int PvsThresholdPercent => App.AlertPvsThresholdPercent;
     public int PvsFloorGb => App.AlertPvsFloorGb;
     public int LongRunningJobMultiplier => App.AlertLongRunningJobMultiplier;

--- a/Lite/Windows/SettingsWindow.xaml.cs
+++ b/Lite/Windows/SettingsWindow.xaml.cs
@@ -677,6 +677,8 @@ public partial class SettingsWindow : Window
             root["alert_low_disk_enabled"] = App.AlertLowDiskEnabled;
             root["alert_low_disk_threshold_percent"] = App.AlertLowDiskThresholdPercent;
             root["alert_low_disk_threshold_gb"] = App.AlertLowDiskThresholdGb;
+            root["alert_disk_critical_free_percent"] = App.AlertDiskCriticalFreePercent;
+            root["alert_disk_critical_free_gb"] = App.AlertDiskCriticalFreeGb;
             root["alert_pvs_enabled"] = App.AlertPvsEnabled;
             root["alert_pvs_threshold_percent"] = App.AlertPvsThresholdPercent;
             root["alert_pvs_floor_gb"] = App.AlertPvsFloorGb;

--- a/PerformanceMonitor.Alerting/AlertEngine.cs
+++ b/PerformanceMonitor.Alerting/AlertEngine.cs
@@ -880,7 +880,8 @@ public sealed class AlertEngine
 
                     var lowDiskContext = AlertContextBuilders.BuildVolumeFreeSpaceContext(serverName, breached); /* :515 */
                     /* :516-522 — #1136: grade WARNING normally, CRITICAL when critically low. */
-                    if (lowDiskContext is not null && LowDiskAlertGate.IsCriticallyLow(worst.FreePercent, worst.FreeGb))
+                    if (lowDiskContext is not null && LowDiskAlertGate.IsCriticallyLow(
+                        worst.FreePercent, worst.FreeGb, _settings.DiskCriticalFreePercent, _settings.DiskCriticalFreeGb))
                     {
                         lowDiskContext.SeverityOverride = AlertSeverityLevel.Critical;
                     }

--- a/PerformanceMonitor.Alerting/IAlertEngineSettings.cs
+++ b/PerformanceMonitor.Alerting/IAlertEngineSettings.cs
@@ -136,6 +136,33 @@ public interface IAlertEngineSettings
     int LowDiskThresholdGb { get; }
 
     /// <summary>
+    /// The low-disk CRITICAL severity tier's percent floor (#1136/#2107): free space at/below this
+    /// % grades the Volume Free Space alert CRITICAL instead of WARNING. Was a compile-time 3.0 in
+    /// <c>LowDiskAlertGate</c>; both apps now pass their configured value.
+    /// </summary>
+    int DiskCriticalFreePercent { get; }
+
+    /// <summary>The critical tier's GB floor — at/below this many GB free is CRITICAL on any
+    /// volume, OR-ed with the percent floor exactly as before (#1136/#2107).</summary>
+    int DiskCriticalFreeGb { get; }
+
+    /// <summary>
+    /// The store/self-monitoring warning percent (#2107, Darling's self-alerts): the monitor's own
+    /// store volume warns below this % free. Lite has no headless store volume to self-monitor and
+    /// returns the shipped default — on the engine surface anyway so the two apps' settings
+    /// objects stay one shape (the PVS-knob precedent).
+    /// </summary>
+    int SelfDiskFreeWarnPercent { get; }
+
+    /// <summary>How long collection may go quiet before Collection Stopped / Agent Not Running
+    /// fire (#2107; was a compile-time 30 minutes). Lite returns the default.</summary>
+    int CollectionStaleMinutes { get; }
+
+    /// <summary>The Collection Stopped fast path — this many consecutive failures with zero
+    /// successes fires without waiting out the staleness window (#2107). Lite returns the default.</summary>
+    int CollectionFailureThreshold { get; }
+
+    /// <summary>
     /// Fire when an ADR database's persistent version store reaches this % of the database's data
     /// files (#1984). Percent rather than absolute size because a shipped absolute guess is
     /// workload-specific and would page half a fleet (the ag_redo_queue precedent) — this ratio is

--- a/PerformanceMonitor.Notifications/LowDiskAlertGate.cs
+++ b/PerformanceMonitor.Notifications/LowDiskAlertGate.cs
@@ -53,7 +53,13 @@ public static class LowDiskAlertGate
     /// by Lite and Dashboard so the two apps grade low-disk identically.
     /// </summary>
     public static bool IsCriticallyLow(double freePercent, double freeGb) =>
-        freePercent <= CriticalFreePercent || freeGb <= CriticalFreeGb;
+        IsCriticallyLow(freePercent, freeGb, CriticalFreePercent, CriticalFreeGb);
+
+    /// <summary>#2107: the configurable form — both apps pass their settings' critical floors; the
+    /// parameterless overload keeps the shipped constants for callers with no settings in reach
+    /// (and for the tests pinning the defaults).</summary>
+    public static bool IsCriticallyLow(double freePercent, double freeGb, double criticalFreePercent, double criticalFreeGb) =>
+        freePercent <= criticalFreePercent || freeGb <= criticalFreeGb;
 
     /// <summary>
     /// Returns true when a low-disk alert should fire this cycle.


### PR DESCRIPTION
Closes #2107 — "it was fine to hardcode these for development but any serious monitoring allows configuring of alert thresholds."

## The six knobs

| Knob | Was | Store column (V55) | Clamp |
|---|---|---|---|
| Store-volume self-alert warn % | `10.0` const | `self_disk_free_warn_percent` | 0–100 |
| Collection Stopped staleness window | `30 min` const | `collection_stale_minutes` | 5–1440 |
| Collection Stopped failure fast path | `10` const | `collection_failure_threshold` | 1–1000 |
| Low-disk CRITICAL tier % floor (#1136) | `3.0` const | `disk_critical_free_percent` | 0–100 |
| Low-disk CRITICAL tier GB floor | `2.0` const | `disk_critical_free_gb` | ≥0 |
| Analysis notify cooldown | `=> 360` hardcode | `analysis_notify_cooldown_minutes` | 30–10080 |

## Surfaces

Full #1984 launch kit: V55 migration (NOT NULL DEFAULTs = the constants replaced, so upgraded stores behave identically until a knob turns), `StoreConfigProvider` round-trip at appended ordinals 47–52, `DarlingAlertReader`/`get_alert_settings` (`low_disk.critical_free_percent`/`critical_free_gb`, new `self_alerts` group, `analysis.notify_cooldown_minutes`), `update_alert_settings` cases with service-matching clamps, Viewer Settings rows + defaults-reset, and `darling.json` seed properties.

**Cross-SKU note:** the CRITICAL tier floors moved onto `IAlertEngineSettings` because the shared engine grades the target-volume alert with them in BOTH apps — Lite now reads its pair from `settings.json` (`alert_disk_critical_free_percent`/`_gb`; UI row deliberately deferred, the keys are hand-editable). The three self-monitoring knobs are Darling-only in effect; Lite's adapter returns the shipped defaults so the settings objects stay one shape (the PVS precedent).

## Compatibility

The pure decision helpers (`IsDiskPressure`, `IsCollectionStopped`, `IsCriticallyLow`) gained parameterized overloads with the constant-form delegating — every existing behavioral pin still holds, and `LowDiskAlertGate`'s deprecated-Dashboard caller keeps the defaults. New `SelfAlertKnobs_DefaultsAreTheConstantsTheyReplaced_AndReadsClampLikeSiblings` pins defaults + clamps through the by-reference reload seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)