### PR TITLE
WMI DriveType 0 is unknown, not local — don't let it short-circuit the mapped-drive fallback

### DIFF
--- a/Darling/Darling.Tests/DarlingInstallLocationTests.cs
+++ b/Darling/Darling.Tests/DarlingInstallLocationTests.cs
@@ -264,10 +264,15 @@ public class DarlingInstallLocationTests
     /// functions here, which PowerShell resolves ahead of the real ones, so the WMI-restricted box is
     /// simulated rather than described.</para>
     ///
-    /// <para>The last case is the one that keeps the fix honest: when WMI answers "local", Get-PSDrive is
-    /// rigged to THROW. A terminating error would surface as stderr and fail this test, so the case passing
-    /// proves the fallback was never consulted — the guard still trusts a definite WMI answer, and does not
-    /// invent a refusal from a drive that merely has a DisplayRoot.</para>
+    /// <para>Case 4 is the one that keeps the fix honest: when WMI answers "local", Get-PSDrive is rigged
+    /// to THROW. A terminating error would surface as stderr and fail this test, so the case passing proves
+    /// the fallback was never consulted — the guard still trusts a definite WMI answer, and does not invent
+    /// a refusal from a drive that merely has a DisplayRoot.</para>
+    ///
+    /// <para>Case 5 draws the line around what "definite" means. <c>DriveType 0</c> is WMI's <i>unknown</i>,
+    /// not local, and a partial row is likeliest on precisely the restricted images this fallback exists
+    /// for — so it must fall through rather than short-circuit. It works because 0 is falsy in PowerShell,
+    /// which is worth pinning rather than trusting to stay true.</para>
     /// </summary>
     [Fact]
     public void NetworkPathKind_WhenWmiIsUnavailable_FallsBackToPSDriveDisplayRoot()
@@ -302,6 +307,8 @@ function Get-PSDrive {
             ("4", "", "mapped drive", "WMI itself said network, no fallback needed"),
             ("3", "throw", "<none>",
                 "a definite local answer from WMI must not consult the fallback at all"),
+            ("0", @"\\fileserver\share", "mapped drive",
+                "DriveType 0 is unknown, not local - a partial WMI row must not short-circuit the fallback"),
         };
 
         for (var i = 0; i < cases.Length; i++)

--- a/Darling/tools/install-darling.ps1
+++ b/Darling/tools/install-darling.ps1
@@ -127,8 +127,11 @@ function Get-NetworkPathKind([string]$path) {
         # DriveType 4 = network drive.
         if ($drive -and $drive.DriveType -eq 4) { return 'mapped drive' }
         # A DEFINITE answer is trusted, including "local" - so the fallback below is not consulted and
-        # cannot second-guess WMI on a box where WMI works.
-        if ($drive) { return $null }
+        # cannot second-guess WMI on a box where WMI works. DriveType 0 is "unknown", which is NOT an
+        # answer: 0 is falsy here, so an unknown row falls through to the probe below instead of being
+        # read as "local". That matters because a partial WMI response is likeliest on exactly the
+        # restricted images this fallback exists for (review catch on #2248).
+        if ($drive -and $drive.DriveType) { return $null }
     }
     catch {
         # WMI unavailable (locked-down or Server Core images). Fall through to the probe below rather


### PR DESCRIPTION
Follow-up to #2248, from its own review. Flagged there as non-blocking; acting on it because the scenario it describes is the one the fix exists for.

## The residual hole

#2248 added a `Get-PSDrive` fallback for when WMI can't answer, and short-circuited it on a definite WMI answer:

```powershell
if ($drive) { return $null }
```

Any non-null row counted as definite — including one where `DriveType` is `0`, which is WMI's **unknown**, not local. A partial or degraded WMI response is likeliest on precisely the locked-down and Server Core images the fallback was written for, so the guard could still fail open on a mapped drive there: WMI answers *something*, the fallback never runs, and the install proceeds onto a share.

## The fix

```powershell
if ($drive -and $drive.DriveType) { return $null }
```

`0` is falsy in PowerShell, so an unknown row now falls through to the probe while `DriveType = 3` still short-circuits exactly as before. That falsiness is load-bearing, so it's pinned rather than left implicit:

| # | WMI | `DisplayRoot` | expected | protects |
|---|---|---|---|---|
| 4 | `DriveType = 3` | **throws** | `<none>` | a definite local answer skips the fallback entirely |
| **5** | **`DriveType = 0`** | `\\fileserver\share` | **`mapped drive`** | **an unknown row is not an answer** |

Case 4 and case 5 are deliberately adjacent: together they say "trust WMI when it knows, ignore it when it doesn't", and either alone would permit the other's bug. Case 4 still rigs `Get-PSDrive` to throw, so it can only pass if the fallback was never consulted.

Verified the same way as #2248 — builds clean, and the executed cases run under Windows PowerShell 5.1 in CI, since this machine has no PowerShell at all.