### PR TITLE
Make the analysis timeout mean something, and stop a wedged server going silent

### DIFF
--- a/Lite.Tests/AnalysisBudgetTests.cs
+++ b/Lite.Tests/AnalysisBudgetTests.cs
@@ -147,6 +147,15 @@ public sealed class AnalysisBudgetTests : IClassFixture<SharedDuckDbFixture>
             "StuckAnalysisMaxBackoffDoublings",
             source,
             StringComparison.Ordinal);
+
+        /* And the shutdown hold has to wait on an UNCANCELLED token. Offloading the pass onto the
+           pool is what makes the hold necessary at all — the store work can now still be in flight
+           when the loop is told to stop — and handing the already-fired stopping token to the wait
+           would collapse it instantly, which looks identical to having waited. */
+        Assert.Contains(
+            "await analyzeTask.WaitAsync(AnalysisUnwindGrace, CancellationToken.None);",
+            source,
+            StringComparison.Ordinal);
     }
 
     private static string FindRepoDirectory(string relativePath)

--- a/Lite.Tests/AnalysisBudgetTests.cs
+++ b/Lite.Tests/AnalysisBudgetTests.cs
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using PerformanceMonitorLite.Analysis;
+using PerformanceMonitorLite.Database;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// #2412: <c>App.AnalysisTimeoutSeconds</c> cancelled nothing. The scheduler raced
+/// <c>AnalyzeAsync</c> against a <c>Task.Delay</c> and, on losing, logged one warning and moved
+/// on while the pass kept running — so the setting bounded how long the LOOP waited and nothing
+/// about the analysis itself.
+///
+/// <para>The consequence was worse than the mislabelled knob. The in-flight guard is released only
+/// on true completion (correctly — that is what stops a hung server piling up tasks), so a pass
+/// that never completed left its marker set for the life of the process and that server was
+/// skipped by <c>continue</c> on every later cycle, silently, with the single original warning the
+/// only trace it ever left.</para>
+///
+/// <para>Two layers guard the repair. The behavioural pair proves a pass carrying a cancelled
+/// budget ABANDONS rather than running to completion — and abandons for that reason rather than
+/// being turned away by the 24-hour data gate, which would make the assertion vacuous. The source
+/// pin holds the three properties of the scheduler that no test in this suite can reach, because
+/// <c>CollectionBackgroundService</c> needs a whole host to instantiate.</para>
+/// </summary>
+public sealed class AnalysisBudgetTests : IClassFixture<SharedDuckDbFixture>
+{
+    private readonly DuckDbInitializer _duckDb;
+
+    public AnalysisBudgetTests(SharedDuckDbFixture fixture)
+    {
+        fixture.ResetData();
+        _duckDb = fixture.DuckDb;
+    }
+
+    /// <summary>
+    /// The discriminator is <c>LastAnalysisTime</c>. Every path that RUNS — a completed pass, and
+    /// the insufficient-data gate — stamps it. Only the abandon path returns without stamping, so
+    /// a null there cannot be produced by a pass that merely found nothing to say.
+    ///
+    /// <para>The control runs first, on the same seed and the same context, and is what stops this
+    /// passing vacuously: it proves the pipeline reaches the end of a pass over this data, so the
+    /// null that follows is the cancellation and not a broken fixture.</para>
+    /// </summary>
+    [Fact]
+    public async Task AnalyzeAsync_WithACancelledBudget_AbandonsInsteadOfCompleting()
+    {
+        using var seeder = new TestDataSeeder(_duckDb);
+        await seeder.SeedCleanServerAsync();
+
+        var control = new AnalysisService(_duckDb) { MinimumDataHours = 0 };
+        await control.AnalyzeAsync(TestDataSeeder.CreateTestContext());
+        Assert.NotNull(control.LastAnalysisTime);
+
+        var service = new AnalysisService(_duckDb) { MinimumDataHours = 0 };
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var context = TestDataSeeder.CreateTestContext();
+        context.CancellationToken = cts.Token;
+
+        var findings = await service.AnalyzeAsync(context);
+
+        Assert.Empty(findings);
+        Assert.Null(service.InsufficientDataMessage);
+        Assert.Null(service.LastAnalysisTime);
+        Assert.False(service.IsAnalyzing);
+    }
+
+    /// <summary>
+    /// The scheduler calls the four-argument overload, so the token has to survive the hop from
+    /// that signature onto the context the pipeline actually reads. Drop that one assignment and
+    /// this pass would run the whole pipeline over an empty window and stamp
+    /// <c>LastAnalysisTime</c> — which is exactly what the assertion below refuses.
+    /// </summary>
+    [Fact]
+    public async Task AnalyzeAsync_CarriesTheCallersBudgetOntoTheContext()
+    {
+        using var seeder = new TestDataSeeder(_duckDb);
+        await seeder.SeedCleanServerAsync();
+
+        var service = new AnalysisService(_duckDb) { MinimumDataHours = 0 };
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var findings = await service.AnalyzeAsync(
+            TestDataSeeder.TestServerId, TestDataSeeder.TestServerName, hoursBack: 4, cts.Token);
+
+        Assert.Empty(findings);
+        Assert.Null(service.LastAnalysisTime);
+    }
+
+    /// <summary>
+    /// Three properties, each of which the fix is worthless without.
+    ///
+    /// <para>The pass must leave the loop's thread. DuckDB.NET implements no async execution, so
+    /// every read completes synchronously on the calling thread and an <c>AnalyzeAsync</c> invoked
+    /// inline ran to completion BEFORE the timeout race was reached — the race could never fire for
+    /// the phase that would actually be slow.</para>
+    ///
+    /// <para>Something must raise the cancellation at the budget, or the token is decoration.</para>
+    ///
+    /// <para>And the skip branch must report. That bare <c>continue</c> is the whole defect: it is
+    /// the line that made a permanently wedged server invisible.</para>
+    /// </summary>
+    [Fact]
+    public void ScheduledAnalysis_OffloadsThePass_ArmsTheBudget_AndReportsAStuckServer()
+    {
+        /* Line endings are normalised because the assertions below span lines and the working
+           copy is CRLF on Windows and LF elsewhere. */
+        var source = File.ReadAllText(
+            Path.Combine(FindRepoDirectory(Path.Combine("Lite", "Services")), "CollectionBackgroundService.cs"))
+            .Replace("\r\n", "\n", StringComparison.Ordinal);
+
+        /* The offload and the token have to be on the SAME call — a Task.Run somewhere in the file
+           and an AnalyzeAsync somewhere else would satisfy two independent Contains checks while
+           leaving the pass running inline on the loop's thread. */
+        Assert.Matches(
+            new Regex(@"Task\.Run\(\s*\(\)\s*=>\s*analysisService\.AnalyzeAsync\(serverId, serverName, hoursBack: 4, cts\.Token\)"),
+            source);
+
+        Assert.Contains(
+            "passCts.CancelAfter(timeout)",
+            source,
+            StringComparison.Ordinal);
+
+        Assert.Contains(
+            "ReportStuckAnalysis(serverId, serverName, timeout);",
+            source,
+            StringComparison.Ordinal);
+
+        /* The reporting has to back off. Scheduled analysis runs on a 30-minute default cadence, so
+           a fixed repeat would be either slower than the cadence or one line per cycle forever. */
+        Assert.Contains(
+            "StuckAnalysisMaxBackoffDoublings",
+            source,
+            StringComparison.Ordinal);
+    }
+
+    private static string FindRepoDirectory(string relativePath)
+    {
+        var dir = AppContext.BaseDirectory;
+        for (int i = 0; i < 8 && dir is not null; i++)
+        {
+            var candidate = Path.Combine(dir, relativePath);
+            if (Directory.Exists(candidate))
+            {
+                return candidate;
+            }
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        throw new DirectoryNotFoundException($"Could not locate {relativePath} above {AppContext.BaseDirectory}");
+    }
+}

--- a/Lite/Analysis/AnalysisService.cs
+++ b/Lite/Analysis/AnalysisService.cs
@@ -231,11 +231,21 @@ public class AnalysisService
 
             return findings;
         }
