### PR TITLE
Read server_id from the store instead of re-deriving it (#2218 step 1)

### DIFF
--- a/Darling/Darling.Tests/PostgresTargetConfigTests.cs
+++ b/Darling/Darling.Tests/PostgresTargetConfigTests.cs
@@ -307,6 +307,14 @@ public class PostgresTargetConfigTests
             ("ExcludedDatabases", "excluded_databases"),
             ("MonthlyCostUsd", "monthly_cost_usd"),
             ("AlertDeliveryModeOverride", "alert_delivery_mode_override"),
+            /* #2218. The one entry whose property name deliberately does not resemble its column: the
+               property says STORED because that is the whole point — it is the registry's value, and null
+               means "no store row yet", which is what makes MonitoredServer.ServerId fall back to the
+               derivation. It belongs in this list rather than beside Password's exemption because it really
+               does round-trip, through the table's own PRIMARY KEY. That column existed from V17 and this
+               read simply did not select it, which is the class of bug this test was written for: a property
+               and a column that fail to meet, with nothing failing to compile. */
+            ("StoredServerId", "server_id"),
         };
 
         /* Password is the deliberate exception: a plaintext dev password is never persisted, and is

--- a/Darling/Darling.Tests/ServerIdentityFromStoreTests.cs
+++ b/Darling/Darling.Tests/ServerIdentityFromStoreTests.cs
@@ -1,0 +1,310 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Npgsql;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.Darling.Service;
+using PerformanceMonitor.Darling.Storage;
+using PerformanceMonitor.Notifications;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #2218 step one: a monitored server's <c>server_id</c> comes from the STORE, and is derived in exactly one
+/// place when there is nothing stored yet.
+///
+/// <para><b>What was wrong.</b> <c>config.config_monitored_servers.server_id</c> is that table's PRIMARY KEY
+/// and is authoritative once seeded — but the read selected fifteen columns and not that one, so the registry's
+/// own key was discarded and twelve downstream sites re-derived it from <c>host</c>, <c>database</c> and
+/// <c>read_only_intent</c>: every operator-command lookup, the reconcile, the self-alert stamps, the schedule
+/// resolution. Identity-derived-from-editable-config cannot be replaced while that is true, because a stored
+/// surrogate is only worth anything if nothing re-derives it behind the store's back.</para>
+///
+/// <para><b>Behaviour is unchanged today and that is the point.</b> The seed and the Viewer both write exactly
+/// the hash this used to recompute, so stored and derived are equal on every existing store and no data moves.
+/// What changed is that the derivation is now the FALLBACK, in one property, so the later change is that
+/// property rather than twelve call sites — see #2158 and #2228 for what it is a prerequisite for.</para>
+///
+/// <para>The live arm therefore does the one thing production cannot yet produce: a row whose stored
+/// <c>server_id</c> DISAGREES with the hash of its own host. Without that, every assertion here would pass
+/// just as well against the old code, since the two values coincide.</para>
+/// </summary>
+public sealed class ServerIdentityFromStoreTests
+{
+    private static int Derived(string host, string? database = null, bool readOnlyIntent = false) =>
+        ServerIdHelper.GetDeterministicHashCode(ServerIdHelper.BuildStorageName(host, database, readOnlyIntent));
+
+    /// <summary>A <c>darling.json</c> entry before the first seed has no store row, so identity is derived —
+    /// which is what makes the seed able to mint it, and what keeps <c>--test-connection</c> working against a
+    /// file on a host that has never started the service.</summary>
+    [Theory]
+    [InlineData("sql01", null, false)]
+    [InlineData("myazure.database.windows.net", "AdventureWorks", false)]
+    [InlineData("ag-listener", null, true)]
+    public void WithNothingStored_IdentityIsTheDerivation(string host, string? database, bool readOnlyIntent)
+    {
+        var server = new MonitoredServer { Host = host, Database = database, ReadOnlyIntent = readOnlyIntent };
+
+        Assert.Null(server.StoredServerId);
+        Assert.Equal(Derived(host, database, readOnlyIntent), server.ServerId);
+    }
+
+    /// <summary>
+    /// THE SEAM. A stored id wins over the derivation, and keeps winning when the fields the derivation reads
+    /// change underneath it.
+    ///
+    /// <para>This is the property the whole change exists for: an operator repointing a server at a new host
+    /// — the #2158 case, and what the use1 fleet did on 2026-08-09 — must not move the identity its collected
+    /// history and its per-server config are keyed on. Note the assertion is not merely "stored equals
+    /// ServerId": it is that ServerId is stable across an edit that changes the hash.</para>
+    /// </summary>
+    [Fact]
+    public void AStoredIdWins_AndSurvivesAnEditThatChangesTheHash()
+    {
+        var server = new MonitoredServer { Host = "old-host", StoredServerId = 424242 };
+
+        Assert.Equal(424242, server.ServerId);
+        Assert.NotEqual(Derived("old-host"), server.ServerId);
+
+        server.Host = "new-host";
+        server.ReadOnlyIntent = true;
+        server.Database = "someDb";
+
+        /* The derivation moved. The identity did not. */
+        Assert.NotEqual(Derived("old-host"), Derived("new-host", "someDb", true));
+        Assert.Equal(424242, server.ServerId);
+    }
+
+    /// <summary>
+    /// The store is the only authority for a stored id — <c>darling.json</c> cannot set one.
+    ///
+    /// <para>Deliberate rather than incidental: the registry is authoritative for identity once seeded, so a
+    /// file that could pin <c>server_id</c> would be a second authority able to disagree with it, and disagree
+    /// SILENTLY, because nothing downstream re-checks. Both spellings are tried because a reader guessing at
+    /// the property name is exactly who would try this.</para>
+    /// </summary>
+    [Theory]
+    [InlineData("""{"host":"sql01","storedServerId":999}""")]
+    [InlineData("""{"host":"sql01","serverId":999}""")]
+    [InlineData("""{"host":"sql01","server_id":999}""")]
+    public void ADarlingJsonEntryCannotPinAnIdentity(string json)
+    {
+        var server = JsonSerializer.Deserialize<MonitoredServer>(json,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+
+        Assert.Null(server.StoredServerId);
+        Assert.Equal(Derived("sql01"), server.ServerId);
+    }
+
+    /// <summary>
+    /// Nothing in the service re-derives identity any more. Three files, because between them they held every
+    /// one of the twelve converted sites — the worker's lookups and stamps, the connect-time stamp the
+    /// collectors inherit, and the MCP host's plan-fetch map.
+    ///
+    /// <para>A source pin rather than a behavioural one because the failure it guards is a NEW call site being
+    /// added later, which no test of today's behaviour can see: a fresh
+    /// <c>GetDeterministicHashCode(config.StorageName)</c> would agree with the stored id on every store that
+    /// exists right now, and only start lying once ids stop being derivable — i.e. long after the commit that
+    /// introduced it.</para>
+    /// </summary>
+    [Theory]
+    [InlineData("Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs")]
+    [InlineData("Darling/PerformanceMonitor.Darling.Service/DarlingServerConnector.cs")]
+    [InlineData("Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpHostService.cs")]
+    public void TheServiceNoLongerDerivesIdentity(string relativePath)
+    {
+        var root = FindRepoRoot();
+        Assert.True(root is not null, "repo root not found -- the source pin cannot run");
+
+        var offenders = File.ReadAllLines(Path.Combine(root!, relativePath))
+            .Select((line, index) => (Line: line, Number: index + 1))
+            /* Doc comments name the helper on purpose (the cadence-jitter doc explains what its input is). */
+            .Where(l => !l.Line.TrimStart().StartsWith("///", StringComparison.Ordinal))
+            .Where(l => l.Line.Contains("GetDeterministicHashCode(", StringComparison.Ordinal))
+            .Select(l => $"{relativePath}:{l.Number}")
+            .ToList();
+
+        Assert.Empty(offenders);
+    }
+
+    /// <summary>
+    /// The remaining derivations are the ALLOCATION sites, and they are exactly these. Pinned as a closed set
+    /// so a new one has to be argued for in review rather than appearing: an allocation site is where identity
+    /// is minted and made permanent, so an unnoticed extra one mints identities nothing else agrees with.
+    /// </summary>
+    [Fact]
+    public void IdentityIsMintedInExactlyThreePlaces()
+    {
+        var root = FindRepoRoot();
+        Assert.True(root is not null, "repo root not found -- the source pin cannot run");
+
+        var expected = new[]
+        {
+            /* The single fallback: MonitoredServer.ServerId. */
+            "Darling/PerformanceMonitor.Darling.Service/DarlingConfig.cs",
+            /* add_servers, which hashes a storage key string rather than a MonitoredServer. */
+            "Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpServerAdminTools.cs",
+            /* The Viewer, which writes registry rows without ever building a MonitoredServer. */
+            "Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.MonitoredServers.cs",
+        };
+
+        var found = new[]
+        {
+            "Darling/PerformanceMonitor.Darling.Service",
+            "Darling/PerformanceMonitor.Darling.Viewer",
+            "Darling/PerformanceMonitor.Darling.Storage",
+        }
+            .SelectMany(dir => Directory.EnumerateFiles(Path.Combine(root!, dir), "*.cs", SearchOption.AllDirectories))
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                        && !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .Where(path => File.ReadAllLines(path)
+                .Any(line => !line.TrimStart().StartsWith("///", StringComparison.Ordinal)
+                          && !line.TrimStart().StartsWith("*", StringComparison.Ordinal)
+                          && line.Contains("GetDeterministicHashCode(", StringComparison.Ordinal)))
+            .Select(path => Path.GetRelativePath(root!, path).Replace(Path.DirectorySeparatorChar, '/'))
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.Equal(expected.OrderBy(p => p, StringComparer.Ordinal), found);
+    }
+
+    /* ---------------- live (DARLING_TEST_PG): the store's id is what the service uses ---------------- */
+
+    /// <summary>
+    /// The round-trip, against a row whose stored <c>server_id</c> is deliberately NOT the hash of its host —
+    /// which is the only way to tell the new read from the old one, since production rows have the two equal.
+    ///
+    /// <para>It also asserts every other column the read projects, because <b>adding a column to a positional
+    /// reader is exactly how a silent mis-map happens</b>: shift one ordinal and <c>auth</c> arrives in
+    /// <c>username</c>, which no compiler and no id assertion would catch. Distinctive values per column, so a
+    /// mis-map cannot coincide with a plausible default.</para>
+    ///
+    /// <para>Its own scratch database (<see cref="ScratchPostgres"/>) because <c>SeedIfEmptyAsync</c> no-ops on
+    /// a store any earlier test already seeded.</para>
+    /// </summary>
+    [Fact]
+    public async Task TheLoadedServerCarriesTheStoresOwnId_NotAFreshHash()
+    {
+        var baseConnectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(baseConnectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the server_id round-trip (the test mints its own scratch database).");
+
+        var ct = TestContext.Current.CancellationToken;
+
+        await using var scratch = await ScratchPostgres.CreateAsync(baseConnectionString!, ct);
+        await using (var connection = new NpgsqlConnection(scratch.ConnectionString))
+        {
+            await connection.OpenAsync(ct);
+            await PgMigrations.MigrateAsync(connection, ct);
+        }
+
+        await using var dataSource = NpgsqlDataSource.Create(scratch.ConnectionString);
+        var provider = new StoreConfigProvider(dataSource);
+
+        var seeded = new MonitoredServer
+        {
+            Name = "identity-roundtrip",
+            Host = "identity-host",
+            Database = "identityDb",
+            Auth = "sql",
+            Username = "identity-user",
+            EncryptedPassword = "not-a-real-blob",
+            EncryptMode = "Strict",
+            TrustServerCertificate = true,
+            ReadOnlyIntent = true,
+            MultiSubnetFailover = true,
+            ExcludedDatabases = { "excluded-one", "excluded-two" },
+            MonthlyCostUsd = 1234.56m,
+            AlertDeliveryModeOverride = AlertNotificationMode.PerEvent,
+            Engine = "postgres",
+            Port = 6432,
+        };
+
+        var config = new DarlingConfig();
+        config.Servers.Add(seeded);
+        await provider.SeedIfEmptyAsync(config, ct);
+
+        /* The seed writes the derivation, which is what makes every existing store migration-free. Assert it
+           rather than assume it -- if this ever stops holding, the "no data moves" claim stops holding too. */
+        var seededId = Derived("identity-host", "identityDb", readOnlyIntent: true);
+        Assert.Equal(seededId, await ReadServerIdByNameAsync(dataSource, "identity-roundtrip", ct));
+
+        /* Now the thing production cannot produce yet: re-key the row so the stored id disagrees with the hash
+           of its own host. Legal precisely because nothing references config_monitored_servers -- there is not
+           one foreign key to it, which is separately why an edit orphans a server's config today (#2158). */
+        const int Surrogate = 20260814;
+        Assert.NotEqual(Surrogate, seededId);
+        await using (var rekey = dataSource.CreateCommand(
+            "UPDATE config_monitored_servers SET server_id = $1 WHERE name = $2"))
+        {
+            rekey.Parameters.AddWithValue(Surrogate);
+            rekey.Parameters.AddWithValue("identity-roundtrip");
+            Assert.Equal(1, await rekey.ExecuteNonQueryAsync(ct));
+        }
+
+        var view = await provider.LoadViewAsync(new DarlingConfig(), ct);
+        Assert.NotNull(view);
+        var loaded = Assert.Single(view!.EnabledServers, s => s.Name == "identity-roundtrip");
+
+        /* THE ASSERTION: the surrogate, not the hash. Old code returns the hash here. */
+        Assert.Equal(Surrogate, loaded.StoredServerId);
+        Assert.Equal(Surrogate, loaded.ServerId);
+        Assert.NotEqual(Derived(loaded.Host, loaded.Database, loaded.ReadOnlyIntent), loaded.ServerId);
+
+        /* Every other projected column, in the reader's own order, because that is what a shifted ordinal
+           breaks. Each value is distinctive: a mis-map surfaces as a wrong value, not a plausible default. */
+        Assert.Equal("identity-roundtrip", loaded.Name);
+        Assert.Equal("identity-host", loaded.Host);
+        Assert.Equal("identityDb", loaded.Database);
+        Assert.Equal("sql", loaded.Auth);
+        Assert.Equal("identity-user", loaded.Username);
+        Assert.Equal("not-a-real-blob", loaded.EncryptedPassword);
+        Assert.Equal("Strict", loaded.EncryptMode);
+        Assert.True(loaded.TrustServerCertificate);
+        Assert.True(loaded.ReadOnlyIntent);
+        Assert.True(loaded.MultiSubnetFailover);
+        Assert.Equal(new[] { "excluded-one", "excluded-two" }, loaded.ExcludedDatabases);
+        Assert.Equal(1234.56m, loaded.MonthlyCostUsd);
+        Assert.Equal(AlertNotificationMode.PerEvent, loaded.AlertDeliveryModeOverride);
+        Assert.Equal("postgres", loaded.Engine);
+        Assert.Equal(6432, loaded.Port);
+    }
+
+    private static async Task<int> ReadServerIdByNameAsync(
+        NpgsqlDataSource dataSource, string name, System.Threading.CancellationToken ct)
+    {
+        await using var command = dataSource.CreateCommand(
+            "SELECT server_id FROM config_monitored_servers WHERE name = $1");
+        command.Parameters.AddWithValue(name);
+        return Convert.ToInt32(await command.ExecuteScalarAsync(ct), System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>Walks up to the directory holding <c>PerformanceMonitor.sln</c> — the same idiom as
+    /// <c>CollectorStateContractTests.FindRepoRoot</c>.</summary>
+    private static string? FindRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        for (var i = 0; i < 10 && directory is not null; i++)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "PerformanceMonitor.sln")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+}

--- a/Darling/Darling.Tests/ServerIdentityFromStoreTests.cs
+++ b/Darling/Darling.Tests/ServerIdentityFromStoreTests.cs
@@ -40,6 +40,14 @@ namespace Darling.Tests;
 /// <c>server_id</c> DISAGREES with the hash of its own host. Without that, every assertion here would pass
 /// just as well against the old code, since the two values coincide.</para>
 /// </summary>
+/* #1776 own-store: deliberately NOT [Collection("live-postgres")]. The one live test reaches DARLING_TEST_PG
+   only to CREATE and DROP its own database through ScratchPostgres, then works entirely inside it — it never
+   touches the shared database's tables, so it cannot race the live collection and serializing every pure test
+   here alongside it would be pure slowdown. Same shape and same reason as DarlingAlertTuningKnobsTests and
+   DarlingDeliveryModeTests, which also pair pure pins with one scratch-store seed/read round-trip. Kept in one
+   class rather than split, for that symmetry and because the split would leave a single-test file whose
+   subject is the same seam the pure pins above cover. This comment is here so the next sweep does not "fix"
+   it. */
 public sealed class ServerIdentityFromStoreTests
 {
     private static int Derived(string host, string? database = null, bool readOnlyIntent = false) =>

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingConfig.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingConfig.cs
@@ -1177,4 +1177,38 @@ public sealed class MonitoredServer
     /// </summary>
     [JsonIgnore]
     public string StorageName => PerformanceMonitor.Common.ServerIdHelper.BuildStorageName(Host, Database, ReadOnlyIntent);
+
+    /// <summary>
+    /// <c>config_monitored_servers.server_id</c> as READ FROM THE STORE, or null for an entry that has no
+    /// store row yet — a <c>darling.json</c> bootstrap entry before the first seed.
+    ///
+    /// <para><b>Not settable from the file</b> (<see cref="JsonIgnore"/>) on purpose. The registry is
+    /// authoritative for identity once seeded, so letting an operator pin a <c>server_id</c> in
+    /// <c>darling.json</c> would create a second authority that could disagree with it — and disagree
+    /// silently, since nothing downstream re-checks.</para>
+    /// </summary>
+    [JsonIgnore]
+    public int? StoredServerId { get; set; }
+
+    /// <summary>
+    /// This server's <c>server_id</c>: the stored value when there is one, otherwise derived from
+    /// <see cref="StorageName"/>.
+    ///
+    /// <para><b>This is the single place a monitored server's identity is decided</b> (#2218, #2158). It used
+    /// to be recomputed at twelve call sites — every operator-command lookup, the reconcile, the self-alert
+    /// stamps, the schedule resolution — which is what makes identity-derived-from-mutable-config expensive
+    /// to change: a stored surrogate is only useful if nothing re-derives it behind the store's back.</para>
+    ///
+    /// <para><b>Today the two are always equal</b>, because the seed and the Viewer both write exactly this
+    /// hash, so reading the stored value changes no behaviour and no data moves. The point is that the
+    /// FALLBACK is now the only derivation: when identity stops being derivable, this property is what
+    /// changes, and the twelve call sites do not.</para>
+    ///
+    /// <para>The store is preferred over the derivation rather than merely agreeing with it, because that is
+    /// the ordering that makes a stored id which no longer matches its host keep working — which is the
+    /// whole point of storing it.</para>
+    /// </summary>
+    [JsonIgnore]
+    public int ServerId =>
+        StoredServerId ?? PerformanceMonitor.Common.ServerIdHelper.GetDeterministicHashCode(StorageName);
 }

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingServerConnector.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingServerConnector.cs
@@ -181,7 +181,11 @@ SELECT
                 HasMsdbAccess = hasMsdbAccess,
             },
             StorageName = storageName,
-            ServerId = ServerIdHelper.GetDeterministicHashCode(storageName),
+            /* #2218: the STORED identity, not a fresh hash of storageName. This is the runtime's only
+               identity stamp — DarlingCollectorRunner copies it onto every CollectorContext, so every
+               collected row keys on whatever this says — which is why it has to read the registry rather
+               than re-derive from the connection fields the operator can edit. */
+            ServerId = config.ServerId,
             HasMsdbAccess = hasMsdbAccess,
             IsAwsRds = isAwsRds,
             EngineEdition = engineEdition,
@@ -242,7 +246,7 @@ SELECT
                 IsInRecovery = isInRecovery,
             },
             StorageName = storageName,
