### PR TITLE
Store self-metrics measure background jobs — duration vs cadence as a series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Every previously-hardcoded alert threshold is now a real setting** ([#2107], the split-out from gotqn's #2101 - "it was fine to hardcode these for development but any serious monitoring allows configuring of alert thresholds") - six new knobs ride the store control plane (V55), the Viewer's Settings window, and `get_alert_settings`/`update_alert_settings`, clamped on read like their siblings: the monitor store volume's self-alert warning percent (was 10), the Collection Stopped staleness window (was 30 minutes) and consecutive-failure fast path (was 10), the low-disk CRITICAL severity tier's percent and GB floors (were 3% / 2 GB - these grade the target-volume alert in BOTH apps, and Lite reads its pair from `settings.json` as `alert_disk_critical_free_percent` / `alert_disk_critical_free_gb`), and the analysis notification cooldown (was a hardcoded 360 in Darling while Lite always honored a configured value - the parity gap closed). MCP shape: `low_disk.critical_free_percent` / `low_disk.critical_free_gb`, a new `self_alerts` group, and `analysis.notify_cooldown_minutes`.
+- **The store measures its own background jobs** ([#2136], the visibility half) - the hourly #2068 self-metrics sweep now writes one row per TimescaleDB background job (object_kind `background_job`, V56 columns): last run duration, schedule interval, total runs, total failures. Why: the store's heaviest recurring work is its own job machinery - on the production 52-server store the four most expensive jobs are all the query_store_stats family (compression 157s, interval_hourly refresh 96s) - their runtimes scale SERIALLY with raw volume (the finalize hash-aggregate runs in one process), and a job that outgrows its own cadence compounds refresh lag silently. With the interval stored beside the duration, 'how close is each job to its ceiling' is one division over a 400-day series instead of archaeology - the number an onboarding wave moves first. A threshold alert on the series is the issue's next half.
 
 ### Fixed
 
@@ -2638,3 +2639,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2126]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/2126
 [#2129]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/2129
 [#2133]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/2133
+[#2136]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/2136

--- a/Darling/Darling.Tests/DarlingObservabilityTests.cs
+++ b/Darling/Darling.Tests/DarlingObservabilityTests.cs
@@ -76,8 +76,8 @@ public sealed class DarlingObservabilityTests
         Assert.Equal(33, PgMigrations.Scripts[32].Version);
         /* The newest migration is asserted by identity rather than by ordinal: this ladder is walked by every
            stacked branch at once, and a positional pin turns each addition into a conflict for the next. */
-        Assert.Equal(55, PgMigrations.Scripts[^1].Version);
-        Assert.Equal(55, StorageVersion.SchemaVersion);
+        Assert.Equal(56, PgMigrations.Scripts[^1].Version);
+        Assert.Equal(56, StorageVersion.SchemaVersion);
 
         /* V34 (#991) creates the two Availability Group collector tables. Schema-qualified collect.* and
            CREATE TABLE IF NOT EXISTS, per the file's additive-create idiom (V29): a no-op on a fresh store

--- a/Darling/Darling.Tests/PvsStatsStoreTests.cs
+++ b/Darling/Darling.Tests/PvsStatsStoreTests.cs
@@ -45,8 +45,8 @@ public sealed class PvsStatsStoreTests
            (#2060, the persisted finding drill-down), then V53 (#2068, the store self-metrics table) followed
            this migration — the newest-rung pins track the newest, the V47 identity pins below are
            unchanged. */
-        Assert.Equal(55, PgMigrations.Scripts[^1].Version);
-        Assert.Equal(55, StorageVersion.SchemaVersion);
+        Assert.Equal(56, PgMigrations.Scripts[^1].Version);
+        Assert.Equal(56, StorageVersion.SchemaVersion);
 
         /* collect.-qualified like V44 and V34, and idempotent so a re-run is a no-op. */
         Assert.Contains("CREATE TABLE IF NOT EXISTS collect.pvs_stats (", v47.Sql, StringComparison.Ordinal);

--- a/Darling/Darling.Tests/PvsStatsStoreTests.cs
+++ b/Darling/Darling.Tests/PvsStatsStoreTests.cs
@@ -87,7 +87,7 @@ public sealed class PvsStatsStoreTests
            migration reports every healthy store as skewed and refuses to open it — permanently.
            (53 since #2068's store self-metrics table; the full-sentinel pin lives in
            ViewerDataServiceTests.) */
-        Assert.Equal(55, ViewerDataService.RequiredStoreSchemaVersion);
+        Assert.Equal(56, ViewerDataService.RequiredStoreSchemaVersion);
         Assert.Contains("table_name = 'pvs_stats'", ViewerDataService.StoreSchemaProbeSql, StringComparison.Ordinal);
 
         /* The V47 arm: pvs_stats present (and nothing newer) maps to exactly 47. */

--- a/Darling/Darling.Tests/StoreSelfMetricsTests.cs
+++ b/Darling/Darling.Tests/StoreSelfMetricsTests.cs
@@ -8,6 +8,8 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
+using Npgsql;
 using PerformanceMonitor.Darling.Storage;
 using PerformanceMonitor.Darling.Viewer;
 using Xunit;
@@ -29,8 +31,8 @@ public sealed class StoreSelfMetricsTests
         var v53 = PgMigrations.Scripts.Single(m => m.Version == 53);
 
         Assert.Equal("store-self-metrics", v53.Name);
-        Assert.Equal(55, PgMigrations.Scripts[^1].Version);
-        Assert.Equal(55, StorageVersion.SchemaVersion);
+        Assert.Equal(56, PgMigrations.Scripts[^1].Version);
+        Assert.Equal(56, StorageVersion.SchemaVersion);
 
         /* collect.-qualified like V44/V47/V49, and idempotent so a re-run is a no-op. */
         Assert.Contains("CREATE TABLE IF NOT EXISTS collect.store_metrics (", v53.Sql, StringComparison.Ordinal);
@@ -56,6 +58,43 @@ public sealed class StoreSelfMetricsTests
     }
 
     [Fact]
+    public void V56_JobTelemetryColumns_MigrationAndSweepAgree_AndTheProbeKnowsTheRung()
+    {
+        /* #2136: every column the background-job sweep arm writes must exist in the V56 migration, or the
+           first hourly run after an upgrade fails on a column fresh code writes and the store lacks —
+           the exact failure class the V53 column pin above guards. */
+        var v56 = PgMigrations.Scripts.Single(m => m.Version == 56);
+        Assert.Equal("store-metrics-background-jobs", v56.Name);
+        foreach (var column in new[]
+        {
+            "last_run_duration_ms", "schedule_interval_ms", "total_runs", "total_failures",
+        })
+        {
+            Assert.Contains($"ADD COLUMN IF NOT EXISTS {column} bigint", v56.Sql, StringComparison.Ordinal);
+            Assert.Contains(column, StoreSelfMetrics.BackgroundJobInsertSql, StringComparison.Ordinal);
+        }
+
+        /* The insert reads only TimescaleDB catalog surfaces, which is why the sweep gates it with the
+           hypertable arm — a plain-PG store skips it silently. schedule_interval rides along so
+           "duration vs cadence" — the tripwire that matters — is one division over the stored series. */
+        Assert.Contains("FROM timescaledb_information.job_stats", StoreSelfMetrics.BackgroundJobInsertSql, StringComparison.Ordinal);
+        Assert.Contains("JOIN timescaledb_information.jobs", StoreSelfMetrics.BackgroundJobInsertSql, StringComparison.Ordinal);
+        Assert.Contains("'background_job'", StoreSelfMetrics.BackgroundJobInsertSql, StringComparison.Ordinal);
+
+        /* The probe sentinel + arm: a fully-migrated V56 store maps to exactly the required version
+           (the connect-time-gate trap), and a V55 store without the columns caps at 55. */
+        Assert.Contains("column_name = 'last_run_duration_ms'", ViewerDataService.StoreSchemaProbeSql, StringComparison.Ordinal);
+        Assert.Equal(56, ViewerDataService.MapProbedSchemaVersion(
+            true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
+            true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
+            true, true, true, true, true, true, hasJobMetricsColumns: true));
+        Assert.Equal(55, ViewerDataService.MapProbedSchemaVersion(
+            true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
+            true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,
+            true, true, true, true, true, true, hasJobMetricsColumns: false));
+    }
+
+    [Fact]
     public void StoreMetrics_IsNotACollectorTable_SoTheMachineryItMeasuresCannotReachIt()
     {
         /* TimescaleSupport's hypertable conversion + compression policies and DarlingRetention's purge both
@@ -70,7 +109,7 @@ public sealed class StoreSelfMetricsTests
     {
         /* The trap a StorageVersion bump sets: a probe that cannot SEE the newest migration maps every
            healthy store below RequiredStoreSchemaVersion and the connect-time gate refuses it permanently. */
-        Assert.Equal(55, ViewerDataService.RequiredStoreSchemaVersion);
+        Assert.Equal(56, ViewerDataService.RequiredStoreSchemaVersion);
         Assert.Contains("table_name = 'store_metrics'", ViewerDataService.StoreSchemaProbeSql, StringComparison.Ordinal);
 
         /* The V53 arm: store_metrics present (and everything below it, but NOT V54's gz column —
@@ -165,5 +204,55 @@ public sealed class StoreSelfMetricsTests
            makes a run's rows join and keeps the timestamps naive UTC by the cross-store contract. */
         Assert.DoesNotContain("now()", sql, StringComparison.Ordinal);
         Assert.Contains("$1", sql, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The sweep END TO END against a real TimescaleDB (#2136) — the drift-catcher the SQL pins alone
+    /// cannot be: every INSERT the sweep runs must agree with the columns the migrations created, and the
+    /// failure class this guards (sweep writes a column the upgraded store lacks) only surfaces when the
+    /// statements actually execute. Mints its own scratch store (the #1776 own-store idiom), migrates it,
+    /// converts + applies compression policies so real background jobs exist, then asserts one run writes
+    /// hypertable, dimension, store, AND background_job rows — the job rows carrying a schedule interval,
+    /// because "duration vs cadence" is the series' whole point.
+    /// </summary>
+    [Fact]
+    public async Task Sweep_EndToEnd_WritesEveryObjectKind_IncludingBackgroundJobs_AgainstDevPostgres()
+    {
+        var baseConnectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(baseConnectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string (with TimescaleDB installed) to run the live self-metrics sweep test (it mints its own scratch database).");
+
+        var ct = TestContext.Current.CancellationToken;
+
+        await using var scratch = await ScratchPostgres.CreateAsync(baseConnectionString!, ct);
+        await using var connection = new NpgsqlConnection(scratch.ConnectionString);
+        await connection.OpenAsync(ct);
+        await PgMigrations.MigrateAsync(connection, ct);
+
+        Assert.True(await TimescaleSupport.TryEnableAsync(connection, null, ct),
+            "the dev fixture is expected to have TimescaleDB installed");
+        await TimescaleSupport.ConvertToHypertablesAsync(connection, null, ct);
+        await TimescaleSupport.ApplyCompressionPolicyAsync(connection, null, ct);
+
+        var written = await StoreSelfMetrics.SweepAsync(
+            connection, timescaleAvailable: true, DateTime.UtcNow, null, ct);
+        Assert.True(written > 0, "the sweep wrote nothing");
+
+        await using var kinds = new NpgsqlCommand(@"
+SELECT
+    count(*) FILTER (WHERE object_kind = 'hypertable'),
+    count(*) FILTER (WHERE object_kind = 'dimension'),
+    count(*) FILTER (WHERE object_kind = 'store'),
+    count(*) FILTER (WHERE object_kind = 'background_job'),
+    count(*) FILTER (WHERE object_kind = 'background_job' AND schedule_interval_ms > 0)
+FROM collect.store_metrics", connection);
+        await using var reader = await kinds.ExecuteReaderAsync(ct);
+        Assert.True(await reader.ReadAsync(ct));
+
+        Assert.True(reader.GetInt64(0) > 0, "no hypertable rows");
+        Assert.True(reader.GetInt64(1) > 0, "no dimension rows");
+        Assert.Equal(1, reader.GetInt64(2));
+        Assert.True(reader.GetInt64(3) > 0, "no background_job rows — the compression policies just applied guarantee jobs exist");
+        Assert.True(reader.GetInt64(4) > 0, "background_job rows carry no schedule interval — duration-vs-cadence needs it");
     }
 }

--- a/Darling/Darling.Tests/StoreSelfMetricsTests.cs
+++ b/Darling/Darling.Tests/StoreSelfMetricsTests.cs
@@ -22,6 +22,10 @@ namespace Darling.Tests;
 /// whole design leans on — the table that MEASURES the compression/retention machinery is not in the
 /// collector catalog, so that machinery can never recurse onto it (no hypertable conversion, no
 /// compression policy, no catalog-driven purge; its retention is the sweep's own bounded DELETE).
+///
+/// <para><b>#1776 own-store</b> — the one live test here mints its own scratch database via
+/// ScratchPostgres (it applies compression policies, which the shared fixture must never inherit), so
+/// it cannot race the shared store and serializing it would be pure slowdown.</para>
 /// </summary>
 public sealed class StoreSelfMetricsTests
 {

--- a/Darling/Darling.Tests/StoreSelfMetricsTests.cs
+++ b/Darling/Darling.Tests/StoreSelfMetricsTests.cs
@@ -258,5 +258,14 @@ FROM collect.store_metrics", connection);
         Assert.Equal(1, reader.GetInt64(2));
         Assert.True(reader.GetInt64(3) > 0, "no background_job rows — the compression policies just applied guarantee jobs exist");
         Assert.True(reader.GetInt64(4) > 0, "background_job rows carry no schedule interval — duration-vs-cadence needs it");
+        await reader.CloseAsync();
+
+        /* And the READ path carries the new fields end to end (the review catch: written but never read
+           back would leave get_store_metrics returning job rows with null metrics). */
+        await using var dataSource = NpgsqlDataSource.Create(scratch.ConnectionString);
+        var latest = await PerformanceMonitor.Darling.Service.Mcp.DarlingStoreMetricsReader.GetLatestAsync(dataSource, ct);
+        var job = latest.FirstOrDefault(r => r.ObjectKind == "background_job");
+        Assert.NotNull(job);
+        Assert.True(job!.ScheduleIntervalMs is > 0, "the reader dropped the job's schedule interval");
     }
 }

--- a/Darling/Darling.Tests/ViewerDataServiceTests.cs
+++ b/Darling/Darling.Tests/ViewerDataServiceTests.cs
@@ -546,7 +546,7 @@ public sealed class ViewerSchemaVersionGateTests
            the connect-time gate refuse to open the viewer against a perfectly healthy store. */
         Assert.Equal(
             ViewerDataService.RequiredStoreSchemaVersion,
-            ViewerDataService.MapProbedSchemaVersion(true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true));
+            ViewerDataService.MapProbedSchemaVersion(true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true));
     }
 }
 

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpStoreMetricsTools.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpStoreMetricsTools.cs
@@ -35,7 +35,7 @@ public sealed class DarlingMcpStoreMetricsTools
     public const int MaxDaysBack = StoreSelfMetrics.RetentionDays;
 
     [McpServerTool(Name = "get_store_metrics"), Description(
-        "Gets the monitoring store's OWN size and growth metrics — not a monitored SQL Server's. The service records an hourly self-metrics snapshot: per-hypertable total size, pre/post-compression bytes and chunk count; the query-text and query-plan payload dimension tables' total size (the store's dominant payloads) and row counts; and the whole store's size with the enabled-server count. Returns the latest snapshot per object plus a daily series over the window, with the whole-store daily growth in bytes and the derived per-server ingest rate (daily growth / enabled servers). Use for capacity forecasting: what is driving store growth, how fast, and what adding N servers would multiply.")]
+        "Gets the monitoring store's OWN size and growth metrics — not a monitored SQL Server's. The service records an hourly self-metrics snapshot: per-hypertable total size, pre/post-compression bytes and chunk count; the query-text and query-plan payload dimension tables' total size (the store's dominant payloads) and row counts; the whole store's size with the enabled-server count; and one row per TimescaleDB background job (CAGG refresh, compression, retention) with its last run duration, schedule interval, duration-vs-cadence percent, and run/failure totals — the jobs whose runtimes scale with fleet size. Returns the latest snapshot per object plus a daily series over the window, with the whole-store daily growth in bytes and the derived per-server ingest rate (daily growth / enabled servers). Use for capacity forecasting: what is driving store growth, how fast, what adding N servers would multiply, and which background job is closest to outgrowing its own cadence.")]
     public static async Task<string> GetStoreMetrics(
         NpgsqlDataSource postgres,
         [Description("Days of daily-series history. Default 30; max 400 (the series' own retention).")] int days_back = 30)
@@ -101,6 +101,16 @@ public sealed class DarlingMcpStoreMetricsTools
                             : (double?)null,
                         chunk_count = r.ChunkCount,
                         row_count = r.RowCount,
+                        /* #2136 background_job rows only (NULL elsewhere): last run duration, the job's own
+                           cadence, and how much of that cadence the run consumed — the ceiling-proximity
+                           number an onboarding wave moves first. */
+                        last_run_duration_ms = r.LastRunDurationMs,
+                        schedule_interval_ms = r.ScheduleIntervalMs,
+                        duration_vs_cadence_percent = r.LastRunDurationMs is > 0 && r.ScheduleIntervalMs is > 0
+                            ? Math.Round(100.0 * r.LastRunDurationMs.Value / r.ScheduleIntervalMs.Value, 1)
+                            : (double?)null,
+                        total_runs = r.TotalRuns,
+                        total_failures = r.TotalFailures,
                     }),
                 daily = daily
                     .Where(p => p.ObjectKind != "store")
@@ -119,6 +129,10 @@ public sealed class DarlingMcpStoreMetricsTools
                             compressed_after_bytes = p.CompressedAfterBytes,
                             chunk_count = p.ChunkCount,
                             row_count = p.RowCount,
+                            last_run_duration_ms = p.LastRunDurationMs,
+                            schedule_interval_ms = p.ScheduleIntervalMs,
+                            total_runs = p.TotalRuns,
+                            total_failures = p.TotalFailures,
                         }),
                     }),
             }, McpHelpers.JsonOptions);

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingStoreMetricsReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingStoreMetricsReader.cs
@@ -38,7 +38,11 @@ SELECT DISTINCT ON (object_kind, object_name)
     compressed_after_bytes,
     chunk_count,
     row_count,
