### PR TITLE
Cover the reconcile engine gate behaviorally — the seam I said it needed turned out to exist (#2230)

### DIFF
--- a/Darling/Darling.Tests/PostgresEngineGateBehaviorTests.cs
+++ b/Darling/Darling.Tests/PostgresEngineGateBehaviorTests.cs
@@ -240,6 +240,7 @@ public sealed class PostgresEngineGateBehaviorTests
         StorageName = PgHost,
         ServerId = ServerIdFor(PgHost),
     };
+
     private static void SetField(DarlingWorker worker, string name, object value) =>
         typeof(DarlingWorker)
             .GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)!

--- a/Darling/Darling.Tests/PostgresEngineGateBehaviorTests.cs
+++ b/Darling/Darling.Tests/PostgresEngineGateBehaviorTests.cs
@@ -29,10 +29,12 @@ namespace Darling.Tests;
 /// scan cannot tell a gate that returns early from one that falls through and happens to write the same
 /// text.</para>
 ///
-/// <para><b>Why this gate and not the other two.</b> Its observable is a PRESENCE — a row in
-/// <c>analysis_state</c> carrying the engine tombstone — so it can be asserted directly. The reconcile and
-/// snapshot_now gates observe an ABSENCE (no connection attempted), which needs a counting seam that does
-/// not exist yet; #2230 says as much, and this is the tractable half.</para>
+/// <para><b>Two of the three doors.</b> The analyze_now gate's observable is a PRESENCE — a row in
+/// <c>analysis_state</c> carrying the engine tombstone — so it is asserted directly. The reconcile gate
+/// looked like it needed a counting seam to observe an absence, and that was wrong: the belt gate inside
+/// <see cref="DarlingXeSessions.ReconcileLongQueryCompletionsAsync"/> is public and its own precondition,
+/// so an ungated call THROWS and a gated one returns — a difference an assertion can see with no seam, no
+/// live store, and no network. snapshot_now remains uncovered; see #2230.</para>
 ///
 /// <para><b>The regression it guards is specific and was real.</b> Clicking "Generate now" against a
 /// PostgreSQL target used to run the full SQL-Server-shaped pass, find nothing, and persist the GENERIC
@@ -182,6 +184,62 @@ public sealed class PostgresEngineGateBehaviorTests
         }
     }
 
