### PR TITLE
Lite's MCP reports every alert group Darling's does

### DIFF
--- a/Lite.Tests/McpAlertSettingsKeyTests.cs
+++ b/Lite.Tests/McpAlertSettingsKeyTests.cs
@@ -11,6 +11,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Text.RegularExpressions;
+using PerformanceMonitor.Notifications;
 using PerformanceMonitorLite;
 using PerformanceMonitorLite.Mcp;
 using Xunit;
@@ -26,9 +28,11 @@ namespace Lite.Tests;
 /// just as happily if someone re-added the old key beside the new one, which is the likelier accident than
 /// deleting the new one — and for an MCP client, two keys meaning the same thing is its own bug.</para>
 ///
-/// <para>Runtime rather than source-parsing: the payload is an anonymous type serialized by
-/// <c>JsonSerializer</c> with a naming policy in <c>McpHelpers.JsonOptions</c>, so the C# identifier is not
-/// automatically the wire key. Only serializing it actually proves what a client receives.</para>
+/// <para>Runtime rather than source-parsing: the payload is an anonymous type handed to
+/// <c>JsonSerializer</c> with the SHARED <c>McpHelpers.JsonOptions</c>, and what that turns a C# identifier
+/// into is that object's business, not this file's — it carries no naming policy today, and the day it
+/// acquires one every key here changes without a line of this payload being touched. Only serializing it
+/// actually proves what a client receives.</para>
 ///
 /// <para>#1965: because it is runtime, <see cref="Settings"/> reads whatever the App.Alert* statics hold at
 /// that instant, so this class shares the "app-alert-statics" collection with the classes that write them —
@@ -36,6 +40,12 @@ namespace Lite.Tests;
 /// App.LoadAlertSettings). xUnit runs separate classes in parallel, and a foreign write of
 /// <c>CpuAlertMode.Total</c> landing between this class's set and its assert failed the SqlOnly case. The
 /// <c>finally</c> restore below could not help: the window is before the assert, not after it.</para>
+///
+/// <para>#2394 widened it from pinning three renamed keys to pinning the whole SHAPE. Lite reported four
+/// groups where Darling reports nineteen, so the drift this class was written to catch had already happened
+/// on a scale no per-key assertion would notice. The parity assertions below therefore DERIVE Darling's shape
+/// from Darling's source rather than transcribing it — a hand-copied list of nineteen groups is precisely the
+/// artifact that stays green on the day a twentieth arrives.</para>
 /// </summary>
 [Collection("app-alert-statics")]
 public sealed class McpAlertSettingsKeyTests
@@ -120,6 +130,195 @@ public sealed class McpAlertSettingsKeyTests
         }
 
         throw new FileNotFoundException($"Could not locate {relativePath} walking up from {AppContext.BaseDirectory}");
