### PR TITLE
The delta gap guard sat on the fleet's median sweep gap, so half of every delta collector's output was a zero that never happened

### DIFF
--- a/Darling/Darling.Tests/DarlingDeltaSeederTests.cs
+++ b/Darling/Darling.Tests/DarlingDeltaSeederTests.cs
@@ -173,7 +173,7 @@ public sealed class DarlingDeltaSeederTests
             await DeleteTestRowsAsync(connection, TestContext.Current.CancellationToken);
 
             /* Two rows for the same wait type: an older baseline and the latest one, both recent
-               enough to stay inside the wait-stats 300-second gap policy. */
+               enough to stay inside the 300 s gap this call passes explicitly. */
             var olderTime = DateTime.SpecifyKind(DateTime.UtcNow.AddMinutes(-2), DateTimeKind.Unspecified);
             var latestTime = DateTime.SpecifyKind(DateTime.UtcNow.AddMinutes(-1), DateTimeKind.Unspecified);
             await InsertWaitStatsRowAsync(connection, olderTime, waitingTasks: 10, waitTimeMs: 2000, signalWaitTimeMs: 500);

--- a/Darling/Darling.Tests/DeltaGapPolicyTests.cs
+++ b/Darling/Darling.Tests/DeltaGapPolicyTests.cs
@@ -177,14 +177,22 @@ public sealed class DeltaGapPolicyTests
     }
 
     /// <summary>The read has to carry the denominator, or the distinction dies at the API boundary —
-    /// which is the half of #2234 that made a fabricated zero unfalsifiable from outside.</summary>
+    /// which is the half of #2234 that made a fabricated zero unfalsifiable from outside.
+    /// <para>And it must AGGREGATE it correctly: the value and delta are additive across a counter's
+    /// instance rows, the interval is not — it is one measured gap repeated per instance. Fleet-measured,
+    /// Transactions/sec carries a median of 12 (max 17) rows per collection_time, so SUM would report a
+    /// rate 12-17x too low. Pinning the aggregate by name because a review caught exactly that.</para>
+    /// </summary>
     [Fact]
