### PR TITLE
Make Darling's MCP alert payload and its writer agree (#2417)

### DIFF
--- a/Darling/Darling.Tests/DarlingMcpAlertToolsTests.cs
+++ b/Darling/Darling.Tests/DarlingMcpAlertToolsTests.cs
@@ -12,6 +12,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
@@ -218,6 +219,173 @@ public sealed class DarlingMcpAlertToolsSurfaceAndSqlTests
         Assert.Equal(columns, ordinals.Count);
         Assert.Equal(columns - 1, ordinals.Max());
     }
+
+    /// <summary>
+    /// The round-trip invariant, DERIVED rather than hand-pinned: the set of columns the reader SELECTs must
+    /// equal the set of columns <c>update_alert_settings</c> writes when it is handed <c>get_alert_settings</c>'
+    /// own payload. That is the round trip the tool's description tells a caller to perform — read the
+    /// settings, change one number, write them back — asserted as one set comparison rather than as a list of
+    /// keys somebody has to remember to extend.
+    ///
+    /// <para>#2417 found the drift running in BOTH directions at once, which is why the assertion is an
+    /// equality and not a subset. Six columns were read out of the store on every call and emitted to nobody
+    /// (the AG four and the connection two) — those are missing from the write set. And one key WAS emitted
+    /// that the writer refused (<c>blocking.wait_threshold_seconds</c>), so feeding a read payload back
+    /// failed with "Unknown field", naming a field the caller never chose to send — that shows up as a
+    /// non-null parse error instead of a column set. The third direction, a key emitted for a column nobody
+    /// reads, no hand-maintained list would have noticed at all.</para>
+    ///
+    /// <para>There are NO exemptions, deliberately. Every column on this row is a knob the Viewer's Settings
+    /// window already writes, so leaving one readable-but-not-writable just moves an operator to a hand-typed
+    /// UPDATE — and it would need an exemption entry, which is the same hand-maintained fact that let six
+    /// columns go missing in the first place. If a genuinely read-only column ever arrives, exempt it BY NAME
+    /// here with its reason; do not loosen the equality.</para>
+    /// </summary>
+    [Fact]
+    public void EveryColumnRead_IsEmittedByThePayload_AndAcceptedByTheWriter()
+    {
+        var (columns, error) = ParseAsPartialUpdate(SerializedSettingsPayload(SampleSettingsRow()));
+
+        /* Every key the payload emits is accepted. The parse stops at the FIRST rejection, so a non-null
+           error here names the exact key update_alert_settings would refuse from its own read. */
+        Assert.Null(error);
+
+        /* Each accepted key claimed its own column — two keys sharing one would make whichever lost the
+           parse order a silent no-op, with the caller told both were updated. */
+        Assert.Equal(columns.Count, columns.Distinct(StringComparer.Ordinal).Count());
+
+        Assert.Equal(
+            SelectedAlertSettingsColumns().OrderBy(c => c, StringComparer.Ordinal).ToArray(),
+            columns.OrderBy(c => c, StringComparer.Ordinal).ToArray());
+    }
+
+    /// <summary>
+    /// The write bounds for everything #2417 made writable, against <c>DarlingAlertSettings</c>' clamps —
+    /// the same parity <see cref="FileGrowthWriteBounds_MatchTheEngineClamps"/> holds for the file-growth
+    /// knobs, and for the same reason: a bound that differs lets the tool ACCEPT a value the engine then
+    /// silently rewrites on read, which presents as the setting not sticking. Nothing says no.
+    ///
+    /// <para>The two booleans are asserted to reach the engine UNCLAMPED. That is the case that would
+    /// otherwise go unnoticed — a range added to one of them later needs a matching gate here, and this is
+    /// what makes the day it appears loud.</para>
+    ///
+    /// <para>Zero is IN range on all four numerics because 0 is a shipped configuration on each: no
+    /// connection re-fire, no AG lag gate, no redo-queue gate (<c>ag_redo_queue_alert_kb</c> ships at 0
+    /// precisely because a healthy queue size is workload-specific), no second blocking gate. A floor of 1
+    /// would make the shipped row unwritable through the tool that reports it.</para>
+    /// </summary>
+    [Fact]
+    public void AgConnectionAndBlockingWaitWriteBounds_MatchTheEngineClamps()
+    {
+        var tools = ReadRepoFile(System.IO.Path.Combine(
+            "Darling", "PerformanceMonitor.Darling.Service", "Mcp", "DarlingMcpAlertTools.cs"));
+        var settings = ReadRepoFile(System.IO.Path.Combine(
+            "Darling", "PerformanceMonitor.Darling.Service", "DarlingAlertSettings.cs"));
+
+        /* engine */
+        Assert.Contains("NotifyConnectionDownAtStartup => _config.Alerts.NotifyConnectionDownAtStartup;", settings, StringComparison.Ordinal);
+        Assert.Contains("_config.Alerts.ConnectionRefireMinutes, 0, 1440", settings, StringComparison.Ordinal);
+        Assert.Contains("NotifyAgHealth => _config.Alerts.NotifyAgHealth;", settings, StringComparison.Ordinal);
+        Assert.Contains("_config.Alerts.AgLagAlertSeconds, 0, 86400", settings, StringComparison.Ordinal);
+        Assert.Contains("_config.Alerts.AgRedoQueueAlertKb, 0L, 1073741824L", settings, StringComparison.Ordinal);
+        Assert.Contains("_config.Alerts.AgDisconnectRefireMinutes, 0, 1440", settings, StringComparison.Ordinal);
+        Assert.Contains("Math.Max(0, _config.Alerts.BlockingWaitSecondsThreshold)", settings, StringComparison.Ordinal);
+
+        /* tool: the same numbers, and no gate at all on the two booleans */
+        Assert.Contains("AddBool(\"notify_connection_down_at_startup\"", tools, StringComparison.Ordinal);
+        Assert.Contains("\"connection_refire_minutes\", 0, 1440", tools, StringComparison.Ordinal);
+        Assert.Contains("AddBool(\"notify_ag_health\"", tools, StringComparison.Ordinal);
+        Assert.Contains("\"ag.lag_threshold_seconds\", 0, 86400", tools, StringComparison.Ordinal);
+        Assert.Contains("\"ag.redo_queue_threshold_kb\", 0L, 1073741824L", tools, StringComparison.Ordinal);
+        Assert.Contains("\"ag.disconnect_refire_minutes\", 0, 1440", tools, StringComparison.Ordinal);
+        Assert.Contains("\"blocking.wait_threshold_seconds\", 0, int.MaxValue", tools, StringComparison.Ordinal);
+    }
+
+    /// <summary>The reader's SELECT list, split from the SHIPPED constant the same way
+    /// <see cref="AlertSettingsSelect_ColumnCount_MatchesTheOrdinalsRead"/> counts it — so it cannot drift
+    /// from what the reader actually asks the store for.</summary>
+    private static IReadOnlyList<string> SelectedAlertSettingsColumns()
+    {
+        var sql = Reader.AlertSettingsSelectSql;
+        var select = sql[(sql.IndexOf("SELECT", StringComparison.Ordinal) + 6)..
+                          sql.IndexOf("FROM config_alert_settings", StringComparison.Ordinal)];
+        return select.Split(',', StringSplitOptions.RemoveEmptyEntries)
+            .Select(c => c.Trim())
+            .Where(c => c.Length > 0)
+            .ToList();
+    }
+
+    /// <summary>get_alert_settings' payload for one row, serialized through the SAME options the tool
+    /// serializes with and re-parsed. Runtime rather than source-parsing for the reason Lite's
+    /// <c>McpAlertSettingsKeyTests</c> gives: the C# identifier is not automatically the wire key, so only
+    /// serializing proves what a client receives — and therefore what it would hand back.</summary>
+    private static JsonObject SerializedSettingsPayload(Reader.AlertSettingsReadRow row)
+    {
+        var build = typeof(DarlingMcpAlertTools).GetMethod(
+            "BuildAlertSettingsPayload", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var payload = build.Invoke(null, new object[] { row })!;
+        var json = JsonSerializer.Serialize(payload, payload.GetType(), McpHelpers.JsonOptions);
+        return (JsonObject)JsonNode.Parse(json)!;
+    }
+
+    /// <summary>Runs a body through the tool's REAL partial-update parser and reports the columns it would
+    /// write plus the first validation error, if any.</summary>
+    private static (IReadOnlyList<string> Columns, string? Error) ParseAsPartialUpdate(JsonObject body)
+    {
+        var build = typeof(DarlingMcpAlertTools).GetMethod(
+            "BuildAlertSettingsUpdate", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var result = build.Invoke(null, new object[] { body })!;
+        var type = result.GetType();
+        var updates = (IEnumerable<(string Column, NpgsqlParameter Param)>)type.GetField("Item1")!.GetValue(result)!;
+        return (updates.Select(u => u.Column).ToList(), (string?)type.GetField("Item2")!.GetValue(result));
+    }
+
+    /// <summary>A plausible settings row whose every value sits INSIDE the writer's bounds, so the invariant
+    /// above fails on a missing or unaccepted KEY rather than on a value. Named arguments deliberately: a new
+    /// column makes this stop compiling until someone supplies it, which is the moment to decide whether the
+    /// payload and the writer learn about it too. (Ordinal safety of the SELECT itself is
+    /// <see cref="AlertSettingsSelect_ColumnCount_MatchesTheOrdinalsRead"/>'s job, not this one's.)</summary>
+    private static Reader.AlertSettingsReadRow SampleSettingsRow() => new(
+        Enabled: true,
+        CpuEnabled: true, CpuThresholdPercent: 80, CpuMode: "sql",
+        BlockingEnabled: true, BlockingCountThreshold: 5,
+        DeadlockEnabled: true, DeadlockCountThreshold: 3,
+        PoisonWaitEnabled: true, PoisonWaitThresholdMs: 1000,
+        LongRunningQueryEnabled: true, LongRunningQueryThresholdMinutes: 5,
+        TempDbSpaceEnabled: true, TempDbSpaceThresholdPercent: 80,
+        LowDiskEnabled: true, LowDiskThresholdPercent: 10, LowDiskThresholdGb: 20,
+        LongRunningJobEnabled: true, LongRunningJobMultiplier: 3,
+        FailedJobEnabled: true, FailedJobLookbackMinutes: 60,
+        CooldownMinutes: 15,
+        ExcludedDatabases: new[] { "tempdb" },
+        AnalysisEnabled: true, AnalysisIntervalMinutes: 60,
+        AnalysisNotificationsEnabled: true, AnalysisNotifySeverity: 1.0,
+        DeliveryMode: "Summary", PerEventMax: 10,
+        LongRunningQueryMaxResults: 25,
+        LongRunningQueryExcludeSpServerDiagnostics: true,
+        LongRunningQueryExcludeWaitFor: true,
+        LongRunningQueryExcludeBackups: true,
+        LongRunningQueryExcludeMiscWaits: true,
+        LongRunningQueryExcludeCdc: true,
+        NotifyConnectionChanges: true,
+        NotifyConnectionDownAtStartup: true,
+        ConnectionRefireMinutes: 30,
+        NotifyAgHealth: true,
+        AgLagAlertSeconds: 300,
+        AgRedoQueueAlertKb: 1048576L,
+        AgDisconnectRefireMinutes: 30,
+        BlockingWaitSecondsThreshold: 60,
+        PvsEnabled: true, PvsThresholdPercent: 40, PvsFloorGb: 1,
+        DatabaseStateEnabled: true,
+        SelfDiskFreeWarnPercent: 15,
+        CollectionStaleMinutes: 30,
+        CollectionFailureThreshold: 3,
+        DiskCriticalFreePercent: 5,
+        DiskCriticalFreeGb: 10,
+        AnalysisNotifyCooldownMinutes: 360,
+        StoreJobCadenceWarnPercent: 80,
+        FileGrowthEnabled: true, FileGrowthRiseMb: 1024, FileGrowthVolumePercent: 10,
+        FileGrowthLookbackMinutes: 60);
 
     private static string ReadRepoFile(
         string relative, [System.Runtime.CompilerServices.CallerFilePath] string thisFile = "")

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpAlertTools.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpAlertTools.cs
@@ -123,7 +123,7 @@ public sealed class DarlingMcpAlertTools
         }
     }
 
