### PR TITLE
Say which plane decided the MCP endpoint is on, and on what port (#2389)

### DIFF
--- a/Darling/Darling.Tests/DarlingHostBindingTests.cs
+++ b/Darling/Darling.Tests/DarlingHostBindingTests.cs
@@ -315,9 +315,11 @@ public sealed class DarlingHostBindingTests
         Assert.Contains("false in config.config_service.mcp_enabled", report, StringComparison.Ordinal);
         Assert.Contains("CONTROL PLANE WINS", report, StringComparison.Ordinal);
         Assert.Contains("--enable-mcp/--disable-mcp", report, StringComparison.Ordinal);
-        /* The other half of the confusion: network.* is file-authoritative, so an exposure block stays live
-           while the control plane keeps the endpoint off. */
+        /* The other half of the confusion: network.* is file-authoritative and no store setting can move it. */
         Assert.Contains("mcp.network", report, StringComparison.Ordinal);
+        Assert.Contains("cannot change where this endpoint binds", report, StringComparison.Ordinal);
+        /* The endpoint IS down here, so the consequence names that state — and only in that state. */
+        Assert.Contains("not what is keeping this endpoint down", report, StringComparison.Ordinal);
         /* Only the field that actually DIFFERS gets a clause — the ports agree here, so no port clause.
            (The closing advice still names mcp.port, which is why this pins the clause form, not the key.) */
         Assert.DoesNotContain("port is 5152 in darling.json", report, StringComparison.Ordinal);
@@ -335,6 +337,33 @@ public sealed class DarlingHostBindingTests
         Assert.Contains("false in darling.json (mcp.enabled)", report, StringComparison.Ordinal);
         Assert.Contains("true in config.config_service.mcp_enabled", report, StringComparison.Ordinal);
         Assert.Contains("port is 5152 in darling.json (mcp.port) but 5199 in config.config_service.mcp_port", report, StringComparison.Ordinal);
+
+        /* Review catch: the control plane turned this endpoint ON despite the file, so the closing consequence
+           must not claim it is being kept off — a diagnostic that exists to stop operators being misled about
+           the effective state cannot itself misstate it. */
+        Assert.DoesNotContain("keeping this endpoint down", report, StringComparison.Ordinal);
+        Assert.Contains("what this RUNNING endpoint is bound and gated by", report, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The likeliest real mismatch, and the one that reads least like a bug: both planes agree the endpoint
+    /// runs and only the PORT differs, because someone moved it in the Viewer's Settings. It is still a
+    /// reportable disagreement — the file value is dead and the firewall rule is named off it (#2414) — but the
+    /// endpoint is up, so nothing in the message may say otherwise.
+    /// </summary>
+    [Fact]
+    public void DescribeToggleOverride_PortOnlyMismatch_ReportsIt_WithoutClaimingTheEndpointIsDown()
+    {
+        var toggle = DarlingHostBinding.ResolveEndpointToggle((true, 5199), fileEnabled: true, filePort: 5152);
+        var report = DarlingHostBinding.DescribeToggleOverride(toggle, "mcp", "MCP", fileEnabled: true, filePort: 5152);
+
+        Assert.NotNull(report);
+        Assert.True(toggle.PortOverridden);
+        Assert.False(toggle.EnabledOverridden);
+        Assert.Contains("port is 5152 in darling.json (mcp.port) but 5199 in config.config_service.mcp_port", report, StringComparison.Ordinal);
+        /* The planes agree on enabled, so no enabled clause. */
+        Assert.DoesNotContain("in darling.json (mcp.enabled)", report, StringComparison.Ordinal);
+        Assert.DoesNotContain("keeping this endpoint down", report, StringComparison.Ordinal);
     }
 
     /// <summary>The web dashboard is the same defect on the same seam, so it shares the resolver: one

--- a/Darling/Darling.Tests/DarlingHostBindingTests.cs
+++ b/Darling/Darling.Tests/DarlingHostBindingTests.cs
@@ -6,6 +6,7 @@
  * Licensed under the MIT License. See LICENSE file in the project root for full license information.
  */
 
+using System;
 using System.Net;
 using Microsoft.Extensions.Logging;
 using PerformanceMonitor.Darling.Service.Hosting;
@@ -246,5 +247,125 @@ public sealed class DarlingHostBindingTests
         Assert.Equal((int)DarlingHostBinding.BindReason.ListenInvalid, (int)DarlingMcpHostService.McpBindReason.ListenInvalid);
         Assert.Equal((int)DarlingHostBinding.BindReason.TokenMissing, (int)DarlingMcpHostService.McpBindReason.TokenMissing);
         Assert.Equal((int)DarlingHostBinding.BindReason.AllowFromInvalid, (int)DarlingMcpHostService.McpBindReason.AllowFromInvalid);
+    }
+
+    /* ================================================================================================
+       #2389: WHICH PLANE decided enabled/port. One mcp object in darling.json has two owners —
+       enabled/port are a seed the store overrides forever after, network.* is file-only and restart-only —
+       and before this the supervisor's `published?.Enabled ?? config.Mcp.Enabled` could not say which side
+       it had taken. The resolution now carries its provenance, so the start line names it and a
+       disagreement is reported at the point of override.
+       ================================================================================================ */
+
+    /// <summary>Nothing published yet (worker bootstrapping, or a store it never reached): the FILE values
+    /// apply, unchanged — and are flagged as such, because the control plane can still contradict them.</summary>
+    [Fact]
+    public void ResolveEndpointToggle_Unpublished_TakesTheFileValues_AndSaysSo()
+    {
+        var toggle = DarlingHostBinding.ResolveEndpointToggle(published: null, fileEnabled: true, filePort: 5152);
+
+        Assert.True(toggle.Enabled);
+        Assert.Equal(5152, toggle.Port);
+        Assert.Equal(DarlingHostBinding.EndpointToggleOrigin.File, toggle.Origin);
+
+        /* Nothing is published, so there is nothing to disagree WITH — an unpublished read is not an override. */
+        Assert.False(toggle.EnabledOverridden);
+        Assert.False(toggle.PortOverridden);
+        Assert.Null(DarlingHostBinding.DescribeToggleOverride(toggle, "mcp", "MCP", fileEnabled: true, filePort: 5152));
+    }
+
+    /// <summary>The published row wins — the pre-existing behavior, pinned so the diagnostic did not change it.</summary>
+    [Theory]
+    [InlineData(true, 5152, false, 5199)]
+    [InlineData(false, 5199, true, 5152)]
+    public void ResolveEndpointToggle_Published_AlwaysWins(bool storeEnabled, int storePort, bool fileEnabled, int filePort)
+    {
+        var toggle = DarlingHostBinding.ResolveEndpointToggle((storeEnabled, storePort), fileEnabled, filePort);
+
+        Assert.Equal(storeEnabled, toggle.Enabled);
+        Assert.Equal(storePort, toggle.Port);
+        Assert.Equal(DarlingHostBinding.EndpointToggleOrigin.ControlPlane, toggle.Origin);
+    }
+
+    /// <summary>Agreeing planes are silent: the warning fires on the MISMATCH, not on every start.</summary>
+    [Fact]
+    public void DescribeToggleOverride_PlanesAgree_IsSilent()
+    {
+        var toggle = DarlingHostBinding.ResolveEndpointToggle((true, 5152), fileEnabled: true, filePort: 5152);
+
+        Assert.False(toggle.EnabledOverridden);
+        Assert.False(toggle.PortOverridden);
+        Assert.Null(DarlingHostBinding.DescribeToggleOverride(toggle, "mcp", "MCP", fileEnabled: true, filePort: 5152));
+    }
+
+    /// <summary>
+    /// The reported case (#2389): darling.json says enabled, the store says disabled, the store wins and the
+    /// server is stopped five seconds after announcing a successful start. The message has to name BOTH sides
+    /// with the key/column an operator can act on, say which one wins, and disclose the opposite ownership of
+    /// the network block — otherwise the reader concludes their file edit worked.
+    /// </summary>
+    [Fact]
+    public void DescribeToggleOverride_FileEnabledButStoreDisabled_NamesBothPlanesAndTheWinner()
+    {
+        var toggle = DarlingHostBinding.ResolveEndpointToggle((false, 5152), fileEnabled: true, filePort: 5152);
+        var report = DarlingHostBinding.DescribeToggleOverride(toggle, "mcp", "MCP", fileEnabled: true, filePort: 5152);
+
+        Assert.NotNull(report);
+        Assert.Contains("true in darling.json (mcp.enabled)", report, StringComparison.Ordinal);
+        Assert.Contains("false in config.config_service.mcp_enabled", report, StringComparison.Ordinal);
+        Assert.Contains("CONTROL PLANE WINS", report, StringComparison.Ordinal);
+        Assert.Contains("--enable-mcp/--disable-mcp", report, StringComparison.Ordinal);
+        /* The other half of the confusion: network.* is file-authoritative, so an exposure block stays live
+           while the control plane keeps the endpoint off. */
+        Assert.Contains("mcp.network", report, StringComparison.Ordinal);
+        /* Only the field that actually DIFFERS gets a clause — the ports agree here, so no port clause.
+           (The closing advice still names mcp.port, which is why this pins the clause form, not the key.) */
+        Assert.DoesNotContain("port is 5152 in darling.json", report, StringComparison.Ordinal);
+    }
+
+    /// <summary>The port has the identical shape (the issue's second half): a server on an unexpected port
+    /// with no explanation. Both fields differing are reported together, in one line.</summary>
+    [Fact]
+    public void DescribeToggleOverride_ReportsThePortToo_AndBothFieldsAtOnce()
+    {
+        var toggle = DarlingHostBinding.ResolveEndpointToggle((true, 5199), fileEnabled: false, filePort: 5152);
+        var report = DarlingHostBinding.DescribeToggleOverride(toggle, "mcp", "MCP", fileEnabled: false, filePort: 5152);
+
+        Assert.NotNull(report);
+        Assert.Contains("false in darling.json (mcp.enabled)", report, StringComparison.Ordinal);
+        Assert.Contains("true in config.config_service.mcp_enabled", report, StringComparison.Ordinal);
+        Assert.Contains("port is 5152 in darling.json (mcp.port) but 5199 in config.config_service.mcp_port", report, StringComparison.Ordinal);
+    }
+
+    /// <summary>The web dashboard is the same defect on the same seam, so it shares the resolver: one
+    /// <c>section</c> argument drives the file key, the store column and the CLI verb, which is what stops the
+    /// two surfaces' wordings from drifting apart.</summary>
+    [Fact]
+    public void DescribeToggleOverride_WebSurface_NamesTheWebKeysAndVerbs()
+    {
+        var toggle = DarlingHostBinding.ResolveEndpointToggle((false, 5153), fileEnabled: true, filePort: 5153);
+        var report = DarlingHostBinding.DescribeToggleOverride(toggle, "web", "Web dashboard", fileEnabled: true, filePort: 5153);
+
+        Assert.NotNull(report);
+        Assert.Contains("web.enabled", report, StringComparison.Ordinal);
+        Assert.Contains("config.config_service.web_enabled", report, StringComparison.Ordinal);
+        Assert.Contains("--enable-web/--disable-web", report, StringComparison.Ordinal);
+        Assert.DoesNotContain("mcp", report, StringComparison.Ordinal);
+    }
+
+    /// <summary>The start line's provenance clause distinguishes the two planes, and the file case admits it
+    /// is provisional — that line is the one the operator greps and stops reading.</summary>
+    [Fact]
+    public void DescribeToggleOrigin_DistinguishesThePlanes_AndFlagsTheFileCaseAsProvisional()
+    {
+        var fromStore = DarlingHostBinding.DescribeToggleOrigin(
+            DarlingHostBinding.ResolveEndpointToggle((true, 5152), fileEnabled: true, filePort: 5152));
+        var fromFile = DarlingHostBinding.DescribeToggleOrigin(
+            DarlingHostBinding.ResolveEndpointToggle(published: null, fileEnabled: true, filePort: 5152));
+
+        Assert.Contains("config.config_service", fromStore, StringComparison.Ordinal);
+        Assert.Contains("darling.json", fromFile, StringComparison.Ordinal);
+        Assert.Contains("PROVISIONAL", fromFile, StringComparison.Ordinal);
+        Assert.NotEqual(fromStore, fromFile);
     }
 }

