### PR TITLE
Bound one database's collection by wall clock, so it cannot starve the rest (#2150)

### DIFF
--- a/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
@@ -309,6 +309,14 @@ public sealed class DarlingCollectorRunner
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 attempted++;
+
+                /* #2150: THE path the field report is on — Azure SQL DB collects query_store per database
+                   here, not through the enumerated driver, so the wall-clock ceiling has to be applied on
+                   both. Null for every collector that declares none, in which case dbToken IS
+                   cancellationToken and this loop is byte-for-byte what it was. */
+                using var dbBudget = EnumeratedCollectorDriver.StartItemBudget(
+                    definition.PerItemWallClockBudget, cancellationToken);
+                var dbToken = dbBudget?.Token ?? cancellationToken;
                 try
                 {
                     /* The authoritative database_name for XE rows read on this path — see
@@ -393,11 +401,14 @@ public sealed class DarlingCollectorRunner
 
                     var sqlSlice = Stopwatch.StartNew();
                     List<TRow> batch;
-                    using (var dbConnection = await OpenDatabaseConnectionAsync(perDbProvider, server, databaseName, cancellationToken))
+                    /* dbToken, not cancellationToken (#2150): connect, execute and drain are the phases the
+                       budget bounds. The FLUSH below deliberately stays on cancellationToken — abandoning a
+                       write already in flight would trade a slow cycle for a partially-written one. */
+                    using (var dbConnection = await OpenDatabaseConnectionAsync(perDbProvider, server, databaseName, dbToken))
                     using (var dbCommand = CreateCollectorCommand(perDbProvider, dbPlan, dbConnection, perDbTimeout))
-                    using (var dbReader = await dbCommand.ExecuteReaderAsync(cancellationToken))
+                    using (var dbReader = await dbCommand.ExecuteReaderAsync(dbToken))
                     {
-                        batch = await definition.ReadAsync(dbReader, context, cancellationToken);
+                        batch = await definition.ReadAsync(dbReader, context, dbToken);
 
                         /* #1875: the payload path's probe-failure contract, on the path that used to
                            ignore it. blocked_process_report is the declaring collector that also runs per
@@ -408,7 +419,7 @@ public sealed class DarlingCollectorRunner
                         if (definition.EmitsProbeFailures)
                         {
                             cycleProbeFailures.Add(
-                                await EnumeratedCollectorDriver.ReadPayloadProbeFailuresAsync(dbReader, cancellationToken));
+                                await EnumeratedCollectorDriver.ReadPayloadProbeFailuresAsync(dbReader, dbToken));
                         }
                     }
                     sqlMs += sqlSlice.ElapsedMilliseconds;
@@ -445,6 +456,36 @@ public sealed class DarlingCollectorRunner
                     {
                         OnQueryStoreItemSucceeded(server.ServerId, databaseName);
                     }
+                }
+                catch (Exception ex) when (EnumeratedCollectorDriver.ItemBudgetExpired(dbBudget, cancellationToken))
+                {
+                    /* #2150: this database ran out of wall clock. Counted as a per-database failure so the
+                       cycle moves on — one database must not be able to starve the rest, which is the harm
+                       the field report describes. Ahead of the generic catch because a cancelled command
+                       does not reliably arrive as an OperationCanceledException, so that filter cannot be
+                       trusted to claim it; the token check is what keeps a real shutdown out of this arm.
+                       The provider's own cancellation exception is dropped in favour of the budget message:
+                       it describes HOW the read was stopped, not why. */
+                    _ = ex;
+                    var budgetFailure = EnumeratedCollectorDriver.ItemBudgetException(
+                        definition.PerItemWallClockBudget!.Value);
+                    failed++;
+                    firstFailure ??= budgetFailure;
+
+                    /* Same #2111 stamp the generic arm makes, and it MATTERS more here: this is what turns
+                       the bound from a cut that repeats forever into one that converges. The consecutive
+                       count narrows this database's next catch-up window, so a database that cannot finish
+                       in the budget keeps halving until it can. */
+                    if (string.Equals(definition.Name, QueryStoreCollector.Instance.Name, StringComparison.Ordinal))
+                    {
+                        OnQueryStoreItemFailed(server.ServerId, databaseName);
+                    }
+
+                    /* WARNING, not Debug, unlike the routine per-database skip beside it: an offline
+                       database is ordinary and this is a collector that could not finish its work. */
+                    _logger?.LogWarning(
+                        "{Collector} on '{Server}' database [{Database}] {Message}",
+                        definition.Name, server.Config.DisplayName, databaseName, budgetFailure.Message);
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException and not OutOfMemoryException)
                 {
@@ -713,7 +754,10 @@ public sealed class DarlingCollectorRunner
                         _logger?.LogWarning("Failed to collect {Collector} from [{Database}] on '{Server}': {Message}",
                             definition.Name, item, server.Config.DisplayName, ex.Message);
                     },
-                    cancellationToken);
+                    cancellationToken,
+                    /* #2150: the per-database wall-clock ceiling. Null for every collector but
+                       query_store, so this argument leaves every other cycle untouched. */
+                    perItemBudget: definition.PerItemWallClockBudget);
 
                 rowsWritten = driverResult.Rows;
                 sqlMs += driverResult.SqlMs;

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
@@ -466,6 +466,16 @@ public sealed class DarlingCollectorRunner
                         OnQueryStoreItemSucceeded(server.ServerId, databaseName);
                     }
                 }
