### PR TITLE
Pin the container SDK image to the band global.json asks for

### DIFF
--- a/Darling/Dockerfile
+++ b/Darling/Dockerfile
@@ -13,7 +13,16 @@
 # Secrets never land in darling.json — use env:/file: references (#1804 stage 1), which are compose
 # `secrets:`-friendly.
 
-FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+# Pinned to the SDK feature band global.json asks for, NOT the floating :10.0 tag. global.json requests
+# 10.0.302 with rollForward "latestPatch", which rolls only inside the 3xx band — so the moment the floating
+# tag advanced to an SDK 10.0.400 image, every container build died with "A compatible .NET SDK was not
+# found ... Requested SDK version: 10.0.302 / Installed SDKs: 10.0.400" and a bare exit code 155. It broke
+# dev and both open PRs at once, and it broke on a Microsoft image refresh rather than on any commit here.
+#
+# The runner-side build never saw it because setup-dotnet resolves its SDK FROM global.json; only the
+# container had an independent opinion about which SDK to use. Pinning removes that second opinion: bump
+# this line and global.json together, deliberately, instead of being bumped by an upstream tag move.
+FROM mcr.microsoft.com/dotnet/sdk:10.0.302 AS build
 WORKDIR /src
 COPY . .
 RUN dotnet publish Darling/PerformanceMonitor.Darling.Service/PerformanceMonitor.Darling.Service.csproj \


### PR DESCRIPTION

Every container build started failing tonight, on dev and on both open PRs, without
any commit causing it. The Dockerfile built from the floating
mcr.microsoft.com/dotnet/sdk:10.0 tag; that tag advanced to an image shipping SDK
10.0.400, and global.json requests 10.0.302 with rollForward "latestPatch", which
rolls only inside the 3xx band. So the publish inside the container died with:

  A compatible .NET SDK was not found.
  Requested SDK version: 10.0.302
  global.json file: /src/global.json
  Installed SDKs: 10.0.400

surfacing as a bare "exit code: 155" with no compiler diagnostics at all, which is
what made it read like a code failure rather than an image drift.

The runner-side publish in the same job succeeded seconds earlier, because
setup-dotnet resolves its SDK FROM global.json (global-json-file: global.json).
Only the container held an independent opinion about which SDK to use, and that
opinion was supplied by whatever the upstream tag happened to point at that hour.

Pinning to 10.0.302 removes the second opinion: the container now uses exactly what
the repo asks for, and this line and global.json get bumped together, deliberately,
rather than one of them being bumped by a tag move at Microsoft.

The aspnet runtime stage stays on the floating :10.0 tag deliberately. global.json
gates the SDK only, runtime roll-forward is permissive by design, and pinning it
would mean tracking security patches by hand in a place nobody would remember to
look.

Confirmed repo-wide rather than assumed mine: PR #2194, an unrelated change from a
different work stream, fails the identical step the same way, and dev's own Linux
build passed at 18:22 and would fail on its next run.

## Blast radius

This unblocks **every** open PR, not just mine — #2194 and #2196 both fail on this step right now, and dev will fail on its next Linux build. Merging this first is the cheapest path to green for everything else.

## How was this tested?

Docker isn't available on this machine, and the failure is CI-only, so the verification is:

- The `10.0.302` SDK tag exists on MCR (manifest returns HTTP 200), and it matches `global.json` exactly rather than approximately.
- The diagnosis is confirmed by control rather than by reasoning alone: PR #2194 is an unrelated change and fails the identical step with the identical message, and the runner-side publish of the same csproj succeeded in the same job seconds before the container one failed.
- CI on this PR is the real proof — if the container build goes green here while #2194 is still red, that's the mechanism confirmed end to end.

## Note for whoever bumps .NET next

`global.json` and this `FROM` line are now coupled and must move together. That coupling is the point — the alternative is what just happened, where an upstream tag decided the repo's SDK version at 18:26 on a Tuesday.