### PR TITLE
Write SHA256SUMS.txt with LF so shasum -c works

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -515,7 +515,16 @@ jobs:
             $hash = (Get-FileHash $_.FullName -Algorithm SHA256).Hash.ToLower()
             "$hash  $($_.Name)"
           }
-          $checksums | Out-File -FilePath releases/SHA256SUMS.txt -Encoding utf8
+          # LF and no BOM, written explicitly (#2383). Out-File on Windows emits CRLF whatever
+          # the encoding, and `shasum -c` on macOS/Linux then takes the trailing \r as part of
+          # the FILENAME - every entry reports "No such file or directory / FAILED open or
+          # read", which is precisely what a tampered download looks like. The hashes were
+          # always right; the file just could not be used by the tool it exists for, on the two
+          # platforms where that tool is the default. A BOM breaks the first line the same way.
+          [IO.File]::WriteAllText(
+            "$PWD/releases/SHA256SUMS.txt",
+            (($checksums -join "`n") + "`n"),
+            [Text.UTF8Encoding]::new($false))
           Write-Host "Checksums:"
           $checksums | ForEach-Object { Write-Host $_ }
 


### PR DESCRIPTION
Fixes #2383, found verifying the v3.5.0 assets.

`Out-File` on Windows emits CRLF whatever the encoding, so `shasum -c` on macOS/Linux takes the trailing carriage return as part of the filename and reports every entry as `No such file or directory / FAILED open or read`. That is what a tampered or truncated download looks like — the hashes were always right, the file just could not be used by the tool it exists for, on the two platforms where that tool is the default.

```
$ tr -d '\r' < SHA256SUMS.txt | shasum -a 256 -c -
PerformanceMonitorDarling-3.5.0.zip: OK
PerformanceMonitorLite-3.5.0.zip: OK
```

`WriteAllText` with an explicit LF join also avoids a BOM, which would break the first entry identically.

Anchored on `$PWD` deliberately: `[IO.File]::WriteAllText` resolves relative paths against .NET's current directory rather than PowerShell's location, so the bare `releases/SHA256SUMS.txt` the old line used would not reliably land in the same place. That divergence is the trap in swapping `Out-File` for the .NET API.

`SHA256SUMS-linux.txt` is written by `sha256sum` on the Linux job and was never affected — it verifies as published.

**Caveat:** the step is gated on `github.event_name == 'release'`, so this cannot be exercised by CI and lands unverified until the next release publishes. Worth actually running `shasum -c` against that release's checksum file rather than assuming.
