### PR TITLE
Execution coverage for the blocking reader's ordinals (#2225 review follow-up)

### DIFF
--- a/Darling/Darling.Tests/DarlingPgBlockingReaderOrdinalTests.cs
+++ b/Darling/Darling.Tests/DarlingPgBlockingReaderOrdinalTests.cs
@@ -200,8 +200,11 @@ public sealed class DarlingPgBlockingReaderOrdinalTests
            which is the only reason it is not now a pin that lies. */
         sql = Regex.Replace(sql, @"/\*.*?\*/", string.Empty, RegexOptions.Singleline);
 
-        /* The final SELECT is the last line that is exactly "SELECT" — raw string literals dedent, so the
-           outer one sits at column 0 while every CTE-internal SELECT is indented. */
+        /* The final projection is the LAST bare "SELECT" line, and Last() is what makes that true — not
+           indentation. Trim() strips leading whitespace, so every CTE's own SELECT matches this predicate
+           too; the outer one wins only because it is textually last in the query. (An earlier version of
+           this comment claimed indentation was doing the work, which would have misled anyone reformatting
+           the query.) */
         var lines = sql.Split('\n');
         var start = Enumerable.Range(0, lines.Length).Last(i => lines[i].Trim() == "SELECT");
 

--- a/Darling/Darling.Tests/DarlingPgBlockingReaderOrdinalTests.cs
+++ b/Darling/Darling.Tests/DarlingPgBlockingReaderOrdinalTests.cs
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq;
+using System.Text.RegularExpressions;
+using PerformanceMonitor.Darling.Service.Mcp;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// EXECUTION coverage for the blocking reads' ordinal mapping, as opposed to the text pins in
+/// <see cref="DarlingPgBlockingReaderTests"/>.
+///
+/// <para><b>Why the text pins are not enough, which review had to point out.</b> Every other test on this
+/// reader asserts against the SQL STRING. The projection's column order and the mapper's
+/// <c>reader.GetX(n)</c> ordinals are two independent lists that must agree, and no string assertion can see
+/// a disagreement: swap <c>root_username</c> and <c>root_application_name</c> — adjacent, both
+/// <c>string?</c>, semantically confusable — and every <c>Assert.Contains</c> still passes while the data
+/// comes back transposed.</para>
+///
+/// <para>The same hazard already had a pin on the probe/mapper pair
+/// (<c>StoreSchemaProbe_ColumnCount_MatchesTheMapArity</c>) and on the collector side
+/// (<c>PgBlockingCollectorDefinitionTests.WritesEveryDeclaredPayloadColumn</c>). The reader side had none,
+/// and its projection was edited three times in one PR — a scalar became an array, a count became nullable,
+/// a flag was appended — so the risk was live, not theoretical.</para>
+///
+/// <para><b>Every sentinel is distinguishable</b>, which is the whole method: same-typed neighbours get
+/// different values, so a transposition changes an assertion rather than moving an identical value into an
+/// identical slot. Testing this at all required a seam — the read methods take an
+/// <c>NpgsqlDataSource</c> and build their own command — hence <c>MapChainRow</c>/<c>MapCycleRow</c>.</para>
+/// </summary>
+public sealed class DarlingPgBlockingReaderOrdinalTests
+{
+    [Fact]
+    public void MapChainRow_LandsEveryColumnInItsOwnField()
+    {
+        var reader = new StubReader(new object[]
+        {
+            new DateTime(2026, 8, 13, 9, 15, 0, DateTimeKind.Unspecified), //  0 captured_at
+            1_754_000_009_876_543L,                                        //  1 root_backend_id
+            9999,                                                          //  2 root_pid
+            new[] { "orders", "billing" },                                 //  3 databases
+            "root-user",                                                   //  4 root_username
+            "root-app",                                                    //  5 root_application_name
+            "idle in transaction",                                         //  6 root_state
+            "SELECT 'root query'",                                         //  7 root_query
+            true,                                                          //  8 root_is_idle_in_transaction
+            240_111L,                                                      //  9 root_xact_duration_ms
+            239_222L,                                                      // 10 root_query_duration_ms
+            7,                                                             // 11 total_victims
+            3,                                                             // 12 direct_victims
+            4,                                                             // 13 max_depth
+            8_444L,                                                        // 14 worst_victim_wait_ms
+            "UPDATE 'worst victim'",                                       // 15 worst_victim_query
+            5L,                                                            // 16 samples_as_root
+            true,                                                          // 17 query_text_may_be_truncated
+            false,                                                         // 18 chain_may_be_truncated
+        });
+
+        var row = DarlingPgBlockingReader.MapChainRow(reader);
+
+        Assert.Equal(new DateTime(2026, 8, 13, 9, 15, 0, DateTimeKind.Unspecified), row.CapturedAt);
+        Assert.Equal(1_754_000_009_876_543L, row.RootBackendId);
+        Assert.Equal(9999, row.RootPid);
+        Assert.Equal(new[] { "orders", "billing" }, row.Databases);
+
+        /* The transposition pair: distinct values, distinct fields. */
+        Assert.Equal("root-user", row.RootUsername);
+        Assert.Equal("root-app", row.RootApplicationName);
+
+        Assert.Equal("idle in transaction", row.RootState);
+        Assert.Equal("SELECT 'root query'", row.RootQuery);
+        Assert.True(row.RootIsIdleInTransaction);
+
+        /* Two adjacent bigints that differ, so swapping them fails. */
+        Assert.Equal(240_111L, row.RootXactDurationMs);
+        Assert.Equal(239_222L, row.RootQueryDurationMs);
+
+        /* Three adjacent ints that differ, likewise. */
+        Assert.Equal(7, row.TotalVictims);
+        Assert.Equal(3, row.DirectVictims);
+        Assert.Equal(4, row.MaxDepth);
+
+        Assert.Equal(8_444L, row.WorstVictimWaitMs);
+        Assert.Equal("UPDATE 'worst victim'", row.WorstVictimQuery);
+        Assert.Equal(5L, row.SamplesAsRoot);
+
+        /* The two booleans differ, so a swap is visible. */
+        Assert.True(row.QueryTextMayBeTruncated);
+        Assert.False(row.ChainMayBeTruncated);
+    }
+
+    /// <summary>
+    /// The nullable and sentinel semantics, at the ordinals that carry them: <c>samples_as_root</c> is NULL
+    /// when the root's own backend id did not resolve (recurrence genuinely unknown, distinct from "seen
+    /// once"), and the durations fall back to -1 rather than 0 because 0 reads as "started this instant".
+    /// </summary>
+    [Fact]
+    public void MapChainRow_PreservesNullRecurrenceAndTheDurationSentinels()
+    {
+        var reader = new StubReader(new object[]
+        {
+            new DateTime(2026, 8, 13, 9, 15, 0, DateTimeKind.Unspecified),
+            0L, 4242, Array.Empty<string>(),
+            DBNull.Value, DBNull.Value, DBNull.Value, DBNull.Value, false,
+            DBNull.Value, DBNull.Value,           // durations absent
+            1, 1, 1, DBNull.Value, DBNull.Value,
+            DBNull.Value,                          // samples_as_root: the vanished-blocker case
+            false, false,
+        });
+
+        var row = DarlingPgBlockingReader.MapChainRow(reader);
+
+        Assert.Null(row.SamplesAsRoot);
+        Assert.Equal(-1, row.RootXactDurationMs);
+        Assert.Equal(-1, row.RootQueryDurationMs);
+        Assert.Equal(-1, row.WorstVictimWaitMs);
+        Assert.Null(row.RootUsername);
+        Assert.Empty(row.Databases);
+    }
+
+    [Fact]
+    public void MapCycleRow_LandsEveryColumnInItsOwnField()
+    {
+        var reader = new StubReader(new object[]
+        {
+            new DateTime(2026, 8, 13, 9, 16, 0, DateTimeKind.Unspecified), // 0 captured_at
+            3,                                                             // 1 participant_count
+            new[] { 900, 901, 902 },                                       // 2 pids
+            "cycle-db",                                                    // 3 database_name
+            "cycle-app",                                                   // 4 application_name
+            2,                                                             // 5 blocked_behind_count
+            new[] { 910, 911 },                                            // 6 blocked_behind_pids
+        });
+
+        var row = DarlingPgBlockingReader.MapCycleRow(reader);
+
+        Assert.Equal(new DateTime(2026, 8, 13, 9, 16, 0, DateTimeKind.Unspecified), row.CapturedAt);
+
+        /* participant_count and blocked_behind_count are both int and both counts — the pair most likely to
+           be transposed, so they differ here (3 vs 2), as do their pid arrays. */
+        Assert.Equal(3, row.ParticipantCount);
+        Assert.Equal(new[] { 900, 901, 902 }, row.Pids);
+        Assert.Equal(2, row.BlockedBehindCount);
+        Assert.Equal(new[] { 910, 911 }, row.BlockedBehindPids);
+
+        Assert.Equal("cycle-db", row.DatabaseName);
+        Assert.Equal("cycle-app", row.ApplicationName);
+    }
+
+    /// <summary>A cycle with nothing queued behind it reports 0 and an empty array, never null.</summary>
+    [Fact]
+    public void MapCycleRow_ABareCycleReportsZeroBehind()
+    {
+        var reader = new StubReader(new object[]
+        {
+            new DateTime(2026, 8, 13, 9, 16, 0, DateTimeKind.Unspecified),
+            2, new[] { 200, 201 }, DBNull.Value, DBNull.Value, 0, Array.Empty<int>(),
+        });
+
+        var row = DarlingPgBlockingReader.MapCycleRow(reader);
+
+        Assert.Equal(0, row.BlockedBehindCount);
+        Assert.Empty(row.BlockedBehindPids);
+        Assert.Null(row.DatabaseName);
+    }
+
+    /// <summary>
+    /// The mapper arity must equal the projection's column count, so an appended column cannot be silently
+    /// ignored. Counted from the SQL by paren depth (the same technique
+    /// <c>StoreSchemaProbe_ColumnCount_MatchesTheMapArity</c> uses, for the same reason: nested parenthesised
+    /// expressions make token counting lie), and compared against the record's constructor arity, which is
+    /// what the mapper fills.
+    /// </summary>
+    [Theory]
+    [InlineData(nameof(DarlingPgBlockingReader.PgBlockingChainsSql))]
+    [InlineData(nameof(DarlingPgBlockingReader.PgBlockingCyclesSql))]
+    public void MapperArity_MatchesTheProjectionColumnCount(string sqlName)
+    {
+        var sql = sqlName == nameof(DarlingPgBlockingReader.PgBlockingChainsSql)
+            ? DarlingPgBlockingReader.PgBlockingChainsSql
+            : DarlingPgBlockingReader.PgBlockingCyclesSql;
+        var recordType = sqlName == nameof(DarlingPgBlockingReader.PgBlockingChainsSql)
+            ? typeof(DarlingPgBlockingReader.PgBlockingChainRow)
+            : typeof(DarlingPgBlockingReader.PgBlockingCycleRow);
+
+        /* Strip SQL block comments FIRST. The projection carries explanatory comment blocks whose PROSE
+           contains commas at paren depth 0, and counting those as column separators over-reported the chains
+           projection by exactly 2 — caught by running this logic in a harness rather than leaving it to CI,
+           which is the only reason it is not now a pin that lies. */
+        sql = Regex.Replace(sql, @"/\*.*?\*/", string.Empty, RegexOptions.Singleline);
+
+        /* The final SELECT is the last line that is exactly "SELECT" — raw string literals dedent, so the
+           outer one sits at column 0 while every CTE-internal SELECT is indented. */
+        var lines = sql.Split('\n');
+        var start = Enumerable.Range(0, lines.Length).Last(i => lines[i].Trim() == "SELECT");
+
+        var columns = 1;
+        var depth = 0;
+        for (var i = start + 1; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            /* The projection ends at the first top-level FROM. */
+            if (depth == 0 && line.TrimStart().StartsWith("FROM ", StringComparison.Ordinal))
+            {
+                break;
+            }
+
+            foreach (var c in line)
+            {
+                if (c == '(') depth++;
+                else if (c == ')') depth--;
+                else if (c == ',' && depth == 0) columns++;
+            }
+        }
+
+        var arity = recordType.GetConstructors().Single().GetParameters().Length;
+        Assert.Equal(arity, columns);
+    }
+
+    /// <summary>
+    /// A minimal <see cref="DbDataReader"/> over one row of boxed values. Only the members the mappers use
+    /// are implemented; anything else throws, so a mapper that starts reading by NAME (which would defeat the
+    /// point of an ordinal test) fails loudly instead of quietly passing.
+    /// </summary>
+    private sealed class StubReader : DbDataReader
+    {
+        private readonly object[] _values;
+        private int _row = -1;
+
+        public StubReader(object[] values) => _values = values;
+
+        private object Raw(int ordinal) => _values[ordinal];
+
+        public override bool IsDBNull(int ordinal) => Raw(ordinal) is DBNull;
+        public override DateTime GetDateTime(int ordinal) => (DateTime)Raw(ordinal);
+        public override long GetInt64(int ordinal) => (long)Raw(ordinal);
+        public override int GetInt32(int ordinal) => (int)Raw(ordinal);
+        public override bool GetBoolean(int ordinal) => (bool)Raw(ordinal);
+        public override string GetString(int ordinal) => (string)Raw(ordinal);
+        public override T GetFieldValue<T>(int ordinal) => (T)Raw(ordinal);
+        public override object GetValue(int ordinal) => Raw(ordinal);
+        public override int FieldCount => _values.Length;
+        public override bool Read() => ++_row == 0;
+        public override bool HasRows => true;
+
+        public override int Depth => 0;
+        public override bool IsClosed => false;
+        public override int RecordsAffected => 0;
+        public override object this[int ordinal] => Raw(ordinal);
+        public override object this[string name] => throw new NotSupportedException("ordinal access only");
+        public override int GetOrdinal(string name) => throw new NotSupportedException("ordinal access only");
+        public override string GetName(int ordinal) => throw new NotSupportedException("ordinal access only");
+        public override bool NextResult() => false;
+        public override IEnumerator GetEnumerator() => throw new NotSupportedException();
+        public override int GetValues(object[] values) => throw new NotSupportedException();
+        public override string GetDataTypeName(int ordinal) => throw new NotSupportedException();
+        public override Type GetFieldType(int ordinal) => Raw(ordinal).GetType();
+        public override byte GetByte(int ordinal) => throw new NotSupportedException();
+        public override long GetBytes(int ordinal, long dataOffset, byte[]? buffer, int bufferOffset, int length) => throw new NotSupportedException();
+        public override char GetChar(int ordinal) => throw new NotSupportedException();
+        public override long GetChars(int ordinal, long dataOffset, char[]? buffer, int bufferOffset, int length) => throw new NotSupportedException();
+        public override decimal GetDecimal(int ordinal) => throw new NotSupportedException();
+        public override double GetDouble(int ordinal) => throw new NotSupportedException();
+        public override float GetFloat(int ordinal) => throw new NotSupportedException();
+        public override Guid GetGuid(int ordinal) => throw new NotSupportedException();
+        public override short GetInt16(int ordinal) => throw new NotSupportedException();
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingPgBlockingReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingPgBlockingReader.cs
@@ -319,25 +319,25 @@ public static class DarlingPgBlockingReader
         ArgumentNullException.ThrowIfNull(reader);
 
         return new PgBlockingChainRow(
-                reader.GetDateTime(0),
-                reader.IsDBNull(1) ? 0 : reader.GetInt64(1),
-                reader.IsDBNull(2) ? 0 : reader.GetInt32(2),
-                reader.IsDBNull(3) ? Array.Empty<string>() : reader.GetFieldValue<string[]>(3),
-                reader.IsDBNull(4) ? null : reader.GetString(4),
-                reader.IsDBNull(5) ? null : reader.GetString(5),
-                reader.IsDBNull(6) ? null : reader.GetString(6),
-                reader.IsDBNull(7) ? null : reader.GetString(7),
-                !reader.IsDBNull(8) && reader.GetBoolean(8),
-                reader.IsDBNull(9) ? -1 : reader.GetInt64(9),
-                reader.IsDBNull(10) ? -1 : reader.GetInt64(10),
-                reader.IsDBNull(11) ? 0 : reader.GetInt32(11),
-                reader.IsDBNull(12) ? 0 : reader.GetInt32(12),
-                reader.IsDBNull(13) ? 0 : reader.GetInt32(13),
-                reader.IsDBNull(14) ? -1 : reader.GetInt64(14),
-                reader.IsDBNull(15) ? null : reader.GetString(15),
-                reader.IsDBNull(16) ? null : reader.GetInt64(16),
-                !reader.IsDBNull(17) && reader.GetBoolean(17),
-                !reader.IsDBNull(18) && reader.GetBoolean(18));
+            reader.GetDateTime(0),
+            reader.IsDBNull(1) ? 0 : reader.GetInt64(1),
+            reader.IsDBNull(2) ? 0 : reader.GetInt32(2),
+            reader.IsDBNull(3) ? Array.Empty<string>() : reader.GetFieldValue<string[]>(3),
+            reader.IsDBNull(4) ? null : reader.GetString(4),
+            reader.IsDBNull(5) ? null : reader.GetString(5),
+            reader.IsDBNull(6) ? null : reader.GetString(6),
+            reader.IsDBNull(7) ? null : reader.GetString(7),
+            !reader.IsDBNull(8) && reader.GetBoolean(8),
+            reader.IsDBNull(9) ? -1 : reader.GetInt64(9),
+            reader.IsDBNull(10) ? -1 : reader.GetInt64(10),
+            reader.IsDBNull(11) ? 0 : reader.GetInt32(11),
+            reader.IsDBNull(12) ? 0 : reader.GetInt32(12),
+            reader.IsDBNull(13) ? 0 : reader.GetInt32(13),
+            reader.IsDBNull(14) ? -1 : reader.GetInt64(14),
+            reader.IsDBNull(15) ? null : reader.GetString(15),
+            reader.IsDBNull(16) ? null : reader.GetInt64(16),
+            !reader.IsDBNull(17) && reader.GetBoolean(17),
+            !reader.IsDBNull(18) && reader.GetBoolean(18));
     }
 
     public sealed record PgBlockingCycleRow(
@@ -541,13 +541,13 @@ public static class DarlingPgBlockingReader
         ArgumentNullException.ThrowIfNull(reader);
 
         return new PgBlockingCycleRow(
-                reader.GetDateTime(0),
-                reader.IsDBNull(1) ? 0 : reader.GetInt32(1),
-                reader.IsDBNull(2) ? Array.Empty<int>() : reader.GetFieldValue<int[]>(2),
-                reader.IsDBNull(3) ? null : reader.GetString(3),
-                reader.IsDBNull(4) ? null : reader.GetString(4),
-                reader.IsDBNull(5) ? 0 : reader.GetInt32(5),
-                reader.IsDBNull(6) ? Array.Empty<int>() : reader.GetFieldValue<int[]>(6));
+            reader.GetDateTime(0),
+            reader.IsDBNull(1) ? 0 : reader.GetInt32(1),
+            reader.IsDBNull(2) ? Array.Empty<int>() : reader.GetFieldValue<int[]>(2),
+            reader.IsDBNull(3) ? null : reader.GetString(3),
+            reader.IsDBNull(4) ? null : reader.GetString(4),
+            reader.IsDBNull(5) ? 0 : reader.GetInt32(5),
+            reader.IsDBNull(6) ? Array.Empty<int>() : reader.GetFieldValue<int[]>(6));
     }
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingPgBlockingReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingPgBlockingReader.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql;
@@ -292,7 +293,32 @@ public static class DarlingPgBlockingReader
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
         {
-            rows.Add(new PgBlockingChainRow(
+            rows.Add(MapChainRow(reader));
+        }
+
+        return rows;
+    }
+
+    /// <summary>
+    /// Maps one chain row by ORDINAL, extracted so it can be tested against a fake reader.
+    ///
+    /// <para>Everything else about this read is pinned by asserting on the SQL TEXT, which cannot see the one
+    /// defect that matters here: the projection's column order and this method's ordinals are two lists that
+    /// must agree, and nothing makes them. Reordering <c>root_username</c> and <c>root_application_name</c> —
+    /// both <c>string?</c>, adjacent, and semantically confusable — would silently transpose them and every
+    /// text assertion would still pass. The same hazard on the probe/mapper pair got its own pin
+    /// (<c>StoreSchemaProbe_ColumnCount_MatchesTheMapArity</c>) and on the collector side too
+    /// (<c>WritesEveryDeclaredPayloadColumn</c>); the reader side had none, which review caught.</para>
+    ///
+    /// <para>The projection was edited three times while this PR was open — <c>databases</c> replaced a
+    /// scalar, <c>samples_as_root</c> became nullable, <c>chain_may_be_truncated</c> was appended — so the
+    /// risk was live rather than hypothetical.</para>
+    /// </summary>
+    internal static PgBlockingChainRow MapChainRow(DbDataReader reader)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+
+        return new PgBlockingChainRow(
                 reader.GetDateTime(0),
                 reader.IsDBNull(1) ? 0 : reader.GetInt64(1),
                 reader.IsDBNull(2) ? 0 : reader.GetInt32(2),
@@ -311,10 +337,7 @@ public static class DarlingPgBlockingReader
                 reader.IsDBNull(15) ? null : reader.GetString(15),
                 reader.IsDBNull(16) ? null : reader.GetInt64(16),
                 !reader.IsDBNull(17) && reader.GetBoolean(17),
-                !reader.IsDBNull(18) && reader.GetBoolean(18)));
-        }
-
-        return rows;
+                !reader.IsDBNull(18) && reader.GetBoolean(18));
     }
 
     public sealed record PgBlockingCycleRow(
@@ -506,17 +529,25 @@ public static class DarlingPgBlockingReader
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
         {
-            rows.Add(new PgBlockingCycleRow(
+            rows.Add(MapCycleRow(reader));
+        }
+
+        return rows;
+    }
+
+    /// <summary>Maps one cycle row by ORDINAL — same seam, same reason, see <see cref="MapChainRow"/>.</summary>
+    internal static PgBlockingCycleRow MapCycleRow(DbDataReader reader)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+
+        return new PgBlockingCycleRow(
                 reader.GetDateTime(0),
                 reader.IsDBNull(1) ? 0 : reader.GetInt32(1),
                 reader.IsDBNull(2) ? Array.Empty<int>() : reader.GetFieldValue<int[]>(2),
                 reader.IsDBNull(3) ? null : reader.GetString(3),
                 reader.IsDBNull(4) ? null : reader.GetString(4),
                 reader.IsDBNull(5) ? 0 : reader.GetInt32(5),
-                reader.IsDBNull(6) ? Array.Empty<int>() : reader.GetFieldValue<int[]>(6)));
-        }
-
-        return rows;
+                reader.IsDBNull(6) ? Array.Empty<int>() : reader.GetFieldValue<int[]>(6));
     }
 
     /// <summary>