-    [McpServerTool(Name = "get_alert_settings"), Description("Gets the current alert configuration the service is using: which alerts are enabled and their thresholds (CPU, blocking, deadlocks, poison waits, long-running queries/jobs, tempdb, low disk, failed jobs, database state), the cooldown, excluded databases, the deadlock/blocking delivery mode, and the scheduled-analysis cadence. This is the single global settings row the service hot-swaps in. SMTP/webhook delivery credentials are managed separately and are not reported here.")]
+    [McpServerTool(Name = "get_alert_settings"), Description("Gets the current alert configuration the service is using: which alerts are enabled and their thresholds (CPU, blocking, deadlocks, poison waits, long-running queries/jobs, tempdb, low disk, failed jobs, database state, Availability Group health, connection loss), the cooldown, excluded databases, the deadlock/blocking delivery mode, and the scheduled-analysis cadence. This is the single global settings row the service hot-swaps in. SMTP/webhook delivery credentials are managed separately and are not reported here.")]
     public static async Task<string> GetAlertSettings(
         NpgsqlDataSource postgres)
     {
@@ -144,11 +144,26 @@ public sealed class DarlingMcpAlertTools
     }
 
     /// <summary>The nested JSON shape get_alert_settings returns AND update_alert_settings echoes back — the same
