### PR TITLE
Harden for the registered service account, not the caller

### DIFF
--- a/Darling/Darling.Tests/DarlingHardenFilesVerbTests.cs
+++ b/Darling/Darling.Tests/DarlingHardenFilesVerbTests.cs
@@ -114,6 +114,105 @@ public class DarlingHardenFilesVerbTests
         Assert.Contains("AllowInteractive: true", body, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// #2371: the verb hardens for the account the SERVICE is registered under, never for whoever is running it.
+    ///
+    /// <para><b>The bug this pins.</b> Every original caller of <c>DarlingFileSecurity</c> runs INSIDE the
+    /// service, so "the current identity" and "the account the service runs as" were the same value and the
+    /// distinction did not exist. This verb inverts that by construction: it exists because a virtual service
+    /// account cannot re-ACL a file it does not own, so it is ALWAYS run by somebody else. Resolving from the
+    /// caller therefore granted the operator and stripped the service — measured on a live box, where an
+    /// elevated run removed <c>NT SERVICE\PerformanceMonitor Darling</c> from all four targets and printed
+    /// <c>All 4 item(s) secured</c> while doing it. The install kept working until its next restart, which is
+    /// far enough away that nobody would connect the two.</para>
+    /// </summary>
+    [Fact]
+    public void TheVerb_HardensForTheRegisteredServiceAccount_NotTheCaller()
+    {
+        var source = ReadRepoFile(Path.Combine(
+            "Darling", "PerformanceMonitor.Darling.Service", "DarlingCliCommands.cs"));
+
+        var at = source.IndexOf("public static int HardenFiles(", StringComparison.Ordinal);
+        Assert.True(at >= 0, "HardenFiles is gone (#2352)");
+
+        var body = source[at..Math.Min(source.Length, at + 8000)];
+
+        /* It asks the SCM, and hardens for what it gets back. */
+        Assert.Contains("RegisteredServiceAccount(ServiceName)", body, StringComparison.Ordinal);
+        Assert.Contains("HardenForAccount(", body, StringComparison.Ordinal);
+
+        /* The resolution happens BEFORE the first target is hardened, or the early targets get the caller's
+           ACL and the later ones the service's -- a split-brain worse than either alone. */
+        Assert.True(
+            body.IndexOf("HardenForAccount(", StringComparison.Ordinal)
+                < body.IndexOf("DarlingFileSecurity.HardenFile(", StringComparison.Ordinal),
+            "the service account must be resolved before anything is hardened (#2371)");
+    }
+
+    /// <summary>
+    /// #2371: private is only half of correct, so the verify pass checks BOTH directions.
+    ///
+    /// <para><c>IsReadableByOrdinaryUsers</c> asks whether anyone TOO MANY can read. It cannot see the opposite
+    /// failure — an ACL that excludes ordinary users AND the service is maximally private and completely broken,
+    /// and it passed the old check, which is why the live run reported success on four locked-out targets.</para>
+    /// </summary>
+    [Fact]
+    public void TheVerb_AlsoVerifiesTheServiceCanStillReadEachTarget()
+    {
+        var source = ReadRepoFile(Path.Combine(
+            "Darling", "PerformanceMonitor.Darling.Service", "DarlingCliCommands.cs"));
+
+        var at = source.IndexOf("public static int HardenFiles(", StringComparison.Ordinal);
+        var body = source[at..Math.Min(source.Length, at + 8000)];
+
+        Assert.Contains("GrantsHardenedAccount(", body, StringComparison.Ordinal);
+        Assert.Contains("LOCKED OUT", body, StringComparison.Ordinal);
+
+        /* A lockout counts as exposure, so the verb exits non-zero and a provisioning script stops. Both
+           branches feed the same counter the STILL READABLE path does. */
+        var lockedAt = body.IndexOf("LOCKED OUT", StringComparison.Ordinal);
+        Assert.Contains("exposed++", body[lockedAt..Math.Min(body.Length, lockedAt + 700)], StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The resolver reads the SCM's own <c>ObjectName</c>, which is the account the service is logged on with —
+    /// and returns null rather than throwing when the service is not registered, so a console run or a
+    /// pre-install harden falls back to the caller instead of failing.
+    /// </summary>
+    [Fact]
+    public void TheResolver_ReturnsNull_WhenTheServiceIsNotRegistered()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        Assert.Null(DarlingFileSecurity.RegisteredServiceAccount(
+            "PerformanceMonitor Darling NoSuchService " + Guid.NewGuid().ToString("N")));
+    }
+
+    /// <summary>
+    /// <c>LocalSystem</c> is the one <c>ObjectName</c> with no <see cref="System.Security.Principal.NTAccount"/>
+    /// spelling to translate — the SCM stores it unqualified — so it is mapped to its well-known SID by hand.
+    /// An install re-homed to LocalSystem would otherwise fall back to the caller and reintroduce the bug on
+    /// exactly the configuration that looks most ordinary.
+    /// </summary>
+    [Fact]
+    public void TheResolver_HandlesTheUnqualifiedLocalSystemAlias()
+    {
+        var source = ReadRepoFile(Path.Combine(
+            "Darling", "PerformanceMonitor.Darling.Service", "DarlingFileSecurity.cs"));
+
+        var at = source.IndexOf("RegisteredServiceAccount(", StringComparison.Ordinal);
+        Assert.True(at >= 0, "the SCM resolver is gone (#2371)");
+
+        var body = source[at..Math.Min(source.Length, at + 1800)];
+
+        Assert.Contains("ObjectName", body, StringComparison.Ordinal);
+        Assert.Contains("LocalSystem", body, StringComparison.Ordinal);
+        Assert.Contains("WellKnownSidType.LocalSystemSid", body, StringComparison.Ordinal);
+    }
+
     private static string ReadRepoFile(string relative, [CallerFilePath] string thisFile = "")
     {
         for (var dir = new DirectoryInfo(Path.GetDirectoryName(thisFile)!); dir is not null; dir = dir.Parent)

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingCliCommands.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingCliCommands.cs
@@ -2829,7 +2829,26 @@ public static class DarlingCliCommands
             targets.Add(new(Path.Combine(storeRoot, "pg-admin-credential.dpapi"), false, false, "the admin credential"));
         }
 
+        /* #2371: harden for the account the SERVICE runs as, not for whoever is running THIS. The verb is
+           documented to be run elevated and exists because the service cannot re-ACL a file it does not own,
+           so the caller is never the service — and resolving from the caller granted the operator and stripped
+           the service, leaving an install that worked until its next restart. Falls back to the caller when
+           the service is not registered (a console run, or hardening a tree before install), which is the only
+           case where those two are legitimately the same account. */
+        var registered = DarlingFileSecurity.RegisteredServiceAccount(ServiceName);
+        if (registered is not null)
+        {
+            DarlingFileSecurity.HardenForAccount(registered);
+        }
+
         output.WriteLine($"Hardening for service account: {DarlingFileSecurity.ServiceAccountDisplayName}");
+        if (registered is null)
+        {
+            output.WriteLine(
+                $"  (the '{ServiceName}' service is not registered on this machine, so this is the account " +
+                "you are running as - install the service first if you expected its own account here)");
+        }
+
         output.WriteLine();
 
         var exposed = 0;
@@ -2871,6 +2890,17 @@ public static class DarlingCliCommands
             {
                 error.WriteLine($"  STILL READABLE  {target.Path} ({target.What})");
                 error.WriteLine($"           {DarlingFileSecurity.DescribeOwnerAndExposure(target.Path)}");
+                exposed++;
+            }
+            else if (!DarlingFileSecurity.GrantsHardenedAccount(target.Path))
+            {
+                /* #2371: private is only half of correct. An ACL that excludes ordinary users but also excludes
+                   the service is a locked-out install, and it reports as SECURED under the readability check
+                   alone — then fails on the next start, far enough away that nobody connects the two. */
+                error.WriteLine($"  LOCKED OUT  {target.Path} ({target.What})");
+                error.WriteLine(
+                    $"           secured, but {DarlingFileSecurity.ServiceAccountDisplayName} cannot read it - " +
+                    "the service would fail on its next start. Grant that account and re-run.");
                 exposed++;
             }
             else

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingFileSecurity.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingFileSecurity.cs
@@ -60,9 +60,97 @@ public static class DarlingFileSecurity
         new(WellKnownSidType.WorldSid, null),
     ];
 
-    /// <summary>The account this process runs as — the service account when hosted as a service.</summary>
+    /* #2371: set by --harden-files to the account the SERVICE is registered under, because that verb is the
+       one caller that is deliberately NOT the service. Null everywhere else, so the in-service callers keep
+       resolving themselves exactly as before. */
+    private static SecurityIdentifier? _serviceAccountOverride;
+
+    /// <summary>
+    /// Harden FOR <paramref name="account"/> rather than for whoever is running this process (#2371).
+    ///
+    /// <para>Every original caller of this class runs INSIDE the service, so "the current identity" and "the
+    /// account the service runs as" were the same value and the distinction did not exist. <c>--harden-files</c>
+    /// breaks that: it exists precisely because a virtual service account cannot re-ACL a file it does not own,
+    /// so it is always run by somebody else — and resolving from the caller there grants the OPERATOR and drops
+    /// the service, which is a working install turned into one that fails on its next start.</para>
+    /// </summary>
+    public static void HardenForAccount(SecurityIdentifier account) => _serviceAccountOverride = account;
+
+    /// <summary>
+    /// The account the service is REGISTERED under, read from its SCM entry rather than from this process —
+    /// `ObjectName` is what the SCM logs the service on with. Returns null when the service is not registered
+    /// (a console run, or hardening a tree before install), leaving the caller to fall back.
+    ///
+    /// <para>Handles the well-known aliases the SCM stores unqualified: <c>LocalSystem</c> has no
+    /// <see cref="NTAccount"/> spelling to translate, while a virtual account (<c>NT SERVICE\…</c>), a domain
+    /// account and a gMSA all translate directly.</para>
+    /// </summary>
+    public static SecurityIdentifier? RegisteredServiceAccount(string serviceName)
+    {
+        try
+        {
+            using var key = Microsoft.Win32.Registry.LocalMachine.OpenSubKey(
+                $@"SYSTEM\CurrentControlSet\Services\{serviceName}");
+
+            if (key?.GetValue("ObjectName") is not string account || string.IsNullOrWhiteSpace(account))
+            {
+                return null;
+            }
+
+            account = account.Trim();
+
+            return account.Equals("LocalSystem", StringComparison.OrdinalIgnoreCase)
+                ? new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null)
+                : (SecurityIdentifier)new NTAccount(account).Translate(typeof(SecurityIdentifier));
+        }
+        catch (Exception)
+        {
+            /* Same reasoning as the display name below: a resolution failure must degrade to the old
+               behaviour, never take the harden down. */
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Whether <paramref name="path"/> still grants the account being hardened for. The harden's own check is
+    /// <see cref="IsReadableByOrdinaryUsers"/>, which asks whether anyone TOO MANY can read — this is the
+    /// other half, and the one #2371 needed: an ACL can be perfectly private and still lock the service out
+    /// of its own credentials.
+    /// </summary>
+    public static bool GrantsHardenedAccount(string path)
+    {
+        try
+        {
+            var target = ServiceAccount;
+            var rules = (Directory.Exists(path)
+                ? new DirectoryInfo(path).GetAccessControl().GetAccessRules(true, true, typeof(SecurityIdentifier))
+                : new FileInfo(path).GetAccessControl().GetAccessRules(true, true, typeof(SecurityIdentifier)));
+
+            foreach (FileSystemAccessRule rule in rules)
+            {
+                if (rule.AccessControlType == AccessControlType.Allow
+                    && rule.IdentityReference is SecurityIdentifier sid
+                    && sid.Equals(target)
+                    && (rule.FileSystemRights & FileSystemRights.Read) != 0)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+        catch (Exception)
+        {
+            /* Unreadable ACL is not proof of absence, so do not report a lockout we cannot see. */
+            return true;
+        }
+    }
+
+    /// <summary>The account to harden FOR: the registered service account when
+    /// <see cref="HardenForAccount"/> named one, otherwise the account this process runs as.</summary>
     private static SecurityIdentifier ServiceAccount =>
-        WindowsIdentity.GetCurrent().User
+        _serviceAccountOverride
+            ?? WindowsIdentity.GetCurrent().User
             ?? throw new InvalidOperationException("Cannot resolve the current Windows identity for ACL hardening.");
 
     /// <summary>
@@ -79,7 +167,11 @@ public static class DarlingFileSecurity
         {
             try
             {
-                return WindowsIdentity.GetCurrent().Name;
+                /* #2371: when hardening for the REGISTERED account, name that one — printing the caller here
+                   would describe an ACL the harden is not writing. */
+                return _serviceAccountOverride is not null
+                    ? ((NTAccount)_serviceAccountOverride.Translate(typeof(NTAccount))).Value
+                    : WindowsIdentity.GetCurrent().Name;
             }
             catch (Exception)
             {


### PR DESCRIPTION
Fixes #2371 — found dogfooding #2352 on the third Darling box during the 3.5.0 soak, on the exact case it was built for.

`--harden-files` resolved the account to grant from `WindowsIdentity.GetCurrent()`. Run the documented way — elevated, from something that is not the service — that is the OPERATOR, so the harden wrote a DACL for them and dropped the account the service runs as.

The live run, via SSM (which runs as `NT AUTHORITY\SYSTEM`):

```
Hardening for service account: NT AUTHORITY\SYSTEM

  SECURED  C:\PerformanceMonitorDarling\darling.json (the live config)
  SECURED  C:\ProgramData\PerformanceMonitorDarling (the store directory)
  SECURED  C:\ProgramData\PerformanceMonitorDarling\pg-credential.dpapi (the store credential)
  SECURED  C:\ProgramData\PerformanceMonitorDarling\pg-admin-credential.dpapi (the admin credential)

All 4 item(s) secured. The service re-asserts these ACLs at every start.
```

`NT SERVICE\PerformanceMonitor Darling` held `(F)` on all four before that, and on none of them after, while the SCM still reported it as the service's account. The service stayed up on its open handles and would have failed on the next start with no read on its config or either DPAPI credential — the failure #2185/#2197 exist to diagnose, manufactured by the tool meant to prevent it.

**Why it was not caught by construction.** Every original caller of `DarlingFileSecurity` runs INSIDE the service, so "the current identity" and "the account the service runs as" were the same value and the distinction did not exist. This verb inverts that: it exists *because* a virtual service account cannot re-ACL a file it does not own, so its caller is never the service. The property's doc comment already stated the requirement it was missing — "must name the account the service RUNS AS" — one level up from where it was being read.

**The fix.** The account comes from the SCM's `ObjectName`, which is what the service is logged on with, and which also covers the re-homed domain-account and gMSA cases that comment was worried about. It falls back to the caller when the service is not registered (a console run, or hardening a tree before install) — the only configuration where the two are legitimately the same — and says so rather than silently hardening for the wrong principal. `LocalSystem` is mapped by hand since the SCM stores it unqualified and it has no `NTAccount` spelling to translate.

**The verify pass gains its other half.** `IsReadableByOrdinaryUsers` asks whether anyone TOO MANY can read. It cannot see the opposite failure, and an ACL that excludes ordinary users AND the service is maximally private and completely broken — which is exactly why the run above printed `SECURED` four times. A locked-out target now reports `LOCKED OUT` and counts as exposure, so the verb exits non-zero and a provisioning script stops instead of proceeding on a broken install.

Tests pin the resolution order too: the account must be resolved BEFORE the first target is hardened, or early targets get the caller's ACL and later ones the service's, which is worse than either alone.

The box is restored and healthy — I re-granted the account on all four paths and restarted the service to prove it rather than assuming:

```
2026-08-19 17:32:07.374 [INFO ] [DarlingWorker] Postgres store ready (schema v79, 0 migration(s) applied)
```
