### PR TITLE
Give Lite a box for the analysis re-notify cooldown

### DIFF
--- a/Lite/Windows/SettingsWindow.xaml
+++ b/Lite/Windows/SettingsWindow.xaml
@@ -414,6 +414,16 @@
                     <TextBlock Text="(0.0 - 2.0)" VerticalAlignment="Center" Margin="4,0,0,0"
                                Foreground="{DynamicResource ForegroundMutedBrush}"/>
                 </StackPanel>
+                <!-- #2393: analysis_notify_cooldown_minutes has been read (and clamped) by App.LoadAlertSettings
+                     since the key existed, and the Darling viewer has offered it since #2107; Lite simply never
+                     drew the box, so the one knob that quiets chatty analysis notifications was hand-edit-only. -->
+                <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
+                    <TextBlock Text="Re-notify an unchanged finding after" VerticalAlignment="Center" Margin="0,0,8,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AnalysisNotifyCooldownBox" Width="55" TextAlignment="Center" VerticalAlignment="Center"/>
+                    <TextBlock Text="minutes (30 - 10080)" VerticalAlignment="Center" Margin="4,0,0,0"
+                               Foreground="{DynamicResource ForegroundMutedBrush}"/>
+                </StackPanel>
                 <TextBlock Text="Requires SMTP or a webhook configured below for delivery; findings are recorded in the Alerts tab either way."
                            FontSize="11" FontStyle="Italic" Foreground="{DynamicResource ForegroundMutedBrush}"
                            Margin="20,4,0,0" TextWrapping="Wrap"/>

--- a/Lite/Windows/SettingsWindow.xaml.cs
+++ b/Lite/Windows/SettingsWindow.xaml.cs
@@ -534,6 +534,7 @@ public partial class SettingsWindow : Window
         AnalysisNotificationsCheckBox.IsChecked = App.AnalysisNotificationsEnabled;
         AnalysisIntervalBox.Text = App.AnalysisIntervalMinutes.ToString();
         AnalysisNotifySeverityBox.Text = App.AnalysisNotifySeverity.ToString("0.0", System.Globalization.CultureInfo.InvariantCulture);
+        AnalysisNotifyCooldownBox.Text = App.AnalysisNotifyCooldownMinutes.ToString();
         UpdateAlertControlStates();
     }
 
@@ -640,6 +641,13 @@ public partial class SettingsWindow : Window
             App.AnalysisNotifySeverity = analysisSeverity;
         else
             validationErrors.Add("Analysis notify severity must be between 0.0 and 2.0.");
+        /* Same range App.LoadAlertSettings clamps this key to on read, so the value the box accepts and the
+           value the next launch honors can never disagree -- Lite's settings adapter passes the static
+           straight through to AnalysisNotificationService without a second clamp. */
+        if (int.TryParse(AnalysisNotifyCooldownBox.Text, out var analysisCooldown) && analysisCooldown >= 30 && analysisCooldown <= 10080)
+            App.AnalysisNotifyCooldownMinutes = analysisCooldown;
+        else
+            validationErrors.Add("Analysis re-notify cooldown must be between 30 and 10080 minutes.");
 
         var settingsPath = Path.Combine(App.ConfigDirectory, "settings.json");
         try
@@ -714,6 +722,7 @@ public partial class SettingsWindow : Window
             root["analysis_notifications_enabled"] = App.AnalysisNotificationsEnabled;
             root["analysis_interval_minutes"] = App.AnalysisIntervalMinutes;
             root["analysis_notify_severity"] = App.AnalysisNotifySeverity;
+            root["analysis_notify_cooldown_minutes"] = App.AnalysisNotifyCooldownMinutes;
 
             var options = new JsonSerializerOptions { WriteIndented = true };
             File.WriteAllText(settingsPath, root.ToJsonString(options));
@@ -766,6 +775,7 @@ public partial class SettingsWindow : Window
         AlertPerEventMaxBox.Text = "10";
         AnalysisIntervalBox.Text = "30";
         AnalysisNotifySeverityBox.Text = "1.5";
+        AnalysisNotifyCooldownBox.Text = "360";
         AlertExcludedDatabasesBox.Text = "";
         MuteRuleDefaultExpirationCombo.SelectedIndex = 1; // 24 hours
         UpdateAlertPreviewText();


### PR DESCRIPTION
Closes #2393.

Lite's Settings window now has a "Re-notify an unchanged finding after ___ minutes (30 - 10080)" box in the Automated Analysis section, seeded from `App.AnalysisNotifyCooldownMinutes` and written back to `analysis_notify_cooldown_minutes`.

## Why this one