-    /// field names update_alert_settings accepts on the way in, so a read → modify → write round-trips.</summary>
+    /// field names update_alert_settings accepts on the way in, so a read → modify → write round-trips.
+    ///
+    /// <para>That last clause is an INVARIANT, not a habit: #2417 found it broken in both directions at once
+    /// (six columns read and emitted to nobody, one key emitted the writer refused). It is now asserted as a
+    /// set equality between this payload's keys and the columns <c>AlertSettingsSelectSql</c> reads —
+    /// <c>EveryColumnRead_IsEmittedByThePayload_AndAcceptedByTheWriter</c>. Adding a key here without the
+    /// matching arm in <see cref="BuildAlertSettingsUpdate"/> (or the reverse) fails that test rather than
+    /// shipping.</para></summary>
     private static object BuildAlertSettingsPayload(DarlingAlertReader.AlertSettingsReadRow s) => new
     {
         alerts_enabled = s.Enabled,
         notify_connection_changes = s.NotifyConnectionChanges,
+        /* #2417: the connection family's two sub-settings, kept TOP-LEVEL beside their master switch
+           rather than folded into a `connection` group. The master shipped as a top-level key and Lite
+           emits it there too, so a group could only ever hold two of the three -- splitting one family
+           across two levels of the document is worse for a reader than two extra top-level keys. The
+           spellings are the store's own column names, which are also the keys Lite already reads out of
+           settings.json (App.LoadAlertSettings), so Lite's payload can adopt them verbatim. */
+        notify_connection_down_at_startup = s.NotifyConnectionDownAtStartup,
+        connection_refire_minutes = s.ConnectionRefireMinutes,
         cpu = new { enabled = s.CpuEnabled, threshold_percent = s.CpuThresholdPercent, mode = s.CpuMode },
         blocking = new
         {
@@ -203,6 +218,22 @@ public sealed class DarlingMcpAlertTools
         long_running_job = new { enabled = s.LongRunningJobEnabled, multiplier = s.LongRunningJobMultiplier },
         failed_job = new { enabled = s.FailedJobEnabled, lookback_minutes = s.FailedJobLookbackMinutes },
         database_state = new { enabled = s.DatabaseStateEnabled },
+        /* #2417: the AG family, read out of the store since V35/V37 and emitted to nobody until now -- so
+           an agent asked why nothing alerted when a replica fell behind could not see the lag threshold,
+           could not see whether AG notification was on at all, and had no way to tell "configured not to
+           alert" from "failed to alert". Grouped like every other alert family, and the master switch is
+           named `enabled` for the same reason cpu/blocking/pvs/database_state are: inside this payload
+           `enabled` always means "this alert family is on", and notify_ag_health IS that switch rather
+           than a second opt-in behind one. The thresholds take the house <what>_threshold_<unit> spelling
+           (blocking.wait_threshold_seconds, poison_wait.threshold_ms, low_disk.threshold_gb) instead of
+           transliterating the columns' older _alert_<unit> suffix, which appears nowhere else on the wire. */
+        ag = new
+        {
+            enabled = s.NotifyAgHealth,
+            lag_threshold_seconds = s.AgLagAlertSeconds,
+            redo_queue_threshold_kb = s.AgRedoQueueAlertKb,
+            disconnect_refire_minutes = s.AgDisconnectRefireMinutes
+        },
         cooldown_minutes = s.CooldownMinutes,
         excluded_databases = s.ExcludedDatabases,
         delivery = new { mode = s.DeliveryMode, per_event_max = s.PerEventMax },
@@ -471,6 +502,26 @@ public sealed class DarlingMcpAlertTools
             }
         }
 