-    enabled_server_count
+    enabled_server_count,
+    last_run_duration_ms,
+    schedule_interval_ms,
+    total_runs,
+    total_failures
 FROM collect.store_metrics
 ORDER BY object_kind, object_name, metric_time DESC";
 
@@ -55,12 +59,17 @@ SELECT DISTINCT ON (object_kind, object_name, date_trunc('day', metric_time))
     compressed_after_bytes,
     chunk_count,
     row_count,
-    enabled_server_count
+    enabled_server_count,
+    last_run_duration_ms,
+    schedule_interval_ms,
+    total_runs,
+    total_failures
 FROM collect.store_metrics
 WHERE metric_time >= $1
 ORDER BY object_kind, object_name, date_trunc('day', metric_time), metric_time DESC";
 
-    /// <summary>One object's newest self-metrics row.</summary>
+    /// <summary>One object's newest self-metrics row. The four job fields (#2136, V56) are non-null only
+    /// on <c>background_job</c> rows — every other kind leaves them NULL, as the sweep writes them.</summary>
     public sealed record StoreMetricRow(
         string ObjectKind,
         string ObjectName,
@@ -70,9 +79,14 @@ ORDER BY object_kind, object_name, date_trunc('day', metric_time), metric_time D
         long? CompressedAfterBytes,
         int? ChunkCount,
         long? RowCount,
-        int? EnabledServerCount);
+        int? EnabledServerCount,
+        long? LastRunDurationMs = null,
+        long? ScheduleIntervalMs = null,
+        long? TotalRuns = null,
+        long? TotalFailures = null);
 
