### PR TITLE
Say why Lite's card is amber, and which axis the word is about (#2437)

### DIFF
--- a/Lite.Tests/LiteOverviewCardExplainsItselfTests.cs
+++ b/Lite.Tests/LiteOverviewCardExplainsItselfTests.cs
@@ -1,0 +1,314 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Windows.Media;
+using PerformanceMonitorLite.Services;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// #2437 / #2422: Lite's Overview card stops keeping the answer to itself.
+///
+/// <para><b>What was reported.</b> Against the Darling viewer, but the defect is verbatim here: a card said a
+/// word in a colour and would not say what about. @ehaar's question was "what is it that this text warns me
+/// about?", and the reader's only recourse was to scan the metric rows guessing which one the card meant —
+/// once per card, on every card. #2429 answered it on the viewer; <c>Lite/MainWindow.xaml:442</c> was the same
+/// bare <c>Text="{Binding StatusDisplay}"</c> with no ToolTip.</para>
+///
+/// <para><b>What is pinned here.</b> The property that makes the viewer's version work, and the one thing a
+/// port could quietly lose: the sentence is assembled from the card's OWN metric displays, gated on the SAME
+/// predicates the row brushes are painted from, so it can never name a metric whose row is green or stay
+/// silent about one that is not. <see cref="TheTooltip_NamesExactlyTheRowsTheCardHasColoured"/> asserts that
+/// against the shipped brushes rather than against a copy of the thresholds — a re-derivation of severity
+/// would pass every text assertion below and still be worse than no tooltip.</para>
+///
+/// <para><b>What Lite does NOT have.</b> There is no <c>AwaitingFirstCollection</c> flag on Lite's card, so the
+/// status/tooltip desync family #2429 spent four review rounds on cannot arise. What Lite has instead is the
+/// inverse conflation, pinned by <see cref="TheTooltip_SaysWhichAxisTheStatusWordIsAbout"/>: its status word is
+/// a CONNECTION word, so a card in real metric trouble reads a green "Online" while its border is red, and its
+/// amber "Warning" is about failing collectors and says nothing about the metrics at all.</para>
+/// </summary>
+public sealed class LiteOverviewCardExplainsItselfTests
+{
+    /* Every fixture leaves OtherProcessCpuPercent null on purpose. CpuPercentForAlert reads the process-wide
+       App.AlertCpuMode, which another suite legitimately flips; with no other-process figure both modes read
+       the same number, so nothing here depends on which one happens to be set. */
+
+    private static ServerSummaryItem Healthy() =>
+        new() { DisplayName = "calm", ServerId = 1, IsOnline = true, CpuPercent = 5 };
+
+    private static ServerSummaryItem Busy() =>
+        new() { DisplayName = "busy", ServerId = 2, IsOnline = true, CpuPercent = 96, DeadlockCount = 2 };
+
+    private static ServerSummaryItem CollectorsFailing() =>
+        new() { DisplayName = "erroring", ServerId = 3, IsOnline = true, CpuPercent = 5, HasCollectorErrors = true };
+
+    private static ServerSummaryItem Offline() =>
+        new() { DisplayName = "dark", ServerId = 4, IsOnline = false, CpuPercent = 96, DeadlockCount = 2 };
+
+    private static ServerSummaryItem NotYetChecked() =>
+        new() { DisplayName = "queued", ServerId = 5, IsOnline = null, CpuPercent = 62 };
+
+    private static IEnumerable<ServerSummaryItem> EveryState() =>
+        new[] { Healthy(), Busy(), CollectorsFailing(), Offline(), NotYetChecked() };
+
+    // ── the card explains itself ───────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The invariant the whole change rests on, asserted against the SHIPPED brushes rather than a copy of the
+    /// thresholds: the tooltip names a metric exactly when that metric's row is not green. A Lite tooltip that
+    /// recomputed severity independently would satisfy every wording assertion below and still drift from the
+    /// rows sitting directly underneath it, which is the one failure mode a tooltip must not have.
+    /// </summary>
+    [Fact]
+    public void TheTooltip_NamesExactlyTheRowsTheCardHasColoured()
+    {
+        var green = Healthy().CpuBrush.Color;
+
+        foreach (var card in EveryState())
+        {
+            /* Offline is the documented exception and is checked on its own below: the card draws a dimming
+               overlay over those rows because the numbers under it are pre-blackout. */
+            if (card.IsOffline)
+            {
+                continue;
+            }
+
+            var tooltip = card.StatusTooltip;
+
+            Assert.Equal(card.CpuBrush.Color != green, tooltip.Contains("CPU ", StringComparison.Ordinal));
+            Assert.Equal(card.BlockingBrush.Color != green, tooltip.Contains("Blocking ", StringComparison.Ordinal));
+            Assert.Equal(card.DeadlockBrush.Color != green, tooltip.Contains("Deadlocks ", StringComparison.Ordinal));
+        }
+    }
+
+    /// <summary>The numbers in the sentence are the card's own display strings, character for character —
+    /// not a second formatting of the same values, which is how a tooltip ends up rounding differently from
+    /// the row it is explaining.</summary>
+    [Fact]
+    public void TheTooltip_QuotesTheCardsOwnDisplays()
+    {
+        var card = Busy();
+
+        Assert.Equal("96%", card.CpuDisplay);
+        Assert.Equal("2", card.DeadlockDisplay);
+        Assert.Equal("CPU 96%, Deadlocks 2", card.StatusReason);
+        Assert.Contains("Needs attention: CPU 96%, Deadlocks 2", card.StatusTooltip, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Lite's conflation, which is not the viewer's. There the amber "Warning" means the collection has gone
+    /// stale; here it means collectors are erroring, and the metric rows have no say in the status word at all —
+    /// so a card in real trouble reads a green "Online" over a red border. Both halves have to be named or the
+    /// tooltip just repeats the word.
+    /// </summary>
+    [Fact]
+    public void TheTooltip_SaysWhichAxisTheStatusWordIsAbout()
+    {
+        var erroring = CollectorsFailing();
+
+        Assert.Equal("Warning", erroring.StatusDisplay);
+        Assert.Contains("collectors are failing", erroring.StatusTooltip, StringComparison.Ordinal);
+        /* ...and says so without claiming a metric problem the rows do not show. */
+        Assert.Contains("Every metric on this card is inside its threshold", erroring.StatusTooltip, StringComparison.Ordinal);
+
+        var busy = Busy();
+
+        Assert.Equal("Online", busy.StatusDisplay);
+        Assert.Contains("Needs attention: CPU 96%, Deadlocks 2", busy.StatusTooltip, StringComparison.Ordinal);
+        /* The border is already red for this card. The word never was, which is the whole point. */
+        Assert.NotEqual(Healthy().CardBorderBrush.Color, busy.CardBorderBrush.Color);
+    }
+
+    /// <summary>A calm card gets an all-clear, not a demand. The viewer had to guard this because its ranking's
+    /// "Needs attention" fallback would otherwise reach every healthy card in the fleet; the same sentence is
+    /// available to get wrong here, and the card grid shows EVERY server.</summary>
+    [Fact]
+    public void TheTooltip_OnACalmCard_DoesNotClaimItNeedsAttention()
+    {
+        var tooltip = Healthy().StatusTooltip;
+
+        Assert.Contains("Online — the last connection check succeeded", tooltip, StringComparison.Ordinal);
+        Assert.Contains("Every metric on this card is inside its threshold", tooltip, StringComparison.Ordinal);
+        Assert.DoesNotContain("Needs attention", tooltip, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// An offline card is not told to act on the numbers behind its own blackout overlay. Those are the last
+    /// values collected before the server went dark; the card dims them for that reason, and a tooltip
+    /// demanding attention for them would contradict the card while the reader is looking at it.
+    /// </summary>
+    [Fact]
+    public void TheTooltip_OnAnOfflineCard_DoesNotDemandActionOnPreBlackoutNumbers()
+    {
+        var card = Offline();
+        var tooltip = card.StatusTooltip;
+
+        Assert.True(card.IsOffline);
+        Assert.Contains("Offline — the last connection check failed", tooltip, StringComparison.Ordinal);
+        Assert.DoesNotContain("Needs attention", tooltip, StringComparison.Ordinal);
+        Assert.DoesNotContain("CPU", tooltip, StringComparison.Ordinal);
+
+        /* The reason itself is still computed — the omission is a tooltip decision, made in one place, not a
+           hole in what the card knows. */
+        Assert.Equal("CPU 96%, Deadlocks 2", card.StatusReason);
+    }
+
+    /// <summary>"Unknown" is the one word with nothing behind it: no connection check has run. Not knowing
+    /// whether a server is reachable is no reason to withhold the CPU number that WAS collected.</summary>
+    [Fact]
+    public void TheTooltip_OnAnUncheckedCard_StillReportsWhatWasCollected()
+    {
+        var tooltip = NotYetChecked().StatusTooltip;
+
+        Assert.Contains("Unknown — this server has not been connection-checked yet", tooltip, StringComparison.Ordinal);
+        Assert.Contains("Needs attention: CPU 62%", tooltip, StringComparison.Ordinal);
+    }
+
+    /// <summary>Every card gets a tooltip, every tooltip ends on the gesture that acts on it, and no tooltip is
+    /// ever the bare word the reader already read.</summary>
+    [Fact]
+    public void EveryCard_GetsATooltipThatSaysSomethingTheWordDidNot()
+    {
+        foreach (var card in EveryState())
+        {
+            var tooltip = card.StatusTooltip;
+
+            Assert.NotEqual(card.StatusDisplay, tooltip);
+            Assert.Contains(card.StatusDisplay + " — ", tooltip, StringComparison.Ordinal);
+            Assert.EndsWith("Double-click the card to open this server's tab", tooltip, StringComparison.Ordinal);
+        }
+    }
+
+    /// <summary>
+    /// The word, the colour and the tooltip's first line are three renderings of ONE discriminant, which is what
+    /// makes them incapable of disagreeing rather than merely observed not to. The viewer arrived at the same
+    /// collapse over two review rounds on #2429, each of which found a different flag pair where two independent
+    /// readings contradicted each other.
+    /// </summary>
+    [Fact]
+    public void TheCardStatus_IsTheOnlyPlaceTheStatusFlagsAreRead()
+    {
+        Assert.Equal(ServerCardStatus.Online, Healthy().CardStatus);
+        Assert.Equal(ServerCardStatus.CollectorErrors, CollectorsFailing().CardStatus);
+        Assert.Equal(ServerCardStatus.Offline, Offline().CardStatus);
+        Assert.Equal(ServerCardStatus.Unknown, NotYetChecked().CardStatus);
+
+        /* An offline card's collector-error marker must not turn it amber — the flags are read once, in order. */
+        var offlineAndErroring = Offline();
+        offlineAndErroring.HasCollectorErrors = true;
+        Assert.Equal(ServerCardStatus.Offline, offlineAndErroring.CardStatus);
+        Assert.Equal("Offline", offlineAndErroring.StatusDisplay);
+        Assert.Contains("Offline", offlineAndErroring.StatusTooltip, StringComparison.Ordinal);
+
+        var source = ReadRepoFile(Path.Combine("Lite", "Services", "LocalDataService.Overview.cs"));
+        Assert.Contains("public ServerCardStatus CardStatus => IsOnline switch", source, StringComparison.Ordinal);
+        Assert.Contains("public string StatusDisplay => CardStatus switch", source, StringComparison.Ordinal);
+        Assert.Contains("public SolidColorBrush StatusBrush => MakeBrush(CardStatus switch", source, StringComparison.Ordinal);
+        Assert.Contains("private string StatusHeadline => CardStatus switch", source, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The row brushes and the reason read the SAME gates. This is the source-level half of
+    /// <see cref="TheTooltip_NamesExactlyTheRowsTheCardHasColoured"/>: that test proves they agree today, this
+    /// one forbids the second copy of a threshold that would let them stop agreeing later. Memory is absent from
+    /// both because the Memory row carries no severity brush — there is no band on this card to report.
+    /// </summary>
+    [Fact]
+    public void TheRowBrushes_AndTheReason_ReadOneGateEach()
+    {
+        var source = ReadRepoFile(Path.Combine("Lite", "Services", "LocalDataService.Overview.cs"));
+
+        Assert.Contains("private bool CpuIsElevated => CpuPercentForAlert >= 50;", source, StringComparison.Ordinal);
+        Assert.Contains("private bool CpuIsCritical => CpuPercentForAlert >= 80;", source, StringComparison.Ordinal);
+        Assert.Contains("private bool BlockingIsElevated => BlockingCount > 0;", source, StringComparison.Ordinal);
+        Assert.Contains("private bool DeadlocksAreElevated => DeadlockCount > 0;", source, StringComparison.Ordinal);
+
+        /* Both readers of each gate, named: the row's brush, and the reason. */
+        Assert.Contains("MakeBrush(CpuIsCritical ? \"#E57373\" : CpuIsElevated ? \"#FFB74D\"", source, StringComparison.Ordinal);
+        Assert.Contains("MakeBrush(BlockingIsElevated ? \"#FFB74D\"", source, StringComparison.Ordinal);
+        Assert.Contains("MakeBrush(DeadlocksAreElevated ? \"#E57373\"", source, StringComparison.Ordinal);
+        Assert.Contains("if (CpuIsElevated)", source, StringComparison.Ordinal);
+        Assert.Contains("if (BlockingIsElevated)", source, StringComparison.Ordinal);
+        Assert.Contains("if (DeadlocksAreElevated)", source, StringComparison.Ordinal);
+
+        /* And no second copy of any threshold. These are the literals the brushes carried before the gates
+           existed; a tooltip written against its own copy of them is the drift this whole class is about. */
+        Assert.DoesNotContain("CpuPercentForAlert >= 80 ? \"#FFB74D\"", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("BlockingCount > 0 ? \"#FFB74D\"", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("DeadlockCount > 0 ? \"#E57373\"", source, StringComparison.Ordinal);
+    }
+
+    // ── the wiring, which only source can show ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The card's status line actually carries the tooltip. <c>Background="Transparent"</c> is load-bearing
+    /// rather than decorative: a TextBlock with a null Background hit-tests on its rendered glyphs alone, so
+    /// the tooltip would appear over the letters of "Warning" and nowhere in the space around them. Removing
+    /// either attribute compiles perfectly clean, which is why this reads XAML.
+    /// </summary>
+    [Fact]
+    public void TheCardStatusLine_IsBoundToTheTooltip_AndIsHoverable()
+    {
+        var xaml = ReadRepoFile(Path.Combine("Lite", "MainWindow.xaml"));
+
+        var at = xaml.IndexOf("Text=\"{Binding StatusDisplay}\"", StringComparison.Ordinal);
+        Assert.True(at > 0, "the Overview card's status TextBlock is gone — find where it moved before editing this test");
+
+        var element = xaml[at..(xaml.IndexOf("/>", at, StringComparison.Ordinal) + 2)];
+
+        Assert.Contains("ToolTip=\"{Binding StatusTooltip}\"", element, StringComparison.Ordinal);
+        Assert.Contains("Background=\"Transparent\"", element, StringComparison.Ordinal);
+
+        /* The status dot carries it too — it is the same signal, and it is the thing a reader points at first. */
+        var dot = xaml.IndexOf("Fill=\"{Binding StatusBrush}\"", StringComparison.Ordinal);
+        Assert.True(dot > 0, "the Overview card's status dot is gone");
+        Assert.Contains("ToolTip=\"{Binding StatusTooltip}\"", xaml[dot..(xaml.IndexOf("/>", dot, StringComparison.Ordinal) + 2)], StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The closing line is the viewer's, verbatim. The reason all three surfaces are being fixed together is
+    /// that a reader moving between Lite, the viewer and the web dashboard should meet one vocabulary rather
+    /// than three levels of helpfulness — so this is a pin, not a coincidence.
+    /// </summary>
+    [Fact]
+    public void TheTooltipsClosingLine_MatchesTheDarlingViewers()
+    {
+        const string action = "Double-click the card to open this server's tab";
+
+        Assert.EndsWith(action, Healthy().StatusTooltip, StringComparison.Ordinal);
+
+        var viewer = ReadRepoFile(Path.Combine(
+            "Darling", "PerformanceMonitor.Darling.Viewer", "ViewerDataService.Fleet.cs"));
+        Assert.Contains("\"" + action + "\"", viewer, StringComparison.Ordinal);
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>Locates a repo file by walking up from this file's compile-time path — the
+    /// <c>AlertFiringLogTests</c> / <c>ThemeCompletenessTests</c> idiom, no build-output copying.</summary>
+    private static string ReadRepoFile(string relative, [CallerFilePath] string thisFile = "")
+    {
+        for (var dir = new DirectoryInfo(Path.GetDirectoryName(thisFile)!); dir is not null; dir = dir.Parent)
+        {
+            var candidate = Path.Combine(dir.FullName, relative);
+            if (File.Exists(candidate))
+            {
+                return File.ReadAllText(candidate).Replace("\r\n", "\n", StringComparison.Ordinal);
+            }
+        }
+
+        throw new FileNotFoundException($"Could not locate {relative} walking up from {thisFile}");
+    }
+}

--- a/Lite.Tests/LiteOverviewCardExplainsItselfTests.cs
+++ b/Lite.Tests/LiteOverviewCardExplainsItselfTests.cs
@@ -217,6 +217,49 @@ public sealed class LiteOverviewCardExplainsItselfTests
         Assert.Contains("public string StatusDisplay => CardStatus switch", source, StringComparison.Ordinal);
         Assert.Contains("public SolidColorBrush StatusBrush => MakeBrush(CardStatus switch", source, StringComparison.Ordinal);
         Assert.Contains("private string StatusHeadline => CardStatus switch", source, StringComparison.Ordinal);
+
+        /* And exactly one switch on the flag itself. This is the assertion behind the claim in
+           ServerCardStatus's doc comment; without it the claim is prose that review has to re-check by hand,
+           which is how it came to overstate what was true in the first place (raised on #2451). */
+        Assert.Equal(1, CountOccurrences(source, "IsOnline switch"));
+    }
+
+    /// <summary>
+    /// The card's BORDER renders the same discriminant its word does. Review on #2451 found the last place it
+    /// did not: <c>CardBorderBrush</c> read <c>IsOffline</c> and <c>HasCollectorErrors</c> raw, so it agreed
+    /// with the status word by coincidence rather than by construction — and on one pair it already did not
+    /// agree. An unchecked card carrying a collector-error marker drew the amber "collectors failing" border
+    /// while its word read "Unknown". The loader only sets that marker when the connection check succeeded, so
+    /// the pair is unreached in practice, which is the argument for making it unrepresentable rather than
+    /// leaving a caller to keep avoiding it.
+    /// </summary>
+    [Fact]
+    public void TheCardBorder_RendersTheSameDiscriminantTheWordDoes()
+    {
+        var neutral = Healthy().CardBorderBrush.Color;
+
+        var notChecked = NotYetChecked();
+        notChecked.HasCollectorErrors = true;
+
+        Assert.Equal(ServerCardStatus.Unknown, notChecked.CardStatus);
+        Assert.Equal("Unknown", notChecked.StatusDisplay);
+        Assert.DoesNotContain("collectors", notChecked.StatusTooltip, StringComparison.Ordinal);
+        Assert.Equal(neutral, notChecked.CardBorderBrush.Color);
+
+        /* A card that IS erroring still gets its amber border — and it is now literally the same amber the
+           status word is painted, because both render the same state. */
+        var erroring = CollectorsFailing();
+        Assert.NotEqual(neutral, erroring.CardBorderBrush.Color);
+        Assert.Equal(erroring.StatusBrush.Color, erroring.CardBorderBrush.Color);
+
+        /* Precedence is unchanged: a dark server outranks its own metrics. */
+        Assert.Equal(Offline().CardBorderBrush.Color, Busy().CardBorderBrush.Color);
+
+        var source = ReadRepoFile(Path.Combine("Lite", "Services", "LocalDataService.Overview.cs"));
+        Assert.Contains("CardStatus == ServerCardStatus.Offline ? \"#E57373\"", source, StringComparison.Ordinal);
+        Assert.Contains("CardStatus == ServerCardStatus.CollectorErrors ? \"#FFD54F\"", source, StringComparison.Ordinal);
+        Assert.Contains("public bool IsOffline => CardStatus == ServerCardStatus.Offline;", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("IsOffline ? \"#E57373\"", source, StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -295,6 +338,18 @@ public sealed class LiteOverviewCardExplainsItselfTests
     }
 
     // ── helpers ────────────────────────────────────────────────────────────────────────────────────
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+        return count;
+    }
 
     /// <summary>Locates a repo file by walking up from this file's compile-time path — the
     /// <c>AlertFiringLogTests</c> / <c>ThemeCompletenessTests</c> idiom, no build-output copying.</summary>

--- a/Lite/MainWindow.xaml
+++ b/Lite/MainWindow.xaml
@@ -433,13 +433,27 @@
                                                                 </Grid>
                                                             </Viewbox>
                                                             <Ellipse Width="10" Height="10" Fill="{Binding StatusBrush}"
+                                                                     ToolTip="{Binding StatusTooltip}"
                                                                      VerticalAlignment="Center"/>
                                                         </StackPanel>
                                                         <TextBlock Text="{Binding DisplayName}" FontSize="16" FontWeight="SemiBold"
                                                                    TextTrimming="CharacterEllipsis"
                                                                    Foreground="{DynamicResource ForegroundBrush}"/>
                                                     </DockPanel>
+                                                    <!-- #2437 (the Lite half of #2422): the status line carries the
+                                                         reason it is that colour. It was a bare word — a reader saw
+                                                         "Warning" in amber and had to scan the metric rows guessing
+                                                         which one it meant, on every card. The tooltip is built from
+                                                         the card's OWN displays (StatusReason), so it cannot disagree
+                                                         with the rows directly underneath it, and it says which axis
+                                                         the word is about: in Lite "Warning" is failing COLLECTORS,
+                                                         while a card in metric trouble still says "Online".
+                                                         Background=Transparent is load-bearing: a TextBlock with a
+                                                         null Background hit-tests on its rendered glyphs alone, so
+                                                         the tooltip would appear over the letters of "Warning" and
+                                                         nowhere in the space around them. -->
                                                     <TextBlock Text="{Binding StatusDisplay}" Foreground="{Binding StatusBrush}"
+                                                               Background="Transparent" ToolTip="{Binding StatusTooltip}"
                                                                FontSize="11" Margin="0,0,0,10"/>
                                                     <!-- Tag pills (#2020 2b-i): the server's tags as coloured chips,
                                                          collapsed when it has none so untagged cards are unchanged. -->

--- a/Lite/Services/LocalDataService.Overview.cs
+++ b/Lite/Services/LocalDataService.Overview.cs
@@ -142,6 +142,40 @@ public sealed class ServerTagPill
     public System.Windows.Media.Brush TextBrush => TagColorBrushes.PillText;
 }
 
+/// <summary>
+/// The Overview card's status-line state, as a VALUE rather than a rendered string. The word on the card
+/// (<see cref="ServerSummaryItem.StatusDisplay"/>), the colour it is painted
+/// (<see cref="ServerSummaryItem.StatusBrush"/>) and the first line of its tooltip
+/// (<see cref="ServerSummaryItem.StatusTooltip"/>) are all renderings OF THIS — the
+/// (<c>IsOnline</c>, <c>HasCollectorErrors</c>) pair is read here and nowhere else, so no two of them can land
+/// on different answers for the same card. The Darling viewer's twin (<c>ServerCardStatus</c> there) exists
+/// because two review passes on #2429 each found a flag combination where two independent readings disagreed;
+/// the word and the colour here already carried their own copy of the ladder, and the tooltip would have been
+/// a third.
+///
+/// <para><b>The amber state is NOT the viewer's.</b> The viewer derives its status from collection freshness
+/// and calls this member <c>Stale</c>; Lite's <c>IsOnline</c> comes from a live connection check and
+/// <c>HasCollectorErrors</c> from <c>ErroringCollectors > 0</c> — collectors that are actually failing. Same
+/// amber, same word "Warning", different cause. That is precisely why the tooltip has to say which one it is
+/// rather than leaving the reader to infer it from a colour.</para>
+/// </summary>
+public enum ServerCardStatus
+{
+    /// <summary>The last connection check succeeded and no collector is erroring.</summary>
+    Online,
+
+    /// <summary>Connected, but one or more collectors have consecutive errors — the card's amber "Warning".
+    /// Nothing to do with the metric rows, which is the whole reason it needs explaining.</summary>
+    CollectorErrors,
+
+    /// <summary>The last connection check failed — the card's red offline overlay.</summary>
+    Offline,
+
+    /// <summary>The server has not been connection-checked yet (<c>IsOnline</c> is null): a card built before
+    /// the first check completed, not a dead server.</summary>
+    Unknown,
+}
+
 public class ServerSummaryItem
 {
     public string DisplayName { get; set; } = "";
@@ -193,41 +227,147 @@ public class ServerSummaryItem
     public string DeadlockDisplay => DeadlockCount > 0 ? DeadlockCount.ToString() : "0";
     public string LastCollectionDisplay => LastCollectionTime.HasValue ? ServerTimeHelper.FormatServerTime(LastCollectionTime, "HH:mm:ss") : "Never";
 
-    /* Connection status */
-    public string StatusDisplay => IsOnline switch
+    /* Connection status. This is the ONE place the (IsOnline, HasCollectorErrors) pair is read; the word, the
+       colour and the tooltip's first line all render the result. See ServerCardStatus. */
+    public ServerCardStatus CardStatus => IsOnline switch
     {
-        true when HasCollectorErrors => "Warning",
-        true => "Online",
-        false => "Offline",
+        true when HasCollectorErrors => ServerCardStatus.CollectorErrors,
+        true => ServerCardStatus.Online,
+        false => ServerCardStatus.Offline,
+        _ => ServerCardStatus.Unknown
+    };
+
+    public string StatusDisplay => CardStatus switch
+    {
+        ServerCardStatus.CollectorErrors => "Warning",
+        ServerCardStatus.Online => "Online",
+        ServerCardStatus.Offline => "Offline",
         _ => "Unknown"
     };
-    public SolidColorBrush StatusBrush => MakeBrush(IsOnline switch
+    public SolidColorBrush StatusBrush => MakeBrush(CardStatus switch
     {
-        true when HasCollectorErrors => "#FFD54F",  // amber — connected but collectors failing
-        true => "#81C784",
-        false => "#E57373",
+        ServerCardStatus.CollectorErrors => "#FFD54F",  // amber — connected but collectors failing
+        ServerCardStatus.Online => "#81C784",
+        ServerCardStatus.Offline => "#E57373",
         _ => "#888888"
     });
     public bool IsOffline => IsOnline == false;
 
+    /* ── Per-row concern gates ───────────────────────────────────────────────────────────────────────
+       Each metric row's "this is not green" test, evaluated ONCE. The row's own brush reads it and so does
+       StatusReason, which is what makes the tooltip incapable of naming a metric whose row is green — or of
+       staying silent about one that is not. A tooltip built from an independent severity calculation would
+       lose exactly that property, and the one place it would disagree is a card the reader is staring at.
+
+       Note the gates follow the ROW, not the card border: the CPU row goes amber at 50 while the border only
+       escalates at 80. The reason names rows, so it uses the row's threshold. */
+    private bool CpuIsElevated => CpuPercentForAlert >= 50;
+    private bool CpuIsCritical => CpuPercentForAlert >= 80;
+    private bool BlockingIsElevated => BlockingCount > 0;
+    private bool DeadlocksAreElevated => DeadlockCount > 0;
+
     /* Color coding */
-    public SolidColorBrush CpuBrush
+    public SolidColorBrush CpuBrush => MakeBrush(CpuIsCritical ? "#E57373" : CpuIsElevated ? "#FFB74D" : "#81C784");
+    public SolidColorBrush BlockingBrush => MakeBrush(BlockingIsElevated ? "#FFB74D" : "#81C784");
+    public SolidColorBrush DeadlockBrush => MakeBrush(DeadlocksAreElevated ? "#E57373" : "#81C784");
+    public SolidColorBrush CardBorderBrush => MakeBrush(
+        IsOffline ? "#E57373" :
+        DeadlocksAreElevated ? "#E57373" :
+        BlockingIsElevated ? "#FFB74D" :
+        CpuIsCritical ? "#FFB74D" :
+        HasCollectorErrors ? "#FFD54F" :   // amber border when collectors are failing
+        "#2a2d35");
+
+    /* ── The card explains itself (#2437 / #2422) ────────────────────────────────────────────────────
+       Reported against the Darling viewer and fixed there in #2429; Lite's card had the identical bare
+       status binding. A reader saw a word and a colour and had to scan the metric rows guessing which one
+       the card meant — once per card, on every card.
+
+       Lite's version has one more thing to say than the viewer's, because Lite's status word is a CONNECTION
+       word, not a health band: a card with 96% CPU and two deadlocks still says "Online" in green while its
+       border is red, and a card saying "Warning" in amber is reporting failing COLLECTORS and nothing about
+       the metrics at all. Fusing the two into one clause would reproduce the ambiguity in prose, so the
+       tooltip keeps them on separate lines: what the status word means, then what the rows say. */
+
+    /// <summary>What the status word means, in words — the tooltip's first line. Switches on
+    /// <see cref="CardStatus"/>, the same discriminant <see cref="StatusDisplay"/> renders, so a tooltip that
+    /// hangs off a word can never contradict it.</summary>
+    private string StatusHeadline => CardStatus switch
+    {
+        ServerCardStatus.CollectorErrors => "Warning — one or more collectors are failing on this server",
+        ServerCardStatus.Online => "Online — the last connection check succeeded",
+        ServerCardStatus.Offline => "Offline — the last connection check failed",
+        _ => "Unknown — this server has not been connection-checked yet",
+    };
+
+    /// <summary>
+    /// The metric rows that are not green, in the card's OWN display strings — "CPU 96% (SQL 90%), Deadlocks 2".
+    /// Assembled from the displays rather than from the underlying numbers so the sentence and the rows cannot
+    /// render differently, and gated on the same predicates the row brushes use so it cannot name a different
+    /// set of rows than the ones that are coloured. Empty when every row is green.
+    ///
+    /// <para>Memory is absent deliberately: the Memory row carries no severity brush on this card, so there is
+    /// no band to report. Inventing a threshold here would be the one thing this property exists to prevent —
+    /// a tooltip asserting something the rows underneath it do not.</para>
+    /// </summary>
+    public string StatusReason
     {
         get
         {
-            var v = CpuPercentForAlert;
-            return MakeBrush(v >= 80 ? "#E57373" : v >= 50 ? "#FFB74D" : "#81C784");
+            var parts = new List<string>();
+
+            if (CpuIsElevated)
+            {
+                parts.Add("CPU " + CpuDisplay);
+            }
+
+            if (BlockingIsElevated)
+            {
+                parts.Add("Blocking " + BlockingDisplay);
+            }
+
+            if (DeadlocksAreElevated)
+            {
+                parts.Add("Deadlocks " + DeadlockDisplay);
+            }
+
+            return string.Join(", ", parts);
         }
     }
-    public SolidColorBrush BlockingBrush => MakeBrush(BlockingCount > 0 ? "#FFB74D" : "#81C784");
-    public SolidColorBrush DeadlockBrush => MakeBrush(DeadlockCount > 0 ? "#E57373" : "#81C784");
-    public SolidColorBrush CardBorderBrush => MakeBrush(
-        IsOnline == false ? "#E57373" :
-        DeadlockCount > 0 ? "#E57373" :
-        BlockingCount > 0 ? "#FFB74D" :
-        CpuPercentForAlert >= 80 ? "#FFB74D" :
-        HasCollectorErrors ? "#FFD54F" :   // amber border when collectors are failing
-        "#2a2d35");
+
+    /// <summary>
+    /// The Overview card's status tooltip (#2437, answering #2422 on Lite's surface): what the status word
+    /// means, what the metric rows say, and what to do next.
+    ///
+    /// <para>The metric line is omitted on an Offline card. The card draws a dimming overlay across those rows
+    /// precisely because the numbers under it are the last ones collected before the server went dark, so
+    /// demanding attention for them would contradict the card while the reader is looking at it.</para>
+    /// </summary>
+    public string StatusTooltip
+    {
+        get
+        {
+            var lines = new List<string> { StatusHeadline };
+
+            if (CardStatus != ServerCardStatus.Offline)
+            {
+                var reason = StatusReason;
+                lines.Add(reason.Length > 0
+                    ? "Needs attention: " + reason
+                    : "Every metric on this card is inside its threshold");
+            }
+
+            lines.Add(CardTooltipAction);
+
+            return string.Join("\n", lines);
+        }
+    }
+
+    /// <summary>The line every card tooltip ends on — the gesture the card actually supports.
+    /// <c>OverviewCard_MouseLeftButtonDown</c> acts only on <c>ClickCount == 2</c>, so naming a single click
+    /// would be naming a no-op. The viewer's card tooltip ends on this same sentence, so a reader moving
+    /// between the two apps is told the same thing in the same words.</summary>
+    private const string CardTooltipAction = "Double-click the card to open this server's tab";
 
     private static SolidColorBrush MakeBrush(string hex)
     {

--- a/Lite/Services/LocalDataService.Overview.cs
+++ b/Lite/Services/LocalDataService.Overview.cs
@@ -145,13 +145,22 @@ public sealed class ServerTagPill
 /// <summary>
 /// The Overview card's status-line state, as a VALUE rather than a rendered string. The word on the card
 /// (<see cref="ServerSummaryItem.StatusDisplay"/>), the colour it is painted
-/// (<see cref="ServerSummaryItem.StatusBrush"/>) and the first line of its tooltip
+/// (<see cref="ServerSummaryItem.StatusBrush"/>), the card's border
+/// (<see cref="ServerSummaryItem.CardBorderBrush"/>), the offline overlay
+/// (<see cref="ServerSummaryItem.IsOffline"/>) and the first line of its tooltip
 /// (<see cref="ServerSummaryItem.StatusTooltip"/>) are all renderings OF THIS — the
 /// (<c>IsOnline</c>, <c>HasCollectorErrors</c>) pair is read here and nowhere else, so no two of them can land
 /// on different answers for the same card. The Darling viewer's twin (<c>ServerCardStatus</c> there) exists
 /// because two review passes on #2429 each found a flag combination where two independent readings disagreed;
 /// the word and the colour here already carried their own copy of the ladder, and the tooltip would have been
 /// a third.
+///
+/// <para>Review on #2451 found the fifth: <c>CardBorderBrush</c> read <c>IsOffline</c> and
+/// <c>HasCollectorErrors</c> raw, agreeing with the status word by coincidence rather than by construction.
+/// It disagreed on one pair already — an unchecked card carrying a collector-error marker drew the amber
+/// "collectors failing" border while its word read "Unknown". The Overview loader only sets that marker when
+/// the connection check SUCCEEDED, so the pair is unreached in practice, which is exactly the argument for
+/// making it unrepresentable rather than leaving it to a caller to keep avoiding.</para>
 ///
 /// <para><b>The amber state is NOT the viewer's.</b> The viewer derives its status from collection freshness
 /// and calls this member <c>Stale</c>; Lite's <c>IsOnline</c> comes from a live connection check and
@@ -251,7 +260,7 @@ public class ServerSummaryItem
         ServerCardStatus.Offline => "#E57373",
         _ => "#888888"
     });
-    public bool IsOffline => IsOnline == false;
+    public bool IsOffline => CardStatus == ServerCardStatus.Offline;
 
     /* ── Per-row concern gates ───────────────────────────────────────────────────────────────────────
        Each metric row's "this is not green" test, evaluated ONCE. The row's own brush reads it and so does
@@ -270,12 +279,15 @@ public class ServerSummaryItem
     public SolidColorBrush CpuBrush => MakeBrush(CpuIsCritical ? "#E57373" : CpuIsElevated ? "#FFB74D" : "#81C784");
     public SolidColorBrush BlockingBrush => MakeBrush(BlockingIsElevated ? "#FFB74D" : "#81C784");
     public SolidColorBrush DeadlockBrush => MakeBrush(DeadlocksAreElevated ? "#E57373" : "#81C784");
+    /* The border ranks the same states the status word names, so it reads the SAME discriminant rather than
+       the flags behind it — see ServerCardStatus for the pair the raw reads disagreed on. The precedence is
+       unchanged: a dark server first, then the metric rows worst-first, then failing collectors. */
     public SolidColorBrush CardBorderBrush => MakeBrush(
-        IsOffline ? "#E57373" :
+        CardStatus == ServerCardStatus.Offline ? "#E57373" :
         DeadlocksAreElevated ? "#E57373" :
         BlockingIsElevated ? "#FFB74D" :
         CpuIsCritical ? "#FFB74D" :
-        HasCollectorErrors ? "#FFD54F" :   // amber border when collectors are failing
+        CardStatus == ServerCardStatus.CollectorErrors ? "#FFD54F" :   // amber border when collectors are failing
         "#2a2d35");
 
     /* ── The card explains itself (#2437 / #2422) ────────────────────────────────────────────────────


### PR DESCRIPTION
Part 2 of #2437 — the Lite half. (The web dashboard half is #2447: different language, different risk.)

`Lite/MainWindow.xaml:442` was the same bare binding #2429 fixed in the Darling viewer:

```xml
<TextBlock Text="{Binding StatusDisplay}" Foreground="{Binding StatusBrush}"
           FontSize="11" Margin="0,0,0,10"/>
```

A word, a colour, and no way to ask what it meant. A Lite user reads "Warning" and scans the metric rows for the yellow one, exactly as @ehaar had to on the viewer in #2422.

## The reason is built from the card's own rows, not recomputed

This is a **port, not a wiring change**: Lite has no `FleetRollup` and no `BuildReason`, so the reason had to be built. The property worth copying carefully is the one that makes the viewer's version work at all — `BuildReason` is assembled from the card's OWN metric displays, so it cannot drift from the six rows underneath it. A Lite implementation that recomputed severity would satisfy every wording assertion in the test file and still be worse than no tooltip, because the one place it would disagree is a card the reader is staring at.

`StatusReason` therefore quotes `CpuDisplay`, `BlockingDisplay` and `DeadlockDisplay` verbatim, and is gated on the **same predicates the row brushes are painted from**. That meant giving each row's "not green" test a name and having both readers use it rather than each carrying its own copy of the threshold:

```csharp
private bool CpuIsElevated => CpuPercentForAlert >= 50;
public SolidColorBrush CpuBrush => MakeBrush(CpuIsCritical ? "#E57373" : CpuIsElevated ? "#FFB74D" : "#81C784");
```

and the test asserts the invariant against the **shipped brushes**, not against a copy of the numbers:

```csharp
Assert.Equal(card.CpuBrush.Color != green, tooltip.Contains("CPU ", StringComparison.Ordinal));
```

Memory is deliberately absent. The Memory row carries no severity brush on this card, so there is no band to report — inventing a threshold there is the single thing this property exists to prevent.

## Lite's conflation is not the viewer's, and the tooltip has to say so

Checked in source rather than assumed. The viewer derives its status from **collection freshness** and re-purposes `HasCollectorErrors` to mean "stale" — its own doc comment says so. Lite's `IsOnline` comes from `_serverManager.GetConnectionStatus(...)`, a live connection check, and its `HasCollectorErrors` from `_collectorService.GetHealthSummary(server).ErroringCollectors > 0`, which counts collectors with `ConsecutiveErrors > 0`. So **Lite does not have the stale-collection conflation** — its amber "Warning" is a real collector-failure state.

It has the inverse one instead, and it is arguably sharper. Lite's status word is a **connection** word, not a health band: it never reflects the metric rows at all, so a card at 96% CPU with two deadlocks reads a **green "Online"** while its border is red. Fusing the two axes into one clause would reproduce that ambiguity in prose, so the tooltip keeps them on separate lines — what the status word means, then what the rows say.

What the tooltips actually read, run against the shipped source:

| card | word | tooltip |
|---|---|---|
| calm | Online | `Online — the last connection check succeeded` / `Every metric on this card is inside its threshold` |
| CPU 96%, 2 deadlocks | **Online** | `Online — the last connection check succeeded` / `Needs attention: CPU 96%, Deadlocks 2` |
| collectors failing | Warning | `Warning — one or more collectors are failing on this server` / `Every metric on this card is inside its threshold` |
| collectors failing + CPU 62% | Warning | `Warning — one or more collectors are failing on this server` / `Needs attention: CPU 62%` |
| offline | Offline | `Offline — the last connection check failed` |
| not yet checked | Unknown | `Unknown — this server has not been connection-checked yet` / `Needs attention: CPU 62%` |

each closing on `Double-click the card to open this server's tab` — the viewer's line verbatim, pinned rather than left to coincidence, because the point of doing all three surfaces is that a reader moving between them meets one vocabulary.

Row 2 is the one to look at. That card is in real trouble and the only thing on it that ever said so was a border colour.

## Three smaller decisions

**An Offline card gets no metric line.** The card draws a dimming overlay across those rows precisely because the numbers under it are the last ones collected before the server went dark; demanding attention for them would contradict the card while the reader is looking at it. `StatusReason` still computes them — the omission is a tooltip decision made in one place, not a hole in what the card knows.

**The `(IsOnline, HasCollectorErrors)` pair now has one reader.** The word and the colour already carried their own copy of that ladder and the tooltip would have been a third. `ServerCardStatus` is #2429's collapse ported; its amber member is named `CollectorErrors` rather than `Stale` because that is what it means here, and the difference is written down where the next person will find it.

Review found a fifth reading I had missed, and it turned out to be a live desync rather than a latent one. `CardBorderBrush` read `IsOffline` and `HasCollectorErrors` raw, so on `dev` a card that has never been connection-checked but carries a collector-error marker draws the amber "collectors failing" border while its word reads `Unknown`:

```
status word   : Unknown
border colour : #FFD54F      <- dev
neutral border: #2A2D35
```

The border and `IsOffline` (which the offline overlay binds) now render `CardStatus` too; precedence is unchanged, and the amber border is literally the same amber the word is painted because both render one state. The doc claim that the flag pair has one reader is now asserted rather than left as prose — `Assert.Equal(1, CountOccurrences(source, "IsOnline switch"))` — which is the assertion that would have caught the overclaim when it was written.

**`Background="Transparent"` is load-bearing**, as #2429 found: a `TextBlock` with a null `Background` hit-tests on its rendered glyphs alone, so the tooltip would have appeared over the letters of "Warning" and nowhere in the space around them. The status dot carries the same tooltip — same signal, and it is the thing a reader points at first.

Lite has **no `AwaitingFirstCollection` flag** — verified before relying on it — so the status/tooltip desync family #2429 spent four review rounds on cannot arise here. Only the unexplained-word half applied.

## Verification

`Lite.Tests` targets `net10.0-windows` and cannot run on macOS, so the logic was run for real anyway: a throwaway `net10.0` harness **splices `ServerCardStatus` and `ServerSummaryItem` straight out of the shipped file** (never retyped — a generator reads the source and emits it) behind a `System.Windows.Media` shim, and **all 12 tests in the new class pass** against it. The table above is that harness's output. Pointed at `dev`'s copy of the same file it does not compile at all, because none of the members exist there.

The source- and XAML-scanning half was simulated in Python against both versions: **20 of 23 assertions fail on `dev` and all pass on the branch**. The three that pass on `dev` are the two guards that locate the status TextBlock and the status dot, plus the viewer's half of the closing-line parity pin, which this PR does not touch. That half has to text-scan, because a `ToolTip` attribute lives in XAML where no assertion about a C# object can reach it and removing it compiles perfectly clean.

Whole solution builds, 0 errors. CHANGELOG deliberately untouched — #2395 is an open release-prep PR that owns that file for 3.5.1.

**One thing noted and not fixed here:** `ServerConnection.DotStatus` (`Lite/Models/ServerConnection.cs:199`) is a *fourth* copy of the same four-word ladder, for the sidebar row. It is a different type on a different surface and unifying it is not this PR's lane, but it is the next place this can drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
