### PR TITLE
Hand Darling's analysis token to the store reads it is meant to abandon (#2443)

### DIFF
--- a/Darling/Darling.Tests/AnalysisPassTokenThreadingTests.cs
+++ b/Darling/Darling.Tests/AnalysisPassTokenThreadingTests.cs
@@ -1,0 +1,349 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+using PerformanceMonitor.Analysis;
+using PerformanceMonitor.Darling.Analysis;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// The analysis pass's token has to reach the reads, not just the gaps between them (#2443).
+///
+/// <para>#2438 armed a per-pass budget and #2430's classifier told a timeout from a stop, so an
+/// overrunning server became loudly stuck instead of silently skipped forever. What neither did was
+/// hand the token to the store layer: 168 of this project's async store calls took the no-argument
+/// overload, so abandonment happened BETWEEN stages. A pass gave up while its wedged query kept a
+/// connection and a session alive until the query finished on its own — on a healthy fleet
+/// invisible, and on the pathological case these fixes exist for, the monitoring tool holding a
+/// session it had already stopped waiting for.</para>
+///
+/// <para>The threading itself is mechanical; this file is the part that lasts. A sweep this size
+/// only stays swept if something counts it, and the failure mode it guards against is specific:
+/// adding <c>CancellationToken cancellationToken = default</c> to signatures and stopping there,
+/// which leaves every call site passing <see cref="CancellationToken.None"/> while LOOKING threaded.
+/// So the pin is on the CALL, not the signature — a no-argument <c>ExecuteReaderAsync()</c> is what
+/// goes red, and no default can hide it.</para>
+/// </summary>
+public sealed class AnalysisPassTokenThreadingTests
+{
+    /// <summary>
+    /// The no-argument overloads. Each has a token-taking sibling, so the empty parentheses are the
+    /// whole tell — there is no shape of correct code in this project that needs them.
+    /// </summary>
+    private static readonly Regex s_untokenedStoreCall = new(
+        @"\.(?:ExecuteReaderAsync|ExecuteNonQueryAsync|ExecuteScalarAsync|ReadAsync|OpenAsync|OpenConnectionAsync)\(\s*\)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// A member declaration, used only to attribute a call to the method that makes it. Deliberately
+    /// crude — it needs to name the enclosing method, not parse C#. The <c>[^=;()]*</c> is what keeps
+    /// field initializers and expression-bodied properties out.
+    /// </summary>
+    private static readonly Regex s_memberDeclaration = new(
+        @"^\s*(?:public|private|internal|protected)[^=;()]*\s(?<name>[A-Za-z_][A-Za-z0-9_]*)\s*\(",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private const string ExemptionMarker = "#2443 exempt";
+
+    /// <summary>
+    /// Every method allowed to make an untokened store call, and the reason it is allowed to. This is
+    /// an enumeration and not a wildcard on purpose: the exemption list this repo spent a day removing
+    /// was a wildcard, and the way that one grew was that nobody had to name a new entry.
+    ///
+    /// <para>Two kinds live here and they are not the same kind. The read-back surfaces are OFF the
+    /// pass — the viewer, the MCP and the retention sweep have no per-pass budget and no wedged
+    /// analysis to abandon, so there is no token to thread and inventing one would be pretending.
+    /// <c>InsertFindingAsync</c> is the other kind: it is ON the pass and the token is deliberately
+    /// withheld, because a finding set cut in half is a third outcome that reads like neither of the
+    /// two the classifier names (see the method's own note, and
+    /// <see cref="TheFindingInsertIsAbandonedBeforeItStartsOrNotAtAll"/>).</para>
+    /// </summary>
+    private static readonly Dictionary<string, string> s_exempt = new(StringComparer.Ordinal)
+    {
+        ["GetRecentFindingsAsync"] = "read-back: the MCP + viewer findings read, no pass to abandon",
+        ["GetLatestFindingsAsync"] = "read-back: the viewer's Recommendations tab, no pass to abandon",
+        ["GetMutedStoriesAsync"] = "read-back: the viewer's mute registry read, no pass to abandon",
+        ["MuteStoryAsync"] = "off-pass write: the MCP/viewer mute verb, no pass to abandon",
+        ["UnmuteStoryAsync"] = "off-pass write: the viewer's unmute verb, no pass to abandon",
+        ["CleanupOldFindingsAsync"] = "off-pass write: the worker's retention sweep, its own lifetime",
+        ["InsertFindingAsync"] = "on-pass write, token withheld: a half-written finding set must not exist"
+    };
+
+    /// <summary>
+    /// The sweep, and the thing that keeps it swept. Every store call in the analysis project must
+    /// take the pass's token, and the ones that do not must be exempt BY NAME with a marker in their
+    /// own doc comment — so the reason travels with the code rather than living only here.
+    ///
+    /// <para>Scanned over the whole project directory rather than a file list, because a file list is
+    /// a thing a new partial can be added outside of. A seventh <c>PgFactCollector</c> partial is
+    /// covered the day it exists.</para>
+    /// </summary>
+    [Fact]
+    public void NoStoreCallOnTheAnalysisPassRunsWithoutThePassToken()
+    {
+        var offenders = new List<string>();
+
+        foreach (var (file, lines) in AnalysisSources())
+        {
+            var enclosing = string.Empty;
+
+            for (var i = 0; i < lines.Length; i++)
+            {
+                var declaration = s_memberDeclaration.Match(lines[i]);
+                if (declaration.Success)
+                {
+                    enclosing = declaration.Groups["name"].Value;
+                }
+
+                if (!s_untokenedStoreCall.IsMatch(lines[i]))
+                {
+                    continue;
+                }
+
+                if (s_exempt.ContainsKey(enclosing) && DocBlockAbove(lines, IndexOfDeclaration(lines, i)).Contains(ExemptionMarker, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                offenders.Add($"{file}:{i + 1} in {enclosing}(): {lines[i].Trim()}");
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            "These store calls run without the pass's cancellation token, so the pass can be abandoned "
+            + "around them but never inside one. Pass context.CancellationToken (or the method's own token "
+            + $"parameter). If the call genuinely must complete, add its method to {nameof(s_exempt)} and put a "
+            + $"'{ExemptionMarker}' note in its doc comment saying why:\n"
+            + string.Join("\n", offenders));
+    }
+
+    /// <summary>
+    /// The other half of the agreement: an exemption that no longer corresponds to an untokened call is
+    /// a claim the code stopped making, and it must not be allowed to sit there authorizing the next
+    /// one. Every entry must still be earning its place, and every marker in the source must belong to
+    /// an entry.
+    /// </summary>
+    [Fact]
+    public void EveryExemptionIsStillEarningItsPlace()
+    {
+        var untokenedBy = new Dictionary<string, int>(StringComparer.Ordinal);
+        var markedMethods = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var (_, lines) in AnalysisSources())
+        {
+            var enclosing = string.Empty;
+            var enclosingAt = -1;
+
+            for (var i = 0; i < lines.Length; i++)
+            {
+                var declaration = s_memberDeclaration.Match(lines[i]);
+                if (declaration.Success)
+                {
+                    enclosing = declaration.Groups["name"].Value;
+                    enclosingAt = i;
+                    if (DocBlockAbove(lines, enclosingAt).Contains(ExemptionMarker, StringComparison.Ordinal))
+                    {
+                        markedMethods.Add(enclosing);
+                    }
+                }
+
+                if (s_untokenedStoreCall.IsMatch(lines[i]) && enclosingAt >= 0)
+                {
+                    untokenedBy[enclosing] = untokenedBy.TryGetValue(enclosing, out var n) ? n + 1 : 1;
+                }
+            }
+        }
+
+        Assert.Equal(s_exempt.Keys.OrderBy(k => k, StringComparer.Ordinal), markedMethods.OrderBy(k => k, StringComparer.Ordinal));
+        Assert.Equal(s_exempt.Keys.OrderBy(k => k, StringComparer.Ordinal), untokenedBy.Keys.OrderBy(k => k, StringComparer.Ordinal));
+
+        /* The counts are stated so a NEW untokened call inside an already-exempt method cannot ride in
+           on the exemption. 15 read-back calls across six methods, and the one finding INSERT. */
+        Assert.Equal(16, untokenedBy.Values.Sum());
+        Assert.Equal(1, untokenedBy["InsertFindingAsync"]);
+    }
+
+    /// <summary>
+    /// The fact collector is where the token would have been silently useless. Its per-query catches were
+    /// bare <c>catch { }</c> — deliberately, so a missing table degrades to "no facts" — which meant an
+    /// armed token produced thirty-three swallowed cancellations and a pass that carried on collecting
+    /// under a token that had already fired. Every catch there now lets an abandonment through, which is
+    /// what turns the threaded token into an exit rather than thirty-three wasted connection opens.
+    /// </summary>
+    [Fact]
+    public void EveryCatchOnTheFactCollectorLetsAnAbandonmentThrough()
+    {
+        var bare = new List<string>();
+        var opensCatch = new Regex(@"^\s*catch\b", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        var classified = new Regex(
+            @"^\s*catch\s*\(\s*Exception\s+ex\s*\)\s*when\s*\(\s*!AnalysisShutdown\.IsExpectedAbandon\(",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        foreach (var (file, lines) in AnalysisSources())
+        {
+            if (!Path.GetFileName(file).StartsWith("PgFactCollector.", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            for (var i = 0; i < lines.Length; i++)
+            {
+                if (opensCatch.IsMatch(lines[i]) && !classified.IsMatch(lines[i]))
+                {
+                    bare.Add($"{file}:{i + 1}: {lines[i].Trim()}");
+                }
+            }
+        }
+
+        Assert.True(bare.Count == 0,
+            "A fact-collector catch that does not classify swallows the abandonment the token was armed for, "
+            + "and the pass keeps collecting under a fired token:\n" + string.Join("\n", bare));
+
+        /* 27 collect methods guard their read this way; the number is stated so deleting one is a decision.
+           The other four collect methods have no catch at all and never had one — their reads propagate
+           straight to the pass, which is the same outcome by a shorter route. */
+        Assert.Equal(27, AnalysisSources()
+            .Where(s => Path.GetFileName(s.File).StartsWith("PgFactCollector.", StringComparison.Ordinal))
+            .SelectMany(s => s.Lines)
+            .Count(line => classified.IsMatch(line)));
+    }
+
+    /// <summary>
+    /// The behavioural half, and the reason a source pin alone is not enough here. Reverted, this test
+    /// fails with an <c>NpgsqlException</c> rather than an <see cref="OperationCanceledException"/>, which
+    /// is the whole defect in one line: handed a token that had ALREADY fired,
+    /// <see cref="PgFactCollector.CollectFactsAsync"/> still dialled the store. The collectors that carry
+    /// a catch then swallowed the failure and the pass carried on to the next one, so a cancelled pass
+    /// spent thirty-three connection opens finding out what the token had said before the first.
+    ///
+    /// <para>No store is needed to run this, precisely because the token is already cancelled — a pass
+    /// that observes it never reaches the network.</para>
+    /// </summary>
+    [Fact]
+    public async Task AFiredTokenStopsFactCollectionAtTheFirstReadInsteadOfRunningEveryCollector()
+    {
+        await using var dataSource = NpgsqlDataSource.Create(
+            "Host=127.0.0.1;Port=1;Username=nobody;Password=nobody;Database=nowhere;Timeout=1;Command Timeout=1");
+
+        var collector = new PgFactCollector(dataSource);
+        var context = new AnalysisContext
+        {
+            ServerId = 1,
+            ServerName = "wedged",
+            TimeRangeStart = DateTime.UtcNow.AddHours(-4),
+            TimeRangeEnd = DateTime.UtcNow,
+            CancellationToken = new CancellationToken(canceled: true)
+        };
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => collector.CollectFactsAsync(context));
+    }
+
+    /// <summary>
+    /// The decision this issue asked to be made explicitly rather than assumed: what a cancelled PERSIST
+    /// means. The insert batch has no transaction (per-row failure isolation is deliberate — one bad row
+    /// logs and the batch continues), every row shares one <c>analysis_time</c>, and the latest-findings
+    /// read keys on <c>MAX(analysis_time)</c>. So a batch cut in half does not read as truncated; it reads
+    /// as a complete analysis that found fewer problems, and the server looks HEALTHIER for having been
+    /// abandoned. That is a third outcome, distinct from the timeout and the shutdown the classifier names,
+    /// and it must not exist. The connection open is therefore the last abandonment point: before the first
+    /// row, or not at all.
+    /// </summary>
+    [Fact]
+    public void TheFindingInsertIsAbandonedBeforeItStartsOrNotAtAll()
+    {
+        var store = ReadSource(Path.Combine(AnalysisDirectory(), "PgFindingStore.cs"));
+
+        /* The abandonment point: the batch's connection open observes the pass token. */
+        Assert.Contains(
+            "await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);",
+            store, StringComparison.Ordinal);
+
+        /* And nothing after it does. A ThrowIfCancellationRequested between rows would MAKE the partial
+           set rather than prevent it, which is why there is none. */
+        var insertBatch = Between(store, "public async Task<List<AnalysisFinding>> InsertFindingsAsync(", "public async Task<List<AnalysisFinding>> SaveFindingsAsync(");
+        Assert.DoesNotContain("ThrowIfCancellationRequested", insertBatch, StringComparison.Ordinal);
+
+        /* The row write states the decision where someone changing it will read it. */
+        Assert.Contains(ExemptionMarker, Between(store, "/// Inserts one finding on an already-open connection", "private async Task InsertFindingAsync("), StringComparison.Ordinal);
+    }
+
+    private static string Between(string source, string start, string end)
+    {
+        var from = source.IndexOf(start, StringComparison.Ordinal);
+        Assert.True(from >= 0, $"anchor not found: {start}");
+        var to = source.IndexOf(end, from, StringComparison.Ordinal);
+        Assert.True(to > from, $"anchor not found after {start}: {end}");
+        return source[from..to];
+    }
+
+    /// <summary>The declaration line a call at <paramref name="callLine"/> belongs to (scanning up).</summary>
+    private static int IndexOfDeclaration(string[] lines, int callLine)
+    {
+        for (var i = callLine; i >= 0; i--)
+        {
+            if (s_memberDeclaration.IsMatch(lines[i]))
+            {
+                return i;
+            }
+        }
+
+        return 0;
+    }
+
+    /// <summary>The contiguous <c>///</c> block immediately above a declaration, as one string.</summary>
+    private static string DocBlockAbove(string[] lines, int declarationLine)
+    {
+        var doc = new List<string>();
+        for (var i = declarationLine - 1; i >= 0 && lines[i].TrimStart().StartsWith("///", StringComparison.Ordinal); i--)
+        {
+            doc.Add(lines[i]);
+        }
+
+        return string.Join("\n", doc);
+    }
+
+    private static IEnumerable<(string File, string[] Lines)> AnalysisSources()
+    {
+        var files = Directory.GetFiles(AnalysisDirectory(), "*.cs", SearchOption.TopDirectoryOnly);
+        Assert.NotEmpty(files);
+
+        foreach (var file in files.OrderBy(f => f, StringComparer.Ordinal))
+        {
+            /* The working copy is CRLF; split on the LF so a line never carries a stray CR. */
+            yield return (Path.GetFileName(file), ReadSource(file).Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n'));
+        }
+    }
+
+    private static string AnalysisDirectory() =>
+        Path.Combine(RepoRoot(), "Darling", "PerformanceMonitor.Darling.Analysis");
+
+    private static string RepoRoot([CallerFilePath] string thisFile = "")
+    {
+        var dir = Path.GetDirectoryName(thisFile)!;
+        while (dir is not null && !File.Exists(Path.Combine(dir, "PerformanceMonitor.sln")) && !Directory.Exists(Path.Combine(dir, ".git")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        Assert.NotNull(dir);
+        return dir!;
+    }
+
+    private static string ReadSource(string path) => File.ReadAllText(path);
+}

--- a/Darling/Darling.Tests/DarlingAnalysisStoreTests.cs
+++ b/Darling/Darling.Tests/DarlingAnalysisStoreTests.cs
@@ -222,12 +222,12 @@ public sealed class DarlingAnalysisStoreTests
            to null without touching any server (Lite's ServerManager-miss semantics). */
         var resolved = false;
         var fetcher = new PgPlanFetcher(_ => { resolved = true; return null; });
-        Assert.Null(await fetcher.FetchPlanXmlAsync(TestServerId, "0x0600FF00"));
+        Assert.Null(await fetcher.FetchPlanXmlAsync(TestServerId, "0x0600FF00", TestContext.Current.CancellationToken));
         Assert.True(resolved);
 
         /* An empty plan handle short-circuits before the resolver is consulted. */
         resolved = false;
-        Assert.Null(await fetcher.FetchPlanXmlAsync(TestServerId, ""));
+        Assert.Null(await fetcher.FetchPlanXmlAsync(TestServerId, "", TestContext.Current.CancellationToken));
         Assert.False(resolved);
     }
 

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgBlockingPairRowQuery.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgBlockingPairRowQuery.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data.Common;
+using System.Threading;
 using System.Threading.Tasks;
 using Npgsql;
 using PerformanceMonitor.Analysis;
@@ -125,8 +126,15 @@ LIMIT 5000";
     /// fragments as the blocked-process-report queries, against v_dmv_blocking_snapshots, so <see cref="Read"/>
     /// maps it unchanged. Takes a command factory so the caller's connection runs it — the Lite shape, kept so
     /// the future drill-down/viewer slices call it identically.
+    ///
+    /// <para>#2443: the token is required, not defaulted. Three callers share this fetch and two of
+    /// them are on the analysis pass; a default would have let either keep passing nothing while the
+    /// signature claimed the read was abandonable. The viewer's call is the one that legitimately has
+    /// no pass to abandon, and it says so at its own call site rather than here.</para>
     /// </summary>
-    internal static async Task AppendDmvSnapshotRowsAsync(Func<NpgsqlCommand> createCommand, List<BlockingPairRow> rows, int serverId, DateTime start, DateTime end)
+    internal static async Task AppendDmvSnapshotRowsAsync(
+        Func<NpgsqlCommand> createCommand, List<BlockingPairRow> rows, int serverId, DateTime start, DateTime end,
+        CancellationToken cancellationToken)
     {
         var dmv = new List<BlockingPairRow>();
         using (var cmd = createCommand())
@@ -136,8 +144,8 @@ LIMIT 5000";
             cmd.Parameters.AddWithValue(DateTime.SpecifyKind(start, DateTimeKind.Unspecified));
             cmd.Parameters.AddWithValue(DateTime.SpecifyKind(end, DateTimeKind.Unspecified));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
+            using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
                 dmv.Add(Read(reader));
         }
 

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgDrillDownCollector.Blocking.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgDrillDownCollector.Blocking.cs
@@ -29,7 +29,7 @@ LIMIT 3";
 
     private async Task CollectTopDeadlocks(AnalysisFinding finding, AnalysisContext context)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var cmd = new NpgsqlCommand(TopDeadlocksSql, connection);
         cmd.Parameters.AddWithValue(context.ServerId);
@@ -37,8 +37,8 @@ LIMIT 3";
         cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             /* #1140: parse the involved objects from the graph for the dedup fingerprint + a readable
                Objects field. The raw graph XML is NOT surfaced (it would bloat the alert detail). */
@@ -88,7 +88,7 @@ LIMIT 5";
 
     private async Task CollectTopBlockingChains(AnalysisFinding finding, AnalysisContext context)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var cmd = new NpgsqlCommand(TopBlockingChainsSql, connection);
         cmd.Parameters.AddWithValue(context.ServerId);
@@ -96,8 +96,8 @@ LIMIT 5";
         cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             items.Add(new
             {
@@ -141,7 +141,7 @@ LIMIT 5000";
     /// </summary>
     private async Task CollectReconstructedBlockingChains(AnalysisFinding finding, AnalysisContext context)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var cmd = new NpgsqlCommand(ReconstructedChainsSql, connection);
         cmd.Parameters.AddWithValue(context.ServerId);
@@ -149,16 +149,17 @@ LIMIT 5000";
         cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
         var rows = new List<BlockingPairRow>();
-        using (var reader = await cmd.ExecuteReaderAsync())
+        using (var reader = await cmd.ExecuteReaderAsync(context.CancellationToken))
         {
-            while (await reader.ReadAsync())
+            while (await reader.ReadAsync(context.CancellationToken))
                 rows.Add(PgBlockingPairRowQuery.Read(reader));
         }
 
         // Always-on DMV blocking snapshot fallback. Merge BEFORE the empty check so DMV-only blocking
         // (blocked-process-report unavailable, e.g. AWS RDS) still reconstructs.
         await PgBlockingPairRowQuery.AppendDmvSnapshotRowsAsync(
-            connection.CreateCommand, rows, context.ServerId, context.TimeRangeStart, context.TimeRangeEnd);
+            connection.CreateCommand, rows, context.ServerId, context.TimeRangeStart, context.TimeRangeEnd,
+            context.CancellationToken);
 
         if (rows.Count == 0) return;
 
@@ -207,7 +208,7 @@ LIMIT 10";
 
     private async Task CollectLockModeBreakdown(AnalysisFinding finding, AnalysisContext context)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var cmd = new NpgsqlCommand(LockModeBreakdownSql, connection);
         cmd.Parameters.AddWithValue(context.ServerId);
@@ -215,8 +216,8 @@ LIMIT 10";
         cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             items.Add(new
             {

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgDrillDownCollector.Config.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgDrillDownCollector.Config.cs
@@ -28,14 +28,14 @@ ORDER BY database_name";
 
     private async Task CollectConfigIssues(AnalysisFinding finding, AnalysisContext context)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var cmd = new NpgsqlCommand(ConfigIssuesSql, connection);
         cmd.Parameters.AddWithValue(context.ServerId);
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             var issues = new List<string>();
             if (!reader.IsDBNull(2) && reader.GetBoolean(2)) issues.Add("auto_shrink ON");

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgDrillDownCollector.Plans.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgDrillDownCollector.Plans.cs
@@ -49,22 +49,27 @@ LIMIT 1";
         string? planHandle = null;
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(PlanHandleLookupSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(queryHash);
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (await reader.ReadAsync() && !reader.IsDBNull(0))
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (await reader.ReadAsync(context.CancellationToken) && !reader.IsDBNull(0))
                 planHandle = reader.GetString(0);
         }
-        catch { return; }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* No plan_handle for this hash — the fetch below has nothing to ask for. An abandonment
+               is NOT swallowed here (#2443). */
+            return;
+        }
 
         if (string.IsNullOrEmpty(planHandle)) return;
 
         // Fetch plan XML live from SQL Server
-        var planXml = await _planFetcher.FetchPlanXmlAsync(context.ServerId, planHandle);
+        var planXml = await _planFetcher.FetchPlanXmlAsync(context.ServerId, planHandle, context.CancellationToken);
         if (string.IsNullOrEmpty(planXml)) return;
 
         try
@@ -142,15 +147,15 @@ LIMIT 10";
             /* PG port: Lite scopes the connection in a block to release its DuckDB read lock
                before the CPU-only parse; the scoping is kept so the connection closes before
                the parse, even though PG holds no lock. */
-            await using (var connection = await _postgres.OpenConnectionAsync())
+            await using (var connection = await _postgres.OpenConnectionAsync(context.CancellationToken))
             {
                 using var cmd = new NpgsqlCommand(PlanAdvisoryXmlSql, connection);
                 cmd.Parameters.AddWithValue(context.ServerId);
                 cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
                 cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-                using var reader = await cmd.ExecuteReaderAsync();
-                while (await reader.ReadAsync())
+                using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+                while (await reader.ReadAsync(context.CancellationToken))
                 {
                     if (!reader.IsDBNull(0))
                         planXmls.Add(reader.GetString(0));
@@ -190,9 +195,10 @@ LIMIT 10";
                     .ToList();
             }
         }
-        catch
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
         {
             // Plan read/parse can fail on malformed XML — skip, the detail is best-effort.
+            // An abandonment is NOT swallowed here (#2443).
         }
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgDrillDownCollector.Queries.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgDrillDownCollector.Queries.cs
@@ -48,7 +48,7 @@ LIMIT 5";
     private async Task CollectQueriesAtSpike(AnalysisFinding finding, AnalysisContext context)
     {
         // Find the peak CPU time, then get queries active within 2 minutes of it
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         // Step 1: Find when the spike occurred
         using var peakCmd = new NpgsqlCommand(SpikePeakSql, connection);
@@ -59,9 +59,9 @@ LIMIT 5";
 
         DateTime? peakTime = null;
         int peakCpu = 0;
-        using (var peakReader = await peakCmd.ExecuteReaderAsync())
+        using (var peakReader = await peakCmd.ExecuteReaderAsync(context.CancellationToken))
         {
-            if (await peakReader.ReadAsync())
+            if (await peakReader.ReadAsync(context.CancellationToken))
             {
                 peakTime = peakReader.GetDateTime(0);
                 peakCpu = peakReader.GetInt32(1);
@@ -78,9 +78,9 @@ LIMIT 5";
         queryCmd.Parameters.AddWithValue(AsNaive(peakTime.Value.AddMinutes(2)));
 
         var items = new List<object>();
-        using (var reader = await queryCmd.ExecuteReaderAsync())
+        using (var reader = await queryCmd.ExecuteReaderAsync(context.CancellationToken))
         {
-            while (await reader.ReadAsync())
+            while (await reader.ReadAsync(context.CancellationToken))
             {
                 items.Add(new
                 {
@@ -126,7 +126,7 @@ LIMIT 5";
 
     private async Task CollectTopCpuQueries(AnalysisFinding finding, AnalysisContext context)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var cmd = new NpgsqlCommand(TopCpuQueriesSql, connection);
         cmd.CommandTimeout = DrillDownCommandTimeoutSeconds;
@@ -135,8 +135,8 @@ LIMIT 5";
         cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             items.Add(new
             {
@@ -168,7 +168,7 @@ LIMIT 5";
 
     private async Task CollectTopSpillingQueries(AnalysisFinding finding, AnalysisContext context)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var cmd = new NpgsqlCommand(TopSpillingQueriesSql, connection);
         cmd.CommandTimeout = DrillDownCommandTimeoutSeconds;
@@ -177,8 +177,8 @@ LIMIT 5";
         cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             items.Add(new
             {
@@ -248,7 +248,7 @@ LIMIT 5";
     /// </summary>
     private async Task CollectParameterSensitiveQueries(AnalysisFinding finding, AnalysisContext context)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var cmd = new NpgsqlCommand(ParameterSensitiveSql, connection);
         cmd.CommandTimeout = DrillDownCommandTimeoutSeconds;
@@ -257,8 +257,8 @@ LIMIT 5";
         cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             items.Add(new
             {
@@ -492,7 +492,7 @@ LIMIT 5";
     /// </summary>
     private async Task CollectRegressedQueries(AnalysisFinding finding, AnalysisContext context)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var cmd = new NpgsqlCommand(RegressedQueriesSql, connection);
         cmd.CommandTimeout = DrillDownCommandTimeoutSeconds;
@@ -505,8 +505,8 @@ LIMIT 5";
         cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             items.Add(new
             {
@@ -567,7 +567,7 @@ GROUP BY database_name, query_hash";
         var queryHash = finding.RootFactKey.Replace("BAD_ACTOR_", "");
         if (string.IsNullOrEmpty(queryHash)) return;
 
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var cmd = new NpgsqlCommand(BadActorDetailSql, connection);
         cmd.CommandTimeout = DrillDownCommandTimeoutSeconds;
@@ -576,8 +576,8 @@ GROUP BY database_name, query_hash";
         cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
         cmd.Parameters.AddWithValue(queryHash);
 
-        using var reader = await cmd.ExecuteReaderAsync();
-        if (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        if (await reader.ReadAsync(context.CancellationToken))
         {
             finding.DrillDown!["bad_actor_query"] = new
             {
@@ -610,7 +610,7 @@ LIMIT 5";
 
     private async Task CollectPendingGrants(AnalysisFinding finding, AnalysisContext context)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var cmd = new NpgsqlCommand(PendingGrantsSql, connection);
         cmd.CommandTimeout = DrillDownCommandTimeoutSeconds;
@@ -619,8 +619,8 @@ LIMIT 5";
         cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             items.Add(new
             {

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgDrillDownCollector.Storage.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgDrillDownCollector.Storage.cs
@@ -31,7 +31,7 @@ LIMIT 10";
 
     private async Task CollectFileLatencyBreakdown(AnalysisFinding finding, AnalysisContext context)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var cmd = new NpgsqlCommand(FileLatencyBreakdownSql, connection);
         cmd.Parameters.AddWithValue(context.ServerId);
@@ -39,8 +39,8 @@ LIMIT 10";
         cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             items.Add(new
             {
@@ -82,14 +82,14 @@ LIMIT 50";
     /// </summary>
     private async Task CollectAutogrowthPercentFiles(AnalysisFinding finding, AnalysisContext context)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var cmd = new NpgsqlCommand(AutogrowthPercentFilesSql, connection);
         cmd.Parameters.AddWithValue(context.ServerId);
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             var database = reader.IsDBNull(0) ? "" : reader.GetString(0);
             var fileType = reader.IsDBNull(1) ? "" : reader.GetString(1);
@@ -125,7 +125,7 @@ LIMIT 5";
 
     private async Task CollectTempDbBreakdown(AnalysisFinding finding, AnalysisContext context)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var cmd = new NpgsqlCommand(TempDbBreakdownSql, connection);
         cmd.Parameters.AddWithValue(context.ServerId);
@@ -133,8 +133,8 @@ LIMIT 5";
         cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             items.Add(new
             {

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgFactCollector.Activity.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgFactCollector.Activity.cs
@@ -56,15 +56,15 @@ LIMIT 5";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(BadActorSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            while (await reader.ReadAsync(context.CancellationToken))
             {
                 var dbName = reader.IsDBNull(0) ? "" : reader.GetString(0);
                 var queryHash = reader.IsDBNull(1) ? "" : reader.GetString(1);
@@ -102,7 +102,10 @@ LIMIT 5";
                 });
             }
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string ActiveQuerySql = @"
@@ -126,15 +129,15 @@ AND   collection_time <= $3";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(ActiveQuerySql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var totalSnapshots = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
             if (totalSnapshots == 0) return;
@@ -164,7 +167,10 @@ AND   collection_time <= $3";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string RunningJobsSql = @"
@@ -185,15 +191,15 @@ AND   collection_time <= $3";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(RunningJobsSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var runningCount = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
             if (runningCount == 0) return;
@@ -217,7 +223,10 @@ AND   collection_time <= $3";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string SessionStatsSql = @"
@@ -245,15 +254,15 @@ FROM latest WHERE rn = 1";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(SessionStatsSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var totalConns = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
             if (totalConns == 0) return;
@@ -281,7 +290,10 @@ FROM latest WHERE rn = 1";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
 }

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgFactCollector.Config.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgFactCollector.Config.cs
@@ -49,7 +49,7 @@ WHERE rn = 1";
     /// </summary>
     private async Task CollectServerConfigFactsAsync(AnalysisContext context, List<Fact> facts)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var cmd = new NpgsqlCommand(ServerConfigSql, connection);
         cmd.Parameters.AddWithValue(context.ServerId);
@@ -59,9 +59,9 @@ WHERE rn = 1";
         double? maxMemoryMb = null;
         double? minMemoryMb = null;
 
-        using (var reader = await cmd.ExecuteReaderAsync())
+        using (var reader = await cmd.ExecuteReaderAsync(context.CancellationToken))
         {
-            while (await reader.ReadAsync())
+            while (await reader.ReadAsync(context.CancellationToken))
             {
                 var configName = reader.GetString(0);
                 var value = Convert.ToDouble(reader.GetValue(1));
@@ -120,13 +120,13 @@ LIMIT 1";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(ServerMetadataSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var edition = reader.IsDBNull(0) ? 0 : Convert.ToInt32(reader.GetValue(0));
             var majorVersion = reader.IsDBNull(1) ? 0 : Convert.ToInt32(reader.GetValue(1));
@@ -136,7 +136,10 @@ LIMIT 1";
             if (majorVersion > 0)
                 facts.Add(new Fact { Source = "config", Key = "SERVER_MAJOR_VERSION", Value = majorVersion, ServerId = context.ServerId });
         }
-        catch { /* Columns may not exist yet (pre-migration) */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Columns may not exist yet (pre-migration). An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string DatabaseConfigSql = @"
@@ -171,13 +174,13 @@ AND database_name NOT IN ('master', 'msdb', 'model', 'tempdb')";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(DatabaseConfigSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var dbCount = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
             if (dbCount == 0) return;
@@ -213,7 +216,10 @@ AND database_name NOT IN ('master', 'msdb', 'model', 'tempdb')";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string TraceFlagsSql = @"
@@ -235,16 +241,16 @@ ORDER BY trace_flag";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(TraceFlagsSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
 
-            using var reader = await cmd.ExecuteReaderAsync();
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
             var metadata = new Dictionary<string, double>();
             var flagCount = 0;
 
-            while (await reader.ReadAsync())
+            while (await reader.ReadAsync(context.CancellationToken))
             {
                 var flag = Convert.ToInt32(reader.GetValue(0));
                 metadata[$"TF_{flag}"] = 1;
@@ -264,7 +270,10 @@ ORDER BY trace_flag";
                 Metadata = metadata
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string ServerPropertiesSql = @"
@@ -284,13 +293,13 @@ LIMIT 1";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(ServerPropertiesSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var cpuCount = reader.IsDBNull(0) ? 0 : Convert.ToInt32(reader.GetValue(0));
             var htRatio = reader.IsDBNull(1) ? 0 : Convert.ToInt32(reader.GetValue(1));
@@ -327,7 +336,10 @@ LIMIT 1";
             // score 0 is simply never emitted (noise control).
             FactCollectorHelpers.EmitServerHealthFacts(context, facts, edition, physicalMemMb, lpim, ifi, dumpCount);
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
 }

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgFactCollector.QueryPerf.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgFactCollector.QueryPerf.cs
@@ -38,15 +38,15 @@ AND   delta_execution_count > 0";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(QueryStatsSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var totalSpills = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
             var highDopQueries = reader.IsDBNull(1) ? 0L : ToInt64(reader.GetValue(1));
@@ -88,7 +88,10 @@ AND   delta_execution_count > 0";
                 });
             }
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string ParameterSensitivitySql = @"
@@ -144,7 +147,7 @@ LIMIT 20";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(ParameterSensitivitySql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
@@ -158,8 +161,8 @@ LIMIT 20";
             var worstGrantRatio = 0.0;
             var worstSpillDivergence = 0;
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            while (await reader.ReadAsync(context.CancellationToken))
             {
                 // Rows arrive ordered by worker_ratio DESC — the first row is the worst offender.
                 if (offenderCount == 0)
@@ -193,7 +196,10 @@ LIMIT 20";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     /// <summary>The PLAN_REGRESSION comparison window, in days — how far back a query's "best known" plan
@@ -381,7 +387,7 @@ LIMIT 20";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(PlanRegressionSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
@@ -402,8 +408,8 @@ LIMIT 20";
             var worstLatestForced = 0;
             var worstForceFailures = 0L;
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            while (await reader.ReadAsync(context.CancellationToken))
             {
                 // Rows arrive ordered by regression_factor DESC — the first row is the worst offender.
                 if (offenderCount == 0)
@@ -447,7 +453,10 @@ LIMIT 20";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string ProcedureStatsSql = @"
@@ -470,15 +479,15 @@ AND   delta_execution_count > 0";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(ProcedureStatsSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var distinctProcs = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
             var totalExecs = reader.IsDBNull(1) ? 0L : ToInt64(reader.GetValue(1));
@@ -505,7 +514,10 @@ AND   delta_execution_count > 0";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string PlanAdvisorySql = @"
@@ -534,15 +546,15 @@ LIMIT 10";
             /* PG port: Lite scopes the connection in a block to release its DuckDB read lock
                before the CPU-only parse; the scoping is kept so the connection closes before
                the parse, even though PG holds no lock. */
-            await using (var connection = await _postgres.OpenConnectionAsync())
+            await using (var connection = await _postgres.OpenConnectionAsync(context.CancellationToken))
             {
                 using var command = new NpgsqlCommand(PlanAdvisorySql, connection);
                 command.Parameters.AddWithValue(context.ServerId);
                 command.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
                 command.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-                using var reader = await command.ExecuteReaderAsync();
-                while (await reader.ReadAsync())
+                using var reader = await command.ExecuteReaderAsync(context.CancellationToken);
+                while (await reader.ReadAsync(context.CancellationToken))
                 {
                     if (!reader.IsDBNull(0))
                         planXmls.Add(reader.GetString(0));
@@ -587,9 +599,10 @@ LIMIT 10";
                 });
             }
         }
-        catch
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
         {
             // query_stats / plan parse may be unavailable — skip, the advisory is best-effort.
+            // An abandonment is NOT swallowed here (#2443).
         }
     }
 

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgFactCollector.Resources.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgFactCollector.Resources.cs
@@ -32,14 +32,14 @@ LIMIT 1";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(MemoryStatsSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var totalPhysical = reader.IsDBNull(0) ? 0.0 : Convert.ToDouble(reader.GetValue(0));
             var bufferPool = reader.IsDBNull(1) ? 0.0 : Convert.ToDouble(reader.GetValue(1));
@@ -52,7 +52,10 @@ LIMIT 1";
             if (targetMemory > 0)
                 facts.Add(new Fact { Source = "memory", Key = "MEMORY_TARGET_MB", Value = targetMemory, ServerId = context.ServerId });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string RunnableTaskStatsSql = @"
@@ -82,15 +85,15 @@ LIMIT 1";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(RunnableTaskStatsSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var totalRunnable = reader.IsDBNull(0) ? 0.0 : Convert.ToDouble(reader.GetValue(0));
             var runnableWarning = reader.IsDBNull(1) ? 0.0 : Convert.ToDouble(reader.GetValue(1));
@@ -108,7 +111,10 @@ LIMIT 1";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string MemoryGrantSql = @"
@@ -131,15 +137,15 @@ AND   collection_time <= $3";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(MemoryGrantSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var maxWaiters = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
             var avgWaiters = reader.IsDBNull(1) ? 0.0 : Convert.ToDouble(reader.GetValue(1));
@@ -166,7 +172,10 @@ AND   collection_time <= $3";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string MemoryClerkSql = @"
@@ -189,18 +198,18 @@ LIMIT 10";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(MemoryClerkSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
             var metadata = new Dictionary<string, double>();
             var totalMb = 0.0;
             var clerkCount = 0;
 
-            while (await reader.ReadAsync())
+            while (await reader.ReadAsync(context.CancellationToken))
             {
                 var clerkType = reader.GetString(0);
                 var memoryMb = Convert.ToDouble(reader.GetValue(1));
@@ -223,7 +232,10 @@ LIMIT 10";
                 Metadata = metadata
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string CpuUtilizationSql = @"
@@ -246,15 +258,15 @@ AND   collection_time <= $3";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(CpuUtilizationSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var avgSqlCpu = reader.IsDBNull(0) ? 0.0 : Convert.ToDouble(reader.GetValue(0));
             var maxSqlCpu = reader.IsDBNull(1) ? 0.0 : Convert.ToDouble(reader.GetValue(1));
@@ -298,7 +310,10 @@ AND   collection_time <= $3";
                 });
             }
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string PerfmonSql = @"
@@ -322,15 +337,15 @@ FROM latest WHERE rn = 1";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(PerfmonSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            while (await reader.ReadAsync(context.CancellationToken))
             {
                 var counterName = reader.GetString(0);
                 var cntrValue = reader.IsDBNull(1) ? 0L : ToInt64(reader.GetValue(1));
@@ -363,7 +378,10 @@ FROM latest WHERE rn = 1";
                 });
             }
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string PlanCacheStatsSql = @"
@@ -395,14 +413,14 @@ WHERE rnk = 1";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(PlanCacheStatsSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             // SUM(integer) is bigint in Postgres — read every aggregate through ToInt64 (the Lite-parity
             // shape), then widen the MB sizes to double for the metadata.
@@ -432,7 +450,10 @@ WHERE rnk = 1";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string MemoryPressureEventsSql = @"
@@ -459,15 +480,15 @@ AND   collection_time <= $3";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(MemoryPressureEventsSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var pressureEventCount = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
             var maxProcess = reader.IsDBNull(1) ? 0.0 : Convert.ToDouble(reader.GetValue(1));
@@ -492,7 +513,10 @@ AND   collection_time <= $3";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
 }

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgFactCollector.Storage.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgFactCollector.Storage.cs
@@ -37,20 +37,23 @@ WHERE rn = 1";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(DatabaseSizeSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var totalSize = reader.IsDBNull(0) ? 0.0 : Convert.ToDouble(reader.GetValue(0));
             if (totalSize > 0)
                 facts.Add(new Fact { Source = "config", Key = "DATABASE_TOTAL_SIZE_MB", Value = totalSize, ServerId = context.ServerId });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string IoLatencySql = @"
@@ -73,15 +76,15 @@ AND   (delta_reads > 0 OR delta_writes > 0)";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(IoLatencySql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var totalStallReadMs = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
             var totalReads = reader.IsDBNull(1) ? 0L : ToInt64(reader.GetValue(1));
@@ -124,7 +127,10 @@ AND   (delta_reads > 0 OR delta_writes > 0)";
                 });
             }
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string TempDbSql = @"
@@ -148,15 +154,15 @@ AND   collection_time <= $3";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(TempDbSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var maxReserved = reader.IsDBNull(0) ? 0.0 : Convert.ToDouble(reader.GetValue(0));
             var maxUserObj = reader.IsDBNull(1) ? 0.0 : Convert.ToDouble(reader.GetValue(1));
@@ -189,7 +195,10 @@ AND   collection_time <= $3";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string FileAutogrowthSql = @"
@@ -220,13 +229,13 @@ AND   database_name NOT IN ('master', 'msdb', 'model', 'tempdb')";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(FileAutogrowthSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var fileCount = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
             if (fileCount == 0) return;
@@ -246,7 +255,10 @@ AND   database_name NOT IN ('master', 'msdb', 'model', 'tempdb')";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string DiskSpaceSql = @"
@@ -273,14 +285,14 @@ FROM latest WHERE rn = 1";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(DiskSpaceSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var minFreePct = reader.IsDBNull(0) ? 1.0 : Convert.ToDouble(reader.GetValue(0));
             var minFreeMb = reader.IsDBNull(1) ? 0.0 : Convert.ToDouble(reader.GetValue(1));
@@ -306,6 +318,9 @@ FROM latest WHERE rn = 1";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgFactCollector.Waits.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgFactCollector.Waits.cs
@@ -37,15 +37,15 @@ ORDER BY SUM(delta_wait_time_ms) DESC";
     /// </summary>
     private async Task CollectWaitStatsFactsAsync(AnalysisContext context, List<Fact> facts)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var command = new NpgsqlCommand(WaitStatsSql, connection);
         command.Parameters.AddWithValue(context.ServerId);
         command.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
         command.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-        using var reader = await command.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await command.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             var waitType = reader.GetString(0);
             var waitingTasks = reader.IsDBNull(1) ? 0L : ToInt64(reader.GetValue(1));
@@ -95,15 +95,15 @@ AND   collection_time <= $3";
     /// </summary>
     private async Task CollectBlockingFactsAsync(AnalysisContext context, List<Fact> facts)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var command = new NpgsqlCommand(BlockingSql, connection);
         command.Parameters.AddWithValue(context.ServerId);
         command.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
         command.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-        using var reader = await command.ExecuteReaderAsync();
-        if (!await reader.ReadAsync()) return;
+        using var reader = await command.ExecuteReaderAsync(context.CancellationToken);
+        if (!await reader.ReadAsync(context.CancellationToken)) return;
 
         var eventCount = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
         if (eventCount <= 0) return;
@@ -149,15 +149,15 @@ AND   collection_time <= $3";
     /// </summary>
     private async Task CollectDeadlockFactsAsync(AnalysisContext context, List<Fact> facts)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var command = new NpgsqlCommand(DeadlocksSql, connection);
         command.Parameters.AddWithValue(context.ServerId);
         command.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
         command.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-        using var reader = await command.ExecuteReaderAsync();
-        if (!await reader.ReadAsync()) return;
+        using var reader = await command.ExecuteReaderAsync(context.CancellationToken);
+        if (!await reader.ReadAsync(context.CancellationToken)) return;
 
         var deadlockCount = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
         if (deadlockCount <= 0) return;
@@ -211,7 +211,7 @@ LIMIT 5000";
 
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var command = new NpgsqlCommand(BlockingChainSql, connection);
             command.Parameters.AddWithValue(context.ServerId);
@@ -219,16 +219,17 @@ LIMIT 5000";
             command.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
             var rows = new List<BlockingPairRow>();
-            using (var reader = await command.ExecuteReaderAsync())
+            using (var reader = await command.ExecuteReaderAsync(context.CancellationToken))
             {
-                while (await reader.ReadAsync())
+                while (await reader.ReadAsync(context.CancellationToken))
                     rows.Add(PgBlockingPairRowQuery.Read(reader));
             }
 
             // Always-on DMV blocking snapshot fallback (works when the blocked-process-report XE is empty,
             // e.g. AWS RDS). Merge BEFORE the empty check so DMV-only blocking still produces facts.
             await PgBlockingPairRowQuery.AppendDmvSnapshotRowsAsync(
-                connection.CreateCommand, rows, context.ServerId, context.TimeRangeStart, context.TimeRangeEnd);
+                connection.CreateCommand, rows, context.ServerId, context.TimeRangeStart, context.TimeRangeEnd,
+                context.CancellationToken);
 
             if (rows.Count == 0) return;
 
@@ -259,7 +260,10 @@ LIMIT 5000";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
 }

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgFindingStore.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgFindingStore.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Npgsql;
@@ -167,7 +168,7 @@ VALUES ($1, $2, $3, $4, $5, $6)";
         try
         {
             await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
-            var mutedHashes = await GetMutedHashesAsync(connection, context.ServerId);
+            var mutedHashes = await GetMutedHashesAsync(connection, context.ServerId, context.CancellationToken);
 
             foreach (var story in stories)
             {
@@ -223,6 +224,22 @@ VALUES ($1, $2, $3, $4, $5, $6)";
     /// shared <see cref="AlertContextSerializer"/>, so a Darling finding's persisted action
     /// round-trips byte-identically to a Dashboard one. Returns the same list for caller
     /// convenience; the in-memory findings are unchanged.
+    ///
+    /// <para>#2443: the connection open is the LAST cancellation point on this pass, and that is a
+    /// decision rather than an oversight. Past it the batch runs to completion, because the third
+    /// outcome — a half-written finding set — is worse than either of the two the classifier already
+    /// names. There is no transaction here (per-row failure isolation is deliberate: one bad row
+    /// logs and the batch continues), every row in a batch shares one <c>analysis_time</c>, and
+    /// <see cref="PgFindingStore.GetLatestFindingsSql"/> keys on <c>MAX(analysis_time)</c> — so a
+    /// batch cut in half does not read as truncated, it reads as a complete analysis that found
+    /// fewer problems. The server would look HEALTHIER for having been abandoned, with nothing
+    /// marking the set incomplete. Cancelling before the first row costs this cycle's findings and
+    /// says so; cancelling after it silently changes what the store means.</para>
+    ///
+    /// <para>The tail is affordable to finish: N small INSERTs against the LOCAL managed store on
+    /// loopback, not against a monitored server. It is not where a pass wedges. This is the same
+    /// call <c>DarlingAnalysisService</c> made one layer up in #2299 — "the post-enrichment tail
+    /// carries no check" — restated at the write it protects.</para>
     /// </summary>
     public async Task<List<AnalysisFinding>> InsertFindingsAsync(
         List<AnalysisFinding> findings, AnalysisContext context)
@@ -241,6 +258,8 @@ VALUES ($1, $2, $3, $4, $5, $6)";
         {
             await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
+            /* No token check between rows: see the note above. Once the first row is written this
+               batch is finishing. */
             foreach (var finding in findings)
             {
                 await InsertFindingAsync(connection, finding);
@@ -273,7 +292,11 @@ VALUES ($1, $2, $3, $4, $5, $6)";
 
     /// <summary>
     /// Returns the most recent findings for a server within the given time range, newest and
-    /// most severe first, including each finding's persisted remediation action.
+    /// most severe first, including each finding's persisted remediation action.    ///
+    /// <para>#2443 exempt: off the analysis pass. This surface serves the viewer, the MCP and the
+    /// retention sweep — lifetimes with no per-pass budget and no wedged analysis to abandon — so
+    /// its store calls take no pass token. Threading one here would mean inventing a caller that
+    /// does not exist.</para>
     /// </summary>
     public async Task<List<AnalysisFinding>> GetRecentFindingsAsync(
         int serverId, int hoursBack = 24, int limit = 100)
@@ -305,7 +328,11 @@ VALUES ($1, $2, $3, $4, $5, $6)";
     /// <summary>
     /// Returns the latest analysis run's findings for a server (most recent analysis_time),
     /// most severe first. Unlike the Dashboard twin this read also returns
-    /// remediation_action_json — both reads share one column list and one reader.
+    /// remediation_action_json — both reads share one column list and one reader.    ///
+    /// <para>#2443 exempt: off the analysis pass. This surface serves the viewer, the MCP and the
+    /// retention sweep — lifetimes with no per-pass budget and no wedged analysis to abandon — so
+    /// its store calls take no pass token. Threading one here would mean inventing a caller that
+    /// does not exist.</para>
     /// </summary>
     public async Task<List<AnalysisFinding>> GetLatestFindingsAsync(int serverId)
     {
@@ -332,7 +359,11 @@ VALUES ($1, $2, $3, $4, $5, $6)";
     }
 
     /// <summary>
-    /// Mutes a story pattern so it won't appear in future analysis runs.
+    /// Mutes a story pattern so it won't appear in future analysis runs.    ///
+    /// <para>#2443 exempt: off the analysis pass. This surface serves the viewer, the MCP and the
+    /// retention sweep — lifetimes with no per-pass budget and no wedged analysis to abandon — so
+    /// its store calls take no pass token. Threading one here would mean inventing a caller that
+    /// does not exist.</para>
     /// </summary>
     public async Task MuteStoryAsync(int serverId, string storyPathHash, string storyPath, string? reason = null)
     {
@@ -358,7 +389,11 @@ VALUES ($1, $2, $3, $4, $5, $6)";
     }
 
     /// <summary>
-    /// Unmutes a story pattern (Dashboard-twin surface).
+    /// Unmutes a story pattern (Dashboard-twin surface).    ///
+    /// <para>#2443 exempt: off the analysis pass. This surface serves the viewer, the MCP and the
+    /// retention sweep — lifetimes with no per-pass budget and no wedged analysis to abandon — so
+    /// its store calls take no pass token. Threading one here would mean inventing a caller that
+    /// does not exist.</para>
     /// </summary>
     public async Task UnmuteStoryAsync(long muteId)
     {
@@ -384,7 +419,11 @@ VALUES ($1, $2, $3, $4, $5, $6)";
     /// global marker); legacy <c>server_id = 0</c> rows written before that fix are honored as global
     /// too (<see cref="GetMutedStoriesSql"/> filters both), so an all-servers mute is visible to every
     /// server. A NULL/0 (global) row here is flagged muted but left un-unmutable from the per-server
-    /// viewer, since deleting it would unmute the pattern everywhere.
+    /// viewer, since deleting it would unmute the pattern everywhere.    ///
+    /// <para>#2443 exempt: off the analysis pass. This surface serves the viewer, the MCP and the
+    /// retention sweep — lifetimes with no per-pass budget and no wedged analysis to abandon — so
+    /// its store calls take no pass token. Threading one here would mean inventing a caller that
+    /// does not exist.</para>
     /// </summary>
     public async Task<List<MutedStory>> GetMutedStoriesAsync(int serverId)
     {
@@ -417,7 +456,11 @@ VALUES ($1, $2, $3, $4, $5, $6)";
     }
 
     /// <summary>
-    /// Cleans up old findings beyond the retention period.
+    /// Cleans up old findings beyond the retention period.    ///
+    /// <para>#2443 exempt: off the analysis pass. This surface serves the viewer, the MCP and the
+    /// retention sweep — lifetimes with no per-pass budget and no wedged analysis to abandon — so
+    /// its store calls take no pass token. Threading one here would mean inventing a caller that
+    /// does not exist.</para>
     /// </summary>
     public async Task CleanupOldFindingsAsync(int retentionDays = 30)
     {
@@ -440,7 +483,8 @@ VALUES ($1, $2, $3, $4, $5, $6)";
     /// twins: an unreadable mute registry returns the hashes read so far (usually empty) and
     /// findings flow through unfiltered rather than being suppressed.
     /// </summary>
-    private async Task<HashSet<string>> GetMutedHashesAsync(NpgsqlConnection connection, int serverId)
+    private async Task<HashSet<string>> GetMutedHashesAsync(
+        NpgsqlConnection connection, int serverId, CancellationToken cancellationToken)
     {
         var hashes = new HashSet<string>();
 
@@ -449,14 +493,18 @@ VALUES ($1, $2, $3, $4, $5, $6)";
             using var command = new NpgsqlCommand(GetMutedHashesSql, connection);
             command.Parameters.AddWithValue(serverId);
 
-            using var reader = await command.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
+            using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
             {
                 hashes.Add(reader.GetString(0));
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, cancellationToken))
         {
+            /* #2443: fail-open is right for an unreadable registry, but NOT for an abandonment —
+               "the mutes could not be read" and "we stopped reading" are different answers, and
+               swallowing the second would let the pass go on to enrich and persist an unfiltered
+               finding set under a token that has already fired. */
             _logger?.LogError("[PgFindingStore] GetMutedHashesAsync failed: {Message}", ex.Message);
         }
 
@@ -467,6 +515,13 @@ VALUES ($1, $2, $3, $4, $5, $6)";
     /// Inserts one finding on an already-open connection (the caller owns it, so a batch
     /// shares a single connection). Per-row failure isolation like the Dashboard twin: one
     /// bad row logs and the batch continues.
+    ///
+    /// <para>#2443 exempt: this write deliberately takes no token. Cancelling inside a single-row
+    /// INSERT buys nothing — the row is milliseconds of work on loopback — and costs the one thing
+    /// worth having: a definite answer about whether it committed. Npgsql's cancel is a request to
+    /// the server, so a cancelled <c>ExecuteNonQueryAsync</c> can leave a row that did land, in a
+    /// set nothing marks as partial. <see cref="InsertFindingsAsync"/> carries the full reasoning
+    /// and the abandonment point that replaces this one.</para>
     /// </summary>
     private async Task InsertFindingAsync(NpgsqlConnection connection, AnalysisFinding finding)
     {

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgFindingStore.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgFindingStore.cs
@@ -292,7 +292,8 @@ VALUES ($1, $2, $3, $4, $5, $6)";
 
     /// <summary>
     /// Returns the most recent findings for a server within the given time range, newest and
-    /// most severe first, including each finding's persisted remediation action.    ///
+    /// most severe first, including each finding's persisted remediation action.
+    ///
     /// <para>#2443 exempt: off the analysis pass. This surface serves the viewer, the MCP and the
     /// retention sweep — lifetimes with no per-pass budget and no wedged analysis to abandon — so
     /// its store calls take no pass token. Threading one here would mean inventing a caller that
@@ -328,7 +329,8 @@ VALUES ($1, $2, $3, $4, $5, $6)";
     /// <summary>
     /// Returns the latest analysis run's findings for a server (most recent analysis_time),
     /// most severe first. Unlike the Dashboard twin this read also returns
-    /// remediation_action_json — both reads share one column list and one reader.    ///
+    /// remediation_action_json — both reads share one column list and one reader.
+    ///
     /// <para>#2443 exempt: off the analysis pass. This surface serves the viewer, the MCP and the
     /// retention sweep — lifetimes with no per-pass budget and no wedged analysis to abandon — so
     /// its store calls take no pass token. Threading one here would mean inventing a caller that
@@ -359,7 +361,8 @@ VALUES ($1, $2, $3, $4, $5, $6)";
     }
 
     /// <summary>
-    /// Mutes a story pattern so it won't appear in future analysis runs.    ///
+    /// Mutes a story pattern so it won't appear in future analysis runs.
+    ///
     /// <para>#2443 exempt: off the analysis pass. This surface serves the viewer, the MCP and the
     /// retention sweep — lifetimes with no per-pass budget and no wedged analysis to abandon — so
     /// its store calls take no pass token. Threading one here would mean inventing a caller that
@@ -389,7 +392,8 @@ VALUES ($1, $2, $3, $4, $5, $6)";
     }
 
     /// <summary>
-    /// Unmutes a story pattern (Dashboard-twin surface).    ///
+    /// Unmutes a story pattern (Dashboard-twin surface).
+    ///
     /// <para>#2443 exempt: off the analysis pass. This surface serves the viewer, the MCP and the
     /// retention sweep — lifetimes with no per-pass budget and no wedged analysis to abandon — so
     /// its store calls take no pass token. Threading one here would mean inventing a caller that
@@ -419,7 +423,8 @@ VALUES ($1, $2, $3, $4, $5, $6)";
     /// global marker); legacy <c>server_id = 0</c> rows written before that fix are honored as global
     /// too (<see cref="GetMutedStoriesSql"/> filters both), so an all-servers mute is visible to every
     /// server. A NULL/0 (global) row here is flagged muted but left un-unmutable from the per-server
-    /// viewer, since deleting it would unmute the pattern everywhere.    ///
+    /// viewer, since deleting it would unmute the pattern everywhere.
+    ///
     /// <para>#2443 exempt: off the analysis pass. This surface serves the viewer, the MCP and the
     /// retention sweep — lifetimes with no per-pass budget and no wedged analysis to abandon — so
     /// its store calls take no pass token. Threading one here would mean inventing a caller that
@@ -456,7 +461,8 @@ VALUES ($1, $2, $3, $4, $5, $6)";
     }
 
     /// <summary>
-    /// Cleans up old findings beyond the retention period.    ///
+    /// Cleans up old findings beyond the retention period.
+    ///
     /// <para>#2443 exempt: off the analysis pass. This surface serves the viewer, the MCP and the
     /// retention sweep — lifetimes with no per-pass budget and no wedged analysis to abandon — so
     /// its store calls take no pass token. Threading one here would mean inventing a caller that

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgPlanFetcher.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgPlanFetcher.cs
@@ -59,7 +59,7 @@ FROM sys.dm_exec_query_plan(CONVERT(varbinary(64), @plan_handle, 1));";
         _logger = logger;
     }
 
-    public async Task<string?> FetchPlanXmlAsync(int serverId, string planHandle)
+    public async Task<string?> FetchPlanXmlAsync(int serverId, string planHandle, CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(planHandle))
         {
@@ -82,13 +82,13 @@ FROM sys.dm_exec_query_plan(CONVERT(varbinary(64), @plan_handle, 1));";
             };
 
             await using var connection = new SqlConnection(builder.ConnectionString);
-            await connection.OpenAsync();
+            await connection.OpenAsync(cancellationToken);
 
             await using var command = new SqlCommand(PlanQuery, connection);
             command.CommandTimeout = 15;
             command.Parameters.AddWithValue("@plan_handle", planHandle);
 
-            var result = await command.ExecuteScalarAsync();
+            var result = await command.ExecuteScalarAsync(cancellationToken);
             if (result == null || result is DBNull)
             {
                 return null;
@@ -96,8 +96,12 @@ FROM sys.dm_exec_query_plan(CONVERT(varbinary(64), @plan_handle, 1));";
 
             return result.ToString();
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
+            /* #2443: an abandoned fetch is not a plan that failed to come back. Degrading it to null
+               here would log an ERROR for work we called off AND let the pass carry on enriching
+               against a token that has already fired — the sibling by-sql_handle fetch has excluded
+               cancellation from this arm since it was written, and this one now agrees. */
             _logger?.LogError("[PgPlanFetcher] Failed to fetch plan for handle {PlanHandle}: {Message}", planHandle, ex.Message);
             return null;
         }

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -3947,8 +3947,11 @@ LIMIT 1", connection);
                 JsonError($"server '{displayName}' is not currently connected — the live plan cache can only be read from a connected server"));
         }
 
+        /* #2443: both arms now take the SAME token. The by-sql_handle arm always had it; the
+           by-plan_handle arm did not, so a cancelled fetch_plan command kept a session open on the
+           monitored server for whichever key the caller happened to use. */
         var planXml = request.UsePlanHandle
-            ? await planFetcher.FetchPlanXmlAsync(serverId, request.PlanHandle!)
+            ? await planFetcher.FetchPlanXmlAsync(serverId, request.PlanHandle!, cancellationToken)
             : await planFetcher.FetchPlanBySqlHandleAsync(
                 serverId, request.DatabaseName, request.SqlHandle!,
                 request.StatementStartOffset, request.StatementEndOffset, cancellationToken);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Blocking.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Blocking.cs
@@ -367,8 +367,10 @@ public sealed partial class ViewerDataService
 
         // Always-on DMV blocking snapshot: merge in the fallback rows so the viewer works even when the
         // blocked-process-report XE captured nothing (threshold unset / AWS RDS). Same connection.
+        /* #2443: the viewer passes its own window token — this read serves a person waiting at a
+           grid, not an analysis pass, so there is no budget or service stop for it to abandon under. */
         await PgBlockingPairRowQuery.AppendDmvSnapshotRowsAsync(
-            connection.CreateCommand, rows, serverId, startUtc, endUtc);
+            connection.CreateCommand, rows, serverId, startUtc, endUtc, cancellationToken);
 
         return rows;
     }

--- a/Lite/Analysis/DrillDownCollector.Plans.cs
+++ b/Lite/Analysis/DrillDownCollector.Plans.cs
@@ -63,7 +63,7 @@ LIMIT 1";
         if (string.IsNullOrEmpty(planHandle)) return;
 
         // Fetch plan XML live from SQL Server
-        var planXml = await _planFetcher.FetchPlanXmlAsync(context.ServerId, planHandle);
+        var planXml = await _planFetcher.FetchPlanXmlAsync(context.ServerId, planHandle, context.CancellationToken);
         if (string.IsNullOrEmpty(planXml)) return;
 
         try

--- a/Lite/Analysis/SqlPlanFetcher.cs
+++ b/Lite/Analysis/SqlPlanFetcher.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
 using PerformanceMonitor.Analysis;
@@ -20,7 +21,7 @@ public class SqlPlanFetcher : IPlanFetcher
         _serverManager = serverManager;
     }
 
-    public async Task<string?> FetchPlanXmlAsync(int serverId, string planHandle)
+    public async Task<string?> FetchPlanXmlAsync(int serverId, string planHandle, CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(planHandle)) return null;
 
@@ -43,7 +44,7 @@ public class SqlPlanFetcher : IPlanFetcher
             };
 
             await using var connection = new SqlConnection(builder.ConnectionString);
-            await connection.OpenAsync();
+            await connection.OpenAsync(cancellationToken);
 
             await using var cmd = new SqlCommand(@"
 SET NOCOUNT ON;
@@ -53,7 +54,7 @@ FROM sys.dm_exec_query_plan(CONVERT(varbinary(64), @plan_handle, 1))", connectio
             cmd.CommandTimeout = 15;
             cmd.Parameters.AddWithValue("@plan_handle", planHandle);
 
-            var result = await cmd.ExecuteScalarAsync();
+            var result = await cmd.ExecuteScalarAsync(cancellationToken);
             if (result == null || result is DBNull) return null;
 
             return result.ToString();

--- a/Lite/Analysis/SqlPlanFetcher.cs
+++ b/Lite/Analysis/SqlPlanFetcher.cs
@@ -59,8 +59,15 @@ FROM sys.dm_exec_query_plan(CONVERT(varbinary(64), @plan_handle, 1))", connectio
 
             return result.ToString();
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
+            /* #2443: review caught this, and it is a real behaviour gap rather than a tidiness one.
+               Lite arms a genuine per-pass budget (#2412), so the token this method now takes can and
+               does fire mid-fetch on a healthy running app. An unconditional catch would log
+               "Failed to fetch plan for handle …: The operation was canceled." as an ERROR for work
+               we ourselves called off, AND swallow it, so the pass would carry on enriching under a
+               fired token instead of unwinding to AnalysisService's one quiet line. Same arm the
+               Darling twin's PgPlanFetcher carries for the identical call shape. */
             AppLogger.Error("SqlPlanFetcher",
                 $"Failed to fetch plan for handle {planHandle}: {ex.Message}");
             return null;

--- a/PerformanceMonitor.Analysis/IPlanFetcher.cs
+++ b/PerformanceMonitor.Analysis/IPlanFetcher.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace PerformanceMonitor.Analysis;
@@ -14,6 +15,13 @@ public interface IPlanFetcher
     /// <summary>
     /// Fetches the execution plan XML for a given plan_handle.
     /// Returns null if the plan is no longer in cache.
+    ///
+    /// <para>#2443: the token is REQUIRED rather than defaulted, and that is deliberate. This is the
+    /// one call on the analysis pass that opens a session on a MONITORED server rather than on the
+    /// monitoring store, so it is the one an abandoned pass most needs to be able to let go of. A
+    /// defaulted parameter would let a call site keep passing nothing while the signature claimed
+    /// otherwise; requiring it makes every implementer and every caller name the token it abandons
+    /// under.</para>
     /// </summary>
-    Task<string?> FetchPlanXmlAsync(int serverId, string planHandle);
+    Task<string?> FetchPlanXmlAsync(int serverId, string planHandle, CancellationToken cancellationToken);
 }

--- a/deprecated/Dashboard/Analysis/SqlServerDrillDownCollector.Plans.cs
+++ b/deprecated/Dashboard/Analysis/SqlServerDrillDownCollector.Plans.cs
@@ -61,7 +61,7 @@ ORDER BY collection_time DESC;";
         if (string.IsNullOrEmpty(planHandle)) return;
 
         // Fetch plan XML live from SQL Server
-        var planXml = await _planFetcher.FetchPlanXmlAsync(context.ServerId, planHandle);
+        var planXml = await _planFetcher.FetchPlanXmlAsync(context.ServerId, planHandle, context.CancellationToken);
         if (string.IsNullOrEmpty(planXml)) return;
 
         try

--- a/deprecated/Dashboard/Analysis/SqlServerPlanFetcher.cs
+++ b/deprecated/Dashboard/Analysis/SqlServerPlanFetcher.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
 using PerformanceMonitor.Analysis;
@@ -21,7 +22,7 @@ public class SqlServerPlanFetcher : IPlanFetcher
         _connectionString = connectionString;
     }
 
-    public async Task<string?> FetchPlanXmlAsync(int serverId, string planHandle)
+    public async Task<string?> FetchPlanXmlAsync(int serverId, string planHandle, CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(planHandle)) return null;
 
@@ -34,7 +35,7 @@ public class SqlServerPlanFetcher : IPlanFetcher
             };
 
             await using var connection = new SqlConnection(builder.ConnectionString);
-            await connection.OpenAsync();
+            await connection.OpenAsync(cancellationToken);
 
             await using var cmd = new SqlCommand(@"
 SET NOCOUNT ON;
@@ -44,7 +45,7 @@ FROM sys.dm_exec_query_plan(CONVERT(varbinary(64), @plan_handle, 1));", connecti
             cmd.CommandTimeout = 15;
             cmd.Parameters.AddWithValue("@plan_handle", planHandle);
 
-            var result = await cmd.ExecuteScalarAsync();
+            var result = await cmd.ExecuteScalarAsync(cancellationToken);
             if (result == null || result is DBNull) return null;
 
             return result.ToString();


### PR DESCRIPTION
Closes half of #2443 — the Darling half. Lite follows in a second PR so each diff stays reviewable.

## What was wrong

#2438 armed a per-pass budget for Darling's analysis and #2430's classifier taught it to tell a timeout from a shutdown, so an overrunning server became loudly stuck instead of silently skipped forever. Neither of those handed the token to the store layer. Abandonment happened **between** stages, never inside a read, so a pass gave up while its wedged query kept a connection and a session alive until the query finished on its own — the monitoring service holding a session on a server it had already stopped waiting for.

Re-derived count on `dev`: **168 of 211** async store calls in `PerformanceMonitor.Darling.Analysis` took the no-argument overload. `PgFactCollector.*` 93, `PgDrillDownCollector.*` 53, `PgFindingStore` 18, `PgBlockingPairRowQuery` 2, `PgPlanFetcher` 2. (The issue said 167/209 and 1 for the plan fetcher; the extra is `PgPlanFetcher`'s bare `OpenAsync()`, which counts for exactly the same reason the `ExecuteScalarAsync()` beside it does.)

## What this changes

**152 of them are now threaded with `context.CancellationToken`, and not one signature gained a defaulted parameter.** That is the point of the shape rather than an accident of it: the `AnalysisContext` already reaches every pipeline stage, so the pass's own token was in scope at all 152 sites the whole time. The two places that genuinely needed a new parameter — `PgBlockingPairRowQuery.AppendDmvSnapshotRowsAsync` and `IPlanFetcher.FetchPlanXmlAsync` — take it **required**, so no call site can keep passing nothing while the signature says otherwise.

Requiring it immediately paid for itself: `DarlingWorker`'s `fetch_plan` command already had a `cancellationToken` in scope and already passed it to the by-`sql_handle` arm, and simply did not pass it to the by-`plan_handle` arm two lines above. Nothing defended against that. The compiler found it the moment the default was refused.

### Threading the reads alone would have accomplished almost nothing

This is the part worth reading twice. The fact collector's 27 per-query catches are bare `catch { }` **on purpose** — a missing table degrades to "no facts", never an exception — so an armed token would have been swallowed 27 times and the pass would have carried on to the next collector each time, dialling the store again to be told again.

The behavioural test measures exactly this. Reverted, it fails with an `NpgsqlException` rather than an `OperationCanceledException`: handed a token that had **already been cancelled before the call**, the collector still went to the network. So every one of those catches now carries the classification the rest of the pass has used since #2299 — `when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))` — and an abandonment propagates to the single line the pass logs for it. Catch bodies and comments are unchanged; the only thing that stops being caught is the one thing we asked for.

## What cancellation means, per caller

Decided rather than assumed, because it is not one answer:

| Caller | Cancellation abandons | Loss | Threaded? |
|---|---|---|---|
| `PgFactCollector.*` | a read of the monitoring store | this cycle's facts | yes — 93 |
| `PgDrillDownCollector.*` | a read, plus a live plan fetch on a **monitored** server | enrichment detail | yes — 53 |
| `PgPlanFetcher` | a session on a **monitored** SQL Server | one plan | yes — 2, required param |
| `PgFindingStore.FilterMutedFindingsAsync` | a read of the mute registry | nothing written | yes |
| `PgFindingStore.InsertFinding*` | a **write** | see below | **no, deliberately** |

### A partial persist cannot happen on the cancellation path, and that is the decision

The insert's connection open is the **last** abandonment point. Past it the batch finishes.

A half-written finding set is a third outcome, and unlike the timeout and the shutdown #2430's classifier names, this one is invisible. There is no transaction (per-row failure isolation is deliberate), every row in a batch shares one `analysis_time`, and `GetLatestFindingsSql` keys on `MAX(analysis_time)` — so a batch cut in half **does not read as truncated**. It reads as a complete analysis that found fewer problems. The server would look *healthier* for having been abandoned, with nothing marking the set incomplete. Cancelling before the first row costs this cycle's findings and says so in the line the pass already logs; cancelling after it quietly changes what the store means.

Cancelling *inside* a row would be worse and buys nothing: Npgsql's cancel is a request to the server, so a cancelled `ExecuteNonQueryAsync` can leave a row that did land, in a set nothing marks as partial — an ambiguous commit in exchange for milliseconds of loopback work. And the tail is affordable to finish: N small INSERTs against the local managed store, which is not where a pass wedges. This restates at the write the same call `DarlingAnalysisService` made a layer up in #2299 ("the post-enrichment tail carries no check"), so the reasoning is at the code rather than two files away.

**A partial set is still reachable from a store *fault* mid-batch.** That predates this work and is unchanged by it; filed as #2448 with the mechanism, the three options and the measurement that should decide between them.

## The 16 exemptions, and why they are named one at a time

15 are `PgFindingStore`'s read-back surfaces — the viewer's findings and mute reads, the MCP mute verb, the retention sweep. They are off the pass entirely, serving lifetimes with no per-pass budget and no wedged analysis, so there is no token to thread and inventing one would be pretending. `AnalysisShutdownResidueTests` has said this in prose since #2299; it is now enforced. The 16th is the finding INSERT above.

Every one is exempt **by method name in the test** and carries a `#2443 exempt` note in its own doc comment. The enumeration is in the test so a new exemption cannot arrive silently; the marker is in the source so the reason travels with the code. A second test asserts the reverse direction — an exemption that no longer corresponds to an untokened call is a claim the code stopped making, and it must not sit there authorising the next one.

## The test is the durable part

`AnalysisPassTokenThreadingTests`, five tests, all five verified red with the change reverted:

- **the sweep** — no no-argument `ExecuteReaderAsync()` / `ExecuteNonQueryAsync()` / `ExecuteScalarAsync()` / `ReadAsync()` / `OpenAsync()` / `OpenConnectionAsync()` outside the named exemptions. Pinned on the **call**, not the signature, because the known way this regrows is a defaulted parameter that leaves every call site passing `None` while looking threaded. Scans the whole project directory rather than a file list, so a seventh `PgFactCollector` partial is covered the day it exists.
- **the exemptions are still earning their place** — both directions, with counts, so a new untokened call cannot ride in on an existing exemption.
- **every fact-collector catch lets an abandonment through** — the pin that stops the token being silently useless.
- **a fired token stops collection at the first read** — behavioural, needs no store, and its reverted failure mode (`NpgsqlException`) is the defect stated exactly.
- **the insert is abandoned before it starts or not at all** — including the *absence* of a between-rows check, because adding one there would make the partial set rather than prevent it, and that is not obvious from reading the loop.

## Verification

- Full solution builds clean on macOS (`EnableWindowsTargeting`), 0 errors, no new warnings.
- Each of the four commits builds clean on its own, checked individually.
- `Darling.Tests` is `net10.0-windows` and cannot run on macOS, so the new file plus `AnalysisShutdownResidueTests` were compiled unchanged into a `net10.0` xUnit harness and run there: **12/12 pass**, and 5/12 fail with the change reverted. CI is the arbiter for the rest of the suite.
- `AnalysisShutdownResidueTests`' existing per-file catch-filter counts are unchanged by design — the new filter in `GetMutedHashesAsync` binds its own `cancellationToken` parameter, not `context.CancellationToken`, so that pin still reads 2 for the finding store.

## Cross-SKU footprint

`IPlanFetcher` is shared, so its three implementers and three call sites move in one commit or none of them compile: `Lite/Analysis/SqlPlanFetcher.cs`, `Lite/Analysis/DrillDownCollector.Plans.cs`, and the deprecated Dashboard pair, which is still in the solution and still built by CI. Those are signature and call-site edits only — no Lite behaviour changes here.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
