### PR TITLE
Scope an Azure SQL DB sweep to the database it registered (#2220)

### DIFF
--- a/Darling/Darling.Tests/AzureSweepScopeTests.cs
+++ b/Darling/Darling.Tests/AzureSweepScopeTests.cs
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using PerformanceMonitor.Collectors;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #2220: which databases one Azure SQL DB registration's per-database sweep covers.
+///
+/// <para><b>The field report.</b> A single real deadlock in one Azure SQL Database produced near-identical
+/// "Deadlocks Detected" alerts on every OTHER monitored database sharing the same logical server — and the
+/// stored data matched: byte-identical deadlock graphs and the same top query, with counters within ~1%,
+/// under six unrelated <c>server_id</c>s. Azure SQL DB engines are isolated per database, so one database's
+/// sessions cannot block another's; the rows were not cross-talk, they were the same rows collected six
+/// times.</para>
+///
+/// <para><b>The cause, and why it is not a typo.</b> The enumeration read <c>master</c> unconditionally and
+/// swept every online database on the logical server, storing all of it under whichever registration ran the
+/// sweep. Two parts of the product hold incompatible ideas of what a registration IS, both deliberate: the
+/// enumeration assumes one registration = one LOGICAL SERVER (#857's shape), while identity assumes one
+/// registration = one DATABASE (<c>server_id</c> hashes <c>host[:database][:RO]</c>, and the Azure
+/// query_store path needs a per-database connection anyway, #1836). The second shape silently behaved like
+/// the first, N times over — N registrations of N databases is N² collection.</para>
+///
+/// <para>Pinned in BOTH suites against the shared implementation. A scoping rule that disagrees between Lite
+/// and Darling is the same class of defect as the one being fixed, and both runners previously carried their
+/// own private copy of it.</para>
+/// </summary>
+public sealed class AzureSweepScopeTests
+{
+    /// <summary>
+    /// THE FIX. A registration naming a database sweeps exactly that database — the reported case, where
+    /// fifteen registrations on one logical server each swept all fifteen.
+    /// </summary>
+    [Theory]
+    [InlineData("db1")]
+    [InlineData("AdventureWorks")]
+    [InlineData("Sibling-A")]
+    public void ARegistrationThatNamesADatabase_SweepsOnlyThatDatabase(string catalog)
+    {
+        Assert.Equal(new[] { catalog }, AzureSweepScope.OwnDatabaseOrEmpty(catalog));
+        Assert.True(AzureSweepScope.IsScopedToOneDatabase(catalog));
+    }
+
+    /// <summary>
+    /// A registration naming NO database is a registration of the logical server, so it must enumerate —
+    /// signalled by the empty list rather than by a separate flag, because the caller's next step is a list
+    /// either way. This is the behaviour #857 was written for and it is deliberately unchanged.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void ARegistrationThatNamesNoDatabase_StillEnumeratesTheServer(string? catalog)
+    {
+        Assert.Empty(AzureSweepScope.OwnDatabaseOrEmpty(catalog));
+        Assert.False(AzureSweepScope.IsScopedToOneDatabase(catalog));
+    }
+
+    /// <summary>
+    /// <c>master</c> counts as naming none, in any casing. A connection string with no
+    /// <c>Initial Catalog</c> lands in <c>master</c> on Azure SQL DB, so treating it as a named database
+    /// would scope such a registration to the one database holding none of the user's data — collecting
+    /// nothing and looking healthy while doing it.
+    /// </summary>
+    [Theory]
+    [InlineData("master")]
+    [InlineData("MASTER")]
+    [InlineData("Master")]
+    public void MasterIsNotADatabaseAnyoneRegisteredFor(string catalog)
+    {
+        Assert.Empty(AzureSweepScope.OwnDatabaseOrEmpty(catalog));
+        Assert.False(AzureSweepScope.IsScopedToOneDatabase(catalog));
+    }
+
+    /// <summary>
+    /// A database that merely CONTAINS "master" is a real database and is swept. Guards the obvious
+    /// over-match, which would silently stop collecting from it.
+    /// </summary>
+    [Theory]
+    [InlineData("mastermind")]
+    [InlineData("paymaster")]
+    [InlineData("master_archive")]
+    public void ADatabaseNamedLikeMasterIsStillItsOwnDatabase(string catalog)
+    {
+        Assert.Equal(new[] { catalog }, AzureSweepScope.OwnDatabaseOrEmpty(catalog));
+    }
+
+    /// <summary>
+    /// The two members cannot disagree: the boolean is the list's emptiness, named for the decision it
+    /// drives. Pinned because two predicates that answer the same question are how a caller ends up asking
+    /// the one that has not been updated.
+    /// </summary>
+    [Theory]
+    [InlineData("db1")]
+    [InlineData("master")]
+    [InlineData(null)]
+    [InlineData("")]
+    public void TheBooleanAndTheListAlwaysAgree(string? catalog)
+    {
+        Assert.Equal(
+            AzureSweepScope.OwnDatabaseOrEmpty(catalog).Count > 0,
+            AzureSweepScope.IsScopedToOneDatabase(catalog));
+    }
+
+    /// <summary>
+    /// The returned list is the caller's to keep: both runners hand it straight to their per-database loop,
+    /// and a shared or cached instance would let one sweep's mutation reach another's.
+    /// </summary>
+    [Fact]
+    public void EachCallReturnsItsOwnList()
+    {
+        var first = AzureSweepScope.OwnDatabaseOrEmpty("db1");
+        var second = AzureSweepScope.OwnDatabaseOrEmpty("db1");
+
+        Assert.NotSame(first, second);
+        first.Add("mutated");
+        Assert.Single(second);
+    }
+}

--- a/Darling/Darling.Tests/AzureSweepScopeTests.cs
+++ b/Darling/Darling.Tests/AzureSweepScopeTests.cs
@@ -46,7 +46,6 @@ public sealed class AzureSweepScopeTests
     public void ARegistrationThatNamesADatabase_SweepsOnlyThatDatabase(string catalog)
     {
         Assert.Equal(new[] { catalog }, AzureSweepScope.OwnDatabaseOrEmpty(catalog));
-        Assert.True(AzureSweepScope.IsScopedToOneDatabase(catalog));
     }
 
     /// <summary>
@@ -60,7 +59,6 @@ public sealed class AzureSweepScopeTests
     public void ARegistrationThatNamesNoDatabase_StillEnumeratesTheServer(string? catalog)
     {
         Assert.Empty(AzureSweepScope.OwnDatabaseOrEmpty(catalog));
-        Assert.False(AzureSweepScope.IsScopedToOneDatabase(catalog));
     }
 
     /// <summary>
@@ -76,7 +74,6 @@ public sealed class AzureSweepScopeTests
     public void MasterIsNotADatabaseAnyoneRegisteredFor(string catalog)
     {
         Assert.Empty(AzureSweepScope.OwnDatabaseOrEmpty(catalog));
-        Assert.False(AzureSweepScope.IsScopedToOneDatabase(catalog));
     }
 
     /// <summary>
@@ -90,23 +87,6 @@ public sealed class AzureSweepScopeTests
     public void ADatabaseNamedLikeMasterIsStillItsOwnDatabase(string catalog)
     {
         Assert.Equal(new[] { catalog }, AzureSweepScope.OwnDatabaseOrEmpty(catalog));
-    }
-
-    /// <summary>
-    /// The two members cannot disagree: the boolean is the list's emptiness, named for the decision it
-    /// drives. Pinned because two predicates that answer the same question are how a caller ends up asking
-    /// the one that has not been updated.
-    /// </summary>
-    [Theory]
-    [InlineData("db1")]
-    [InlineData("master")]
-    [InlineData(null)]
-    [InlineData("")]
-    public void TheBooleanAndTheListAlwaysAgree(string? catalog)
-    {
-        Assert.Equal(
-            AzureSweepScope.OwnDatabaseOrEmpty(catalog).Count > 0,
-            AzureSweepScope.IsScopedToOneDatabase(catalog));
     }
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
@@ -1558,12 +1558,28 @@ RETURNING s.state_key";
     {
         var targetDb = new SqlConnectionStringBuilder(server.ConnectionString).InitialCatalog;
 
-        /* Skip the throttle when there is nothing to fall back TO — see Lite's twin. With no target
-           database the fallback can only throw, so honouring the throttle would guarantee 15 minutes
-           of failure without ever attempting to recover. */
-        var hasFallback = SingleDbOrEmpty(targetDb).Count > 0;
+        /* #2220: a registration that NAMES a database is a registration OF that database, so its sweep
+           covers exactly that one and never touches master. Before this, EVERY database-scoped collector
+           enumerated master and swept every online database on the logical server, storing all of it under
+           the one server_id of whichever registration ran the sweep — N registrations of N databases on one
+           server meant N² collection with every registration's history contaminated by its siblings'.
 
-        if (hasFallback && IsMasterProbeThrottled(server.ServerId))
+           This also subsumes the #857 case it looks like it bypasses, and improves on it: a login granted
+           access to one user database but not to master HAS a named database, so it now returns here without
+           probing master at all, rather than probing, failing, forming a verdict and falling back. Master is
+           reached only by a registration that names no database — the logical-server registration, which has
+           nothing else to enumerate from. */
+        var ownDatabase = AzureSweepScope.OwnDatabaseOrEmpty(targetDb);
+        if (ownDatabase.Count > 0)
+        {
+            return ownDatabase;
+        }
+
+        /* Reached only when the registration names no database, so there is nothing to fall back TO and
+           the throttle would guarantee 15 minutes of failure without attempting to recover. Kept as the
+           guard it always was rather than deleted: it states the precondition this path now satisfies by
+           construction. */
+        if (IsMasterProbeThrottled(server.ServerId))
         {
             return FallbackDatabaseList(server, targetDb, reason: "master previously inaccessible", quiet: true);
         }
@@ -1734,14 +1750,11 @@ RETURNING s.state_key";
         return databases;
     }
 
-    private static List<string> SingleDbOrEmpty(string? targetDb)
-    {
-        if (string.IsNullOrEmpty(targetDb) || string.Equals(targetDb, "master", StringComparison.OrdinalIgnoreCase))
-        {
-            return new List<string>();
-        }
-        return new List<string> { targetDb };
-    }
+    /* #2220: delegates to the shared rule. Both runners carried their own copy of this predicate, and a
+       sweep-scoping rule that disagrees between Lite and Darling is the same class of defect as the one
+       #2220 fixes. */
+    private static List<string> SingleDbOrEmpty(string? targetDb) =>
+        AzureSweepScope.OwnDatabaseOrEmpty(targetDb);
 
     /// <summary>
     /// Whether master enumeration failed in a way that means database-scoped collectors should fall back

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
@@ -1550,9 +1550,22 @@ RETURNING s.state_key";
     }
 
     /// <summary>
