### PR TITLE
Assert compression-job health from the settled snapshot (#2206)

### DIFF
--- a/Darling/Darling.Tests/TimescaleSupportTests.cs
+++ b/Darling/Darling.Tests/TimescaleSupportTests.cs
@@ -1570,6 +1570,11 @@ LIMIT 1", connection))
         var observed = await ReadObservedJobIdsAsync(connection, ct);
         Assert.Contains(jobId, observed);
 
+        /* Deliberately tautological, and kept for what it documents rather than what it can catch: `healthy` is
+           the snapshot the wait already found clean, so this cannot fail today. It states the property leg (1)
+           exists to assert, at the place a reader looks for it, and it fails loudly if the helper is ever
+           changed to return something other than the satisfying poll's own result. The load-bearing check is
+           the wait's bounded loop, which fails carrying the detector's reason string. */
         Assert.DoesNotContain(healthy, s => s.JobId == jobId);
 
         /* (2) The #1586 REGRESSION GUARD: the production re-arm runs the real alter_job against TimescaleDB and

--- a/Darling/Darling.Tests/TimescaleSupportTests.cs
+++ b/Darling/Darling.Tests/TimescaleSupportTests.cs
@@ -1538,24 +1538,38 @@ LIMIT 1", connection))
            CORRECT to flag -infinity — so asserting immediately after ApplyCompressionPolicy raced that window
            and intermittently false-failed on a slow CI runner. Deterministically settle the job into the
            healthy state the assertion is actually about: give it a real FUTURE next_start (via the same
-           alter_job the self-heal uses), then wait for the catalog to reflect a non-(-infinity) next_start. */
+           alter_job the self-heal uses), then wait for the detector itself to report it healthy.
+
+           The wait's RESULT is what the assertion below reads, and that is the whole point rather than a
+           convenience: a wait that only proves "healthy at some instant", followed by a fresh read, asserts
+           against a DIFFERENT observation than the one it validated, and the job can leave the healthy state
+           in the gap between them (the scheduler picking it up reads next_start = -infinity with status
+           Running mid-run — see leg 3). That gap is this test's third flake in the same class, after #1760
+           polled a copy of one detector arm and after the wait was introduced to close it; it survived
+           because the helper's guarantee stops at the moment it returns. Consuming the returned snapshot
+           makes settled-according-to-the-wait and settled-according-to-the-assertion the same observation
+           by construction, which is what the helper's contract claimed all along. */
         using (var arm = new NpgsqlCommand("SELECT alter_job($1::integer, next_start => now() + interval '1 hour')", connection))
         {
             arm.Parameters.Add(new NpgsqlParameter { Value = jobId });
             await arm.ExecuteNonQueryAsync(ct);
         }
-        await WaitUntilDetectorReportsHealthyAsync(connection, jobId, ct);
+        var healthy = await WaitUntilDetectorReportsHealthyAsync(connection, jobId, ct);
 
         /* The SQL really is valid against the live catalog, and this job really is in its result set.
            ReadStuckCompressionJobsAsync is failure-isolated (a broken query is swallowed and returns an EMPTY
            list), so DoesNotContain ALONE would pass just as happily against SQL that never compiled — the one
            thing this leg claims to prove. Run the production const directly, where a syntax or column error
            throws, and require the job to be present: only then does "not flagged" mean the detector looked at
-           this job and judged it healthy. */
+           this job and judged it healthy.
+
+           This one keeps its OWN read, which is safe where the health assertion is not: StuckCompressionJobsSql
+           filters on proc_name alone, so it returns every compression job whatever state it is in, and "this job
+           is in the result set" cannot race. Flagging is the C# predicate applied on top of those rows, and that
+           is the only part that moves. */
         var observed = await ReadObservedJobIdsAsync(connection, ct);
         Assert.Contains(jobId, observed);
 