-    /// <summary>One object's settled point for one day (the day's last sample).</summary>
+    /// <summary>One object's settled point for one day (the day's last sample). Job fields as on
+    /// <see cref="StoreMetricRow"/>.</summary>
     public sealed record StoreMetricDailyPoint(
         string ObjectKind,
         string ObjectName,
@@ -82,7 +96,11 @@ ORDER BY object_kind, object_name, date_trunc('day', metric_time), metric_time D
         long? CompressedAfterBytes,
         int? ChunkCount,
         long? RowCount,
-        int? EnabledServerCount);
+        int? EnabledServerCount,
+        long? LastRunDurationMs = null,
+        long? ScheduleIntervalMs = null,
+        long? TotalRuns = null,
+        long? TotalFailures = null);
 
     /// <summary>One day's whole-store growth: the byte delta from the previous day's settled point, and
     /// that delta divided by the day's enabled-server count — the number onboarding N servers multiplies.
@@ -108,7 +126,11 @@ ORDER BY object_kind, object_name, date_trunc('day', metric_time), metric_time D
                 reader.IsDBNull(5) ? null : reader.GetInt64(5),
                 reader.IsDBNull(6) ? null : reader.GetInt32(6),
                 reader.IsDBNull(7) ? null : reader.GetInt64(7),
