### PR TITLE
Catch review runs that post nothing, from outside the workflow they watch (#2229)

### DIFF
--- a/.github/workflows/claude-review-guard.yml
+++ b/.github/workflows/claude-review-guard.yml
@@ -34,6 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     # The review is capped at 30 minutes; leave room to observe one that uses all of it.
     timeout-minutes: 40
+    # No issues: scope here, despite the tally reading repos/.../issues/$PR/comments for
+    # top-level output. A pull request IS an issue to that API, and the PullRequests scope
+    # covers its comments: run 31726598542 was granted exactly Actions/Checks/Contents/
+    # Metadata/PullRequests read and counted issue: 1 from that endpoint without a 403.
     permissions:
       actions: read
       checks: read

--- a/.github/workflows/claude-review-guard.yml
+++ b/.github/workflows/claude-review-guard.yml
@@ -1,0 +1,177 @@
+name: Claude review guard
+
+# #2229: the review workflow can finish green and leave nothing an operator can read. Two ways,
+# both observed on this repo, both silent:
+#
+#   1. claude-code-action refuses to run when .github/workflows/claude-review.yml differs from the
+#      DEFAULT branch -- the check is server-side, during the OIDC token exchange. It exits SUCCESS
+#      in about four seconds and sets no output a caller can read.
+#   2. The review runs for real and posts nothing anyway. PR #2213 did this eleven times; one run
+#      spent $4.18 over 24 turns with 6 permission denials, reported subtype=success, and left zero
+#      comments. A 104-file change merged unreviewed and nothing anywhere said so.
+#
+# This guard is a SEPARATE workflow on purpose. Editing claude-review.yml makes this branch's copy
+# differ from the default branch, which triggers cause (1) for EVERY pull request in the repo until
+# the next release -- so a guard living inside the file it protects would disable review each time
+# it was touched. Nothing here invokes claude-code-action, so this file can be edited freely.
+#
+# It polls rather than using `on: workflow_run` because workflow_run only ever fires from the copy
+# of a workflow that is on the default branch: that variant would be dormant, and untestable, until
+# a release shipped it.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [dev, main]
+
+# Match the review's own cancel-in-progress behavior. A new push cancels the review it is watching,
+# so the guard has to go too, or it waits out its deadline on a run that was cancelled by design.
+concurrency:
+  group: claude-review-guard-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    # The review is capped at 30 minutes; leave room to observe one that uses all of it.
+    timeout-minutes: 40
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Verify the review posted something
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          R: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          WF: .github/workflows/claude-review.yml
+          # Coupling to a step NAME in the other workflow. Deliberate: the step's conclusion is the
+          # only structured way to tell "no token, skipped cleanly" from "ran and said nothing".
+          REVIEW_STEP: Claude review
+        run: |
+          set -euo pipefail
+
+          summary() { echo "$1" >> "$GITHUB_STEP_SUMMARY"; }
+
+          # Wait for the review run on this exact commit. Nothing appearing inside the grace window
+          # means review is not operating here at all -- no secret, or a fork PR, which the review
+          # workflow no-ops by design and which is not this guard's business.
+          run_id=''; status=''; conclusion=''; created=''
+          for attempt in $(seq 1 70); do
+            line=$(gh api \
+              "repos/$R/actions/workflows/claude-review.yml/runs?head_sha=$SHA&per_page=1" \
+              --jq '.workflow_runs[0] // empty
+                    | "\(.id) \(.status) \(.conclusion // "-") \(.created_at)"')
+            if [ -n "$line" ]; then
+              read -r run_id status conclusion created <<<"$line"
+              [ "$status" = "completed" ] && break
+            elif [ "$attempt" -ge 6 ]; then
+              echo "::notice title=No review run::No Claude Auto Review run exists for $SHA, so"\
+                "review is not operating on this PR (missing secret, or a fork). Nothing to verify."
+              exit 0
+            fi
+            sleep 30
+          done
+
+          if [ "$status" != "completed" ]; then
+            echo "::warning title=Review did not finish::Gave up waiting on review run $run_id for"\
+              "PR #$PR after 35 minutes. Its own 30-minute timeout will mark it; this PR is NOT"\
+              "Claude-reviewed."
+            summary '### Claude review did not finish inside the guard window'
+            exit 0
+          fi
+
+          if [ "$conclusion" = "cancelled" ] || [ "$conclusion" = "skipped" ]; then
+            echo "::notice title=Review $conclusion::run $run_id was $conclusion; nothing to verify."
+            exit 0
+          fi
+
+          # The step's own conclusion, which separates a clean no-op from a real run.
+          step=$(gh api "repos/$R/actions/runs/$run_id/jobs" --paginate \
+            --jq '[.jobs[].steps[] | select(.name == env.REVIEW_STEP)] | .[0].conclusion // empty')
+
+          if [ -z "$step" ]; then
+            echo "::error title=Guard cannot find the review step::No step named"\
+              "'$REVIEW_STEP' in run $run_id. This guard reads that step to verify the review, so"\
+              "renaming it in $WF blinds the guard -- update REVIEW_STEP here to match."
+            summary "### Guard is blind: no step named \`$REVIEW_STEP\` in the review run"
+            exit 1
+          fi
+
+          if [ "$step" = "skipped" ]; then
+            echo "::notice title=Review skipped cleanly::The '$REVIEW_STEP' step was skipped"\
+              "(no CLAUDE_CODE_OAUTH_TOKEN, or a fork PR). Nothing to verify."
+            exit 0
+          fi
+
+          # Did the action invoke Claude at all? Its workflow-validation skip reaches the outside
+          # world ONLY as a warning annotation: it sets skipped_due_to_workflow_validation_mismatch,
+          # but that output is not declared in the composite action's outputs block, and it returns
+          # before execution_file and conclusion are ever set. Actions job ids double as check-run
+          # ids, which is what makes the annotation readable from a different workflow.
+          never_ran=''
+          for job in $(gh api "repos/$R/actions/runs/$run_id/jobs" --paginate --jq '.jobs[].id'); do
+            if gh api "repos/$R/check-runs/$job/annotations" --jq '.[].message' 2>/dev/null \
+                 | grep -qF 'Skipping action due to workflow validation'; then
+              never_ran=1
+              break
+            fi
+          done
+
+          if [ -n "$never_ran" ]; then
+            touched=$(gh api "repos/$R/pulls/$PR/files" --paginate --jq '.[].filename' \
+              | { grep -Fx "$WF" || true; })
+            summary '### Claude review never ran'
+            if [ -n "$touched" ]; then
+              # Expected and unavoidable: the action requires that file to match the default branch
+              # byte for byte, so a PR editing it cannot be reviewed until it merges. A warning, not
+              # a failure -- a mark that is always red on workflow PRs is one people learn to ignore.
+              echo "::warning title=Review skipped - PR edits the workflow::This PR changes $WF,"\
+                "which claude-code-action refuses to run until it matches $DEFAULT_BRANCH. This PR"\
+                "is NOT Claude-reviewed and cannot be until it merges -- a human must review it."
+              summary "- Expected: this PR edits \`$WF\`, so a human must review it."
+              exit 0
+            fi
+            # Nothing in this PR explains the skip, so $WF on this branch has drifted from the
+            # default branch -- which silently disables review for EVERY PR, not just this one.
+            echo "::error title=Review disabled repo-wide::Claude never ran and this PR does not"\
+              "touch $WF, so that file has drifted from $DEFAULT_BRANCH. Every PR in the repo is"\
+              "silently going unreviewed until the two match."
+            summary "- Unexpected: \`$WF\` has drifted from \`$DEFAULT_BRANCH\`; ALL PRs go unreviewed."
+            exit 1
+          fi
+
+          if [ "$step" != "success" ]; then
+            echo "::error title=Review step failed::The '$REVIEW_STEP' step reported '$step' in run"\
+              "$run_id, so no review happened. Read that run for the cause; do NOT read this PR as"\
+              "reviewed."
+            summary "### Claude review failed (step conclusion: \`$step\`)"
+            exit 1
+          fi
+
+          # Count all three artifact kinds. Reviews on this repo routinely carry an EMPTY body and
+          # put every finding in INLINE comments -- #2225 had fifteen reviews with body_len=0 and
+          # twelve findings inline, so a check counting review bodies alone would call it silent.
+          issue=$(gh api "repos/$R/issues/$PR/comments" --paginate \
+            --jq "[.[] | select(.created_at > \"$created\")] | length")
+          inline=$(gh api "repos/$R/pulls/$PR/comments" --paginate \
+            --jq "[.[] | select(.created_at > \"$created\")] | length")
+          reviews=$(gh api "repos/$R/pulls/$PR/reviews" --paginate \
+            --jq "[.[] | select(.submitted_at != null and .submitted_at > \"$created\")] | length")
+          total=$(( issue + inline + reviews ))
+          echo "posted since $created -- issue: $issue, inline: $inline, reviews: $reviews"
+          summary '### Claude review output'
+          summary "- issue comments: $issue"
+          summary "- inline comments: $inline"
+          summary "- reviews: $reviews"
+
+          if [ "$total" -eq 0 ]; then
+            echo "::error title=Review posted nothing::Review run $run_id completed but left no"\
+              "comment, inline comment, or review on PR #$PR. Real money was spent and the output"\
+              "vanished (#2229, and PR #2213 which did this eleven times). Do NOT read this PR as"\
+              "reviewed; re-run the review workflow."
+            exit 1
+          fi

--- a/.github/workflows/claude-review-guard.yml
+++ b/.github/workflows/claude-review-guard.yml
@@ -51,6 +51,8 @@ jobs:
           # Coupling to a step NAME in the other workflow. Deliberate: the step's conclusion is the
           # only structured way to tell "no token, skipped cleanly" from "ran and said nothing".
           REVIEW_STEP: Claude review
+          # Author of every artifact the review leaves behind (the action reports bot_name).
+          REVIEW_BOT: claude[bot]
         run: |
           set -euo pipefail
 
@@ -59,7 +61,7 @@ jobs:
           # Wait for the review run on this exact commit. Nothing appearing inside the grace window
           # means review is not operating here at all -- no secret, or a fork PR, which the review
           # workflow no-ops by design and which is not this guard's business.
-          run_id=''; status=''; conclusion=''; created=''
+          run_id=''; status=''; conclusion=''; created=''; seen=''
           for attempt in $(seq 1 70); do
             line=$(gh api \
               "repos/$R/actions/workflows/claude-review.yml/runs?head_sha=$SHA&per_page=1" \
@@ -67,8 +69,11 @@ jobs:
                     | "\(.id) \(.status) \(.conclusion // "-") \(.created_at)"')
             if [ -n "$line" ]; then
               read -r run_id status conclusion created <<<"$line"
+              seen=1
               [ "$status" = "completed" ] && break
-            elif [ "$attempt" -ge 6 ]; then
+            # Keyed on never having seen a run, not on this poll being empty: a transient empty
+            # listing after one was found must not be read as "review is not operating here".
+            elif [ -z "$seen" ] && [ "$attempt" -ge 6 ]; then
               echo "::notice title=No review run::No Claude Auto Review run exists for $SHA, so"\
                 "review is not operating on this PR (missing secret, or a fork). Nothing to verify."
               exit 0
@@ -152,17 +157,25 @@ jobs:
             exit 1
           fi
 
-          # Count all three artifact kinds. Reviews on this repo routinely carry an EMPTY body and
-          # put every finding in INLINE comments -- #2225 had fifteen reviews with body_len=0 and
-          # twelve findings inline, so a check counting review bodies alone would call it silent.
+          # Count all three artifact kinds, scoped to the reviewer. Reviews on this repo routinely
+          # carry an EMPTY body and put every finding in INLINE comments -- #2225 had fifteen
+          # reviews with body_len=0 and twelve findings inline, so counting review bodies alone
+          # would call it silent. The AUTHOR filter matters just as much: the review window runs up
+          # to 30 minutes, so without it any human or unrelated bot commenting inside that window
+          # satisfies the guard and recreates the false pass this exists to catch. If the app is
+          # ever renamed this reports a false "posted nothing" -- loud and wrong, which is the safer
+          # direction for a guard to fail.
+          mine='select(.user.login == env.REVIEW_BOT)'
           issue=$(gh api "repos/$R/issues/$PR/comments" --paginate \
-            --jq "[.[] | select(.created_at > \"$created\")] | length")
+            --jq "[.[] | $mine | select(.created_at > \"$created\")] | length")
           inline=$(gh api "repos/$R/pulls/$PR/comments" --paginate \
-            --jq "[.[] | select(.created_at > \"$created\")] | length")
+            --jq "[.[] | $mine | select(.created_at > \"$created\")] | length")
           reviews=$(gh api "repos/$R/pulls/$PR/reviews" --paginate \
-            --jq "[.[] | select(.submitted_at != null and .submitted_at > \"$created\")] | length")
+            --jq "[.[] | $mine | select(.submitted_at != null
+                                        and .submitted_at > \"$created\")] | length")
           total=$(( issue + inline + reviews ))
