### PR TITLE
Expose the file-growth alert knobs on all three user-facing surfaces

### DIFF
--- a/Darling/Darling.Tests/DarlingMcpAlertToolsTests.cs
+++ b/Darling/Darling.Tests/DarlingMcpAlertToolsTests.cs
@@ -142,6 +142,96 @@ public sealed class DarlingMcpAlertToolsSurfaceAndSqlTests
         Assert.Contains("LIMIT $2", sql, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// #2391: #2349's four knobs are readable and writable through the MCP. They reached 3.5.0 with the
+    /// store plane only — clamped on read in <c>DarlingAlertSettings</c>, columns in V79 — but with no group
+    /// on either tool and no Viewer control, so an alert that ships OFF could only be switched on with a
+    /// hand-written <c>UPDATE</c> against <c>config_alert_settings</c>. Reported by @gotqn, who correctly
+    /// held it against the #2107 precedent: a knob rides the store plane, the Settings window AND the two
+    /// MCP tools, or it is not reachable.
+    /// </summary>
+    [Fact]
+    public void FileGrowthKnobs_AreOnBothMcpTools()
+    {
+        Assert.Contains("file_growth_enabled", Reader.AlertSettingsSelectSql, StringComparison.Ordinal);
+        Assert.Contains("file_growth_rise_mb", Reader.AlertSettingsSelectSql, StringComparison.Ordinal);
+        Assert.Contains("file_growth_volume_percent", Reader.AlertSettingsSelectSql, StringComparison.Ordinal);
+        Assert.Contains("file_growth_lookback_minutes", Reader.AlertSettingsSelectSql, StringComparison.Ordinal);
+
+        var tools = ReadRepoFile(System.IO.Path.Combine(
+            "Darling", "PerformanceMonitor.Darling.Service", "Mcp", "DarlingMcpAlertTools.cs"));
+
+        /* Readable AND writable — a read-only knob still leaves the UPDATE in someone's runbook. */
+        Assert.Contains("file_growth = new", tools, StringComparison.Ordinal);
+        Assert.Contains("case \"file_growth\":", tools, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The write bounds must match <c>DarlingAlertSettings</c>' clamps exactly. If they drift the tool
+    /// accepts a value the engine then silently rewrites on read, which presents as the setting not
+    /// sticking — a worse bug than a rejected input, because nothing says no.
+    ///
+    /// <para>Zero is deliberately IN range for the rise: #2349 disables one gate with zero rather than
+    /// treating it as invalid, so a floor of 1 would remove the rise-only and level-only configurations.</para>
+    /// </summary>
+    [Fact]
+    public void FileGrowthWriteBounds_MatchTheEngineClamps()
+    {
+        var tools = ReadRepoFile(System.IO.Path.Combine(
+            "Darling", "PerformanceMonitor.Darling.Service", "Mcp", "DarlingMcpAlertTools.cs"));
+        var settings = ReadRepoFile(System.IO.Path.Combine(
+            "Darling", "PerformanceMonitor.Darling.Service", "DarlingAlertSettings.cs"));
+
+        /* engine: Max(0, rise) | Clamp(volume, 0, 100) | Clamp(lookback, 5, 1440) */
+        Assert.Contains("Math.Max(0, _config.Alerts.FileGrowthRiseMb)", settings, StringComparison.Ordinal);
+        Assert.Contains("FileGrowthVolumePercent, 0, 100", settings, StringComparison.Ordinal);
+        Assert.Contains("FileGrowthLookbackMinutes, 5, 1440", settings, StringComparison.Ordinal);
+
+        /* tool: the same numbers */
+        Assert.Contains("\"file_growth.rise_mb\", 0, int.MaxValue", tools, StringComparison.Ordinal);
+        Assert.Contains("\"file_growth.volume_percent\", 0, 100", tools, StringComparison.Ordinal);
+        Assert.Contains("\"file_growth.lookback_minutes\", 5, 1440", tools, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The SELECT's column count and the positional read must agree. Every field on
+    /// <c>AlertSettingsReadRow</c> is read by ORDINAL, so a column inserted anywhere but the end re-maps
+    /// every field after it — silently, since the types mostly line up. Derived rather than hand-counted so
+    /// the next knob cannot get this wrong.
+    /// </summary>
+    [Fact]
+    public void AlertSettingsSelect_ColumnCount_MatchesTheOrdinalsRead()
+    {
+        var source = ReadRepoFile(System.IO.Path.Combine(
+            "Darling", "PerformanceMonitor.Darling.Service", "Mcp", "DarlingAlertReader.cs"));
+
+        var sql = Reader.AlertSettingsSelectSql;
+        var select = sql[(sql.IndexOf("SELECT", StringComparison.Ordinal) + 6)..
+                          sql.IndexOf("FROM config_alert_settings", StringComparison.Ordinal)];
+        var columns = select.Replace("\n", " ").Split(',', StringSplitOptions.RemoveEmptyEntries).Length;
+
+        var at = source.IndexOf("return new AlertSettingsReadRow(", StringComparison.Ordinal);
+        var body = source[at..source.IndexOf(");", at, StringComparison.Ordinal)];
+        var ordinals = System.Text.RegularExpressions.Regex.Matches(body, @"reader\.\w+\((\d+)\)")
+            .Select(m => int.Parse(m.Groups[1].Value)).Distinct().ToList();
+
+        Assert.Equal(columns, ordinals.Count);
+        Assert.Equal(columns - 1, ordinals.Max());
+    }
+
+    private static string ReadRepoFile(
+        string relative, [System.Runtime.CompilerServices.CallerFilePath] string thisFile = "")
+    {
+        for (var dir = new System.IO.DirectoryInfo(System.IO.Path.GetDirectoryName(thisFile)!);
+             dir is not null; dir = dir.Parent)
+        {
+            var candidate = System.IO.Path.Combine(dir.FullName, relative);
+            if (System.IO.File.Exists(candidate)) return System.IO.File.ReadAllText(candidate);
+        }
+
+        throw new System.IO.FileNotFoundException($"Could not locate {relative}");
+    }
+
     [Fact]
     public void AlertSettingsSql_ReadsSingleGlobalRow()
     {

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingAlertReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingAlertReader.cs
@@ -144,10 +144,16 @@ LIMIT $2";
         int DiskCriticalFreePercent,
         int DiskCriticalFreeGb,
         int AnalysisNotifyCooldownMinutes,
-        int StoreJobCadenceWarnPercent);
+        int StoreJobCadenceWarnPercent,
+        /* #2391 (V79, #2349's knobs): APPENDED, never inserted — every field above is positional and read
+           by ordinal, so placing these anywhere but the end would silently re-map all of them. */
+        bool FileGrowthEnabled,
+        int FileGrowthRiseMb,
+        int FileGrowthVolumePercent,
+        int FileGrowthLookbackMinutes);
 
     /// <summary>The single global alert-settings row (id=1) — the viewer's <c>AlertSettingsSelectSql</c>. The
-    /// 47 columns are read in the SAME order the service reads them (<c>StoreConfigProvider</c>). This had
+    /// 58 columns are read in the SAME order the service reads them (<c>StoreConfigProvider</c>). This had
     /// stopped at 36, so <c>get_alert_settings</c> reported a store whose newest five knobs did not exist:
     /// an MCP client could not see the V33 connection opt-ins or the V35 Availability Group family at all.</summary>
     public const string AlertSettingsSelectSql = @"
@@ -167,7 +173,8 @@ SELECT enabled, cpu_enabled, cpu_threshold_percent, cpu_mode, blocking_enabled, 
        pvs_floor_gb, database_state_enabled,
        self_disk_free_warn_percent, collection_stale_minutes, collection_failure_threshold,
        disk_critical_free_percent, disk_critical_free_gb, analysis_notify_cooldown_minutes,
-       store_job_cadence_warn_percent
+       store_job_cadence_warn_percent,
+       file_growth_enabled, file_growth_rise_mb, file_growth_volume_percent, file_growth_lookback_minutes
 FROM config_alert_settings
 WHERE id = 1";
 
@@ -205,6 +212,8 @@ WHERE id = 1";
             /* #2107 threshold knobs (V55) at 47–52; #2136 cadence-warn knob (V57) at 53. */
             reader.GetInt32(47), reader.GetInt32(48), reader.GetInt32(49),
             reader.GetInt32(50), reader.GetInt32(51), reader.GetInt32(52),
-            reader.GetInt32(53));
+            reader.GetInt32(53),
+            /* #2391: V79 file-growth knobs at 54–57. */
+            reader.GetBoolean(54), reader.GetInt32(55), reader.GetInt32(56), reader.GetInt32(57));
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpAlertTools.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpAlertTools.cs
@@ -191,6 +191,15 @@ public sealed class DarlingMcpAlertTools
             store_job_cadence_warn_percent = s.StoreJobCadenceWarnPercent
         },
         pvs = new { enabled = s.PvsEnabled, threshold_percent = s.PvsThresholdPercent, floor_gb = s.PvsFloorGb },
+        /* #2391: #2349's knobs reached 3.5.0 with the store plane only, so an alert that ships OFF could
+           be enabled only by UPDATEing config_alert_settings by hand. Reported by @gotqn. */
+        file_growth = new
+        {
+            enabled = s.FileGrowthEnabled,
+            rise_mb = s.FileGrowthRiseMb,
+            volume_percent = s.FileGrowthVolumePercent,
+            lookback_minutes = s.FileGrowthLookbackMinutes
+        },
         long_running_job = new { enabled = s.LongRunningJobEnabled, multiplier = s.LongRunningJobMultiplier },
         failed_job = new { enabled = s.FailedJobEnabled, lookback_minutes = s.FailedJobLookbackMinutes },
         database_state = new { enabled = s.DatabaseStateEnabled },
@@ -671,6 +680,25 @@ public sealed class DarlingMcpAlertTools
                             case "threshold_percent": AddInt("pvs_threshold_percent", n, "pvs.threshold_percent", 0, 100); break;
                             case "floor_gb": AddInt("pvs_floor_gb", n, "pvs.floor_gb", 0, int.MaxValue); break;
                             default: error = $"Unknown field 'pvs.{k}'."; break;
+                        }
+                    });
+                    break;
+
+                /* #2391: bounds mirror DarlingAlertSettings' clamps EXACTLY — Max(0) on the rise,
+                   [0,100] on the volume percent, [5,1440] on the lookback. If these drift apart the tool
+                   accepts a value the engine then silently rewrites, which reads as the setting not
+                   sticking. Zero on either gate disables that gate rather than being invalid (#2349),
+                   which is why the rise floor is 0 and not 1. */
+                case "file_growth":
+                    Group(prop.Value, "file_growth", (k, n) =>
+                    {
+                        switch (k)
+                        {
+                            case "enabled": AddBool("file_growth_enabled", n, "file_growth.enabled"); break;
+                            case "rise_mb": AddInt("file_growth_rise_mb", n, "file_growth.rise_mb", 0, int.MaxValue); break;
+                            case "volume_percent": AddInt("file_growth_volume_percent", n, "file_growth.volume_percent", 0, 100); break;
+                            case "lookback_minutes": AddInt("file_growth_lookback_minutes", n, "file_growth.lookback_minutes", 5, 1440); break;
+                            default: error = $"Unknown field 'file_growth.{k}'."; break;
                         }
                     });
                     break;