+    }
+
+    /// <summary>Darling's one group Lite deliberately does not report. Named once so the omission reads as a
+    /// decision in both places that reference it.</summary>
+    private const string SelfAlertsGroup = "self_alerts";
+
+    /// <summary>
+    /// Darling's <c>BuildAlertSettingsPayload</c> shape read out of Darling's SOURCE — each top-level key in
+    /// document order with its nested keys (an empty list for a scalar like <c>cooldown_minutes</c>). Derived
+    /// rather than transcribed for the reason in the class summary, and the same reasoning that makes
+    /// <see cref="CpuModeVocabulary_IsByteForByteDarlings"/> read Darling's file instead of asserting Lite's
+    /// own constants back at itself.
+    /// </summary>
+    private static IReadOnlyList<KeyValuePair<string, IReadOnlyList<string>>> DarlingPayloadShape()
+    {
+        var source = File.ReadAllText(FindRepoFile(Path.Combine(
+            "Darling", "PerformanceMonitor.Darling.Service", "Mcp", "DarlingMcpAlertTools.cs")));
+
+        /* Comments come out first: the payload carries several, and the "(0 = off)" inside one would
+           otherwise scan as a key. Nothing between the anchor and the initializer's closing brace is a
+           string literal, so comments are the only C# escape this has to understand. */
+        source = Regex.Replace(source, @"/\*.*?\*/", " ", RegexOptions.Singleline);
+        source = Regex.Replace(source, "//[^\r\n]*", " ");
+
+        /* Anchored on the DEFINITION rather than the name: get_alert_settings CALLS
+           BuildAlertSettingsPayload earlier in the file, so a bare name search would brace-match that call
+           site's catch block and silently return the wrong object. */
+        var start = source.IndexOf("private static object BuildAlertSettingsPayload", StringComparison.Ordinal);
+        Assert.True(start >= 0, "Darling's BuildAlertSettingsPayload definition could not be located.");
+
+        var shape = new List<KeyValuePair<string, IReadOnlyList<string>>>();
+        List<string>? nested = null;
+        var depth = 0;
+
+        for (var i = source.IndexOf('{', start); i >= 0 && i < source.Length; i++)
+        {
+            var c = source[i];
+            if (c == '{')
+            {
+                depth++;
+                continue;
+            }
+
+            if (c == '}')
+            {
+                depth--;
+                if (depth == 0) break;
+                continue;
+            }
+
+            if ((depth != 1 && depth != 2) || !(char.IsLetter(c) || c == '_')) continue;
+
+            /* The tail of an identifier already consumed, or a member access (s.CpuEnabled) - not a key. */
+            var previous = i > 0 ? source[i - 1] : ' ';
+            if (char.IsLetterOrDigit(previous) || previous == '_' || previous == '.') continue;
+
+            var end = i;
+            while (end < source.Length && (char.IsLetterOrDigit(source[end]) || source[end] == '_')) end++;
+
+            var after = end;
+            while (after < source.Length && char.IsWhiteSpace(source[after])) after++;
+
+            /* An identifier followed by a single '=' is an initializer key. Depth 1 opens a group, depth 2
+               fills the one it opened; document order makes that association exact without a stack. */
+            if (after < source.Length && source[after] == '=' &&
+                (after + 1 >= source.Length || source[after + 1] != '='))
+            {
+                var name = source[i..end];
+                if (depth == 1)
+                {
+                    nested = new List<string>();
+                    shape.Add(new KeyValuePair<string, IReadOnlyList<string>>(name, nested));
+                }
+                else
+                {
+                    nested?.Add(name);
+                }
+            }
+
+            i = end - 1;
+        }
+
+        /* The harness proves itself before anything is trusted to it. A parse that quietly returned nothing
+           would make every assertion built on it vacuously true, which is worse than having no check at all. */
+        var groups = shape.Select(g => g.Key).ToList();
+        Assert.InRange(shape.Count, 15, 40);
+        Assert.Contains("cpu", groups);
+        Assert.Contains("analysis", groups);
+        Assert.Contains(SelfAlertsGroup, groups);
+        Assert.DoesNotContain("smtp", groups);
+        Assert.Equal(new[] { "enabled", "threshold_percent", "mode" }, shape.Single(g => g.Key == "cpu").Value);
+
+        return shape;
+    }
+
+    /// <summary>
+    /// #2394: Lite reported four groups — cpu, blocking, deadlocks, smtp — where Darling reports nineteen,
+    /// even though the SHARED alert engine was already evaluating every one of them here through
+    /// <c>AppAlertEngineSettings</c>. Nothing about Lite's alerting was narrower; only the MCP surface was, so
+    /// an agent triaging a Lite instance could not read whether tempdb-space, low-disk, PVS, file-growth,
+    /// long-running-query/job, failed-job, database-state or analysis alerting was even switched on.
+    /// <para>Both directions are asserted. A key Lite emits that Darling does not is as much a defect as a
+    /// missing one: two spellings of the same setting across the two apps is exactly the #1839/#1911 class of
+    /// bug this file exists to stop, and only smtp is a legitimate Lite addition.</para>
+    /// </summary>
+    [Fact]
+    public void GetAlertSettings_ReportsEveryGroupDarlingDoes_SpelledDarlingsWay()
+    {
+        var darling = DarlingPayloadShape();
+        var root = Settings();
+        var problems = new List<string>();
+
+        foreach (var (group, darlingKeys) in darling)
+        {
+            if (group == SelfAlertsGroup) continue;
+
+            if (!root.TryGetProperty(group, out var element))
+            {
+                problems.Add($"missing group '{group}'");
+                continue;
+            }
+
+            /* A scalar (cooldown_minutes, excluded_databases) has no nested keys to compare. */
+            if (darlingKeys.Count == 0) continue;
+
+            var liteKeys = KeysOf(element);
+            problems.AddRange(darlingKeys.Except(liteKeys).Select(k => $"missing '{group}.{k}'"));
+            problems.AddRange(liteKeys.Except(darlingKeys).Select(k => $"'{group}.{k}' is Lite-only"));
+        }
+
+        Assert.True(
+            problems.Count == 0,
+            "Lite's get_alert_settings has drifted from Darling's shape: " + string.Join("; ", problems));
+
+        /* smtp is Lite's ONE addition — Lite delivers its own email where Darling manages delivery
+           credentials outside the settings row. Pinned as an exact set so a second Lite-only group cannot be
+           added without this test being the place someone justifies it. */
+        Assert.Equal(
+            new[] { "smtp" },
+            KeysOf(root).Except(darling.Select(g => g.Key)).ToArray());
+    }
+
+    /// <summary>
+    /// The one group Lite deliberately does NOT report, asserted so the hole reads as a decision rather than
+    /// the oversight it would otherwise look like. <c>AppAlertEngineSettings</c> returns shipped constants for
+    /// three of self_alerts' four members precisely because a single-instance WPF app has no headless store
+    /// volume and no fleet collection loop to self-monitor, and Lite has no concept whatsoever of the fourth,
+    /// store_job_cadence_warn_percent. Reporting constants under names that read as knobs would tell an agent
+    /// it can tune something Lite cannot.
+    /// </summary>
+    [Fact]
+    public void GetAlertSettings_OmitsSelfAlerts_WhichLiteHasNoEquivalentFor()
+    {
+        Assert.Contains(SelfAlertsGroup, DarlingPayloadShape().Select(g => g.Key));
+        Assert.DoesNotContain(SelfAlertsGroup, KeysOf(Settings()));
+    }
+
+    /// <summary>
+    /// The value half for <c>delivery.mode</c> — the second value-level alignment after <c>cpu.mode</c>, and
+    /// the one place <c>ToString()</c> is the right answer rather than a mapping: <see cref="AlertNotificationMode"/>
+    /// is the SHARED enum both SKUs run on, and Darling's store holds literally its <c>ToString()</c>, so the
+    /// two apps cannot drift the way Lite's app-local <c>CpuAlertMode</c> could.
+    /// <para>Pinned against Darling's ACCEPTED vocabulary rather than against the enum, because a rename that
+    /// moved the shared enum would move Lite's emitted value with it and an enum-derived assertion would
+    /// happily follow — while Darling's validator, which holds the two names as literals, would not.</para>
+    /// </summary>
+    [Theory]
+    [InlineData(AlertNotificationMode.Summary, "Summary")]
+    [InlineData(AlertNotificationMode.PerEvent, "PerEvent")]
+    public void GetAlertSettings_DeliveryMode_IsDarlingsAcceptedVocabulary(AlertNotificationMode mode, string expected)
+    {
+        var original = App.AlertDeliveryMode;
+        try
+        {
+            App.AlertDeliveryMode = mode;
+
+            Assert.Equal(expected, Settings().GetProperty("delivery").GetProperty("mode").GetString());
+
+            var darlingTools = File.ReadAllText(FindRepoFile(Path.Combine(
+                "Darling", "PerformanceMonitor.Darling.Service", "Mcp", "DarlingMcpAlertTools.cs")));
+            Assert.Contains(
+                "AddEnum(\"delivery_mode\", n, \"delivery.mode\", \"Summary\", \"PerEvent\")",
+                darlingTools,
+                StringComparison.Ordinal);
+        }
+        finally
+        {
+            App.AlertDeliveryMode = original;
+        }
     }
 
     [Fact]