+                catch (OutOfMemoryException)
+                {
+                    /* AHEAD of the budget arm, because ItemBudgetExpired classifies on the TOKENS and never
+                       looks at the exception type (review catch). Without this, an OOM thrown while the
+                       budget's timer had already fired — materializing a large batch, or inside the store
+                       write — would be caught by that arm and logged as a routine per-database timeout,
+                       silently breaking the invariant the generic catch below states outright. The shared
+                       EnumeratedCollectorDriver already orders it this way; these two loops did not. */
+                    throw;
+                }
                 catch (Exception ex) when (EnumeratedCollectorDriver.ItemBudgetExpired(dbBudget, cancellationToken))
                 {
                     /* #2150: this database ran out of wall clock. Counted as a per-database failure so the

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
@@ -334,9 +334,18 @@ public sealed class DarlingCollectorRunner
                            branch on Azure SQL DB (#1836) and does need the bound, so it applies
                            WatermarkPolicy.ClampCatchup inside its own cutoff computation: the clamp
                            travels with the collector that needs it instead of with the path. */
+                    /* dbToken throughout this branch (#2150 review catch): the interface contract says the
+                       budget covers "the watermark refresh, the command, and the whole drain", and the
+                       enumerated path's perItemWatermark delegate already honours that. Leaving these three
+                       store round-trips on cancellationToken made THIS loop — the one the field report is
+                       actually on — the only place the promise was not kept, and a store that has stopped
+                       answering is exactly the stall the budget exists to bound. Safe for the hole records
+                       specifically: a budget expiry abandons the whole pass, so the watermark does not
+                       advance, the clamp is re-derived next cycle, and the hole is re-recorded (merged wider
+                       with any already pending) rather than lost. */
                         context.Watermark = await GetLastCollectedTimeForDatabaseAsync(
                             server.ServerId, definition.TargetTable, definition.WatermarkColumn!,
-                            definition.PerDatabaseWatermarkColumn!, databaseName, cancellationToken);
+                            definition.PerDatabaseWatermarkColumn!, databaseName, dbToken);
 
                         /* #2111 adaptive shrink, Azure arm — tighten BEFORE BuildQuery: the
                            definition's own clamp only floors OLDER watermarks, so a tighter one
@@ -356,7 +365,7 @@ public sealed class DarlingCollectorRunner
                                     _logger?.LogWarning(
                                         "query_store on '{Server}' database [{Database}] adaptive catch-up shrink: {Failures} consecutive failed cycles — window narrowed to {Minutes:F0}m; the skipped range rides the backfill hole.",
                                         server.Config.DisplayName, databaseName, azureFailures, adaptiveSpan.TotalMinutes);
-                                    await RecordQueryStoreBackfillHoleAsync(server.ServerId, databaseName, azureRaw, tighterFloor, cancellationToken);
+                                    await RecordQueryStoreBackfillHoleAsync(server.ServerId, databaseName, azureRaw, tighterFloor, dbToken);
                                     context.Watermark = tighterFloor;
                                 }
                             }
@@ -394,7 +403,7 @@ public sealed class DarlingCollectorRunner
                                 && WatermarkPolicy.ClampCatchup(context.Watermark, collectionTime) is DateTime azureClampedFloor)
                             {
                                 await RecordQueryStoreBackfillHoleAsync(
-                                    server.ServerId, databaseName, context.Watermark.Value, azureClampedFloor, cancellationToken);
+                                    server.ServerId, databaseName, context.Watermark.Value, azureClampedFloor, dbToken);
                             }
                         }
                     }

--- a/Lite.Tests/EnumeratedCollectorDriverTests.cs
+++ b/Lite.Tests/EnumeratedCollectorDriverTests.cs
@@ -200,4 +200,207 @@ public sealed class EnumeratedCollectorDriverTests
         Assert.Equal((3, 1), (completed.Single(c => c.Item == "a").Count, completed.Single(c => c.Item == "b").Count));
         Assert.Equal(4, result.Rows);
     }
+
+    /* ---------------- #2150: the per-item wall-clock budget ---------------- */
+
+    /// <summary>
+    /// A single slow database is abandoned and the rest of the cycle continues. THE property the field
+    /// report needs: two Azure SQL DB databases produced per-database passes of up to 99.8 minutes, and
+    /// because a host's live collectors run one after another, that one pass starved every other collector
+    /// on the server (#2148's "all collection stopped").
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_AnItemThatExceedsItsBudget_IsAbandoned_AndTheRestStillCollect()
+    {
+        var errors = new List<(string Item, string Message)>();
+        var written = new List<int>();
+
+        var result = await EnumeratedCollectorDriver.RunAsync<int>(
+            new[] { "fast-a", "slow", "fast-b" },
+            perItemWatermark: null,
+            readItem: async (item, ct) =>
+            {
+                if (item == "slow")
+                {
+                    /* Longer than any test would tolerate, so the budget is what ends it — and awaited on
+                       the token so the wait is what gets cancelled rather than the delay elapsing. */
+                    await Task.Delay(TimeSpan.FromMinutes(5), ct);
+                }
+
+                return new List<int> { item.Length };
+            },
+            writeBatch: (batch, ct) => { written.AddRange(batch); return Task.CompletedTask; },
+            onItemComplete: (item, count, sqlMs, storageMs) => { },
+            onItemError: (item, ex) => errors.Add((item, ex.Message)),
+            CancellationToken.None,
+            perItemBudget: TimeSpan.FromMilliseconds(150));
+
+        /* The two healthy databases collected; the slow one did not, and nothing threw. */
+        Assert.Equal(new[] { 6, 6 }, written);
+        Assert.Equal(2, result.Rows);
+
+        /* And it reported ITSELF, with the budget named — a skipped database that says only "cancelled"
+           sends an operator looking for a shutdown that did not happen. */
+        var failure = Assert.Single(errors);
+        Assert.Equal("slow", failure.Item);
+        Assert.Contains("wall-clock budget", failure.Message, StringComparison.Ordinal);
+        Assert.Contains("re-read next cycle", failure.Message, StringComparison.Ordinal);
+        /* And it names the actual NUMBER. Asserted because "contains 'wall-clock budget'" passed happily
+           against a first cut that rendered this 150 ms budget as "0.0-minute" — a message with no number
+           in it at all, on the one line an operator works from. */
+        Assert.Contains("0.15-second", failure.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The budget renders in the unit it was set in. The shipped value is 10 minutes, so a minutes-only
+    /// format would never have looked wrong in the field — but small values are what a person types while
+    /// diagnosing, which is exactly when the message matters. Found by a scratch harness, not by reading.
+    /// </summary>
+    [Theory]
+    [InlineData(600, "10-minute")]
+    [InlineData(90, "1.5-minute")]
+    [InlineData(60, "1-minute")]
+    [InlineData(59.5, "59.5-second")]
+    [InlineData(30, "30-second")]
+    [InlineData(0.15, "0.15-second")]
+    public void DescribeBudget_NamesANumberAtEveryScale(double seconds, string expected)
+    {
+        Assert.Equal(expected, EnumeratedCollectorDriver.DescribeBudget(TimeSpan.FromSeconds(seconds)));
+    }
+
+    /// <summary>
+    /// Shutdown still propagates. The budget's whole risk is misreading a real cancellation as a per-item
+    /// skip, which would have the loop keep collecting through a service stop — so this is the arm that
+    /// makes the feature safe rather than the one that makes it work.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_HostShutdown_StillPropagates_EvenWithABudgetSet()
+    {
+        using var cts = new CancellationTokenSource();
+        var errors = new List<string>();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await EnumeratedCollectorDriver.RunAsync<int>(
+                new[] { "a", "b" },
+                perItemWatermark: null,
+                readItem: async (item, ct) =>
+                {
+                    await cts.CancelAsync();
+                    ct.ThrowIfCancellationRequested();
+                    return new List<int> { 1 };
+                },
+                writeBatch: (batch, ct) => Task.CompletedTask,
+                onItemComplete: (item, count, sqlMs, storageMs) => { },
+                onItemError: (item, ex) => errors.Add(item),
+                cts.Token,
+                /* Generous, so the ONLY cancelled token is the outer one — the ambiguous case is covered by
+                   ItemBudgetExpired's own tests below. */
+                perItemBudget: TimeSpan.FromMinutes(10)));
+
+        Assert.Empty(errors);
+    }
+
+    /// <summary>
+    /// No budget means the loop is what it always was: the delegates get the caller's own token, not a
+    /// linked one. Asserted by IDENTITY rather than by behaviour, because "no wrapper" is the property —
+    /// a linked token with no timer behaves identically and would hide an unnecessary allocation per item.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_WithNoBudget_PassesTheCallersOwnToken()
+    {
+        using var cts = new CancellationTokenSource();
+        var seen = new List<CancellationToken>();
+
+        await EnumeratedCollectorDriver.RunAsync<int>(
+            new[] { "a" },
+            perItemWatermark: (item, ct) => { seen.Add(ct); return Task.CompletedTask; },
+            readItem: (item, ct) => { seen.Add(ct); return Task.FromResult(new List<int>()); },
+            writeBatch: (batch, ct) => Task.CompletedTask,
+            onItemComplete: (item, count, sqlMs, storageMs) => { },
+            onItemError: (item, ex) => { },
+            cts.Token);
+
+        Assert.Equal(2, seen.Count);
+        Assert.All(seen, token => Assert.Equal(cts.Token, token));
+    }
+
+    /// <summary>
+    /// The WRITE is outside the budget. Abandoning a flush already in flight would trade a slow cycle for a
+    /// partially-written one, which is the worse of the two — so the write gets the caller's token even when
+    /// the read was bounded.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_TheWrite_IsNotSubjectToTheItemBudget()
+    {
+        using var cts = new CancellationTokenSource();
+        CancellationToken readToken = default, writeToken = default;
+
+        await EnumeratedCollectorDriver.RunAsync<int>(
+            new[] { "a" },
+            perItemWatermark: null,
+            readItem: (item, ct) => { readToken = ct; return Task.FromResult(new List<int> { 1 }); },
+            writeBatch: (batch, ct) => { writeToken = ct; return Task.CompletedTask; },
+            onItemComplete: (item, count, sqlMs, storageMs) => { },
+            onItemError: (item, ex) => { },
+            cts.Token,
+            perItemBudget: TimeSpan.FromMinutes(10));
+
+        Assert.NotEqual(cts.Token, readToken);   // the read was bounded
+        Assert.Equal(cts.Token, writeToken);     // the write was not
+    }
+
+    /// <summary>
+    /// The classifier, all four combinations. It decides whether an exception is a per-item skip or a
+    /// shutdown, and it is deliberately asked of the TOKENS rather than of the exception type: cancelling a
+    /// SqlClient command does not reliably surface as an OperationCanceledException, so the type cannot
+    /// answer this. Shutdown must win the ambiguous case, or the loop keeps collecting through a stop.
+    /// </summary>
+    [Fact]
+    public void ItemBudgetExpired_TellsABudgetApartFromAShutdown()
+    {
+        using var outer = new CancellationTokenSource();
+        using var budget = CancellationTokenSource.CreateLinkedTokenSource(outer.Token);
+
+        /* Neither: an ordinary per-item failure, which the generic catch owns. */
+        Assert.False(EnumeratedCollectorDriver.ItemBudgetExpired(budget, outer.Token));
+
+        /* No budget at all (every collector but query_store) can never be a budget expiry. */
+        Assert.False(EnumeratedCollectorDriver.ItemBudgetExpired(null, outer.Token));
+
+        /* The budget alone: a per-item skip. */
+        budget.Cancel();
+        Assert.True(EnumeratedCollectorDriver.ItemBudgetExpired(budget, outer.Token));
+
+        /* Both — the race between a budget firing and a service stop. Shutdown wins. */
+        outer.Cancel();
+        Assert.False(EnumeratedCollectorDriver.ItemBudgetExpired(budget, outer.Token));
+    }
+
+    /// <summary>A zero or negative budget is treated as no budget rather than as an instantly-expired one,
+    /// so a misconfigured value degrades to today's behaviour instead of collecting nothing at all.</summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void StartItemBudget_ANonPositiveBudget_IsNoBudget(int minutes)
+    {
+        Assert.Null(EnumeratedCollectorDriver.StartItemBudget(
+            TimeSpan.FromMinutes(minutes), CancellationToken.None));
+    }
+
+    /// <summary>
+    /// query_store is the collector that declares a budget, and the only one. The value is pinned because
+    /// it is a published constant with a measured justification (#2150): 4.8 s median and 31 s max over 198
+    /// healthy field passes against 37.6 minutes at the low end of the pathological ones.
+    /// </summary>
+    [Fact]
+    public void OnlyQueryStore_DeclaresAWallClockBudget()
+    {
+        Assert.Equal(TimeSpan.FromMinutes(10), QueryStoreCollector.Instance.PerItemWallClockBudget);
+        Assert.Equal(QueryStoreCollector.PerDatabaseWallClockBudget, QueryStoreCollector.Instance.PerItemWallClockBudget);
+
+        /* The siblings that also run per database stay unbounded: neither has an unbounded-input shape, and
+           a budget on a collector with no field evidence for one is a cut waiting to surprise somebody. */
+        Assert.Null(DatabaseSizeStatsCollector.Instance.PerItemWallClockBudget);
+        Assert.Null(DatabaseScopedConfigCollector.Instance.PerItemWallClockBudget);
+    }
 }

