### PR TITLE
Say why the card is amber, and give "+52 more" somewhere to go (#2424)

### DIFF
--- a/Darling/Darling.Tests/ViewerOverviewExplainsItselfTests.cs
+++ b/Darling/Darling.Tests/ViewerOverviewExplainsItselfTests.cs
@@ -176,6 +176,119 @@ public sealed class ViewerOverviewExplainsItselfTests
         }
     }
 
+    /// <summary>
+    /// THE INVARIANT, rather than the two instances of it that review found one at a time. The card's status
+    /// word and its tooltip must agree for EVERY combination of the two freshness flags, including the ones
+    /// <c>ApplyFreshness</c> cannot reach — both flags are plain settable properties, so a fixture or a new
+    /// data path can construct any of them.
+    ///
+    /// <para>Two rounds on #2429 each surfaced a different contradicting pair (<c>IsOnline</c> null with no
+    /// awaiting marker, then <c>IsOnline</c> true WITH one). Guarding those two would have left the third to
+    /// be found the same way, so the renderings now share one discriminant
+    /// (<see cref="ServerCardStatus"/>) and this walks the whole product to prove no pair is left.</para>
+    /// </summary>
+    [Fact]
+    public void TheCardsTooltip_AgreesWithTheStatusWord_ForEveryCombinationOfTheFreshnessFlags()
+    {
+        bool?[] online = { true, false, null };
+        bool[] awaiting = { true, false };
+        bool[] stale = { true, false };
+        double?[] cpu = { null, 96 };
+
+        /* A long max-wait with a zero event count bands Blocking as Warning while BuildReason's own gate
+           (count > 0) skips it — a card outside Healthy with nothing to name, which is the other way the
+           ranking-only fallback reaches a tooltip. It is in the sweep because widening the sweep is what
+           found it. */
+        long[] maxBlockingMs = { 0, 20000 };
+        int[] failedCollectors = { 0, 1 };
+
+        /* Status word -> the words no tooltip under it may use, because each names a different state. */
+        var forbidden = new Dictionary<string, string[]>(StringComparer.Ordinal)
+        {
+            ["Online"] = new[] { "Offline", "Awaiting first collection", "Unknown" },
+            ["Warning"] = new[] { "Offline", "Awaiting first collection", "Unknown" },
+            ["Offline"] = new[] { "Awaiting first collection", "Unknown" },
+            ["Awaiting first collection"] = new[] { "Offline", "Unknown" },
+            ["Unknown"] = new[] { "Offline", "Awaiting first collection" },
+        };
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var cases = 0;
+
+        foreach (var o in online)
+        foreach (var a in awaiting)
+        foreach (var st in stale)
+        foreach (var c in cpu)
+        foreach (var blockMs in maxBlockingMs)
+        foreach (var failed in failedCollectors)
+        {
+            var card = new ServerSummaryItem
+            {
+                DisplayName = "s",
+                ServerId = 1,
+                IsOnline = o,
+                AwaitingFirstCollection = a,
+                HasCollectorErrors = st,
+                CpuPercent = c,
+                MaxBlockingWaitMs = blockMs,
+                FailedCollectorCount = failed,
+            };
+
+            var word = card.StatusDisplay;
+            var tooltip = card.StatusTooltip;
+            seen.Add(word);
+            cases++;
+
+            var where = $"IsOnline={o?.ToString() ?? "null"} Awaiting={a} Stale={st} Cpu={c?.ToString() ?? "null"} " +
+                        $"MaxBlockingMs={blockMs} FailedCollectors={failed} " +
+                        $"-> word '{word}' tooltip '{tooltip.Replace("\n", " | ", StringComparison.Ordinal)}'";
+
+            foreach (var banned in forbidden[word])
+            {
+                Assert.False(tooltip.Contains(banned, StringComparison.Ordinal),
+                    $"the tooltip claims '{banned}' under a status word of '{word}'. {where}");
+            }
+
+            /* And the ranking-only fallback never reaches a card, whatever the flags say. */
+            Assert.False(tooltip.Contains("Needs attention", StringComparison.Ordinal), where);
+        }
+
+        Assert.Equal(96, cases);
+
+        /* The sweep really did exercise all five status words, so a future rewrite that collapses one of them
+           cannot leave this test passing over a smaller surface than it claims to cover. */
+        Assert.Equal(5, seen.Count);
+    }
+
+    /// <summary>The word, the colour, the reason and the tooltip are four renderings of ONE discriminant. That is
+    /// what makes the sweep above hold by construction instead of by luck.</summary>
+    [Fact]
+    public void TheCardStatus_IsTheOnlyPlaceTheFreshnessFlagsAreRead()
+    {
+        Assert.Equal(ServerCardStatus.Online, Healthy().CardStatus);
+        Assert.Equal(ServerCardStatus.Stale, Stale().CardStatus);
+        Assert.Equal(ServerCardStatus.Offline, Offline().CardStatus);
+        Assert.Equal(ServerCardStatus.AwaitingFirstCollection, Awaiting().CardStatus);
+        Assert.Equal(ServerCardStatus.Unknown, UnknownStatus().CardStatus);
+
+        /* The pair the second review round found: awaiting set alongside an online card. The status word has
+           always ignored the marker there, and now so does everything downstream of it. */
+        var onlineAndAwaiting = Healthy();
+        onlineAndAwaiting.AwaitingFirstCollection = true;
+
+        Assert.Equal(ServerCardStatus.Online, onlineAndAwaiting.CardStatus);
+        Assert.Equal("Online", onlineAndAwaiting.StatusDisplay);
+        Assert.DoesNotContain("Awaiting", onlineAndAwaiting.StatusTooltip, StringComparison.Ordinal);
+        Assert.DoesNotContain("Awaiting", FleetRollup.BuildReason(onlineAndAwaiting), StringComparison.Ordinal);
+
+        /* The source pin: nothing but CardStatus may branch on the flag pair. */
+        var overview = ReadRepoFile(Path.Combine(
+            "Darling", "PerformanceMonitor.Darling.Viewer", "ViewerDataService.Overview.cs"));
+        Assert.Contains("public ServerCardStatus CardStatus => IsOnline switch", overview, StringComparison.Ordinal);
+        Assert.Contains("public string StatusDisplay => CardStatus switch", overview, StringComparison.Ordinal);
+        Assert.Contains("public SolidColorBrush StatusBrush => MakeBrush(CardStatus switch", overview, StringComparison.Ordinal);
+    }
+
     /// <summary>The card view-model exposes it, because a static nothing binds to fixes nothing.</summary>
     [Fact]
     public void TheCardViewModel_ExposesTheTooltip_WithoutReimplementingIt()

