### PR TITLE
The nightly writes SHA256SUMS.txt with CRLF too

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -521,6 +521,9 @@ jobs:
           # read", which is precisely what a tampered download looks like. The hashes were
           # always right; the file just could not be used by the tool it exists for, on the two
           # platforms where that tool is the default. A BOM breaks the first line the same way.
+          #
+          # There is a SECOND copy of this step in nightly.yml. #2384 fixed only this one, and the
+          # nightly went on publishing CRLF for another day; keep them in step.
           [IO.File]::WriteAllText(
             "$PWD/releases/SHA256SUMS.txt",
             (($checksums -join "`n") + "`n"),

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -195,7 +195,20 @@ jobs:
             $hash = (Get-FileHash $_.FullName -Algorithm SHA256).Hash.ToLower()
             "$hash  $($_.Name)"
           }
-          $checksums | Out-File -FilePath releases/SHA256SUMS.txt -Encoding utf8
+          # LF and no BOM, written explicitly (#2383). Out-File on Windows emits CRLF whatever
+          # the encoding, and `shasum -c` on macOS/Linux then takes the trailing \r as part of
+          # the FILENAME - every entry reports "No such file or directory / FAILED open or
+          # read", which is precisely what a tampered download looks like. The hashes were
+          # always right; the file just could not be used by the tool it exists for, on the two
+          # platforms where that tool is the default. A BOM breaks the first line the same way.
+          #
+          # This is the SECOND copy of that step. #2384 fixed the release workflow and left this
+          # one, so every nightly since has published a checksum file nobody outside Windows can
+          # verify - and the nightly is the build most likely to be checked by hand.
+          [IO.File]::WriteAllText(
+            "$PWD/releases/SHA256SUMS.txt",
+            (($checksums -join "`n") + "`n"),
+            [Text.UTF8Encoding]::new($false))
           Write-Host "Checksums:"
           $checksums | ForEach-Object { Write-Host $_ }
 


### PR DESCRIPTION
#2384 fixed `build.yml` and left the identical step in `nightly.yml`, so every nightly since has published a checksum file that `shasum -c` cannot read.

Found while auditing what in 3.5.1 is verified by anything other than reading the diff — this one is only exercised by actually running the pipeline, so I checked the published artifact:

```
$ file nightly_SHA256SUMS.txt
ASCII text, with CRLF line terminators

$ head -1 nightly_SHA256SUMS.txt | cat -v
f27860c5...  PerformanceMonitorDarling-3.5.0-nightly.20260821.zip^M
```

And with the artifact present, so the failure is the trailing CR rather than a missing file:

```
CRLF  ->  shasum: artifact.zip: No such file or directory
          artifact.zip: FAILED open or read
LF    ->  artifact.zip: OK
```

The nightly is the worse of the two to get wrong. It is a prerelease, so whoever downloads it is disproportionately likely to check a hash by hand — and `FAILED open or read` is exactly what a tampered download looks like.

Same fix as #2384. Both copies now carry a note that the other exists, since the whole defect was one being updated without the other.