--- a/Lite.Tests/EnumeratedCollectorDriverTests.cs
+++ b/Lite.Tests/EnumeratedCollectorDriverTests.cs
@@ -350,6 +350,48 @@ public sealed class EnumeratedCollectorDriverTests
     }
 
     /// <summary>
+    /// An OutOfMemoryException that fires while the budget has ALREADY expired must still propagate.
+    ///
+    /// <para>The reason it is not obvious: <see cref="EnumeratedCollectorDriver.ItemBudgetExpired"/>
+    /// classifies on the TOKENS and never looks at the exception type — which is deliberate, because a
+    /// cancelled SqlClient command does not reliably arrive as an OperationCanceledException. The cost is
+    /// that the budget arm would happily claim an unrelated fatal exception, so its ORDERING behind the
+    /// OOM rethrow is load-bearing rather than stylistic. Review found both hosts' per-database loops
+    /// missing that ordering; this pins the shared driver's.</para>
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_AnOomWithAnExpiredBudget_StillPropagates()
+    {
+        var errors = new List<string>();
+
+        await Assert.ThrowsAsync<OutOfMemoryException>(async () =>
+            await EnumeratedCollectorDriver.RunAsync<int>(
+                new[] { "a" },
+                perItemWatermark: null,
+                readItem: async (item, ct) =>
+                {
+                    /* Let the budget expire FIRST, then throw something unrelated and fatal. */
+                    try
+                    {
+                        await Task.Delay(TimeSpan.FromSeconds(5), ct);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                    }
+
+                    throw new OutOfMemoryException("unrelated to the budget");
+                },
+                writeBatch: (batch, ct) => Task.CompletedTask,
+                onItemComplete: (item, count, sqlMs, storageMs) => { },
+                onItemError: (item, ex) => errors.Add(item),
+                CancellationToken.None,
+                perItemBudget: TimeSpan.FromMilliseconds(100)));
+
+        /* Not swallowed as a routine per-database timeout. */
+        Assert.Empty(errors);
+    }
+
+    /// <summary>
     /// The classifier, all four combinations. It decides whether an exception is a per-item skip or a
     /// shutdown, and it is deliberately asked of the TOKENS rather than of the exception type: cancelling a
     /// SqlClient command does not reliably surface as an OperationCanceledException, so the type cannot