--- a/Lite/Mcp/McpAlertTools.cs
+++ b/Lite/Mcp/McpAlertTools.cs
@@ -76,7 +76,7 @@ public sealed class McpAlertTools
         }
     }
 
-    [McpServerTool(Name = "get_alert_settings"), Description("Gets the current alert and SMTP email configuration settings.")]
+    [McpServerTool(Name = "get_alert_settings"), Description("Gets the current alert configuration this instance is running on: which alerts are enabled and their thresholds (CPU, blocking, deadlocks, poison waits, long-running queries and jobs, tempdb space, low disk, PVS, file growth, failed jobs, database state), the cooldown, the excluded databases, the deadlock/blocking delivery mode, the scheduled-analysis cadence, and the SMTP email configuration. The same nested shape Darling's get_alert_settings returns, minus its self_alerts group (the headless service's own store-volume and collection-health thresholds, which a single-instance Lite install has no equivalent for) and plus smtp, which Lite delivers itself. Read-only: Lite has no update_alert_settings, so these change in the Settings window.")]
     public static Task<string> GetAlertSettings()
     {
         try
@@ -118,6 +118,105 @@ public sealed class McpAlertTools
                     /* Same alignment: Darling reports this as count_threshold too. */
                     count_threshold = App.AlertDeadlockThreshold
                 },