-    /// Lists databases on an Azure SQL DB logical server, mirroring Lite's #857 behavior: try
-    /// master enumeration first (with the per-server exclusion filter), and on a master-access
-    /// error fall back to the connection's own database, throttling re-probes per server.
+    /// The databases one Azure SQL DB registration's per-database sweep covers.
+    ///
+    /// <para><b>A registration that names a database sweeps that database, and nothing else</b> (#2220) —
+    /// which is the common case, since <c>server_id</c> hashes <c>host[:database][:RO]</c> and registering
+    /// each database separately is how you get separate identities. That path returns immediately and never
+    /// touches <c>master</c>.</para>
+    ///
+    /// <para>Only a registration naming NO database — or naming <c>master</c>, where a catalog-less Azure
+    /// connection lands — is a registration of the logical SERVER, and only that one enumerates: master
+    /// first with the per-server exclusion filter, and on a master-access error a fallback that has nothing
+    /// to fall back to and therefore throws (#857's shape, now the exceptional path rather than the default).
+    /// The re-probe throttle is deliberately NOT consulted there; see the comment at the call site.</para>
+    ///
+    /// <para>It read master unconditionally before #2220, sweeping every online database on the logical
+    /// server into whichever registration ran the sweep — N registrations of N databases meant N² collection
+    /// with every registration's history contaminated by its siblings'.</para>
     /// </summary>
     internal async Task<List<string>> GetAzureDatabaseListAsync(ServerRuntime server, CancellationToken cancellationToken)
     {

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
@@ -1575,14 +1575,18 @@ RETURNING s.state_key";
             return ownDatabase;
         }
 
