### PR TITLE
Give Lite a switch for the startup update check (#2413)

### DIFF
--- a/Lite/Windows/SettingsWindow.xaml
+++ b/Lite/Windows/SettingsWindow.xaml
@@ -172,7 +172,7 @@
                      alerting. Turning alerts off must not gray this out or claim it depends on them. -->
                 <CheckBox x:Name="CheckForUpdatesOnStartupCheckBox" Content="Check GitHub for a new version at startup" Margin="0,8,0,0"
                           Foreground="{DynamicResource ForegroundBrush}"
-                          ToolTip="Off = Lite never contacts github.com on its own. Help &gt; About still checks when you open it, and installs in place from there."/>
+                          ToolTip="Off = Lite never contacts github.com on its own. The sidebar's About button still checks when you open it, and installs in place from there."/>
                 <CheckBox x:Name="AlertsEnabledCheckBox" Content="Enable notifications" Margin="0,8,0,0"
                           Foreground="{DynamicResource ForegroundBrush}" Checked="AlertsEnabledCheckBox_Changed" Unchecked="AlertsEnabledCheckBox_Changed"/>
                 <CheckBox x:Name="NotifyConnectionCheckBox" Content="Connection lost / restored" Margin="20,6,0,0"

--- a/Lite/Windows/SettingsWindow.xaml
+++ b/Lite/Windows/SettingsWindow.xaml
@@ -165,6 +165,14 @@
                 </StackPanel>
                 <CheckBox x:Name="MinimizeToTrayCheckBox" Content="Minimize to system tray" Margin="0,8,0,0"
                           Foreground="{DynamicResource ForegroundBrush}"/>
+                <!-- #2413: five seconds after every launch Lite called github.com looking for a new
+                     version, on by default, and the only way to refuse was to hand-edit a key that
+                     appeared in no window and no sample file. It sits beside Minimize to tray, ABOVE the
+                     Enable notifications master switch, because it is application behavior and not
+                     alerting. Turning alerts off must not gray this out or claim it depends on them. -->
+                <CheckBox x:Name="CheckForUpdatesOnStartupCheckBox" Content="Check GitHub for a new version at startup" Margin="0,8,0,0"
+                          Foreground="{DynamicResource ForegroundBrush}"
+                          ToolTip="Off = Lite never contacts github.com on its own. Help &gt; About still checks when you open it, and installs in place from there."/>
                 <CheckBox x:Name="AlertsEnabledCheckBox" Content="Enable notifications" Margin="0,8,0,0"
                           Foreground="{DynamicResource ForegroundBrush}" Checked="AlertsEnabledCheckBox_Changed" Unchecked="AlertsEnabledCheckBox_Changed"/>
                 <CheckBox x:Name="NotifyConnectionCheckBox" Content="Connection lost / restored" Margin="20,6,0,0"

--- a/Lite/Windows/SettingsWindow.xaml.cs
+++ b/Lite/Windows/SettingsWindow.xaml.cs
@@ -58,6 +58,7 @@ public partial class SettingsWindow : Window
         LoadCsvSeparator();
         LoadColorTheme();
         LoadTimeDisplayMode();
+        LoadCheckForUpdates();
         LoadAlertSettings();
         LoadSmtpSettings();
         LoadWebhookSettings();
@@ -217,6 +218,7 @@ public partial class SettingsWindow : Window
         SaveCsvSeparator();
         SaveColorTheme();
         SaveTimeDisplayMode();
+        SaveCheckForUpdates();
         bool alertsValid = SaveAlertSettings();
         SaveSmtpSettings();
         bool webhooksValid = SaveWebhookSettings();
@@ -469,6 +471,37 @@ public partial class SettingsWindow : Window
         }
 
         WriteSetting("time display mode", root => root["time_display_mode"] = App.TimeDisplayMode);