+                /* #2394: everything from here down to analysis was already wired end to end on Lite —
+                   AppAlertEngineSettings has projected each of these statics onto the SHARED engine's
+                   IAlertEngineSettings since the Phase-5 forwarding, so the alerts evaluate here exactly as
+                   they do on Darling. Only the MCP surface was narrow, which meant an agent triaging a Lite
+                   instance could not read whether tempdb-space, low-disk, PVS, file-growth,
+                   long-running-query/job, failed-job, database-state or analysis alerting was even switched
+                   on. Group and key spellings are Darling's verbatim, because one MCP schema across both SKUs
+                   is the whole point of the #1839/#1911 alignments above — and note McpHelpers.JsonOptions
+                   sets no naming policy, so the C# identifier IS the wire key. */
+                poison_wait = new
+                {
+                    enabled = App.AlertPoisonWaitEnabled,
+                    threshold_ms = App.AlertPoisonWaitThresholdMs
+                },
+                long_running_query = new
+                {
+                    enabled = App.AlertLongRunningQueryEnabled,
+                    threshold_minutes = App.AlertLongRunningQueryThresholdMinutes,
+                    max_results = App.AlertLongRunningQueryMaxResults,
+                    exclude_sp_server_diagnostics = App.AlertLongRunningQueryExcludeSpServerDiagnostics,
+                    exclude_wait_for = App.AlertLongRunningQueryExcludeWaitFor,
+                    exclude_backups = App.AlertLongRunningQueryExcludeBackups,
+                    exclude_misc_waits = App.AlertLongRunningQueryExcludeMiscWaits,
+                    exclude_cdc = App.AlertLongRunningQueryExcludeCdc
+                },
+                tempdb_space = new
+                {
+                    enabled = App.AlertTempDbSpaceEnabled,
+                    threshold_percent = App.AlertTempDbSpaceThresholdPercent
+                },
+                low_disk = new
+                {
+                    enabled = App.AlertLowDiskEnabled,
+                    threshold_percent = App.AlertLowDiskThresholdPercent,
+                    threshold_gb = App.AlertLowDiskThresholdGb,
+                    /* Darling nests the #1136 CRITICAL-tier floors INSIDE low_disk and drops the "disk"
+                       prefix the statics carry, so these are critical_free_*, not disk_critical_free_*.
+                       Naming them after the App members would have read as correct and been a fifth
+                       key-level mismatch. */
+                    critical_free_percent = App.AlertDiskCriticalFreePercent,
+                    critical_free_gb = App.AlertDiskCriticalFreeGb
+                },
+                /* Darling reports a self_alerts group in this position — its own store volume, collection
+                   staleness/failure counts, and store-job cadence. Deliberately NOT emitted here.
+                   AppAlertEngineSettings returns shipped constants for three of those members precisely
+                   because Lite has no headless store volume and no fleet collection loop to self-monitor,
+                   and Lite has no concept whatsoever of the fourth (store_job_cadence_warn_percent).
+                   Reporting constants under names that read as knobs would tell an agent it can tune
+                   something Lite cannot, and an admitted gap beats an overstated capability. */
+                pvs = new
+                {
+                    enabled = App.AlertPvsEnabled,
+                    threshold_percent = App.AlertPvsThresholdPercent,
+                    floor_gb = App.AlertPvsFloorGb
+                },
+                file_growth = new
+                {
+                    enabled = App.AlertFileGrowthEnabled,
+                    rise_mb = App.AlertFileGrowthRiseMb,
+                    volume_percent = App.AlertFileGrowthVolumePercent,
+                    lookback_minutes = App.AlertFileGrowthLookbackMinutes
+                },
+                long_running_job = new
+                {
+                    enabled = App.AlertLongRunningJobEnabled,
+                    multiplier = App.AlertLongRunningJobMultiplier
+                },
+                failed_job = new
+                {
+                    enabled = App.AlertFailedJobEnabled,
+                    lookback_minutes = App.AlertFailedJobLookbackMinutes
+                },
+                database_state = new { enabled = App.AlertDatabaseStateEnabled },
+                cooldown_minutes = App.AlertCooldownMinutes,
+                excluded_databases = App.AlertExcludedDatabases,
+                delivery = new
+                {
+                    /* The second value-level alignment after cpu.mode — and the one place ToString() is the
+                       right answer rather than a mapping. AlertNotificationMode is the SHARED enum both SKUs
+                       run on, and Darling's store holds literally a.DeliveryMode.ToString(), so the two apps
+                       cannot drift the way Lite's app-local CpuAlertMode could. Darling's
+                       update_alert_settings validates delivery.mode against "Summary"/"PerEvent", which are
+                       those same member names. */
+                    mode = App.AlertDeliveryMode.ToString(),
+                    per_event_max = App.AlertPerEventMaxPerCycle
+                },
+                analysis = new
+                {
+                    enabled = App.AnalysisEnabled,
+                    interval_minutes = App.AnalysisIntervalMinutes,
+                    /* Darling's own note applies here too: this is the ANALYSIS section's delivery gate, and
+                       is why the master switch above had to be renamed off notifications_enabled. */
+                    notifications_enabled = App.AnalysisNotificationsEnabled,
+                    notify_severity = App.AnalysisNotifySeverity,
+                    notify_cooldown_minutes = App.AnalysisNotifyCooldownMinutes
+                },
+                /* Lite-only, and left last so the shared groups above stay in Darling's order: Lite delivers
+                   its own email, where Darling manages delivery credentials outside the settings row and
+                   reports no smtp group at all. The password is reported as a boolean, never a value. */
                 smtp = new
                 {
                     enabled = App.SmtpEnabled,

--- a/Lite/Mcp/McpInstructions.cs
+++ b/Lite/Mcp/McpInstructions.cs
@@ -123,7 +123,7 @@ internal static class McpInstructions
         | Tool | Purpose | Key Parameters |
         |------|---------|----------------|
         | `get_alert_history` | Recent alert history: what fired, when, email status | `hours_back` (default 24), `limit` (default 50) |
-        | `get_alert_settings` | Current alert thresholds and SMTP configuration | none |
+        | `get_alert_settings` | Every alert group's enable flag and thresholds (CPU, blocking, deadlocks, poison waits, long-running queries/jobs, tempdb, low disk, PVS, file growth, failed jobs, database state), plus cooldown, excluded databases, delivery mode, analysis cadence and SMTP configuration | none |
         | `get_mute_rules` | Configured mute rules that suppress specific recurring alerts (still logged) | `enabled_only` (default true) |
 
         ### Job Tools


### PR DESCRIPTION
Closes #2394 — scope 1 only, read-only parity.

Lite's `get_alert_settings` reported four groups (`cpu`, `blocking`, `deadlocks`, `smtp`) where Darling's reports nineteen. The issue's framing holds up completely against the source: nothing about Lite's alerting is narrower. `PerformanceMonitor.Alerting` evaluates the same alerts on both SKUs against `IAlertEngineSettings`, and `AppAlertEngineSettings` already projects every one of Lite's `App.Alert*` statics onto that interface. So an operator could have tempdb-space, low-disk, PVS, file-growth, long-running-query, long-running-job, failed-job, database-state and analysis alerting all live, and an agent triaging that instance could not read whether any of it was even switched on. The gap was purely the MCP surface, and this closes it.

Thirteen groups are added — `poison_wait`, `long_running_query`, `tempdb_space`, `low_disk`, `pvs`, `file_growth`, `long_running_job`, `failed_job`, `database_state`, `cooldown_minutes`, `excluded_databases`, `delivery`, `analysis` — spelled Darling's way down to the last key, in Darling's order, because one MCP schema across both apps is what #1839 and #1911 were for.

The two spellings that are easy to get wrong were checked against Darling's emitted shape rather than guessed. `low_disk` nests the #1136 CRITICAL floors as `critical_free_percent` / `critical_free_gb`, dropping the "disk" that the `App.AlertDiskCriticalFree*` statics carry — naming them after the statics would have read as correct and been a fifth key-level mismatch. And `delivery.mode` is a value-level alignment like `cpu.mode`, though it is the one place `ToString()` is right rather than a mapping: `AlertNotificationMode` is the shared enum both SKUs run on and Darling's store holds literally `a.DeliveryMode.ToString()`, so the two cannot drift the way Lite's app-local `CpuAlertMode` could.

## The one group not added

`self_alerts` — Darling's own store volume, collection staleness/failure counts, and store-job cadence. This is a genuine Darling-only concept rather than an omission of convenience. `AppAlertEngineSettings` returns shipped constants (`10`, `30`, `10`) for three of its four members precisely because a single-instance WPF app has no headless store volume and no fleet collection loop to self-monitor, and Lite has no member at all for the fourth, `store_job_cadence_warn_percent`. Reporting constants under names that read as knobs would tell an agent it can tune something Lite cannot, and an admitted gap beats an overstated capability. The omission is asserted as a decision, not left to look like an oversight.

`smtp` stays as Lite's one addition — Lite delivers its own email, where Darling manages delivery credentials outside the settings row and reports no `smtp` group at all.

## Why there is no `update_alert_settings`

Out of scope, and the issue is right that it needs a design decision first. Darling's tools write `config_alert_settings` and the service picks the change up through `StoreConfigProvider.ApplyToConfig` — a live reload with no restart. Lite has no equivalent plane: its settings are `App.Alert*` statics that the Settings window writes to settings.json, and `SaveAlertSettings` reads its **controls**, not the statics — so an open Settings window would silently overwrite an MCP-applied change on the next Save. That wants a change-notification seam (the issue's scope 3), not a tool bolted on next to the hazard.

