### PR TITLE
Clear the baseline analyzer warnings so a zero-warning gate is readable (#2193)

### DIFF
--- a/Darling/Darling.Tests/NpgsqlRootCertificateValidationTests.cs
+++ b/Darling/Darling.Tests/NpgsqlRootCertificateValidationTests.cs
@@ -130,9 +130,19 @@ public sealed class NpgsqlRootCertificateValidationTests
             handshakeCompleted = true;
 
             /* Past the handshake the client sends its startup message; just swallow a little and
-               close — the failure Npgsql then reports is a protocol error, not a certificate one. */
+               close — the failure Npgsql then reports is a protocol error, not a certificate one.
+
+               CA2022 (inexact read) is suppressed rather than "fixed", because the fix it asks for would
+               break this. The byte COUNT is deliberately meaningless here: the read exists only to let the
+               client finish its startup write before the server drops the connection, and any number of
+               bytes serves that. ReadExactlyAsync — the usual remedy, and the one #2193 suggested — would
+               block until a full 256 bytes arrived, which this client never sends, hanging the test until
+               its timeout. The warning is right that the result is unused; it is wrong that this code
+               depends on a complete read. */
             var scratch = new byte[256];
+#pragma warning disable CA2022 // Avoid inexact read: any count satisfies this drain, see above.
             try { await ssl.ReadAsync(scratch, cts.Token); } catch { /* client may bail first */ }
+#pragma warning restore CA2022
         }, cts.Token);
 
         var builder = new NpgsqlConnectionStringBuilder

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -1908,10 +1908,11 @@ public sealed class DarlingWorker : BackgroundService
                 var step = _backfillSliceSteps.GetOrAdd(runtime.ServerId, static _ => new AbandonableStep());
                 var result = await step.RunAsync(
                     () => backfill.RunServerSliceAsync(runtime, stoppingToken),
-                    BackfillSliceDeadline, stoppingToken,
+                    BackfillSliceDeadline,
                     onLateFault: ex => _logger.LogError(ex,
                         "query_store backfill slice on '{Server}' faulted AFTER being abandoned — this is the wedge's own exception (#2148)",
-                        runtime.Config.DisplayName));
+                        runtime.Config.DisplayName),
+                    cancellationToken: stoppingToken);
 
                 switch (result.Outcome)
                 {

--- a/Lite.Tests/AbandonableStepTests.cs
+++ b/Lite.Tests/AbandonableStepTests.cs
@@ -213,7 +213,7 @@ public sealed class AbandonableStepTests
         using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
         var wedge = new TaskCompletionSource();
 
-        var result = await step.RunAsync(() => wedge.Task, Generous, cts.Token);
+        var result = await step.RunAsync(() => wedge.Task, Generous, cancellationToken: cts.Token);
 
         Assert.Equal(AbandonableStepOutcome.Cancelled, result.Outcome);
 

--- a/Lite.Tests/AgAlertEvaluatorTests.cs
+++ b/Lite.Tests/AgAlertEvaluatorTests.cs
@@ -143,15 +143,16 @@ public class AgAlertEvaluatorTests
         Assert.Contains(item.Fields, f => f.Label == "Replica");
         Assert.Contains(("Suspend Reason", "SUSPEND_FROM_USER"), item.Fields);
 
-        var behind = Assert.Single(e.EvaluateDatabases(
-            ServerId, new[] { Database(suspended: false, lagSeconds: 600) }, 300, 0, Cooldown)
-            .Where(a => a.MetricName == AgAlertPolicy.SyncFellBehindMetric));
+        var behind = Assert.Single(
+            e.EvaluateDatabases(
+                ServerId, new[] { Database(suspended: false, lagSeconds: 600) }, 300, 0, Cooldown),
+            a => a.MetricName == AgAlertPolicy.SyncFellBehindMetric);
         Assert.Contains(Assert.Single(behind.Context!.Details).Fields, f => f.Label == "Database");
 
         /* Resolutions stay context-less — they carry no database-scoped payload to route on. */
-        var resumed = Assert.Single(e.EvaluateDatabases(
-            ServerId, new[] { Database(suspended: false) }, 300, 0, Cooldown)
-            .Where(a => a.IsResolution));
+        var resumed = Assert.Single(
+            e.EvaluateDatabases(ServerId, new[] { Database(suspended: false) }, 300, 0, Cooldown),
+            a => a.IsResolution);
         Assert.Null(resumed.Context);
     }
 

