### PR TITLE
Describe what the fixture's class-per-database actually buys

### DIFF
--- a/Lite.Tests/SharedDuckDbFixture.cs
+++ b/Lite.Tests/SharedDuckDbFixture.cs
@@ -20,8 +20,28 @@ namespace PerformanceMonitorLite.Tests;
 ///
 /// Deliberately IClassFixture (one database per class), NOT a collection fixture: a
 /// single shared collection would serialize these classes against each other and give
-/// back most of the win. Each class owns its own database file, keeping xUnit's
-/// cross-class parallelism intact.
+/// back most of the win. Each class owns its own database file, so the SCHEMA-BUILD cost
+/// — the ~80 DDL statements above, which is what this fixture exists to amortise — runs
+/// concurrently across classes.
+///
+/// <para><b>What that does NOT buy (#2376).</b> The file separation is real, but it does
+/// not make the classes independent at RUNTIME: <c>DuckDbInitializer</c>'s reader/writer
+/// lock is <c>private static readonly</c>, so every read and write in the suite queues on
+/// ONE process-wide lock no matter which database file it targets. Classes therefore still
+/// serialize against each other inside their locked sections — through a lock rather than
+/// through a collection, and without a collection's ordering.</para>
+///
+/// <para>That lock is correct and must not be narrowed to fix this: production creates
+/// several <c>DuckDbInitializer</c> instances over the same <c>App.DatabasePath</c>
+/// (MainWindow, DatabaseStateOverridesWindow, and DuckDbAlertHistoryStore), and the static
+/// lock is exactly what keeps those mutually exclusive. Per-instance would trade a slow
+/// suite for a real data race.</para>
+///
+/// <para>The practical consequence is worth knowing when a test here fails oddly: a
+/// scheduling-pressure window can starve the 5-second write-lock acquisition in
+/// <c>LocalDataService.GetDatabaseStateDeviationsAsync</c>, whose maintenance block is
+/// best-effort and simply SKIPS on timeout. That is #2374 — a test that assumed the
+/// maintenance had run, rather than waiting for it, failed a nightly.</para>
 /// </summary>
 public sealed class SharedDuckDbFixture : IAsyncLifetime
 {


### PR DESCRIPTION
Refs #2376, reduced scope after correcting my own numbers on that issue.

I filed #2376 saying the process-wide lock was costing a 500-second suite. That figure came from the one run that FAILED — the flake. Successful runs are **190–222 s**. I generalised from a single outlier, so the "restructure 42 classes into a collection" idea is not justified and I am not proposing it.

What survives is smaller and still worth fixing: **the comment asserts a property the lock does not permit.**

```
Each class owns its own database file, keeping xUnit's cross-class parallelism intact.
```

`DuckDbInitializer`'s lock is `private static readonly`, so every read and write in the suite queues on one process-wide lock regardless of which database file it targets. The classes serialize anyway — through a lock instead of through a collection, and without a collection's ordering. The file separation is real, but what it buys is the **schema-build** cost running concurrently (~80 DDL statements per class), which is what the fixture exists to amortise. That is now what the comment says.

A comment stating a false invariant is worse than no comment, because the next reader reasons from it — I did, while diagnosing #2374, and it cost me a wrong hypothesis before I checked the lock's declaration.

Two things deliberately included:

- **That the lock must NOT be narrowed.** Production creates several `DuckDbInitializer` instances over the same `App.DatabasePath` (MainWindow, DatabaseStateOverridesWindow, DuckDbAlertHistoryStore), and the static lock is what keeps them mutually exclusive. Per-instance is the obvious-looking fix and would trade a slow suite for a real data race. Better to say so where someone would go looking.
- **The practical consequence**, since it already cost a nightly: scheduling pressure can starve the 5-second write-lock acquisition in `GetDatabaseStateDeviationsAsync`, whose maintenance block is best-effort and skips on timeout (#2374).

Comment only, no behaviour change. The `LockRecursionException` → no-op-disposable swallow noted on the issue is left untouched — with `NoRecursion` it fires for any nesting rather than only the leak its comment describes, but I have not tied it to an observed failure, and changing lock semantics over a comment-level concern is a bad trade.