--- a/Lite/Services/RemoteCollectorService.DefinitionRunner.cs
+++ b/Lite/Services/RemoteCollectorService.DefinitionRunner.cs
@@ -318,6 +318,16 @@ public partial class RemoteCollectorService
                             context.PerItemShippedBoundary?.ToString("o") ?? "n/a");
                     }
                 }
+                catch (OutOfMemoryException)
+                {
+                    /* AHEAD of the budget arm, because ItemBudgetExpired classifies on the TOKENS and never
+                       looks at the exception type (review catch). Without this, an OOM thrown while the
+                       budget's timer had already fired — materializing a large batch, or inside the store
+                       write — would be caught by that arm and logged as a routine per-database timeout,
+                       silently breaking the invariant the generic catch below states outright. The shared
+                       EnumeratedCollectorDriver already orders it this way; these two loops did not. */
+                    throw;
+                }
                 catch (Exception ex) when (EnumeratedCollectorDriver.ItemBudgetExpired(dbBudget, cancellationToken))
                 {
                     /* #2150: this database ran out of wall clock. Counted as a per-database failure so the

--- a/Lite/Services/RemoteCollectorService.DefinitionRunner.cs
+++ b/Lite/Services/RemoteCollectorService.DefinitionRunner.cs
@@ -164,6 +164,15 @@ public partial class RemoteCollectorService
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 attempted++;
+
+                /* #2150: THE path the field report is on — Azure SQL DB collects query_store per database
+                   here, not through the enumerated driver, so the wall-clock ceiling has to be applied on
+                   both. Null for every collector that declares none, in which case dbToken IS
+                   cancellationToken and this loop is byte-for-byte what it was. Darling's twin is the same
+                   shape in DarlingCollectorRunner. */
+                using var dbBudget = EnumeratedCollectorDriver.StartItemBudget(
+                    definition.PerItemWallClockBudget, cancellationToken);
+                var dbToken = dbBudget?.Token ?? cancellationToken;
                 try
                 {
                     /* The authoritative database_name for XE rows read on this path — see
@@ -244,11 +253,14 @@ public partial class RemoteCollectorService
 
                     var sqlSlice = Stopwatch.StartNew();
                     List<TRow> batch;
-                    using (var dbConnection = await OpenAzureDatabaseConnectionAsync(server, databaseName, cancellationToken))
+                    /* dbToken, not cancellationToken (#2150): connect, execute and drain are the phases the
+                       budget bounds. The FLUSH below deliberately stays on cancellationToken — abandoning a
+                       write already in flight would trade a slow cycle for a partially-written one. */
+                    using (var dbConnection = await OpenAzureDatabaseConnectionAsync(server, databaseName, dbToken))
                     using (var dbCommand = CreateCollectorCommand(dbPlan, dbConnection, commandTimeout))
-                    using (var dbReader = await dbCommand.ExecuteReaderAsync(cancellationToken))
+                    using (var dbReader = await dbCommand.ExecuteReaderAsync(dbToken))
                     {
-                        batch = await definition.ReadAsync(dbReader, context, cancellationToken);
+                        batch = await definition.ReadAsync(dbReader, context, dbToken);
 
                         /* #1875: the payload path's probe-failure contract, on the path that used to
                            ignore it. blocked_process_report is the declaring collector that also runs per
@@ -259,7 +271,7 @@ public partial class RemoteCollectorService
                         if (definition.EmitsProbeFailures)
                         {
                             cycleProbeFailures.Add(
-                                await EnumeratedCollectorDriver.ReadPayloadProbeFailuresAsync(dbReader, cancellationToken));
+                                await EnumeratedCollectorDriver.ReadPayloadProbeFailuresAsync(dbReader, dbToken));
                         }
                     }
                     sqlMs += sqlSlice.ElapsedMilliseconds;
@@ -296,6 +308,35 @@ public partial class RemoteCollectorService
                             context.PerItemTextBytesShipped / (1024.0 * 1024.0),
                             context.PerItemShippedBoundary?.ToString("o") ?? "n/a");
                     }
+                }
+                catch (Exception ex) when (EnumeratedCollectorDriver.ItemBudgetExpired(dbBudget, cancellationToken))
+                {
+                    /* #2150: this database ran out of wall clock. Counted as a per-database failure so the
+                       cycle moves on — one database must not be able to starve the rest, which is the harm
+                       the field report describes, and it bites hardest on Lite because its live collectors
+                       run strictly one after another. Ahead of the generic catch because a cancelled command
+                       does not reliably arrive as an OperationCanceledException, so that filter cannot be
+                       trusted to claim it; the token check is what keeps a real shutdown out of this arm. */
+                    _ = ex;
+                    var budgetFailure = EnumeratedCollectorDriver.ItemBudgetException(
+                        definition.PerItemWallClockBudget!.Value);
+                    failed++;
+                    firstFailure ??= budgetFailure;
+
+                    /* Same #2111 stamp the generic arm makes, and it MATTERS more here: this is what turns
+                       the bound from a cut that repeats forever into one that converges. The consecutive
+                       count narrows this database's next catch-up window, so a database that cannot finish
+                       in the budget keeps halving until it can. */
+                    if (string.Equals(definition.Name, QueryStoreCollector.Instance.Name, StringComparison.Ordinal))
+                    {
+                        OnQueryStoreItemFailed(serverId, databaseName);
+                    }
+
+                    /* WARNING, not Debug, unlike the routine per-database skip beside it: an offline
+                       database is ordinary and this is a collector that could not finish its work. */
+                    _logger?.LogWarning(
+                        "{Collector} on '{Server}' database [{Database}] {Message}",
+                        definition.Name, server.DisplayName, databaseName, budgetFailure.Message);
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException and not OutOfMemoryException)
                 {
@@ -526,7 +567,10 @@ public partial class RemoteCollectorService
                         _logger?.LogWarning("Failed to collect {Collector} from [{Database}] on '{Server}': {Message}",
                             definition.Name, item, server.DisplayName, ex.Message);
                     },
-                    cancellationToken);
+                    cancellationToken,
+                    /* #2150: the per-database wall-clock ceiling. Null for every collector but
+                       query_store, so this argument leaves every other cycle untouched. */
+                    perItemBudget: definition.PerItemWallClockBudget);
 
                 rowsWritten = driverResult.Rows;
                 sqlMs += driverResult.SqlMs;