-                reader.IsDBNull(8) ? null : reader.GetInt32(8)));
+                reader.IsDBNull(8) ? null : reader.GetInt32(8),
+                reader.IsDBNull(9) ? null : reader.GetInt64(9),
+                reader.IsDBNull(10) ? null : reader.GetInt64(10),
+                reader.IsDBNull(11) ? null : reader.GetInt64(11),
+                reader.IsDBNull(12) ? null : reader.GetInt64(12)));
         }
 
         return rows;
@@ -133,7 +155,11 @@ ORDER BY object_kind, object_name, date_trunc('day', metric_time), metric_time D
                 reader.IsDBNull(5) ? null : reader.GetInt64(5),
                 reader.IsDBNull(6) ? null : reader.GetInt32(6),
                 reader.IsDBNull(7) ? null : reader.GetInt64(7),
-                reader.IsDBNull(8) ? null : reader.GetInt32(8)));
+                reader.IsDBNull(8) ? null : reader.GetInt32(8),
+                reader.IsDBNull(9) ? null : reader.GetInt64(9),
+                reader.IsDBNull(10) ? null : reader.GetInt64(10),
+                reader.IsDBNull(11) ? null : reader.GetInt64(11),
+                reader.IsDBNull(12) ? null : reader.GetInt64(12)));
         }
 
         return rows;

