### PR TITLE
Hand the operator the removal, not just the opening (#2445)

### DIFF
--- a/Darling/Darling.Tests/DarlingFirewallCheckTests.cs
+++ b/Darling/Darling.Tests/DarlingFirewallCheckTests.cs
@@ -922,6 +922,153 @@ public class DarlingFirewallCheckTests
         Assert.Contains("--configure-firewall", DarlingCliCommands.UsageText(), StringComparison.Ordinal);
     }
 
+    /* ---- #2445: what the NOT-elevated branch hands over ---- */
+
+    /// <summary>
+    /// The whole policy table, because the interesting cases are the two that print nothing and the one that
+    /// prints a command WITHOUT failing the verb — none of which any single scenario test would show together.
+    /// </summary>
+    [Theory]
+    /* An Open plan is unchanged by #2445: the rule has to exist with these exact parameters, which no probe
+       could confirm, so it prints and fails exactly as it always has whatever the probe would have said. */
+    [InlineData(DarlingCliCommands.FirewallRuleAction.Open, true, null, DarlingCliCommands.FirewallHandoff.OpenCommand)]
+    [InlineData(DarlingCliCommands.FirewallRuleAction.Open, true, true, DarlingCliCommands.FirewallHandoff.OpenCommand)]
+    [InlineData(DarlingCliCommands.FirewallRuleAction.Open, false, false, DarlingCliCommands.FirewallHandoff.OpenCommand)]
+    /* The defect this issue is about: a Remove with a rule really sitting there now gets its own command. */
+    [InlineData(DarlingCliCommands.FirewallRuleAction.Remove, true, true, DarlingCliCommands.FirewallHandoff.SweepCommand)]
+    /* ...and the common case stays exactly as quiet as it was, because the probe MEASURED that. */
+    [InlineData(DarlingCliCommands.FirewallRuleAction.Remove, true, false, DarlingCliCommands.FirewallHandoff.Nothing)]
+    /* A probe that could not answer offers the command but is not evidence of drift. */
+    [InlineData(DarlingCliCommands.FirewallRuleAction.Remove, true, null, DarlingCliCommands.FirewallHandoff.SweepCommandUnverified)]
+    /* #2436's withheld sweep: nothing is handed over on any probe answer, including "a rule is there" — that
+       rule may be the one the endpoint is being served on. */
+    [InlineData(DarlingCliCommands.FirewallRuleAction.Remove, false, true, DarlingCliCommands.FirewallHandoff.Nothing)]
+    [InlineData(DarlingCliCommands.FirewallRuleAction.Remove, false, false, DarlingCliCommands.FirewallHandoff.Nothing)]
+    [InlineData(DarlingCliCommands.FirewallRuleAction.Remove, false, null, DarlingCliCommands.FirewallHandoff.Nothing)]
+    public void ClassifyNotElevatedHandoff_IsTheWholeTable(
+        DarlingCliCommands.FirewallRuleAction action,
+        bool sweepOtherPorts,
+        bool? rulesFound,
+        DarlingCliCommands.FirewallHandoff expected)
+    {
+        Assert.Equal(expected, DarlingCliCommands.ClassifyNotElevatedHandoff(action, sweepOtherPorts, rulesFound));
+    }
+
+    /// <summary>
+    /// The exit code is a claim about the FIREWALL. install-darling.ps1 prints a re-run banner on a non-zero
+    /// from this verb, so an unverified sweep must not raise one: "the probe did not answer" is not drift, and
+    /// a banner that fires without cause is how operators learn to ignore the one that has cause. Under-
+    /// reporting is the safe direction here because the running service re-probes the same rule on every start.
+    /// </summary>
+    [Fact]
+    public void NotElevatedRunHasWork_CountsMeasuredWorkOnly()
+    {
+        Assert.False(DarlingCliCommands.NotElevatedRunHasWork([]));
+        Assert.False(DarlingCliCommands.NotElevatedRunHasWork([DarlingCliCommands.FirewallHandoff.Nothing]));
+        Assert.False(DarlingCliCommands.NotElevatedRunHasWork([DarlingCliCommands.FirewallHandoff.SweepCommandUnverified]));
+
+        Assert.True(DarlingCliCommands.NotElevatedRunHasWork([DarlingCliCommands.FirewallHandoff.SweepCommand]));
+        Assert.True(DarlingCliCommands.NotElevatedRunHasWork([DarlingCliCommands.FirewallHandoff.OpenCommand]));
+
+        /* Mixed: one measured removal among unverifiable siblings still means an elevated shell has work. */
+        Assert.True(DarlingCliCommands.NotElevatedRunHasWork(
+        [
+            DarlingCliCommands.FirewallHandoff.Nothing,
+            DarlingCliCommands.FirewallHandoff.SweepCommandUnverified,
+            DarlingCliCommands.FirewallHandoff.SweepCommand,
+        ]));
+    }
+
+    /// <summary>
+    /// The wiring, against plans the real planner produced rather than against hand-built flags — this is the
+    /// pairing that matters and the one an enum table alone cannot show. An admin who ran <c>--disable-mcp</c>
+    /// and re-ran this verb unelevated gets the sweep command; the surface #2436 declines to sweep gets
+    /// nothing, on the SAME probe answer.
+    /// </summary>
+    [Fact]
+    public void TheHandoff_FollowsThePlannersSweepPermission_NotJustTheAction()
+    {
+        /* Control plane answered "off" for a fully LAN-configured MCP: a Remove that IS allowed to sweep. */
+        var disabled = ManagedConfig();
+        disabled.Mcp.Enabled = true;
+        disabled.Mcp.Network = new McpNetworkConfig { Listen = "192.168.1.205", AllowFrom = "192.168.1.0/24", Token = "t" };
+        var disabledPlan = Assert.Single(
+            DarlingCliCommands.PlanFirewallRules(disabled, mcpStore: (false, 5152)).Where(p => p.Surface == "MCP"));
+
+        Assert.Equal(DarlingCliCommands.FirewallRuleAction.Remove, disabledPlan.Action);
+        Assert.True(disabledPlan.SweepOtherPorts);
+        Assert.Equal(
+            DarlingCliCommands.FirewallHandoff.SweepCommand,
+            DarlingCliCommands.ClassifyNotElevatedHandoff(disabledPlan.Action, disabledPlan.SweepOtherPorts, rulesFound: true));
+
+        /* Same shape, but the store could not be read, so the file's "off" may be years stale and the rule
+           may be the live one. Handing that sweep to an operator would hand them the outage by copy-paste. */
+        var unreadable = ManagedConfig();
+        unreadable.Mcp.Enabled = false;
+        unreadable.Mcp.Network = new McpNetworkConfig { Listen = "192.168.1.205", AllowFrom = "192.168.1.0/24", Token = "t" };
+        var withheldPlan = Assert.Single(
+            DarlingCliCommands.PlanFirewallRules(unreadable, storeUnavailableReason: "the store did not answer within 10 seconds")
+                .Where(p => p.Surface == "MCP"));
+
+        Assert.Equal(DarlingCliCommands.FirewallRuleAction.Remove, withheldPlan.Action);
+        Assert.False(withheldPlan.SweepOtherPorts);
+        Assert.Equal(
+            DarlingCliCommands.FirewallHandoff.Nothing,
+            DarlingCliCommands.ClassifyNotElevatedHandoff(withheldPlan.Action, withheldPlan.SweepOtherPorts, rulesFound: true));
+    }
+
+    /// <summary>
+    /// The probe has to ask EXACTLY what the sweep would act on. A narrower question reports "nothing to do"
+    /// about rules the sweep would still collect; a wider one offers a command covering rules this product does
+    /// not own. Both go through the same wildcard builder, which is what makes that true by construction — this
+    /// pins that they still do.
+    /// </summary>
+    [Fact]
+    public void TheProbeAsksExactlyWhatTheSweepWouldDelete()
+    {
+        var wildcard = DarlingFirewallCheck.SurfaceRuleWildcard(DarlingMcpHostService.McpFirewallRuleName(5152));
+        Assert.Equal("PerformanceMonitor Darling MCP (port *)", wildcard);
+
+        var probe = DarlingFirewallCheck.BuildProbeCommand(wildcard);
+        var sweep = DarlingManagedPostgres.BuildFirewallSweepCommand(wildcard);
+
+        Assert.Contains("-DisplayName 'PerformanceMonitor Darling MCP (port *)'", probe, StringComparison.Ordinal);
+        Assert.Contains("-DisplayName 'PerformanceMonitor Darling MCP (port *)'", sweep, StringComparison.Ordinal);
+
+        /* Still read-only with a wildcard in it — this is the branch that holds no privilege. */
+        Assert.Contains("Get-NetFirewallRule", probe, StringComparison.Ordinal);
+        Assert.DoesNotContain("Remove-NetFirewallRule", probe, StringComparison.Ordinal);
+        Assert.DoesNotContain("New-NetFirewallRule", probe, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Source pins on the not-elevated branch itself, because the policy above is only worth anything if that
+    /// branch actually consults it. All three are expressible against dev and all three are red there, which
+    /// is the statement the enum tests cannot make.
+    /// </summary>
+    [Fact]
+    public void TheNotElevatedBranch_MeasuresAndOffersARemedyForARemoval()
+    {
+        var branch = NotElevatedBranch();
+
+        /* It offers BOTH remedies now. Before #2445 only the enable command appeared here, so a run whose
+           whole work was a removal handed the operator nothing at all. */
+        Assert.Contains("BuildFirewallEnableCommand", branch, StringComparison.Ordinal);
+        Assert.Contains("BuildFirewallSweepCommand", branch, StringComparison.Ordinal);
+
+        /* And it MEASURES rather than assuming. The old unconditional "toOpen == 0 means nothing to do" early
+           return is what said 0 over a stale rule; it must not come back. */
+        Assert.Contains("ProbeSurfaceRulesAsync(", branch, StringComparison.Ordinal);
+        Assert.Contains("NotElevatedRunHasWork(", branch, StringComparison.Ordinal);
+        Assert.DoesNotContain("if (toOpen == 0)", branch, StringComparison.Ordinal);
+
+        /* The probe is spent ONLY where its answer can change something — a Remove this run is allowed to
+           sweep. Probing an Open plan buys nothing, and probing a withheld sweep would invite printing it. */
+        Assert.Contains(
+            "plan.Action == FirewallRuleAction.Remove && plan.SweepOtherPorts",
+            branch, StringComparison.Ordinal);
+    }
+
     /* ---- helpers ---- */
 
     /// <summary>A managed, fully loopback-only config — the default install, and the baseline every exposure
@@ -935,6 +1082,38 @@ public class DarlingFirewallCheckTests
 
     private static System.Collections.Generic.IEnumerable<DarlingCliCommands.FirewallRulePlan> PlansFor(DarlingConfig config, string surface)
         => DarlingCliCommands.PlanFirewallRules(config).Where(p => p.Surface == surface);
+
+    /// <summary>
+    /// The <c>--configure-firewall</c> not-elevated branch as text, for the source pins above. Sliced rather
+    /// than searched whole-file because both remedy builders appear in the ELEVATED path a few lines below, so
+    /// a whole-file <c>Contains</c> would stay green with this branch deleted entirely.
+    /// <para>Anchored from the VERB's signature first, which is load-bearing rather than tidy:
+    /// <c>if (!IsElevated())</c> also appears in <c>--configure-network</c> several hundred lines above, and a
+    /// slice starting there swallowed the whole file — every assertion below passed against dev, where the
+    /// thing they pin does not exist. Every anchor is asserted, and so is the slice's SIZE, because the way
+    /// this pin fails is by quietly widening rather than by not matching.</para>
+    /// </summary>
+    private static string NotElevatedBranch()
+    {
+        var source = ReadRepoFile(Path.Combine("Darling", "PerformanceMonitor.Darling.Service", "DarlingCliCommands.cs"));
+
+        var verb = source.IndexOf("public static async Task<int> ConfigureFirewallAsync(", StringComparison.Ordinal);
+        Assert.True(verb >= 0, "ConfigureFirewallAsync was renamed; this pin is not reading what it thinks it is");
+
+        var start = source.IndexOf("        if (!IsElevated())", verb, StringComparison.Ordinal);
+        Assert.True(start > verb, "the not-elevated branch anchor is stale; this pin is not reading what it thinks it is");
+
+        var end = source.IndexOf("        var failures = 0;", start, StringComparison.Ordinal);
+        Assert.True(end > start, "the end-of-branch anchor is stale; this pin is not reading what it thinks it is");
+
+        var branch = source[start..end];
+        Assert.True(
+            branch.Length < 8000,
+            $"the sliced not-elevated branch is {branch.Length} characters, which is far more than one branch — "
+                + "an anchor has drifted and these pins would pass on text they are not about.");
+
+        return branch;
+    }
 
     private static string ReadRepoFile(string relativePath)
     {

--- a/Darling/Darling.Tests/DocCommentHygieneTests.cs
+++ b/Darling/Darling.Tests/DocCommentHygieneTests.cs
@@ -41,6 +41,16 @@ namespace Darling.Tests;
 /// closed and whether they are written single-line or spread over many. The mixed form is the one a
 /// closing-tag matcher cannot see at all: a single-line summary followed by a multi-line one.</para>
 ///
+/// <para><b>An ATTRIBUTE does not end a doc run (#2445).</b> The #2190 rule keyed off a contiguous run of
+/// <c>///</c> lines, so a stacked pair separated by an attribute line was two runs of one opening each and
+/// invisible — which is exactly how a displaced block sat on dev carrying
+/// <c>[SupportedOSPlatform("windows")]</c> with it, silently platform-annotating the record struct it landed
+/// on. Attributes belong to the member BELOW them, so a run continues across them: a <c>///</c> line, any
+/// number of attribute lines, and more <c>///</c> lines all still document one member. An attribute never
+/// STARTS a run — one above a doc block is that member's own, and the doc block below it is still its first
+/// summary. Widening the rule this way found exactly one offender in the whole tree, the one it was written
+/// for, which is the measurement that says it is a sharpened rule rather than a looser one.</para>
+///
 /// <para><b>Coverage limit, stated rather than assumed.</b> CI path filters are per-project, so this runs on
 /// any pull request that trips the <c>darling</c> or <c>core</c> filter, and on every nightly and release
 /// build — but a change touching ONLY Lite or Installer will not run it, and would be caught on the next
@@ -98,6 +108,9 @@ public sealed class DocCommentHygieneTests
             "an insertion pushed it away from. Seven of the eight found in #1745 were displaced doc blocks " +
             "whose real member had been left undocumented, and deleting them would have lost the documentation " +
             "rather than deduplicating it.\n\n" +
+            "Where the two summaries are separated by an ATTRIBUTE line, the attribute travelled with the " +
+            "displaced block and is now annotating the wrong member — move or delete BOTH, not just the text " +
+            "(#2445).\n\n" +
             "Where an insertion split a block, also check whether the member it came from has since been " +
             "re-documented in place. If it has, the stray text is a stranded HEAD rather than the whole block, " +
             "and moving it back would create the very duplicate this rule forbids — confirm sentence by " +
@@ -124,12 +137,24 @@ public sealed class DocCommentHygieneTests
     /* A stacked run reaching end of file with no member under it. Not valid C#, but it pins the scan's
        one-past-the-end step: a run that never meets a non-doc line has to be closed, not dropped. */
     [InlineData(true, "/// <summary>\n/// A.\n/// <summary>\n/// B.")]
+    /* Split by an attribute, which is how the stranded ConfigureFirewallAsync block hid on dev: two runs of
+       one opening each to the pre-#2445 rule, one member with two summaries in fact. */
+    [InlineData(true, "/// <summary>\n/// A.\n/// </summary>\n[SupportedOSPlatform(\"windows\")]\n/// <summary>\n/// B.\n/// </summary>\nvoid M();")]
     /* One summary plus the other doc tags that legitimately follow it. */
     [InlineData(false, "/// <summary>\n/// A.\n/// </summary>\n/// <param name=\"x\">X.</param>\n/// <returns>Y.</returns>\nvoid M(int x);")]
     /* One summary carrying several <para> blocks, as most of this repo's docs do. */
     [InlineData(false, "/// <summary>\n/// A.\n///\n/// <para>B.</para>\n///\n/// <para>C.</para>\n/// </summary>\nvoid M();")]
     /* Two members, one summary each: the declarations between them end each run. */
     [InlineData(false, "/// <summary>A.</summary>\nint A;\n/// <summary>B.</summary>\nint B;")]
+    /* A documented member that also carries attributes — the ordinary shape of most of this repo. Widening
+       the run across attributes must not turn this into an offender. */
+    [InlineData(false, "/// <summary>A.</summary>\n[Fact]\n[Trait(\"k\", \"v\")]\nvoid M();")]
+    /* The negative control for that widening, and the one that would catch it going too far: two members that
+       each have a summary and an attribute must stay two runs, not merge into one with two openings. */
+    [InlineData(false, "/// <summary>A.</summary>\n[Fact]\nvoid A();\n/// <summary>B.</summary>\n[Fact]\nvoid B();")]
+    /* An attribute ABOVE a doc block belongs to that same member and must not open a run of its own, or the
+       block below it would be counted as a second summary. */
+    [InlineData(false, "[Fact]\n/// <summary>A.</summary>\nvoid M();")]
     /* Escaped mentions in prose are not openings — this very file is full of them. */
     [InlineData(false, "/// <summary>\n/// Two &lt;summary&gt; mentions in one &lt;summary&gt; block.\n/// </summary>\nvoid M();")]
     public void DetectorCountsSummaryOpeningsPerDocRun(bool stacked, string source)
@@ -142,9 +167,13 @@ public sealed class DocCommentHygieneTests
     }
 
     /// <summary>
-    /// Every contiguous run of <c>///</c> lines carrying more than one <c>&lt;summary&gt;</c> opening, as the
-    /// run's first line and the line of each opening. A run ends at the first line that is not a doc comment,
-    /// which is what ties it to exactly one member: the declaration itself terminates it.
+    /// Every run of <c>///</c> lines carrying more than one <c>&lt;summary&gt;</c> opening, as the run's first
+    /// line and the line of each opening. A run ends at the first line that is neither a doc comment nor an
+    /// attribute, which is what ties it to exactly one member: the declaration itself terminates it.
+    /// <para>Attributes are inside the run rather than ending it (#2445) because they document the member
+    /// BELOW them, so <c>/// … [Attr] /// …</c> is one member with two summaries. They cannot OPEN a run: an
+    /// attribute reached while <c>start == 0</c> falls through to the terminator branch, which is a no-op
+    /// there, so an attribute written above a doc block leaves that block as the run's first opening.</para>
     /// </summary>
     private static List<(int Start, List<int> Openings)> StackedSummaryRuns(string[] lines)
     {
@@ -157,7 +186,8 @@ public sealed class DocCommentHygieneTests
 
         for (var i = 0; i <= lines.Length; i++)
         {
-            if (i < lines.Length && lines[i].TrimStart().StartsWith("///", StringComparison.Ordinal))
+            var trimmed = i < lines.Length ? lines[i].TrimStart() : string.Empty;
+            if (i < lines.Length && trimmed.StartsWith("///", StringComparison.Ordinal))
             {
                 if (start == 0)
                 {
@@ -166,6 +196,10 @@ public sealed class DocCommentHygieneTests
                 }
 
                 openings.AddRange(Enumerable.Repeat(i + 1, SummaryOpening.Matches(lines[i]).Count));
+            }
+            else if (start != 0 && trimmed.StartsWith("[", StringComparison.Ordinal))
+            {
+                /* Inside a run: an attribute annotates the member below it, so it separates nothing. */
             }
             else if (start != 0)
             {

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingCliCommands.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingCliCommands.cs
@@ -2927,13 +2927,6 @@ public static class DarlingCliCommands
         };
 
     /// <summary>
-    /// Creates or removes every scoped Darling firewall rule so the live firewall matches darling.json.
-    /// Requires elevation (that is the entire point of the verb) and is idempotent — safe to re-run on every
-    /// upgrade, which is exactly how install-darling.ps1 uses it. Returns 0 when the firewall ends up matching
-    /// the config, 1 when it could not be made to.
-    /// </summary>
-    [SupportedOSPlatform("windows")]
-    /// <summary>
     /// One target of <see cref="HardenFiles"/>: a path, whether the interactive operator legitimately reads it,
     /// and what it is called in the report. Kept as data so the list is readable as a policy rather than as
     /// control flow — which file gets INTERACTIVE read is the only judgement in this verb, and it should be

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingCliCommands.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingCliCommands.cs
@@ -3119,6 +3119,119 @@ public static class DarlingCliCommands
         }
     }
 
+    /// <summary>What the NOT-elevated <c>--configure-firewall</c> branch owes the operator for one surface
+    /// (#2445), and therefore whether an elevated shell really has work to do.</summary>
+    public enum FirewallHandoff
+    {
+        /// <summary>Nothing to hand over — the desired state already holds, or this run is not entitled to ask
+        /// for the change. Prints no command and does not make the verb fail.</summary>
+        Nothing,
+
+        /// <summary>A rule has to be CREATED. Prints the enable command and fails the verb, exactly as this
+        /// branch always has for an Open plan.</summary>
+        OpenCommand,
+
+        /// <summary>A rule the desired state forbids was FOUND by the read-only probe. Prints the same sweep
+        /// command the elevated path would have run, and fails the verb — there is measured elevated work.</summary>
+        SweepCommand,
+
+        /// <summary>The probe could not answer, so whether such a rule exists is unknown. Prints the sweep
+        /// command, because it is a no-op when there is nothing to remove and the operator can only act on what
+        /// they are handed — but does NOT fail the verb. An exit code here is a claim about the FIREWALL, and
+        /// "the probe did not answer" is not one.</summary>
+        SweepCommandUnverified,
+    }
+
+    /// <summary>
+    /// PURE: what the not-elevated branch owes ONE plan. <paramref name="rulesFound"/> is the read-only probe's
+    /// answer for this surface's wildcard — null when it could not answer — and is only ever consulted for a
+    /// Remove, because only there does the answer change anything.
+    ///
+    /// <para><b>Why the Remove half is measured and the Open half is not.</b> An Open plan already knows the
+    /// verb's whole job: the rule has to exist with these exact parameters, the enable command is idempotent
+    /// (it removes its own DisplayName first), and a probe could at best say a rule with that name exists —
+    /// not that its port, direction and RemoteAddress are the ones this config asks for. So the probe would buy
+    /// nothing there and this keeps the pre-#2445 behaviour exactly. A Remove is the opposite: the desired
+    /// state is the ABSENCE of a rule, absence is the overwhelmingly common case (every default loopback
+    /// install), and the two things this branch has to decide — whether to print a command at all, and whether
+    /// to report failure — are BOTH answered by "is one actually there". The alternative considered and
+    /// rejected was gating on <c>Note is not null</c>, which is a proxy for "a rule might exist" and is wrong in
+    /// both directions: it prints a sweep for a fail-closed surface that never had a rule, and stays silent
+    /// about a plain-loopback surface holding a stale rule from an exposure someone turned off by hand — the
+    /// exact state <see cref="FirewallRuleVerdict.LoopbackStaleRule"/> exists to name.</para>
+    ///
+    /// <para><b>Why a withheld sweep hands over nothing at all.</b> #2436 withholds
+    /// <see cref="FirewallRulePlan.SweepOtherPorts"/> for a surface darling.json exposes on a run that could not
+    /// read the control plane, because there the file's "switched off" may be years stale and the rule matching
+    /// the wildcard may be the one the endpoint is being served on. Printing that sweep command would hand the
+    /// operator, by copy and paste, the very outage the elevated path just declined to cause — and the operator
+    /// pasting it has no way to see that it was declined. The plan's <see cref="FirewallRulePlan.Note"/> is
+    /// printed above and says why; the remedy is a re-run with the store up, not a command.</para>
+    /// </summary>
+    public static FirewallHandoff ClassifyNotElevatedHandoff(
+        FirewallRuleAction action, bool sweepOtherPorts, bool? rulesFound) =>
+        action == FirewallRuleAction.Open ? FirewallHandoff.OpenCommand
+        : !sweepOtherPorts ? FirewallHandoff.Nothing
+        : rulesFound switch
+        {
+            true => FirewallHandoff.SweepCommand,
+            false => FirewallHandoff.Nothing,
+            _ => FirewallHandoff.SweepCommandUnverified,
+        };
+
+    /// <summary>
+    /// PURE: whether a not-elevated run has to report failure — true only where an elevated shell really has
+    /// work to do, which is what the exit code is supposed to mean.
+    /// <para><see cref="FirewallHandoff.SweepCommandUnverified"/> deliberately does not count. A non-zero exit
+    /// from this verb is a signal other things act on — <c>install-darling.ps1</c> prints a re-run banner on
+    /// it — and turning "the probe did not answer" into that signal would report drift the run never saw.
+    /// Under-reporting there is the safe direction: the running service probes the same rule on every start
+    /// and WARNs a stale one by name (<see cref="DarlingFirewallCheck"/>), so an unmeasured rule is found
+    /// within one service start, whereas a bogus failure teaches operators to ignore the banner.</para>
+    /// </summary>
+    public static bool NotElevatedRunHasWork(IEnumerable<FirewallHandoff> handoffs) =>
+        handoffs.Any(h => h is FirewallHandoff.OpenCommand or FirewallHandoff.SweepCommand);
+
+    /// <summary>
+    /// Read-only "does ANY rule for this surface exist" for the not-elevated branch (#2445). True/false when the
+    /// probe answered, null when it could not. Never writes anything and never throws except on cancellation.
+    ///
+    /// <para>It runs <see cref="DarlingFirewallCheck.BuildProbeCommand"/> — the probe the RUNNING service
+    /// already uses, shaped to exit 0 whether or not a rule matches — against
+    /// <see cref="DarlingFirewallCheck.SurfaceRuleWildcard"/>, which is the same wildcard the elevated sweep
+    /// deletes by. That pairing is the point rather than convenience: a narrower question would report "nothing
+    /// to do" about rules the sweep would still collect, and a wider one would offer a command covering rules
+    /// this product does not own. Probe and remedy share the builders, so they cannot come to disagree.</para>
+    ///
+    /// <para>Affordable precisely HERE, in the one branch that by definition holds no privilege:
+    /// <c>Get-NetFirewallRule</c> needs no elevation — reads succeed under a restricted token where writes
+    /// return PermissionDenied — and this costs at most one bounded PowerShell round trip per surface, only on
+    /// a path <c>install-darling.ps1</c> cannot take, since it refuses to run unelevated at all.</para>
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    private static async Task<bool?> ProbeSurfaceRulesAsync(string wildcard, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var (exitCode, psOutput) = await DarlingManagedPostgres.RunPowerShellAsync(
+                DarlingFirewallCheck.BuildProbeCommand(wildcard), cancellationToken);
+
+            /* The probe exits 0 for BOTH answers, so a non-zero exit means the probe itself broke; do not read
+               a count out of a run that failed. Same reasoning as DarlingFirewallCheck.CheckAsync. */
+            return exitCode == 0 ? DarlingFirewallCheck.TryParseProbeOutput(psOutput) : null;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            /* A missing or broken powershell.exe is "could not tell", never "no rule" — guessing absence would
+               manufacture a clean bill of health for a firewall this run never read. */
+            return null;
+        }
+    }
+
     /// <summary>
     /// Creates or removes every scoped Darling firewall rule so the live firewall matches darling.json.
     /// Requires elevation (that is the entire point of the verb) and is idempotent — safe to re-run on every
@@ -3187,21 +3300,86 @@ public static class DarlingCliCommands
                 output.WriteLine($"{plan.Surface}: {plan.Note}.");
             }
 