--- a/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml
@@ -439,6 +439,19 @@
                                Foreground="{DynamicResource ForegroundBrush}"/>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
+                    <CheckBox x:Name="AlertFileGrowthCheckBox" Content="Database file grew over" VerticalAlignment="Center"
+                              Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AlertFileGrowthRiseMbBox" Width="60" Text="10240" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="MB within" VerticalAlignment="Center" Margin="2,0,0,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AlertFileGrowthLookbackMinutesBox" Width="45" Text="60" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="min, or is over" VerticalAlignment="Center" Margin="2,0,0,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AlertFileGrowthVolumePercentBox" Width="45" Text="60" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="% of its volume (0 disables either gate)" VerticalAlignment="Center" Margin="2,0,0,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
                     <CheckBox x:Name="AlertLongRunningJobCheckBox" Content="Agent jobs running over" VerticalAlignment="Center"
                               Foreground="{DynamicResource ForegroundBrush}"/>
                     <TextBox x:Name="AlertLongRunningJobMultiplierBox" Width="35" Text="3" Margin="6,0,0,0" VerticalAlignment="Center"/>

--- a/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml.cs
@@ -748,6 +748,10 @@ public partial class SettingsWindow : Window
         AlertPvsCheckBox.IsChecked = r.PvsEnabled;
         AlertPvsThresholdPercentBox.Text = r.PvsThresholdPercent.ToString(CultureInfo.InvariantCulture);
         AlertPvsFloorGbBox.Text = r.PvsFloorGb.ToString(CultureInfo.InvariantCulture);