## Tests

`McpAlertSettingsKeyTests` is extended, not rewritten — its existing assertions are all still there. It grows from pinning three renamed keys to pinning the whole shape, which is the lesson of this issue: the drift it was written to catch had already happened at a scale no per-key assertion would notice.

The new parity assertion **derives** Darling's shape from Darling's source (`BuildAlertSettingsPayload`) rather than transcribing it. A hand-copied list of nineteen groups is exactly the artifact that stays green on the day a twentieth arrives. Both directions are asserted, so a key Lite emits that Darling does not fails too — two spellings of one setting across the two apps is the same class of bug as a missing one — and `smtp` is pinned as the exact set of legitimate Lite-only additions, so a second one cannot appear without someone justifying it here.

The parser proves itself before it is trusted: it asserts the parse found a plausible number of groups and that known anchors (`cpu`, `analysis`, `self_alerts`, and `cpu`'s three nested keys) are present, because a parse that quietly returned nothing would make every assertion built on it vacuously true.

## Verification, and what it does and does not cover

`Lite.Tests` targets `net10.0-windows`, so it **builds** on macOS but cannot run; CI is the arbiter. `McpAlertSettingsKeyTests` is a runtime test, so rather than assert it passes, the logic was verified three ways against the real files:

1. **The shipped parser loop, run for real.** The `DarlingPayloadShape` scanning loop was copied verbatim into a throwaway `net10.0` harness and run against the actual `DarlingMcpAlertTools.cs` and `McpAlertTools.cs`. It reads 19 groups from Darling with correct nested keys, and the parity comparison passes group-for-group and key-for-key.
2. **It fails without the fix.** The same comparison against `dev`'s pre-fix `McpAlertTools.cs` reports 6 groups and **13 parity problems** — every group this PR adds. A check that passed both before and after would be worse than none.
3. **The source-to-wire link.** The whole key-name argument rests on the C# identifier being the wire key, so that was verified rather than assumed: a harness reads the real `McpHelpers.JsonOptions` by reflection (it is `internal`) and confirms it carries **no** naming policy, that snake_case identifiers survive verbatim at both nesting levels, that `List<string>` serializes as an array under its identifier, and that `AlertNotificationMode.Summary/PerEvent.ToString()` are byte-for-byte the two values Darling's `update_alert_settings` accepts for `delivery.mode`.

What that does **not** cover: the `App.Alert*` static reads themselves, which need a WPF assembly and therefore CI.

## Notes for review

**No CHANGELOG entry**, deliberately. #2395 is cutting `[3.5.1]` right now and dev has no `[Unreleased]` section, so an entry here would either collide with that diff or wrongly claim to be in a release this landed after. Happy to fold one into the next section once the cut lands.

One correction rode along: the class doc-comment claimed the payload is serialized "with a naming policy in `McpHelpers.JsonOptions`". There is no naming policy — the options object is `new() { WriteIndented = false }`. The reason the test is runtime rather than source-parsing is still sound (that object owns the mapping and could acquire a policy tomorrow, changing every key without this payload being touched), so the reasoning is kept and the false fact is fixed.

**Two things worth separate issues, found while matching the shape — neither touched here:**

- Darling's `AlertSettingsReadRow` reads `notify_connection_down_at_startup`, `connection_refire_minutes`, `notify_ag_health`, `ag_lag_alert_seconds`, `ag_redo_queue_alert_kb` and `ag_disconnect_refire_minutes`, and `BuildAlertSettingsPayload` reports **none** of them. The reader's own comment says it was widened so "an MCP client could not see the V33 connection opt-ins or the V35 Availability Group family at all" — the reader was widened and the payload was not, so neither SKU reports the AG family. Lite has the matching statics (`App.NotifyAgHealth`, `AgLagAlertSeconds`, `AgRedoQueueAlertKb`), so this is a both-SKUs gap, and it is Darling's payload that has to move first for parity to mean anything.
- Darling's `get_alert_settings` emits `blocking.wait_threshold_seconds`, but `update_alert_settings`' `blocking` group dispatches only on `enabled` and `count_threshold` — so feeding a full `get_alert_settings` payload back to it is rejected with `Unknown field 'blocking.wait_threshold_seconds'`. `BuildAlertSettingsPayload`'s doc comment promises "the same field names update_alert_settings accepts on the way in, so a read → modify → write round-trips", and for that one key it does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
