### PR TITLE
Say which write a read-only seat is missing, and where

### DIFF
--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerActualPlanFlow.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerActualPlanFlow.cs
@@ -179,7 +179,8 @@ public static class ViewerActualPlanFlow
     private static void ShowReadOnly(Window owner)
         => MessageBox.Show(owner,
             "Capturing an actual plan asks the service to re-execute the query, which it does by running a " +
-            "command — a read-only viewer seat can't enqueue commands. Reconnect with a read-write profile to " +
-            "capture actual plans.",
+            "command — a read-only viewer seat can't enqueue commands. The command is queued in the MONITORING " +
+            "STORE, not on the monitored server. Reconnect with a read-write store profile to capture actual " +
+            "plans.",
             "Read-Only Viewer", MessageBoxButton.OK, MessageBoxImage.Information);
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.CollectionHealth.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.CollectionHealth.cs
@@ -84,7 +84,9 @@ public partial class ViewerServerTab
         {
             MessageBox.Show(
                 "Purging asks the service to run the retention purge, which it does by running a command — a " +
-                "read-only viewer seat can't enqueue commands. Reconnect with a read-write profile to purge.",
+                "read-only viewer seat can't enqueue commands. The command is queued in the MONITORING STORE, " +
+                "and the purge only ever deletes from the store — never from a monitored server. Reconnect " +
+                "with a read-write store profile to purge.",
                 "Read-Only Viewer", MessageBoxButton.OK, MessageBoxImage.Information);
             return;
         }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.CurrentActiveQueries.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.CurrentActiveQueries.cs
@@ -32,6 +32,18 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// </summary>
 public partial class ViewerServerTab
 {
+    /// <summary>
+    /// #2400: the read-only refusal names WHICH write is blocked, because the previous wording ("reconnect
+    /// with a read-write profile") reads as "grant this viewer write access to my production SQL Server" —
+    /// which is the one thing it does not mean, and a reasonable person declines rather than asks. The write
+    /// is an INSERT into config_command in the monitoring store; the monitored server is only ever READ, by
+    /// the service, over its own connection.
+    /// </summary>
+    private const string ReadOnlySeatMessage =
+        "Read-only viewer — the live fetch queues a request for the service in the MONITORING STORE, which a "
+        + "read-only seat can't write to. Nothing is sent to or written on the monitored server. Reconnect "
+        + "with a read-write store profile to fetch live active queries.";
+
     /// <summary>Refresh button — fires the live fetch (never auto-fires; a live server hit is explicit).</summary>
     private async void RefreshCurrentActiveQueries_Click(object sender, RoutedEventArgs e)
         => await LoadCurrentActiveQueriesAsync();
@@ -42,8 +54,7 @@ public partial class ViewerServerTab
            rather than attempting an enqueue that would throw. */
         if (_dataService.IsReadOnly)
         {
-            CurrentActiveQueriesStatus.Text =
-                "Read-only viewer — reconnect with a read-write profile to fetch live active queries.";
+            CurrentActiveQueriesStatus.Text = ReadOnlySeatMessage;
             return;
         }
 
@@ -76,8 +87,7 @@ public partial class ViewerServerTab
         catch (ViewerReadOnlyException)
         {
             /* Grants changed under us between the IsReadOnly check and the enqueue. */
-            CurrentActiveQueriesStatus.Text =
-                "Read-only viewer — reconnect with a read-write profile to fetch live active queries.";
+            CurrentActiveQueriesStatus.Text = ReadOnlySeatMessage;
         }
         catch (Exception ex)
         {

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
@@ -789,6 +789,7 @@
                                         VerticalAlignment="Center"/>
                                 <TextBlock x:Name="CurrentActiveQueriesStatus"
                                            Text="Click Refresh to fetch what is running on the server right now."
+                                           TextWrapping="Wrap" MaxWidth="640"
                                            FontSize="12" Foreground="DarkGoldenrod" FontWeight="SemiBold" VerticalAlignment="Center"/>
                             </StackPanel>
                             <DataGrid Grid.Row="1" x:Name="CurrentActiveQueriesGrid" Style="{StaticResource DarkGrid}"


### PR DESCRIPTION
@ghauan asked on #2400 why **Current Active Queries** needs a read-write profile when the stored **Active Queries** tab does not.

The mechanism: the live fetch enqueues a `fetch_active_queries` command — an `INSERT` into `config_command` in the **monitoring store**. The service then reads the DMV over its own connection and writes the rows back into `result_json`. The viewer never touches the monitored server, and neither does the write.

None of the four read-only refusals said any of that:

```
CurrentActiveQueries  "Read-only viewer — reconnect with a read-write profile to fetch live active queries."
ActualPlanFlow        "…can't enqueue commands. Reconnect with a read-write profile to capture actual plans."
CollectionHealth      "…can't enqueue commands. Reconnect with a read-write profile to purge."
```

"Reconnect with a read-write profile" reads as *give this viewer write access to my production SQL Server*. That is the one thing it does not mean — and it is a request a careful DBA is right to refuse. Being asked about it is the signal: the wording made a safe operation sound unsafe, so the message was working against the product.

All four now name the store as what is written and state that the monitored server is only ever read. The purge message additionally says the purge deletes from the store only, since that is the same fear one step worse.

Also gives the Current Active Queries status `TextBlock` `TextWrapping` and a `MaxWidth` — it sits in a horizontal `StackPanel`, so the longer text would have been clipped instead of shown. An explanation nobody can read is not an explanation.

I have replied on the issue with the full mechanism, and asked @ghauan to confirm one thing that would change the answer: the read-only probe (`has_table_privilege('config_mute_rules', 'INSERT')`) **fails safe**, so a mis-provisioned store or a transient error also lands you in a read-only seat. Worth ruling that out if they expected read-write.