### PR TITLE
#2193 follow-up: nest the para inside <summary>, drop a dead using

### DIFF
--- a/Lite.Tests/AgAlertEvaluatorTests.cs
+++ b/Lite.Tests/AgAlertEvaluatorTests.cs
@@ -8,7 +8,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using PerformanceMonitor.Common;
 using PerformanceMonitorLite.Services;
 using Xunit;

--- a/PerformanceMonitor.Common/AbandonableStep.cs
+++ b/PerformanceMonitor.Common/AbandonableStep.cs
@@ -71,11 +71,11 @@ public sealed class AbandonableStep
     /// awaited path did NOT already receive; a fault landing in the microseconds between the deadline
     /// decision and the abandonment flag can be missed (never doubled), which costs one log line, not
     /// correctness — the caller already logged the abandonment itself.
-    /// </summary>
     /// <para><b>Parameter order:</b> <paramref name="cancellationToken"/> is LAST, per CA1068. It was third
     /// until #2193, which is the ordering the analyzer flags — and every call site already passed
     /// <paramref name="onLateFault"/> by name, so the move cost nothing at the callers and the compiler
     /// found all of them.</para>
+    /// </summary>
     public async Task<AbandonableStepResult> RunAsync(
         Func<Task> step, TimeSpan timeout, Action<Exception>? onLateFault = null,
         CancellationToken cancellationToken = default)


### PR DESCRIPTION
Two review findings from #2238 that I merged past. The comment landed at 13:01 and I merged at 13:29 — I fetched its timestamp and merged in the same command without reading the body, which is my merge-time re-check rule followed in letter and missed in spirit. Both findings were correct.

1. **The `<para>` sat outside `</summary>`** in `AbandonableStep.cs` — a floating sibling element that doc tooling parents as an orphan rather than as part of the method's summary. This file's own class-level comment nests its `<para>` blocks *inside* `<summary>`, so it now matches the local convention instead of contradicting it two dozen lines away.

2. **`using System.Linq;` went dead** in `AgAlertEvaluatorTests` once the `Where` clauses were replaced by the predicate overloads. Verified rather than assumed — every remaining `Assert.Single` / `Assert.All` / `Assert.Contains` in that file is xUnit's own method, not LINQ. Given #2193's whole point was clearing exactly this class of leftover, leaving it would have been odd.

Solution still builds **`0 Warning(s), 0 Error(s)`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)