### PR TITLE
Guard the guard's own plumbing: mktemp/cat failures degrade instead of killing the step (#2309 follow-up)

### DIFF
--- a/.github/workflows/claude-review-guard.yml
+++ b/.github/workflows/claude-review-guard.yml
@@ -95,16 +95,20 @@ jobs:
             # sites compare ("$step" != "success") or feed to arithmetic -- that would be this
             # exact defect class reintroduced through the fix (review catch on #2309's own PR).
             local errfile err
-            errfile=$(mktemp)
+            # The plumbing itself must not be able to kill the step either (review catch on the
+            # #2309 fix): a failed mktemp degrades to /dev/null (stderr is then lost but the
+            # verdict path survives), and the cat/rm are failure-tolerant for the same reason.
+            errfile=$(mktemp 2>/dev/null || echo /dev/null)
             if ! LOOKUP_OUT=$(gh api "$@" 2>"$errfile"); then
-              err=$(cat "$errfile" 2>/dev/null); rm -f "$errfile"
+              err=$(cat "$errfile" 2>/dev/null || true)
+              [ "$errfile" != /dev/null ] && rm -f "$errfile" || true
               echo "::warning title=Guard lookup failed::gh api (${what}) failed: ${err:-$LOOKUP_OUT}."\
                 "A lookup failure must not become a review verdict (#2309), so the review is"\
                 "UNCONFIRMED -- read the PR's comments to confirm it by eye, or re-run this guard."
               summary "- Guard lookup failed at ${what}; review UNCONFIRMED (#2309)."
               exit 0
             fi
-            rm -f "$errfile"
+            [ "$errfile" != /dev/null ] && rm -f "$errfile" || true
           }
 
           # Wait for the review run on this exact commit. Nothing appearing inside the grace window


### PR DESCRIPTION
Follow-up to #2311, addressing the review's residual finding that landed minutes before the merge: `errfile=$(mktemp)` and `err=$(cat ...)` were themselves plain assignments under `set -e`, so the helper's own plumbing could still kill the step with none of the warning/summary/exit-0 handling it exists to provide.

Now: a failed `mktemp` degrades to `/dev/null` (stderr detail is lost, the verdict path survives — commented in place), the `cat` is `|| true`-tolerant, and the `rm` never fires at `/dev/null`. Verified with a four-case stub matrix: gh-fails, noisy-success, mktemp-fails-with-clean-gh, and both-fail — every path either reaches the verdict or exits 0 with the warning; none can die raw. YAML parses and the extracted script passes `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)