### PR DESCRIPTION
Follow-up to a review comment on #2225 that **landed after I last checked and before I merged** — 07:38Z comment, 07:20Z check, 08:10Z merge. My process error; the finding is correct.

## The gap

Every other test on `DarlingPgBlockingReader` asserts against the SQL **string**. The projection's column order and the mapper's `reader.GetX(n)` ordinals are two independent lists that must agree, and no string assertion can see a disagreement — swap `root_username` and `root_application_name` (adjacent, both `string?`, semantically confusable) and every `Assert.Contains` still passes while the data comes back transposed.

That hazard already had a pin on the probe/mapper pair (`StoreSchemaProbe_ColumnCount_MatchesTheMapArity`) and on the collector side (`WritesEveryDeclaredPayloadColumn`). The reader side had none.

**The risk was live, not hypothetical.** That projection was edited three times while #2225 was open: a scalar became an array (`databases`), a count became nullable (`samples_as_root`), a flag was appended (`chain_may_be_truncated`). I checked the current alignment by hand — it is correct. There was no bug, only no guard.

## Why no such test existed

The read methods take an `NpgsqlDataSource` and build their own command, so there was no seam to inject a fake reader. Extracted `MapChainRow`/`MapCycleRow` taking a `DbDataReader`, mirroring the collector's already-testable `ReadAsync(DbDataReader, ...)`.