--- a/Darling/Darling.Tests/DarlingMcpSupervisorTests.cs
+++ b/Darling/Darling.Tests/DarlingMcpSupervisorTests.cs
@@ -7,6 +7,7 @@
  */
 
 using System;
+using System.IO;
 using PerformanceMonitor.Darling.Service.Mcp;
 using Xunit;
 
@@ -67,5 +68,59 @@ public sealed class DarlingMcpSupervisorTests
     {
         Assert.Equal(TimeSpan.FromSeconds(5), DarlingMcpHostService.SupervisorPollInterval);
         Assert.Equal(TimeSpan.FromSeconds(30), DarlingMcpHostService.FailedStartBackoff);
+    }
+
+    /* ================================================================================================
+       #2389: the SOURCE pin. The defect was not in a decision function — it was that the supervisor's
+       `published?.Enabled ?? config.Mcp.Enabled` silently took a side and had no way to say so, while
+       the MCP network block beside it stayed file-authoritative. A behavioural test of the old code
+       passes: it resolved the right value, it just could not report it. So pin the CALL SITE, which is what a
+       future "simplification" back to the null-coalesce would break.
+       ================================================================================================ */
+
+    [Fact]
+    public void TheSupervisor_ResolvesThroughTheProvenanceAwareHelper_NotASilentNullCoalesce()
+    {
+        var source = ReadHostSource("DarlingMcpHostService.cs");
+
+        /* The silent form, gone from both halves of the resolution. */
+        Assert.DoesNotContain("published?.Enabled ??", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("published?.Port ??", source, StringComparison.Ordinal);
+
+        /* Replaced by the shared resolver, and BOTH of its diagnostics wired up: the override report (the
+           disagreement, at the point of override) and the origin clause (on the start line the operator
+           greps). Either one missing leaves half the confusion in place. */
+        Assert.Contains("DarlingHostBinding.ResolveEndpointToggle(", source, StringComparison.Ordinal);
+        Assert.Contains("DarlingHostBinding.DescribeToggleOverride(", source, StringComparison.Ordinal);
+        Assert.Contains("DarlingHostBinding.DescribeToggleOrigin(", source, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The disagreement is a WARNING and it is deduplicated, not emitted on every 5s poll tick: the report is
+    /// compared to the last one emitted, and cleared when the planes agree again so a LATER re-divergence is
+    /// still reported. An undeduplicated warning would be 17,280 lines a day and get filtered out, which is the
+    /// same silence in a different costume.
+    /// </summary>
+    [Fact]
+    public void TheOverrideReport_IsWarnedOncePerDistinctState()
+    {
+        var source = ReadHostSource("DarlingMcpHostService.cs");
+
+        Assert.Contains("_logger.LogWarning(\"{Report}\", overrideReport);", source, StringComparison.Ordinal);
+        Assert.Contains("!string.Equals(overrideReport, lastOverrideReport, StringComparison.Ordinal)", source, StringComparison.Ordinal);
+        Assert.Contains("lastOverrideReport = overrideReport;", source, StringComparison.Ordinal);
+    }
+
+    /// <summary>Reads the real host source, copied beside the test binary by the csproj (the same fixture the
+    /// Host-header guard pins parse).</summary>
+    private static string ReadHostSource(string fileName)
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "Fixtures", fileName);
+        Assert.True(File.Exists(path), $"{fileName} was not copied beside the test binary — check the csproj None/Link item.");
+
+        var source = File.ReadAllText(path);
+        /* Guard the guard: an unrecognizable restructure must fail loudly, not pass vacuously. */
+        Assert.Contains("var published = _state.Read();", source, StringComparison.Ordinal);
+        return source;
     }
 }