+        AlertFileGrowthCheckBox.IsChecked = r.FileGrowthEnabled;
+        AlertFileGrowthRiseMbBox.Text = r.FileGrowthRiseMb.ToString(CultureInfo.InvariantCulture);
+        AlertFileGrowthVolumePercentBox.Text = r.FileGrowthVolumePercent.ToString(CultureInfo.InvariantCulture);
+        AlertFileGrowthLookbackMinutesBox.Text = r.FileGrowthLookbackMinutes.ToString(CultureInfo.InvariantCulture);
         AlertLongRunningJobCheckBox.IsChecked = r.LongRunningJobEnabled;
         AlertLongRunningJobMultiplierBox.Text = r.LongRunningJobMultiplier.ToString(CultureInfo.InvariantCulture);
         AlertFailedJobCheckBox.IsChecked = r.FailedJobEnabled;
@@ -802,6 +806,7 @@ public partial class SettingsWindow : Window
             TempDbSpaceEnabled = AlertTempDbSpaceCheckBox.IsChecked == true,
             LowDiskEnabled = AlertLowDiskCheckBox.IsChecked == true,
             PvsEnabled = AlertPvsCheckBox.IsChecked == true,
+            FileGrowthEnabled = AlertFileGrowthCheckBox.IsChecked == true,
             LongRunningJobEnabled = AlertLongRunningJobCheckBox.IsChecked == true,
             FailedJobEnabled = AlertFailedJobCheckBox.IsChecked == true,
             DatabaseStateEnabled = AlertDatabaseStateCheckBox.IsChecked == true,