-        /* Reached only when the registration names no database, so there is nothing to fall back TO and
-           the throttle would guarantee 15 minutes of failure without attempting to recover. Kept as the
-           guard it always was rather than deleted: it states the precondition this path now satisfies by
-           construction. */
-        if (IsMasterProbeThrottled(server.ServerId))
-        {
-            return FallbackDatabaseList(server, targetDb, reason: "master previously inaccessible", quiet: true);
-        }
+        /* NO throttle check here, and that is deliberate rather than an omission — restoring what the
+           `hasFallback &&` guard used to achieve. This branch is reached ONLY when the registration names no
+           database, so there is nothing to fall back TO: honouring the throttle would return
+           FallbackDatabaseList, which throws immediately without probing, and would keep throwing for the
+           whole recheck interval while never attempting the one thing that could recover. Probing master
+           every cycle is the cheaper failure. (Review caught me reintroducing exactly this: I read
+           `hasFallback &&` as a redundant condition when it was there to DISABLE the throttle.)
+
+           The throttle machinery itself is left alone. It is tested behaviour from #857/#1506, and it is now
+           unreachable in production for a different reason than this one: its whole purpose was to stop
+           re-probing master for a registration that HAS a fallback, and such a registration no longer probes
+           master at all. Retiring it is its own change, with those tests. */
 
         /* The query and the hop to master both come from the provider, so the enumeration set is defined
            in exactly one place per engine. What stays here is the failure policy below, which is the

--- a/Lite.Tests/AzureSweepScopeTests.cs
+++ b/Lite.Tests/AzureSweepScopeTests.cs
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using PerformanceMonitor.Collectors;
+using Xunit;
+
+namespace Lite.Tests;
+
+/// <summary>
+/// #2220: which databases one Azure SQL DB registration's per-database sweep covers.
+///
+/// <para><b>The field report.</b> A single real deadlock in one Azure SQL Database produced near-identical
+/// "Deadlocks Detected" alerts on every OTHER monitored database sharing the same logical server — and the
+/// stored data matched: byte-identical deadlock graphs and the same top query, with counters within ~1%,
+/// under six unrelated <c>server_id</c>s. Azure SQL DB engines are isolated per database, so one database's
+/// sessions cannot block another's; the rows were not cross-talk, they were the same rows collected six
+/// times.</para>
+///
+/// <para><b>The cause, and why it is not a typo.</b> The enumeration read <c>master</c> unconditionally and
+/// swept every online database on the logical server, storing all of it under whichever registration ran the
+/// sweep. Two parts of the product hold incompatible ideas of what a registration IS, both deliberate: the
+/// enumeration assumes one registration = one LOGICAL SERVER (#857's shape), while identity assumes one
+/// registration = one DATABASE (<c>server_id</c> hashes <c>host[:database][:RO]</c>, and the Azure
+/// query_store path needs a per-database connection anyway, #1836). The second shape silently behaved like
+/// the first, N times over — N registrations of N databases is N² collection.</para>
+///
+/// <para>Pinned in BOTH suites against the shared implementation — this is Lite's half. A rule that disagrees
+/// and Darling is the same class of defect as the one being fixed, and both runners previously carried their
+/// own private copy of it.</para>
+/// </summary>
+public sealed class AzureSweepScopeTests
+{
+    /// <summary>
+    /// THE FIX. A registration naming a database sweeps exactly that database — the reported case, where
+    /// fifteen registrations on one logical server each swept all fifteen.
+    /// </summary>
+    [Theory]
+    [InlineData("db1")]
+    [InlineData("AdventureWorks")]
+    [InlineData("Sibling-A")]
+    public void ARegistrationThatNamesADatabase_SweepsOnlyThatDatabase(string catalog)
+    {
+        Assert.Equal(new[] { catalog }, AzureSweepScope.OwnDatabaseOrEmpty(catalog));
+        Assert.True(AzureSweepScope.IsScopedToOneDatabase(catalog));
+    }
+
+    /// <summary>
+    /// A registration naming NO database is a registration of the logical server, so it must enumerate —
+    /// signalled by the empty list rather than by a separate flag, because the caller's next step is a list
+    /// either way. This is the behaviour #857 was written for and it is deliberately unchanged.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void ARegistrationThatNamesNoDatabase_StillEnumeratesTheServer(string? catalog)
+    {
+        Assert.Empty(AzureSweepScope.OwnDatabaseOrEmpty(catalog));
+        Assert.False(AzureSweepScope.IsScopedToOneDatabase(catalog));
+    }
+
+    /// <summary>
+    /// <c>master</c> counts as naming none, in any casing. A connection string with no
+    /// <c>Initial Catalog</c> lands in <c>master</c> on Azure SQL DB, so treating it as a named database
+    /// would scope such a registration to the one database holding none of the user's data — collecting
+    /// nothing and looking healthy while doing it.
+    /// </summary>
+    [Theory]
+    [InlineData("master")]
+    [InlineData("MASTER")]
+    [InlineData("Master")]
+    public void MasterIsNotADatabaseAnyoneRegisteredFor(string catalog)
+    {
+        Assert.Empty(AzureSweepScope.OwnDatabaseOrEmpty(catalog));
+        Assert.False(AzureSweepScope.IsScopedToOneDatabase(catalog));
+    }
+
+    /// <summary>
+    /// A database that merely CONTAINS "master" is a real database and is swept. Guards the obvious
+    /// over-match, which would silently stop collecting from it.
+    /// </summary>
+    [Theory]
+    [InlineData("mastermind")]
+    [InlineData("paymaster")]
+    [InlineData("master_archive")]
+    public void ADatabaseNamedLikeMasterIsStillItsOwnDatabase(string catalog)
+    {
+        Assert.Equal(new[] { catalog }, AzureSweepScope.OwnDatabaseOrEmpty(catalog));
+    }
+
+    /// <summary>
+    /// The two members cannot disagree: the boolean is the list's emptiness, named for the decision it
+    /// drives. Pinned because two predicates that answer the same question are how a caller ends up asking
+    /// the one that has not been updated.
+    /// </summary>
+    [Theory]
+    [InlineData("db1")]
+    [InlineData("master")]
+    [InlineData(null)]
+    [InlineData("")]
+    public void TheBooleanAndTheListAlwaysAgree(string? catalog)
+    {
+        Assert.Equal(
+            AzureSweepScope.OwnDatabaseOrEmpty(catalog).Count > 0,
+            AzureSweepScope.IsScopedToOneDatabase(catalog));
+    }
+
+    /// <summary>
+    /// The returned list is the caller's to keep: both runners hand it straight to their per-database loop,
+    /// and a shared or cached instance would let one sweep's mutation reach another's.
+    /// </summary>
+    [Fact]
+    public void EachCallReturnsItsOwnList()
+    {
+        var first = AzureSweepScope.OwnDatabaseOrEmpty("db1");
+        var second = AzureSweepScope.OwnDatabaseOrEmpty("db1");
+
+        Assert.NotSame(first, second);
+        first.Add("mutated");
+        Assert.Single(second);
+    }
+}

--- a/Lite.Tests/AzureSweepScopeTests.cs
+++ b/Lite.Tests/AzureSweepScopeTests.cs
@@ -29,9 +29,9 @@ namespace Lite.Tests;
 /// query_store path needs a per-database connection anyway, #1836). The second shape silently behaved like
 /// the first, N times over — N registrations of N databases is N² collection.</para>
 ///
-/// <para>Pinned in BOTH suites against the shared implementation — this is Lite's half. A rule that disagrees
-/// and Darling is the same class of defect as the one being fixed, and both runners previously carried their
-/// own private copy of it.</para>
+/// <para>Pinned in BOTH suites against the shared implementation — this is Lite's half. A scoping rule that
+/// disagrees between Lite and Darling is the same class of defect as the one being fixed, and both runners
+/// previously carried their own private copy of it.</para>
 /// </summary>
 public sealed class AzureSweepScopeTests
 {

--- a/Lite.Tests/AzureSweepScopeTests.cs
+++ b/Lite.Tests/AzureSweepScopeTests.cs
@@ -46,7 +46,6 @@ public sealed class AzureSweepScopeTests
     public void ARegistrationThatNamesADatabase_SweepsOnlyThatDatabase(string catalog)
     {
         Assert.Equal(new[] { catalog }, AzureSweepScope.OwnDatabaseOrEmpty(catalog));
-        Assert.True(AzureSweepScope.IsScopedToOneDatabase(catalog));
     }
 
     /// <summary>
@@ -60,7 +59,6 @@ public sealed class AzureSweepScopeTests
     public void ARegistrationThatNamesNoDatabase_StillEnumeratesTheServer(string? catalog)
     {
         Assert.Empty(AzureSweepScope.OwnDatabaseOrEmpty(catalog));
-        Assert.False(AzureSweepScope.IsScopedToOneDatabase(catalog));
     }
 
     /// <summary>
@@ -76,7 +74,6 @@ public sealed class AzureSweepScopeTests
     public void MasterIsNotADatabaseAnyoneRegisteredFor(string catalog)
     {
         Assert.Empty(AzureSweepScope.OwnDatabaseOrEmpty(catalog));
-        Assert.False(AzureSweepScope.IsScopedToOneDatabase(catalog));
     }
 
     /// <summary>
@@ -90,23 +87,6 @@ public sealed class AzureSweepScopeTests
     public void ADatabaseNamedLikeMasterIsStillItsOwnDatabase(string catalog)
     {
         Assert.Equal(new[] { catalog }, AzureSweepScope.OwnDatabaseOrEmpty(catalog));
-    }
-
-    /// <summary>
-    /// The two members cannot disagree: the boolean is the list's emptiness, named for the decision it
-    /// drives. Pinned because two predicates that answer the same question are how a caller ends up asking
-    /// the one that has not been updated.
-    /// </summary>
-    [Theory]
-    [InlineData("db1")]
-    [InlineData("master")]
-    [InlineData(null)]
-    [InlineData("")]
-    public void TheBooleanAndTheListAlwaysAgree(string? catalog)
-    {
-        Assert.Equal(
-            AzureSweepScope.OwnDatabaseOrEmpty(catalog).Count > 0,
-            AzureSweepScope.IsScopedToOneDatabase(catalog));
     }
 
     /// <summary>

--- a/Lite/Services/RemoteCollectorService.cs
+++ b/Lite/Services/RemoteCollectorService.cs
@@ -848,13 +848,18 @@ WHERE server_id = $3";
             return ownDatabase;
         }
 
-        /* Reached only when the registration names no database, so there is nothing to fall back TO and
-           the throttle would buy one saved round-trip at the cost of 15 minutes of guaranteed failure.
-           Probe master instead: it might work now. */
-        if (IsMasterProbeThrottled(serverId))
-        {
-            return FallbackDatabaseList(server, targetDb, reason: "master previously inaccessible", quiet: true);
-        }
+        /* NO throttle check here, and that is deliberate rather than an omission — restoring what the
+           `hasFallback &&` guard used to achieve. This branch is reached ONLY when the registration names no
+           database, so there is nothing to fall back TO: honouring the throttle would return
+           FallbackDatabaseList, which throws immediately without probing, and would keep throwing for the
+           whole recheck interval while never attempting the one thing that could recover. Probing master
+           every cycle is the cheaper failure. (Review caught me reintroducing exactly this: I read
+           `hasFallback &&` as a redundant condition when it was there to DISABLE the throttle.)
+
+           The throttle machinery itself is left alone. It is tested behaviour from #857/#1506, and it is now
+           unreachable in production for a different reason than this one: its whole purpose was to stop
+           re-probing master for a registration that HAS a fallback, and such a registration no longer probes
+           master at all. Retiring it is its own change, with those tests. */
 
         var connStr = new SqlConnectionStringBuilder(baseConnStr)
         {

--- a/Lite/Services/RemoteCollectorService.cs
+++ b/Lite/Services/RemoteCollectorService.cs
@@ -831,13 +831,27 @@ WHERE server_id = $3";
         var baseConnStr = _serverManager.CredentialResolver.GetConnectionString(server);
         var targetDb = new SqlConnectionStringBuilder(baseConnStr).InitialCatalog;
 
-        /* Skip the throttle when there is nothing to fall back TO. With no target database the fallback
-           can only throw, and an error lands in collection_log either way — so honouring the throttle
-           here would buy one saved round-trip at the cost of 15 minutes of guaranteed failure with no
-           attempt to recover. Probe master instead: it might work now. */
-        var hasFallback = SingleDbOrEmpty(targetDb).Count > 0;
+        /* #2220: a registration that NAMES a database is a registration OF that database, so its sweep
+           covers exactly that one and never touches master. Before this, EVERY database-scoped collector
+           enumerated master and swept every online database on the logical server, storing all of it under
+           the one server_id of whichever registration ran the sweep — N registrations of N databases on one
+           server meant N² collection with every registration's history contaminated by its siblings'.
 
-        if (hasFallback && IsMasterProbeThrottled(serverId))
+           This also subsumes the #857 case it looks like it bypasses, and improves on it: a login granted
+           access to one user database but not to master HAS a named database, so it now returns here without
+           probing master at all, rather than probing, failing, forming a verdict and falling back. Master is
+           reached only by a registration that names no database — the logical-server registration, which has
+           nothing else to enumerate from. */
+        var ownDatabase = AzureSweepScope.OwnDatabaseOrEmpty(targetDb);
+        if (ownDatabase.Count > 0)
+        {
+            return ownDatabase;
+        }
+
+        /* Reached only when the registration names no database, so there is nothing to fall back TO and
+           the throttle would buy one saved round-trip at the cost of 15 minutes of guaranteed failure.
+           Probe master instead: it might work now. */
+        if (IsMasterProbeThrottled(serverId))
         {
             return FallbackDatabaseList(server, targetDb, reason: "master previously inaccessible", quiet: true);
         }
@@ -1024,12 +1038,9 @@ WHERE server_id = $3";
         return $"AND {columnExpression} NOT IN ({string.Join(", ", quoted)})";
     }
 