--- a/Darling/PerformanceMonitor.Darling.Storage/PgMigrations.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/PgMigrations.cs
@@ -112,6 +112,7 @@ public static class PgMigrations
         new Migration(53, "store-self-metrics", V53Sql),
         new Migration(54, "plan-dim-gzip", V54Sql + "\n" + PgSchemaGenerator.GenerateQueryStatsResolvingView()),
         new Migration(55, "self-alert-knobs", V55Sql),
+        new Migration(56, "store-metrics-background-jobs", V56Sql),
     };
 
     /// <summary>
@@ -1089,6 +1090,25 @@ ALTER TABLE config.config_alert_settings
     ADD COLUMN IF NOT EXISTS disk_critical_free_gb integer NOT NULL DEFAULT 2;
 ALTER TABLE config.config_alert_settings
     ADD COLUMN IF NOT EXISTS analysis_notify_cooldown_minutes integer NOT NULL DEFAULT 360;";
+
+    /// <summary>
+    /// V56 — background-job telemetry columns on the #2068 self-metrics series (#2136): the store's own
+    /// TimescaleDB background jobs (CAGG refreshes, compression, retention) are its heaviest recurring
+    /// work — measured on the production store, the four most expensive jobs are all the
+    /// query_store_stats family (compression 157s, interval_hourly refresh 96s) — and their runtimes
+    /// scale serially with raw volume, so an onboarding wave moves them first. Job rows ride the same
+    /// hourly sweep under <c>object_kind = 'background_job'</c>. All nullable, appended (the V55/#1984
+    /// ordinal rule); non-job rows simply leave them NULL.
+    /// </summary>
+    private const string V56Sql = @"
+ALTER TABLE collect.store_metrics
+    ADD COLUMN IF NOT EXISTS last_run_duration_ms bigint;
+ALTER TABLE collect.store_metrics
+    ADD COLUMN IF NOT EXISTS schedule_interval_ms bigint;
+ALTER TABLE collect.store_metrics
+    ADD COLUMN IF NOT EXISTS total_runs bigint;
+ALTER TABLE collect.store_metrics
+    ADD COLUMN IF NOT EXISTS total_failures bigint;";
 
     /// <summary>
     /// V9 — the FinOps copy-parity fields that were user-input config or previously live-only:

--- a/Darling/PerformanceMonitor.Darling.Storage/StorageVersion.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/StorageVersion.cs
@@ -16,5 +16,5 @@ namespace PerformanceMonitor.Darling.Storage;
 /// </summary>
 public static class StorageVersion
 {
-    public const int SchemaVersion = 55;
+    public const int SchemaVersion = 56;
 }

--- a/Darling/PerformanceMonitor.Darling.Storage/StoreSelfMetrics.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/StoreSelfMetrics.cs
@@ -96,15 +96,18 @@ LEFT JOIN LATERAL (
     /// interval_hourly refresh at 96s on a 52-server store), and a job that outgrows its own schedule
     /// interval compounds refresh lag silently. One row per job per sweep makes that a queryable series:
     /// object_name is <c>proc_name</c> plus the hypertable/CAGG it serves (the telemetry job has
-    /// neither), and <c>schedule_interval_ms</c> rides along so "duration vs cadence" — the honest
-    /// tripwire — is one division. $1 metric_time.
+    /// neither) plus a <c>[job_id]</c> suffix — the uniqueness guarantee (review catch): two user-added
+    /// jobs sharing a proc_name, or two hypertable-less jobs, would otherwise collide into one
+    /// object_name and the readers' DISTINCT ON would silently drop one job's telemetry. job_id is
+    /// stable for a job's lifetime, so per-job series continuity holds. <c>schedule_interval_ms</c>
+    /// rides along so "duration vs cadence" — the honest tripwire — is one division. $1 metric_time.
     /// </summary>
     public const string BackgroundJobInsertSql = @"
 INSERT INTO collect.store_metrics
     (metric_time, object_name, object_kind, last_run_duration_ms, schedule_interval_ms, total_runs, total_failures)
 SELECT
     $1,
-    j.proc_name || coalesce(' ' || j.hypertable_name, ''),
+    j.proc_name || coalesce(' ' || j.hypertable_name, '') || ' [' || j.job_id || ']',
     'background_job',
     (EXTRACT(EPOCH FROM js.last_run_duration) * 1000)::bigint,
     (EXTRACT(EPOCH FROM j.schedule_interval) * 1000)::bigint,

--- a/Darling/PerformanceMonitor.Darling.Storage/StoreSelfMetrics.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/StoreSelfMetrics.cs
@@ -88,6 +88,32 @@ LEFT JOIN LATERAL (
 ) c ON true";
 
     /// <summary>
+    /// The background-job rows (#2136) — TimescaleDB stores only, like the hypertable arm (the
+    /// timescaledb_information views do not exist on plain PostgreSQL). The store's own background jobs
+    /// (CAGG refreshes, compression, retention) are its heaviest recurring work, their runtimes scale
+    /// SERIALLY with raw volume (the finalize hash-aggregate runs in one process — measured in #2136:
+    /// the four most expensive jobs are all the query_store_stats family, compression at 157s and the
+    /// interval_hourly refresh at 96s on a 52-server store), and a job that outgrows its own schedule
+    /// interval compounds refresh lag silently. One row per job per sweep makes that a queryable series:
+    /// object_name is <c>proc_name</c> plus the hypertable/CAGG it serves (the telemetry job has
+    /// neither), and <c>schedule_interval_ms</c> rides along so "duration vs cadence" — the honest
+    /// tripwire — is one division. $1 metric_time.
+    /// </summary>
+    public const string BackgroundJobInsertSql = @"
+INSERT INTO collect.store_metrics
+    (metric_time, object_name, object_kind, last_run_duration_ms, schedule_interval_ms, total_runs, total_failures)
+SELECT
+    $1,
+    j.proc_name || coalesce(' ' || j.hypertable_name, ''),
+    'background_job',
+    (EXTRACT(EPOCH FROM js.last_run_duration) * 1000)::bigint,
+    (EXTRACT(EPOCH FROM j.schedule_interval) * 1000)::bigint,
+    js.total_runs,
+    js.total_failures
+FROM timescaledb_information.job_stats AS js
+JOIN timescaledb_information.jobs AS j USING (job_id)";
+
+    /// <summary>
     /// The payload dimension rows — every store shape (the dims are plain tables everywhere). Table names
     /// are the <see cref="PayloadDimensions"/> compile-time constants, so interpolation is safe (the
     /// DarlingRetention.DeleteSqlFor reasoning). The exact <c>count(*)</c> is deliberate over
@@ -161,6 +187,10 @@ WHERE metric_time < $1";
             using var hypertables = new NpgsqlCommand(HypertableInsertSql, connection);
             hypertables.Parameters.AddWithValue(metricTime);
             written += await hypertables.ExecuteNonQueryAsync(cancellationToken);
+
+            using var jobs = new NpgsqlCommand(BackgroundJobInsertSql, connection);
+            jobs.Parameters.AddWithValue(metricTime);
+            written += await jobs.ExecuteNonQueryAsync(cancellationToken);
         }
 
         using (var dimensions = new NpgsqlCommand(DimensionInsertSql, connection))

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.cs
@@ -437,7 +437,8 @@ SELECT
     EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'analysis_findings' AND column_name = 'drill_down_json'),
     EXISTS (SELECT 1 FROM information_schema.tables  WHERE table_name = 'store_metrics'),
     EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'query_plan_dim' AND column_name = 'query_plan_gz'),