@@ -855,6 +860,13 @@ public partial class SettingsWindow : Window
             row.PvsThresholdPercent = pvsPct;
         if (int.TryParse(AlertPvsFloorGbBox.Text, out var pvsFloor) && pvsFloor >= 0)
             row.PvsFloorGb = pvsFloor;
+        /* #2391: validated to the same ranges DarlingAlertSettings clamps. */
+        if (int.TryParse(AlertFileGrowthRiseMbBox.Text, out var growthRise) && growthRise >= 0)
+            row.FileGrowthRiseMb = growthRise;
+        if (int.TryParse(AlertFileGrowthVolumePercentBox.Text, out var growthPct) && growthPct is >= 0 and <= 100)
+            row.FileGrowthVolumePercent = growthPct;
+        if (int.TryParse(AlertFileGrowthLookbackMinutesBox.Text, out var growthLookback) && growthLookback is >= 5 and <= 1440)
+            row.FileGrowthLookbackMinutes = growthLookback;
         if (int.TryParse(AlertLongRunningJobMultiplierBox.Text, out var jobMult) && jobMult is >= 2 and <= 20)
             row.LongRunningJobMultiplier = jobMult;
         if (int.TryParse(AlertFailedJobLookbackBox.Text, out var failedJobLookback) && failedJobLookback is >= 1 and <= 1440)
@@ -932,6 +944,9 @@ public partial class SettingsWindow : Window
         AnalysisNotifyCooldownBox.Text = "360";
         AlertPvsThresholdPercentBox.Text = "40";
         AlertPvsFloorGbBox.Text = "1";
+        AlertFileGrowthRiseMbBox.Text = "10240";
+        AlertFileGrowthVolumePercentBox.Text = "60";
+        AlertFileGrowthLookbackMinutesBox.Text = "60";
         AlertLongRunningJobMultiplierBox.Text = "3";
         AlertFailedJobLookbackBox.Text = "60";
         AlertCooldownBox.Text = "5";
@@ -984,6 +999,8 @@ public partial class SettingsWindow : Window
             parts.Add($"disk free < {AlertLowDiskThresholdPercentBox.Text}% or {AlertLowDiskThresholdGbBox.Text}GB");
         if (AlertPvsCheckBox.IsChecked == true)
             parts.Add($"PVS >= {AlertPvsThresholdPercentBox.Text}% of database");
+        if (AlertFileGrowthCheckBox.IsChecked == true)
+            parts.Add($"file growth > {AlertFileGrowthRiseMbBox.Text}MB/{AlertFileGrowthLookbackMinutesBox.Text}m or volume > {AlertFileGrowthVolumePercentBox.Text}%");
         if (AlertLongRunningJobCheckBox.IsChecked == true)
             parts.Add($"jobs > {AlertLongRunningJobMultiplierBox.Text}x avg");
         if (AlertFailedJobCheckBox.IsChecked == true)
@@ -1038,6 +1055,10 @@ public partial class SettingsWindow : Window
         AlertCollectionStaleMinutesBox.IsEnabled = enabled;
         AlertCollectionFailureThresholdBox.IsEnabled = enabled;
         AlertStoreJobCadenceWarnPercentBox.IsEnabled = enabled;
+        AlertFileGrowthCheckBox.IsEnabled = enabled;
+        AlertFileGrowthRiseMbBox.IsEnabled = enabled;
+        AlertFileGrowthVolumePercentBox.IsEnabled = enabled;
+        AlertFileGrowthLookbackMinutesBox.IsEnabled = enabled;
         AlertLongRunningJobCheckBox.IsEnabled = enabled;
         AlertLongRunningJobMultiplierBox.IsEnabled = enabled;
         AlertFailedJobCheckBox.IsEnabled = enabled;

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.AlertSettings.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.AlertSettings.cs
@@ -60,7 +60,10 @@ public sealed partial class ViewerDataService
         "pvs_enabled, pvs_threshold_percent, pvs_floor_gb, database_state_enabled, " +
         "self_disk_free_warn_percent, collection_stale_minutes, collection_failure_threshold, " +
         "disk_critical_free_percent, disk_critical_free_gb, analysis_notify_cooldown_minutes, " +