-          echo "posted since $created -- issue: $issue, inline: $inline, reviews: $reviews"
+          echo "posted by $REVIEW_BOT since $created -- issue: $issue, inline: $inline,"\
+            "reviews: $reviews"
           summary '### Claude review output'
           summary "- issue comments: $issue"
           summary "- inline comments: $inline"
@@ -170,7 +183,8 @@ jobs:
 
           if [ "$total" -eq 0 ]; then
             echo "::error title=Review posted nothing::Review run $run_id completed but left no"\
-              "comment, inline comment, or review on PR #$PR. Real money was spent and the output"\
+              "comment, inline comment, or review by $REVIEW_BOT on PR #$PR. Real money was spent"\
+              "and the output"\
               "vanished (#2229, and PR #2213 which did this eleven times). Do NOT read this PR as"\
               "reviewed; re-run the review workflow."
             exit 1

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -32,16 +32,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      # #2229: the review can execute genuinely, spend tokens, and post NOTHING anywhere, and the
-      # action still succeeds. Stamp the time first so the check below only counts artifacts this
-      # run produced.
-      - name: Stamp review start
-        id: stamp
-        if: ${{ env.CLAUDE_CODE_OAUTH_TOKEN != '' }}
-        run: echo "since=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
-
       - name: Claude review