+        /* ag_redo_queue_alert_kb is the one bigint on this row, and DarlingAlertSettings clamps it in
+           long arithmetic. Binding it through AddInt would work today only because the ceiling happens to
+           fit in an int; typing it here means a raised ceiling stays writable instead of silently
+           rejecting every value above int.MaxValue as "not an integer". */
+        void AddLong(string column, JsonNode? node, string field, long min, long max)
+        {
+            if (error != null) return;
+            if (node is JsonValue v && v.TryGetValue<long>(out var l))
+            {
+                if (l < min || l > max)
+                    error = $"'{field}' must be an integer between {min} and {max}.";
+                else
+                    updates.Add((column, new NpgsqlParameter<long> { TypedValue = l }));
+            }
+            else
+            {
+                error = $"'{field}' must be an integer between {min} and {max}.";
+            }
+        }
+
         void AddDouble(string column, JsonNode? node, string field, double min, double max)
         {
             if (error != null) return;
@@ -556,6 +607,11 @@ public sealed class DarlingMcpAlertTools
             {
                 case "alerts_enabled": AddBool("enabled", prop.Value, "alerts_enabled"); break;
                 case "notify_connection_changes": AddBool("notify_connection_changes", prop.Value, "notify_connection_changes"); break;
+                /* #2417: bounds mirror DarlingAlertSettings' clamps EXACTLY -- Clamp(0, 1440) on the
+                   refire, nothing to clamp on the at-startup opt-in. Zero is IN range because 0 is the
+                   shipped configuration (one alert per outage, no re-fire), not an invalid one. */
+                case "notify_connection_down_at_startup": AddBool("notify_connection_down_at_startup", prop.Value, "notify_connection_down_at_startup"); break;
+                case "connection_refire_minutes": AddInt("connection_refire_minutes", prop.Value, "connection_refire_minutes", 0, 1440); break;
                 case "cooldown_minutes": AddInt("cooldown_minutes", prop.Value, "cooldown_minutes", 1, 120); break;
                 case "excluded_databases": AddStringArray("excluded_databases", prop.Value, "excluded_databases"); break;
 
@@ -579,6 +635,13 @@ public sealed class DarlingMcpAlertTools
                         {
                             case "enabled": AddBool("blocking_enabled", n, "blocking.enabled"); break;
                             case "count_threshold": AddInt("blocking_count_threshold", n, "blocking.count_threshold", 1, int.MaxValue); break;
+                            /* #2417: get_alert_settings has emitted this key since #1839 and the writer
+                               never took it, so handing a whole read payload back -- the round trip this
+                               tool's own description tells the caller to perform -- was rejected with
+                               "Unknown field 'blocking.wait_threshold_seconds'", naming a field the caller
+                               did not choose to send. The bound is the engine's Math.Max(0, ...), so 0
+                               keeps disabling the second gate rather than becoming invalid. */
+                            case "wait_threshold_seconds": AddInt("blocking_wait_seconds_threshold", n, "blocking.wait_threshold_seconds", 0, int.MaxValue); break;
                             default: error = $"Unknown field 'blocking.{k}'."; break;
                         }
                     });