--- a/Darling/Darling.Tests/DarlingWebSupervisorTests.cs
+++ b/Darling/Darling.Tests/DarlingWebSupervisorTests.cs
@@ -7,6 +7,7 @@
  */
 
 using System;
+using System.IO;
 using PerformanceMonitor.Darling.Service;
 using PerformanceMonitor.Darling.Service.Hosting;
 using PerformanceMonitor.Darling.Service.Mcp;
@@ -124,5 +125,59 @@ public sealed class DarlingWebSupervisorTests
     {
         Assert.Equal(TimeSpan.FromSeconds(5), DarlingWebHostService.SupervisorPollInterval);
         Assert.Equal(TimeSpan.FromSeconds(30), DarlingWebHostService.FailedStartBackoff);
+    }
+
+    /* ================================================================================================
+       #2389: the SOURCE pin. The defect was not in a decision function — it was that the supervisor's
+       `published?.Enabled ?? config.Web.Enabled` silently took a side and had no way to say so, while
+       the web network block beside it stayed file-authoritative. A behavioural test of the old code
+       passes: it resolved the right value, it just could not report it. So pin the CALL SITE, which is what a
+       future "simplification" back to the null-coalesce would break.
+       ================================================================================================ */
+
+    [Fact]
+    public void TheSupervisor_ResolvesThroughTheProvenanceAwareHelper_NotASilentNullCoalesce()
+    {
+        var source = ReadHostSource("DarlingWebHostService.cs");
+
+        /* The silent form, gone from both halves of the resolution. */
+        Assert.DoesNotContain("published?.Enabled ??", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("published?.Port ??", source, StringComparison.Ordinal);
+
+        /* Replaced by the shared resolver, and BOTH of its diagnostics wired up: the override report (the
+           disagreement, at the point of override) and the origin clause (on the start line the operator
+           greps). Either one missing leaves half the confusion in place. */
+        Assert.Contains("DarlingHostBinding.ResolveEndpointToggle(", source, StringComparison.Ordinal);
+        Assert.Contains("DarlingHostBinding.DescribeToggleOverride(", source, StringComparison.Ordinal);
+        Assert.Contains("DarlingHostBinding.DescribeToggleOrigin(", source, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The disagreement is a WARNING and it is deduplicated, not emitted on every 5s poll tick: the report is
+    /// compared to the last one emitted, and cleared when the planes agree again so a LATER re-divergence is
+    /// still reported. An undeduplicated warning would be 17,280 lines a day and get filtered out, which is the
+    /// same silence in a different costume.
+    /// </summary>
+    [Fact]
+    public void TheOverrideReport_IsWarnedOncePerDistinctState()
+    {
+        var source = ReadHostSource("DarlingWebHostService.cs");
+
+        Assert.Contains("_logger.LogWarning(\"{Report}\", overrideReport);", source, StringComparison.Ordinal);
+        Assert.Contains("!string.Equals(overrideReport, lastOverrideReport, StringComparison.Ordinal)", source, StringComparison.Ordinal);
+        Assert.Contains("lastOverrideReport = overrideReport;", source, StringComparison.Ordinal);
+    }
+
+    /// <summary>Reads the real host source, copied beside the test binary by the csproj (the same fixture the
+    /// Host-header guard pins parse).</summary>
+    private static string ReadHostSource(string fileName)
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "Fixtures", fileName);
+        Assert.True(File.Exists(path), $"{fileName} was not copied beside the test binary — check the csproj None/Link item.");
+
+        var source = File.ReadAllText(path);
+        /* Guard the guard: an unrecognizable restructure must fail loudly, not pass vacuously. */
+        Assert.Contains("var published = _state.Read();", source, StringComparison.Ordinal);
+        return source;
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingCliCommands.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingCliCommands.cs
@@ -1422,12 +1422,15 @@ public static class DarlingCliCommands
         {
             output.WriteLine();
             output.WriteLine("== MCP exposure ==");
-            if (!config.Mcp.Enabled)
-            {
-                output.WriteLine("NOTE: mcp.enabled is currently false. The wizard writes the network block, but the endpoint");
-                output.WriteLine("      stays down until you enable MCP in the Viewer's Settings (enabled/port are control-plane");
-                output.WriteLine("      after first run; the wizard never edits them).");
-            }
+            /* #2389: unconditional, and about the PRECEDENCE rather than the file value. This used to print
+               only when mcp.enabled was FALSE in the file, which is exactly backwards — a file that says true
+               while config_service.mcp_enabled says false is the combination that misleads, and it printed
+               nothing there. The wizard holds no store connection, so it cannot report the effective value;
+               what it can do honestly is say which plane decides and where the file value stops mattering. */
+            output.WriteLine($"NOTE: darling.json has mcp.enabled = {(config.Mcp.Enabled ? "true" : "false")}, but after the first run that is only");
+            output.WriteLine("      the SEED — config.config_service.mcp_enabled decides whether the endpoint actually runs, and");
+            output.WriteLine("      this wizard neither reads nor writes it. It writes the network block only (which IS file-only");
+            output.WriteLine("      and restart-only); use --enable-mcp / --disable-mcp or the Viewer's Settings to turn MCP on.");
 
             mcp = GatherMcpInputs(input, output, error, config.Mcp);
             if (mcp is null)
@@ -1441,12 +1444,11 @@ public static class DarlingCliCommands
         {
             output.WriteLine();
             output.WriteLine("== Web dashboard exposure ==");
-            if (!config.Web.Enabled)
-            {
-                output.WriteLine("NOTE: web.enabled is currently false. The wizard writes the network block, but the dashboard");
-                output.WriteLine("      stays down until you enable it with --enable-web or the Viewer's Settings (enabled/port");
-                output.WriteLine("      are control-plane after first run; the wizard never edits them).");
-            }
+            /* #2389: the MCP note's twin — unconditional, and about which plane decides. */
+            output.WriteLine($"NOTE: darling.json has web.enabled = {(config.Web.Enabled ? "true" : "false")}, but after the first run that is only");
+            output.WriteLine("      the SEED — config.config_service.web_enabled decides whether the dashboard actually runs, and");
+            output.WriteLine("      this wizard neither reads nor writes it. It writes the network block only (which IS file-only");
+            output.WriteLine("      and restart-only); use --enable-web / --disable-web or the Viewer's Settings to turn it on.");
 
             web = GatherWebInputs(input, output, error, config.Web);
             if (web is null)
@@ -2086,11 +2088,12 @@ public static class DarlingCliCommands
             output.WriteLine("  MCP firewall rule (run ELEVATED; scoped to the port + CIDR):");
             output.WriteLine("    " + DarlingManagedPostgres.BuildFirewallEnableCommand(
                 DarlingMcpHostService.McpFirewallRuleName(mcpPort), mcpPort, mcpCidr!));
-            if (!mcpEnabled)
-            {
-                output.WriteLine("  NOTE: mcp.enabled is false, so the MCP endpoint stays down until you enable MCP in the");
-                output.WriteLine("        Viewer's Settings. The network block you just wrote applies once MCP is enabled.");
-            }
+            /* #2389: unconditional and about the PLANE, not the file value. This printed only when the FILE
+               said false, which left the actually-misleading combination — file true, store false — with no
+               note at all; and mcpEnabled here is the file's value, which on a seeded box decides nothing. */
+            output.WriteLine("  NOTE: the network block you just wrote is FILE-authoritative and applies on restart, but whether");
+            output.WriteLine("        MCP runs at all is config.config_service.mcp_enabled — darling.json's mcp.enabled is only the");
+            output.WriteLine($"        first-run seed, and it currently reads {(mcpEnabled ? "true" : "false")}. Enable with --enable-mcp or the Viewer's Settings.");
         }
 
         if (webConfigured)
@@ -2107,12 +2110,10 @@ public static class DarlingCliCommands
             output.WriteLine("  Remote browser login (after the service restarts):");
             output.WriteLine($"    http://{webHost}:{webPort}/?token=<your-access-token>");
             output.WriteLine("  (the token is exchanged for a session cookie and stripped from the URL; loopback needs no token)");
-            if (!webEnabled)
-            {
-                output.WriteLine("  NOTE: web.enabled is false, so the dashboard stays down until you enable it with --enable-web");
-                output.WriteLine("        or the Viewer's Settings. The network block you just wrote applies once the web dashboard");
-                output.WriteLine("        is enabled.");
-            }
+            /* #2389: the MCP note's twin — unconditional, and about which plane decides. */
+            output.WriteLine("  NOTE: the network block you just wrote is FILE-authoritative and applies on restart, but whether");
+            output.WriteLine("        the dashboard runs at all is config.config_service.web_enabled — darling.json's web.enabled is");
+            output.WriteLine($"        only the first-run seed, and it currently reads {(webEnabled ? "true" : "false")}. Enable with --enable-web or Settings.");
         }
     }
 

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingConfig.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingConfig.cs
@@ -721,10 +721,17 @@ public sealed class SmtpConfig
 /// </summary>
 public sealed class McpConfig
 {
-    /// <summary>Default OFF — the headless twin of both apps' mcp_enabled=false default.</summary>
+    /// <summary>Default OFF — the headless twin of both apps' mcp_enabled=false default.
+    /// <para>A first-run SEED only (#2389): once the store is seeded, <c>config.config_service.mcp_enabled</c>
+    /// is authoritative and this value is never read again except before the worker's first publish. Editing it
+    /// on a seeded box changes nothing — use <c>--enable-mcp</c>/<c>--disable-mcp</c> or the Viewer's Settings.
+    /// <see cref="Network"/>, sitting right beside it, is the OPPOSITE: file-only with no store equivalent.
+    /// The supervisor reports the disagreement when the two planes differ.</para></summary>
     [JsonPropertyName("enabled")]
     public bool Enabled { get; set; }
 
+    /// <summary>A first-run SEED only, like <see cref="Enabled"/> — <c>config.config_service.mcp_port</c> wins
+    /// on a seeded store.</summary>
     [JsonPropertyName("port")]
     public int Port { get; set; } = 5152;
 

--- a/Darling/PerformanceMonitor.Darling.Service/Hosting/DarlingHostBinding.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Hosting/DarlingHostBinding.cs
@@ -7,6 +7,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Runtime.Versioning;
 using System.Security.Cryptography;
@@ -229,5 +230,101 @@ internal static class DarlingHostBinding
         var expectedHash = SHA256.HashData(Encoding.UTF8.GetBytes(expected));
         var presentedHash = SHA256.HashData(Encoding.UTF8.GetBytes(presented));
         return CryptographicOperations.FixedTimeEquals(expectedHash, presentedHash);
+    }
+
+    /* ---------------------------------------------------------------------------------------------------
+       WHICH PLANE decided this endpoint is on, and on what port (#2389). One <c>mcp</c> object in darling.json
+       has TWO owners: <c>enabled</c>/<c>port</c> are a first-run SEED that the store's config_service row
+       overrides forever after, while <c>network.*</c> (listen / allowFrom / the DPAPI token) is file-only and
+       restart-only. Nothing in the file distinguishes them, so an operator who edits mcp.enabled, restarts and
+       greps the log finds "Starting MCP server on http://<lan-ip>:5152" -- true, and then contradicted five
+       seconds later when the worker's first publish arrives and the supervisor reconciles to the store.
+
+       network.* deliberately STAYS file-only rather than being moved into the store to match: the DPAPI token
+       is LocalMachine-scoped, so a blob in config_service is undecryptable on any other host that reads that
+       store, and a bind address + CIDR + token living in config_service would let a REMOTE admin store
+       connection -- the pivot the postgres.network role warning already names -- re-point this listener onto a
+       LAN interface behind a credential of its own choosing. Exposure should require touching the host. So the
+       split is kept and made VISIBLE instead: the effective values carry their origin into the start line, and
+       a disagreement is reported at the point of override rather than left to be inferred from two INFO lines.
+       --------------------------------------------------------------------------------------------------- */
+
+    /// <summary>Which plane supplied the effective enable/port a host supervisor is acting on (#2389).</summary>
+    internal enum EndpointToggleOrigin
+    {
+        /// <summary>darling.json, because the worker has not published yet (still bootstrapping, or it never
+        /// reached the store). PROVISIONAL: the control plane can contradict it within one poll interval.</summary>
+        File,
+
+        /// <summary>The store's <c>config.config_service</c> row, published by the worker. Authoritative.</summary>
+        ControlPlane,
+    }
+
+    /// <summary>The effective (enabled, port) a supervisor acts on, WITH its provenance (#2389).
+    /// <see cref="EnabledOverridden"/> / <see cref="PortOverridden"/> are true only when the control plane
+    /// supplied a value that DIFFERS from darling.json's -- the reportable disagreement.</summary>
+    internal readonly record struct EndpointToggle(
+        bool Enabled, int Port, EndpointToggleOrigin Origin, bool EnabledOverridden, bool PortOverridden);
+
+    /// <summary>
+    /// PURE: the store row wins whenever the worker has published one -- byte-for-byte the old
+    /// <c>published?.Enabled ?? config.Mcp.Enabled</c> pair -- but it also reports WHERE the values came from
+    /// and whether they contradict the file, which a null-coalesce structurally cannot.
+    /// </summary>
+    internal static EndpointToggle ResolveEndpointToggle((bool Enabled, int Port)? published, bool fileEnabled, int filePort)
+        => published is null
+            ? new EndpointToggle(fileEnabled, filePort, EndpointToggleOrigin.File, false, false)
+            : new EndpointToggle(
+                published.Value.Enabled,
+                published.Value.Port,
+                EndpointToggleOrigin.ControlPlane,
+                EnabledOverridden: published.Value.Enabled != fileEnabled,
+                PortOverridden: published.Value.Port != filePort);
+
+    /// <summary>
+    /// PURE: the provenance clause the start line carries, so "Starting ... on http://..." says on whose
+    /// authority it is starting -- and admits when it is running on file values the control plane has not
+    /// weighed in on yet, which is the line the operator greps and stops reading.
+    /// </summary>
+    internal static string DescribeToggleOrigin(EndpointToggle toggle)
+        => toggle.Origin == EndpointToggleOrigin.ControlPlane
+            ? "the control plane (config.config_service)"
+            : "darling.json (PROVISIONAL - the control plane has not published yet and may stop or rebind this server)";
+
+    /// <summary>
+    /// PURE: the one-line report of a control-plane override, or null when the two planes agree (or nothing is
+    /// published yet, in which case there is nothing to disagree with). <paramref name="section"/> is the
+    /// darling.json object name, the config_service column prefix, and the CLI verb suffix at once ("mcp" -&gt;
+    /// mcp.enabled / config_service.mcp_enabled / --enable-mcp), which is what keeps the MCP and web wordings
+    /// from drifting apart. The file values are passed in rather than re-derived so the message quotes what the
+    /// caller actually loaded.
+    /// </summary>
+    internal static string? DescribeToggleOverride(
+        EndpointToggle toggle, string section, string surface, bool fileEnabled, int filePort)
+    {
+        if (toggle.Origin != EndpointToggleOrigin.ControlPlane || (!toggle.EnabledOverridden && !toggle.PortOverridden))
+        {
+            return null;
+        }
+
+        var fields = new List<string>(2);
+        if (toggle.EnabledOverridden)
+        {
+            fields.Add(
+                $"enabled is {(fileEnabled ? "true" : "false")} in darling.json ({section}.enabled) but "
+                + $"{(toggle.Enabled ? "true" : "false")} in config.config_service.{section}_enabled");
+        }
+
+        if (toggle.PortOverridden)
+        {
+            fields.Add($"port is {filePort} in darling.json ({section}.port) but {toggle.Port} in config.config_service.{section}_port");
+        }
+
+        return $"{surface} configuration disagrees across the two planes and the CONTROL PLANE WINS: "
+            + string.Join("; ", fields)
+            + $". After the first run darling.json's {section}.enabled/{section}.port are only the SEED -- change them with "
+            + $"--enable-{section}/--disable-{section} or the Viewer's Settings, or the file values will keep being ignored. "
+            + $"The {section}.network block is the OPPOSITE: file-only, restart-only, no store equivalent -- so an exposure "
+            + "block in darling.json is live even while the control plane keeps this endpoint off.";
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Service/Hosting/DarlingHostBinding.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Hosting/DarlingHostBinding.cs
@@ -320,11 +320,22 @@ internal static class DarlingHostBinding
             fields.Add($"port is {filePort} in darling.json ({section}.port) but {toggle.Port} in config.config_service.{section}_port");
         }
 
+        /* The ownership disclosure is unconditional because it is true in every state; the CONSEQUENCE is not.
+           Review catch: a single closing sentence claiming "the control plane keeps this endpoint off" is wrong
+           whenever the control plane turned it ON despite the file, and wrong for a port-only mismatch where
+           both planes agree it runs -- which is the likelier real case. So the state-specific half is emitted
+           only in the state it describes. */
+        var consequence = toggle.Enabled
+            ? " It is what this RUNNING endpoint is bound and gated by, and no store setting can move it."
+            : " It is not what is keeping this endpoint down, and it takes effect as written the moment the "
+                + "control plane enables it.";
+
         return $"{surface} configuration disagrees across the two planes and the CONTROL PLANE WINS: "
             + string.Join("; ", fields)
             + $". After the first run darling.json's {section}.enabled/{section}.port are only the SEED -- change them with "
             + $"--enable-{section}/--disable-{section} or the Viewer's Settings, or the file values will keep being ignored. "
-            + $"The {section}.network block is the OPPOSITE: file-only, restart-only, no store equivalent -- so an exposure "
-            + "block in darling.json is live even while the control plane keeps this endpoint off.";
+            + $"The {section}.network block is the OPPOSITE: file-only, restart-only, no store equivalent -- the control "
+            + "plane cannot change where this endpoint binds or what token it requires."
+            + consequence;
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpHostService.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpHostService.cs
@@ -137,6 +137,9 @@ public sealed class DarlingMcpHostService : BackgroundService
            network exposure block is restart-only by design). */
         DarlingConfig? config = null;
         var lastFailedStartUtc = DateTime.MinValue;
