### PR TITLE
The nightly ignored the ref it was dispatched onto

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,6 +52,13 @@ jobs:
 
   # Everything below runs only in a workflow_dispatch run — the scheduled re-dispatch or a
   # manual one — which executes from the dispatched ref (dev for the scheduled path).
+  #
+  # Each checkout resolves that ref EXPLICITLY rather than pinning `ref: dev`. Three of these
+  # were pinned, so a manual dispatch onto any other branch published dev's artifacts while
+  # reporting the dispatched ref as the run's head SHA — the run, the API and the release page
+  # all named a branch that was not what got built. That is worse than simply ignoring the
+  # input, because the mismatch is invisible: it surfaced as a release-candidate build stamping
+  # the PREVIOUS version, which is only noticeable if you happen to read the artifact name.
   check:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
@@ -61,7 +68,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: dev
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || 'dev' }}
           fetch-depth: 0
 
       - name: Check for new commits in last 24 hours
@@ -91,7 +98,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: dev
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || 'dev' }}
 
       - name: Setup .NET 10.0
         uses: actions/setup-dotnet@v6
@@ -424,7 +431,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: dev
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || 'dev' }}
 
       - name: Setup .NET 10.0
         uses: actions/setup-dotnet@v6


### PR DESCRIPTION
Found while building a 3.5.1 release candidate to soak before tagging: I dispatched `nightly.yml` onto `release/3.5.1` and got artifacts built from `dev`.

```
check      ref: dev          <- hardcoded
build      ref: dev          <- hardcoded  (builds + publishes the artifacts)
darling-pg ref: <dispatched> <- correct
linux      ref: dev          <- hardcoded
```

So the run tested `release/3.5.1` and shipped `dev`.

**The reason this is worth more than a one-line fix:** nothing that would normally confirm what you built disagrees. The run's head SHA, the API, and the Actions UI all report `release/3.5.1`, because that genuinely is what was dispatched — only the checkout went elsewhere. I verified the head SHA matched the branch tip and that it contained #2388/#2390/#2397, and every one of those checks passed while the artifact was still dev.

What actually gave it away was the asset name: `PerformanceMonitorDarling-3.5.0-nightly.20260821.zip` on a branch whose `Lite/PerformanceMonitorLite.csproj` says `3.5.1`. Both version steps read that file, so the stamped version is a direct readout of which tree was checked out — visible only if you read the filename and know what to expect.

The workflow's own comment already stated the intent:

> Everything below runs only in a workflow_dispatch run — the scheduled re-dispatch or a manual one — **which executes from the dispatched ref** (dev for the scheduled path).

so the pins contradicted the documented design rather than expressing it. All four checkouts now resolve identically, falling back to `dev` for the scheduled path — which re-dispatches with `--ref dev` regardless.