-        var healthy = await TimescaleSupport.ReadStuckCompressionJobsAsync(connection, DateTime.UtcNow, null, ct);
         Assert.DoesNotContain(healthy, s => s.JobId == jobId);
 
         /* (2) The #1586 REGRESSION GUARD: the production re-arm runs the real alter_job against TimescaleDB and
@@ -1593,8 +1607,15 @@ LIMIT 1", connection))
     /// drift, so settled-according-to-the-wait IS settled-according-to-the-assertion. Bounded, and it fails
     /// loudly carrying the detector's OWN reason string — a job that never settles is genuinely stuck and must
     /// not silently pass, and the reason names which arm held it rather than assuming <c>next_start</c>.</para>
+    ///
+    /// <para>RETURNS the flagged list from the poll that satisfied it, and callers must assert against THAT
+    /// rather than issuing a fresh read. The guarantee above holds only at the instant this returns: the
+    /// scheduler is free to pick the job up immediately afterward, and mid-run it reads
+    /// <c>next_start = -infinity</c> with status Running, which the detector flags and is right to flag. A
+    /// caller that re-queries is therefore asserting on an observation this method never validated — which is
+    /// exactly how the race came back after being closed once.</para>
     /// </summary>
-    private static async Task WaitUntilDetectorReportsHealthyAsync(
+    private static async Task<IReadOnlyList<StuckCompressionJob>> WaitUntilDetectorReportsHealthyAsync(
         NpgsqlConnection connection, long jobId, System.Threading.CancellationToken ct)
     {
         var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
@@ -1604,7 +1625,7 @@ LIMIT 1", connection))
             var mine = flagged.FirstOrDefault(s => s.JobId == jobId);
             if (mine is null)
             {
-                return;
+                return flagged;
             }
 
             Assert.True(DateTime.UtcNow < deadline,


### PR DESCRIPTION
Fixes #2206.

## The failure

Tonight's nightly on dev ([run 31534394223](https://github.com/erikdarlingdata/PerformanceMonitor/actions/runs/31534394223)) went red on **one test out of 4,507**:

```
CompressionJobSelfHeal_DetectionQueryValid_AndRearmSucceeds_AgainstDevPostgres [FAIL]
  Assert.DoesNotContain() Failure: Filter matched in collection
  TimescaleSupportTests.cs:1559
```

Not a regression from the four merges since the last green nightly (#2202, #2194, #2204, #2195) — none of them touch Timescale or compression. I checked that before looking at the test.

## Why it raced

`WaitUntilDetectorReportsHealthyAsync` returns the moment one poll finds the job unflagged. Leg (1) then ran two more queries and asserted health from a **fresh read**, so the thing asserted was never the thing the wait validated. The test documents a state that lands squarely in that gap: from scheduler pickup to completion, `job_stats` reads `next_start = -infinity` with status Running — and the detector flags that, correctly.

The helper's doc comment claims "settled-according-to-the-wait IS settled-according-to-the-assertion." True for leg (3), which ends with the wait. Leg (1) broke it by re-reading.

## The fix

The helper returns the flagged list from the poll that satisfied it, and the assertion reads that snapshot. The two statements become the same observation by construction.

The observability assertion keeps its own read, and that one genuinely cannot race: `StuckCompressionJobsSql` filters on `proc_name` alone, so it returns every compression job whatever state it is in. Flagging is the C# predicate applied on top of those rows, and that is the only moving part. Keeping it as a separate read also preserves what it exists to prove — that the production SQL compiles and sees this job, so `DoesNotContain` can't pass vacuously against a query that was swallowed by the failure-isolated wrapper.

## Worth flagging for review

**This is the third fix in this class, so the pattern matters more than the patch.** #1760 polled `next_start <> '-infinity'` — one of the detector's two arms, and the very value the caller had just written, so it was satisfied on its first poll and waited for nothing. The follow-up replaced that with polling the detector, which made the first observation deterministic and left the second one racing. Both times the helper's guarantee stopped at the moment it returned and the caller reached past it. That's why the fix here is to make the guarantee *consumable* rather than to widen a window or add a retry: there is no longer an "after" for the caller to read.

I could not run this test locally to prove the fix — it is `net10.0-windows` and gated on `DARLING_TEST_PG`, so a live TimescaleDB fixture is required and CI is the only place it runs. What I verified locally is that `Darling.Tests` compiles clean. The real proof is this PR's `Darling PostgreSQL tests` check plus the next nightly, and I'll watch both.
