### PR TITLE
Cap the plan dimension's purge by rows instead of by a time slice

### DIFF
--- a/Darling/Darling.Tests/DarlingRetentionTests.cs
+++ b/Darling/Darling.Tests/DarlingRetentionTests.cs
@@ -677,4 +677,130 @@ WHERE hypertable_name = 'wait_stats'
         Assert.Equal(1, calls);
         Assert.Equal(7, result);
     }
+
+    /* ---------------- #2386: the plan dim is capped by ROWS, not by a time slice ---------------- */
+
+    /// <summary>
+    /// The statement, and the two properties that make it work where the time slice does not.
+    ///
+    /// <para><b>Measured on the live use2 store</b> (133 GB / 12.4 M rows): deletes run at ~1,000 rows/sec,
+    /// linear from 10 k to 50 k, worst observed 834 rows/sec. A one-DAY slice there is ~755 k rows of
+    /// ~9.5 KB gzipped plan XML — ~7 GB of TOAST in one statement, needing ~755 s against a 300 s command
+    /// timeout. It timed out, rolled back, deleted nothing, and every later sweep retried the same doomed
+    /// slice, so retention on the store's largest table stopped permanently while the table kept
+    /// growing.</para>
+    /// </summary>
+    [Fact]
+    public void RowCappedDelete_IsOldestFirst_AndBoundedByRows()
+    {
+        var sql = DarlingRetention.RowCappedDeleteSql("query_plan_dim", "last_seen", 50_000);
+
+        Assert.Equal(
+            "DELETE FROM query_plan_dim WHERE ctid IN ("
+            + "SELECT ctid FROM query_plan_dim WHERE last_seen < $1 "
+            + "ORDER BY last_seen LIMIT 50000)",
+            sql);
+
+        /* Oldest-first is not cosmetic: progress has to be monotonic. An unordered cap nibbles arbitrary
+           rows and leaves MIN(last_seen) where it was, so the floor never advances and the next sweep
+           faces the same work. */
+        Assert.Contains("ORDER BY last_seen LIMIT", sql, StringComparison.Ordinal);
+
+        /* Bounded by rows, never by a time span — that is the whole point. */
+        Assert.DoesNotContain("INTERVAL", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The cap is a measurement, not a round number. 50 k costs ~50 s at the measured rate, leaving ~5x
+    /// margin under <c>DeleteTimeoutSeconds</c> — margin that exists because a loaded box is slower than
+    /// the idle one this was measured on. 100 k would run ~97 s nominal and ~291 s under a 3x slowdown,
+    /// i.e. back against the wall this fix exists to move away from.
+    /// </summary>
+    [Fact]
+    public void ThePlanDimRowCap_LeavesRoomUnderTheCommandTimeout()
+    {
+        Assert.Equal(50_000, DarlingRetention.PlanDimDeleteRowCap);
+
+        /* At the WORST measured throughput (834 rows/sec), the cap must still finish comfortably inside
+           the command timeout. Pinned as arithmetic so raising the cap without re-measuring fails here. */
+        const int worstObservedRowsPerSecond = 834;
+        var worstCaseSeconds = DarlingRetention.PlanDimDeleteRowCap / (double)worstObservedRowsPerSecond;
+
+        Assert.True(
+            worstCaseSeconds < 120,
+            $"cap would take {worstCaseSeconds:F0}s at the worst measured rate; the timeout is 300s and "
+            + "the margin is deliberate");
+    }
+
+    /// <summary>
+    /// Only the plan dimension is capped. <c>query_text_dim</c> is ~40 MB in total and drains in a single
+    /// slice, and the fact tables need the compressed-chunk-safe shape that the <c>ctid</c> idiom cannot
+    /// provide (#1564) — so the row cap is scoped to the one table whose rows are large enough to matter.
+    /// </summary>
+    [Fact]
+    public void OnlyThePlanDim_TakesTheRowCap()
+    {
+        var source = ReadRetentionSource();
+
+        var at = source.IndexOf("foreach (var dimTable in PayloadDimensions.DimTables)", StringComparison.Ordinal);
+        Assert.True(at >= 0, "the dim purge loop moved (#2386)");
+
+        var body = source[at..Math.Min(source.Length, at + 2200)];
+
+        /* The plan dim is selected by name, and BOTH the statement and the drain batch size follow it. */
+        Assert.Contains("PayloadDimensions.QueryPlanDimTable", body, StringComparison.Ordinal);
+        Assert.Contains("RowCappedDeleteSql(", body, StringComparison.Ordinal);
+        Assert.Contains("TimeSlicedDeleteSql(", body, StringComparison.Ordinal);
+        Assert.Contains("batchSize:", body, StringComparison.Ordinal);
+
+        /* A row-capped statement MUST carry its cap as the batch size, or the drain loop reverts to
+           "stop when a batch clears nothing" and does one batch per sweep instead of draining. */
+        Assert.Contains("PlanDimDeleteRowCap", body, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A timed-out purge reports what it actually removed. Each statement autocommits, so a failure on the
+    /// fifth batch does not undo the first four — but the old catch returned null and discarded the running
+    /// total, so the sweep summary said "0 row(s) deleted, 1 failed" for a purge that had deleted 755 k
+    /// rows. That is the line an operator reads, and it turned "slower than the timeout" into "completely
+    /// stuck", which is a different problem with a different fix.
+    /// </summary>
+    [Fact]
+    public void AFailedPurge_ReportsTheRowsItDidRemove()
+    {
+        var source = ReadRetentionSource();
+
+        var at = source.IndexOf("private static async Task<int?> PurgeOneAsync(", StringComparison.Ordinal);
+        Assert.True(at >= 0, "PurgeOneAsync moved (#2386)");
+
+        var body = source[at..Math.Min(source.Length, at + 4000)];
+
+        Assert.Contains("after removing {Rows} row(s)", body, StringComparison.Ordinal);
+
+        /* The accumulator has to live outside the try, or the catch cannot see it. Anchored on the CATCH
+           rather than on "try": the word appears in the explanatory comment above the block, so matching
+           it finds prose instead of code and the assertion passes for the wrong reason. */
+        Assert.True(
+            body.IndexOf("var deleted = 0;", StringComparison.Ordinal)
+                < body.IndexOf("catch (Exception ex)", StringComparison.Ordinal),
+            "the row accumulator must be declared before the catch can read it (#2386)");
+    }
+
+    private static string ReadRetentionSource(
+        [System.Runtime.CompilerServices.CallerFilePath] string thisFile = "")
+    {
+        var relative = System.IO.Path.Combine(
+            "Darling", "PerformanceMonitor.Darling.Service", "DarlingRetention.cs");
+        for (var dir = new System.IO.DirectoryInfo(System.IO.Path.GetDirectoryName(thisFile)!);
+             dir is not null; dir = dir.Parent)
+        {
+            var candidate = System.IO.Path.Combine(dir.FullName, relative);
+            if (System.IO.File.Exists(candidate))
+            {
+                return System.IO.File.ReadAllText(candidate);
+            }
+        }
+
+        throw new System.IO.FileNotFoundException($"Could not locate {relative}");
+    }
 }

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingRetention.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingRetention.cs
@@ -465,9 +465,24 @@ public static class DarlingRetention
                        is ~40 MB against the plan dim's 127 GB — shortening it buys nothing and would quietly
                        break "text stays analyzable for the facts' full retention", which is half the knob's
                        own justification. The router is pure so the scoping is pinned by tests. */
+                    /* #2386: the plan dim is capped by ROWS, every other dim keeps the one-day slice.
+                       Only this table carries multi-kilobyte TOAST payloads, so only this one has a day
+                       that cannot be deleted inside the command timeout — query_text_dim is ~40 MB
+                       total and drains in a single slice. Scoped rather than global so a table that is
+                       fine keeps the compressed-chunk-safe shape it needs. */
+                    var isPlanDim = string.Equals(
+                        dimTable, PayloadDimensions.QueryPlanDimTable, StringComparison.Ordinal);
+
                     var dimDeleted = await PurgeOneAsync(
-                        postgres, dimTable, TimeSlicedDeleteSql(dimTable, PayloadDimensions.LastSeenColumn),
-                        ComputeDimTableCutoff(dimTable, dimensionCutoff, planDimensionCutoff), logger, cancellationToken);
+                        postgres,
+                        dimTable,
+                        isPlanDim
+                            ? RowCappedDeleteSql(dimTable, PayloadDimensions.LastSeenColumn, PlanDimDeleteRowCap)
+                            : TimeSlicedDeleteSql(dimTable, PayloadDimensions.LastSeenColumn),
+                        ComputeDimTableCutoff(dimTable, dimensionCutoff, planDimensionCutoff),
+                        logger,
+                        cancellationToken,
+                        batchSize: isPlanDim ? PlanDimDeleteRowCap : 1);
                     if (dimDeleted is not null)
                     {
                         tablesPurged++;
@@ -662,6 +677,46 @@ public static class DarlingRetention
              + $" AND {timeColumn} >= (SELECT min({timeColumn}) FROM {table} WHERE {expired})"
              + $" AND {timeColumn} < (SELECT min({timeColumn}) FROM {table} WHERE {expired}) + INTERVAL '{TimescaleSupport.ChunkIntervalDays} days'";
     }
+
+    /// <summary>
+    /// Rows per statement for the plan dimension's purge (#2386). Measured on the use2 store, whose
+    /// <c>query_plan_dim</c> is 133 GB over 12.4 M rows: deletes run at <b>~1,000 rows/sec</b>, linear
+    /// from 10 k to 50 k, worst observed 834 rows/sec. 50 k therefore costs ~50 s against
+    /// <see cref="DeleteTimeoutSeconds"/>'s 300 s — about 5x margin, which is the point: a loaded box is
+    /// slower than the idle one this was measured on, and 100 k (~97 s nominal) would sit at ~291 s under
+    /// a 3x slowdown, i.e. against the wall.
+    /// </summary>
+    internal const int PlanDimDeleteRowCap = 50_000;
+
+    /// <summary>
+    /// The plan dimension's purge statement: capped by ROW COUNT rather than by a time slice (#2386).
+    ///
+    /// <para><b>Why the time slice cannot work here.</b> <see cref="TimeSlicedDeleteSql"/> bounds work at
+    /// one day, justified as "exactly what a steady-state daily purge deletes in total". True, and that is
+    /// the problem for this table: a day is ~755 k rows whose gzipped plan XML averages ~9.5 KB, so one
+    /// statement must remove <b>~7 GB of TOAST</b>. Measured, that needs ~755 s against a 300 s command
+    /// timeout — 2.5x over, not borderline. It times out, the statement rolls back, nothing is deleted,
+    /// and the next sweep retries the identical doomed slice. Retention on the largest table in the store
+    /// stops permanently, and the table only grows. No choice of horizon avoids it: the slice width is set
+    /// by the data at the old end, not by where the cutoff sits, so stepping the horizon down one day at a
+    /// time meets the same full day at the first step.</para>
+    ///
+    /// <para><b>Why a row cap is available here specifically.</b> The <c>ctid</c> row-cap idiom was
+    /// abandoned in #1564 because reading the <c>ctid</c> system column through TimescaleDB's transparent
+    /// decompression is unsupported, so it errored the moment any in-range chunk was compressed.
+    /// <c>query_plan_dim</c> is a PLAIN table, never a hypertable — that constraint has never applied to
+    /// it, and the fact tables that do need the compressed-safe shape keep
+    /// <see cref="TimeSlicedDeleteSql"/>.</para>
+    ///
+    /// <para><c>ORDER BY {timeColumn}</c> keeps the delete oldest-first, which the index on that column
+    /// serves directly (measured: the planner takes an index-only scan, and the sibling <c>min()</c> probe
+    /// costs 0.364 ms — the scan was never the expense). Oldest-first matters because progress has to be
+    /// monotonic: an unordered cap would nibble arbitrary rows and leave the floor where it was.</para>
+    /// </summary>
+    internal static string RowCappedDeleteSql(string table, string timeColumn, int cap) =>
+        $"DELETE FROM {table} WHERE ctid IN ("
+      + $"SELECT ctid FROM {table} WHERE {timeColumn} < $1 "
+      + $"ORDER BY {timeColumn} LIMIT {cap})";
 
     /// <summary>
     /// The dimension GC's cutoff (#1795): the ASSUMED horizon (widest dim-feeding fact retention +
@@ -882,8 +937,17 @@ public static class DarlingRetention
         string deleteSql,
         DateTime cutoff,
         ILogger? logger,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        int batchSize = 1)
     {
+        /* Accumulated OUTSIDE the try so the catch can report progress (#2386). Each statement
+           autocommits, so a timeout on the fifth batch does not undo the first four — but the old
+           catch returned null and threw the running total away, and the sweep's summary then said
+           "0 row(s) deleted, 1 failed" for a purge that had removed 755k rows. That reads as total
+           paralysis, which is what made this bug look worse than it was and hid that progress was
+           being made one slice per sweep. */
+        var deleted = 0;
+
         try
         {
             await using var connection = await postgres.OpenConnectionAsync(cancellationToken);
@@ -902,14 +966,28 @@ public static class DarlingRetention
             using var command = new NpgsqlCommand(deleteSql, connection) { CommandTimeout = DeleteTimeoutSeconds };
             command.Parameters.AddWithValue(cutoff);
 
-            /* batchSize 1: the time-sliced statement has no row cap, so "fewer than the cap" degenerates
-               to "deleted zero rows" — a slice that clears anything means older slices may remain. */
-            return await DrainBatchesAsync(ct => command.ExecuteNonQueryAsync(ct), batchSize: 1, cancellationToken);
+            /* batchSize 1 for the TIME-SLICED statement: it has no row cap, so "fewer than the cap"
+               degenerates to "deleted zero rows" — a slice that clears anything means older slices may
+               remain. A ROW-capped caller passes its cap instead, which restores the drain loop's real
+               contract (a full-cap batch means there may be more). */
+            return await DrainBatchesAsync(
+                async ct =>
+                {
+                    var rows = await command.ExecuteNonQueryAsync(ct);
+                    deleted += rows;
+                    return rows;
+                },
+                batchSize,
+                cancellationToken);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            /* Failure-isolated per table — one stuck DELETE must not stop the sweep. */
-            logger?.LogWarning("Retention purge failed for {Table}: {Message}", tableName, ex.Message);
+            /* Failure-isolated per table — one stuck DELETE must not stop the sweep. Reports what DID
+               land, because those batches are committed and saying otherwise sends an operator looking
+               for a stall that is really a throughput limit. */
+            logger?.LogWarning(
+                "Retention purge failed for {Table} after removing {Rows} row(s): {Message}",
+                tableName, deleted, ex.Message);
             return null;
         }
     }


### PR DESCRIPTION
Refs #2386. Constants measured on the live use2 store, and the statement itself validated there before this was written.

## The bug

`TimeSlicedDeleteSql` bounds work at one day, justified as "exactly what a steady-state daily purge deletes in total". True — and that is precisely the problem for `query_plan_dim`. A day there is ~755 k rows whose gzipped plan XML averages ~9.5 KB, so one statement must remove **~7 GB of TOAST**. That needs ~755 s against a 300 s command timeout: it times out, rolls back, deletes nothing, and the next sweep retries the identical doomed slice. Retention on the largest table in the store stops permanently, and the table only grows.

No horizon avoids it. The slice width is set by the data at the old end, not by where the cutoff sits — so stepping the retention setting down a day at a time meets the same full day at the first step. Tightening the horizon is what surfaces it, which means **the natural response to "my store is too big" is what switches retention off.**

## Measured, not guessed

```
min() subquery      0.364 ms   index-only scan on idx_query_plan_dim_last_seen -- never the expense
10,000 rows        12.18 s      821 rows/sec
25,000 rows        24.84 s    1,006 rows/sec
50,000 rows        48.70 s    1,027 rows/sec
worst observed                  834 rows/sec
```

The `min()` probes were my first suspect and they are free; all of the time is removing TOAST and maintaining two indexes.

**Cap 50,000** costs ~50 s — about 5x margin under the timeout. The margin is the point: a loaded box is slower than the idle one this was measured on, and 100,000 (~97 s nominal) would sit at ~291 s under a 3x slowdown, back against the wall this exists to move away from. A test pins the cap against the worst measured rate so raising it without re-measuring fails.

## Validated against the real store

The exact generated statement, prepared with its `$1` binding and the bare table name the code emits:

```
PREPARE                                     -- valid; search_path is collect, config, public
DELETE  2476    2.2 s   -- short batch ends the drain loop
DELETE 50000   43.9 s   -- full cap, comfortably inside the timeout (then ROLLBACK)
```

I also drained the backlog by hand with this shape — 4 batches, `still_expired` 0, `MIN(last_seen)` tracking the cutoff exactly.

## Why the row cap is available here

`ctid` was abandoned in #1564 because reading it through TimescaleDB's transparent decompression is unsupported, so the statement errored once any in-range chunk was compressed. **`query_plan_dim` is a plain table, never a hypertable** — that constraint has never applied to it. Fact tables keep `TimeSlicedDeleteSql`, and `query_text_dim` (~40 MB total) drains in a single slice, so the cap is scoped to the one table whose rows are large enough to matter.

`ORDER BY last_seen` keeps it oldest-first, which matters for correctness rather than tidiness: an unordered cap nibbles arbitrary rows and leaves `MIN(last_seen)` where it was, so the floor never advances.

## Reporting fix, included

Each statement autocommits, so a timeout on a later batch does not undo earlier ones — but the catch returned `null` and discarded the running total, so the sweep summary read `0 row(s) deleted, 1 failed` for a purge that had removed 755 k rows. That is what made this look like total paralysis rather than a throughput limit, and it is a different problem with a different fix. The warning now names the rows that landed.

## What this does NOT do

**It does not shrink the store.** `DELETE` marks tuples dead; autovacuum makes the space reusable inside the existing file but does not return it to the filesystem — measured, 180 k rows and ~1.7 GB of TOAST removed with `pg_total_relation_size` unchanged at 133 GB. Only `VACUUM FULL` returns it, and that rewrites a 133 GB table under an exclusive lock.

So the honest promise is that retention **caps growth**: the dimension plateaus at roughly daily-volume x horizon, with the on-disk figure staying at its high-water mark. #2316's framing should be corrected the same way, or the next person to look will think it is still broken.
