### PR TITLE
Prune per-database state on Azure SQL DB (#2191)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,7 +230,34 @@ ORDER BY
 OPTION(RECOMPILE);
 ```
 
-The full T-SQL style guide is in [CLAUDE.md](CLAUDE.md).
+A few more rules that come up in review, and the reasoning behind the ones that are
+not obvious:
+
+- **Unicode literals**: prefix with `N` (`N'ONLINE'`, not `'ONLINE'`).
+- **`ON` continues its `JOIN` at two spaces**, so the join graph reads down the left edge.
+- **`AND` / `OR` align their predicates** (`AND   d.state_desc = N'ONLINE'`), so a `WHERE`
+  clause reads as a list rather than as prose.
+- **`GROUP BY` / `ORDER BY` put each term on its own indented line**, so adding one is a
+  one-line diff.
+- **Never suggest missing-index DMV recommendations.** `sys.dm_db_missing_index_*` output
+  is not used in this project and changes proposing it will not be accepted.
+- **No full-text search.**
+- **No ASCII-art headers or banner comments.** Block comments carry the reasoning; dividers
+  do not.
+
+Collector queries specifically:
+
+- **`OPTION(RECOMPILE)` on collector queries.** These run with parameters whose selectivity
+  varies enormously between a first-run catch-up window and a steady-state minute, and a plan
+  cached from one is wrong for the other. A statement added to an existing batch needs its own
+  hint — one on a neighbouring statement does not cover it.
+- **Schema-qualify everything in migrations** (`collect.*`, `config.*`). The migrate session's
+  `search_path` resolves bare names to a different schema, so an unqualified `CREATE` can land
+  an object in the wrong one silently.
+- **Comments explain WHY, at length.** This codebase's comments carry measurements, issue
+  numbers, and the failure the line prevents. A comment restating the code is noise; one
+  recording "this threshold was 300s and the fleet's median gap is 299s, so it discarded half
+  of every sweep" is what stops the next person undoing it.
 
 ### C# Style
 

--- a/Darling/Darling.Tests/AzureForeignStatePruneTests.cs
+++ b/Darling/Darling.Tests/AzureForeignStatePruneTests.cs
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Linq;
+using PerformanceMonitor.Collectors;
+using PerformanceMonitor.Darling.Service;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #2191: the Azure SQL DB arm of the #2188 per-database state prune.
+///
+/// <para><b>Why it was unreachable, and why it is not now.</b> The on-prem prune anti-joins
+/// <c>database_states</c>, which is an unfiltered <c>sys.databases</c> read — the only list that answers "does
+/// this name still exist" without confusing a dropped database for an offline, excluded or unprobeable one.
+/// <c>DatabaseStateCollector.AppliesTo</c> is <c>!IsAzureSqlDb</c>, so an Azure server has no such snapshot and
+/// the prune correctly no-opped there, leaving <c>planwm:</c> / <c>done:</c> / <c>hole:</c> rows to accumulate.
+/// #2191 asked for "an authoritative unfiltered sys.databases read from master, used only on the success
+/// path", and rejected the per-cycle enumeration because it filters ONLINE, applies the excluded-database
+/// list, and falls back to a single database on a master-access error.</para>
+///
+/// <para><b>#2220 removed the need for any of that.</b> A registration that names a database now sweeps only
+/// that database, so its one legitimate key is derivable from the connection string's own catalog — current by
+/// construction, nothing filtered, nothing that can go stale. The question changed from "which databases still
+/// exist on the instance" to "which database does this registration own", and the second needs no snapshot.</para>
+///
+/// <para><b>What it deletes in the field.</b> Mostly #2220's residue: before that fix every Azure registration
+/// swept each sibling database and wrote a watermark for it under its own <c>server_id</c>.
+/// <c>collector_state</c> carries no retention, so unlike the collected rows those orphans would persist
+/// indefinitely instead of ageing out — which is why this matters even though the contamination has stopped.</para>
+/// </summary>
+public sealed class AzureForeignStatePruneTests
+{
+    /// <summary>
+    /// The statement keeps the registration's OWN key and nothing else — asserted on the SQL because the
+    /// delete is the whole behaviour and it has no in-process seam.
+    /// </summary>
+    [Fact]
+    public void ThePruneKeepsExactlyTheRegistrationsOwnKey()
+    {
+        var sql = DarlingCollectorRunner.PruneForeignDatabaseStateKeysSql;
+
+        /* Scoped to one server, one state owner, and one key prefix, so it cannot reach another collector's
+           state or another server's. */
+        Assert.Contains("s.server_id = $1", sql, StringComparison.Ordinal);
+        Assert.Contains("s.collector_name = $2", sql, StringComparison.Ordinal);
+        Assert.Contains("starts_with(s.state_key, $3)", sql, StringComparison.Ordinal);
+
+        /* The rule itself: everything under the prefix EXCEPT this registration's own database. */
+        Assert.Contains("s.state_key <> $3 || $4", sql, StringComparison.Ordinal);
+
+        /* Names what it deleted. The only symptom of a wrong delete here is a silent plan-XML refetch, so a
+           rows-affected count would leave nothing to diagnose with. */
+        Assert.Contains("RETURNING s.state_key", sql, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// It must NOT carry the on-prem statement's snapshot machinery. Pinned as an absence because copying
+    /// those guards over would be the natural-looking mistake, and they cannot work here: there is no
+    /// snapshot to be empty or stale, so an anti-join against <c>database_states</c> — which is empty on
+    /// every Azure server by design — would delete every row instead of none.
+    /// </summary>
+    [Fact]
+    public void ThePruneDoesNotReachForASnapshotThatCannotExistOnAzure()
+    {
+        var sql = DarlingCollectorRunner.PruneForeignDatabaseStateKeysSql;
+
+        Assert.DoesNotContain("database_states", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("updated_at", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("NOT EXISTS", sql, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The on-prem statement keeps ITS guards. Same file, opposite requirement — pinned together so a future
+    /// edit cannot "simplify" the two into one shape, which would either delete every on-prem row when a
+    /// snapshot is missing or leave Azure orphaning again.
+    /// </summary>
+    [Fact]
+    public void TheOnPremPruneStillGuardsOnTheSnapshotAndItsFreshness()
+    {
+        var sql = DarlingCollectorRunner.PruneOrphanedDatabaseStateKeysSql;
+
+        Assert.Contains("database_states", sql, StringComparison.Ordinal);
+        Assert.Contains("snapshot.newest IS NOT NULL", sql, StringComparison.Ordinal);
+        Assert.Contains("s.updated_at < snapshot.newest", sql, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// THE SAFETY PROPERTY. A registration naming no database — or naming <c>master</c>, where a
+    /// catalog-less Azure connection lands — is a registration of the logical SERVER, whose legitimate
+    /// database set is everything on it. Pruning against a single name there would delete every live
+    /// watermark it has, so the caller's gate is <see cref="AzureSweepScope.OwnDatabaseOrEmpty"/> and this
+    /// pins that the gate closes for exactly those cases.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("master")]
+    [InlineData("MASTER")]
+    public void ALogicalServerRegistrationIsNeverPrunedAgainstASingleName(string? catalog)
+    {
+        Assert.Empty(AzureSweepScope.OwnDatabaseOrEmpty(catalog));
+    }
+
+    /// <summary>And it opens for a registration that does name one, which is the case #2191 is about.</summary>
+    [Theory]
+    [InlineData("db1")]
+    [InlineData("Payments")]
+    public void ADatabaseNamedRegistrationIsPruned(string catalog)
+    {
+        Assert.Single(AzureSweepScope.OwnDatabaseOrEmpty(catalog));
+    }
+
+    /// <summary>
+    /// Both arms iterate the SHARED prefix set, so a prefix cannot be pruned on one target type and left
+    /// orphaning on the other — the drift this list exists to prevent.
+    /// </summary>
+    [Fact]
+    public void BothArmsPruneEveryPerDatabasePrefix()
+    {
+        Assert.Equal(3, QueryStorePerDatabaseState.PrunableKeys.Count);
+        Assert.Contains(QueryStorePerDatabaseState.PrunableKeys,
+            k => k.Prefix == QueryStorePlanXmlState.WatermarkKeyPrefix);
+        Assert.Contains(QueryStorePerDatabaseState.PrunableKeys,
+            k => k.Prefix == QueryStoreBackfillState.DoneKeyPrefix);
+        Assert.Contains(QueryStorePerDatabaseState.PrunableKeys,
+            k => k.Prefix == QueryStoreBackfillState.HoleKeyPrefix);
+
+        /* Nothing may sit outside both lists — a server-scoped key added to PrunableKeys by reflex would be
+           deleted every cycle. */
+        Assert.Empty(QueryStorePerDatabaseState.NotKeyedByDatabase);
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
@@ -202,6 +202,21 @@ public sealed class DarlingCollectorRunner
         {
             await PruneOrphanedQueryStoreDatabaseStateAsync(server.ServerId, cancellationToken);
         }
+        else if (string.Equals(definition.Name, QueryStoreCollector.Instance.Name, StringComparison.Ordinal)
+                 && server.Target.IsAzureSqlDb)
+        {
+            /* #2191's boundary, now crossable. Azure SQL DB has no database_states snapshot by design, which
+               is why this was a stated no-op — but after #2220 a registration that names a database sweeps
+               only that database, so its one legitimate key is the connection string's own catalog. No
+               master read, nothing filtered, nothing that can go stale. A registration naming NO database is
+               still skipped: it is a registration of the logical SERVER, and a single-name prune there would
+               delete every live watermark it legitimately has. */
+            var ownDatabase = new SqlConnectionStringBuilder(server.ConnectionString).InitialCatalog;
+            if (AzureSweepScope.OwnDatabaseOrEmpty(ownDatabase).Count > 0)
+            {
+                await PruneForeignQueryStoreDatabaseStateAsync(server.ServerId, ownDatabase, cancellationToken);
+            }
+        }
 
         /* #2164: the per-database plan-XML watermarks, owned by the HOST under its own state collector name
            rather than declared by the definition — the QueryStoreBackfillState seam. The definition cannot
@@ -1389,6 +1404,37 @@ AND   NOT EXISTS
 RETURNING s.state_key";
 
     /// <summary>
+    /// The Azure SQL DB variant (#2191): prune every per-database state key that is not the ONE database this
+    /// registration names. <c>$1</c> server_id, <c>$2</c> collector_name, <c>$3</c> key prefix, <c>$4</c> the
+    /// registration's own database.
+    ///
+    /// <para><b>Why this needs no snapshot, and no freshness guard.</b> The on-prem statement anti-joins
+    /// <c>database_states</c> because the question there is "does this name still exist on the instance", and
+    /// it needs the two guards because a SNAPSHOT can be empty or stale. Here there is no snapshot: after
+    /// #2220 a registration that names a database sweeps only that database, so its one legitimate key is
+    /// derivable from the connection string's own catalog — which is current by construction and cannot go
+    /// stale, be empty, or be filtered. That is why #2191 looked unfixable when it was filed and is not now:
+    /// it asked for "an authoritative unfiltered sys.databases read from master, used only on the success
+    /// path", and #2220 removed the need for any master read on this path at all.</para>
+    ///
+    /// <para><b>What it actually deletes, today.</b> Mostly #2220's residue. Before that fix each Azure
+    /// registration swept every sibling database on the logical server and wrote a watermark for each, all
+    /// under its own server_id — so these keys are the state half of that contamination. <c>collector_state</c>
+    /// carries no retention (it is state, not facts), so unlike the collected rows those orphans would
+    /// otherwise persist forever rather than ageing out.</para>
+    ///
+    /// <para>Bounded consequence, exactly as on the on-prem path: deleting a watermark that should have
+    /// stayed costs one full plan-XML refetch for that database and nothing else.</para>
+    /// </summary>
+    internal const string PruneForeignDatabaseStateKeysSql = @"
+DELETE FROM collector_state s
+WHERE s.server_id = $1
+AND   s.collector_name = $2
+AND   starts_with(s.state_key, $3)
+AND   s.state_key <> $3 || $4
+RETURNING s.state_key";
+
+    /// <summary>
     /// Runs <see cref="PruneOrphanedDatabaseStateKeysSql"/> for every owner/prefix in the SHARED
     /// <see cref="QueryStorePerDatabaseState.PrunableKeys"/> — the same set Lite's DuckDB twin
     /// (<c>RemoteCollectorService.PruneOrphanedQueryStoreDatabaseStateAsync</c>) iterates, so a prefix
@@ -1433,6 +1479,64 @@ RETURNING s.state_key";
         catch (Exception ex)
         {
             _logger?.LogDebug(ex, "Pruning orphaned query_store database state failed; next cycle retries");
+        }
+    }
+
+    /// <summary>
+    /// The Azure SQL DB arm of the #2188 prune (#2191): retire every per-database state key that does not
+    /// belong to the one database this registration names.
+    ///
+    /// <para>Runs the same shared <see cref="QueryStorePerDatabaseState.PrunableKeys"/> set as the on-prem
+    /// path, so a prefix cannot be pruned on one target type and left orphaning on the other.</para>
+    /// </summary>
+    /// <param name="ownDatabase">
+    /// The registration's own database — the connection string's initial catalog. Callers must only reach
+    /// here when that is non-empty: a registration naming no database (or naming <c>master</c>) is a
+    /// registration of the logical SERVER, whose legitimate database set is everything on it, and pruning
+    /// against a single name there would delete every live watermark it has.
+    /// </param>
+    internal async Task PruneForeignQueryStoreDatabaseStateAsync(
+        int serverId, string ownDatabase, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(ownDatabase))
+        {
+            return;
+        }
+
+        try
+        {
+            await using var connection = await _postgres.OpenConnectionAsync(cancellationToken);
+            var pruned = new List<string>();
+
+            foreach (var (owner, prefix) in QueryStorePerDatabaseState.PrunableKeys)
+            {
+                using var command = new NpgsqlCommand(PruneForeignDatabaseStateKeysSql, connection);
+                command.Parameters.AddWithValue(serverId);
+                command.Parameters.AddWithValue(owner);
+                command.Parameters.AddWithValue(prefix);
+                command.Parameters.AddWithValue(ownDatabase);
+
+                using var reader = await command.ExecuteReaderAsync(cancellationToken);
+                while (await reader.ReadAsync(cancellationToken))
+                {
+                    pruned.Add(reader.GetString(0));
+                }
+            }
+
+            if (pruned.Count > 0)
+            {
+                /* Names the keys rather than counting them, like the on-prem twin: the only symptom of a
+                   wrong delete here is a silent refetch, so a bare number would leave nothing to diagnose
+                   with. On an Azure server upgraded past #2220 this fires ONCE and clears that fix's state
+                   residue, which is worth saying plainly rather than looking like a recurring anomaly. */
+                _logger?.LogInformation(
+                    "[server_id {ServerId}] pruned {Count} query_store state row(s) belonging to databases other than this registration's [{Database}]: {Keys}",
+                    serverId, pruned.Count, ownDatabase, string.Join(", ", pruned));
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Pruning foreign query_store database state failed; next cycle retries");
         }
     }
 

--- a/Lite.Tests/QueryStoreStatePruneTests.cs
+++ b/Lite.Tests/QueryStoreStatePruneTests.cs
@@ -71,6 +71,11 @@ public sealed class QueryStoreStatePruneTests : IClassFixture<SharedDuckDbFixtur
     {
         public Task PruneAsync(int serverId) =>
             PruneOrphanedQueryStoreDatabaseStateAsync(serverId, CancellationToken.None);
+
+        /// <summary>The #2191 Azure arm, which prunes against the registration's own database rather than
+        /// against a database_states snapshot.</summary>
+        public Task PruneForeignAsync(int serverId, string ownDatabase) =>
+            PruneForeignQueryStoreDatabaseStateAsync(serverId, ownDatabase, CancellationToken.None);
     }
 
     /// <summary>
@@ -339,5 +344,96 @@ VALUES ($1, $2, $3, $4, $5)";
         /* Same fields as DarlingCollectorRunner's line, so one sentence serves both SKUs. */
         Assert.Contains($"[server_id {ServerId}]", line, StringComparison.Ordinal);
         Assert.Contains("2 query_store state row(s)", line, StringComparison.Ordinal);
+    }
+    /* ─────────────── #2191: the Azure arm, pruned against the registration's own database ─────────────── */
+
+    /// <summary>
+    /// The Azure prune keeps the registration's own database and retires every sibling — executed against
+    /// real DuckDB, so this covers the statement itself (<c>starts_with</c> plus
+    /// <c>state_key &lt;&gt; prefix || own</c>) rather than its text.
+    ///
+    /// <para>These keys are what #2220 left behind: before that fix each Azure registration swept every
+    /// sibling database on the logical server and wrote a watermark for it under its OWN server_id. And
+    /// <c>collector_state</c> carries no retention, so they would persist indefinitely rather than ageing out
+    /// with the collected rows.</para>
+    /// </summary>
+    [Fact]
+    public async Task ForeignPrune_KeepsThisRegistrationsDatabase_AndRetiresItsSiblings()
+    {
+        /* Deliberately NO database_states snapshot: an Azure server never has one, and the point of this arm
+           is that it does not need one. */
+        await SeedStateAsync(ServerId, QueryStoreBackfillState.StateCollectorName, Done("Payments"), "2026-08-11T09:00:00Z");
+        await SeedStateAsync(ServerId, QueryStoreBackfillState.StateCollectorName, Hole("Payments"), EncodedHole());
+        await SeedStateAsync(ServerId, QueryStoreBackfillState.StateCollectorName, Done("Sibling-A"), "2026-08-11T09:00:00Z");
+        await SeedStateAsync(ServerId, QueryStoreBackfillState.StateCollectorName, Hole("Sibling-B"), EncodedHole());
+
+        /* The prefix trap, same one the on-prem test carries: an inequality written as a prefix comparison
+           would spare "PaymentsArchive" because "Payments" is a prefix of it. */
+        await SeedStateAsync(ServerId, QueryStoreBackfillState.StateCollectorName, Done("PaymentsArchive"), "2026-08-11T09:00:00Z");
+
+        /* Not database-keyed, and another collector, and another server — all three must survive. */
+        await SeedStateAsync(ServerId, QueryStoreBackfillState.StateCollectorName, "unrelated-bookkeeping", "keep me");
+        await SeedStateAsync(ServerId, DefaultTraceEventsCollector.Instance.Name,
+            DefaultTraceEventsCollector.LastTraceFilePathStateKey, @"S:\MSSQL\Log\log_766.trc");
+        await SeedStateAsync(NeighborServerId, QueryStoreBackfillState.StateCollectorName, Done("Sibling-A"), "2026-08-11T09:00:00Z");
+
+        await _pruner.PruneForeignAsync(ServerId, "Payments");
+
+        Assert.Null(await ValueAsync(ServerId, QueryStoreBackfillState.StateCollectorName, Done("Sibling-A")));
+        Assert.Null(await ValueAsync(ServerId, QueryStoreBackfillState.StateCollectorName, Hole("Sibling-B")));
+        Assert.Null(await ValueAsync(ServerId, QueryStoreBackfillState.StateCollectorName, Done("PaymentsArchive")));
+
+        Assert.Equal("2026-08-11T09:00:00Z", await ValueAsync(ServerId, QueryStoreBackfillState.StateCollectorName, Done("Payments")));
+        Assert.Equal(EncodedHole(), await ValueAsync(ServerId, QueryStoreBackfillState.StateCollectorName, Hole("Payments")));
+        Assert.Equal("keep me", await ValueAsync(ServerId, QueryStoreBackfillState.StateCollectorName, "unrelated-bookkeeping"));
+        Assert.Equal(@"S:\MSSQL\Log\log_766.trc", await ValueAsync(ServerId, DefaultTraceEventsCollector.Instance.Name,
+            DefaultTraceEventsCollector.LastTraceFilePathStateKey));
+        Assert.Equal("2026-08-11T09:00:00Z", await ValueAsync(NeighborServerId, QueryStoreBackfillState.StateCollectorName, Done("Sibling-A")));
+
+        /* Idempotent: it runs every query_store cycle, so a second pass must touch nothing. */
+        await _pruner.PruneForeignAsync(ServerId, "Payments");
+        Assert.Equal(4L, await CountAsync(ServerId));
+    }
+
+    /// <summary>
+    /// An empty own-database short-circuits BEFORE the statement runs, deleting nothing.
+    ///
+    /// <para>This is the arm's safety property rather than an edge case. A registration naming no database is
+    /// a registration of the logical SERVER, whose legitimate database set is everything on it — so running
+    /// the single-name prune there would delete every live watermark it has. The caller gates on
+    /// <c>AzureSweepScope</c>, and the method guards again itself, because the consequence of getting it
+    /// wrong is silent and total.</para>
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    public async Task ForeignPrune_WithNoOwnDatabase_RetiresNothing(string ownDatabase)
+    {
+        await SeedStateAsync(ServerId, QueryStoreBackfillState.StateCollectorName, Done("Payments"), "2026-08-11T09:00:00Z");
+        await SeedStateAsync(ServerId, QueryStoreBackfillState.StateCollectorName, Done("Sibling-A"), "2026-08-11T09:00:00Z");
+
+        await _pruner.PruneForeignAsync(ServerId, ownDatabase);
+
+        Assert.Equal(2L, await CountAsync(ServerId));
+    }
+
+    /// <summary>
+    /// Every per-database prefix is pruned, not just the backfill ones — the watermark prefix included, even
+    /// though Lite writes none today (it never sets <c>CapturePlanXml</c>). Pinned for the same reason the
+    /// on-prem twin pins it: the shared prefix list is what stops a prefix being pruned on one SKU and
+    /// orphaning on the other, and a Lite-only omission would be invisible on Darling.
+    /// </summary>
+    [Fact]
+    public async Task ForeignPrune_CoversTheWatermarkPrefixToo()
+    {
+        var foreignWatermark = QueryStorePlanXmlState.KeyFor("Sibling-A");
+        var ownWatermark = QueryStorePlanXmlState.KeyFor("Payments");
+
+        await SeedStateAsync(ServerId, QueryStorePlanXmlState.StateCollectorName, foreignWatermark, "8140");
+        await SeedStateAsync(ServerId, QueryStorePlanXmlState.StateCollectorName, ownWatermark, "8150");
+
+        await _pruner.PruneForeignAsync(ServerId, "Payments");
+
+        Assert.Null(await ValueAsync(ServerId, QueryStorePlanXmlState.StateCollectorName, foreignWatermark));
+        Assert.Equal("8150", await ValueAsync(ServerId, QueryStorePlanXmlState.StateCollectorName, ownWatermark));
     }
 }

--- a/Lite/Services/RemoteCollectorService.DefinitionRunner.cs
+++ b/Lite/Services/RemoteCollectorService.DefinitionRunner.cs
@@ -104,6 +104,21 @@ public partial class RemoteCollectorService
         {
             await PruneOrphanedQueryStoreDatabaseStateAsync(serverId, cancellationToken);
         }
+        else if (string.Equals(definition.Name, QueryStoreCollector.Instance.Name, StringComparison.Ordinal)
+                 && target.IsAzureSqlDb)
+        {
+            /* #2191's boundary, now crossable. Azure SQL DB has no database_states snapshot by design, which
+               is why the arm above states it as a no-op — but after #2220 a registration that names a database
+               sweeps only that database, so its one legitimate key is the connection string's own catalog. A
+               registration naming NO database is still skipped: it is a registration of the logical SERVER,
+               and a single-name prune there would delete every live watermark it has. */
+            var ownDatabase = new SqlConnectionStringBuilder(
+                _serverManager.CredentialResolver.GetConnectionString(server)).InitialCatalog;
+            if (AzureSweepScope.OwnDatabaseOrEmpty(ownDatabase).Count > 0)
+            {
+                await PruneForeignQueryStoreDatabaseStateAsync(serverId, ownDatabase, cancellationToken);
+            }
+        }
 
         var context = new CollectorContext
         {

--- a/Lite/Services/RemoteCollectorService.QueryStoreBackfill.cs
+++ b/Lite/Services/RemoteCollectorService.QueryStoreBackfill.cs
@@ -557,6 +557,25 @@ AND   NOT EXISTS
 RETURNING state_key";
 
     /// <summary>
+    /// The Azure SQL DB variant (#2191) — the DuckDB twin of
+    /// <c>DarlingCollectorRunner.PruneForeignDatabaseStateKeysSql</c>. Prunes every per-database state key
+    /// that is not the ONE database this registration names.
+    ///
+    /// <para>No snapshot and no freshness guard, and that is the difference rather than an omission: the
+    /// on-prem statement guards because a SNAPSHOT can be empty or stale, while the single legitimate name
+    /// here comes from the connection string's own catalog, which is current by construction. #2191 asked for
+    /// "an authoritative unfiltered sys.databases read from master, used only on the success path"; #2220
+    /// removed the need for any master read on this path, which is what makes it reachable now.</para>
+    /// </summary>
+    private const string PruneForeignDatabaseStateKeysSql = @"
+DELETE FROM collector_state
+WHERE server_id = $1
+AND   collector_name = $2
+AND   starts_with(state_key, $3)
+AND   state_key <> $3 || $4
+RETURNING state_key";
+
+    /// <summary>
     /// Runs <see cref="PruneOrphanedDatabaseStateKeysSql"/> for every shared owner/prefix pair, once per
     /// query_store cycle for one server — the same trigger and the same placement as Darling's, so the two
     /// cannot drift on WHEN they prune either.
@@ -601,6 +620,64 @@ RETURNING state_key";
         catch (Exception ex)
         {
             _logger?.LogDebug(ex, "Pruning orphaned query_store database state failed; next cycle retries");
+        }
+    }
+
+    /// <summary>
+    /// The Azure SQL DB arm of the #2188 prune (#2191) — Darling's twin is
+    /// <c>PruneForeignQueryStoreDatabaseStateAsync</c>, same trigger, same placement, same shared
+    /// <see cref="QueryStorePerDatabaseState.PrunableKeys"/> set, so the two cannot drift on which prefixes
+    /// get pruned or when.
+    ///
+    /// <para>What it deletes today is mostly #2220's residue: before that fix each Azure registration swept
+    /// every sibling database on the logical server and wrote a watermark for each under its own server_id.
+    /// <c>collector_state</c> carries no retention, so unlike the collected rows those orphans would persist
+    /// indefinitely rather than ageing out.</para>
+    /// </summary>
+    /// <param name="ownDatabase">The registration's own database. Callers must only reach here when it is
+    /// non-empty — a registration naming none is a registration of the logical SERVER, and a single-name
+    /// prune there would delete every live watermark it legitimately has.</param>
+    protected async Task PruneForeignQueryStoreDatabaseStateAsync(
+        int serverId, string ownDatabase, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(ownDatabase))
+        {
+            return;
+        }
+
+        try
+        {
+            using var conn = _duckDb.CreateConnection();
+            await conn.OpenAsync(cancellationToken);
+            var pruned = new List<string>();
+
+            foreach (var (owner, prefix) in QueryStorePerDatabaseState.PrunableKeys)
+            {
+                using var cmd = conn.CreateCommand();
+                cmd.CommandText = PruneForeignDatabaseStateKeysSql;
+                cmd.Parameters.Add(new DuckDB.NET.Data.DuckDBParameter { Value = serverId });
+                cmd.Parameters.Add(new DuckDB.NET.Data.DuckDBParameter { Value = owner });
+                cmd.Parameters.Add(new DuckDB.NET.Data.DuckDBParameter { Value = prefix });
+                cmd.Parameters.Add(new DuckDB.NET.Data.DuckDBParameter { Value = ownDatabase });
+
+                using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+                while (await reader.ReadAsync(cancellationToken))
+                {
+                    pruned.Add(reader.GetString(0));
+                }
+            }
+
+            if (pruned.Count > 0)
+            {
+                /* Same sentence as Darling's twin, so an operator reading either SKU's log sees one wording. */
+                _logger?.LogInformation(
+                    "[server_id {ServerId}] pruned {Count} query_store state row(s) belonging to databases other than this registration's [{Database}]: {Keys}",
+                    serverId, pruned.Count, ownDatabase, string.Join(", ", pruned));
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogDebug(ex, "Pruning foreign query_store database state failed; next cycle retries");
         }
     }
 


### PR DESCRIPTION
Fixes #2191.

## The issue was right that it was blocked, and #2220 unblocked it

#2191 asked for *"an authoritative unfiltered `sys.databases` name list read from the logical master, used only when the master read actually succeeded"* — and correctly rejected the per-cycle Azure enumeration, which filters `ONLINE`, applies the excluded-database list, and falls back to a single database on a master-access error.

**#2220 removed the need for all of that.** A registration that names a database now sweeps only that database, so its one legitimate per-database key comes from the connection string's own catalog: current by construction, nothing filtered, nothing that can go stale, no master read. The question changed from *"which databases still exist on the instance"* to *"which database does this registration own"*, and the second needs no snapshot.

## The shape, and what it deliberately does not have

```sql
DELETE FROM collector_state s
WHERE s.server_id = $1
AND   s.collector_name = $2
AND   starts_with(s.state_key, $3)
AND   s.state_key <> $3 || $4
RETURNING s.state_key
```

**No snapshot guard and no freshness guard, and that is the difference rather than an omission.** The on-prem statement has both because a *snapshot* can be empty or stale. Copying them here would be actively harmful: `database_states` is empty on every Azure server by design, so an anti-join against nothing deletes **every** row instead of none. Pinned as an absence for exactly that reason — with a companion pin that the on-prem statement **keeps** its guards, so a later edit cannot merge the two shapes into one.

A registration naming **no** database, or naming `master`, is still skipped. That is a registration of the logical **server**, whose legitimate database set is everything on it; a single-name prune there would delete every live watermark it has. The gate is the same `AzureSweepScope` predicate #2220 introduced.

## Why this was worth doing tonight rather than later

What it deletes in the field is mostly **#2220's residue** — before that fix every Azure registration swept each sibling database and wrote a watermark for it under its own `server_id`.

And this is the part that would not have resolved itself: **`collector_state` carries no retention.** Verified — zero references in `DarlingRetention`. It is state, not facts. So where the #2220 reporter's team reasonably chose to let the contaminated *collected rows* age out, these orphans would have persisted indefinitely. On an upgraded Azure server this fires once, names what it removed, and clears them.

## Parity

Both SKUs, since Lite supports Azure SQL DB too, iterating the same shared `QueryStorePerDatabaseState.PrunableKeys` set — so a prefix cannot be pruned on one target type and left orphaning on the other. Same log sentence in both, so an operator reading either SKU sees one wording.

Full solution builds clean, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)