-        catch (Exception ex) when (context.CancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException ex) when (context.CancellationToken.IsCancellationRequested)
         {
             /* #2412: the pass was abandoned because it outlived its budget (or the app is
                stopping), which is not a fault and must not read as one. Whatever this pass would
-               have written is gone; the next scheduled pass recomputes it from the store. */
+               have written is gone; the next scheduled pass recomputes it from the store.
+
+               Both halves of the filter are load-bearing, and the TYPE half especially so here.
+               This token fires on TIMEOUT as well as at shutdown, so it is signalled during
+               ordinary running — a blanket `Exception` filter would relabel any genuine fault
+               that happened to land after the budget elapsed as abandonment and drop it to Info,
+               burying the one line of evidence it left. OperationCanceledException is what the
+               checkpoints throw, and what DuckDB's own duckdb_interrupt surfaces, so nothing the
+               cancellation actually produces is lost by naming it. This is the Darling twin's
+               AnalysisShutdown.IsShutdownAbandon discipline — signalled token AND a shape the
+               cancellation really produces — narrowed to the one shape that arises here. */
             AppLogger.Info("AnalysisService",
                 $"Analysis abandoned for {context.ServerName} — this pass's findings are lost by design; the next pass recomputes them ({ex.Message})");
             return [];

--- a/Lite/Analysis/AnalysisService.cs
+++ b/Lite/Analysis/AnalysisService.cs
@@ -112,6 +112,17 @@ public class AnalysisService
 
         try
         {
+            /* #2412: a checkpoint ahead of every store-touching stage, so the rule is simply that
+               no store read STARTS after the budget has gone. One check at the top of the method
+               would not deliver that — each stage below is a many-query phase, and a cancelled
+               pass would run out whichever one it was already inside. This first checkpoint earns
+               its place even though the read below is a single scalar: an already-cancelled
+               context arrives here whenever the budget is very short or the pass queued behind a
+               wedged server, and it should not buy a round-trip. The post-enrichment tail (action
+               build + insert) carries no check on purpose — by then the expensive work is paid
+               for and finishing is what preserves it. */
+            context.CancellationToken.ThrowIfCancellationRequested();
+
             // 0. Check minimum data span — total history, not the analysis window.
             // A server with 100h of total history can be analyzed over a 4h window.
             var dataSpanHours = await GetTotalDataSpanHoursAsync(context.ServerId);
@@ -135,11 +146,6 @@ public class AnalysisService
                 return [];
             }
 
-            /* #2412: abandon BETWEEN the expensive store stages when the pass has outlived its
-               budget. Each of the three below is a many-query phase, so a check only at the top
-               of the method would let a cancelled pass run to completion anyway. The
-               post-enrichment tail (action build + insert) carries no check on purpose: by then
-               the expensive work is already paid for and finishing preserves it. */
             context.CancellationToken.ThrowIfCancellationRequested();
 
             // 1. Collect facts from DuckDB
@@ -182,6 +188,8 @@ public class AnalysisService
             // solo; db-scoped object anomalies never cross databases. Presentation-only: nothing is
             // dropped, only the incident tag is reconciled.
             AnomalyIncidentReconciler.Reconcile(stories);
+
+            context.CancellationToken.ThrowIfCancellationRequested();
 
             // 4. Mute-filter the stories into the surviving findings WITHOUT inserting yet (the
             //    Darling twin's D2/P2 reorder) — enrichment + action-build happen on the survivors

--- a/Lite/Analysis/AnalysisService.cs
+++ b/Lite/Analysis/AnalysisService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using DuckDB.NET.Data;
 using PerformanceMonitor.Analysis;
@@ -76,7 +77,12 @@ public class AnalysisService
     /// Runs the full analysis pipeline for a server.
     /// Default time range is the last 4 hours.
     /// </summary>
-    public async Task<List<AnalysisFinding>> AnalyzeAsync(int serverId, string serverName, int hoursBack = 4)
+    /// <param name="cancellationToken">#2412: abandons the pass at the scheduler's per-server
+    /// budget (and at app shutdown). Optional so the on-demand callers — the Recommendations tab
+    /// and the MCP tool, neither of which has a budget to enforce — keep the prior behavior. The
+    /// argument order matches the Darling twin's AnalyzeAsync so the two stay transplantable.</param>
+    public async Task<List<AnalysisFinding>> AnalyzeAsync(
+        int serverId, string serverName, int hoursBack = 4, CancellationToken cancellationToken = default)
     {
         var timeRangeEnd = DateTime.UtcNow;
         var timeRangeStart = timeRangeEnd.AddHours(-hoursBack);
@@ -86,7 +92,8 @@ public class AnalysisService
             ServerId = serverId,
             ServerName = serverName,
             TimeRangeStart = timeRangeStart,
-            TimeRangeEnd = timeRangeEnd
+            TimeRangeEnd = timeRangeEnd,
+            CancellationToken = cancellationToken
         };
 
         return await AnalyzeAsync(context);
@@ -128,6 +135,13 @@ public class AnalysisService
                 return [];
             }
 
