### PR TITLE
The viewer stops replacing a settings file it could not read (#2434)

### DIFF
--- a/Darling/Darling.Tests/ViewerSettingsFileGuardTests.cs
+++ b/Darling/Darling.Tests/ViewerSettingsFileGuardTests.cs
@@ -7,8 +7,10 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using PerformanceMonitor.Common;
 using PerformanceMonitor.Darling.Viewer;
 using Xunit;
@@ -56,6 +58,8 @@ public sealed class ViewerSettingsFileGuardTests : IDisposable
     private string SettingsPath => Path.Combine(_directory, "viewer-settings.json");
 
     private string PreferencesPath => Path.Combine(_directory, "viewer-preferences.json");
+
+    private string RegistryPath => Path.Combine(_directory, "viewer-servers.json");
 
     private string[] QuarantineCopies(string ofFile) =>
         Directory.GetFiles(_directory)
@@ -181,6 +185,77 @@ public sealed class ViewerSettingsFileGuardTests : IDisposable
     }
 
     /// <summary>
+    /// The third store, and the one where losing the file costs the operator the most: the registry of
+    /// monitored servers. Its shape used to make this worse rather than better — it began EMPTY on an
+    /// unreadable file, so the very first favourite toggle wrote an empty list over the whole registry.
+    /// </summary>
+    [Fact]
+    public void Save_CopiesAnUnreadableServerRegistryAside_BeforeReplacingIt()
+    {
+        const string Corrupt = @"[{""ServerName"":""SQL2022"",}]";
+        File.WriteAllText(RegistryPath, Corrupt);
+        var store = new ViewerServerStore(RegistryPath, new NoSecrets());
+
+        Assert.Equal(SettingsFileState.Unreadable, store.LastLoadState);
+        Assert.NotNull(store.LastLoadProblem);
+
+        store.AddServer(new ViewerServerEntry { ServerName = "SQL2019", DisplayName = "Dev" }, null, null);
+
+        var copies = QuarantineCopies(RegistryPath);
+        Assert.Single(copies);
+        Assert.Equal(Corrupt, File.ReadAllText(copies[0]));
+    }
+
+    /// <summary>
+    /// And the control that makes the one above meaningful, because it is the mistake that was one line
+    /// away: the registry's root is a JSON ARRAY, which the merge path's "the root must be an object" rule
+    /// calls unreadable. Borrowing that rule for the typed read would have quarantined a copy of every
+    /// healthy registry on every favourite toggle — data loss traded for litter, and litter is how a real
+    /// quarantine copy gets ignored.
+    /// </summary>
+    [Fact]
+    public void Save_LeavesNoCopyBehind_ForAHealthyRegistry_ThoughItsRootIsAnArray()
+    {
+        var store = new ViewerServerStore(RegistryPath, new NoSecrets());
+        store.AddServer(new ViewerServerEntry { ServerName = "SQL2022", DisplayName = "Prod" }, null, null);
+
+        var reopened = new ViewerServerStore(RegistryPath, new NoSecrets());
+        Assert.Equal(SettingsFileState.Readable, reopened.LastLoadState);
+
+        reopened.AddServer(new ViewerServerEntry { ServerName = "SQL2019", DisplayName = "Dev" }, null, null);
+
+        Assert.Empty(QuarantineCopies(RegistryPath));
+        Assert.Equal(2, reopened.GetAllServers().Count);
+    }
+
+    /// <summary>
+    /// An empty registry file and a missing one are both "no servers", and only one of them is worth
+    /// saying anything about. A first run must stay silent or every new install opens on a warning.
+    /// </summary>
+    [Fact]
+    public void Load_IsSilentlyAbsent_ForARegistryThatWasNeverWritten()
+    {
+        var store = new ViewerServerStore(RegistryPath, new NoSecrets());
+
+        Assert.Equal(SettingsFileState.Absent, store.LastLoadState);
+        Assert.Null(store.LastLoadProblem);
+        Assert.Empty(store.GetAllServers());
+    }
+
+    /// <summary>The registry never touches Windows Credential Manager from a test.</summary>
+    private sealed class NoSecrets : IViewerServerSecretStore
+    {
+        private readonly Dictionary<string, (string Username, string Password)> _map = new();
+
+        public void Save(string id, string username, string password) => _map[id] = (username, password);
+
+        public (string Username, string Password)? Find(string id) =>
+            _map.TryGetValue(id, out var v) ? v : null;
+
+        public void Delete(string id) => _map.Remove(id);
+    }
+
+    /// <summary>
     /// The control, and it matters as much as the pin above: a readable file is replaced with no copy made.
     /// A quarantine on every save would fill the operator's %APPDATA% with junk and teach them to ignore
     /// the one copy that ever means anything.
@@ -236,20 +311,28 @@ public sealed class ViewerSettingsStoreWiringTests
     public static TheoryData<string> StoreFiles() => new()
     {
         "ViewerAppSettings.cs",
-        "ViewerPreferences.cs"
+        "ViewerPreferences.cs",
+        "ViewerServerStore.cs"
     };
 
+    /// <summary>
+    /// Keyed on <c>_filePath</c> — the store's OWN file — rather than on <c>File.*</c> in general, because
+    /// ViewerServerStore legitimately reads a file the user picked in ImportServersFromFile, and a rule
+    /// that could not tell those apart would either miss the defect or forbid a feature.
+    ///
+    /// <para>The lookbehind is not decoration: without it <c>ViewerSettingsFile.Save(_filePath, ...)</c>
+    /// contains the very text the rule bans, so the guard fails on the fix it exists to require.</para>
+    /// </summary>
     [Theory]
     [MemberData(nameof(StoreFiles))]
-    public void EveryViewerSettingsStore_ReadsAndWritesThroughTheGuardedHelper(string fileName)
+    public void EveryViewerSettingsStore_ReadsAndWritesItsOwnFileThroughTheGuardedHelper(string fileName)
     {
         var source = File.ReadAllText(FindViewerFile(fileName));
 
         Assert.Contains("ViewerSettingsFile.Load<", source, StringComparison.Ordinal);
         Assert.Contains("ViewerSettingsFile.Save(", source, StringComparison.Ordinal);
 
-        Assert.DoesNotContain("File.WriteAllText(", source, StringComparison.Ordinal);
-        Assert.DoesNotContain("JsonSerializer.Deserialize<", source, StringComparison.Ordinal);
+        Assert.DoesNotMatch(new Regex(@"(?<!\w)File\.\w+\(\s*_filePath"), source);
     }
 
     /// <summary>