--- a/Lite/Services/RemoteCollectorService.DefinitionRunner.cs
+++ b/Lite/Services/RemoteCollectorService.DefinitionRunner.cs
@@ -190,9 +190,18 @@ public partial class RemoteCollectorService
                            branch on Azure SQL DB (#1836) and does need the bound, so it applies
                            WatermarkPolicy.ClampCatchup inside its own cutoff computation: the clamp
                            travels with the collector that needs it instead of with the path. */
+                    /* dbToken throughout this branch (#2150 review catch): the interface contract says the
+                       budget covers "the watermark refresh, the command, and the whole drain", and the
+                       enumerated path's perItemWatermark delegate already honours that. Leaving these three
+                       store round-trips on cancellationToken made THIS loop — the one the field report is
+                       actually on — the only place the promise was not kept, and a store that has stopped
+                       answering is exactly the stall the budget exists to bound. Safe for the hole records
+                       specifically: a budget expiry abandons the whole pass, so the watermark does not
+                       advance, the clamp is re-derived next cycle, and the hole is re-recorded (merged wider
+                       with any already pending) rather than lost. */
                         context.Watermark = await GetLastCollectedTimeForDatabaseAsync(
                             serverId, definition.TargetTable, definition.WatermarkColumn!,
-                            definition.PerDatabaseWatermarkColumn!, databaseName, cancellationToken);
+                            definition.PerDatabaseWatermarkColumn!, databaseName, dbToken);
 
                         /* #2111 adaptive shrink, Azure arm — tighten BEFORE BuildQuery: the
                            definition's own clamp only floors OLDER watermarks, so a tighter one
@@ -210,7 +219,7 @@ public partial class RemoteCollectorService
                                     _logger?.LogWarning(
                                         "query_store on '{Server}' database [{Database}] adaptive catch-up shrink: {Failures} consecutive failed cycles — window narrowed to {Minutes:F0}m; the skipped range rides the backfill hole.",
                                         server.DisplayName, databaseName, azureFailures, adaptiveSpan.TotalMinutes);
-                                    await RecordQueryStoreBackfillHoleAsync(serverId, databaseName, azureRaw, tighterFloor, cancellationToken);
+                                    await RecordQueryStoreBackfillHoleAsync(serverId, databaseName, azureRaw, tighterFloor, dbToken);
                                     context.Watermark = tighterFloor;
                                 }
                             }
@@ -246,7 +255,7 @@ public partial class RemoteCollectorService
                                 && string.Equals(definition.Name, QueryStoreCollector.Instance.Name, StringComparison.Ordinal)
                                 && WatermarkPolicy.ClampCatchup(context.Watermark, collectionTime) is DateTime azureClampedFloor)
                             {
-                                await RecordQueryStoreBackfillHoleAsync(serverId, databaseName, context.Watermark.Value, azureClampedFloor, cancellationToken);
+                                await RecordQueryStoreBackfillHoleAsync(serverId, databaseName, context.Watermark.Value, azureClampedFloor, dbToken);
                             }
                         }
                     }

--- a/PerformanceMonitor.Collectors/CollectorDefinitionBase.cs
+++ b/PerformanceMonitor.Collectors/CollectorDefinitionBase.cs
@@ -6,6 +6,7 @@
  * Licensed under the MIT License. See LICENSE file in the project root for full license information.
  */
 