+            /* #2412: abandon BETWEEN the expensive store stages when the pass has outlived its
+               budget. Each of the three below is a many-query phase, so a check only at the top
+               of the method would let a cancelled pass run to completion anyway. The
+               post-enrichment tail (action build + insert) carries no check on purpose: by then
+               the expensive work is already paid for and finishing preserves it. */
+            context.CancellationToken.ThrowIfCancellationRequested();
+
             // 1. Collect facts from DuckDB
             var facts = await _collector.CollectFactsAsync(context);
 
@@ -136,6 +150,8 @@ public class AnalysisService
                 LastAnalysisTime = DateTime.UtcNow;
                 return [];
             }
+
+            context.CancellationToken.ThrowIfCancellationRequested();
 
             // 1.5. Detect anomalies (compare analysis window against baseline)
             var anomalies = await _anomalyDetector.DetectAnomaliesAsync(context);
@@ -171,6 +187,8 @@ public class AnalysisService
             //    Darling twin's D2/P2 reorder) — enrichment + action-build happen on the survivors
             //    first so the BUILT RemediationAction is persisted on each row.
             var findings = await _findingStore.FilterMutedFindingsAsync(stories, context);
+
+            context.CancellationToken.ThrowIfCancellationRequested();
 
             // 5. Enrich the survivors with drill-down data (ephemeral except through the built action).
             await _drillDown.EnrichFindingsAsync(findings, context);
@@ -212,6 +230,15 @@ public class AnalysisService
                 $"highest severity {(findings.Count > 0 ? findings.Max(f => f.Severity) : 0):F2}");
 
             return findings;
