### PR TITLE
The fixture's lock contention is writer-driven, not a flat tax

### DIFF
--- a/Lite.Tests/SharedDuckDbFixture.cs
+++ b/Lite.Tests/SharedDuckDbFixture.cs
@@ -25,11 +25,23 @@ namespace PerformanceMonitorLite.Tests;
 /// concurrently across classes.
 ///
 /// <para><b>What that does NOT buy (#2376).</b> The file separation is real, but it does
-/// not make the classes independent at RUNTIME: <c>DuckDbInitializer</c>'s reader/writer
-/// lock is <c>private static readonly</c>, so every read and write in the suite queues on
-/// ONE process-wide lock no matter which database file it targets. Classes therefore still
-/// serialize against each other inside their locked sections — through a lock rather than
-/// through a collection, and without a collection's ordering.</para>
+/// not make the classes independent at RUNTIME: <c>DuckDbInitializer</c>'s lock is
+/// <c>private static readonly</c>, so it is ONE lock for the whole process no matter which
+/// database file a call targets.</para>
+///
+/// <para>Be precise about what that costs, because the obvious reading overstates it. The
+/// lock is a <c>ReaderWriterLockSlim</c>, so readers do NOT queue behind each other — any
+/// number of <c>AcquireReadLock</c> holders run concurrently across classes, and this suite
+/// is overwhelmingly readers (~184 read call sites against ~20 write sites). The
+/// serialization is writer-driven: a writer excludes everyone, and readers block only while
+/// a writer holds the lock or is waiting for it. The contention is therefore bursty around
+/// the write sites — archival, compaction, CHECKPOINT, the mute and alert-history stores —
+/// rather than a flat tax on every database call.</para>
+///
+/// <para>That distinction decides what a fix could even look like: a collection fixture
+/// would serialize the READERS as well, so it does not address writer-driven contention and
+/// would cost more than it saves. Nobody has measured how much of the suite's ~190-220s is
+/// this, and the honest answer is that it may be very little.</para>
 ///
 /// <para>That lock is correct and must not be narrowed to fix this: production creates
 /// several <c>DuckDbInitializer</c> instances over the same <c>App.DatabasePath</c>


### PR DESCRIPTION
Follow-up to #2385, which fixed one overstatement in `SharedDuckDbFixture`'s doc comment and introduced another.

The comment now reads:

> every read and write in the suite queues on ONE process-wide lock

That is not what `ReaderWriterLockSlim` does. `AcquireReadLock` takes a **shared** read lock, so readers run concurrently with each other — and this suite is overwhelmingly readers:

```
~184  AcquireReadLock call sites
 ~20  AcquireWriteLock call sites
```

Readers block only while a writer holds the lock or is queued for it, so the contention is bursty around the write sites (archival, compaction, CHECKPOINT, the mute and alert-history stores) rather than a flat tax on every database call.

This matters because of what the wrong reading suggests doing. "Every read and write queues on one lock" points straight at a collection fixture — which serializes the **readers** too, so it cannot address writer-driven contention and would cost more than it saves. The comment now says that explicitly.

It also now states plainly that nobody has measured how much of the suite's ~190–222s this is. That number is the one #2376 originally got wrong (it cited 500s from a single failed run), and leaving an unquantified cost sitting next to a proposed fix is how that happens again.

Doc comment only — no behavior change.