@@ -734,6 +797,24 @@ public sealed class DarlingMcpAlertTools
                         {
                             case "enabled": AddBool("database_state_enabled", n, "database_state.enabled"); break;
                             default: error = $"Unknown field 'database_state.{k}'."; break;
+                        }
+                    });
+                    break;
+
+                /* #2417: bounds mirror DarlingAlertSettings' clamps EXACTLY -- Clamp(lag, 0, 86400),
+                   Clamp(redo, 0L, 1073741824L), Clamp(refire, 0, 1440). Zero is IN range on all three
+                   and means OFF for that gate (the redo queue SHIPS at 0, because a healthy queue size
+                   is workload-specific), so a floor of 1 would remove the shipped configuration. */
+                case "ag":
+                    Group(prop.Value, "ag", (k, n) =>
+                    {
+                        switch (k)
+                        {
+                            case "enabled": AddBool("notify_ag_health", n, "ag.enabled"); break;
+                            case "lag_threshold_seconds": AddInt("ag_lag_alert_seconds", n, "ag.lag_threshold_seconds", 0, 86400); break;
+                            case "redo_queue_threshold_kb": AddLong("ag_redo_queue_alert_kb", n, "ag.redo_queue_threshold_kb", 0L, 1073741824L); break;
+                            case "disconnect_refire_minutes": AddInt("ag_disconnect_refire_minutes", n, "ag.disconnect_refire_minutes", 0, 1440); break;
+                            default: error = $"Unknown field 'ag.{k}'."; break;
                         }
                     });
                     break;

--- a/Lite.Tests/McpAlertSettingsKeyTests.cs
+++ b/Lite.Tests/McpAlertSettingsKeyTests.cs
@@ -136,6 +136,18 @@ public sealed class McpAlertSettingsKeyTests
     /// decision in both places that reference it.</summary>
     private const string SelfAlertsGroup = "self_alerts";
 
+    /// <summary>#2417: the MEMBER-level counterpart to <see cref="SelfAlertsGroup"/> — Darling keys Lite
+    /// genuinely has no equivalent for, exempted BY NAME so the hole is a decision someone justified here
+    /// rather than a loosened assertion. Each entry is paid for by a test asserting the omission is still
+    /// real, so an exemption cannot outlive its reason.
+    ///
+    /// <para><c>ag.disconnect_refire_minutes</c> is Darling's #1696 / store-V37 knob. Lite's AG work
+    /// (#1726) mirrored three of those four knobs and has no re-fire at all — no static, no settings.json
+    /// key, no edge state that could re-announce a still-disconnected replica. Emitting it as a constant 0
+    /// would tell an agent it can tune something Lite cannot, which is the same reasoning that omits
+    /// self_alerts whole.</para></summary>
+    private static readonly string[] LiteOmittedMembers = { "ag.disconnect_refire_minutes" };
+
     /// <summary>
     /// Darling's <c>BuildAlertSettingsPayload</c> shape read out of Darling's SOURCE — each top-level key in
     /// document order with its nested keys (an empty list for a scalar like <c>cooldown_minutes</c>). Derived
@@ -256,7 +268,10 @@ public sealed class McpAlertSettingsKeyTests
             if (darlingKeys.Count == 0) continue;
 
             var liteKeys = KeysOf(element);
-            problems.AddRange(darlingKeys.Except(liteKeys).Select(k => $"missing '{group}.{k}'"));
+            problems.AddRange(darlingKeys
+                .Where(k => !LiteOmittedMembers.Contains($"{group}.{k}", StringComparer.Ordinal))
+                .Except(liteKeys)
+                .Select(k => $"missing '{group}.{k}'"));
             problems.AddRange(liteKeys.Except(darlingKeys).Select(k => $"'{group}.{k}' is Lite-only"));
         }
 
@@ -270,6 +285,31 @@ public sealed class McpAlertSettingsKeyTests
         Assert.Equal(
             new[] { "smtp" },
             KeysOf(root).Except(darling.Select(g => g.Key)).ToArray());
+    }
+
+    /// <summary>
+    /// The one MEMBER Lite deliberately does not report, asserted for the same reason its group-level
+    /// sibling below is: so the hole reads as a decision rather than the oversight it would otherwise look
+    /// like — and so the exemption cannot quietly outlive its reason. Both halves are asserted. Darling
+    /// must still emit it (otherwise the exemption is dead weight hiding a Darling regression), and Lite
+    /// must still not (otherwise the exemption is masking a key that has since arrived and could now be
+    /// compared).
+    ///
+    /// <para>The gap itself is real and worth closing: Lite has no AG disconnect re-fire, so a replica
+    /// disconnected for a week is announced exactly once here where Darling can re-announce it. That is
+    /// #1696's Lite half, and it is a feature rather than a payload key — which is why this PR reports the
+    /// three knobs Lite really has instead of inventing a fourth.</para>
+    /// </summary>
+    [Fact]
+    public void GetAlertSettings_OmitsAgDisconnectRefire_WhichLiteHasNoEquivalentFor()
+    {
+        var ag = DarlingPayloadShape().Single(g => g.Key == "ag").Value;
+        Assert.Contains("disconnect_refire_minutes", ag);
+        Assert.DoesNotContain("disconnect_refire_minutes", KeysOf(Settings().GetProperty("ag")));
+
+        /* Pinned as an exact set, so a second member-level exemption cannot be added without this test
+           being the place someone justifies it — the same guard the smtp assertion applies to groups. */
+        Assert.Equal(new[] { "ag.disconnect_refire_minutes" }, LiteOmittedMembers);
     }
 
     /// <summary>