-            if (toOpen == 0)
+            /* #2445: MEASURE the Remove half instead of guessing at it. This branch used to print a command
+               only for Open plans, so a run whose whole work was a removal said "nothing needs an open port",
+               exited 0, and left a stale inbound allow rule sitting there with nothing offered to close it.
+               #2436 made that shape ordinary rather than exotic — a surface is now a Remove when the control
+               plane has it switched OFF, so it covers an admin who just ran --disable-mcp and re-ran this verb
+               from a normal prompt.
+
+               The read-only probe is what makes all three behaviours honest at once, and it is affordable here
+               for a reason worth stating: Get-NetFirewallRule needs no elevation, so this branch could always
+               have looked and simply never did. Without it the only gate available is a proxy for "a rule might
+               exist", which would print sweep commands on every default loopback install and STILL miss a stale
+               rule on a surface that has no note. With it, a clean box prints nothing extra and exits 0 exactly
+               as before, and a box with a stale rule gets that rule's own sweep command and a non-zero exit.
+               Only the Remove plans that are permitted to sweep are probed, so the cost is at most one bounded
+               PowerShell round trip per such surface, on a path install-darling.ps1 cannot reach — it fails
+               outright when not elevated, so the re-run banner this could have fired is not on that path. */
+            var handoffs = new List<(FirewallRulePlan Plan, FirewallHandoff Handoff)>();
+            foreach (var plan in plans)
+            {
+                bool? rulesFound = null;
+                if (plan.Action == FirewallRuleAction.Remove && plan.SweepOtherPorts)
+                {
+                    rulesFound = await ProbeSurfaceRulesAsync(
+                        DarlingFirewallCheck.SurfaceRuleWildcard(plan.RuleName), cancellationToken);
+                }
+
+                handoffs.Add((plan, ClassifyNotElevatedHandoff(plan.Action, plan.SweepOtherPorts, rulesFound)));
+            }
+
+            if (handoffs.All(h => h.Handoff == FirewallHandoff.Nothing))
             {
                 output.WriteLine(
-                    "No endpoint wants an open port, so no rule was opened. (This shell is not elevated, but " +
-                    "there was nothing to open.)");
+                    "No endpoint wants an open port, and no scoped Darling rule is open that should not be, so " +
+                    "there is nothing for an elevated shell to do. (This shell is not elevated, but reading the " +
+                    "firewall does not need elevation — so that is measured, not assumed.)");
                 return 0;
             }
 
