### PR TITLE
Pin the migration ladder dense above the historical V45 hole (#2226)

### DIFF
--- a/Darling/Darling.Tests/MigrationLadderPins.cs
+++ b/Darling/Darling.Tests/MigrationLadderPins.cs
@@ -58,11 +58,27 @@ public sealed class MigrationLadderPins
     {
         /* The replay math above only holds when versions are strictly increasing and unique — a
            duplicated or out-of-order version would let two rungs disagree about what "already ran"
-           means. Density is deliberately NOT pinned: the ladder has one historical gap (V45) and a
-           gap is harmless (the stamp comparison is >, not sequence arithmetic). Cheap to pin,
-           catastrophic to debug from a half-migrated field store. */
+           means. The historical V45 hole stays sanctioned (a gap NOBODY fills is harmless — the
+           stamp comparison is >, not sequence arithmetic); new gaps are the next pin's job. Cheap
+           to pin, catastrophic to debug from a half-migrated field store. */
         var versions = PgMigrations.Scripts.Select(m => m.Version).ToList();
         Assert.Equal(versions.OrderBy(v => v).ToList(), versions);
         Assert.Equal(versions.Count, versions.Distinct().Count());
+    }
+
+    [Fact]
+    public void TheLadder_IsDenseAboveTheHistoricalGap()
+    {
+        /* #2226: a NEW gap is a rung some other branch intends to fill later — and the applier
+           ascends with `version <= currentVersion ? skip`, so a rung filled AFTER a store stamped
+           past it is skipped silently and forever: its objects never exist, readers of them fail
+           permanently, and no upgrade can repair the store. That exact window nearly opened between
+           two in-flight branches (one at V61, one at V62 while dev's MAX was 60; nightlies ship
+           from dev, so the window is real). Density makes the hazard fail at AUTHORING time, in the
+           author's own test run: every branch must take max(dev)+1, and two branches that both do
+           so collide loudly at rebase instead of coexisting into a field incident. V45 is the one
+           sanctioned hole, vacant for many releases and filled by nobody. */
+        var above = PgMigrations.Scripts.Select(m => m.Version).Where(v => v > 45).OrderBy(v => v).ToList();
+        Assert.Equal(Enumerable.Range(above[0], above.Count).ToList(), above);
     }
 }


### PR DESCRIPTION
Closes #2226.

One new pin in `MigrationLadderPins`: every ladder version above the historical V45 hole must be contiguous. The applier ascends with `version <= currentVersion ? skip`, so a rung filled AFTER a store has stamped past it is skipped silently and forever — no error, no log, and no upgrade can repair the store. A collision is loud (rebase conflict, and the existing no-duplicates pin); a gap is quiet, and quiet is the one that surfaces in the field. This makes a gapped rung fail at authoring time in the author's own `dotnet test`, which converts the current merge-order coordination (a convention held together by PR-thread comments) into a build-time invariant: every branch takes max(dev)+1, re-verified at its own merge.

The sibling test's "density is deliberately NOT pinned" comment is updated to match — V45 stays sanctioned (a hole nobody fills is harmless), new gaps are this pin's job.

## Why now

The near-miss is live, and wider than #2226 knew: dev's MAX is 60, **#2211 and #2221 both carry V61 today** (qs-plan-fetch and incident-occurrence-counters — a duplicate the ordering pin will catch at whichever rebase happens second), #2224 carries V62, and #2213/#2225 carry V61-V68+. Whichever merge order actually happens, this pin plus the existing duplicate pin make every wrong outcome fail CI instead of shipping a stranded-store window through a nightly.

Effect on the in-flight PRs, stated plainly:

- **#2224 (V62, mine)** becomes mechanically gated: red until a V61 lands on dev, exactly matching the merge gate already written in its body. Endorsed — that gate should be CI, not prose.
- **#2211 / #2221 (both V61)**: first to merge keeps 61; the second renumbers at its own merge (the duplicate pin makes forgetting loud).
- **#2213 / #2225 (stacked)**: renumber to max(dev)+1.. at merge, as already agreed on the #2213 thread.

## Evidence

- On dev's ladder (46..60 dense above the hole): all three pins pass.
- Watched-red on the real hazard instance — the V62-carrying #2224 branch with no V61: the pin fails with `Expected: [..., 60, 61] / Actual: [..., 60, 62]` at the exact position. Restored after observing.
- Full-rebuild warning census unchanged: exactly the tracked pair (CA1068 x2, CA2022 x2).

Test-only change; no CHANGELOG entry per repo precedent for pin/infra commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