-    public void ThePerfmonTrendReadProjectsTheInterval()
+    public void ThePerfmonTrendReadProjectsTheInterval_AggregatedAsMaxNotSum()
     {
-        Assert.Contains(
-            "SUM(sample_interval_seconds)",
-            PerformanceMonitor.Darling.Service.Mcp.DarlingTrendReader.PerfmonTrendSql,
-            StringComparison.Ordinal);
+        var sql = PerformanceMonitor.Darling.Service.Mcp.DarlingTrendReader.PerfmonTrendSql;
+
+        Assert.Contains("MAX(sample_interval_seconds)", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("SUM(sample_interval_seconds)", sql, StringComparison.Ordinal);
+        /* The additive pair must stay additive — this guards the fix from being over-applied. */
+        Assert.Contains("SUM(cntr_value)", sql, StringComparison.Ordinal);
+        Assert.Contains("SUM(delta_cntr_value)", sql, StringComparison.Ordinal);
     }
 
     private static string RepoRoot()

--- a/Darling/Darling.Tests/DeltaGapPolicyTests.cs
+++ b/Darling/Darling.Tests/DeltaGapPolicyTests.cs
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.IO;
+using System.Linq;
+using PerformanceMonitor.Collectors;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #2233 / #2234: the gap policy every delta collector shares, and the invariant that makes a stored
+/// zero readable.
+///
+/// <para>The old policy rejected any baseline older than 300 s and returned 0. Measured against the
+/// fleet that threshold sat on the MEDIAN sweep gap — 99,717 consecutive perfmon gaps over 52 servers
+/// and 7 days: p50 299 s, p90 580 s, p99 830 s, max 2,514 s — so it fired 50.0% of the time during
+/// ordinary operation instead of after the restarts it was written for, and each firing stored a 0 that
+/// is indistinguishable from a genuinely idle interval.</para>
+///
+/// <para>The pins below are behavioral, not textual: the 600 s case is the one that flips with the
+/// threshold (0 before, a real delta after), and the reset case pins the invariant
+/// <c>interval == 0 &lt;=&gt; no delta was knowable</c> that the whole (delta, interval) reading rests
+/// on.</para>
+/// </summary>
+public sealed class DeltaGapPolicyTests
+{
+    private const int ServerId = 1;
+    private const string Collector = "perfmon";
+    private const string Key = "SQLServer:SQL Statistics|Batch Requests/sec|";
+
+    private static DateTime T0 => new(2026, 8, 13, 12, 0, 0, DateTimeKind.Unspecified);
+
+    /// <summary>The measured fleet median. A gap this size is ORDINARY, and the old 300 s policy
+    /// rejected it — this is the 50% of output that was a fabricated zero.</summary>
+    [Fact]
+    public void AGapAtTheFleetMedian_YieldsARealDelta_NotAFabricatedZero()
+    {
+        var calc = new CollectorDeltaCalculator();
+
+        var first = calc.CalculateDeltaWithInterval(ServerId, Collector, Key, 1_000, out var firstInterval,
+            collectionTime: T0, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+        Assert.Equal(0, first);          /* first sighting: baseline only */
+        Assert.Equal(0, firstInterval);
+
+        /* 299 s — the measured p50. Under the old 300 s policy this squeaked through; at p90 (580 s)
+           it did not, which is why half the fleet's points were zeros. */
+        var second = calc.CalculateDeltaWithInterval(ServerId, Collector, Key, 1_500, out var secondInterval,
+            collectionTime: T0.AddSeconds(299), maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+
+        Assert.Equal(500, second);
+        Assert.Equal(299, secondInterval);
+    }
+
+    /// <summary>The pin that flips with the fix: 600 s is past the OLD 300 s policy and inside the new
+    /// one. 8.3% of real fleet gaps land here.</summary>
+    [Fact]
+    public void AGapPastTheOldPolicyButInsideTheNewOne_YieldsARealDelta()
+    {
+        var calc = new CollectorDeltaCalculator();
+        calc.CalculateDelta(ServerId, Collector, Key, 20_000_000,
+            collectionTime: T0, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+
+        var delta = calc.CalculateDeltaWithInterval(ServerId, Collector, Key, 20_055_000, out var interval,
+            collectionTime: T0.AddSeconds(600), maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+
+        /* Exactly the shape #2234 reported from production: the cumulative counter advanced ~55,000
+           while delta_value came back 0. It must now report the advance and the span it covered. */
+        Assert.Equal(55_000, delta);
+        Assert.Equal(600, interval);
+    }
+
+    /// <summary>The guard still guards: past an hour the baseline is treated as too stale to subtract
+    /// from, and the interval says so rather than implying an idle hour.</summary>
+    [Fact]
+    public void AGapPastTheNewPolicy_YieldsZeroAndReportsNoInterval()
+    {
+        var calc = new CollectorDeltaCalculator();
+        calc.CalculateDelta(ServerId, Collector, Key, 1_000,
+            collectionTime: T0, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+
+        var delta = calc.CalculateDeltaWithInterval(ServerId, Collector, Key, 9_999, out var interval,
+            collectionTime: T0.AddSeconds(CollectorDeltaCalculator.DefaultMaxGapSeconds + 1),
+            maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+
+        Assert.Equal(0, delta);
+        Assert.Equal(0, interval);
+    }
+
+    /// <summary>The invariant, and the case that used to break it: a counter reset makes the delta
+    /// unknowable, so the interval must be 0 too. Reporting 0 work over a REAL interval is a claim
+    /// that nothing happened for that long — the one place that claim would be false.</summary>
+    [Fact]
+    public void ACounterReset_YieldsZeroAndReportsNoInterval_SoItCannotReadAsIdle()
+    {
+        var calc = new CollectorDeltaCalculator();
+        calc.CalculateDelta(ServerId, Collector, Key, 5_000,
+            collectionTime: T0, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+
+        /* Counter went backwards (instance restart / plan cache eviction). */
+        var delta = calc.CalculateDeltaWithInterval(ServerId, Collector, Key, 12, out var interval,
+            collectionTime: T0.AddSeconds(120), maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+
+        Assert.Equal(0, delta);
+        Assert.Equal(0, interval);
+    }
+
+    /// <summary>A normal sweep with real work: both halves non-zero, which is the only combination a
+    /// consumer may read as a rate.</summary>
+    [Fact]
+    public void AnOrdinarySweep_ReportsBothTheDeltaAndTheSpanItCovered()
+    {
+        var calc = new CollectorDeltaCalculator();
+        calc.CalculateDelta(ServerId, Collector, Key, 100,
+            collectionTime: T0, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+
+        var delta = calc.CalculateDeltaWithInterval(ServerId, Collector, Key, 700, out var interval,
+            collectionTime: T0.AddSeconds(60), maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+
+        Assert.Equal(600, delta);
+        Assert.Equal(60, interval);
+        Assert.Equal(10.0, delta / (double)interval);   /* the rate a caller derives */
+    }
+
+    /// <summary>A genuinely idle interval is the one case that legitimately stores a 0 delta — and it
+    /// keeps a real interval, which is exactly what distinguishes it from the three unknowns.</summary>
+    [Fact]
+    public void AGenuinelyIdleInterval_KeepsItsRealInterval()
+    {
+        var calc = new CollectorDeltaCalculator();
+        calc.CalculateDelta(ServerId, Collector, Key, 4_242,
+            collectionTime: T0, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+
+        var delta = calc.CalculateDeltaWithInterval(ServerId, Collector, Key, 4_242, out var interval,
+            collectionTime: T0.AddSeconds(180), maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+
+        Assert.Equal(0, delta);
+        Assert.Equal(180, interval);
+    }
+
+    /// <summary>No collector may reintroduce a hard-coded gap. The literal is what drifted for 41 call
+    /// sites and five doc comments, so the pin is on the literal, not on any one collector.</summary>
+    [Fact]
+    public void NoCollectorPassesAHardCodedGap()
+    {
+        var collectors = Path.Combine(RepoRoot(), "PerformanceMonitor.Collectors");
+        Assert.True(Directory.Exists(collectors), $"collectors directory not found at {collectors}");
+
+        var offenders = Directory.EnumerateFiles(collectors, "*.cs", SearchOption.AllDirectories)
+            .Select(path => (path, text: File.ReadAllText(path)))
+            .Where(f => System.Text.RegularExpressions.Regex.IsMatch(f.text, @"maxGapSeconds: *[0-9]"))
+            .Select(f => Path.GetFileName(f.path))
+            .ToList();
+
+        Assert.Empty(offenders);
+    }
+
+    /// <summary>The perfmon collector must MEASURE its interval. It wrote a literal 60 — the configured
+    /// cadence — while the real median gap was 299 s, so every rate derived from it was up to 5x high.
+    /// </summary>
+    [Fact]
+    public void ThePerfmonCollectorMeasuresItsInterval_RatherThanAssertingTheCadence()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            RepoRoot(), "PerformanceMonitor.Collectors", "PerfmonStatsCollector.cs"));
+
+        Assert.Contains("CalculateDeltaWithInterval", source, StringComparison.Ordinal);
+        Assert.Contains(".Value(sampleIntervalSeconds)", source, StringComparison.Ordinal);
+        /* The literal it used to write, as the payload value. */
+        Assert.DoesNotContain(".Value(60)", source, StringComparison.Ordinal);
+    }
+
+    /// <summary>The read has to carry the denominator, or the distinction dies at the API boundary —
+    /// which is the half of #2234 that made a fabricated zero unfalsifiable from outside.</summary>
+    [Fact]
+    public void ThePerfmonTrendReadProjectsTheInterval()
+    {
+        Assert.Contains(
+            "SUM(sample_interval_seconds)",
+            PerformanceMonitor.Darling.Service.Mcp.DarlingTrendReader.PerfmonTrendSql,
+            StringComparison.Ordinal);
+    }
+
+    private static string RepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir != null && !File.Exists(Path.Combine(dir, "PerformanceMonitor.sln")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        Assert.NotNull(dir);
+        return dir!;
+    }
+}

--- a/Darling/Darling.Tests/ViewerPerfmonRunningJobsTests.cs
+++ b/Darling/Darling.Tests/ViewerPerfmonRunningJobsTests.cs
@@ -41,15 +41,20 @@ public sealed class ViewerPerfmonSqlTests
     }
 
     [Fact]
-    public void PerfmonTrendsSql_SumsValueAndDelta_GroupedByCounterAndTime()
+    public void PerfmonTrendsSql_SumsValueAndDelta_ButTakesTheIntervalAsMax()
     {
         var sql = ViewerDataService.PerfmonTrendsSql(3);
 
         Assert.Contains("FROM v_perfmon_stats", sql, StringComparison.Ordinal);
-        /* The two aggregates are CAST to bigint for the typed GetInt64 reader (Postgres SUM(bigint)
+        /* Every aggregate is CAST to bigint for the typed GetInt64 reader (Postgres SUM(bigint)
            returns numeric). */
         Assert.Contains("CAST(SUM(cntr_value) AS bigint)", sql, StringComparison.Ordinal);
         Assert.Contains("CAST(SUM(delta_cntr_value) AS bigint)", sql, StringComparison.Ordinal);
+        /* The interval is NOT additive across a counter's instance rows — it is one measured sweep gap
+           repeated per instance, so SUM would multiply the denominator by the instance count (12-17 for
+           Transactions/sec on the fleet). Same pin as the MCP read carries, #2234. */
+        Assert.Contains("CAST(MAX(sample_interval_seconds) AS bigint)", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("SUM(sample_interval_seconds)", sql, StringComparison.Ordinal);
         Assert.Contains("GROUP BY counter_name, collection_time", sql, StringComparison.Ordinal);
         Assert.Contains("ORDER BY counter_name, collection_time", sql, StringComparison.Ordinal);
     }

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpTrendTools.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpTrendTools.cs
@@ -137,11 +137,18 @@ public sealed class DarlingMcpTrendTools
                     new { collected_counters = collected });
             }
 
+            /* sample_interval_seconds is the delta's denominator, and the only way a caller can tell a
+               fabricated zero from an idle interval: 0 means no delta was knowable (first sighting,
+               counter reset, or a gap past the policy), so delta_value = 0 with an interval of 0 must
+               NOT be read as "no activity". Derive rates as delta_value / sample_interval_seconds
+               rather than assuming a fixed cadence — fleet gaps run p50 299 s, p99 830 s, so dividing
+               by the configured 60 s is wrong by whatever the jitter was (#2233, #2234). */
             var result = points.Select(p => new
             {
                 time = p.CollectionTime.ToString("o"),
                 value = p.Value,
-                delta_value = p.DeltaValue
+                delta_value = p.DeltaValue,
+                sample_interval_seconds = p.SampleIntervalSeconds
             });
 
             return JsonSerializer.Serialize(new

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingTrendReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingTrendReader.cs
@@ -46,13 +46,13 @@ internal static class DarlingTrendReader
         DateTime CollectionTime, double TotalServerMemoryMb, double TargetServerMemoryMb,
         double BufferPoolMb, double PlanCacheMb);
 
-    /// <summary>One perfmon-trend point for a single counter: the counter value and per-interval delta,
-    /// both summed across the counter's instances at that collection (Lite's <c>PerfmonTrendPoint</c>).</summary>
-    /// <summary>One perfmon point: the cumulative counter, the delta, and the wall-clock seconds that
-    /// delta actually covers, summed the same way. <c>SampleIntervalSeconds</c> is what makes a zero
-    /// readable: the collector reports 0 in exactly the cases where no delta was knowable (first
-    /// sighting, counter reset, gap past the policy), so (0, 0) is "unknown" while (0, n) is "genuinely
-    /// idle". Without it the two are the same number and a fabricated zero reads as quiet (#2234).
+    /// <summary>One perfmon-trend point for a single counter: the counter value, the per-interval delta,
+    /// and the wall-clock seconds that delta covers, all summed across the counter's instances at that
+    /// collection (Lite's <c>PerfmonTrendPoint</c>, plus the interval Lite does not carry).
+    /// <para><c>SampleIntervalSeconds</c> is what makes a zero readable: the collector reports 0 in
+    /// exactly the cases where no delta was knowable (first sighting, counter reset, gap past the
+    /// policy), so (0, 0) is "unknown" while (0, n) is "genuinely idle". Without it the two are the same
+    /// number and a fabricated zero reads as quiet (#2234).</para>
     /// <para>Rows written before that fix carry a hard-coded 60 regardless of the real gap, so a rate
     /// derived over a window spanning the upgrade is only as good as its newest rows.</para></summary>
     public sealed record PerfmonTrendPoint(DateTime CollectionTime, long Value, long DeltaValue, long SampleIntervalSeconds);

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingTrendReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingTrendReader.cs
@@ -48,7 +48,14 @@ internal static class DarlingTrendReader
 
     /// <summary>One perfmon-trend point for a single counter: the counter value and per-interval delta,
     /// both summed across the counter's instances at that collection (Lite's <c>PerfmonTrendPoint</c>).</summary>
-    public sealed record PerfmonTrendPoint(DateTime CollectionTime, long Value, long DeltaValue);
+    /// <summary>One perfmon point: the cumulative counter, the delta, and the wall-clock seconds that
+    /// delta actually covers, summed the same way. <c>SampleIntervalSeconds</c> is what makes a zero
+    /// readable: the collector reports 0 in exactly the cases where no delta was knowable (first
+    /// sighting, counter reset, gap past the policy), so (0, 0) is "unknown" while (0, n) is "genuinely
+    /// idle". Without it the two are the same number and a fabricated zero reads as quiet (#2234).
+    /// <para>Rows written before that fix carry a hard-coded 60 regardless of the real gap, so a rate
+    /// derived over a window spanning the upgrade is only as good as its newest rows.</para></summary>
+    public sealed record PerfmonTrendPoint(DateTime CollectionTime, long Value, long DeltaValue, long SampleIntervalSeconds);
 
     /// <summary>One file I/O-latency-trend point: average read/write latency (stall-ms / op) per collection
     /// for one (database, file) — the tool surfaces database_name + latencies, mirroring Lite's
@@ -121,7 +128,8 @@ internal static class DarlingTrendReader
         SELECT
             collection_time,
             CAST(SUM(cntr_value) AS bigint) AS cntr_value,
-            CAST(SUM(delta_cntr_value) AS bigint) AS delta_cntr_value
+            CAST(SUM(delta_cntr_value) AS bigint) AS delta_cntr_value,
+            CAST(SUM(sample_interval_seconds) AS bigint) AS sample_interval_seconds
         FROM v_perfmon_stats
         WHERE server_id = $1
         AND   counter_name = $2
@@ -146,7 +154,8 @@ internal static class DarlingTrendReader
             items.Add(new PerfmonTrendPoint(
                 reader.GetDateTime(0),
                 reader.IsDBNull(1) ? 0 : reader.GetInt64(1),
-                reader.IsDBNull(2) ? 0 : reader.GetInt64(2)));
+                reader.IsDBNull(2) ? 0 : reader.GetInt64(2),
+                reader.IsDBNull(3) ? 0 : reader.GetInt64(3)));
         }
 
         return items;

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingTrendReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingTrendReader.cs
@@ -123,13 +123,22 @@ internal static class DarlingTrendReader
     /// viewer's perfmon read: SUM the counter's instances per collection. Postgres <c>SUM(bigint)</c> is
     /// numeric, so both SUMs CAST back to bigint for the typed GetInt64 reader (the viewer's PerfmonTrendsSql
     /// makes the same cast). $1 server_id, $2 counter_name, $3/$4 window (naive UTC).
+    /// <para>The interval is MAX, not SUM, and that distinction is load-bearing. cntr_value and
+    /// delta_cntr_value are additive across a counter's instance rows — summing Transactions/sec over
+    /// every database is a meaningful total — but the interval is the same measured sweep gap repeated
+    /// once per instance, so summing it multiplies the denominator by the instance count. Measured on
+    /// the fleet: Transactions/sec, Log Flushes/sec and Log Bytes Flushed/sec carry a median of 12 and
+    /// up to 17 rows per collection_time, so a summed denominator would report rates 12-17x too LOW —
+    /// the same silent corruption this read exists to expose, pointed the other way. MAX also ignores a
+    /// 0 from an instance seen for the first time, while still reporting 0 when every instance is
+    /// unknown.</para>
     /// </summary>
     public const string PerfmonTrendSql = """
         SELECT
             collection_time,
             CAST(SUM(cntr_value) AS bigint) AS cntr_value,
             CAST(SUM(delta_cntr_value) AS bigint) AS delta_cntr_value,
-            CAST(SUM(sample_interval_seconds) AS bigint) AS sample_interval_seconds
+            CAST(MAX(sample_interval_seconds) AS bigint) AS sample_interval_seconds
         FROM v_perfmon_stats
         WHERE server_id = $1
         AND   counter_name = $2

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Perfmon.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Perfmon.cs
@@ -17,14 +17,19 @@ namespace PerformanceMonitor.Darling.Viewer;
 
 /// <summary>
 /// One point on a selected perfmon counter's trend line: the raw counter value and the per-interval
-/// delta, both summed across the counter's instances at each collection_time. Copied from Lite's
+/// delta, both summed across the counter's instances at each collection_time, plus the wall-clock
+/// seconds that delta covers — MAX, not SUM, because the interval is one measured sweep gap repeated
+/// per instance rather than a per-instance quantity (#2234; Transactions/sec carries a median of 12
+/// instance rows). The picker does not derive a rate today, so the field rides along unplotted so that
+/// whoever adds one has a real denominator instead of a fabricated cadence. Copied from Lite's
 /// <c>PerfmonTrendPoint</c> (LocalDataService.Perfmon.cs). The picker plots <see cref="DeltaValue"/>;
 /// <see cref="Value"/> rides along for parity with Lite's row shape.
 /// </summary>
 public sealed record PerfmonTrendPoint(
     DateTime CollectionTime,
     long Value,
-    long DeltaValue);
+    long DeltaValue,
+    long SampleIntervalSeconds);
 
 public sealed partial class ViewerDataService
 {
@@ -63,7 +68,8 @@ public sealed partial class ViewerDataService
                 counter_name,
                 collection_time,
                 CAST(SUM(cntr_value) AS bigint) AS cntr_value,
-                CAST(SUM(delta_cntr_value) AS bigint) AS delta_cntr_value
+                CAST(SUM(delta_cntr_value) AS bigint) AS delta_cntr_value,
+                CAST(MAX(sample_interval_seconds) AS bigint) AS sample_interval_seconds
             FROM v_perfmon_stats
             WHERE server_id = $1
             AND   collection_time >= $2
@@ -143,7 +149,8 @@ public sealed partial class ViewerDataService
             list.Add(new PerfmonTrendPoint(
                 reader.GetDateTime(1),
                 reader.IsDBNull(2) ? 0 : reader.GetInt64(2),
-                reader.IsDBNull(3) ? 0 : reader.GetInt64(3)));
+                reader.IsDBNull(3) ? 0 : reader.GetInt64(3),
+                reader.IsDBNull(4) ? 0 : reader.GetInt64(4)));
         }
 
         return result;

--- a/Lite.Tests/FileIoCollectorDefinitionTests.cs
+++ b/Lite.Tests/FileIoCollectorDefinitionTests.cs
@@ -115,7 +115,7 @@ public sealed class FileIoCollectorDefinitionTests
 
         Assert.Equal(8, deltas.Calls.Count);
         Assert.All(deltas.Calls, c => Assert.Equal("SO|SO_data", c.Key));
-        Assert.All(deltas.Calls, c => Assert.Equal(300, c.MaxGap));
+        Assert.All(deltas.Calls, c => Assert.Equal(CollectorDeltaCalculator.DefaultMaxGapSeconds, c.MaxGap));
         Assert.Equal(
             new[]
             {

--- a/Lite.Tests/Helpers/CollectorDefinitionTestFakes.cs
+++ b/Lite.Tests/Helpers/CollectorDefinitionTestFakes.cs
@@ -125,6 +125,11 @@ internal sealed class RecordingCollectorDeltaCalculator : ICollectorDeltaCalcula
 
     public int LastServerId { get; private set; }
 
+    /// <summary>What <see cref="CalculateDeltaWithInterval"/> hands back. Left at 0 so every existing
+    /// pin is unaffected; set it to something distinctive to prove a collector writes the MEASURED
+    /// interval rather than a constant of its own (#2234, where perfmon wrote a literal 60).</summary>
+    public int ReportedInterval { get; set; }
+
     public long CalculateDelta(int serverId, string collectorName, string key, long currentValue,
         DateTime? collectionTime = null, int maxGapSeconds = 0)
     {
@@ -136,7 +141,7 @@ internal sealed class RecordingCollectorDeltaCalculator : ICollectorDeltaCalcula
     public long CalculateDeltaWithInterval(int serverId, string collectorName, string key, long currentValue,
         out int intervalSeconds, DateTime? collectionTime = null, int maxGapSeconds = 0)
     {
-        intervalSeconds = 0;
+        intervalSeconds = ReportedInterval;
         return CalculateDelta(serverId, collectorName, key, currentValue, collectionTime, maxGapSeconds);
     }
 }

--- a/Lite.Tests/LatchStatsCollectorDefinitionTests.cs
+++ b/Lite.Tests/LatchStatsCollectorDefinitionTests.cs
@@ -102,11 +102,11 @@ OPTION(RECOMPILE);";
         /* Payload order: raw values then the three deltas (recording calculator returns value * 10). */
         Assert.Equal(new object?[] { "BUFFER", 7L, 300L, 20L, 70L, 3000L, 200L }, writer.Values);
 
-        /* Delta contract: group names, key = latch_class, the host collection time, 300 s gap policy. */
+        /* Delta contract: group names, key = latch_class, the host collection time, the shared gap policy. */
         Assert.Equal(3, deltas.Calls.Count);
-        Assert.Equal(("latch_stats_waiting_requests", "BUFFER", 7L, context.CollectionTime, 300), deltas.Calls[0]);
-        Assert.Equal(("latch_stats_wait_time", "BUFFER", 300L, context.CollectionTime, 300), deltas.Calls[1]);
-        Assert.Equal(("latch_stats_max_wait", "BUFFER", 20L, context.CollectionTime, 300), deltas.Calls[2]);
+        Assert.Equal(("latch_stats_waiting_requests", "BUFFER", 7L, context.CollectionTime, CollectorDeltaCalculator.DefaultMaxGapSeconds), deltas.Calls[0]);
+        Assert.Equal(("latch_stats_wait_time", "BUFFER", 300L, context.CollectionTime, CollectorDeltaCalculator.DefaultMaxGapSeconds), deltas.Calls[1]);
+        Assert.Equal(("latch_stats_max_wait", "BUFFER", 20L, context.CollectionTime, CollectorDeltaCalculator.DefaultMaxGapSeconds), deltas.Calls[2]);
         Assert.All(deltas.Calls, _ => Assert.Equal(42, deltas.LastServerId));
     }
 }

--- a/Lite.Tests/LiteDeltaSeederTests.cs
+++ b/Lite.Tests/LiteDeltaSeederTests.cs
@@ -162,7 +162,7 @@ public sealed class LiteDeltaSeederTests : IClassFixture<SharedDuckDbFixture>, I
     /// <summary>
     /// The memory-grant baselines carry their collection_time, so the gap policy can reject a stale
     /// one. Seeded with a null timestamp (as they were before #1772) the policy cannot fire at all,
-    /// and the row below — inside the 15-minute read window but well outside the 300-second gap —
+    /// and the row below — inside the 15-minute read window but well outside the gap passed below —
     /// produces a fabricated spike of 40 instead of 0 on the first cycle after a restart.
     /// </summary>
     [Fact]

--- a/Lite.Tests/MemoryGrantsCollectorDefinitionTests.cs
+++ b/Lite.Tests/MemoryGrantsCollectorDefinitionTests.cs
@@ -17,7 +17,7 @@ namespace Lite.Tests;
 
 /// <summary>
 /// Pins the parity contract of the extracted memory_grant_stats definition: column mapping,
-/// the composite "{pool}_{semaphore}" delta key, the two delta groups with the 300 s gap
+/// the composite "{pool}_{semaphore}" delta key, the two delta groups with the shared gap
 /// policy, and the payload order matching the memory_grant_stats schema.
 /// </summary>
 public sealed class MemoryGrantsCollectorDefinitionTests
@@ -84,9 +84,9 @@ public sealed class MemoryGrantsCollectorDefinitionTests
             new object?[] { (short)1, 2, 100.5m, 200.5m, 90.25m, 80.75m, 10.5m, 8.25m, 3, 4, 5L, 6L, 50L, 60L },
             writer.Values);
 
-        /* Delta contract: composite key "{pool}_{semaphore}", both groups, 300 s gap policy. */
+        /* Delta contract: composite key "{pool}_{semaphore}", both groups, the shared gap policy. */
         Assert.Equal(2, deltas.Calls.Count);
-        Assert.Equal(("memory_grants_timeouts", "2_1", 5L, context.CollectionTime, 300), deltas.Calls[0]);
-        Assert.Equal(("memory_grants_forced", "2_1", 6L, context.CollectionTime, 300), deltas.Calls[1]);
+        Assert.Equal(("memory_grants_timeouts", "2_1", 5L, context.CollectionTime, CollectorDeltaCalculator.DefaultMaxGapSeconds), deltas.Calls[0]);
+        Assert.Equal(("memory_grants_forced", "2_1", 6L, context.CollectionTime, CollectorDeltaCalculator.DefaultMaxGapSeconds), deltas.Calls[1]);
     }
 }

--- a/Lite.Tests/PerfmonAndDmvBlockingCollectorDefinitionTests.cs
+++ b/Lite.Tests/PerfmonAndDmvBlockingCollectorDefinitionTests.cs
@@ -65,9 +65,11 @@ public sealed class PerfmonStatsCollectorDefinitionTests
     }
 
     [Fact]
-    public async Task WritePayload_PinsDeltaContract_AndConstantInterval()
+    public async Task WritePayload_PinsDeltaContract_AndTheMeasuredInterval()
     {
-        var deltas = new RecordingCollectorDeltaCalculator();
+        /* A distinctive interval, deliberately neither 0 nor the 60 this collector used to hard-code,
+           so the payload assertion below can only pass if the MEASURED value is what gets written. */
+        var deltas = new RecordingCollectorDeltaCalculator { ReportedInterval = 137 };
         var context = CollectorTestContext.Make(deltas);
         using var reader = new FakeCollectorDataReader(
             new object[] { "SQLServer:SQL Statistics", "Batch Requests/sec", "", 987654L });
@@ -76,9 +78,9 @@ public sealed class PerfmonStatsCollectorDefinitionTests
         var writer = new RecordingCollectorRowWriter();
         PerfmonStatsCollector.Instance.WritePayload(Assert.Single(rows), writer, context);
 
-        Assert.Equal(new object?[] { "SQLServer:SQL Statistics", "Batch Requests/sec", "", 987654L, 9876540L, 60 }, writer.Values);
+        Assert.Equal(new object?[] { "SQLServer:SQL Statistics", "Batch Requests/sec", "", 987654L, 9876540L, 137 }, writer.Values);
         var call = Assert.Single(deltas.Calls);
-        Assert.Equal(("perfmon", "SQLServer:SQL Statistics|Batch Requests/sec|", 987654L, context.CollectionTime, 300), call);
+        Assert.Equal(("perfmon", "SQLServer:SQL Statistics|Batch Requests/sec|", 987654L, context.CollectionTime, CollectorDeltaCalculator.DefaultMaxGapSeconds), call);
     }
 }
 

--- a/Lite.Tests/PerfmonIntervalAggregationTests.cs
+++ b/Lite.Tests/PerfmonIntervalAggregationTests.cs
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using Xunit;
+
+namespace Lite.Tests;
+
+/// <summary>
+/// #2234: Lite's half of the "a zero delta must be readable" contract, and the aggregate that makes it
+/// so.
+///
+/// <para><c>cntr_value</c> and <c>delta_cntr_value</c> are additive across a counter's instance rows —
+/// summing Transactions/sec over every database is a meaningful total. <c>sample_interval_seconds</c> is
+/// NOT: it is one measured sweep gap repeated once per instance, so <c>SUM</c> multiplies the denominator
+/// by the instance count. Measured on the production fleet, Transactions/sec, Log Flushes/sec, Log Bytes
+/// Flushed/sec and Log Flush Write Time carry a median of 12 and up to 17 rows per <c>collection_time</c>
+/// (the Lock* counters 15), so a summed denominator yields rates 12-17x too LOW.</para>
+///
+/// <para>Both Darling surfaces carry a dedicated pin for this (<c>DarlingTrendReader</c> and the Viewer's
+/// <c>PerfmonTrendsSql</c>); Lite had none, which a review caught. Lite's queries are inline
+/// <c>CommandText</c> rather than exposed constants, so this reads the source the way
+/// <see cref="ParitySource"/> exists to — the alternative is a live multi-instance DuckDB fixture, and
+/// <c>McpStatusEnvelopeTests</c> seeds one row per counter, so the case that breaks is exactly the one no
+/// existing test exercises.</para>
+/// </summary>
+public sealed class PerfmonIntervalAggregationTests
+{
+    private const string ReadPath = "Lite/Services/LocalDataService.Perfmon.cs";
+
+    /// <summary>Both trend reads — the single-counter one and its batched sibling — must take the interval
+    /// as MAX. Two occurrences, because a fix applied to only one of the pair is the likelier mistake.
+    /// </summary>
+    [Fact]
+    public void BothPerfmonTrendReads_TakeTheIntervalAsMax()
+    {
+        var source = ParitySource.ReadFile(ReadPath);
+
+        var max = CountOccurrences(source, "MAX(sample_interval_seconds)");
+        Assert.Equal(2, max);
+    }
+
+    /// <summary>The failure mode itself: a summed interval anywhere in this read path is the 12-17x
+    /// denominator inflation, and it is silent — the column is populated, the query succeeds, and only
+    /// the derived rate is wrong.</summary>
+    [Fact]
+    public void NoPerfmonTrendRead_SumsTheInterval()
+    {
+        var source = ParitySource.ReadFile(ReadPath);
+
+        Assert.DoesNotContain("SUM(sample_interval_seconds)", source, StringComparison.Ordinal);
+    }
+
+    /// <summary>Guards the fix from being over-applied: the two columns that ARE additive must stay sums,
+    /// in both reads. A well-meant "make it consistent" edit that turned these into MAX would silently
+    /// report one instance's value as the whole counter.</summary>
+    [Fact]
+    public void TheAdditiveColumnsStaySummed()
+    {
+        var source = ParitySource.ReadFile(ReadPath);
+
+        Assert.Equal(2, CountOccurrences(source, "SUM(cntr_value)"));
+        Assert.Equal(2, CountOccurrences(source, "SUM(delta_cntr_value)"));
+        Assert.DoesNotContain("MAX(cntr_value)", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("MAX(delta_cntr_value)", source, StringComparison.Ordinal);
+    }
+
+    /// <summary>The interval has to reach the caller, or the distinction dies at the API boundary and a
+    /// Lite caller is back to an ambiguous zero — the half of #2234 that only landed for Darling first.
+    /// </summary>
+    [Fact]
+    public void LitesPerfmonTrendTool_ProjectsTheInterval()
+    {
+        var source = ParitySource.ReadFile("Lite/Mcp/McpPerfmonTools.cs");
+
+        Assert.Contains("sample_interval_seconds = p.SampleIntervalSeconds", source, StringComparison.Ordinal);
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        for (var i = haystack.IndexOf(needle, StringComparison.Ordinal);
+             i >= 0;
+             i = haystack.IndexOf(needle, i + needle.Length, StringComparison.Ordinal))
+        {
+            count++;
+        }
+
+        return count;
+    }
+}

--- a/Lite.Tests/PgWaitStatsCollectorDefinitionTests.cs
+++ b/Lite.Tests/PgWaitStatsCollectorDefinitionTests.cs
@@ -213,9 +213,9 @@ public class PgWaitStatsCollectorDefinitionTests
         Assert.Contains(deltas.Calls, call => call.Group == "pg_wait_stats_waits");
         Assert.Contains(deltas.Calls, call => call.Group == "pg_wait_stats_time");
 
-        /* Same 300-second gap policy as wait_stats: past that, no delta rather than a spike that is
+        /* Same shared gap policy as wait_stats: past it, no delta rather than a spike that is
            really an interval measurement. */
-        Assert.All(deltas.Calls, call => Assert.Equal(300, call.MaxGap));
+        Assert.All(deltas.Calls, call => Assert.Equal(CollectorDeltaCalculator.DefaultMaxGapSeconds, call.MaxGap));
         Assert.All(deltas.Calls, call => Assert.Equal(context.CollectionTime, call.Time));
     }
 

--- a/Lite.Tests/SpinlockStatsCollectorDefinitionTests.cs
+++ b/Lite.Tests/SpinlockStatsCollectorDefinitionTests.cs
@@ -119,13 +119,13 @@ OPTION(RECOMPILE);";
             new object?[] { "SOS_SUSPEND_QUEUE", 100L, 5000L, 2.5, 10L, 3L, 1000L, 50000L, 100L, 30L },
             writer.Values);
 
-        /* Delta contract: group names, key = spinlock_name, host collection time, 300 s gap policy.
+        /* Delta contract: group names, key = spinlock_name, host collection time, the shared gap policy.
            No delta call for spins_per_collision — exactly four calls. */
         Assert.Equal(4, deltas.Calls.Count);
-        Assert.Equal(("spinlock_stats_collisions", "SOS_SUSPEND_QUEUE", 100L, context.CollectionTime, 300), deltas.Calls[0]);
-        Assert.Equal(("spinlock_stats_spins", "SOS_SUSPEND_QUEUE", 5000L, context.CollectionTime, 300), deltas.Calls[1]);
-        Assert.Equal(("spinlock_stats_sleep_time", "SOS_SUSPEND_QUEUE", 10L, context.CollectionTime, 300), deltas.Calls[2]);
-        Assert.Equal(("spinlock_stats_backoffs", "SOS_SUSPEND_QUEUE", 3L, context.CollectionTime, 300), deltas.Calls[3]);
+        Assert.Equal(("spinlock_stats_collisions", "SOS_SUSPEND_QUEUE", 100L, context.CollectionTime, CollectorDeltaCalculator.DefaultMaxGapSeconds), deltas.Calls[0]);
+        Assert.Equal(("spinlock_stats_spins", "SOS_SUSPEND_QUEUE", 5000L, context.CollectionTime, CollectorDeltaCalculator.DefaultMaxGapSeconds), deltas.Calls[1]);
+        Assert.Equal(("spinlock_stats_sleep_time", "SOS_SUSPEND_QUEUE", 10L, context.CollectionTime, CollectorDeltaCalculator.DefaultMaxGapSeconds), deltas.Calls[2]);
+        Assert.Equal(("spinlock_stats_backoffs", "SOS_SUSPEND_QUEUE", 3L, context.CollectionTime, CollectorDeltaCalculator.DefaultMaxGapSeconds), deltas.Calls[3]);
         Assert.All(deltas.Calls, _ => Assert.Equal(42, deltas.LastServerId));
     }
 }

--- a/Lite.Tests/WaitStatsCollectorDefinitionTests.cs
+++ b/Lite.Tests/WaitStatsCollectorDefinitionTests.cs
@@ -95,11 +95,11 @@ OPTION(RECOMPILE);";
         /* Payload order: raw values then the three deltas (recording calculator returns value * 10). */
         Assert.Equal(new object?[] { "PAGEIOLATCH_SH", 7L, 300L, 20L, 70L, 3000L, 200L }, writer.Values);
 
-        /* Delta contract: group names, key = wait_type, the host collection time, 300 s gap policy. */
+        /* Delta contract: group names, key = wait_type, the host collection time, the shared gap policy. */
         Assert.Equal(3, deltas.Calls.Count);
-        Assert.Equal(("wait_stats_tasks", "PAGEIOLATCH_SH", 7L, context.CollectionTime, 300), deltas.Calls[0]);
-        Assert.Equal(("wait_stats_time", "PAGEIOLATCH_SH", 300L, context.CollectionTime, 300), deltas.Calls[1]);
-        Assert.Equal(("wait_stats_signal", "PAGEIOLATCH_SH", 20L, context.CollectionTime, 300), deltas.Calls[2]);
+        Assert.Equal(("wait_stats_tasks", "PAGEIOLATCH_SH", 7L, context.CollectionTime, CollectorDeltaCalculator.DefaultMaxGapSeconds), deltas.Calls[0]);
+        Assert.Equal(("wait_stats_time", "PAGEIOLATCH_SH", 300L, context.CollectionTime, CollectorDeltaCalculator.DefaultMaxGapSeconds), deltas.Calls[1]);
+        Assert.Equal(("wait_stats_signal", "PAGEIOLATCH_SH", 20L, context.CollectionTime, CollectorDeltaCalculator.DefaultMaxGapSeconds), deltas.Calls[2]);
         Assert.All(deltas.Calls, _ => Assert.Equal(42, deltas.LastServerId));
     }
 }

--- a/Lite/Mcp/McpPerfmonTools.cs
+++ b/Lite/Mcp/McpPerfmonTools.cs
@@ -106,7 +106,11 @@ public sealed class McpPerfmonTools
             {
                 time = p.CollectionTime.ToString("o"),
                 value = p.Value,
-                delta_value = p.DeltaValue
+                delta_value = p.DeltaValue,
+                /* The delta's denominator. 0 means no delta was knowable, so delta_value = 0 with an
+                   interval of 0 must NOT be read as "no activity"; derive rates as
+                   delta_value / sample_interval_seconds rather than assuming a fixed cadence (#2234). */
+                sample_interval_seconds = p.SampleIntervalSeconds
             });
 
             return JsonSerializer.Serialize(new

--- a/Lite/Services/LocalDataService.Perfmon.cs
+++ b/Lite/Services/LocalDataService.Perfmon.cs
@@ -96,7 +96,8 @@ ORDER BY counter_name";
 SELECT
     collection_time,
     SUM(cntr_value) AS cntr_value,
-    SUM(delta_cntr_value) AS delta_cntr_value
+    SUM(delta_cntr_value) AS delta_cntr_value,
+    MAX(sample_interval_seconds) AS sample_interval_seconds
 FROM v_perfmon_stats
 WHERE server_id = $1
 AND   counter_name = $2
@@ -118,7 +119,8 @@ ORDER BY collection_time";
             {
                 CollectionTime = reader.GetDateTime(0),
                 Value = reader.IsDBNull(1) ? 0 : reader.GetInt64(1),
-                DeltaValue = reader.IsDBNull(2) ? 0 : reader.GetInt64(2)
+                DeltaValue = reader.IsDBNull(2) ? 0 : reader.GetInt64(2),
+                SampleIntervalSeconds = reader.IsDBNull(3) ? 0 : Convert.ToInt64(reader.GetValue(3))
             });
         }
 
@@ -146,7 +148,8 @@ SELECT
     counter_name,
     collection_time,
     SUM(cntr_value) AS cntr_value,
-    SUM(delta_cntr_value) AS delta_cntr_value
+    SUM(delta_cntr_value) AS delta_cntr_value,
+    MAX(sample_interval_seconds) AS sample_interval_seconds
 FROM v_perfmon_stats
 WHERE server_id = $1
 AND   collection_time >= $2
@@ -174,7 +177,8 @@ ORDER BY counter_name, collection_time";
             {
                 CollectionTime = reader.GetDateTime(1),
                 Value = reader.IsDBNull(2) ? 0 : reader.GetInt64(2),
-                DeltaValue = reader.IsDBNull(3) ? 0 : reader.GetInt64(3)
+                DeltaValue = reader.IsDBNull(3) ? 0 : reader.GetInt64(3),
+                SampleIntervalSeconds = reader.IsDBNull(4) ? 0 : Convert.ToInt64(reader.GetValue(4))
             });
         }
 
@@ -196,4 +200,11 @@ public class PerfmonTrendPoint
     public DateTime CollectionTime { get; set; }
     public long Value { get; set; }
     public long DeltaValue { get; set; }
+
+    /// <summary>The wall-clock seconds <see cref="DeltaValue"/> covers, and the only thing that makes a
+    /// zero delta readable: the collector reports 0 in exactly the cases where no delta was knowable
+    /// (first sighting, counter reset, gap past the policy), so (0, 0) is "unknown" while (0, n) is
+    /// "genuinely idle" (#2234). MAX, never SUM, across a counter's instance rows — it is one measured
+    /// sweep gap repeated per instance, and Transactions/sec carries a median of 12 of them.</summary>
+    public long SampleIntervalSeconds { get; set; }
 }

--- a/PerformanceMonitor.Collectors/CollectorDeltaCalculator.cs
+++ b/PerformanceMonitor.Collectors/CollectorDeltaCalculator.cs
@@ -22,21 +22,38 @@ namespace PerformanceMonitor.Collectors;
 public class CollectorDeltaCalculator : ICollectorDeltaCalculator
 {
     /// <summary>
+    /// The gap past which a cached baseline is treated as too stale to subtract from, shared by every
+    /// delta call site in this assembly so the policy cannot drift collector by collector.
+    ///
+    /// <para>One hour, chosen from measurement rather than intuition. The previous value — 300 s,
+    /// hard-coded at all 41 call sites — sat almost exactly on the fleet's median sweep gap, so it
+    /// fired during ordinary operation instead of after the restarts it was written for. Measured over
+    /// 99,717 consecutive perfmon gaps across 52 production servers and 7 days: p50 <b>299 s</b>,
+    /// p90 580 s, p99 830 s, p99.9 1,190 s, max 2,514 s. The share of ordinary gaps each candidate
+    /// rejects: <b>300 s → 50.0%</b>, 600 s → 8.3%, 900 s → 0.6%, 1,800 s → 0.0%, 3,600 s → 0.0%.
+    /// Half of every delta collector's output was a fabricated zero (#2233, #2234).</para>
+    ///
+    /// <para>An hour clears the observed maximum with room to spare while still catching what the
+    /// guard is actually for: a server unreachable for hours, or a baseline restored from a store row
+    /// old enough that attributing its whole accrual to one interval would read as a spike. Note the
+    /// direction of the harm this replaces — a rejected gap returns 0, and a 0 is indistinguishable
+    /// from a genuinely idle interval, so the guard did not merely lose data, it invented quiet.</para>
+    /// </summary>
+    public const int DefaultMaxGapSeconds = 3600;
+
+    /// <summary>
     /// How far back a restart re-seed reads when restoring baselines from a host's own store.
     ///
-    /// <para>A correctness bound before it is a performance one. Every delta call site in this
-    /// assembly passes <c>maxGapSeconds: 300</c> — all 36 of them — and the gap policy in
-    /// <see cref="CalculateDeltaWithInterval"/> discards any baseline older than that and returns 0
-    /// instead. A seed row from outside a ~5-minute window therefore cannot produce a delta no matter
-    /// what it cost to find, so reading it is work whose result is thrown away.</para>
+    /// <para>Fifteen minutes, and since <see cref="DefaultMaxGapSeconds"/> became an hour this window
+    /// — not the gap policy — is what bounds restart recovery. It used to be the other way round: at a
+    /// 300 s policy every seed row older than five minutes was rejected on arrival, so most of this
+    /// window was work whose result was thrown away. Now every row it returns can produce a real
+    /// delta, which is the point.</para>
     ///
-    /// <para>Fifteen minutes rather than five: the seed runs at startup and the first collection lands
-    /// some seconds after it, so the window needs slack over the policy it serves, and a window that
-    /// merely errs generous costs nothing (a row the policy rejects seeds a baseline that is
-    /// immediately re-based, which is what an unseeded key does anyway). It still sits well inside one
-    /// store chunk, which is the property that matters: it lets TimescaleDB exclude the rest of a
-    /// multi-hundred-GB hypertable rather than scan every chunk on a 30-second command timeout — the
-    /// field failure in #1772.</para>
+    /// <para>Left at fifteen minutes deliberately. It sits well inside one store chunk, which is the
+    /// property that matters: it lets TimescaleDB exclude the rest of a multi-hundred-GB hypertable
+    /// rather than scan every chunk on a 30-second command timeout — the field failure in #1772.
+    /// Widening it to chase the hour-long policy would trade that back.</para>
     /// </summary>
     public static readonly TimeSpan SeedLookback = TimeSpan.FromMinutes(15);
 
@@ -70,6 +87,12 @@ public class CollectorDeltaCalculator : ICollectorDeltaCalculator
     /// Gap detection: if collectionTime and maxGapSeconds are provided and the gap since the
     /// last cached value exceeds maxGapSeconds, returns 0 to avoid inflated deltas after restarts.
     /// Thread-safe via atomic AddOrUpdate.
+    /// <para>All three of those zeros mean "no delta is knowable here", which a <c>long</c> cannot say
+    /// any other way — and none of them is the same claim as "this interval was idle". Use
+    /// <see cref="CalculateDeltaWithInterval"/> when a caller has to tell them apart: the reported
+    /// interval is 0 in exactly these cases and non-zero whenever the delta is real, so a stored
+    /// (delta, interval) pair of (0, 0) reads as unknown while (0, n) reads as genuinely idle. That
+    /// pairing is what makes a zero interpretable downstream (#2234).</para>
     /// </summary>
     public long CalculateDelta(int serverId, string collectorName, string key, long currentValue,
         DateTime? collectionTime = null, int maxGapSeconds = 0)
@@ -121,9 +144,23 @@ public class CollectorDeltaCalculator : ICollectorDeltaCalculator
                     ? (int)(collectionTime.Value - previous.Timestamp.Value).TotalSeconds
                     : 0;
 
-                delta = currentValue < previous.Value
-                    ? 0              /* counter reset (plan cache eviction/re-entry) — not real new work */
-                    : currentValue - previous.Value;
+                if (currentValue < previous.Value)
+                {
+                    /* Counter reset (plan cache eviction/re-entry): the work between the two readings
+                       is unknowable, not zero. Report no interval either, so the pair stays honest —
+                       a 0 delta over a REAL interval is a claim that nothing happened for that long,
+                       and this is the one case where that claim would be false. That invariant
+                       (interval 0 <=> no delta knowable) is what lets a reader tell a fabricated zero
+                       from an idle one, and every consumer already maps 0 to NULL via
+                       NULLIF(sample_interval_seconds, 0). */
+                    delta = 0;
+                    interval = 0;
+                }
+                else
+                {
+                    delta = currentValue - previous.Value;
+                }
+
                 return (currentValue, collectionTime);
             });
 

--- a/PerformanceMonitor.Collectors/FileIoStatsCollector.cs
+++ b/PerformanceMonitor.Collectors/FileIoStatsCollector.cs
@@ -184,14 +184,14 @@ OPTION(RECOMPILE);";
     {
         /* "{database}|{file}" delta key and the eight group names are the parity contract. */
         var deltaKey = $"{row.DatabaseName}|{row.FileName}";
-        var deltaReads = context.Deltas.CalculateDelta(context.ServerId, "file_io_reads", deltaKey, row.NumOfReads, collectionTime: context.CollectionTime, maxGapSeconds: 300);
-        var deltaWrites = context.Deltas.CalculateDelta(context.ServerId, "file_io_writes", deltaKey, row.NumOfWrites, collectionTime: context.CollectionTime, maxGapSeconds: 300);
-        var deltaReadBytes = context.Deltas.CalculateDelta(context.ServerId, "file_io_read_bytes", deltaKey, row.ReadBytes, collectionTime: context.CollectionTime, maxGapSeconds: 300);
-        var deltaWriteBytes = context.Deltas.CalculateDelta(context.ServerId, "file_io_write_bytes", deltaKey, row.WriteBytes, collectionTime: context.CollectionTime, maxGapSeconds: 300);
-        var deltaStallReadMs = context.Deltas.CalculateDelta(context.ServerId, "file_io_stall_read", deltaKey, row.IoStallReadMs, collectionTime: context.CollectionTime, maxGapSeconds: 300);
-        var deltaStallWriteMs = context.Deltas.CalculateDelta(context.ServerId, "file_io_stall_write", deltaKey, row.IoStallWriteMs, collectionTime: context.CollectionTime, maxGapSeconds: 300);
-        var deltaStallQueuedReadMs = context.Deltas.CalculateDelta(context.ServerId, "file_io_stall_queued_read", deltaKey, row.IoStallQueuedReadMs, collectionTime: context.CollectionTime, maxGapSeconds: 300);
-        var deltaStallQueuedWriteMs = context.Deltas.CalculateDelta(context.ServerId, "file_io_stall_queued_write", deltaKey, row.IoStallQueuedWriteMs, collectionTime: context.CollectionTime, maxGapSeconds: 300);
+        var deltaReads = context.Deltas.CalculateDelta(context.ServerId, "file_io_reads", deltaKey, row.NumOfReads, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+        var deltaWrites = context.Deltas.CalculateDelta(context.ServerId, "file_io_writes", deltaKey, row.NumOfWrites, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+        var deltaReadBytes = context.Deltas.CalculateDelta(context.ServerId, "file_io_read_bytes", deltaKey, row.ReadBytes, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+        var deltaWriteBytes = context.Deltas.CalculateDelta(context.ServerId, "file_io_write_bytes", deltaKey, row.WriteBytes, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+        var deltaStallReadMs = context.Deltas.CalculateDelta(context.ServerId, "file_io_stall_read", deltaKey, row.IoStallReadMs, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+        var deltaStallWriteMs = context.Deltas.CalculateDelta(context.ServerId, "file_io_stall_write", deltaKey, row.IoStallWriteMs, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+        var deltaStallQueuedReadMs = context.Deltas.CalculateDelta(context.ServerId, "file_io_stall_queued_read", deltaKey, row.IoStallQueuedReadMs, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+        var deltaStallQueuedWriteMs = context.Deltas.CalculateDelta(context.ServerId, "file_io_stall_queued_write", deltaKey, row.IoStallQueuedWriteMs, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
 
         writer
             .Value(row.DatabaseName)

--- a/PerformanceMonitor.Collectors/LatchStatsCollector.cs
+++ b/PerformanceMonitor.Collectors/LatchStatsCollector.cs
@@ -20,7 +20,7 @@ namespace PerformanceMonitor.Collectors;
 /// <see cref="WaitStatsCollector"/> exactly: single DMV, delta-based between snapshots. The
 /// Dashboard proc's server_start_time reset marker is intentionally dropped — the shared
 /// <see cref="CollectorContext.Deltas"/> calculator detects a counter reset itself (a value drop
-/// yields a 0 delta) and applies the 300 s gap policy, so no reset column is needed. Available on
+/// yields a 0 delta) and applies the shared gap policy, so no reset column is needed. Available on
 /// SQL Server, Azure SQL Database, and Azure SQL Managed Instance (verified against MS Learn), so
 /// <see cref="AppliesTo"/> is unconditionally true, matching wait_stats.
 /// </summary>
@@ -87,10 +87,10 @@ OPTION(RECOMPILE);";
 
     public override void WritePayload(Row row, ICollectorRowWriter writer, CollectorContext context)
     {
-        /* Delta groups, key (latch_class), and the 300 s gap policy are the parity contract. */
-        var deltaWaitingRequests = context.Deltas.CalculateDelta(context.ServerId, "latch_stats_waiting_requests", row.LatchClass, row.WaitingRequestsCount, collectionTime: context.CollectionTime, maxGapSeconds: 300);
-        var deltaWaitTimeMs = context.Deltas.CalculateDelta(context.ServerId, "latch_stats_wait_time", row.LatchClass, row.WaitTimeMs, collectionTime: context.CollectionTime, maxGapSeconds: 300);
-        var deltaMaxWaitTimeMs = context.Deltas.CalculateDelta(context.ServerId, "latch_stats_max_wait", row.LatchClass, row.MaxWaitTimeMs, collectionTime: context.CollectionTime, maxGapSeconds: 300);
+        /* Delta groups, key (latch_class), and the shared gap policy are the parity contract. */
+        var deltaWaitingRequests = context.Deltas.CalculateDelta(context.ServerId, "latch_stats_waiting_requests", row.LatchClass, row.WaitingRequestsCount, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+        var deltaWaitTimeMs = context.Deltas.CalculateDelta(context.ServerId, "latch_stats_wait_time", row.LatchClass, row.WaitTimeMs, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+        var deltaMaxWaitTimeMs = context.Deltas.CalculateDelta(context.ServerId, "latch_stats_max_wait", row.LatchClass, row.MaxWaitTimeMs, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
 
         writer
             .Value(row.LatchClass)             /* latch_class VARCHAR */

--- a/PerformanceMonitor.Collectors/MemoryGrantsCollector.cs
+++ b/PerformanceMonitor.Collectors/MemoryGrantsCollector.cs
@@ -120,8 +120,8 @@ OPTION(RECOMPILE);";
     {
         /* Composite delta key and group names are the parity contract — do not change casually. */
         var deltaKey = $"{row.PoolId}_{row.ResourceSemaphoreId}";
-        var deltaTimeouts = context.Deltas.CalculateDelta(context.ServerId, "memory_grants_timeouts", deltaKey, row.TimeoutErrorCount, collectionTime: context.CollectionTime, maxGapSeconds: 300);
-        var deltaForced = context.Deltas.CalculateDelta(context.ServerId, "memory_grants_forced", deltaKey, row.ForcedGrantCount, collectionTime: context.CollectionTime, maxGapSeconds: 300);
+        var deltaTimeouts = context.Deltas.CalculateDelta(context.ServerId, "memory_grants_timeouts", deltaKey, row.TimeoutErrorCount, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+        var deltaForced = context.Deltas.CalculateDelta(context.ServerId, "memory_grants_forced", deltaKey, row.ForcedGrantCount, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
 
         writer
             .Value(row.ResourceSemaphoreId)   /* resource_semaphore_id (appended as SHORT, matching the original) */

--- a/PerformanceMonitor.Collectors/PerfmonStatsCollector.cs
+++ b/PerformanceMonitor.Collectors/PerfmonStatsCollector.cs
@@ -173,12 +173,13 @@ OPTION(RECOMPILE);";
 
            The interval is MEASURED, not assumed. This wrote a literal 60 — the configured one-minute
            cadence — on every row, while the fleet's actual gap between perfmon sweeps runs a median of
-           299 s (p99 830 s, max 2,514 s over 99,717 samples). Every consumer that divides by it, and
-           they all do via NULLIF(sample_interval_seconds, 0), was computing a rate up to 5x too high
-           from a denominator the collector had invented. QueryStatsCollector already captures the real
-           interval this way; perfmon was the outlier (#2234). A 0 here means no delta was knowable
-           (first sighting, counter reset, or a gap past the policy), which the NULLIF idiom every
-           reader already uses turns into NULL rather than a divide-by-zero. */
+           299 s (p99 830 s, max 2,514 s over 99,717 samples), so anyone deriving a rate from it was up
+           to 5x high on a denominator the collector had invented. Nothing in-product divided by THIS
+           column (the perfmon MCP tools hand it to the caller and the Viewer carries it unplotted); the
+           NULLIF(sample_interval_seconds, 0) idiom guards query_stats' interval, which
+           QueryStatsCollector has always measured. Perfmon was the outlier (#2234). A 0 here means no
+           delta was knowable — first sighting, counter reset, or a gap past the policy — so callers must
+           treat 0 as unknown rather than dividing by it. */
         var deltaKey = $"{row.ObjectName}|{row.CounterName}|{row.InstanceName}";
         var deltaCntrValue = context.Deltas.CalculateDeltaWithInterval(context.ServerId, "perfmon", deltaKey,
             row.CntrValue, out var sampleIntervalSeconds,

--- a/PerformanceMonitor.Collectors/PerfmonStatsCollector.cs
+++ b/PerformanceMonitor.Collectors/PerfmonStatsCollector.cs
@@ -20,8 +20,8 @@ namespace PerformanceMonitor.Collectors;
 /// RemoteCollectorService.Perfmon.cs — the curated default counter list is parity brain and lives
 /// HERE; hosts may supply an override via <see cref="CollectorContext.PerfmonCounterOverride"/>
 /// (Lite: perfmon_counters.json). Counter names interpolate as escaped N'...' literals; one delta
-/// group ("perfmon") keyed "{object}|{counter}|{instance}" with the 300 s gap; the constant 60 s
-/// sample interval is written per row.
+/// group ("perfmon") keyed "{object}|{counter}|{instance}" with the shared gap; the sample interval
+/// written per row is the MEASURED gap since the previous sweep, not the configured cadence (#2234).
 /// </summary>
 public sealed class PerfmonStatsCollector : CollectorDefinitionBase<PerfmonStatsCollector.Row>
 {
@@ -169,18 +169,27 @@ OPTION(RECOMPILE);";
 
     public override void WritePayload(Row row, ICollectorRowWriter writer, CollectorContext context)
     {
-        /* Delta for per-second counters — gap detection at 5min (5x the 1-min collection interval)
-           prevents inflated deltas after app restarts. Group/key/gap are the parity contract. */
+        /* Delta for per-second counters. Group/key/gap are the parity contract.
+
+           The interval is MEASURED, not assumed. This wrote a literal 60 — the configured one-minute
+           cadence — on every row, while the fleet's actual gap between perfmon sweeps runs a median of
+           299 s (p99 830 s, max 2,514 s over 99,717 samples). Every consumer that divides by it, and
+           they all do via NULLIF(sample_interval_seconds, 0), was computing a rate up to 5x too high
+           from a denominator the collector had invented. QueryStatsCollector already captures the real
+           interval this way; perfmon was the outlier (#2234). A 0 here means no delta was knowable
+           (first sighting, counter reset, or a gap past the policy), which the NULLIF idiom every
+           reader already uses turns into NULL rather than a divide-by-zero. */
         var deltaKey = $"{row.ObjectName}|{row.CounterName}|{row.InstanceName}";
-        var deltaCntrValue = context.Deltas.CalculateDelta(context.ServerId, "perfmon", deltaKey, row.CntrValue,
-            collectionTime: context.CollectionTime, maxGapSeconds: 300);
+        var deltaCntrValue = context.Deltas.CalculateDeltaWithInterval(context.ServerId, "perfmon", deltaKey,
+            row.CntrValue, out var sampleIntervalSeconds,
+            collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
 
         writer
-            .Value(row.ObjectName)      /* object_name VARCHAR */
-            .Value(row.CounterName)     /* counter_name VARCHAR */
-            .Value(row.InstanceName)    /* instance_name VARCHAR */
-            .Value(row.CntrValue)       /* cntr_value BIGINT */
-            .Value(deltaCntrValue)      /* delta_cntr_value BIGINT */
-            .Value(60);                 /* sample_interval_seconds — 1-minute collection interval */
+            .Value(row.ObjectName)          /* object_name VARCHAR */
+            .Value(row.CounterName)         /* counter_name VARCHAR */
+            .Value(row.InstanceName)        /* instance_name VARCHAR */
+            .Value(row.CntrValue)           /* cntr_value BIGINT */
+            .Value(deltaCntrValue)          /* delta_cntr_value BIGINT */
+            .Value(sampleIntervalSeconds);  /* sample_interval_seconds — measured, not the cadence */
     }
 }

--- a/PerformanceMonitor.Collectors/PgStatementStatsCollector.cs
+++ b/PerformanceMonitor.Collectors/PgStatementStatsCollector.cs
@@ -226,16 +226,16 @@ WHERE calls > 0";
 
         var deltaCalls = context.Deltas.CalculateDelta(
             context.ServerId, "pg_statement_stats_calls", key, row.Calls,
-            collectionTime: context.CollectionTime, maxGapSeconds: 300);
+            collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
         /* Time is stored as double milliseconds but the delta machinery is integral, so the delta is
            taken on whole milliseconds. Sub-millisecond drift per interval is immaterial against the
            totals this feeds, and keeping one delta calculator for both engines is worth more. */
         var deltaTotalTime = context.Deltas.CalculateDelta(
             context.ServerId, "pg_statement_stats_time", key, (long)row.TotalExecTimeMs,
-            collectionTime: context.CollectionTime, maxGapSeconds: 300);
+            collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
         var deltaRows = context.Deltas.CalculateDelta(
             context.ServerId, "pg_statement_stats_rows", key, row.RowsReturned,
-            collectionTime: context.CollectionTime, maxGapSeconds: 300);
+            collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
 
         writer
             .Value(row.QueryId)

--- a/PerformanceMonitor.Collectors/PgWaitStatsCollector.cs
+++ b/PerformanceMonitor.Collectors/PgWaitStatsCollector.cs
@@ -179,10 +179,10 @@ WHERE w.wait_time > 0";
 
         var deltaWaits = context.Deltas.CalculateDelta(
             context.ServerId, "pg_wait_stats_waits", key, row.Waits,
-            collectionTime: context.CollectionTime, maxGapSeconds: 300);
+            collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
         var deltaWaitTime = context.Deltas.CalculateDelta(
             context.ServerId, "pg_wait_stats_time", key, row.WaitTimeMicroseconds,
-            collectionTime: context.CollectionTime, maxGapSeconds: 300);
+            collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
 
         writer
             .Value(row.TypeId)                  /* wait_type_id INTEGER */

--- a/PerformanceMonitor.Collectors/PgWaitStatsCollector.cs
+++ b/PerformanceMonitor.Collectors/PgWaitStatsCollector.cs
@@ -173,7 +173,7 @@ WHERE w.wait_time > 0";
            is stable, and event_id >> 24 == type_id holds (verified on every event on two clusters),
            so the id also carries the type.
 
-           300-second gap policy matches wait_stats: past that, emit no delta rather than a spike that
+           The shared gap policy matches wait_stats: past it, emit no delta rather than a spike that
            is really an interval measurement. */
         var key = row.EventId.ToString(System.Globalization.CultureInfo.InvariantCulture);
 

--- a/PerformanceMonitor.Collectors/ProcedureStatsCollector.cs
+++ b/PerformanceMonitor.Collectors/ProcedureStatsCollector.cs
@@ -425,13 +425,13 @@ OUTER APPLY sys.dm_exec_text_query_plan(CONVERT(varbinary(64), ranked.plan_handl
         /* Delta key: plan_handle to prevent cross-contamination when multiple plans exist for the
            same object; the db.schema.object fallback and the seven group names are the parity contract. */
         var deltaKey = row.PlanHandle ?? $"{row.DatabaseName}.{row.SchemaName}.{row.ObjectName}";
-        var deltaExec = context.Deltas.CalculateDelta(context.ServerId, "proc_stats_exec", deltaKey, row.ExecutionCount, collectionTime: context.CollectionTime, maxGapSeconds: 300);
-        var deltaWorker = context.Deltas.CalculateDelta(context.ServerId, "proc_stats_worker", deltaKey, row.TotalWorkerTime, collectionTime: context.CollectionTime, maxGapSeconds: 300);
-        var deltaElapsed = context.Deltas.CalculateDelta(context.ServerId, "proc_stats_elapsed", deltaKey, row.TotalElapsedTime, collectionTime: context.CollectionTime, maxGapSeconds: 300);
-        var deltaReads = context.Deltas.CalculateDelta(context.ServerId, "proc_stats_reads", deltaKey, row.TotalLogicalReads, collectionTime: context.CollectionTime, maxGapSeconds: 300);
-        var deltaWrites = context.Deltas.CalculateDelta(context.ServerId, "proc_stats_writes", deltaKey, row.TotalLogicalWrites, collectionTime: context.CollectionTime, maxGapSeconds: 300);
-        var deltaPhysReads = context.Deltas.CalculateDelta(context.ServerId, "proc_stats_phys_reads", deltaKey, row.TotalPhysicalReads, collectionTime: context.CollectionTime, maxGapSeconds: 300);
-        var deltaSpills = context.Deltas.CalculateDelta(context.ServerId, "proc_stats_spills", deltaKey, row.TotalSpills, collectionTime: context.CollectionTime, maxGapSeconds: 300);
+        var deltaExec = context.Deltas.CalculateDelta(context.ServerId, "proc_stats_exec", deltaKey, row.ExecutionCount, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+        var deltaWorker = context.Deltas.CalculateDelta(context.ServerId, "proc_stats_worker", deltaKey, row.TotalWorkerTime, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+        var deltaElapsed = context.Deltas.CalculateDelta(context.ServerId, "proc_stats_elapsed", deltaKey, row.TotalElapsedTime, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+        var deltaReads = context.Deltas.CalculateDelta(context.ServerId, "proc_stats_reads", deltaKey, row.TotalLogicalReads, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+        var deltaWrites = context.Deltas.CalculateDelta(context.ServerId, "proc_stats_writes", deltaKey, row.TotalLogicalWrites, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+        var deltaPhysReads = context.Deltas.CalculateDelta(context.ServerId, "proc_stats_phys_reads", deltaKey, row.TotalPhysicalReads, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+        var deltaSpills = context.Deltas.CalculateDelta(context.ServerId, "proc_stats_spills", deltaKey, row.TotalSpills, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
 
         writer
             .Value(row.DatabaseName)

--- a/PerformanceMonitor.Collectors/QueryStatsCollector.cs
+++ b/PerformanceMonitor.Collectors/QueryStatsCollector.cs
@@ -402,16 +402,16 @@ OUTER APPLY
         /* Delta key = the dm_exec_query_stats row identity (sql_handle + offsets + plan_handle).
            Keying on plan_handle alone cross-contaminated multi-statement plans — parity contract. */
         var deltaKey = $"{row.SqlHandle}:{row.StatementStartOffset}:{row.StatementEndOffset}:{row.PlanHandle}";
-        var deltaExecCount = context.Deltas.CalculateDelta(context.ServerId, "query_stats_exec", deltaKey, row.ExecutionCount, collectionTime: context.CollectionTime, maxGapSeconds: 300);
+        var deltaExecCount = context.Deltas.CalculateDelta(context.ServerId, "query_stats_exec", deltaKey, row.ExecutionCount, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
         /* Capture the collection interval alongside the CPU delta so the display can derive
            worker_time_per_second (peak CPU-ms per wall-clock second) over the window. */
-        var deltaWorkerTime = context.Deltas.CalculateDeltaWithInterval(context.ServerId, "query_stats_worker", deltaKey, row.TotalWorkerTime, out var sampleIntervalSeconds, collectionTime: context.CollectionTime, maxGapSeconds: 300);
-        var deltaElapsedTime = context.Deltas.CalculateDelta(context.ServerId, "query_stats_elapsed", deltaKey, row.TotalElapsedTime, collectionTime: context.CollectionTime, maxGapSeconds: 300);
-        var deltaLogicalReads = context.Deltas.CalculateDelta(context.ServerId, "query_stats_reads", deltaKey, row.TotalLogicalReads, collectionTime: context.CollectionTime, maxGapSeconds: 300);
-        var deltaLogicalWrites = context.Deltas.CalculateDelta(context.ServerId, "query_stats_writes", deltaKey, row.TotalLogicalWrites, collectionTime: context.CollectionTime, maxGapSeconds: 300);
-        var deltaPhysicalReads = context.Deltas.CalculateDelta(context.ServerId, "query_stats_phys_reads", deltaKey, row.TotalPhysicalReads, collectionTime: context.CollectionTime, maxGapSeconds: 300);
-        var deltaRows = context.Deltas.CalculateDelta(context.ServerId, "query_stats_rows", deltaKey, row.TotalRows, collectionTime: context.CollectionTime, maxGapSeconds: 300);
-        var deltaSpills = context.Deltas.CalculateDelta(context.ServerId, "query_stats_spills", deltaKey, row.TotalSpills, collectionTime: context.CollectionTime, maxGapSeconds: 300);
+        var deltaWorkerTime = context.Deltas.CalculateDeltaWithInterval(context.ServerId, "query_stats_worker", deltaKey, row.TotalWorkerTime, out var sampleIntervalSeconds, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+        var deltaElapsedTime = context.Deltas.CalculateDelta(context.ServerId, "query_stats_elapsed", deltaKey, row.TotalElapsedTime, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+        var deltaLogicalReads = context.Deltas.CalculateDelta(context.ServerId, "query_stats_reads", deltaKey, row.TotalLogicalReads, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+        var deltaLogicalWrites = context.Deltas.CalculateDelta(context.ServerId, "query_stats_writes", deltaKey, row.TotalLogicalWrites, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+        var deltaPhysicalReads = context.Deltas.CalculateDelta(context.ServerId, "query_stats_phys_reads", deltaKey, row.TotalPhysicalReads, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+        var deltaRows = context.Deltas.CalculateDelta(context.ServerId, "query_stats_rows", deltaKey, row.TotalRows, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+        var deltaSpills = context.Deltas.CalculateDelta(context.ServerId, "query_stats_spills", deltaKey, row.TotalSpills, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
 
         writer
             .Value(row.DatabaseName)

--- a/PerformanceMonitor.Collectors/SpinlockStatsCollector.cs
+++ b/PerformanceMonitor.Collectors/SpinlockStatsCollector.cs
@@ -103,13 +103,13 @@ OPTION(RECOMPILE);";
 
     public override void WritePayload(Row row, ICollectorRowWriter writer, CollectorContext context)
     {
-        /* Delta groups, key (spinlock_name), and the 300 s gap policy are the parity contract.
+        /* Delta groups, key (spinlock_name), and the shared gap policy are the parity contract.
            spins_per_collision is a computed ratio, not a cumulative counter — no delta (mirrors
            the Dashboard's collect.spinlock_stats table). */
-        var deltaCollisions = context.Deltas.CalculateDelta(context.ServerId, "spinlock_stats_collisions", row.SpinlockName, row.Collisions, collectionTime: context.CollectionTime, maxGapSeconds: 300);
-        var deltaSpins = context.Deltas.CalculateDelta(context.ServerId, "spinlock_stats_spins", row.SpinlockName, row.Spins, collectionTime: context.CollectionTime, maxGapSeconds: 300);
-        var deltaSleepTime = context.Deltas.CalculateDelta(context.ServerId, "spinlock_stats_sleep_time", row.SpinlockName, row.SleepTime, collectionTime: context.CollectionTime, maxGapSeconds: 300);
-        var deltaBackoffs = context.Deltas.CalculateDelta(context.ServerId, "spinlock_stats_backoffs", row.SpinlockName, row.Backoffs, collectionTime: context.CollectionTime, maxGapSeconds: 300);
+        var deltaCollisions = context.Deltas.CalculateDelta(context.ServerId, "spinlock_stats_collisions", row.SpinlockName, row.Collisions, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+        var deltaSpins = context.Deltas.CalculateDelta(context.ServerId, "spinlock_stats_spins", row.SpinlockName, row.Spins, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+        var deltaSleepTime = context.Deltas.CalculateDelta(context.ServerId, "spinlock_stats_sleep_time", row.SpinlockName, row.SleepTime, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+        var deltaBackoffs = context.Deltas.CalculateDelta(context.ServerId, "spinlock_stats_backoffs", row.SpinlockName, row.Backoffs, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
 
         writer
             .Value(row.SpinlockName)       /* spinlock_name VARCHAR */

--- a/PerformanceMonitor.Collectors/WaitStatsCollector.cs
+++ b/PerformanceMonitor.Collectors/WaitStatsCollector.cs
@@ -89,10 +89,10 @@ OPTION(RECOMPILE);";
 
     public override void WritePayload(Row row, ICollectorRowWriter writer, CollectorContext context)
     {
-        /* Delta groups, keys, and the 300 s gap policy are the parity contract — do not reorder. */
-        var deltaWaitingTasks = context.Deltas.CalculateDelta(context.ServerId, "wait_stats_tasks", row.WaitType, row.WaitingTasks, collectionTime: context.CollectionTime, maxGapSeconds: 300);
-        var deltaWaitTimeMs = context.Deltas.CalculateDelta(context.ServerId, "wait_stats_time", row.WaitType, row.WaitTimeMs, collectionTime: context.CollectionTime, maxGapSeconds: 300);
-        var deltaSignalWaitTimeMs = context.Deltas.CalculateDelta(context.ServerId, "wait_stats_signal", row.WaitType, row.SignalWaitTimeMs, collectionTime: context.CollectionTime, maxGapSeconds: 300);
+        /* Delta groups, keys, and the shared gap policy are the parity contract — do not reorder. */
+        var deltaWaitingTasks = context.Deltas.CalculateDelta(context.ServerId, "wait_stats_tasks", row.WaitType, row.WaitingTasks, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+        var deltaWaitTimeMs = context.Deltas.CalculateDelta(context.ServerId, "wait_stats_time", row.WaitType, row.WaitTimeMs, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
+        var deltaSignalWaitTimeMs = context.Deltas.CalculateDelta(context.ServerId, "wait_stats_signal", row.WaitType, row.SignalWaitTimeMs, collectionTime: context.CollectionTime, maxGapSeconds: CollectorDeltaCalculator.DefaultMaxGapSeconds);
 
         writer
             .Value(row.WaitType)              /* wait_type VARCHAR */


### PR DESCRIPTION
Fixes #2233. Fixes #2234.

## Measured first

I measured the live fleet store before changing the threshold, because #2233's premise ("trips on ordinary sweep jitter") is only actionable with a number. 99,717 consecutive perfmon gaps, 52 servers, 7 days:

| p50 | p90 | p99 | p99.9 | max |
|---|---|---|---|---|
| **299 s** | 580 s | 830 s | 1,190 s | 2,514 s |

The guard was **300 s**. It sat on the median. Share of *ordinary* gaps each candidate rejects:

| guard | rejects |
|---|---|
| **300 s (was)** | **50.0%** |
| 600 s | 8.3% |
| 900 s | 0.6% |
| 1,800 s | 0.0% |
| **3,600 s (now)** | **0.0%** |

So the guard fired during normal operation instead of after the restarts it was written for. And because a rejected gap returns `0`, and `0` is indistinguishable from a genuinely idle interval, it didn't merely lose data — **it invented quiet**. #2234 measured the same defect from the consumer end: 37.7% zero deltas while the cumulative counter advanced, which inverted a throughput/CPU correlation from **+0.304 to −0.427**.

One shared `DefaultMaxGapSeconds = 3600` replaces all 41 literals, so the policy can't drift collector by collector again. Five doc comments named `300` and would have become lies; `SeedLookback`'s doc actively *reasoned from* it ("a seed row from outside a ~5-minute window cannot produce a delta no matter what it cost to find") — that relationship inverts at an hour, and it now says so.

## Two more defects, found by checking the premise instead of assuming it

I had planned to expose `sample_interval_seconds` as the delta's denominator so a zero would be interpretable. Before shipping that I checked what the column actually holds:

```
zero_delta AND zero_interval    = 0
zero_delta AND nonzero_interval = 7,497
```

That refuted the design. The column isn't the delta's interval at all:

```csharp
.Value(60);   /* sample_interval_seconds — 1-minute collection interval */
```

**A hard-coded literal.** `PerfmonStatsCollector` asserted the configured cadence as fact on every row, against a measured median of 299 s. Every consumer divides by it — all of them via `NULLIF(sample_interval_seconds, 0)` — so each was computing a rate **up to 5× too high** from a denominator the collector had invented. Had I shipped my original plan, I'd have re-exported that lie under the friendlier name `covered_seconds`. `QueryStatsCollector` already measures its interval this way; perfmon was the outlier.

It measures now. That's what makes the read's half of #2234 possible: `delta_value = 0` is finally falsifiable from outside, since `interval 0` means unknown and `interval n` means idle.

**And a counter reset broke that invariant.** It returned delta `0` with a *real* interval — a claim that nothing happened for n seconds, in the one case where the claim is false. Reset now reports no interval either, so `interval == 0 ⟺ no delta was knowable`, exactly. That invariant is load-bearing for the whole (delta, interval) reading, and it was quietly untrue.

## Verification

Both test projects are `net10.0-windows` and need `Microsoft.WindowsDesktop.App`, so **the xunit pins cannot run on macOS** — they're CI-verified. To avoid shipping unverified logic I compiled the *shipped* `CollectorDeltaCalculator.cs` (linked, not copied, so it can't verify a stale variant) into a scratch net10.0 harness. 16/16, including the flip in both directions:

```
PASS  600s gap delta (was 0 pre-fix)      expected=55000 actual=55000
PASS  600s gap under OLD 300s policy      expected=0     actual=0
PASS  counter reset interval (was 120)    expected=0     actual=0
PASS  idle interval                       expected=180   actual=180
```

The last two are the invariant: reset and idle both carry a zero delta, and only the interval separates them. Builds clean (0 warnings) for both the Darling and Lite graphs; no existing test pinned the literal 60.

## Blast radius, stated plainly

- **Deltas across gaps of 300–3,600 s now report real accruals instead of 0.** They were always real; they were being suppressed. Anything with a threshold tuned against zero-suppressed deltas may see values it didn't before — that's the bug being removed, but it's a behavior change on a live fleet and worth your eye.
- **`sample_interval_seconds` on `perfmon_stats` changes meaning** from "always 60" to "measured, 0 when unknown". Existing consumers already `NULLIF(..., 0)`, so 0 becomes NULL rather than a divide-by-zero. Rows written before this keep their 60, so a rate over a window spanning the upgrade is only as good as its newest rows.
- **Not touched:** `Lite/Analysis/BaselineProvider.cs:299` carries a hand-rolled workaround for this exact bug — `QUALIFY NOT (delta_cntr_value = 0 AND LAG(delta_cntr_value) > 1000)`, filtering suspicious zeros. It should become unnecessary, but removing it is a separate behavioral change and belongs in its own PR. Other collectors' interval columns are unexamined; perfmon is the one #2234 named.