+            var hasWork = NotElevatedRunHasWork(handoffs.Select(h => h.Handoff));
+
             error.WriteLine("This shell is not elevated, so NO firewall rule was changed. Run these in an ELEVATED PowerShell:");
-            foreach (var plan in plans.Where(p => p.Action == FirewallRuleAction.Open))
+            foreach (var (plan, handoff) in handoffs)
             {
-                error.WriteLine("  " + DarlingManagedPostgres.BuildFirewallEnableCommand(plan.RuleName, plan.Port, plan.Cidr!));
+                switch (handoff)
+                {
+                    case FirewallHandoff.OpenCommand:
+                        error.WriteLine("  " + DarlingManagedPostgres.BuildFirewallEnableCommand(plan.RuleName, plan.Port, plan.Cidr!));
+                        break;
+
+                    /* The same builder and the same wildcard the elevated path would have used, so the command
+                       an operator pastes and the command the verb runs cannot drift apart. */
+                    case FirewallHandoff.SweepCommand:
+                        error.WriteLine(
+                            $"  # {plan.Surface}: a scoped rule is open on this surface and none belongs on any port.");
+                        error.WriteLine("  " + DarlingManagedPostgres.BuildFirewallSweepCommand(
+                            DarlingFirewallCheck.SurfaceRuleWildcard(plan.RuleName)));
+                        break;
+
+                    case FirewallHandoff.SweepCommandUnverified:
+                        error.WriteLine(
+                            $"  # {plan.Surface}: the read-only rule probe gave no usable answer, so this may be a no-op.");
+                        error.WriteLine("  " + DarlingManagedPostgres.BuildFirewallSweepCommand(
+                            DarlingFirewallCheck.SurfaceRuleWildcard(plan.RuleName)));
+                        break;
+
+                    case FirewallHandoff.Nothing:
+                    default:
+                        break;
+                }
             }
 
