### PR TITLE
Drop the dead memory_ratio computation from the two FinOps inventory reads

### DIFF
--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.Inventory.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.Inventory.cs
@@ -38,9 +38,10 @@ WITH cpu_24h AS (
     WHERE server_id = $1
     AND   collection_time >= $2
 ),
+/* Only the worker counts are consumed now: memory_ratio used to feed this read's own CASE, and that
+   CASE was the #2246 bug. The verdict comes from ProvisioningVerdict, so the division would be dead. */
 mem_latest AS (
     SELECT
-        CAST(total_server_memory_mb AS DECIMAL(10,2)) / NULLIF(target_server_memory_mb, 0) AS memory_ratio,
         max_workers_count,
         current_workers_count
     FROM v_memory_stats

--- a/Lite/Services/LocalDataService.FinOps.ServerProperties.cs
+++ b/Lite/Services/LocalDataService.FinOps.ServerProperties.cs
@@ -208,9 +208,10 @@ WITH cpu_24h AS (
     WHERE server_id = $1
     AND   collection_time >= $2
 ),
+/* Only the worker counts are consumed now: memory_ratio used to feed this read's own CASE, and that
+   CASE was the #2246 bug. The verdict comes from ProvisioningVerdict, so the division would be dead. */
 mem_latest AS (
     SELECT
-        CAST(total_server_memory_mb AS DECIMAL(10,2)) / NULLIF(target_server_memory_mb, 0) AS memory_ratio,
         max_workers_count,
         current_workers_count
     FROM v_memory_stats


### PR DESCRIPTION
Follow-up to #2251, from two review comments I merged past — the chain that printed the open threads went on to merge in the same command instead of gating on them. My error, and the second time today, so worth naming rather than glossing.

The finding itself is small and correct: `memory_ratio` fed those reads' own inline `CASE`, and that `CASE` **was** the #2246 bug. Now that the verdict comes from `ProvisioningVerdict.Evaluate`, only `max_workers_count` / `current_workers_count` are consumed from `mem_latest`, so the division computed a value nothing selects. Dropped in both copies, with a comment saying why so it doesn't get "restored" as an apparent omission.

Both projects build clean.