### PR TITLE
Make one badly-shaped setting cost one setting (#2444)

### DIFF
--- a/Lite.Tests/SettingsSampleTests.cs
+++ b/Lite.Tests/SettingsSampleTests.cs
@@ -12,6 +12,7 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using PerformanceMonitor.Common;
 using Xunit;
 
 namespace PerformanceMonitorLite.Tests;
@@ -71,10 +72,7 @@ public sealed class SettingsSampleTests
         var read = ReadKeysFromLoaders();
         var documented = SampleKeys();
 
-        var missing = read.Keys
-            .Where(k => !documented.Contains(k) && !LoaderOnlyKeys.Contains(k))
-            .OrderBy(k => k, StringComparer.Ordinal)
-            .ToList();
+        var missing = UndocumentedKeys(read, documented);
 
         Assert.True(
             missing.Count == 0,
@@ -144,16 +142,116 @@ public sealed class SettingsSampleTests
     }
 
     /// <summary>
+    /// Alternation, evaluated left to right in one pass, so the "which file is open" state and the key hits
+    /// stay in source order.
+    /// <para>The <c>TryGetProperty</c> half keys on a METHOD NAME, which is the constraint every refactor of
+    /// the loaders runs into — see <c>TheReadHelpersName_IsWhatThisExtractionKeysOn</c> for why the #2444
+    /// read helper is spelled the way it is.</para>
+    /// </summary>
+    private static readonly Regex Scanner = new(
+        "\"(?<file>[A-Za-z0-9_.\\-]+\\.json)\"|TryGetProperty\\(\"(?<key>[^\"]+)\"",
+        RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// The self-test #2444 owed this guard. The loaders' reads moved onto a helper
+    /// (<see cref="SettingsReader"/>), and the reason they still work is that the helper's method carries the
+    /// same NAME the extraction keys on — which is a fact about a string, held together by nothing the
+    /// compiler checks. So it is checked here, against a source this test writes, in both shapes: the one the
+    /// loaders used before #2444 and the one they use now.
+    ///
+    /// <para>And it does not stop at "the keys are found". A guard that extracts keys but no longer COMPARES
+    /// them is the same vacuous green as one that extracts nothing, so this runs the real
+    /// <see cref="UndocumentedKeys"/> over a sample that is deliberately missing one key and asserts that it
+    /// is named. That is the property the two symmetry tests exist for, proved on a fixture rather than on
+    /// the tree — where it can only ever be proved by breaking the tree.</para>
+    /// </summary>
+    [Fact]
+    public void KeyExtraction_SeesBothReaderShapes_AndStillCatchesAnUndocumentedKey()
+    {
+        const string source = """
+            var settings = SettingsFileGuard.Read(Path.Combine(configDirectory, "settings.json"));
+            if (root.TryGetProperty("old_shape_key", out var a)) A = a.GetBoolean();
+            if (read.TryGetProperty("new_shape_key", out var b)) B = b.Bool(B);
+            if (read.TryGetProperty("undocumented_key", out var c)) C = c.Int(C);
+            """;
+
+        var found = new Dictionary<string, string>(StringComparer.Ordinal);
+        ExtractKeys(source, "synthetic.cs", found);
+
+        Assert.Contains("old_shape_key", found.Keys);
+        Assert.Contains("new_shape_key", found.Keys);
+
+        /* The guard still bites: one key is left out of the "sample", and it is the one named. */
+        var documented = new HashSet<string>(StringComparer.Ordinal) { "old_shape_key", "new_shape_key" };
+        Assert.Equal(new[] { "undocumented_key" }, UndocumentedKeys(found, documented));
+
+        /* ...and stays silent when the sample really does document everything. */
+        documented.Add("undocumented_key");
+        Assert.Empty(UndocumentedKeys(found, documented));
+
+        /* The trap itself, so the paragraph above is a measurement rather than a warning. This is the shape
+           #2428 tried — a read helper that takes the key as an ordinary argument — and every key written that
+           way is invisible here. That is what makes the helper's NAME load-bearing rather than incidental. */
+        const string hidden = """
+            var settings = SettingsFileGuard.Read(Path.Combine(configDirectory, "settings.json"));
+            ReadInt(root, "invisible_key", ref X);
+            """;
+
+        var missed = new Dictionary<string, string>(StringComparer.Ordinal);
+        ExtractKeys(hidden, "synthetic.cs", missed);
+        Assert.Empty(missed);
+    }
+
+    /// <summary>
+    /// The other half of the scoping contract, pinned for the same reason: a read attributed to the WRONG
+    /// file would make the sample look as though it were missing keys it has no business documenting. Each
+    /// hit belongs to the most recent <c>*.json</c> literal above it, which is how App.xaml.cs's
+    /// servers.json and collection_schedule.json loaders stay out of this set without needing an exemption.
+    /// </summary>
+    [Fact]
+    public void KeyExtraction_AttributesEachReadToTheFileOpenedAboveIt()
+    {
+        const string source = """
+            var servers = Path.Combine(dir, "servers.json");
+            if (root.TryGetProperty("not_a_settings_key", out var a)) A = a.GetBoolean();
+            var settings = SettingsFileGuard.Read(Path.Combine(dir, "settings.json"));
+            if (read.TryGetProperty("a_settings_key", out var b)) B = b.Bool(B);
+            """;
+
+        var found = new Dictionary<string, string>(StringComparer.Ordinal);
+        ExtractKeys(source, "synthetic.cs", found);
+
+        Assert.Equal(new[] { "a_settings_key" }, found.Keys.ToArray());
+    }
+
+    /// <summary>
+    /// Names the dependency this guard acquired in #2444 so a rename fails HERE, with the reason, rather
+    /// than as an unexplained collapse of the key count somewhere else.
+    ///
+    /// <para><c>SettingsReader</c>'s read method is called <c>TryGetProperty</c> because that is the literal
+    /// this extraction matches. Spell it <c>TryRead</c> and all eighty-seven of Lite's keys vanish from the
+    /// extracted set, both symmetry tests pass on what is left, and settings.sample.json is free to drift
+    /// exactly the way #2418 was filed about. PR #2428 hit this and had to read back through
+    /// <c>JsonDocument</c>; #2444 kept the name instead, and this is the note that says so out loud.</para>
+    /// </summary>
+    [Fact]
+    public void TheReadHelpersName_IsWhatThisExtractionKeysOn()
+    {
+        Assert.Contains("TryGetProperty", Scanner.ToString(), StringComparison.Ordinal);
+
+        Assert.True(
+            typeof(SettingsReader).GetMethod("TryGetProperty") is not null,
+            "SettingsReader no longer has a public TryGetProperty. That name is what this file's extraction "
+                + "matches on, so renaming it removes every Lite settings key from the extracted set and lets "
+                + "settings.sample.json drift undetected (#2418, #2428, #2444). If it really must be renamed, "
+                + "teach the Scanner regex the new name in the SAME change and prove it here.");
+    }
+
+    /// <summary>
     /// key -> the source file it was found in, for a failure message that names where to look.
     /// </summary>
     private static Dictionary<string, string> ReadKeysFromLoaders()
     {
-        /* Alternation, evaluated left to right in one pass, so the "which file is open" state and the
-           key hits stay in source order. */
-        var scanner = new Regex(
-            "\"(?<file>[A-Za-z0-9_.\\-]+\\.json)\"|TryGetProperty\\(\"(?<key>[^\"]+)\"",
-            RegexOptions.CultureInvariant);
-
         var keys = new Dictionary<string, string>(StringComparer.Ordinal);
 
         foreach (var name in ReaderSources)
@@ -163,22 +261,43 @@ public sealed class SettingsSampleTests
                 File.Exists(path),
                 $"{name} was not copied beside the test binary — check the csproj None/Link item.");
 
-            var openFile = string.Empty;
-            foreach (Match match in scanner.Matches(File.ReadAllText(path)))
-            {
-                if (match.Groups["file"].Success)
-                {
-                    openFile = match.Groups["file"].Value;
-                }
-                else if (openFile == "settings.json")
-                {
-                    keys.TryAdd(match.Groups["key"].Value, name);
-                }
-            }
+            ExtractKeys(File.ReadAllText(path), name, keys);
         }
 
         return keys;
     }
