### PR TITLE
Lite's query_store prune names the retired keys, like Darling's (#2205)

### DIFF
--- a/Lite.Tests/QueryStoreStatePruneTests.cs
+++ b/Lite.Tests/QueryStoreStatePruneTests.cs
@@ -7,9 +7,11 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using DuckDB.NET.Data;
+using Microsoft.Extensions.Logging;
 using PerformanceMonitor.Collectors;
 using PerformanceMonitorLite.Database;
 using PerformanceMonitorLite.Services;
@@ -64,11 +66,30 @@ public sealed class QueryStoreStatePruneTests : IClassFixture<SharedDuckDbFixtur
     public void Dispose() => _seedConn?.Dispose();
 
     /// <summary>Exposes the runner's protected prune and state accessors; only <c>_duckDb</c> is exercised.</summary>
-    private sealed class Pruner(DuckDbInitializer duckDb)
-        : RemoteCollectorService(duckDb, serverManager: null!, scheduleManager: null!)
+    private sealed class Pruner(DuckDbInitializer duckDb, ILogger<RemoteCollectorService>? logger = null)
+        : RemoteCollectorService(duckDb, serverManager: null!, scheduleManager: null!, logger)
     {
         public Task PruneAsync(int serverId) =>
             PruneOrphanedQueryStoreDatabaseStateAsync(serverId, CancellationToken.None);
+    }
+
+    /// <summary>
+    /// Captures formatted log lines so the prune's DIAGNOSTIC can be asserted, not just its effect.
+    /// <para>#2205: correctness already matched Darling exactly, and the gap was forensic — Lite logged a
+    /// COUNT where Darling names the retired keys, so on Lite you could see that three rows went without
+    /// seeing WHICH databases' watermark and backfill state was retired. A count cannot be told apart from
+    /// a mistaken prune of the same size, which is the case an operator most needs to see.</para>
+    /// </summary>
+    private sealed class CapturingLogger : ILogger<RemoteCollectorService>
+    {
+        public List<string> Lines { get; } = new();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter) => Lines.Add(formatter(state, exception));
     }
 
     private static string Done(string database) => QueryStoreBackfillState.DoneKeyPrefix + database;
@@ -282,5 +303,41 @@ VALUES ($1, $2, $3, $4, $5)";
         cmd.CommandText = "SELECT COUNT(*) FROM collector_state WHERE server_id = $1";
         cmd.Parameters.Add(new DuckDBParameter { Value = serverId });
         return Convert.ToInt64(await cmd.ExecuteScalarAsync(), System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
+    /// #2205: the log line must NAME the pruned keys, matching Darling's wording field for field.
+    ///
+    /// <para>Watched red before it went green: with the previous <c>ExecuteNonQueryAsync</c> +
+    /// counter, the message read "Pruned 2 query_store state row(s)…" and contained neither key, so both
+    /// key assertions failed while the row-level assertions passed — which is exactly the shape of the
+    /// defect. The <c>DELETE … RETURNING</c> it now depends on was verified against real DuckDB 1.5.5
+    /// before the change, using the shipped SQL string rather than a copy.</para>
+    /// </summary>
+    [Fact]
+    public async Task Prune_LogNamesTheRetiredKeys_NotJustACount()
+    {
+        var logger = new CapturingLogger();
+        var pruner = new Pruner(_duckDb, logger);
+
+        await SeedSnapshotAsync(Newest, "Live");
+        await SeedStateAsync(ServerId, QueryStoreBackfillState.StateCollectorName, Done("Live"), "2026-08-11T09:00:00Z");
+        await SeedStateAsync(ServerId, QueryStoreBackfillState.StateCollectorName, Done("DroppedOne"), "2026-08-11T09:00:00Z");
+        await SeedStateAsync(ServerId, QueryStoreBackfillState.StateCollectorName, Hole("DroppedTwo"), EncodedHole());
+
+        await pruner.PruneAsync(ServerId);
+
+        var line = Assert.Single(logger.Lines, l => l.Contains("pruned", StringComparison.OrdinalIgnoreCase));
+
+        /* The keys themselves — the whole point of the change. */
+        Assert.Contains(Done("DroppedOne"), line, StringComparison.Ordinal);
+        Assert.Contains(Hole("DroppedTwo"), line, StringComparison.Ordinal);
+
+        /* And it must not name a database that was NOT pruned, or the log is worse than a count. */
+        Assert.DoesNotContain("Live", line, StringComparison.Ordinal);
+
+        /* Same fields as DarlingCollectorRunner's line, so one sentence serves both SKUs. */
+        Assert.Contains($"[server_id {ServerId}]", line, StringComparison.Ordinal);
+        Assert.Contains("2 query_store state row(s)", line, StringComparison.Ordinal);
     }
 }