-    private static List<string> SingleDbOrEmpty(string? targetDb)
-    {
-        if (string.IsNullOrEmpty(targetDb) || string.Equals(targetDb, "master", StringComparison.OrdinalIgnoreCase))
-            return new List<string>();
-        return new List<string> { targetDb };
-    }
+    /* #2220: delegates to the shared rule — see AzureSweepScope for why this is not duplicated per host. */
+    private static List<string> SingleDbOrEmpty(string? targetDb) =>
+        AzureSweepScope.OwnDatabaseOrEmpty(targetDb);
 
     /// <summary>
     /// Whether master enumeration failed in a way that means database-scoped collectors should fall back

--- a/Lite/Services/RemoteCollectorService.cs
+++ b/Lite/Services/RemoteCollectorService.cs
@@ -815,15 +815,24 @@ WHERE server_id = $3";
     }
 
     /// <summary>
-    /// Enumerates online databases on an Azure SQL DB logical server.
-    /// HAS_DBACCESS() returns false for user databases from master on Azure SQL DB,
-    /// so we skip that filter — inaccessible databases should be handled by callers via try/catch.
+    /// The databases one Azure SQL DB registration's per-database sweep covers.
     ///
-    /// On Azure SQL DB, logins are sometimes granted access only to a specific user database and
-    /// not to master (e.g. Microsoft Dynamics 365 FO). In that case, master enumeration fails with
-    /// an access/login error; we fall back to returning the connection's initial catalog as a
-    /// single-database list, and throttle re-probes of master so we don't retry it every cycle.
-    /// See issue #857.
+    /// <para><b>A registration that names a database sweeps that database, and nothing else</b> (#2220) —
+    /// the common case, since <c>server_id</c> hashes <c>host[:database][:RO]</c> and registering each
+    /// database separately is how you get separate identities. That path returns immediately and never
+    /// touches <c>master</c>. It also covers #857's own case better than #857 did: a login with access to one
+    /// user database but not to master has a named database, so it no longer probes master, fails, and falls
+    /// back — it simply never probes.</para>
+    ///
+    /// <para>Only a registration naming NO database — or naming <c>master</c>, where a catalog-less Azure
+    /// connection lands — is a registration of the logical SERVER, and only that one enumerates.
+    /// HAS_DBACCESS() returns false for user databases from master on Azure SQL DB, so that filter is
+    /// skipped and inaccessible databases are handled by callers via try/catch. The re-probe throttle is
+    /// deliberately NOT consulted on that path; see the comment at the call site.</para>
+    ///
+    /// <para>It read master unconditionally before #2220, sweeping every online database on the logical
+    /// server into whichever registration ran the sweep — N registrations of N databases meant N² collection
+    /// with every registration's history contaminated by its siblings'.</para>
     /// </summary>
     protected async Task<List<string>> GetAzureDatabaseListAsync(ServerConnection server, CancellationToken cancellationToken)
     {

--- a/PerformanceMonitor.Collectors/AzureSweepScope.cs
+++ b/PerformanceMonitor.Collectors/AzureSweepScope.cs
@@ -62,14 +62,4 @@ public static class AzureSweepScope
 
         return new List<string> { initialCatalog };
     }