--- a/Darling/Darling.Tests/ViewerSettingsFileGuardTests.cs
+++ b/Darling/Darling.Tests/ViewerSettingsFileGuardTests.cs
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.IO;
+using System.Linq;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.Darling.Viewer;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #2434. The viewer's two per-user JSON stores had #2425's defect and a worse version of its consequence.
+///
+/// <para><b>The failure was unreportable, not merely unreported.</b> Both loaders ended in a bare
+/// <c>catch</c> whose only output was <c>Debug.WriteLine</c>, which carries
+/// <c>[Conditional("DEBUG")]</c> and is removed by the compiler from a Release build. In the viewer anyone
+/// actually runs there was no log line, no dialog and no trace — the settings simply became defaults.</para>
+///
+/// <para><b>And the next click destroyed the file.</b> Neither Save merged; each serialized its whole
+/// in-memory object over the file. Lite's pre-#2425 writers at least parsed first and so ABORTED against a
+/// corrupt file, which left it intact by accident. The viewer had no such accident: load-then-save from the
+/// time-display dropdown or the Overview sort selector replaced every setting in an unreadable file with a
+/// default, on one click nobody would call a save.</para>
+///
+/// <para>So the pins below come in pairs — what the store now SAYS about each of the three states, and what
+/// it leaves on disk. The second is the one that turns an annoyance into data loss.</para>
+/// </summary>
+public sealed class ViewerSettingsFileGuardTests : IDisposable
+{
+    /// <summary>A viewer-settings.json a user would recognize: real keys, one trailing comma.</summary>
+    private const string TrailingComma = @"{
+  ""AlertsEnabled"": true,
+  ""AlertCpuThreshold"": 91,
+}";
+
+    private readonly string _directory =
+        Path.Combine(Path.GetTempPath(), $"viewer-settings-guard-{Guid.NewGuid():N}");
+
+    public ViewerSettingsFileGuardTests() => Directory.CreateDirectory(_directory);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_directory))
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+    }
+
+    private string SettingsPath => Path.Combine(_directory, "viewer-settings.json");
+
+    private string PreferencesPath => Path.Combine(_directory, "viewer-preferences.json");
+
+    private string[] QuarantineCopies(string ofFile) =>
+        Directory.GetFiles(_directory)
+            .Where(f => f.StartsWith(ofFile + SettingsFileGuard.QuarantineInfix, StringComparison.Ordinal))
+            .ToArray();
+
+    /// <summary>
+    /// The legitimate first run, and the reason the three states are not two: no file, no problem, nothing
+    /// to say. Anything reported here becomes a log line and a dialog for a user who has done nothing
+    /// wrong, which is how a diagnostic earns being ignored.
+    /// </summary>
+    [Fact]
+    public void Load_IsSilentlyAbsent_WhenThereIsNoFile()
+    {
+        var store = new ViewerAppSettingsStore(SettingsPath);
+
+        var settings = store.Load();
+
+        Assert.Equal(SettingsFileState.Absent, store.LastLoadState);
+        Assert.Null(store.LastLoadProblem);
+        Assert.Equal(80, settings.AlertCpuThreshold);
+    }
+
+    [Fact]
+    public void Load_IsReadable_ForAnOrdinaryFile()
+    {
+        File.WriteAllText(SettingsPath, @"{""AlertCpuThreshold"":91}");
+        var store = new ViewerAppSettingsStore(SettingsPath);
+
+        var settings = store.Load();
+
+        Assert.Equal(SettingsFileState.Readable, store.LastLoadState);
+        Assert.Null(store.LastLoadProblem);
+        Assert.Equal(91, settings.AlertCpuThreshold);
+    }
+
+    /// <summary>
+    /// The headline case. Defaults are still returned — the viewer must not refuse to open over a bad
+    /// settings file — but the store now says the file was there and could not be read, and says WHERE it
+    /// broke. "line 4" is a minute's work with an editor; "using defaults" sends someone hunting through a
+    /// file they already believe is correct, which is what the old Debug trace would have said if it
+    /// survived compilation at all.
+    /// </summary>
+    [Fact]
+    public void Load_ReportsUnreadable_AndWhere_ForACorruptFile()
+    {
+        File.WriteAllText(SettingsPath, TrailingComma);
+        var store = new ViewerAppSettingsStore(SettingsPath);
+
+        var settings = store.Load();
+
+        Assert.Equal(SettingsFileState.Unreadable, store.LastLoadState);
+        Assert.NotNull(store.LastLoadProblem);
+        Assert.Contains("line 4", store.LastLoadProblem!, StringComparison.Ordinal);
+        Assert.Equal(80, settings.AlertCpuThreshold);
+    }
+
+    /// <summary>
+    /// A file that is a perfectly good JSON object and still cannot be used: one key holding a value of the
+    /// wrong shape. It gets its own case because only the TYPED deserialize can see it, which is why that
+    /// deserialize is inside the guard rather than in front of it — a classify step that stops at "is this
+    /// a JSON object" calls this file readable and hands the exception straight back to the bare catch it
+    /// was meant to replace.
+    /// </summary>
+    [Fact]
+    public void Load_ReportsUnreadable_WhenAValueHasTheWrongShape()
+    {
+        File.WriteAllText(PreferencesPath, @"{""DefaultTimeRangeIndex"":""not a number""}");
+        var store = new ViewerPreferencesStore(PreferencesPath);
+
+        var preferences = store.Load();
+
+        Assert.Equal(SettingsFileState.Unreadable, store.LastLoadState);
+        Assert.NotNull(store.LastLoadProblem);
+        Assert.Equal(3, preferences.DefaultTimeRangeIndex);
+    }
+
+    /// <summary>
+    /// The data-loss pin, and the one this issue exists for. On dev, one click on the time-display dropdown
+    /// loads an unreadable viewer-settings.json as defaults and then serializes those defaults straight over
+    /// it — every setting in the file gone, nothing kept, nothing said. The copy has to be made BEFORE the
+    /// write, it has to hold the original bytes verbatim, and the save itself still has to happen.
+    /// </summary>
+    [Fact]
+    public void Save_CopiesAnUnreadableFileAside_BeforeReplacingIt()
+    {
+        File.WriteAllText(SettingsPath, TrailingComma);
+        var store = new ViewerAppSettingsStore(SettingsPath);
+
+        var settings = store.Load();
+        settings.TimeDisplayMode = "UTC";
+        var saved = store.Save(settings);
+
+        Assert.True(saved);
+
+        var copies = QuarantineCopies(SettingsPath);
+        Assert.Single(copies);
+        Assert.Equal(TrailingComma, File.ReadAllText(copies[0]));
+
+        /* And the save it was protecting still happened. */
+        Assert.Contains("UTC", File.ReadAllText(SettingsPath), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The same pin on the preferences store, because that is the file the SIDEBAR rewrites: collapsing a
+    /// tag group is a whole-file replace of viewer-preferences.json and nobody thinks of it as a save. One
+    /// store fixed and the other not would leave the defect exactly where it is hardest to notice.
+    /// </summary>
+    [Fact]
+    public void Save_CopiesAnUnreadablePreferencesFileAside_BeforeReplacingIt()
+    {
+        File.WriteAllText(PreferencesPath, "{ not json at all");
+        var store = new ViewerPreferencesStore(PreferencesPath);
+
+        var preferences = store.Load();
+        preferences.CollapsedFleetGroups.Add("Favorites");
+
+        Assert.True(store.Save(preferences));
+
+        var copies = QuarantineCopies(PreferencesPath);
+        Assert.Single(copies);
+        Assert.Equal("{ not json at all", File.ReadAllText(copies[0]));
+    }
+
+    /// <summary>
+    /// The control, and it matters as much as the pin above: a readable file is replaced with no copy made.
+    /// A quarantine on every save would fill the operator's %APPDATA% with junk and teach them to ignore
+    /// the one copy that ever means anything.
+    /// </summary>
+    [Fact]
+    public void Save_LeavesNoCopyBehind_WhenTheFileWasReadable()
+    {
+        File.WriteAllText(SettingsPath, @"{""AlertCpuThreshold"":91}");
+        var store = new ViewerAppSettingsStore(SettingsPath);
+
+        Assert.True(store.Save(store.Load()));
+
+        Assert.Empty(QuarantineCopies(SettingsPath));
+    }
+
+    /// <summary>The first run from the writer's side: a file that was never there leaves no copy either.</summary>
+    [Fact]
+    public void Save_LeavesNoCopyBehind_OnAFirstRun()
+    {
+        var store = new ViewerAppSettingsStore(SettingsPath);
+
+        Assert.True(store.Save(new ViewerAppSettings()));
+
+        Assert.Empty(QuarantineCopies(SettingsPath));
+        Assert.True(File.Exists(SettingsPath));
+    }
+
+    /// <summary>
+    /// Save answers whether it wrote. It is a bool rather than an exception because the two handlers that
+    /// call it persist on an ordinary click and neither wraps it — but the answer only stops a UI claiming
+    /// a save that did not happen if it EXISTS, and on dev it does not: Save returns void there.
+    /// </summary>
+    [Fact]
+    public void Save_ReportsSuccess_OnAnOrdinaryWrite()
+    {
+        bool saved = new ViewerAppSettingsStore(SettingsPath).Save(new ViewerAppSettings());
+
+        Assert.True(saved);
+    }
+}
+
+/// <summary>
+/// The category behind #2434 rather than the instance. The defect was never "ViewerAppSettingsStore.Save is
+/// wrong" — it was that each store rolled its own read and its own whole-file replace, so whether a save
+/// could destroy your configuration depended on which of them you were in. A third store written the same
+/// way tomorrow would be just as silent, and nothing but this would notice.
+///
+/// <para>Source-parsing because the invariant is a wiring one. A behavioral test can prove the guard works
+/// and still not notice a store that never asks it.</para>
+/// </summary>
+public sealed class ViewerSettingsStoreWiringTests
+{
+    public static TheoryData<string> StoreFiles() => new()
+    {
+        "ViewerAppSettings.cs",
+        "ViewerPreferences.cs"
+    };
+
+    [Theory]
+    [MemberData(nameof(StoreFiles))]
+    public void EveryViewerSettingsStore_ReadsAndWritesThroughTheGuardedHelper(string fileName)
+    {
+        var source = File.ReadAllText(FindViewerFile(fileName));
+
+        Assert.Contains("ViewerSettingsFile.Load<", source, StringComparison.Ordinal);
+        Assert.Contains("ViewerSettingsFile.Save(", source, StringComparison.Ordinal);
+
+        Assert.DoesNotContain("File.WriteAllText(", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("JsonSerializer.Deserialize<", source, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The exact shape that made the loss unreportable: a diagnostic the compiler deletes from the build
+    /// the operator runs. Banned outright in the stores so it cannot come back by copy-paste from a sibling.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(StoreFiles))]
+    public void NoViewerSettingsStore_ReportsThroughDebugWriteLine(string fileName)
+    {
+        var source = File.ReadAllText(FindViewerFile(fileName));
+
+        Assert.DoesNotContain("Debug.WriteLine", source, StringComparison.Ordinal);
+    }
+
+    private static string FindViewerFile(string fileName)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        for (var i = 0; i < 10 && directory is not null; i++)
+        {
+            var candidate = Path.Combine(
+                directory.FullName, "Darling", "PerformanceMonitor.Darling.Viewer", fileName);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new FileNotFoundException($"Could not locate {fileName} walking up from {AppContext.BaseDirectory}");
+    }
+}

--- a/Darling/Darling.Tests/ViewerSettingsFileGuardTests.cs
+++ b/Darling/Darling.Tests/ViewerSettingsFileGuardTests.cs
@@ -242,6 +242,24 @@ public sealed class ViewerSettingsFileGuardTests : IDisposable
         Assert.Empty(store.GetAllServers());
     }
 
+    /// <summary>
+    /// The registry answers whether its write landed, which is what lets the sidebar's pin status line and
+    /// the import dialog stop claiming things that did not happen. It starts true so "nothing has failed"
+    /// is the position before any write, not a claim about one nobody made.
+    /// </summary>
+    [Fact]
+    public void TheRegistry_ReportsWhetherItsWriteLanded()
+    {
+        var store = new ViewerServerStore(RegistryPath, new NoSecrets());
+
+        Assert.True(store.LastSaveSucceeded);
+
+        store.AddServer(new ViewerServerEntry { ServerName = "SQL2022", DisplayName = "Prod" }, null, null);
+
+        Assert.True(store.LastSaveSucceeded);
+        Assert.True(File.Exists(RegistryPath));
+    }
+
     /// <summary>The registry never touches Windows Credential Manager from a test.</summary>
     private sealed class NoSecrets : IViewerServerSecretStore
     {

--- a/Darling/PerformanceMonitor.Darling.Viewer/App.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/App.xaml.cs
@@ -54,6 +54,18 @@ public partial class App : Application
             return;
         }
 
+        /* Minimal file logging (ported from Lite's AppLogger) so the sidebar's View Log / Open Log
+           Folder buttons have a real target and operator bug reports carry viewer diagnostics.
+
+           Initialized HERE, ahead of the theme read below, rather than after the single-instance dance
+           where it used to sit (#2434). That read is the viewer's FIRST touch of viewer-settings.json, so
+           it is the first thing that can discover the file is unreadable — and ViewerLogger.Log drops
+           anything enqueued before Initialize, which would have made the earliest and most useful
+           diagnostic the one guaranteed to vanish. Nothing between here and its old position depends on
+           the ordering: Initialize creates a directory and starts a timer, and it swallows its own
+           failure. */
+        ViewerLogger.Initialize();
+
         /* Apply the saved color theme through ThemeManager (App.xaml merges Dark as the design-time
            default) so ThemeManager owns the app-level merged dictionary at runtime, before StartupUri
            creates MainWindow. Reads the viewer-local settings directly (cheap JSON read) so the very
@@ -74,10 +86,6 @@ public partial class App : Application
            are unaffected (ScottPlot renders via SkiaSharp/CPU into a bitmap, not WPF's GPU path). Matches Lite. */
         System.Windows.Media.RenderOptions.ProcessRenderMode =
             System.Windows.Interop.RenderMode.SoftwareOnly;
-
-        /* Minimal file logging (ported from Lite's AppLogger) so the sidebar's View Log / Open Log
-           Folder buttons have a real target and operator bug reports carry viewer diagnostics. */
-        ViewerLogger.Initialize();
 
         /* Single-instance with upgrade handoff (shared PerformanceMonitor.Ui coordinator, mirroring Lite /
            Dashboard). Runs before base.OnStartup creates the StartupUri window, so a second launch surfaces

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.ServerManagement.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.ServerManagement.cs
@@ -261,7 +261,13 @@ public partial class MainWindow
         var isFavorite = _serverStore.ToggleFavorite(server.ServerName);
         server.IsFavorite = isFavorite;
         ReapplyFavoritesToServerList();
-        StatusText.Text = isFavorite ? $"Pinned {server.DisplayName}" : $"Unpinned {server.DisplayName}";
+
+        /* #2434: the status line is this action's whole report, so it must not say the pin happened when
+           viewer-servers.json refused the write — the star would be back where it was on the next launch
+           with nothing said. The store's log line has the reason; this is the half the user sees. */
+        StatusText.Text = _serverStore.LastSaveSucceeded
+            ? (isFavorite ? $"Pinned {server.DisplayName}" : $"Unpinned {server.DisplayName}")
+            : $"Could not save the pin for {server.DisplayName} — see the viewer log. It will be back as it was on the next launch.";
     }
 
     private async void ServerContextMenu_Edit_Click(object sender, RoutedEventArgs e)
@@ -321,7 +327,10 @@ public partial class MainWindow
         try
         {
             await _dataService.DeleteMonitoredServerAsync(server.ServerId);
-            /* Drop the viewer-local favorite pin + alert-acknowledgement state for the gone server. */
+            /* Drop the viewer-local favorite pin + alert-acknowledgement state for the gone server.
+               Deliberately not gated on the write (#2434), unlike the pin toggle and the import above:
+               this is removing a pin for a server that no longer exists, so a refused write leaves a stale
+               entry nothing reads rather than losing anything the operator would miss. The store logs it. */
             _serverStore.SetFavorite(server.ServerName, false);
             _alertStateService.RemoveServerState(server.ServerId);
             await LoadServersAsync(preserveSelection: true);
@@ -676,7 +685,17 @@ public partial class MainWindow
                 pushedToStore = await ViewerServerMigration.ImportFromStoreAsync(_serverStore, ProfileStore, _dataService);
             }
 
-            var message = $"Imported {imported} server definition(s).";
+            /* #2434: "Imported N" is a claim about a file, and the registry write behind it can refuse —
+               it does when viewer-servers.json could not be read AND could not be copied aside, which is
+               exactly when the operator most needs to be told rather than reassured. Only checked when
+               something was actually imported: with nothing to write, no write was attempted. */
+            var registrySaved = imported == 0 || _serverStore.LastSaveSucceeded;
+
+            var message = registrySaved
+                ? $"Imported {imported} server definition(s)."
+                : $"Read {imported} server definition(s), but they could not be saved to "
+                  + $"{Path.GetFileName(ViewerServerStore.DefaultFilePath())} — see the viewer log. They will "
+                  + "not be there on the next launch.";
             if (skipped > 0)
             {
                 message += $"\nSkipped {skipped} already-configured server(s).";
@@ -692,7 +711,8 @@ public partial class MainWindow
             message += "\n\nServer credentials are NOT importable (they live only in Windows Credential Manager, " +
                        "per user). Re-enter any SQL/service-principal secret in Manage Servers.";
 
-            MessageBox.Show(message, "Import Settings", MessageBoxButton.OK, MessageBoxImage.Information);
+            MessageBox.Show(message, "Import Settings", MessageBoxButton.OK,
+                registrySaved ? MessageBoxImage.Information : MessageBoxImage.Warning);
 
             if (imported > 0 || pushedToStore > 0)
             {

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.Tags.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.Tags.cs
@@ -110,9 +110,20 @@ public partial class MainWindow
     private void PersistCollapseState()
     {
         _preferences.CollapsedFleetGroups = _fleet.CollapsedKeys.Select(k => k.ToStorageString()).ToList();
+
+        /* #2434: Save answers with a bool now instead of throwing, and this is the write that most needed
+           the guard behind it — collapsing a sidebar group is a whole-file rewrite of viewer-preferences.json
+           and nobody thinks of it as a save. Deliberately log-only rather than a dialog: a modal every time
+           a group collapses would be worse than the thing it reports, and the collapse state is the one
+           setting the next launch visibly re-states for you. The catch stays for anything Save's own
+           best-effort failure path cannot reach — a sidebar click must not take the viewer down. */
         try
         {
-            _preferencesStore.Save(_preferences);
+            if (!_preferencesStore.Save(_preferences))
+            {
+                ViewerLogger.Warn("Tags",
+                    "The sidebar collapse state was not saved; the groups will be back as they were on the next launch.");
+            }
         }
         catch (Exception ex)
         {

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
@@ -1104,17 +1104,11 @@ public partial class MainWindow : Window
     // ── Time-display mode (Server / Local / UTC) ─────────────────────────────────────
 
     /// <summary>
-    /// A server tab's Server/Local/UTC picker changed (the raising tab already set the global mode via
-    /// <see cref="ViewerTimeHelper.CurrentDisplayMode"/> and reloaded itself). Persist the new mode and sync
-    /// every OTHER open tab's picker so they agree — the mode is process-wide, and a background tab reloads
-    /// on activation and picks it up.
-    /// </summary>
-    /// <summary>
     /// Says that a setting the user just changed did not reach disk (#2434).
     ///
-    /// <para>These two handlers persist on an ordinary click — picking a time-display mode, re-sorting the
-    /// Overview — so a failure here has no Save button to report through, and until now had nowhere to go
-    /// at all: the store's Save could throw, neither handler caught it, and the whole-object write had
+    /// <para>The two handlers below persist on an ordinary click — picking a time-display mode, re-sorting
+    /// the Overview — so a failure there has no Save button to report through, and until now had nowhere to
+    /// go at all: the store's Save could throw, neither handler caught it, and the whole-object write had
     /// already replaced whatever it could not read. Save answers with a bool instead of throwing now, and
     /// this is what does something with the answer. Which file and what was wrong with it is in the log;
     /// what the user needs from a dialog is that the click did not stick.</para>
@@ -1128,6 +1122,12 @@ public partial class MainWindow : Window
             "Settings", MessageBoxButton.OK, MessageBoxImage.Warning);
     }
 
+    /// <summary>
+    /// A server tab's Server/Local/UTC picker changed (the raising tab already set the global mode via
+    /// <see cref="ViewerTimeHelper.CurrentDisplayMode"/> and reloaded itself). Persist the new mode and sync
+    /// every OTHER open tab's picker so they agree — the mode is process-wide, and a background tab reloads
+    /// on activation and picks it up.
+    /// </summary>
     private void OnDisplayModeChanged(TimeDisplayMode mode)
     {
         var settings = _appSettingsStore.Load();

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
@@ -91,6 +91,15 @@ public partial class MainWindow : Window
     private readonly ViewerAppSettingsStore _appSettingsStore = new();
 
     /// <summary>
+    /// The per-user settings files that were on disk at startup and could not be read, each with why
+    /// (#2434). Collected in the constructor, where both stores are loaded, and reported once from
+    /// <see cref="OnLoaded"/> — a dialog raised from the constructor has no window behind it. Empty on
+    /// every ordinary run INCLUDING a first run: an absent file is not a problem, and saying so would make
+    /// a warning out of the most normal thing the viewer ever does.
+    /// </summary>
+    private readonly List<string> _unreadableSettingsFiles = new();
+
+    /// <summary>
     /// The system-tray icon + minimize-to-tray behavior (ported from Lite's SystemTrayService, adapted for
     /// the headless viewer). Null until <see cref="OnLoaded"/> initializes it once the store connects.
     /// </summary>
@@ -163,12 +172,14 @@ public partial class MainWindow : Window
     {
         InitializeComponent();
         _preferences = _preferencesStore.Load();
+        NoteUnreadableSettingsFile(_preferencesStore.FilePath, _preferencesStore.LastLoadState, _preferencesStore.LastLoadProblem);
         /* Seed the persisted app settings the viewer honors at runtime BEFORE any tab/chart renders: the CSV
            export separator (grid exports) and the Server/Local/UTC time-display mode (every timestamp render
            routes through ViewerTimeHelper, which reads CurrentDisplayMode). UiTimeContext is deliberately left
            at its identity default — Darling charts pre-convert their X through ForDisplay, so wiring it would
            double-convert on hover/crosshair. */
         var appSettings = _appSettingsStore.Load();
+        NoteUnreadableSettingsFile(_appSettingsStore.FilePath, _appSettingsStore.LastLoadState, _appSettingsStore.LastLoadProblem);
         ViewerExportSettings.Apply(appSettings);
         /* Seed the new-mute-rule default expiration preference so every MuteRuleEditDialog opens on it, and the
            dismiss/mute action-logging opt-in the Alerts tab honors. */
@@ -196,9 +207,52 @@ public partial class MainWindow : Window
         Closed += OnClosed;
     }
 
+    /// <summary>Records a settings file that is present and could not be read, for the one startup report.
+    /// Absent and readable both record nothing, which is the whole point of the three-way split.</summary>
+    private void NoteUnreadableSettingsFile(string filePath, SettingsFileState state, string? problem)
+    {
+        if (state == SettingsFileState.Unreadable)
+        {
+            _unreadableSettingsFiles.Add($"{System.IO.Path.GetFileName(filePath)} — {problem}");
+        }
+    }
+
+    /// <summary>
+    /// One dialog, once, when a settings file the viewer has just fallen back to defaults for is still
+    /// sitting on disk unreadable (#2434).
+    ///
+    /// <para>The fallback used to report itself through <c>Debug.WriteLine</c>, which the compiler removes
+    /// from a Release build — so in the viewer anyone actually runs, the operator's settings quietly became
+    /// defaults and there was nowhere whatsoever to find out why. The log carries it now, but a person
+    /// looking at an app that has forgotten its configuration should not have to go and find a log to learn
+    /// that it did.</para>
+    ///
+    /// <para>Raised from Loaded so it has a window behind it, and before the store connect below on
+    /// purpose: it costs nothing when there is nothing to say, and the connection-failure overlay would
+    /// otherwise bury the one message that explains why the settings changed.</para>
+    /// </summary>
+    private void ReportUnreadableSettingsFiles()
+    {
+        if (_unreadableSettingsFiles.Count == 0)
+        {
+            return;
+        }
+
+        MessageBox.Show(
+            "The viewer could not read these settings files, so the settings they hold are at their "
+            + "defaults for this session:\n\n"
+            + string.Join("\n", _unreadableSettingsFiles)
+            + "\n\nThey have been left exactly as they are. Fix the JSON and restart to get those settings "
+            + "back — or save from the Settings window, which copies an unreadable file aside as "
+            + "'.unreadable-<timestamp>' before replacing it.",
+            "Settings", MessageBoxButton.OK, MessageBoxImage.Warning);
+    }
+
     private async void OnLoaded(object sender, RoutedEventArgs e)
     {
         Loaded -= OnLoaded;
+
+        ReportUnreadableSettingsFiles();
 
         /* #1954: say WHERE the config came from before trying to read it, so a missing or unparseable
            darling.json still names the file the viewer looked at and the rule that picked it. Resolving
@@ -1055,11 +1109,34 @@ public partial class MainWindow : Window
     /// every OTHER open tab's picker so they agree — the mode is process-wide, and a background tab reloads
     /// on activation and picks it up.
     /// </summary>
+    /// <summary>
+    /// Says that a setting the user just changed did not reach disk (#2434).
+    ///
+    /// <para>These two handlers persist on an ordinary click — picking a time-display mode, re-sorting the
+    /// Overview — so a failure here has no Save button to report through, and until now had nowhere to go
+    /// at all: the store's Save could throw, neither handler caught it, and the whole-object write had
+    /// already replaced whatever it could not read. Save answers with a bool instead of throwing now, and
+    /// this is what does something with the answer. Which file and what was wrong with it is in the log;
+    /// what the user needs from a dialog is that the click did not stick.</para>
+    /// </summary>
+    private void WarnSettingNotSaved(string what, string filePath)
+    {
+        MessageBox.Show(
+            $"Your {what} could not be saved to '{System.IO.Path.GetFileName(filePath)}'. It applies for "
+            + "the rest of this session but will not survive a restart. The viewer log (sidebar: View Log) "
+            + "says why.",
+            "Settings", MessageBoxButton.OK, MessageBoxImage.Warning);
+    }
+
     private void OnDisplayModeChanged(TimeDisplayMode mode)
     {
         var settings = _appSettingsStore.Load();
         settings.TimeDisplayMode = mode.ToString();
-        _appSettingsStore.Save(settings);
+        if (!_appSettingsStore.Save(settings))
+        {
+            WarnSettingNotSaved("time display mode", _appSettingsStore.FilePath);
+        }
+
         SyncDisplayModeToOpenTabs(mode);
     }
 
@@ -1103,7 +1180,10 @@ public partial class MainWindow : Window
 
         var settings = _appSettingsStore.Load();
         settings.OverviewSortMode = ServerOverviewSort.ToToken(_overviewSortMode);
-        _appSettingsStore.Save(settings);
+        if (!_appSettingsStore.Save(settings))
+        {
+            WarnSettingNotSaved("Overview sort order", _appSettingsStore.FilePath);
+        }
 
         /* Sorts the FULL card set, never the bound list: with the needs-attention filter on, the bound list is
            a subset, and sorting that would quietly discard every card the filter is hiding. */
@@ -1618,7 +1698,10 @@ public partial class MainWindow : Window
         if (settings.ShowDialog() == true && settings.Result is not null)
         {
             _preferences = settings.Result;
-            _preferencesStore.Save(_preferences);
+            if (!_preferencesStore.Save(_preferences))
+            {
+                WarnSettingNotSaved("default time range and auto-refresh", _preferencesStore.FilePath);
+            }
         }
 
         /* Re-seed the runtime settings the viewer honors from whatever the window persisted (it self-saves):

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
@@ -173,6 +173,11 @@ public partial class MainWindow : Window
         InitializeComponent();
         _preferences = _preferencesStore.Load();
         NoteUnreadableSettingsFile(_preferencesStore.FilePath, _preferencesStore.LastLoadState, _preferencesStore.LastLoadProblem);
+        /* The registry loads in its own field initializer, which has already run by the time the
+           constructor body does, so its state is available here — and it is the one of the three worth
+           surfacing most: a viewer that opens with no servers because it could not read viewer-servers.json
+           looks exactly like a viewer nobody has configured yet. */
+        NoteUnreadableSettingsFile(_serverStore.FilePath, _serverStore.LastLoadState, _serverStore.LastLoadProblem);
         /* Seed the persisted app settings the viewer honors at runtime BEFORE any tab/chart renders: the CSV
            export separator (grid exports) and the Server/Local/UTC time-display mode (every timestamp render
            routes through ViewerTimeHelper, which reads CurrentDisplayMode). UiTimeContext is deliberately left

--- a/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml.cs
@@ -1506,7 +1506,22 @@ public partial class SettingsWindow : Window
         SaveCsvSeparator();
         SaveTimeDisplayMode();
         SaveColorTheme();
-        _appSettingsStore.Save(_appSettings);
+
+        /* #2434: a whole-object replace that did not happen must not pass for one that did. Said here,
+           at the point it happens, rather than folded into the validation list below — that list's
+           sentence is about values the window rejected, which is a different thing from a file it could
+           not write. The operator config further down goes to the Darling store and reports separately,
+           so a failure here does not stop it. */
+        if (!_appSettingsStore.Save(_appSettings))
+        {
+            MessageBox.Show(
+                "The viewer's own settings could not be written to "
+                + $"'{System.IO.Path.GetFileName(_appSettingsStore.FilePath)}', so the viewer-local "
+                + "preferences on this page (theme, CSV separator, timestamp display, tray options) will be "
+                + "back to their previous values on the next launch. The viewer log says why.",
+                "Settings", MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
+
         Result = BuildViewerPreferences();
 
         if (errors.Count > 0)

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerAppSettings.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerAppSettings.cs
@@ -8,7 +8,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Text.Json;
@@ -262,6 +261,9 @@ public sealed class ViewerAppSettingsStore
 {
     private static readonly JsonSerializerOptions s_jsonOptions = new() { WriteIndented = true };
 
+    /// <summary>The <see cref="ViewerLogger"/> source every diagnostic from this store is filed under.</summary>
+    private const string LogSource = "ViewerAppSettingsStore";
+
     private readonly string _filePath;
 
     /// <param name="filePath">Override the on-disk location (tests pass a temp file); null uses <see cref="DefaultFilePath"/>.</param>
@@ -273,6 +275,19 @@ public sealed class ViewerAppSettingsStore
     /// <summary>The resolved settings file path (surfaced mainly so tests and diagnostics can name it).</summary>
     public string FilePath => _filePath;
 
+    /// <summary>
+    /// What the last <see cref="Load"/> on this instance found: <see cref="SettingsFileState.Absent"/> for
+    /// a first run, <see cref="SettingsFileState.Readable"/> for an ordinary one, and
+    /// <see cref="SettingsFileState.Unreadable"/> when defaults were substituted for a file that is still
+    /// on disk. <see cref="MainWindow"/> reads it to raise ONE startup dialog for the last case; every
+    /// other caller can ignore it, because <see cref="ViewerSettingsFile"/> has already logged.
+    /// </summary>
+    public SettingsFileState LastLoadState { get; private set; } = SettingsFileState.Absent;
+
+    /// <summary>Why the last <see cref="Load"/> could not read the file — the line and position of a parse
+    /// error where there is one — or null when there was nothing wrong with it.</summary>
+    public string? LastLoadProblem { get; private set; }
+
     /// <summary>%APPDATA%\PerformanceMonitorDarling\viewer-settings.json.</summary>
     public static string DefaultFilePath()
     {
@@ -283,41 +298,29 @@ public sealed class ViewerAppSettingsStore
     }
 
     /// <summary>
-    /// Reads the settings, returning defaults when the file does not exist yet or cannot be read/parsed —
-    /// the viewer never blocks on a first run or a corrupt file. Loaded values are normalized into range.
+    /// Reads the settings, returning defaults when the file does not exist yet or cannot be read/parsed.
+    /// Loaded values are normalized into range. A file that is present and unreadable is reported to the
+    /// log and left on <see cref="LastLoadState"/> — it is never treated as a first run (#2434).
     /// </summary>
     public ViewerAppSettings Load()
     {
-        try
-        {
-            if (!File.Exists(_filePath))
-            {
-                return new ViewerAppSettings();
-            }
-
-            var json = File.ReadAllText(_filePath);
-            var settings = JsonSerializer.Deserialize<ViewerAppSettings>(json, s_jsonOptions);
-            return (settings ?? new ViewerAppSettings()).Normalize();
-        }
-        catch (Exception ex)
-        {
-            Debug.WriteLine($"ViewerAppSettingsStore: failed to load '{_filePath}', using defaults: {ex.Message}");
-            return new ViewerAppSettings();
-        }
+        var read = ViewerSettingsFile.Load<ViewerAppSettings>(_filePath, LogSource, s_jsonOptions);
+        LastLoadState = read.State;
+        LastLoadProblem = read.Problem;
+        return read.Value!.Normalize();
     }
 
-    /// <summary>Writes the settings as indented JSON, creating the app-data directory on first save.</summary>
-    public void Save(ViewerAppSettings settings)
+    /// <summary>
+    /// Writes the settings as indented JSON, creating the app-data directory on first save, and returns
+    /// whether the write happened. False means nothing reached disk — either the write itself failed, or
+    /// the existing file could not be read AND could not be copied aside, in which case it is deliberately
+    /// left exactly as it is rather than replaced with defaults (#2434).
+    /// </summary>
+    public bool Save(ViewerAppSettings settings)
     {
         ArgumentNullException.ThrowIfNull(settings);
 
-        var directory = Path.GetDirectoryName(_filePath);
-        if (!string.IsNullOrEmpty(directory))
-        {
-            Directory.CreateDirectory(directory);
-        }
-
-        File.WriteAllText(_filePath, JsonSerializer.Serialize(settings, s_jsonOptions));
+        return ViewerSettingsFile.Save(_filePath, settings, LogSource, s_jsonOptions);
     }
 }
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerPreferences.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerPreferences.cs
@@ -8,9 +8,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Text.Json;
+using PerformanceMonitor.Common;
 
 namespace PerformanceMonitor.Darling.Viewer;
 
@@ -92,6 +92,9 @@ public sealed class ViewerPreferencesStore
 {
     private static readonly JsonSerializerOptions s_jsonOptions = new() { WriteIndented = true };
 
+    /// <summary>The <see cref="ViewerLogger"/> source every diagnostic from this store is filed under.</summary>
+    private const string LogSource = "ViewerPreferencesStore";
+
     private readonly string _filePath;
 
     /// <param name="filePath">Override the on-disk location (tests pass a temp file); null uses <see cref="DefaultFilePath"/>.</param>
@@ -103,6 +106,17 @@ public sealed class ViewerPreferencesStore
     /// <summary>The resolved settings file path (surfaced mainly so tests and diagnostics can name it).</summary>
     public string FilePath => _filePath;
 
+    /// <summary>
+    /// What the last <see cref="Load"/> on this instance found. Same three-way split as
+    /// <see cref="ViewerAppSettingsStore.LastLoadState"/>, and for the same reason: a missing
+    /// viewer-preferences.json is a first run and must stay silent, while a present one that could not be
+    /// read is a configuration the viewer is currently ignoring.
+    /// </summary>
+    public SettingsFileState LastLoadState { get; private set; } = SettingsFileState.Absent;
+
+    /// <summary>Why the last <see cref="Load"/> could not read the file, or null when it could.</summary>
+    public string? LastLoadProblem { get; private set; }
+
     /// <summary>%APPDATA%\PerformanceMonitorDarling\viewer-preferences.json.</summary>
     public static string DefaultFilePath()
     {
@@ -113,42 +127,28 @@ public sealed class ViewerPreferencesStore
     }
 
     /// <summary>
-    /// Reads the settings, returning defaults when the file does not exist yet or cannot be read/parsed —
-    /// the viewer never blocks on a first run or a corrupt file. Loaded values are clamped to valid ranges.
+    /// Reads the preferences, returning defaults when the file does not exist yet or cannot be
+    /// read/parsed. Loaded values are clamped to valid ranges. A present-but-unreadable file is reported
+    /// rather than silently treated as absent (#2434).
     /// </summary>
     public ViewerPreferences Load()
     {
-        try
-        {
-            if (!File.Exists(_filePath))
-            {
-                return new ViewerPreferences();
-            }
-
-            var json = File.ReadAllText(_filePath);
-            var preferences = JsonSerializer.Deserialize<ViewerPreferences>(json, s_jsonOptions);
-            return (preferences ?? new ViewerPreferences()).Normalize();
-        }
-        catch (Exception ex)
-        {
-            /* The viewer writes no application log of its own (its diagnostics go to Debug output), so a
-               corrupt-file fallback is a Debug trace, not a log entry — and never a crash on startup. */
-            Debug.WriteLine($"ViewerPreferencesStore: failed to load '{_filePath}', using defaults: {ex.Message}");
-            return new ViewerPreferences();
-        }
+        var read = ViewerSettingsFile.Load<ViewerPreferences>(_filePath, LogSource, s_jsonOptions);
+        LastLoadState = read.State;
+        LastLoadProblem = read.Problem;
+        return read.Value!.Normalize();
     }
 
-    /// <summary>Writes the settings as indented JSON, creating the app-data directory on first save.</summary>
-    public void Save(ViewerPreferences preferences)
+    /// <summary>
+    /// Writes the preferences as indented JSON, creating the app-data directory on first save, and returns
+    /// whether the write happened. Collapsing a sidebar group is a whole-file rewrite of this document and
+    /// nobody thinks of it as a save, which is precisely why the unreadable case is copied aside first and
+    /// a refusal is reported rather than swallowed (#2434).
+    /// </summary>
+    public bool Save(ViewerPreferences preferences)
     {
         ArgumentNullException.ThrowIfNull(preferences);
 
-        var directory = Path.GetDirectoryName(_filePath);
-        if (!string.IsNullOrEmpty(directory))
-        {
-            Directory.CreateDirectory(directory);
-        }
-
-        File.WriteAllText(_filePath, JsonSerializer.Serialize(preferences, s_jsonOptions));
+        return ViewerSettingsFile.Save(_filePath, preferences, LogSource, s_jsonOptions);
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerStore.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerStore.cs
@@ -120,6 +120,18 @@ public sealed class ViewerServerStore
     /// <summary>Why the registry could not be read, or null when it could.</summary>
     public string? LastLoadProblem { get; private set; }
 
+    /// <summary>
+    /// Whether the last write of the registry reached disk (#2434). Every mutator here ends in the same
+    /// <see cref="Save"/>, and several of them keep return types that already mean something else —
+    /// <c>ToggleFavorite</c> answers "is it favourite now", <c>ImportServersFromFile</c> answers with
+    /// counts — so the answer lives here rather than being crammed into those. A caller that is about to
+    /// tell the user something happened can ask; one doing incidental cleanup need not.
+    ///
+    /// <para>True until a write is attempted, so "nothing has failed" is the starting position rather
+    /// than a claim about a write nobody made.</para>
+    /// </summary>
+    public bool LastSaveSucceeded { get; private set; } = true;
+
     /// <summary>%APPDATA%\PerformanceMonitorDarling\viewer-servers.json.</summary>
     public static string DefaultFilePath()
     {
@@ -382,5 +394,9 @@ public sealed class ViewerServerStore
     /// Delete, favourite, tag, import — so this is the whole-file replacement that stands behind an
     /// ordinary click, exactly as the display-mode dropdown does for viewer-settings.json.
     /// </summary>
-    private bool Save() => ViewerSettingsFile.Save(_filePath, _servers, LogSource, s_jsonOptions);
+    private bool Save()
+    {
+        LastSaveSucceeded = ViewerSettingsFile.Save(_filePath, _servers, LogSource, s_jsonOptions);
+        return LastSaveSucceeded;
+    }
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerStore.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerStore.cs
@@ -8,7 +8,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
@@ -91,6 +90,9 @@ public sealed class ViewerServerStore
 {
     private static readonly JsonSerializerOptions s_jsonOptions = new() { WriteIndented = true };
 
+    /// <summary>The <see cref="ViewerLogger"/> source every diagnostic from this store is filed under.</summary>
+    private const string LogSource = "ViewerServerStore";
+
     private readonly string _filePath;
     private readonly IViewerServerSecretStore _secrets;
     private readonly List<ViewerServerEntry> _servers;
@@ -106,6 +108,17 @@ public sealed class ViewerServerStore
 
     /// <summary>The resolved registry file path (surfaced for tests and diagnostics).</summary>
     public string FilePath => _filePath;
+
+    /// <summary>
+    /// What the load in the constructor found. <see cref="SettingsFileState.Absent"/> is a first run and
+    /// says nothing; <see cref="SettingsFileState.Unreadable"/> means the operator's registry is on disk,
+    /// could not be read, and is being ignored — which is the difference between "you have not added any
+    /// servers yet" and "your servers are still in that file" (#2434).
+    /// </summary>
+    public SettingsFileState LastLoadState { get; private set; } = SettingsFileState.Absent;
+
+    /// <summary>Why the registry could not be read, or null when it could.</summary>
+    public string? LastLoadProblem { get; private set; }
 
     /// <summary>%APPDATA%\PerformanceMonitorDarling\viewer-servers.json.</summary>
     public static string DefaultFilePath()
@@ -349,36 +362,25 @@ public sealed class ViewerServerStore
         }
     }
 
+    /// <summary>
+    /// Reads the registry, beginning empty when there is nothing usable to read — a corrupt registry must
+    /// never block startup. What changed with #2434 is what happens NEXT: beginning empty and then writing
+    /// that empty list back over the file was how an unreadable registry became a lost one, and the very
+    /// first Add Server did it. The state is recorded, the failure is reported to the viewer's log, and
+    /// <see cref="Save"/> copies the file aside before it replaces it.
+    /// </summary>
     private List<ViewerServerEntry> LoadFromDisk()
     {
-        try
-        {
-            if (!File.Exists(_filePath))
-            {
-                return new List<ViewerServerEntry>();
-            }
-
-            var json = File.ReadAllText(_filePath);
-            return JsonSerializer.Deserialize<List<ViewerServerEntry>>(json, s_jsonOptions)
-                ?? new List<ViewerServerEntry>();
-        }
-        catch (Exception ex)
-        {
-            /* A corrupt or unreadable registry must never block startup — begin empty and log. */
-            Debug.WriteLine($"ViewerServerStore: failed to load '{_filePath}', starting empty: {ex.Message}");
-            ViewerLogger.Warn("ViewerServerStore", $"Failed to load '{_filePath}': {ex.Message}");
-            return new List<ViewerServerEntry>();
-        }
+        var read = ViewerSettingsFile.Load<List<ViewerServerEntry>>(_filePath, LogSource, s_jsonOptions);
+        LastLoadState = read.State;
+        LastLoadProblem = read.Problem;
+        return read.Value!;
     }
 
-    private void Save()
-    {
-        var directory = Path.GetDirectoryName(_filePath);
-        if (!string.IsNullOrEmpty(directory))
-        {
-            Directory.CreateDirectory(directory);
-        }
-
-        File.WriteAllText(_filePath, JsonSerializer.Serialize(_servers, s_jsonOptions));
-    }
+    /// <summary>
+    /// Persists the registry, and reports whether it reached disk. Every mutator here calls it — Add, Edit,
+    /// Delete, favourite, tag, import — so this is the whole-file replacement that stands behind an
+    /// ordinary click, exactly as the display-mode dropdown does for viewer-settings.json.
+    /// </summary>
+    private bool Save() => ViewerSettingsFile.Save(_filePath, _servers, LogSource, s_jsonOptions);
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerSettingsFile.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerSettingsFile.cs
@@ -7,6 +7,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using PerformanceMonitor.Common;
@@ -46,6 +47,29 @@ namespace PerformanceMonitor.Darling.Viewer;
 internal static class ViewerSettingsFile
 {
     /// <summary>
+    /// The (file, problem) pairs already reported this session, so one broken file is one log line rather
+    /// than one per read.
+    ///
+    /// <para>Nothing reads these files once. The theme is applied from viewer-settings.json before the
+    /// window exists, MainWindow loads it again to seed itself, the Settings window loads it on open and
+    /// MainWindow re-loads it on close, and the control-plane migration loads it too — so an unreported
+    /// duplicate would put five identical ERROR lines in the log for one defect, which is a poor reward for
+    /// whoever went looking. The first line is the one that carries the fact; the rest carry nothing.</para>
+    ///
+    /// <para>Keyed on the problem as well as the path deliberately: if the file changes mid-session and
+    /// breaks in a NEW way, that is a new fact and it is said again.</para>
+    /// </summary>
+    private static readonly HashSet<string> s_reported = new(StringComparer.Ordinal);
+
+    private static bool FirstReportOf(string filePath, string? problem)
+    {
+        lock (s_reported)
+        {
+            return s_reported.Add($"{filePath}|{problem}");
+        }
+    }
+
+    /// <summary>
     /// Reads <paramref name="filePath"/> into <typeparamref name="T"/>, substituting a default instance
     /// when there is nothing usable to read. The returned <c>State</c> is what a caller needs to decide
     /// whether the defaults it just got are a legitimate first run or a configuration that is still on
@@ -57,7 +81,7 @@ internal static class ViewerSettingsFile
     {
         var read = SettingsFileGuard.ReadObject<T>(filePath, options);
 
-        if (read.State == SettingsFileState.Unreadable)
+        if (read.State == SettingsFileState.Unreadable && FirstReportOf(filePath, read.Problem))
         {
             ViewerLogger.Error(logSource,
                 $"'{filePath}' could not be read ({read.Problem}), so every setting it holds is at its " +

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerSettingsFile.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerSettingsFile.cs
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.IO;
+using System.Text.Json;
+using PerformanceMonitor.Common;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// The one read and the one write behind both of the viewer's per-user JSON settings files —
+/// <see cref="ViewerAppSettingsStore"/> (viewer-settings.json) and <see cref="ViewerPreferencesStore"/>
+/// (viewer-preferences.json) — sitting on the shared <see cref="SettingsFileGuard"/> (#2434).
+///
+/// <para>Both stores previously ended their load in a bare <c>catch</c> whose only output was a
+/// <see cref="System.Diagnostics.Debug"/> trace. <c>Debug.WriteLine</c> carries
+/// <see cref="System.Diagnostics.ConditionalAttribute"/>("DEBUG") and is removed by the compiler from a
+/// Release build, so in the viewer anyone actually runs, a settings file that could not be read produced
+/// no record at all — not a log line, not a dialog, nothing. And neither Save merged: each serialized its
+/// whole in-memory object over the file, so a load that had silently fallen back to defaults, followed by
+/// any save at all, replaced every setting in the file with a default. Changing the time-display dropdown
+/// once was enough.</para>
+///
+/// <para>So there are two rules here, and the second is the one that turns an annoyance into data loss.
+/// A file that is present and unreadable is always reported, to the log the viewer now has
+/// (<see cref="ViewerLogger"/> — the "the viewer writes no application log of its own" comment these
+/// stores carried predates it). And nothing replaces a file it could not read until a copy of it exists:
+/// when even the copy cannot be made, the save is refused and says so, because leaving the file alone
+/// beats replacing it when the alternative is permanent.</para>
+///
+/// <para>An ABSENT file goes through both paths in total silence. A first run has nothing to preserve and
+/// nothing to explain, and a warning there would be pure noise — keeping absent apart from unreadable is
+/// half the reason the guard exists.</para>
+/// </summary>
+internal static class ViewerSettingsFile
+{
+    /// <summary>
+    /// Reads <paramref name="filePath"/> into <typeparamref name="T"/>, substituting a default instance
+    /// when there is nothing usable to read. The returned <c>State</c> is what a caller needs to decide
+    /// whether the defaults it just got are a legitimate first run or a configuration that is still on
+    /// disk and could not be understood; the log line for the second case is written here, so a call site
+    /// that never looks at the state is still not silent.
+    /// </summary>
+    internal static SettingsObjectRead<T> Load<T>(string filePath, string logSource, JsonSerializerOptions options)
+        where T : class, new()
+    {
+        var read = SettingsFileGuard.ReadObject<T>(filePath, options);
+
+        if (read.State == SettingsFileState.Unreadable)
+        {
+            ViewerLogger.Error(logSource,
+                $"'{filePath}' could not be read ({read.Problem}), so every setting it holds is at its " +
+                "default for this session. The file has not been changed; the next save copies it aside " +
+                "before replacing it.");
+        }
+
+        return read.Value is null ? read with { Value = new T() } : read;
+    }
+
+    /// <summary>
+    /// Serializes <paramref name="value"/> over <paramref name="filePath"/>, and returns whether it
+    /// actually reached disk.
+    ///
+    /// <para>The bool is the point. This is a whole-object replacement, so a save that fails silently and
+    /// a save that worked are indistinguishable to a caller that cannot ask — which is how a UI ends up
+    /// saying it saved something it did not. Every failure here is logged AND reported, and the two call
+    /// sites that persist a setting from an ordinary click surface it to the user rather than dropping
+    /// it into a log nobody reads after a dialog said it worked.</para>
+    ///
+    /// <para>It returns false rather than throwing because the handlers that call it — a dropdown
+    /// selection change, a sidebar group collapsing — do not wrap it, and a full disk is not a reason to
+    /// take the viewer down.</para>
+    /// </summary>
+    internal static bool Save<T>(string filePath, T value, string logSource, JsonSerializerOptions options)
+    {
+        var permit = SettingsFileGuard.PermitReplace(filePath, DateTime.Now);
+
+        if (!permit.Allowed)
+        {
+            ViewerLogger.Error(logSource,
+                $"'{filePath}' could not be read ({permit.Problem}) and no copy of it could be made, so " +
+                "it has been left untouched rather than overwritten with defaults, and nothing was saved. " +
+                "Fix the file, or move it aside by hand, and try again.");
+            return false;
+        }
+
+        if (permit.QuarantinedTo is not null)
+        {
+            ViewerLogger.Warn(logSource,
+                $"'{Path.GetFileName(filePath)}' could not be read ({permit.Problem}), so this save " +
+                "rewrites it from defaults. The unreadable original was copied to " +
+                $"'{Path.GetFileName(permit.QuarantinedTo)}' first — the settings it held are recoverable " +
+                "from there.");
+        }
+
+        try
+        {
+            var directory = Path.GetDirectoryName(filePath);
+            if (!string.IsNullOrEmpty(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            File.WriteAllText(filePath, JsonSerializer.Serialize(value, options));
+            return true;
+        }
+        catch (Exception ex)
+        {
+            ViewerLogger.Error(logSource, $"'{filePath}' could not be written, so nothing was saved", ex);
+            return false;
+        }
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerSettingsFile.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerSettingsFile.cs
@@ -37,6 +37,11 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// <para>An ABSENT file goes through both paths in total silence. A first run has nothing to preserve and
 /// nothing to explain, and a warning there would be pure noise — keeping absent apart from unreadable is
 /// half the reason the guard exists.</para>
+///
+/// <para>Generic in the value rather than written per store, because there are three of these files and
+/// the third — <see cref="ViewerServerStore"/>'s registry of monitored servers — is the one where losing
+/// the file costs the operator the most and is a JSON ARRAY rather than an object. Everything the guard
+/// decides is decided by the same code for all three.</para>
 /// </summary>
 internal static class ViewerSettingsFile
 {
@@ -78,8 +83,9 @@ internal static class ViewerSettingsFile
     /// take the viewer down.</para>
     /// </summary>
     internal static bool Save<T>(string filePath, T value, string logSource, JsonSerializerOptions options)
+        where T : class
     {
-        var permit = SettingsFileGuard.PermitReplace(filePath, DateTime.Now);
+        var permit = SettingsFileGuard.PermitReplace<T>(filePath, DateTime.Now, options);
 
         if (!permit.Allowed)
         {

--- a/Lite.Tests/SettingsFileGuardTests.cs
+++ b/Lite.Tests/SettingsFileGuardTests.cs
@@ -9,7 +9,7 @@
 using System;
 using System.IO;
 using System.Text.RegularExpressions;
-using PerformanceMonitorLite.Services;
+using PerformanceMonitor.Common;
 using Xunit;
 
 namespace PerformanceMonitorLite.Tests;

--- a/Lite/App.xaml.cs
+++ b/Lite/App.xaml.cs
@@ -20,6 +20,7 @@ using System.Windows.Interop;
 using PerformanceMonitor.Notifications;
 using System.Windows.Threading;
 using PerformanceMonitorLite.Services;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Ui;
 
 namespace PerformanceMonitorLite;

--- a/Lite/Mcp/McpSettings.cs
+++ b/Lite/Mcp/McpSettings.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.IO;
 using System.Text.Json;
+using PerformanceMonitor.Common;
 using PerformanceMonitorLite.Services;
 
 namespace PerformanceMonitorLite.Mcp;

--- a/PerformanceMonitor.Common/Services/SettingsFileGuard.cs
+++ b/PerformanceMonitor.Common/Services/SettingsFileGuard.cs
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2026 Erik Darling, Darling Data LLC
  *
- * This file is part of the SQL Server Performance Monitor Lite.
+ * This file is part of the SQL Server Performance Monitor.
  *
  * Licensed under the MIT License. See LICENSE file in the project root for full license information.
  */
@@ -12,7 +12,7 @@ using System.IO;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
-namespace PerformanceMonitorLite.Services;
+namespace PerformanceMonitor.Common;
 
 /// <summary>
 /// What a read of settings.json found. Telling <see cref="Absent"/> from <see cref="Unreadable"/> is the
@@ -47,6 +47,17 @@ public readonly record struct SettingsFileRead(
     string? Problem);
 
 /// <summary>
+/// The outcome of <see cref="SettingsFileGuard.ReadObject{T}"/>, for a store that round-trips a whole
+/// object rather than merging a document key by key. <c>Value</c> is non-null only for
+/// <see cref="SettingsFileState.Readable"/>; the caller supplies its own defaults for the other two
+/// states, and must tell them apart before deciding whether to say anything about it.
+/// </summary>
+public readonly record struct SettingsObjectRead<T>(
+    SettingsFileState State,
+    T? Value,
+    string? Problem) where T : class;
+
+/// <summary>
 /// The outcome of <see cref="SettingsFileGuard.RootForWrite"/>. <c>Problem</c> is null on the ordinary
 /// paths (the file parsed, or there was no file). When it is set, <c>QuarantinedTo</c> says where the
 /// unreadable original was copied — and a null there means the copy could not be made, which the caller
@@ -58,13 +69,32 @@ public readonly record struct SettingsWriteRoot(
     string? QuarantinedTo);
 
 /// <summary>
-/// The one place that decides whether settings.json can be read, and what to do about it when it cannot
-/// (#2425).
+/// The outcome of <see cref="SettingsFileGuard.PermitReplace"/>: whether a store that REPLACES the whole
+/// file is allowed to go ahead. <c>Allowed</c> is false in exactly one situation — the file could not be
+/// read AND could not be copied aside — and it must be honoured, because the write it is refusing would
+/// be the last event in the life of a configuration nobody ever managed to read.
+/// </summary>
+public readonly record struct SettingsReplacePermit(
+    bool Allowed,
+    string? Problem,
+    string? QuarantinedTo);
+
+/// <summary>
+/// The one place that decides whether a JSON settings file can be read, and what to do about it when it
+/// cannot (#2425, #2434).
 ///
 /// <para>Kept free of WPF, of the logger and of any process-wide state on purpose. Every decision that
 /// matters here — absent versus unreadable, what the user is told about a parse error, whether a Save is a
 /// merge or a replacement, whether the old file is preserved first — is a pure function of a path and a
 /// clock, which is what makes it testable without a UI thread on a platform that can run the suite.</para>
+///
+/// <para>It lives in Common rather than in Lite because #2434 found the identical defect in the Darling
+/// viewer's two stores, and the half that matters — classify, then copy aside before replacing — is the
+/// half that is genuinely common. What differs is only the shape of the document above it: Lite merges a
+/// <see cref="JsonObject"/> key by key (<see cref="RootForWrite"/>), while the viewer round-trips a whole
+/// object through <see cref="JsonSerializer"/> and REPLACES the file (<see cref="ReadObject{T}"/> and
+/// <see cref="PermitReplace"/>). Mirroring this class into the viewer instead would have meant two copies
+/// of the quarantine rule, which is exactly the drift that produced the second instance.</para>
 /// </summary>
 public static class SettingsFileGuard
 {
@@ -225,6 +255,67 @@ public static class SettingsFileGuard
         }
 
         return new SettingsWriteRoot(new JsonObject(), read.Problem, Quarantine(settingsPath, timestamp));
+    }
+
+    /// <summary>
+    /// <see cref="Read"/> for a store whose file is one serialized object rather than a document to merge
+    /// into: classifies the file, and on <see cref="SettingsFileState.Readable"/> deserializes it to
+    /// <typeparamref name="T"/>.
+    ///
+    /// <para>The typed deserialize is inside the guard rather than in front of it because it can fail on a
+    /// file <see cref="Read"/> is perfectly happy with — one key holding a value of the wrong shape, a
+    /// quoted number where an int belongs. That file is unreadable in every sense the caller cares about,
+    /// and the caller cares because the next Save replaces it.</para>
+    /// </summary>
+    public static SettingsObjectRead<T> ReadObject<T>(string settingsPath, JsonSerializerOptions? options = null)
+        where T : class
+    {
+        var read = Read(settingsPath);
+
+        if (read.State != SettingsFileState.Readable || read.Text is null)
+        {
+            return new SettingsObjectRead<T>(read.State, null, read.Problem);
+        }
+
+        try
+        {
+            var value = JsonSerializer.Deserialize<T>(read.Text, options);
+
+            /* Read has already rejected the JSON literal null, so a null here is the object model refusing
+               a document Read accepted. Same state, same consequence: do not replace what you could not
+               understand. */
+            return value is null
+                ? new SettingsObjectRead<T>(SettingsFileState.Unreadable, null,
+                    "the file did not deserialize to a settings object")
+                : new SettingsObjectRead<T>(SettingsFileState.Readable, value, null);
+        }
+        catch (Exception ex) when (ex is JsonException or NotSupportedException or ArgumentException)
+        {
+            return new SettingsObjectRead<T>(SettingsFileState.Unreadable, null, Describe(ex));
+        }
+    }
+
+    /// <summary>
+    /// <see cref="RootForWrite"/>'s twin for a store that REPLACES the file instead of merging into it.
+    /// There is no document to hand back — the caller already holds the object it means to serialize — so
+    /// the only question left is whether writing it is allowed to destroy what is there now.
+    ///
+    /// <para>An absent or readable file is a plain yes: nothing is lost, because a first run has nothing
+    /// to lose and a readable file's contents are what the caller loaded in the first place. An unreadable
+    /// one is copied aside first, and the answer is yes only if that copy exists. A caller that ignores a
+    /// no and writes anyway has just done the thing this whole class exists to prevent.</para>
+    /// </summary>
+    public static SettingsReplacePermit PermitReplace(string settingsPath, DateTime timestamp)
+    {
+        var read = Read(settingsPath);
+
+        if (read.State != SettingsFileState.Unreadable)
+        {
+            return new SettingsReplacePermit(true, null, null);
+        }
+
+        var quarantinedTo = Quarantine(settingsPath, timestamp);
+        return new SettingsReplacePermit(quarantinedTo is not null, read.Problem, quarantinedTo);
     }
 
     /* System.Text.Json appends " Path: $ | LineNumber: 41 | BytePositionInLine: 6." to its parse messages.

--- a/PerformanceMonitor.Common/Services/SettingsFileGuard.cs
+++ b/PerformanceMonitor.Common/Services/SettingsFileGuard.cs
@@ -112,34 +112,15 @@ public static class SettingsFileGuard
     /// </summary>
     public static SettingsFileRead Read(string settingsPath)
     {
-        if (string.IsNullOrWhiteSpace(settingsPath) || !File.Exists(settingsPath))
+        var text = ReadText(settingsPath, out var state, out var problem);
+        if (state != SettingsFileState.Readable)
         {
-            return new SettingsFileRead(SettingsFileState.Absent, null, null, null);
-        }
-
-        string text;
-        try
-        {
-            text = File.ReadAllText(settingsPath);
-        }
-        catch (Exception ex)
-        {
-            /* A locked, denied or truncated file is unreadable in exactly the sense that matters: we do
-               not know what it says, so it must not be replaced. */
-            return new SettingsFileRead(SettingsFileState.Unreadable, null, null, Describe(ex));
-        }
-
-        if (string.IsNullOrWhiteSpace(text))
-        {
-            /* Reported rather than treated as absent. There is nothing to preserve in an empty file, but
-               there IS something to explain: settings that were there yesterday are gone today, and an
-               interrupted write is the likeliest reason. */
-            return new SettingsFileRead(SettingsFileState.Unreadable, null, text, "the file is empty");
+            return new SettingsFileRead(state, null, text, problem);
         }
 
         try
         {
-            var node = JsonNode.Parse(text);
+            var node = JsonNode.Parse(text!);
             if (node is JsonObject root)
             {
                 return new SettingsFileRead(SettingsFileState.Readable, root, text, null);
@@ -258,35 +239,42 @@ public static class SettingsFileGuard
     }
 
     /// <summary>
-    /// <see cref="Read"/> for a store whose file is one serialized object rather than a document to merge
-    /// into: classifies the file, and on <see cref="SettingsFileState.Readable"/> deserializes it to
+    /// <see cref="Read"/> for a store whose file is one serialized value rather than a document to merge
+    /// into: classifies the file, and when there is text to work with deserializes it to
     /// <typeparamref name="T"/>.
     ///
     /// <para>The typed deserialize is inside the guard rather than in front of it because it can fail on a
-    /// file <see cref="Read"/> is perfectly happy with — one key holding a value of the wrong shape, a
-    /// quoted number where an int belongs. That file is unreadable in every sense the caller cares about,
-    /// and the caller cares because the next Save replaces it.</para>
+    /// file that is perfectly good JSON — one key holding a value of the wrong shape, a quoted number where
+    /// an int belongs. That file is unreadable in every sense the caller cares about, and the caller cares
+    /// because the next Save replaces it.</para>
+    ///
+    /// <para>Deliberately does NOT apply <see cref="Read"/>'s "the root must be an object" rule, and the
+    /// distinction is load-bearing rather than pedantic: that rule exists because a merge has nothing to
+    /// merge into otherwise, and the viewer's server registry is a legitimate JSON ARRAY. Borrowing the
+    /// rule here would have declared every healthy registry unreadable and quarantined a copy of it on
+    /// every add, edit and favourite toggle. The typed deserialize is the right judge of whether the file
+    /// says what this caller reads — for a settings object an array still fails, and for a
+    /// <c>List&lt;T&gt;</c> an object still fails.</para>
     /// </summary>
     public static SettingsObjectRead<T> ReadObject<T>(string settingsPath, JsonSerializerOptions? options = null)
         where T : class
     {
-        var read = Read(settingsPath);
-
-        if (read.State != SettingsFileState.Readable || read.Text is null)
+        var text = ReadText(settingsPath, out var state, out var problem);
+        if (state != SettingsFileState.Readable)
         {
-            return new SettingsObjectRead<T>(read.State, null, read.Problem);
+            return new SettingsObjectRead<T>(state, null, problem);
         }
 
         try
         {
-            var value = JsonSerializer.Deserialize<T>(read.Text, options);
+            var value = JsonSerializer.Deserialize<T>(text!, options);
 
-            /* Read has already rejected the JSON literal null, so a null here is the object model refusing
-               a document Read accepted. Same state, same consequence: do not replace what you could not
-               understand. */
+            /* The JSON literal null parses and deserializes to null. Reported, because it is the shape that
+               reads as "nothing was configured" to a caller that only null-checks, and the consequence of
+               believing that is a file replaced from defaults. */
             return value is null
                 ? new SettingsObjectRead<T>(SettingsFileState.Unreadable, null,
-                    "the file did not deserialize to a settings object")
+                    "the file holds the JSON literal null rather than the settings it should")
                 : new SettingsObjectRead<T>(SettingsFileState.Readable, value, null);
         }
         catch (Exception ex) when (ex is JsonException or NotSupportedException or ArgumentException)
@@ -305,9 +293,17 @@ public static class SettingsFileGuard
     /// one is copied aside first, and the answer is yes only if that copy exists. A caller that ignores a
     /// no and writes anyway has just done the thing this whole class exists to prevent.</para>
     /// </summary>
-    public static SettingsReplacePermit PermitReplace(string settingsPath, DateTime timestamp)
+    public static SettingsReplacePermit PermitReplace<T>(
+        string settingsPath,
+        DateTime timestamp,
+        JsonSerializerOptions? options = null)
+        where T : class
     {
-        var read = Read(settingsPath);
+        /* Generic in T, and re-reading rather than being told, so that the question asked here is exactly
+           the question the store's own Load asks: can this file still be read as what is about to replace
+           it? A permit that judged the file by some other standard would either quarantine healthy files
+           or wave through the destruction of one it never understood. */
+        var read = ReadObject<T>(settingsPath, options);
 
         if (read.State != SettingsFileState.Unreadable)
         {
@@ -316,6 +312,47 @@ public static class SettingsFileGuard
 
         var quarantinedTo = Quarantine(settingsPath, timestamp);
         return new SettingsReplacePermit(quarantinedTo is not null, read.Problem, quarantinedTo);
+    }
+
+    /// <summary>
+    /// Everything both readers agree on before the JSON matters: no file is Absent and silent, a file that
+    /// will not come off disk is Unreadable, and an empty one is Unreadable rather than Absent — there is
+    /// nothing to preserve in an empty file but there IS something to explain, since the settings that were
+    /// there yesterday are gone today and an interrupted write is the likeliest reason.
+    /// </summary>
+    private static string? ReadText(string settingsPath, out SettingsFileState state, out string? problem)
+    {
+        if (string.IsNullOrWhiteSpace(settingsPath) || !File.Exists(settingsPath))
+        {
+            state = SettingsFileState.Absent;
+            problem = null;
+            return null;
+        }
+
+        string text;
+        try
+        {
+            text = File.ReadAllText(settingsPath);
+        }
+        catch (Exception ex)
+        {
+            /* A locked, denied or truncated file is unreadable in exactly the sense that matters: we do
+               not know what it says, so it must not be replaced. */
+            state = SettingsFileState.Unreadable;
+            problem = Describe(ex);
+            return null;
+        }
+
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            state = SettingsFileState.Unreadable;
+            problem = "the file is empty";
+            return text;
+        }
+
+        state = SettingsFileState.Readable;
+        problem = null;
+        return text;
     }
 
     /* System.Text.Json appends " Path: $ | LineNumber: 41 | BytePositionInLine: 6." to its parse messages.


### PR DESCRIPTION
One click on the time-display dropdown was enough to lose every setting in the Darling viewer's `viewer-settings.json`, and in a shipped build nothing anywhere recorded that it had happened.

Both of the viewer's per-user stores ended their load in a bare `catch` whose only output was `Debug.WriteLine`. That carries `[Conditional("DEBUG")]` and the compiler removes it from a Release build, so this was not "unlogged" — it was **unreportable**: no log line, no dialog, not even a trace. And neither `Save` merged; each serialized its whole in-memory object over the file. `OnDisplayModeChanged` and the Overview sort selector both do load-then-save, so an unreadable file was loaded as defaults and those defaults were written straight back over it. Lite's pre-#2425 writers at least parsed first and aborted, which left the file intact by accident. The viewer had no such accident.

## The premise held up in source, with one correction to make

Everything in the issue checked out: the `Debug.WriteLine` catch in both stores, the whole-object `File.WriteAllText` in both `Save`s, the load-then-save at `MainWindow.xaml.cs` L1042 and L1086, `SettingsWindow.xaml.cs` L1509, and `ViewerControlPlaneMigration` being fed from `_appSettingsStore.Load()`.

The correction is that the issue's third bullet — "`ViewerLogger` exists, and the `Debug.WriteLine` comment predates it, worth re-checking rather than trusted" — is exactly right, and the re-check found one thing the issue could not have known. `ViewerLogger.Log` returns early when the logger has not been initialized, unlike Lite's `AppLogger`, which enqueues unconditionally. `App.OnStartup` reads `viewer-settings.json` for the color theme **before** `ViewerLogger.Initialize()`. So simply logging from the store would have dropped the earliest and most useful diagnostic — the very first read of the file — on the floor. `Initialize` moves ahead of the theme read; it creates a directory, starts a timer and swallows its own failure, and nothing between the two positions depends on the ordering.

## There is a third store, and writing the category guard is what found it

The issue names two stores. There are three. `ViewerServerStore` persists `viewer-servers.json` — the operator's registry of monitored servers, their display names, favourites, view filters and credential-profile links — through the identical whole-object round trip, with the same bare catch and the same `Debug.WriteLine`.

Its shape made the loss arrive sooner rather than later. `LoadFromDisk` began **empty** on an unreadable registry, so the first favourite toggle serialized an empty list over the file. There is no intermediate state in which anyone could have noticed: the servers were simply not there, and then the file said so.

It is fixed here rather than filed, because a guard listing two of the three stores would be exactly the scenario-shaped fix it was written to prevent. Two things had to move in the guard to take it, and one of them is a trap worth naming:

- **`ReadObject` no longer applies `Read`'s "the root must be an object" rule.** That rule exists because a MERGE has nothing to merge into otherwise; the registry is a legitimate JSON **array**. Borrowing the rule here would have called every healthy registry unreadable and dropped a quarantine copy beside it on every favourite toggle — data loss traded for litter, and litter is how a real quarantine copy gets ignored. `Save_LeavesNoCopyBehind_ForAHealthyRegistry_ThoughItsRootIsAnArray` is the control for exactly that mistake, because it was one line away.
- **`PermitReplace` became generic**, so it asks whether the file can still be read AS the thing about to replace it — the same question the store's own `Load` asks — rather than by some other standard.

`Read` and `ReadObject` now share a `ReadText` helper instead of the second calling the first, so absent / empty / unparseable is decided in one place for both.

## Shared, not mirrored

`SettingsFileGuard` moved to `PerformanceMonitor.Common/Services/`. Common is referenced by Lite **and** the viewer, targets `net10.0`, and carries no WPF and no logger — which is what the guard was already written to be, a pure function of a path and a clock. The move is a namespace change and nothing else; `SettingsWindow.xaml.cs` already had the `using`.

The issue is right that only half of it is common, and that is the half that matters. Lite merges a `JsonObject` key by key, so `RootForWrite` hands back a document to merge into. The viewer round-trips a whole object and REPLACES the file, so it has no document to be handed and one question left: whether the write is allowed to destroy what is there now. Two members answer that shape:

- **`PermitReplace`** — absent or readable is a plain yes; unreadable is copied aside first and the answer is yes only if the copy exists.
- **`ReadObject<T>`** — `Read` plus the typed deserialize. That deserialize is *inside* the guard rather than in front of it because it fails on files `Read` is perfectly happy with: `{"DefaultTimeRangeIndex":"not a number"}` is a valid JSON object and still unusable, and a classify step that stops at "is this a JSON object" hands the exception straight back to the bare catch it was meant to replace.

Mirroring the class into the viewer would have meant two copies of the quarantine rule, and this issue exists because the first copy already had a sibling nobody had looked at.

## What the viewer does now

Both stores read and write through one helper, `ViewerSettingsFile`. Absent stays completely silent — a first run has nothing to preserve and nothing to explain, and a warning there is how a diagnostic earns being ignored. A present file that cannot be read is reported to `ViewerLogger`, left exactly where it is, and copied aside as `viewer-settings.json.unreadable-<timestamp>` before any save replaces it. When even the copy cannot be made, the save is refused and says so: leaving the file alone beats replacing it when the alternative is permanent.

One broken file gets one log line, not one per read. Nothing reads these files once — the theme is applied from `viewer-settings.json` before the window exists, `MainWindow` loads it again to seed itself, the Settings window loads it on open and `MainWindow` re-loads it on close, and the control-plane migration loads it too — so one trailing comma would otherwise account for five identical ERROR lines, which is a poor reward for the one person who went and opened the log. Reported once per (file, problem); keyed on the problem as well as the path, so a file that changes mid-session and breaks in a NEW way is said again. (Sharing one store instance between `App` and `MainWindow` was the other way to get here and is the wrong lever — it makes the number of log lines a property of object ownership across startup, so the next caller needing its own read quietly brings it back.)

`Save` answers with a `bool` instead of throwing. Three of its four call sites never caught anything, so on a full disk the old contract was a crash — and a save nobody can ask about is precisely how a UI ends up claiming it saved something it did not (#2433, next door). The two handlers that persist on an ordinary click now say when the click did not stick. `PersistCollapseState` logs instead: a modal every time a sidebar group collapses would be worse than what it reports, and that is the write that most needed the guard behind it, because collapsing a group is a whole-file rewrite of `viewer-preferences.json` that nobody thinks of as a save. `MainWindow` raises one dialog at `Loaded` for a file that was unreadable at startup — somebody looking at an app that has forgotten its configuration should not have to go and find a log to learn that it did.

## Verification

`Darling.Tests` targets `net10.0-windows` and cannot run on macOS, so the real test file was compiled into a throwaway `net10.0` harness with a minimal xUnit shim, against the REAL `ViewerAppSettings.cs`, `ViewerPreferences.cs`, `ViewerLogger.cs` and `ViewerSettingsFile.cs` from each branch plus a project reference to the real `PerformanceMonitor.Common` — not a transcription of them. Compiled `-c Release` on purpose, so `Debug.WriteLine` is genuinely gone the way it is in a shipped build.

Against dev the test file **does not compile at all** — 13 `CS` errors, because `LastLoadState`, `LastLoadProblem`, `SettingsFileState` and a `Save` that returns anything do not exist there. That absence is the finding, not a measurement, so the pass/fail split below runs the subset that *can* be expressed against dev's contract, identical bodies on both sides:

| | dev's behavior | this branch |
|---|---|---|
| quarantine + wiring + "is it reportable at all" | **3 passed, 10 failed** | **13 passed, 0 failed** |
| the full committed test file | **does not compile (13 errors)** | **19 passed, 0 failed** |

The three that pass on dev are the controls — a readable file, a first run, and a healthy array-rooted registry all leave no quarantine copy — which were never broken and are the first thing a wrong fix breaks. The ten failures are the ones that matter: no copy made before ANY of the three stores replaced an unreadable file, all six source-wiring guards red, and `Load_LeavesARecordAShippedBuildCanSee` finding nothing whatsoever in either channel a shipped viewer has (the Trace listeners `Debug.WriteLine` routes to, and the viewer's own log file) — the only line in the log is `ViewerLogger`'s own "Logging initialized".

That last one stays in the harness rather than the committed suite, deliberately. It needs process-wide `ViewerLogger` and `Trace.Listeners`, and more to the point CI runs `dotnet test` in Debug, where `Debug.WriteLine` still works — so as a standing guard it would pass on unfixed code, which is worse than not having it. The standing guard for the same property is `NoViewerSettingsStore_ReportsThroughDebugWriteLine`, which is a source scan and is configuration-independent.

`ViewerSettingsStoreWiringTests` is the category rather than the instance, and it earned its keep before it ever ran in CI — writing it is what turned up the third store. The defect was never that one store's `Save` was wrong; it was that each store rolled its own read in front of its own whole-file replace, so whether a save could destroy your configuration depended on which store you happened to be in. A fourth written the same way tomorrow fails that test instead of shipping. It keys on `_filePath` — the store's own file — rather than on `File.*` in general, because `ImportServersFromFile` legitimately reads a file the user picked, and a rule that could not tell those apart would either miss the defect or forbid a feature.

## One note on the merge

#2435 landed on dev while this was open and made `McpSettings.Load` take `SettingsFileGuard` — from `Lite/Services`, where it lived at the time. The two merge cleanly and do not compile: git has no way to see that a `using` directive one file over is what the other lane's new call site needs. One `using` is the whole fix, and nothing about #2435's reasoning changes — it is the same type with the same behavior, one assembly further down. Worth knowing that the PR build catches this, because a local build of the branch alone does not.

## Deliberately not in scope

~~`ViewerServerStore`'s mutators still return `void`~~ — filed as a residue, then argued out of it by review, correctly: the two settings files say when a save did not land and leaving the registry silent is the inconsistency rather than the compromise, on the file this PR itself calls the costliest to lose.

The answer lives on the store as `LastSaveSucceeded` rather than in the return types, because two mutators already answer other questions — `ToggleFavorite` says whether it is favourite *now*, `ImportServersFromFile` answers with counts. A caller about to tell the user something happened can ask; one doing incidental cleanup need not. Two ask: the sidebar's pin toggle, whose status line is that click's whole report, and `"Imported N server definition(s)."`, which is a claim about a file made at exactly the moment a refused write matters most. The two `SetFavorite(..., false)` cleanups on server removal deliberately do not, and say so in place — they remove a pin for a server that no longer exists, so a refused write strands an entry nothing reads rather than losing anything.

`ViewerSettings` (the viewer's read of the SERVICE's `darling.json`) is a different file with a different owner and its own diagnostics path (#1954), and it is read-only from the viewer — there is no save that could replace it, which is the whole hazard here. Left alone.

The startup dialog reports the file and the parse position but not which SETTINGS were lost, because the whole-object round trip cannot know: the deserialize failed. Naming them would mean per-property reads, which is the viewer's version of the eighty-eight-try-blocks item #2428 filed for Lite.

Fixes #2434