--- a/Lite.Tests/LiteServerTagsStoreTests.cs
+++ b/Lite.Tests/LiteServerTagsStoreTests.cs
@@ -92,10 +92,10 @@ public sealed class LiteServerTagsStoreTests : IClassFixture<SharedDuckDbFixture
         Assert.Equal(2, assigned.Count(a => a.TagId == tag));
 
         await _service.UnassignServerTagAsync(new[] { 100 }, tag);
-        Assert.Single((await _service.GetServerTagAssignmentsAsync()).Where(a => a.TagId == tag));
+        Assert.Single(await _service.GetServerTagAssignmentsAsync(), a => a.TagId == tag);
 
         await _service.ClearServerTagsForServerAsync(200);
-        Assert.Empty((await _service.GetServerTagAssignmentsAsync()).Where(a => a.TagId == tag));
+        Assert.DoesNotContain(await _service.GetServerTagAssignmentsAsync(), a => a.TagId == tag);
     }
 
     [Fact]

--- a/Lite/Services/CollectionBackgroundService.cs
+++ b/Lite/Services/CollectionBackgroundService.cs
@@ -130,9 +130,10 @@ public class CollectionBackgroundService : BackgroundService
                        refresh that never returns, a network path that swallows packets) must not stop
                        every server's collection. */
                     var check = await _connectionCheckStep.RunAsync(
-                        () => _serverManager.CheckAllConnectionsAsync(), ConnectionCheckDeadline, stoppingToken,
+                        () => _serverManager.CheckAllConnectionsAsync(), ConnectionCheckDeadline,
                         onLateFault: ex => _logger?.LogError(ex,
-                            "Connection check faulted AFTER being abandoned — this is the wedge's own exception (#2148)"));
+                            "Connection check faulted AFTER being abandoned — this is the wedge's own exception (#2148)"),
+                        cancellationToken: stoppingToken);
                     LogStepOutcome(check, "Connection check", ConnectionCheckDeadline);
                 }
 

--- a/Lite/Services/LocalDataService.cs
+++ b/Lite/Services/LocalDataService.cs
@@ -76,7 +76,7 @@ public partial class LocalDataService
     /// <summary>
     /// Safely converts a DuckDB value to double, handling BigInteger from SUM aggregations.
     /// </summary>