-
-    /// <summary>
-    /// True when the registration names its own database, so its sweep is scoped to that one database and
-    /// must NOT enumerate the logical server.
-    ///
-    /// <para>The same question as <see cref="OwnDatabaseOrEmpty"/>'s count, named for the decision it drives
-    /// so a call site reads as the rule rather than as a length check.</para>
-    /// </summary>
-    public static bool IsScopedToOneDatabase(string? initialCatalog) =>
-        OwnDatabaseOrEmpty(initialCatalog).Count > 0;
 }

--- a/PerformanceMonitor.Collectors/AzureSweepScope.cs
+++ b/PerformanceMonitor.Collectors/AzureSweepScope.cs
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+
+namespace PerformanceMonitor.Collectors;
+
+/// <summary>
+/// Which databases one Azure SQL DB registration's per-database sweep covers (#2220).
+///
+/// <para><b>The defect this decides.</b> A database-scoped collector on Azure SQL DB used to enumerate
+/// <c>master</c> unconditionally and sweep EVERY online database on the logical server, storing all of it
+/// under the one <c>server_id</c> of whichever registration ran the sweep. On a logical server holding N
+/// separately-registered databases that is N registrations × N databases: N² collection, and every
+/// registration's stored history contaminated with its siblings'. The field report is byte-identical
+/// deadlock graphs and the same top query appearing under six unrelated identities, which is exactly what
+/// reading one database's rows six times looks like.</para>
+///
+/// <para><b>Why it happened rather than being an oversight.</b> Two parts of the product hold incompatible
+/// ideas of what an Azure SQL DB registration IS, and both are deliberate. The enumeration assumes one
+/// registration = one LOGICAL SERVER, which is the shape #857 was written for. Identity assumes one
+/// registration = one DATABASE: <c>server_id</c> is the hash of <c>host[:database][:RO]</c>, so registering
+/// two databases on one server is the supported way to get two identities — and the Azure query_store path
+/// (#1836) needs a per-database connection anyway. Nothing reconciled the two, so the second shape silently
+/// behaved like the first, N times over.</para>
+///
+/// <para><b>The rule.</b> A registration that NAMES a database is a registration OF that database, and its
+/// sweep covers exactly that one. Only a registration that names none — or names <c>master</c>, which on
+/// Azure SQL DB is where a catalog-less connection lands — is a registration of the logical SERVER, and only
+/// that one enumerates.</para>
+///
+/// <para>Shared rather than duplicated per host on purpose: both runners had their own private copy of this
+/// predicate, and a scoping rule that disagrees between Lite and Darling is the same class of bug as the one
+/// being fixed. One implementation, pinned by both test suites.</para>
+/// </summary>
+public static class AzureSweepScope
+{
+    /// <summary>
+    /// The single database this registration names, or an EMPTY list when it names none.
+    ///
+    /// <para>Empty is not "no databases" — it means "this registration is of the logical server, so the
+    /// caller must enumerate". The two are told apart by the count, which is why this returns a list rather
+    /// than a nullable string: the caller's next step is a list either way.</para>
+    ///
+    /// <para><c>master</c> counts as naming none. A connection string with no <c>Initial Catalog</c> lands in
+    /// <c>master</c> on Azure SQL DB, so treating it as a named database would scope every catalog-less
+    /// registration to a database that holds none of the user's data.</para>
+    /// </summary>
+    public static List<string> OwnDatabaseOrEmpty(string? initialCatalog)
+    {
+        if (string.IsNullOrEmpty(initialCatalog)
+            || string.Equals(initialCatalog, "master", StringComparison.OrdinalIgnoreCase))
+        {
+            return new List<string>();
+        }
+
+        return new List<string> { initialCatalog };
+    }
+
+    /// <summary>
+    /// True when the registration names its own database, so its sweep is scoped to that one database and
+    /// must NOT enumerate the logical server.
+    ///
+    /// <para>The same question as <see cref="OwnDatabaseOrEmpty"/>'s count, named for the decision it drives
+    /// so a call site reads as the rule rather than as a length check.</para>
+    /// </summary>
+    public static bool IsScopedToOneDatabase(string? initialCatalog) =>
+        OwnDatabaseOrEmpty(initialCatalog).Count > 0;
+}