-            return 1;
+            if (!hasWork)
+            {
+                error.WriteLine(
+                    "Returning 0: nothing above is CONFIRMED work. The read-only probe could not answer for at " +
+                    "least one surface, so those commands are offered as a precaution — and a non-zero exit is a " +
+                    "claim about the firewall, which this run has no measurement to support.");
+            }
+
+            return hasWork ? 1 : 0;
         }
 
         var failures = 0;
@@ -3278,8 +3456,11 @@ public static class DarlingCliCommands
             return 1;
         }
 
+        /* Not "every endpoint is loopback-only" any more: since #2436 a surface is also a Remove when it is
+           fully LAN-configured and the control plane has it switched OFF. That is the same misleading summary
+           #2442 fixed one branch up, and the per-surface lines above already carry the real reason. */
         output.WriteLine(toOpen == 0
-            ? "Done. Every endpoint is loopback-only, so no port was opened."
+            ? "Done. No endpoint wants an open port, so no port was opened."
             : $"Done. {toOpen} endpoint(s) exposed on the LAN; their scoped rules are in place.");
         return 0;
     }

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingFirewallCheck.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingFirewallCheck.cs
@@ -115,6 +115,13 @@ internal static class DarlingFirewallCheck
     /// stores one per profile) and a single match would otherwise have no <c>.Count</c>.</item>
     /// </list>
     /// The name goes through the same single-quoted-literal escaping as the write builders.