`App.LoadAlertSettings` has read that key for as long as it has existed and clamps it to 30-10080. `AppAlertSettings` then passes the static straight through to `AnalysisNotificationService` with no second clamp, so it is literally the value that decides how long an unchanged finding stays quiet before it notifies again. It is the knob a Lite user reaches for when analysis notifications are too chatty, and it is the only one that answers that complaint — and until now the only way to turn it was a text editor.

The Darling viewer has had `AnalysisNotifyCooldownBox` since #2107, so this is a straight parity gap, and the control here is the viewer's control: same label, same range hint, same 360 default on Restore Defaults. The two SKUs now offer the same three analysis knobs.

Worth restating what this is *not*, because it changes what the fix has to be: nothing was being lost. `SaveAlertSettings` parses the existing settings.json into a `JsonNode` and mutates it, so a key the writer never touches survives every save. Hand-editing worked and stuck. The defect was that nobody could find the knob, which is why it went unnoticed for so long.

## Why it is not in `UpdateAlertControlStates`

`UpdateAlertControlStates` is the "Alerts Enabled" master switch, and analysis notifications do not consult it. `AnalysisNotificationService` never reads `AlertsEnabled`; analysis runs, and records findings in the Alerts tab, with alerting off entirely — the section's own italic caption says so. Neither app gates `AnalysisIntervalBox` or `AnalysisNotifySeverityBox` there either. Graying this box out alongside the CPU and blocking thresholds would advertise a dependency the engine does not have.

For the record on the drift guard: `AlertSettingsControlWiringTests`' gate/reset check matches `Alert*Box`, so it does not reach an `Analysis*Box` in either app — which is why Darling passes today with its cooldown box ungated. The guard that *does* reach this change is `LiteSaveAlertSettings_PersistsEveryStaticItAssigns`, and the `root["analysis_notify_cooldown_minutes"] = App.AnalysisNotifyCooldownMinutes;` line is what satisfies it. I simulated both guards against the patched source (the suites are net10.0-windows and cannot execute on macOS): Lite loads 22 threshold boxes with none ungated and none unreset, Darling 28 the same, and Save assigns 56 statics with 0 unpersisted.

## The other two keys, and why they are not here

**`analysis_timeout_seconds`** — deliberately not exposed, and I'd argue it should not be. Neither SKU offers it, so adding it is a product decision rather than a parity fix, and Darling's position is explicit rather than accidental: `DarlingWorker` hardcodes the 120-second budget with a comment saying it is "not a control-plane knob" while the cadence, enabled gate and notify gate all became control-plane knobs around it. The other half is what the timeout actually does in Lite. `CollectionBackgroundService` does not cancel the analysis when the budget expires — `AnalyzeAsync` keeps running, still persists its findings through `SaveFindingsAsync`, and an in-flight marker stops the server being relaunched next cycle. All the timeout decides is how long the sweep waits before moving on, which means the user-visible effect of raising it is "notifications for a slow server arrive instead of being skipped", not "analysis completes". That is a diagnostic backstop for a hung server, not a dial anyone should be turning from a settings window, and exposing it would invite tuning against a mental model the code does not implement. Leaving it hand-editable is the right amount of access.

**`check_for_updates_on_startup`** — also not here, but for the opposite reason: it deserves more than a line in this PR. It is default-on and it makes an unsolicited outbound call to github.com five seconds after every launch, and there is no switch for it anywhere in the product. That is a genuine argument for a visible toggle, but it belongs in the General section next to "Minimize to tray" rather than buried in an alert-settings parity change, it is not a parity gap (Darling has no equivalent — the headless service does not self-update this way), and it is a privacy default that is yours to set rather than mine to change in passing. I'd rather file it as its own issue with that framing than have it ride along here.

## Separate finding

Lite's MCP `get_alert_settings` reports only `alerts_enabled`, `notify_connection_changes`, `cpu`, `blocking`, `deadlocks` and `smtp`. Darling's reports an `analysis` sub-object including `notify_cooldown_minutes`, and its `update_alert_settings` accepts that key. So after this PR the two settings *windows* agree while the two MCP surfaces still do not — an agent can read and set the analysis cooldown on Darling and cannot even see it on Lite. That is a bigger surface than the three keys #2393 is about (tempdb, disk, PVS, file growth and the job alerts are all missing from Lite's payload too), so I have left it alone; worth its own issue if you want the MCP shapes aligned.

## Verification

Built `PerformanceMonitorLite` and `Lite.Tests` on macOS with `EnableWindowsTargeting`, both clean with 0 warnings, and confirmed the XAML codegen emitted the `AnalysisNotifyCooldownBox` field that the code-behind compiles against. The suites themselves are Windows-only, so CI is the arbiter; the guard simulation above is what stands in locally. Line endings verified CRLF-only before and after on both files.