+    }
+
+    /// <summary>
+    /// #2413: <c>check_for_updates_on_startup</c> has gated
+    /// <c>MainWindow.CheckForUpdatesOnStartupAsync</c> for as long as the key has existed and defaults
+    /// to on, so out of the box Lite calls github.com five seconds after every launch. The key was
+    /// drawn in no window and shipped in no sample file, which left refusing it to a hand edit nobody
+    /// could discover -- and left a user who WANTS update notifications no way to confirm they are on.
+    /// The switch is the whole change; the default is deliberately untouched.
+    ///
+    /// <para>Wired through its own <see cref="App.WriteSetting"/> call rather than through
+    /// <c>SaveAlertSettings</c>, even though the checkbox sits beside Minimize to tray, which is. This
+    /// is application behavior, not alerting: it must not gray out with the "Enable notifications"
+    /// master switch in <c>UpdateAlertControlStates</c>, and Restore Defaults has no business stomping
+    /// it. The single-value pattern the Dashboard Defaults knobs use is the one that fits, and it
+    /// keeps this out of the scope of the <c>LiteSaveAlertSettings_PersistsEveryStaticItAssigns</c>
+    /// drift guard, which is correct -- that guard's subject is the alert block.</para>
+    ///
+    /// <para>AboutWindow's check stays unconditional on purpose. Opening Help &gt; About IS asking, so
+    /// the setting that governs the unsolicited call has no claim on the one the user requested.</para>
+    /// </summary>
+    private void LoadCheckForUpdates()
+    {
+        CheckForUpdatesOnStartupCheckBox.IsChecked = App.CheckForUpdatesOnStartup;
+    }
+
+    private void SaveCheckForUpdates()
+    {
+        App.CheckForUpdatesOnStartup = CheckForUpdatesOnStartupCheckBox.IsChecked == true;
+
+        WriteSetting("update check on startup", root => root["check_for_updates_on_startup"] = App.CheckForUpdatesOnStartup);
     }
 
     private void LoadAlertSettings()

--- a/Lite/Windows/SettingsWindow.xaml.cs
+++ b/Lite/Windows/SettingsWindow.xaml.cs
@@ -489,8 +489,10 @@ public partial class SettingsWindow : Window
     /// keeps this out of the scope of the <c>LiteSaveAlertSettings_PersistsEveryStaticItAssigns</c>
     /// drift guard, which is correct -- that guard's subject is the alert block.</para>
     ///