+
+    /// <summary>
+    /// The extraction itself, over TEXT rather than over a path, so the self-tests below can run it against a
+    /// source they control instead of only against whatever the tree happens to contain today. Split out
+    /// during #2444: the loaders' read shape changed, and a guard whose only exercise is the real file cannot
+    /// show that it still SEES the new shape — it can only fail later, obliquely, on a count.
+    /// </summary>
+    private static void ExtractKeys(string source, string sourceName, Dictionary<string, string> into)
+    {
+        var openFile = string.Empty;
+        foreach (Match match in Scanner.Matches(source))
+        {
+            if (match.Groups["file"].Success)
+            {
+                openFile = match.Groups["file"].Value;
+            }
+            else if (openFile == "settings.json")
+            {
+                into.TryAdd(match.Groups["key"].Value, sourceName);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The comparison <see cref="Sample_DocumentsEveryKeyTheLoadersRead"/> makes, so the self-test below
+    /// exercises the REAL check rather than a re-implementation of it that could drift away from it.
+    /// </summary>
+    private static List<string> UndocumentedKeys(Dictionary<string, string> read, HashSet<string> documented) =>
+        read.Keys
+            .Where(k => !documented.Contains(k) && !LoaderOnlyKeys.Contains(k))
+            .OrderBy(k => k, StringComparer.Ordinal)
+            .ToList();
 
     private static HashSet<string> SampleKeys()
     {

--- a/Lite.Tests/SettingsValueReadTests.cs
+++ b/Lite.Tests/SettingsValueReadTests.cs
@@ -198,6 +198,44 @@ public class SettingsValueReadTests
     }
 
     /// <summary>
+    /// Review found the boundary the clamp promise stopped at (#2453): the clamped readers go through
+    /// <c>TryGetInt64</c>, so a number beyond Int64 fell out of the clamp and was reported as though it were
+    /// not a whole number — a nonsense sentence about a number, and in a dialog. It clamps by SIGN instead,
+    /// which makes the promise absolute rather than "up to Int64".
+    /// </summary>
+    [Fact]
+    public void ANumberBeyondInt64_StillClampsToABound()
+    {
+        var read = ReaderOver("""{ "vast": 99999999999999999999, "vast_negative": -99999999999999999999 }""");
+
+        Assert.True(read.TryGetProperty("vast", out var vast));
+        Assert.Equal(100, vast.Int(1, 0, 100));
+
+        Assert.True(read.TryGetProperty("vast_negative", out var negative));
+        Assert.Equal(0, negative.Int(1, 0, 100));
+
+        Assert.Empty(read.Problems);
+    }
+
+    /// <summary>
+    /// The other side of that boundary. An UNCLAMPED read has no range to put an unusable number into, so it
+    /// does report one — but as out of range, naming the value, rather than as the wrong shape.
+    /// </summary>
+    [Fact]
+    public void AnUnclampedReadReportsAnOutOfRangeNumber_AsOutOfRangeRatherThanWrongShape()
+    {
+        var read = ReaderOver("""{ "vast": 99999999999999999999 }""");
+
+        Assert.True(read.TryGetProperty("vast", out var vast));
+        Assert.Equal(7, vast.Int(7));
+
+        var problem = Assert.Single(read.Problems);
+        Assert.Equal("vast", problem.Key);
+        Assert.Contains("out of range", problem.Problem, StringComparison.Ordinal);
+        Assert.DoesNotContain("where a whole number belongs", problem.Problem, StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// The line between "wrong shape" and "wrong word", which decides what the startup dialog is allowed to
     /// complain about. A number where a theme name belongs is this file's business; a string that is simply
     /// not one of the three theme names is the caller's own vocabulary, has always been ignored quietly, and

--- a/Lite.Tests/SettingsValueReadTests.cs
+++ b/Lite.Tests/SettingsValueReadTests.cs
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using PerformanceMonitor.Common;
+using PerformanceMonitorLite;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// #2444 — one badly-shaped value used to cost every setting after it.
+///
+/// <para>#2425 split the DOCUMENT fault out of <c>App.LoadAlertSettings</c>'s single <c>try</c>, so a
+/// trailing comma is now reported rather than silently reverting everything. What it left behind was the
+/// VALUE fault: a key holding a string where an int belongs threw on its own <c>Get*</c> call and abandoned
+/// every read after it, so which settings survived depended on where the bad key happened to sit in the
+/// file. One wrong value near the top cost almost everything; the same value near the bottom cost almost
+/// nothing. That ordering is an implementation detail of the loader's line order, and it was invisible.</para>
+///
+/// <para>The position tests below are the ones that matter, and they are position tests on purpose: a
+/// fixture with a single bad key and nothing after it passes against the OLD code too. Only a bad key with
+/// good keys on BOTH sides can tell "this key fell back" from "this key and the rest of the file fell
+/// back".</para>
+///
+/// <para>Shares the <c>app-alert-statics</c> collection with the other classes that drive
+/// <c>App.LoadAlertSettings</c>: it rewrites the whole alert block, and xUnit runs classes in parallel.</para>
+/// </summary>
+[Collection("app-alert-statics")]
+public class SettingsValueReadTests
+{
+    private static void FailOnWrite(string key, string value) =>
+        Assert.Fail($"LoadAlertSettings wrote credential '{key}' when nothing should have been saved.");
+
+    private static string WriteSettings(string tag, string json)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"pmlite_{tag}_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "settings.json"), json);
+        return dir;
+    }
+
+    private static SettingsReader ReaderOver(string json) =>
+        new(JsonDocument.Parse(json).RootElement);
+
+    /* ---- the defect, end to end through the real loader ---- */
+
+    /// <summary>
+    /// The headline. A quoted number sits between two perfectly good settings; the good ones both apply and
+    /// only the bad key falls back. Against dev the LAST key is never reached at all, which is the whole of
+    /// #2444 in one assertion.
+    /// </summary>
+    [Fact]
+    public void ABadValue_CostsItsOwnKeyAndNothingAfterIt()
+    {
+        var dir = WriteSettings("badvalue",
+            """
+            {
+              "alerts_enabled": true,
+              "alert_cpu_threshold": "ninety",
+              "analysis_timeout_seconds": 123
+            }
+            """);
+
+        try
+        {
+            App.AlertsEnabled = false;
+            App.AlertCpuThreshold = 42;
+            App.AnalysisTimeoutSeconds = 99;
+
+            App.LoadAlertSettings(dir, key => "stored:" + key, FailOnWrite);
+
+            /* Before the bad key: always worked, still works. */
+            Assert.True(App.AlertsEnabled);
+
+            /* The bad key itself: keeps the value it had, which is the only correct answer. */
+            Assert.Equal(42, App.AlertCpuThreshold);
+
+            /* After the bad key: THIS is the regression. It was unreachable on dev. */
+            Assert.Equal(123, App.AnalysisTimeoutSeconds);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    /// <summary>
+    /// The same shape one level down, and a second throw site the old single <c>try</c> hid: an array whose
+    /// ELEMENT is the wrong kind. <c>elem.GetString()</c> throws on the number, and on dev that one element
+    /// cost every setting in the rest of the file.
+    /// </summary>
+    [Fact]
+    public void AWrongShapedArrayElement_CostsNeitherTheListNorTheRestOfTheFile()
+    {
+        var dir = WriteSettings("badelement",
+            """
+            {
+              "alert_excluded_databases": ["keep_me", 5, "keep_me_too"],
+              "analysis_timeout_seconds": 321
+            }
+            """);
+
+        try
+        {
+            App.AnalysisTimeoutSeconds = 99;
+
+            App.LoadAlertSettings(dir, key => "stored:" + key, FailOnWrite);
+
+            Assert.Equal(new[] { "keep_me", "keep_me_too" }, App.AlertExcludedDatabases);
+            Assert.Equal(321, App.AnalysisTimeoutSeconds);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    /* ---- the reader's own policy ---- */
+
+    /// <summary>
+    /// Reports the whole set, not the first. A user who hand-edited one line has one mistake; a user who
+    /// pasted a block out of settings.sample.json has several, and stopping at the first means they fix,
+    /// restart, and discover the next one — several times over.
+    /// </summary>
+    [Fact]
+    public void EveryBadKeyIsReported_NotOnlyTheFirst()
+    {
+        var read = ReaderOver(
+            """
+            { "a": "no", "b": 1, "c": true, "d": [1], "e": null }
+            """);
+
+        /* Every one of the five is a different wrong shape, and every one hands back the caller's value. */
+        Assert.True(read.TryGetProperty("a", out var a));
+        Assert.True(a.Bool(fallback: true));
+
+        Assert.True(read.TryGetProperty("b", out var b));
+        Assert.Equal("kept", b.Text("kept"));
+
+        Assert.True(read.TryGetProperty("c", out var c));
+        Assert.Equal(5, c.Int(5));
+
+        Assert.True(read.TryGetProperty("d", out var d));
+        Assert.Equal(2.5, d.Double(2.5, 0, 10));
+
+        Assert.True(read.TryGetProperty("e", out var e));
+        Assert.Equal("kept", e.Text("kept"));
+
+        Assert.Equal(new[] { "a", "b", "c", "d", "e" }, read.Problems.Select(p => p.Key).ToArray());
+
+        /* The message names the kind that WAS there, which is what lets someone find the line. */
+        Assert.Contains("string", read.Problems[0].Problem, StringComparison.Ordinal);
+        Assert.Contains("true or false", read.Problems[0].Problem, StringComparison.Ordinal);
+        Assert.Contains("null", read.Problems[4].Problem, StringComparison.Ordinal);
+    }
+
+    /// <summary>An absent key is how every default works and how an older settings.json behaves. It is never
+    /// a problem, and reporting it would make the dialog fire on nearly every install.</summary>
+    [Fact]
+    public void AnAbsentKeyIsNotAProblem()
+    {
+        var read = ReaderOver("""{ "present": 1 }""");
+
+        Assert.False(read.TryGetProperty("absent", out _));
+        Assert.True(read.TryGetProperty("present", out var present));
+        Assert.Equal(1, present.Int(0));
+        Assert.Empty(read.Problems);
+    }
+
+    /// <summary>
+    /// The latent bug the clamps' move made unreachable. The old inline form was
+    /// <c>(int)Math.Max(0, v.GetInt64())</c>, which floors and then NARROWS — so a hand-typed value beyond
+    /// int range wrapped, and a "bigger threshold" became a negative one. The reader clamps before it
+    /// narrows, so the worst a huge number can do is land on the bound. This is not a shape fault, so it is
+    /// deliberately NOT reported: the value was readable, it was just out of range.
+    /// </summary>
+    [Fact]
+    public void AnOutOfRangeNumberClampsToTheBound_RatherThanWrappingNegative()
+    {
+        var read = ReaderOver("""{ "huge": 5000000000, "negative": -7 }""");
+
+        Assert.True(read.TryGetProperty("huge", out var huge));
+        Assert.Equal(int.MaxValue, huge.Int(1, 0, int.MaxValue));
+
+        Assert.True(read.TryGetProperty("negative", out var negative));
+        Assert.Equal(0, negative.Int(1, 0, 100));
+
+        Assert.Empty(read.Problems);
+    }
+
+    /// <summary>
+    /// The line between "wrong shape" and "wrong word", which decides what the startup dialog is allowed to
+    /// complain about. A number where a theme name belongs is this file's business; a string that is simply
+    /// not one of the three theme names is the caller's own vocabulary, has always been ignored quietly, and
+    /// widening THAT into a dialog is a separate decision from this one.
+    /// </summary>
+    [Fact]
+    public void OnlyTheShapeIsReported_NotAnUnrecognisedButWellShapedString()
+    {
+        var wrongShape = ReaderOver("""{ "color_theme": 5 }""");
+        Assert.True(wrongShape.TryGetProperty("color_theme", out var number));
+        Assert.Null(number.TextOrNull());
+        Assert.Equal("color_theme", Assert.Single(wrongShape.Problems).Key);
+
+        var wrongWord = ReaderOver("""{ "color_theme": "Chartreuse" }""");
+        Assert.True(wrongWord.TryGetProperty("color_theme", out var text));
+        Assert.Equal("Chartreuse", text.TextOrNull());
+        Assert.Empty(wrongWord.Problems);
+    }
+
+    /// <summary>A value read twice cannot be reported twice — the dialog lists keys, and a key listed
+    /// twice reads as two different problems with the same name.</summary>
+    [Fact]
+    public void OneKeyIsReportedOnce()
+    {
+        var read = ReaderOver("""{ "n": "not a number" }""");
+
+        Assert.True(read.TryGetProperty("n", out var n));
+        Assert.Equal(1, n.Int(1));
+        Assert.Equal(2, n.Int(2, 0, 10));
+
+        Assert.Equal("n", Assert.Single(read.Problems).Key);
+    }
+}

--- a/Lite.Tests/SettingsValueReadTests.cs
+++ b/Lite.Tests/SettingsValueReadTests.cs
@@ -218,19 +218,55 @@ public class SettingsValueReadTests
     }
 
     /// <summary>
-    /// The other side of that boundary. An UNCLAMPED read has no range to put an unusable number into, so it
-    /// does report one — but as out of range, naming the value, rather than as the wrong shape.
+    /// The regression the FIRST cut of that fix introduced, and the sharper of the two review findings.
+    /// <c>TryGetInt64</c> returns false for a number that is not a pure integer token as well as for one that
+    /// is too big, so choosing the bound by SIGN turned <c>analysis_timeout_seconds: 30.0</c> into 600 — a
+    /// value the user never asked for, never saw flagged, and could not have found. Reading the remainder as
+    /// a double is what tells the two apart, and 30.0 is plainly 30.
     /// </summary>
     [Fact]
-    public void AnUnclampedReadReportsAnOutOfRangeNumber_AsOutOfRangeRatherThanWrongShape()
+    public void AFractionalNumber_ReadsAsItsValue_RatherThanLandingOnTheMaximum()
     {
-        var read = ReaderOver("""{ "vast": 99999999999999999999 }""");
+        var read = ReaderOver("""{ "whole": 30.0, "fraction": 5.5, "under": -0.5 }""");
 
-        Assert.True(read.TryGetProperty("vast", out var vast));
-        Assert.Equal(7, vast.Int(7));
+        Assert.True(read.TryGetProperty("whole", out var whole));
+        Assert.Equal(30, whole.Int(99, 30, 600));
 
-        var problem = Assert.Single(read.Problems);
-        Assert.Equal("vast", problem.Key);
+        /* Truncated INTO the range, which is the same silent adjustment the clamp already is and is confined
+           to the readers whose caller declared a range for exactly that. It is not 100. */
+        Assert.True(read.TryGetProperty("fraction", out var fraction));
+        Assert.Equal(5, fraction.Int(99, 0, 100));
+
+        Assert.True(read.TryGetProperty("under", out var under));
+        Assert.Equal(0, under.Int(99, 0, 100));
+
+        Assert.Empty(read.Problems);
+    }
+
+    /// <summary>
+    /// The other side of the boundary. An UNCLAMPED read has no range to put an unusable number into, so it
+    /// must not invent one — and it names which of the two problems the value has, because "holds a JSON
+    /// number where a whole number belongs" is a nonsense sentence about a number. A number that IS exact is
+    /// still taken however it was written.
+    /// </summary>
+    [Fact]
+    public void AnUnclampedRead_TakesAnExactNumber_AndNamesWhyItRejectsTheRest()
+    {
+        var exact = ReaderOver("""{ "n": 30.0 }""");
+        Assert.True(exact.TryGetProperty("n", out var n));
+        Assert.Equal(30, n.Int(7));
+        Assert.Empty(exact.Problems);
+
+        var fractional = ReaderOver("""{ "n": 90.7 }""");
+        Assert.True(fractional.TryGetProperty("n", out var f));
+        Assert.Equal(7, f.Int(7));
+        Assert.Contains("not a whole number", Assert.Single(fractional.Problems).Problem, StringComparison.Ordinal);
+
+        var vast = ReaderOver("""{ "n": 99999999999999999999 }""");
+        Assert.True(vast.TryGetProperty("n", out var v));
+        Assert.Equal(7, v.Int(7));
+
+        var problem = Assert.Single(vast.Problems);
         Assert.Contains("out of range", problem.Problem, StringComparison.Ordinal);
         Assert.DoesNotContain("where a whole number belongs", problem.Problem, StringComparison.Ordinal);
     }

--- a/Lite/App.xaml.cs
+++ b/Lite/App.xaml.cs
@@ -700,6 +700,52 @@ public partial class App : Application
     }
 
     /// <summary>
+    /// Every settings.json key whose VALUE was the wrong shape, accumulated across both loaders and consumed
+    /// once by <see cref="ReportUnreadableSettingsToUser"/> (#2444).
+    ///
+    /// <para>Separate from <see cref="s_unreadableSettingsProblem"/> because they are different failures with
+    /// different costs, and the difference is the whole of #2444. An unparseable DOCUMENT costs every setting
+    /// and there is nothing to enumerate. A badly-shaped VALUE now costs exactly its own key, so the useful
+    /// thing to say is WHICH keys — the message that used to be shown sent someone to proofread an
+    /// eighty-seven-key file with no idea which line was wrong.</para>
+    ///
+    /// <para>They cannot both be set on one run: a document that will not parse never reaches a value read.
+    /// Kept as two fields anyway rather than one string, because collapsing them would make the loaders
+    /// responsible for deciding which message wins, and that decision belongs where the message is shown.</para>
+    /// </summary>
+    private static readonly List<string> s_badSettingValues = new();
+
+    /// <summary>
+    /// Records the keys a loader could not read (#2444): to the log immediately, and to
+    /// <see cref="s_badSettingValues"/> for the one startup dialog.
+    ///
+    /// <para>Reports the whole SET rather than the first. A user who hand-edited one line probably has one
+    /// mistake, but a user who pasted a block out of settings.sample.json has several — and failing on the
+    /// first means they fix it, restart, and discover the next one, several times over. The old code could
+    /// not have done this even in principle: it threw on the first bad value and never reached the rest.</para>
+    /// </summary>
+    private static void ReportBadSettingValues(IReadOnlyList<SettingsValueProblem> problems)
+    {
+        if (problems.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var problem in problems)
+        {
+            if (!s_badSettingValues.Contains(problem.ToString(), StringComparer.Ordinal))
+            {
+                s_badSettingValues.Add(problem.ToString());
+            }
+        }
+
+        AppLogger.Error("Settings",
+            $"settings.json parsed, but {problems.Count} of its values could not be read and are at their " +
+            "defaults for this session. Every OTHER setting in the file loaded normally.\n  " +
+            string.Join("\n  ", problems));
+    }
+
+    /// <summary>
     /// Shows the one-time modal for an unreadable settings.json. Called after the main window exists so it
     /// cannot be the app's entire first impression, and so a later startup failure still fails the way it
     /// did before.
@@ -713,6 +759,11 @@ public partial class App : Application
         var problem = s_unreadableSettingsProblem;
         if (problem == null)
         {
+            /* #2444: the document parsed, so if anything went wrong it was individual VALUES, and this is the
+               only place that says so where someone will see it. Deliberately a second message rather than a
+               second dialog — the two cannot both happen on one run, and an app that opens two modals before
+               its first window is used is an app people click through. */
+            ReportBadSettingValuesToUser();
             return;
         }
 
@@ -725,6 +776,36 @@ public partial class App : Application
             "Your file has not been changed. Fix it and restart to get your settings back. If you save from " +
             "the Settings window instead, the unreadable file is copied aside as " +
             "settings.json.unreadable-<timestamp> first, so it is recoverable either way.",
+            "Settings", MessageBoxButton.OK, MessageBoxImage.Warning);
+    }
+
+    /// <summary>
+    /// The visible half of #2444: the keys that fell back, by name, once the main window is up.
+    ///
+    /// <para>Visible at all because a log line is not a startup message. The value half used to log and stop
+    /// there, so a user whose thresholds had silently reverted had no signal unless they went looking — and
+    /// #2425 had already decided, for the document half, that someone looking at an app which has forgotten
+    /// its configuration should not have to find a log to learn why. The same argument applies to a setting
+    /// that reverted; what is new is that the message can now be specific enough to act on, which is what
+    /// makes it worth a dialog rather than noise.</para>
+    ///
+    /// <para>It says what SURVIVED as well as what did not, because "a value could not be read" over an
+    /// eighty-seven-key file reads as "everything is gone" — which is what it used to mean.</para>
+    /// </summary>
+    private static void ReportBadSettingValuesToUser()
+    {
+        if (s_badSettingValues.Count == 0)
+        {
+            return;
+        }
+
+        MessageBox.Show(
+            $"{s_badSettingValues.Count} setting(s) in settings.json could not be read and are at their " +
+            "defaults for this session. Everything else in the file loaded normally.\n\n" +
+            $"{Path.Combine(ConfigDirectory, "settings.json")}\n\n" +
+            string.Join("\n", s_badSettingValues) + "\n\n" +
+            "Your file has not been changed. Fix these values and restart, or save from the Settings window " +
+            "to write the current values back over them.",
             "Settings", MessageBoxButton.OK, MessageBoxImage.Warning);
     }
 
@@ -744,24 +825,30 @@ public partial class App : Application
 
         try
         {
-            /* Reads through JsonDocument.TryGetProperty rather than JsonNode.TryGetPropertyValue, which
-               would be the more natural pairing with the guard's parsed Root. Two reasons: it keeps this
-               loader the same shape as LoadAlertSettings below, and #2418's SettingsSampleTests extracts
-               the documented key list by regexing the TryGetProperty key literals out of this very file.
-               Spelled the other way this key silently drops out of that guard, and settings.sample.json is
-               then free to document a setting nothing reads. (Which is also why the call is not written out
-               in this comment: the extractor cannot tell a comment from code, and would read the example as
-               a real key.) */
+            /* Reads through a SettingsReader rather than JsonNode.TryGetPropertyValue, which would be the
+               more natural pairing with the guard's parsed Root. Two reasons: it keeps this loader the same
+               shape as LoadAlertSettings below, and #2418's SettingsSampleTests extracts the documented key
+               list by regexing the TryGetProperty key literals out of this very file. Spelled any other way
+               this key silently drops out of that guard, and settings.sample.json is then free to document a
+               setting nothing reads. (Which is also why the call is not written out in this comment: the
+               extractor cannot tell a comment from code, and would read the example as a real key.) */
             using var doc = System.Text.Json.JsonDocument.Parse(settings.Text);
-            if (doc.RootElement.TryGetProperty("default_time_range_hours", out var val))
+            var read = new SettingsReader(doc.RootElement);
+
+            if (read.TryGetProperty("default_time_range_hours", out var val))
             {
-                DefaultTimeRangeHours = val.GetInt32();
+                DefaultTimeRangeHours = val.Int(DefaultTimeRangeHours);
             }
+
+            /* #2444: this loader already named its one key, which is the behaviour LoadAlertSettings could
+               not manage across eighty-seven. It now says so through the shared reporter instead of its own
+               log line, so the startup dialog can name this key beside the others. */
+            ReportBadSettingValues(read.Problems);
         }
         catch (Exception ex)
         {
-            /* The document parsed, so anything landing here is ONE bad value rather than a broken file.
-               That distinction is worth keeping: the key it names is the only thing that fell back. */
+            /* The document parsed and every value read is shape-checked rather than caught, so nothing
+               EXPECTED lands here any more. Kept because an unexpected throw must not take startup down. */
             AppLogger.Warn("Settings",
                 $"settings.json key 'default_time_range_hours' could not be read ({ex.Message}); the " +
                 $"default of {DefaultTimeRangeHours} hours is in use.");
@@ -813,100 +900,125 @@ public partial class App : Application
         try
         {
             using var doc = System.Text.Json.JsonDocument.Parse(settings.Text);
-            var root = doc.RootElement;
 
-            if (root.TryGetProperty("alerts_enabled", out var v)) AlertsEnabled = v.GetBoolean();
-            if (root.TryGetProperty("notify_connection_changes", out v)) NotifyConnectionChanges = v.GetBoolean();
-            if (root.TryGetProperty("notify_connection_down_at_startup", out v)) NotifyConnectionDownAtStartup = v.GetBoolean();
-            if (root.TryGetProperty("connection_refire_minutes", out v)) ConnectionRefireMinutes = Math.Clamp(v.GetInt32(), 0, 1440);
+            /* #2444: every read below goes through SettingsReader, which checks ValueKind and RECORDS a key
+               it cannot read instead of throwing on it. Before this, all eighty-seven shared one try, so one
+               key of the wrong shape abandoned every read after it and which settings survived depended on
+               where the bad key sat in the file — an implementation detail of this method's line order.
+
+               The reads keep their existing call shape on purpose and not by habit: #2418's
+               SettingsSampleTests regexes the key literals out of this file by the method NAME, and requires
+               every key it finds to be documented in settings.sample.json and vice versa. A helper spelled
+               any other way makes all eighty-seven vanish from that extraction and lets the sample drift
+               exactly the way #2418 was filed about -- which is what PR #2428 hit. So SettingsReader's method
+               carries the same name deliberately, and the extractor needed no change. (The call is not
+               written out here for the reason the sibling loader above gives: the extractor cannot tell a
+               comment from code, and would read the example as a real key.)
+
+               The clamps moved into the reader with the reads. They were repeated inline at every call site,
+               and two of the forms — (int)Math.Max(0, v.GetInt64()) — narrowed AFTER the floor, so a
+               hand-typed value beyond int range wrapped negative. Int(fallback, min, max) clamps first. */
+            var read = new SettingsReader(doc.RootElement);
+
+            if (read.TryGetProperty("alerts_enabled", out var v)) AlertsEnabled = v.Bool(AlertsEnabled);
+            if (read.TryGetProperty("notify_connection_changes", out v)) NotifyConnectionChanges = v.Bool(NotifyConnectionChanges);
+            if (read.TryGetProperty("notify_connection_down_at_startup", out v)) NotifyConnectionDownAtStartup = v.Bool(NotifyConnectionDownAtStartup);
+            if (read.TryGetProperty("connection_refire_minutes", out v)) ConnectionRefireMinutes = v.Int(ConnectionRefireMinutes, 0, 1440);
             /* #1696 AG knobs, clamped on READ to the same ranges Darling clamps, so a hand-edited settings.json
                cannot drive a nonsense threshold in either app. */
-            if (root.TryGetProperty("notify_ag_health", out v)) NotifyAgHealth = v.GetBoolean();
-            if (root.TryGetProperty("ag_lag_alert_seconds", out v)) AgLagAlertSeconds = Math.Clamp(v.GetInt32(), 0, 86400);
-            if (root.TryGetProperty("ag_redo_queue_alert_kb", out v)) AgRedoQueueAlertKb = Math.Clamp(v.GetInt64(), 0L, 1073741824L);
-            if (root.TryGetProperty("ag_disconnect_refire_minutes", out v)) AgDisconnectRefireMinutes = Math.Clamp(v.GetInt32(), 0, 1440);
-            if (root.TryGetProperty("alert_cpu_enabled", out v)) AlertCpuEnabled = v.GetBoolean();
-            if (root.TryGetProperty("alert_cpu_threshold", out v)) AlertCpuThreshold = v.GetInt32();
-            if (root.TryGetProperty("alert_cpu_mode", out v) && Enum.TryParse<CpuAlertMode>(v.GetString(), out var mode))
+            if (read.TryGetProperty("notify_ag_health", out v)) NotifyAgHealth = v.Bool(NotifyAgHealth);
+            if (read.TryGetProperty("ag_lag_alert_seconds", out v)) AgLagAlertSeconds = v.Int(AgLagAlertSeconds, 0, 86400);
+            if (read.TryGetProperty("ag_redo_queue_alert_kb", out v)) AgRedoQueueAlertKb = v.Long(AgRedoQueueAlertKb, 0L, 1073741824L);
+            if (read.TryGetProperty("ag_disconnect_refire_minutes", out v)) AgDisconnectRefireMinutes = v.Int(AgDisconnectRefireMinutes, 0, 1440);
+            if (read.TryGetProperty("alert_cpu_enabled", out v)) AlertCpuEnabled = v.Bool(AlertCpuEnabled);
+            if (read.TryGetProperty("alert_cpu_threshold", out v)) AlertCpuThreshold = v.Int(AlertCpuThreshold);
+            if (read.TryGetProperty("alert_cpu_mode", out v) && Enum.TryParse<CpuAlertMode>(v.TextOrNull(), out var mode))
                 AlertCpuMode = mode;
-            if (root.TryGetProperty("alert_blocking_enabled", out v)) AlertBlockingEnabled = v.GetBoolean();
-            if (root.TryGetProperty("alert_blocking_threshold", out v)) AlertBlockingThreshold = v.GetInt32();
-            if (root.TryGetProperty("alert_blocking_wait_seconds_threshold", out v)) AlertBlockingWaitSecondsThreshold = v.GetInt32();
-            if (root.TryGetProperty("alert_deadlock_enabled", out v)) AlertDeadlockEnabled = v.GetBoolean();
-            if (root.TryGetProperty("alert_deadlock_threshold", out v)) AlertDeadlockThreshold = v.GetInt32();
-            if (root.TryGetProperty("alert_poison_wait_enabled", out v)) AlertPoisonWaitEnabled = v.GetBoolean();
-            if (root.TryGetProperty("alert_poison_wait_threshold_ms", out v)) AlertPoisonWaitThresholdMs = v.GetInt32();
-            if (root.TryGetProperty("alert_long_running_query_enabled", out v)) AlertLongRunningQueryEnabled = v.GetBoolean();
-            if (root.TryGetProperty("alert_long_running_query_threshold_minutes", out v)) AlertLongRunningQueryThresholdMinutes = v.GetInt32();
-            if (root.TryGetProperty("alert_long_running_query_max_results", out v)) AlertLongRunningQueryMaxResults = (int)Math.Clamp(v.GetInt64(), 1, 1000);
-            if (root.TryGetProperty("alert_long_running_query_exclude_sp_server_diagnostics", out v)) AlertLongRunningQueryExcludeSpServerDiagnostics = v.GetBoolean();
-            if (root.TryGetProperty("alert_long_running_query_exclude_waitfor", out v)) AlertLongRunningQueryExcludeWaitFor = v.GetBoolean();
-            if (root.TryGetProperty("alert_long_running_query_exclude_backups", out v)) AlertLongRunningQueryExcludeBackups = v.GetBoolean();
-            if (root.TryGetProperty("alert_long_running_query_exclude_misc_waits", out v)) AlertLongRunningQueryExcludeMiscWaits = v.GetBoolean();
-            if (root.TryGetProperty("alert_long_running_query_exclude_cdc", out v)) AlertLongRunningQueryExcludeCdc = v.GetBoolean();
-            if (root.TryGetProperty("alert_excluded_databases", out v) && v.ValueKind == System.Text.Json.JsonValueKind.Array)
+            if (read.TryGetProperty("alert_blocking_enabled", out v)) AlertBlockingEnabled = v.Bool(AlertBlockingEnabled);
+            if (read.TryGetProperty("alert_blocking_threshold", out v)) AlertBlockingThreshold = v.Int(AlertBlockingThreshold);
+            if (read.TryGetProperty("alert_blocking_wait_seconds_threshold", out v)) AlertBlockingWaitSecondsThreshold = v.Int(AlertBlockingWaitSecondsThreshold);
+            if (read.TryGetProperty("alert_deadlock_enabled", out v)) AlertDeadlockEnabled = v.Bool(AlertDeadlockEnabled);
+            if (read.TryGetProperty("alert_deadlock_threshold", out v)) AlertDeadlockThreshold = v.Int(AlertDeadlockThreshold);
+            if (read.TryGetProperty("alert_poison_wait_enabled", out v)) AlertPoisonWaitEnabled = v.Bool(AlertPoisonWaitEnabled);
+            if (read.TryGetProperty("alert_poison_wait_threshold_ms", out v)) AlertPoisonWaitThresholdMs = v.Int(AlertPoisonWaitThresholdMs);
+            if (read.TryGetProperty("alert_long_running_query_enabled", out v)) AlertLongRunningQueryEnabled = v.Bool(AlertLongRunningQueryEnabled);
+            if (read.TryGetProperty("alert_long_running_query_threshold_minutes", out v)) AlertLongRunningQueryThresholdMinutes = v.Int(AlertLongRunningQueryThresholdMinutes);
+            if (read.TryGetProperty("alert_long_running_query_max_results", out v)) AlertLongRunningQueryMaxResults = v.Int(AlertLongRunningQueryMaxResults, 1, 1000);
+            if (read.TryGetProperty("alert_long_running_query_exclude_sp_server_diagnostics", out v)) AlertLongRunningQueryExcludeSpServerDiagnostics = v.Bool(AlertLongRunningQueryExcludeSpServerDiagnostics);
+            if (read.TryGetProperty("alert_long_running_query_exclude_waitfor", out v)) AlertLongRunningQueryExcludeWaitFor = v.Bool(AlertLongRunningQueryExcludeWaitFor);
+            if (read.TryGetProperty("alert_long_running_query_exclude_backups", out v)) AlertLongRunningQueryExcludeBackups = v.Bool(AlertLongRunningQueryExcludeBackups);
+            if (read.TryGetProperty("alert_long_running_query_exclude_misc_waits", out v)) AlertLongRunningQueryExcludeMiscWaits = v.Bool(AlertLongRunningQueryExcludeMiscWaits);
+            if (read.TryGetProperty("alert_long_running_query_exclude_cdc", out v)) AlertLongRunningQueryExcludeCdc = v.Bool(AlertLongRunningQueryExcludeCdc);
+            if (read.TryGetProperty("alert_excluded_databases", out v) && v.IsArray())
             {
                 AlertExcludedDatabases = new List<string>();
-                foreach (var elem in v.EnumerateArray())
+
+                /* The ELEMENT kind is filtered rather than read, which the fleet-group list below already
+                   did: elem.GetString() throws on a number in the array, and inside the old single try that
+                   one element cost every setting after it. It is skipped rather than reported — an element
+                   has no key to name, and the list itself is not the thing that failed. */
+                foreach (var elem in v.Element.EnumerateArray())
                 {
-                    var db = elem.GetString();
+                    var db = elem.ValueKind == JsonValueKind.String ? elem.GetString() : null;
                     if (!string.IsNullOrWhiteSpace(db)) AlertExcludedDatabases.Add(db);
                 }
             }
-            if (root.TryGetProperty("alert_tempdb_space_enabled", out v)) AlertTempDbSpaceEnabled = v.GetBoolean();
-            if (root.TryGetProperty("alert_tempdb_space_threshold_percent", out v)) AlertTempDbSpaceThresholdPercent = v.GetInt32();
-            if (root.TryGetProperty("alert_low_disk_enabled", out v)) AlertLowDiskEnabled = v.GetBoolean();
-            if (root.TryGetProperty("alert_low_disk_threshold_percent", out v)) AlertLowDiskThresholdPercent = (int)Math.Clamp(v.GetInt64(), 0, 100);
-            if (root.TryGetProperty("alert_low_disk_threshold_gb", out v)) AlertLowDiskThresholdGb = (int)Math.Max(0, v.GetInt64());
+            if (read.TryGetProperty("alert_tempdb_space_enabled", out v)) AlertTempDbSpaceEnabled = v.Bool(AlertTempDbSpaceEnabled);
+            if (read.TryGetProperty("alert_tempdb_space_threshold_percent", out v)) AlertTempDbSpaceThresholdPercent = v.Int(AlertTempDbSpaceThresholdPercent);
+            if (read.TryGetProperty("alert_low_disk_enabled", out v)) AlertLowDiskEnabled = v.Bool(AlertLowDiskEnabled);
+            if (read.TryGetProperty("alert_low_disk_threshold_percent", out v)) AlertLowDiskThresholdPercent = v.Int(AlertLowDiskThresholdPercent, 0, 100);
+            if (read.TryGetProperty("alert_low_disk_threshold_gb", out v)) AlertLowDiskThresholdGb = v.Int(AlertLowDiskThresholdGb, 0, int.MaxValue);
             /* #2107: the CRITICAL tier floors, clamped like the WARNING thresholds above. */
-            if (root.TryGetProperty("alert_disk_critical_free_percent", out v)) AlertDiskCriticalFreePercent = Math.Clamp(v.GetInt32(), 0, 100);
-            if (root.TryGetProperty("alert_disk_critical_free_gb", out v)) AlertDiskCriticalFreeGb = (int)Math.Max(0, v.GetInt64());
-            if (root.TryGetProperty("alert_pvs_enabled", out v)) AlertPvsEnabled = v.GetBoolean();
-            if (root.TryGetProperty("alert_pvs_threshold_percent", out v)) AlertPvsThresholdPercent = (int)Math.Clamp(v.GetInt64(), 0, 100);
-            if (root.TryGetProperty("alert_file_growth_enabled", out v)) AlertFileGrowthEnabled = v.GetBoolean();
-            if (root.TryGetProperty("alert_file_growth_rise_mb", out v)) AlertFileGrowthRiseMb = (int)Math.Max(0, v.GetInt64());
-            if (root.TryGetProperty("alert_file_growth_volume_percent", out v)) AlertFileGrowthVolumePercent = (int)Math.Clamp(v.GetInt64(), 0, 100);
-            if (root.TryGetProperty("alert_file_growth_lookback_minutes", out v)) AlertFileGrowthLookbackMinutes = (int)Math.Clamp(v.GetInt64(), 5, 1440);
-            if (root.TryGetProperty("alert_pvs_floor_gb", out v)) AlertPvsFloorGb = (int)Math.Max(0, v.GetInt64());
-            if (root.TryGetProperty("alert_long_running_job_enabled", out v)) AlertLongRunningJobEnabled = v.GetBoolean();
-            if (root.TryGetProperty("alert_long_running_job_multiplier", out v)) AlertLongRunningJobMultiplier = v.GetInt32();
-            if (root.TryGetProperty("alert_failed_job_enabled", out v)) AlertFailedJobEnabled = v.GetBoolean();
-            if (root.TryGetProperty("alert_failed_job_lookback_minutes", out v)) AlertFailedJobLookbackMinutes = (int)Math.Clamp(v.GetInt64(), 1, 1440);
-            if (root.TryGetProperty("alert_database_state_enabled", out v)) AlertDatabaseStateEnabled = v.GetBoolean();
-            if (root.TryGetProperty("alert_cooldown_minutes", out v)) AlertCooldownMinutes = (int)Math.Clamp(v.GetInt64(), 1, 120);
-            if (root.TryGetProperty("email_cooldown_minutes", out v)) EmailCooldownMinutes = (int)Math.Clamp(v.GetInt64(), 1, 120);
-            if (root.TryGetProperty("alert_delivery_mode", out v) && Enum.TryParse<AlertNotificationMode>(v.GetString(), out var deliveryMode))
+            if (read.TryGetProperty("alert_disk_critical_free_percent", out v)) AlertDiskCriticalFreePercent = v.Int(AlertDiskCriticalFreePercent, 0, 100);
+            if (read.TryGetProperty("alert_disk_critical_free_gb", out v)) AlertDiskCriticalFreeGb = v.Int(AlertDiskCriticalFreeGb, 0, int.MaxValue);
+            if (read.TryGetProperty("alert_pvs_enabled", out v)) AlertPvsEnabled = v.Bool(AlertPvsEnabled);
+            if (read.TryGetProperty("alert_pvs_threshold_percent", out v)) AlertPvsThresholdPercent = v.Int(AlertPvsThresholdPercent, 0, 100);
+            if (read.TryGetProperty("alert_file_growth_enabled", out v)) AlertFileGrowthEnabled = v.Bool(AlertFileGrowthEnabled);
+            if (read.TryGetProperty("alert_file_growth_rise_mb", out v)) AlertFileGrowthRiseMb = v.Int(AlertFileGrowthRiseMb, 0, int.MaxValue);
+            if (read.TryGetProperty("alert_file_growth_volume_percent", out v)) AlertFileGrowthVolumePercent = v.Int(AlertFileGrowthVolumePercent, 0, 100);
+            if (read.TryGetProperty("alert_file_growth_lookback_minutes", out v)) AlertFileGrowthLookbackMinutes = v.Int(AlertFileGrowthLookbackMinutes, 5, 1440);
+            if (read.TryGetProperty("alert_pvs_floor_gb", out v)) AlertPvsFloorGb = v.Int(AlertPvsFloorGb, 0, int.MaxValue);
+            if (read.TryGetProperty("alert_long_running_job_enabled", out v)) AlertLongRunningJobEnabled = v.Bool(AlertLongRunningJobEnabled);
+            if (read.TryGetProperty("alert_long_running_job_multiplier", out v)) AlertLongRunningJobMultiplier = v.Int(AlertLongRunningJobMultiplier);
+            if (read.TryGetProperty("alert_failed_job_enabled", out v)) AlertFailedJobEnabled = v.Bool(AlertFailedJobEnabled);
+            if (read.TryGetProperty("alert_failed_job_lookback_minutes", out v)) AlertFailedJobLookbackMinutes = v.Int(AlertFailedJobLookbackMinutes, 1, 1440);
+            if (read.TryGetProperty("alert_database_state_enabled", out v)) AlertDatabaseStateEnabled = v.Bool(AlertDatabaseStateEnabled);
+            if (read.TryGetProperty("alert_cooldown_minutes", out v)) AlertCooldownMinutes = v.Int(AlertCooldownMinutes, 1, 120);
+            if (read.TryGetProperty("email_cooldown_minutes", out v)) EmailCooldownMinutes = v.Int(EmailCooldownMinutes, 1, 120);
+            if (read.TryGetProperty("alert_delivery_mode", out v) && Enum.TryParse<AlertNotificationMode>(v.TextOrNull(), out var deliveryMode))
                 AlertDeliveryMode = deliveryMode;
-            if (root.TryGetProperty("alert_per_event_max_per_cycle", out v)) AlertPerEventMaxPerCycle = (int)Math.Clamp(v.GetInt64(), 1, 100);
-            if (root.TryGetProperty("mute_rule_default_expiration", out v))
+            if (read.TryGetProperty("alert_per_event_max_per_cycle", out v)) AlertPerEventMaxPerCycle = v.Int(AlertPerEventMaxPerCycle, 1, 100);
+            if (read.TryGetProperty("mute_rule_default_expiration", out v))
             {
-                var exp = v.GetString();
+                var exp = v.TextOrNull();
                 if (exp is "1 hour" or "24 hours" or "7 days" or "Never")
                     MuteRuleDefaultExpiration = exp;
             }
-            if (root.TryGetProperty("log_alert_dismissals", out v)) LogAlertDismissals = v.GetBoolean();
+            if (read.TryGetProperty("log_alert_dismissals", out v)) LogAlertDismissals = v.Bool(LogAlertDismissals);
 
             /* Connection settings */
-            if (root.TryGetProperty("connection_timeout_seconds", out v))
+            if (read.TryGetProperty("connection_timeout_seconds", out v))
             {
-                var timeout = v.GetInt32();
+                /* Rejected rather than clamped, which is why it does not use the reader's clamping overload:
+                   an out-of-range timeout here has always been ignored in favour of the current value. */
+                var timeout = v.Int(ConnectionTimeoutSeconds);
                 if (timeout >= 5 && timeout <= 60) ConnectionTimeoutSeconds = timeout;
             }
 
             /* CSV export settings */
-            if (root.TryGetProperty("csv_separator", out v))
+            if (read.TryGetProperty("csv_separator", out v))
             {
-                var sep = v.GetString();
+                var sep = v.TextOrNull();
                 if (sep == "," || sep == ";" || sep == "\t") CsvSeparator = sep;
             }
 
             /* System tray settings */
-            if (root.TryGetProperty("minimize_to_tray", out v)) MinimizeToTray = v.GetBoolean();
+            if (read.TryGetProperty("minimize_to_tray", out v)) MinimizeToTray = v.Bool(MinimizeToTray);
 
             /* Time display mode */
-            if (root.TryGetProperty("time_display_mode", out v))
+            if (read.TryGetProperty("time_display_mode", out v))
             {
-                var t = v.GetString();
+                var t = v.TextOrNull();
                 if (t == "ServerTime" || t == "LocalTime" || t == "UTC")
                 {
                     TimeDisplayMode = t;
@@ -916,62 +1028,62 @@ public partial class App : Application
             }
 
             /* Color theme */
-            if (root.TryGetProperty("color_theme", out v))
+            if (read.TryGetProperty("color_theme", out v))
             {
-                var t = v.GetString();
+                var t = v.TextOrNull();
                 if (t == "Dark" || t == "Light" || t == "CoolBreeze") ColorTheme = t;
             }
 
             /* NOC Overview tile sort */
-            if (root.TryGetProperty("overview_sort_mode", out v)) OverviewSortMode = ServerOverviewSort.ParseMode(v.GetString());
+            if (read.TryGetProperty("overview_sort_mode", out v)) OverviewSortMode = ServerOverviewSort.ParseMode(v.TextOrNull());
 
             /* Sidebar fleet-tree collapsed groups (#2020 2b-i-b) */
-            if (root.TryGetProperty("collapsed_fleet_groups", out v) && v.ValueKind == JsonValueKind.Array)
+            if (read.TryGetProperty("collapsed_fleet_groups", out v) && v.IsArray())
             {
-                CollapsedFleetGroups = v.EnumerateArray()
+                CollapsedFleetGroups = v.Element.EnumerateArray()
                     .Where(e => e.ValueKind == JsonValueKind.String)
                     .Select(e => e.GetString()!)
                     .ToList();
             }
 
             /* Update check settings */
-            if (root.TryGetProperty("check_for_updates_on_startup", out v)) CheckForUpdatesOnStartup = v.GetBoolean();
+            if (read.TryGetProperty("check_for_updates_on_startup", out v)) CheckForUpdatesOnStartup = v.Bool(CheckForUpdatesOnStartup);
 
             /* Teams webhook settings */
-            if (root.TryGetProperty("teams_webhook_enabled", out v)) TeamsWebhookEnabled = v.GetBoolean();
-            if (root.TryGetProperty("teams_proxy_address", out v)) TeamsProxyAddress = v.GetString() ?? "";
+            if (read.TryGetProperty("teams_webhook_enabled", out v)) TeamsWebhookEnabled = v.Bool(TeamsWebhookEnabled);
+            if (read.TryGetProperty("teams_proxy_address", out v)) TeamsProxyAddress = v.Text(TeamsProxyAddress);
 
             /* Slack webhook settings */
-            if (root.TryGetProperty("slack_webhook_enabled", out v)) SlackWebhookEnabled = v.GetBoolean();
-            if (root.TryGetProperty("slack_proxy_address", out v)) SlackProxyAddress = v.GetString() ?? "";
+            if (read.TryGetProperty("slack_webhook_enabled", out v)) SlackWebhookEnabled = v.Bool(SlackWebhookEnabled);
+            if (read.TryGetProperty("slack_proxy_address", out v)) SlackProxyAddress = v.Text(SlackProxyAddress);
 
             /* Generic webhook settings (#1506). The URL + headers JSON are secrets and load from Credential
                Manager below; only these three are plain prefs. */
-            if (root.TryGetProperty("generic_webhook_enabled", out v)) GenericWebhookEnabled = v.GetBoolean();
-            if (root.TryGetProperty("generic_proxy_address", out v)) GenericWebhookProxyAddress = v.GetString() ?? "";
-            if (root.TryGetProperty("generic_body_template", out v)) GenericWebhookBodyTemplate = v.GetString() ?? "";
+            if (read.TryGetProperty("generic_webhook_enabled", out v)) GenericWebhookEnabled = v.Bool(GenericWebhookEnabled);
+            if (read.TryGetProperty("generic_proxy_address", out v)) GenericWebhookProxyAddress = v.Text(GenericWebhookProxyAddress);
+            if (read.TryGetProperty("generic_body_template", out v)) GenericWebhookBodyTemplate = v.Text(GenericWebhookBodyTemplate);
 
             /* PagerDuty webhook settings. The routing key is a secret and loads from Credential Manager below;
                only the enable flag and EU-region toggle are plain prefs. */
-            if (root.TryGetProperty("pagerduty_webhook_enabled", out v)) PagerDutyWebhookEnabled = v.GetBoolean();
-            if (root.TryGetProperty("pagerduty_use_eu_region", out v)) PagerDutyUseEuRegion = v.GetBoolean();
-            if (root.TryGetProperty("pagerduty_proxy_address", out v)) PagerDutyProxyAddress = v.GetString() ?? "";
+            if (read.TryGetProperty("pagerduty_webhook_enabled", out v)) PagerDutyWebhookEnabled = v.Bool(PagerDutyWebhookEnabled);
+            if (read.TryGetProperty("pagerduty_use_eu_region", out v)) PagerDutyUseEuRegion = v.Bool(PagerDutyUseEuRegion);
+            if (read.TryGetProperty("pagerduty_proxy_address", out v)) PagerDutyProxyAddress = v.Text(PagerDutyProxyAddress);
 
             /* Migrate webhook URLs from plaintext settings.json to Credential Manager. A legacy plaintext
                URL still wins over whatever the store held, matching the old order (save, then read back);
                the live property is set here rather than re-reading, since we just wrote the value. */
-            if (root.TryGetProperty("teams_webhook_url", out v))
+            if (read.TryGetProperty("teams_webhook_url", out v))
             {
-                var legacyUrl = v.GetString() ?? "";
+                var legacyUrl = v.Text("");
                 if (!string.IsNullOrWhiteSpace(legacyUrl))
                 {
                     writeSecret(TeamsWebhookCredentialKey, legacyUrl);
                     TeamsWebhookUrl = legacyUrl;
                 }
             }
-            if (root.TryGetProperty("slack_webhook_url", out v))
+            if (read.TryGetProperty("slack_webhook_url", out v))
             {
-                var legacyUrl = v.GetString() ?? "";
+                var legacyUrl = v.Text("");
                 if (!string.IsNullOrWhiteSpace(legacyUrl))
                 {
                     writeSecret(SlackWebhookCredentialKey, legacyUrl);
@@ -980,33 +1092,37 @@ public partial class App : Application
             }
 
             /* SMTP settings */
-            if (root.TryGetProperty("smtp_enabled", out v)) SmtpEnabled = v.GetBoolean();
-            if (root.TryGetProperty("smtp_server", out v)) SmtpServer = v.GetString() ?? "";
-            if (root.TryGetProperty("smtp_port", out v)) SmtpPort = v.GetInt32();
-            if (root.TryGetProperty("smtp_use_ssl", out v)) SmtpUseSsl = v.GetBoolean();
-            if (root.TryGetProperty("smtp_username", out v)) SmtpUsername = v.GetString() ?? "";
-            if (root.TryGetProperty("smtp_from_address", out v)) SmtpFromAddress = v.GetString() ?? "";
-            if (root.TryGetProperty("smtp_recipients", out v)) SmtpRecipients = v.GetString() ?? "";
+            if (read.TryGetProperty("smtp_enabled", out v)) SmtpEnabled = v.Bool(SmtpEnabled);
+            if (read.TryGetProperty("smtp_server", out v)) SmtpServer = v.Text(SmtpServer);
+            if (read.TryGetProperty("smtp_port", out v)) SmtpPort = v.Int(SmtpPort);
+            if (read.TryGetProperty("smtp_use_ssl", out v)) SmtpUseSsl = v.Bool(SmtpUseSsl);
+            if (read.TryGetProperty("smtp_username", out v)) SmtpUsername = v.Text(SmtpUsername);
+            if (read.TryGetProperty("smtp_from_address", out v)) SmtpFromAddress = v.Text(SmtpFromAddress);
+            if (read.TryGetProperty("smtp_recipients", out v)) SmtpRecipients = v.Text(SmtpRecipients);
 
-            if (root.TryGetProperty("analysis_enabled", out v)) AnalysisEnabled = v.GetBoolean();
-            if (root.TryGetProperty("query_store_backfill_enabled", out v)) QueryStoreBackfillEnabled = v.GetBoolean();
-            if (root.TryGetProperty("analysis_notifications_enabled", out v)) AnalysisNotificationsEnabled = v.GetBoolean();
-            if (root.TryGetProperty("analysis_interval_minutes", out v)) AnalysisIntervalMinutes = (int)Math.Clamp(v.GetInt64(), 5, 360);
-            if (root.TryGetProperty("analysis_notify_severity", out v)) AnalysisNotifySeverity = Math.Clamp(v.GetDouble(), 0.0, 2.0);
-            if (root.TryGetProperty("analysis_notify_cooldown_minutes", out v)) AnalysisNotifyCooldownMinutes = (int)Math.Clamp(v.GetInt64(), 30, 10080);
-            if (root.TryGetProperty("analysis_timeout_seconds", out v)) AnalysisTimeoutSeconds = (int)Math.Clamp(v.GetInt64(), 30, 600);
+            if (read.TryGetProperty("analysis_enabled", out v)) AnalysisEnabled = v.Bool(AnalysisEnabled);
+            if (read.TryGetProperty("query_store_backfill_enabled", out v)) QueryStoreBackfillEnabled = v.Bool(QueryStoreBackfillEnabled);
+            if (read.TryGetProperty("analysis_notifications_enabled", out v)) AnalysisNotificationsEnabled = v.Bool(AnalysisNotificationsEnabled);
+            if (read.TryGetProperty("analysis_interval_minutes", out v)) AnalysisIntervalMinutes = v.Int(AnalysisIntervalMinutes, 5, 360);
+            if (read.TryGetProperty("analysis_notify_severity", out v)) AnalysisNotifySeverity = v.Double(AnalysisNotifySeverity, 0.0, 2.0);
+            if (read.TryGetProperty("analysis_notify_cooldown_minutes", out v)) AnalysisNotifyCooldownMinutes = v.Int(AnalysisNotifyCooldownMinutes, 30, 10080);
+            if (read.TryGetProperty("analysis_timeout_seconds", out v)) AnalysisTimeoutSeconds = v.Int(AnalysisTimeoutSeconds, 30, 600);
+
+            /* #2444: reported AFTER every read, which is the point — the whole set, named, and every key that
+               was fine applied. Empty on a healthy file, so this costs nothing on the normal path. */
+            ReportBadSettingValues(read.Problems);
         }
         catch (Exception ex)
         {
             /* SettingsFileGuard already parsed this exact text, so nothing reaching here is a document-level
-               fault. It is one key holding a value of the wrong shape — a quoted number, a string where a
-               bool belongs — and every key AFTER it keeps its default too. Which key that was is not known
-               here; isolating each of the eighty-eight behind its own try would name it, and that is filed
-               separately rather than smuggled into this fix. Saying it happened is the part that was
-               missing. */
+               fault — and since #2444 nothing reaching here is a badly-shaped VALUE either, because those are
+               checked by kind and recorded rather than thrown. So this catch no longer has a known cause and
+               is kept only so that an unforeseen one cannot take startup down with it. Note what it costs
+               when it does fire: the reads are ordered, so anything after the throw is still lost, which is
+               the residue this fix removes for every case it can name. */
             AppLogger.Error("Settings",
-                "settings.json parsed, but a value in it could not be read, so that key and every alert " +
-                "setting after it are at their defaults for this session", ex);
+                "settings.json parsed, but reading its values failed unexpectedly, so some alert settings " +
+                "are at their defaults for this session", ex);
         }
     }
 

--- a/Lite/App.xaml.cs
+++ b/Lite/App.xaml.cs
@@ -739,9 +739,14 @@ public partial class App : Application
             }
         }
 
+        /* Says "every other key this loader read", not "every other setting in the file": both loaders call
+           this and LoadDefaultTimeRange runs first, so a claim about the whole file would be written before
+           the alert settings had been read at all. The dialog CAN make the whole-file claim, because it is
+           shown once, after both loaders have run. */
         AppLogger.Error("Settings",
-            $"settings.json parsed, but {problems.Count} of its values could not be read and are at their " +
-            "defaults for this session. Every OTHER setting in the file loaded normally.\n  " +
+            $"settings.json parsed, but {problems.Count} value(s) in it could not be read and are at their " +
+            "defaults for this session. Only the keys named here fell back -- every other key this loader " +
+            "read was applied.\n  " +
             string.Join("\n  ", problems));
     }
 

--- a/PerformanceMonitor.Common/Services/SettingsValueReader.cs
+++ b/PerformanceMonitor.Common/Services/SettingsValueReader.cs
@@ -206,11 +206,6 @@ public readonly struct SettingsValue
         Element.ValueKind == JsonValueKind.Array || Reject(false, "a list");
 
     /// <summary>
-    /// Records this key against its reader and hands back the caller's fallback, so every reader above is one
-    /// expression. The message names the kind that WAS there, in the same phrasing the MCP settings loader
-    /// already uses, because "it holds a JSON string" is what lets someone find the line in their file.
-    /// </summary>
-    /// <summary>
     /// Records a value that IS a number and still cannot be used, naming which of the two problems it has —
     /// "holds a JSON number where a whole number belongs" is a nonsense sentence about a number, and this one
     /// reaches a dialog. The token is truncated because a hand-edited file is where a thousand-digit number
@@ -234,6 +229,11 @@ public readonly struct SettingsValue
         return fallback;
     }
 
+    /// <summary>
+    /// Records this key against its reader and hands back the caller's fallback, so every reader above is one
+    /// expression. The message names the kind that WAS there, in the same phrasing the MCP settings loader
+    /// already uses, because "it holds a JSON string" is what lets someone find the line in their file.
+    /// </summary>
     private T Reject<T>(T fallback, string expected)
     {
         _reader?.Reject(

--- a/PerformanceMonitor.Common/Services/SettingsValueReader.cs
+++ b/PerformanceMonitor.Common/Services/SettingsValueReader.cs
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.Json;
+
+namespace PerformanceMonitor.Common;
+
+/// <summary>
+/// One key whose value was the wrong SHAPE, and what was wrong with it (#2444). Carried rather than thrown,
+/// because the whole point is that a bad key costs its own setting and nothing else.
+/// </summary>
+public readonly record struct SettingsValueProblem(string Key, string Problem)
+{
+    /// <summary>One line, ready to put in a log or a dialog.</summary>
+    public override string ToString() => $"{Key} — {Problem}";
+}
+
+/// <summary>
+/// Reads typed values out of an already-parsed settings.json object, recording the keys it could not read
+/// instead of throwing on the first one (#2444).
+///
+/// <para><b>The defect this replaces.</b> <c>App.LoadAlertSettings</c> wrapped all eighty-seven reads in one
+/// <c>try</c>. A single key of the wrong shape — a quoted number, a string where a bool belongs — threw on
+/// its own <c>Get*</c> call and abandoned every read AFTER it, so which settings survived depended on where
+/// the bad key happened to sit in the file. One wrong value near the top cost almost everything; the same
+/// value near the bottom cost almost nothing. Nothing about that was visible, and the ordering it turned on
+/// is an implementation detail of the loader.</para>
+///
+/// <para><b>Checked by kind, not caught.</b> The same call <c>McpSettings.Load</c> already makes, for the
+/// reason it gives: a <c>catch</c> around <c>GetBoolean</c> is what turned a quoted
+/// <c>"true"</c> into a silently disabled endpoint. Every read below asks <c>ValueKind</c> first, so a wrong
+/// shape is a recorded ANSWER rather than an exception, and the caller keeps the value it already had.
+/// <c>null</c> is treated as a wrong shape too, uniformly: Lite never writes one, so a null in this file is
+/// a hand-edit and is exactly the class of mistake this exists to name.</para>
+///
+/// <para><b>Why the method is called <c>TryGetProperty</c>.</b> That name is load-bearing, not a stylistic
+/// echo of <see cref="JsonElement"/>'s. <c>SettingsSampleTests</c> (#2418) extracts the documented key list
+/// by regexing <c>TryGetProperty("…"</c> literals out of <c>App.xaml.cs</c>, and requires every key it finds
+/// to be documented in <c>settings.sample.json</c> and vice versa. A helper spelled any other way makes all
+/// eighty-seven keys vanish from that extraction, and the sample is then free to drift exactly the way #2418
+/// was filed about — which is what PR #2428 hit, and why it had to read back through
+/// <see cref="JsonDocument"/>. So the call sites keep the literal in the shape the extractor already
+/// understands, the extractor needs no change, and <c>KeyExtraction_SeesBothReaderShapes…</c> pins that this
+/// shape really is seen rather than assuming it.</para>
+/// </summary>
+public sealed class SettingsReader
+{
+    private readonly JsonElement _root;
+    private readonly List<SettingsValueProblem> _problems = new();
+
+    /// <param name="root">The parsed settings.json object. <c>SettingsFileGuard.Read</c> has already decided
+    /// that it IS an object, so a document-level fault never reaches here — everything this type reports is a
+    /// single value's shape.</param>
+    public SettingsReader(JsonElement root) => _root = root;
+
+    /// <summary>Every key whose value could not be read, in the order they were met. Empty is the normal
+    /// case and means every key present in the file was applied.</summary>
+    public IReadOnlyList<SettingsValueProblem> Problems => _problems;
+
+    /// <summary>
+    /// The key's value, or false when the file does not carry that key at all. An absent key is NOT a
+    /// problem — it is how every default works and how a settings.json written by an older version behaves.
+    /// </summary>
+    public bool TryGetProperty(string key, out SettingsValue value)
+    {
+        if (_root.TryGetProperty(key, out var element))
+        {
+            value = new SettingsValue(this, key, element);
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    /// <summary>Records one key as unreadable. Idempotent per key so a value read twice cannot report twice.</summary>
+    internal void Reject(string key, string problem)
+    {
+        foreach (var existing in _problems)
+        {
+            if (string.Equals(existing.Key, key, StringComparison.Ordinal))
+            {
+                return;
+            }
+        }
+
+        _problems.Add(new SettingsValueProblem(key, problem));
+    }
+}
+
+/// <summary>
+/// One key's value, which knows its own NAME — that is the whole reason this is a type rather than a bare
+/// <see cref="JsonElement"/>. Every reader below takes the value to keep when the shape is wrong, so a call
+/// site reads as one line and cannot forget to handle the failure: there is no failure path to forget.
+///
+/// <para>The clamps live here rather than at the eighty-seven call sites that used to repeat
+/// <c>Math.Clamp(v.GetInt64(), …)</c> inline. That collapses the read AND makes one latent bug unreachable:
+/// the old <c>(int)Math.Max(0, v.GetInt64())</c> form casts an out-of-range Int64 into an <c>int</c>, which
+/// wraps — so a hand-typed 5000000000 became a negative threshold. <see cref="Int(int,int,int)"/> clamps
+/// before it narrows, so the worst a huge number can do is land on the bound.</para>
+/// </summary>
+public readonly struct SettingsValue
+{
+    private readonly SettingsReader? _reader;
+    private readonly string _key;
+
+    internal SettingsValue(SettingsReader reader, string key, JsonElement element)
+    {
+        _reader = reader;
+        _key = key;
+        Element = element;
+    }
+
+    /// <summary>The raw element, for the two array-valued settings that enumerate it themselves.</summary>
+    public JsonElement Element { get; }
+
+    /// <summary>The value as a bool, or <paramref name="fallback"/> when it is not <c>true</c>/<c>false</c>.</summary>
+    public bool Bool(bool fallback) =>
+        Element.ValueKind is JsonValueKind.True or JsonValueKind.False
+            ? Element.GetBoolean()
+            : Reject(fallback, "true or false");
+
+    /// <summary>The value as an int, unclamped — for the settings that have never had a range.</summary>
+    public int Int(int fallback) =>
+        Element.ValueKind == JsonValueKind.Number && Element.TryGetInt32(out var number)
+            ? number
+            : Reject(fallback, "a whole number");
+
+    /// <summary>
+    /// The value as an int, clamped into <paramref name="min"/>..<paramref name="max"/>. Read as Int64 first
+    /// on purpose: a number too large for an <c>int</c> is a value out of range, which the clamp is there to
+    /// handle, not a value of the wrong shape.
+    /// </summary>
+    public int Int(int fallback, int min, int max) =>
+        Element.ValueKind == JsonValueKind.Number && Element.TryGetInt64(out var number)
+            ? (int)Math.Clamp(number, min, max)
+            : Reject(fallback, "a whole number");
+
+    /// <summary>The value as a long, clamped into <paramref name="min"/>..<paramref name="max"/>.</summary>
+    public long Long(long fallback, long min, long max) =>
+        Element.ValueKind == JsonValueKind.Number && Element.TryGetInt64(out var number)
+            ? Math.Clamp(number, min, max)
+            : Reject(fallback, "a whole number");
+
+    /// <summary>The value as a double, clamped into <paramref name="min"/>..<paramref name="max"/>.</summary>
+    public double Double(double fallback, double min, double max) =>
+        Element.ValueKind == JsonValueKind.Number && Element.TryGetDouble(out var number)
+            ? Math.Clamp(number, min, max)
+            : Reject(fallback, "a number");
+
+    /// <summary>The value as a string, or <paramref name="fallback"/> when it is not one.</summary>
+    public string Text(string fallback) =>
+        Element.ValueKind == JsonValueKind.String
+            ? Element.GetString() ?? fallback
+            : Reject(fallback, "text");
+
+    /// <summary>
+    /// The value as a string, or null when it is not one — for the settings that validate the string
+    /// themselves (an enum token, a whitelist of separators). A value that is a string but not a RECOGNISED
+    /// one is not reported here: it is the caller's own vocabulary, it has always been ignored silently, and
+    /// widening that into a startup dialog is a different decision from this one.
+    /// </summary>
+    public string? TextOrNull() =>
+        Element.ValueKind == JsonValueKind.String ? Element.GetString() : Reject<string?>(null, "text");
+
+    /// <summary>Whether the value is an array, recording it when it is not.</summary>
+    public bool IsArray() =>
+        Element.ValueKind == JsonValueKind.Array || Reject(false, "a list");
+
+    /// <summary>
+    /// Records this key against its reader and hands back the caller's fallback, so every reader above is one
+    /// expression. The message names the kind that WAS there, in the same phrasing the MCP settings loader
+    /// already uses, because "it holds a JSON string" is what lets someone find the line in their file.
+    /// </summary>
+    private T Reject<T>(T fallback, string expected)
+    {
+        _reader?.Reject(
+            _key,
+            string.Format(
+                CultureInfo.InvariantCulture,
+                "holds a JSON {0} where {1} belongs",
+                Element.ValueKind.ToString().ToLowerInvariant(),
+                expected));
+
+        return fallback;
+    }
+}

--- a/PerformanceMonitor.Common/Services/SettingsValueReader.cs
+++ b/PerformanceMonitor.Common/Services/SettingsValueReader.cs
@@ -128,11 +128,16 @@ public readonly struct SettingsValue
             ? Element.GetBoolean()
             : Reject(fallback, "true or false");
 
-    /// <summary>The value as an int, unclamped — for the settings that have never had a range.</summary>
+    /// <summary>
+    /// The value as an int, unclamped — for the settings that have never had a range. With no range there is
+    /// nothing to put an unusable number INTO, so one is reported; it is reported as out of range rather than
+    /// as the wrong shape, because "holds a JSON number where a whole number belongs" is a nonsense sentence
+    /// about a number.
+    /// </summary>
     public int Int(int fallback) =>
-        Element.ValueKind == JsonValueKind.Number && Element.TryGetInt32(out var number)
-            ? number
-            : Reject(fallback, "a whole number");
+        Element.ValueKind != JsonValueKind.Number ? Reject(fallback, "a whole number")
+        : Element.TryGetInt32(out var number) ? number
+        : RejectAsOutOfRange(fallback);
 
     /// <summary>
     /// The value as an int, clamped into <paramref name="min"/>..<paramref name="max"/>. Read as Int64 first
@@ -140,21 +145,31 @@ public readonly struct SettingsValue
     /// handle, not a value of the wrong shape.
     /// </summary>
     public int Int(int fallback, int min, int max) =>
-        Element.ValueKind == JsonValueKind.Number && Element.TryGetInt64(out var number)
-            ? (int)Math.Clamp(number, min, max)
-            : Reject(fallback, "a whole number");
+        Element.ValueKind != JsonValueKind.Number ? Reject(fallback, "a whole number")
+        : Element.TryGetInt64(out var number) ? (int)Math.Clamp(number, min, max)
+        : IsNegative() ? min : max;
 
     /// <summary>The value as a long, clamped into <paramref name="min"/>..<paramref name="max"/>.</summary>
     public long Long(long fallback, long min, long max) =>
-        Element.ValueKind == JsonValueKind.Number && Element.TryGetInt64(out var number)
-            ? Math.Clamp(number, min, max)
-            : Reject(fallback, "a whole number");
+        Element.ValueKind != JsonValueKind.Number ? Reject(fallback, "a whole number")
+        : Element.TryGetInt64(out var number) ? Math.Clamp(number, min, max)
+        : IsNegative() ? min : max;
 
     /// <summary>The value as a double, clamped into <paramref name="min"/>..<paramref name="max"/>.</summary>
     public double Double(double fallback, double min, double max) =>
-        Element.ValueKind == JsonValueKind.Number && Element.TryGetDouble(out var number)
-            ? Math.Clamp(number, min, max)
-            : Reject(fallback, "a number");
+        Element.ValueKind != JsonValueKind.Number ? Reject(fallback, "a number")
+        : Element.TryGetDouble(out var number) ? Math.Clamp(number, min, max)
+        : IsNegative() ? min : max;
+
+    /// <summary>
+    /// Which BOUND a number that will not fit in an <see cref="long"/> clamps to (review finding on #2444).
+    /// A value beyond Int64 in either direction cannot be inside any range a caller can express, so the only
+    /// question is which end, and the sign answers it — which keeps the clamped readers' promise absolute
+    /// rather than "up to Int64", and stops a plainly-whole number being reported as not a whole number.
+    /// <para>Read off the raw token rather than through a <see cref="double"/>: <c>long.MaxValue</c> does not
+    /// survive that round trip, so a bound near it would come back wrong in the one case this exists for.</para>
+    /// </summary>
+    private bool IsNegative() => Element.GetRawText().TrimStart().StartsWith('-');
 
     /// <summary>The value as a string, or <paramref name="fallback"/> when it is not one.</summary>
     public string Text(string fallback) =>
@@ -180,6 +195,21 @@ public readonly struct SettingsValue
     /// expression. The message names the kind that WAS there, in the same phrasing the MCP settings loader
     /// already uses, because "it holds a JSON string" is what lets someone find the line in their file.
     /// </summary>
+    private T RejectAsOutOfRange<T>(T fallback)
+    {
+        /* The token, truncated: a hand-edited file is where a thousand-digit number comes from, and this
+           string goes into a dialog. */
+        var token = Element.GetRawText();
+        _reader?.Reject(
+            _key,
+            string.Format(
+                CultureInfo.InvariantCulture,
+                "holds {0}, which is out of range for this setting",
+                token.Length > 40 ? token[..40] + "…" : token));
+
+        return fallback;
+    }
+
     private T Reject<T>(T fallback, string expected)
     {
         _reader?.Reject(

--- a/PerformanceMonitor.Common/Services/SettingsValueReader.cs
+++ b/PerformanceMonitor.Common/Services/SettingsValueReader.cs
@@ -129,47 +129,62 @@ public readonly struct SettingsValue
             : Reject(fallback, "true or false");
 
     /// <summary>
-    /// The value as an int, unclamped — for the settings that have never had a range. With no range there is
-    /// nothing to put an unusable number INTO, so one is reported; it is reported as out of range rather than
-    /// as the wrong shape, because "holds a JSON number where a whole number belongs" is a nonsense sentence
-    /// about a number.
+    /// The value as an int, unclamped — for the settings that have never had a range.
+    ///
+    /// <para><b>Where this differs from the clamped reader, and why.</b> A clamped read has somewhere to put
+    /// a number that will not fit — the bound the caller declared — so it puts it there. This one has
+    /// nowhere, so it must not invent a range: <c>90.7</c> for a setting with no declared bounds becomes
+    /// nothing, and is reported. A number that IS exact is still taken however it was written, so
+    /// <c>30.0</c> reads as 30 the same way it does everywhere else in this type.</para>
     /// </summary>
     public int Int(int fallback) =>
         Element.ValueKind != JsonValueKind.Number ? Reject(fallback, "a whole number")
         : Element.TryGetInt32(out var number) ? number
-        : RejectAsOutOfRange(fallback);
+        : Wide(out var wide) && wide == Math.Floor(wide) && wide >= int.MinValue && wide <= int.MaxValue
+            ? (int)wide
+            : RejectAsUnusableNumber(fallback);
 
     /// <summary>
-    /// The value as an int, clamped into <paramref name="min"/>..<paramref name="max"/>. Read as Int64 first
-    /// on purpose: a number too large for an <c>int</c> is a value out of range, which the clamp is there to
-    /// handle, not a value of the wrong shape.
+    /// The value as an int, clamped into <paramref name="min"/>..<paramref name="max"/>.
+    ///
+    /// <para>Every JSON number reaches a bound, which is the promise and it is deliberately absolute (two
+    /// review findings on #2444, in the same place). <c>TryGetInt64</c> answers most of them; it returns
+    /// false for a number beyond Int64 AND for one that is not a pure integer token, so <c>30.0</c> and
+    /// <c>5.5</c> fail it exactly as <c>99999999999999999999</c> does. Reading the remainder as a double
+    /// handles all three: the vast ones land on a bound, and the fractional ones truncate into range.</para>
+    ///
+    /// <para>Truncating is the same species of silent adjustment the clamp already is, and it is confined to
+    /// the readers whose caller declared a range for exactly that purpose. The first cut of the Int64 fix
+    /// chose the bound by SIGN instead, which was right for the vast case and silently turned
+    /// <c>analysis_timeout_seconds: 30.0</c> into 600 — a value the user never asked for, never saw flagged,
+    /// and could not have found, which is the failure #2444 exists to end rather than to relocate.</para>
     /// </summary>
     public int Int(int fallback, int min, int max) =>
         Element.ValueKind != JsonValueKind.Number ? Reject(fallback, "a whole number")
         : Element.TryGetInt64(out var number) ? (int)Math.Clamp(number, min, max)
-        : IsNegative() ? min : max;
+        : Wide(out var wide) ? (wide >= max ? max : wide <= min ? min : (int)wide)
+        : RejectAsUnusableNumber(fallback);
 
-    /// <summary>The value as a long, clamped into <paramref name="min"/>..<paramref name="max"/>.</summary>
+    /// <summary>The value as a long, clamped into <paramref name="min"/>..<paramref name="max"/>. Same three
+    /// cases as <see cref="Int(int,int,int)"/>, compared rather than clamped because a bound near
+    /// <c>long.MaxValue</c> does not survive a round trip through a <see cref="double"/>.</summary>
     public long Long(long fallback, long min, long max) =>
         Element.ValueKind != JsonValueKind.Number ? Reject(fallback, "a whole number")
         : Element.TryGetInt64(out var number) ? Math.Clamp(number, min, max)
-        : IsNegative() ? min : max;
+        : Wide(out var wide) ? (wide >= max ? max : wide <= min ? min : (long)wide)
+        : RejectAsUnusableNumber(fallback);
 
     /// <summary>The value as a double, clamped into <paramref name="min"/>..<paramref name="max"/>.</summary>
     public double Double(double fallback, double min, double max) =>
         Element.ValueKind != JsonValueKind.Number ? Reject(fallback, "a number")
-        : Element.TryGetDouble(out var number) ? Math.Clamp(number, min, max)
-        : IsNegative() ? min : max;
+        : Wide(out var number) ? Math.Clamp(number, min, max)
+        : RejectAsUnusableNumber(fallback);
 
-    /// <summary>
-    /// Which BOUND a number that will not fit in an <see cref="long"/> clamps to (review finding on #2444).
-    /// A value beyond Int64 in either direction cannot be inside any range a caller can express, so the only
-    /// question is which end, and the sign answers it — which keeps the clamped readers' promise absolute
-    /// rather than "up to Int64", and stops a plainly-whole number being reported as not a whole number.
-    /// <para>Read off the raw token rather than through a <see cref="double"/>: <c>long.MaxValue</c> does not
-    /// survive that round trip, so a bound near it would come back wrong in the one case this exists for.</para>
-    /// </summary>
-    private bool IsNegative() => Element.GetRawText().TrimStart().StartsWith('-');
+    /// <summary>The number as a finite double, false when it will not be one. Infinity is excluded because a
+    /// clamp against it is a comparison that means nothing, and NaN cannot come out of a JSON number at
+    /// all — this is the guard, not a claim that either is reachable.</summary>
+    private bool Wide(out double value) =>
+        Element.TryGetDouble(out value) && double.IsFinite(value);
 
     /// <summary>The value as a string, or <paramref name="fallback"/> when it is not one.</summary>
     public string Text(string fallback) =>
@@ -195,17 +210,26 @@ public readonly struct SettingsValue
     /// expression. The message names the kind that WAS there, in the same phrasing the MCP settings loader
     /// already uses, because "it holds a JSON string" is what lets someone find the line in their file.
     /// </summary>
-    private T RejectAsOutOfRange<T>(T fallback)
+    /// <summary>
+    /// Records a value that IS a number and still cannot be used, naming which of the two problems it has —
+    /// "holds a JSON number where a whole number belongs" is a nonsense sentence about a number, and this one
+    /// reaches a dialog. The token is truncated because a hand-edited file is where a thousand-digit number
+    /// comes from.
+    /// </summary>
+    private T RejectAsUnusableNumber<T>(T fallback)
     {
-        /* The token, truncated: a hand-edited file is where a thousand-digit number comes from, and this
-           string goes into a dialog. */
         var token = Element.GetRawText();
+        var reason = Wide(out var wide) && wide != Math.Floor(wide)
+            ? "which is not a whole number"
+            : "which is out of range for this setting";
+
         _reader?.Reject(
             _key,
             string.Format(
                 CultureInfo.InvariantCulture,
-                "holds {0}, which is out of range for this setting",
-                token.Length > 40 ? token[..40] + "…" : token));
+                "holds {0}, {1}",
+                token.Length > 40 ? token[..40] + "…" : token,
+                reason));
 
         return fallback;
     }


### PR DESCRIPTION
Closes #2444.

## The defect

`App.LoadAlertSettings` wrapped all eighty-seven reads in one `try`. #2425 took the parse out of it; the value half was untouched. A key holding a string where an int belongs threw on its own `Get*` call and abandoned every read after it, so which settings survived depended on where the bad key sat in the file — and that ordering is an implementation detail of the method's line order.

Measured against dev's own source rather than described: `alert_cpu_threshold` is read with `v.GetInt32()` **12,389 characters before** `analysis_timeout_seconds`, inside a single **13,902-character** `try` with no inner `try`. `GetInt32()` on a JSON string throws. So `{"alert_cpu_threshold": "ninety"}` costs `analysis_timeout_seconds` and every other key below it.

## The two judgement calls the issue named

**A read helper that carries the key name — yes.** Eighty-seven `try` blocks would work and would be unreadable. `SettingsReader` checks `ValueKind` before it calls a getter and *records* the key it could not read. That is the call `McpSettings.Load` already makes, for the reason it gives on the line: a `catch` around `GetBoolean` is what turned a quoted `"true"` into a silently disabled endpoint, and a hand-edited file is exactly where a quoted boolean comes from.

**Report the whole set — yes, and it is the same fix.** Someone who edited one line has one mistake; someone who pasted a block out of `settings.sample.json` has several, and stopping at the first means they fix, restart, and discover the next one, several times over. The old code could not have done this even in principle — it threw on the first bad value and never reached the rest — so "which key" and "all of them" are not two decisions.

## The extractor trap

**The key literals stay in the shape the extractor already expects, and the extractor is unchanged.** `SettingsReader`'s method is called `TryGetProperty`, so a call site still reads `read.TryGetProperty("alert_cpu_threshold", out v)` and `SettingsSampleTests`'s regex matches it exactly as before. The name is load-bearing, not a stylistic echo, and it is documented as such at the definition, at the call site, and in the guard.

Keeping the shape was the lower-risk half of the choice the issue offered — but it creates a new dependency held together by nothing the compiler checks, so the guard gets the self-test the issue asked for anyway:

- **Both call shapes are seen** — the pre-#2444 `root.TryGetProperty(…)` and the new `read.TryGetProperty(…)` — over a source the test writes.
- **It still catches an undocumented key.** The synthetic sample is missing one key on purpose and the *real* `UndocumentedKeys` comparison names it. A guard that extracts keys but no longer compares them is the same vacuous green as one that extracts nothing, and the only thing standing between that and a green build was a floor of `>= 50`.
- **The trap itself is measured.** The shape #2428 tried — a read helper taking the key as an ordinary argument — is run through the same extraction and yields **nothing**. That is what makes the name load-bearing rather than a claim that it is.
- **The name is asserted directly**, so a rename fails there, with the reason, instead of as an unexplained collapse of the key count elsewhere.
- **The scoping contract** gets its own case: each read belongs to the most recent `*.json` literal above it, which is how `servers.json` and `collection_schedule.json`'s loaders stay out of this set without an exemption — and how a loader moved above the `settings.json` literal would silently leave it.

To do any of that, the extraction and the comparison are split out to run over text. Both are the shipped ones the real tests call, not copies.

The literal is also kept out of the new comments. `LoadDefaultTimeRange` already warns that the extractor cannot tell a comment from code and would read an example as a real key; the first draft of this change put `TryGetProperty("` in two prose lines and would have injected two junk keys into the extracted set.

## Two things that fall out

**A latent overflow, now unreachable.** Two of the inline clamp forms were `(int)Math.Max(0, v.GetInt64())` — floor, then *narrow*. A hand-typed value beyond int range wrapped, so a bigger threshold became a negative one. `Int(fallback, min, max)` clamps before it narrows.

**A second throw site the single `try` hid.** `alert_excluded_databases` called `elem.GetString()` on every element; a number in that array threw, and cost every setting after it. It now filters by element kind, which the fleet-group list beside it already did.

## The message becomes visible, and specific

The value fault logged and stopped there, so a user whose thresholds had silently reverted had no signal unless they went looking. #2425 had already decided, for the document half, that someone looking at an app which has forgotten its configuration should not have to find a log to learn why; the same argument applies to a setting that reverted. What is new is that the message can name the keys *and* say everything else loaded — which is what makes it worth a dialog rather than noise, and is the difference from the message that used to send someone to proofread an eighty-seven-key file.

It reuses the one startup modal #2425 added rather than opening a second. The two cannot both happen on one run: a document that will not parse never reaches a value read.

The `catch` stays with no known cause left in it, so an unforeseen throw cannot take startup down — and its comment now says what it still costs when it fires, because the reads are ordered and anything after a throw is still lost.

## Where the reader lives, and the load/save mental model

`PerformanceMonitor.Common`, beside `SettingsFileGuard`, not in Lite. #2441 rewrote `SaveAlertSettings` so all ten writers mutate one document opened once through `App.SettingsRootForWrite()` and written once; the load side now has the matching shape — one document opened once through `SettingsFileGuard.Read`, one reader over it, one report at the end. Both sides treat a per-key failure as a value to carry rather than an exception to throw, and neither can now lose the rest of the file to one key.

It is in Common rather than Lite because that is the seam the Viewer's dialog needs for the gap #2444 names one level up: it round-trips a whole object, so its deserialize fails before any property exists and it cannot say which settings were lost either. **Deferred, not folded in** — the Viewer's loader is a different mechanism (whole-object deserialize, not per-property reads) and converting it is its own change with its own tests.

## Verification

`Lite.Tests` targets `net10.0-windows` and cannot run on macOS, so everything runnable was compiled into a `net10.0` xUnit-shim harness against the real `PerformanceMonitor.Common` build, with the real `App.xaml.cs` and `settings.sample.json` as fixtures.

- **13 passed / 0 failed** on this branch.
- That includes **all four pre-existing `SettingsSampleTests`**, which is the result that matters most here — they are the guard this refactor was most likely to break, and they are green with two-way symmetry over all **89** documented keys and both exemption sets still empty.
- Against dev the same file runs **6 passed / 0 failed** with the one test that needs the new type removed. The extraction self-tests are guards, not regression tests, and pass on both sides by design — that is what they are for.
- Everything in `SettingsValueReadTests` that exercises `SettingsReader` **cannot compile against dev**, which is the stronger statement.

The two loader-level cases need WPF and can only run on CI, so their premise was measured rather than assumed — the character offsets and the single `try` above, plus `GetInt32()`'s throw, both taken from the shipped dev source and the shipped BCL in the harness. Those are exactly the two facts those cases assert the absence of. Stating the scope precisely: **the reader and the guard ran here; the two end-to-end loader cases did not, and CI is the arbiter for them.**

No CHANGELOG entry, matching #2425, #2428, #2432 and #2442: `[3.5.0]` is a shipped, dated section and there is no `[Unreleased]` on dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
