### PR TITLE
FinOps provisioning verdict: thresholds measured from the fleet, not chosen (#2246)

### DIFF
--- a/Darling/Darling.Tests/ProvisioningVerdictTests.cs
+++ b/Darling/Darling.Tests/ProvisioningVerdictTests.cs
@@ -150,6 +150,38 @@ public sealed class ProvisioningVerdictTests
         Assert.Equal(ProvisioningVerdict.RightSized, verdict);
     }
 
+    /// <summary>
+    /// The REASON must name the condition that actually fired. The UI used to derive this itself as
+    /// "p95 &gt; 85 ? CPU : blame the memory ratio", so once the verdict gained grant-pressure and
+    /// worker-thread reasons, every one of those would have been explained as a memory ratio that no longer
+    /// decides anything — citing a threshold the code does not check. These pin that each cause explains
+    /// itself.
+    /// </summary>
+    [Fact]
+    public void TheReasonNamesTheConditionThatFired()
+    {
+        var cpu = ProvisioningVerdict.UnderProvisionedReason(92m, 0, 0, 0, 576, 200);
+        Assert.Contains("CPU p95 is 92.0%", cpu, System.StringComparison.Ordinal);
+
+        /* Grant pressure with QUIET cpu: the old text would have blamed the memory ratio here. */
+        var grants = ProvisioningVerdict.UnderProvisionedReason(11m, 3, 1, 2, 576, 142);
+        Assert.Contains("workspace memory", grants, System.StringComparison.Ordinal);
+        Assert.Contains("3 grant waiter(s)", grants, System.StringComparison.Ordinal);
+        Assert.Contains("1 grant timeout(s)", grants, System.StringComparison.Ordinal);
+        Assert.Contains("2 forced grant(s)", grants, System.StringComparison.Ordinal);
+        /* And it must NOT cite the retired threshold. */
+        Assert.DoesNotContain("0.95", grants, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("memory ratio", grants, System.StringComparison.Ordinal);
+
+        var workers = ProvisioningVerdict.UnderProvisionedReason(11m, 0, 0, 0, 100, 81);
+        Assert.Contains("Worker threads", workers, System.StringComparison.Ordinal);
+        Assert.Contains("81 of 100", workers, System.StringComparison.Ordinal);
+
+        /* Asked about inputs that are not under-provisioned, it says so rather than inventing a cause. */
+        var none = ProvisioningVerdict.UnderProvisionedReason(11m, 0, 0, 0, 576, 142);
+        Assert.Contains("No under-provisioning condition", none, System.StringComparison.Ordinal);
+    }
+
     /// <summary>The boundaries themselves, since every one of them is a published constant that something
     /// downstream will eventually be tuned against. Strict comparisons, so a value sitting exactly ON a
     /// limit does not trip it.</summary>

--- a/Darling/Darling.Tests/ProvisioningVerdictTests.cs
+++ b/Darling/Darling.Tests/ProvisioningVerdictTests.cs
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using PerformanceMonitor.Common;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #2246: the FinOps provisioning verdict, which used to report <c>UNDER_PROVISIONED</c> for every server
+/// alive.
+///
+/// <para><b>What it got wrong.</b> The rule tested
+/// <c>total_server_memory_mb / target_server_memory_mb &gt; 0.95</c>. Those are the perfmon Total and Target
+/// Server Memory counters, and they converge at 1.0 the moment an instance is warmed. Measured on 42
+/// production servers: median <b>1.0000</b>, min 0.9997, max 1.0002 — so every server tripped it, and
+/// <c>OVER_PROVISIONED</c>, whose arm needs the same ratio below 0.5, was unreachable at any workload.</para>
+///
+/// <para><b>Why these tests exist rather than a fleet check.</b> The replacement reads real pressure signals
+/// — grant waiters, grant timeouts, forced grants — and across the store's entire retained history those are
+/// zero: 0 nonzero of 2,938,711 grant rows, and 0 of 1,000,560 <c>Memory Grants Pending</c> samples. That is
+/// the correct answer for a fleet with no memory pressure, and it also means the fleet CANNOT demonstrate
+/// that the alarm fires. So the positive control is built here instead, one input at a time.</para>
+///
+/// <para>Every threshold asserted below has the fleet distribution behind it, recorded on
+/// <see cref="ProvisioningVerdict"/> itself: CPU p95 max 51.0 against a limit of 85, worker ratio max 0.635
+/// against 0.8, grant utilization max 18.8% against 50%.</para>
+/// </summary>
+public sealed class ProvisioningVerdictTests
+{
+    /// <summary>A quiet server with no pressure anywhere: the downsizing candidate the report exists to
+    /// find, and the verdict the old rule could never reach.</summary>
+    [Fact]
+    public void AQuietServerWithNoPressure_IsOverProvisioned()
+    {
+        Assert.Equal(
+            ProvisioningVerdict.OverProvisioned,
+            ProvisioningVerdict.Evaluate(
+                avgCpuPercent: 6m, maxCpuPercent: 22m, p95CpuPercent: 11m,
+                maxGrantWaiters: 0, grantTimeouts: 0, forcedGrants: 0,
+                grantUtilizationPercent: 0.5m, maxWorkers: 576, currentWorkers: 142));
+    }
+
+    /// <summary>The fleet's own median server, from the measurement that drove this change: avg 6.5, p95
+    /// 11.0, grant utilization 0.5%, worker ratio 0.246. It must come out OVER_PROVISIONED — under the old
+    /// rule this exact server was reported as starved for memory.</summary>
+    [Fact]
+    public void TheFleetsMedianServer_IsNotReportedAsStarved()
+    {
+        var verdict = ProvisioningVerdict.Evaluate(
+            avgCpuPercent: 6.5m, maxCpuPercent: 30m, p95CpuPercent: 11.0m,
+            maxGrantWaiters: 0, grantTimeouts: 0, forcedGrants: 0,
+            grantUtilizationPercent: 0.5m, maxWorkers: 576, currentWorkers: 142);
+
+        Assert.NotEqual(ProvisioningVerdict.UnderProvisioned, verdict);
+        Assert.Equal(ProvisioningVerdict.OverProvisioned, verdict);
+    }
+
+    /// <summary>Busy enough not to shrink, not pressured enough to grow.</summary>
+    [Fact]
+    public void ABusyButHealthyServer_IsRightSized()
+    {
+        Assert.Equal(
+            ProvisioningVerdict.RightSized,
+            ProvisioningVerdict.Evaluate(
+                avgCpuPercent: 35m, maxCpuPercent: 70m, p95CpuPercent: 60m,
+                maxGrantWaiters: 0, grantTimeouts: 0, forcedGrants: 0,
+                grantUtilizationPercent: 12m, maxWorkers: 576, currentWorkers: 200));
+    }
+
+    /// <summary>THE POSITIVE CONTROL the fleet cannot supply: each pressure input alone must raise
+    /// UNDER_PROVISIONED, driven one at a time so a single over-broad condition cannot mask a dead one.
+    /// </summary>
+    [Theory]
+    [InlineData(1, 0, 0, "a query waited for a workspace-memory grant")]
+    [InlineData(0, 1, 0, "a grant request timed out")]
+    [InlineData(0, 0, 1, "a grant was forced through below its request")]
+    public void AnyMemoryPressureSignal_AloneRaisesUnderProvisioned(
+        long waiters, long timeouts, long forced, string because)
+    {
+        var verdict = ProvisioningVerdict.Evaluate(
+            avgCpuPercent: 6m, maxCpuPercent: 22m, p95CpuPercent: 11m,
+            maxGrantWaiters: waiters, grantTimeouts: timeouts, forcedGrants: forced,
+            grantUtilizationPercent: 0.5m, maxWorkers: 576, currentWorkers: 142);
+
+        /* The CPU numbers here are the quiet ones from the OVER_PROVISIONED case above, so this also pins
+           the ORDERING: pressure outranks idleness. Recommending a smaller instance for a server whose
+           queries are queueing for memory would be the worst possible answer. */
+        Assert.Equal(ProvisioningVerdict.UnderProvisioned, verdict);
+        Assert.NotEqual(ProvisioningVerdict.OverProvisioned, verdict);
+        Assert.False(string.IsNullOrEmpty(because));
+    }
+
+    /// <summary>Sustained CPU still means under-provisioned. Threshold unchanged from the rule this
+    /// replaces; the fleet's highest p95 is 51.0, so it stays reachable rather than academic.</summary>
+    [Fact]
+    public void SustainedHighCpu_IsUnderProvisioned()
+    {
+        Assert.Equal(
+            ProvisioningVerdict.UnderProvisioned,
+            ProvisioningVerdict.Evaluate(
+                avgCpuPercent: 70m, maxCpuPercent: 99m, p95CpuPercent: 92m,
+                maxGrantWaiters: 0, grantTimeouts: 0, forcedGrants: 0,
+                grantUtilizationPercent: 5m, maxWorkers: 576, currentWorkers: 200));
+    }
+
+    /// <summary>Worker-thread saturation, the term the Full Dashboard's view has always carried and the app
+    /// copies dropped — so a worker-starved server was invisible to both of them.</summary>
+    [Fact]
+    public void WorkerThreadSaturation_IsUnderProvisioned()
+    {
+        Assert.Equal(
+            ProvisioningVerdict.UnderProvisioned,
+            ProvisioningVerdict.Evaluate(
+                avgCpuPercent: 6m, maxCpuPercent: 22m, p95CpuPercent: 11m,
+                maxGrantWaiters: 0, grantTimeouts: 0, forcedGrants: 0,
+                grantUtilizationPercent: 0.5m, maxWorkers: 100, currentWorkers: 81));
+    }
+
+    /// <summary>Unknown is not saturation. A sample that never reported a worker ceiling must not imply
+    /// exhaustion — the same rule the collector gates follow for an unclassified target, and without it a
+    /// missing column would silently flag every server.</summary>
+    [Fact]
+    public void AnUnknownWorkerCeiling_IsNotSaturation()
+    {
+        Assert.Equal(
+            ProvisioningVerdict.OverProvisioned,
+            ProvisioningVerdict.Evaluate(
+                avgCpuPercent: 6m, maxCpuPercent: 22m, p95CpuPercent: 11m,
+                maxGrantWaiters: 0, grantTimeouts: 0, forcedGrants: 0,
+                grantUtilizationPercent: 0.5m, maxWorkers: 0, currentWorkers: 9999));
+    }
+
+    /// <summary>Quiet on CPU but working its semaphore hard: not a downsizing candidate. This is the term
+    /// that stops "idle" from being decided on CPU alone, and the fleet's peak utilization is 18.8%, so it
+    /// excludes nothing real today.</summary>
+    [Fact]
+    public void IdleCpuButHighGrantUtilization_IsNotOverProvisioned()
+    {
+        var verdict = ProvisioningVerdict.Evaluate(
+            avgCpuPercent: 6m, maxCpuPercent: 22m, p95CpuPercent: 11m,
+            maxGrantWaiters: 0, grantTimeouts: 0, forcedGrants: 0,
+            grantUtilizationPercent: 65m, maxWorkers: 576, currentWorkers: 142);
+
+        Assert.Equal(ProvisioningVerdict.RightSized, verdict);
+    }
+
+    /// <summary>The boundaries themselves, since every one of them is a published constant that something
+    /// downstream will eventually be tuned against. Strict comparisons, so a value sitting exactly ON a
+    /// limit does not trip it.</summary>
+    [Fact]
+    public void TheThresholdsAreStrict_AtTheirExactValues()
+    {
+        /* p95 exactly 85 is not "> 85". */
+        Assert.NotEqual(
+            ProvisioningVerdict.UnderProvisioned,
+            ProvisioningVerdict.Evaluate(50m, 90m, ProvisioningVerdict.HighCpuP95Percent,
+                0, 0, 0, 5m, 576, 200));
+
+        /* avg exactly 15 is not "< 15", so it cannot be over-provisioned. */
+        Assert.Equal(
+            ProvisioningVerdict.RightSized,
+            ProvisioningVerdict.Evaluate(ProvisioningVerdict.IdleAvgCpuPercent, 30m, 20m,
+                0, 0, 0, 5m, 576, 142));
+
+        /* worker ratio exactly 0.8 is not "> 0.8". */
+        Assert.Equal(
+            ProvisioningVerdict.OverProvisioned,
+            ProvisioningVerdict.Evaluate(6m, 22m, 11m, 0, 0, 0, 0.5m, maxWorkers: 100, currentWorkers: 80));
+    }
+}

--- a/Darling/Darling.Tests/ViewerFinOpsTests.cs
+++ b/Darling/Darling.Tests/ViewerFinOpsTests.cs
@@ -309,16 +309,35 @@ public sealed class ViewerFinOpsSqlTests
         }
     }
 