--- a/Lite.Tests/McpAlertSettingsKeyTests.cs
+++ b/Lite.Tests/McpAlertSettingsKeyTests.cs
@@ -145,7 +145,8 @@ public sealed class McpAlertSettingsKeyTests
     /// (#1726) mirrored three of those four knobs and has no re-fire at all — no static, no settings.json
     /// key, no edge state that could re-announce a still-disconnected replica. Emitting it as a constant 0
     /// would tell an agent it can tune something Lite cannot, which is the same reasoning that omits
-    /// self_alerts whole.</para></summary>
+    /// self_alerts whole. Filed as #2426 — the exemption is the honest report of a gap, not the fix for
+    /// it.</para></summary>
     private static readonly string[] LiteOmittedMembers = { "ag.disconnect_refire_minutes" };
 
     /// <summary>
@@ -298,7 +299,7 @@ public sealed class McpAlertSettingsKeyTests
     /// <para>The gap itself is real and worth closing: Lite has no AG disconnect re-fire, so a replica
     /// disconnected for a week is announced exactly once here where Darling can re-announce it. That is
     /// #1696's Lite half, and it is a feature rather than a payload key — which is why this PR reports the
-    /// three knobs Lite really has instead of inventing a fourth.</para>
+    /// three knobs Lite really has instead of inventing a fourth. Filed as #2426.</para>
     /// </summary>
     [Fact]
     public void GetAlertSettings_OmitsAgDisconnectRefire_WhichLiteHasNoEquivalentFor()

--- a/Lite/Mcp/McpAlertTools.cs
+++ b/Lite/Mcp/McpAlertTools.cs
@@ -210,7 +210,7 @@ public sealed class McpAlertTools
                    three of those four knobs. Emitting a constant 0 would tell an agent it can tune
                    something Lite cannot, which is exactly why self_alerts is omitted whole above. The
                    omission is pinned by name in McpAlertSettingsKeyTests so it cannot outlive its
-                   reason. */
+                   reason, and the gap itself is filed as #2426. */
                 ag = new
                 {
                     enabled = App.NotifyAgHealth,

--- a/Lite/Mcp/McpAlertTools.cs
+++ b/Lite/Mcp/McpAlertTools.cs
@@ -76,7 +76,7 @@ public sealed class McpAlertTools
         }
     }
 