+        /* #2389: the last control-plane-override report emitted, so a steady disagreement is stated once per
+           distinct state instead of on every 5s poll tick. */
+        string? lastOverrideReport = null;
         while (!stoppingToken.IsCancellationRequested)
         {
             if (config is null && DateTime.UtcNow - lastFailedStartUtc >= FailedStartBackoff)
@@ -169,13 +172,29 @@ public sealed class DarlingMcpHostService : BackgroundService
             }
 
             var published = _state.Read();
-            var enabled = published?.Enabled ?? config.Mcp.Enabled;
-            var desiredPort = published?.Port ?? config.Mcp.Port;
 
-            switch (DecideMcpAction(_app is not null, _runningPort, enabled, desiredPort))
+            /* #2389: the store still wins whenever the worker has published (unchanged), but the resolution
+               now carries WHICH plane supplied each value, so neither the start line nor a disagreement has to
+               be inferred from two INFO lines five seconds apart. */
+            var toggle = DarlingHostBinding.ResolveEndpointToggle(
+                published is null ? null : (published.Enabled, published.Port), config.Mcp.Enabled, config.Mcp.Port);
+
+            /* Report the DISAGREEMENT at the point of override, not the outcome. Once per distinct state (the
+               last-reported string, the same shape as the firewall check's ShouldReport) so a steady mismatch
+               says its piece once per service start rather than every poll tick, while a LATER re-divergence —
+               someone toggling the store after boot — is still reported. */
+            var overrideReport = DarlingHostBinding.DescribeToggleOverride(toggle, "mcp", "MCP", config.Mcp.Enabled, config.Mcp.Port);
+            if (overrideReport is not null && !string.Equals(overrideReport, lastOverrideReport, StringComparison.Ordinal))
+            {
+                _logger.LogWarning("{Report}", overrideReport);
+            }
+
+            lastOverrideReport = overrideReport;
+
+            switch (DecideMcpAction(_app is not null, _runningPort, toggle.Enabled, toggle.Port))
             {
                 case McpSupervisorAction.Start when DateTime.UtcNow - lastFailedStartUtc >= FailedStartBackoff:
-                    if (!await TryStartServerAsync(config, desiredPort, stoppingToken))
+                    if (!await TryStartServerAsync(config, toggle, stoppingToken))
                     {
                         lastFailedStartUtc = DateTime.UtcNow;
                     }
@@ -188,9 +207,9 @@ public sealed class DarlingMcpHostService : BackgroundService
 
                 case McpSupervisorAction.Restart:
                     _logger.LogInformation(
-                        "MCP port changed via the control plane ({Old} -> {New}) — rebinding", _runningPort, desiredPort);
+                        "MCP port changed via the control plane ({Old} -> {New}) — rebinding", _runningPort, toggle.Port);
                     await StopServerAsync(stoppingToken);