-    protected static double ToDouble(object value)
+    private static double ToDouble(object value)
     {
         if (value is BigInteger bi)
             return (double)bi;
@@ -86,7 +86,7 @@ public partial class LocalDataService
     /// <summary>
     /// Safely converts a DuckDB value to long, handling BigInteger from SUM/COUNT aggregations.
     /// </summary>
-    protected static long ToInt64(object value)
+    private static long ToInt64(object value)
     {
         if (value is BigInteger bi)
             return (long)bi;
@@ -98,7 +98,7 @@ public partial class LocalDataService
     /// Returns UTC time for collection_time queries (most tables store collection_time in UTC).
     /// When fromDate/toDate are provided, they should already be in UTC.
     /// </summary>
-    protected static (DateTime startTime, DateTime endTime) GetTimeRange(int hoursBack, DateTime? fromDate, DateTime? toDate)
+    private static (DateTime startTime, DateTime endTime) GetTimeRange(int hoursBack, DateTime? fromDate, DateTime? toDate)
     {
         if (fromDate.HasValue && toDate.HasValue)
         {
@@ -115,7 +115,7 @@ public partial class LocalDataService
     /// <summary>
     /// Gets the time range in server local time (for tables like cpu_utilization_stats.sample_time).
     /// </summary>
-    protected static (DateTime startTime, DateTime endTime) GetTimeRangeServerLocal(int hoursBack, DateTime? fromDate, DateTime? toDate)
+    private static (DateTime startTime, DateTime endTime) GetTimeRangeServerLocal(int hoursBack, DateTime? fromDate, DateTime? toDate)
     {
         var serverNow = DateTime.UtcNow.AddMinutes(ServerTimeHelper.UtcOffsetMinutes);
 
@@ -132,7 +132,7 @@ public partial class LocalDataService
     /// Starts query timing for performance logging. Use with 'using' statement.
     /// Only logs queries that exceed the slow query threshold (default 500ms).
     /// </summary>
-    protected static Helpers.QueryExecutionContext TimeQuery(string context, string sql)
+    private static Helpers.QueryExecutionContext TimeQuery(string context, string sql)
     {
         return Helpers.QueryLogger.StartQuery(context, sql, source: "DuckDB");
     }

--- a/Lite/Services/RemoteCollectorService.QueryStoreBackfill.cs
+++ b/Lite/Services/RemoteCollectorService.QueryStoreBackfill.cs
@@ -74,10 +74,11 @@ public partial class RemoteCollectorService
             var step = _backfillSliceSteps.GetOrAdd(server.Id, static _ => new AbandonableStep());
             var result = await step.RunAsync(
                 () => RunQueryStoreBackfillSliceAsync(server, cancellationToken),
-                BackfillSliceDeadline, cancellationToken,
+                BackfillSliceDeadline,
                 onLateFault: ex => _logger?.LogError(ex,
                     "query_store backfill slice on '{Server}' faulted AFTER being abandoned — this is the wedge's own exception (#2148)",
-                    server.DisplayName));
+                    server.DisplayName),
+                cancellationToken: cancellationToken);
 
             switch (result.Outcome)
             {

--- a/PerformanceMonitor.Common/AbandonableStep.cs
+++ b/PerformanceMonitor.Common/AbandonableStep.cs
@@ -72,9 +72,13 @@ public sealed class AbandonableStep
     /// decision and the abandonment flag can be missed (never doubled), which costs one log line, not
     /// correctness — the caller already logged the abandonment itself.
     /// </summary>
+    /// <para><b>Parameter order:</b> <paramref name="cancellationToken"/> is LAST, per CA1068. It was third
+    /// until #2193, which is the ordering the analyzer flags — and every call site already passed
+    /// <paramref name="onLateFault"/> by name, so the move cost nothing at the callers and the compiler
+    /// found all of them.</para>
     public async Task<AbandonableStepResult> RunAsync(
-        Func<Task> step, TimeSpan timeout, CancellationToken cancellationToken = default,
-        Action<Exception>? onLateFault = null)
+        Func<Task> step, TimeSpan timeout, Action<Exception>? onLateFault = null,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(step);
 


### PR DESCRIPTION
Closes #2193. **Solution now builds `0 Warning(s), 0 Error(s)`.**

Baseline before, reproduced on `dev` with `--no-incremental` (an incremental build hides them, which is worth knowing — my first check came back clean and wasn't):

| project | warnings |
|---|---|
| `Lite/PerformanceMonitorLite.csproj` | 22 |
| `Darling/Darling.Tests` | 2 |
| `Lite.Tests` | 4 |

## CS0628 ×20 — mechanical

Five members `protected` on a `sealed` type in `LocalDataService`, so the accessibility was dead. `protected` → `private`. Counted twice because the WPF temp csproj compiles the same file.

## CA1068 ×2 — smaller than the issue expected

`CancellationToken` moved last in `AbandonableStep.RunAsync`. The issue flagged this as a real signature decision touching both SKUs — it does touch both, but it cost nothing at the callers: **all three production sites already passed `onLateFault` by name**, so only the token needed naming. The compiler found every site (`CS1744` at exactly those three, plus one test), which is the completeness argument for reordering rather than grepping.

## CA2022 — suppressed, because the suggested fix would break the test

The issue proposes `ReadExactlyAsync` as "the usual answer". Here it would be wrong: `ReadExactlyAsync` blocks until the buffer is full, and this read **deliberately does not care how many bytes arrive** — it exists only to let the client finish its startup write before the server drops the connection. Waiting for a full 256 bytes the client never sends would hang the test to its timeout.

So the pragma stays, with the reasoning inline. The warning is right that the result is unused; it is wrong that this code depends on a complete read. That distinction is the one thing a future reader needs.

## Plus 4 the issue doesn't name

`xUnit2031` ×3 and `xUnit2029` in `AgAlertEvaluatorTests` / `LiteServerTagsStoreTests` — `Assert.Single`/`Assert.Empty` with a `Where` clause instead of the predicate overloads. Beyond the filed scope, but leaving them defeats the issue's stated objective ("a warning appearing in a PR build is unambiguously that PR's") — 4 warnings to read around is the same problem as 24. Behaviour is identical, and `Assert.Empty(...Where(...))` → `Assert.DoesNotContain` also produces a better failure message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)