+using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Threading;
@@ -46,6 +47,8 @@ public abstract class CollectorDefinitionBase<TRow> : ICollectorDefinition<TRow>
     public virtual int? PerItemRowCountWarnThreshold => null;
 
     public virtual int? PerItemTextByteBudget => null;
+
+    public virtual TimeSpan? PerItemWallClockBudget => null;
 
     public virtual CollectorTargetEngine TargetEngine => CollectorTargetEngine.SqlServer;
 

--- a/PerformanceMonitor.Collectors/EnumeratedCollectorDriver.cs
+++ b/PerformanceMonitor.Collectors/EnumeratedCollectorDriver.cs
@@ -203,8 +203,20 @@ public static class EnumeratedCollectorDriver
     /// </summary>
     public const string UnnamedItem = "(unnamed item)";
 
+    /// <summary>
+    /// What an item abandoned at its wall-clock budget reports (#2150), <c>{0}</c> = the budget, already
+    /// rendered by <see cref="DescribeBudget"/>. Shared so the enumerated loop and each host's per-database
+    /// (Azure SQL DB) loop say the same thing, and so the wording an operator greps for is one string.
+    /// </summary>
+    public const string WallClockBudgetErrorFormat =
+        "abandoned after exceeding its {0} per-database wall-clock budget; the range was not "
+        + "collected and will be re-read next cycle (the watermark did not advance)";
+
     /// <summary><see cref="ProbeFailureNoteFormat"/> parsed once (CA1863) — the const stays the greppable, pinnable text.</summary>
     private static readonly CompositeFormat s_probeFailureNote = CompositeFormat.Parse(ProbeFailureNoteFormat);
+
+    /// <summary><see cref="WallClockBudgetErrorFormat"/> parsed once (CA1863).</summary>
+    private static readonly CompositeFormat s_wallClockBudget = CompositeFormat.Parse(WallClockBudgetErrorFormat);
 
     /// <summary><see cref="UnreadableFailureSetErrorFormat"/> parsed once (CA1863).</summary>
     private static readonly CompositeFormat s_unreadableFailureSet = CompositeFormat.Parse(UnreadableFailureSetErrorFormat);
@@ -382,6 +394,13 @@ public static class EnumeratedCollectorDriver
     /// surface the row-cap / byte-budget warning here — the context truncation signal persists until the
     /// next item's read resets it, so reading it post-flush is equivalent).</param>
     /// <param name="onItemError">Per-item skip log, invoked when one item fails (offline DB, timeout, permissions).</param>