-                    if (!await TryStartServerAsync(config, desiredPort, stoppingToken))
+                    if (!await TryStartServerAsync(config, toggle, stoppingToken))
                     {
                         lastFailedStartUtc = DateTime.UtcNow;
                     }
@@ -258,15 +277,21 @@ public sealed class DarlingMcpHostService : BackgroundService
     }
 
     /// <summary>
-    /// One start ATTEMPT of the inner MCP web app at <paramref name="effectivePort"/> (#1560): the whole
+    /// One start ATTEMPT of the inner MCP web app at <paramref name="toggle"/>'s port (#1560): the whole
     /// pre-supervisor startup body, with two changes — the port comes from the live control-plane value
     /// rather than the file, and every bail path returns false so the supervisor can retry with backoff
     /// instead of standing down for the process lifetime. The bind/network/token decisions still come from
     /// the FILE-loaded config (network exposure is deliberately restart-only); returns true when the app
     /// is started and listening.
+    /// <para>#2389: the toggle carries the enable/port PROVENANCE, not just the port, so the start line names
+    /// the plane each half of the bind came from — the operator greps that line and stops reading, so it has
+    /// to admit when it is starting on file values the control plane may be about to contradict.</para>
     /// </summary>
-    private async Task<bool> TryStartServerAsync(DarlingConfig config, int effectivePort, CancellationToken stoppingToken)
+    private async Task<bool> TryStartServerAsync(
+        DarlingConfig config, DarlingHostBinding.EndpointToggle toggle, CancellationToken stoppingToken)
     {
+        var effectivePort = toggle.Port;
+
         /* Decide the effective bind PURELY, then map the reason -> severity here (Round-4 #7: the caller,
            not the pure fn, chooses LogCritical vs LogWarning; tests assert (Mode, Reason) without a logger). */
         var bind = ResolveMcpBind(config.Mcp, config.Postgres.Managed);
@@ -706,15 +731,21 @@ public sealed class DarlingMcpHostService : BackgroundService
 
             _app.MapMcp();
 
+            /* #2389: name the authority for each half of what is being started. enabled/port come from
+               whichever plane the supervisor resolved; listen/allowFrom/token are always darling.json. */
+            var origin = DarlingHostBinding.DescribeToggleOrigin(toggle);
             if (networkMode)
             {
                 _logger.LogInformation(
-                    "Starting MCP server on http://{Listen}:{Port} (LAN-exposed to {Cidr} behind a bearer token + in-app CIDR; loopback also bound)",
-                    primaryBind, effectivePort, allowedCidr);
+                    "Starting MCP server on http://{Listen}:{Port} (LAN-exposed to {Cidr} behind a bearer token + in-app CIDR; loopback also bound) — "
+                    + "enabled/port from {Origin}; listen/allowFrom/token from darling.json mcp.network (file-only, restart-only)",
+                    primaryBind, effectivePort, allowedCidr, origin);
             }
             else
             {
-                _logger.LogInformation("Starting MCP server on http://localhost:{Port} (loopback only)", effectivePort);
+                _logger.LogInformation(
+                    "Starting MCP server on http://localhost:{Port} (loopback only) — enabled/port from {Origin}",
+                    effectivePort, origin);
             }
 
             /* StartAsync, not RunAsync (#1560): the supervisor loop owns the wait — the app keeps

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingWebHostService.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingWebHostService.cs
@@ -117,6 +117,9 @@ public sealed class DarlingWebHostService : BackgroundService
            lifetime exactly as before (the network exposure block is restart-only by design). */
         DarlingConfig? config = null;
         var lastFailedStartUtc = DateTime.MinValue;