-        "store_job_cadence_warn_percent";
+        "store_job_cadence_warn_percent, " +
+        /* #2391: V79 (#2349). APPENDED — this list drives the SELECT ordinals AND the upsert
+           parameter positions, so inserting anywhere but the end re-maps both at once. */
+        "file_growth_enabled, file_growth_rise_mb, file_growth_volume_percent, file_growth_lookback_minutes";
 
     /// <summary>The single global alert-settings row (id=1), for the Settings window prefill + the migrate-in
     /// defaults check. Column order matches <see cref="AlertSettingsColumns"/>.</summary>
@@ -74,7 +77,7 @@ public sealed partial class ViewerDataService
 INSERT INTO config_alert_settings (id, " + AlertSettingsColumns + @", modified_at)
 VALUES (1, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22,
         $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43,
-        $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54,
+        $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58,
         (now() AT TIME ZONE 'UTC'))
 ON CONFLICT (id) DO UPDATE SET
     enabled = EXCLUDED.enabled,
@@ -131,6 +134,10 @@ ON CONFLICT (id) DO UPDATE SET
     disk_critical_free_gb = EXCLUDED.disk_critical_free_gb,
     analysis_notify_cooldown_minutes = EXCLUDED.analysis_notify_cooldown_minutes,
     store_job_cadence_warn_percent = EXCLUDED.store_job_cadence_warn_percent,
+    file_growth_enabled = EXCLUDED.file_growth_enabled,
+    file_growth_rise_mb = EXCLUDED.file_growth_rise_mb,
+    file_growth_volume_percent = EXCLUDED.file_growth_volume_percent,
+    file_growth_lookback_minutes = EXCLUDED.file_growth_lookback_minutes,
     modified_at = (now() AT TIME ZONE 'UTC')";
 
     /// <summary>The two <c>cpu_mode</c> values the service honors (it compares case-insensitively against
@@ -214,6 +221,10 @@ ON CONFLICT (id) DO UPDATE SET
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = r.DiskCriticalFreeGb });               // $52 (#2107, V55)
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = r.AnalysisNotifyCooldownMinutes });    // $53 (#2107, V55)
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = r.StoreJobCadenceWarnPercent });      // $54 (#2136, V57)
+        command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = r.FileGrowthEnabled });             // $55 (#2349/#2391, V79)
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = r.FileGrowthRiseMb });               // $56 (#2349/#2391, V79)
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = r.FileGrowthVolumePercent });        // $57 (#2349/#2391, V79)
+        command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = r.FileGrowthLookbackMinutes });      // $58 (#2349/#2391, V79)
     }
 
     private static AlertSettingsRow ReadAlertSettingsRow(NpgsqlDataReader reader) => new()
@@ -279,6 +290,10 @@ ON CONFLICT (id) DO UPDATE SET
         DiskCriticalFreeGb = reader.GetInt32(51),
         AnalysisNotifyCooldownMinutes = reader.GetInt32(52),
         StoreJobCadenceWarnPercent = reader.GetInt32(53),
+        FileGrowthEnabled = reader.GetBoolean(54),
+        FileGrowthRiseMb = reader.GetInt32(55),
+        FileGrowthVolumePercent = reader.GetInt32(56),
+        FileGrowthLookbackMinutes = reader.GetInt32(57),
     };
 
     /// <summary>Maps the Settings window's CPU-mode combo tag ("Total"/"SqlOnly") to the store value.</summary>
@@ -338,6 +353,13 @@ public sealed class AlertSettingsRow
     public int DiskCriticalFreeGb { get; set; } = 2;
     public int AnalysisNotifyCooldownMinutes { get; set; } = 360;
     public int StoreJobCadenceWarnPercent { get; set; } = 25;
+
+    /* #2391: defaults mirror the V79 column defaults, so a viewer prefilling against a store that has
+       not seeded the row shows what the store would have given it. Ships OFF, per #2349. */
+    public bool FileGrowthEnabled { get; set; }
+    public int FileGrowthRiseMb { get; set; } = 10240;
+    public int FileGrowthVolumePercent { get; set; } = 60;
+    public int FileGrowthLookbackMinutes { get; set; } = 60;
 
     public bool CpuEnabled { get; set; } = true;
     public int CpuThresholdPercent { get; set; } = 80;