+    /// <summary>
+    /// The reconcile door, gated (#2230). <see cref="DarlingXeSessions.ReconcileLongQueryCompletionsAsync"/>
+    /// carries its own engine precondition — "belt to the worker's braces" — and it is the belt that
+    /// actually stopped the field failure, so it is the one worth pinning.
+    ///
+    /// <para>The regression was measured, not theoretical: ungated, this method built a
+    /// <c>SqlConnection</c> from a PostgreSQL connection string, the ctor threw
+    /// <c>Keyword not supported: 'host'</c>, the caller's catch skipped the latch assignment, and because
+    /// <c>LongQueryTraceApplied</c> resets to null on every connect it retried EVERY sweep forever —
+    /// ~1,440 warnings/day/server (#2213 round 2).</para>
+    ///
+    /// <para>Both <c>enabled</c> values, because the gate sits ahead of that branch: ungated, the false arm
+    /// would try to DROP a session over the same impossible connection.</para>
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ReconcileLongQueryCompletions_AgainstAPostgresTarget_ReturnsBeforeBuildingASqlConnection(bool enabled)
+    {
+        /* runner is null on purpose: reaching it would mean the gate did not fire. */
+        await DarlingXeSessions.ReconcileLongQueryCompletionsAsync(
+            PostgresRuntime(), runner: null!, enabled, NullLogger<DarlingWorker>.Instance, CancellationToken.None);
+    }
+
+    /// <summary>
+    /// The proof the test above is not vacuous. Same connection string, ENGINE flipped to SQL Server: the
+    /// gate no longer applies, the ctor rejects the string, and the exact field exception surfaces. Without
+    /// this arm, the pin above would pass just as happily against a method that had stopped connecting for
+    /// some unrelated reason.
+    /// </summary>
+    [Fact]
+    public async Task ReconcileLongQueryCompletions_SameStringButSqlServerEngine_ThrowsTheFieldFailure()
+    {
+        /* The engine is the ONLY difference from the gated case — same host, same connection string. */
+        var ungated = PostgresRuntime(CollectorTargetEngine.SqlServer);
+
+        var ex = await Assert.ThrowsAsync<ArgumentException>(() =>
+            DarlingXeSessions.ReconcileLongQueryCompletionsAsync(
+                ungated, runner: null!, enabled: true, NullLogger<DarlingWorker>.Instance, CancellationToken.None));
+
+        /* The words from the sweep log, so a future reader can match this pin to that incident. */
+        Assert.Contains("Keyword not supported", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("host", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>A PostgreSQL runtime whose connection string is the PostgreSQL shape that <c>SqlConnection</c>
+    /// cannot parse — the combination that produced the field failure.</summary>
+    private static ServerRuntime PostgresRuntime(
+        CollectorTargetEngine engine = CollectorTargetEngine.PostgreSql) => new()
+    {
+        Config = new MonitoredServer { Name = "pg-reconcile-gate", Host = PgHost, Engine = "postgres" },
+        ConnectionString = $"Host={PgHost};Database=postgres;Username=monitor",
+        Target = new CollectorTargetInfo { Engine = engine },
+        StorageName = PgHost,
+        ServerId = ServerIdFor(PgHost),
+    };
     private static void SetField(DarlingWorker worker, string name, object value) =>
         typeof(DarlingWorker)
             .GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)!


### PR DESCRIPTION
#2230's second of three doors. Leaves the issue open at 2/3.

## Correcting my own note

When I covered the `analyze_now` gate, I wrote in that test's doc:

> The reconcile and snapshot_now gates observe an ABSENCE (no connection attempted), which needs a counting seam that does not exist yet.

Half wrong. `DarlingXeSessions.ReconcileLongQueryCompletionsAsync` carries its **own** engine precondition — "belt to the worker's braces", per its comment — and it's `public static`. So an ungated call **throws** where a gated one **returns**, which an assertion can see with no seam, no live store, and no network. The doc is corrected in place rather than left to mislead the next person who reads it.

## The regression, which was measured

Ungated, the method built a `SqlConnection` from a PostgreSQL connection string:

```
ArgumentException: Keyword not supported: 'host'.
```

The caller's `catch` then skipped the latch assignment, and because `LongQueryTraceApplied` resets to `null` on every connect, it retried **every sweep, forever** — roughly **1,440 warnings/day/server** (#2213 round 2).

I confirmed that exception locally against `Microsoft.Data.SqlClient` before writing the assertion, rather than trusting my memory of the message.

## What's pinned

| fact | asserts |
|---|---|
| PG target, `enabled: true` | returns, no throw |
| PG target, `enabled: false` | returns, no throw — the gate sits **ahead** of the enabled branch, so ungated the false arm would try to DROP a session over the same impossible connection |
| **SQL Server engine, same connection string** | **throws** `Keyword not supported: 'host'` |

That last row is what makes the first two mean anything. `runner` is passed `null` on purpose in the PG arms: reaching it would mean the gate didn't fire. And the engine is the *only* difference between the gated and ungated cases — same host, same string — so the test can't pass because of some incidental change to connection handling.

## Verification

Builds clean (0 warnings). The tests themselves can't run on macOS — both test projects are `net10.0-windows` and need `Microsoft.WindowsDesktop.App`, which doesn't exist for this platform — so they're CI-verified. What I *did* verify locally is the pair of facts the assertions rest on: the gate is the method's first statement (read from source), and `SqlConnection` rejects that string (run locally, output above).

## Still open

`snapshot_now` remains uncovered. It's the one that genuinely does observe an absence with no public precondition of its own, so it needs either a counting seam or a different observable. #2230 stays open and says so.