+        /* #2389: the last control-plane-override report emitted, so a steady disagreement is stated once per
+           distinct state instead of on every 5s poll tick. */
+        string? lastOverrideReport = null;
         while (!stoppingToken.IsCancellationRequested)
         {
             if (config is null && DateTime.UtcNow - lastFailedStartUtc >= FailedStartBackoff)
@@ -149,13 +152,28 @@ public sealed class DarlingWebHostService : BackgroundService
             }
 
             var published = _state.Read();
-            var enabled = published?.Enabled ?? config.Web.Enabled;
-            var desiredPort = published?.Port ?? config.Web.Port;
 
-            switch (DecideWebAction(_app is not null, _runningPort, enabled, desiredPort))
+            /* #2389: the store still wins whenever the worker has published (unchanged), but the resolution
+               now carries WHICH plane supplied each value — the MCP host's twin, sharing one resolver so the
+               two surfaces cannot drift. */
+            var toggle = DarlingHostBinding.ResolveEndpointToggle(
+                published is null ? null : (published.Enabled, published.Port), config.Web.Enabled, config.Web.Port);
+
+            /* Report the DISAGREEMENT at the point of override, once per distinct state, so a file edit that
+               the control plane is quietly ignoring says so instead of presenting as a successful start. */
+            var overrideReport = DarlingHostBinding.DescribeToggleOverride(
+                toggle, "web", "Web dashboard", config.Web.Enabled, config.Web.Port);
+            if (overrideReport is not null && !string.Equals(overrideReport, lastOverrideReport, StringComparison.Ordinal))
+            {
+                _logger.LogWarning("{Report}", overrideReport);
+            }
+
+            lastOverrideReport = overrideReport;
+
+            switch (DecideWebAction(_app is not null, _runningPort, toggle.Enabled, toggle.Port))
             {
                 case WebSupervisorAction.Start when DateTime.UtcNow - lastFailedStartUtc >= FailedStartBackoff:
-                    if (!await TryStartServerAsync(config, desiredPort, stoppingToken))
+                    if (!await TryStartServerAsync(config, toggle, stoppingToken))
                     {
                         lastFailedStartUtc = DateTime.UtcNow;
                     }
@@ -168,9 +186,9 @@ public sealed class DarlingWebHostService : BackgroundService
 
                 case WebSupervisorAction.Restart:
                     _logger.LogInformation(
-                        "Web dashboard port changed via the control plane ({Old} -> {New}) — rebinding", _runningPort, desiredPort);
+                        "Web dashboard port changed via the control plane ({Old} -> {New}) — rebinding", _runningPort, toggle.Port);
                     await StopServerAsync(stoppingToken);
