### PR TITLE
Give the web dashboard's "+52 more" somewhere to go (#2437)

### DIFF
--- a/Darling/Darling.Tests/FleetPageAttentionFilterTests.cs
+++ b/Darling/Darling.Tests/FleetPageAttentionFilterTests.cs
@@ -127,6 +127,15 @@ public sealed class FleetPageAttentionFilterTests
         Assert.Contains("\"the 1 server monitored is healthy\"", FleetJs, StringComparison.Ordinal);
         Assert.Contains("\"no servers to filter\"", FleetJs, StringComparison.Ordinal);
 
+        /* The one place this surface needs words the viewer does not have, and review found out why: the
+           viewer's Overview has no search box, so "the 1 server monitored is healthy" is simply true there.
+           Here the denominator is what the SEARCH left, so on a 57-server fleet narrowed to one match that
+           sentence claims the fleet holds one server while 56 others exist and were never looked at. An
+           all-clear has to name the population it is clearing. */
+        Assert.Contains("\"the 1 matching server is healthy\"", FleetJs, StringComparison.Ordinal);
+        Assert.Contains("\"all \" + total + \" matching servers are healthy\"", FleetJs, StringComparison.Ordinal);
+        Assert.Contains("attentionCountText(shown, total, term !== \"\")", FleetJs, StringComparison.Ordinal);
+
         var viewer = ReadRepoFile(Path.Combine(
             "Darling", "PerformanceMonitor.Darling.Viewer", "ViewerDataService.Fleet.cs"));
         Assert.Contains("$\"showing {shown} of {total}\"", viewer, StringComparison.Ordinal);

--- a/Darling/Darling.Tests/FleetPageAttentionFilterTests.cs
+++ b/Darling/Darling.Tests/FleetPageAttentionFilterTests.cs
@@ -144,12 +144,22 @@ public sealed class FleetPageAttentionFilterTests
     [Fact]
     public void TheActiveState_IsPaintedByWhatItSays_NotByBeingOn()
     {
-        Assert.Contains("\"attention-note \" + (shown > 0 ? \"warn\" : \"ok\")", FleetJs, StringComparison.Ordinal);
+        /* THREE sentences, not two. Review caught the third: a search term that matched nothing leaves the
+           filter with nothing to judge, and the green all-clear arm fired there — a colour asserting that the
+           fleet is fine when its problem servers were never looked at, which is the exact defect in miniature. */
+        Assert.Contains("const searchFoundNothing = term !== \"\" && total === 0;", FleetJs, StringComparison.Ordinal);
+        Assert.Contains("searchFoundNothing ? \"none\" : shown > 0 ? \"warn\" : \"ok\"", FleetJs, StringComparison.Ordinal);
+        Assert.Contains("nothing matches that term, so no server was judged.", FleetJs, StringComparison.Ordinal);
+
+        /* The notice re-words itself with no page load, so it is announced rather than silently swapped —
+           util.js's noticeStrip idiom for the same kind of non-fatal live notice. Also raised in review. */
+        Assert.Contains("role: \"status\"", FleetJs, StringComparison.Ordinal);
 
         var css = ReadRepoFile(Path.Combine(
             "Darling", "PerformanceMonitor.Darling.Service", "wwwroot", "css", "app.css"));
         Assert.Contains(".attention-note.warn", css, StringComparison.Ordinal);
         Assert.Contains(".attention-note.ok", css, StringComparison.Ordinal);
+        Assert.Contains(".attention-note.none", css, StringComparison.Ordinal);
 
         /* And the affordances the JS names actually have rules — a class with no stylesheet behind it renders
            as body text, which is precisely the inert muted div this replaces. */

--- a/Darling/Darling.Tests/FleetPageAttentionFilterTests.cs
+++ b/Darling/Darling.Tests/FleetPageAttentionFilterTests.cs
@@ -203,10 +203,14 @@ public sealed class FleetPageAttentionFilterTests
 
         Assert.Contains("mount(gridNode, [notice, renderGrouped(matched)]);", FleetJs, StringComparison.Ordinal);
 
-        /* The empty-grid line names whichever filter emptied it: telling a reader whose fleet is simply healthy
-           that nothing matches a search term they never typed is the same class of lie in miniature. */
-        Assert.Contains("No servers need attention.", FleetJs, StringComparison.Ordinal);
-        Assert.Contains("No servers needing attention match", FleetJs, StringComparison.Ordinal);
+        /* The empty-grid line names whichever filter emptied it, and with both on it names the RIGHT one.
+           Telling a reader whose fleet is simply healthy that nothing matches a search term they never typed
+           is the same class of lie in miniature; so is blaming the attention filter for a term that matched
+           nothing at all, which is vacuously true and points at the wrong control (raised in review). */
+        Assert.Contains("if (!term) return attentionOnly ? \"No servers need attention.\"", FleetJs, StringComparison.Ordinal);
+        Assert.Contains("if (searchedCount === 0) return \"No servers match", FleetJs, StringComparison.Ordinal);
+        Assert.Contains("return \"No servers matching \u201C\" + term + \"\u201D need attention.\";", FleetJs, StringComparison.Ordinal);
+        Assert.Contains("noMatchText(searched.length)", FleetJs, StringComparison.Ordinal);
     }
 
     // ── helpers ────────────────────────────────────────────────────────────────────────────────────