-            ServerId = ServerIdHelper.GetDeterministicHashCode(storageName),
+            ServerId = config.ServerId,
         };
     }
 

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -2211,7 +2211,8 @@ public sealed class DarlingWorker : BackgroundService
     /// <c>[0, period)</c> without any further mixing (an extra multiply was reviewed out as unnecessary — the
     /// input is already avalanched). This is the ONE consumer that wants the value only as a spreading
     /// function rather than as an identity, so if #2218 ever makes ids sequential the extra mixing that was
-    /// reviewed out has to come back here: consecutive integers modulo a period do not spread, they line up. Restart-stable because it is a pure function of the id — no <see cref="Random"/>.
+    /// reviewed out has to come back here: consecutive integers modulo a period do not spread, they line up.
+    /// Restart-stable because it is a pure function of the id — no <see cref="Random"/>.
     /// A non-positive period yields no offset (guards the callers where a period could in principle be zero, and
     /// keeps the result well-defined for tests). Applied ONLY at initial cadence stamps, never the steady-state
     /// advance: directly for the on-connect analysis stamp, and — capped at min(interval, 150s) via

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -1011,7 +1011,7 @@ public sealed class DarlingWorker : BackgroundService
             {
                 Config = server,
                 FirstSweepDueUtc = ColdStartFirstSweepDue(
-                    coldStartInstant, ServerIdHelper.GetDeterministicHashCode(server.StorageName)),
+                    coldStartInstant, server.ServerId),
             });
         }
 
