### PR TITLE
Bound PLAN_REGRESSION on the partitioning column too

### DIFF
--- a/Darling/Darling.Tests/PgFactCollectorTests.cs
+++ b/Darling/Darling.Tests/PgFactCollectorTests.cs
@@ -351,4 +351,64 @@ VALUES ($1, $2, $3, $4, $5, $6)", connection);
             $"DELETE FROM cpu_utilization_stats WHERE server_id IN ({TestServerId}, {EmptyServerId});", connection);
         await cleanup.ExecuteNonQueryAsync(ct);
     }
+
+    /* ---------------- #2387: PLAN_REGRESSION must prune on the partitioning column ---------------- */
+
+    /// <summary>
+    /// The comparison window is on <c>last_execution_time</c> — a plan regression is about when the query
+    /// last RAN — but <c>query_store_stats</c> is partitioned and compressed on <c>collection_time</c>, so a
+    /// predicate on <c>last_execution_time</c> alone prunes nothing. Reported by @ethosthalsell: every
+    /// analysis cycle read the server's whole history and decompressed whatever was compressed, PER SERVER,
+    /// with cost scaling on STORE SIZE rather than on the configured window — which is why no VM size fixed
+    /// it. Same class as #2344's unbounded watermark <c>MAX</c>, one query over.
+    ///
+    /// <para><b>Why the extra predicate is safe.</b> It cannot change the result: a row cannot be collected
+    /// before the execution it reports, so <c>last_execution_time &gt;= X</c> already implies
+    /// <c>collection_time &gt;= X</c>. It is redundant to the ANSWER and load-bearing for the PLANNER —
+    /// #2344's "provably free" argument exactly.</para>
+    ///
+    /// <para><b>Measured on the live use1 store</b> (44 GB, 6 chunks, 4 compressed): a
+    /// <c>collection_time</c> bound tight enough to bite reports <c>Chunks excluded during startup: 4</c>,
+    /// against <c>0</c> without one. The magnitude depends on how much history the store holds BEYOND the
+    /// window — on a store whose raw tier is trimmed to 4 days this prunes nothing and costs nothing, and on
+    /// the reporter's store carrying months it is the whole fix.</para>
+    /// </summary>
+    [Fact]
+    public void PlanRegressionSql_BoundsThePartitioningColumn_NotOnlyLastExecutionTime()
+    {
+        var sql = PgFactCollector.PlanRegressionSql;
+
+        /* The semantic window stays where it belongs. */
+        Assert.Contains("last_execution_time >= $2", sql, StringComparison.Ordinal);
+
+        /* And the partitioning column is bounded too, or TimescaleDB cannot exclude a single chunk. */
+        Assert.Contains("collection_time >= $3", sql, StringComparison.Ordinal);
+
+        /* Its own parameter, NOT "$2 - INTERVAL '1 day'": a bare parameter comparison is the form runtime
+           chunk exclusion handles most reliably, and it keeps the skew margin visible in C# where the
+           reason for it is written down. */
+        Assert.DoesNotContain("$2 - INTERVAL", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The chunk-exclusion bound sits BELOW the comparison window by a clock-skew margin.
+    /// <c>last_execution_time</c> comes from the monitored server's clock and <c>collection_time</c> from the
+    /// store's, so a monitored server running fast can report an execution later than the collection that
+    /// carried it. Without the margin those newest rows would be excluded — a silent under-count, and a
+    /// worse bug than the one being fixed. A margin ABOVE the window would be the wrong direction and prune
+    /// nothing extra, so the ordering is asserted rather than the literals.
+    /// </summary>
+    [Fact]
+    public void TheExclusionBound_SitsBelowTheComparisonWindow()
+    {
+        Assert.True(
+            PgFactCollector.PlanRegressionSkewMarginDays > 0,
+            "a zero margin would exclude rows whose monitored-server clock runs ahead of the store's");
+
+        Assert.Equal(14, PgFactCollector.PlanRegressionWindowDays);
+        Assert.True(
+            PgFactCollector.PlanRegressionWindowDays + PgFactCollector.PlanRegressionSkewMarginDays
+                > PgFactCollector.PlanRegressionWindowDays,
+            "the exclusion bound must reach further back than the comparison window, never less far");
+    }
 }

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgFactCollector.QueryPerf.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgFactCollector.QueryPerf.cs
@@ -196,6 +196,18 @@ LIMIT 20";
         catch { /* Table may not exist or have no data */ }
     }
 
+    /// <summary>The PLAN_REGRESSION comparison window, in days — how far back a query's "best known" plan
+    /// may have been observed.</summary>
+    internal const int PlanRegressionWindowDays = 14;
+
+    /// <summary>
+    /// How far BELOW the comparison window the chunk-exclusion bound sits (#2387). `last_execution_time`
+    /// is the monitored server's clock and `collection_time` is the store's; a monitored server running
+    /// ahead can report an execution time later than the collection that carried it. A day absorbs any
+    /// plausible drift while still excluding all but ~15 days of a store that may hold months.
+    /// </summary>
+    internal const int PlanRegressionSkewMarginDays = 1;
+
     /* PG port: any_value() below is standard SQL:2023, in Postgres since 16 — the product's
        minimum supported PG is 17, so it stays verbatim (DuckDB and PG agree on its semantics:
        an arbitrary non-null value from the group). */
@@ -235,6 +247,17 @@ WITH deduped AS
     WHERE server_id = $1
     AND   execution_type_desc = 'Regular'
     AND   last_execution_time >= $2