-    /// <para>AboutWindow's check stays unconditional on purpose. Opening Help &gt; About IS asking, so
-    /// the setting that governs the unsolicited call has no claim on the one the user requested.</para>
+    /// <para>AboutWindow's check stays unconditional on purpose. Opening About IS asking, so the setting
+    /// that governs the unsolicited call has no claim on the one the user requested. The tooltip says so,
+    /// and says it as "the sidebar's About button" rather than the "Help &gt; About" the title-bar and tray
+    /// strings claim, because Lite has no Help menu -- About is a sidebar button beside Settings.</para>
     /// </summary>
     private void LoadCheckForUpdates()
     {


### PR DESCRIPTION
Fixes #2413.

Five seconds after every launch, `MainWindow.CheckForUpdatesOnStartupAsync` calls github.com looking for a new version. It is gated on `App.CheckForUpdatesOnStartup`, which defaults to `true` and was drawn in no window, so the only supported way to refuse an unsolicited outbound call from a DBA workstation was to hand-edit `check_for_updates_on_startup` into settings.json. This adds the checkbox, and that is the whole change.

The issue said the key "appears in no sample file", and that turns out to be stronger than it reads: `Lite/config/settings.json` is the only thing resembling a sample, and it is `CopyToOutputDirectory=Never` and not in `ConfigSeeder`'s seed list, so it ships nowhere and seeds nothing. It also still carries `"theme": "light"` where the loader reads `color_theme`. I left it alone rather than adding a key to a file nothing reads, but it is worth someone deciding whether it should be deleted or made real.

**The default is unchanged.** Leaving it on with a visible switch beside it is defensible and is what the issue scoped. Whether it should stay on is a product question about how users learn a release exists, and I did not want to answer it as a side effect of drawing a checkbox — say the word and I will file it separately.

## Where it lives, and why not in `SaveAlertSettings`

The checkbox sits directly under "Minimize to system tray", which puts it above `AlertsEnabledCheckBox` — the master switch where Lite's alert block actually begins. Note that in Lite there is no "General" section: "Minimize to tray" is the first child of the **Notifications** border, sitting above that gate precisely because it is not an alert setting. The update announcement is itself a tray balloon (`AnnounceUpdate` → `_trayService.ShowNotification`), so the two tray-behavior switches reading together at the top of that panel is the placement that made sense.

Persistence deliberately does **not** go through `SaveAlertSettings`, even though `MinimizeToTray` next to it does. Being in the alert block would mean two wrong things: the control would gray out in `UpdateAlertControlStates` with the "Enable notifications" master switch, claiming a dependency the update check does not have, and `RestoreAlertDefaultsButton_Click` would stomp it. So it takes the shape the Dashboard Defaults knobs already use — `LoadCheckForUpdates` seeded from the static in the constructor, `SaveCheckForUpdates` called from the Save button, and one `App.WriteSetting` merge into settings.json.

The key name is unchanged, so anyone who already hand-edited it keeps their setting, and `WriteSetting` parses the existing document and mutates it rather than rewriting, so nothing else in the file moves.

## The drift guard

`AlertSettingsControlWiringTests.LiteSaveAlertSettings_PersistsEveryStaticItAssigns` asserts every `App.X =` inside `SaveAlertSettings` has a matching `root[...] = App.X` in the same body. Putting the assignment in its own method leaves it outside that fact's scope, which is the correct answer rather than a dodge — the guard's subject is the alert block. The sibling `EveryLoadedThresholdBox_IsAlsoGatedAndReset` matches `\bAlert\w*Box\b` and explicitly drops anything ending in `CheckBox`, so it never reaches this control either.

`Lite.Tests` targets `net10.0-windows` and cannot run on macOS, so I reimplemented both facts in Python against the patched source — the same brace-matching method-body extraction and the same regexes — plus assertions on the new wiring itself. Both existing facts pass unchanged for Lite and for Darling (22 and 28 loaded threshold boxes, none ungated, none unreset; 56 assigned statics, all persisted), `CheckForUpdatesOnStartup` is confirmed absent from `SaveAlertSettings`'s body, the control is confirmed absent from both the gate and the reset methods, and the XAML control is confirmed to sit between `MinimizeToTrayCheckBox` and `AlertsEnabledCheckBox`. CI is still the arbiter for the real run.

I did not add a new test. The risk this change carries — loaded but never saved — is shared by all five existing single-value `Save*` methods and none of them has a guard, so a pin for mine alone would be arbitrary; a general "every `Load*` in the constructor has a `Save*` in the Save button" check would need an exception list for `LoadServerScheduleSummary` and a special case for `SaveMcpSettingsAsync`, which is the hand-maintained-list smell. Happy to take it as a follow-up if you want it.

## Darling

**No equivalent, confirmed.** The Darling Viewer's only Velopack use is in `AboutWindow`, on demand when the user opens it; there is no startup check and no setting to match wording with. Lite's `AboutWindow` does the same on-demand check, and I left it unconditional on purpose — opening About is asking, and this setting governs the call the user did not ask for. The tooltip says so, so a user turning the switch off is told where the deliberate check still lives; see the comment below for why it names the sidebar button rather than the "Help > About" the rest of the product promises.

## Verification

Built `Lite/PerformanceMonitorLite.csproj` and `Lite.Tests/Lite.Tests.csproj` on macOS with `EnableWindowsTargeting`, both clean. The first attempt failed on `MC3000` because the XAML comment contained `--`, which XML forbids; reworded. `global.json` was restored and is not in the diff.