+    /// <para>Takes either ONE rule's exact DisplayName — what <see cref="CheckAsync"/> asks, because the service
+    /// verifies the specific rule its own config wants — or a <see cref="SurfaceRuleWildcard"/>, which is what
+    /// <c>--configure-firewall</c>'s not-elevated branch asks (#2445): there the question is whether the sweep
+    /// it is about to hand over would remove anything, so the probe has to cover exactly what the sweep would
+    /// delete. Single quoting is literal to the SHELL and not to the cmdlet, so a <c>*</c> reaches
+    /// <c>-DisplayName</c> as the wildcard it is — the same way it does for the sweep's
+    /// <c>Remove-NetFirewallRule -DisplayName</c>, which is where that behaviour is already load-bearing.</para>
     /// </summary>
     internal static string BuildProbeCommand(string ruleName) =>
         $"$c = @(Get-NetFirewallRule -DisplayName {DarlingManagedPostgres.SingleQuotedPowerShell(ruleName)} " +


### PR DESCRIPTION
Closes #2445.

The issue asked one question — may this branch spend a read-only `Get-NetFirewallRule` probe per surface — and said the answer decides everything else. It does, and the answer is yes.

## The trade collapses to one unknown

Exit code and output noise look like two decisions and are one. Both turn on whether a rule is actually sitting there, and every answer that guesses instead of looking is wrong in some direction:

- **Always print a sweep and exit non-zero.** Three commands on every default loopback install, and a re-run banner on a run that had nothing to do.
- **Gate on `plan.Note is not null`.** Quiets that case, and is a proxy for "a rule might exist" that is wrong in *both* directions: it prints a sweep for a fail-closed surface that never had a rule, and stays silent about a plain-loopback surface holding a stale rule from an exposure someone turned off by hand — which is the state `FirewallRuleVerdict.LoopbackStaleRule` exists to name.

`Get-NetFirewallRule` needs no elevation. That is not a new finding, it is the premise of the runtime check `DarlingFirewallCheck` was built on ("reads succeed under a restricted token where writes return PermissionDenied", verified on Windows 11 26200). So this branch could always have looked and simply never did.

## The probe already existed, and it fits without changing shape

`DarlingFirewallCheck.BuildProbeCommand` is PURE, always exits 0 whether or not a rule matches, and never throws — the two properties this branch needs. The one thing worth stating is what it is *asked*: `SurfaceRuleWildcard(plan.RuleName)`, the same wildcard the elevated sweep deletes by. Probe and remedy share both builders, so they cannot come to disagree about scope. A narrower question would report "nothing to do" about rules the sweep would still collect; a wider one would offer a command covering rules this product does not own.

Its doc gains a paragraph saying a wildcard is now a supported argument, and why single-quoting does not defeat it — the sweep has relied on that same behaviour since #2432, so this is documenting an existing load-bearing property rather than adding one.