+    /// <summary>
+    /// The inventory grid read now projects the verdict INPUTS and classifies in C# through the shared
+    /// <c>ProvisioningVerdict</c>, rather than deciding inline in SQL.
+    ///
+    /// <para>It used to carry its own <c>CASE ... memory_ratio &gt; 0.95 THEN UNDER_PROVISIONED</c> — copies
+    /// 5 and 6 of the bug in #2246, and on the screen the field report was actually looking at, so the grid
+    /// disagreed with the drill-down for the same server. The absence assertions are the drift guard: a SQL
+    /// verdict here can never come back without failing this test.</para>
+    /// </summary>
     [Fact]
-    public void ServerMetricsSql_ReadsCpuStorageIdleProvisioning()
+    public void ServerMetricsSql_ProjectsTheVerdictInputs_AndDoesNotDecideInSql()
     {
         var sql = ViewerDataService.ServerMetricsSql;
         Assert.Contains("FROM v_cpu_utilization_stats", sql, StringComparison.Ordinal);
         Assert.Contains("FROM v_database_size_stats", sql, StringComparison.Ordinal);
         Assert.Contains("FROM v_query_stats", sql, StringComparison.Ordinal);
         Assert.Contains("EXCEPT", sql, StringComparison.Ordinal);
-        Assert.Contains("OVER_PROVISIONED", sql, StringComparison.Ordinal);
-        Assert.Contains("UNDER_PROVISIONED", sql, StringComparison.Ordinal);
+
+        /* The pressure inputs the shared predicate needs, which this read did not fetch before. */
+        Assert.Contains("FROM v_memory_grant_stats", sql, StringComparison.Ordinal);
+        Assert.Contains("waiter_count", sql, StringComparison.Ordinal);
+        Assert.Contains("timeout_error_count_delta", sql, StringComparison.Ordinal);
+        Assert.Contains("forced_grant_count_delta", sql, StringComparison.Ordinal);
+        Assert.Contains("max_workers_count", sql, StringComparison.Ordinal);
+
+        /* And the verdict itself must NOT be decided here any more. */
+        Assert.DoesNotContain("OVER_PROVISIONED", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("UNDER_PROVISIONED", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("RIGHT_SIZED", sql, StringComparison.Ordinal);
     }
 
     // ── PG dialect guard across every FinOps read ──

--- a/Darling/Darling.Tests/ViewerFinOpsTests.cs
+++ b/Darling/Darling.Tests/ViewerFinOpsTests.cs
@@ -340,6 +340,36 @@ public sealed class ViewerFinOpsSqlTests
         Assert.DoesNotContain("RIGHT_SIZED", sql, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// The drift guard, applied uniformly to all THREE reads that feed the provisioning verdict rather than
+    /// only the one that used to decide in SQL (#2246).
+    ///
+    /// <para>Darling has no live-Postgres harness for these, so a source pin is the whole safety net: if a
+    /// future edit drops the grants CTE, the reader keeps consuming ordinals the SELECT list no longer
+    /// produces and the verdict silently falls back to "no pressure anywhere" — the same shape of silent
+    /// wrongness this issue is about. The SQL was executed against the live store when it was written; this
+    /// is what keeps it honest afterwards.</para>
+    /// </summary>
+    [Theory]
+    [InlineData(nameof(ViewerDataService.UtilizationEfficiencySql))]
+    [InlineData(nameof(ViewerDataService.ProvisioningTrendSql))]
+    [InlineData(nameof(ViewerDataService.ServerMetricsSql))]
+    public void EveryVerdictRead_FetchesThePressureInputs(string sqlName)
+    {
+        var sql = (string)typeof(ViewerDataService).GetField(sqlName)!.GetValue(null)!;
+
+        Assert.Contains("FROM v_memory_grant_stats", sql, StringComparison.Ordinal);
+        Assert.Contains("waiter_count", sql, StringComparison.Ordinal);
+        Assert.Contains("timeout_error_count_delta", sql, StringComparison.Ordinal);
+        Assert.Contains("forced_grant_count_delta", sql, StringComparison.Ordinal);
+        Assert.Contains("max_workers_count", sql, StringComparison.Ordinal);
+
+        /* And none of them may decide the verdict, which is now the shared predicate's job alone. */
+        Assert.DoesNotContain("OVER_PROVISIONED", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("UNDER_PROVISIONED", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("RIGHT_SIZED", sql, StringComparison.Ordinal);
+    }
+
     // ── PG dialect guard across every FinOps read ──
 
     [Theory]

--- a/Darling/PerformanceMonitor.Darling.Viewer/FinOpsTab.Loaders.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/FinOpsTab.Loaders.cs
@@ -299,9 +299,13 @@ public partial class FinOpsTab
         {
             "RIGHT_SIZED" => $"CPU is moderately loaded (avg {data.AvgCpuPct:N1}%, p95 {data.P95CpuPct:N1}%) and memory is well-utilized (buffer pool uses {bpPct:N0}% of physical RAM). No action needed.",
             "OVER_PROVISIONED" => $"CPU is lightly loaded (avg {data.AvgCpuPct:N1}%, max {data.MaxCpuPct}%) and buffer pool uses only {bpPct:N0}% of physical RAM. This server may have more resources than it needs.",
-            "UNDER_PROVISIONED" => data.P95CpuPct > 85
-                ? $"CPU p95 is {data.P95CpuPct:N1}% (threshold: 85%). This server may need more CPU capacity."
-                : $"Buffer pool uses {bpPct:N0}% of physical RAM and memory ratio is {data.MemoryRatio:N2} (threshold: 0.95). Memory pressure is high.",
+            /* The reason comes from the same place as the verdict. This branch used to read
+               "P95CpuPct > 85 ? CPU : memory ratio is {x} (threshold: 0.95)", so a server flagged for grant
+               pressure or worker saturation would have been explained as a memory ratio that no longer
+               decides anything, citing a threshold the code does not check (#2246). */
+            "UNDER_PROVISIONED" => ProvisioningVerdict.UnderProvisionedReason(
+                data.P95CpuPct, data.MaxGrantWaiters, data.GrantTimeouts, data.ForcedGrants,
+                data.MaxWorkersCount, data.CurrentWorkersCount),
             _ => ""
         };
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.Inventory.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.Inventory.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql;
+using PerformanceMonitor.Common;
 
 namespace PerformanceMonitor.Darling.Viewer;
 
@@ -39,7 +40,9 @@ WITH cpu_24h AS (
 ),
 mem_latest AS (
     SELECT
-        CAST(total_server_memory_mb AS DECIMAL(10,2)) / NULLIF(target_server_memory_mb, 0) AS memory_ratio
+        CAST(total_server_memory_mb AS DECIMAL(10,2)) / NULLIF(target_server_memory_mb, 0) AS memory_ratio,
+        max_workers_count,
+        current_workers_count
     FROM v_memory_stats
     WHERE server_id = $1
     AND   (server_id, collection_time) IN (
@@ -48,6 +51,19 @@ mem_latest AS (
         WHERE server_id = $1
         GROUP BY server_id
     )
+),
+/* Same workspace-memory pressure signals as the drill-down read, so the INVENTORY GRID cannot classify a
+   server by a rule the drill-down no longer uses (#2246 — this grid is the screen the field report was
+   looking at). */
+grants AS (
+    SELECT
+        MAX(waiter_count) AS max_grant_waiters,
+        SUM(COALESCE(timeout_error_count_delta, 0)) AS grant_timeouts,
+        SUM(COALESCE(forced_grant_count_delta, 0)) AS forced_grants,
+        MAX(100.0 * granted_memory_mb / NULLIF(target_memory_mb, 0)) AS grant_utilization_pct
+    FROM v_memory_grant_stats
+    WHERE server_id = $1
+    AND   collection_time >= $2
 ),
 storage_totals AS (
     SELECT
@@ -87,18 +103,20 @@ SELECT
     c.avg_cpu_pct,
     st.total_storage_gb,
     id.idle_db_count,
-    CASE
-        WHEN c.avg_cpu_pct < 15 AND c.max_cpu_pct < 40 AND COALESCE(m.memory_ratio, 0) < 0.5
-        THEN 'OVER_PROVISIONED'
-        WHEN c.p95_cpu_pct > 85 OR COALESCE(m.memory_ratio, 0) > 0.95
-        THEN 'UNDER_PROVISIONED'
-        ELSE 'RIGHT_SIZED'
-    END AS provisioning_status
+    c.max_cpu_pct,
+    c.p95_cpu_pct,
+    COALESCE(m.max_workers_count, 0),
+    COALESCE(m.current_workers_count, 0),
+    COALESCE(g.max_grant_waiters, 0),
+    COALESCE(g.grant_timeouts, 0),
+    COALESCE(g.forced_grants, 0),
+    COALESCE(g.grant_utilization_pct, 0)
 FROM (SELECT 1) AS anchor
 LEFT JOIN cpu_24h c ON true
 LEFT JOIN mem_latest m ON true
 LEFT JOIN storage_totals st ON true
-LEFT JOIN idle_dbs id ON true";
+LEFT JOIN idle_dbs id ON true
+LEFT JOIN grants g ON true";
 
     public async Task<(decimal? AvgCpuPct, decimal? StorageTotalGb, int? IdleDbCount, string? ProvisioningStatus)> GetServerMetricsAsync(int serverId, CancellationToken cancellationToken = default)
     {
@@ -113,11 +131,25 @@ LEFT JOIN idle_dbs id ON true";
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         if (await reader.ReadAsync(cancellationToken))
         {
+            /* The verdict is computed HERE rather than as a SQL CASE, so this grid and the drill-down
+               cannot disagree — they now call the same predicate. The old inline CASE was copies 5 and 6
+               of the ratio bug, on the screen the field report was actually looking at (#2246). */
+            var status = ProvisioningVerdict.Evaluate(
+                avgCpuPercent: reader.IsDBNull(0) ? 0m : Convert.ToDecimal(reader.GetValue(0)),
+                maxCpuPercent: reader.IsDBNull(3) ? 0m : Convert.ToDecimal(reader.GetValue(3)),
+                p95CpuPercent: reader.IsDBNull(4) ? 0m : Convert.ToDecimal(reader.GetValue(4)),
+                maxGrantWaiters: reader.IsDBNull(7) ? 0L : Convert.ToInt64(reader.GetValue(7)),
+                grantTimeouts: reader.IsDBNull(8) ? 0L : Convert.ToInt64(reader.GetValue(8)),
+                forcedGrants: reader.IsDBNull(9) ? 0L : Convert.ToInt64(reader.GetValue(9)),
+                grantUtilizationPercent: reader.IsDBNull(10) ? 0m : Convert.ToDecimal(reader.GetValue(10)),
+                maxWorkers: reader.IsDBNull(5) ? 0 : Convert.ToInt32(reader.GetValue(5)),
+                currentWorkers: reader.IsDBNull(6) ? 0 : Convert.ToInt32(reader.GetValue(6)));
+
             return (
                 reader.IsDBNull(0) ? null : Convert.ToDecimal(reader.GetValue(0)),
                 reader.IsDBNull(1) ? null : Convert.ToDecimal(reader.GetValue(1)),
                 reader.IsDBNull(2) ? null : Convert.ToInt32(reader.GetValue(2)),
-                reader.IsDBNull(3) ? null : reader.GetString(3)
+                status
             );
         }
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.Utilization.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.Utilization.cs
@@ -140,6 +140,10 @@ LEFT JOIN grants g ON true";
             BufferPoolMb = reader.IsDBNull(7) ? 0 : Convert.ToInt32(reader.GetValue(7)),
             MemoryRatio = memRatio,
             ProvisioningStatus = status,
+            MaxGrantWaiters = reader.IsDBNull(12) ? 0L : Convert.ToInt64(reader.GetValue(12)),
+            GrantTimeouts = reader.IsDBNull(13) ? 0L : Convert.ToInt64(reader.GetValue(13)),
+            ForcedGrants = reader.IsDBNull(14) ? 0L : Convert.ToInt64(reader.GetValue(14)),
+            GrantUtilizationPct = reader.IsDBNull(15) ? 0m : Convert.ToDecimal(reader.GetValue(15)),
             MaxWorkersCount = maxWorkers,
             CurrentWorkersCount = currentWorkers,
             CpuCount = reader.IsDBNull(11) ? 0 : Convert.ToInt32(reader.GetValue(11))

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.Utilization.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.Utilization.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql;
+using PerformanceMonitor.Common;
 
 namespace PerformanceMonitor.Darling.Viewer;
 
@@ -59,6 +60,20 @@ server_info AS (
     WHERE server_id = $1
     ORDER BY collection_time DESC
     LIMIT 1
+),
+/* Workspace-memory pressure, which is what being short of memory actually looks like: a query asked the
+   resource semaphore for a grant and did not simply get it. Counts of events, so no threshold to tune
+   (#2246). The utilization peak rides along to stop a CPU-quiet server that is straining its semaphore
+   from being called idle. */
+grants AS (
+    SELECT
+        MAX(waiter_count) AS max_grant_waiters,
+        SUM(COALESCE(timeout_error_count_delta, 0)) AS grant_timeouts,
+        SUM(COALESCE(forced_grant_count_delta, 0)) AS forced_grants,
+        MAX(100.0 * granted_memory_mb / NULLIF(target_memory_mb, 0)) AS grant_utilization_pct
+    FROM v_memory_grant_stats
+    WHERE server_id = $1
+    AND   collection_time >= $2
 )
 SELECT
     c.avg_cpu_pct,
@@ -72,10 +87,15 @@ SELECT
     m.memory_ratio,
     m.max_workers_count,
     m.current_workers_count,
-    s.cpu_count
+    s.cpu_count,
+    COALESCE(g.max_grant_waiters, 0),
+    COALESCE(g.grant_timeouts, 0),
+    COALESCE(g.forced_grants, 0),
+    COALESCE(g.grant_utilization_pct, 0)
 FROM cpu_stats c
 CROSS JOIN mem_latest m
-LEFT JOIN server_info s ON true";
+LEFT JOIN server_info s ON true
+LEFT JOIN grants g ON true";
 
     public async Task<UtilizationEfficiencyRow?> GetUtilizationEfficiencyAsync(int serverId, CancellationToken cancellationToken = default)
     {
@@ -93,11 +113,20 @@ LEFT JOIN server_info s ON true";
         var p95Cpu = reader.IsDBNull(2) ? 0m : Convert.ToDecimal(reader.GetValue(2));
         var memRatio = reader.IsDBNull(8) ? 0m : Convert.ToDecimal(reader.GetValue(8));
 
-        var status = "RIGHT_SIZED";
-        if (avgCpu < 15 && maxCpu < 40 && memRatio < 0.5m)
-            status = "OVER_PROVISIONED";
-        else if (p95Cpu > 85 || memRatio > 0.95m)
-            status = "UNDER_PROVISIONED";
+        var maxWorkers = reader.IsDBNull(9) ? 0 : Convert.ToInt32(reader.GetValue(9));
+        var currentWorkers = reader.IsDBNull(10) ? 0 : Convert.ToInt32(reader.GetValue(10));
+
+        /* memory_ratio is still SELECTed and still displayed — it is a real fact about the instance — but it
+           is no longer part of the verdict: Total over Target Server Memory converges at 1.0 on any warmed
+           server, so it reported every server as under-provisioned (#2246). */
+        var status = ProvisioningVerdict.Evaluate(
+            avgCpu, maxCpu, p95Cpu,
+            maxGrantWaiters: reader.IsDBNull(12) ? 0L : Convert.ToInt64(reader.GetValue(12)),
+            grantTimeouts: reader.IsDBNull(13) ? 0L : Convert.ToInt64(reader.GetValue(13)),
+            forcedGrants: reader.IsDBNull(14) ? 0L : Convert.ToInt64(reader.GetValue(14)),
+            grantUtilizationPercent: reader.IsDBNull(15) ? 0m : Convert.ToDecimal(reader.GetValue(15)),
+            maxWorkers: maxWorkers,
+            currentWorkers: currentWorkers);
 
         return new UtilizationEfficiencyRow
         {
@@ -111,8 +140,8 @@ LEFT JOIN server_info s ON true";
             BufferPoolMb = reader.IsDBNull(7) ? 0 : Convert.ToInt32(reader.GetValue(7)),
             MemoryRatio = memRatio,
             ProvisioningStatus = status,
-            MaxWorkersCount = reader.IsDBNull(9) ? 0 : Convert.ToInt32(reader.GetValue(9)),
-            CurrentWorkersCount = reader.IsDBNull(10) ? 0 : Convert.ToInt32(reader.GetValue(10)),
+            MaxWorkersCount = maxWorkers,
+            CurrentWorkersCount = currentWorkers,
             CpuCount = reader.IsDBNull(11) ? 0 : Convert.ToInt32(reader.GetValue(11))
         };
     }
@@ -133,8 +162,24 @@ WITH daily_cpu AS (
 daily_mem AS (
     SELECT
         CAST(collection_time AS DATE) AS day,
-        AVG(CAST(total_server_memory_mb AS DECIMAL(10,2)) / NULLIF(target_server_memory_mb, 0)) AS avg_memory_ratio
+        AVG(CAST(total_server_memory_mb AS DECIMAL(10,2)) / NULLIF(target_server_memory_mb, 0)) AS avg_memory_ratio,
+        MAX(max_workers_count) AS max_workers_count,
+        MAX(current_workers_count) AS current_workers_count
     FROM v_memory_stats
+    WHERE server_id = $1
+    AND   collection_time >= $2
+    GROUP BY CAST(collection_time AS DATE)
+),
+/* Same pressure signals as the point-in-time read, per day, so a day cannot be classified by a rule
+   the current verdict does not use (#2246). */
+daily_grants AS (
+    SELECT
+        CAST(collection_time AS DATE) AS day,
+        MAX(waiter_count) AS max_grant_waiters,
+        SUM(COALESCE(timeout_error_count_delta, 0)) AS grant_timeouts,
+        SUM(COALESCE(forced_grant_count_delta, 0)) AS forced_grants,
+        MAX(100.0 * granted_memory_mb / NULLIF(target_memory_mb, 0)) AS grant_utilization_pct
+    FROM v_memory_grant_stats
     WHERE server_id = $1
     AND   collection_time >= $2
     GROUP BY CAST(collection_time AS DATE)
@@ -144,9 +189,16 @@ SELECT
     c.avg_cpu_pct,
     c.max_cpu_pct,
     c.p95_cpu_pct,
-    COALESCE(m.avg_memory_ratio, 0)
+    COALESCE(m.avg_memory_ratio, 0),
+    COALESCE(g.max_grant_waiters, 0),
+    COALESCE(g.grant_timeouts, 0),
+    COALESCE(g.forced_grants, 0),
+    COALESCE(g.grant_utilization_pct, 0),
+    COALESCE(m.max_workers_count, 0),
+    COALESCE(m.current_workers_count, 0)
 FROM daily_cpu c
 LEFT JOIN daily_mem m ON m.day = c.day
+LEFT JOIN daily_grants g ON g.day = c.day
 ORDER BY c.day";
 
     public async Task<List<ProvisioningTrendRow>> GetProvisioningTrendAsync(int serverId, CancellationToken cancellationToken = default)
@@ -166,11 +218,14 @@ ORDER BY c.day";
             var p95Cpu = reader.IsDBNull(3) ? 0m : Convert.ToDecimal(reader.GetValue(3));
             var memRatio = reader.IsDBNull(4) ? 0m : Convert.ToDecimal(reader.GetValue(4));
 
-            var status = "RIGHT_SIZED";
-            if (avgCpu < 15 && maxCpu < 40 && memRatio < 0.5m)
-                status = "OVER_PROVISIONED";
-            else if (p95Cpu > 85 || memRatio > 0.95m)
-                status = "UNDER_PROVISIONED";
+            var status = ProvisioningVerdict.Evaluate(
+                avgCpu, maxCpu, p95Cpu,
+                maxGrantWaiters: reader.IsDBNull(5) ? 0L : Convert.ToInt64(reader.GetValue(5)),
+                grantTimeouts: reader.IsDBNull(6) ? 0L : Convert.ToInt64(reader.GetValue(6)),
+                forcedGrants: reader.IsDBNull(7) ? 0L : Convert.ToInt64(reader.GetValue(7)),
+                grantUtilizationPercent: reader.IsDBNull(8) ? 0m : Convert.ToDecimal(reader.GetValue(8)),
+                maxWorkers: reader.IsDBNull(9) ? 0 : Convert.ToInt32(reader.GetValue(9)),
+                currentWorkers: reader.IsDBNull(10) ? 0 : Convert.ToInt32(reader.GetValue(10)));
 
             items.Add(new ProvisioningTrendRow
             {

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.cs
@@ -95,6 +95,21 @@ public sealed class UtilizationEfficiencyRow
     public int PhysicalMemoryMb { get; set; }
     public int BufferPoolMb { get; set; }
     public decimal MemoryRatio { get; set; }
+
+    /// <summary>Peak resource-semaphore waiters over the window. Any waiter at all means a query asked for
+    /// workspace memory and did not simply get it — the signal the verdict uses in place of the ratio that
+    /// pinned at 1.0 (#2246).</summary>
+    public long MaxGrantWaiters { get; set; }
+
+    /// <summary>Grant timeouts accrued over the window (delta, not cumulative).</summary>
+    public long GrantTimeouts { get; set; }
+
+    /// <summary>Grants forced through below what was requested, over the window.</summary>
+    public long ForcedGrants { get; set; }
+
+    /// <summary>Peak granted-over-target workspace memory, as a percentage. Fleet max is 18.8%.</summary>
+    public decimal GrantUtilizationPct { get; set; }
+
     public int MaxWorkersCount { get; set; }
     public int CurrentWorkersCount { get; set; }
     public int CpuCount { get; set; }

--- a/Lite.Tests/FinOpsVerdictSourcePinTests.cs
+++ b/Lite.Tests/FinOpsVerdictSourcePinTests.cs
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using Xunit;
+
+namespace Lite.Tests;
+
+/// <summary>
+/// #2246, Lite's half. The provisioning verdict used to be duplicated SIX times — Darling's point-in-time,
+/// trend and inventory reads, and Lite's three — each testing
+/// <c>total_server_memory_mb / target_server_memory_mb &gt; 0.95</c>, a ratio measured at median 1.0000 across
+/// 42 production servers. Every server came out UNDER_PROVISIONED and OVER_PROVISIONED was unreachable.
+///
+/// <para><b>Why source pins rather than behavioural ones.</b> Darling exposes its reads as
+/// <c>public const string</c>, so its tests assert against the shipped SQL directly. Lite builds the same
+/// queries as inline <c>command.CommandText</c>, so there is nothing to reference — the reads are only
+/// reachable through a live DuckDB store. These pins therefore read the source, the same technique
+/// <see cref="ParitySource"/> exists for, and cover the two invariants a broken edit would trip: the pressure
+/// inputs must be SELECTed, and the verdict must not be decided in SQL.</para>
+///
+/// <para>Without them the identical mistake fails fast on Darling and silently on Lite, which is the drift
+/// this whole issue is about — the shared predicate removed the duplicated LOGIC, but the two apps still
+/// carry their own copies of the SQL that feeds it.</para>
+/// </summary>
+public sealed class FinOpsVerdictSourcePinTests
+{
+    private const string Utilization = "Lite/Services/LocalDataService.FinOps.Utilization.cs";
+    private const string Inventory = "Lite/Services/LocalDataService.FinOps.ServerProperties.cs";
+
+    /// <summary>Both Lite reads must fetch the workspace-memory pressure signals the shared predicate
+    /// consumes. A reader wired to ordinals the SELECT list no longer produces is the failure this catches
+    /// earliest.</summary>
+    [Theory]
+    [InlineData(Utilization)]
+    [InlineData(Inventory)]
+    public void BothLiteReads_FetchThePressureInputs(string path)
+    {
+        var source = ParitySource.ReadFile(path);
+
+        Assert.Contains("FROM v_memory_grant_stats", source, StringComparison.Ordinal);
+        Assert.Contains("waiter_count", source, StringComparison.Ordinal);
+        Assert.Contains("timeout_error_count_delta", source, StringComparison.Ordinal);
+        Assert.Contains("forced_grant_count_delta", source, StringComparison.Ordinal);
+        Assert.Contains("granted_memory_mb", source, StringComparison.Ordinal);
+        Assert.Contains("max_workers_count", source, StringComparison.Ordinal);
+    }
+
+    /// <summary>Both must classify through the shared predicate rather than deciding for themselves. The
+    /// inventory read in particular used to carry an inline SQL <c>CASE</c>, and it feeds the Server
+    /// Inventory grid — the screen the field report was looking at.</summary>
+    [Theory]
+    [InlineData(Utilization)]
+    [InlineData(Inventory)]
+    public void BothLiteReads_ClassifyThroughTheSharedPredicate(string path)
+    {
+        var source = ParitySource.ReadFile(path);
+
+        Assert.Contains("ProvisioningVerdict.Evaluate(", source, StringComparison.Ordinal);
+    }
+
+    /// <summary>The verdict must not be decided in SQL. These literals are how the inventory read used to do
+    /// it, so their absence is the guard against a SQL-side verdict coming back — which would silently
+    /// disagree with the drill-down for the same server.</summary>
+    [Theory]
+    [InlineData(Utilization)]
+    [InlineData(Inventory)]
+    public void NoLiteRead_DecidesTheVerdictInSql(string path)
+    {
+        var source = ParitySource.ReadFile(path);
+
+        Assert.DoesNotContain("'OVER_PROVISIONED'", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("'UNDER_PROVISIONED'", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("'RIGHT_SIZED'", source, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The retired threshold itself, gone from every Lite FinOps read.
+    ///
+    /// <para>0.95 and 0.5 were the two ratio comparisons that produced the bug. Pinning the NUMBER rather
+    /// than the expression is deliberate: the defect survived being copied six times precisely because each
+    /// copy was spelled slightly differently, and a literal is what a copy carries unchanged.</para>
+    /// </summary>
+    [Theory]
+    [InlineData(Utilization)]
+    [InlineData(Inventory)]
+    public void TheRetiredMemoryRatioThresholdIsGone(string path)
+    {
+        var source = ParitySource.ReadFile(path);
+
+        Assert.DoesNotContain("> 0.95", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("0.95m", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("< 0.5 ", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("0.5m)", source, StringComparison.Ordinal);
+    }
+}

--- a/Lite/Controls/FinOpsTab.xaml.cs
+++ b/Lite/Controls/FinOpsTab.xaml.cs
@@ -370,9 +370,13 @@ public partial class FinOpsTab : UserControl
         {
             "RIGHT_SIZED" => $"CPU is moderately loaded (avg {data.AvgCpuPct:N1}%, p95 {data.P95CpuPct:N1}%) and memory is well-utilized (buffer pool uses {bpPct:N0}% of physical RAM). No action needed.",
             "OVER_PROVISIONED" => $"CPU is lightly loaded (avg {data.AvgCpuPct:N1}%, max {data.MaxCpuPct}%) and buffer pool uses only {bpPct:N0}% of physical RAM. This server may have more resources than it needs.",
-            "UNDER_PROVISIONED" => data.P95CpuPct > 85
-                ? $"CPU p95 is {data.P95CpuPct:N1}% (threshold: 85%). This server may need more CPU capacity."
-                : $"Buffer pool uses {bpPct:N0}% of physical RAM and memory ratio is {data.MemoryRatio:N2} (threshold: 0.95). Memory pressure is high.",
+            /* The reason comes from the same place as the verdict. This branch used to read
+               "P95CpuPct > 85 ? CPU : memory ratio is {x} (threshold: 0.95)", so a server flagged for grant
+               pressure or worker saturation would have been explained as a memory ratio that no longer
+               decides anything, citing a threshold the code does not check (#2246). */
+            "UNDER_PROVISIONED" => ProvisioningVerdict.UnderProvisionedReason(
+                data.P95CpuPct, data.MaxGrantWaiters, data.GrantTimeouts, data.ForcedGrants,
+                data.MaxWorkersCount, data.CurrentWorkersCount),
             _ => ""
         };
 

--- a/Lite/Services/LocalDataService.FinOps.ServerProperties.cs
+++ b/Lite/Services/LocalDataService.FinOps.ServerProperties.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using DuckDB.NET.Data;
 using Microsoft.Data.SqlClient;
+using PerformanceMonitor.Common;
 
 namespace PerformanceMonitorLite.Services;
 
@@ -209,7 +210,9 @@ WITH cpu_24h AS (
 ),
 mem_latest AS (
     SELECT
-        CAST(total_server_memory_mb AS DECIMAL(10,2)) / NULLIF(target_server_memory_mb, 0) AS memory_ratio
+        CAST(total_server_memory_mb AS DECIMAL(10,2)) / NULLIF(target_server_memory_mb, 0) AS memory_ratio,
+        max_workers_count,
+        current_workers_count
     FROM v_memory_stats
     WHERE server_id = $1
     AND   (server_id, collection_time) IN (
@@ -218,6 +221,19 @@ mem_latest AS (
         WHERE server_id = $1
         GROUP BY server_id
     )
+),
+/* Same workspace-memory pressure signals as the drill-down read, so the INVENTORY GRID cannot classify a
+   server by a rule the drill-down no longer uses (#2246 — this grid is the screen the field report was
+   looking at). */
+grants AS (
+    SELECT
+        MAX(waiter_count) AS max_grant_waiters,
+        SUM(COALESCE(timeout_error_count_delta, 0)) AS grant_timeouts,
+        SUM(COALESCE(forced_grant_count_delta, 0)) AS forced_grants,
+        MAX(100.0 * granted_memory_mb / NULLIF(target_memory_mb, 0)) AS grant_utilization_pct
+    FROM v_memory_grant_stats
+    WHERE server_id = $1
+    AND   collection_time >= $2
 ),
 storage_totals AS (
     SELECT
@@ -257,18 +273,20 @@ SELECT
     c.avg_cpu_pct,
     st.total_storage_gb,
     id.idle_db_count,
-    CASE
-        WHEN c.avg_cpu_pct < 15 AND c.max_cpu_pct < 40 AND COALESCE(m.memory_ratio, 0) < 0.5
-        THEN 'OVER_PROVISIONED'
-        WHEN c.p95_cpu_pct > 85 OR COALESCE(m.memory_ratio, 0) > 0.95
-        THEN 'UNDER_PROVISIONED'
-        ELSE 'RIGHT_SIZED'
-    END AS provisioning_status
+    c.max_cpu_pct,
+    c.p95_cpu_pct,
+    COALESCE(m.max_workers_count, 0),
+    COALESCE(m.current_workers_count, 0),
+    COALESCE(g.max_grant_waiters, 0),
+    COALESCE(g.grant_timeouts, 0),
+    COALESCE(g.forced_grants, 0),
+    COALESCE(g.grant_utilization_pct, 0)
 FROM (SELECT 1) AS anchor
 LEFT JOIN cpu_24h c ON true
 LEFT JOIN mem_latest m ON true
 LEFT JOIN storage_totals st ON true
-LEFT JOIN idle_dbs id ON true";
+LEFT JOIN idle_dbs id ON true
+LEFT JOIN grants g ON true";
 
         command.Parameters.Add(new DuckDBParameter { Value = serverId });
         command.Parameters.Add(new DuckDBParameter { Value = cpuCutoff });
@@ -277,11 +295,25 @@ LEFT JOIN idle_dbs id ON true";
         using var reader = await command.ExecuteReaderAsync();
         if (await reader.ReadAsync())
         {
+            /* The verdict is computed HERE rather than as a SQL CASE, so this grid and the drill-down cannot
+               disagree — they now call the same predicate. The old inline CASE was copies 5 and 6 of the
+               ratio bug, on the screen the field report was actually looking at (#2246). */
+            var status = ProvisioningVerdict.Evaluate(
+                avgCpuPercent: reader.IsDBNull(0) ? 0m : Convert.ToDecimal(reader.GetValue(0)),
+                maxCpuPercent: reader.IsDBNull(3) ? 0m : Convert.ToDecimal(reader.GetValue(3)),
+                p95CpuPercent: reader.IsDBNull(4) ? 0m : Convert.ToDecimal(reader.GetValue(4)),
+                maxGrantWaiters: reader.IsDBNull(7) ? 0L : ToInt64(reader.GetValue(7)),
+                grantTimeouts: reader.IsDBNull(8) ? 0L : ToInt64(reader.GetValue(8)),
+                forcedGrants: reader.IsDBNull(9) ? 0L : ToInt64(reader.GetValue(9)),
+                grantUtilizationPercent: reader.IsDBNull(10) ? 0m : Convert.ToDecimal(reader.GetValue(10)),
+                maxWorkers: reader.IsDBNull(5) ? 0 : Convert.ToInt32(reader.GetValue(5)),
+                currentWorkers: reader.IsDBNull(6) ? 0 : Convert.ToInt32(reader.GetValue(6)));
+
             return (
                 reader.IsDBNull(0) ? null : Convert.ToDecimal(reader.GetValue(0)),
                 reader.IsDBNull(1) ? null : Convert.ToDecimal(reader.GetValue(1)),
                 reader.IsDBNull(2) ? null : Convert.ToInt32(reader.GetValue(2)),
-                reader.IsDBNull(3) ? null : reader.GetString(3)
+                status
             );
         }
 

--- a/Lite/Services/LocalDataService.FinOps.Utilization.cs
+++ b/Lite/Services/LocalDataService.FinOps.Utilization.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using DuckDB.NET.Data;
+using PerformanceMonitor.Common;
 
 namespace PerformanceMonitorLite.Services;
 
@@ -57,6 +58,20 @@ server_info AS (
     WHERE server_id = $1
     ORDER BY collection_time DESC
     LIMIT 1
+),
+/* Workspace-memory pressure, which is what being short of memory actually looks like: a query asked the
+   resource semaphore for a grant and did not simply get it. Counts of events, so no threshold to tune
+   (#2246). The utilization peak rides along to stop a CPU-quiet server that is straining its semaphore
+   from being called idle. Same CTE as Darling's read, against the same column names. */
+grants AS (
+    SELECT
+        MAX(waiter_count) AS max_grant_waiters,
+        SUM(COALESCE(timeout_error_count_delta, 0)) AS grant_timeouts,
+        SUM(COALESCE(forced_grant_count_delta, 0)) AS forced_grants,
+        MAX(100.0 * granted_memory_mb / NULLIF(target_memory_mb, 0)) AS grant_utilization_pct
+    FROM v_memory_grant_stats
+    WHERE server_id = $1
+    AND   collection_time >= $2
 )
 SELECT
     c.avg_cpu_pct,
@@ -70,10 +85,15 @@ SELECT
     m.memory_ratio,
     m.max_workers_count,
     m.current_workers_count,
-    s.cpu_count
+    s.cpu_count,
+    COALESCE(g.max_grant_waiters, 0),
+    COALESCE(g.grant_timeouts, 0),
+    COALESCE(g.forced_grants, 0),
+    COALESCE(g.grant_utilization_pct, 0)
 FROM cpu_stats c
 CROSS JOIN mem_latest m
-LEFT JOIN server_info s ON true";
+LEFT JOIN server_info s ON true
+LEFT JOIN grants g ON true";
 
         command.Parameters.Add(new DuckDBParameter { Value = serverId });
         command.Parameters.Add(new DuckDBParameter { Value = cutoff });
@@ -86,11 +106,20 @@ LEFT JOIN server_info s ON true";
         var p95Cpu = reader.IsDBNull(2) ? 0m : Convert.ToDecimal(reader.GetValue(2));
         var memRatio = reader.IsDBNull(8) ? 0m : Convert.ToDecimal(reader.GetValue(8));
 
-        var status = "RIGHT_SIZED";
-        if (avgCpu < 15 && maxCpu < 40 && memRatio < 0.5m)
-            status = "OVER_PROVISIONED";
-        else if (p95Cpu > 85 || memRatio > 0.95m)
-            status = "UNDER_PROVISIONED";
+        var maxWorkers = reader.IsDBNull(9) ? 0 : Convert.ToInt32(reader.GetValue(9));
+        var currentWorkers = reader.IsDBNull(10) ? 0 : Convert.ToInt32(reader.GetValue(10));
+
+        /* memory_ratio is still SELECTed and still displayed — it is a real fact about the instance — but it
+           is no longer part of the verdict: Total over Target Server Memory converges at 1.0 on any warmed
+           server, so it reported every server as under-provisioned (#2246). */
+        var status = ProvisioningVerdict.Evaluate(
+            avgCpu, maxCpu, p95Cpu,
+            maxGrantWaiters: reader.IsDBNull(12) ? 0L : ToInt64(reader.GetValue(12)),
+            grantTimeouts: reader.IsDBNull(13) ? 0L : ToInt64(reader.GetValue(13)),
+            forcedGrants: reader.IsDBNull(14) ? 0L : ToInt64(reader.GetValue(14)),
+            grantUtilizationPercent: reader.IsDBNull(15) ? 0m : Convert.ToDecimal(reader.GetValue(15)),
+            maxWorkers: maxWorkers,
+            currentWorkers: currentWorkers);
 
         return new UtilizationEfficiencyRow
         {
@@ -104,8 +133,8 @@ LEFT JOIN server_info s ON true";
             BufferPoolMb = reader.IsDBNull(7) ? 0 : Convert.ToInt32(reader.GetValue(7)),
             MemoryRatio = memRatio,
             ProvisioningStatus = status,
-            MaxWorkersCount = reader.IsDBNull(9) ? 0 : Convert.ToInt32(reader.GetValue(9)),
-            CurrentWorkersCount = reader.IsDBNull(10) ? 0 : Convert.ToInt32(reader.GetValue(10)),
+            MaxWorkersCount = maxWorkers,
+            CurrentWorkersCount = currentWorkers,
             CpuCount = reader.IsDBNull(11) ? 0 : Convert.ToInt32(reader.GetValue(11))
         };
     }
@@ -135,8 +164,24 @@ WITH daily_cpu AS (
 daily_mem AS (
     SELECT
         CAST(collection_time AS DATE) AS day,
-        AVG(CAST(total_server_memory_mb AS DECIMAL(10,2)) / NULLIF(target_server_memory_mb, 0)) AS avg_memory_ratio
+        AVG(CAST(total_server_memory_mb AS DECIMAL(10,2)) / NULLIF(target_server_memory_mb, 0)) AS avg_memory_ratio,
+        MAX(max_workers_count) AS max_workers_count,
+        MAX(current_workers_count) AS current_workers_count
     FROM v_memory_stats
+    WHERE server_id = $1
+    AND   collection_time >= $2
+    GROUP BY CAST(collection_time AS DATE)
+),
+/* Same pressure signals as the point-in-time read, per day, so a day cannot be classified by a rule the
+   current verdict does not use (#2246). */
+daily_grants AS (
+    SELECT
+        CAST(collection_time AS DATE) AS day,
+        MAX(waiter_count) AS max_grant_waiters,
+        SUM(COALESCE(timeout_error_count_delta, 0)) AS grant_timeouts,
+        SUM(COALESCE(forced_grant_count_delta, 0)) AS forced_grants,
+        MAX(100.0 * granted_memory_mb / NULLIF(target_memory_mb, 0)) AS grant_utilization_pct
+    FROM v_memory_grant_stats
     WHERE server_id = $1
     AND   collection_time >= $2
     GROUP BY CAST(collection_time AS DATE)
@@ -146,9 +191,16 @@ SELECT
     c.avg_cpu_pct,
     c.max_cpu_pct,
     c.p95_cpu_pct,
-    COALESCE(m.avg_memory_ratio, 0)
+    COALESCE(m.avg_memory_ratio, 0),
+    COALESCE(g.max_grant_waiters, 0),
+    COALESCE(g.grant_timeouts, 0),
+    COALESCE(g.forced_grants, 0),
+    COALESCE(g.grant_utilization_pct, 0),
+    COALESCE(m.max_workers_count, 0),
+    COALESCE(m.current_workers_count, 0)
 FROM daily_cpu c
 LEFT JOIN daily_mem m ON m.day = c.day
+LEFT JOIN daily_grants g ON g.day = c.day
 ORDER BY c.day";
 
         command.Parameters.Add(new DuckDBParameter { Value = serverId });
@@ -163,11 +215,14 @@ ORDER BY c.day";
             var p95Cpu = reader.IsDBNull(3) ? 0m : Convert.ToDecimal(reader.GetValue(3));
             var memRatio = reader.IsDBNull(4) ? 0m : Convert.ToDecimal(reader.GetValue(4));
 
-            var status = "RIGHT_SIZED";
-            if (avgCpu < 15 && maxCpu < 40 && memRatio < 0.5m)
-                status = "OVER_PROVISIONED";
-            else if (p95Cpu > 85 || memRatio > 0.95m)
-                status = "UNDER_PROVISIONED";
+            var status = ProvisioningVerdict.Evaluate(
+                avgCpu, maxCpu, p95Cpu,
+                maxGrantWaiters: reader.IsDBNull(5) ? 0L : ToInt64(reader.GetValue(5)),
+                grantTimeouts: reader.IsDBNull(6) ? 0L : ToInt64(reader.GetValue(6)),
+                forcedGrants: reader.IsDBNull(7) ? 0L : ToInt64(reader.GetValue(7)),
+                grantUtilizationPercent: reader.IsDBNull(8) ? 0m : Convert.ToDecimal(reader.GetValue(8)),
+                maxWorkers: reader.IsDBNull(9) ? 0 : Convert.ToInt32(reader.GetValue(9)),
+                currentWorkers: reader.IsDBNull(10) ? 0 : Convert.ToInt32(reader.GetValue(10)));
 
             items.Add(new ProvisioningTrendRow
             {

--- a/Lite/Services/LocalDataService.FinOps.Utilization.cs
+++ b/Lite/Services/LocalDataService.FinOps.Utilization.cs
@@ -133,6 +133,10 @@ LEFT JOIN grants g ON true";
             BufferPoolMb = reader.IsDBNull(7) ? 0 : Convert.ToInt32(reader.GetValue(7)),
             MemoryRatio = memRatio,
             ProvisioningStatus = status,
+            MaxGrantWaiters = reader.IsDBNull(12) ? 0L : ToInt64(reader.GetValue(12)),
+            GrantTimeouts = reader.IsDBNull(13) ? 0L : ToInt64(reader.GetValue(13)),
+            ForcedGrants = reader.IsDBNull(14) ? 0L : ToInt64(reader.GetValue(14)),
+            GrantUtilizationPct = reader.IsDBNull(15) ? 0m : Convert.ToDecimal(reader.GetValue(15)),
             MaxWorkersCount = maxWorkers,
             CurrentWorkersCount = currentWorkers,
             CpuCount = reader.IsDBNull(11) ? 0 : Convert.ToInt32(reader.GetValue(11))

--- a/Lite/Services/LocalDataService.FinOps.cs
+++ b/Lite/Services/LocalDataService.FinOps.cs
@@ -77,6 +77,21 @@ public class UtilizationEfficiencyRow
     public int PhysicalMemoryMb { get; set; }
     public int BufferPoolMb { get; set; }
     public decimal MemoryRatio { get; set; }
+
+    /// <summary>Peak resource-semaphore waiters over the window. Any waiter at all means a query asked for
+    /// workspace memory and did not simply get it — the signal the verdict uses in place of the ratio that
+    /// pinned at 1.0 (#2246).</summary>
+    public long MaxGrantWaiters { get; set; }
+
+    /// <summary>Grant timeouts accrued over the window (delta, not cumulative).</summary>
+    public long GrantTimeouts { get; set; }
+
+    /// <summary>Grants forced through below what was requested, over the window.</summary>
+    public long ForcedGrants { get; set; }
+
+    /// <summary>Peak granted-over-target workspace memory, as a percentage. Fleet max is 18.8%.</summary>
+    public decimal GrantUtilizationPct { get; set; }
+
     public int MaxWorkersCount { get; set; }
     public int CurrentWorkersCount { get; set; }
     public int CpuCount { get; set; }

--- a/PerformanceMonitor.Common/ProvisioningVerdict.cs
+++ b/PerformanceMonitor.Common/ProvisioningVerdict.cs
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+
+namespace PerformanceMonitor.Common;
+
+/// <summary>
+/// The FinOps provisioning verdict for one server — over-provisioned, right-sized, or under-provisioned —
+/// as a single shared predicate both apps call.
+///
+/// <para><b>Why this is shared rather than inlined.</b> The rule this replaces was copy-pasted four times
+/// (Darling's point-in-time and trend reads, Lite's two), and every copy carried the same defect: it tested
+/// <c>total_server_memory_mb / target_server_memory_mb &gt; 0.95</c>. Those are the perfmon Total and Target
+/// Server Memory counters, and they converge at 1.0 the moment an instance is warmed — Target is what SQL
+/// Server wants and Total is what it holds. Measured across a 42-server production fleet, that ratio ran
+/// median <b>1.0000</b> (min 0.9997, max 1.0002), so the rule reported <b>UNDER_PROVISIONED for every
+/// server</b> and <c>OVER_PROVISIONED</c>, whose arm needs the same ratio below 0.5, was unreachable at any
+/// workload (#2246). One predicate, compiler-shared, is the same answer the collector gate surface reached
+/// when it collapsed two drifting layers into one.</para>
+///
+/// <para><b>Every threshold below was measured, not chosen.</b> Fleet distributions over 24 hours:</para>
+/// <list type="bullet">
+/// <item>CPU p95 per server: min 0.0, p25 6.5, median 11.0, p95 48.6, max <b>51.0</b> — so
+/// <see cref="HighCpuP95Percent"/> at 85 is comfortably clear of a healthy fleet and still reachable.</item>
+/// <item>Worker ratio per server: median 0.246, max <b>0.635</b>; zero servers over 0.8 and zero exhaustion
+/// warnings, so <see cref="HighWorkerRatio"/> at 0.8 does not false-fire here.</item>
+/// <item>Workspace-grant utilization (granted / target): median <b>0.5%</b>, p95 12.0%, max 18.8% — so
+/// <see cref="IdleGrantUtilizationPercent"/> at 50 excludes nothing real today while still refusing to call
+/// a server idle that is straining its semaphore.</item>
+/// <item>Grant waiters, grant timeouts, forced grants and <c>Memory Grants Pending</c>: <b>zero across
+/// 2,938,711 grant rows and 1,000,560 counter rows</b>, the entire retained history. This fleet has no
+/// memory pressure, which is exactly why a correct memory term must be SILENT on it.</item>
+/// </list>
+///
+/// <para><b>The honest gap.</b> Because nothing in that history ever recorded grant pressure, there is no
+/// positive control from the fleet: the measurements show the memory term stays quiet when it should, and
+/// cannot show it fires when it should. That is established by construction in the tests instead, which
+/// drive each pressure input directly.</para>
+///
+/// <para><b>Pressure outranks idleness</b> — <see cref="Evaluate"/> tests under-provisioning first. A server
+/// can be quiet on CPU while queries queue for workspace memory, and calling that one over-provisioned would
+/// recommend taking away the resource it is short of.</para>
+/// </summary>
+public static class ProvisioningVerdict
+{
+    /// <summary>Sustained CPU at or above this p95 is under-provisioned. Fleet max p95 is 51.0.</summary>
+    public const decimal HighCpuP95Percent = 85m;
+
+    /// <summary>Below this average CPU, with <see cref="IdleMaxCpuPercent"/> also satisfied, a server is a
+    /// downsizing candidate.</summary>
+    public const decimal IdleAvgCpuPercent = 15m;
+
+    /// <summary>An idle server must also never have spiked past this. Guards against averaging away a
+    /// short daily peak that the smaller instance would not survive.</summary>
+    public const decimal IdleMaxCpuPercent = 40m;
+
+    /// <summary>Worker-thread saturation. The Full Dashboard's view has always carried this term and the
+    /// app copies dropped it, so a genuinely worker-starved server was invisible to them (#2246).</summary>
+    public const double HighWorkerRatio = 0.8;
+
+    /// <summary>A server using more than this share of its workspace-memory grant target is not idle, no
+    /// matter how quiet its CPU looks. Fleet max is 18.8%.</summary>
+    public const decimal IdleGrantUtilizationPercent = 50m;
+
+    /// <summary>Over-provisioned: a downsizing candidate.</summary>
+    public const string OverProvisioned = "OVER_PROVISIONED";
+
+    /// <summary>Neither idle enough to shrink nor under pressure.</summary>
+    public const string RightSized = "RIGHT_SIZED";
+
+    /// <summary>Under pressure on CPU, workspace memory, or worker threads.</summary>
+    public const string UnderProvisioned = "UNDER_PROVISIONED";
+
+    /// <summary>
+    /// The verdict for one server from one window's measurements.
+    /// </summary>
+    /// <param name="avgCpuPercent">Mean SQL Server CPU over the window.</param>
+    /// <param name="maxCpuPercent">Peak SQL Server CPU over the window.</param>
+    /// <param name="p95CpuPercent">95th-percentile SQL Server CPU over the window.</param>
+    /// <param name="maxGrantWaiters">Peak <c>waiter_count</c> from the resource semaphore. Any waiter at all
+    /// means a query could not get workspace memory when it asked.</param>
+    /// <param name="grantTimeouts">Grant timeouts accrued over the window (delta, not cumulative).</param>
+    /// <param name="forcedGrants">Forced grants accrued over the window (delta, not cumulative).</param>
+    /// <param name="grantUtilizationPercent">Peak granted-over-target workspace memory, as a percentage.</param>
+    /// <param name="maxWorkers">The instance's worker-thread ceiling; 0 or negative means unknown, which
+    /// cannot imply saturation.</param>
+    /// <param name="currentWorkers">Workers in use at the latest sample.</param>
+    public static string Evaluate(
+        decimal avgCpuPercent,
+        decimal maxCpuPercent,
+        decimal p95CpuPercent,
+        long maxGrantWaiters,
+        long grantTimeouts,
+        long forcedGrants,
+        decimal grantUtilizationPercent,
+        int maxWorkers,
+        int currentWorkers)
+    {
+        /* Any of these three is a query that asked for workspace memory and did not simply get it. They are
+           counts of events, not levels, so there is no threshold to tune — and on a fleet with no memory
+           pressure they are all zero, which is the point. */
+        var memoryPressure = maxGrantWaiters > 0 || grantTimeouts > 0 || forcedGrants > 0;
+
+        /* maxWorkers <= 0 means the sample never reported a ceiling. Unknown is not saturation: the same
+           rule the collector gates follow, where an unclassified target must never be gated off by
+           assumption. */
+        var workerPressure = maxWorkers > 0
+            && currentWorkers / (double)maxWorkers > HighWorkerRatio;
+
+        if (p95CpuPercent > HighCpuP95Percent || memoryPressure || workerPressure)
+        {
+            return UnderProvisioned;
+        }
+
+        if (avgCpuPercent < IdleAvgCpuPercent
+            && maxCpuPercent < IdleMaxCpuPercent
+            && grantUtilizationPercent < IdleGrantUtilizationPercent)
+        {
+            return OverProvisioned;
+        }
+
+        return RightSized;
+    }
+}

--- a/PerformanceMonitor.Common/ProvisioningVerdict.cs
+++ b/PerformanceMonitor.Common/ProvisioningVerdict.cs
@@ -127,4 +127,48 @@ public static class ProvisioningVerdict
 
         return RightSized;
     }
+
+    /// <summary>
+    /// Why <see cref="Evaluate"/> returned <see cref="UnderProvisioned"/>, in the operator's words.
+    ///
+    /// <para>Shared for the same reason the verdict is: the UI used to re-derive the cause with
+    /// <c>P95CpuPct &gt; 85 ? "CPU..." : "memory ratio is {x} (threshold: 0.95)"</c>, so once the verdict
+    /// gained grant-pressure and worker-thread reasons, every one of those would have been explained as a
+    /// memory ratio that no longer decides anything — a fabricated cause citing a threshold the code does
+    /// not check. Deriving the text beside the decision is what stops that recurring.</para>
+    ///
+    /// <para>Checked in the same order <see cref="Evaluate"/> checks them, so the reason names the condition
+    /// that actually fired first.</para>
+    /// </summary>
+    public static string UnderProvisionedReason(
+        decimal p95CpuPercent,
+        long maxGrantWaiters,
+        long grantTimeouts,
+        long forcedGrants,
+        int maxWorkers,
+        int currentWorkers)
+    {
+        if (p95CpuPercent > HighCpuP95Percent)
+        {
+            return $"CPU p95 is {p95CpuPercent:N1}% (threshold: {HighCpuP95Percent:N0}%). "
+                + "This server may need more CPU capacity.";
+        }
+
+        if (maxGrantWaiters > 0 || grantTimeouts > 0 || forcedGrants > 0)
+        {
+            return "Queries could not get the workspace memory they asked for: peak "
+                + $"{maxGrantWaiters} grant waiter(s), {grantTimeouts} grant timeout(s), "
+                + $"{forcedGrants} forced grant(s). This server may need more memory.";
+        }
+
+        if (maxWorkers > 0 && currentWorkers / (double)maxWorkers > HighWorkerRatio)
+        {
+            return $"Worker threads are near the limit: {currentWorkers} of {maxWorkers} in use "
+                + $"(threshold: {HighWorkerRatio:P0}). This server may need more CPU capacity.";
+        }
+
+        /* Reachable only if a caller asks for a reason on inputs that are not under-provisioned. Say so
+           rather than inventing a cause, which is the failure this method exists to end. */
+        return "No under-provisioning condition is currently met.";
+    }
 }


### PR DESCRIPTION
Fixes #2246.

## What was wrong

The verdict tested `total_server_memory_mb / target_server_memory_mb > 0.95`. Those are the perfmon **Total** and **Target** Server Memory counters — Target is what SQL Server wants, Total is what it holds — so they converge at 1.0 the moment an instance is warmed. Measured across 42 production servers:

```
median 1.0000    min 0.9997    max 1.0002    ->  42/42 above 0.95
```

Every server reported `UNDER_PROVISIONED`, and `OVER_PROVISIONED` — whose arm needs the same ratio below **0.5** — was unreachable at any workload. Duplicated in four places (Darling point-in-time + trend, Lite's two), all identical.

## Porting the Full Dashboard's formula does not fix it

I proposed that first, then measured it before anyone built it:

```
CURRENT ratio (total / target):        median 1.0000    42/42 > 0.95
PORTED  ratio (SUM(clerks) / target):  median 0.9662    42/42 > 0.95
```

Still fires on everything, and recovering `memory_clerks`' truncated tail (`TOP (25) ... HAVING > 1024`, binding on every server) would push it *higher*. **The threshold was as broken as the metric**, so agreement with the old view was never the goal — the reporter's Azure DB just happens to land under 0.95 with that numerator.

## Thresholds, each with its distribution

| term | fleet distribution | limit |
|---|---|---|
| CPU p95 per server | min 0.0, p25 6.5, **median 11.0**, p95 48.6, max **51.0** | `> 85` |
| worker ratio | median 0.246, max **0.635**, zero exhaustion warnings | `> 0.8` |
| grant utilization | median **0.5%**, p95 12.0%, max 18.8% | `< 50` to be idle |
| grant waiters / timeouts / forced | **0 across 2,938,711 rows**, entire retained history | any `> 0` |

**The memory term is silent on this fleet, and that is the right answer** — nothing here has memory pressure. My earlier acceptance bar ("more than one verdict across 42 healthy servers") was aimed at the wrong term: the spread comes from CPU, and it is already there. Prototyped against the live store, the new rule gives **25 OVER / 17 RIGHT / 0 UNDER** where the old gave 42 UNDER.

**Pressure outranks idleness**, so UNDER is tested first. A server can be quiet on CPU while queries queue for workspace memory, and recommending a smaller instance for that one would take away the resource it is short of.

## Why the predicate moved to Common

The duplication *is* the bug: one rule, four copies, same defect in each. `ProvisioningVerdict` is one compiler-shared surface — the same conclusion the collector gate surface reached when it collapsed two drifting layers into one. It also restores the **worker-thread term** the Full Dashboard has always carried and both app copies dropped, so a genuinely worker-starved server was invisible to them.

`memory_ratio` is still selected and still displayed. It's a real fact about the instance; it just no longer decides anything.

## Verification

- **The shipped SQL of both reads executed against the live store** — 16 and 11 columns, ordinals matching the readers. Real output for one server: `memory_ratio 1.00003` (the bug, still displayed), grants `0/0/0`, utilization 0.04%, workers 52/512. The trend now **varies by day** (two days at 25% utilization) where every day used to be UNDER.
- **14/14 locally** against the linked source, including the three **positive controls** — waiter, timeout, forced grant, each alone, with idle CPU so they also pin the ordering. Those matter because the fleet cannot supply them: no grant pressure exists anywhere in the retained history, so "it stays quiet" is all the fleet can prove.
- Strict boundaries pinned (p95 exactly 85, avg exactly 15, ratio exactly 0.8 must **not** trip), and unknown-worker-ceiling must not read as saturation.
- Builds clean, 0 warnings, both SKUs.

## What this changes for users

Servers currently labelled `UNDER_PROVISIONED` will mostly become `OVER_PROVISIONED` or `RIGHT_SIZED`. That is the point — the column becomes usable for downsizing decisions — but it is a visible behaviour change on a shipped report, so it wants your eye before release. Anyone who had tuned around "everything is under-provisioned" will see different advice.