### PR TITLE
Seed inside the retention horizon these tests arm (#2223)

### DIFF
--- a/Darling/Darling.Tests/QueryStoreCorrectedRollupLiveTests.cs
+++ b/Darling/Darling.Tests/QueryStoreCorrectedRollupLiveTests.cs
@@ -51,6 +51,55 @@ public sealed class QueryStoreCorrectedRollupLiveTests
     /// closed form so the expectation is derived, not a magic number transcribed from a test run.</summary>
     private const long InflatedSum = ReCollections * (ReCollections + 1L) / 2L;
 
+    /// <summary>
+    /// L1's retention horizon in days, read from the product constant rather than transcribed (#2223).
+    /// </summary>
+    private static readonly int L1RetentionDays =
+        int.Parse(TimescaleSupport.IntervalRetentionInterval.Split(' ')[0], CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// How deep every retention-arming test in this class seeds its history — DERIVED from L1's horizon, with
+    /// two days of margin, so nothing a test seeds is ever eligible for deletion by a policy that test itself
+    /// arms.
+    ///
+    /// <para><b>#2223, and it was a class-wide contradiction rather than one test's bug.</b> All four tests here
+    /// that call <c>EnsureRetentionPoliciesAsync</c> used to seed a hardcoded 9 days while step 1 of each arms
+    /// L1's retention at <c>drop_after =&gt; INTERVAL '7 days'</c>. Each therefore armed a policy guaranteed to
+    /// want to delete two days of its own fixture, and then asserted against floors those buckets defined.</para>
+    ///
+    /// <para><b>How it failed.</b> In the re-hold test, <c>l1Floor</c> is read once and the backfill it is
+    /// compared against runs ~20 lines later. If the armed retention job fires inside that window it drops L1's
+    /// two oldest buckets, so the rebuilt consumer can only backfill to <c>now - 7 days</c> while the assertion
+    /// still holds the pre-deletion floor. The reported failure was consumer <c>08-05</c> against L1
+    /// <c>08-03</c> on a fixture seeded from <c>08-03</c> — the consumer floor was EXACTLY
+    /// <c>now - IntervalRetentionInterval</c>, which is what identified the mechanism. Intermittent because it
+    /// depends on the job firing in that window: solo runs passed every time, full-suite runs failed about half,
+    /// and more wall clock means more chances.</para>
+    ///
+    /// <para>Derived rather than re-hardcoded to a smaller number so that changing the product horizon moves
+    /// every fixture with it, instead of silently reintroducing this the next time it is tuned. The relationship
+    /// is pinned by <see cref="SeededHistoryStaysInsideTheHorizonItArms"/>.</para>
+    /// </summary>
+    private static readonly int SeedDepthDays = L1RetentionDays - 2;
+
+    /// <summary>
+    /// The #2223 invariant itself: a test may not seed history that a policy it arms would delete. Pinned as a
+    /// test rather than trusted as arithmetic, because the product horizon is tunable and the whole failure mode
+    /// was a fixture silently drifting outside it.
+    /// </summary>
+    [Fact]
+    public void SeededHistoryStaysInsideTheHorizonItArms()
+    {
+        Assert.True(SeedDepthDays < L1RetentionDays,
+            $"seeded history ({SeedDepthDays}d) must stay inside L1's retention horizon " +
+            $"({TimescaleSupport.IntervalRetentionInterval}) or the retention job these tests arm can delete " +
+            $"the buckets they assert on — that is #2223.");
+
+        /* And deep enough to still be the scenario: the coverage gap has to span more than one daily bucket. */
+        Assert.True(SeedDepthDays >= 3,
+            $"seeded history ({SeedDepthDays}d) must span at least three days for a multi-bucket coverage gap.");
+    }
+
     [Fact]
     public async Task CorrectedRollups_DedupTheReCollectedInterval_WhileTheOldPairKeepsInflating()
     {
@@ -174,7 +223,7 @@ public sealed class QueryStoreCorrectedRollupLiveTests
         await TimescaleSupport.ConvertToHypertablesAsync(connection, null, ct);
 
         var now = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Unspecified);
-        var oldest = now.Date.AddDays(-9);
+        var oldest = now.Date.AddDays(-SeedDepthDays);
 
         /* Pre-existing raw history, one interval per hour, going back well past any refresh policy's 3-day
            window — the shape every real store upgrading into this build is in. */
@@ -391,7 +440,7 @@ public sealed class QueryStoreCorrectedRollupLiveTests
         await TimescaleSupport.ConvertToHypertablesAsync(connection, null, ct);
 
         var now = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Unspecified);
-        var oldest = now.Date.AddDays(-9);
+        var oldest = now.Date.AddDays(-SeedDepthDays);
 
         for (var offset = 0; oldest.AddHours(offset) < now; offset += 3)
         {
@@ -495,7 +544,7 @@ public sealed class QueryStoreCorrectedRollupLiveTests
         await TimescaleSupport.ConvertToHypertablesAsync(connection, null, ct);
 
         var now = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Unspecified);
-        var oldest = now.Date.AddDays(-9);
+        var oldest = now.Date.AddDays(-SeedDepthDays);
         var span = (From: oldest.AddDays(-1), To: now.AddDays(1));
 
         for (var offset = 0; oldest.AddHours(offset) < now; offset += 3)
@@ -603,7 +652,7 @@ public sealed class QueryStoreCorrectedRollupLiveTests
         await TimescaleSupport.ConvertToHypertablesAsync(connection, null, ct);
 
         var now = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Unspecified);