## What the branch does now

| plan | probe | handed over | exit |
|---|---|---|---|
| Open | not spent | enable command | 1 |
| Remove, sweep allowed, rule found | true | that surface's sweep command | 1 |
| Remove, sweep allowed, no rule | false | nothing | 0 |
| Remove, sweep allowed, probe failed | null | sweep command, with a caveat | 0 |
| Remove, **sweep withheld (#2436)** | not spent | **nothing** | 0 |

A clean box prints nothing extra and exits 0, exactly as before — but now because it was measured, not assumed. A box with a stale rule gets that rule's own sweep command and a non-zero exit.

**Cost.** At most one bounded PowerShell round trip per Remove plan that is allowed to sweep, on a path `install-darling.ps1` cannot reach: it `Fail`s outright when not elevated (line 170). So the re-run banner the issue weighed is not on this path at all — the exit code matters here for someone scripting the verb directly, which is a smaller blast radius than the issue assumed.

**An Open plan is deliberately unchanged.** It already knows the verb's whole job, the enable command is idempotent, and a probe could at best say a rule with that name exists — not that its port, direction and RemoteAddress are the ones this config asks for. Spending a probe there buys nothing, so pre-#2445 behaviour is preserved exactly.

## Not undoing #2442

The withheld sweep hands over **nothing**, on any probe answer including "a rule is there". That surface is one darling.json exposes on a run that could not read the control plane, so the file's `enabled = false` may be years stale and the rule matching the wildcard may be the one the endpoint is being served on. Printing that command would hand the operator, by copy and paste, the very outage the elevated path had just declined to cause — and they would have no way to see that it had been declined. The plan's `Note` is printed above and says why; the remedy is a re-run with the store up, which is what the installer's post-start reconcile exists to make happen.

`TheHandoff_FollowsThePlannersSweepPermission_NotJustTheAction` pins that against plans the real planner produced, not against hand-built flags — the two configs differ only in whether the store answered, and they get opposite handoffs on the same probe answer.

## An unverifiable probe does not fail the verb

A non-zero exit is a claim about the *firewall*, and "the probe did not answer" is not one. Under-reporting is the safe direction: the running service re-probes the same rule on every start and WARNs a stale one by name, so an unmeasured rule surfaces within one service start — whereas a banner that fires without cause is how operators learn to ignore the one that has cause. The command is still printed, with a comment saying it may be a no-op, and a closing line says why the verb is returning 0 anyway.

## Two things fixed on the way

**The elevated path's closing line.** `"Done. Every endpoint is loopback-only, so no port was opened."` became false in #2436, for the same reason #2442 fixed its not-elevated twin: a surface is now also a Remove when it is fully LAN-configured and switched off. The per-surface lines above already carry the real reason.

**A source pin that was passing on text it was not about.** `NotElevatedBranch()` anchored only on `if (!IsElevated())`, which also appears in `--configure-network` several hundred lines earlier — so the slice ran from there to the end of the verb and every assertion in it passed against dev, where the thing they pin does not exist. It now anchors from `ConfigureFirewallAsync`'s signature first and asserts the slice's SIZE, because the way a source pin fails is by quietly widening rather than by not matching. This is why the dev split below is worth reading: the first version of it reported a false green.

## The stranded doc block (first commit)

`ConfigureFirewallAsync`'s summary sat several hundred lines above the method, followed by `[SupportedOSPlatform("windows")]` and then `HardenTarget`'s own block — so the file documented that method twice, documented `HardenTarget` with the second copy, and the attribute travelled with the displaced block and quietly platform-annotated a private record struct.

`DocCommentHygieneTests` could not see it: it counts `<summary>` openings per contiguous run of `///` lines, and the attribute line ends a run. That is #2190's blind spot one step further out, so the rule is widened deliberately rather than the instance being fixed quietly — a doc run now continues across attribute lines, and an attribute can never *start* one. Four new self-test cases pin the shape it must catch and the three it must leave alone, including the negative control that two members each carrying a summary and an attribute stay two runs.

**The measurement is the argument for widening:** the widened rule finds **exactly one** offender in the whole tree, the one it was written for. It is red against dev naming `DarlingCliCommands.cs:2929`, and green here. The displaced block is deleted rather than moved, because the method has carried an identical copy in place the whole time (#2190's stranded-head case, confirmed sentence by sentence).

It rides in this PR rather than its own because it is the doc comment *of the method this PR rewrites*, and leaving a duplicate copy of a summary while changing what that summary describes would be leaving the file worse.

## Verification

The suite targets `net10.0-windows` and cannot run on macOS, so the real test files were compiled into a `net10.0` xUnit-shim harness and run against both branches.

- **98 passed / 0 failed** on this branch (`DarlingFirewallCheckTests` + `DocCommentHygieneTests`, including the tree-wide scan).
- **Eleven of the new cases cannot compile against dev** — `FirewallHandoff`, `ClassifyNotElevatedHandoff` and `NotElevatedRunHasWork` do not exist there — which is the stronger statement.
- With those removed, dev runs **72 passed / 1 failed** on the same file, and the red one is `TheNotElevatedBranch_MeasuresAndOffersARemedyForARemoval`, failing on `BuildFirewallSweepCommand` — precisely the defect this issue describes.
- The widened `DocCommentHygieneTests` is **red against dev**, naming the single offender, and green here.

`TheProbeAsksExactlyWhatTheSweepWouldDelete` passes on dev too, and is named as what it is: a pin on a property of the existing builders that this change now depends on, not a regression test.

No CHANGELOG entry, matching #2432, #2428 and #2442: `[3.5.0]` is a shipped, dated section and there is no `[Unreleased]` on dev, so an entry here would attribute the fix to a release that does not contain it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
