### PR TITLE
install-darling.ps1: mapped-drive detection fails open without WMI (#2201)

### DIFF
--- a/Darling/Darling.Tests/DarlingInstallLocationTests.cs
+++ b/Darling/Darling.Tests/DarlingInstallLocationTests.cs
@@ -326,6 +326,7 @@ function Get-PSDrive {
                 $"{answers[0]} — {because}");
         }
     }
+
     /// <summary>Runs <paramref name="script"/> under Windows PowerShell 5.1 and returns its non-empty output
     /// lines. Written to a temp file rather than passed with -Command: the script under test is a whole
     /// function body, and quoting it through a command line is a source of failures that have nothing to do

--- a/Darling/Darling.Tests/DarlingInstallLocationTests.cs
+++ b/Darling/Darling.Tests/DarlingInstallLocationTests.cs
@@ -248,6 +248,84 @@ public class DarlingInstallLocationTests
         }
     }
 
+    /// <summary>
+    /// #2201: the mapped-drive probe must not fail OPEN when WMI is unavailable.
+    ///
+    /// <para><b>The defect.</b> The probe asks <c>Get-CimInstance Win32_LogicalDisk</c> for the drive type.
+    /// On a WMI-restricted image (locked-down or Server Core) that call throws, or answers with nothing at
+    /// all, and the guard then returns "not network" — for exactly the drive-letter-mapped share it exists
+    /// to refuse. UNC paths are caught lexically before this point, so the exposure is only mapped LETTERS
+    /// on boxes where WMI is restricted.</para>
+    ///
+    /// <para><b>Why executed rather than structural.</b> The fix is a fallback ORDER — try WMI, and only on
+    /// its silence consult <c>Get-PSDrive</c>, whose <c>DisplayRoot</c> names the share a letter maps to
+    /// without touching WMI. A source scan can see that both cmdlets appear; it cannot see which answer
+    /// wins, nor that the fallback is skipped when WMI already answered. Both cmdlets are shadowed by
+    /// functions here, which PowerShell resolves ahead of the real ones, so the WMI-restricted box is
+    /// simulated rather than described.</para>
+    ///
+    /// <para>The last case is the one that keeps the fix honest: when WMI answers "local", Get-PSDrive is
+    /// rigged to THROW. A terminating error would surface as stderr and fail this test, so the case passing
+    /// proves the fallback was never consulted — the guard still trusts a definite WMI answer, and does not
+    /// invent a refusal from a drive that merely has a DisplayRoot.</para>
+    /// </summary>
+    [Fact]
+    public void NetworkPathKind_WhenWmiIsUnavailable_FallsBackToPSDriveDisplayRoot()
+    {
+        /* Shadows need [CmdletBinding()] so the shipped call sites can pass -ErrorAction, which is a common
+           parameter and not one a plain function accepts. */
+        const string Shadows = @"
+function Get-CimInstance {
+    [CmdletBinding()]
+    param([Parameter(ValueFromRemainingArguments = $true)] $Rest)
+    if ($env:PM_WMI -eq ""throw"") { throw ""WMI is not available on this image"" }
+    if ($env:PM_WMI -eq ""silent"") { return $null }
+    return [pscustomobject]@{ DriveType = [int]$env:PM_WMI }
+}
+function Get-PSDrive {
+    [CmdletBinding()]
+    param([Parameter(ValueFromRemainingArguments = $true)] $Rest)
+    if ($env:PM_PSDRIVE -eq ""throw"") { throw ""Get-PSDrive must not be consulted when WMI answered"" }
+    return [pscustomobject]@{ DisplayRoot = $env:PM_PSDRIVE }
+}
+";
+
+        /* wmi: "throw" | "silent" | a DriveType number (4 = network, 3 = local fixed disk). */
+        var cases = new (string Wmi, string DisplayRoot, string Expected, string Because)[]
+        {
+            ("silent", @"\\fileserver\share", "mapped drive",
+                "WMI answered nothing on a restricted image and the letter maps to a share"),
+            ("throw", @"\\fileserver\share", "mapped drive",
+                "WMI threw and the letter maps to a share"),
+            ("silent", "", "<none>",
+                "no evidence either way must stay not-network: the guard may not invent a refusal"),
+            ("4", "", "mapped drive", "WMI itself said network, no fallback needed"),
+            ("3", "throw", "<none>",
+                "a definite local answer from WMI must not consult the fallback at all"),
+        };
+
+        for (var i = 0; i < cases.Length; i++)
+        {
+            var (wmi, displayRoot, expected, because) = cases[i];
+
+            var probe = new StringBuilder();
+            probe.AppendLine($"$env:PM_WMI = '{wmi}'");
+            probe.AppendLine($"$env:PM_PSDRIVE = '{displayRoot}'");
+            probe.AppendLine(Shadows);
+            probe.AppendLine(ExtractFunction(InstallScript, "Get-NetworkPathKind"));
+            probe.AppendLine(@"$k = Get-NetworkPathKind 'Z:\PerformanceMonitorDarling'; " +
+                "if ($null -eq $k) { '<none>' } else { $k }");
+
+            var answers = RunWindowsPowerShell(probe.ToString());
+
+            Assert.Single(answers);
+            /* Assert.True over Assert.Equal so the REASON travels with the failure: "expected mapped
+               drive, got <none>" is not actionable on its own, and this test has five cases. */
+            Assert.True(expected == answers[0],
+                $"case {i} (wmi={wmi}, DisplayRoot='{displayRoot}'): expected {expected}, got " +
+                $"{answers[0]} — {because}");
+        }
+    }
     /// <summary>Runs <paramref name="script"/> under Windows PowerShell 5.1 and returns its non-empty output
     /// lines. Written to a temp file rather than passed with -Command: the script under test is a whole
     /// function body, and quoting it through a command line is a source of failures that have nothing to do