### PR DESCRIPTION
Fixes #2220.

## The report was right, and the reporter found the mechanism before I did

One real deadlock in one Azure SQL Database produced near-identical alerts on every *other* monitored database on the same logical server. Azure SQL DB engines are isolated per database, so one database's sessions cannot block another's — and the stored data bore that out: byte-identical deadlock graphs and the same top query, counters within ~1%, under six unrelated `server_id`s. Not cross-talk. **The same rows, collected six times.**

Confirmed from source. `GetAzureDatabaseListAsync` → `BuildDatabaseListPlan` hops to **master**:

```sql
SELECT name FROM sys.databases WHERE state_desc = N'ONLINE' AND database_id > 0 {exclusion} ORDER BY name;
```

That returns **every online database on the logical server**, narrowed only by that registration's `ExcludedDatabases` — a denylist, not an allowlist. The caller sweeps all of them and stores every row under the one `server_id` of whichever registration ran the sweep. The single-database behaviour existed only as the fallback for a master-**access error**, so the safe path was the exceptional one.

On a logical server holding N separately-registered databases: **N registrations × N databases = N² collection, with every registration's history contaminated by its siblings'.** This is a data-correctness bug, not alert noise.

## Why it happened, which is the part worth keeping

Two parts of the product hold **incompatible ideas of what an Azure SQL DB registration is**, and both are deliberate:

- the enumeration assumes one registration = one **logical server** — the shape #857 was written for;
- identity assumes one registration = one **database**: `server_id` hashes `host[:database][:RO]`, so registering two databases on one server is the *supported* way to get two identities, and the Azure query_store path needs a per-database connection anyway (#1836).

Nothing reconciled them, so the second shape silently behaved like the first.

## The rule

A registration that **names** a database is a registration **of** that database, and sweeps exactly that one. Only a registration naming none — or naming `master`, where a catalog-less Azure connection lands — is a registration of the **server**, and only that one enumerates.

This also **subsumes #857's motivating case and improves on it**: a login granted access to one user database but not to master *has* a named database, so it now returns without probing master at all, rather than probing, failing, forming a verdict and falling back.

## Extracted to shared code rather than fixed twice

Both runners carried their own private copy of this predicate. A sweep-scoping rule that disagrees between Lite and Darling is the same class of defect as the one being fixed, so it now lives in `AzureSweepScope` and **both suites pin it**.

## Deliberately not done here

The master-probe throttle (`_azureMasterInaccessibleSince` / `IsMasterProbeThrottled` / `OnServerReconnected`) is now **unreachable for any registration that names a database** — which is #857's whole population. Removing that machinery is a separate change from a correctness fix a reporter is waiting on; its guard is left stating the precondition this path now satisfies by construction. Happy to do the cleanup as a follow-up.

## Verification

Rule checked against compiled code (12/12 in a scratch harness, since `net10.0-windows` xunit will not run on this machine), including the over-match cases — `mastermind`, `paymaster`, `master_archive` are real databases and are still swept — and that each call returns its own list, since both runners hand it straight to their per-database loop. Full solution builds clean, 0 warnings.

**What this does not fix:** existing stored data. Any store that has been collecting Azure SQL DB siblings already holds rows under the wrong `server_id`, and this change stops the contamination rather than unwinding it. Worth deciding separately whether that needs a cleanup path or just a note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
