### PR TITLE
The purge log says which cutoff it used and whether it drained

### DIFF
--- a/Darling/Darling.Tests/DarlingRetentionTests.cs
+++ b/Darling/Darling.Tests/DarlingRetentionTests.cs
@@ -804,7 +804,12 @@ WHERE hypertable_name = 'wait_stats'
         var at = source.IndexOf("private static async Task<int?> PurgeOneAsync(", StringComparison.Ordinal);
         Assert.True(at >= 0, "PurgeOneAsync moved (#2386)");
 
-        var body = source[at..Math.Min(source.Length, at + 4000)];
+        /* Brace-matched rather than a fixed character window. The window was 4000, the method is now 4651
+           chars, and the catch this test exists to check sits at 4521 — so #2401's comment additions pushed
+           the assertion's target out of the slice and the test failed while the code it guards was correct.
+           A guard whose reach depends on how much prose the method carries is a guard that goes off at the
+           wrong times. */
+        var body = MethodBodyFrom(source, at);
 
         Assert.Contains("after removing {Rows} row(s)", body, StringComparison.Ordinal);
 
@@ -815,6 +820,26 @@ WHERE hypertable_name = 'wait_stats'
             body.IndexOf("var deleted = 0;", StringComparison.Ordinal)
                 < body.IndexOf("catch (Exception ex)", StringComparison.Ordinal),
             "the row accumulator must be declared before the catch can read it (#2386)");
+    }
+
+    /// <summary>
+    /// The full body of the member starting at <paramref name="declarationAt"/>, by brace matching. Replaces
+    /// the fixed-size slices these source guards used to take: those silently shrink their own coverage as a
+    /// method grows, so an assertion can stop reaching its target without anything failing to compile.
+    /// </summary>
+    private static string MethodBodyFrom(string source, int declarationAt)
+    {
+        var open = source.IndexOf('{', declarationAt);
+        Assert.True(open >= 0, "no body found at the declaration offset");
+
+        var depth = 0;
+        for (var i = open; i < source.Length; i++)
+        {
+            if (source[i] == '{') depth++;
+            else if (source[i] == '}' && --depth == 0) return source[declarationAt..i];
+        }
+
+        throw new InvalidOperationException("unbalanced braces scanning the method body");
     }
 
     private static string ReadRetentionSource(

--- a/Darling/Darling.Tests/DarlingRetentionTests.cs
+++ b/Darling/Darling.Tests/DarlingRetentionTests.cs
@@ -189,6 +189,37 @@ public sealed class DarlingRetentionTests
         Assert.Equal(2, calls);
     }
 
+    /// <summary>
+    /// The row-capped drain has to SAY what it did, because rows-deleted alone cannot tell a drain from a
+    /// peel — and that ambiguity is #2386's failure mode, where a purge that cleared one bounded slice and
+    /// a purge that cleared a real backlog wrote the same log line. It also has to print the resolved
+    /// cutoff rather than leaving a reader to apply the retention knob, which is a day off: the cutoff
+    /// carries a one-day margin, so counting rows older than the knob overstates the eligible set by a full
+    /// day of ingest.
+    ///
+    /// <para>Source-level rather than a log-capture harness: what is being pinned is that the call site
+    /// passes those two values at all. A logger fake would assert the same thing through more machinery,
+    /// and the failure this guards against is someone simplifying the message back to a row count.</para>
+    /// </summary>
+    [Fact]
+    public void TheRowCappedDrain_LogsItsBatchCountAndResolvedCutoff()
+    {
+        var source = ReadRetentionSource();
+        var at = source.IndexOf("await DrainBatchesAsync(", StringComparison.Ordinal);
+        Assert.True(at >= 0, "the drain call site moved (#2386)");
+        var body = source[Math.Max(0, at - 2000)..Math.Min(source.Length, at + 2500)];
+
+        Assert.Contains("batches++", body, StringComparison.Ordinal);
+        Assert.Contains("{Batches} batch(es)", body, StringComparison.Ordinal);
+
+        /* The cutoff the DELETE actually bound, not the knob it was derived from. */
+        Assert.Contains("cutoff {Cutoff:", body, StringComparison.Ordinal);
+
+        /* Only the row-capped path: the time-sliced statement passes batchSize 1, where "batches" is
+           always 1 and would say nothing. */
+        Assert.Contains("if (batchSize > 1)", body, StringComparison.Ordinal);
+    }
+
     /* ---------------- run-record status/message (pure) ---------------- */
 
     [Fact]

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingRetention.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingRetention.cs
@@ -970,15 +970,39 @@ public static class DarlingRetention
                degenerates to "deleted zero rows" — a slice that clears anything means older slices may
                remain. A ROW-capped caller passes its cap instead, which restores the drain loop's real
                contract (a full-cap batch means there may be more). */
-            return await DrainBatchesAsync(
+            var batches = 0;
+            var drained = await DrainBatchesAsync(
                 async ct =>
                 {
+                    batches++;
                     var rows = await command.ExecuteNonQueryAsync(ct);
                     deleted += rows;
                     return rows;
                 },
                 batchSize,
                 cancellationToken);
+
+            /* A row-capped drain reports the two facts the sweep summary cannot carry, because both are
+               per-table and the summary is fleet-wide.
+
+               The CUTOFF, because it is not the retention knob and reading it as the knob is a live trap:
+               ComputeDimensionCutoff subtracts the configured days PLUS a one-day margin for the hourly
+               last_seen refresh, so counting rows older than the knob value overstates what is eligible by
+               a full day of ingest — on this table that is hundreds of thousands of rows, which reads as a
+               backlog retention is failing to clear when it is simply not due yet.
+
+               And the BATCH COUNT, because rows-deleted alone cannot distinguish a drain from a peel. That
+               is the #2386 failure mode exactly: a purge that removed one bounded slice and reported
+               success looked identical in the log to one that cleared everything expired. One batch means
+               the table was already inside its horizon; many means there was a backlog and it is gone. */
+            if (batchSize > 1)
+            {
+                logger?.LogInformation(
+                    "Retention purge drained {Rows} row(s) from {Table} in {Batches} batch(es) (cap {Cap}), cutoff {Cutoff:yyyy-MM-dd HH:mm}Z",
+                    drained, tableName, batches, batchSize, cutoff);
+            }
+
+            return drained;
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {


### PR DESCRIPTION
Both of these come out of getting #2386 wrong twice while reading its log, and both are things the log could have told me.

**The cutoff is not the knob.** `ComputeDimensionCutoff` subtracts the configured retention days **plus a one-day margin** for the hourly `last_seen` refresh guard. So `WHERE last_seen < now() - interval '21 days'` — the obvious way to ask "how far behind is retention" when the knob reads 21 — overstates the eligible set by a full day of ingest. On `query_plan_dim` that gap is:

```
21d (the knob)        738,218 rows
22d (the real cutoff)   7,400 rows
```

I read the first number as a backlog retention was failing to clear. It was mostly rows that were not due yet. The log now prints the timestamp the DELETE actually bound.

**Rows-deleted cannot tell a drain from a peel**, and that ambiguity is #2386's failure mode rather than an aesthetic complaint. A purge that cleared one bounded slice and a purge that cleared a real backlog wrote the same line. One batch means the table was already inside its horizon; nine means there was a backlog and it is gone.

Row-capped path only — the time-sliced statement passes `batchSize: 1`, where the count is always 1 and would say nothing.

Guard test pins that the call site passes both values; I simulated it against the real source before pushing rather than finding out in CI, since its anchor is a string my own change rewrote.