--- a/Darling/tools/install-darling.ps1
+++ b/Darling/tools/install-darling.ps1
@@ -118,16 +118,29 @@ function Get-NetworkPathKind([string]$path) {
         return 'UNC'
     }
 
+    $qualifier = $null
+    try { $qualifier = Split-Path -Qualifier $path -ErrorAction Stop } catch { }
+    if (-not $qualifier) { return $null }
+
     try {
-        $qualifier = Split-Path -Qualifier $path -ErrorAction Stop
         $drive = Get-CimInstance -ClassName Win32_LogicalDisk -Filter "DeviceID='$qualifier'" -ErrorAction Stop
         # DriveType 4 = network drive.
         if ($drive -and $drive.DriveType -eq 4) { return 'mapped drive' }
+        # A DEFINITE answer is trusted, including "local" - so the fallback below is not consulted and
+        # cannot second-guess WMI on a box where WMI works.
+        if ($drive) { return $null }
     }
     catch {
-        # No qualifier, or WMI unavailable. Unknown is not network: this branch must never invent a
-        # refusal, since the profile check above is the one carrying the evidence.
+        # WMI unavailable (locked-down or Server Core images). Fall through to the probe below rather
+        # than answering "not network", which is the fail-open in #2201.
     }
+
+    # No answer from WMI. DisplayRoot is populated ONLY for a drive letter mapped to a share, and comes
+    # from .NET rather than WMI, so it survives a restricted image. That keeps the rule this function has
+    # always followed - unknown is not network, and a refusal needs evidence - while no longer MISSING the
+    # one case the guard exists to catch. Unknown still returns $null two lines down.
+    $psDrive = Get-PSDrive -Name $qualifier.TrimEnd(':') -ErrorAction SilentlyContinue
+    if ($psDrive -and -not [string]::IsNullOrWhiteSpace($psDrive.DisplayRoot)) { return 'mapped drive' }
 
     return $null
 }


### PR DESCRIPTION
Fixes #2201. **Draft on purpose** — the first commit is the test alone, pushed to be watched red, because I can't run Windows PowerShell 5.1 on this machine and CI is therefore the only place the red is observable. The fix follows as a second commit with the test untouched.

## The defect

`Get-NetworkPathKind` decides whether an install path lives on a network drive. UNC paths are caught lexically, but a mapped **letter** is identified by asking WMI for the drive type:

```powershell
$drive = Get-CimInstance -ClassName Win32_LogicalDisk -Filter "DeviceID='$qualifier'" -ErrorAction Stop
if ($drive -and $drive.DriveType -eq 4) { return 'mapped drive' }
```

On a WMI-restricted image (locked-down or Server Core) that either throws or answers with nothing, and the guard returns "not network" — fail-open for exactly the class it exists to refuse. The consequence is #2187's failure all over again: a service installed on a share, running as a virtual account that reaches the network as the computer account, which cannot read it.

## Why a test and not just the one-line fix

The existing `catch` states a real contract in prose:

> Unknown is not network: this branch must never invent a refusal, since the profile check above is the one carrying the evidence.

That is worth keeping, and it is what makes a naive "check `DisplayRoot` too" fix wrong. `Get-PSDrive`'s `DisplayRoot` is *evidence* — it is populated only for a letter mapped to a share, and it is obtained through .NET without WMI — so consulting it on WMI's silence adds evidence rather than inventing a refusal. But it must not override a definite WMI answer.

So the pin is executed, not structural: a source scan can see both cmdlets appear and cannot see which answer wins. Both are shadowed by PowerShell functions (which resolve ahead of the real cmdlets), so the restricted image is simulated rather than described.

| # | WMI | `DisplayRoot` | expected | what it protects |
|---|---|---|---|---|
| 0 | answers nothing | `\\fileserver\share` | `mapped drive` | the reported defect |
| 1 | throws | `\\fileserver\share` | `mapped drive` | the other WMI failure mode |
| 2 | answers nothing | empty | `<none>` | no evidence stays not-network |
| 3 | `DriveType = 4` | empty | `mapped drive` | unchanged behaviour, no fallback needed |
| 4 | `DriveType = 3` | **throws** | `<none>` | the fallback is never consulted when WMI answered |

Case 4 is the one that keeps the fix honest: `Get-PSDrive` is rigged to throw, so the case can only pass if the code never called it. A terminating error would surface as stderr and fail the test.

Cases 0 and 1 are the ones expected red on this commit.