### PR TITLE
Derive the insert-autovacuum tuning from the catalog, not a hand list

### DIFF
--- a/Darling/Darling.Tests/PgTableTuningTests.cs
+++ b/Darling/Darling.Tests/PgTableTuningTests.cs
@@ -7,6 +7,7 @@
  */
 
 using System;
+using System.Linq;
 using PerformanceMonitor.Darling.Storage;
 using Xunit;
 
@@ -52,6 +53,50 @@ public sealed class PgTableTuningTests
         Assert.Contains("ALTER TABLE collect.pg_statement_stats SET (autovacuum_vacuum_insert_scale_factor = 0.02, autovacuum_vacuum_insert_threshold = 10000)", sql, StringComparison.Ordinal);
 
         Assert.Equal(11, PgTableTuning.Statements.Count);   /* +1 #1981 query_stats handle index, +1 pg_statement_stats */
+    }
+
+    /// <summary>
+    /// #2405: the four literal ALTERs are a floor for a plain-PostgreSQL store, not the coverage. On a
+    /// TimescaleDB store the tuning is DERIVED from the catalog, because "pure-insert append-only fact table"
+    /// describes every collector target by construction while the literal list described whichever four had
+    /// been the subject of an EXPLAIN investigation — 4 of 51 hypertables on the dogfood store.
+    ///
+    /// <para>Pinned at the SQL level: the predicate must select hypertables that lack the option (so a re-run
+    /// no-ops rather than re-ALTERing all 51), must read the TimescaleDB catalog, and must quote the
+    /// identifier it hands back, since that string is interpolated into the ALTER.</para>
+    /// </summary>
+    [Fact]
+    public void TheHypertableSweep_SelectsOnlyUntunedHypertables_AndQuotesTheIdentifier()
+    {
+        var sql = PgTableTuning.UntunedHypertablesSql;
+
+        Assert.Contains("timescaledb_information.hypertables", sql, StringComparison.Ordinal);
+        Assert.Contains("format('%I.%I'", sql, StringComparison.Ordinal);
+
+        /* Idempotence lives in the predicate, not in a guard at the call site. */
+        Assert.Contains("NOT LIKE '%insert_scale_factor%'", sql, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The literal statements and the derived sweep must set the SAME options, or a store would be tuned two
+    /// different ways depending on which path reached the table first — and the derived sweep's predicate
+    /// (which matches on <c>insert_scale_factor</c>) would still consider the other spelling "tuned", making
+    /// the divergence permanent and invisible.
+    /// </summary>
+    [Fact]
+    public void TheLiteralStatementsAndTheDerivedSweep_ShareOneSpellingOfTheOptions()
+    {
+        Assert.Equal(
+            "autovacuum_vacuum_insert_scale_factor = 0.02, autovacuum_vacuum_insert_threshold = 10000",
+            PgTableTuning.InsertTuningOptions);
+
+        var literals = PgTableTuning.Statements
+            .Where(s => s.Contains("autovacuum_vacuum_insert_scale_factor", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.Equal(4, literals.Count);
+        Assert.All(literals, s =>
+            Assert.Contains("(" + PgTableTuning.InsertTuningOptions + ")", s, StringComparison.Ordinal));
     }
 
     private static int CountOccurrences(string haystack, string needle)

--- a/Darling/PerformanceMonitor.Darling.Storage/PgTableTuning.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/PgTableTuning.cs
@@ -66,15 +66,15 @@ public static class PgTableTuning
         "CREATE INDEX IF NOT EXISTS idx_query_stats_server_hash_time ON collect.query_stats (server_id, query_hash, collection_time DESC)",
         "CREATE INDEX IF NOT EXISTS idx_query_store_stats_query_hash ON collect.query_store_stats (query_hash, collection_time) INCLUDE (database_name, module_name, execution_count, avg_duration_us, max_duration_us, avg_cpu_time_us, max_cpu_time_us)",
         "CREATE INDEX IF NOT EXISTS idx_query_store_stats_server_db_query_plan_time ON collect.query_store_stats (server_id, database_name, query_id, plan_id, collection_time DESC)",
-        "ALTER TABLE collect.procedure_stats SET (autovacuum_vacuum_insert_scale_factor = 0.02, autovacuum_vacuum_insert_threshold = 10000)",
-        "ALTER TABLE collect.query_stats SET (autovacuum_vacuum_insert_scale_factor = 0.02, autovacuum_vacuum_insert_threshold = 10000)",
-        "ALTER TABLE collect.query_store_stats SET (autovacuum_vacuum_insert_scale_factor = 0.02, autovacuum_vacuum_insert_threshold = 10000)",
+        "ALTER TABLE collect.procedure_stats SET (" + InsertTuningOptions + ")",
+        "ALTER TABLE collect.query_stats SET (" + InsertTuningOptions + ")",
+        "ALTER TABLE collect.query_store_stats SET (" + InsertTuningOptions + ")",
         /* pg_statement_stats is query_stats' per-minute PostgreSQL twin — same shape, same cadence, same
            pure-insert hypertable chunks — so the identical reasoning applies: the stock 0.2 scale factor
            leaves the day's hot chunk stale before the TimescaleDB rollover and the Index Only Scan degrades
            to heap fetches. It was simply missed when the PostgreSQL collectors landed, since this list is
            hand-maintained rather than derived from the catalog. */
-        "ALTER TABLE collect.pg_statement_stats SET (autovacuum_vacuum_insert_scale_factor = 0.02, autovacuum_vacuum_insert_threshold = 10000)",
+        "ALTER TABLE collect.pg_statement_stats SET (" + InsertTuningOptions + ")",
     };
 
     /// <summary>
@@ -110,6 +110,103 @@ public static class PgTableTuning
         logger?.LogInformation(
             "Composer performance tuning applied ({Applied}/{Total} covering-index / autovacuum statements)",
             applied, Statements.Count);
+
+        applied += await ApplyHypertableInsertTuningAsync(connection, logger, cancellationToken);
+        return applied;
+    }
+
+    /// <summary>The reloptions every pure-insert hypertable gets. Shared with the literal statements above so
+    /// the two spellings cannot drift apart.</summary>
+    public const string InsertTuningOptions =
+        "autovacuum_vacuum_insert_scale_factor = 0.02, autovacuum_vacuum_insert_threshold = 10000";
+
+    /// <summary>
+    /// Every hypertable that does not already carry the insert tuning, resolved from the TimescaleDB catalog.
+    /// The name is built with <c>format('%I.%I')</c> so it comes back correctly quoted.
+    /// </summary>
+    public const string UntunedHypertablesSql = @"
+SELECT format('%I.%I', h.hypertable_schema, h.hypertable_name)
+FROM timescaledb_information.hypertables h
+JOIN pg_class c ON c.relname = h.hypertable_name
+JOIN pg_namespace n ON n.oid = c.relnamespace AND n.nspname = h.hypertable_schema
+WHERE COALESCE(array_to_string(c.reloptions, ','), '') NOT LIKE '%insert_scale_factor%'";
+
+    /// <summary>
+    /// Applies the insert tuning to every hypertable still missing it, DERIVED from the catalog rather than
+    /// from the hand-written list above (#2405).
+    ///
+    /// <para>The literal statements exist because a plain-PostgreSQL store has no TimescaleDB catalog to read,
+    /// and those four tables are the ones whose read paths were measured; this sweep is what makes the property
+    /// hold for the rest. It matters because "pure-insert append-only fact table" describes EVERY collector
+    /// target by construction, while the literal list described whichever four had been the subject of an
+    /// EXPLAIN investigation — 4 of 51 hypertables on the dogfood store, with untuned tables (perfmon_stats at
+    /// 5.3 GB, spinlock_stats at 3.7 GB, wait_stats at 2.8 GB) larger than tuned ones. A list that has to be
+    /// remembered when a collector lands is a list that gets missed, and this one already had been: the file's
+    /// own comment records pg_statement_stats being added late for exactly that reason.</para>
+    ///
+    /// <para>Deliberately scoped to HYPERTABLES, not to everything in <c>collect</c>. Insert-driven autovacuum
+    /// governs the visibility map and freezing on append-only data; a plain table whose churn is DELETEs needs
+    /// <c>autovacuum_vacuum_scale_factor</c> instead, which is a different knob for a different failure and is
+    /// set explicitly where it applies. Sweeping every table here would silently apply the inert one.</para>
+    ///
+    /// <para>The 10,000-row threshold is what keeps this safe on the many small hypertables: the scale factor is
+    /// not consulted until that many inserts have accumulated, so a low-rate table is not pushed into
+    /// constant autovacuum. Per-table failure isolation matches <see cref="ApplyAsync"/>, and a store without
+    /// TimescaleDB simply finds no catalog and no-ops.</para>
+    /// </summary>
+    public static async Task<int> ApplyHypertableInsertTuningAsync(
+        NpgsqlConnection connection, ILogger? logger, CancellationToken cancellationToken = default)
+    {
+        if (connection is null)
+        {
+            throw new ArgumentNullException(nameof(connection));
+        }
+
+        var targets = new List<string>();
+        try
+        {
+            using var query = new NpgsqlCommand(UntunedHypertablesSql, connection) { CommandTimeout = SetupTimeoutSeconds };
+            await using var reader = await query.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                targets.Add(reader.GetString(0));
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            /* No TimescaleDB (a plain-PostgreSQL store) or an unreadable catalog — the literal statements above
+               already ran, so this is a no-op rather than a failure. */
+            logger?.LogDebug("Hypertable insert-tuning sweep skipped: {Message}", ex.Message);
+            return 0;
+        }
+
+        if (targets.Count == 0)
+        {
+            return 0;
+        }
+
+        var applied = 0;
+        foreach (var target in targets)
+        {
+            /* Identifier comes from the catalog already quoted by format('%I.%I') — never user input. */
+            var statement = $"ALTER TABLE {target} SET ({InsertTuningOptions})";
+            try
+            {
+                using var command = new NpgsqlCommand(statement, connection) { CommandTimeout = SetupTimeoutSeconds };
+                await command.ExecuteNonQueryAsync(cancellationToken);
+                applied++;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                logger?.LogWarning(
+                    "Insert-autovacuum tuning failed for {Table} — the store keeps working without it: {Message}",
+                    target, ex.Message);
+            }
+        }
+
+        logger?.LogInformation(
+            "Insert-autovacuum tuning applied to {Applied}/{Total} previously-untuned hypertable(s)",
+            applied, targets.Count);
         return applied;
     }
 }


### PR DESCRIPTION
Measured on the dogfood store:

```
hypertables WITH the insert tuning:   4
hypertables WITHOUT it:              47
```

with untuned tables larger than tuned ones:

| untuned | size |
|---|---|
| perfmon_stats | 5330 MB |
| spinlock_stats | 3707 MB |
| wait_stats | 2773 MB |
| index_object_stats | 1907 MB |
| query_snapshots | 1259 MB |
| file_io_stats | 1227 MB |

Every one is a pure-insert collector fact table, structurally identical to the four that were covered. The four were not selected on merit — they are whichever tables had been the subject of an EXPLAIN investigation.

This file already recorded the mechanism, about a table it had missed once before:

> It was simply missed when the PostgreSQL collectors landed, since this list is hand-maintained rather than derived from the catalog.

A list of which tables are append-heavy describes a property **every** collector target has by construction. It should not be a list.

**The sweep** resolves hypertables lacking the option from `timescaledb_information.hypertables` and ALTERs those, per-table failure-isolated like the statements above it. Idempotence is in the predicate, so a re-run selects nothing rather than re-ALTERing 51 tables every service start.

**The four literals stay.** A plain-PostgreSQL store has no TimescaleDB catalog to read, and those four are the measured floor for that case. They now share a single `const` with the sweep — two spellings would tune a store two different ways depending on which path reached a table first, and because the sweep's predicate matches on `insert_scale_factor`, it would treat the other spelling as already-tuned and make the divergence permanent and invisible.

**Scoped to hypertables deliberately.** Insert-driven autovacuum governs the visibility map on append-only data. A plain table whose churn is DELETEs needs `autovacuum_vacuum_scale_factor` instead — that is #2404 for `query_plan_dim`. Sweeping everything in `collect` would silently apply the inert knob to the tables that need the other one.

The `10000` threshold is what keeps this safe on the many small hypertables: the scale factor is not consulted until that many inserts accumulate.