--- a/Darling/Darling.Tests/FleetPageAttentionFilterTests.cs
+++ b/Darling/Darling.Tests/FleetPageAttentionFilterTests.cs
@@ -190,14 +190,18 @@ public sealed class FleetPageAttentionFilterTests
     [Fact]
     public void TheGrid_IsFilteredOnce_AndBothViewsShowTheActiveState()
     {
-        Assert.Contains("cardMatches(c, fleetFilter) && (!attentionOnly || cardNeedsAttention(c))", FleetJs, StringComparison.Ordinal);
+        Assert.Contains("const searched = lastCards.filter((c) => cardMatches(c, fleetFilter));", FleetJs, StringComparison.Ordinal);
+        Assert.Contains("attentionOnly ? searched.filter(cardNeedsAttention) : searched", FleetJs, StringComparison.Ordinal);
 
         /* One call site: the grouped view and the flat view are projected from the SAME filtered list, so a
            tag-grouped fleet cannot end up with its own opinion about what needs attention. */
-        Assert.Equal(1, CountOccurrences(FleetJs, "|| cardNeedsAttention(c))"));
+        Assert.Equal(1, CountOccurrences(FleetJs, "searched.filter(cardNeedsAttention)"));
+
+        /* And the notice's denominator is what the SEARCH left, not the fleet. With a term typed, "showing 4 of
+           57" invites reading 4 as the fleet's problem count; the other 53 were never looked at. */
+        Assert.Contains("attentionNotice(matched.length, searched.length)", FleetJs, StringComparison.Ordinal);
 
         Assert.Contains("mount(gridNode, [notice, renderGrouped(matched)]);", FleetJs, StringComparison.Ordinal);
-        Assert.Contains("const notice = attentionOnly ? attentionNotice(matched.length) : null;", FleetJs, StringComparison.Ordinal);
 
         /* The empty-grid line names whichever filter emptied it: telling a reader whose fleet is simply healthy
            that nothing matches a search term they never typed is the same class of lie in miniature. */

--- a/Darling/Darling.Tests/FleetPageAttentionFilterTests.cs
+++ b/Darling/Darling.Tests/FleetPageAttentionFilterTests.cs
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.Darling.Service.Mcp;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #2437 / #2424: the web dashboard's "+N more need attention" stops being a dead end.
+///
+/// <para><b>What was reported.</b> On a 57-server fleet the fleet page rendered "+52 more need attention" as an
+/// inert muted div — no handler, no navigation, nothing. @ehaar's question on the desktop twin was literally
+/// "where do I find these warnings?", and the honest answer on this surface was the same: nowhere. The 52 are
+/// not missing data; <c>BuildRollup</c> computes the whole problem set and then truncates it for display, so the
+/// ranking beyond <c>DefaultWorstCount</c> is discarded rather than unavailable.</para>
+///
+/// <para><b>What is pinned here.</b> The two properties #2429 settled on, ported. First, the browser filters on
+/// the SAME predicate the count was computed from — the card's server-computed <c>band</c>, not a client-side
+/// re-derivation — so the destination cannot disagree with the label that sent you there. That half is pinned
+/// against BOTH artifacts: the reduction's own arithmetic runs here, and the literal the browser compares
+/// against is built from the shipped serializer rather than typed out. Second, the active state is visible and
+/// clearable, so a filtered grid can never be mistaken for an unfiltered one.</para>
+///
+/// <para>The wiring half text-scans the shipped <c>fleet.js</c> (located by walking up from this file's
+/// compile-time path, the <see cref="ViewerGridPayloadColumnOrderPinTests"/> pattern) because this repository
+/// carries no JavaScript test runner and a handler in a browser module is out of reach of any assertion about a
+/// C# object. Behaviour was verified separately by running that same file under a DOM shim; see the PR.</para>
+/// </summary>
+public sealed class FleetPageAttentionFilterTests
+{
+    /// <summary>The shipped module, newlines normalised so a multi-line anchor holds whether the checkout gave
+    /// this file CRLF (.gitattributes says it does) or LF.</summary>
+    private static string FleetJs => ReadRepoFile(Path.Combine(
+        "Darling", "PerformanceMonitor.Darling.Service", "wwwroot", "js", "pages", "fleet.js"));
+
+    /// <summary>
+    /// The count and the filter are one predicate. <c>BuildRollup</c> derives "+N more" from
+    /// <c>Band != Healthy</c>, the payload carries that band per card, and the browser compares against the
+    /// token the SHIPPED serializer emits for <see cref="FleetHealthBand.Healthy"/> — so the string in the JS is
+    /// pinned to the enum rather than transcribed from it. Renaming the band member breaks this test instead of
+    /// silently emptying the grid the link lands on.
+    /// </summary>
+    [Fact]
+    public void TheBrowsersFilter_ReadsTheSameBandTheCountWasComputedFrom()
+    {
+        var cards = BuildFleet(healthy: 45, critical: 4, warning: 6, offline: 2);
+        var rollup = DarlingFleetReader.BuildRollup(cards, DateTime.UtcNow, DateTime.UtcNow.AddHours(-1), DateTime.UtcNow);
+
+        /* The server's own arithmetic: everything not Healthy is either ranked or counted in the overflow. */
+        var problems = cards.Count(c => c.Band != FleetHealthBand.Healthy);
+        Assert.Equal(12, problems);
+        Assert.Equal(problems, rollup.WorstServers.Count + rollup.AdditionalProblemCount);
+        Assert.Equal(problems, rollup.WarningCount + rollup.CriticalCount + rollup.OfflineCount);
+
+        /* And the browser's predicate compares against the band this payload actually carries. */
+        var healthyToken = JsonSerializer.Serialize(FleetHealthBand.Healthy, DarlingFleetReader.JsonOptions);
+        Assert.Equal("\"Healthy\"", healthyToken);
+        Assert.Contains("return c.band !== " + healthyToken + ";", FleetJs, StringComparison.Ordinal);
+
+        /* Read off the card, never recomputed from the metrics — the R1 rule the whole page is built on. */
+        Assert.DoesNotContain("cpu_severity ===", FleetJs, StringComparison.Ordinal);
+    }
+
+    /// <summary>The ranking cap is what creates the overflow, so the number the link carries is the number the
+    /// reduction produced — not a second opinion assembled in the browser.</summary>
+    [Fact]
+    public void TheOverflowCount_IsTheServersOwn()
+    {
+        var rollup = DarlingFleetReader.BuildRollup(
+            BuildFleet(healthy: 5, critical: 40, warning: 12, offline: 0),
+            DateTime.UtcNow, DateTime.UtcNow.AddHours(-1), DateTime.UtcNow);
+
+        Assert.Equal(5, rollup.WorstServers.Count);
+        Assert.Equal(47, rollup.AdditionalProblemCount);
+        Assert.Contains("\"+ \" + d.additional_problem_count + \" more need attention\"", FleetJs, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The line navigates, and can be reached without a mouse. <c>onActivate</c> rather than <c>onClick</c> is
+    /// the load-bearing choice: it is util.el's path that also installs <c>role="button"</c>, a tabindex and
+    /// Enter/Space, which is what every other clickable div on this page already gets. A plain click handler
+    /// would look identical on screen and be invisible to a keyboard.
+    /// </summary>
+    [Fact]
+    public void TheOverflowLine_IsActivatable_AndTurnsTheFilterOn()
+    {
+        var js = FleetJs;
+        var at = js.IndexOf("if (d.additional_problem_count > 0) {", StringComparison.Ordinal);
+        Assert.True(at > 0, "the '+N more need attention' affordance is gone — find where it moved before editing this test");
+
+        var end = js.IndexOf("\n    }", at, StringComparison.Ordinal);
+        Assert.True(end > at, "could not find the end of the overflow-line block");
+        var block = js[at..end];
+
+        Assert.Contains("onActivate: () => setAttentionOnly(true)", block, StringComparison.Ordinal);
+
+        /* The class it USED to carry. A muted div is the shape of a caption, and that is exactly how a reader
+           treated it: as a number reporting that 52 servers exist somewhere, not as the way to them. */
+        Assert.DoesNotContain("class: \"muted\"", block, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The filter is clearable and says what it did. A filtered grid that looks unfiltered is a worse defect
+    /// than the dead end it replaces, and the all-clear case — the filter on with nothing left to show — is the
+    /// one that would otherwise read as a broken page. The wording is the desktop viewer's
+    /// <c>FleetRollup.AttentionFilterCountText</c> verbatim, because the reason all three surfaces are being
+    /// fixed together is that a reader moving between them should meet one vocabulary.
+    /// </summary>
+    [Fact]
+    public void TheFilter_SaysWhatItDid_InTheSameWordsTheViewerUses()
+    {
+        Assert.Contains("\"showing \" + shown + \" of \" + total", FleetJs, StringComparison.Ordinal);
+        Assert.Contains("\"all \" + total + \" servers are healthy\"", FleetJs, StringComparison.Ordinal);
+        Assert.Contains("\"the 1 server monitored is healthy\"", FleetJs, StringComparison.Ordinal);
+        Assert.Contains("\"no servers to filter\"", FleetJs, StringComparison.Ordinal);
+
+        var viewer = ReadRepoFile(Path.Combine(
+            "Darling", "PerformanceMonitor.Darling.Viewer", "ViewerDataService.Fleet.cs"));
+        Assert.Contains("$\"showing {shown} of {total}\"", viewer, StringComparison.Ordinal);
+        Assert.Contains("$\"all {total} servers are healthy\"", viewer, StringComparison.Ordinal);
+        Assert.Contains("\"the 1 server monitored is healthy\"", viewer, StringComparison.Ordinal);
+        Assert.Contains("\"no servers to filter\"", viewer, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The colour follows the SENTENCE, not the filter. This line says either "N servers need attention" or an
+    /// all-clear, and painting the all-clear amber would be a colour contradicting its own text — the family of
+    /// defect the whole change is about. Raised in review on #2429 for the viewer's count; it costs one ternary
+    /// here and the same mistake was available.
+    /// </summary>
+    [Fact]
+    public void TheActiveState_IsPaintedByWhatItSays_NotByBeingOn()
+    {
+        Assert.Contains("\"attention-note \" + (shown > 0 ? \"warn\" : \"ok\")", FleetJs, StringComparison.Ordinal);
+
+        var css = ReadRepoFile(Path.Combine(
+            "Darling", "PerformanceMonitor.Darling.Service", "wwwroot", "css", "app.css"));
+        Assert.Contains(".attention-note.warn", css, StringComparison.Ordinal);
+        Assert.Contains(".attention-note.ok", css, StringComparison.Ordinal);
+
+        /* And the affordances the JS names actually have rules — a class with no stylesheet behind it renders
+           as body text, which is precisely the inert muted div this replaces. */
+        Assert.Contains(".attention-link", css, StringComparison.Ordinal);
+        Assert.Contains(".attention-control", css, StringComparison.Ordinal);
+        Assert.Contains(".attention-link:focus-visible", css, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// One place turns the filter on and off, and the header checkbox is where its state lives — so the "+N
+    /// more" link cannot shrink the grid behind the toggle's back, and either affordance can undo the other.
+    /// The toggle is also re-seeded from module state on every render, which is what stops the 60-second
+    /// refresh quietly dropping an active filter.
+    /// </summary>
+    [Fact]
+    public void TheFilterState_HasOneHome_AndSurvivesTheRefresh()
+    {
+        Assert.Contains("function setAttentionOnly(on)", FleetJs, StringComparison.Ordinal);
+        Assert.Contains("if (attentionToggle) attentionToggle.checked = on;", FleetJs, StringComparison.Ordinal);
+        Assert.Contains("cb.checked = attentionOnly;", FleetJs, StringComparison.Ordinal);
+        Assert.Contains("onActivate: () => setAttentionOnly(false)", FleetJs, StringComparison.Ordinal);
+
+        /* The declaration and exactly one assignment — the setter. A second writer is how a link and a toggle
+           end up disagreeing about whether the grid is filtered. */
+        Assert.Equal(2, CountOccurrences(FleetJs, "attentionOnly = "));
+
+        /* Deliberately NOT persisted, unlike the sort and the grouped view: a sort is a preference, this is a
+           triage action tied to a moment, and a page that opens with 52 of 57 servers already hidden is a
+           support ticket even with the toggle in plain sight (#2429's ruling, ported). */
+        Assert.DoesNotContain("darling.fleet.attention", FleetJs, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The grid is filtered in ONE place, composed with the search term rather than replacing it, and both
+    /// render paths (flat and tag-grouped) get the notice — a grouped fleet must not be the one view where an
+    /// active filter is invisible.
+    /// </summary>
+    [Fact]
+    public void TheGrid_IsFilteredOnce_AndBothViewsShowTheActiveState()
+    {
+        Assert.Contains("cardMatches(c, fleetFilter) && (!attentionOnly || cardNeedsAttention(c))", FleetJs, StringComparison.Ordinal);
+
+        /* One call site: the grouped view and the flat view are projected from the SAME filtered list, so a
+           tag-grouped fleet cannot end up with its own opinion about what needs attention. */
+        Assert.Equal(1, CountOccurrences(FleetJs, "|| cardNeedsAttention(c))"));
+
+        Assert.Contains("mount(gridNode, [notice, renderGrouped(matched)]);", FleetJs, StringComparison.Ordinal);
+        Assert.Contains("const notice = attentionOnly ? attentionNotice(matched.length) : null;", FleetJs, StringComparison.Ordinal);
+
+        /* The empty-grid line names whichever filter emptied it: telling a reader whose fleet is simply healthy
+           that nothing matches a search term they never typed is the same class of lie in miniature. */
+        Assert.Contains("No servers need attention.", FleetJs, StringComparison.Ordinal);
+        Assert.Contains("No servers needing attention match", FleetJs, StringComparison.Ordinal);
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>A fleet of pre-banded cards — the shape <c>BuildCard</c> produces, which is the only input
+    /// <c>BuildRollup</c> reads. The bands are set directly because the reduction bands nothing itself; it
+    /// counts what the shared classifier already decided.</summary>
+    private static List<FleetServerCard> BuildFleet(int healthy, int critical, int warning, int offline)
+    {
+        var fleet = new List<FleetServerCard>();
+        var id = 0;
+
+        void Add(int count, FleetHealthBand band, string prefix)
+        {
+            for (var i = 0; i < count; i++)
+            {
+                fleet.Add(new FleetServerCard
+                {
+                    ServerId = ++id,
+                    DisplayName = $"{prefix}{i:00}",
+                    ServerName = $"{prefix}{i:00}",
+                    Band = band,
+                    IsOnline = band != FleetHealthBand.Offline,
+                });
+            }
+        }
+
+        Add(healthy, FleetHealthBand.Healthy, "h");
+        Add(critical, FleetHealthBand.Critical, "c");
+        Add(warning, FleetHealthBand.Warning, "w");
+        Add(offline, FleetHealthBand.Offline, "o");
+
+        return fleet;
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+        return count;
+    }
+
+    private static string ReadRepoFile(string relative, [CallerFilePath] string thisFile = "")
+    {
+        for (var dir = new DirectoryInfo(Path.GetDirectoryName(thisFile)!); dir is not null; dir = dir.Parent)
+        {
+            var candidate = Path.Combine(dir.FullName, relative);
+            if (File.Exists(candidate))
+            {
+                return File.ReadAllText(candidate).Replace("\r\n", "\n", StringComparison.Ordinal);
+            }
+        }
+
+        throw new FileNotFoundException($"Could not locate {relative} walking up from {thisFile}");
+    }
+}

--- a/Darling/Darling.Tests/FleetPageAttentionFilterTests.cs
+++ b/Darling/Darling.Tests/FleetPageAttentionFilterTests.cs
@@ -222,14 +222,14 @@ public sealed class FleetPageAttentionFilterTests
 
         Assert.Contains("mount(gridNode, [notice, renderGrouped(matched)]);", FleetJs, StringComparison.Ordinal);
 
-        /* The empty-grid line names whichever filter emptied it, and with both on it names the RIGHT one.
-           Telling a reader whose fleet is simply healthy that nothing matches a search term they never typed
-           is the same class of lie in miniature; so is blaming the attention filter for a term that matched
-           nothing at all, which is vacuously true and points at the wrong control (raised in review). */
-        Assert.Contains("if (!term) return attentionOnly ? \"No servers need attention.\"", FleetJs, StringComparison.Ordinal);
-        Assert.Contains("if (searchedCount === 0) return \"No servers match", FleetJs, StringComparison.Ordinal);
-        Assert.Contains("return \"No servers matching \u201C\" + term + \"\u201D need attention.\";", FleetJs, StringComparison.Ordinal);
-        Assert.Contains("noMatchText(searched.length)", FleetJs, StringComparison.Ordinal);
+        /* One sentence per state. The notice already explains an empty grid whenever it is showing, and in
+           more precise words, so the grid-area fallback is suppressed under it rather than stacking a second
+           box that says the same thing differently — which is the PR's own design goal losing to itself, and
+           a deviation from the desktop viewer, which shows only its count (raised in review). What is left is
+           the case the notice does not cover: the filter off, the search term the only thing that emptied it. */
+        Assert.Contains(": notice ? null : el(\"div\", { class: \"muted\"", FleetJs, StringComparison.Ordinal);
+        Assert.Contains("return term ? \"No servers match", FleetJs, StringComparison.Ordinal);
+        Assert.DoesNotContain("need attention.\";", FleetJs, StringComparison.Ordinal);
     }
 
     // ── helpers ────────────────────────────────────────────────────────────────────────────────────

--- a/Darling/PerformanceMonitor.Darling.Service/wwwroot/css/app.css
+++ b/Darling/PerformanceMonitor.Darling.Service/wwwroot/css/app.css
@@ -708,6 +708,9 @@ table.data td.sev-Healthy { color: var(--ok); }
 }
 .attention-note.warn { background: rgba(255, 213, 79, 0.10); border: 1px solid rgba(255, 213, 79, 0.35); color: var(--warn); }
 .attention-note.ok { background: rgba(129, 199, 132, 0.10); border: 1px solid rgba(129, 199, 132, 0.35); color: var(--ok); }
+/* Neither: the search matched nothing, so the filter judged nothing. Green would read as an all-clear the
+   data does not support, amber would claim a problem it never looked for. */
+.attention-note.none { background: var(--bg-dark); border: 1px solid var(--border); color: var(--muted); }
 .attention-note .attention-link { margin: 0; }
 
 /* ─────────────────────────── status bar footer ─────────────────────────── */

--- a/Darling/PerformanceMonitor.Darling.Service/wwwroot/css/app.css
+++ b/Darling/PerformanceMonitor.Darling.Service/wwwroot/css/app.css
@@ -671,6 +671,45 @@ table.data td.sev-Healthy { color: var(--ok); }
 }
 .search-input:focus { outline: none; border-color: var(--accent); }
 
+/* ─────────────────────────── needs-attention filter (#2437) ─────────────────────────── */
+
+/* The header toggle, styled as the group-by-tag toggle beside it — it is the same kind of thing, a view
+   control over the same cards, so it should not look like a new concept. */
+.attention-control { display: inline-flex; align-items: center; gap: 0.35rem; font-size: 0.78rem; color: var(--muted); cursor: pointer; }
+.attention-control input { cursor: pointer; }
+
+/* The "+N more need attention" line and the notice's way back out. Underlined, accented and pointer-cursored
+   because a line that navigates has to look like one: the defect being fixed was an inert muted div, which is
+   the shape of a caption, and every reader treated it as one. The focus ring matches the page's other
+   activatable divs (util.el's onActivate makes them role=button + tabbable). */
+.attention-link {
+  display: inline-block;
+  margin: 0.4rem 0 0.2rem;
+  color: var(--accent);
+  font-size: 0.85rem;
+  text-decoration: underline;
+  cursor: pointer;
+}
+.attention-link:hover { filter: brightness(1.15); }
+.attention-link:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+/* The active state, on the grid it shrank. It carries its own colour: the amber arm is a count of servers
+   wanting attention, the green arm is an all-clear, and painting an all-clear amber would be a colour
+   contradicting its own text. */
+.attention-note {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin: 0 0 0.75rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius);
+  font-size: 0.85rem;
+}
+.attention-note.warn { background: rgba(255, 213, 79, 0.10); border: 1px solid rgba(255, 213, 79, 0.35); color: var(--warn); }
+.attention-note.ok { background: rgba(129, 199, 132, 0.10); border: 1px solid rgba(129, 199, 132, 0.35); color: var(--ok); }
+.attention-note .attention-link { margin: 0; }
+
 /* ─────────────────────────── status bar footer ─────────────────────────── */
 
 #statusbar {

--- a/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/pages/fleet.js
+++ b/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/pages/fleet.js
@@ -125,10 +125,17 @@ function cardNeedsAttention(c) {
    FleetRollup.AttentionFilterCountText (#2424), because the point of doing all three surfaces at once is
    that a reader moving between them meets one vocabulary rather than three. The all-clear arms matter as
    much as the count: a filtered grid holding nothing is otherwise an empty page with no explanation, and an
-   empty FLEET must not be told that zero of its servers are healthy. */
-function attentionCountText(shown, total) {
+   empty FLEET must not be told that zero of its servers are healthy.
+
+   The `narrowed` arms are the one place this surface needs words the viewer does not have, and review found
+   out why: the viewer's Overview has no search box, so "the 1 server monitored is healthy" is simply true
+   there. Here the denominator is what the SEARCH left, so on a 57-server fleet narrowed to one match that
+   sentence claims the fleet holds one server, while 56 others exist and were never looked at. The all-clear
+   has to name the population it is clearing. */
+function attentionCountText(shown, total, narrowed) {
   if (shown > 0) return "showing " + shown + " of " + total;
   if (total <= 0) return "no servers to filter";
+  if (narrowed) return total === 1 ? "the 1 matching server is healthy" : "all " + total + " matching servers are healthy";
   if (total === 1) return "the 1 server monitored is healthy";
   return "all " + total + " servers are healthy";
 }
@@ -273,7 +280,7 @@ function attentionNotice(shown, total) {
   const kind = searchFoundNothing ? "none" : shown > 0 ? "warn" : "ok";
   const sentence = searchFoundNothing
     ? label + " — nothing matches that term, so no server was judged."
-    : label + " — " + attentionCountText(shown, total) + ".";
+    : label + " — " + attentionCountText(shown, total, term !== "") + ".";
 
   return el("div", { class: "attention-note " + kind, role: "status" }, [
     el("span", { text: sentence }),

--- a/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/pages/fleet.js
+++ b/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/pages/fleet.js
@@ -251,7 +251,7 @@ function redrawCards() {
     notice,
     matched.length
       ? el("div", { class: "grid" }, matched.map(serverCard))
-      : el("div", { class: "muted", style: "padding:0.5rem", text: noMatchText() }),
+      : el("div", { class: "muted", style: "padding:0.5rem", text: noMatchText(searched.length) }),
   ]);
 }
 
@@ -272,13 +272,16 @@ function attentionNotice(shown, total) {
   ]);
 }
 
-/** The empty-grid line has to name whichever filter emptied it. Reusing the search-term wording unguarded
-    would tell a reader whose fleet is simply healthy that nothing matches a term they never typed. */
-function noMatchText() {
+/** The empty-grid line has to name whichever filter emptied it, and with both on it has to name the RIGHT one.
+    Reusing the search wording unguarded tells a reader whose fleet is simply healthy that nothing matches a
+    term they never typed; saying "no servers needing attention match X" when X matched nothing at all is
+    vacuously true and points at the wrong filter. searched is the split: it is the term's result before the
+    toggle sees it. */
+function noMatchText(searchedCount) {
   const term = fleetFilter.trim();
-  if (term && attentionOnly) return "No servers needing attention match “" + term + "”.";
-  if (term) return "No servers match “" + term + "”.";
-  return "No servers need attention.";
+  if (!term) return attentionOnly ? "No servers need attention." : "No servers to show.";
+  if (searchedCount === 0) return "No servers match “" + term + "”.";
+  return "No servers matching “" + term + "” need attention.";
 }
 
 /** Turns the needs-attention filter on or off from either end — the header toggle or the "+N more" line —

--- a/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/pages/fleet.js
+++ b/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/pages/fleet.js
@@ -256,14 +256,27 @@ function redrawCards() {
 }
 
 /** Why the grid is short, and how to make it whole again — rendered only while the filter is on.
-    The colour follows the SENTENCE, not the filter: this line says either "N servers need attention" or an
-    all-clear, and painting the all-clear amber would be a colour contradicting its own text — the same family
-    of defect this whole change is about. (Raised in review on #2429 and ported.) */
+
+    The colour follows the SENTENCE, not the filter. Painting an all-clear amber would be a colour
+    contradicting its own text (the #2429 review finding), and there are THREE sentences here, not two: a
+    search term that matched nothing leaves the filter with nothing to judge, and green there would be an
+    all-clear the data does not support — the fleet's problem servers were not found healthy, they were never
+    looked at. That case gets the neutral treatment and says what actually happened.
+
+    role="status" is util.js's noticeStrip idiom for exactly this: a non-fatal notice that appears and
+    re-words itself with no page load, so a screen reader hears the count change instead of the grid silently
+    shrinking. Raised in review. */
 function attentionNotice(shown, total) {
   const term = fleetFilter.trim();
   const label = term ? "Needs attention only, matching “" + term + "”" : "Needs attention only";
-  return el("div", { class: "attention-note " + (shown > 0 ? "warn" : "ok") }, [
-    el("span", { text: label + " — " + attentionCountText(shown, total) + "." }),
+  const searchFoundNothing = term !== "" && total === 0;
+  const kind = searchFoundNothing ? "none" : shown > 0 ? "warn" : "ok";
+  const sentence = searchFoundNothing
+    ? label + " — nothing matches that term, so no server was judged."
+    : label + " — " + attentionCountText(shown, total) + ".";
+
+  return el("div", { class: "attention-note " + kind, role: "status" }, [
+    el("span", { text: sentence }),
     el("span", {
       class: "attention-link",
       text: "Show all servers",

--- a/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/pages/fleet.js
+++ b/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/pages/fleet.js
@@ -227,8 +227,12 @@ export async function renderFleet(main) {
     (re)fill the grid — no refetch. */
 function redrawCards() {
   if (!gridNode) return;
-  const matched = lastCards
-    .filter((c) => cardMatches(c, fleetFilter) && (!attentionOnly || cardNeedsAttention(c)))
+  /* The two filters compose, and the search's result is the denominator the notice reports against. With a
+     term typed, "showing 4 of 57" invites reading 4 as the fleet's problem count, which it is not — the other
+     53 were not judged healthy, they were never looked at. The label has to mean what the grid holds. */
+  const searched = lastCards.filter((c) => cardMatches(c, fleetFilter));
+  const matched = (attentionOnly ? searched.filter(cardNeedsAttention) : searched)
+    .slice()
     .sort(SORTS[fleetSort] || SORTS.severity);
 
   /* The active state rides with the CARDS, not only with the toggle that set it. The desktop viewer can put
@@ -236,7 +240,7 @@ function redrawCards() {
      page head scrolls away, so a reader who has scrolled down to the grid would see a short fleet and nothing
      saying why. A filtered grid that looks unfiltered is a worse defect than the dead end it replaced, so the
      notice sits on the grid and carries its own way out. */
-  const notice = attentionOnly ? attentionNotice(matched.length) : null;
+  const notice = attentionOnly ? attentionNotice(matched.length, searched.length) : null;
 
   if (fleetGrouped && lastTags.length) {
     mount(gridNode, [notice, renderGrouped(matched)]);
@@ -255,9 +259,11 @@ function redrawCards() {
     The colour follows the SENTENCE, not the filter: this line says either "N servers need attention" or an
     all-clear, and painting the all-clear amber would be a colour contradicting its own text — the same family
     of defect this whole change is about. (Raised in review on #2429 and ported.) */
-function attentionNotice(shown) {
+function attentionNotice(shown, total) {
+  const term = fleetFilter.trim();
+  const label = term ? "Needs attention only, matching “" + term + "”" : "Needs attention only";
   return el("div", { class: "attention-note " + (shown > 0 ? "warn" : "ok") }, [
-    el("span", { text: "Needs attention only — " + attentionCountText(shown, lastCards.length) + "." }),
+    el("span", { text: label + " — " + attentionCountText(shown, total) + "." }),
     el("span", {
       class: "attention-link",
       text: "Show all servers",

--- a/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/pages/fleet.js
+++ b/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/pages/fleet.js
@@ -258,7 +258,11 @@ function redrawCards() {
     notice,
     matched.length
       ? el("div", { class: "grid" }, matched.map(serverCard))
-      : el("div", { class: "muted", style: "padding:0.5rem", text: noMatchText(searched.length) }),
+      /* The notice already explains an empty grid whenever it is showing, in more precise words than this
+         line can manage — so this is the case it does NOT cover: no attention filter, and the search term is
+         the only thing that could have emptied the grid. Two boxes saying the same thing in different words
+         is the one-sentence-per-state goal losing to itself, and the desktop viewer shows only its count. */
+      : notice ? null : el("div", { class: "muted", style: "padding:0.5rem", text: noMatchText() }),
   ]);
 }
 
@@ -292,16 +296,13 @@ function attentionNotice(shown, total) {
   ]);
 }
 
-/** The empty-grid line has to name whichever filter emptied it, and with both on it has to name the RIGHT one.
-    Reusing the search wording unguarded tells a reader whose fleet is simply healthy that nothing matches a
-    term they never typed; saying "no servers needing attention match X" when X matched nothing at all is
-    vacuously true and points at the wrong filter. searched is the split: it is the term's result before the
-    toggle sees it. */
-function noMatchText(searchedCount) {
+/** The empty-grid line, reached only with the attention filter OFF (see redrawCards) — so the search term is
+    the only thing that can have emptied the grid, and this says so without guessing. The term-less arm is
+    unreachable today (renderFleet takes the empty-fleet path before the grid exists) and is worded honestly
+    rather than left to fall through to a sentence about a term nobody typed. */
+function noMatchText() {
   const term = fleetFilter.trim();
-  if (!term) return attentionOnly ? "No servers need attention." : "No servers to show.";
-  if (searchedCount === 0) return "No servers match “" + term + "”.";
-  return "No servers matching “" + term + "” need attention.";
+  return term ? "No servers match “" + term + "”." : "No servers to show.";
 }
 
 /** Turns the needs-attention filter on or off from either end — the header toggle or the "+N more" line —

--- a/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/pages/fleet.js
+++ b/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/pages/fleet.js
@@ -34,6 +34,15 @@ let fleetFilter = "";
 let lastCards = [];
 let gridNode = null;
 
+/* #2437 (the web twin of #2424): the needs-attention filter over the card grid — the destination the
+   "+N more need attention" line finally has. Deliberately NOT persisted the way the sort and the grouped
+   view are: a sort is a preference, this is a triage action tied to a moment, and a fleet page that opens
+   with 52 of 57 servers already hidden is a support ticket even with the toggle in plain sight.
+   attentionToggle is the header checkbox, held so the "+N more" line can turn it ON rather than filtering
+   behind its back — a grid that silently shrank is the worse version of this defect. */
+let attentionOnly = false;
+let attentionToggle = null;
+
 /* Grouped (tree) view — the web twin of the desktop FleetView: opt-in, and both the toggle and the collapsed
    groups persist client-side (localStorage, guarded so a locked-down browser still renders flat). lastTags is
    the full tag forest /api/fleet returns, so an organisational parent tag with no directly-tagged servers still
@@ -102,6 +111,28 @@ function cardMatches(c, q) {
   );
 }
 
+/* The needs-attention predicate (#2437). It reads the card's PRE-BANDED `band` — the same field
+   BuildRollup counted `additional_problem_count` from (`cards.Where(c => c.Band != FleetHealthBand.Healthy)`)
+   and the same one the Warning / Critical / Offline roll-up tiles are summed from. That is the whole point: a
+   client-side approximation of "needs attention" would eventually disagree with the number that sent the
+   reader here, which is this defect wearing a new hat. R1 still holds — no threshold is re-derived here, a
+   server-computed band is read. */
+function cardNeedsAttention(c) {
+  return c.band !== "Healthy";
+}
+
+/* What the filter did, shown beside the cards it left. Word-for-word the desktop viewer's
+   FleetRollup.AttentionFilterCountText (#2424), because the point of doing all three surfaces at once is
+   that a reader moving between them meets one vocabulary rather than three. The all-clear arms matter as
+   much as the count: a filtered grid holding nothing is otherwise an empty page with no explanation, and an
+   empty FLEET must not be told that zero of its servers are healthy. */
+function attentionCountText(shown, total) {
+  if (shown > 0) return "showing " + shown + " of " + total;
+  if (total <= 0) return "no servers to filter";
+  if (total === 1) return "the 1 server monitored is healthy";
+  return "all " + total + " servers are healthy";
+}
+
 /* The server's tags as read-only coloured pills (#2020). Colour is the stored #RRGGBB or, when unset, a
    neutral pill (matching the desktop apps — no palette is resolved here). The hex is format-checked before it
    reaches the style attribute, so only a well-formed colour from the store is ever applied. Nothing renders
@@ -165,7 +196,20 @@ export async function renderFleet(main) {
       })
     );
     if (d.additional_problem_count > 0) {
-      nodes.push(el("div", { class: "muted", style: "margin:0.4rem 0 0.2rem", text: "+ " + d.additional_problem_count + " more need attention" }));
+      /* #2437: the overflow line is the way TO the overflow, not a report that it exists. It was an inert
+         muted div: on a 57-server fleet it read "+52 more need attention" and the reporter's question was
+         literally "where do I find these warnings?". Activating it turns the needs-attention filter on, so
+         the answer is the card grid below, with every metric chip those servers have. onActivate rather than
+         onClick because a line that navigates has to be reachable from the keyboard too — it installs
+         role=button, tabindex and Enter/Space alongside the click. */
+      nodes.push(
+        el("div", {
+          class: "attention-link",
+          text: "+ " + d.additional_problem_count + " more need attention",
+          title: "Show only the servers that need attention",
+          onActivate: () => setAttentionOnly(true),
+        })
+      );
     }
   }
 
@@ -179,22 +223,65 @@ export async function renderFleet(main) {
   mount(main, nodes);
 }
 
-/** Filter the cached cards by the search term, sort by the current choice, and (re)fill the grid — no refetch. */
+/** Filter the cached cards by the search term AND the needs-attention toggle, sort by the current choice, and
+    (re)fill the grid — no refetch. */
 function redrawCards() {
   if (!gridNode) return;
-  const matched = lastCards.filter((c) => cardMatches(c, fleetFilter)).sort(SORTS[fleetSort] || SORTS.severity);
+  const matched = lastCards
+    .filter((c) => cardMatches(c, fleetFilter) && (!attentionOnly || cardNeedsAttention(c)))
+    .sort(SORTS[fleetSort] || SORTS.severity);
+
+  /* The active state rides with the CARDS, not only with the toggle that set it. The desktop viewer can put
+     its count beside the toggle and stop there because its roll-up header is docked and never scrolls; this
+     page head scrolls away, so a reader who has scrolled down to the grid would see a short fleet and nothing
+     saying why. A filtered grid that looks unfiltered is a worse defect than the dead end it replaced, so the
+     notice sits on the grid and carries its own way out. */
+  const notice = attentionOnly ? attentionNotice(matched.length) : null;
 
   if (fleetGrouped && lastTags.length) {
-    mount(gridNode, renderGrouped(matched));
+    mount(gridNode, [notice, renderGrouped(matched)]);
     return;
   }
 
-  mount(
-    gridNode,
+  mount(gridNode, [
+    notice,
     matched.length
-      ? [el("div", { class: "grid" }, matched.map(serverCard))]
-      : [el("div", { class: "muted", style: "padding:0.5rem", text: "No servers match “" + fleetFilter.trim() + "”." })]
-  );
+      ? el("div", { class: "grid" }, matched.map(serverCard))
+      : el("div", { class: "muted", style: "padding:0.5rem", text: noMatchText() }),
+  ]);
+}
+
+/** Why the grid is short, and how to make it whole again — rendered only while the filter is on.
+    The colour follows the SENTENCE, not the filter: this line says either "N servers need attention" or an
+    all-clear, and painting the all-clear amber would be a colour contradicting its own text — the same family
+    of defect this whole change is about. (Raised in review on #2429 and ported.) */
+function attentionNotice(shown) {
+  return el("div", { class: "attention-note " + (shown > 0 ? "warn" : "ok") }, [
+    el("span", { text: "Needs attention only — " + attentionCountText(shown, lastCards.length) + "." }),
+    el("span", {
+      class: "attention-link",
+      text: "Show all servers",
+      onActivate: () => setAttentionOnly(false),
+    }),
+  ]);
+}
+
+/** The empty-grid line has to name whichever filter emptied it. Reusing the search-term wording unguarded
+    would tell a reader whose fleet is simply healthy that nothing matches a term they never typed. */
+function noMatchText() {
+  const term = fleetFilter.trim();
+  if (term && attentionOnly) return "No servers needing attention match “" + term + "”.";
+  if (term) return "No servers match “" + term + "”.";
+  return "No servers need attention.";
+}
+
+/** Turns the needs-attention filter on or off from either end — the header toggle or the "+N more" line —
+    keeping the checkbox and the grid in step. The checkbox is where the state lives: whichever affordance set
+    it, the reader can see the filter is on and can turn it off in one place. */
+function setAttentionOnly(on) {
+  attentionOnly = on;
+  if (attentionToggle) attentionToggle.checked = on;
+  redrawCards();
 }
 
 /* Renders the grouped (tree) view: DFS group headers each followed by a grid of their cards. Collapsing a
@@ -264,6 +351,7 @@ function pageHead(d) {
     el("h2", { text: "Fleet Overview" }),
     el("div", { class: "spacer" }),
     d && d.total_servers ? searchControl() : null,
+    d && d.total_servers ? attentionControl() : null,
     d && d.tags && d.tags.length ? groupControl() : null,
     d && d.total_servers ? sortControl() : null,
     d ? el("div", { class: "meta", text: "Updated " + localTime(d.generated_at) }) : null,
@@ -285,6 +373,21 @@ function searchControl() {
     redrawCards();
   });
   return el("label", { class: "search-control" }, [el("span", { text: "Search" }), input]);
+}
+
+/** The needs-attention toggle (#2437) — a view control over the same cards, so it sits beside Search and Sort
+    rather than being a mode the "+N more" link switches on invisibly. It re-reads the module-level
+    attentionOnly on every re-render, exactly like the sort and search controls, so the 60s refresh cannot
+    silently drop an active filter. */
+function attentionControl() {
+  const cb = el("input", { type: "checkbox", class: "attention-toggle", "aria-label": "Show only servers that need attention" });
+  cb.checked = attentionOnly;
+  cb.addEventListener("change", () => setAttentionOnly(cb.checked));
+  attentionToggle = cb;
+  return el("label", {
+    class: "attention-control",
+    title: "Show only the cards that are not Healthy — Critical, Warning or Offline. Uncheck to show the whole fleet again.",
+  }, [cb, el("span", { text: "Needs attention only" })]);
 }
 
 /** Client-side card-sort control on the fleet header (M8): severity (default) / name / CPU. */


### PR DESCRIPTION
Part 1 of #2437 — the web dashboard half. (The Lite half is a separate PR: different language, different risk.)

`fleet.js:168` rendered the overflow as an inert muted div:

```js
nodes.push(el("div", { class: "muted", style: "margin:0.4rem 0 0.2rem",
                       text: "+ " + d.additional_problem_count + " more need attention" }));
```

A number, a colour, and nothing to click. @ehaar asked the same question of the desktop twin in #2422 — *"where do I find these warnings?"* — and the honest answer on this surface was the same: nowhere. Those 52 servers are not missing data. `BuildRollup` computes the whole problem set and then truncates it to `DefaultWorstCount` for display, so everything past the fifth is discarded rather than unavailable.

## The line is now the way to them

Activating it turns on a needs-attention filter over the card grid immediately below — the surface that actually answers the question, because it is where the six metric chips live. #2429 settled two properties on the viewer and both port intact.

### The filter runs the same predicate the count was computed from

`BuildRollup` counts `cards.Where(c => c.Band != FleetHealthBand.Healthy)`; the payload already carries that band per card, banded server-side by the shared `ServerHealthClassifier`; `cardNeedsAttention` reads it off the card. So the destination cannot disagree with the label that sent you there, and R1 still holds — no threshold is re-derived in the browser. A client-side approximation of "needs attention" is not a shortcut here, it is this defect wearing a new hat.

That is pinned against **both** artifacts rather than transcribed:

```csharp
var healthyToken = JsonSerializer.Serialize(FleetHealthBand.Healthy, DarlingFleetReader.JsonOptions);
Assert.Equal("\"Healthy\"", healthyToken);
Assert.Contains("return c.band !== " + healthyToken + ";", FleetJs, StringComparison.Ordinal);
```

Renaming the band member now breaks the test instead of silently emptying the grid the link lands on.

### An active filter is visible and clearable

The viewer can put its count beside the toggle and stop there, because its roll-up header is docked and never scrolls. **This page head scrolls away**, so the notice rides with the cards instead and carries its own way out (`Show all servers`). Its wording is the desktop's, word for word — `showing 12 of 57`, and the all-clear arms too, because a filtered grid holding nothing is otherwise an empty page with no explanation.

The colour follows the **sentence**, not the filter. That is a review finding from #2429 ported rather than rediscovered: this line says either a count of servers wanting attention or an all-clear, and painting an all-clear amber would be a colour contradicting its own text — the family of defect this whole change is about.

| state | notice | colour |
|---|---|---|
| 12 of 57 need attention | `Needs attention only — showing 12 of 57.` | amber |
| ...with `off` also typed in Search | `Needs attention only, matching “off” — showing 2 of 2.` | amber |
| fleet is calm, filter on | `Needs attention only — all 57 servers are healthy.` | green |
| single-server install | `Needs attention only — the 1 server monitored is healthy.` | green |
| search matched nothing | `Needs attention only, matching “xyz” — nothing matches that term, so no server was judged.` | neutral |
| search narrowed it, all calm | `Needs attention only, matching “warn0” — all 10 matching servers are healthy.` | green |

Rows 2 and 5 are follow-up commits, both of them this PR's own defect turned on itself. The first version counted against the *fleet*, which is fine alone and wrong once a search term is also narrowing the grid — `showing 4 of 57` invites reading 4 as the fleet's problem count. And a term that matched nothing left `shown` at 0, so it took the **green all-clear arm**: the colour that means everything is fine, over a fleet whose problem servers were never looked at. That is the same colour-contradicting-its-own-text finding #2429's review raised about the amber arm, ported without noticing it had a third case.

Row 6 is the third: `AttentionFilterCountText` is ported from a surface where it is unconditionally true, because the viewer's Overview has no search box and its `total` **is** the fleet. Here `total` is what the search left, so `the 1 server monitored is healthy` claimed the fleet held one server while 56 others existed and were never looked at. The unnarrowed arms stay verbatim — the cross-surface vocabulary pin still holds and still means something — and with a term active the sentence names the search instead.

The notice also carries `role="status"`, matching `util.js`'s `noticeStrip` — it appears and re-words itself with no page load, and a filter you can reach by keyboard whose result is never announced is a half-finished job.

The toggle sits beside Search and Sort because it is the same kind of thing — a view control over the same cards — and it is where the state lives: the link turns it **on** rather than filtering behind its back, so either affordance can undo the other. It is deliberately **not** persisted the way the sort and the grouped view are (both are in `localStorage`): a sort is a preference, this is a triage action tied to a moment, and a page that opens with 52 of 57 servers already hidden is a support ticket even with the box in plain sight.

`onActivate` rather than `onClick`, because that is `util.el`'s path that also installs `role="button"`, a tabindex and Enter/Space — the same treatment every other clickable div on this page already gets; a plain click handler would look identical and be invisible to a keyboard.

One sentence per state, including the empty ones. The notice explains an empty grid whenever it is showing, so the grid-area fallback is suppressed under it rather than stacking a second box that says the same thing in different words — the desktop viewer shows only its count and leaves the grid blank, and this now matches. What remains is the case the notice does not cover: the filter off, where the search term is the only thing that can have emptied the grid.

## Verification

This repository has no JavaScript test runner, so the pins **text-scan the shipped module**, the way `ViewerGridPayloadColumnOrderPinTests` already scans `server.js`. **Six of the seven fail against `dev`**; the one that passes is the guard that finds the overflow line at all plus the server-side arithmetic, which has not changed.

Behaviour was verified for real anyway, because a source scan cannot see whether the thing works. The **shipped `fleet.js`** was run under a minimal DOM shim (no npm, no jsdom — `createElement`/`createTextNode` and a stubbed `fetch`) against a fabricated `/api/fleet` body of the shape `BuildRollup` emits: **31 assertions, all passing**, over a 57-server fleet, a mixed fleet, an all-healthy fleet and a one-server install — including that the filtered grid holds exactly the 12 problem servers and no healthy card, that the five already ranked are still reachable in it, that search composes with the filter, and the keyboard path in and out. Against `dev` the same harness cannot get past the third assertion, because the affordance does not exist.

**One thing noted and not fixed here**, raised in review and pre-existing: `renderGrouped`'s own empty-state branch is unreachable whenever `lastTags.length > 0`, because `buildTagGroups` emits a header per tag in the forest even when no card falls under it. So narrowing to zero in the grouped view renders a tree of zero-count headers rather than a message. That was already true of the search box; the attention filter is a second way to reach it. It is cosmetic rather than confusing here — the notice sits above the tree and says what happened — and unpicking it means changing how the grouped view treats empty groups, which is #2020's lane rather than this one.

Whole solution builds, 0 errors. CHANGELOG deliberately untouched — #2395 is an open release-prep PR that owns that file for 3.5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