-    [McpServerTool(Name = "get_alert_settings"), Description("Gets the current alert configuration this instance is running on: which alerts are enabled and their thresholds (CPU, blocking, deadlocks, poison waits, long-running queries and jobs, tempdb space, low disk, PVS, file growth, failed jobs, database state), the cooldown, the excluded databases, the deadlock/blocking delivery mode, the scheduled-analysis cadence, and the SMTP email configuration. The same nested shape Darling's get_alert_settings returns, minus its self_alerts group (the headless service's own store-volume and collection-health thresholds, which a single-instance Lite install has no equivalent for) and plus smtp, which Lite delivers itself. Read-only: Lite has no update_alert_settings, so these change in the Settings window.")]
+    [McpServerTool(Name = "get_alert_settings"), Description("Gets the current alert configuration this instance is running on: which alerts are enabled and their thresholds (CPU, blocking, deadlocks, poison waits, long-running queries and jobs, tempdb space, low disk, PVS, file growth, failed jobs, database state, Availability Group health, connection loss), the cooldown, the excluded databases, the deadlock/blocking delivery mode, the scheduled-analysis cadence, and the SMTP email configuration. The same nested shape Darling's get_alert_settings returns, minus its self_alerts group (the headless service's own store-volume and collection-health thresholds, which a single-instance Lite install has no equivalent for) and plus smtp, which Lite delivers itself. Read-only: Lite has no update_alert_settings, so these change in the Settings window.")]
     public static Task<string> GetAlertSettings()
     {
         try
@@ -88,6 +88,13 @@ public sealed class McpAlertTools
                    sub-object's own toggle), so the old Lite name was not merely different — it collided. */
                 alerts_enabled = App.AlertsEnabled,
                 notify_connection_changes = App.NotifyConnectionChanges,
+                /* #2417: the connection family's two sub-settings. Darling keeps these TOP-LEVEL beside
+                   their master switch rather than in a `connection` group, because the master shipped as a
+                   top-level key and a group could only ever have held two of the three; the spellings are
+                   its column names, which are also the keys Lite's own settings.json already uses. Both
+                   statics have been wired through to the connection-alert path since #1659. */
+                notify_connection_down_at_startup = App.NotifyConnectionDownAtStartup,
+                connection_refire_minutes = App.ConnectionRefireMinutes,
                 cpu = new
                 {
                     enabled = App.AlertCpuEnabled,
@@ -191,6 +198,25 @@ public sealed class McpAlertTools
                     lookback_minutes = App.AlertFailedJobLookbackMinutes
                 },
                 database_state = new { enabled = App.AlertDatabaseStateEnabled },
+                /* #2417: the Availability Group family, which Darling emitted to nobody until now and
+                   Lite therefore could not mirror. Lite has evaluated all four AG conditions since #1726
+                   off these same statics, so this is surface, not new alerting. Group and key spellings
+                   are Darling's verbatim, including `enabled` for what the store calls notify_ag_health —
+                   inside this payload `enabled` always means "this alert family is on".
+
+                   Darling reports a FOURTH member here, disconnect_refire_minutes (#1696, store V37), and
+                   it is deliberately absent: Lite has no AG disconnect re-fire at ALL — no static, no
+                   settings.json key, and no edge state that could re-announce — because #1726 mirrored
+                   three of those four knobs. Emitting a constant 0 would tell an agent it can tune
+                   something Lite cannot, which is exactly why self_alerts is omitted whole above. The
+                   omission is pinned by name in McpAlertSettingsKeyTests so it cannot outlive its
+                   reason. */
+                ag = new
+                {
+                    enabled = App.NotifyAgHealth,
+                    lag_threshold_seconds = App.AgLagAlertSeconds,
+                    redo_queue_threshold_kb = App.AgRedoQueueAlertKb
+                },
                 cooldown_minutes = App.AlertCooldownMinutes,
                 excluded_databases = App.AlertExcludedDatabases,
                 delivery = new

--- a/PerformanceMonitor.Common/PerformanceMonitor.Common.csproj
+++ b/PerformanceMonitor.Common/PerformanceMonitor.Common.csproj
@@ -36,5 +36,9 @@
     <InternalsVisibleTo Include="PerformanceMonitor.Darling.Service" />
     <InternalsVisibleTo Include="Lite.Tests" />
     <InternalsVisibleTo Include="Dashboard.Tests" />
+    <!-- #2417: Darling.Tests serializes the MCP alert payload through McpHelpers.JsonOptions rather
+         than a look-alike, so a naming policy added there can never leave the round-trip invariant
+         asserting keys no client ever receives. The two sibling test projects were already here. -->
+    <InternalsVisibleTo Include="Darling.Tests" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Closes #2417.

`get_alert_settings` and `update_alert_settings` are the read and write halves of one file, and they had drifted apart in both directions at once. Six columns `AlertSettingsReadRow` reads were emitted to nobody, and one key the payload did emit was refused by the writer.

The six are the V33 connection opt-ins and the V35/V37 Availability Group family. The reader was widened for them on purpose — its own comment says an MCP client could not otherwise see them at all — but the payload never followed, so every call pulled them out of the store and dropped them on the floor. The AG four are the ones that cost something, because those are the settings whose misconfiguration is least visible anywhere else: an agent asked why nothing alerted when a replica fell behind could not see the lag threshold, could not see whether AG notification was on at all, and had no way to tell "configured not to alert" apart from "failed to alert".

In the other direction the payload emitted `blocking.wait_threshold_seconds` and the `blocking` arm of the update switch did not take it, so handing a whole read payload back to the writer — the round trip the tool's own description tells the caller to perform — was rejected with `Unknown field`, naming a field the caller never chose to send.

### What the fix decides

**All six are writable, not merely readable.** Every column on this row is a knob the Viewer's Settings window already writes, so a read-only knob just moves an operator to a hand-typed `UPDATE` — and read-only would have needed an exemption entry in the new test, which is the same hand-maintained fact that let the six go missing. Every bound mirrors `DarlingAlertSettings`' clamp exactly: `Clamp(0, 1440)` on both re-fires, `Clamp(0, 86400)` on the lag, `Clamp(0L, 1073741824L)` on the redo queue, `Math.Max(0, ...)` on the blocking wait. A bound that differs would let the tool accept a value the engine silently rewrites on read, which presents as the setting not sticking and nothing saying no. Zero stays in range on all four numerics — it is the shipped configuration meaning that gate is off, and the redo queue ships at zero precisely because a healthy queue size is workload-specific. The redo queue binds through a new `AddLong` rather than `AddInt` because it is the one `bigint` on the row and its ceiling only happens to fit in an int today.

**The wire keys are the house's, not transliterations of the columns.** AG becomes a group like every other alert family, with its master switch named `ag.enabled` for the same reason `cpu`/`blocking`/`pvs`/`database_state` spell theirs that way — inside this payload `enabled` always means "this alert family is on", and `notify_ag_health` IS that switch rather than a second opt-in behind one. Its thresholds take the `<what>_threshold_<unit>` spelling the neighbours already use (`blocking.wait_threshold_seconds`, `poison_wait.threshold_ms`, `low_disk.threshold_gb`) instead of the columns' older `_alert_<unit>` suffix, which appears nowhere on the wire.

The two connection settings stay **top-level** beside `notify_connection_changes` rather than becoming a `connection` group. The family's master switch shipped as a top-level key and Lite emits it there too, so a group could only ever have held two of the three — splitting one family across two levels of the document is worse for a reader than two extra top-level keys. Their spellings are the store's column names, which are also the keys Lite already reads out of `settings.json`, so Lite's payload can adopt them verbatim when it follows.

```json
"notify_connection_changes": true,
"notify_connection_down_at_startup": true,
"connection_refire_minutes": 30,
...
"ag": { "enabled": true, "lag_threshold_seconds": 300, "redo_queue_threshold_kb": 1048576, "disconnect_refire_minutes": 30 },
```

### The part worth keeping

The existing tests pin individual keys, which is exactly why six missing keys and one unroundtrippable key both survived. The new one is derived: it builds a settings row, runs it through the real `BuildAlertSettingsPayload`, serializes it through the same options the tool serializes with, and feeds the result to the real `BuildAlertSettingsUpdate` — then asserts the set of columns that comes out equals the set of columns `AlertSettingsSelectSql` reads.

One equality closes all three directions. A column read but not emitted is missing from the write set. A key emitted but refused shows up as a parse error naming itself. And a key emitted for a column nobody reads fails the direction no hand-maintained list would ever have noticed. There are **no exemptions**, deliberately — if a genuinely read-only column ever arrives it gets exempted by name with its reason, rather than the equality being loosened.

A second test holds the clamp parity for everything this PR made writable, in the shape `FileGrowthWriteBounds_MatchTheEngineClamps` already established, including asserting that the two booleans reach the engine **unclamped** so the day a range is added to one of them is loud.

### Verification

`Darling.Tests` targets `net10.0-windows` and cannot run on macOS, so the invariant was executed against the **real compiled assemblies** through a throwaway `net10.0` harness (assembly named `Darling.Tests` so the `InternalsVisibleTo` grants apply) running the new test's exact logic. Red/green:

| built against | result |
|---|---|
| this branch | all three assertions pass |
| `dev` as-is | fails at `Unknown field 'blocking.wait_threshold_seconds'` |
| `dev` + only the blocking arm added | fails naming exactly the six: `ag_disconnect_refire_minutes, ag_lag_alert_seconds, ag_redo_queue_alert_kb, connection_refire_minutes, notify_ag_health, notify_connection_down_at_startup` |

That third row is the one that matters — it shows the invariant catches each defect independently rather than one masking the other.

Every clamp literal the parity test asserts was grepped out of `DarlingAlertSettings.cs` and `DarlingMcpAlertTools.cs` before being written down. Service, Viewer, `Darling.Tests` and `Lite.Tests` all build clean.

**Nothing about the SELECT or the by-ordinal read changed.** Every column was already being read, which is what made this a payload defect rather than a schema one, so `AlertSettingsSelect_ColumnCount_MatchesTheOrdinalsRead` is untouched and still holds.

`PerformanceMonitor.Common` gains an `InternalsVisibleTo` for `Darling.Tests` so the new test serializes through `McpHelpers.JsonOptions` itself rather than a look-alike — a naming policy added there can never leave the invariant asserting keys no client receives. `Lite.Tests` and `Dashboard.Tests` were already on that list.

### Lite followed in the same PR, because CI now requires it

The first CI run went red on `Lite.Tests`, and correctly. #2410 landed on `dev` between this branch's base and that run: `GetAlertSettings_ReportsEveryGroupDarlingDoes_SpelledDarlingsWay` parses Darling's `BuildAlertSettingsPayload` and requires Lite's payload to carry every group and key it finds. So the "Darling moves first, Lite follows separately" plan the issue describes is no longer available — the test named exactly the three additions (`missing group 'notify_connection_down_at_startup'; missing group 'connection_refire_minutes'; missing group 'ag'`). That test is doing what it was written to do, so Lite follows here rather than the test being weakened.

Six of the seven needed no new plumbing. `App.NotifyConnectionDownAtStartup` / `App.ConnectionRefireMinutes` have driven the connection-alert path since #1659, and `App.NotifyAgHealth` / `App.AgLagAlertSeconds` / `App.AgRedoQueueAlertKb` have driven all four AG conditions since #1726. Only the MCP surface was narrow — the same gap #2394 closed for the other nine groups.

**The seventh is a real asymmetry, exempted by name rather than faked.** Darling's `ag_disconnect_refire_minutes` is #1696 / store V37, and Lite has no AG disconnect re-fire *at all* — no static, no `settings.json` key, no edge state that could re-announce. Emitting a constant `0` would tell an agent it can tune something Lite cannot, which is the reasoning this file already applies to `self_alerts`, here at member granularity instead of group. `LiteOmittedMembers` holds the one entry, and a new test asserts **both** halves still hold — Darling still emits it (so the exemption cannot become dead weight hiding a Darling regression) and Lite still does not (so it cannot mask a key that has since arrived). The set is pinned exactly, so a second exemption has to be justified in that test the way a second Lite-only group has to be justified in the `smtp` assertion.

`Lite.Tests` cannot run on macOS either, so the parity test's parser was ported to Python and **validated against the test's own self-checks before being trusted** — the 15–40 group count, `cpu`/`analysis`/`self_alerts` present, `smtp` absent, and `cpu`'s members exactly `enabled`/`threshold_percent`/`mode`. Then:

| run against | result |
|---|---|
| `dev`'s Lite payload | reproduces CI's failure message **byte for byte** |
| this branch | passes |
| this branch, exemption removed | fails on `ag.disconnect_refire_minutes` and nothing else |

That last row is what shows the exemption is both load-bearing and minimal. Darling's own round-trip invariant re-ran green after the merge.

### Deferred

**#2426** — Lite has no AG disconnect re-fire, so a replica disconnected for a week is announced once where Darling can re-announce it. That is #1696's Lite half: a static, a clamp on load and save, a Settings box, and real edge state. It is a feature, not a payload key, and does not belong in a payload-symmetry change. Filed with the mechanism, the four steps to close it, and the note that `ConnectionRefireMinutes` and the AG re-fire are the same #1674 shape and may want one shared helper.

The CHANGELOG entry is also deliberately not here — see the comment below. `[3.5.1]` is being cut in #2395, so adding the section here would put this PR in conflict with a release PR over a file it otherwise does not touch. The bullet is written out ready to paste, and the safe order is #2395 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