## Method

Every sentinel is **distinguishable** — same-typed neighbours get different values — so a transposition changes an assertion rather than moving an identical value into an identical slot. Adjacent pairs deliberately differ: two `bigint` durations (240111 / 239222), three `int` counts (7 / 3 / 4), two `bool` flags (true / false), and on the cycles side `participant_count` vs `blocked_behind_count` with different pid arrays.

**Proven to have teeth**: transposing ordinals 4 and 5 in the mapper fails exactly two assertions; reverting restores all-pass.

Also pins mapper arity == projection column count for both queries, so an appended column cannot be silently unread.

## Two bugs in my own test, both caught by a harness rather than by CI

`Darling.Tests` can't execute on macOS, so I ran the test bodies verbatim in a throwaway `net10.0` harness:

1. **The arity check counted 21 against a 19-arity record** — the projection's comment *prose* contains commas at paren depth 0. Now strips SQL comments first. Left alone this would have shipped as a pin that lies.
2. **My explanation of that fix wrote a literal `*/` inside a block comment.** C# doesn't nest them, so the comment terminated early and the remaining prose became code — a hard build break in the shipped test file.

Neither would have been caught by reading it.

## Verification

Full solution builds 0 errors; harness ALL PASS (19/19 chains, 7/7 cycles, every ordinal and sentinel assertion); teeth proven by deliberate transposition.

Related: #2229 is the CI issue about reviews that post nothing — worth noting all 15 `claude[bot]` reviews on #2225 had **empty bodies**, with every finding in inline comments only. Any automated "did the review post anything" check has to count inline comments or it will report false negatives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)