--- a/Lite/Services/RemoteCollectorService.QueryStoreBackfill.cs
+++ b/Lite/Services/RemoteCollectorService.QueryStoreBackfill.cs
@@ -552,7 +552,8 @@ AND   NOT EXISTS
           WHERE ds.server_id = $1
           AND   ds.collection_time = (SELECT MAX(collection_time) FROM database_states WHERE server_id = $1)
           AND   collector_state.state_key = $3 || ds.database_name
-      )";
+      )
+RETURNING state_key";
 
     /// <summary>
     /// Runs <see cref="PruneOrphanedDatabaseStateKeysSql"/> for every shared owner/prefix pair, once per
@@ -565,7 +566,7 @@ AND   NOT EXISTS
         {
             using var conn = _duckDb.CreateConnection();
             await conn.OpenAsync(cancellationToken);
-            var pruned = 0;
+            var pruned = new List<string>();
 
             foreach (var (owner, prefix) in QueryStorePerDatabaseState.PrunableKeys)
             {
@@ -574,14 +575,26 @@ AND   NOT EXISTS
                 cmd.Parameters.Add(new DuckDB.NET.Data.DuckDBParameter { Value = serverId });
                 cmd.Parameters.Add(new DuckDB.NET.Data.DuckDBParameter { Value = owner });
                 cmd.Parameters.Add(new DuckDB.NET.Data.DuckDBParameter { Value = prefix });
-                pruned += await cmd.ExecuteNonQueryAsync(cancellationToken);
+
+                /* RETURNING and a reader, not a rows-affected count (#2205). The only symptom of a WRONG
+                   delete here is a silent refetch, so a bare number leaves nothing to diagnose it with — on
+                   Lite you could see that three rows went without seeing WHICH databases' watermark and
+                   backfill state was retired. Correctness already matched Darling exactly (same anti-join,
+                   same freshness guard, pinned by the #2195 tests); this closes the FORENSICS gap. */
+                using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+                while (await reader.ReadAsync(cancellationToken))
+                {
+                    pruned.Add(reader.GetString(0));
+                }
             }
 
-            if (pruned > 0)
+            if (pruned.Count > 0)
             {
+                /* Same shape and same fields as DarlingCollectorRunner's, so an operator reading either
+                   SKU's log sees the same sentence. */
                 _logger?.LogInformation(
-                    "Pruned {Count} query_store state row(s) for database(s) no longer on server {ServerId}",
-                    pruned, serverId);
+                    "[server_id {ServerId}] pruned {Count} query_store state row(s) for database(s) no longer on the server: {Keys}",
+                    serverId, pruned.Count, string.Join(", ", pruned));
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
Closes #2205.

Darling's prune uses `DELETE … RETURNING s.state_key` and logs the retired keys; Lite's DuckDB twin summed `ExecuteNonQueryAsync` into a count. Correctness was already identical — same anti-join, same freshness guard, pinned by the #2195 tests — so this is purely forensic.

**Why the forensics matter here specifically.** The symptom of a *wrong* delete on this path is a silent refetch, which leaves nothing else to diagnose it with. A count cannot be distinguished from a mistaken prune of the same size, and on Lite you could see that three rows went without seeing which databases' watermark and backfill state went with them.

The log line is now Darling's word for word, so one sentence serves both SKUs:

```
[server_id 21880] pruned 2 query_store state row(s) for database(s) no longer on the server: done:DroppedOne, hole:DroppedTwo
```

## Verified the premise before relying on it

The whole change rests on DuckDB supporting `DELETE … RETURNING`, which the issue asserts. I ran the **shipped SQL constant** — extracted from the source file with a regex rather than retyped — against **real DuckDB 1.5.5** on a synthetic `collector_state` / `database_states` pair:

```
extracted SQL ends with: RETURNING state_key
PASS  DELETE ... RETURNING is supported by DuckDB and yields rows  (qs_wm_dropped_a, qs_wm_dropped_b)
PASS  it names exactly the two orphans
PASS  kept / fresh / other-server all survive
```

So `RETURNING` works, it names only the orphans, and the freshness guard still spares the row newer than the snapshot as well as the neighbouring server's row.

Side finding worth recording: `DuckDB.NET.Data` alone ships **no native library** — a harness needs `DuckDB.NET.Data.Full`, or `Open()` dies in `dlopen` looking for `libduckdb`.

## Test

`Prune_LogNamesTheRetiredKeys_NotJustACount`, in the existing real-DuckDB class. **Watched red before green:** with the old counter the message read `"Pruned 2 query_store state row(s)…"` and contained neither key, so both key assertions failed while the row-level ones passed — precisely the shape of the defect.

It also asserts the line does **not** name a database that survived, because a log naming the wrong keys is worse than a count. The `Pruner` test double now takes an `ILogger` so the diagnostic itself is asserted rather than just its effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)