@@ -1048,7 +1048,7 @@ public sealed class DarlingWorker : BackgroundService
                 lock (_serversLock)
                 {
                     return servers
-                        .Find(s => ServerIdHelper.GetDeterministicHashCode(s.Config.StorageName) == id)
+                        .Find(s => s.Config.ServerId == id)
                         ?.Config.AlertDeliveryModeOverride;
                 }
             });
@@ -1561,7 +1561,7 @@ public sealed class DarlingWorker : BackgroundService
                 server.NextSelfAlertSweep = DateTime.UtcNow.Add(s_alertSweepInterval);
                 await _selfAlerts!.EvaluateStoreAlertsAsync(
                     _postgres!,
-                    ServerIdHelper.GetDeterministicHashCode(server.Config.StorageName),
+                    server.Config.ServerId,
                     server.Config.DisplayName,
                     connected: server.Runtime is not null,
                     stoppingToken);
@@ -1678,7 +1678,7 @@ public sealed class DarlingWorker : BackgroundService
             return;
         }
 
-        var serverId = ServerIdHelper.GetDeterministicHashCode(server.Config.StorageName);
+        var serverId = server.Config.ServerId;
         var enabled = StoreConfigProvider.ResolveSchedule("long_query_completions", serverId, _scheduleOverrides).Enabled;
 
         if (server.LongQueryTraceApplied == enabled)
