### PR TITLE
#2136: gate + reset the cadence-warn Settings box (nightly wiring-test catch)

### DIFF
--- a/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml.cs
@@ -892,6 +892,7 @@ public partial class SettingsWindow : Window
         AlertSelfDiskWarnPercentBox.Text = "10";
         AlertCollectionStaleMinutesBox.Text = "30";
         AlertCollectionFailureThresholdBox.Text = "10";
+        AlertStoreJobCadenceWarnPercentBox.Text = "25";
         AnalysisNotifyCooldownBox.Text = "360";
         AlertPvsThresholdPercentBox.Text = "40";
         AlertPvsFloorGbBox.Text = "1";
@@ -1000,6 +1001,7 @@ public partial class SettingsWindow : Window
         AlertSelfDiskWarnPercentBox.IsEnabled = enabled;
         AlertCollectionStaleMinutesBox.IsEnabled = enabled;
         AlertCollectionFailureThresholdBox.IsEnabled = enabled;
+        AlertStoreJobCadenceWarnPercentBox.IsEnabled = enabled;
         AlertLongRunningJobCheckBox.IsEnabled = enabled;
         AlertLongRunningJobMultiplierBox.IsEnabled = enabled;
         AlertFailedJobCheckBox.IsEnabled = enabled;


### PR DESCRIPTION
The nightly's `AlertSettingsControlWiringTests` source-scan caught `AlertStoreJobCadenceWarnPercentBox` (added in #2141) loaded but absent from both `UpdateAlertControlStates` (unchecking Alerts Enabled left it editable) and `RestoreAlertDefaultsButton_Click` (Restore Defaults left a stale value). Both call sites added, matching its #2107 siblings — exactly the forgotten-call-site class that test exists to catch.

The same nightly run also failed `TimescaleSupportTests.EndToEnd_DetectConvertAndDropChunksPurge_AgainstDevPostgres` on a `40P01` deadlock between the retention purge's `drop_chunks` and a background job on the shared dev store (the DELETE fallback deadlocked too) — unrelated to #2140/#2141, flaky-shaped, will re-kick the nightly after this merges and file the test-hardening item separately.