-        id: review
         if: ${{ env.CLAUDE_CODE_OAUTH_TOKEN != '' }}
         uses: anthropics/claude-code-action@v1
         with:
@@ -61,91 +52,9 @@ jobs:
             this codebase and explicitly unwanted.
 
             The PR branch is already checked out in the working directory.
-            You MUST post at least one GitHub comment before finishing, even when the change is
-            clean: in that case post a brief top-level comment saying so. A review that posts
-            nothing is indistinguishable from a review that silently failed to post (#2229), and
-            the run below will flag it.
             Use `gh pr comment` for top-level feedback, and
             `mcp__github_inline_comment__create_inline_comment` (with confirmed: true) for
             specific line-level issues. Only post GitHub comments — do not emit review text as
             plain messages.
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
-
-      # The discriminator #2229 asks for: did this run leave anything an operator can read? Counts all
-      # three artifact kinds, because reviews on this repo routinely carry an EMPTY body and put every
-      # finding in INLINE comments -- a check that counted review bodies alone would call 15 genuine
-      # reviews silent. Separates "reviewed and said nothing" from "never ran" first, so a run that
-      # never reached Claude is never reported as a silent reviewer. Fails loudly, but this workflow is
-      # advisory and not a required check, so a red mark here never blocks a merge.
-      - name: Verify the review posted something
-        if: ${{ always() && env.CLAUDE_CODE_OAUTH_TOKEN != '' && steps.stamp.outputs.since != '' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR: ${{ github.event.pull_request.number }}
-          SINCE: ${{ steps.stamp.outputs.since }}
-          RAN: ${{ steps.review.outputs.execution_file }}
-          OUTCOME: ${{ steps.review.outcome }}
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-        run: |
-          set -euo pipefail
-          R='${{ github.repository }}'
-          WF='.github/workflows/claude-review.yml'
-          # An EMPTY execution_file means the action returned before it ever invoked Claude. Its
-          # workflow-validation skip path sets neither execution_file nor conclusion and exits
-          # SUCCESS, and the composite action does not surface its own
-          # skipped_due_to_workflow_validation_mismatch output -- so this is the only signal it
-          # leaves. Counting comments in that state would blame a reviewer that never ran.
-          if [ -z "${RAN:-}" ]; then
-            if [ "${OUTCOME:-}" != "success" ]; then
-              echo "::error title=Review action failed before invoking Claude::The action reported"\
-                "'$OUTCOME' with no execution file, so no review happened. Read the step above for the"\
-                "cause; do NOT read this PR as reviewed."
-              echo '### Claude review never ran (action failed)' >> "$GITHUB_STEP_SUMMARY"
-              exit 1
-            fi
-            touched=$(gh api "repos/$R/pulls/$PR/files" --paginate --jq '.[].filename' \
-              | { grep -Fx "$WF" || true; })
-            {
-              echo '### Claude review never ran'
-              echo 'The action exited before invoking Claude and still reported success.'
-            } >> "$GITHUB_STEP_SUMMARY"
-            if [ -n "$touched" ]; then
-              # Expected and unavoidable: the action requires this file to match the default branch
-              # byte for byte, so a PR editing it cannot be Claude-reviewed until it merges. Warn
-              # rather than fail -- a mark that is always red on workflow PRs teaches people to
-              # ignore it.
-              echo "::warning title=Review skipped - PR edits the workflow::This PR changes $WF, which"\
-                "claude-code-action refuses to run until it matches $DEFAULT_BRANCH. This PR is NOT"\
-                "Claude-reviewed and this guard cannot verify it -- a human must review it."
-              echo "- Expected: this PR edits \`$WF\`, so a human must review it." >> "$GITHUB_STEP_SUMMARY"
-              exit 0
-            fi
-            # Nothing in this PR explains the skip, so $WF on this branch has drifted from the
-            # default branch -- which silently disables review for EVERY PR, not just this one.
-            echo "::error title=Review disabled repo-wide::Claude never ran and this PR does not touch"\
-              "$WF, so that file has drifted from $DEFAULT_BRANCH. Every PR is silently going"\
-              "unreviewed until the two match."
-            echo "- Unexpected: \`$WF\` has drifted from \`$DEFAULT_BRANCH\`; ALL PRs go unreviewed." >> "$GITHUB_STEP_SUMMARY"
-            exit 1
-          fi
-          issue=$(gh api "repos/$R/issues/$PR/comments" --paginate \
-            --jq "[.[] | select(.created_at > \"$SINCE\")] | length")
-          inline=$(gh api "repos/$R/pulls/$PR/comments" --paginate \
-            --jq "[.[] | select(.created_at > \"$SINCE\")] | length")
-          reviews=$(gh api "repos/$R/pulls/$PR/reviews" --paginate \
-            --jq "[.[] | select(.submitted_at != null and .submitted_at > \"$SINCE\")] | length")
-          total=$(( issue + inline + reviews ))
-          echo "posted since $SINCE -- issue comments: $issue, inline: $inline, reviews: $reviews"
-          {
-            echo '### Claude review output'
-            echo "- issue comments: $issue"
-            echo "- inline comments: $inline"
-            echo "- reviews: $reviews"
-          } >> "$GITHUB_STEP_SUMMARY"
-          if [ "$total" -eq 0 ]; then
-            echo "::error title=Review posted nothing::The review ran but left no comment, inline comment,"\
-              "or review on PR #$PR since $SINCE. Tokens were spent and the output vanished (#2229). Do NOT"\
-              "read this PR as reviewed; re-run the workflow."
-            exit 1
-          fi

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -41,6 +41,7 @@ jobs:
         run: echo "since=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Claude review
+        id: review
         if: ${{ env.CLAUDE_CODE_OAUTH_TOKEN != '' }}
         uses: anthropics/claude-code-action@v1
         with:
@@ -74,17 +75,60 @@ jobs:
       # The discriminator #2229 asks for: did this run leave anything an operator can read? Counts all
       # three artifact kinds, because reviews on this repo routinely carry an EMPTY body and put every
       # finding in INLINE comments -- a check that counted review bodies alone would call 15 genuine
-      # reviews silent. Fails the step (loudly, visibly) but this workflow is advisory and not a required
-      # check, so a red mark here never blocks a merge.
+      # reviews silent. Separates "reviewed and said nothing" from "never ran" first, so a run that
+      # never reached Claude is never reported as a silent reviewer. Fails loudly, but this workflow is
+      # advisory and not a required check, so a red mark here never blocks a merge.
       - name: Verify the review posted something
         if: ${{ always() && env.CLAUDE_CODE_OAUTH_TOKEN != '' && steps.stamp.outputs.since != '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
           SINCE: ${{ steps.stamp.outputs.since }}
+          RAN: ${{ steps.review.outputs.execution_file }}
+          OUTCOME: ${{ steps.review.outcome }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
           R='${{ github.repository }}'
+          WF='.github/workflows/claude-review.yml'
+          # An EMPTY execution_file means the action returned before it ever invoked Claude. Its
+          # workflow-validation skip path sets neither execution_file nor conclusion and exits
+          # SUCCESS, and the composite action does not surface its own
+          # skipped_due_to_workflow_validation_mismatch output -- so this is the only signal it
+          # leaves. Counting comments in that state would blame a reviewer that never ran.
+          if [ -z "${RAN:-}" ]; then
+            if [ "${OUTCOME:-}" != "success" ]; then
+              echo "::error title=Review action failed before invoking Claude::The action reported"\
+                "'$OUTCOME' with no execution file, so no review happened. Read the step above for the"\
+                "cause; do NOT read this PR as reviewed."
+              echo '### Claude review never ran (action failed)' >> "$GITHUB_STEP_SUMMARY"
+              exit 1
+            fi
+            touched=$(gh api "repos/$R/pulls/$PR/files" --paginate --jq '.[].filename' \
+              | { grep -Fx "$WF" || true; })
+            {
+              echo '### Claude review never ran'
+              echo 'The action exited before invoking Claude and still reported success.'
+            } >> "$GITHUB_STEP_SUMMARY"
+            if [ -n "$touched" ]; then
+              # Expected and unavoidable: the action requires this file to match the default branch
+              # byte for byte, so a PR editing it cannot be Claude-reviewed until it merges. Warn
+              # rather than fail -- a mark that is always red on workflow PRs teaches people to
+              # ignore it.
+              echo "::warning title=Review skipped - PR edits the workflow::This PR changes $WF, which"\
+                "claude-code-action refuses to run until it matches $DEFAULT_BRANCH. This PR is NOT"\
+                "Claude-reviewed and this guard cannot verify it -- a human must review it."
+              echo "- Expected: this PR edits \`$WF\`, so a human must review it." >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+            # Nothing in this PR explains the skip, so $WF on this branch has drifted from the
+            # default branch -- which silently disables review for EVERY PR, not just this one.
+            echo "::error title=Review disabled repo-wide::Claude never ran and this PR does not touch"\
+              "$WF, so that file has drifted from $DEFAULT_BRANCH. Every PR is silently going"\
+              "unreviewed until the two match."
+            echo "- Unexpected: \`$WF\` has drifted from \`$DEFAULT_BRANCH\`; ALL PRs go unreviewed." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
           issue=$(gh api "repos/$R/issues/$PR/comments" --paginate \
             --jq "[.[] | select(.created_at > \"$SINCE\")] | length")
           inline=$(gh api "repos/$R/pulls/$PR/comments" --paginate \

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -32,6 +32,14 @@ jobs:
         with:
           fetch-depth: 1
 
+      # #2229: the review can execute genuinely, spend tokens, and post NOTHING anywhere, and the
+      # action still succeeds. Stamp the time first so the check below only counts artifacts this
+      # run produced.
+      - name: Stamp review start
+        id: stamp
+        if: ${{ env.CLAUDE_CODE_OAUTH_TOKEN != '' }}
+        run: echo "since=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
       - name: Claude review
         if: ${{ env.CLAUDE_CODE_OAUTH_TOKEN != '' }}
         uses: anthropics/claude-code-action@v1
@@ -52,9 +60,48 @@ jobs:
             this codebase and explicitly unwanted.
 
             The PR branch is already checked out in the working directory.
+            You MUST post at least one GitHub comment before finishing, even when the change is
+            clean: in that case post a brief top-level comment saying so. A review that posts
+            nothing is indistinguishable from a review that silently failed to post (#2229), and
+            the run below will flag it.
             Use `gh pr comment` for top-level feedback, and
             `mcp__github_inline_comment__create_inline_comment` (with confirmed: true) for
             specific line-level issues. Only post GitHub comments — do not emit review text as
             plain messages.
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+
+      # The discriminator #2229 asks for: did this run leave anything an operator can read? Counts all
+      # three artifact kinds, because reviews on this repo routinely carry an EMPTY body and put every
+      # finding in INLINE comments -- a check that counted review bodies alone would call 15 genuine
+      # reviews silent. Fails the step (loudly, visibly) but this workflow is advisory and not a required
+      # check, so a red mark here never blocks a merge.
+      - name: Verify the review posted something
+        if: ${{ always() && env.CLAUDE_CODE_OAUTH_TOKEN != '' && steps.stamp.outputs.since != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          SINCE: ${{ steps.stamp.outputs.since }}
+        run: |
+          set -euo pipefail
+          R='${{ github.repository }}'
+          issue=$(gh api "repos/$R/issues/$PR/comments" --paginate \
+            --jq "[.[] | select(.created_at > \"$SINCE\")] | length")
+          inline=$(gh api "repos/$R/pulls/$PR/comments" --paginate \
+            --jq "[.[] | select(.created_at > \"$SINCE\")] | length")
+          reviews=$(gh api "repos/$R/pulls/$PR/reviews" --paginate \
+            --jq "[.[] | select(.submitted_at != null and .submitted_at > \"$SINCE\")] | length")
+          total=$(( issue + inline + reviews ))
+          echo "posted since $SINCE -- issue comments: $issue, inline: $inline, reviews: $reviews"
+          {
+            echo '### Claude review output'
+            echo "- issue comments: $issue"
+            echo "- inline comments: $inline"
+            echo "- reviews: $reviews"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$total" -eq 0 ]; then
+            echo "::error title=Review posted nothing::The review ran but left no comment, inline comment,"\
+              "or review on PR #$PR since $SINCE. Tokens were spent and the output vanished (#2229). Do NOT"\
+              "read this PR as reviewed; re-run the workflow."
+            exit 1
+          fi


### PR DESCRIPTION
Detects #2229. Deliberately does **not** close it: this adds detection, and the cure (widening `allowedTools` so the reviewer can read files) needs a `claude-review.yml` edit that should ride with a release. See the root-cause comment on the issue.

## What #2229 actually is

I found the root cause in PR #2213's logs. It had **eleven** review runs, every one `conclusion=success`, and **zero** comments of any kind. One run:

```json
{ "type": "result", "subtype": "success", "is_error": false,
  "duration_ms": 161983, "num_turns": 24,
  "total_cost_usd": 4.1758517500000005,
  "permission_denials_count": 6 }
```

$4.18, 24 turns, **6 permission denials**, `is_error: false`, nothing posted. The `allowedTools` list grants exactly four tools:

```
mcp__github_inline_comment__create_inline_comment
Bash(gh pr comment:*)  Bash(gh pr diff:*)  Bash(gh pr view:*)
```

None of them can read a file — while the prompt tells the reviewer *"The PR branch is already checked out in the working directory."* On a 104-file change it burned turns being denied and posted nothing, and a 104-file change merged unreviewed with nothing anywhere saying so.

Across the last twelve merged PRs, #2213 is both the churn outlier (12,091 lines vs 2,318 next) and the only one with zero output:

| PR | files | churn | artifacts |
|---|---|---|---|
| 2213 | 104 | 12,091 | **0** |
| 2225 | 24 | 2,318 | 37 |
| 2237 | 1 | 296 | 12 |
| 2221 | 25 | 1,897 | 13 |

## Why the guard is a separate file

The first cut of this PR edited `claude-review.yml` — and **failed on itself**, which is how the second mechanism surfaced:

```
Skipping action due to workflow validation: Workflow validation failed. The workflow file
must exist and have identical content to the version on the repository's default branch.
```

Step conclusion: **success**. Runtime: **4 seconds**. The check is server-side, during the OIDC token exchange. The action's skip path sets `skipped_due_to_workflow_validation_mismatch`, but that output **is not declared in the composite action's `outputs:` block**, and it returns before `execution_file` and `conclusion` are ever set — so from outside, a run that never happened is indistinguishable from a clean review.

The sharp edge reaches every PR, not just workflow ones. `dev` and `main` carry identical blobs today, which is the only reason review works at all. **Any edit that lands on `dev` and waits for a release silently disables review for the whole repo**, green checks throughout. So a guard living inside `claude-review.yml` would disable the thing it protects every time it was touched. This one lives outside, invokes nothing, and can be edited freely.

It polls rather than using `on: workflow_run`, which only ever fires from the **default branch's** copy of a workflow — that variant would be dormant, and untestable, until a release shipped it.

## What it reports

| state | signal | verdict |
|---|---|---|
| no run for this SHA | nothing after ~2.5 min | notice, pass (no secret / fork) |
| run cancelled or superseded | run conclusion | notice, pass |
| step skipped | step conclusion `skipped` | notice, pass (no token) |
| **never ran, PR edits the workflow** | skip annotation + PR touches file | **warning, pass** |
| **never ran, workflow untouched** | skip annotation, file not in PR | **fail: drift, ALL PRs unreviewed** |
| review step failed | step conclusion | fail |
| **ran, posted nothing** | 0 artifacts since run start | **fail (#2229, #2213)** |
| ran and posted | ≥1 of issue / inline / review | pass |

Two deliberate choices. Counting **all three** artifact kinds, because reviews here routinely carry an empty body and put every finding inline — #2225 had fifteen reviews with `body_len=0` and twelve findings inline, so counting bodies alone would call it silent. And the workflow-editing skip is a **warning, not a failure**: it is guaranteed on every PR that touches that file, and a mark that is always red is one people learn to ignore. Drift is the case that gets to fail.

## Verification

Ten branches exercised against a stubbed `gh` and stubbed clock, including the #2225 shape that must stay green and both hard-fail paths. YAML parses, `bash -n` clean, 177 CRLF / 0 LF-only per `.gitattributes`. `claude-review.yml` is byte-identical to `main` (blob `a096a7f9`), so this PR causes no drift and gets a real review.

## Not fixed here

- **The cure for #2213's failure** needs `claude-review.yml`: add `Read`/`Grep`/`Glob` to `allowedTools` so the reviewer can open the files the prompt says are checked out, and require a posted comment so "clean" is distinguishable from "silent". That edit costs a drift window, so it should ride with a release rather than sit on `dev`.
- **`CLAUDE.md` does not exist on any branch**, yet the review prompt opens with "Follow the conventions in CLAUDE.md and the T-SQL style guide it points to." Neither file exists. Filed separately.