@@ -2069,13 +2069,13 @@ public sealed class DarlingWorker : BackgroundService
         var desiredById = new Dictionary<int, MonitoredServer>();
         foreach (var d in desired)
         {
-            desiredById[ServerIdHelper.GetDeterministicHashCode(d.StorageName)] = d;
+            desiredById[d.ServerId] = d;
         }
 
         for (int i = servers.Count - 1; i >= 0; i--)
         {
             var state = servers[i];
-            var id = ServerIdHelper.GetDeterministicHashCode(state.Config.StorageName);
+            var id = state.Config.ServerId;
             if (!desiredById.TryGetValue(id, out var desiredServer))
             {
                 _logger.LogInformation(
@@ -2205,10 +2205,13 @@ public sealed class DarlingWorker : BackgroundService
     /// <summary>
     /// A deterministic, restart-stable per-server phase offset within a cadence period (#1553 cadence jitter),
     /// used to break the fleet-wide lockstep at cadence boundaries — the field incident re-herded every server
-    /// at once, so at each boundary all collectors fired together. The <paramref name="serverId"/> is ALREADY an
-    /// FNV-1a hash (<see cref="ServerIdHelper.GetDeterministicHashCode"/>), so a plain modulo spreads it across
+    /// at once, so at each boundary all collectors fired together. The <paramref name="serverId"/> is
+    /// <see cref="MonitoredServer.ServerId"/>, which today is an FNV-1a hash
+    /// (<see cref="ServerIdHelper.GetDeterministicHashCode"/>) — so a plain modulo spreads it across
     /// <c>[0, period)</c> without any further mixing (an extra multiply was reviewed out as unnecessary — the
-    /// input is already avalanched). Restart-stable because it is a pure function of the id — no <see cref="Random"/>.
+    /// input is already avalanched). This is the ONE consumer that wants the value only as a spreading
+    /// function rather than as an identity, so if #2218 ever makes ids sequential the extra mixing that was
+    /// reviewed out has to come back here: consecutive integers modulo a period do not spread, they line up. Restart-stable because it is a pure function of the id — no <see cref="Random"/>.
     /// A non-positive period yields no offset (guards the callers where a period could in principle be zero, and
     /// keeps the result well-defined for tests). Applied ONLY at initial cadence stamps, never the steady-state
     /// advance: directly for the on-connect analysis stamp, and — capped at min(interval, 150s) via
@@ -2888,7 +2891,7 @@ LIMIT 1", connection);
         ServerLoopState? server;
         lock (_serversLock)
         {
-            server = servers.Find(s => ServerIdHelper.GetDeterministicHashCode(s.Config.StorageName) == serverId);
+            server = servers.Find(s => s.Config.ServerId == serverId);
         }
 
         if (server is null)
@@ -3241,9 +3244,12 @@ LIMIT 1", connection);
 
             /* Stage 4: the online->offline connection edge (Server Unreachable) — fires once when a
                previously-connected server can no longer be reached; a repeated failed reconnect does NOT
-               re-fire (the state machine dedups). server_id is derived from the config since Runtime is null. */
+               re-fire (the state machine dedups). server_id comes from the CONFIG rather than the runtime,
+               because Runtime is null here by definition -- and post-#2218 the config carries the STORED id,
+               so an alert on a server that has never once connected keys on the same identity its collected
+               history does. */
             await _selfAlerts!.ApplyConnectionOutcomeAsync(
-                ServerIdHelper.GetDeterministicHashCode(server.Config.StorageName),
+                server.Config.ServerId,
                 server.Config.DisplayName, online: false, error: ex.Message, cancellationToken);
         }
     }
@@ -3343,7 +3349,7 @@ LIMIT 1", connection);
         ServerLoopState? server;
         lock (_serversLock)
         {
-            server = servers.Find(s => ServerIdHelper.GetDeterministicHashCode(s.Config.StorageName) == serverId);
+            server = servers.Find(s => s.Config.ServerId == serverId);
         }
 
         if (server is null)
@@ -3442,7 +3448,7 @@ LIMIT 1", connection);
         string displayName;
         lock (_serversLock)
         {
-            server = servers.Find(s => ServerIdHelper.GetDeterministicHashCode(s.Config.StorageName) == serverId);
+            server = servers.Find(s => s.Config.ServerId == serverId);
             connected = server?.Runtime is not null;
             displayName = server?.Config.DisplayName ?? serverId.ToString(CultureInfo.InvariantCulture);
         }
@@ -3508,7 +3514,7 @@ LIMIT 1", connection);
         string displayName;
         lock (_serversLock)
         {
-            server = servers.Find(s => ServerIdHelper.GetDeterministicHashCode(s.Config.StorageName) == serverId);
+            server = servers.Find(s => s.Config.ServerId == serverId);
             runtime = server?.Runtime;
             displayName = server?.Config.DisplayName ?? serverId.ToString(CultureInfo.InvariantCulture);
         }
@@ -3635,7 +3641,7 @@ LIMIT 1";
         string displayName;
         lock (_serversLock)
         {
-            var server = servers.Find(s => ServerIdHelper.GetDeterministicHashCode(s.Config.StorageName) == serverId);
+            var server = servers.Find(s => s.Config.ServerId == serverId);
             serverExists = server is not null;
             connectionString = server?.Runtime?.ConnectionString;
             isAzureSqlDb = server?.Runtime?.Target.IsAzureSqlDb ?? false;

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpHostService.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpHostService.cs
@@ -364,7 +364,7 @@ public sealed class DarlingMcpHostService : BackgroundService
             var serversById = new Dictionary<int, MonitoredServer>();
             foreach (var server in config.Servers)
             {
-                serversById.TryAdd(ServerIdHelper.GetDeterministicHashCode(server.StorageName), server);
+                serversById.TryAdd(server.ServerId, server);
             }
 
             var planFetcher = new PgPlanFetcher(

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpHostService.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpHostService.cs
@@ -358,11 +358,41 @@ public sealed class DarlingMcpHostService : BackgroundService
             var postgres = NpgsqlDataSource.Create(storeConnectionString);
             _appDataSource = postgres;
 
-            /* serverId → connection string from config (first entry wins on a duplicate storage
-               name, mirroring the worker's FirstOrDefault over runtimes). Resolution is lazy so
-               DPAPI decrypt runs only when a plan fetch actually needs the connection. */
+            /* serverId → connection string, keyed by the STORE's identity (review catch on #2218).
+               Resolution is lazy so DPAPI decrypt runs only when a plan fetch actually needs the
+               connection; first entry wins on a duplicate storage name, mirroring the worker's
+               FirstOrDefault over runtimes.
+
+               This used to read config.Servers — i.e. darling.json — which is wrong in two ways that
+               both end in "live plan fetch returns null for a server the MCP tools can otherwise see":
+
+                 1. TODAY: the registry is authoritative after the first seed, so a server added by
+                    add_servers or the Viewer is in the store and NOT in the file (#2254/#2256). It was
+                    therefore absent from this map entirely, while every MCP tool resolved it fine —
+                    DarlingServerResolver reads the STORE. Analysis and plan drill-down for those
+                    servers silently had no connection.
+                 2. AFTER #2218 step 2: [JsonIgnore] keeps StoredServerId off the file, so a file-sourced
+                    MonitoredServer always falls back to the derived id. The tools hand this map the
+                    store's id. They agree only while identity is still derivable.
+
+               So the fix is the same for both: key on the registry. Store-unreachable falls back to the
+               file, which is this host's documented posture (it deliberately starts on darling.json when
+               the store is down) — and a fallback that is only reached when the store cannot answer
+               cannot be the thing that disagrees with it. */
+            IReadOnlyList<MonitoredServer> registryServers = config.Servers;
+            var storeView = await new StoreConfigProvider(postgres, _logger).LoadViewAsync(config, stoppingToken);
+            if (storeView is not null)
+            {
+                registryServers = storeView.EnabledServers;
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "MCP could not read the monitored-server registry — live plan fetch will use darling.json, so any server added through add_servers or the Viewer will have no connection until the store answers.");
+            }
+
             var serversById = new Dictionary<int, MonitoredServer>();
-            foreach (var server in config.Servers)
+            foreach (var server in registryServers)
             {
                 serversById.TryAdd(server.ServerId, server);
             }

--- a/Darling/PerformanceMonitor.Darling.Service/StoreConfigProvider.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/StoreConfigProvider.cs
@@ -200,7 +200,11 @@ public sealed class StoreConfigProvider
 
         foreach (var server in fileServers)
         {
-            if (!storeServerIds.Contains(ServerIdHelper.GetDeterministicHashCode(server.StorageName)))
+            /* A file entry has no StoredServerId, so ServerId here IS the derivation — which is what this
+               comparison needs: it is asking "would the id this file entry describes be in the store". Once
+               identity stops being derivable (#2218) that question stops being answerable this way and has
+               to move onto the observed-identity fingerprint; noted on #2228 rather than pre-solved here. */
+            if (!storeServerIds.Contains(server.ServerId))
             {
                 missing.Add(server.DisplayName);
             }
@@ -375,7 +379,10 @@ INSERT INTO config_monitored_servers (
     monthly_cost_usd, capture_plans, alert_delivery_mode_override, engine, port, is_enabled, created_at, modified_at)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, NULL, $14, $16, $17, TRUE, $15, $15)
 ON CONFLICT (server_id) DO NOTHING", connection);
-            command.Parameters.AddWithValue(ServerIdHelper.GetDeterministicHashCode(server.StorageName));
+            /* THE ALLOCATION SITE. A darling.json entry has no StoredServerId, so this is the derivation —
+               and this is where it is minted and made permanent. When new rows stop being hash-keyed
+               (#2218), this is the write that changes; every READ already goes through the stored value. */
+            command.Parameters.AddWithValue(server.ServerId);
             command.Parameters.AddWithValue(server.DisplayName);
             command.Parameters.AddWithValue(server.Host);
             AddNullableText(command, server.Database);
@@ -658,10 +665,14 @@ FROM config_notification WHERE id = 1", connection);
         NpgsqlConnection connection, DarlingConfig bootstrap, CancellationToken ct)
     {
         var servers = new List<MonitoredServer>();
+        /* server_id is LAST rather than first (#2218): every ordinal in BuildServerFromRow is positional, so
+           appending is the only addition that cannot silently re-map an existing column onto the wrong
+           property. It was absent entirely before this — the registry's own PRIMARY KEY was read past, and
+           twelve downstream sites re-derived it from the mutable columns instead. */
         using var command = new NpgsqlCommand(@"
 SELECT name, host, database, auth, username, encrypted_password, encrypt_mode, trust_server_certificate,
        read_only_intent, multi_subnet_failover, excluded_databases, monthly_cost_usd, alert_delivery_mode_override,
-       engine, port
+       engine, port, server_id
 FROM config_monitored_servers WHERE is_enabled = TRUE
 ORDER BY name", connection);
         using var reader = await command.ExecuteReaderAsync(ct);
@@ -707,6 +718,10 @@ ORDER BY name", connection);
                store mid-migration, not an expected path. */
             Engine = reader.IsDBNull(13) ? "sqlserver" : reader.GetString(13),
             Port = reader.IsDBNull(14) ? 0 : reader.GetInt32(14),
+            /* #2218: the row's OWN primary key, which this read used to discard. NOT NULL in the table, so
+               the DBNull guard is for a store mid-migration rather than an expected path — and a null there
+               falls back to the derivation, which is exactly what it did before this column was read at all. */
+            StoredServerId = reader.IsDBNull(15) ? null : reader.GetInt32(15),
         };
 
         if (server.UsesSqlAuth && string.IsNullOrWhiteSpace(server.EncryptedPassword))

--- a/Darling/PerformanceMonitor.Darling.Storage/PgMigrations.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/PgMigrations.cs
@@ -1749,8 +1749,11 @@ ALTER TABLE server_properties ADD COLUMN IF NOT EXISTS utc_offset_minutes intege
 /* --- A. Config plane: the Viewer writes desired state, the service reads + honors it. --- */
 
 /* 1. config_monitored_servers — the desired-state twin of the collect.servers observed registry.
-      server_id = ServerIdHelper.GetDeterministicHashCode(BuildStorageName(host,database,ro)), the
-      SAME identity the collectors stamp, so it JOINs collected data. is_enabled drives collection;
+      server_id is THIS ROW'S identity and this table owns it: the service reads it here rather than
+      recomputing it, so a stored id keeps working when the fields below no longer produce it (#2218).
+      It is minted from the storage identity host[:database][:RO] — the same value the collectors
+      stamp, which is why it JOINs collected data and why no existing store needs migrating — but that
+      is now the ALLOCATION rule, not a definition anything re-derives. is_enabled drives collection;
       the connection fields reconstruct a MonitoredServer for the service's connect path. */
 CREATE TABLE IF NOT EXISTS config.config_monitored_servers (
     server_id integer NOT NULL PRIMARY KEY,


### PR DESCRIPTION
Step one of #2218, and a strict improvement on its own regardless of where the design lands. Prerequisite for #2158 and #2228.

## The finding that made this cheap

`config.config_monitored_servers.server_id` is that table's PRIMARY KEY and is authoritative once seeded. `ReadMonitoredServersAsync` selected **fifteen columns and not that one** — so the registry's own key was read past, and **twelve** downstream sites re-derived it from `host`/`database`/`read_only_intent`: every operator-command lookup, the reconcile, the self-alert stamps, the schedule resolution, and the connect-time stamp the collectors inherit.

So step 1 is not "allocate a surrogate." It is **stop discarding the one we have.**

## The change

`MonitoredServer` gains:

```csharp
public int? StoredServerId { get; set; }              // the store's value; null before the first seed
public int ServerId => StoredServerId ?? hash(StorageName);
```

That property is now the only place a monitored server's identity is decided.

| | before | after |
|---|---|---|
| `DarlingWorker.cs` derivations | **12** | **0** |
| `DarlingServerConnector` stamps | 2 | 0 |
| `DarlingMcpHostService` | 1 | 0 |
| mint/allocation sites | 3 | 3 (unchanged) |

**Behaviour is unchanged and no data moves.** The seed and the Viewer both write exactly the hash this used to recompute, so stored and derived are equal on every store that exists. What changed is that the derivation is the FALLBACK, in one place — so when identity stops being derivable, that property changes and the twelve call sites do not.

The store is preferred over the derivation rather than merely *agreeing* with it. That ordering is what makes a stored id which no longer matches its host keep working, which is the entire point of storing it.

`StoredServerId` is `[JsonIgnore]`: `darling.json` must not be able to pin an identity, or it becomes a second authority able to disagree with the registry — and disagree **silently**, since nothing downstream re-checks.

## Deliberately not done here

- **`StoreConfigProvider:203`**, the #2254 file-vs-store diagnostic, still compares a file-derived id against stored ids. That is the right question today and the wrong one later; it needs the observed-identity fingerprint. Noted on #2228 rather than half-solved.
- **`CadencePhaseOffset`** consumes the id purely as a *spreading function*. Its doc now says so, and says what breaks if ids ever become sequential: consecutive integers modulo a period do not spread, they line up.

## Tests

Pure: the fallback; **the seam** — a stored id survives an edit that changes the hash; the `JsonIgnore` refusal in three spellings.

Two source pins: no derivation left in the three converted files, and **minting is a closed set of three files**, so a fourth has to be argued for in review rather than appearing. A source pin because the failure it guards is a *new* call site added later — a fresh `GetDeterministicHashCode(config.StorageName)` agrees with the stored id on every store that exists right now, and only starts lying long after the commit that introduced it.

Live (scratch database): seed, assert the seed wrote the derivation — the "no migration needed" claim, asserted rather than assumed — then **re-key the row so its stored `server_id` disagrees with the hash of its own host**, and assert the loaded server carries the surrogate. That is the one thing production cannot produce yet; without it every assertion here would pass against the old code, since the two values coincide.

That test also asserts **all fifteen other projected columns**, each with a distinctive value, because adding a column to a positional reader is exactly how a silent mis-map happens: shift one ordinal and `auth` arrives in `username`, which no compiler and no id assertion would catch. `server_id` was appended LAST for the same reason.

## Notes

- Also corrected the V17 SQL comment, which asserted `server_id` **is** the hash. It is now the *allocation rule* rather than a definition anything re-derives. Inert for migrated stores (V17 does not re-run), and it removes a false positive from the new source pin without weakening it.
- Full solution builds clean, 0 warnings. Both source pins simulated locally against the real tree before shipping them — that is how the V17 false positive was found. **I cannot run `net10.0-windows` xunit locally, so CI is the only place the pass is observable.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)