+    /// <param name="perItemBudget">
+    /// Wall-clock ceiling for one item's watermark refresh plus its read (#2150), from
+    /// <c>ICollectorDefinition.PerItemWallClockBudget</c>. Null (every collector but <c>query_store</c>) leaves
+    /// the loop exactly as it was. Exceeding it abandons THAT item as a per-item failure and continues;
+    /// the WRITE is deliberately outside the budget, because abandoning a flush that is already underway
+    /// would trade a slow cycle for a partially-written one.
+    /// </param>
     public static async Task<EnumeratedRunResult> RunAsync<TRow>(
         IReadOnlyList<string> items,
         Func<string, CancellationToken, Task>? perItemWatermark,
@@ -389,7 +408,8 @@ public static class EnumeratedCollectorDriver
         Func<List<TRow>, CancellationToken, Task> writeBatch,
         Action<string, int, long, long> onItemComplete,
         Action<string, Exception> onItemError,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        TimeSpan? perItemBudget = null)
     {
         var totalRows = 0;
         long sqlMs = 0;
@@ -402,17 +422,24 @@ public static class EnumeratedCollectorDriver
             List<TRow>? batch = null;
             long itemSqlMs = 0;
             var sqlSlice = Stopwatch.StartNew();
+
+            /* #2150: the item's wall-clock budget. Null for every collector that declares none, in which
+               case itemToken IS cancellationToken and this loop is what it always was. */
+            using var itemBudget = StartItemBudget(perItemBudget, cancellationToken);
+            var itemToken = itemBudget?.Token ?? cancellationToken;
             try
             {
                 /* Per-database watermark refresh (query_store): its cutoff — including the 24h catch-up
                    clamp — is computed HERE, inside the loop, so each database's commit advances only its
-                   own watermark and an abort loses no other database's intervals. */
+                   own watermark and an abort loses no other database's intervals. Inside the budget on
+                   purpose: it is a store read, and a store that has stopped answering is exactly the kind
+                   of stall the budget exists to bound. */
                 if (perItemWatermark is not null)
                 {
-                    await perItemWatermark(item, cancellationToken);
+                    await perItemWatermark(item, itemToken);
                 }
 
-                batch = await readItem(item, cancellationToken);
+                batch = await readItem(item, itemToken);
             }
             catch (OutOfMemoryException)
             {
@@ -421,6 +448,18 @@ public static class EnumeratedCollectorDriver
                    per-item batch is a local that unwinds with this frame — so filter+rethrow is the whole
                    handler; the host classifies the run ERROR. */
                 throw;
+            }
+            catch (Exception ex) when (ItemBudgetExpired(itemBudget, cancellationToken))
+            {
+                /* #2150: THIS item ran out of wall clock. Reported as a per-item failure so the sweep
+                   continues, which is the entire point — one database must not be able to starve the rest.
+                   Ahead of the generic catch because a cancelled command does not reliably arrive as an
+                   OperationCanceledException, so the generic filter cannot be trusted to claim it; and the
+                   token check is what keeps a real shutdown out of this arm. `ex` is deliberately dropped
+                   in favour of the budget message: whatever the provider raised on cancellation is an
+                   artifact of HOW it was cancelled, not why. */
+                _ = ex;
+                onItemError(item, ItemBudgetException(perItemBudget!.Value));
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
@@ -460,4 +499,64 @@ public static class EnumeratedCollectorDriver
 
         return new EnumeratedRunResult(totalRows, sqlMs, storageMs);
     }
+
+    /// <summary>
+    /// Starts one item's wall-clock budget (#2150), or returns null when the definition declares none —
+    /// which is every collector but <c>query_store</c>, so the unbounded path stays byte-identical.
+    ///
+    /// <para>A LINKED source, so host shutdown still cancels the item promptly; the timer only adds a
+    /// second reason to stop. Callers must pass <see cref="CancellationTokenSource.Token"/> to the work
+    /// and dispose the source when the item ends.</para>
+    /// </summary>
+    public static CancellationTokenSource? StartItemBudget(TimeSpan? budget, CancellationToken outer)
+    {
+        if (budget is not TimeSpan span || span <= TimeSpan.Zero)
+        {
+            return null;
+        }
+
+        var source = CancellationTokenSource.CreateLinkedTokenSource(outer);
+        source.CancelAfter(span);
+        return source;
+    }
+
+    /// <summary>
+    /// Did THIS item's budget fire, as opposed to the host shutting down?
+    ///
+    /// <para>The distinction is the whole point: a budget expiry is a per-item fault to be reported and
+    /// skipped, while shutdown must propagate and stop the sweep. Shutdown deliberately WINS the ambiguous
+    /// case — if both are cancelled, this returns false and the exception propagates — because misreading a
+    /// shutdown as a per-item skip would have the loop keep collecting through it.</para>
+    ///
+    /// <para>Classifying on the TOKENS rather than the exception type is deliberate too. Cancelling a
+    /// SqlClient command mid-execute does not reliably surface as <see cref="OperationCanceledException"/>:
+    /// it commonly arrives as a provider exception ("Operation cancelled by user"), and which one depends on
+    /// whether the cancellation landed during the open or during the drain. The tokens know; the exception
+    /// type does not.</para>
+    /// </summary>
+    public static bool ItemBudgetExpired(CancellationTokenSource? itemBudget, CancellationToken outer) =>
+        itemBudget is not null
+        && itemBudget.IsCancellationRequested
+        && !outer.IsCancellationRequested;
+
+    /// <summary>The exception handed to the per-item error hook for an abandoned item, so both loops report
+    /// it identically. A <see cref="TimeoutException"/> because that is what it is — and because the hosts'
+    /// hooks log <c>ex.Message</c>, which carries the whole explanation.</summary>
+    public static TimeoutException ItemBudgetException(TimeSpan budget) =>
+        new(string.Format(CultureInfo.InvariantCulture, s_wallClockBudget, DescribeBudget(budget)));
+
+    /// <summary>
+    /// Renders a budget the way the operator set it, choosing the unit rather than fixing one.
+    ///
+    /// <para>Fixing it at minutes was the first cut, and a scratch harness caught it reporting a
+    /// sub-minute budget as "0.0-minute" — a message that names no number at all, on the one line an
+    /// operator has to work from. The shipped value is 10 minutes so it would never have shown in the
+    /// field; a test asserting the message merely CONTAINS "wall-clock budget" would not have shown it
+    /// either. Small values are the ones a person types while diagnosing, which is exactly when the
+    /// message matters most.</para>
+    /// </summary>
+    public static string DescribeBudget(TimeSpan budget) =>
+        budget < TimeSpan.FromMinutes(1)
+            ? string.Format(CultureInfo.InvariantCulture, "{0:0.###}-second", budget.TotalSeconds)
+            : string.Format(CultureInfo.InvariantCulture, "{0:0.#}-minute", budget.TotalMinutes);
 }

--- a/PerformanceMonitor.Collectors/ICollectorDefinition.cs
+++ b/PerformanceMonitor.Collectors/ICollectorDefinition.cs
@@ -6,6 +6,7 @@
  * Licensed under the MIT License. See LICENSE file in the project root for full license information.
  */
 
+using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Threading;
@@ -101,6 +102,28 @@ public interface ICollectorDefinition<TRow> : ICollectorSchemaInfo
     /// only the definition holds the reader.
     /// </summary>
     int? PerItemTextByteBudget { get; }
+
+    /// <summary>
+    /// WALL-CLOCK ceiling for one per-database unit of work — the watermark refresh, the command, and the
+    /// whole drain (#2150). Null (the common case) = unbounded, exactly as before.
+    ///
+    /// <para><b>Why the command timeout is not this.</b> <c>CommandTimeout</c> bounds the wait for a network
+    /// read, and SqlClient RESETS it on every read that arrives — so a result set that trickles rows
+    /// continuously never trips it, however long it takes in total. A 100-minute read under a 30-second
+    /// timeout is the documented behaviour, not a bug, which is why the field report in #2150 shows six
+    /// per-database passes of up to 99.8 minutes against a 30-second timeout.</para>
+    ///
+    /// <para><b>What exceeding it means.</b> The item is abandoned and reported as a per-item FAILURE, and
+    /// the cycle continues to the next database — the same treatment an offline database gets. Nothing is
+    /// silently dropped: a collector with a watermark did not advance it, so the abandoned range is simply
+    /// re-read next cycle. For <c>query_store</c> that failure also feeds the #2111 consecutive-failure
+    /// count, so the window NARROWS on the next pass instead of retrying the same impossible width — a
+    /// bound that converges rather than one that just repeats.</para>
+    ///
+    /// <para>Host-enforced rather than definition-enforced, unlike the byte budget: only the host owns the
+    /// cancellation token and the loop, and the point is to bound the definition's own read.</para>
+    /// </summary>
+    TimeSpan? PerItemWallClockBudget { get; }
 
     /// <summary>
     /// Builds the T-SQL (and any bound parameters) for this cycle. Constant for most collectors;

--- a/PerformanceMonitor.Collectors/QueryStoreCollector.cs
+++ b/PerformanceMonitor.Collectors/QueryStoreCollector.cs
@@ -327,6 +327,37 @@ END;
     public const int MaxTextBytesPerDatabase = 64 * 1024 * 1024;
 
     /// <summary>
