### PR TITLE
Six cases, not five

### DIFF
--- a/Darling/Darling.Tests/DarlingInstallLocationTests.cs
+++ b/Darling/Darling.Tests/DarlingInstallLocationTests.cs
@@ -327,7 +327,7 @@ function Get-PSDrive {
 
             Assert.Single(answers);
             /* Assert.True over Assert.Equal so the REASON travels with the failure: "expected mapped
-               drive, got <none>" is not actionable on its own, and this test has five cases. */
+               drive, got <none>" is not actionable on its own, and this test has six cases. */
             Assert.True(expected == answers[0],
                 $"case {i} (wmi={wmi}, DisplayRoot='{displayRoot}'): expected {expected}, got " +
                 $"{answers[0]} — {because}");


### PR DESCRIPTION
One-word correction. I added a sixth case in #2249 and left the comment above the assertion saying five; its review caught it after merge.