-                    if (!await TryStartServerAsync(config, desiredPort, stoppingToken))
+                    if (!await TryStartServerAsync(config, toggle, stoppingToken))
                     {
                         lastFailedStartUtc = DateTime.UtcNow;
                     }
@@ -260,13 +278,18 @@ public sealed class DarlingWebHostService : BackgroundService
     }
 
     /// <summary>
-    /// One start ATTEMPT of the inner web app at <paramref name="effectivePort"/>: the port comes from the live
+    /// One start ATTEMPT of the inner web app at <paramref name="toggle"/>'s port: the port comes from the live
     /// control-plane value, and every bail path returns false so the supervisor retries with backoff instead of
     /// standing down for the process lifetime. The bind/network/token decisions come from the FILE-loaded config
     /// (network exposure is deliberately restart-only); returns true when the app is started and listening.
+    /// <para>#2389: the toggle carries the enable/port PROVENANCE, not just the port, so the start line names
+    /// the plane each half of the bind came from.</para>
     /// </summary>
-    private async Task<bool> TryStartServerAsync(DarlingConfig config, int effectivePort, CancellationToken stoppingToken)
+    private async Task<bool> TryStartServerAsync(
+        DarlingConfig config, DarlingHostBinding.EndpointToggle toggle, CancellationToken stoppingToken)
     {
+        var effectivePort = toggle.Port;
+
         var web = config.Web;
         var network = web.Network;
 
@@ -476,15 +499,21 @@ public sealed class DarlingWebHostService : BackgroundService
             _app.UseDefaultFiles();
             _app.UseStaticFiles();
 
+            /* #2389: name the authority for each half of what is being started — enabled/port from whichever
+               plane the supervisor resolved, listen/allowFrom/token always from darling.json. */
+            var origin = DarlingHostBinding.DescribeToggleOrigin(toggle);
             if (networkMode)
             {
                 _logger.LogInformation(
-                    "Starting web dashboard on http://{Listen}:{Port} (LAN-exposed to {Cidr} behind a token->cookie gate + in-app CIDR; loopback also bound, tokenless)",
-                    primaryBind, effectivePort, allowedCidr);
+                    "Starting web dashboard on http://{Listen}:{Port} (LAN-exposed to {Cidr} behind a token->cookie gate + in-app CIDR; loopback also bound, tokenless) — "
+                    + "enabled/port from {Origin}; listen/allowFrom/token from darling.json web.network (file-only, restart-only)",
+                    primaryBind, effectivePort, allowedCidr, origin);
             }
             else
             {
-                _logger.LogInformation("Starting web dashboard on http://localhost:{Port} (loopback only)", effectivePort);
+                _logger.LogInformation(
+                    "Starting web dashboard on http://localhost:{Port} (loopback only) — enabled/port from {Origin}",
+                    effectivePort, origin);
             }
 
             /* StartAsync, not RunAsync: the supervisor loop owns the wait — the app keeps serving until


### PR DESCRIPTION
Closes #2389.

## What the truth actually is

The first job was to establish which plane owns which field, because the issue's premise is that the same `mcp` object has two owners and nothing says so. It does. Here is every resolution site:

| Field | darling.json | Store | Wins at runtime | How |
|---|---|---|---|---|
| enabled | `mcp.enabled` | `config.config_service.mcp_enabled` | **Store** | `published?.Enabled ?? config.Mcp.Enabled` in the supervisor; the worker publishes on boot and every reload, so the file value applies only in the pre-publish window |
| port | `mcp.port` | `config.config_service.mcp_port` | **Store** | identical shape |
| network.listen | `mcp.network.listen` | — | **File**, restart-only | `ResolveMcpBind(config.Mcp, …)` off the host's own `DarlingConfig.Load()` |
| network.allowFrom | `mcp.network.allowFrom` | — | **File**, restart-only | same |
| network.encryptedToken / token | `mcp.network.*` | — | **File**, restart-only | same |
| postgres.managed (gates exposure) | `postgres.managed` | — | **File** | same |

`web` is the byte-identical twin: `web.enabled`/`web.port` store-authoritative, `web.network.*` file-only.

Two details worth stating because they change how the bug reads. First, the file is not a fallback that lost an argument — `SeedServiceRowAsync` writes it once with `ON CONFLICT DO NOTHING`, so on a seeded store it is dead input, and the worker publishes the file values itself when the store read fails, meaning `published` is non-null in both the healthy and the store-down case. Second, the MCP host calls `DarlingConfig.Load()` itself and holds that instance for the process lifetime, so the worker's `ApplyToConfig` never touches the host's copy: the two values genuinely coexist in one process.

## Why (a)/(c) and not (b)

Moving `mcp.network` into the store to match `mcp.enabled` is not safely achievable, and the DPAPI problem is only half of why. `encryptedToken` is `LocalMachine`-scoped with entropy `PerformanceMonitor.Darling.v1`, so a blob in `config_service` is undecryptable on any other host that reads that store — and there is no plaintext alternative worth having, because a bind address, a CIDR and a bearer token living in `config_service` would let a remote admin store connection (the pivot the `postgres.network.role` warning already names) re-point this listener onto a LAN interface behind a credential of its own choosing. Changing an exposure surface should require touching the host. So the split is kept, and the fix makes it visible and explicit instead.

## What changed

The resolution now goes through one shared helper in `DarlingHostBinding` — the same anti-drift home the bind ladder already lives in — that returns the effective `(enabled, port)` **with** its provenance and whether it contradicts the file. `published?.Enabled ?? …` structurally cannot report which side it took; that is the whole defect, and it is why the fix is at the resolution site rather than in a decision function.

Two surfaces then say what they know. The start line names the plane each half of the bind came from and admits when it is running on file values the control plane has not weighed in on yet — that is the line the operator greps and stops reading, so it had to stop presenting a provisional start as a settled one. And a real disagreement is reported as a warning at the point of override, naming both sides with the key and the column, which one wins, the verb that changes the winning one, and the opposite ownership of the network block. It fires only on the mismatch and only once per distinct state, so a steady disagreement says its piece once per service start instead of every five seconds, and a later re-divergence is still reported.

On the reported box that turns this:

```
22:58:51 [INFO] Starting MCP server on http://10.149.45.159:5152 (LAN-exposed to …)
22:58:56 [INFO] MCP server disabled via the control plane — stopping (no restart needed)
```

into this:

```
[WARN] MCP configuration disagrees across the two planes and the CONTROL PLANE WINS: enabled is true in
       darling.json (mcp.enabled) but false in config.config_service.mcp_enabled. After the first run
       darling.json's mcp.enabled/mcp.port are only the SEED -- change them with --enable-mcp/--disable-mcp
       or the Viewer's Settings, or the file values will keep being ignored. The mcp.network block is the
       OPPOSITE: file-only, restart-only, no store equivalent -- so an exposure block in darling.json is
       live even while the control plane keeps this endpoint off.
[INFO] MCP server disabled via the control plane — stopping (no restart needed)
```

The port gets the same treatment, per the issue — same shape, and a server on an unexpected port with no explanation is the same defect wearing a different symptom.

The web dashboard shares the resolver rather than getting a parallel copy. One `section` argument drives the file key, the store column and the CLI verb, which is what keeps the two wordings from drifting.

Three CLI notes had the same defect in miniature: `--configure-network`'s MCP and web notes and `PrintNextSteps`' two reminders all printed **only when the file said the endpoint was disabled**, which is exactly backwards — a file that says `true` while the store says `false` is the combination that misleads, and they printed nothing there. The wizard holds no store connection and cannot report the effective value, so what it says now is which plane decides and where the file value stops mattering.

I deliberately did not defer the start log until after the first reconcile, which the issue floats as an option. The line is true when it is printed and the server really does bind; suppressing it would trade one misleading log for another, and would also hide a start that failed before the first publish. Naming the provenance fixes the misreading without making the log less complete.

## Verification

Windows-only suites can't execute on macOS, so: the solution builds clean (0 warnings), and the pure resolver was run against the **shipped build** from a throwaway `net10.0` harness — 26 assertions covering the unpublished/agreeing/disagreeing cases, both fields, both surfaces and both origin clauses, all green. The source pins were simulated in Python against the fixture copies the tests actually read, and each one was re-run against `dev`'s version of the two hosts to confirm it goes red without the fix rather than passing both ways. The existing pins that parse these same two files (Host-header guard ordering, the firewall check, the identity-derivation ban) were re-simulated and still pass.

## Not fixed here

The sweep for resolution sites turned up an adjacent defect of the same family, filed as #2414 rather than folded in: the firewall verbs (`--enable-mcp`'s firewall half and `--configure-firewall`) name the scoped rule from **darling.json's** port while the endpoint binds the **store's**, so changing the port in the Viewer leaves an exposed endpoint with no firewall path and an elevated verb that keeps creating the wrong rule. It needs a store read in the CLI, which is a different change from this one. The warning added here at least makes the precondition visible.


`darling.sample.json` already described this split correctly, on both the `mcp` and `web` blocks. The documentation was right the whole time; the runtime was silent. That is worth saying because it means no doc change would have prevented this.