+    /// The WALL-CLOCK ceiling for one database's pass (#2150), and the bound of last resort: the row cap
+    /// bounds ROWS, the byte budget bounds BYTES, and neither bounds TIME.
+    ///
+    /// <para><b>The field report it exists for.</b> Two Azure SQL DB elastic-pool databases, same day,
+    /// across the 3.3.0 → 3.4.0 upgrade: 198 passes at a median of <b>4.8 s</b> before, then six passes of
+    /// 0.1, 37.6, 46.1, 82.1, 0.1 and <b>99.8 minutes</b> after. Because a host's live collectors run one
+    /// after another, a single 100-minute pass starves every other collector on that server — which is the
+    /// actual mechanism behind #2148's "all collection stopped".</para>
+    ///
+    /// <para><b>Why nothing already caught it.</b> The <c>CommandTimeout</c> was 30 s the whole time. It
+    /// bounds the wait for a network read and SqlClient resets it on each read that arrives, so a result
+    /// set that trickles rows never trips it — see <see cref="PerItemWallClockBudget"/>.</para>
+    ///
+    /// <para><b>Why ten minutes.</b> It has to sit far above every healthy observation and far below every
+    /// pathological one. Healthy: 4.8 s median and 31 s max across 198 field passes; 375–524 ms for the
+    /// staged query measured on a 212k-row Query Store; 6 s for the two fast post-upgrade passes.
+    /// Pathological: 37.6 minutes at the low end. Ten minutes is ~19× the worst healthy pass, ~10× the
+    /// Darling command-timeout default, and ~3.7× under the smallest pass this is meant to stop.</para>
+    ///
+    /// <para><b>It converges rather than repeating.</b> A cut pass ships nothing, so the watermark does not
+    /// advance and the range is re-read — but the failure also feeds #2111's consecutive-failure count, so
+    /// the catch-up window halves per failure toward 15 minutes until a pass fits. A success resets it and
+    /// the database returns to full width. Without that this would be a bound that fires forever on the same
+    /// impossible width; with it, a database that cannot finish narrows until it can.</para>
+    /// </summary>
+    public static readonly TimeSpan PerDatabaseWallClockBudget = TimeSpan.FromMinutes(10);
+
+    /// <inheritdoc />
+    public override TimeSpan? PerItemWallClockBudget => PerDatabaseWallClockBudget;
+
+    /// <summary>
     /// The self-identification marker every collector query carries in its leading comment. Self rows
     /// are excluded CLIENT-SIDE in the shared read loop both paths use (#1565) — the old SQL-side
     /// NOT LIKE predicate was 75% of the read's elapsed time (a full nvarchar(max) scan per row on a


### PR DESCRIPTION
Step 3 of #2150 — the containment. The query itself (steps 1–2) stays open; this stops one database from taking the whole host down with it, which is the reported harm.

## The report

Two Azure SQL DB elastic-pool databases, same day, across the 3.3.0 → 3.4.0 upgrade:

| build | passes | median | max |
|---|---|---|---|
| 3.3.0 | 198 | **4.8 s** | 31 s |
| 3.4.0 | 6 | — | **99.8 min** |

A host's live collectors run one after another, so one 100-minute pass starves every other collector on that server. That is the actual mechanism behind #2148's "all collection stopped".

## Nothing already caught it, and nothing could have

`CommandTimeout` was **30 seconds the whole time.** It bounds the wait for a network read, and SqlClient **resets it on every read that arrives** — so a result set that trickles rows continuously never trips it, however long it takes in total. A 100-minute read under a 30-second timeout is documented behaviour, not a bug.

## The change

`ICollectorDefinition.PerItemWallClockBudget` — null for every collector but `query_store`, which declares **10 minutes**. Applied in **both** places a per-database pass can happen:

- the shared `EnumeratedCollectorDriver` loop (on-prem enumeration), and
- **each host's own per-database loop** (Azure SQL DB) — which is the path the report is on and does *not* go through the driver. Missing that would have shipped a fix that does not cover the reporter.

**Exceeding it abandons that database as a per-item failure and continues.** Nothing is lost: the watermark did not advance, so the range is re-read next cycle.

**And it converges rather than repeating.** The failure also feeds #2111's consecutive-failure count, so the catch-up window halves toward 15 minutes until a pass fits; a success resets it and the database returns to full width. Without that, this would be a bound that fires forever on the same impossible width.

## Why ten minutes, measured rather than chosen

| | |
|---|---|
| healthy, field | 4.8 s median, 31 s max across 198 passes |
| healthy, box | 375–524 ms for the staged query on a 212k-row Query Store |
| healthy, post-upgrade | 6 s for the two fast passes |
| **pathological** | **37.6 minutes at the low end** |

Ten minutes is ~19× the worst healthy pass, ~10× Darling's command-timeout default, and ~3.7× under the smallest pass this is meant to stop.

## Three design points

- **Classification is on the TOKENS, not the exception type.** Cancelling a SqlClient command does not reliably surface as `OperationCanceledException` — it commonly arrives as a provider exception, and which one depends on whether the cancellation landed during the open or the drain. So the budget arm is filtered on "did *my* source fire and the outer one not", and it sits **ahead** of the existing generic catch. **Shutdown deliberately wins the ambiguous case**, because misreading a service stop as a per-item skip would have the loop keep collecting through it.
- **The write is outside the budget.** Abandoning a flush already in flight would trade a slow cycle for a partially-written one.
- **A non-positive budget is treated as no budget**, so a misconfigured value degrades to today's behaviour rather than collecting nothing at all.

## Verification

`net10.0-windows` xunit cannot run on this machine, so I exercised the real driver through a scratch console harness: **27/27**, covering the abandon-and-continue path, shutdown propagation, token identity when no budget is set, the write's token, all four classifier combinations, the non-positive case, and which collectors declare a budget.

**That harness earned its keep.** The first cut formatted the budget as minutes only and reported a 150 ms budget as `0.0-minute` — a message naming no number, on the one line an operator has to work from. The shipped value is 10 minutes, so it would never have looked wrong in the field, **and the xunit assertion I had written (message *contains* "wall-clock budget") passed against it.** `DescribeBudget` now picks its unit, and the pin asserts the rendered number.

Full solution builds clean, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