-    EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'config_alert_settings' AND column_name = 'self_disk_free_warn_percent')";
+    EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'config_alert_settings' AND column_name = 'self_disk_free_warn_percent'),
+    EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'store_metrics' AND column_name = 'last_run_duration_ms')";
 
     /// <summary>The store schema version this viewer build requires — the highest migration it knows
     /// (<see cref="StorageVersion.SchemaVersion"/>). The connect-time gate blocks a store below this.</summary>
@@ -458,7 +459,7 @@ SELECT
             await using var reader = await command.ExecuteReaderAsync(cancellationToken);
             if (await reader.ReadAsync(cancellationToken))
             {
-                return MapProbedSchemaVersion(reader.GetBoolean(0), reader.GetBoolean(1), reader.GetBoolean(2), reader.GetBoolean(3), reader.GetBoolean(4), reader.GetBoolean(5), reader.GetBoolean(6), reader.GetBoolean(7), reader.GetBoolean(8), reader.GetBoolean(9), reader.GetBoolean(10), reader.GetBoolean(11), reader.GetBoolean(12), reader.GetBoolean(13), reader.GetBoolean(14), reader.GetBoolean(15), reader.GetBoolean(16), reader.GetBoolean(17), reader.GetBoolean(18), reader.GetBoolean(19), reader.GetBoolean(20), reader.GetBoolean(21), reader.GetBoolean(22), reader.GetBoolean(23), reader.GetBoolean(24), reader.GetBoolean(25), reader.GetBoolean(26), reader.GetBoolean(27), reader.GetBoolean(28), reader.GetBoolean(29), reader.GetBoolean(30), reader.GetBoolean(31), reader.GetBoolean(32), reader.GetBoolean(33), reader.GetBoolean(34), reader.GetBoolean(35), reader.GetBoolean(36), reader.GetBoolean(37));
+                return MapProbedSchemaVersion(reader.GetBoolean(0), reader.GetBoolean(1), reader.GetBoolean(2), reader.GetBoolean(3), reader.GetBoolean(4), reader.GetBoolean(5), reader.GetBoolean(6), reader.GetBoolean(7), reader.GetBoolean(8), reader.GetBoolean(9), reader.GetBoolean(10), reader.GetBoolean(11), reader.GetBoolean(12), reader.GetBoolean(13), reader.GetBoolean(14), reader.GetBoolean(15), reader.GetBoolean(16), reader.GetBoolean(17), reader.GetBoolean(18), reader.GetBoolean(19), reader.GetBoolean(20), reader.GetBoolean(21), reader.GetBoolean(22), reader.GetBoolean(23), reader.GetBoolean(24), reader.GetBoolean(25), reader.GetBoolean(26), reader.GetBoolean(27), reader.GetBoolean(28), reader.GetBoolean(29), reader.GetBoolean(30), reader.GetBoolean(31), reader.GetBoolean(32), reader.GetBoolean(33), reader.GetBoolean(34), reader.GetBoolean(35), reader.GetBoolean(36), reader.GetBoolean(37), reader.GetBoolean(38));
             }
 
             return null;
@@ -483,8 +484,20 @@ SELECT
     /// is unit-tested without a live store; any schema bump past the newest arm trips the pinning test that keeps
     /// this in step with <see cref="StorageVersion.SchemaVersion"/>.
     /// </summary>