+    -- #2387: the SEMANTIC window is last_execution_time above; this is a REDUNDANT bound on the
+    -- partitioning column so TimescaleDB can exclude chunks. Without it this reads the server's whole
+    -- history every analysis cycle, decompressing whatever is compressed, per server -- cost scaling with
+    -- STORE SIZE rather than with the configured window, which is why no VM size fixes it. Redundant to
+    -- the ANSWER because a row cannot be collected before the execution it reports, so
+    -- last_execution_time >= X already implies collection_time >= X. $3 carries a skew margin below X
+    -- because last_execution_time comes from the MONITORED server's clock and collection_time from the
+    -- store's: a monitored server running fast would otherwise have its newest rows excluded here, which
+    -- would be a silent under-count and a worse bug than the one this fixes. Do not delete as dead
+    -- weight -- it is doing all the pruning.
+    AND   collection_time >= $3
 ),
 plan_agg AS
 (
@@ -350,8 +373,9 @@ LIMIT 20";
     /// cost >= 2x the best plan that query is known to perform well with. Emits one
     /// aggregate PLAN_REGRESSION fact. Sourced from Query Store (v_query_store_stats);
     /// no fact when Query Store is not enabled on the monitored databases.
-    /// Unlike other collectors this windows on last_execution_time (14-day comparison
-    /// window), NOT collection_time — see plan note.
+    /// Windows on last_execution_time (the 14-day comparison window) because a plan regression is about
+    /// when the query last RAN, not when we happened to collect it. It ALSO carries a redundant
+    /// collection_time bound so TimescaleDB can exclude chunks — see the note in the SQL (#2387).
     /// </summary>
     private async Task CollectPlanRegressionFactsAsync(AnalysisContext context, List<Fact> facts)
     {
@@ -361,7 +385,13 @@ LIMIT 20";
 
             using var cmd = new NpgsqlCommand(PlanRegressionSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
-            cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeStart.AddDays(-14)));
+            cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeStart.AddDays(-PlanRegressionWindowDays)));
+
+            /* #2387: the chunk-exclusion bound, one CLOCK-SKEW MARGIN below the comparison window. Bound as
+               its own parameter rather than written as "$2 - INTERVAL '1 day'" so the planner compares
+               against a bare parameter, which is the form runtime chunk exclusion handles most reliably. */
+            cmd.Parameters.AddWithValue(AsNaive(
+                context.TimeRangeStart.AddDays(-(PlanRegressionWindowDays + PlanRegressionSkewMarginDays))));
 
             var offenderCount = 0;
             var worstFactor = 0.0;


### PR DESCRIPTION
Fixes #2387, reported by @ethosthalsell — who identified the mechanism, the reason the covering indexes do not rescue it, and the fact that the code comment claimed the tradeoff was deliberate. All three held up.

## The bug

The comparison window is on `last_execution_time`, which is correct — a plan regression is about when the query last **ran**, not when we collected it. But `query_store_stats` is partitioned and compressed on `collection_time`, so a predicate on `last_execution_time` alone prunes nothing. Every analysis cycle read the server's whole history and decompressed whatever was compressed, **per server, per cycle**, with cost scaling on store size rather than on the configured window. That is why the reporter's box sat at 100% CPU with 34 postgres backends and why no VM size fixed it.

Same class as #2344's unbounded `MAX(last_execution_time)` in the watermark read, one query over. Fixing that one and leaving this is on us.

## Why the added predicate is safe

It cannot change the result. A row cannot be collected before the execution it reports, so `last_execution_time >= X` already implies `collection_time >= X`. Redundant to the **answer**, load-bearing for the **planner** — #2344's "provably free" argument exactly.

`$3` sits one skew margin **below** the window rather than equal to it. `last_execution_time` is the monitored server's clock and `collection_time` is the store's, so a server running fast can report an execution later than the collection carrying it; without the margin those newest rows would be silently excluded, which is a worse bug than the one being fixed. Bound as its own parameter rather than `"$2 - INTERVAL '1 day'"` because a bare parameter comparison is the form runtime chunk exclusion handles most reliably.

## Measurement, including the part I got wrong

Measured on the live use1 store — 44 GB, 6 chunks, 4 compressed.

**My first reading was wrong and I nearly reported it.** Running the unbounded query first and the bounded one second showed reads dropping 41,379 → 208, which looked like a 199x win. Reversing the order killed it:

```
RUN1  WITH bound (cold)     read=40698  written=3127
RUN2  WITHOUT bound (warm)  read=37389  written=858
```

Same reads either way. The "improvement" was cache warming from the first query, and `Chunks excluded during startup: 0` in every run was the tell I should have taken seriously immediately.

The reason is that use1's `query_store_stats` spans only **08-15 to 08-21**. Retention keeps the raw tier short, so a 15-day bound has no history beyond the window to prune — this store structurally cannot demonstrate the fix.

**What IS demonstrated is the mechanism.** With a `collection_time` bound tight enough to bite:

```
collection_time >= now() - interval '1 day'
  → Chunks excluded during startup: 4     (of 6)
```

against `0` with no such bound. The predicate prunes; the magnitude depends entirely on how much history the store holds beyond the window. On a store whose rollups are armed this costs nothing and saves nothing. On the reporter's — months of history, rollups not armed — it is the whole fix.

So this ships on a proven mechanism plus the reporter's field evidence, not on a benchmark I can reproduce here. Worth someone re-running `EXPLAIN (ANALYZE, BUFFERS)` on a store that actually holds months, which is the only place the numbers will be dramatic.

## Tests

Two, both source-level since the SQL is a constant: that the semantic window stays on `last_execution_time` while `collection_time` is bounded as its own `$3`, and that the exclusion bound reaches further back than the comparison window rather than less far.