-        var oldest = now.Date.AddDays(-9);
+        var oldest = now.Date.AddDays(-SeedDepthDays);
         var span = (From: oldest.AddDays(-1), To: now.AddDays(1));
 
         for (var offset = 0; oldest.AddHours(offset) < now; offset += 3)

--- a/Darling/Darling.Tests/QueryStoreCorrectedRollupLiveTests.cs
+++ b/Darling/Darling.Tests/QueryStoreCorrectedRollupLiveTests.cs
@@ -52,10 +52,18 @@ public sealed class QueryStoreCorrectedRollupLiveTests
     private const long InflatedSum = ReCollections * (ReCollections + 1L) / 2L;
 
     /// <summary>
-    /// L1's retention horizon in days, read from the product constant rather than transcribed (#2223).
+    /// L1's retention horizon in days (#2223), from the product's own TIMESPAN rather than re-parsing the
+    /// interval string.
+    ///
+    /// <para>Review catch: the first cut split <c>IntervalRetentionInterval</c> on whitespace and parsed the
+    /// leading number, reimplementing a conversion that already exists typed — and one that would quietly
+    /// produce a wrong seed depth if the interval were ever written <c>"1 week"</c>. It matters more here than
+    /// it looks: this feeds a static initializer, so a bad parse fails as a
+    /// <c>TypeInitializationException</c> across the whole class rather than as anything readable.
+    /// <c>TimescaleContinuousAggregateTests</c> pins the span equal to the string, so this cannot drift from
+    /// the SQL the policy is created with.</para>
     /// </summary>
-    private static readonly int L1RetentionDays =
-        int.Parse(TimescaleSupport.IntervalRetentionInterval.Split(' ')[0], CultureInfo.InvariantCulture);
+    private static readonly int L1RetentionDays = TimescaleSupport.IntervalRetentionSpan.Days;
 
     /// <summary>
     /// How deep every retention-arming test in this class seeds its history — DERIVED from L1's horizon, with


### PR DESCRIPTION
Fixes #2223.

## Root cause: retention, not the refresh policy

The earlier tracing on the issue correctly ruled out the suspected mechanism — refresh-policy contention doesn't produce the observed floor either way round. It's the **retention** policy, and not contention but actual deletion.

`TimescaleSupport.IntervalRetentionInterval = "7 days"`. All **four** tests in `QueryStoreCorrectedRollupLiveTests` that call `EnsureRetentionPoliciesAsync` seeded a hardcoded **nine** days of history. So each one armed a policy guaranteed to want to delete two days of its own fixture, then asserted against floors those deleted buckets defined.

In the re-hold test specifically: `l1Floor` is read once after step 2, and the step-4 backfill it is compared against runs ~20 lines later. If the armed retention job fires inside that window it drops L1's two oldest buckets, so the rebuilt consumer can only backfill to `now - 7d` while the assertion still holds the pre-deletion floor.

**The arithmetic is what identified it.** Reported failure: consumer `08-05`, L1 `08-03`, fixture seeded from `08-03` = `now.Date - 9d`, so `now.Date` = `08-12`. The consumer floor `08-05` is **exactly `now - 7 days`** — L1's retention horizon. Not the refresh policy's 3-day `start_offset`, which the earlier tracing looked at and was right to discard.

It also explains the observed frequency, which neither earlier theory did: it needs the job to fire inside that window. Solo runs passed every time (little elapsed time); full-suite runs failed about half (more wall clock, and four tests arming the same policy).

## Fix

The fixture depth is now **derived from the product constant** with two days of margin, so nothing a test seeds is ever eligible for deletion by a policy that test itself arms.

Derived rather than re-hardcoded to a smaller number, so that tuning the horizon moves every fixture with it instead of silently reintroducing this — the same pin-the-invariant lesson as today's schema-version pin conflicts, where dev had independently replaced brittle literals with invariant forms for exactly this reason. All four call sites updated, and the relationship is pinned by a new test rather than trusted as arithmetic.

**It was a class-wide contradiction, not one test's bug** — the other three retention-arming tests carried the same latent hazard and are fixed by the same change.

## What I can and cannot claim

Diagnosed entirely from source. I cannot run this suite — it needs live PostgreSQL + TimescaleDB, and both test projects are `net10.0-windows` — so CI is the only place a pass is observable, and **one green run cannot confirm a fix for an intermittent test anyway.**

What *is* verifiable, and is the actual claim: the contradiction is gone. The fixture is now provably inside the horizon it arms, by construction and by a pin. If the test still fails after this, the cause is something else and the arithmetic above is ruled out rather than merely re-rolled.

Left alone deliberately: the `RefreshWithRetryAsync` machinery and the step-2 shallow-or-empty guard. Both are correct for what they handle, and the earlier tracing already established that the refresh policy is not the culprit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
