### PR TITLE
One Save, one write, one answer (#2433)

### DIFF
--- a/Lite.Tests/SettingsFileGuardTests.cs
+++ b/Lite.Tests/SettingsFileGuardTests.cs
@@ -7,7 +7,9 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 using PerformanceMonitorLite.Services;
 using Xunit;
@@ -283,53 +285,91 @@ public sealed class SettingsFileGuardTests
 }
 
 /// <summary>
-/// The category guard behind #2425, rather than the instance. The defect was never "WriteSetting is
-/// wrong" — it was that five separate methods each rolled their own read of settings.json in front of a
-/// whole-document rewrite, so the safety of a Save depended on which method you happened to be in. A sixth
-/// written the same way tomorrow would be just as silent, and nothing but this would notice.
+/// The category guard behind #2425 and #2433, rather than the instance. The defect was never "WriteSetting
+/// is wrong" — it was that separate methods each rolled their own read of settings.json in front of their
+/// own whole-document rewrite, so the safety of a Save depended on which method you happened to be in, and
+/// so did whether anyone could find out afterwards that it had failed.
 ///
-/// <para>Source-parsing because the invariant is a wiring one: each write site must take the read that
-/// preserves what it cannot parse. A behavioral test can prove the guard works and still not notice a
-/// caller that never asks it.</para>
+/// <para>#2425 answered the first half by making every one of those reads the quarantining one. #2433
+/// answered the second by removing the reads and the writes: the Settings window opens the document once,
+/// hands it to all ten of its writers, and writes it once. So the invariant this guard pins is now
+/// stronger and simpler than counting reads against writes per file — settings.json has exactly ONE
+/// writer in the whole of Lite, and that writer takes the quarantining read.</para>
+///
+/// <para>Source-parsing because the invariant is a wiring one. A behavioral test can prove the guard works
+/// and still not notice a caller that never asks it.</para>
 /// </summary>
 public sealed class SettingsWriterQuarantineWiringTests
 {
-    public static TheoryData<string> WritingFiles() => new()
+    [Fact]
+    public void SettingsJson_HasExactlyOneWriterInAllOfLite()
     {
-        Path.Combine("Lite", "App.xaml.cs"),
-        Path.Combine("Lite", "Windows", "SettingsWindow.xaml.cs")
-    };
+        var writers = new List<string>();
+        var described = new List<string>();
+        var total = 0;
 
-    [Theory]
-    [MemberData(nameof(WritingFiles))]
-    public void EverySettingsJsonRewrite_TakesTheQuarantiningRead(string relativePath)
+        foreach (var file in LiteSourceFiles())
+        {
+            var rewrites = Regex.Matches(WithoutComments(File.ReadAllText(file)), @"File\.WriteAllText\(\s*settingsPath").Count;
+            if (rewrites == 0)
+            {
+                continue;
+            }
+
+            total += rewrites;
+            writers.Add(file);
+            described.Add($"{Path.GetFileName(file)} ({rewrites})");
+        }
+
+        Assert.True(total > 0,
+            "No settings.json rewrite found anywhere in Lite — this guard's anchor moved and it is testing nothing.");
+        Assert.True(total == 1,
+            $"{total} whole-document rewrite(s) of settings.json across {writers.Count} file(s): " +
+            string.Join(", ", described) + ". A second writer brings back both defects at once — a rewrite " +
+            "that reads the file itself can replace an unparseable settings.json without copying it aside " +
+            "(#2425), and a save split across several writes has no single honest answer to report (#2433).");
+        Assert.EndsWith("App.xaml.cs", writers[0], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheOneWriter_TakesTheQuarantiningRead()
     {
-        var source = File.ReadAllText(FindRepoFile(relativePath));
+        var source = File.ReadAllText(FindRepoFile(Path.Combine("Lite", "App.xaml.cs")));
 
-        var rewrites = Regex.Matches(source, @"File\.WriteAllText\(settingsPath").Count;
-        var guardedReads = Regex.Matches(source, @"[=(,]\s*(?:App\.)?SettingsRootForWrite\(\)").Count;
-
-        Assert.True(rewrites > 0,
-            $"{relativePath}: no settings.json rewrite found — this guard's anchor moved and it is testing nothing.");
-        Assert.True(rewrites == guardedReads,
-            $"{relativePath}: {rewrites} whole-document rewrite(s) of settings.json but {guardedReads} call(s) to " +
-            "App.SettingsRootForWrite(). A rewrite that reads the file itself will replace an unparseable " +
-            "settings.json without copying it aside first, which is #2425 all over again.");
+        Assert.Matches(new Regex(@"[=(,]\s*SettingsRootForWrite\(\)"), source);
     }
 
     /// <summary>
     /// The exact shape that made a non-object root a silent total overwrite: Parse returns null for the JSON
     /// literal null, the null-coalesce reads that as "no file", and the save replaces the document. Banned
-    /// outright so it cannot be reintroduced by copy-paste from a sibling writer.
+    /// across all of Lite so it cannot be reintroduced by copy-paste from a sibling writer.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(WritingFiles))]
-    public void NoWriter_FallsBackToAFreshDocumentOnAFailedParse(string relativePath)
+    [Fact]
+    public void NoWriter_FallsBackToAFreshDocumentOnAFailedParse()
     {
-        var source = File.ReadAllText(FindRepoFile(relativePath));
+        var banned = new Regex(@"JsonNode\.Parse\([^;]*\)\s*\?\?\s*new JsonObject\(\)");
 
-        Assert.DoesNotMatch(new Regex(@"JsonNode\.Parse\([^;]*\)\s*\?\?\s*new JsonObject\(\)"), source);
+        foreach (var file in LiteSourceFiles())
+        {
+            Assert.DoesNotMatch(banned, WithoutComments(File.ReadAllText(file)));
+        }
     }
+
+    /* Both scans run on code with the comments removed, and SettingsFileGuard is why: the one place that
+       explains WHY `JsonNode.Parse(json) ?? new JsonObject()` is banned has to quote it to explain it, and
+       a scanner that cannot tell a comment from code reads the explanation as the offence. Same trap as
+       #2418's key extractor, one file over. */
+    private static string WithoutComments(string source)
+    {
+        var withoutBlocks = Regex.Replace(source, @"/\*.*?\*/", "", RegexOptions.Singleline);
+        return Regex.Replace(withoutBlocks, @"//[^\r\n]*", "");
+    }
+
+    private static IEnumerable<string> LiteSourceFiles() =>
+        Directory.EnumerateFiles(FindRepoDirectory("Lite"), "*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                     && !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .OrderBy(f => f, StringComparer.Ordinal);
 
     private static string FindRepoFile(string relativePath)
     {
@@ -345,5 +385,21 @@ public sealed class SettingsWriterQuarantineWiringTests
         }
 
         throw new FileNotFoundException($"Could not locate {relativePath} walking up from {AppContext.BaseDirectory}");
+    }
+
+    private static string FindRepoDirectory(string relativePath)
+    {
+        var dir = AppContext.BaseDirectory;
+        for (var i = 0; i < 8 && dir is not null; i++)
+        {
+            var candidate = Path.Combine(dir, relativePath);
+            if (Directory.Exists(candidate) && File.Exists(Path.Combine(dir, "PerformanceMonitor.sln")))
+            {
+                return candidate;
+            }
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        throw new DirectoryNotFoundException($"Could not locate {relativePath} walking up from {AppContext.BaseDirectory}");
     }
 }

--- a/Lite.Tests/SettingsSaveReportTests.cs
+++ b/Lite.Tests/SettingsSaveReportTests.cs
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using PerformanceMonitorLite.Services;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// #2433. Lite's Settings window said "Settings saved." on a save that wrote nothing.
+///
+/// <para>Ten writers backed that one button and each rewrote the whole of settings.json behind its own
+/// catch. Seven returned <c>void</c> and could not report a write failure by construction; the three that
+/// returned something returned whether the BOXES validated, which is a different question. So the toast
+/// was shown whenever nothing objected, and "nothing objected" was never about whether a byte reached
+/// disk.</para>
+///
+/// <para>The repair was to remove the question rather than answer it: one read, ten mutators on one
+/// document, one write. That leaves a single ordering rule, which is what these pin — and the rule that
+/// matters is that a failed write outranks a validation objection. A writer that rejected a value has
+/// already raised its own dialog naming it; what the user has not been told, and can find out nowhere
+/// else, is that none of it was saved.</para>
+/// </summary>
+public sealed class SettingsSaveReportTests
+{
+    [Fact]
+    public void AnOrdinarySave_Reports_Saved()
+    {
+        Assert.Equal(
+            SettingsSaveOutcome.Saved,
+            SettingsSaveReport.Classify(documentWritten: true, mcpChanged: false,
+                alertsValid: true, mcpValid: true, webhooksValid: true));
+    }
+
+    [Fact]
+    public void AnMcpChange_AsksForARestart()
+    {
+        Assert.Equal(
+            SettingsSaveOutcome.SavedAndMcpNeedsRestart,
+            SettingsSaveReport.Classify(documentWritten: true, mcpChanged: true,
+                alertsValid: true, mcpValid: true, webhooksValid: true));
+    }
+
+    /// <summary>
+    /// The headline case. Everything on the page validated, so on dev this is exactly the state that
+    /// produced "Settings saved." over a save that wrote nothing at all.
+    /// </summary>
+    [Fact]
+    public void AFailedWrite_IsNeverReportedAsSaved()
+    {
+        Assert.Equal(
+            SettingsSaveOutcome.NothingWritten,
+            SettingsSaveReport.Classify(documentWritten: false, mcpChanged: false,
+                alertsValid: true, mcpValid: true, webhooksValid: true));
+    }
+
+    /// <summary>
+    /// And it stays the headline case when a writer ALSO objected. The objection has its own dialog; the
+    /// failed write does not, and it is the one that describes what happened to the other nine writers'
+    /// work. Ordering the other way round would leave the most important fact of the save unsaid.
+    /// </summary>
+    [Theory]
+    [InlineData(false, true, true)]
+    [InlineData(true, false, true)]
+    [InlineData(true, true, false)]
+    public void AFailedWrite_OutranksAValidationObjection(bool alertsValid, bool mcpValid, bool webhooksValid)
+    {
+        Assert.Equal(
+            SettingsSaveOutcome.NothingWritten,
+            SettingsSaveReport.Classify(documentWritten: false, mcpChanged: true,
+                alertsValid, mcpValid, webhooksValid));
+    }
+
+    /// <summary>
+    /// A rejected value suppresses the toast without claiming nothing was saved — because the rest of the
+    /// document DID reach disk. This is the arm that would be a lie under any of the three options #2433
+    /// listed that kept the writes separate.
+    /// </summary>
+    [Theory]
+    [InlineData(false, true, true)]
+    [InlineData(true, false, true)]
+    [InlineData(true, true, false)]
+    public void AnObjection_SuppressesTheToast_WithoutClaimingNothingWasSaved(
+        bool alertsValid, bool mcpValid, bool webhooksValid)
+    {
+        Assert.Equal(
+            SettingsSaveOutcome.WrittenWithObjections,
+            SettingsSaveReport.Classify(documentWritten: true, mcpChanged: false,
+                alertsValid, mcpValid, webhooksValid));
+    }
+}
+
+/// <summary>
+/// The category behind #2433 rather than the instance, and the companion to
+/// <see cref="SettingsWriterQuarantineWiringTests"/>'s one-writer pin: the Save button must ask whether the
+/// write happened before it is allowed to say anything, and none of its writers may go behind its back to
+/// settings.json.
+///
+/// <para>Source-parsing because the defect was a wiring one. Every individual writer was correct about the
+/// thing it knew; what was missing was any path from "the write failed" to the sentence the user reads.</para>
+/// </summary>
+public sealed class SettingsSaveButtonHonestyTests
+{
+    private static string SettingsWindowSource() =>
+        File.ReadAllText(FindRepoFile(Path.Combine("Lite", "Windows", "SettingsWindow.xaml.cs")));
+
+    /// <summary>
+    /// The toast is reachable only through the classifier, so a future edit cannot restore the old
+    /// "nothing objected, therefore say it saved" shortcut without deleting this.
+    /// </summary>
+    [Fact]
+    public void TheSaveButton_AsksTheClassifierBeforeItSaysAnything()
+    {
+        var body = MethodBody(SettingsWindowSource(), "SaveButton_Click");
+
+        Assert.Contains("App.WriteSettingsDocument(", body, StringComparison.Ordinal);
+        Assert.Contains("SettingsSaveReport.Classify(", body, StringComparison.Ordinal);
+
+        /* Every "Settings saved" string in the method must sit under a classifier arm; the only way to
+           check that cheaply is that the classify call comes first. */
+        var classify = body.IndexOf("SettingsSaveReport.Classify(", StringComparison.Ordinal);
+        var firstToast = body.IndexOf("Settings saved", StringComparison.Ordinal);
+        Assert.True(classify < firstToast,
+            "SaveButton_Click can reach \"Settings saved.\" without going through SettingsSaveReport.Classify, " +
+            "which is #2433: the toast is about whether the boxes validated rather than whether anything " +
+            "reached disk.");
+    }
+
+    /// <summary>
+    /// Each Save* the button calls takes the shared document. A writer that opened settings.json for itself
+    /// would be back to its own read, its own write and its own swallowed failure — one write is what makes
+    /// one answer possible.
+    /// </summary>
+    [Fact]
+    public void EveryWriterTheSaveButtonCalls_TakesTheSharedDocument()
+    {
+        var source = SettingsWindowSource();
+        var body = MethodBody(source, "SaveButton_Click");
+
+        var called = Regex.Matches(body, @"\b(Save[A-Za-z]+)\(root\)")
+            .Select(m => m.Groups[1].Value)
+            .ToList();
+
+        Assert.True(called.Count >= 9,
+            $"SaveButton_Click hands the shared document to only {called.Count} writer(s) — the rest are " +
+            "opening settings.json for themselves again.");
+
+        foreach (var name in called)
+        {
+            Assert.Matches(new Regex($@"\b{name}\(JsonNode root\)"), source);
+        }
+    }
+
+    private static string MethodBody(string source, string methodName)
+    {
+        var signature = source.IndexOf(methodName + "(", StringComparison.Ordinal);
+        Assert.True(signature >= 0, $"No method named {methodName} — this guard's anchor moved and it is testing nothing.");
+
+        var open = source.IndexOf('{', signature);
+        Assert.True(open >= 0, $"{methodName} has no body.");
+
+        var depth = 0;
+        for (var i = open; i < source.Length; i++)
+        {
+            if (source[i] == '{') depth++;
+            else if (source[i] == '}' && --depth == 0) return source[open..i];
+        }
+
+        throw new InvalidOperationException($"{methodName}'s body is unbalanced.");
+    }
+
+    private static string FindRepoFile(string relativePath)
+    {
+        var dir = AppContext.BaseDirectory;
+        for (var i = 0; i < 8 && dir is not null; i++)
+        {
+            var candidate = Path.Combine(dir, relativePath);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        throw new FileNotFoundException($"Could not locate {relativePath} walking up from {AppContext.BaseDirectory}");
+    }
+}

--- a/Lite.Tests/SettingsSaveReportTests.cs
+++ b/Lite.Tests/SettingsSaveReportTests.cs
@@ -160,6 +160,25 @@ public sealed class SettingsSaveButtonHonestyTests
         }
     }
 
+    /// <summary>
+    /// The window's other claim about a save, and the one that used to contradict the dialog. The theme
+    /// selector applies its choice LIVE, and <c>_saved</c> is what stops the close handlers reverting that
+    /// preview — so setting it on the click rather than on the write left an unpersisted theme applied for
+    /// the rest of the run while the dialog said nothing had been saved. It has to track the write.
+    /// </summary>
+    [Fact]
+    public void TheLiveThemePreview_OnlySurvivesASaveThatWrote()
+    {
+        var source = SettingsWindowSource();
+        var body = MethodBody(source, "SaveButton_Click");
+
+        Assert.Contains("_saved = written;", body, StringComparison.Ordinal);
+        Assert.DoesNotContain("_saved = true;", body, StringComparison.Ordinal);
+
+        /* And the gate it feeds is still there, so this cannot quietly stop meaning anything. */
+        Assert.Contains("if (!_saved)", source, StringComparison.Ordinal);
+    }
+
     private static string MethodBody(string source, string methodName)
     {
         var signature = source.IndexOf(methodName + "(", StringComparison.Ordinal);

--- a/Lite.Tests/SettingsSaveReportTests.cs
+++ b/Lite.Tests/SettingsSaveReportTests.cs
@@ -179,6 +179,49 @@ public sealed class SettingsSaveButtonHonestyTests
         Assert.Contains("if (!_saved)", source, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// The restart is a bigger claim than the toast, so it needs the same gate. MainWindow reads
+    /// <c>McpSettingsChanged</c> after <c>ShowDialog</c> and, when it is set, stops and restarts the MCP
+    /// server — dropping every connected client — then reloads the port from settings.json on DISK. Set on
+    /// the click rather than the write, a failed save produced a disruptive restart back onto the OLD
+    /// configuration, moments after the app had said nothing was saved.
+    /// </summary>
+    [Fact]
+    public void TheMcpRestart_OnlyFollowsASaveThatWrote()
+    {
+        var body = MethodBody(SettingsWindowSource(), "SaveButton_Click");
+
+        Assert.Contains("if (mcpChanged && written) McpSettingsChanged = true;", body, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Every mutator sits inside the guarded region, not just the read and the write.
+    ///
+    /// <para>Before the consolidation each writer carried its own try, so an exception thrown while BUILDING
+    /// a value — not only on the disk I/O — was caught, logged, and the remaining writers still ran.
+    /// Guarding only the ends would leave the mutators between them able to escape into the generic
+    /// "An error occurred" dispatcher dialog, which is precisely the class of silence this PR is about.
+    /// Nothing is written in that case either, and that is what the user should be told.</para>
+    /// </summary>
+    [Fact]
+    public void EveryMutator_SitsInsideTheGuardedRegion()
+    {
+        var body = MethodBody(SettingsWindowSource(), "SaveButton_Click");
+
+        var openTry = body.IndexOf("try", StringComparison.Ordinal);
+        var firstMutator = body.IndexOf("SaveMcpSettingsAsync(root)", StringComparison.Ordinal);
+        var lastMutator = body.IndexOf("SaveWebhookSettings(root)", StringComparison.Ordinal);
+        var theCatch = body.IndexOf("catch (Exception", StringComparison.Ordinal);
+
+        Assert.True(openTry >= 0 && firstMutator >= 0 && lastMutator >= 0 && theCatch >= 0,
+            "SaveButton_Click no longer has the shape this guard describes — its anchors moved and it is " +
+            "testing nothing.");
+        Assert.True(openTry < firstMutator && lastMutator < theCatch,
+            "A mutator sits outside SaveButton_Click's try, so an exception building a settings value " +
+            "escapes into App's generic unhandled-exception dialog instead of the honest \"Nothing was " +
+            "saved\" this method owes the user.");
+    }
+
     private static string MethodBody(string source, string methodName)
     {
         var signature = source.IndexOf(methodName + "(", StringComparison.Ordinal);

--- a/Lite/App.xaml.cs
+++ b/Lite/App.xaml.cs
@@ -1037,20 +1037,49 @@ public partial class App : Application
     }
 
     /// <summary>
+    /// The one place settings.json is written, and the one that answers whether the write happened (#2433).
+    ///
+    /// <para>Before this, five methods each ended in their own <c>File.WriteAllText</c> inside their own
+    /// catch, and not one of them could tell its caller anything. The Settings window said "Settings saved."
+    /// whether or not a single byte reached disk, because the only place the truth existed was the log, and
+    /// nobody reads a log after a dialog says it worked. A bool is the smallest thing that fixes that, and
+    /// having exactly one writer is what makes the bool mean something: there is no longer a save that
+    /// half happened.</para>
+    ///
+    /// <para><paramref name="what"/> names the thing being saved so the log line is about the operator's
+    /// action rather than about a filename.</para>
+    /// </summary>
+    internal static bool WriteSettingsDocument(JsonNode root, string what)
+    {
+        var settingsPath = Path.Combine(ConfigDirectory, "settings.json");
+
+        try
+        {
+            File.WriteAllText(settingsPath, root.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+            return true;
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error("Settings", $"Failed to save {what}: settings.json could not be written ({ex.Message})");
+            return false;
+        }
+    }
+
+    /// <summary>
     /// Applies <paramref name="mutate"/> to settings.json and writes it back indented; logs and swallows any
-    /// error under <paramref name="what"/>. Shared by the single-value Save* methods (and MainWindow's
-    /// Overview sort selector) so the read/merge/write/catch boilerplate lives in one place. The read is
+    /// error under <paramref name="what"/>. This is the SINGLE-VALUE path — MainWindow's Overview sort
+    /// selector and anything else that changes one knob outside the Settings window's Save button, which
+    /// opens the document once for all of its writers instead (#2433). The read is
     /// <see cref="SettingsRootForWrite"/>, which is what keeps an unparseable file from being replaced
     /// unrecorded.
     /// </summary>
     public static void WriteSetting(string what, Action<JsonNode> mutate)
     {
-        var settingsPath = Path.Combine(ConfigDirectory, "settings.json");
         try
         {
             JsonNode root = SettingsRootForWrite();
             mutate(root);
-            File.WriteAllText(settingsPath, root.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+            WriteSettingsDocument(root, what);
         }
         catch (Exception ex)
         {

--- a/Lite/Services/SettingsSaveReport.cs
+++ b/Lite/Services/SettingsSaveReport.cs
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+namespace PerformanceMonitorLite.Services;
+
+/// <summary>
+/// What the Settings window's Save button is entitled to say (#2433).
+/// </summary>
+public enum SettingsSaveOutcome
+{
+    /// <summary>settings.json could not be written. Nothing on the page reached disk.</summary>
+    NothingWritten,
+
+    /// <summary>The document was written, but a writer rejected some of what was typed and has already
+    /// said so in its own dialog naming the values it refused.</summary>
+    WrittenWithObjections,
+
+    /// <summary>Everything reached disk and every writer was happy.</summary>
+    Saved,
+
+    /// <summary>As <see cref="Saved"/>, plus the MCP server's enablement or port changed, which the
+    /// running process cannot pick up.</summary>
+    SavedAndMcpNeedsRestart
+}
+
+/// <summary>
+/// The rule the Settings window's toast follows, kept as a pure function so it can be pinned without a UI
+/// thread (#2433).
+///
+/// <para>The window used to say "Settings saved." whenever nothing objected, and "nothing objected" was
+/// answered by three bools that all meant "the boxes validated" — a different question from whether a byte
+/// reached disk, which nothing was in a position to answer at all. The ten writers each rewrote the whole
+/// document behind their own catch, so "SMTP saved, alerts did not" was a reachable state and no single
+/// sentence could have described it honestly.</para>
+///
+/// <para>The fix folded the ten rewrites into one write, which removes that state instead of describing
+/// it, and this is what is left: one ordering rule over four inputs. The rule worth writing down is that
+/// <see cref="SettingsSaveOutcome.NothingWritten"/> outranks the validation objections. A writer that
+/// rejected a value has already raised its own dialog about that value; what the user has NOT been told,
+/// and cannot find out anywhere else, is that none of it was saved.</para>
+/// </summary>
+public static class SettingsSaveReport
+{
+    /// <param name="documentWritten">Whether the one write of settings.json succeeded.</param>
+    /// <param name="mcpChanged">Whether the MCP enablement or port changed, needing a restart.</param>
+    /// <param name="alertsValid">Whether every alert box validated.</param>
+    /// <param name="mcpValid">Whether the MCP port validated and could be bound.</param>
+    /// <param name="webhooksValid">Whether the generic webhook configuration validated.</param>
+    public static SettingsSaveOutcome Classify(
+        bool documentWritten,
+        bool mcpChanged,
+        bool alertsValid,
+        bool mcpValid,
+        bool webhooksValid)
+    {
+        if (!documentWritten)
+        {
+            return SettingsSaveOutcome.NothingWritten;
+        }
+
+        if (!alertsValid || !mcpValid || !webhooksValid)
+        {
+            return SettingsSaveOutcome.WrittenWithObjections;
+        }
+
+        return mcpChanged ? SettingsSaveOutcome.SavedAndMcpNeedsRestart : SettingsSaveOutcome.Saved;
+    }
+}

--- a/Lite/Windows/SettingsWindow.xaml.cs
+++ b/Lite/Windows/SettingsWindow.xaml.cs
@@ -256,29 +256,37 @@ public partial class SettingsWindow : Window
     private async void SaveButton_Click(object sender, RoutedEventArgs e)
     {
         JsonNode root;
+        bool mcpChanged, mcpValid, alertsValid, webhooksValid;
+
+        /* The read AND every mutator, under one catch. Before the consolidation each writer carried its
+           own try, so an exception thrown while BUILDING a value -- not just on the disk I/O -- was caught,
+           logged under that one setting, and the remaining writers still ran. Guarding only the read and
+           the write would have left the nine mutators between them unguarded, so an unexpected throw would
+           escape into App's generic "An error occurred" dispatcher dialog instead of the honest answer this
+           method now owes the user. Nothing was written in that case either, and that is what to say. */
         try
         {
             root = App.SettingsRootForWrite();
+
+            (mcpChanged, mcpValid) = await SaveMcpSettingsAsync(root);
+            SaveDefaultTimeRange(root);
+            SaveConnectionTimeout(root);
+            SaveCsvSeparator(root);
+            SaveColorTheme(root);
+            SaveTimeDisplayMode(root);
+            SaveCheckForUpdates(root);
+            alertsValid = SaveAlertSettings(root);
+            SaveSmtpSettings(root);
+            webhooksValid = SaveWebhookSettings(root);
         }
         catch (Exception ex)
         {
-            AppLogger.Error("Settings", $"Failed to save settings: {ex.Message}");
+            AppLogger.Error("Settings", "Failed to save settings", ex);
             MessageBox.Show(
                 $"Nothing was saved.\n\n{ex.Message}",
                 "Settings", MessageBoxButton.OK, MessageBoxImage.Warning);
             return;
         }
-
-        var (mcpChanged, mcpValid) = await SaveMcpSettingsAsync(root);
-        SaveDefaultTimeRange(root);
-        SaveConnectionTimeout(root);
-        SaveCsvSeparator(root);
-        SaveColorTheme(root);
-        SaveTimeDisplayMode(root);
-        SaveCheckForUpdates(root);
-        bool alertsValid = SaveAlertSettings(root);
-        SaveSmtpSettings(root);
-        bool webhooksValid = SaveWebhookSettings(root);
 
         bool written = App.WriteSettingsDocument(root, "settings");
 
@@ -287,7 +295,13 @@ public partial class SettingsWindow : Window
            the window contradict itself: the dialog below says nothing was saved while the unpersisted theme
            stays applied for the rest of the run and comes back to its old value on the next launch. */
         _saved = written;
-        if (mcpChanged) McpSettingsChanged = true;
+
+        /* Gated on the write for the same reason _saved is, and the consequence is louder. MainWindow
+           reads this after ShowDialog and, when it is set, stops and restarts the MCP server -- dropping
+           every connected client -- then reloads the port from settings.json on DISK, not from the document
+           above. On a failed write that is a disruptive restart back onto the OLD configuration, moments
+           after the app has told the user nothing was saved. */
+        if (mcpChanged && written) McpSettingsChanged = true;
 
         /* #2431: the save above copies an unreadable settings.json aside and writes a fresh one, so a
            warning raised when this window opened may simply not be true any more — and this window stays

--- a/Lite/Windows/SettingsWindow.xaml.cs
+++ b/Lite/Windows/SettingsWindow.xaml.cs
@@ -9,10 +9,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Net;
-using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using System.Windows;
@@ -210,40 +208,96 @@ public partial class SettingsWindow : Window
         UpdateCollectionStatus();
     }
 
+    /// <summary>
+    /// #2433: one read of settings.json, ten writers mutating the SAME document, one write, and therefore
+    /// one truthful answer about whether anything reached disk.
+    ///
+    /// <para>Each of the ten used to open, parse and rewrite the whole document itself — ten read/parse/write
+    /// cycles for one click of Save — and each swallowed its own write failure into the log. Seven of them
+    /// returned <c>void</c> and so could not report anything by construction; the three that returned
+    /// something returned whether the BOXES validated, which is a different question from whether the save
+    /// happened. So "Settings saved." was shown whether or not a byte was written, and a partial save —
+    /// SMTP written, alerts not — was a reachable state that no single sentence could describe.</para>
+    ///
+    /// <para>Folding them into one write removes that state rather than describing it, which is why this
+    /// shape was chosen over giving each writer a bool. The writers no longer read or write anything: they
+    /// mutate the document they are handed, and the question "did this Save work?" now has exactly one
+    /// answer for the button to report.</para>
+    ///
+    /// <para>The read is <see cref="App.SettingsRootForWrite"/>, which throws only when settings.json could
+    /// not be parsed AND could not be copied aside (#2425). That throw used to land in ten separate catches
+    /// that each logged and let the toast claim success; it is the narrow residue #2433 was filed for, and
+    /// it now stops the save and says so.</para>
+    /// </summary>
     private async void SaveButton_Click(object sender, RoutedEventArgs e)
     {
-        var (mcpChanged, mcpValid) = await SaveMcpSettingsAsync();
-        SaveDefaultTimeRange();
-        SaveConnectionTimeout();
-        SaveCsvSeparator();
-        SaveColorTheme();
-        SaveTimeDisplayMode();
-        SaveCheckForUpdates();
-        bool alertsValid = SaveAlertSettings();
-        SaveSmtpSettings();
-        bool webhooksValid = SaveWebhookSettings();
+        JsonNode root;
+        try
+        {
+            root = App.SettingsRootForWrite();
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Error("Settings", $"Failed to save settings: {ex.Message}");
+            MessageBox.Show(
+                $"Nothing was saved.\n\n{ex.Message}",
+                "Settings", MessageBoxButton.OK, MessageBoxImage.Warning);
+            return;
+        }
+
+        var (mcpChanged, mcpValid) = await SaveMcpSettingsAsync(root);
+        SaveDefaultTimeRange(root);
+        SaveConnectionTimeout(root);
+        SaveCsvSeparator(root);
+        SaveColorTheme(root);
+        SaveTimeDisplayMode(root);
+        SaveCheckForUpdates(root);
+        bool alertsValid = SaveAlertSettings(root);
+        SaveSmtpSettings(root);
+        bool webhooksValid = SaveWebhookSettings(root);
+
+        bool written = App.WriteSettingsDocument(root, "settings");
 
         _saved = true;
         if (mcpChanged) McpSettingsChanged = true;
 
-        if (!alertsValid || !mcpValid || !webhooksValid) return;
+        switch (SettingsSaveReport.Classify(written, mcpChanged, alertsValid, mcpValid, webhooksValid))
+        {
+            case SettingsSaveOutcome.NothingWritten:
+                MessageBox.Show(
+                    "Your settings could not be written to settings.json, so nothing was saved and the "
+                    + "changes on this page will be gone when the window closes. The application log says "
+                    + "why.",
+                    "Settings", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
 
-        var message = mcpChanged
-            ? "Settings saved. MCP changes take effect after restarting the application."
-            : "Settings saved.";
-        MessageBox.Show(message, "Settings", MessageBoxButton.OK, MessageBoxImage.Information);
+            case SettingsSaveOutcome.WrittenWithObjections:
+                /* The objecting writer has already raised its own dialog naming what it rejected, and the
+                   rest of the document DID reach disk. Adding a second dialog here would either repeat it
+                   or contradict it. */
+                return;
+
+            case SettingsSaveOutcome.SavedAndMcpNeedsRestart:
+                MessageBox.Show(
+                    "Settings saved. MCP changes take effect after restarting the application.",
+                    "Settings", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+
+            default:
+                MessageBox.Show("Settings saved.", "Settings", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+        }
     }
 
-    private async Task<(bool Changed, bool Valid)> SaveMcpSettingsAsync()
+    /// <summary>
+    /// Mutates the MCP keys on the shared document (#2433). <c>Valid</c> means the port survived
+    /// validation and the bind probe — NOT that a write happened, which is
+    /// <see cref="SaveButton_Click"/>'s single question now and no longer this method's to guess at.
+    /// </summary>
+    private async Task<(bool Changed, bool Valid)> SaveMcpSettingsAsync(JsonNode root)
     {
-        var settingsPath = Path.Combine(App.ConfigDirectory, "settings.json");
-
         try
         {
-            /* #2425: the shared read, which copies an unparseable settings.json aside before this whole-
-               document rewrite can replace it, and throws into the catch below when it cannot. */
-            JsonNode root = App.SettingsRootForWrite();
-
             var oldEnabled = root["mcp_enabled"]?.GetValue<bool>() ?? false;
             var oldPort = root["mcp_port"]?.GetValue<int>() ?? 5151;
             var newEnabled = McpEnabledCheckBox.IsChecked == true;
@@ -283,9 +337,6 @@ public partial class SettingsWindow : Window
                 portValid = false;
             }
 
-            var options = new JsonSerializerOptions { WriteIndented = true };
-            File.WriteAllText(settingsPath, root.ToJsonString(options));
-
             if (!portValid)
             {
                 MessageBox.Show(
@@ -297,8 +348,16 @@ public partial class SettingsWindow : Window
         }
         catch (Exception ex)
         {
+            /* All that is left in here is the bind probe — the read and the write have both moved out. If
+               it threw we do not know whether the port is free, so the MCP keys are left as they were and
+               the caller is told the page did not validate. Reporting Valid = true here was the #2433
+               instance the review bot found, and it is not survivable now that this method writes nothing
+               it could be wrong about. */
             AppLogger.Error("Settings", $"Failed to save MCP settings: {ex.Message}");
-            return (false, true);
+            MessageBox.Show(
+                $"The MCP port could not be checked, so the MCP settings were left unchanged:\n\n{ex.Message}",
+                "Settings", MessageBoxButton.OK, MessageBoxImage.Warning);
+            return (false, false);
         }
     }
 
@@ -315,14 +374,12 @@ public partial class SettingsWindow : Window
         };
     }
 
-    /// <summary>
-    /// Delegates to <see cref="App.WriteSetting"/> — the single read/merge/write/catch home for
-    /// settings.json single-value updates (now shared with MainWindow's Overview sort selector). Kept as a
-    /// thin alias so the existing Save* call sites and their JsonNode mutate lambdas are untouched.
-    /// </summary>
-    private static void WriteSetting(string what, Action<JsonNode> mutate) => App.WriteSetting(what, mutate);
+    /* The local WriteSetting alias is gone with #2433: every Save* below now mutates the one document
+       SaveButton_Click opened, rather than opening, parsing and rewriting settings.json for itself.
+       App.WriteSetting survives for the single-value knobs outside this window (MainWindow's Overview sort
+       selector), which really are one read and one write on their own. */
 
-    private void SaveDefaultTimeRange()
+    private void SaveDefaultTimeRange(JsonNode root)
     {
         var hours = DefaultTimeRangeCombo.SelectedIndex switch
         {
@@ -336,7 +393,7 @@ public partial class SettingsWindow : Window
 
         App.DefaultTimeRangeHours = hours;
 
-        WriteSetting("default time range", root => root["default_time_range_hours"] = hours);
+        root["default_time_range_hours"] = hours;
     }
 
     private void CopyMcpCommandButton_Click(object sender, RoutedEventArgs e)
@@ -367,14 +424,14 @@ public partial class SettingsWindow : Window
         ConnectionTimeoutBox.Text = App.ConnectionTimeoutSeconds.ToString();
     }
 
-    private void SaveConnectionTimeout()
+    private void SaveConnectionTimeout(JsonNode root)
     {
         if (int.TryParse(ConnectionTimeoutBox.Text, out var timeout) && timeout >= 5 && timeout <= 60)
         {
             App.ConnectionTimeoutSeconds = timeout;
         }
 
-        WriteSetting("connection timeout", root => root["connection_timeout_seconds"] = App.ConnectionTimeoutSeconds);
+        root["connection_timeout_seconds"] = App.ConnectionTimeoutSeconds;
     }
 
     private void LoadCsvSeparator()
@@ -391,14 +448,14 @@ public partial class SettingsWindow : Window
             CsvSeparatorCombo.SelectedIndex = 0;
     }
 
-    private void SaveCsvSeparator()
+    private void SaveCsvSeparator(JsonNode root)
     {
         if (CsvSeparatorCombo.SelectedItem is ComboBoxItem selected && selected.Tag is string sep)
         {
             App.CsvSeparator = sep;
         }
 
-        WriteSetting("CSV separator", root => root["csv_separator"] = App.CsvSeparator);
+        root["csv_separator"] = App.CsvSeparator;
     }
 
     private bool _isLoadingTheme;
@@ -429,7 +486,7 @@ public partial class SettingsWindow : Window
         _isLoadingTheme = false;
     }
 
-    private void SaveColorTheme()
+    private void SaveColorTheme(JsonNode root)
     {
         if (ColorThemeCombo.SelectedItem is ComboBoxItem selected && selected.Tag is string theme)
         {
@@ -437,7 +494,7 @@ public partial class SettingsWindow : Window
             ThemeManager.Apply(theme);
         }
 
-        WriteSetting("color theme", root => root["color_theme"] = App.ColorTheme);
+        root["color_theme"] = App.ColorTheme;
     }
 
     private void LoadTimeDisplayMode()
@@ -454,7 +511,7 @@ public partial class SettingsWindow : Window
             TimeDisplayModeCombo.SelectedIndex = 0;
     }
 
-    private void SaveTimeDisplayMode()
+    private void SaveTimeDisplayMode(JsonNode root)
     {
         if (TimeDisplayModeCombo.SelectedItem is ComboBoxItem selected && selected.Tag is string mode)
         {
@@ -463,7 +520,7 @@ public partial class SettingsWindow : Window
                 ServerTimeHelper.CurrentDisplayMode = tdm;
         }
 
-        WriteSetting("time display mode", root => root["time_display_mode"] = App.TimeDisplayMode);
+        root["time_display_mode"] = App.TimeDisplayMode;
     }
 
     /// <summary>
@@ -492,11 +549,11 @@ public partial class SettingsWindow : Window
         CheckForUpdatesOnStartupCheckBox.IsChecked = App.CheckForUpdatesOnStartup;
     }
 
-    private void SaveCheckForUpdates()
+    private void SaveCheckForUpdates(JsonNode root)
     {
         App.CheckForUpdatesOnStartup = CheckForUpdatesOnStartupCheckBox.IsChecked == true;
 
-        WriteSetting("update check on startup", root => root["check_for_updates_on_startup"] = App.CheckForUpdatesOnStartup);
+        root["check_for_updates_on_startup"] = App.CheckForUpdatesOnStartup;
     }
 
     private void LoadAlertSettings()
@@ -566,7 +623,12 @@ public partial class SettingsWindow : Window
         UpdateAlertControlStates();
     }
 
-    private bool SaveAlertSettings()
+    /// <summary>
+    /// Mutates the alert keys on the shared document (#2433). The bool still means what it always meant —
+    /// whether every box validated — but it is no longer the only thing the caller has to go on: the write
+    /// itself now reports separately, so a save that threw can no longer come back as <c>true</c>.
+    /// </summary>
+    private bool SaveAlertSettings(JsonNode root)
     {
         App.MinimizeToTray = MinimizeToTrayCheckBox.IsChecked == true;
         App.AlertsEnabled = AlertsEnabledCheckBox.IsChecked == true;
@@ -677,81 +739,66 @@ public partial class SettingsWindow : Window
         else
             validationErrors.Add("Analysis re-notify cooldown must be between 30 and 10080 minutes.");
 
-        var settingsPath = Path.Combine(App.ConfigDirectory, "settings.json");
-        try
-        {
-            /* #2425: the shared read, which copies an unparseable settings.json aside before this whole-
-               document rewrite can replace it, and throws into the catch below when it cannot. */
-            JsonNode root = App.SettingsRootForWrite();
-
-            root["minimize_to_tray"] = App.MinimizeToTray;
-            root["alerts_enabled"] = App.AlertsEnabled;
-            root["notify_connection_changes"] = App.NotifyConnectionChanges;
-            root["notify_connection_down_at_startup"] = App.NotifyConnectionDownAtStartup;
-            root["connection_refire_minutes"] = App.ConnectionRefireMinutes;
-            root["notify_ag_health"] = App.NotifyAgHealth;
-            root["ag_lag_alert_seconds"] = App.AgLagAlertSeconds;
-            root["ag_redo_queue_alert_kb"] = App.AgRedoQueueAlertKb;
-            root["alert_cpu_enabled"] = App.AlertCpuEnabled;
-            root["alert_cpu_threshold"] = App.AlertCpuThreshold;
-            root["alert_cpu_mode"] = App.AlertCpuMode.ToString();
-            root["alert_blocking_enabled"] = App.AlertBlockingEnabled;
-            root["alert_blocking_threshold"] = App.AlertBlockingThreshold;
-            root["alert_blocking_wait_seconds_threshold"] = App.AlertBlockingWaitSecondsThreshold;
-            root["alert_deadlock_enabled"] = App.AlertDeadlockEnabled;
-            root["alert_deadlock_threshold"] = App.AlertDeadlockThreshold;
-            root["alert_database_state_enabled"] = App.AlertDatabaseStateEnabled;
-            root["alert_poison_wait_enabled"] = App.AlertPoisonWaitEnabled;
-            root["alert_poison_wait_threshold_ms"] = App.AlertPoisonWaitThresholdMs;
-            root["alert_long_running_query_enabled"] = App.AlertLongRunningQueryEnabled;
-            root["alert_long_running_query_threshold_minutes"] = App.AlertLongRunningQueryThresholdMinutes;
-            root["alert_long_running_query_max_results"] = App.AlertLongRunningQueryMaxResults;
-            root["alert_long_running_query_exclude_sp_server_diagnostics"] = App.AlertLongRunningQueryExcludeSpServerDiagnostics;
-            root["alert_long_running_query_exclude_waitfor"] = App.AlertLongRunningQueryExcludeWaitFor;
-            root["alert_long_running_query_exclude_backups"] = App.AlertLongRunningQueryExcludeBackups;
-            root["alert_long_running_query_exclude_misc_waits"] = App.AlertLongRunningQueryExcludeMiscWaits;
-            root["alert_long_running_query_exclude_cdc"] = App.AlertLongRunningQueryExcludeCdc;
-            var dbArray = new System.Text.Json.Nodes.JsonArray();
-            foreach (var db in App.AlertExcludedDatabases) dbArray.Add(db);
-            root["alert_excluded_databases"] = dbArray;
-            root["alert_tempdb_space_enabled"] = App.AlertTempDbSpaceEnabled;
-            root["alert_tempdb_space_threshold_percent"] = App.AlertTempDbSpaceThresholdPercent;
-            root["alert_low_disk_enabled"] = App.AlertLowDiskEnabled;
-            root["alert_low_disk_threshold_percent"] = App.AlertLowDiskThresholdPercent;
-            root["alert_low_disk_threshold_gb"] = App.AlertLowDiskThresholdGb;
-            root["alert_disk_critical_free_percent"] = App.AlertDiskCriticalFreePercent;
-            root["alert_disk_critical_free_gb"] = App.AlertDiskCriticalFreeGb;
-            root["alert_pvs_enabled"] = App.AlertPvsEnabled;
-            root["alert_pvs_threshold_percent"] = App.AlertPvsThresholdPercent;
-            root["alert_pvs_floor_gb"] = App.AlertPvsFloorGb;
-            root["alert_file_growth_enabled"] = App.AlertFileGrowthEnabled;
-            root["alert_file_growth_rise_mb"] = App.AlertFileGrowthRiseMb;
-            root["alert_file_growth_volume_percent"] = App.AlertFileGrowthVolumePercent;
-            root["alert_file_growth_lookback_minutes"] = App.AlertFileGrowthLookbackMinutes;
-            root["alert_long_running_job_enabled"] = App.AlertLongRunningJobEnabled;
-            root["alert_long_running_job_multiplier"] = App.AlertLongRunningJobMultiplier;
-            root["alert_failed_job_enabled"] = App.AlertFailedJobEnabled;
-            root["alert_failed_job_lookback_minutes"] = App.AlertFailedJobLookbackMinutes;
-            root["alert_cooldown_minutes"] = App.AlertCooldownMinutes;
-            root["email_cooldown_minutes"] = App.EmailCooldownMinutes;
-            root["alert_delivery_mode"] = App.AlertDeliveryMode.ToString();
-            root["alert_per_event_max_per_cycle"] = App.AlertPerEventMaxPerCycle;
-            root["mute_rule_default_expiration"] = App.MuteRuleDefaultExpiration;
-            root["log_alert_dismissals"] = App.LogAlertDismissals;
-            root["analysis_enabled"] = App.AnalysisEnabled;
-            root["query_store_backfill_enabled"] = App.QueryStoreBackfillEnabled;
-            root["analysis_notifications_enabled"] = App.AnalysisNotificationsEnabled;
-            root["analysis_interval_minutes"] = App.AnalysisIntervalMinutes;
-            root["analysis_notify_severity"] = App.AnalysisNotifySeverity;
-            root["analysis_notify_cooldown_minutes"] = App.AnalysisNotifyCooldownMinutes;
-
-            var options = new JsonSerializerOptions { WriteIndented = true };
-            File.WriteAllText(settingsPath, root.ToJsonString(options));
-        }
-        catch (Exception ex)
-        {
-            AppLogger.Error("Settings", $"Failed to save alert settings: {ex.Message}");
-        }
+        root["minimize_to_tray"] = App.MinimizeToTray;
+        root["alerts_enabled"] = App.AlertsEnabled;
+        root["notify_connection_changes"] = App.NotifyConnectionChanges;
+        root["notify_connection_down_at_startup"] = App.NotifyConnectionDownAtStartup;
+        root["connection_refire_minutes"] = App.ConnectionRefireMinutes;
+        root["notify_ag_health"] = App.NotifyAgHealth;
+        root["ag_lag_alert_seconds"] = App.AgLagAlertSeconds;
+        root["ag_redo_queue_alert_kb"] = App.AgRedoQueueAlertKb;
+        root["alert_cpu_enabled"] = App.AlertCpuEnabled;
+        root["alert_cpu_threshold"] = App.AlertCpuThreshold;
+        root["alert_cpu_mode"] = App.AlertCpuMode.ToString();
+        root["alert_blocking_enabled"] = App.AlertBlockingEnabled;
+        root["alert_blocking_threshold"] = App.AlertBlockingThreshold;
+        root["alert_blocking_wait_seconds_threshold"] = App.AlertBlockingWaitSecondsThreshold;
+        root["alert_deadlock_enabled"] = App.AlertDeadlockEnabled;
+        root["alert_deadlock_threshold"] = App.AlertDeadlockThreshold;
+        root["alert_database_state_enabled"] = App.AlertDatabaseStateEnabled;
+        root["alert_poison_wait_enabled"] = App.AlertPoisonWaitEnabled;
+        root["alert_poison_wait_threshold_ms"] = App.AlertPoisonWaitThresholdMs;
+        root["alert_long_running_query_enabled"] = App.AlertLongRunningQueryEnabled;
+        root["alert_long_running_query_threshold_minutes"] = App.AlertLongRunningQueryThresholdMinutes;
+        root["alert_long_running_query_max_results"] = App.AlertLongRunningQueryMaxResults;
+        root["alert_long_running_query_exclude_sp_server_diagnostics"] = App.AlertLongRunningQueryExcludeSpServerDiagnostics;
+        root["alert_long_running_query_exclude_waitfor"] = App.AlertLongRunningQueryExcludeWaitFor;
+        root["alert_long_running_query_exclude_backups"] = App.AlertLongRunningQueryExcludeBackups;
+        root["alert_long_running_query_exclude_misc_waits"] = App.AlertLongRunningQueryExcludeMiscWaits;
+        root["alert_long_running_query_exclude_cdc"] = App.AlertLongRunningQueryExcludeCdc;
+        var dbArray = new System.Text.Json.Nodes.JsonArray();
+        foreach (var db in App.AlertExcludedDatabases) dbArray.Add(db);
+        root["alert_excluded_databases"] = dbArray;
+        root["alert_tempdb_space_enabled"] = App.AlertTempDbSpaceEnabled;
+        root["alert_tempdb_space_threshold_percent"] = App.AlertTempDbSpaceThresholdPercent;
+        root["alert_low_disk_enabled"] = App.AlertLowDiskEnabled;
+        root["alert_low_disk_threshold_percent"] = App.AlertLowDiskThresholdPercent;
+        root["alert_low_disk_threshold_gb"] = App.AlertLowDiskThresholdGb;
+        root["alert_disk_critical_free_percent"] = App.AlertDiskCriticalFreePercent;
+        root["alert_disk_critical_free_gb"] = App.AlertDiskCriticalFreeGb;
+        root["alert_pvs_enabled"] = App.AlertPvsEnabled;
+        root["alert_pvs_threshold_percent"] = App.AlertPvsThresholdPercent;
+        root["alert_pvs_floor_gb"] = App.AlertPvsFloorGb;
+        root["alert_file_growth_enabled"] = App.AlertFileGrowthEnabled;
+        root["alert_file_growth_rise_mb"] = App.AlertFileGrowthRiseMb;
+        root["alert_file_growth_volume_percent"] = App.AlertFileGrowthVolumePercent;
+        root["alert_file_growth_lookback_minutes"] = App.AlertFileGrowthLookbackMinutes;
+        root["alert_long_running_job_enabled"] = App.AlertLongRunningJobEnabled;
+        root["alert_long_running_job_multiplier"] = App.AlertLongRunningJobMultiplier;
+        root["alert_failed_job_enabled"] = App.AlertFailedJobEnabled;
+        root["alert_failed_job_lookback_minutes"] = App.AlertFailedJobLookbackMinutes;
+        root["alert_cooldown_minutes"] = App.AlertCooldownMinutes;
+        root["email_cooldown_minutes"] = App.EmailCooldownMinutes;
+        root["alert_delivery_mode"] = App.AlertDeliveryMode.ToString();
+        root["alert_per_event_max_per_cycle"] = App.AlertPerEventMaxPerCycle;
+        root["mute_rule_default_expiration"] = App.MuteRuleDefaultExpiration;
+        root["log_alert_dismissals"] = App.LogAlertDismissals;
+        root["analysis_enabled"] = App.AnalysisEnabled;
+        root["query_store_backfill_enabled"] = App.QueryStoreBackfillEnabled;
+        root["analysis_notifications_enabled"] = App.AnalysisNotificationsEnabled;
+        root["analysis_interval_minutes"] = App.AnalysisIntervalMinutes;
+        root["analysis_notify_severity"] = App.AnalysisNotifySeverity;
+        root["analysis_notify_cooldown_minutes"] = App.AnalysisNotifyCooldownMinutes;
 
         if (validationErrors.Count > 0)
         {
@@ -911,7 +958,12 @@ public partial class SettingsWindow : Window
         UpdateSmtpControlStates();
     }
 
-    private void SaveSmtpSettings()
+    /// <summary>
+    /// Mutates the SMTP keys on the shared document (#2433). Still <c>void</c>, and now honestly so: it
+    /// no longer performs a write, so there is no longer a failure for it to be unable to report. That is
+    /// the difference between removing the partial-save state and describing it.
+    /// </summary>
+    private void SaveSmtpSettings(JsonNode root)
     {
         App.SmtpEnabled = SmtpEnabledCheckBox.IsChecked == true;
         App.SmtpServer = SmtpServerBox.Text?.Trim() ?? "";
@@ -928,29 +980,13 @@ public partial class SettingsWindow : Window
             App.SaveSmtpPassword(SmtpPasswordBox.Password);
         }
 
-        /* Save to settings.json */
-        var settingsPath = Path.Combine(App.ConfigDirectory, "settings.json");
-        try
-        {
-            /* #2425: the shared read, which copies an unparseable settings.json aside before this whole-
-               document rewrite can replace it, and throws into the catch below when it cannot. */
-            JsonNode root = App.SettingsRootForWrite();
-
-            root["smtp_enabled"] = App.SmtpEnabled;
-            root["smtp_server"] = App.SmtpServer;
-            root["smtp_port"] = App.SmtpPort;
-            root["smtp_use_ssl"] = App.SmtpUseSsl;
-            root["smtp_username"] = App.SmtpUsername;
-            root["smtp_from_address"] = App.SmtpFromAddress;
-            root["smtp_recipients"] = App.SmtpRecipients;
-
-            var options = new JsonSerializerOptions { WriteIndented = true };
-            File.WriteAllText(settingsPath, root.ToJsonString(options));
-        }
-        catch (Exception ex)
-        {
-            AppLogger.Error("Settings", $"Failed to save SMTP settings: {ex.Message}");
-        }
+        root["smtp_enabled"] = App.SmtpEnabled;
+        root["smtp_server"] = App.SmtpServer;
+        root["smtp_port"] = App.SmtpPort;
+        root["smtp_use_ssl"] = App.SmtpUseSsl;
+        root["smtp_username"] = App.SmtpUsername;
+        root["smtp_from_address"] = App.SmtpFromAddress;
+        root["smtp_recipients"] = App.SmtpRecipients;
     }
 
     private void SmtpEnabledCheckBox_Changed(object sender, RoutedEventArgs e)
@@ -1087,8 +1123,10 @@ public partial class SettingsWindow : Window
     /// or body template that cannot produce a valid request — the values are still saved (so the operator
     /// doesn't lose their typing), but they're told, because a broken template silently drops every alert.
     /// Follows <see cref="SaveAlertSettings"/>'s bool contract: the caller suppresses the "Settings saved" toast.
+    /// Mutates the shared document rather than rewriting settings.json itself (#2433), so the bool is about
+    /// the configuration and nothing else.
     /// </summary>
-    private bool SaveWebhookSettings()
+    private bool SaveWebhookSettings(JsonNode root)
     {
         /* Cleartext warning (#1506): an http:// generic-webhook URL carrying headers sends the Authorization
            token in the clear. Confirm before persisting a config that will transmit credentials unencrypted;
@@ -1130,42 +1168,27 @@ public partial class SettingsWindow : Window
         App.SaveWebhookUrl("GenericWebhookHeaders", App.GenericWebhookHeadersJson);
         App.SaveWebhookUrl("PagerDutyWebhook", App.PagerDutyRoutingKey);
 
-        var settingsPath = Path.Combine(App.ConfigDirectory, "settings.json");
-        try
+        root["teams_webhook_enabled"] = App.TeamsWebhookEnabled;
+        root["teams_proxy_address"] = App.TeamsProxyAddress;
+        root["slack_webhook_enabled"] = App.SlackWebhookEnabled;
+        root["slack_proxy_address"] = App.SlackProxyAddress;
+
+        /* The generic channel's URL + headers are secrets and live in Credential Manager; only these
+           three are safe to persist in settings.json (#1506). The PagerDuty routing key is also a
+           secret and lives in Credential Manager; only the enable flag and EU-region toggle are safe. */
+        root["generic_webhook_enabled"] = App.GenericWebhookEnabled;
+        root["generic_proxy_address"] = App.GenericWebhookProxyAddress;
+        root["generic_body_template"] = App.GenericWebhookBodyTemplate;
+
+        root["pagerduty_webhook_enabled"] = App.PagerDutyWebhookEnabled;
+        root["pagerduty_use_eu_region"] = App.PagerDutyUseEuRegion;
+        root["pagerduty_proxy_address"] = App.PagerDutyProxyAddress;
+
+        /* Remove legacy plaintext webhook URLs from settings.json */
+        if (root is JsonObject obj)
         {
-            /* #2425: the shared read, which copies an unparseable settings.json aside before this whole-
-               document rewrite can replace it, and throws into the catch below when it cannot. */
-            JsonNode root = App.SettingsRootForWrite();
-
-            root["teams_webhook_enabled"] = App.TeamsWebhookEnabled;
-            root["teams_proxy_address"] = App.TeamsProxyAddress;
-            root["slack_webhook_enabled"] = App.SlackWebhookEnabled;
-            root["slack_proxy_address"] = App.SlackProxyAddress;
-
-            /* The generic channel's URL + headers are secrets and live in Credential Manager; only these
-               three are safe to persist in settings.json (#1506). The PagerDuty routing key is also a
-               secret and lives in Credential Manager; only the enable flag and EU-region toggle are safe. */
-            root["generic_webhook_enabled"] = App.GenericWebhookEnabled;
-            root["generic_proxy_address"] = App.GenericWebhookProxyAddress;
-            root["generic_body_template"] = App.GenericWebhookBodyTemplate;
-
-            root["pagerduty_webhook_enabled"] = App.PagerDutyWebhookEnabled;
-            root["pagerduty_use_eu_region"] = App.PagerDutyUseEuRegion;
-            root["pagerduty_proxy_address"] = App.PagerDutyProxyAddress;
-
-            /* Remove legacy plaintext webhook URLs from settings.json */
-            if (root is JsonObject obj)
-            {
-                obj.Remove("teams_webhook_url");
-                obj.Remove("slack_webhook_url");
-            }
-
-            var options = new JsonSerializerOptions { WriteIndented = true };
-            File.WriteAllText(settingsPath, root.ToJsonString(options));
-        }
-        catch (Exception ex)
-        {
-            AppLogger.Error("Settings", $"Failed to save webhook settings: {ex.Message}");
+            obj.Remove("teams_webhook_url");
+            obj.Remove("slack_webhook_url");
         }
 
         if (App.GenericWebhookEnabled)

--- a/Lite/Windows/SettingsWindow.xaml.cs
+++ b/Lite/Windows/SettingsWindow.xaml.cs
@@ -258,7 +258,11 @@ public partial class SettingsWindow : Window
 
         bool written = App.WriteSettingsDocument(root, "settings");
 
-        _saved = true;
+        /* _saved is what stops CloseButton_Click / OnClosing reverting the live theme preview, so it has to
+           mean "the theme reached settings.json" and not "Save was clicked". Set unconditionally it makes
+           the window contradict itself: the dialog below says nothing was saved while the unpersisted theme
+           stays applied for the rest of the run and comes back to its old value on the next launch. */
+        _saved = written;
         if (mcpChanged) McpSettingsChanged = true;
 
         switch (SettingsSaveReport.Classify(written, mcpChanged, alertsValid, mcpValid, webhooksValid))
@@ -460,6 +464,12 @@ public partial class SettingsWindow : Window
 
     private bool _isLoadingTheme;
     private readonly string _originalTheme = ThemeManager.CurrentTheme;
+    /// <summary>
+    /// Whether this window's Save actually reached settings.json. Read by <c>CloseButton_Click</c> and
+    /// <c>OnClosing</c> to decide whether to revert the live theme preview, so it tracks the write rather
+    /// than the click (#2433) — a theme that was previewed but never persisted must not survive the window
+    /// that failed to save it.
+    /// </summary>
     private bool _saved;
     public bool McpSettingsChanged { get; private set; }
 


### PR DESCRIPTION
Lite's Settings window said "Settings saved." whether or not a byte reached disk, and the reason was structural: the ten writers behind that one button each opened, parsed and rewrote the whole of `settings.json` for itself — ten read/parse/write cycles for one click — behind its own catch, and none of them was in a position to tell the caller what had happened.

## The premise, checked, with the counts corrected

The issue's shape is right and its arithmetic is off in both directions, so here is what is actually there.

`SaveButton_Click` calls **ten** writers, not six or four:

```csharp
var (mcpChanged, mcpValid) = await SaveMcpSettingsAsync();
SaveDefaultTimeRange();  SaveConnectionTimeout();  SaveCsvSeparator();
SaveColorTheme();        SaveTimeDisplayMode();    SaveCheckForUpdates();
bool alertsValid = SaveAlertSettings();
SaveSmtpSettings();
bool webhooksValid = SaveWebhookSettings();
```

**Seven return `void`**, not four. The four the brief named — `SaveColorTheme`, `SaveTimeDisplayMode`, `SaveCheckForUpdates`, `SaveSmtpSettings` — are all `void`, and so are `SaveDefaultTimeRange`, `SaveConnectionTimeout` and `SaveCsvSeparator`, which the brief did not list. Six of the seven route through `App.WriteSetting`, which reads and rewrites the document exactly as the others do; only `SaveSmtpSettings` rolls its own.

The brief's correction to the issue is right and worth keeping: **the three that return something ARE honoured.** `if (!alertsValid || !mcpValid || !webhooksValid) return;` really does suppress the toast, so the issue's "every one of them lets the button claim success" overstates it. What those three return is whether the BOXES validated, which is a different question from whether the save happened, and no value of any kind existed for the second question.

The other correction is to the issue's own list of remedies. Its option (2) says to fold **the four whole-document rewrites** into one pass — but the four whole-document rewrites (`Mcp`, `Alert`, `Smtp`, `Webhook`) and the four `void` writers it identifies are *different sets*, overlapping only at `SaveSmtpSettings`. Consolidating only those four would have left the six `WriteSetting` knobs rewriting the file separately, so the click would still have made seven writes and the button still would not have had one answer. What is implemented here is option (2) taken to its actual conclusion: all ten.

## Option 2, and why

`SaveButton_Click` now opens the document once, hands it to all ten writers, and writes it once:

```csharp
JsonNode root = App.SettingsRootForWrite();   // one read, in a try that reports
...
bool written = App.WriteSettingsDocument(root, "settings");   // one write, that answers
switch (SettingsSaveReport.Classify(written, mcpChanged, alertsValid, mcpValid, webhooksValid))
```

The writers no longer read or write anything; they mutate what they are handed. That does more than give the button a bool: it **deletes the state that made a single honest sentence impossible**. "SMTP saved, alerts not" was reachable while there were ten writes and is unreachable now that there is one, which is why this beats the other two options rather than merely costing more than them. `SaveSmtpSettings` stays `void` and is honestly so now — the problem was never that `void` was the wrong signature, it was that the method could fail at something it had no way to mention, and it cannot fail any more.

The narrow residue #2433 was actually filed for is now reported. `App.SettingsRootForWrite` throws only when `settings.json` cannot be parsed AND cannot be copied aside (#2425) — a directory that will not accept a `File.Copy`, a locked file, a full disk. That throw used to land in ten separate catches that each logged and let the toast claim success. It now stops the save before any writer runs, and says so.

`SaveMcpSettingsAsync`'s catch was the instance the review bot flagged. With the read and the write both gone from it, the only thing left inside is the port bind probe, so `Valid = true` is no longer even tempting: if the probe threw we do not know whether the port is free, the MCP keys are left as they were, and the user is told.

## The wiring guard, restated rather than patched

#2425's `SettingsWriterQuarantineWiringTests` counted `File.WriteAllText(settingsPath` against `SettingsRootForWrite()` **per file**, and this change legitimately moves that anchor — `SettingsWindow.xaml.cs` now has zero of the first and one of the second. Rather than adjust the counting, the invariant is restated stronger and simpler: **`settings.json` has exactly ONE writer in the whole of Lite, and that writer takes the quarantining read.** A second writer brings back both defects at once — its own read can replace an unparseable file without copying it aside (#2425), and a save split across several writes has no single honest answer to report (#2433).

Both scans now run with comments stripped, and that is not tidiness — the first run of the new all-of-Lite scan went red on `SettingsFileGuard.cs`, because the one file that explains **why** `JsonNode.Parse(json) ?? new JsonObject()` is banned has to quote it in order to explain it. Same trap as #2418's `TryGetProperty` key extractor, one file over.

## Verification

`Lite.Tests` targets `net10.0-windows` and cannot run on macOS, so the real test files were compiled into a throwaway `net10.0` harness with a minimal xUnit shim, against the real `SettingsFileGuard.cs` and the real `SettingsSaveReport.cs`, and run against both branches. dev has no classifier, so it got a faithful transcription of what dev's `SaveButton_Click` actually decides — including the fact that whether anything was written **is not an input it has**, because no such value existed for it to consult:

```csharp
if (!alertsValid || !mcpValid || !webhooksValid) return SettingsSaveOutcome.WrittenWithObjections;
return mcpChanged ? SavedAndMcpNeedsRestart : Saved;
```

| | dev's behavior | this branch |
|---|---|---|
| `SettingsSaveReportTests` + `SettingsSaveButtonHonestyTests` + `SettingsWriterQuarantineWiringTests` + the existing `SettingsFileGuardTests` | **16 passed, 10 failed** | **26 passed, 0 failed** |

Three more arms came out of review, all of them the same defect wearing different clothes. The theme selector applies its choice LIVE, and `_saved` is what stops the close handlers reverting that preview — set unconditionally on the click, a failed write showed the new "nothing was saved" dialog while the unpersisted theme stayed applied for the rest of the run and quietly reverted at the next launch. `_saved` now tracks the write, and `TheLiveThemePreview_OnlySurvivesASaveThatWrote` asserts both halves: the assignment must be the write's, and the close handlers must still be reading it, or the assertion describes a gate that has moved.

`McpSettingsChanged` was the same shape and a louder claim. `MainWindow` reads it after `ShowDialog` and, when set, stops and restarts the MCP server — dropping every connected client — then reloads the port from `settings.json` on **disk**, not from the document the window just built. A failed write therefore produced a disruptive restart back onto the OLD configuration, moments after the app had said nothing was saved. Same gate now.

And the mutators were outside the guard. Before consolidation each writer carried its own `try`, so an exception thrown while BUILDING a value — not only on the disk I/O — was caught, logged, and the remaining writers still ran. Guarding only the read and the write left the nine mutators between them able to escape into `App`'s generic "An error occurred" dispatcher dialog, which is precisely the class of silence this change exists to remove. The read and every mutator sit under one catch now, funnelling into the same "Nothing was saved" the I/O failure gets — equally true there, and the reason the diff shows one `try` rather than two.

The headline failure is the one sentence this issue is about — `AFailedWrite_IsNeverReportedAsSaved`: `expected <NothingWritten> actual <Saved>`. The other nine are its three theory rows, the theme-preview, MCP-restart and mutator-guard pins, both source-wiring guards on `SaveButton_Click`, and the one-writer pin, which reports dev exactly: *"5 whole-document rewrite(s) of settings.json across 2 file(s): App.xaml.cs (1), SettingsWindow.xaml.cs (4)"*.

The nine passing `SettingsFileGuardTests` and two of the three wiring tests pass on both sides, which is the point of including them: they are #2425's guarantees and this change must not have moved any of them.

## One note on the merge

#2435 landed on dev while this was open and added a block to `SaveButton_Click`: when the window opened over an unreadable `settings.json`, re-read `McpSettings` after saving and refresh the status line, because the save may have fixed the file and this window stays open afterwards. It conflicts textually with a change that replaced the whole method.

Resolved by keeping both ideas rather than either version. dev's copy of the pre-consolidation body goes; its re-read now sits after the single `written`, where the ten independent attempts it was written against used to be. Its reasoning survives the move and gets sharper — *"a write that failed leaves the file exactly as unreadable as it was"* was a hypothetical when nothing could report a failed write, and is now a value the method holds.

## Deliberately not in scope

`App.WriteSetting` survives for the single-value knobs OUTSIDE this window — MainWindow's Overview sort selector is the live caller — because those really are one read and one write on their own, with no sibling writer to be inconsistent with and no toast to be wrong. It now routes through `WriteSettingsDocument`, so its failure is named under the setting the operator changed rather than under a filename, but its swallow-and-log contract is unchanged and it is still the shape #2425 blessed.

The eighty-eight alert reads still share one `try` in `App.LoadAlertSettings`, so one value of the wrong shape still costs every setting after it. Named out loud since #2428 and still filed rather than folded in.

`McpSettings.Load`'s bare catch, which silently disables the MCP server on an unreadable file, is untouched here — it is a load, not a save, and this diff is about what the Save button is entitled to say.

Fixes #2433