--- a/Lite.Tests/AlertSettingsControlWiringTests.cs
+++ b/Lite.Tests/AlertSettingsControlWiringTests.cs
@@ -85,9 +85,57 @@ public sealed class AlertSettingsControlWiringTests
             .ToHashSet(StringComparer.Ordinal);
     }
 
+    /// <summary>
+    /// Lite's other half of the same "adding a knob is more than one edit" problem, and the half the test
+    /// above cannot see. Lite persists to settings.json rather than a store, and <c>SaveAlertSettings</c>
+    /// does both jobs in one method: it copies each control into an <c>App.Alert*</c> static, then writes
+    /// those statics into the <c>root[...]</c> JSON document. Forgetting the second line is silent and
+    /// survives every manual test — the setting takes effect immediately and only reverts on the NEXT
+    /// launch, by which point nobody connects the two. #2391 added four file-growth controls to this
+    /// method; this pins that all four (and every sibling) actually reach disk.
+    ///
+    /// <para>Note this does NOT mean loader/writer key symmetry: the writer parses the existing
+    /// settings.json into <c>root</c> and mutates it, so hand-edited keys it never touches are preserved
+    /// on save. The invariant is narrower — whatever the UI can CHANGE, the UI must WRITE.</para>
+    /// </summary>
+    [Fact]
+    public void LiteSaveAlertSettings_PersistsEveryStaticItAssigns()
+    {
+        var source = File.ReadAllText(FindRepoFile(Path.Combine("Lite", "Windows", "SettingsWindow.xaml.cs")));
+        var body = MethodBody(source, "SaveAlertSettings", "Lite");
+
+        /* "App.Foo =" but not "App.Foo ==" — the assignments the Save button makes. */
+        var assigned = Regex.Matches(body, @"App\.(\w+)\s*=(?!=)")
+            .Select(m => m.Groups[1].Value)
+            .ToHashSet(StringComparer.Ordinal);
+        var persisted = Regex.Matches(body, @"root\[""[^""]+""\]\s*=\s*App\.(\w+)")
+            .Select(m => m.Groups[1].Value)
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.NotEmpty(assigned);
+
+        /* AlertExcludedDatabases is the one legitimate exception: it is a collection, so it reaches the
+           document as a JsonArray built a few lines earlier rather than as a bare "= App.X" assignment. */
+        var unpersisted = assigned.Except(persisted)
+            .Except(new[] { "AlertExcludedDatabases" })
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.True(unpersisted.Count == 0,
+            "Lite: SaveAlertSettings copies these controls into App statics but never writes them to " +
+            "settings.json, so the setting applies for this session and silently reverts on next launch: " +
+            string.Join(", ", unpersisted));
+    }
+
     private static string MethodBody(string source, string methodName, string app)
     {
+        /* Not every anchor returns void — SaveAlertSettings returns bool to report whether it succeeded. */
         var signature = source.IndexOf("void " + methodName, StringComparison.Ordinal);
+        if (signature < 0)
+        {
+            signature = source.IndexOf("bool " + methodName, StringComparison.Ordinal);
+        }
+
         Assert.True(signature >= 0, $"{app}: no method named {methodName} — this guard's anchor moved and it is testing nothing.");
 
         var open = source.IndexOf('{', signature);

--- a/Lite/Windows/SettingsWindow.xaml
+++ b/Lite/Windows/SettingsWindow.xaml
@@ -296,6 +296,19 @@
                                Foreground="{DynamicResource ForegroundBrush}"/>
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
+                    <CheckBox x:Name="AlertFileGrowthCheckBox" Content="Database file grew over" VerticalAlignment="Center"
+                              Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AlertFileGrowthRiseMbBox" Width="60" Text="10240" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="MB within" VerticalAlignment="Center" Margin="2,0,0,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AlertFileGrowthLookbackMinutesBox" Width="45" Text="60" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="min, or is over" VerticalAlignment="Center" Margin="2,0,0,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AlertFileGrowthVolumePercentBox" Width="45" Text="60" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="% of its volume (0 disables either gate)" VerticalAlignment="Center" Margin="2,0,0,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
                     <CheckBox x:Name="AlertLongRunningJobCheckBox" Content="Agent jobs running over" VerticalAlignment="Center"
                               Foreground="{DynamicResource ForegroundBrush}"/>
                     <TextBox x:Name="AlertLongRunningJobMultiplierBox" Width="35" Text="3" Margin="6,0,0,0" VerticalAlignment="Center"/>

--- a/Lite/Windows/SettingsWindow.xaml.cs
+++ b/Lite/Windows/SettingsWindow.xaml.cs
@@ -508,6 +508,10 @@ public partial class SettingsWindow : Window
         AlertPvsCheckBox.IsChecked = App.AlertPvsEnabled;
         AlertPvsThresholdPercentBox.Text = App.AlertPvsThresholdPercent.ToString();
         AlertPvsFloorGbBox.Text = App.AlertPvsFloorGb.ToString();
+        AlertFileGrowthCheckBox.IsChecked = App.AlertFileGrowthEnabled;
+        AlertFileGrowthRiseMbBox.Text = App.AlertFileGrowthRiseMb.ToString();
+        AlertFileGrowthVolumePercentBox.Text = App.AlertFileGrowthVolumePercent.ToString();
+        AlertFileGrowthLookbackMinutesBox.Text = App.AlertFileGrowthLookbackMinutes.ToString();
         AlertLongRunningJobCheckBox.IsChecked = App.AlertLongRunningJobEnabled;
         AlertLongRunningJobMultiplierBox.Text = App.AlertLongRunningJobMultiplier.ToString();
         AlertFailedJobCheckBox.IsChecked = App.AlertFailedJobEnabled;
@@ -594,6 +598,13 @@ public partial class SettingsWindow : Window
             App.AlertPvsThresholdPercent = pvsPct;
         if (int.TryParse(AlertPvsFloorGbBox.Text, out var pvsFloor) && pvsFloor >= 0)
             App.AlertPvsFloorGb = pvsFloor;
+        App.AlertFileGrowthEnabled = AlertFileGrowthCheckBox.IsChecked == true;
+        if (int.TryParse(AlertFileGrowthRiseMbBox.Text, out var growthRise) && growthRise >= 0)
+            App.AlertFileGrowthRiseMb = growthRise;
+        if (int.TryParse(AlertFileGrowthVolumePercentBox.Text, out var growthPct) && growthPct >= 0 && growthPct <= 100)
+            App.AlertFileGrowthVolumePercent = growthPct;
+        if (int.TryParse(AlertFileGrowthLookbackMinutesBox.Text, out var growthLookback) && growthLookback >= 5 && growthLookback <= 1440)
+            App.AlertFileGrowthLookbackMinutes = growthLookback;
         App.AlertLongRunningJobEnabled = AlertLongRunningJobCheckBox.IsChecked == true;
         if (int.TryParse(AlertLongRunningJobMultiplierBox.Text, out var jobMult) && jobMult >= 2 && jobMult <= 20)
             App.AlertLongRunningJobMultiplier = jobMult;
@@ -684,6 +695,10 @@ public partial class SettingsWindow : Window
             root["alert_pvs_enabled"] = App.AlertPvsEnabled;
             root["alert_pvs_threshold_percent"] = App.AlertPvsThresholdPercent;
             root["alert_pvs_floor_gb"] = App.AlertPvsFloorGb;
+            root["alert_file_growth_enabled"] = App.AlertFileGrowthEnabled;
+            root["alert_file_growth_rise_mb"] = App.AlertFileGrowthRiseMb;
+            root["alert_file_growth_volume_percent"] = App.AlertFileGrowthVolumePercent;
+            root["alert_file_growth_lookback_minutes"] = App.AlertFileGrowthLookbackMinutes;
             root["alert_long_running_job_enabled"] = App.AlertLongRunningJobEnabled;
             root["alert_long_running_job_multiplier"] = App.AlertLongRunningJobMultiplier;
             root["alert_failed_job_enabled"] = App.AlertFailedJobEnabled;
@@ -740,6 +755,9 @@ public partial class SettingsWindow : Window
         AlertLowDiskThresholdGbBox.Text = "5";
         AlertPvsThresholdPercentBox.Text = "40";
         AlertPvsFloorGbBox.Text = "1";
+        AlertFileGrowthRiseMbBox.Text = "10240";
+        AlertFileGrowthVolumePercentBox.Text = "60";
+        AlertFileGrowthLookbackMinutesBox.Text = "60";
         AlertLongRunningJobMultiplierBox.Text = "3";
         AlertFailedJobLookbackBox.Text = "60";
         AlertCooldownBox.Text = "5";
@@ -794,6 +812,8 @@ public partial class SettingsWindow : Window
             parts.Add($"disk free < {AlertLowDiskThresholdPercentBox.Text}% or {AlertLowDiskThresholdGbBox.Text}GB");
         if (AlertPvsCheckBox.IsChecked == true)
             parts.Add($"PVS >= {AlertPvsThresholdPercentBox.Text}% of database");
+        if (AlertFileGrowthCheckBox.IsChecked == true)
+            parts.Add($"file growth > {AlertFileGrowthRiseMbBox.Text}MB/{AlertFileGrowthLookbackMinutesBox.Text}m or volume > {AlertFileGrowthVolumePercentBox.Text}%");
         if (AlertLongRunningJobCheckBox.IsChecked == true)
             parts.Add($"jobs > {AlertLongRunningJobMultiplierBox.Text}x avg");
         if (AlertFailedJobCheckBox.IsChecked == true)
@@ -829,6 +849,10 @@ public partial class SettingsWindow : Window
         AlertPvsCheckBox.IsEnabled = enabled;
         AlertPvsThresholdPercentBox.IsEnabled = enabled;
         AlertPvsFloorGbBox.IsEnabled = enabled;
+        AlertFileGrowthCheckBox.IsEnabled = enabled;
+        AlertFileGrowthRiseMbBox.IsEnabled = enabled;
+        AlertFileGrowthVolumePercentBox.IsEnabled = enabled;
+        AlertFileGrowthLookbackMinutesBox.IsEnabled = enabled;
         AlertLongRunningJobCheckBox.IsEnabled = enabled;
         AlertLongRunningJobMultiplierBox.IsEnabled = enabled;
         AlertFailedJobCheckBox.IsEnabled = enabled;


### PR DESCRIPTION
Closes #2391, reported by @gotqn. All three parts.

#2349 shipped the Database File Growth alert **OFF** and gave its four knobs the store plane only — V79 columns, clamped on read in `DarlingAlertSettings`, and nothing else. No group on `get_alert_settings`, nothing accepted by `update_alert_settings`, no Viewer control on either SKU. For an alert that ships OFF that is not an inconvenience, it is the only door: the single supported way to enable a feature someone asked for was a hand-written `UPDATE` against `config_alert_settings`.

@gotqn held it against the #2107 precedent — store plane, Settings window, and both MCP tools together — which is the right standard, and #2349 met one of three.

### 1. MCP (`699839b2`)

`get_alert_settings` grows a `file_growth` group; `update_alert_settings` accepts the four knobs.

The fields are **appended** to `AlertSettingsReadRow` and to the SELECT, never inserted. Every field on that record is read by ordinal, so a column placed anywhere but the end silently re-maps everything after it — and mostly compiles, because the types line up. A test now derives the column count from the SQL and the ordinals from the reader and asserts they agree. Verified: 58 columns, 58 ordinals, contiguous 0–57.

Write bounds mirror the engine's clamps exactly, pinned by a test that reads both files. Drift would let the tool accept a value the engine rewrites on read, which presents as *the setting not sticking* — worse than a rejection, because nothing says no. Zero stays valid on the rise because #2349 uses zero to disable one gate, so a floor of 1 would remove the rise-only and level-only configurations.

### 2 and 3. Both Settings windows (`b30622a9`)

The control row on each SKU, and the six call sites a threshold box needs: seed, save, parse, gate, restore-defaults, and the `Will alert when:` preview. The preview mattered on its own — it enumerates enabled alerts, so an alert that can fire while the summary omits it is worse than having no summary.

`ViewerDataService` keeps its **own** copy of the alert_settings round trip, also read entirely by ordinal, so the four columns are appended last there too rather than slotted beside the knobs they belong with.

The service side needed nothing: `StoreConfigProvider` has selected and read all four since #2349. The gap was only ever the three user-facing surfaces.

### One thing worth review

Lite's `SaveAlertSettings` does two jobs in one method — it copies each control into an `App.Alert*` static, then writes those statics into the JSON document. Skipping the second line is silent and survives every manual test: the setting takes effect immediately and only reverts on the next launch, by which point nobody connects the two. `LiteSaveAlertSettings_PersistsEveryStaticItAssigns` now pins it, with `AlertExcludedDatabases` exempt because it lands as a `JsonArray` rather than a bare assignment.

To be clear about what that guard is **not**: it does not require loader/writer key symmetry. The writer parses the existing settings.json into `root` and mutates it, so hand-edited keys it never touches are preserved across a save. The invariant is narrower — whatever the UI can change, the UI must write.

That asymmetry does leave three knobs Lite can load but has no way to set (`analysis_notify_cooldown_minutes`, `analysis_timeout_seconds`, `check_for_updates_on_startup`; the Darling Viewer exposes the first). They round-trip correctly, so this is a parity gap rather than a bug, and it is out of scope here — filing separately.