+        }
+        catch (Exception ex) when (context.CancellationToken.IsCancellationRequested)
+        {
+            /* #2412: the pass was abandoned because it outlived its budget (or the app is
+               stopping), which is not a fault and must not read as one. Whatever this pass would
+               have written is gone; the next scheduled pass recomputes it from the store. */
+            AppLogger.Info("AnalysisService",
+                $"Analysis abandoned for {context.ServerName} — this pass's findings are lost by design; the next pass recomputes them ({ex.Message})");
+            return [];
         }
         catch (Exception ex)
         {

--- a/Lite/Analysis/DuckDbFactCollector.cs
+++ b/Lite/Analysis/DuckDbFactCollector.cs
@@ -26,39 +26,52 @@ public partial class DuckDbFactCollector : IFactCollector
     {
         var facts = new List<Fact>();
 
-        await CollectWaitStatsFactsAsync(context, facts);
+        /* #2412: one cancellation checkpoint per collector, not one for the phase. This is the
+           longest stage of an analysis pass — thirty-one collectors, each opening the store and
+           running its own reads — so a check only at the phase boundary would let a pass that has
+           already blown its budget run every remaining collector before noticing. Routing the
+           calls through a local step is what buys the per-collector check without writing it out
+           thirty-one times. The two grouping helpers below rewrite facts already in hand rather
+           than reading the store, so they stay inline where their ordering matters. */
+        async Task RunCollectorAsync(Func<AnalysisContext, List<Fact>, Task> collect)
+        {
+            context.CancellationToken.ThrowIfCancellationRequested();
+            await collect(context, facts);
+        }
+
+        await RunCollectorAsync(CollectWaitStatsFactsAsync);
         FactCollectorHelpers.GroupGeneralLockWaits(facts, context);
         FactCollectorHelpers.GroupParallelismWaits(facts, context);
-        await CollectBlockingFactsAsync(context, facts);
-        await CollectBlockingChainFactsAsync(context, facts);
-        await CollectDeadlockFactsAsync(context, facts);
-        await CollectServerConfigFactsAsync(context, facts);
-        await CollectMemoryFactsAsync(context, facts);
-        await CollectDatabaseSizeFactAsync(context, facts);
-        await CollectServerMetadataFactsAsync(context, facts);
-        await CollectCpuUtilizationFactsAsync(context, facts);
-        await CollectRunnableTaskFactsAsync(context, facts);
-        await CollectIoLatencyFactsAsync(context, facts);
-        await CollectTempDbFactsAsync(context, facts);
-        await CollectMemoryGrantFactsAsync(context, facts);
-        await CollectQueryStatsFactsAsync(context, facts);
-        await CollectParameterSensitivityFactsAsync(context, facts);
-        await CollectPlanRegressionFactsAsync(context, facts);
-        await CollectBadActorFactsAsync(context, facts);
-        await CollectPerfmonFactsAsync(context, facts);
-        await CollectMemoryClerkFactsAsync(context, facts);
-        await CollectPlanCacheFactsAsync(context, facts);
-        await CollectMemoryPressureEventFactsAsync(context, facts);
-        await CollectDatabaseConfigFactsAsync(context, facts);
-        await CollectFileAutogrowthFactsAsync(context, facts);
-        await CollectProcedureStatsFactsAsync(context, facts);
-        await CollectActiveQueryFactsAsync(context, facts);
-        await CollectRunningJobFactsAsync(context, facts);
-        await CollectSessionFactsAsync(context, facts);
-        await CollectTraceFlagFactsAsync(context, facts);
-        await CollectServerPropertiesFactsAsync(context, facts);
-        await CollectDiskSpaceFactsAsync(context, facts);
-        await CollectPlanAdvisoryFactsAsync(context, facts);
+        await RunCollectorAsync(CollectBlockingFactsAsync);
+        await RunCollectorAsync(CollectBlockingChainFactsAsync);
+        await RunCollectorAsync(CollectDeadlockFactsAsync);
+        await RunCollectorAsync(CollectServerConfigFactsAsync);
+        await RunCollectorAsync(CollectMemoryFactsAsync);
+        await RunCollectorAsync(CollectDatabaseSizeFactAsync);
+        await RunCollectorAsync(CollectServerMetadataFactsAsync);
+        await RunCollectorAsync(CollectCpuUtilizationFactsAsync);
+        await RunCollectorAsync(CollectRunnableTaskFactsAsync);
+        await RunCollectorAsync(CollectIoLatencyFactsAsync);
+        await RunCollectorAsync(CollectTempDbFactsAsync);
+        await RunCollectorAsync(CollectMemoryGrantFactsAsync);
+        await RunCollectorAsync(CollectQueryStatsFactsAsync);
+        await RunCollectorAsync(CollectParameterSensitivityFactsAsync);
+        await RunCollectorAsync(CollectPlanRegressionFactsAsync);
+        await RunCollectorAsync(CollectBadActorFactsAsync);
+        await RunCollectorAsync(CollectPerfmonFactsAsync);
+        await RunCollectorAsync(CollectMemoryClerkFactsAsync);
+        await RunCollectorAsync(CollectPlanCacheFactsAsync);
+        await RunCollectorAsync(CollectMemoryPressureEventFactsAsync);
+        await RunCollectorAsync(CollectDatabaseConfigFactsAsync);
+        await RunCollectorAsync(CollectFileAutogrowthFactsAsync);
+        await RunCollectorAsync(CollectProcedureStatsFactsAsync);
+        await RunCollectorAsync(CollectActiveQueryFactsAsync);
+        await RunCollectorAsync(CollectRunningJobFactsAsync);
+        await RunCollectorAsync(CollectSessionFactsAsync);
+        await RunCollectorAsync(CollectTraceFlagFactsAsync);
+        await RunCollectorAsync(CollectServerPropertiesFactsAsync);
+        await RunCollectorAsync(CollectDiskSpaceFactsAsync);
+        await RunCollectorAsync(CollectPlanAdvisoryFactsAsync);
 
         return facts;
     }

--- a/Lite/Services/CollectionBackgroundService.cs
+++ b/Lite/Services/CollectionBackgroundService.cs
@@ -53,8 +53,43 @@ public class CollectionBackgroundService : BackgroundService
     private DateTime _lastDismissedAlertsCleanupTime = DateTime.UtcNow;
 
     /* Server IDs whose scheduled analysis is currently running — prevents relaunching
-       analysis for a server whose previous (possibly hung) pass has not finished. */
-    private readonly ConcurrentDictionary<int, byte> _analysisInFlight = new();
+       analysis for a server whose previous (possibly hung) pass has not finished. The value
+       carries when the pass started and how loudly it has been reported, because #2412's defect
+       was that a pass which never finishes leaves this marker set FOREVER and the server is then
+       skipped in silence on every later cycle. */
+    private readonly ConcurrentDictionary<int, AnalysisPassState> _analysisInFlight = new();
+
+    /* How far past its budget an in-flight pass must be before the loop starts reporting it. The
+       ordinary overrun already gets the "exceeded Ns" warning; this is for the pass that ignored
+       the cancellation raised at that budget — wedged inside a single store read, or waiting on
+       the store's read lock behind a long archival, neither of which any token can reach. */
+    private const int StuckAnalysisMultiple = 3;
+
+    /* Reports back off by doubling. Scheduled analysis runs on a 30-minute default cadence, so a
+       fixed repeat interval would either be slower than the cadence (useless) or produce one line
+       per cycle forever (the spam that makes a log unreadable). Doubling gives eight lines in the
+       first day against forty-eight cycles, and a handful per day after — loud enough to be noticed, quiet enough to
+       stay noticed. Capped so the shift cannot run away on a long-lived process. */
+    private const int StuckAnalysisMaxBackoffDoublings = 20;
+
+    /* How long the loop waits BEYOND the budget for a cancelled pass to unwind, so that a pass
+       which honoured its cancellation is observed finishing rather than racing the loop's own
+       timer. Matches the Darling twin's analysis shutdown grace. */
+    private static readonly TimeSpan AnalysisUnwindGrace = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Bookkeeping for one in-flight analysis pass. A class, not a struct, so the loop can update
+    /// the report counters in place without a read-modify-write race against the completion
+    /// continuation (which only ever removes the whole entry).
+    /// </summary>
+    private sealed class AnalysisPassState
+    {
+        public AnalysisPassState(DateTime startedUtc) => StartedUtc = startedUtc;
+
+        public DateTime StartedUtc { get; }
+        public int SkippedCycles { get; set; }
+        public int ReportCount { get; set; }
+    }
 
     /* Archive every hour, retention once per day */
     private static readonly TimeSpan ArchiveInterval = TimeSpan.FromHours(1);
@@ -424,11 +459,16 @@ public class CollectionBackgroundService : BackgroundService
             var serverId = RemoteCollectorService.GetDeterministicHashCode(serverName);
 
             /* Skip a server whose previous analysis is still running — a hung
-               connection that outlived its timeout would otherwise pile up tasks. */
-            if (!_analysisInFlight.TryAdd(serverId, 0))
+               connection that outlived its timeout would otherwise pile up tasks. The skip is
+               still right; what was wrong is that it used to happen in silence. */
+            if (!_analysisInFlight.TryAdd(serverId, new AnalysisPassState(DateTime.UtcNow)))
             {
+                ReportStuckAnalysis(serverId, serverName, timeout);
                 continue;
             }
+
+            CancellationTokenSource? passCts = null;
+            var passStarted = false;
 
             try
             {
@@ -436,15 +476,49 @@ public class CollectionBackgroundService : BackgroundService
                    flag, so a shared instance whose task is abandoned on timeout would
                    block analysis for every other server. */
                 var analysisService = new AnalysisService(_duckDb, planFetcher);
-                var analyzeTask = analysisService.AnalyzeAsync(serverId, serverName, hoursBack: 4);
+
+                /* #2412: the TOKEN is the timeout now; the Task.Delay below is only this loop's
+                   patience. Two things had to change for the budget to mean anything.
+
+                   The pass has to leave this thread. DuckDB.NET implements no async execution —
+                   every read completes synchronously on whichever thread called it — so an
+                   AnalyzeAsync invoked here ran the whole fact-collection phase INLINE and handed
+                   back an already-completed task. The race below could never fire for the phase
+                   that would actually be slow, and a wedged read took the entire collection loop
+                   down with it rather than just this server's analysis. Task.Run puts the pass on
+                   the pool, which makes the race real and keeps collection alive regardless.
+
+                   And something has to raise the cancellation. CancelAfter does it at the same
+                   budget the loop waits on. Arming it BEFORE the task exists means Cancel can
+                   never race the completion continuation's Dispose. */
+                passCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
+                passCts.CancelAfter(timeout);
+
+                var cts = passCts;
+                var analyzeTask = Task.Run(
+                    () => analysisService.AnalyzeAsync(serverId, serverName, hoursBack: 4, cts.Token),
+                    CancellationToken.None);
 
                 /* Clear the in-flight marker only when the task truly finishes — not
                    when the timeout below moves us on — so a hung server is not relaunched. */
                 _ = analyzeTask.ContinueWith(
-                    completed => _analysisInFlight.TryRemove(serverId, out _),
+                    completed =>
+                    {
+                        _analysisInFlight.TryRemove(serverId, out _);
+                        cts.Dispose();
+                    },
                     TaskScheduler.Default);
 
-                var finished = await Task.WhenAny(analyzeTask, Task.Delay(timeout, stoppingToken));
+                /* From here the continuation owns the marker and the token source. Neither
+                   Task.Run nor ContinueWith throws, so there is no window where the pass exists
+                   without something committed to cleaning up after it. */
+                passStarted = true;
+
+                /* Wait the budget PLUS a short grace, so a pass that honours its cancellation is
+                   seen finishing here. Losing that race now carries real information: the pass was
+                   asked to stop and did not. */
+                var finished = await Task.WhenAny(
+                    analyzeTask, Task.Delay(timeout + AnalysisUnwindGrace, stoppingToken));
 
                 if (stoppingToken.IsCancellationRequested)
                 {
@@ -454,7 +528,7 @@ public class CollectionBackgroundService : BackgroundService
                 if (finished != analyzeTask)
                 {
                     _logger?.LogWarning(
-                        "Scheduled analysis for {Server} exceeded {Timeout}s — skipped this cycle",
+                        "Scheduled analysis for {Server} exceeded {Timeout}s and has not unwound the cancellation raised at that budget — skipped this cycle. The server stays skipped while the pass remains in flight; it will be reported again if it stays that way.",
                         serverName, App.AnalysisTimeoutSeconds);
                     continue;
                 }
@@ -462,6 +536,21 @@ public class CollectionBackgroundService : BackgroundService
                 /* Analysis already persisted via SaveFindingsAsync inside AnalyzeAsync.
                    Only route findings to the notification channels when delivery is on. */
                 var findings = await analyzeTask;
+
+                /* A pass cut short at its budget unwound as asked and returned nothing, so there
+                   is nothing to route — say that, rather than letting a cancelled cycle read as a
+                   clean all-clear. Gated on the empty result as well as the token so that a pass
+                   which genuinely finished in the last instant before the deadline still delivers
+                   what it found; the only thing the two conditions can jointly mislabel is a real
+                   run that found nothing, whose delivery would have been a no-op anyway. */
+                if (findings.Count == 0 && cts.IsCancellationRequested)
+                {
+                    _logger?.LogWarning(
+                        "Scheduled analysis for {Server} exceeded {Timeout}s and was cancelled — no findings this cycle; the next cycle recomputes them",
+                        serverName, App.AnalysisTimeoutSeconds);
+                    continue;
+                }
+
                 if (notify)
                 {
                     await _notificationService.NotifyAsync(findings);
@@ -474,11 +563,53 @@ public class CollectionBackgroundService : BackgroundService
             catch (Exception ex)
             {
                 _logger?.LogError(ex, "Scheduled analysis failed for {Server}", serverName);
-                /* If analyzeTask was never created (e.g. ctor threw), the continuation
-                   never ran — clear the marker defensively. */
-                _analysisInFlight.TryRemove(serverId, out _);
+                /* If the pass was never launched (e.g. the ctor threw), no continuation exists to
+                   clear the marker or release the token source — do both here or this server is
+                   skipped forever, which is the very defect this loop is being fixed for. Once the
+                   pass IS running the continuation owns them, and clearing them here would both
+                   pull the token out from under a live pass and re-admit it next cycle. */
+                if (!passStarted)
+                {
+                    _analysisInFlight.TryRemove(serverId, out _);
+                    passCts?.Dispose();
+                }
             }
         }
+    }
+
+    /// <summary>
+    /// #2412: reports a server whose analysis pass is still in flight from an earlier cycle. The
+    /// in-flight guard is deliberately released only on true completion — that is what stops a hung
+    /// server piling up tasks — but it also means a pass that never completes leaves the marker set
+    /// for the life of the process, and every later cycle skipped that server with nothing said. A
+    /// cancellation raised at the budget clears the great majority of those; what remains is the
+    /// pass wedged where no token reaches, and this is what makes that visible instead of silent.
+    /// </summary>
+    private void ReportStuckAnalysis(int serverId, string serverName, TimeSpan timeout)
+    {
+        if (!_analysisInFlight.TryGetValue(serverId, out var state))
+        {
+            /* Finished between the TryAdd above and this read — it was never stuck. */
+            return;
+        }
+
+        state.SkippedCycles++;
+
+        var inFlightFor = DateTime.UtcNow - state.StartedUtc;
+        var reportAfter =
+            (timeout * StuckAnalysisMultiple) *
+            Math.Pow(2, Math.Min(state.ReportCount, StuckAnalysisMaxBackoffDoublings));
+
+        if (inFlightFor < reportAfter)
+        {
+            return;
+        }
+
+        state.ReportCount++;
+
+        _logger?.LogError(
+            "Scheduled analysis for {Server} has been in flight for {Minutes:F0} minutes — over {Multiple}x its {Timeout}s budget — and did not stop when cancelled at that budget. {Skipped} analysis cycle(s) have been skipped for this server since, and every later cycle is skipped too until the pass unwinds or the app restarts. Analysis for every other server is unaffected.",
+            serverName, inFlightFor.TotalMinutes, StuckAnalysisMultiple, App.AnalysisTimeoutSeconds, state.SkippedCycles);
     }
 
     private void LogProcessMemory()

--- a/Lite/Services/CollectionBackgroundService.cs
+++ b/Lite/Services/CollectionBackgroundService.cs
@@ -72,9 +72,12 @@ public class CollectionBackgroundService : BackgroundService
        stay noticed. Capped so the shift cannot run away on a long-lived process. */
     private const int StuckAnalysisMaxBackoffDoublings = 20;
 
-    /* How long the loop waits BEYOND the budget for a cancelled pass to unwind, so that a pass
-       which honoured its cancellation is observed finishing rather than racing the loop's own
-       timer. Matches the Darling twin's analysis shutdown grace. */
+    /* How long the loop gives a cancelled pass to unwind. It serves twice, and the two are not
+       the same wait. On the TIMEOUT path it extends the loop's patience past the budget, so a pass
+       that honours its cancellation is observed finishing rather than racing the loop's own timer.
+       On SHUTDOWN it is the hold below that keeps a pass from being orphaned, which is a wait the
+       loop's Task.Delay cannot provide because that delay observes the stopping token and so
+       collapses the instant it fires. Same five seconds as the Darling twin's shutdown grace. */
     private static readonly TimeSpan AnalysisUnwindGrace = TimeSpan.FromSeconds(5);
 
     /// <summary>
@@ -516,12 +519,37 @@ public class CollectionBackgroundService : BackgroundService
 
                 /* Wait the budget PLUS a short grace, so a pass that honours its cancellation is
                    seen finishing here. Losing that race now carries real information: the pass was
-                   asked to stop and did not. */
+                   asked to stop and did not. Note this delay observes the stopping token and so
+                   collapses the moment it fires — shutdown is handled by the hold below, not here. */
                 var finished = await Task.WhenAny(
                     analyzeTask, Task.Delay(timeout + AnalysisUnwindGrace, stoppingToken));
 
                 if (stoppingToken.IsCancellationRequested)
                 {
+                    /* Hold briefly for the pass to unwind instead of orphaning it (the Darling
+                       twin's #2299 discipline). Offloading onto the pool is what makes this
+                       necessary: the store work used to run inline on this thread and so could not
+                       still be in flight at this line, and now it can — walking away from it
+                       mid-InsertFindingsAsync leaves that write to be torn off by process
+                       teardown. CancellationToken.None on purpose: stoppingToken has already
+                       FIRED, so passing it here would cancel the wait instantly and defeat the
+                       grace entirely. A pass that outlives the hold is left to the in-flight
+                       marker, which keeps it from being relaunched either way. */
+                    try
+                    {
+                        await analyzeTask.WaitAsync(AnalysisUnwindGrace, CancellationToken.None);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        /* Shutdown — quiet and expected. */
+                    }
+                    catch (TimeoutException)
+                    {
+                        _logger?.LogDebug(
+                            "Analysis for {Server} did not unwind within {Grace}s of shutdown — it is abandoned in place",
+                            serverName, (int)AnalysisUnwindGrace.TotalSeconds);
+                    }
+
                     break;
                 }
 


### PR DESCRIPTION
Closes #2412.

## What was wrong

`App.AnalysisTimeoutSeconds` cancelled nothing. The scheduler raced `AnalyzeAsync` against a `Task.Delay` and, on losing, logged one warning and moved on while the pass kept running to completion and persisted its findings anyway. The setting bounded how long the loop waited before starting the next server, and nothing else.

The real defect sat underneath that. The in-flight guard is released only when a pass truly finishes, which is correct — it is what stops a hung server piling up tasks. But with nothing cancelling the pass, a pass that never finishes leaves its marker set for the life of the process, and that server is skipped by `continue` on every later cycle in silence. One log line, then nothing, forever.

## What the investigation turned up that the issue did not have

The timeout could not fire in the first place, so passing a token alone would not have been enough.

DuckDB.NET implements no async execution. `DuckDBCommand` overrides only the synchronous `ExecuteDbDataReader` — verified by reflecting over `DuckDB.NET.Data` 1.5.5, where the only token-bearing member is `ExecuteArrowBatchesAsync`, which nothing here uses. Every read in the pass therefore completes on whichever thread called it, so `AnalyzeAsync` ran its whole fact-collection phase **inline** and handed back an already-completed task. `Task.WhenAny` was racing something that had already won.

Measured against the shipped package, an async method shaped like Lite's collectors returns after the full 7.7 seconds with `IsCompleted` already `true`, and `Task.WhenAny(t, Task.Delay(2000))` picks the pipeline. Only the genuinely-async tail — the `SqlPlanFetcher` call, itself already bounded at 10s connect and 15s command — could ever lose that race. That also means a wedged read did not skip one server: it took the entire collection loop down with it.

## Does cancellation actually reach the reads?

Yes, and it is worth being exact about how far, because "it looks cancelled" was the failure mode to avoid here.

`DbCommand.ExecuteDbDataReaderAsync` registers the token to call `Cancel()`, and `DuckDBCommand.Cancel()` calls `duckdb_interrupt`. Measured on 1.5.5, single-threaded, against a query whose uncancelled baseline is 15,233 ms:

| case | outcome |
|---|---|
| token on `ExecuteReaderAsync` | aborts at **2,004 ms** → `OperationCanceledException` |
| token on `ReadAsync` only | runs the full **15,287 ms** first |
| no token | completes, 15,211 ms |
| explicit `Cancel()` at 2s during a *synchronous* `ExecuteReader` | aborts at **2,002 ms** |

So the store genuinely honours an interrupt — but only where the token is handed to the command, and today's reads are not handed one. What this PR's checkpoints buy is abandonment **between** reads rather than during one: one collector's granularity across the thirty-one-collector phase that dominates a pass, plus stage boundaries either side of it. Threading the token into the individual reads is 138 call sites across fifteen files and belongs in its own change; the measurements above say it would work.

There is also a residue no token can ever reach. `DuckDbInitializer.AcquireReadLock()` calls `ReaderWriterLockSlim.EnterReadLock()`, which takes no token, on a lock that is `private static readonly` — one lock for the whole process. A pass waiting there behind a long archival is wedged uninterruptibly. **That is why the observability half is not a fallback here, it is the part that actually closes the defect.**

## The change

The pass moves onto the pool with `Task.Run`, which makes the timeout race real and keeps collection running whatever analysis does. A linked `CancellationTokenSource` armed with `CancelAfter` raises the cancellation at the same budget the loop waits on; arming it before the task exists means `Cancel` can never race the continuation that disposes it. The loop then waits the budget plus a five-second grace, so losing that race now carries real information — the pass was asked to stop and did not.

The token rides on `AnalysisContext`, which already reaches every stage, and Lite's `AnalyzeAsync` signature now matches the Darling twin's argument for argument so the two stay transplantable. A cancelled pass is logged as abandoned rather than failed. The on-demand callers (Recommendations tab, MCP tool) pass no token and keep their prior behaviour exactly.

And a server whose pass stays in flight past three times its budget is now reported on a doubling backoff, with how long it has been stuck and how many cycles it has cost. Simulated against the shipped constants on the 30-minute default cadence, that is eight lines in the first day against forty-eight cycles — loud enough to be noticed, quiet enough to stay noticed — instead of one line and then permanent silence.

## Tests

`Lite.Tests/AnalysisBudgetTests.cs`, two layers.

The behavioural pair discriminates on `LastAnalysisTime`: every path that *runs* stamps it, including the insufficient-data gate, so only the abandon path can leave it null. One test runs an uncancelled control first on the same seed and asserts it stamps, which is what stops the assertion passing vacuously; the other pins that the four-argument overload carries the caller's token onto the context, since dropping that one assignment would let the pass run the whole pipeline and stamp.

The source pin holds the three scheduler properties no test in this suite can reach — `CollectionBackgroundService` needs a whole host to instantiate. It requires that `Task.Run` and the tokenised `AnalyzeAsync` are on the *same* call (two independent `Contains` checks would pass with the pass still running inline), that something arms the cancellation, and that the skip branch reports rather than being a bare `continue`.

The suite is `net10.0-windows` and cannot run on macOS. It builds clean, and the source-pin logic was simulated in Python against the real source — all four assertions pass, and the "no bare `continue` after the `TryAdd` guard" shape is gone. The backoff schedule above is from the same simulation using the shipped constants.

## Follow-ups worth filing

- **Exposing `analysis_timeout_seconds` in Settings.** Deliberately deferred in #2393 because the name promised what the code did not do. The name is now honest for everything the token can reach, so this becomes reasonable rather than a trap — though the residue above is worth a tooltip.
- **Threading the token into the 138 DuckDB reads**, which the measurements say would interrupt a wedged read rather than only abandoning between reads.
- **Darling has the same defect and this PR does not fix it.** `DarlingWorker.RunAnalysisPassAsync` passes only `stoppingToken` into `AnalyzeAsync` and races `Task.Delay(s_analysisTimeout, stoppingToken)`, so the per-server timeout cancels nothing there either, and its in-flight marker clears only on true completion — the identical permanent skip. It stayed invisible because Npgsql is genuinely async, so a slow pass never wedged the loop the way DuckDB's synchronous execution did here. Deliberately not folded in, because the port is not mechanical: `DarlingAnalysisService` classifies its abandon arm with `AnalysisShutdown.IsShutdownAbandon(ex, context.CancellationToken)`, which is only truthful while that token means *shutdown*. Arm it with `CancelAfter` and every timeout starts logging "abandoned at shutdown" at Information on a running service — the same misclassification review caught on this PR's first round. Darling needs its classifier to separate timeout from stop first, and `AnalysisShutdownResidueTests` pins that call site's argument list.
- **`AcquireReadLock` takes no timeout**, unlike its `AcquireWriteLock` sibling, so an analysis pass can block on it indefinitely with nothing able to interrupt it.

