### PR TITLE
Autovacuum the plan dimension on its delete volume, not its size

### DIFF
--- a/Darling/Darling.Tests/PgTableTuningTests.cs
+++ b/Darling/Darling.Tests/PgTableTuningTests.cs
@@ -51,7 +51,14 @@ public sealed class PgTableTuningTests
         Assert.Contains("ALTER TABLE collect.query_store_stats SET (autovacuum_vacuum_insert_scale_factor = 0.02, autovacuum_vacuum_insert_threshold = 10000)", sql, StringComparison.Ordinal);
         Assert.Contains("ALTER TABLE collect.pg_statement_stats SET (autovacuum_vacuum_insert_scale_factor = 0.02, autovacuum_vacuum_insert_threshold = 10000)", sql, StringComparison.Ordinal);
 
-        Assert.Equal(11, PgTableTuning.Statements.Count);   /* +1 #1981 query_stats handle index, +1 pg_statement_stats */
+        /* #2402: the plan dimension takes the DEAD-TUPLE knob, not the insert one. It is a plain table
+           whose churn comes from retention DELETEs, so autovacuum_vacuum_insert_* — which governs every
+           entry above — does not apply to it at all. Asserted by exact text because the two knob families
+           differ by one word and the wrong one would be silently inert. */
+        Assert.Contains("ALTER TABLE collect.query_plan_dim SET (autovacuum_vacuum_scale_factor = 0.02, autovacuum_vacuum_threshold = 10000)", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("collect.query_plan_dim SET (autovacuum_vacuum_insert_scale_factor", sql, StringComparison.Ordinal);
+
+        Assert.Equal(12, PgTableTuning.Statements.Count);   /* +1 #1981 query_stats handle index, +1 pg_statement_stats, +1 #2402 query_plan_dim */
     }
 
     private static int CountOccurrences(string haystack, string needle)

--- a/Darling/PerformanceMonitor.Darling.Storage/PgTableTuning.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/PgTableTuning.cs
@@ -75,6 +75,22 @@ public static class PgTableTuning
            to heap fetches. It was simply missed when the PostgreSQL collectors landed, since this list is
            hand-maintained rather than derived from the catalog. */
         "ALTER TABLE collect.pg_statement_stats SET (autovacuum_vacuum_insert_scale_factor = 0.02, autovacuum_vacuum_insert_threshold = 10000)",
+        /* #2402: query_plan_dim needs the OTHER knob, and needs it for the opposite reason. Every override
+           above tunes INSERT vacuuming so the visibility map stays current on pure-insert hypertable chunks.
+           This table is not a hypertable and is not insert-only: retention DELETEs from it, so its churn is
+           DEAD TUPLES, which autovacuum_vacuum_insert_* does not govern at all.
+
+           Left at the stock 0.2 it needs 20% of the table dead before autovacuum will look at it — on the
+           dogfood store that is ~2.4 M rows, and it showed: 1,223,777 dead tuples with the last autovacuum
+           two days earlier, while its own TOAST table (which has its own thresholds against 57 M chunks) had
+           been vacuumed 152 times. The parent is the half that matters here, because the dead rows a purge
+           leaves behind are precisely the idx_query_plan_dim_last_seen entries the NEXT purge has to visit
+           and test for visibility before discarding. Untuned, each purge makes the following one slower and
+           then waits days for cleanup.
+
+           0.02 + 10000 sizes the trigger to roughly one purge's worth of deletions rather than to the
+           table's total size, so cleanup follows the work that created it. */
+        "ALTER TABLE collect.query_plan_dim SET (autovacuum_vacuum_scale_factor = 0.02, autovacuum_vacuum_threshold = 10000)",
     };
 
     /// <summary>


### PR DESCRIPTION
From #2402. Measured on the dogfood store:

```
query_plan_dim       n_dead_tup 1,223,777   last_autovacuum 2026-08-19 20:19   (5 runs)
pg_toast_116337049   n_dead_tup 2,510,825   last_autovacuum 2026-08-21 10:14   (152 runs)
reloptions on both:  (none)
```

With no per-table override it inherits `autovacuum_vacuum_scale_factor = 0.2`, so it needs ~2.4 M dead tuples (20% of 12.1 M) before autovacuum looks at it. The TOAST table has its own thresholds against 57 M chunks and gets vacuumed constantly; the parent does not.

The parent is the half that matters. The dead rows a purge leaves are precisely the `idx_query_plan_dim_last_seen` entries the **next** purge has to visit and test for visibility before discarding. Untuned, each purge slows the one after it and then waits days for the cleanup that would have fixed it.

**This is deliberately the other knob.** Every existing override in `PgTableTuning` is `autovacuum_vacuum_**insert**_scale_factor`, which keeps the visibility map current on pure-insert hypertable chunks. `query_plan_dim` is neither a hypertable nor insert-only — its churn is DELETEs — and the insert knobs do not govern dead tuples at all. Copying the line above it would have been **silently inert**, which is why the test asserts the exact text *and* asserts the insert spelling is absent.

`0.02 + 10000` sizes the trigger to roughly one purge's deletions rather than to total table size.

**Also answers the config-drift question** (asked separately): I diffed every `autovacuum*` and `vacuum_*` GUC across use2 / use1 / pgmon.

```
knobs differing across the three boxes:  0
ALTER SYSTEM overrides on any box:       none (only the app's search_path)
non-default GUCs:  autovacuum_worker_slots=16, default_toast_compression=lz4  — identical on all three,
                   both from the app's own marker-guarded postgresql.conf block
```

So use2 has **no** local autovacuum drift, and the app ships no autovacuum GUCs at all — it tunes per-table instead, which is what this PR extends. Whatever was tweaked on use2 at some point either was not autovacuum or did not survive.