-    internal static int MapProbedSchemaVersion(bool hasConfigControlPlane, bool hasAlertDeliveryOverride, bool hasAnalysisState, bool hasAlertTuningKnobs, bool hasDefaultTraceEvents, bool hasIndexObjectStatsLatestIndex, bool hasCollectionLogHypertableOrPlainPg, bool hasJobHistory, bool hasAgentStatus, bool hasGenericWebhook, bool hasDeadlocksDatabaseName, bool hasQueryStoreReplicaRole, bool hasLongQueryCompletions, bool hasWebDashboardConfig, bool hasCustomViews, bool hasServerTags, bool hasConnectionRefireKnobs = false, bool hasAgCollectors = false, bool hasAgAlertKnobs = false, bool hasAgLatencyColumns = false, bool hasAgDisconnectRefire = false, bool hasPayloadDimensions = false, bool hasDimFloorIndexes = false, bool hasBlockingWaitThreshold = false, bool hasQueryStoreIntervalIdentity = false, bool hasPagerDutyWebhook = false, bool hasPagerDutyProxy = false, bool hasCollectorState = false, bool hasPlanCorrection = false, bool hasPvsStats = false, bool hasPvsPressureKnobs = false, bool hasDatabaseStateAlert = false, bool hasServerTagColour = false, bool hasQueryStatsHostObject = false, bool hasFindingDrillDown = false, bool hasStoreMetrics = false, bool hasPlanDimGzip = false, bool hasSelfAlertKnobs = false)
+    internal static int MapProbedSchemaVersion(bool hasConfigControlPlane, bool hasAlertDeliveryOverride, bool hasAnalysisState, bool hasAlertTuningKnobs, bool hasDefaultTraceEvents, bool hasIndexObjectStatsLatestIndex, bool hasCollectionLogHypertableOrPlainPg, bool hasJobHistory, bool hasAgentStatus, bool hasGenericWebhook, bool hasDeadlocksDatabaseName, bool hasQueryStoreReplicaRole, bool hasLongQueryCompletions, bool hasWebDashboardConfig, bool hasCustomViews, bool hasServerTags, bool hasConnectionRefireKnobs = false, bool hasAgCollectors = false, bool hasAgAlertKnobs = false, bool hasAgLatencyColumns = false, bool hasAgDisconnectRefire = false, bool hasPayloadDimensions = false, bool hasDimFloorIndexes = false, bool hasBlockingWaitThreshold = false, bool hasQueryStoreIntervalIdentity = false, bool hasPagerDutyWebhook = false, bool hasPagerDutyProxy = false, bool hasCollectorState = false, bool hasPlanCorrection = false, bool hasPvsStats = false, bool hasPvsPressureKnobs = false, bool hasDatabaseStateAlert = false, bool hasServerTagColour = false, bool hasQueryStatsHostObject = false, bool hasFindingDrillDown = false, bool hasStoreMetrics = false, bool hasPlanDimGzip = false, bool hasSelfAlertKnobs = false, bool hasJobMetricsColumns = false)
     {
+        /* V56 (background-job self-metrics columns, #2136): column-existence sentinel, newest-first arm.
+           store_metrics.last_run_duration_ms exists only at V56 or later. The viewer never reads these
+           columns — they feed the service's own capacity series (job duration vs schedule cadence) over
+           MCP/REST — so like V53's rung nothing in the viewer would fail against a V55 store. The rung
+           exists so a fully-migrated store maps to exactly RequiredStoreSchemaVersion instead of capping
+           at 55 and tripping the connect-time gate against a healthy store. Under-reporting is the
+           guarded failure. */
+        if (hasJobMetricsColumns)
+        {
+            return 56;
+        }
+
         /* V55 (self-alert threshold knobs, #2107): column-existence sentinel, newest-first arm.
            config_alert_settings.self_disk_free_warn_percent exists only at V55 or later. The viewer
            NAMES the V55 columns in AlertSettingsSelectSql/Upsert, so against a V54 store the


### PR DESCRIPTION
The visibility half of #2136 (alerting is the next half).

## What

The hourly #2068 self-metrics sweep writes one row per TimescaleDB background job — `object_kind = 'background_job'`, with **last run duration, schedule interval, total runs, total failures** (V56: four nullable bigint columns, appended per the V55 ordinal rule). TimescaleDB-gated like the hypertable arm; plain-PG stores skip it silently.

## Why

The store's heaviest recurring work is its own job machinery: on the production 52-server store the four most expensive background jobs are all the `query_store_stats` family (compression **157s**, interval_hourly refresh **96s**), their runtimes scale **serially** with raw volume (the finalize hash-aggregate runs in one process — plan analysis in #2136), and a job that outgrows its own cadence compounds refresh lag silently. Storing the interval beside the duration makes 'how close is each job to its ceiling' one division over a 400-day series — the number an onboarding wave moves first.

## Ladder dance (the #2119/#2122 checklist)

- V56 migration (`store-metrics-background-jobs`), idempotent ALTERs, replay-safe.
- `StorageVersion.SchemaVersion` → 56.
- Viewer probe: `store_metrics.last_run_duration_ms` sentinel + newest-first V56 arm (the viewer never reads these columns — under-reporting to the connect gate is the guarded failure, like V53's rung) + reader ordinal 38.
- Every literal version pin visited (StoreSelfMetricsTests, DarlingObservabilityTests, PvsStatsStoreTests) and the all-sentinels tripwire extended.

## Tests

Beyond the pins (migration↔sweep column agreement, probe arm exact-56/caps-at-55, SQL shape): a **new end-to-end live sweep test** — scratch store, real migrations, real compression policies so real jobs exist, one `SweepAsync` run, then every object_kind asserted present including job rows carrying intervals. That's the drift-catcher for 'sweep writes a column the migrations didn't create', which no static pin can be — and this suite previously had no live execution at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)