### PR TITLE
Lite re-fires a standing AG replica disconnect (#2426)

### DIFF
--- a/Darling/Darling.Tests/AgAlertPolicyTests.cs
+++ b/Darling/Darling.Tests/AgAlertPolicyTests.cs
@@ -6,6 +6,7 @@
  * Licensed under the MIT License. See LICENSE file in the project root for full license information.
  */
 
+using System;
 using PerformanceMonitor.Common;
 using Xunit;
 
@@ -79,6 +80,102 @@ public class AgAlertPolicyTests
     {
         Assert.Equal(AgConnectionDecision.None, AgAlertPolicy.DecideConnection(null, "DISCONNECTED"));
         Assert.Equal(AgConnectionDecision.Reconnected, AgAlertPolicy.DecideConnection("DISCONNECTED", "CONNECTED"));
+    }
+
+    /* ---------------- #2426: the disconnect re-fire ---------------- */
+
+    private static readonly DateTime Noon = new(2026, 8, 20, 12, 0, 0, DateTimeKind.Utc);
+
+    [Theory]
+    [InlineData("CONNECTED", "DISCONNECTED", AgConnectionDecision.Disconnected)]
+    [InlineData("DISCONNECTED", "CONNECTED", AgConnectionDecision.Reconnected)]
+    [InlineData("DISCONNECTED", "DISCONNECTED", AgConnectionDecision.None)]
+    [InlineData("CONNECTED", "CONNECTED", AgConnectionDecision.None)]
+    [InlineData(null, "DISCONNECTED", AgConnectionDecision.None)]
+    [InlineData("CONNECTED", null, AgConnectionDecision.None)]
+    public void DecideConnection_RefireOff_IsTheEdgeOnlyOverloadExactly(
+        string? previous, string? current, AgConnectionDecision expected)
+    {
+        /* The shipped default, and the whole matrix rather than one case: null, zero and a negative all
+           mean OFF, and off has to be byte-for-byte the two-argument behavior or an upgrade would start
+           re-alerting on a knob nobody set. */
+        Assert.Equal(expected, AgAlertPolicy.DecideConnection(previous, current, null, null, Noon));
+        Assert.Equal(expected, AgAlertPolicy.DecideConnection(previous, current, TimeSpan.Zero, null, Noon));
+        Assert.Equal(expected, AgAlertPolicy.DecideConnection(previous, current, TimeSpan.FromMinutes(-5), null, Noon));
+    }
+
+    [Fact]
+    public void DecideConnection_StillDisconnected_WaitsOutTheWindow_ThenSaysItAgain()
+    {
+        var refire = TimeSpan.FromMinutes(10);
+
+        /* Announced at noon: inside the window there is nothing new to say. */
+        Assert.Equal(
+            AgConnectionDecision.None,
+            AgAlertPolicy.DecideConnection("DISCONNECTED", "DISCONNECTED", refire, Noon, Noon.AddMinutes(9)));
+
+        /* At the boundary, and still hours later — the point of the knob is that a week-long outage does
+           not read like a blip. */
+        Assert.Equal(
+            AgConnectionDecision.StillDisconnected,
+            AgAlertPolicy.DecideConnection("DISCONNECTED", "DISCONNECTED", refire, Noon, Noon.AddMinutes(10)));
+        Assert.Equal(
+            AgConnectionDecision.StillDisconnected,
+            AgAlertPolicy.DecideConnection("DISCONNECTED", "DISCONNECTED", refire, Noon, Noon.AddHours(8)));
+    }
+
+    [Fact]
+    public void DecideConnection_ARealEdgeOutranksARefire()
+    {
+        var refire = TimeSpan.FromMinutes(10);
+
+        /* The edge that OPENS the outage announces as Disconnected even though the window is trivially due
+           on it, or the caller would have two reasons to announce the same sweep. */
+        Assert.Equal(
+            AgConnectionDecision.Disconnected,
+            AgAlertPolicy.DecideConnection("CONNECTED", "DISCONNECTED", refire, null, Noon));
+
+        /* And a recovery is a recovery whatever the clock says. */
+        Assert.Equal(
+            AgConnectionDecision.Reconnected,
+            AgAlertPolicy.DecideConnection("DISCONNECTED", "CONNECTED", refire, Noon.AddHours(-9), Noon));
+    }
+
+    [Fact]
+    public void DecideConnection_NoStampIsDueNow_SoARestartMidOutageStillReAnnounces()
+    {
+        var refire = TimeSpan.FromMinutes(10);
+
+        /* Both apps hold this edge state in memory, so a restart during a week-long outage sees a replica
+           already DISCONNECTED with no record of it ever having been announced. Rule 1's silent baseline
+           would make that silence permanent, which is the exact failure the knob exists to prevent — so
+           with re-fire ON, and only then, a first sighting announces. */
+        Assert.Equal(
+            AgConnectionDecision.StillDisconnected,
+            AgAlertPolicy.DecideConnection(null, "DISCONNECTED", refire, null, Noon));
+        Assert.Equal(
+            AgConnectionDecision.StillDisconnected,
+            AgAlertPolicy.DecideConnection("DISCONNECTED", "DISCONNECTED", refire, null, Noon));
+
+        /* With it off, rule 1 governs unchanged. */
+        Assert.Equal(
+            AgConnectionDecision.None,
+            AgAlertPolicy.DecideConnection(null, "DISCONNECTED", null, null, Noon));
+    }
+
+    [Fact]
+    public void DecideConnection_ARefireStillNeedsAnExactDisconnected()
+    {
+        var refire = TimeSpan.FromMinutes(10);
+
+        /* Same rule the edge follows, and it matters more here: a re-fire pages repeatedly, so a state
+           string the product never learned to interpret must not become a standing page. */
+        Assert.Equal(
+            AgConnectionDecision.None,
+            AgAlertPolicy.DecideConnection("SOMETHING_NEW", "SOMETHING_NEW", refire, null, Noon));
+        Assert.Equal(
+            AgConnectionDecision.None,
+            AgAlertPolicy.DecideConnection("CONNECTED", null, refire, null, Noon));
     }
 
     /* ---------------- suspension ---------------- */

--- a/Darling/Darling.Tests/DarlingSelfAlertTests.cs
+++ b/Darling/Darling.Tests/DarlingSelfAlertTests.cs
@@ -1830,6 +1830,17 @@ public sealed class DarlingSelfAlertTests
         Assert.Equal("AG Replica Disconnected", h.Deliverer.Outcomes[1].MetricName);
         Assert.Contains("STILL disconnected", h.Deliverer.Outcomes[1].ShortMessage, StringComparison.Ordinal);
 
+        /* #2426, caught in review: the DETAIL has to say it too, and this is the assertion that pays for the
+           branch. ShortMessage is the interactive toast body and reaches neither the history row nor the
+           email — DarlingAlertDeliverer forwards DetailText — so pinning only the short message would leave
+           an operator opening Alert Detail on the sixth re-announcement reading text byte-identical to the
+           first notice, which is the problem the knob exists to end. Both halves asserted, in both
+           directions: the re-fire says so and names the interval, and the opening EDGE does not, or every
+           first notice would claim to be a repeat. */
+        Assert.Contains("STILL DISCONNECTED", h.Deliverer.Outcomes[1].DetailText, StringComparison.Ordinal);
+        Assert.Contains("re-alerting every 10 min", h.Deliverer.Outcomes[1].DetailText, StringComparison.Ordinal);
+        Assert.DoesNotContain("STILL", h.Deliverer.Outcomes[0].DetailText, StringComparison.Ordinal);
+
         /* Reconnect clears the clock, so a later outage starts a fresh episode rather than re-firing late. */
         h.Now = h.Now.AddMinutes(1);
         await e.ApplyAgReplicaHealthAsync(ServerId, Name, new[] { ReplicaRow(connected: "CONNECTED") }, Ct);

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingSelfAlertEvaluator.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingSelfAlertEvaluator.cs
@@ -863,10 +863,23 @@ internal sealed class DarlingSelfAlertEvaluator
 
                 if (connection == AgConnectionDecision.Disconnected || stillDisconnected)
                 {
+                    /* #2426: the re-fire says so in the DETAIL, not only in the short message. ShortMessage is
+                       the interactive toast body and reaches neither the history row nor the email —
+                       DarlingAlertDeliverer forwards DetailText — so an operator opening Alert Detail on the
+                       sixth re-announcement read text byte-identical to the first notice, which is precisely
+                       the "a week-long outage reads like a blip" problem this knob exists to end. The
+                       connection re-fire above already bakes it into detail; this is its AG twin, worded to
+                       match Lite's so the two SKUs' history rows say the same thing. */
+                    var opening = stillDisconnected
+                        ? $"Availability Group '{replica.AgName}': replica {replica.ReplicaServerName} is STILL " +
+                            $"DISCONNECTED from the primary (re-alerting every {refireMinutes.ToString(CultureInfo.InvariantCulture)} min)."
+                        : $"Availability Group '{replica.AgName}': replica {replica.ReplicaServerName} is DISCONNECTED " +
+                            "from the primary.";
+
                     await FireAsync(
                         Key(serverId), serverName, AgReplicaDisconnectedMetric, replica.ConnectedStateDesc, "CONNECTED",
-                        detail: $"Availability Group '{replica.AgName}': replica {replica.ReplicaServerName} is " +
-                            "DISCONNECTED from the primary. A disconnected replica receives no log at all, so it falls " +
+                        detail: opening +
+                            " A disconnected replica receives no log at all, so it falls " +
                             "further behind every second and cannot be failed over to without losing whatever the primary " +
                             "has committed since. If it is a synchronous-commit replica, the primary also loses its " +
                             "automatic-failover partner. Check the replica's SQL Server service, the availability endpoint " +

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingSelfAlertEvaluator.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingSelfAlertEvaluator.cs
@@ -838,21 +838,28 @@ internal sealed class DarlingSelfAlertEvaluator
             if (!string.IsNullOrEmpty(replica.ConnectedStateDesc))
             {
                 _agReplicaConnectedState.TryGetValue(key, out var previousState);
-                var connection = AgAlertPolicy.DecideConnection(previousState, replica.ConnectedStateDesc);
-                _agReplicaConnectedState[key] = replica.ConnectedStateDesc;
 
                 /* #1696 (V37): "AG Replica Disconnected" was a pure edge, so a replica that stayed
                    disconnected for a week announced it ONCE. The #1659 treatment: re-announce every N
                    minutes while it is still down (0 = off, the shipped default, so nothing starts
                    re-alerting on upgrade). Re-fires deliver under the SAME metric name, because webhook
-                   automation keyed on it is exactly what a re-fire exists to re-trigger. */
-                bool stillDisconnected =
-                    connection == AgConnectionDecision.None
-                    && AgAlertPolicy.IsDisconnected(replica.ConnectedStateDesc)
-                    && _agDisconnectRefireMinutes() is int refire
-                    && refire > 0
-                    && (!_lastAgDisconnectAlert.TryGetValue(key, out var lastDown)
-                        || _utcNow() - lastDown >= TimeSpan.FromMinutes(refire));
+                   automation keyed on it is exactly what a re-fire exists to re-trigger.
+
+                   #2426 moved the combined decision into the shared policy rather than leaving it as an
+                   expression here: Lite grew the same knob, and the parts with sharp corners — a re-fire
+                   must not double up with the edge that just fired, and an unrecognized state string must
+                   not count as down — are precisely the parts that drift when written twice. What stays
+                   here is what is genuinely this app's: the stamp, and the delivery it is stamped on. */
+                int refireMinutes = _agDisconnectRefireMinutes();
+                var connection = AgAlertPolicy.DecideConnection(
+                    previousState,
+                    replica.ConnectedStateDesc,
+                    refireMinutes > 0 ? TimeSpan.FromMinutes(refireMinutes) : null,
+                    _lastAgDisconnectAlert.TryGetValue(key, out var lastDown) ? lastDown : (DateTime?)null,
+                    _utcNow());
+                _agReplicaConnectedState[key] = replica.ConnectedStateDesc;
+
+                bool stillDisconnected = connection == AgConnectionDecision.StillDisconnected;
 
                 if (connection == AgConnectionDecision.Disconnected || stillDisconnected)
                 {

--- a/Lite.Tests/AgAlertEvaluatorTests.cs
+++ b/Lite.Tests/AgAlertEvaluatorTests.cs
@@ -101,6 +101,137 @@ public class AgAlertEvaluatorTests
         Assert.True(back.IsResolution);
     }
 
+    /* ---------------- #2426: the disconnect re-fire ---------------- */
+
+    private static readonly DateTime Noon = new(2026, 8, 20, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly TimeSpan Refire = TimeSpan.FromMinutes(10);
+
+    [Fact]
+    public void DisconnectRefire_ReAnnouncesUnderTheSameMetricName_AndSaysThatItIsStill()
+    {
+        var now = Noon;
+        var e = new AgAlertEvaluator(() => now);
+
+        e.EvaluateReplicas(ServerId, new[] { Replica(connected: "CONNECTED") }, Refire);
+
+        var lost = Assert.Single(e.EvaluateReplicas(ServerId, new[] { Replica(connected: "DISCONNECTED") }, Refire));
+        Assert.Equal(AgAlertPolicy.ReplicaDisconnectedMetric, lost.MetricName);
+        Assert.DoesNotContain("STILL", lost.DetailText, StringComparison.Ordinal);
+        e.NoteDelivered(lost);
+
+        /* Inside the window there is nothing new to say. */
+        now = now.AddMinutes(5);
+        Assert.Empty(e.EvaluateReplicas(ServerId, new[] { Replica(connected: "DISCONNECTED") }, Refire));
+
+        /* Past it: the SAME metric name, because webhook automation keyed on it is what a re-fire exists to
+           re-trigger — and a detail that tells an operator reading the history this is hour two, not a
+           second outage. */
+        now = now.AddMinutes(6);
+        var again = Assert.Single(e.EvaluateReplicas(ServerId, new[] { Replica(connected: "DISCONNECTED") }, Refire));
+        Assert.Equal(AgAlertPolicy.ReplicaDisconnectedMetric, again.MetricName);
+        Assert.False(again.IsResolution);
+        Assert.Contains("STILL DISCONNECTED", again.DetailText, StringComparison.Ordinal);
+        Assert.Contains("re-alerting every 10 min", again.DetailText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DisconnectRefire_TheWindowOpensOnDeliveryOnly_NotOnTheDecision()
+    {
+        var now = Noon;
+        var e = new AgAlertEvaluator(() => now);
+
+        e.EvaluateReplicas(ServerId, new[] { Replica(connected: "CONNECTED") }, Refire);
+
+        /* Evaluated and NOT delivered — exactly what MainWindow does every sweep while a server is
+           acknowledged or silenced. */
+        Assert.Single(e.EvaluateReplicas(ServerId, new[] { Replica(connected: "DISCONNECTED") }, Refire));
+
+        /* So nothing consumed the window, and the next sweep still has something to say. Stamping on the
+           decision instead would spend window after window on alerts nobody received, and the operator
+           would come back from an acknowledgement to silence. */
+        now = now.AddMinutes(1);
+        var again = Assert.Single(e.EvaluateReplicas(ServerId, new[] { Replica(connected: "DISCONNECTED") }, Refire));
+        Assert.Contains("STILL DISCONNECTED", again.DetailText, StringComparison.Ordinal);
+
+        /* Delivered this time, so the clock finally starts. */
+        e.NoteDelivered(again);
+        now = now.AddMinutes(1);
+        Assert.Empty(e.EvaluateReplicas(ServerId, new[] { Replica(connected: "DISCONNECTED") }, Refire));
+    }
+
+    [Fact]
+    public void DisconnectRefire_ReconnectClearsTheClock_SoTheNextOutageIsNotHeldQuietByTheLastOnes()
+    {
+        var now = Noon;
+        var e = new AgAlertEvaluator(() => now);
+
+        e.EvaluateReplicas(ServerId, new[] { Replica(connected: "CONNECTED") }, Refire);
+        e.NoteDelivered(Assert.Single(e.EvaluateReplicas(ServerId, new[] { Replica(connected: "DISCONNECTED") }, Refire)));
+
+        now = now.AddMinutes(1);
+        Assert.True(Assert.Single(e.EvaluateReplicas(ServerId, new[] { Replica(connected: "CONNECTED") }, Refire)).IsResolution);
+
+        /* A second outage a minute later whose opening edge is suppressed. With the clock cleared the next
+           sweep re-announces; with the first episode's stamp still on it, this replica would sit silent for
+           the remaining eight minutes of a window that belongs to an outage already over. */
+        now = now.AddMinutes(1);
+        Assert.Single(e.EvaluateReplicas(ServerId, new[] { Replica(connected: "DISCONNECTED") }, Refire));
+
+        now = now.AddMinutes(1);
+        var again = Assert.Single(e.EvaluateReplicas(ServerId, new[] { Replica(connected: "DISCONNECTED") }, Refire));
+        Assert.Contains("STILL DISCONNECTED", again.DetailText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DisconnectRefire_EachReplicaKeepsItsOwnClock()
+    {
+        var now = Noon;
+        var e = new AgAlertEvaluator(() => now);
+
+        e.EvaluateReplicas(ServerId, new[]
+        {
+            Replica(connected: "CONNECTED", replica: "NODE2"),
+            Replica(connected: "CONNECTED", replica: "NODE3"),
+        }, Refire);
+
+        var lost = e.EvaluateReplicas(ServerId, new[]
+        {
+            Replica(connected: "DISCONNECTED", replica: "NODE2"),
+            Replica(connected: "DISCONNECTED", replica: "NODE3"),
+        }, Refire);
+        Assert.Equal(2, lost.Count);
+
+        /* Only NODE2's alert was delivered; NODE3's window is still open. */
+        Assert.Contains("NODE2", lost[0].DetailText, StringComparison.Ordinal);
+        e.NoteDelivered(lost[0]);
+
+        now = now.AddMinutes(1);
+        var again = Assert.Single(e.EvaluateReplicas(ServerId, new[]
+        {
+            Replica(connected: "DISCONNECTED", replica: "NODE2"),
+            Replica(connected: "DISCONNECTED", replica: "NODE3"),
+        }, Refire));
+        Assert.Contains("NODE3", again.DetailText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DisconnectRefire_Forget_DropsTheClockWithTheRestOfTheState()
+    {
+        var now = Noon;
+        var e = new AgAlertEvaluator(() => now);
+
+        e.EvaluateReplicas(ServerId, new[] { Replica(connected: "CONNECTED") }, Refire);
+        e.NoteDelivered(Assert.Single(e.EvaluateReplicas(ServerId, new[] { Replica(connected: "DISCONNECTED") }, Refire)));
+
+        e.Forget(ServerId);
+
+        /* Re-added a minute later: a first sighting again, and with re-fire on that announces rather than
+           baselining silently. A clock that survived Forget would hold it quiet for nine more minutes. */
+        now = now.AddMinutes(1);
+        var again = Assert.Single(e.EvaluateReplicas(ServerId, new[] { Replica(connected: "DISCONNECTED") }, Refire));
+        Assert.Contains("STILL DISCONNECTED", again.DetailText, StringComparison.Ordinal);
+    }
+
     /* ---------------- suspended ---------------- */
 
     [Fact]

--- a/Lite.Tests/AgAlertPolicyTests.cs
+++ b/Lite.Tests/AgAlertPolicyTests.cs
@@ -6,6 +6,7 @@
  * Licensed under the MIT License. See LICENSE file in the project root for full license information.
  */
 
+using System;
 using PerformanceMonitor.Common;
 using Xunit;
 
@@ -79,6 +80,102 @@ public class AgAlertPolicyTests
     {
         Assert.Equal(AgConnectionDecision.None, AgAlertPolicy.DecideConnection(null, "DISCONNECTED"));
         Assert.Equal(AgConnectionDecision.Reconnected, AgAlertPolicy.DecideConnection("DISCONNECTED", "CONNECTED"));
+    }
+
+    /* ---------------- #2426: the disconnect re-fire ---------------- */
+
+    private static readonly DateTime Noon = new(2026, 8, 20, 12, 0, 0, DateTimeKind.Utc);
+
+    [Theory]
+    [InlineData("CONNECTED", "DISCONNECTED", AgConnectionDecision.Disconnected)]
+    [InlineData("DISCONNECTED", "CONNECTED", AgConnectionDecision.Reconnected)]
+    [InlineData("DISCONNECTED", "DISCONNECTED", AgConnectionDecision.None)]
+    [InlineData("CONNECTED", "CONNECTED", AgConnectionDecision.None)]
+    [InlineData(null, "DISCONNECTED", AgConnectionDecision.None)]
+    [InlineData("CONNECTED", null, AgConnectionDecision.None)]
+    public void DecideConnection_RefireOff_IsTheEdgeOnlyOverloadExactly(
+        string? previous, string? current, AgConnectionDecision expected)
+    {
+        /* The shipped default, and the whole matrix rather than one case: null, zero and a negative all
+           mean OFF, and off has to be byte-for-byte the two-argument behavior or an upgrade would start
+           re-alerting on a knob nobody set. */
+        Assert.Equal(expected, AgAlertPolicy.DecideConnection(previous, current, null, null, Noon));
+        Assert.Equal(expected, AgAlertPolicy.DecideConnection(previous, current, TimeSpan.Zero, null, Noon));
+        Assert.Equal(expected, AgAlertPolicy.DecideConnection(previous, current, TimeSpan.FromMinutes(-5), null, Noon));
+    }
+
+    [Fact]
+    public void DecideConnection_StillDisconnected_WaitsOutTheWindow_ThenSaysItAgain()
+    {
+        var refire = TimeSpan.FromMinutes(10);
+
+        /* Announced at noon: inside the window there is nothing new to say. */
+        Assert.Equal(
+            AgConnectionDecision.None,
+            AgAlertPolicy.DecideConnection("DISCONNECTED", "DISCONNECTED", refire, Noon, Noon.AddMinutes(9)));
+
+        /* At the boundary, and still hours later — the point of the knob is that a week-long outage does
+           not read like a blip. */
+        Assert.Equal(
+            AgConnectionDecision.StillDisconnected,
+            AgAlertPolicy.DecideConnection("DISCONNECTED", "DISCONNECTED", refire, Noon, Noon.AddMinutes(10)));
+        Assert.Equal(
+            AgConnectionDecision.StillDisconnected,
+            AgAlertPolicy.DecideConnection("DISCONNECTED", "DISCONNECTED", refire, Noon, Noon.AddHours(8)));
+    }
+
+    [Fact]
+    public void DecideConnection_ARealEdgeOutranksARefire()
+    {
+        var refire = TimeSpan.FromMinutes(10);
+
+        /* The edge that OPENS the outage announces as Disconnected even though the window is trivially due
+           on it, or the caller would have two reasons to announce the same sweep. */
+        Assert.Equal(
+            AgConnectionDecision.Disconnected,
+            AgAlertPolicy.DecideConnection("CONNECTED", "DISCONNECTED", refire, null, Noon));
+
+        /* And a recovery is a recovery whatever the clock says. */
+        Assert.Equal(
+            AgConnectionDecision.Reconnected,
+            AgAlertPolicy.DecideConnection("DISCONNECTED", "CONNECTED", refire, Noon.AddHours(-9), Noon));
+    }
+
+    [Fact]
+    public void DecideConnection_NoStampIsDueNow_SoARestartMidOutageStillReAnnounces()
+    {
+        var refire = TimeSpan.FromMinutes(10);
+
+        /* Both apps hold this edge state in memory, so a restart during a week-long outage sees a replica
+           already DISCONNECTED with no record of it ever having been announced. Rule 1's silent baseline
+           would make that silence permanent, which is the exact failure the knob exists to prevent — so
+           with re-fire ON, and only then, a first sighting announces. */
+        Assert.Equal(
+            AgConnectionDecision.StillDisconnected,
+            AgAlertPolicy.DecideConnection(null, "DISCONNECTED", refire, null, Noon));
+        Assert.Equal(
+            AgConnectionDecision.StillDisconnected,
+            AgAlertPolicy.DecideConnection("DISCONNECTED", "DISCONNECTED", refire, null, Noon));
+
+        /* With it off, rule 1 governs unchanged. */
+        Assert.Equal(
+            AgConnectionDecision.None,
+            AgAlertPolicy.DecideConnection(null, "DISCONNECTED", null, null, Noon));
+    }
+
+    [Fact]
+    public void DecideConnection_ARefireStillNeedsAnExactDisconnected()
+    {
+        var refire = TimeSpan.FromMinutes(10);
+
+        /* Same rule the edge follows, and it matters more here: a re-fire pages repeatedly, so a state
+           string the product never learned to interpret must not become a standing page. */
+        Assert.Equal(
+            AgConnectionDecision.None,
+            AgAlertPolicy.DecideConnection("SOMETHING_NEW", "SOMETHING_NEW", refire, null, Noon));
+        Assert.Equal(
+            AgConnectionDecision.None,
+            AgAlertPolicy.DecideConnection("CONNECTED", null, refire, null, Noon));
     }
 
     /* ---------------- suspension ---------------- */

--- a/Lite.Tests/McpAlertSettingsKeyTests.cs
+++ b/Lite.Tests/McpAlertSettingsKeyTests.cs
@@ -141,13 +141,14 @@ public sealed class McpAlertSettingsKeyTests
     /// rather than a loosened assertion. Each entry is paid for by a test asserting the omission is still
     /// real, so an exemption cannot outlive its reason.
     ///
-    /// <para><c>ag.disconnect_refire_minutes</c> is Darling's #1696 / store-V37 knob. Lite's AG work
-    /// (#1726) mirrored three of those four knobs and has no re-fire at all — no static, no settings.json
-    /// key, no edge state that could re-announce a still-disconnected replica. Emitting it as a constant 0
-    /// would tell an agent it can tune something Lite cannot, which is the same reasoning that omits
-    /// self_alerts whole. Filed as #2426 — the exemption is the honest report of a gap, not the fix for
-    /// it.</para></summary>
-    private static readonly string[] LiteOmittedMembers = { "ag.disconnect_refire_minutes" };
+    /// <para>EMPTY, and the emptiness is asserted in
+    /// <see cref="GetAlertSettings_ReportsEveryGroupDarlingDoes_SpelledDarlingsWay"/> rather than merely
+    /// being true today. Its one entry was <c>ag.disconnect_refire_minutes</c>, Darling's #1696 /
+    /// store-V37 knob, which Lite had no equivalent for at all — no static, no settings.json key, and no
+    /// edge state that could re-announce a still-disconnected replica. #2426 built the re-fire, so the
+    /// exemption came out with it and all four AG members compare. The seam stays for the next such
+    /// case: adding an entry means writing the test that pays for it.</para></summary>
+    private static readonly string[] LiteOmittedMembers = Array.Empty<string>();
 
     /// <summary>
     /// Darling's <c>BuildAlertSettingsPayload</c> shape read out of Darling's SOURCE — each top-level key in
@@ -280,6 +281,11 @@ public sealed class McpAlertSettingsKeyTests
             problems.Count == 0,
             "Lite's get_alert_settings has drifted from Darling's shape: " + string.Join("; ", problems));
 
+        /* #2426: nothing is exempted today, and that is asserted rather than merely true — an entry added
+           to LiteOmittedMembers without the test that justifies it would silently narrow this comparison,
+           which is the drift this whole class exists to stop. */
+        Assert.Empty(LiteOmittedMembers);
+
         /* smtp is Lite's ONE addition — Lite delivers its own email where Darling manages delivery
            credentials outside the settings row. Pinned as an exact set so a second Lite-only group cannot be
            added without this test being the place someone justifies it. */
@@ -289,28 +295,35 @@ public sealed class McpAlertSettingsKeyTests
     }
 
     /// <summary>
-    /// The one MEMBER Lite deliberately does not report, asserted for the same reason its group-level
-    /// sibling below is: so the hole reads as a decision rather than the oversight it would otherwise look
-    /// like — and so the exemption cannot quietly outlive its reason. Both halves are asserted. Darling
-    /// must still emit it (otherwise the exemption is dead weight hiding a Darling regression), and Lite
-    /// must still not (otherwise the exemption is masking a key that has since arrived and could now be
-    /// compared).
+    /// #2426, and the inversion of the exemption that stood here: <c>ag.disconnect_refire_minutes</c> was
+    /// the one MEMBER Lite could not report, because it had no AG disconnect re-fire at all — a replica
+    /// disconnected for a week announced itself exactly once, where Darling re-announced it. Both halves
+    /// of the old exemption are now asserted the other way round. Darling must still emit it (or the
+    /// comparison is over a key nobody publishes), and Lite must too, carrying its own live value rather
+    /// than the constant 0 that was rejected for telling an agent it can tune something the app cannot.
     ///
-    /// <para>The gap itself is real and worth closing: Lite has no AG disconnect re-fire, so a replica
-    /// disconnected for a week is announced exactly once here where Darling can re-announce it. That is
-    /// #1696's Lite half, and it is a feature rather than a payload key — which is why this PR reports the
-    /// three knobs Lite really has instead of inventing a fourth. Filed as #2426.</para>
+    /// <para>The value assertion is the half that matters most and the half a key-presence check would
+    /// miss entirely: it is what distinguishes a real knob from the placeholder this PR exists to avoid
+    /// shipping.</para>
     /// </summary>
     [Fact]
-    public void GetAlertSettings_OmitsAgDisconnectRefire_WhichLiteHasNoEquivalentFor()
+    public void GetAlertSettings_ReportsAgDisconnectRefire_WithLitesOwnValue()
     {
-        var ag = DarlingPayloadShape().Single(g => g.Key == "ag").Value;
-        Assert.Contains("disconnect_refire_minutes", ag);
-        Assert.DoesNotContain("disconnect_refire_minutes", KeysOf(Settings().GetProperty("ag")));
+        var original = App.AgDisconnectRefireMinutes;
+        try
+        {
+            App.AgDisconnectRefireMinutes = 17;
 
-        /* Pinned as an exact set, so a second member-level exemption cannot be added without this test
-           being the place someone justifies it — the same guard the smtp assertion applies to groups. */
-        Assert.Equal(new[] { "ag.disconnect_refire_minutes" }, LiteOmittedMembers);
+            Assert.Contains("disconnect_refire_minutes", DarlingPayloadShape().Single(g => g.Key == "ag").Value);
+
+            var ag = Settings().GetProperty("ag");
+            Assert.Contains("disconnect_refire_minutes", KeysOf(ag));
+            Assert.Equal(17, ag.GetProperty("disconnect_refire_minutes").GetInt32());
+        }
+        finally
+        {
+            App.AgDisconnectRefireMinutes = original;
+        }
     }
 
     /// <summary>

--- a/Lite/App.xaml.cs
+++ b/Lite/App.xaml.cs
@@ -120,6 +120,14 @@ public partial class App : Application
     /// workload-dependent, and because a legitimate post-resume catch-up spike would otherwise page.</summary>
     public static long AgRedoQueueAlertKb { get; set; }
 
+    /// <summary>#2426: re-announce a replica that is STILL disconnected every N minutes (0 = off, the
+    /// shipped default, so nothing starts re-alerting on upgrade). "AG Replica Disconnected" is otherwise a
+    /// pure edge, which means a replica down for a week announces itself exactly once and a week-long outage
+    /// is indistinguishable from a momentary blip in the alert history. Re-fires deliver under the SAME
+    /// metric name so webhook automation keyed on it re-triggers. Darling's ag_disconnect_refire_minutes,
+    /// same 0-1440 clamp.</summary>
+    public static int AgDisconnectRefireMinutes { get; set; }
+
     public static bool AlertCpuEnabled { get; set; } = true;
     public static int AlertCpuThreshold { get; set; } = 80;
     /// <summary>Which CPU metric the alert evaluates against. Total = sql_server_cpu + other_process_cpu (matches OS user+system). SqlOnly = SQL Server scheduler %.</summary>
@@ -815,6 +823,7 @@ public partial class App : Application
             if (root.TryGetProperty("notify_ag_health", out v)) NotifyAgHealth = v.GetBoolean();
             if (root.TryGetProperty("ag_lag_alert_seconds", out v)) AgLagAlertSeconds = Math.Clamp(v.GetInt32(), 0, 86400);
             if (root.TryGetProperty("ag_redo_queue_alert_kb", out v)) AgRedoQueueAlertKb = Math.Clamp(v.GetInt64(), 0L, 1073741824L);
+            if (root.TryGetProperty("ag_disconnect_refire_minutes", out v)) AgDisconnectRefireMinutes = Math.Clamp(v.GetInt32(), 0, 1440);
             if (root.TryGetProperty("alert_cpu_enabled", out v)) AlertCpuEnabled = v.GetBoolean();
             if (root.TryGetProperty("alert_cpu_threshold", out v)) AlertCpuThreshold = v.GetInt32();
             if (root.TryGetProperty("alert_cpu_mode", out v) && Enum.TryParse<CpuAlertMode>(v.GetString(), out var mode))

--- a/Lite/MainWindow.AlertEngine.cs
+++ b/Lite/MainWindow.AlertEngine.cs
@@ -302,7 +302,12 @@ public partial class MainWindow : Window
             var (replicaTimeUtc, replicas) = await data.GetLatestAgReplicaStatesAsync(serverId);
             if (IsFresh(replicaTimeUtc))
             {
-                alerts.AddRange(_agAlertEvaluator.EvaluateReplicas(serverId, replicas));
+                alerts.AddRange(_agAlertEvaluator.EvaluateReplicas(
+                    serverId,
+                    replicas,
+                    App.AgDisconnectRefireMinutes > 0
+                        ? TimeSpan.FromMinutes(App.AgDisconnectRefireMinutes)
+                        : null));
             }
 
             var (databaseTimeUtc, databases) = await data.GetLatestAgDatabaseReplicaStatesAsync(serverId);
@@ -324,6 +329,12 @@ public partial class MainWindow : Window
             foreach (var alert in alerts)
             {
                 SendAgAlert(serverId, serverName, alert);
+
+                /* #2426: the re-fire window opens on DELIVERY, which is what the suppressed return above
+                   makes necessary — an acknowledged or silenced server still evaluates every sweep and
+                   sends nothing, and windows consumed by alerts nobody received would turn the re-fire back
+                   into the silence it exists to end. */
+                _agAlertEvaluator.NoteDelivered(alert);
             }
 
             bool IsFresh(DateTime? snapshotUtc) =>

--- a/Lite/Mcp/McpAlertTools.cs
+++ b/Lite/Mcp/McpAlertTools.cs
@@ -204,18 +204,16 @@ public sealed class McpAlertTools
                    are Darling's verbatim, including `enabled` for what the store calls notify_ag_health —
                    inside this payload `enabled` always means "this alert family is on".
 
-                   Darling reports a FOURTH member here, disconnect_refire_minutes (#1696, store V37), and
-                   it is deliberately absent: Lite has no AG disconnect re-fire at ALL — no static, no
-                   settings.json key, and no edge state that could re-announce — because #1726 mirrored
-                   three of those four knobs. Emitting a constant 0 would tell an agent it can tune
-                   something Lite cannot, which is exactly why self_alerts is omitted whole above. The
-                   omission is pinned by name in McpAlertSettingsKeyTests so it cannot outlive its
-                   reason, and the gap itself is filed as #2426. */
+                   disconnect_refire_minutes was the one member Lite could not honestly report, because
+                   #1726 mirrored three of Darling's four AG knobs and Lite had no re-fire at all — not the
+                   static, not the settings key, and not the edge state that could re-announce. #2426 built
+                   it, so the exemption that stood here is gone and all four members compare. */
                 ag = new
                 {
                     enabled = App.NotifyAgHealth,
                     lag_threshold_seconds = App.AgLagAlertSeconds,
-                    redo_queue_threshold_kb = App.AgRedoQueueAlertKb
+                    redo_queue_threshold_kb = App.AgRedoQueueAlertKb,
+                    disconnect_refire_minutes = App.AgDisconnectRefireMinutes
                 },
                 cooldown_minutes = App.AlertCooldownMinutes,
                 excluded_databases = App.AlertExcludedDatabases,

--- a/Lite/Services/AgAlertEvaluator.cs
+++ b/Lite/Services/AgAlertEvaluator.cs
@@ -26,13 +26,19 @@ namespace PerformanceMonitorLite.Services;
 /// <param name="Context">Discrete facts for database-scoped alerts (#2109) — null for the replica-grain
 /// alerts and resolutions, which carry no database. Trailing optional so existing construction sites
 /// (and the tests that pin them) stay untouched.</param>
+/// <param name="RefireStampKey">Opaque token (#2426), non-null only on an alert whose DELIVERY opens a
+/// re-fire window. The caller hands it back through <see cref="AgAlertEvaluator.NoteDelivered"/> after
+/// sending, which is what keeps the window stamped on delivery rather than on the decision: Lite evaluates
+/// even while a server is acknowledged or silenced and simply does not send, and a suppressed alert must not
+/// consume a window it was never announced in.</param>
 public readonly record struct AgAlert(
     string MetricName,
     string CurrentValue,
     string ThresholdValue,
     string DetailText,
     bool IsResolution,
-    AlertContext? Context = null);
+    AlertContext? Context = null,
+    string? RefireStampKey = null);
 
 /// <summary>
 /// Lite's Availability Group alert state machine (#1696) — the twin of Darling's
@@ -58,6 +64,7 @@ public sealed class AgAlertEvaluator
     private readonly Dictionary<string, string> _replicaConnectedState = new(StringComparer.Ordinal);
     private readonly Dictionary<string, bool> _databaseSuspended = new(StringComparer.Ordinal);
     private readonly Dictionary<string, DateTime> _lastSyncBehindAlert = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, DateTime> _lastDisconnectAlert = new(StringComparer.Ordinal);
     private readonly HashSet<string> _activeSyncBehind = new(StringComparer.Ordinal);
 
     private readonly Func<DateTime> _utcNow;
@@ -68,7 +75,13 @@ public sealed class AgAlertEvaluator
     /// The replica-grain conditions for one server: "AG Failover" and the disconnect/reconnect pair. Both are
     /// pure transitions per ag+replica, and the FIRST sighting of a replica is a silent baseline.
     /// </summary>
-    public List<AgAlert> EvaluateReplicas(int serverId, IReadOnlyList<AgReplicaReading> replicas)
+    /// <param name="disconnectRefireInterval">#2426: how often to re-announce a replica that is STILL
+    /// disconnected. Null (the shipped default) is edge-only — one alert per outage, however long it lasts.
+    /// The re-fire decision is the shared policy's, and the one departure from the silent-baseline rule is
+    /// documented there: with re-fire on, a replica already down at first sighting announces, because Lite's
+    /// AG state is in-memory and would otherwise let a restart silence a standing outage permanently.</param>
+    public List<AgAlert> EvaluateReplicas(
+        int serverId, IReadOnlyList<AgReplicaReading> replicas, TimeSpan? disconnectRefireInterval = null)
     {
         var alerts = new List<AgAlert>();
         if (replicas is null)
@@ -105,25 +118,47 @@ public sealed class AgAlertEvaluator
             if (!string.IsNullOrEmpty(replica.ConnectedStateDesc))
             {
                 _replicaConnectedState.TryGetValue(key, out var previousState);
-                var decision = AgAlertPolicy.DecideConnection(previousState, replica.ConnectedStateDesc);
+                var decision = AgAlertPolicy.DecideConnection(
+                    previousState,
+                    replica.ConnectedStateDesc,
+                    disconnectRefireInterval,
+                    _lastDisconnectAlert.TryGetValue(key, out var lastDisconnect) ? lastDisconnect : null,
+                    _utcNow());
                 _replicaConnectedState[key] = replica.ConnectedStateDesc!;
 
-                if (decision == AgConnectionDecision.Disconnected)
+                if (decision is AgConnectionDecision.Disconnected or AgConnectionDecision.StillDisconnected)
                 {
+                    /* #2426: a re-fire is the SAME metric name and the same guidance — webhook automation
+                       keyed on it is what the re-fire exists to re-trigger — and differs only in saying so,
+                       because an operator reading the alert history has no other way to tell a fresh outage
+                       from the sixth hour of one. The wording matches the connection re-fire's. */
+                    var opening = decision == AgConnectionDecision.StillDisconnected
+                        ? $"Availability Group '{replica.AgName}': replica {replica.ReplicaServerName} is STILL " +
+                          $"DISCONNECTED from the primary (re-alerting every " +
+                          $"{((int)disconnectRefireInterval!.Value.TotalMinutes).ToString(CultureInfo.InvariantCulture)} min)."
+                        : $"Availability Group '{replica.AgName}': replica {replica.ReplicaServerName} is DISCONNECTED " +
+                          "from the primary.";
+
                     alerts.Add(new AgAlert(
                         AgAlertPolicy.ReplicaDisconnectedMetric,
                         replica.ConnectedStateDesc!,
                         "CONNECTED",
-                        $"Availability Group '{replica.AgName}': replica {replica.ReplicaServerName} is DISCONNECTED " +
-                        "from the primary. A disconnected replica receives no log at all, so it falls further behind " +
+                        opening +
+                        " A disconnected replica receives no log at all, so it falls further behind " +
                         "every second and cannot be failed over to without losing whatever the primary has committed " +
                         "since. If it is a synchronous-commit replica, the primary also loses its automatic-failover " +
                         "partner. Check the replica's SQL Server service, the availability endpoint (TCP 5022 by " +
                         "default) and its firewall rule, the WSFC quorum, and the network between the nodes.",
-                        IsResolution: false));
+                        IsResolution: false,
+                        RefireStampKey: key));
                 }
                 else if (decision == AgConnectionDecision.Reconnected)
                 {
+                    /* The clock is cleared on the RECONNECT decision rather than on the resolution's
+                       delivery: once the replica is back there is nothing left to re-announce, so a stamp
+                       surviving a suppressed reconnect notice could only mis-date the NEXT outage — which
+                       announces on its own edge regardless. */
+                    _lastDisconnectAlert.Remove(key);
                     alerts.Add(new AgAlert(
                         AgAlertPolicy.ReplicaReconnectedMetric,
                         replica.ConnectedStateDesc!,
@@ -256,6 +291,26 @@ public sealed class AgAlertEvaluator
         return alerts;
     }
 
+    /// <summary>
+    /// Opens the re-fire window for an alert the caller actually SENT (#2426). Alerts with no
+    /// <see cref="AgAlert.RefireStampKey"/> are ignored, so the caller can hand every alert back without
+    /// caring which ones carry a window.
+    ///
+    /// <para>Deliberately the caller's call rather than something the evaluator does while deciding, and it
+    /// is the same split Lite's connection re-fire already uses (<c>_lastConnectionDownAlertUtc</c> is
+    /// stamped beside <c>SendConnectionAlert</c>, not inside the policy). Lite evaluates AG health on every
+    /// sweep but skips delivery while a server is acknowledged or silenced; stamping at decision time would
+    /// let those suppressed sweeps eat window after window, and the operator would come back from an
+    /// acknowledgement to silence rather than to a re-announcement.</para>
+    /// </summary>
+    public void NoteDelivered(AgAlert alert)
+    {
+        if (alert.RefireStampKey is string key)
+        {
+            _lastDisconnectAlert[key] = _utcNow();
+        }
+    }
+
     /// <summary>Drops all AG state for a server removed from the monitored list, so a later re-add starts at a
     /// fresh baseline rather than inheriting a stale role and paging a phantom failover.</summary>
     public void Forget(int serverId)
@@ -265,6 +320,7 @@ public sealed class AgAlertEvaluator
         ForgetByPrefix(_replicaConnectedState, prefix);
         ForgetByPrefix(_databaseSuspended, prefix);
         ForgetByPrefix(_lastSyncBehindAlert, prefix);
+        ForgetByPrefix(_lastDisconnectAlert, prefix);
         _activeSyncBehind.RemoveWhere(k => k.StartsWith(prefix, StringComparison.Ordinal));
     }
 

--- a/Lite/Windows/SettingsWindow.xaml
+++ b/Lite/Windows/SettingsWindow.xaml
@@ -207,6 +207,14 @@
                     <TextBlock Text="KB (0 = off)" VerticalAlignment="Center" Margin="4,0,0,0"
                                Foreground="{DynamicResource ForegroundBrush}"/>
                 </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="36,4,0,0"
+                            ToolTip="0 = off (one alert per outage). Re-alerts use the same 'AG Replica Disconnected' metric name, so webhook automation keyed on it re-triggers.">
+                    <TextBlock Text="Re-alert while a replica is still disconnected every" VerticalAlignment="Center"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                    <TextBox x:Name="AgDisconnectRefireMinutesBox" Width="45" Text="0" Margin="6,0,0,0" VerticalAlignment="Center"/>
+                    <TextBlock Text="min (0 = off)" VerticalAlignment="Center" Margin="4,0,0,0"
+                               Foreground="{DynamicResource ForegroundBrush}"/>
+                </StackPanel>
                 <StackPanel Orientation="Horizontal" Margin="20,6,0,0">
                     <CheckBox x:Name="AlertCpuCheckBox" Content="CPU above" VerticalAlignment="Center"
                               Foreground="{DynamicResource ForegroundBrush}"/>

--- a/Lite/Windows/SettingsWindow.xaml.cs
+++ b/Lite/Windows/SettingsWindow.xaml.cs
@@ -628,6 +628,7 @@ public partial class SettingsWindow : Window
         NotifyAgHealthCheckBox.IsChecked = App.NotifyAgHealth;
         AgLagAlertSecondsBox.Text = App.AgLagAlertSeconds.ToString();
         AgRedoQueueAlertKbBox.Text = App.AgRedoQueueAlertKb.ToString();
+        AgDisconnectRefireMinutesBox.Text = App.AgDisconnectRefireMinutes.ToString();
         AlertCpuCheckBox.IsChecked = App.AlertCpuEnabled;
         AlertCpuThresholdBox.Text = App.AlertCpuThreshold.ToString();
         AlertCpuModeBox.SelectedIndex = App.AlertCpuMode == CpuAlertMode.SqlOnly ? 1 : 0;
@@ -706,6 +707,8 @@ public partial class SettingsWindow : Window
             App.AgLagAlertSeconds = Math.Clamp(agLag, 0, 86400);
         if (long.TryParse(AgRedoQueueAlertKbBox.Text, out var agRedo))
             App.AgRedoQueueAlertKb = Math.Clamp(agRedo, 0L, 1073741824L);
+        if (int.TryParse(AgDisconnectRefireMinutesBox.Text, out var agRefire))
+            App.AgDisconnectRefireMinutes = Math.Clamp(agRefire, 0, 1440);
         App.AlertCpuEnabled = AlertCpuCheckBox.IsChecked == true;
         if (int.TryParse(AlertCpuThresholdBox.Text, out var cpu) && cpu > 0 && cpu <= 100)
             App.AlertCpuThreshold = cpu;
@@ -809,6 +812,7 @@ public partial class SettingsWindow : Window
         root["notify_ag_health"] = App.NotifyAgHealth;
         root["ag_lag_alert_seconds"] = App.AgLagAlertSeconds;
         root["ag_redo_queue_alert_kb"] = App.AgRedoQueueAlertKb;
+        root["ag_disconnect_refire_minutes"] = App.AgDisconnectRefireMinutes;
         root["alert_cpu_enabled"] = App.AlertCpuEnabled;
         root["alert_cpu_threshold"] = App.AlertCpuThreshold;
         root["alert_cpu_mode"] = App.AlertCpuMode.ToString();

--- a/Lite/config/settings.sample.json
+++ b/Lite/config/settings.sample.json
@@ -39,6 +39,10 @@
   "notify_ag_health": true,
   "ag_lag_alert_seconds": 300,          // clamped 0-86400
   "ag_redo_queue_alert_kb": 0,          // 0 = off; clamped 0-1073741824
+  // 0 = one alert per outage. Above 0, a replica that is STILL disconnected is re-announced
+  // this often, under the same "AG Replica Disconnected" metric name, so webhook automation
+  // keyed on it re-triggers instead of hearing about a week-long outage exactly once.
+  "ag_disconnect_refire_minutes": 0,    // 0 = off; clamped 0-1440
 
   // ---- CPU ---------------------------------------------------------------------------
   "alert_cpu_enabled": true,

--- a/PerformanceMonitor.Common/AgAlertPolicy.cs
+++ b/PerformanceMonitor.Common/AgAlertPolicy.cs
@@ -66,6 +66,12 @@ public enum AgConnectionDecision
 
     /// <summary>Came back to CONNECTED from a known-disconnected state.</summary>
     Reconnected,
+
+    /// <summary>A standing disconnect re-announcement (#1696, opt-in): the replica is still
+    /// DISCONNECTED and the re-fire interval has elapsed since the last disconnect alert. Callers deliver
+    /// this under the SAME metric name as <see cref="Disconnected"/> — webhook automation matches on the
+    /// metric name, and re-triggering it is the entire point of a re-fire.</summary>
+    StillDisconnected,
 }
 
 /// <summary>What one <c>is_suspended</c> observation should announce, if anything.</summary>
@@ -238,6 +244,55 @@ public static class AgAlertPolicy
         }
 
         return !now && was ? AgConnectionDecision.Reconnected : AgConnectionDecision.None;
+    }
+
+    /// <summary>
+    /// The same connection decision with the #1696 re-fire folded in: an "AG Replica Disconnected" that
+    /// nothing clears is otherwise a PURE EDGE, so a replica down for a week announces itself exactly once
+    /// and a week-long outage reads identically to a momentary blip in the alert history.
+    ///
+    /// <para>Both apps call THIS overload rather than each pairing the edge decision with its own
+    /// still-disconnected test — the combination is the part with the sharp corners (a re-fire must not
+    /// double up with the edge that just fired, and an unrecognized state string must not count as down),
+    /// and it is exactly the kind of condition that drifts when it is written twice.</para>
+    ///
+    /// <para><b>Where this deliberately departs from rule 1.</b> With re-fire ON, a FIRST sighting of an
+    /// already-disconnected replica returns <see cref="AgConnectionDecision.StillDisconnected"/> rather than
+    /// the silent baseline rule 1 otherwise mandates. That is on purpose and it is what the knob is for: both
+    /// apps hold this edge state in memory, so every restart re-baselines, and under rule 1 alone a restart
+    /// in the middle of a week-long outage would silence it permanently — the opt-in would fail precisely in
+    /// the case it exists for. It is the AG family's equivalent of
+    /// <see cref="ConnectionAlertDecision.AlreadyDownAtFirstSight"/>, folded into the one knob instead of
+    /// given a second one, because a re-fire interval already IS the operator saying "keep telling me".
+    /// Rule 1 still governs the pure edge: at the shipped default of off, a first sighting is silent.</para>
+    /// </summary>
+    /// <param name="refireInterval">How often to re-announce a still-disconnected replica. Null or
+    /// non-positive = off, which is byte-for-byte the two-argument overload's edge-only behavior.</param>
+    /// <param name="lastDisconnectAlertUtc">When this replica's disconnect was last ANNOUNCED, or null if it
+    /// never has been. Callers stamp it on every Disconnected / StillDisconnected they DELIVER — never on the
+    /// decision, or an alert a master switch suppressed would consume a window it was never announced in —
+    /// and clear it on Reconnected so a later outage starts a fresh episode instead of re-firing late.</param>
+    /// <param name="nowUtc">The caller's clock, injected so the decision pins under test.</param>
+    public static AgConnectionDecision DecideConnection(
+        string? previousStateDesc,
+        string? currentStateDesc,
+        TimeSpan? refireInterval,
+        DateTime? lastDisconnectAlertUtc,
+        DateTime nowUtc)
+    {
+        var edge = DecideConnection(previousStateDesc, currentStateDesc);
+
+        /* A real transition wins outright: the Disconnected edge already announces, and a Reconnected one
+           means there is nothing left to re-announce. Only the quiet cases can become a re-fire, and only
+           when the current reading is one this product recognizes as down. */
+        if (edge != AgConnectionDecision.None || !IsDisconnected(currentStateDesc))
+        {
+            return edge;
+        }
+
+        return AlertRefireWindow.IsDue(refireInterval, lastDisconnectAlertUtc, nowUtc)
+            ? AgConnectionDecision.StillDisconnected
+            : AgConnectionDecision.None;
     }
 
     /// <summary>

--- a/PerformanceMonitor.Common/AlertRefireWindow.cs
+++ b/PerformanceMonitor.Common/AlertRefireWindow.cs
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+
+namespace PerformanceMonitor.Common;
+
+/// <summary>
+/// The one definition of "has this standing condition gone unannounced long enough to say it again" — the
+/// #1659 / #1674 re-fire window, shared by <see cref="ConnectionAlertPolicy"/> and
+/// <see cref="AgAlertPolicy"/>.
+///
+/// <para>Three lines, and extracted anyway because it had already been written twice and #2426 was about to
+/// write it a third time. The two rules worth having in one place are the ones that are easy to get subtly
+/// wrong from memory: a non-positive interval means OFF rather than "every sweep", and a NULL last-alert
+/// stamp means DUE NOW rather than "never announced, so stay quiet". The second is the one that carries a
+/// standing outage across a restart — an app that re-baselines its edge state on launch has no stamp for a
+/// condition that was already true, and treating that as not-due would silence exactly the week-long outage
+/// re-firing exists to keep announcing.</para>
+///
+/// <para>Pure: the caller passes its own clock and owns the stamp. The stamp belongs on DELIVERY, never on
+/// the decision — an alert a master switch or an acknowledgement suppressed must not consume the window it
+/// was never announced in.</para>
+/// </summary>
+public static class AlertRefireWindow
+{
+    /// <param name="interval">The configured re-fire interval. Null or non-positive = off.</param>
+    /// <param name="lastAlertUtc">When this condition was last ANNOUNCED, or null if it never has been.</param>
+    /// <param name="nowUtc">The caller's clock, injected so the decision pins under test.</param>
+    public static bool IsDue(TimeSpan? interval, DateTime? lastAlertUtc, DateTime nowUtc) =>
+        interval is TimeSpan window
+        && window > TimeSpan.Zero
+        && (lastAlertUtc is not DateTime last || nowUtc - last >= window);
+}

--- a/PerformanceMonitor.Common/ConnectionAlertPolicy.cs
+++ b/PerformanceMonitor.Common/ConnectionAlertPolicy.cs
@@ -87,9 +87,11 @@ public static class ConnectionAlertPolicy
             return ConnectionAlertDecision.Restored;
         }
 
+        /* #2426: the window predicate is AlertRefireWindow's, not a fourth line of this method — the
+           AG re-fire needs the identical "non-positive is off, no stamp is due now" rules, and a second
+           hand-written copy of them is how the two would eventually disagree. */
         if (previousOnline == false && !online
-            && refireInterval is TimeSpan interval && interval > TimeSpan.Zero
-            && (lastDownAlertUtc is not DateTime last || nowUtc - last >= interval))
+            && AlertRefireWindow.IsDue(refireInterval, lastDownAlertUtc, nowUtc))
         {
             return ConnectionAlertDecision.StillDown;
         }


### PR DESCRIPTION
Closes #2426.

`AG Replica Disconnected` is a pure edge in Lite, so a replica that goes down and stays down is announced exactly once. A week-long outage reads identically to a momentary blip in the alert history, and no setting in the app changes that. Darling has had `ag_disconnect_refire_minutes` since #1696; #1726 mirrored three of Darling's four AG knobs into Lite and stopped, correctly at the time, because Darling's fourth landed later.

## This was not supply-a-setting

`AgAlertPolicy` is already shared, which makes it tempting to read the gap as a missing config key. It is not. The file's own discipline is that pure decisions live in the policy while each app owns its edge STATE and its delivery, and a re-fire is made of exactly the two halves Lite did not have: a clock per ag+replica, and something that consumes it. The setting is the small part.

## What moved into the shared policy, and why

Darling computed "still disconnected" as a five-clause expression sitting next to its dictionaries. Writing Lite's copy of that expression would have been the second one, and the clauses with sharp corners are not the arithmetic — they are that a re-fire must never double up with the edge that just fired, and that an unrecognized `connected_state_desc` must not become a standing page any more than it may become a single one. Both apps now call one `DecideConnection` overload that returns `StillDisconnected`; what stays app-side is what genuinely is app-shaped, the stamp and the delivery it is stamped on.

That is also the answer to the `ConnectionRefireMinutes` question the issue left open. The two re-fires are **not** one mechanism and are not merged — one is per server off a live connection probe, the other per ag+replica off a collected snapshot. But the WINDOW is the same three-line predicate carrying the same two rules that are easy to misremember: a non-positive interval is off, and a missing stamp is due **now** rather than never-announced-so-stay-quiet. That second rule is what carries a standing outage across a restart, and it was about to be written a third time, so it is `AlertRefireWindow` and `ConnectionAlertPolicy` calls it too.

## The one deliberate departure from rule 1

With re-fire ON, a replica already disconnected the first time it is seen announces rather than baselining silently. Both apps hold this state in memory, so every restart re-baselines; under the silent-baseline rule alone, a restart during a week-long outage would silence it permanently — the opt-in would fail in precisely the case it exists for. Darling has behaved this way since #1696. Stating it in the shared policy is the change, not the behavior.

## Delivery-stamped, on purpose

Lite's stamp is the caller's, beside the send, matching the split its connection re-fire already uses. Lite evaluates AG health on every sweep and skips delivery while a server is acknowledged or silenced, so stamping at decision time would spend window after window on alerts nobody received, and the operator would come back from an acknowledgement to silence rather than to a re-announcement.

## The #2417 exemption comes out with it

`ag.disconnect_refire_minutes` was exempted by name in `McpAlertSettingsKeyTests` with a test asserting both halves of the omission. Both halves are now asserted the other way round: Darling still emits it, and Lite emits it too, carrying its own live value rather than the constant `0` that was rejected for telling an agent it can tune something the app cannot. `LiteOmittedMembers` is empty, and the emptiness is asserted in the parity test rather than merely being true, so the next exemption still has to be justified in that file.

## Verification

The Windows suites cannot run on macOS, so the real test files were compiled into a `net10.0` xUnit-shim harness against the real projects.

- **Most of the new tests cannot be expressed against `dev` at all.** Compiling them against `dev`'s sources fails naming `StillDisconnected`, the five-argument `DecideConnection`, the three-argument `EvaluateReplicas` and `NoteDelivered` as missing.
- **One IS expressible and is red on dev**: the review-driven assertion that Darling's re-fire says so in the `DetailText` it actually stores. Against dev that reads the generic disconnect notice, byte-identical to the first announcement.
- **66 cases pass against this branch** (`AgAlertPolicyTests`, `AgAlertEvaluatorTests`, `ConnectionAlertPolicyTests`), plus Darling's 36 AG self-alert tests.
- **Both behavior-preservation claims were checked by running the UNCHANGED suites on each branch through the same harness.** Darling's 36 AG self-alert tests (`DarlingSelfAlertTests`) and the 11 `ConnectionAlertPolicy` tests produce byte-identical results either side of the refactor.

`SettingsSampleTests` is satisfied: `ag_disconnect_refire_minutes` is documented in `Lite/config/settings.sample.json` beside the AG knobs it belongs with.

## Review round

`claude[bot]` found a parity drift this PR introduced, and it was real. Darling has branched only its `shortMessage` on the AG re-fire since #1696, and `shortMessage` is the interactive toast body — `DarlingAlertDeliverer` forwards `DetailText` into `SendAndRecordAsync`, and `EmailTemplateBuilder` never consumes `ShortMessage` — so the history row and the email for the sixth re-announcement of a week-long outage read byte-identical to the first notice. Lite's new evaluator puts it in the detail because the detail is all Lite has, so the two SKUs would have disagreed about the same condition under the same metric name. Darling's own *connection* re-fire has baked it into `detail` since #1659, so the AG side was inconsistent with its own sibling too. Fixed, worded to match Lite word for word so both apps store identical text, and pinned in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
