### PR TITLE
tempdb_stats can only ever fail on Azure SQL Database — gate it (field report on #2150)

### DIFF
--- a/Lite.Tests/CollectorGateSurfacePinTests.cs
+++ b/Lite.Tests/CollectorGateSurfacePinTests.cs
@@ -80,6 +80,7 @@ public sealed class CollectorGateSurfacePinTests
         Assert.True(TempDbStatsCollector.Instance.AppliesTo(NoMsdb));
         Assert.True(TempDbStatsCollector.Instance.AppliesTo(Unknown));
     }
+
     [Fact]
     public void TraceFlags_AppliesTo_SkipsOnlyAzureSqlDb()
     {

--- a/Lite.Tests/CollectorGateSurfacePinTests.cs
+++ b/Lite.Tests/CollectorGateSurfacePinTests.cs
@@ -61,6 +61,25 @@ public sealed class CollectorGateSurfacePinTests
         Assert.True(ServerConfigCollector.Instance.AppliesTo(Unknown));
     }
 
+    /// <summary>
+    /// #2150 field report: this fired 11x consecutive on an Azure SQL DB elastic pool with error 262,
+    /// "VIEW DATABASE PERFORMANCE STATE permission denied in database 'tempdb'". The query reads
+    /// <c>tempdb.sys.dm_db_file_space_usage</c> three-part, which a non-administrative login on Azure
+    /// SQL DB cannot be granted, so the collector could only ever fail there.
+    /// <para>Managed Instance must KEEP collecting — it has a real tempdb — which is why this asserts
+    /// both directions rather than just the skip.</para>
+    /// </summary>
+    [Fact]
+    public void TempDbStats_AppliesTo_SkipsOnlyAzureSqlDb()
+    {
+        Assert.False(TempDbStatsCollector.Instance.AppliesTo(AzureSqlDb));  /* error 262 in tempdb */
+        Assert.True(TempDbStatsCollector.Instance.AppliesTo(AzureMi));
+        Assert.True(TempDbStatsCollector.Instance.AppliesTo(AwsRds));
+        Assert.True(TempDbStatsCollector.Instance.AppliesTo(OnPrem2016));
+        Assert.True(TempDbStatsCollector.Instance.AppliesTo(OnPrem2014));
+        Assert.True(TempDbStatsCollector.Instance.AppliesTo(NoMsdb));
+        Assert.True(TempDbStatsCollector.Instance.AppliesTo(Unknown));
+    }
     [Fact]
     public void TraceFlags_AppliesTo_SkipsOnlyAzureSqlDb()
     {

--- a/PerformanceMonitor.Collectors/TempDbStatsCollector.cs
+++ b/PerformanceMonitor.Collectors/TempDbStatsCollector.cs
@@ -18,7 +18,8 @@ namespace PerformanceMonitor.Collectors;
 /// TempDB space usage from tempdb.sys.dm_db_file_space_usage plus the top tempdb-consuming
 /// session (two result sets → one row). Extracted verbatim from Lite's
 /// RemoteCollectorService.TempDb.cs. Always yields exactly one row — zeros when the result
-/// sets are empty — matching the original collector's behavior.
+/// sets are empty — matching the original collector's behavior. Not applicable to Azure SQL
+/// Database; see <see cref="AppliesTo"/>.
 /// </summary>
 public sealed class TempDbStatsCollector : CollectorDefinitionBase<TempDbStatsCollector.Row>
 {
@@ -44,7 +45,29 @@ public sealed class TempDbStatsCollector : CollectorDefinitionBase<TempDbStatsCo
 
     public override string? WatermarkColumn => null;
 
-    public override bool AppliesTo(CollectorTargetInfo target) => true;
+    /// <summary>
+    /// Skips Azure SQL Database, which cannot serve this query at all.
+    ///
+    /// <para>The first result set reads <c>tempdb.sys.dm_db_file_space_usage</c> — a THREE-part
+    /// reference out of the connected database — and on Azure SQL DB that requires
+    /// <c>VIEW DATABASE PERFORMANCE STATE</c> <i>in tempdb</i>. A non-administrative login cannot hold
+    /// it there (tempdb permissions are not persistable on Azure SQL DB, and in an elastic pool the
+    /// database is not even the permission boundary), so every cycle failed with error 262 —
+    /// "VIEW DATABASE PERFORMANCE STATE permission denied in database 'tempdb'" — reported from the
+    /// field at 11x consecutive, which is exactly the collection-health pollution the msdb gate on the
+    /// Agent collectors exists to prevent.</para>
+    ///
+    /// <para>Azure Managed Instance keeps collecting: it has a real tempdb and full DMV access, so the
+    /// gate is <c>IsAzureSqlDb</c> specifically, not "anything Azure" — the same distinction
+    /// <see cref="ServerConfigCollector"/> and <see cref="TraceFlagsCollector"/> draw.</para>
+    ///
+    /// <para>The second result set (<c>sys.dm_db_session_space_usage</c>, two-part and in-database)
+    /// WOULD work on Azure SQL DB. Recovering that half needs an Azure-specific query variant rather
+    /// than a gate, so it is deliberately out of scope here: the immediate defect is a collector that
+    /// can only ever fail, and half a row would be a different contract than the one row this
+    /// collector promises.</para>
+    /// </summary>
+    public override bool AppliesTo(CollectorTargetInfo target) => !target.IsAzureSqlDb;
 
     public override bool RunsPerDatabase(CollectorTargetInfo target) => false;
 


### PR DESCRIPTION
Field report on #2150: an Azure SQL DB elastic pool showing

```
tempdb_stats: 11x consecutive - SQL Error #262: VIEW DATABASE PERFORMANCE STATE
              permission denied in database 'tempdb'.
```

## Why it's unfixable by configuration

The collector's first result set reads `tempdb.sys.dm_db_file_space_usage` — a **three-part** reference out of the connected database. On Azure SQL DB that requires `VIEW DATABASE PERFORMANCE STATE` **in tempdb**, and a non-administrative login cannot hold it there: tempdb permissions aren't persistable on Azure SQL DB, and in an elastic pool the database isn't the permission boundary. So this isn't a transient or a grant the reporter can add — the collector could not succeed on that platform under any configuration, and it polluted collection-health every cycle.

`AppliesTo` had been unconditional `true` since the collector was extracted, so this has been true the whole time rather than being a recent regression. Worth stating plainly, because the reporter described the errors as new: what's new is that they're monitoring an elastic pool, not that we broke something. (I checked — the status-bar surface that reports consecutive failures landed in `50d3f857`, 2026-07-08, and shipped in v3.2.0/v3.3.0.)

## The gate

`!target.IsAzureSqlDb`, specifically — **not** "anything Azure". Managed Instance has a real tempdb and full DMV access and keeps collecting. Same distinction `ServerConfigCollector` and `TraceFlagsCollector` already draw, and the pin asserts **both** directions so a future "simplify this" edit can't silently take MI's data away:

```
Assert.False(... AppliesTo(AzureSqlDb));   /* error 262 in tempdb */
Assert.True (... AppliesTo(AzureMi));
Assert.True (... AppliesTo(AwsRds));
Assert.True (... AppliesTo(OnPrem2016));
Assert.True (... AppliesTo(OnPrem2014));
Assert.True (... AppliesTo(NoMsdb));
Assert.True (... AppliesTo(Unknown));
```

Placed in `CollectorGateSurfacePinTests`, which is where the per-collector truth tables already live, so it sits beside the other Azure gates rather than in a new file.

## Deliberately out of scope

The **second** result set (`sys.dm_db_session_space_usage`, two-part and in-database) *would* work on Azure SQL DB. Recovering that half needs an Azure-specific query variant rather than a gate, and half a row is a different contract than the one row this collector promises — it always yields exactly one row, zeros when empty. The choice is recorded in the code so the next person doesn't have to rediscover it.

I also considered the probed-capability route (`HasTempDbAccess`, mirroring `HasMsdbAccess`) rather than a platform gate. It's the better shape *if* some Azure SQL DB logins can read those DMVs — a server administrator can — but it costs a probe query per connect on every target to recover data for a case where the useful half of the payload is a shared, pooled tempdb whose numbers say little about any one database. A platform gate is the honest trade here; if someone wants MI-style fidelity on Azure SQL DB, the query variant above is the way in.

## Verification

Builds clean (0 warnings). The pin can't run on macOS — `Lite.Tests` is `net10.0-windows` and needs `Microsoft.WindowsDesktop.App` — so it's CI-verified. The by-name agreement pin loops `CollectorCatalog.All × AllTargets` and asserts the catalog and the definition agree, so it picks this up without being touched; no count-based pins exist.

**This does not address #2150's other half** — query_store timing out on the same target. That's answered separately on the issue.