--- a/Darling/Darling.Tests/ViewerOverviewExplainsItselfTests.cs
+++ b/Darling/Darling.Tests/ViewerOverviewExplainsItselfTests.cs
@@ -1,0 +1,361 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.Darling.Viewer;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #2424 / #2422: the Overview stops keeping the answer to itself.
+///
+/// <para><b>What was reported.</b> A card said "Warning" in amber and would not say what about. The reporter's
+/// two questions were "what is it that this text warns me about?" and, of "+52 more need attention", "where do I
+/// find these warnings?". Both are questions the tab could already answer for itself — it computes a per-server
+/// reason and the full problem set, then renders a colour and a count.</para>
+///
+/// <para><b>What is pinned here.</b> The reason on the card comes from <see cref="FleetRollup.BuildReason"/>
+/// rather than from a second derivation — that method's whole value is being built from the card's OWN metric
+/// displays, so a tooltip built any other way could contradict the six rows the reader is looking at. And the
+/// overflow line reaches the servers it counts, through the same banding that counted them, with the filter's
+/// active state visible and clearable.</para>
+///
+/// <para>The wiring half text-scans SOURCE (located by walking up from this file's compile-time path, the
+/// <c>ViewerServerInventoryEnabledTests</c> pattern) because a <c>ToolTip</c> attribute and a click handler live
+/// in XAML, where no assertion about a C# object can reach them. Removing either compiles perfectly.</para>
+/// </summary>
+public sealed class ViewerOverviewExplainsItselfTests
+{
+    private static ServerSummaryItem Healthy(string name = "h1", int id = 1) =>
+        new() { DisplayName = name, ServerId = id, IsOnline = true };
+
+    private static ServerSummaryItem Busy(string name = "b1", int id = 2) =>
+        new()
+        {
+            DisplayName = name,
+            ServerId = id,
+            IsOnline = true,
+            CpuPercent = 96,
+            BlockingCount = 6,
+            MaxBlockingWaitMs = 70000,
+        };
+
+    private static ServerSummaryItem Stale(string name = "s1", int id = 3) =>
+        new() { DisplayName = name, ServerId = id, IsOnline = true, HasCollectorErrors = true };
+
+    private static ServerSummaryItem Offline(string name = "o1", int id = 4) =>
+        new() { DisplayName = name, ServerId = id, IsOnline = false };
+
+    private static ServerSummaryItem Awaiting(string name = "a1", int id = 5) =>
+        new() { DisplayName = name, ServerId = id, IsOnline = null, AwaitingFirstCollection = true };
+
+    // ── The card explains itself ───────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The tooltip is BuildReason's own output, not a paraphrase of it. This is the assertion that matters: it
+    /// is what stops a later edit "improving" the card's wording into something that disagrees with the Needs
+    /// Attention row for the same server, which is the exact drift BuildReason was written to prevent.
+    /// </summary>
+    [Fact]
+    public void TheCardsTooltip_IsTheSameSentenceTheRankingShows()
+    {
+        foreach (var card in new[] { Busy(), Stale(), Offline(), Awaiting() })
+        {
+            Assert.Contains(FleetRollup.BuildReason(card), FleetRollup.BuildStatusTooltip(card), StringComparison.Ordinal);
+        }
+    }
+
+    /// <summary>The reporter's first question, answered: the amber word now names the metrics behind it.</summary>
+    [Fact]
+    public void TheCardsTooltip_NamesTheBandAndEveryBadMetric()
+    {
+        var tooltip = FleetRollup.BuildStatusTooltip(Busy());
+
+        Assert.Contains("Critical", tooltip, StringComparison.Ordinal);
+        Assert.Contains("CPU 96%", tooltip, StringComparison.Ordinal);
+        Assert.Contains("Blocking 6", tooltip, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The reporter's card. <c>StatusDisplay</c> renders "Warning" for exactly one condition — an online server
+    /// whose collection has gone stale — and nothing on the card said so. The tooltip has to answer THAT card,
+    /// not just the metric-driven ones.
+    /// </summary>
+    [Fact]
+    public void TheCardsTooltip_ExplainsTheAmberWarningThatMeansStaleCollection()
+    {
+        var stale = Stale();
+
+        Assert.Equal("Warning", stale.StatusDisplay);
+        Assert.Contains("Warning", stale.StatusTooltip, StringComparison.Ordinal);
+        Assert.Contains("collection stale", stale.StatusTooltip, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A green card must not be told it needs attention. BuildReason's fallback is written for a ranking that only
+    /// ever holds problem servers; the card grid shows EVERY server, so reusing the fallback unguarded would put
+    /// "Needs attention" on every healthy card in the fleet — a worse defect than the silence it replaced.
+    /// </summary>
+    [Fact]
+    public void TheCardsTooltip_OnAHealthyCard_DoesNotClaimItNeedsAttention()
+    {
+        var tooltip = FleetRollup.BuildStatusTooltip(Healthy());
+
+        Assert.DoesNotContain("Needs attention", tooltip, StringComparison.Ordinal);
+        Assert.Contains("Healthy", tooltip, StringComparison.Ordinal);
+    }
+
+    /// <summary>Offline and awaiting-first-collection already come back as whole sentences naming themselves, so
+    /// the band label is not stamped in front of them a second time.</summary>
+    [Fact]
+    public void TheCardsTooltip_DoesNotSayOfflineTwice()
+    {
+        var tooltip = FleetRollup.BuildStatusTooltip(Offline());
+
+        Assert.StartsWith("Offline — no recent collection", tooltip, StringComparison.Ordinal);
+        Assert.Equal(1, CountOccurrences(tooltip, "Offline"));
+        Assert.StartsWith("Awaiting first collection", FleetRollup.BuildStatusTooltip(Awaiting()), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The sidebar alert badge's tooltip is the shape being followed — the breakdown, then how to act on it — so
+    /// every card tooltip ends on the gesture that gets the reader to the detail. "How can I resolve this warning"
+    /// was the other half of the report.
+    /// </summary>
+    [Fact]
+    public void TheCardsTooltip_EndsWithHowToActOnIt()
+    {
+        foreach (var card in new[] { Healthy(), Busy(), Stale(), Offline(), Awaiting() })
+        {
+            var tooltip = FleetRollup.BuildStatusTooltip(card);
+
+            Assert.EndsWith("\nDouble-click the card to open this server's tab", tooltip, StringComparison.Ordinal);
+            Assert.False(tooltip.StartsWith('\n'), "the reason must come first, on its own line");
+        }
+    }
+
+    /// <summary>The card view-model exposes it, because a static nothing binds to fixes nothing.</summary>
+    [Fact]
+    public void TheCardViewModel_ExposesTheTooltip_WithoutReimplementingIt()
+    {
+        var card = Busy();
+
+        Assert.Equal(FleetRollup.BuildStatusTooltip(card), card.StatusTooltip);
+    }
+
+    // ── "+N more need attention" reaches the servers it counts ─────────────────────────────────────
+
+    /// <summary>
+    /// The filter and the count are the SAME banding, so "+52 more need attention" lands on a grid holding
+    /// exactly those servers plus the five already listed. Two predicates here would mean a link whose
+    /// destination disagrees with its own label, which is the defect wearing a new hat.
+    /// </summary>
+    [Fact]
+    public void TheFilter_KeepsExactlyTheServersTheRollupCounted()
+    {
+        var fleet = BuildFleet(healthy: 45, critical: 4, warning: 6, offline: 2);
+        var rollup = FleetRollup.Build(fleet, new FleetTotals());
+
+        var filtered = FleetRollup.NeedsAttention(fleet);
+
+        Assert.Equal(12, filtered.Count);
+        Assert.Equal(rollup.WorstServers.Count + rollup.AdditionalProblemCount, filtered.Count);
+        Assert.DoesNotContain(filtered, s => FleetRollup.ClassifyBand(s) == FleetHealthBand.Healthy);
+
+        /* Every server the capped ranking DID list is still in the grid the link lands on — the reader should not
+           have to hold five names in their head while looking at the other seven. */
+        foreach (var ranked in rollup.WorstServers)
+        {
+            Assert.Contains(filtered, s => s.ServerId == ranked.ServerId);
+        }
+    }
+
+    /// <summary>The grid's chosen sort survives the filter — filtering is not a re-order.</summary>
+    [Fact]
+    public void TheFilter_PreservesTheCallersOrder()
+    {
+        var fleet = new List<ServerSummaryItem>
+        {
+            Offline("z-offline", 1),
+            Healthy("m-healthy", 2),
+            Busy("a-busy", 3),
+        };
+
+        Assert.Equal(new[] { "z-offline", "a-busy" }, FleetRollup.NeedsAttention(fleet).Select(s => s.DisplayName));
+    }
+
+    /// <summary>
+    /// The active state carries its own arithmetic. A filtered grid that looks like an unfiltered one is a worse
+    /// bug than the dead-end count it replaced, and the all-clear case — an empty grid with the filter still on —
+    /// is the one that would otherwise read as a broken tab.
+    /// </summary>
+    [Fact]
+    public void TheFilter_SaysWhatItDid_IncludingWhenItLeavesNothing()
+    {
+        Assert.Equal("showing 12 of 57", FleetRollup.AttentionFilterCountText(12, 57));
+        Assert.Equal("all 57 servers are healthy", FleetRollup.AttentionFilterCountText(0, 57));
+        Assert.Equal("the 1 server monitored is healthy", FleetRollup.AttentionFilterCountText(0, 1));
+
+        /* And an Overview with no cards at all does not report that zero servers are healthy. */
+        Assert.Equal("no servers to filter", FleetRollup.AttentionFilterCountText(0, 0));
+    }
+
+    /// <summary>
+    /// The ranking cap stays at five, deliberately, on a fleet where that hides 52. The roll-up panel is docked to
+    /// the top of the Overview and does not scroll — only the card grid beneath it does — so a list that grew with
+    /// the fleet would push the cards it points at off the screen and stop being a shortlist. The overflow is
+    /// answered by giving it a destination, not by making the shortlist long.
+    /// </summary>
+    [Fact]
+    public void TheRankingCap_StaysShort_BecauseTheOverflowNowHasSomewhereToGo()
+    {
+        Assert.Equal(5, FleetRollup.DefaultWorstCount);
+
+        var rollup = FleetRollup.Build(BuildFleet(healthy: 5, critical: 40, warning: 12, offline: 0), new FleetTotals());
+
+        Assert.Equal(5, rollup.WorstServers.Count);
+        Assert.Equal(47, rollup.AdditionalProblemCount);
+        Assert.Equal("+47 more need attention", rollup.AdditionalProblemText);
+    }
+
+    // ── The wiring, which only source can show ─────────────────────────────────────────────────────
+
+    private static string Xaml => ReadRepoFile(Path.Combine(
+        "Darling", "PerformanceMonitor.Darling.Viewer", "MainWindow.xaml"));
+
+    private static string CodeBehind => ReadRepoFile(Path.Combine(
+        "Darling", "PerformanceMonitor.Darling.Viewer", "MainWindow.xaml.cs"));
+
+    /// <summary>
+    /// The card's status actually carries the tooltip. <c>Background="Transparent"</c> is load-bearing rather than
+    /// decorative: a TextBlock with a null Background hit-tests on its rendered glyphs alone, so the tooltip would
+    /// appear over the letters of "Warning" and nowhere in the space around them.
+    /// </summary>
+    [Fact]
+    public void TheCardStatus_IsBoundToTheTooltip_AndIsHoverable()
+    {
+        var at = Xaml.IndexOf("Text=\"{Binding StatusDisplay}\"", StringComparison.Ordinal);
+        Assert.True(at > 0, "the Overview card's status TextBlock is gone — find where it moved before editing this test");
+
+        var element = Xaml[at..(Xaml.IndexOf("/>", at, StringComparison.Ordinal) + 2)];
+
+        Assert.Contains("ToolTip=\"{Binding StatusTooltip}\"", element, StringComparison.Ordinal);
+        Assert.Contains("Background=\"Transparent\"", element, StringComparison.Ordinal);
+    }
+
+    /// <summary>The overflow line navigates, and looks like it does. A dead count that merely reports a number was
+    /// the whole complaint.</summary>
+    [Fact]
+    public void TheOverflowLine_IsAClickableLinkIntoTheFilter()
+    {
+        var at = Xaml.IndexOf("x:Name=\"FleetAdditionalProblems\"", StringComparison.Ordinal);
+        Assert.True(at > 0, "the '+N more need attention' affordance is gone");
+
+        var element = Xaml[at..(Xaml.IndexOf("</Border>", at, StringComparison.Ordinal) + 9)];
+
+        Assert.Contains("MouseLeftButtonUp=\"FleetAdditionalProblems_Click\"", element, StringComparison.Ordinal);
+        Assert.Contains("Cursor=\"Hand\"", element, StringComparison.Ordinal);
+        Assert.Contains("{Binding AdditionalProblemText}", element, StringComparison.Ordinal);
+        Assert.Contains("FleetAdditionalProblems_Click(object sender", CodeBehind, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The filter is clearable and its state is visible: a toggle that reads both ways, wired on BOTH transitions
+    /// so unchecking restores the fleet, sitting in the docked roll-up header that never scrolls away from the grid
+    /// it shrank, with a count beside it.
+    /// </summary>
+    [Fact]
+    public void TheFilter_IsClearable_AndItsActiveStateIsVisible()
+    {
+        Assert.Contains("x:Name=\"OverviewAttentionOnlyCheck\"", Xaml, StringComparison.Ordinal);
+        Assert.Contains("Checked=\"OverviewAttentionOnlyCheck_Changed\"", Xaml, StringComparison.Ordinal);
+        Assert.Contains("Unchecked=\"OverviewAttentionOnlyCheck_Changed\"", Xaml, StringComparison.Ordinal);
+        Assert.Contains("x:Name=\"OverviewAttentionCountText\"", Xaml, StringComparison.Ordinal);
+
+        Assert.Contains("OverviewAttentionOnlyCheck_Changed(object sender", CodeBehind, StringComparison.Ordinal);
+        Assert.Contains("FleetRollup.AttentionFilterCountText(", CodeBehind, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// One projection seam. The grid is set from the full card set through the filter and from nowhere else, so a
+    /// refresh, a re-sort and a tag re-stamp cannot each have their own opinion about whether the filter is on —
+    /// and nothing reads the bound list BACK to answer "what cards exist", which is the mistake
+    /// <see cref="FleetView"/> exists to prevent on the sidebar and would be just as silent here.
+    /// </summary>
+    [Fact]
+    public void TheGrid_IsProjectedThroughTheFilter_AndNothingReadsTheBoundListBack()
+    {
+        Assert.Contains("FleetRollup.NeedsAttention(_overviewCards)", CodeBehind, StringComparison.Ordinal);
+        Assert.Contains("_overviewCards = cards;", CodeBehind, StringComparison.Ordinal);
+
+        Assert.DoesNotContain("OverviewItemsControl.ItemsSource is IEnumerable<ServerSummaryItem>", CodeBehind, StringComparison.Ordinal);
+        Assert.DoesNotContain("OverviewItemsControl.ItemsSource = cards;", CodeBehind, StringComparison.Ordinal);
+
+        /* Exactly two writers: the empty-fleet clear, and the filter projection. */
+        Assert.Equal(2, CountOccurrences(CodeBehind, "OverviewItemsControl.ItemsSource ="));
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────────────────────────────
+
+    private static List<ServerSummaryItem> BuildFleet(int healthy, int critical, int warning, int offline)
+    {
+        var fleet = new List<ServerSummaryItem>();
+        var id = 0;
+
+        for (var i = 0; i < healthy; i++)
+        {
+            fleet.Add(new ServerSummaryItem { DisplayName = $"h{i:00}", ServerId = ++id, IsOnline = true });
+        }
+        for (var i = 0; i < critical; i++)
+        {
+            fleet.Add(new ServerSummaryItem { DisplayName = $"c{i:00}", ServerId = ++id, IsOnline = true, DeadlockCount = 1 });
+        }
+        for (var i = 0; i < warning; i++)
+        {
+            fleet.Add(new ServerSummaryItem { DisplayName = $"w{i:00}", ServerId = ++id, IsOnline = true, FailedCollectorCount = 1 });
+        }
+        for (var i = 0; i < offline; i++)
+        {
+            fleet.Add(new ServerSummaryItem { DisplayName = $"o{i:00}", ServerId = ++id, IsOnline = false });
+        }
+
+        return fleet;
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+        return count;
+    }
+
+    private static string ReadRepoFile(string relative, [CallerFilePath] string thisFile = "")
+    {
+        for (var dir = new DirectoryInfo(Path.GetDirectoryName(thisFile)!); dir is not null; dir = dir.Parent)
+        {
+            var candidate = Path.Combine(dir.FullName, relative);
+            if (File.Exists(candidate))
+            {
+                return File.ReadAllText(candidate);
+            }
+        }
+
+        throw new FileNotFoundException($"Could not locate {relative} walking up from {thisFile}");
+    }
+}

--- a/Darling/Darling.Tests/ViewerOverviewExplainsItselfTests.cs
+++ b/Darling/Darling.Tests/ViewerOverviewExplainsItselfTests.cs
@@ -60,6 +60,11 @@ public sealed class ViewerOverviewExplainsItselfTests
     private static ServerSummaryItem Awaiting(string name = "a1", int id = 5) =>
         new() { DisplayName = name, ServerId = id, IsOnline = null, AwaitingFirstCollection = true };
 
+    /// <summary>The pair StatusDisplay renders as "Unknown": freshness was never classified. ApplyFreshness
+    /// cannot produce it, but a fixture or a future data path can, which is the whole point of pinning it.</summary>
+    private static ServerSummaryItem UnknownStatus(string name = "u1", int id = 6) =>
+        new() { DisplayName = name, ServerId = id, IsOnline = null, AwaitingFirstCollection = false };
+
     // ── The card explains itself ───────────────────────────────────────────────────────────────────
 
     /// <summary>
@@ -129,6 +134,32 @@ public sealed class ViewerOverviewExplainsItselfTests
     }
 
     /// <summary>
+    /// Every arm of <c>StatusDisplay</c> has a matching arm here. The one that does not follow from the band is
+    /// "Unknown" — <c>IsOnline</c> null with no first-collection marker — where <c>ClassifyBand</c> falls through
+    /// to the metrics and, on an otherwise clean card, lands on Healthy. A tooltip hanging off the word "Unknown"
+    /// and reading "Healthy" is the same defect as the silence it replaced, so the two are pinned in lockstep.
+    /// Raised in review on #2429; unreachable through <c>ApplyFreshness</c> today, which is why it needs a pin
+    /// rather than a bug report.
+    /// </summary>
+    [Fact]
+    public void TheCardsTooltip_NeverContradictsAnUnknownStatus()
+    {
+        var unknown = UnknownStatus();
+
+        Assert.Equal("Unknown", unknown.StatusDisplay);
+        Assert.StartsWith("Unknown — no collection status for this server", unknown.StatusTooltip, StringComparison.Ordinal);
+        Assert.DoesNotContain("Healthy", unknown.StatusTooltip, StringComparison.Ordinal);
+
+        /* An unknown card with a genuinely bad metric still gets the metric named — the status word being
+           unknown is not a reason to withhold the one thing that IS known. */
+        var unknownAndBusy = UnknownStatus();
+        unknownAndBusy.CpuPercent = 96;
+
+        Assert.Contains("CPU 96%", unknownAndBusy.StatusTooltip, StringComparison.Ordinal);
+        Assert.DoesNotContain("Needs attention", unknownAndBusy.StatusTooltip, StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// The sidebar alert badge's tooltip is the shape being followed — the breakdown, then how to act on it — so
     /// every card tooltip ends on the gesture that gets the reader to the detail. "How can I resolve this warning"
     /// was the other half of the report.
@@ -136,7 +167,7 @@ public sealed class ViewerOverviewExplainsItselfTests
     [Fact]
     public void TheCardsTooltip_EndsWithHowToActOnIt()
     {
-        foreach (var card in new[] { Healthy(), Busy(), Stale(), Offline(), Awaiting() })
+        foreach (var card in new[] { Healthy(), Busy(), Stale(), Offline(), Awaiting(), UnknownStatus() })
         {
             var tooltip = FleetRollup.BuildStatusTooltip(card);
 

--- a/Darling/Darling.Tests/ViewerOverviewExplainsItselfTests.cs
+++ b/Darling/Darling.Tests/ViewerOverviewExplainsItselfTests.cs
@@ -316,6 +316,11 @@ public sealed class ViewerOverviewExplainsItselfTests
 
         Assert.Contains("OverviewAttentionOnlyCheck_Changed(object sender", CodeBehind, StringComparison.Ordinal);
         Assert.Contains("FleetRollup.AttentionFilterCountText(", CodeBehind, StringComparison.Ordinal);
+
+        /* The colour follows the sentence: this line says either "N servers need attention" or an all-clear, and
+           painting the all-clear amber would be a colour contradicting its own text — the same defect in
+           miniature. Raised in review on #2429. */
+        Assert.Contains("shown > 0 ? \"WarningBrush\" : \"SuccessBrush\"", CodeBehind, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
@@ -741,6 +741,20 @@
                                 <!-- Header -->
                                 <DockPanel Margin="0,0,0,10">
                                     <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Center">
+                                        <!-- #2424: the needs-attention filter over the card grid below. It sits
+                                             beside Sort because it is the same kind of thing — a view control over
+                                             the same cards — and it lives in the roll-up header, which is docked and
+                                             never scrolls away, so an active filter can never be off screen while the
+                                             grid it shrank is on it. The count beside it (set in ApplyOverviewCardFilter)
+                                             is what stops a filtered grid reading as an unfiltered one. -->
+                                        <CheckBox x:Name="OverviewAttentionOnlyCheck" Content="Needs attention only"
+                                                  FontSize="11" VerticalAlignment="Center" Margin="0,0,6,0"
+                                                  ToolTip="Show only the cards that are not Healthy — Critical, Warning, Offline, or awaiting a first collection. Uncheck to show the whole fleet again."
+                                                  Checked="OverviewAttentionOnlyCheck_Changed"
+                                                  Unchecked="OverviewAttentionOnlyCheck_Changed"/>
+                                        <TextBlock x:Name="OverviewAttentionCountText" FontSize="11" VerticalAlignment="Center"
+                                                   Foreground="{DynamicResource WarningBrush}" Margin="0,0,14,0"
+                                                   Visibility="Collapsed"/>
                                         <TextBlock Text="Sort:" FontSize="11" VerticalAlignment="Center"
                                                    Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,0,6,0"/>
                                         <ComboBox x:Name="OverviewSortSelector" Width="120" VerticalAlignment="Center"
@@ -859,9 +873,34 @@
                                         </DataTemplate>
                                     </ItemsControl.ItemTemplate>
                                 </ItemsControl>
-                                <TextBlock x:Name="FleetAdditionalProblemsText" Text="{Binding AdditionalProblemText}"
-                                           FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}"
-                                           Margin="17,2,0,0" Visibility="Collapsed"/>
+                                <!-- #2424: the overflow line is the way TO the overflow, not a report that it
+                                     exists. It was a bare TextBlock: on a 57-server fleet it read "+52 more need
+                                     attention" and the reporter's question was literally "where do I find these?".
+                                     Clicking it turns on the needs-attention card filter, so the answer is the grid
+                                     immediately below, with every metric row those 52 servers have. Underlined and
+                                     Cursor=Hand because a line that navigates has to look like one. -->
+                                <Border x:Name="FleetAdditionalProblems" HorizontalAlignment="Left"
+                                        Cursor="Hand" Padding="2,1" CornerRadius="3"
+                                        Margin="15,2,0,0" Visibility="Collapsed"
+                                        ToolTip="Show only the servers that need attention"
+                                        MouseLeftButtonUp="FleetAdditionalProblems_Click">
+                                    <!-- The hover idiom is the Needs Attention row's, a few lines up: a
+                                         transparent Border that lights on IsMouseOver. Same gesture, same
+                                         feedback, so the overflow line reads as one more thing you can click. -->
+                                    <Border.Style>
+                                        <Style TargetType="Border">
+                                            <Setter Property="Background" Value="Transparent"/>
+                                            <Style.Triggers>
+                                                <Trigger Property="IsMouseOver" Value="True">
+                                                    <Setter Property="Background" Value="{DynamicResource ViewerHoverBrush}"/>
+                                                </Trigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Border.Style>
+                                    <TextBlock x:Name="FleetAdditionalProblemsText" Text="{Binding AdditionalProblemText}"
+                                               FontSize="11" TextDecorations="Underline"
+                                               Foreground="{DynamicResource AccentBrush}"/>
+                                </Border>
                                 <TextBlock x:Name="FleetAllHealthyText" Text="{Binding AllHealthyText}"
                                            FontSize="12" Foreground="{DynamicResource SuccessBrush}" Margin="0,0,0,2" Visibility="Collapsed"/>
                             </StackPanel>
@@ -889,9 +928,17 @@
                                                     <TextBlock Text="{Binding DisplayName}" FontSize="16" FontWeight="SemiBold"
                                                                Foreground="{DynamicResource ForegroundBrush}"/>
                                                     <Ellipse Width="10" Height="10" Fill="{Binding StatusBrush}"
+                                                             ToolTip="{Binding StatusTooltip}"
                                                              HorizontalAlignment="Right" VerticalAlignment="Center"/>
                                                 </DockPanel>
+                                                <!-- #2422: the status line carries the reason it is that colour. The
+                                                     card already computed the sentence (FleetRollup.BuildReason, from
+                                                     these very metric rows) and spent it only on the Needs Attention
+                                                     ranking. Background=Transparent is load-bearing: a TextBlock with a
+                                                     null Background hit-tests on its glyphs alone, so the tooltip would
+                                                     appear over the letters and nowhere between them. -->
                                                 <TextBlock Text="{Binding StatusDisplay}" Foreground="{Binding StatusBrush}"
+                                                           Background="Transparent" ToolTip="{Binding StatusTooltip}"
                                                            FontSize="11" Margin="0,0,0,10"/>
                                                 <!-- Tag pills (#2008 2a): each server's tags as coloured chips.
                                                      Collapsed when the server carries no tags so untagged cards

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
@@ -1279,13 +1279,22 @@ public partial class MainWindow : Window
         ApplyOverviewAttentionCount(shown.Count);
     }
 
-    /// <summary>Shows what the filter did, beside the toggle that did it. Only rendered while the filter is on:
-    /// a grid showing every server needs no arithmetic, and a filtered one must never be mistakable for it.</summary>
+    /// <summary>
+    /// Shows what the filter did, beside the toggle that did it. Only rendered while the filter is on: a grid
+    /// showing every server needs no arithmetic, and a filtered one must never be mistakable for it.
+    ///
+    /// <para>The colour follows the sentence. This line has two of them — a count of servers wanting attention,
+    /// and an all-clear when the filter matched none — and painting the all-clear amber would be a colour
+    /// contradicting its own text, which is the family of defect this whole change is about. Set through
+    /// SetResourceReference (the alert badge's idiom) so it still tracks a theme change.</para>
+    /// </summary>
     private void ApplyOverviewAttentionCount(int shown)
     {
         if (_overviewAttentionOnly)
         {
             OverviewAttentionCountText.Text = FleetRollup.AttentionFilterCountText(shown, _overviewCards.Count);
+            OverviewAttentionCountText.SetResourceReference(
+                ForegroundProperty, shown > 0 ? "WarningBrush" : "SuccessBrush");
             OverviewAttentionCountText.Visibility = Visibility.Visible;
             return;
         }

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
@@ -127,6 +127,24 @@ public partial class MainWindow : Window
     private ServerOverviewSortMode _overviewSortMode;
 
     /// <summary>
+    /// The FULL, sorted Overview card set — the authority behind <c>OverviewItemsControl.ItemsSource</c> since
+    /// #2424, which now shows a possibly-filtered projection of it. Everything that used to read the bound list
+    /// back to answer "what cards are there" reads this instead, for the same reason <see cref="FleetView"/>
+    /// separates <c>All</c> from <c>Visible</c>: the moment the bound list is a SUBSET, a consumer that reads it
+    /// back is silently answering a different question.
+    /// </summary>
+    private List<ServerSummaryItem> _overviewCards = new();
+
+    /// <summary>
+    /// True while the Overview grid is filtered to servers that need attention (#2424) — the destination the
+    /// "+N more need attention" line finally has. Deliberately NOT persisted to ViewerAppSettings the way
+    /// <see cref="_overviewSortMode"/> is: a sort is a preference, this is a triage action tied to a moment, and
+    /// an Overview that opens with 52 of 57 servers already hidden is a support ticket even with the toggle in
+    /// plain sight.
+    /// </summary>
+    private bool _overviewAttentionOnly;
+
+    /// <summary>
     /// The non-secret configuration block shown on every connection/config failure (#1954): which
     /// darling.json won and what was parsed from it. Built at startup before the load is attempted (so a
     /// missing file still reports where the viewer looked) and extended with the parse summary once the file
@@ -1087,12 +1105,12 @@ public partial class MainWindow : Window
         settings.OverviewSortMode = ServerOverviewSort.ToToken(_overviewSortMode);
         _appSettingsStore.Save(settings);
 
-        if (OverviewItemsControl.ItemsSource is IEnumerable<ServerSummaryItem> current)
-        {
-            OverviewItemsControl.ItemsSource = ServerOverviewSort.Order(
-                current.ToList(), _overviewSortMode,
-                s => s.CpuPercentForAlert, s => s.DisplayName, s => s.ServerId);
-        }
+        /* Sorts the FULL card set, never the bound list: with the needs-attention filter on, the bound list is
+           a subset, and sorting that would quietly discard every card the filter is hiding. */
+        _overviewCards = ServerOverviewSort.Order(
+            _overviewCards, _overviewSortMode,
+            s => s.CpuPercentForAlert, s => s.DisplayName, s => s.ServerId);
+        ApplyOverviewCardFilter();
     }
 
     /// <summary>Attaches each server's tags as coloured pills to its Overview summary, joining the loaded tag
@@ -1123,17 +1141,19 @@ public partial class MainWindow : Window
         }
     }
 
-    /// <summary>Re-stamps tag pills onto the cards the Overview is currently showing (after a tag colour /
-    /// assignment change), reassigning ItemsSource so the change renders without a full per-server reload.
+    /// <summary>Re-stamps tag pills onto the Overview's cards (after a tag colour / assignment change) and
+    /// re-projects so the change renders without a full per-server reload. Stamps the FULL card set rather than
+    /// the bound list, so a card the needs-attention filter is hiding does not come back missing its pills.
     /// A no-op unless the Overview is populated.</summary>
     private void RestampOverviewTagPills()
     {
-        if (OverviewItemsControl.ItemsSource is IEnumerable<ServerSummaryItem> items)
+        if (_overviewCards.Count == 0)
         {
-            var list = items.ToList();
-            StampTagPills(list);
-            OverviewItemsControl.ItemsSource = list;
+            return;
         }
+
+        StampTagPills(_overviewCards);
+        ApplyOverviewCardFilter();
     }
 
     /// <summary>
@@ -1152,16 +1172,14 @@ public partial class MainWindow : Window
         var servers = _fleet.All;
         if (servers.Count == 0)
         {
-            OverviewItemsControl.ItemsSource = null;
-            FleetRollupContainer.Visibility = Visibility.Collapsed;
+            ClearOverviewCards();
             return;
         }
 
         var list = servers.ToList();
         if (list.Count == 0)
         {
-            OverviewItemsControl.ItemsSource = null;
-            FleetRollupContainer.Visibility = Visibility.Collapsed;
+            ClearOverviewCards();
             return;
         }
 
@@ -1190,7 +1208,11 @@ public partial class MainWindow : Window
             built,
             _overviewSortMode,
             s => s.CpuPercentForAlert, s => s.DisplayName, s => s.ServerId);
-        OverviewItemsControl.ItemsSource = cards;
+
+        /* The full set is the authority; the grid shows whatever the needs-attention filter leaves of it. A
+           refresh must not silently drop the filter, so this re-applies it rather than binding `cards` directly. */
+        _overviewCards = cards;
+        ApplyOverviewCardFilter();
 
         /* Fleet-wide NOC roll-up above the cards — the cross-server totals SQL aggregate (the read only
            Darling's central store can serve) plus the band counts / worst-N ranking reduced from the
@@ -1224,9 +1246,74 @@ public partial class MainWindow : Window
         FleetRollupContainer.Visibility = rollup.TotalServers > 0 ? Visibility.Visible : Visibility.Collapsed;
 
         FleetWorstServersList.Visibility = rollup.HasProblems ? Visibility.Visible : Visibility.Collapsed;
-        FleetAdditionalProblemsText.Visibility =
+        FleetAdditionalProblems.Visibility =
             rollup.AdditionalProblemCount > 0 ? Visibility.Visible : Visibility.Collapsed;
         FleetAllHealthyText.Visibility = rollup.HasProblems ? Visibility.Collapsed : Visibility.Visible;
+    }
+
+    /// <summary>Empties the Overview: no cards, no roll-up, and no stale authority left behind for the filter
+    /// or the tag re-stamp to project from.</summary>
+    private void ClearOverviewCards()
+    {
+        _overviewCards = new List<ServerSummaryItem>();
+        OverviewItemsControl.ItemsSource = null;
+        FleetRollupContainer.Visibility = Visibility.Collapsed;
+        ApplyOverviewAttentionCount(shown: 0);
+    }
+
+    /// <summary>
+    /// Projects <see cref="_overviewCards"/> onto the grid through the needs-attention filter (#2424) — the
+    /// ONE place ItemsSource is set for a populated Overview, so a refresh, a re-sort and a tag re-stamp cannot
+    /// each have their own opinion about whether the filter is still on.
+    ///
+    /// <para>The predicate is <see cref="FleetRollup.NeedsAttention"/>, the same banding the roll-up counted
+    /// the "+N more" with, so the grid the link lands on holds exactly the servers the link was counting.</para>
+    /// </summary>
+    private void ApplyOverviewCardFilter()
+    {
+        var shown = _overviewAttentionOnly
+            ? FleetRollup.NeedsAttention(_overviewCards)
+            : _overviewCards;
+
+        OverviewItemsControl.ItemsSource = shown;
+        ApplyOverviewAttentionCount(shown.Count);
+    }
+
+    /// <summary>Shows what the filter did, beside the toggle that did it. Only rendered while the filter is on:
+    /// a grid showing every server needs no arithmetic, and a filtered one must never be mistakable for it.</summary>
+    private void ApplyOverviewAttentionCount(int shown)
+    {
+        if (_overviewAttentionOnly)
+        {
+            OverviewAttentionCountText.Text = FleetRollup.AttentionFilterCountText(shown, _overviewCards.Count);
+            OverviewAttentionCountText.Visibility = Visibility.Visible;
+            return;
+        }
+
+        OverviewAttentionCountText.Text = string.Empty;
+        OverviewAttentionCountText.Visibility = Visibility.Collapsed;
+    }
+
+    /// <summary>The needs-attention toggle: re-projects the grid from the unchanged card set, so turning it off
+    /// restores the full fleet without a store round-trip. Deliberately carries no IsLoaded guard, unlike the sort
+    /// selector — that one needs it because seeding the ComboBox raises SelectionChanged during construction, and
+    /// nothing seeds this box. A guard here would only be able to drop a real transition and leave a ticked box
+    /// over an unfiltered grid, which is the same lie as the one this fixes, in the other direction.</summary>
+    private void OverviewAttentionOnlyCheck_Changed(object sender, RoutedEventArgs e)
+    {
+        _overviewAttentionOnly = OverviewAttentionOnlyCheck.IsChecked == true;
+        ApplyOverviewCardFilter();
+    }
+
+    /// <summary>
+    /// "+N more need attention" — the servers the ranking's cap could not show. Clicking it turns the filter on
+    /// rather than doing the filtering itself, so the state lands in the toggle where the reader can see it is on
+    /// and can turn it off; the alternative, a grid that silently shrank, is the worse version of this defect.
+    /// </summary>
+    private void FleetAdditionalProblems_Click(object sender, MouseButtonEventArgs e)
+    {
+        OverviewAttentionOnlyCheck.IsChecked = true;
+        e.Handled = true;
     }
 
     /// <summary>Double-clicking an Overview card opens (or focuses) that server's tab (Lite's rule).</summary>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Fleet.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Fleet.cs
@@ -336,7 +336,14 @@ public sealed class FleetRollup
     /// Warning too; otherwise Healthy. No new thresholds are introduced here.
     /// </summary>
     public static FleetHealthBand ClassifyBand(ServerSummaryItem s) =>
-        ServerHealthClassifier.ClassifyBand(s.IsOnline, s.AwaitingFirstCollection, s.HasCollectorErrors, s.OverallMetricSeverity);
+        ServerHealthClassifier.ClassifyBand(
+            s.IsOnline,
+            /* Via the card's discriminant, not the raw flag. The shared classifier honours an awaiting marker
+               whatever IsOnline says, so an online card carrying a stray marker banded Warning while the card
+               said "Online" and had nothing to report — a third reading of the same pair. See ServerCardStatus. */
+            s.CardStatus == ServerCardStatus.AwaitingFirstCollection,
+            s.HasCollectorErrors,
+            s.OverallMetricSeverity);
 
     /// <summary>
     /// The worst-first ordering score — the SHARED <see cref="ServerHealthClassifier.FleetHealthScore"/> over
@@ -354,12 +361,15 @@ public sealed class FleetRollup
     /// </summary>
     public static string BuildReason(ServerSummaryItem s)
     {
-        if (s.IsOnline == false)
+        /* Keyed on the card's own status discriminant rather than on the flags behind it. Reading
+           AwaitingFirstCollection independently of IsOnline is what let an online card claim it was awaiting
+           its first collection — see ServerCardStatus. */
+        if (s.CardStatus == ServerCardStatus.Offline)
         {
             return "Offline — no recent collection";
         }
 
-        if (s.AwaitingFirstCollection)
+        if (s.CardStatus == ServerCardStatus.AwaitingFirstCollection)
         {
             return "Awaiting first collection";
         }
@@ -395,8 +405,16 @@ public sealed class FleetRollup
             parts.Add("collection stale");
         }
 
-        return parts.Count > 0 ? string.Join(", ", parts) : "Needs attention";
+        return parts.Count > 0 ? string.Join(", ", parts) : UnspecifiedReason;
     }
+
+    /// <summary>
+    /// What <see cref="BuildReason"/> answers when it can name nothing — a card banded away from Healthy by a
+    /// severity whose display the reason does not cover. It reads fine in the ranking, where every row is a
+    /// problem server, and reads as an unexplained demand on a card, so the tooltip degrades to the band label
+    /// rather than repeating it. Named so the two sides cannot drift apart on the spelling.
+    /// </summary>
+    public const string UnspecifiedReason = "Needs attention";
 
     /// <summary>The line every card tooltip ends on. The sidebar alert badge's tooltip has the same shape —
     /// the breakdown, then how to act on it — so the Overview card is not the surface that explains itself
@@ -422,39 +440,54 @@ public sealed class FleetRollup
 
     /// <summary>
     /// The tooltip's first line: what this card's state IS, in the words the card's own status line uses,
-    /// followed by the reason when there is one to give. Every arm of <see cref="ServerSummaryItem.StatusDisplay"/>
-    /// has a match here — a tooltip that hangs off a word and then contradicts it is the defect this change
-    /// exists to remove, not a smaller version of it.
+    /// followed by the reason when there is one to give.
+    ///
+    /// <para>It switches on <see cref="ServerSummaryItem.CardStatus"/> — the SAME discriminant
+    /// <see cref="ServerSummaryItem.StatusDisplay"/> renders — rather than re-reading the flags underneath it.
+    /// A tooltip that hangs off a word and then contradicts it is the defect this change exists to remove, and
+    /// two independent readings of the same two flags is precisely how it comes back.</para>
     /// </summary>
     private static string Headline(ServerSummaryItem s)
     {
-        /* Offline and awaiting-first-collection come back from BuildReason as whole sentences that already
-           name the state, so putting a band label in front would only say "Offline" twice. */
-        if (s.IsOnline == false || s.AwaitingFirstCollection)
-        {
-            return BuildReason(s);
-        }
-
         var band = ClassifyBand(s);
 
-        /* The status word carries one arm the band does not: IsOnline null with no first-collection marker
-           renders "Unknown", while ClassifyBand falls straight through to the metrics and can land on Healthy.
-           ApplyFreshness never leaves a card in that pair today, so this is a lockstep guard rather than a
-           live defect — but the tooltip hangs off the word itself, and "Healthy" beside "Unknown" is exactly
-           the contradiction being fixed. Raised in review on #2429. */
-        if (s.IsOnline is null)
+        return s.CardStatus switch
         {
-            return band == FleetHealthBand.Healthy
-                ? UnknownStatus
-                : $"{UnknownStatus}; {BuildReason(s)}";
-        }
+            /* Offline and never-reached come back from BuildReason as whole sentences that already name the
+               state — the same sentence the status word shows — so a band label in front would only say
+               "Offline" twice. */
+            ServerCardStatus.Offline or ServerCardStatus.AwaitingFirstCollection => BuildReason(s),
 
-        /* A healthy card has no reason to give. BuildReason's "Needs attention" fallback is written for a
-           ranking that only ever holds problem servers; the card grid shows EVERY server, so reusing the
-           fallback here would tell a green card the opposite of the truth. */
-        return band == FleetHealthBand.Healthy
-            ? "Healthy — every metric on this card is inside its threshold"
-            : $"{ServerHealthClassifier.BandLabel(band)} — {BuildReason(s)}";
+            /* "Unknown" is the one status word with no band behind it: ClassifyBand goes straight to the
+               metrics and, on a clean card, answers Healthy. The word wins, and the metrics are appended when
+               they have something to add — not knowing whether a server is reporting is no reason to withhold
+               the CPU number that WAS collected. */
+            ServerCardStatus.Unknown => WithReason(UnknownStatus, "; ", s),
+
+            /* Online and stale: the band is the headline. A healthy card gets an all-clear rather than
+               BuildReason's "Needs attention" fallback, which is written for a ranking that only ever holds
+               problem servers and on a grid showing EVERY server would say the opposite of the truth. */
+            _ => band == FleetHealthBand.Healthy
+                ? "Healthy — every metric on this card is inside its threshold"
+                : WithReason(ServerHealthClassifier.BandLabel(band), " — ", s),
+        };
+    }
+
+    /// <summary>
+    /// A headline plus what the card can actually name — or the headline alone when it can name nothing.
+    ///
+    /// <para>Every arm that appends a reason goes through here, because a card CAN sit outside Healthy with
+    /// nothing to say: a Blocking band raised by a long max-wait while the reason's own gate wants a non-zero
+    /// event count, for one. Appending unguarded produces "Warning — Needs attention", which tells the reader
+    /// exactly what they already knew and is how the ranking-only fallback reaches a card at all. Two arms had
+    /// their own copy of the append and only one of them was guarded, which is the same lesson as
+    /// <see cref="ServerCardStatus"/> one level down.</para>
+    /// </summary>
+    private static string WithReason(string headline, string separator, ServerSummaryItem s)
+    {
+        var reason = BuildReason(s);
+
+        return reason == UnspecifiedReason ? headline : headline + separator + reason;
     }
 
     /// <summary>The words behind StatusDisplay's "Unknown" — a card whose freshness was never classified.</summary>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Fleet.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Fleet.cs
@@ -187,7 +187,17 @@ public sealed class FleetRankedServer
 /// </summary>
 public sealed class FleetRollup
 {
-    /// <summary>The default depth of the worst-first ranking (the "Needs attention" list caps at this).</summary>
+    /// <summary>
+    /// The default depth of the worst-first ranking (the "Needs attention" list caps at this).
+    ///
+    /// <para>Deliberately small, and deliberately unchanged by #2424 even though a 57-server fleet can leave
+    /// 52 servers behind it. The ranking renders inside the fleet roll-up panel, which is docked to the top
+    /// of the Overview and does NOT scroll — only the card grid beneath it does. A list that grew with the
+    /// fleet would therefore push the cards it is pointing at off the screen, and it would stop being a
+    /// triage shortlist ("look at these first") and become a second, worse copy of the grid without the
+    /// metrics. The overflow is answered by giving it somewhere to go instead — the needs-attention card
+    /// filter, over the grid that scrolls and carries the six metric rows.</para>
+    /// </summary>
     public const int DefaultWorstCount = 5;
 
     /// <summary>An empty fleet (no servers registered) — every count zero, no ranking.</summary>
@@ -211,7 +221,12 @@ public sealed class FleetRollup
     /// <summary>The worst-first problem servers (band != Healthy), capped at the requested depth.</summary>
     public IReadOnlyList<FleetRankedServer> WorstServers { get; init; } = Array.Empty<FleetRankedServer>();
 
-    /// <summary>Problem servers beyond the capped ranking — surfaced as a "+N more" affordance.</summary>
+    /// <summary>
+    /// Problem servers beyond the capped ranking. Surfaced as the "+N more need attention" affordance,
+    /// which is a LINK into the needs-attention card filter rather than a dead count (#2424): the ranking
+    /// deliberately stays short (see <see cref="DefaultWorstCount"/>), so this number is the whole reason
+    /// the filter exists.
+    /// </summary>
     public int AdditionalProblemCount { get; init; }
 
     /// <summary>Any server needs attention (band != Healthy) — drives the ranking list vs the all-clear line.</summary>
@@ -381,5 +396,82 @@ public sealed class FleetRollup
         }
 
         return parts.Count > 0 ? string.Join(", ", parts) : "Needs attention";
+    }
+
+    /// <summary>The line every card tooltip ends on. The sidebar alert badge's tooltip has the same shape —
+    /// the breakdown, then how to act on it — so the Overview card is not the surface that explains itself
+    /// least; this one names the gesture the card actually supports.</summary>
+    private const string CardTooltipAction = "Double-click the card to open this server's tab";
+
+    /// <summary>
+    /// The Overview card's status tooltip (#2422): the band the card's border is painted from, WHY it is in
+    /// that band, and what to do next. Reported as "the card says Warning and will not say why" — the reader
+    /// had to scan six metric rows hunting for the amber one, once per card, on a 57-server fleet.
+    ///
+    /// <para>It is <see cref="BuildReason"/>'s output verbatim, the same sentence the Needs Attention ranking
+    /// already shows for that exact server. Re-deriving it here instead would forfeit the one property
+    /// BuildReason exists for: it is built from the card's OWN metric displays, so it cannot disagree with the
+    /// six rows the reader is looking at while they are looking at them.</para>
+    /// </summary>
+    public static string BuildStatusTooltip(ServerSummaryItem s)
+    {
+        ArgumentNullException.ThrowIfNull(s);
+
+        var band = ClassifyBand(s);
+
+        /* A healthy card has no reason to give. BuildReason's "Needs attention" fallback is written for a
+           ranking that only ever holds problem servers; the card grid shows EVERY server, so reusing the
+           fallback here would tell a green card the opposite of the truth. */
+        var body = band == FleetHealthBand.Healthy
+            ? "Healthy — every metric on this card is inside its threshold"
+            : DescribeBand(band, s);
+
+        return body + "\n" + CardTooltipAction;
+    }
+
+    /// <summary>The band label in front of the reason — except for the two states whose reason is already a
+    /// whole sentence naming them, where the label would only say "Offline" twice.</summary>
+    private static string DescribeBand(FleetHealthBand band, ServerSummaryItem s)
+    {
+        var reason = BuildReason(s);
+
+        return s.IsOnline == false || s.AwaitingFirstCollection
+            ? reason
+            : $"{ServerHealthClassifier.BandLabel(band)} — {reason}";
+    }
+
+    /// <summary>
+    /// The problem servers among the Overview's cards — band != Healthy — kept in the order the caller handed
+    /// them in, so the grid's chosen sort survives the filter. This is the SAME predicate <see cref="Build"/>
+    /// uses to decide who is in the ranking and who counts toward <see cref="AdditionalProblemCount"/>, which
+    /// is what makes "+52 more need attention" land on exactly 52 cards rather than on a second opinion.
+    /// </summary>
+    public static List<ServerSummaryItem> NeedsAttention(IEnumerable<ServerSummaryItem> summaries)
+    {
+        ArgumentNullException.ThrowIfNull(summaries);
+
+        return summaries.Where(s => ClassifyBand(s) != FleetHealthBand.Healthy).ToList();
+    }
+
+    /// <summary>
+    /// The count shown beside the filter toggle while it is on. A filtered grid that looks like an unfiltered
+    /// one is a worse defect than the one the filter fixes, so the active state carries its own arithmetic —
+    /// including the all-clear case, which is otherwise an empty grid with nothing saying why.
+    /// </summary>
+    public static string AttentionFilterCountText(int shown, int total)
+    {
+        if (shown > 0)
+        {
+            return $"showing {shown} of {total}";
+        }
+
+        /* Nothing left to show. On a populated fleet that is the honest all-clear; with no cards at all it
+           must not report that zero servers are healthy, which is the sort of line that gets screenshotted. */
+        return total switch
+        {
+            <= 0 => "no servers to filter",
+            1 => "the 1 server monitored is healthy",
+            _ => $"all {total} servers are healthy",
+        };
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Fleet.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Fleet.cs
@@ -417,28 +417,48 @@ public sealed class FleetRollup
     {
         ArgumentNullException.ThrowIfNull(s);
 
+        return Headline(s) + "\n" + CardTooltipAction;
+    }
+
+    /// <summary>
+    /// The tooltip's first line: what this card's state IS, in the words the card's own status line uses,
+    /// followed by the reason when there is one to give. Every arm of <see cref="ServerSummaryItem.StatusDisplay"/>
+    /// has a match here — a tooltip that hangs off a word and then contradicts it is the defect this change
+    /// exists to remove, not a smaller version of it.
+    /// </summary>
+    private static string Headline(ServerSummaryItem s)
+    {
+        /* Offline and awaiting-first-collection come back from BuildReason as whole sentences that already
+           name the state, so putting a band label in front would only say "Offline" twice. */
+        if (s.IsOnline == false || s.AwaitingFirstCollection)
+        {
+            return BuildReason(s);
+        }
+
         var band = ClassifyBand(s);
+
+        /* The status word carries one arm the band does not: IsOnline null with no first-collection marker
+           renders "Unknown", while ClassifyBand falls straight through to the metrics and can land on Healthy.
+           ApplyFreshness never leaves a card in that pair today, so this is a lockstep guard rather than a
+           live defect — but the tooltip hangs off the word itself, and "Healthy" beside "Unknown" is exactly
+           the contradiction being fixed. Raised in review on #2429. */
+        if (s.IsOnline is null)
+        {
+            return band == FleetHealthBand.Healthy
+                ? UnknownStatus
+                : $"{UnknownStatus}; {BuildReason(s)}";
+        }
 
         /* A healthy card has no reason to give. BuildReason's "Needs attention" fallback is written for a
            ranking that only ever holds problem servers; the card grid shows EVERY server, so reusing the
            fallback here would tell a green card the opposite of the truth. */
-        var body = band == FleetHealthBand.Healthy
+        return band == FleetHealthBand.Healthy
             ? "Healthy — every metric on this card is inside its threshold"
-            : DescribeBand(band, s);
-
-        return body + "\n" + CardTooltipAction;
+            : $"{ServerHealthClassifier.BandLabel(band)} — {BuildReason(s)}";
     }
 
-    /// <summary>The band label in front of the reason — except for the two states whose reason is already a
-    /// whole sentence naming them, where the label would only say "Offline" twice.</summary>
-    private static string DescribeBand(FleetHealthBand band, ServerSummaryItem s)
-    {
-        var reason = BuildReason(s);
-
-        return s.IsOnline == false || s.AwaitingFirstCollection
-            ? reason
-            : $"{ServerHealthClassifier.BandLabel(band)} — {reason}";
-    }
+    /// <summary>The words behind StatusDisplay's "Unknown" — a card whose freshness was never classified.</summary>
+    private const string UnknownStatus = "Unknown — no collection status for this server";
 
     /// <summary>
     /// The problem servers among the Overview's cards — band != Healthy — kept in the order the caller handed

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Overview.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Overview.cs
@@ -345,6 +345,41 @@ WHERE server_id = $1";
 }
 
 /// <summary>
+/// The Overview card's status-line state, as a VALUE rather than a rendered string. The word on the card
+/// (<see cref="ServerSummaryItem.StatusDisplay"/>), the colour it is painted
+/// (<see cref="ServerSummaryItem.StatusBrush"/>), the reason the ranking shows
+/// (<see cref="FleetRollup.BuildReason"/>) and the sentence in the card's tooltip
+/// (<see cref="FleetRollup.BuildStatusTooltip"/>) are all renderings OF THIS.
+///
+/// <para>That is the entire reason it exists. Those four used to read the
+/// (<c>IsOnline</c>, <c>AwaitingFirstCollection</c>) flag pair independently, and two review passes on #2429
+/// each turned up a DIFFERENT combination where two of the readings contradicted each other — first
+/// <c>IsOnline</c> null with no awaiting marker, then <c>IsOnline</c> true WITH one, which would have put a
+/// green "Online" over a tooltip reading "Awaiting first collection". Both flags are plain settable
+/// properties, so nothing stops a fixture or a new data path reaching either pair. Two instances of one
+/// category is the signal to fix the category: with a single discriminant there is no combination left for
+/// the renderings to disagree about, because they no longer each decide.</para>
+/// </summary>
+public enum ServerCardStatus
+{
+    /// <summary>Collection is current.</summary>
+    Online,
+
+    /// <summary>Online, but the newest collection has lagged — the card's amber "Warning".</summary>
+    Stale,
+
+    /// <summary>Nothing has landed for long enough to call the server dark.</summary>
+    Offline,
+
+    /// <summary>Registered but never collected — the service has not reached it yet, not a dead server.</summary>
+    AwaitingFirstCollection,
+
+    /// <summary>Freshness was never classified. <see cref="ServerSummaryItem.ApplyFreshness"/> cannot produce
+    /// this; a hand-built summary can, which is exactly why it is a named state rather than a fall-through.</summary>
+    Unknown,
+}
+
+/// <summary>
 /// One Overview server card's view-model — copied from Lite's <c>ServerSummaryItem</c>
 /// (Lite/Services/LocalDataService.Overview.cs) and enriched toward the Dashboard's
 /// <c>ServerHealthStatus</c> (Threads / Collectors rows, the resource-semaphore Memory signal, blocking
@@ -560,21 +595,36 @@ public sealed class ServerSummaryItem
         : "Never";
 
     /* Connection status — verbatim from Lite; in the viewer the inputs come from ApplyFreshness.
-       The null arm distinguishes "not reached yet" (bootstrap) from a legacy unknown. */
-    public string StatusDisplay => IsOnline switch
+       The null arm distinguishes "not reached yet" (bootstrap) from a legacy unknown.
+
+       This is the ONE place the (IsOnline, AwaitingFirstCollection) pair is read. Everything downstream —
+       the word, the colour, the ranking's reason, the tooltip — renders the resulting ServerCardStatus, so
+       no two of them can land on different answers for the same card. See ServerCardStatus for the two
+       contradictions that motivated collapsing it. */
+    public ServerCardStatus CardStatus => IsOnline switch
     {
-        true when HasCollectorErrors => "Warning",
-        true => "Online",
-        false => "Offline",
-        _ => AwaitingFirstCollection ? "Awaiting first collection" : "Unknown"
+        true when HasCollectorErrors => ServerCardStatus.Stale,
+        true => ServerCardStatus.Online,
+        false => ServerCardStatus.Offline,
+        _ => AwaitingFirstCollection ? ServerCardStatus.AwaitingFirstCollection : ServerCardStatus.Unknown,
     };
 
-    public SolidColorBrush StatusBrush => MakeBrush(IsOnline switch
+    public string StatusDisplay => CardStatus switch
     {
-        true when HasCollectorErrors => "#FFD54F",  // amber — stale collection
-        true => "#81C784",
-        false => "#E57373",
-        _ => AwaitingFirstCollection ? "#FFD54F" : "#888888"  // amber — queued, not dead
+        ServerCardStatus.Stale => "Warning",
+        ServerCardStatus.Online => "Online",
+        ServerCardStatus.Offline => "Offline",
+        ServerCardStatus.AwaitingFirstCollection => "Awaiting first collection",
+        _ => "Unknown",
+    };
+
+    public SolidColorBrush StatusBrush => MakeBrush(CardStatus switch
+    {
+        ServerCardStatus.Stale => "#FFD54F",  // amber — stale collection
+        ServerCardStatus.Online => "#81C784",
+        ServerCardStatus.Offline => "#E57373",
+        ServerCardStatus.AwaitingFirstCollection => "#FFD54F",  // amber — queued, not dead
+        _ => "#888888",
     });
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Overview.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Overview.cs
@@ -577,6 +577,18 @@ public sealed class ServerSummaryItem
         _ => AwaitingFirstCollection ? "#FFD54F" : "#888888"  // amber — queued, not dead
     });
 
+    /// <summary>
+    /// What the status word MEANS on this card, for the tooltip the status line carries (#2422). A colour and
+    /// a one-word band were the whole answer the Overview gave, and the reporter's question — "what is it that
+    /// this text warns me about?" — is one the card could already answer: <see cref="FleetRollup.BuildReason"/>
+    /// builds the sentence out of THIS card's own metric displays, and until now only the Needs Attention
+    /// ranking got to see it.
+    ///
+    /// <para>Delegated rather than reimplemented on purpose: two independent derivations of "why is this amber"
+    /// would eventually disagree, and the one place they would disagree is a card the reader is staring at.</para>
+    /// </summary>
+    public string StatusTooltip => FleetRollup.BuildStatusTooltip(this);
+
     public bool IsOffline => IsOnline == false;
 
     // ── Per-metric severity bands (delegated to the SHARED ServerHealthClassifier — one place for the


### PR DESCRIPTION
Fixes #2424, and answers both halves of @ehaar's #2422.

Both defects have the same shape: the Overview computes a rich health picture and then renders a lossy summary of it. On a 57-server fleet — which is where this tab earns its keep — they compound. The reporter read "Warning" in amber on the first card and asked what it was warning him about, then read "+52 more need attention" and asked where he could find them. Neither question needed new data; both needed the tab to show something it had already worked out.

## The card says why

`FleetRollup.BuildReason` already turns a card into `"CPU 94%, Blocking 12"` out of that card's **own** metric displays — deliberately, per its own comment, so it can never drift from what the card shows — and every bit of that was spent on the five-row Needs Attention ranking. The card, which is the thing being looked at, never got it.

The status line carries it now as a `ToolTip`, in the shape `MainWindow.AlertBadges.cs` already established for the sidebar badge: the breakdown, then how to act on it. It is `BuildReason`'s output verbatim rather than a second derivation, because a second derivation would eventually disagree with the six metric rows sitting directly underneath it, which is the exact failure `BuildReason` exists to prevent. Two arms sit on top of it:

- a **healthy** card gets an all-clear, not `BuildReason`'s `"Needs attention"` fallback — that fallback is written for a ranking that only ever holds problem servers, and on a grid showing every server it would tell each green card the opposite of the truth;
- **Offline** and **awaiting-first-collection** are not labelled twice, their reason already being a whole sentence naming the state.

What the tooltips actually read, run against the shipped source:

| card | tooltip |
|---|---|
| CPU 96%, 6 blocking events | `Critical — CPU 96%, Blocking 6` |
| online, collection stale | `Warning — collection stale` |
| offline | `Offline — no recent collection` |
| never collected | `Awaiting first collection` |
| calm | `Healthy — every metric on this card is inside its threshold` |

each followed by `Double-click the card to open this server's tab`.

The second row is worth naming, because it is the reporter's exact card. `StatusDisplay` renders `"Warning"` for one condition only — an online server whose collection has gone stale — and nothing on the card said so, while the amber reads naturally as a metric problem.

`Background="Transparent"` on that `TextBlock` is load-bearing rather than decorative: a `TextBlock` with a null `Background` hit-tests on its rendered glyphs alone, so the tooltip would have appeared over the letters of "Warning" and nowhere in the space around them.

## "+52 more" reaches the 52

This took **option 1** from the issue, the filter. The honest answer to "where do I find these warnings?" was nowhere; `FleetRollup` computes the full problem set and truncates it for display, so those 52 were discarded rather than unavailable. The line is now a link into a needs-attention filter over the card grid — the surface that actually answers the question, because the grid is where the six metric rows live. It filters on `FleetRollup.NeedsAttention`, the *same* banding that counted the 52, so the destination cannot disagree with the label that sent you there.

The filter is a toggle beside the existing Sort selector rather than a mode the link switches on invisibly, and the placement is the point: the roll-up header is docked to the top of the Overview and never scrolls, so a filter that is on can never be off screen while the grid it shrank is on it, and `showing 12 of 57` renders beside the toggle whenever it is active. A filtered list that looks unfiltered is a worse defect than the dead end it replaces. It is deliberately **not** persisted the way the sort mode is — a sort is a preference, this is a triage action tied to a moment, and an Overview that opens with 52 of 57 servers already hidden is a support ticket even with the box in plain sight.

## The cap of five stays

Considered and kept, not left alone by default. It hides 52 servers on this fleet, which is the complaint — but the ranking renders inside that same non-scrolling docked panel. A list that grew with the fleet would push the cards it is pointing at off the screen, and would stop being a triage shortlist and become a second, worse copy of the grid without the metrics. The repair for an overflow is a destination rather than a longer list, and it now has one. The reasoning is written down on `DefaultWorstCount` so the next person deciding this has the argument in front of them.

## One structural consequence

`OverviewItemsControl.ItemsSource` was read back in two places to answer "what cards are there" — the re-sort and the tag re-stamp — which is safe only while the bound list is the complete list. That is the exact mistake `FleetView` was written to make impossible on the sidebar. The full sorted set is now the authority and the grid is projected from it through the filter in one place; sorting the bound list under an active filter would have silently discarded every card the filter was hiding. A test pins that there are exactly two `ItemsSource` writers and no readers.

## Verification

The Windows test suites cannot run on macOS, so the pure logic was run for real anyway: a throwaway `net10.0` harness **splices** `FleetRollup` and `ServerSummaryItem` straight out of the shipped files (never retyped) behind a `System.Windows.Media` shim, and every assertion in the new test class passes against it — the table above is its output. Pointed at `dev`'s copies of the same two files, it does not compile, because none of the members exist there.

The four source-scanning facts were simulated in Python against both versions: **18 of 19 assertions fail on `dev` and all pass on the branch** (the one that passes on `dev` is the guard that finds the status `TextBlock` at all). The wiring half has to text-scan source, because a `ToolTip` attribute and a click handler live in XAML where no assertion about a C# object can reach them, and removing either compiles perfectly clean.

Whole solution builds with 0 warnings and 0 errors; `Darling.Tests` builds. CHANGELOG deliberately untouched — #2395 is an open release-prep PR that owns that file for 3.5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
