### PR TITLE
Hand Lite's analysis token to the store reads it is meant to abandon (#2443)

### DIFF
--- a/Darling/Darling.Tests/AnalysisPassTokenThreadingTests.cs
+++ b/Darling/Darling.Tests/AnalysisPassTokenThreadingTests.cs
@@ -1,0 +1,349 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+using PerformanceMonitor.Analysis;
+using PerformanceMonitor.Darling.Analysis;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// The analysis pass's token has to reach the reads, not just the gaps between them (#2443).
+///
+/// <para>#2438 armed a per-pass budget and #2430's classifier told a timeout from a stop, so an
+/// overrunning server became loudly stuck instead of silently skipped forever. What neither did was
+/// hand the token to the store layer: 168 of this project's async store calls took the no-argument
+/// overload, so abandonment happened BETWEEN stages. A pass gave up while its wedged query kept a
+/// connection and a session alive until the query finished on its own — on a healthy fleet
+/// invisible, and on the pathological case these fixes exist for, the monitoring tool holding a
+/// session it had already stopped waiting for.</para>
+///
+/// <para>The threading itself is mechanical; this file is the part that lasts. A sweep this size
+/// only stays swept if something counts it, and the failure mode it guards against is specific:
+/// adding <c>CancellationToken cancellationToken = default</c> to signatures and stopping there,
+/// which leaves every call site passing <see cref="CancellationToken.None"/> while LOOKING threaded.
+/// So the pin is on the CALL, not the signature — a no-argument <c>ExecuteReaderAsync()</c> is what
+/// goes red, and no default can hide it.</para>
+/// </summary>
+public sealed class AnalysisPassTokenThreadingTests
+{
+    /// <summary>
+    /// The no-argument overloads. Each has a token-taking sibling, so the empty parentheses are the
+    /// whole tell — there is no shape of correct code in this project that needs them.
+    /// </summary>
+    private static readonly Regex s_untokenedStoreCall = new(
+        @"\.(?:ExecuteReaderAsync|ExecuteNonQueryAsync|ExecuteScalarAsync|ReadAsync|OpenAsync|OpenConnectionAsync)\(\s*\)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// A member declaration, used only to attribute a call to the method that makes it. Deliberately
+    /// crude — it needs to name the enclosing method, not parse C#. The <c>[^=;()]*</c> is what keeps
+    /// field initializers and expression-bodied properties out.
+    /// </summary>
+    private static readonly Regex s_memberDeclaration = new(
+        @"^\s*(?:public|private|internal|protected)[^=;()]*\s(?<name>[A-Za-z_][A-Za-z0-9_]*)\s*\(",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private const string ExemptionMarker = "#2443 exempt";
+
+    /// <summary>
+    /// Every method allowed to make an untokened store call, and the reason it is allowed to. This is
+    /// an enumeration and not a wildcard on purpose: the exemption list this repo spent a day removing
+    /// was a wildcard, and the way that one grew was that nobody had to name a new entry.
+    ///
+    /// <para>Two kinds live here and they are not the same kind. The read-back surfaces are OFF the
+    /// pass — the viewer, the MCP and the retention sweep have no per-pass budget and no wedged
+    /// analysis to abandon, so there is no token to thread and inventing one would be pretending.
+    /// <c>InsertFindingAsync</c> is the other kind: it is ON the pass and the token is deliberately
+    /// withheld, because a finding set cut in half is a third outcome that reads like neither of the
+    /// two the classifier names (see the method's own note, and
+    /// <see cref="TheFindingInsertIsAbandonedBeforeItStartsOrNotAtAll"/>).</para>
+    /// </summary>
+    private static readonly Dictionary<string, string> s_exempt = new(StringComparer.Ordinal)
+    {
+        ["GetRecentFindingsAsync"] = "read-back: the MCP + viewer findings read, no pass to abandon",
+        ["GetLatestFindingsAsync"] = "read-back: the viewer's Recommendations tab, no pass to abandon",
+        ["GetMutedStoriesAsync"] = "read-back: the viewer's mute registry read, no pass to abandon",
+        ["MuteStoryAsync"] = "off-pass write: the MCP/viewer mute verb, no pass to abandon",
+        ["UnmuteStoryAsync"] = "off-pass write: the viewer's unmute verb, no pass to abandon",
+        ["CleanupOldFindingsAsync"] = "off-pass write: the worker's retention sweep, its own lifetime",
+        ["InsertFindingAsync"] = "on-pass write, token withheld: a half-written finding set must not exist"
+    };
+
+    /// <summary>
+    /// The sweep, and the thing that keeps it swept. Every store call in the analysis project must
+    /// take the pass's token, and the ones that do not must be exempt BY NAME with a marker in their
+    /// own doc comment — so the reason travels with the code rather than living only here.
+    ///
+    /// <para>Scanned over the whole project directory rather than a file list, because a file list is
+    /// a thing a new partial can be added outside of. A seventh <c>PgFactCollector</c> partial is
+    /// covered the day it exists.</para>
+    /// </summary>
+    [Fact]
+    public void NoStoreCallOnTheAnalysisPassRunsWithoutThePassToken()
+    {
+        var offenders = new List<string>();
+
+        foreach (var (file, lines) in AnalysisSources())
+        {
+            var enclosing = string.Empty;
+
+            for (var i = 0; i < lines.Length; i++)
+            {
+                var declaration = s_memberDeclaration.Match(lines[i]);
+                if (declaration.Success)
+                {
+                    enclosing = declaration.Groups["name"].Value;
+                }
+
+                if (!s_untokenedStoreCall.IsMatch(lines[i]))
+                {
+                    continue;
+                }
+
+                if (s_exempt.ContainsKey(enclosing) && DocBlockAbove(lines, IndexOfDeclaration(lines, i)).Contains(ExemptionMarker, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                offenders.Add($"{file}:{i + 1} in {enclosing}(): {lines[i].Trim()}");
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            "These store calls run without the pass's cancellation token, so the pass can be abandoned "
+            + "around them but never inside one. Pass context.CancellationToken (or the method's own token "
+            + $"parameter). If the call genuinely must complete, add its method to {nameof(s_exempt)} and put a "
+            + $"'{ExemptionMarker}' note in its doc comment saying why:\n"
+            + string.Join("\n", offenders));
+    }
+
+    /// <summary>
+    /// The other half of the agreement: an exemption that no longer corresponds to an untokened call is
+    /// a claim the code stopped making, and it must not be allowed to sit there authorizing the next
+    /// one. Every entry must still be earning its place, and every marker in the source must belong to
+    /// an entry.
+    /// </summary>
+    [Fact]
+    public void EveryExemptionIsStillEarningItsPlace()
+    {
+        var untokenedBy = new Dictionary<string, int>(StringComparer.Ordinal);
+        var markedMethods = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var (_, lines) in AnalysisSources())
+        {
+            var enclosing = string.Empty;
+            var enclosingAt = -1;
+
+            for (var i = 0; i < lines.Length; i++)
+            {
+                var declaration = s_memberDeclaration.Match(lines[i]);
+                if (declaration.Success)
+                {
+                    enclosing = declaration.Groups["name"].Value;
+                    enclosingAt = i;
+                    if (DocBlockAbove(lines, enclosingAt).Contains(ExemptionMarker, StringComparison.Ordinal))
+                    {
+                        markedMethods.Add(enclosing);
+                    }
+                }
+
+                if (s_untokenedStoreCall.IsMatch(lines[i]) && enclosingAt >= 0)
+                {
+                    untokenedBy[enclosing] = untokenedBy.TryGetValue(enclosing, out var n) ? n + 1 : 1;
+                }
+            }
+        }
+
+        Assert.Equal(s_exempt.Keys.OrderBy(k => k, StringComparer.Ordinal), markedMethods.OrderBy(k => k, StringComparer.Ordinal));
+        Assert.Equal(s_exempt.Keys.OrderBy(k => k, StringComparer.Ordinal), untokenedBy.Keys.OrderBy(k => k, StringComparer.Ordinal));
+
+        /* The counts are stated so a NEW untokened call inside an already-exempt method cannot ride in
+           on the exemption. 15 read-back calls across six methods, and the one finding INSERT. */
+        Assert.Equal(16, untokenedBy.Values.Sum());
+        Assert.Equal(1, untokenedBy["InsertFindingAsync"]);
+    }
+
+    /// <summary>
+    /// The fact collector is where the token would have been silently useless. Its per-query catches were
+    /// bare <c>catch { }</c> — deliberately, so a missing table degrades to "no facts" — which meant an
+    /// armed token produced thirty-three swallowed cancellations and a pass that carried on collecting
+    /// under a token that had already fired. Every catch there now lets an abandonment through, which is
+    /// what turns the threaded token into an exit rather than thirty-three wasted connection opens.
+    /// </summary>
+    [Fact]
+    public void EveryCatchOnTheFactCollectorLetsAnAbandonmentThrough()
+    {
+        var bare = new List<string>();
+        var opensCatch = new Regex(@"^\s*catch\b", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        var classified = new Regex(
+            @"^\s*catch\s*\(\s*Exception\s+ex\s*\)\s*when\s*\(\s*!AnalysisShutdown\.IsExpectedAbandon\(",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        foreach (var (file, lines) in AnalysisSources())
+        {
+            if (!Path.GetFileName(file).StartsWith("PgFactCollector.", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            for (var i = 0; i < lines.Length; i++)
+            {
+                if (opensCatch.IsMatch(lines[i]) && !classified.IsMatch(lines[i]))
+                {
+                    bare.Add($"{file}:{i + 1}: {lines[i].Trim()}");
+                }
+            }
+        }
+
+        Assert.True(bare.Count == 0,
+            "A fact-collector catch that does not classify swallows the abandonment the token was armed for, "
+            + "and the pass keeps collecting under a fired token:\n" + string.Join("\n", bare));
+
+        /* 27 collect methods guard their read this way; the number is stated so deleting one is a decision.
+           The other four collect methods have no catch at all and never had one — their reads propagate
+           straight to the pass, which is the same outcome by a shorter route. */
+        Assert.Equal(27, AnalysisSources()
+            .Where(s => Path.GetFileName(s.File).StartsWith("PgFactCollector.", StringComparison.Ordinal))
+            .SelectMany(s => s.Lines)
+            .Count(line => classified.IsMatch(line)));
+    }
+
+    /// <summary>
+    /// The behavioural half, and the reason a source pin alone is not enough here. Reverted, this test
+    /// fails with an <c>NpgsqlException</c> rather than an <see cref="OperationCanceledException"/>, which
+    /// is the whole defect in one line: handed a token that had ALREADY fired,
+    /// <see cref="PgFactCollector.CollectFactsAsync"/> still dialled the store. The collectors that carry
+    /// a catch then swallowed the failure and the pass carried on to the next one, so a cancelled pass
+    /// spent thirty-three connection opens finding out what the token had said before the first.
+    ///
+    /// <para>No store is needed to run this, precisely because the token is already cancelled — a pass
+    /// that observes it never reaches the network.</para>
+    /// </summary>
+    [Fact]
+    public async Task AFiredTokenStopsFactCollectionAtTheFirstReadInsteadOfRunningEveryCollector()
+    {
+        await using var dataSource = NpgsqlDataSource.Create(
+            "Host=127.0.0.1;Port=1;Username=nobody;Password=nobody;Database=nowhere;Timeout=1;Command Timeout=1");
+
+        var collector = new PgFactCollector(dataSource);
+        var context = new AnalysisContext
+        {
+            ServerId = 1,
+            ServerName = "wedged",
+            TimeRangeStart = DateTime.UtcNow.AddHours(-4),
+            TimeRangeEnd = DateTime.UtcNow,
+            CancellationToken = new CancellationToken(canceled: true)
+        };
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => collector.CollectFactsAsync(context));
+    }
+
+    /// <summary>
+    /// The decision this issue asked to be made explicitly rather than assumed: what a cancelled PERSIST
+    /// means. The insert batch has no transaction (per-row failure isolation is deliberate — one bad row
+    /// logs and the batch continues), every row shares one <c>analysis_time</c>, and the latest-findings
+    /// read keys on <c>MAX(analysis_time)</c>. So a batch cut in half does not read as truncated; it reads
+    /// as a complete analysis that found fewer problems, and the server looks HEALTHIER for having been
+    /// abandoned. That is a third outcome, distinct from the timeout and the shutdown the classifier names,
+    /// and it must not exist. The connection open is therefore the last abandonment point: before the first
+    /// row, or not at all.
+    /// </summary>
+    [Fact]
+    public void TheFindingInsertIsAbandonedBeforeItStartsOrNotAtAll()
+    {
+        var store = ReadSource(Path.Combine(AnalysisDirectory(), "PgFindingStore.cs"));
+
+        /* The abandonment point: the batch's connection open observes the pass token. */
+        Assert.Contains(
+            "await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);",
+            store, StringComparison.Ordinal);
+
+        /* And nothing after it does. A ThrowIfCancellationRequested between rows would MAKE the partial
+           set rather than prevent it, which is why there is none. */
+        var insertBatch = Between(store, "public async Task<List<AnalysisFinding>> InsertFindingsAsync(", "public async Task<List<AnalysisFinding>> SaveFindingsAsync(");
+        Assert.DoesNotContain("ThrowIfCancellationRequested", insertBatch, StringComparison.Ordinal);
+
+        /* The row write states the decision where someone changing it will read it. */
+        Assert.Contains(ExemptionMarker, Between(store, "/// Inserts one finding on an already-open connection", "private async Task InsertFindingAsync("), StringComparison.Ordinal);
+    }
+
+    private static string Between(string source, string start, string end)
+    {
+        var from = source.IndexOf(start, StringComparison.Ordinal);
+        Assert.True(from >= 0, $"anchor not found: {start}");
+        var to = source.IndexOf(end, from, StringComparison.Ordinal);
+        Assert.True(to > from, $"anchor not found after {start}: {end}");
+        return source[from..to];
+    }
+
+    /// <summary>The declaration line a call at <paramref name="callLine"/> belongs to (scanning up).</summary>
+    private static int IndexOfDeclaration(string[] lines, int callLine)
+    {
+        for (var i = callLine; i >= 0; i--)
+        {
+            if (s_memberDeclaration.IsMatch(lines[i]))
+            {
+                return i;
+            }
+        }
+
+        return 0;
+    }
+
+    /// <summary>The contiguous <c>///</c> block immediately above a declaration, as one string.</summary>
+    private static string DocBlockAbove(string[] lines, int declarationLine)
+    {
+        var doc = new List<string>();
+        for (var i = declarationLine - 1; i >= 0 && lines[i].TrimStart().StartsWith("///", StringComparison.Ordinal); i--)
+        {
+            doc.Add(lines[i]);
+        }
+
+        return string.Join("\n", doc);
+    }
+
+    private static IEnumerable<(string File, string[] Lines)> AnalysisSources()
+    {
+        var files = Directory.GetFiles(AnalysisDirectory(), "*.cs", SearchOption.TopDirectoryOnly);
+        Assert.NotEmpty(files);
+
+        foreach (var file in files.OrderBy(f => f, StringComparer.Ordinal))
+        {
+            /* The working copy is CRLF; split on the LF so a line never carries a stray CR. */
+            yield return (Path.GetFileName(file), ReadSource(file).Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n'));
+        }
+    }
+
+    private static string AnalysisDirectory() =>
+        Path.Combine(RepoRoot(), "Darling", "PerformanceMonitor.Darling.Analysis");
+
+    private static string RepoRoot([CallerFilePath] string thisFile = "")
+    {
+        var dir = Path.GetDirectoryName(thisFile)!;
+        while (dir is not null && !File.Exists(Path.Combine(dir, "PerformanceMonitor.sln")) && !Directory.Exists(Path.Combine(dir, ".git")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        Assert.NotNull(dir);
+        return dir!;
+    }
+
+    private static string ReadSource(string path) => File.ReadAllText(path);
+}

--- a/Darling/Darling.Tests/DarlingAnalysisStoreTests.cs
+++ b/Darling/Darling.Tests/DarlingAnalysisStoreTests.cs
@@ -222,12 +222,12 @@ public sealed class DarlingAnalysisStoreTests
            to null without touching any server (Lite's ServerManager-miss semantics). */
         var resolved = false;
         var fetcher = new PgPlanFetcher(_ => { resolved = true; return null; });
-        Assert.Null(await fetcher.FetchPlanXmlAsync(TestServerId, "0x0600FF00"));
+        Assert.Null(await fetcher.FetchPlanXmlAsync(TestServerId, "0x0600FF00", TestContext.Current.CancellationToken));
         Assert.True(resolved);
 
         /* An empty plan handle short-circuits before the resolver is consulted. */
         resolved = false;
-        Assert.Null(await fetcher.FetchPlanXmlAsync(TestServerId, ""));
+        Assert.Null(await fetcher.FetchPlanXmlAsync(TestServerId, "", TestContext.Current.CancellationToken));
         Assert.False(resolved);
     }
 

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgBlockingPairRowQuery.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgBlockingPairRowQuery.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data.Common;
+using System.Threading;
 using System.Threading.Tasks;
 using Npgsql;
 using PerformanceMonitor.Analysis;
@@ -125,8 +126,15 @@ LIMIT 5000";
     /// fragments as the blocked-process-report queries, against v_dmv_blocking_snapshots, so <see cref="Read"/>
     /// maps it unchanged. Takes a command factory so the caller's connection runs it — the Lite shape, kept so
     /// the future drill-down/viewer slices call it identically.
+    ///
+    /// <para>#2443: the token is required, not defaulted. Three callers share this fetch and two of
+    /// them are on the analysis pass; a default would have let either keep passing nothing while the
+    /// signature claimed the read was abandonable. The viewer's call is the one that legitimately has
+    /// no pass to abandon, and it says so at its own call site rather than here.</para>
     /// </summary>
-    internal static async Task AppendDmvSnapshotRowsAsync(Func<NpgsqlCommand> createCommand, List<BlockingPairRow> rows, int serverId, DateTime start, DateTime end)
+    internal static async Task AppendDmvSnapshotRowsAsync(
+        Func<NpgsqlCommand> createCommand, List<BlockingPairRow> rows, int serverId, DateTime start, DateTime end,
+        CancellationToken cancellationToken)
     {
         var dmv = new List<BlockingPairRow>();
         using (var cmd = createCommand())
@@ -136,8 +144,8 @@ LIMIT 5000";
             cmd.Parameters.AddWithValue(DateTime.SpecifyKind(start, DateTimeKind.Unspecified));
             cmd.Parameters.AddWithValue(DateTime.SpecifyKind(end, DateTimeKind.Unspecified));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
+            using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
                 dmv.Add(Read(reader));
         }
 

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgDrillDownCollector.Blocking.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgDrillDownCollector.Blocking.cs
@@ -29,7 +29,7 @@ LIMIT 3";
 
     private async Task CollectTopDeadlocks(AnalysisFinding finding, AnalysisContext context)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var cmd = new NpgsqlCommand(TopDeadlocksSql, connection);
         cmd.Parameters.AddWithValue(context.ServerId);
@@ -37,8 +37,8 @@ LIMIT 3";
         cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             /* #1140: parse the involved objects from the graph for the dedup fingerprint + a readable
                Objects field. The raw graph XML is NOT surfaced (it would bloat the alert detail). */
@@ -88,7 +88,7 @@ LIMIT 5";
 
     private async Task CollectTopBlockingChains(AnalysisFinding finding, AnalysisContext context)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var cmd = new NpgsqlCommand(TopBlockingChainsSql, connection);
         cmd.Parameters.AddWithValue(context.ServerId);
@@ -96,8 +96,8 @@ LIMIT 5";
         cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             items.Add(new
             {
@@ -141,7 +141,7 @@ LIMIT 5000";
     /// </summary>
     private async Task CollectReconstructedBlockingChains(AnalysisFinding finding, AnalysisContext context)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var cmd = new NpgsqlCommand(ReconstructedChainsSql, connection);
         cmd.Parameters.AddWithValue(context.ServerId);
@@ -149,16 +149,17 @@ LIMIT 5000";
         cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
         var rows = new List<BlockingPairRow>();
-        using (var reader = await cmd.ExecuteReaderAsync())
+        using (var reader = await cmd.ExecuteReaderAsync(context.CancellationToken))
         {
-            while (await reader.ReadAsync())
+            while (await reader.ReadAsync(context.CancellationToken))
                 rows.Add(PgBlockingPairRowQuery.Read(reader));
         }
 
         // Always-on DMV blocking snapshot fallback. Merge BEFORE the empty check so DMV-only blocking
         // (blocked-process-report unavailable, e.g. AWS RDS) still reconstructs.
         await PgBlockingPairRowQuery.AppendDmvSnapshotRowsAsync(
-            connection.CreateCommand, rows, context.ServerId, context.TimeRangeStart, context.TimeRangeEnd);
+            connection.CreateCommand, rows, context.ServerId, context.TimeRangeStart, context.TimeRangeEnd,
+            context.CancellationToken);
 
         if (rows.Count == 0) return;
 
@@ -207,7 +208,7 @@ LIMIT 10";
 
     private async Task CollectLockModeBreakdown(AnalysisFinding finding, AnalysisContext context)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var cmd = new NpgsqlCommand(LockModeBreakdownSql, connection);
         cmd.Parameters.AddWithValue(context.ServerId);
@@ -215,8 +216,8 @@ LIMIT 10";
         cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             items.Add(new
             {

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgDrillDownCollector.Config.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgDrillDownCollector.Config.cs
@@ -28,14 +28,14 @@ ORDER BY database_name";
 
     private async Task CollectConfigIssues(AnalysisFinding finding, AnalysisContext context)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var cmd = new NpgsqlCommand(ConfigIssuesSql, connection);
         cmd.Parameters.AddWithValue(context.ServerId);
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             var issues = new List<string>();
             if (!reader.IsDBNull(2) && reader.GetBoolean(2)) issues.Add("auto_shrink ON");

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgDrillDownCollector.Plans.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgDrillDownCollector.Plans.cs
@@ -49,22 +49,27 @@ LIMIT 1";
         string? planHandle = null;
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(PlanHandleLookupSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(queryHash);
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (await reader.ReadAsync() && !reader.IsDBNull(0))
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (await reader.ReadAsync(context.CancellationToken) && !reader.IsDBNull(0))
                 planHandle = reader.GetString(0);
         }
-        catch { return; }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* No plan_handle for this hash — the fetch below has nothing to ask for. An abandonment
+               is NOT swallowed here (#2443). */
+            return;
+        }
 
         if (string.IsNullOrEmpty(planHandle)) return;
 
         // Fetch plan XML live from SQL Server
-        var planXml = await _planFetcher.FetchPlanXmlAsync(context.ServerId, planHandle);
+        var planXml = await _planFetcher.FetchPlanXmlAsync(context.ServerId, planHandle, context.CancellationToken);
         if (string.IsNullOrEmpty(planXml)) return;
 
         try
@@ -142,15 +147,15 @@ LIMIT 10";
             /* PG port: Lite scopes the connection in a block to release its DuckDB read lock
                before the CPU-only parse; the scoping is kept so the connection closes before
                the parse, even though PG holds no lock. */
-            await using (var connection = await _postgres.OpenConnectionAsync())
+            await using (var connection = await _postgres.OpenConnectionAsync(context.CancellationToken))
             {
                 using var cmd = new NpgsqlCommand(PlanAdvisoryXmlSql, connection);
                 cmd.Parameters.AddWithValue(context.ServerId);
                 cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
                 cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-                using var reader = await cmd.ExecuteReaderAsync();
-                while (await reader.ReadAsync())
+                using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+                while (await reader.ReadAsync(context.CancellationToken))
                 {
                     if (!reader.IsDBNull(0))
                         planXmls.Add(reader.GetString(0));
@@ -190,9 +195,10 @@ LIMIT 10";
                     .ToList();
             }
         }
-        catch
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
         {
             // Plan read/parse can fail on malformed XML — skip, the detail is best-effort.
+            // An abandonment is NOT swallowed here (#2443).
         }
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgDrillDownCollector.Queries.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgDrillDownCollector.Queries.cs
@@ -48,7 +48,7 @@ LIMIT 5";
     private async Task CollectQueriesAtSpike(AnalysisFinding finding, AnalysisContext context)
     {
         // Find the peak CPU time, then get queries active within 2 minutes of it
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         // Step 1: Find when the spike occurred
         using var peakCmd = new NpgsqlCommand(SpikePeakSql, connection);
@@ -59,9 +59,9 @@ LIMIT 5";
 
         DateTime? peakTime = null;
         int peakCpu = 0;
-        using (var peakReader = await peakCmd.ExecuteReaderAsync())
+        using (var peakReader = await peakCmd.ExecuteReaderAsync(context.CancellationToken))
         {
-            if (await peakReader.ReadAsync())
+            if (await peakReader.ReadAsync(context.CancellationToken))
             {
                 peakTime = peakReader.GetDateTime(0);
                 peakCpu = peakReader.GetInt32(1);
@@ -78,9 +78,9 @@ LIMIT 5";
         queryCmd.Parameters.AddWithValue(AsNaive(peakTime.Value.AddMinutes(2)));
 
         var items = new List<object>();
-        using (var reader = await queryCmd.ExecuteReaderAsync())
+        using (var reader = await queryCmd.ExecuteReaderAsync(context.CancellationToken))
         {
-            while (await reader.ReadAsync())
+            while (await reader.ReadAsync(context.CancellationToken))
             {
                 items.Add(new
                 {
@@ -126,7 +126,7 @@ LIMIT 5";
 
     private async Task CollectTopCpuQueries(AnalysisFinding finding, AnalysisContext context)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var cmd = new NpgsqlCommand(TopCpuQueriesSql, connection);
         cmd.CommandTimeout = DrillDownCommandTimeoutSeconds;
@@ -135,8 +135,8 @@ LIMIT 5";
         cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             items.Add(new
             {
@@ -168,7 +168,7 @@ LIMIT 5";
 
     private async Task CollectTopSpillingQueries(AnalysisFinding finding, AnalysisContext context)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var cmd = new NpgsqlCommand(TopSpillingQueriesSql, connection);
         cmd.CommandTimeout = DrillDownCommandTimeoutSeconds;
@@ -177,8 +177,8 @@ LIMIT 5";
         cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             items.Add(new
             {
@@ -248,7 +248,7 @@ LIMIT 5";
     /// </summary>
     private async Task CollectParameterSensitiveQueries(AnalysisFinding finding, AnalysisContext context)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var cmd = new NpgsqlCommand(ParameterSensitiveSql, connection);
         cmd.CommandTimeout = DrillDownCommandTimeoutSeconds;
@@ -257,8 +257,8 @@ LIMIT 5";
         cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             items.Add(new
             {
@@ -492,7 +492,7 @@ LIMIT 5";
     /// </summary>
     private async Task CollectRegressedQueries(AnalysisFinding finding, AnalysisContext context)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var cmd = new NpgsqlCommand(RegressedQueriesSql, connection);
         cmd.CommandTimeout = DrillDownCommandTimeoutSeconds;
@@ -505,8 +505,8 @@ LIMIT 5";
         cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             items.Add(new
             {
@@ -567,7 +567,7 @@ GROUP BY database_name, query_hash";
         var queryHash = finding.RootFactKey.Replace("BAD_ACTOR_", "");
         if (string.IsNullOrEmpty(queryHash)) return;
 
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var cmd = new NpgsqlCommand(BadActorDetailSql, connection);
         cmd.CommandTimeout = DrillDownCommandTimeoutSeconds;
@@ -576,8 +576,8 @@ GROUP BY database_name, query_hash";
         cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
         cmd.Parameters.AddWithValue(queryHash);
 
-        using var reader = await cmd.ExecuteReaderAsync();
-        if (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        if (await reader.ReadAsync(context.CancellationToken))
         {
             finding.DrillDown!["bad_actor_query"] = new
             {
@@ -610,7 +610,7 @@ LIMIT 5";
 
     private async Task CollectPendingGrants(AnalysisFinding finding, AnalysisContext context)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var cmd = new NpgsqlCommand(PendingGrantsSql, connection);
         cmd.CommandTimeout = DrillDownCommandTimeoutSeconds;
@@ -619,8 +619,8 @@ LIMIT 5";
         cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             items.Add(new
             {

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgDrillDownCollector.Storage.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgDrillDownCollector.Storage.cs
@@ -31,7 +31,7 @@ LIMIT 10";
 
     private async Task CollectFileLatencyBreakdown(AnalysisFinding finding, AnalysisContext context)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var cmd = new NpgsqlCommand(FileLatencyBreakdownSql, connection);
         cmd.Parameters.AddWithValue(context.ServerId);
@@ -39,8 +39,8 @@ LIMIT 10";
         cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             items.Add(new
             {
@@ -82,14 +82,14 @@ LIMIT 50";
     /// </summary>
     private async Task CollectAutogrowthPercentFiles(AnalysisFinding finding, AnalysisContext context)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var cmd = new NpgsqlCommand(AutogrowthPercentFilesSql, connection);
         cmd.Parameters.AddWithValue(context.ServerId);
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             var database = reader.IsDBNull(0) ? "" : reader.GetString(0);
             var fileType = reader.IsDBNull(1) ? "" : reader.GetString(1);
@@ -125,7 +125,7 @@ LIMIT 5";
 
     private async Task CollectTempDbBreakdown(AnalysisFinding finding, AnalysisContext context)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var cmd = new NpgsqlCommand(TempDbBreakdownSql, connection);
         cmd.Parameters.AddWithValue(context.ServerId);
@@ -133,8 +133,8 @@ LIMIT 5";
         cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             items.Add(new
             {

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgFactCollector.Activity.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgFactCollector.Activity.cs
@@ -56,15 +56,15 @@ LIMIT 5";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(BadActorSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            while (await reader.ReadAsync(context.CancellationToken))
             {
                 var dbName = reader.IsDBNull(0) ? "" : reader.GetString(0);
                 var queryHash = reader.IsDBNull(1) ? "" : reader.GetString(1);
@@ -102,7 +102,10 @@ LIMIT 5";
                 });
             }
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string ActiveQuerySql = @"
@@ -126,15 +129,15 @@ AND   collection_time <= $3";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(ActiveQuerySql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var totalSnapshots = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
             if (totalSnapshots == 0) return;
@@ -164,7 +167,10 @@ AND   collection_time <= $3";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string RunningJobsSql = @"
@@ -185,15 +191,15 @@ AND   collection_time <= $3";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(RunningJobsSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var runningCount = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
             if (runningCount == 0) return;
@@ -217,7 +223,10 @@ AND   collection_time <= $3";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string SessionStatsSql = @"
@@ -245,15 +254,15 @@ FROM latest WHERE rn = 1";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(SessionStatsSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var totalConns = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
             if (totalConns == 0) return;
@@ -281,7 +290,10 @@ FROM latest WHERE rn = 1";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
 }

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgFactCollector.Config.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgFactCollector.Config.cs
@@ -49,7 +49,7 @@ WHERE rn = 1";
     /// </summary>
     private async Task CollectServerConfigFactsAsync(AnalysisContext context, List<Fact> facts)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var cmd = new NpgsqlCommand(ServerConfigSql, connection);
         cmd.Parameters.AddWithValue(context.ServerId);
@@ -59,9 +59,9 @@ WHERE rn = 1";
         double? maxMemoryMb = null;
         double? minMemoryMb = null;
 
-        using (var reader = await cmd.ExecuteReaderAsync())
+        using (var reader = await cmd.ExecuteReaderAsync(context.CancellationToken))
         {
-            while (await reader.ReadAsync())
+            while (await reader.ReadAsync(context.CancellationToken))
             {
                 var configName = reader.GetString(0);
                 var value = Convert.ToDouble(reader.GetValue(1));
@@ -120,13 +120,13 @@ LIMIT 1";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(ServerMetadataSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var edition = reader.IsDBNull(0) ? 0 : Convert.ToInt32(reader.GetValue(0));
             var majorVersion = reader.IsDBNull(1) ? 0 : Convert.ToInt32(reader.GetValue(1));
@@ -136,7 +136,10 @@ LIMIT 1";
             if (majorVersion > 0)
                 facts.Add(new Fact { Source = "config", Key = "SERVER_MAJOR_VERSION", Value = majorVersion, ServerId = context.ServerId });
         }
-        catch { /* Columns may not exist yet (pre-migration) */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Columns may not exist yet (pre-migration). An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string DatabaseConfigSql = @"
@@ -171,13 +174,13 @@ AND database_name NOT IN ('master', 'msdb', 'model', 'tempdb')";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(DatabaseConfigSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var dbCount = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
             if (dbCount == 0) return;
@@ -213,7 +216,10 @@ AND database_name NOT IN ('master', 'msdb', 'model', 'tempdb')";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string TraceFlagsSql = @"
@@ -235,16 +241,16 @@ ORDER BY trace_flag";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(TraceFlagsSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
 
-            using var reader = await cmd.ExecuteReaderAsync();
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
             var metadata = new Dictionary<string, double>();
             var flagCount = 0;
 
-            while (await reader.ReadAsync())
+            while (await reader.ReadAsync(context.CancellationToken))
             {
                 var flag = Convert.ToInt32(reader.GetValue(0));
                 metadata[$"TF_{flag}"] = 1;
@@ -264,7 +270,10 @@ ORDER BY trace_flag";
                 Metadata = metadata
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string ServerPropertiesSql = @"
@@ -284,13 +293,13 @@ LIMIT 1";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(ServerPropertiesSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var cpuCount = reader.IsDBNull(0) ? 0 : Convert.ToInt32(reader.GetValue(0));
             var htRatio = reader.IsDBNull(1) ? 0 : Convert.ToInt32(reader.GetValue(1));
@@ -327,7 +336,10 @@ LIMIT 1";
             // score 0 is simply never emitted (noise control).
             FactCollectorHelpers.EmitServerHealthFacts(context, facts, edition, physicalMemMb, lpim, ifi, dumpCount);
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
 }

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgFactCollector.QueryPerf.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgFactCollector.QueryPerf.cs
@@ -38,15 +38,15 @@ AND   delta_execution_count > 0";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(QueryStatsSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var totalSpills = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
             var highDopQueries = reader.IsDBNull(1) ? 0L : ToInt64(reader.GetValue(1));
@@ -88,7 +88,10 @@ AND   delta_execution_count > 0";
                 });
             }
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string ParameterSensitivitySql = @"
@@ -144,7 +147,7 @@ LIMIT 20";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(ParameterSensitivitySql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
@@ -158,8 +161,8 @@ LIMIT 20";
             var worstGrantRatio = 0.0;
             var worstSpillDivergence = 0;
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            while (await reader.ReadAsync(context.CancellationToken))
             {
                 // Rows arrive ordered by worker_ratio DESC — the first row is the worst offender.
                 if (offenderCount == 0)
@@ -193,7 +196,10 @@ LIMIT 20";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     /// <summary>The PLAN_REGRESSION comparison window, in days — how far back a query's "best known" plan
@@ -381,7 +387,7 @@ LIMIT 20";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(PlanRegressionSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
@@ -402,8 +408,8 @@ LIMIT 20";
             var worstLatestForced = 0;
             var worstForceFailures = 0L;
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            while (await reader.ReadAsync(context.CancellationToken))
             {
                 // Rows arrive ordered by regression_factor DESC — the first row is the worst offender.
                 if (offenderCount == 0)
@@ -447,7 +453,10 @@ LIMIT 20";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string ProcedureStatsSql = @"
@@ -470,15 +479,15 @@ AND   delta_execution_count > 0";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(ProcedureStatsSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var distinctProcs = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
             var totalExecs = reader.IsDBNull(1) ? 0L : ToInt64(reader.GetValue(1));
@@ -505,7 +514,10 @@ AND   delta_execution_count > 0";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string PlanAdvisorySql = @"
@@ -534,15 +546,15 @@ LIMIT 10";
             /* PG port: Lite scopes the connection in a block to release its DuckDB read lock
                before the CPU-only parse; the scoping is kept so the connection closes before
                the parse, even though PG holds no lock. */
-            await using (var connection = await _postgres.OpenConnectionAsync())
+            await using (var connection = await _postgres.OpenConnectionAsync(context.CancellationToken))
             {
                 using var command = new NpgsqlCommand(PlanAdvisorySql, connection);
                 command.Parameters.AddWithValue(context.ServerId);
                 command.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
                 command.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-                using var reader = await command.ExecuteReaderAsync();
-                while (await reader.ReadAsync())
+                using var reader = await command.ExecuteReaderAsync(context.CancellationToken);
+                while (await reader.ReadAsync(context.CancellationToken))
                 {
                     if (!reader.IsDBNull(0))
                         planXmls.Add(reader.GetString(0));
@@ -587,9 +599,10 @@ LIMIT 10";
                 });
             }
         }
-        catch
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
         {
             // query_stats / plan parse may be unavailable — skip, the advisory is best-effort.
+            // An abandonment is NOT swallowed here (#2443).
         }
     }
 

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgFactCollector.Resources.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgFactCollector.Resources.cs
@@ -32,14 +32,14 @@ LIMIT 1";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(MemoryStatsSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var totalPhysical = reader.IsDBNull(0) ? 0.0 : Convert.ToDouble(reader.GetValue(0));
             var bufferPool = reader.IsDBNull(1) ? 0.0 : Convert.ToDouble(reader.GetValue(1));
@@ -52,7 +52,10 @@ LIMIT 1";
             if (targetMemory > 0)
                 facts.Add(new Fact { Source = "memory", Key = "MEMORY_TARGET_MB", Value = targetMemory, ServerId = context.ServerId });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string RunnableTaskStatsSql = @"
@@ -82,15 +85,15 @@ LIMIT 1";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(RunnableTaskStatsSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var totalRunnable = reader.IsDBNull(0) ? 0.0 : Convert.ToDouble(reader.GetValue(0));
             var runnableWarning = reader.IsDBNull(1) ? 0.0 : Convert.ToDouble(reader.GetValue(1));
@@ -108,7 +111,10 @@ LIMIT 1";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string MemoryGrantSql = @"
@@ -131,15 +137,15 @@ AND   collection_time <= $3";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(MemoryGrantSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var maxWaiters = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
             var avgWaiters = reader.IsDBNull(1) ? 0.0 : Convert.ToDouble(reader.GetValue(1));
@@ -166,7 +172,10 @@ AND   collection_time <= $3";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string MemoryClerkSql = @"
@@ -189,18 +198,18 @@ LIMIT 10";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(MemoryClerkSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
             var metadata = new Dictionary<string, double>();
             var totalMb = 0.0;
             var clerkCount = 0;
 
-            while (await reader.ReadAsync())
+            while (await reader.ReadAsync(context.CancellationToken))
             {
                 var clerkType = reader.GetString(0);
                 var memoryMb = Convert.ToDouble(reader.GetValue(1));
@@ -223,7 +232,10 @@ LIMIT 10";
                 Metadata = metadata
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string CpuUtilizationSql = @"
@@ -246,15 +258,15 @@ AND   collection_time <= $3";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(CpuUtilizationSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var avgSqlCpu = reader.IsDBNull(0) ? 0.0 : Convert.ToDouble(reader.GetValue(0));
             var maxSqlCpu = reader.IsDBNull(1) ? 0.0 : Convert.ToDouble(reader.GetValue(1));
@@ -298,7 +310,10 @@ AND   collection_time <= $3";
                 });
             }
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string PerfmonSql = @"
@@ -322,15 +337,15 @@ FROM latest WHERE rn = 1";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(PerfmonSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            while (await reader.ReadAsync(context.CancellationToken))
             {
                 var counterName = reader.GetString(0);
                 var cntrValue = reader.IsDBNull(1) ? 0L : ToInt64(reader.GetValue(1));
@@ -363,7 +378,10 @@ FROM latest WHERE rn = 1";
                 });
             }
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string PlanCacheStatsSql = @"
@@ -395,14 +413,14 @@ WHERE rnk = 1";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(PlanCacheStatsSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             // SUM(integer) is bigint in Postgres — read every aggregate through ToInt64 (the Lite-parity
             // shape), then widen the MB sizes to double for the metadata.
@@ -432,7 +450,10 @@ WHERE rnk = 1";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string MemoryPressureEventsSql = @"
@@ -459,15 +480,15 @@ AND   collection_time <= $3";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(MemoryPressureEventsSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var pressureEventCount = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
             var maxProcess = reader.IsDBNull(1) ? 0.0 : Convert.ToDouble(reader.GetValue(1));
@@ -492,7 +513,10 @@ AND   collection_time <= $3";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
 }

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgFactCollector.Storage.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgFactCollector.Storage.cs
@@ -37,20 +37,23 @@ WHERE rn = 1";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(DatabaseSizeSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var totalSize = reader.IsDBNull(0) ? 0.0 : Convert.ToDouble(reader.GetValue(0));
             if (totalSize > 0)
                 facts.Add(new Fact { Source = "config", Key = "DATABASE_TOTAL_SIZE_MB", Value = totalSize, ServerId = context.ServerId });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string IoLatencySql = @"
@@ -73,15 +76,15 @@ AND   (delta_reads > 0 OR delta_writes > 0)";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(IoLatencySql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var totalStallReadMs = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
             var totalReads = reader.IsDBNull(1) ? 0L : ToInt64(reader.GetValue(1));
@@ -124,7 +127,10 @@ AND   (delta_reads > 0 OR delta_writes > 0)";
                 });
             }
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string TempDbSql = @"
@@ -148,15 +154,15 @@ AND   collection_time <= $3";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(TempDbSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var maxReserved = reader.IsDBNull(0) ? 0.0 : Convert.ToDouble(reader.GetValue(0));
             var maxUserObj = reader.IsDBNull(1) ? 0.0 : Convert.ToDouble(reader.GetValue(1));
@@ -189,7 +195,10 @@ AND   collection_time <= $3";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string FileAutogrowthSql = @"
@@ -220,13 +229,13 @@ AND   database_name NOT IN ('master', 'msdb', 'model', 'tempdb')";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(FileAutogrowthSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var fileCount = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
             if (fileCount == 0) return;
@@ -246,7 +255,10 @@ AND   database_name NOT IN ('master', 'msdb', 'model', 'tempdb')";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     public const string DiskSpaceSql = @"
@@ -273,14 +285,14 @@ FROM latest WHERE rn = 1";
     {
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var cmd = new NpgsqlCommand(DiskSpaceSql, connection);
             cmd.Parameters.AddWithValue(context.ServerId);
             cmd.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var minFreePct = reader.IsDBNull(0) ? 1.0 : Convert.ToDouble(reader.GetValue(0));
             var minFreeMb = reader.IsDBNull(1) ? 0.0 : Convert.ToDouble(reader.GetValue(1));
@@ -306,6 +318,9 @@ FROM latest WHERE rn = 1";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgFactCollector.Waits.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgFactCollector.Waits.cs
@@ -37,15 +37,15 @@ ORDER BY SUM(delta_wait_time_ms) DESC";
     /// </summary>
     private async Task CollectWaitStatsFactsAsync(AnalysisContext context, List<Fact> facts)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var command = new NpgsqlCommand(WaitStatsSql, connection);
         command.Parameters.AddWithValue(context.ServerId);
         command.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
         command.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-        using var reader = await command.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await command.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             var waitType = reader.GetString(0);
             var waitingTasks = reader.IsDBNull(1) ? 0L : ToInt64(reader.GetValue(1));
@@ -95,15 +95,15 @@ AND   collection_time <= $3";
     /// </summary>
     private async Task CollectBlockingFactsAsync(AnalysisContext context, List<Fact> facts)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var command = new NpgsqlCommand(BlockingSql, connection);
         command.Parameters.AddWithValue(context.ServerId);
         command.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
         command.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-        using var reader = await command.ExecuteReaderAsync();
-        if (!await reader.ReadAsync()) return;
+        using var reader = await command.ExecuteReaderAsync(context.CancellationToken);
+        if (!await reader.ReadAsync(context.CancellationToken)) return;
 
         var eventCount = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
         if (eventCount <= 0) return;
@@ -149,15 +149,15 @@ AND   collection_time <= $3";
     /// </summary>
     private async Task CollectDeadlockFactsAsync(AnalysisContext context, List<Fact> facts)
     {
-        await using var connection = await _postgres.OpenConnectionAsync();
+        await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
         using var command = new NpgsqlCommand(DeadlocksSql, connection);
         command.Parameters.AddWithValue(context.ServerId);
         command.Parameters.AddWithValue(AsNaive(context.TimeRangeStart));
         command.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
-        using var reader = await command.ExecuteReaderAsync();
-        if (!await reader.ReadAsync()) return;
+        using var reader = await command.ExecuteReaderAsync(context.CancellationToken);
+        if (!await reader.ReadAsync(context.CancellationToken)) return;
 
         var deadlockCount = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
         if (deadlockCount <= 0) return;
@@ -211,7 +211,7 @@ LIMIT 5000";
 
         try
         {
-            await using var connection = await _postgres.OpenConnectionAsync();
+            await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
             using var command = new NpgsqlCommand(BlockingChainSql, connection);
             command.Parameters.AddWithValue(context.ServerId);
@@ -219,16 +219,17 @@ LIMIT 5000";
             command.Parameters.AddWithValue(AsNaive(context.TimeRangeEnd));
 
             var rows = new List<BlockingPairRow>();
-            using (var reader = await command.ExecuteReaderAsync())
+            using (var reader = await command.ExecuteReaderAsync(context.CancellationToken))
             {
-                while (await reader.ReadAsync())
+                while (await reader.ReadAsync(context.CancellationToken))
                     rows.Add(PgBlockingPairRowQuery.Read(reader));
             }
 
             // Always-on DMV blocking snapshot fallback (works when the blocked-process-report XE is empty,
             // e.g. AWS RDS). Merge BEFORE the empty check so DMV-only blocking still produces facts.
             await PgBlockingPairRowQuery.AppendDmvSnapshotRowsAsync(
-                connection.CreateCommand, rows, context.ServerId, context.TimeRangeStart, context.TimeRangeEnd);
+                connection.CreateCommand, rows, context.ServerId, context.TimeRangeStart, context.TimeRangeEnd,
+                context.CancellationToken);
 
             if (rows.Count == 0) return;
 
@@ -259,7 +260,10 @@ LIMIT 5000";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
 }

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgFindingStore.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgFindingStore.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Npgsql;
@@ -167,7 +168,7 @@ VALUES ($1, $2, $3, $4, $5, $6)";
         try
         {
             await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
-            var mutedHashes = await GetMutedHashesAsync(connection, context.ServerId);
+            var mutedHashes = await GetMutedHashesAsync(connection, context.ServerId, context.CancellationToken);
 
             foreach (var story in stories)
             {
@@ -223,6 +224,22 @@ VALUES ($1, $2, $3, $4, $5, $6)";
     /// shared <see cref="AlertContextSerializer"/>, so a Darling finding's persisted action
     /// round-trips byte-identically to a Dashboard one. Returns the same list for caller
     /// convenience; the in-memory findings are unchanged.
+    ///
+    /// <para>#2443: the connection open is the LAST cancellation point on this pass, and that is a
+    /// decision rather than an oversight. Past it the batch runs to completion, because the third
+    /// outcome — a half-written finding set — is worse than either of the two the classifier already
+    /// names. There is no transaction here (per-row failure isolation is deliberate: one bad row
+    /// logs and the batch continues), every row in a batch shares one <c>analysis_time</c>, and
+    /// <see cref="PgFindingStore.GetLatestFindingsSql"/> keys on <c>MAX(analysis_time)</c> — so a
+    /// batch cut in half does not read as truncated, it reads as a complete analysis that found
+    /// fewer problems. The server would look HEALTHIER for having been abandoned, with nothing
+    /// marking the set incomplete. Cancelling before the first row costs this cycle's findings and
+    /// says so; cancelling after it silently changes what the store means.</para>
+    ///
+    /// <para>The tail is affordable to finish: N small INSERTs against the LOCAL managed store on
+    /// loopback, not against a monitored server. It is not where a pass wedges. This is the same
+    /// call <c>DarlingAnalysisService</c> made one layer up in #2299 — "the post-enrichment tail
+    /// carries no check" — restated at the write it protects.</para>
     /// </summary>
     public async Task<List<AnalysisFinding>> InsertFindingsAsync(
         List<AnalysisFinding> findings, AnalysisContext context)
@@ -241,6 +258,8 @@ VALUES ($1, $2, $3, $4, $5, $6)";
         {
             await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
+            /* No token check between rows: see the note above. Once the first row is written this
+               batch is finishing. */
             foreach (var finding in findings)
             {
                 await InsertFindingAsync(connection, finding);
@@ -273,7 +292,11 @@ VALUES ($1, $2, $3, $4, $5, $6)";
 
     /// <summary>
     /// Returns the most recent findings for a server within the given time range, newest and
-    /// most severe first, including each finding's persisted remediation action.
+    /// most severe first, including each finding's persisted remediation action.    ///
+    /// <para>#2443 exempt: off the analysis pass. This surface serves the viewer, the MCP and the
+    /// retention sweep — lifetimes with no per-pass budget and no wedged analysis to abandon — so
+    /// its store calls take no pass token. Threading one here would mean inventing a caller that
+    /// does not exist.</para>
     /// </summary>
     public async Task<List<AnalysisFinding>> GetRecentFindingsAsync(
         int serverId, int hoursBack = 24, int limit = 100)
@@ -305,7 +328,11 @@ VALUES ($1, $2, $3, $4, $5, $6)";
     /// <summary>
     /// Returns the latest analysis run's findings for a server (most recent analysis_time),
     /// most severe first. Unlike the Dashboard twin this read also returns
-    /// remediation_action_json — both reads share one column list and one reader.
+    /// remediation_action_json — both reads share one column list and one reader.    ///
+    /// <para>#2443 exempt: off the analysis pass. This surface serves the viewer, the MCP and the
+    /// retention sweep — lifetimes with no per-pass budget and no wedged analysis to abandon — so
+    /// its store calls take no pass token. Threading one here would mean inventing a caller that
+    /// does not exist.</para>
     /// </summary>
     public async Task<List<AnalysisFinding>> GetLatestFindingsAsync(int serverId)
     {
@@ -332,7 +359,11 @@ VALUES ($1, $2, $3, $4, $5, $6)";
     }
 
     /// <summary>
-    /// Mutes a story pattern so it won't appear in future analysis runs.
+    /// Mutes a story pattern so it won't appear in future analysis runs.    ///
+    /// <para>#2443 exempt: off the analysis pass. This surface serves the viewer, the MCP and the
+    /// retention sweep — lifetimes with no per-pass budget and no wedged analysis to abandon — so
+    /// its store calls take no pass token. Threading one here would mean inventing a caller that
+    /// does not exist.</para>
     /// </summary>
     public async Task MuteStoryAsync(int serverId, string storyPathHash, string storyPath, string? reason = null)
     {
@@ -358,7 +389,11 @@ VALUES ($1, $2, $3, $4, $5, $6)";
     }
 
     /// <summary>
-    /// Unmutes a story pattern (Dashboard-twin surface).
+    /// Unmutes a story pattern (Dashboard-twin surface).    ///
+    /// <para>#2443 exempt: off the analysis pass. This surface serves the viewer, the MCP and the
+    /// retention sweep — lifetimes with no per-pass budget and no wedged analysis to abandon — so
+    /// its store calls take no pass token. Threading one here would mean inventing a caller that
+    /// does not exist.</para>
     /// </summary>
     public async Task UnmuteStoryAsync(long muteId)
     {
@@ -384,7 +419,11 @@ VALUES ($1, $2, $3, $4, $5, $6)";
     /// global marker); legacy <c>server_id = 0</c> rows written before that fix are honored as global
     /// too (<see cref="GetMutedStoriesSql"/> filters both), so an all-servers mute is visible to every
     /// server. A NULL/0 (global) row here is flagged muted but left un-unmutable from the per-server
-    /// viewer, since deleting it would unmute the pattern everywhere.
+    /// viewer, since deleting it would unmute the pattern everywhere.    ///
+    /// <para>#2443 exempt: off the analysis pass. This surface serves the viewer, the MCP and the
+    /// retention sweep — lifetimes with no per-pass budget and no wedged analysis to abandon — so
+    /// its store calls take no pass token. Threading one here would mean inventing a caller that
+    /// does not exist.</para>
     /// </summary>
     public async Task<List<MutedStory>> GetMutedStoriesAsync(int serverId)
     {
@@ -417,7 +456,11 @@ VALUES ($1, $2, $3, $4, $5, $6)";
     }
 
     /// <summary>
-    /// Cleans up old findings beyond the retention period.
+    /// Cleans up old findings beyond the retention period.    ///
+    /// <para>#2443 exempt: off the analysis pass. This surface serves the viewer, the MCP and the
+    /// retention sweep — lifetimes with no per-pass budget and no wedged analysis to abandon — so
+    /// its store calls take no pass token. Threading one here would mean inventing a caller that
+    /// does not exist.</para>
     /// </summary>
     public async Task CleanupOldFindingsAsync(int retentionDays = 30)
     {
@@ -440,7 +483,8 @@ VALUES ($1, $2, $3, $4, $5, $6)";
     /// twins: an unreadable mute registry returns the hashes read so far (usually empty) and
     /// findings flow through unfiltered rather than being suppressed.
     /// </summary>
-    private async Task<HashSet<string>> GetMutedHashesAsync(NpgsqlConnection connection, int serverId)
+    private async Task<HashSet<string>> GetMutedHashesAsync(
+        NpgsqlConnection connection, int serverId, CancellationToken cancellationToken)
     {
         var hashes = new HashSet<string>();
 
@@ -449,14 +493,18 @@ VALUES ($1, $2, $3, $4, $5, $6)";
             using var command = new NpgsqlCommand(GetMutedHashesSql, connection);
             command.Parameters.AddWithValue(serverId);
 
-            using var reader = await command.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
+            using var reader = await command.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
             {
                 hashes.Add(reader.GetString(0));
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, cancellationToken))
         {
+            /* #2443: fail-open is right for an unreadable registry, but NOT for an abandonment —
+               "the mutes could not be read" and "we stopped reading" are different answers, and
+               swallowing the second would let the pass go on to enrich and persist an unfiltered
+               finding set under a token that has already fired. */
             _logger?.LogError("[PgFindingStore] GetMutedHashesAsync failed: {Message}", ex.Message);
         }
 
@@ -467,6 +515,13 @@ VALUES ($1, $2, $3, $4, $5, $6)";
     /// Inserts one finding on an already-open connection (the caller owns it, so a batch
     /// shares a single connection). Per-row failure isolation like the Dashboard twin: one
     /// bad row logs and the batch continues.
+    ///
+    /// <para>#2443 exempt: this write deliberately takes no token. Cancelling inside a single-row
+    /// INSERT buys nothing — the row is milliseconds of work on loopback — and costs the one thing
+    /// worth having: a definite answer about whether it committed. Npgsql's cancel is a request to
+    /// the server, so a cancelled <c>ExecuteNonQueryAsync</c> can leave a row that did land, in a
+    /// set nothing marks as partial. <see cref="InsertFindingsAsync"/> carries the full reasoning
+    /// and the abandonment point that replaces this one.</para>
     /// </summary>
     private async Task InsertFindingAsync(NpgsqlConnection connection, AnalysisFinding finding)
     {

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgFindingStore.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgFindingStore.cs
@@ -292,7 +292,8 @@ VALUES ($1, $2, $3, $4, $5, $6)";
 
     /// <summary>
     /// Returns the most recent findings for a server within the given time range, newest and
-    /// most severe first, including each finding's persisted remediation action.    ///
+    /// most severe first, including each finding's persisted remediation action.
+    ///
     /// <para>#2443 exempt: off the analysis pass. This surface serves the viewer, the MCP and the
     /// retention sweep — lifetimes with no per-pass budget and no wedged analysis to abandon — so
     /// its store calls take no pass token. Threading one here would mean inventing a caller that
@@ -328,7 +329,8 @@ VALUES ($1, $2, $3, $4, $5, $6)";
     /// <summary>
     /// Returns the latest analysis run's findings for a server (most recent analysis_time),
     /// most severe first. Unlike the Dashboard twin this read also returns
-    /// remediation_action_json — both reads share one column list and one reader.    ///
+    /// remediation_action_json — both reads share one column list and one reader.
+    ///
     /// <para>#2443 exempt: off the analysis pass. This surface serves the viewer, the MCP and the
     /// retention sweep — lifetimes with no per-pass budget and no wedged analysis to abandon — so
     /// its store calls take no pass token. Threading one here would mean inventing a caller that
@@ -359,7 +361,8 @@ VALUES ($1, $2, $3, $4, $5, $6)";
     }
 
     /// <summary>
-    /// Mutes a story pattern so it won't appear in future analysis runs.    ///
+    /// Mutes a story pattern so it won't appear in future analysis runs.
+    ///
     /// <para>#2443 exempt: off the analysis pass. This surface serves the viewer, the MCP and the
     /// retention sweep — lifetimes with no per-pass budget and no wedged analysis to abandon — so
     /// its store calls take no pass token. Threading one here would mean inventing a caller that
@@ -389,7 +392,8 @@ VALUES ($1, $2, $3, $4, $5, $6)";
     }
 
     /// <summary>
-    /// Unmutes a story pattern (Dashboard-twin surface).    ///
+    /// Unmutes a story pattern (Dashboard-twin surface).
+    ///
     /// <para>#2443 exempt: off the analysis pass. This surface serves the viewer, the MCP and the
     /// retention sweep — lifetimes with no per-pass budget and no wedged analysis to abandon — so
     /// its store calls take no pass token. Threading one here would mean inventing a caller that
@@ -419,7 +423,8 @@ VALUES ($1, $2, $3, $4, $5, $6)";
     /// global marker); legacy <c>server_id = 0</c> rows written before that fix are honored as global
     /// too (<see cref="GetMutedStoriesSql"/> filters both), so an all-servers mute is visible to every
     /// server. A NULL/0 (global) row here is flagged muted but left un-unmutable from the per-server
-    /// viewer, since deleting it would unmute the pattern everywhere.    ///
+    /// viewer, since deleting it would unmute the pattern everywhere.
+    ///
     /// <para>#2443 exempt: off the analysis pass. This surface serves the viewer, the MCP and the
     /// retention sweep — lifetimes with no per-pass budget and no wedged analysis to abandon — so
     /// its store calls take no pass token. Threading one here would mean inventing a caller that
@@ -456,7 +461,8 @@ VALUES ($1, $2, $3, $4, $5, $6)";
     }
 
     /// <summary>
-    /// Cleans up old findings beyond the retention period.    ///
+    /// Cleans up old findings beyond the retention period.
+    ///
     /// <para>#2443 exempt: off the analysis pass. This surface serves the viewer, the MCP and the
     /// retention sweep — lifetimes with no per-pass budget and no wedged analysis to abandon — so
     /// its store calls take no pass token. Threading one here would mean inventing a caller that

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgPlanFetcher.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgPlanFetcher.cs
@@ -59,7 +59,7 @@ FROM sys.dm_exec_query_plan(CONVERT(varbinary(64), @plan_handle, 1));";
         _logger = logger;
     }
 
-    public async Task<string?> FetchPlanXmlAsync(int serverId, string planHandle)
+    public async Task<string?> FetchPlanXmlAsync(int serverId, string planHandle, CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(planHandle))
         {
@@ -82,13 +82,13 @@ FROM sys.dm_exec_query_plan(CONVERT(varbinary(64), @plan_handle, 1));";
             };
 
             await using var connection = new SqlConnection(builder.ConnectionString);
-            await connection.OpenAsync();
+            await connection.OpenAsync(cancellationToken);
 
             await using var command = new SqlCommand(PlanQuery, connection);
             command.CommandTimeout = 15;
             command.Parameters.AddWithValue("@plan_handle", planHandle);
 
-            var result = await command.ExecuteScalarAsync();
+            var result = await command.ExecuteScalarAsync(cancellationToken);
             if (result == null || result is DBNull)
             {
                 return null;
@@ -96,8 +96,12 @@ FROM sys.dm_exec_query_plan(CONVERT(varbinary(64), @plan_handle, 1));";
 
             return result.ToString();
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
+            /* #2443: an abandoned fetch is not a plan that failed to come back. Degrading it to null
+               here would log an ERROR for work we called off AND let the pass carry on enriching
+               against a token that has already fired — the sibling by-sql_handle fetch has excluded
+               cancellation from this arm since it was written, and this one now agrees. */
             _logger?.LogError("[PgPlanFetcher] Failed to fetch plan for handle {PlanHandle}: {Message}", planHandle, ex.Message);
             return null;
         }

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -3947,8 +3947,11 @@ LIMIT 1", connection);
                 JsonError($"server '{displayName}' is not currently connected — the live plan cache can only be read from a connected server"));
         }
 
+        /* #2443: both arms now take the SAME token. The by-sql_handle arm always had it; the
+           by-plan_handle arm did not, so a cancelled fetch_plan command kept a session open on the
+           monitored server for whichever key the caller happened to use. */
         var planXml = request.UsePlanHandle
-            ? await planFetcher.FetchPlanXmlAsync(serverId, request.PlanHandle!)
+            ? await planFetcher.FetchPlanXmlAsync(serverId, request.PlanHandle!, cancellationToken)
             : await planFetcher.FetchPlanBySqlHandleAsync(
                 serverId, request.DatabaseName, request.SqlHandle!,
                 request.StatementStartOffset, request.StatementEndOffset, cancellationToken);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Blocking.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Blocking.cs
@@ -367,8 +367,10 @@ public sealed partial class ViewerDataService
 
         // Always-on DMV blocking snapshot: merge in the fallback rows so the viewer works even when the
         // blocked-process-report XE captured nothing (threshold unset / AWS RDS). Same connection.
+        /* #2443: the viewer passes its own window token — this read serves a person waiting at a
+           grid, not an analysis pass, so there is no budget or service stop for it to abandon under. */
         await PgBlockingPairRowQuery.AppendDmvSnapshotRowsAsync(
-            connection.CreateCommand, rows, serverId, startUtc, endUtc);
+            connection.CreateCommand, rows, serverId, startUtc, endUtc, cancellationToken);
 
         return rows;
     }

--- a/Lite.Tests/AnalysisPassTokenThreadingTests.cs
+++ b/Lite.Tests/AnalysisPassTokenThreadingTests.cs
@@ -1,0 +1,390 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using PerformanceMonitorLite.Analysis;
+using PerformanceMonitorLite.Database;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// The analysis pass's token has to reach the reads, not just the gaps between them (#2443).
+///
+/// <para>#2419 armed a per-pass budget and put a checkpoint ahead of every store-touching stage, which
+/// closed the user-visible defect in #2412: a wedged server became loudly stuck instead of silently
+/// skipped forever. What it did not do was hand the token to the store layer — its own diff touched no
+/// store file — so abandonment happened BETWEEN stages. A collector that had already started ran to
+/// completion, and the pass that had given up went on holding the read lock and the connection it was
+/// no longer waiting for.</para>
+///
+/// <para>The threading is mechanical; this file is the part that lasts. A sweep of 203 call sites only
+/// stays swept if something counts it, and the failure mode it guards against is specific: adding
+/// <c>CancellationToken cancellationToken = default</c> to signatures and stopping there, which leaves
+/// every call site passing <see cref="CancellationToken.None"/> while LOOKING threaded. So the pin is on
+/// the CALL, not the signature — a no-argument <c>ExecuteReaderAsync()</c> is what goes red, and no
+/// default can hide it. The Darling twin is <c>AnalysisPassTokenThreadingTests</c> in Darling.Tests.</para>
+/// </summary>
+public sealed class AnalysisPassTokenThreadingTests
+{
+    /// <summary>
+    /// The no-argument overloads, plus the read lock. Each has a token-taking sibling, so the empty
+    /// parentheses are the whole tell. <c>AcquireReadLock()</c> belongs on this list and not on a list
+    /// of its own: every store read on the pass takes that lock BEFORE it opens its connection, so a
+    /// pass that reached the reads with a token and the lock without one would still be uninterruptible
+    /// behind an archival — which is exactly the gap #2443 called out as Lite-only.
+    /// </summary>
+    private static readonly Regex s_untokenedStoreCall = new(
+        @"\.(?:ExecuteReaderAsync|ExecuteNonQueryAsync|ExecuteScalarAsync|ReadAsync|OpenAsync)\(\s*\)|AcquireReadLock\(\s*\)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// A member declaration, used only to attribute a call to the method that makes it. Deliberately
+    /// crude — it needs to name the enclosing method, not parse C#. The <c>[^=;()]*</c> is what keeps
+    /// field initializers and expression-bodied properties out.
+    /// </summary>
+    private static readonly Regex s_memberDeclaration = new(
+        @"^\s*(?:public|private|internal|protected)[^=;()]*\s(?<name>[A-Za-z_][A-Za-z0-9_]*)\s*\(",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private const string ExemptionMarker = "#2443 exempt";
+
+    /// <summary>
+    /// Every method allowed to make an untokened store call, and the reason it is allowed to — the same
+    /// five the Darling twin exempts, for the same two reasons. This is an enumeration and not a
+    /// wildcard on purpose: the exemption list this repo spent a day removing was a wildcard, and the
+    /// way that one grew was that nobody ever had to name a new entry.
+    ///
+    /// <para>The four read-back surfaces are OFF the pass — the viewer, the MCP and the retention sweep
+    /// have no per-pass budget and no wedged analysis to abandon, so there is no token to thread.
+    /// <c>InsertFindingAsync</c> is the other kind: ON the pass, token deliberately withheld, because a
+    /// finding set cut in half is an outcome that reads like a healthy one (see
+    /// <see cref="TheFindingInsertIsAbandonedBeforeItStartsOrNotAtAll"/>).</para>
+    /// </summary>
+    private static readonly Dictionary<string, string> s_exempt = new(StringComparer.Ordinal)
+    {
+        ["GetRecentFindingsAsync"] = "read-back: the recommendations reader + MCP findings read",
+        ["GetLatestFindingsAsync"] = "read-back: the viewer's latest-run findings",
+        ["MuteStoryAsync"] = "off-pass write: the MCP/viewer mute verb",
+        ["CleanupOldFindingsAsync"] = "off-pass write: the retention sweep, its own lifetime",
+        ["InsertFindingAsync"] = "on-pass write, token withheld: a half-written finding set must not exist"
+    };
+
+    /// <summary>
+    /// The sweep, and the thing that keeps it swept. Scanned over the whole analysis directory rather
+    /// than a file list, because a file list is a thing a seventh <c>DuckDbFactCollector</c> partial can
+    /// be added outside of.
+    /// </summary>
+    [Fact]
+    public void NoStoreCallOnTheAnalysisPassRunsWithoutThePassToken()
+    {
+        var offenders = new List<string>();
+
+        foreach (var (file, lines) in AnalysisSources())
+        {
+            var enclosing = string.Empty;
+
+            for (var i = 0; i < lines.Length; i++)
+            {
+                var declaration = s_memberDeclaration.Match(lines[i]);
+                if (declaration.Success)
+                {
+                    enclosing = declaration.Groups["name"].Value;
+                }
+
+                if (!s_untokenedStoreCall.IsMatch(lines[i]))
+                {
+                    continue;
+                }
+
+                if (s_exempt.ContainsKey(enclosing)
+                    && DocBlockAbove(lines, IndexOfDeclaration(lines, i)).Contains(ExemptionMarker, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                offenders.Add($"{file}:{i + 1} in {enclosing}(): {lines[i].Trim()}");
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            "These store calls run without the pass's cancellation token, so the pass can be abandoned "
+            + "around them but never inside one. Pass context.CancellationToken (or the method's own token "
+            + $"parameter). If the call genuinely must complete, add its method to {nameof(s_exempt)} and put a "
+            + $"'{ExemptionMarker}' note in its doc comment saying why:\n"
+            + string.Join("\n", offenders));
+    }
+
+    /// <summary>
+    /// The other half of the agreement: an exemption that no longer corresponds to an untokened call is
+    /// a claim the code stopped making, and it must not be allowed to sit there authorising the next one.
+    /// </summary>
+    [Fact]
+    public void EveryExemptionIsStillEarningItsPlace()
+    {
+        var untokenedBy = new Dictionary<string, int>(StringComparer.Ordinal);
+        var markedMethods = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var (_, lines) in AnalysisSources())
+        {
+            var enclosing = string.Empty;
+            var enclosingAt = -1;
+
+            for (var i = 0; i < lines.Length; i++)
+            {
+                var declaration = s_memberDeclaration.Match(lines[i]);
+                if (declaration.Success)
+                {
+                    enclosing = declaration.Groups["name"].Value;
+                    enclosingAt = i;
+                    if (DocBlockAbove(lines, enclosingAt).Contains(ExemptionMarker, StringComparison.Ordinal))
+                    {
+                        markedMethods.Add(enclosing);
+                    }
+                }
+
+                if (s_untokenedStoreCall.IsMatch(lines[i]) && enclosingAt >= 0)
+                {
+                    untokenedBy[enclosing] = untokenedBy.TryGetValue(enclosing, out var n) ? n + 1 : 1;
+                }
+            }
+        }
+
+        Assert.Equal(s_exempt.Keys.OrderBy(k => k, StringComparer.Ordinal), markedMethods.OrderBy(k => k, StringComparer.Ordinal));
+        Assert.Equal(s_exempt.Keys.OrderBy(k => k, StringComparer.Ordinal), untokenedBy.Keys.OrderBy(k => k, StringComparer.Ordinal));
+
+        /* Stated so a NEW untokened call inside an already-exempt method cannot ride in on the
+           exemption: 14 read-back calls across four methods, plus the one finding INSERT. */
+        Assert.Equal(15, untokenedBy.Values.Sum());
+        Assert.Equal(1, untokenedBy["InsertFindingAsync"]);
+    }
+
+    /// <summary>
+    /// The fact collector is where the token would have been silently useless. Its per-query catches were
+    /// bare <c>catch { }</c> — deliberately, so a missing table degrades to "no facts" — which meant an
+    /// armed token produced 27 swallowed cancellations and a pass that carried on collecting under a
+    /// token that had already fired. Every catch there now lets an abandonment through, which is what
+    /// turns the threaded token into an exit rather than 27 wasted lock acquisitions.
+    /// </summary>
+    [Fact]
+    public void EveryCatchOnTheFactCollectorLetsAnAbandonmentThrough()
+    {
+        var bare = new List<string>();
+        var opensCatch = new Regex(@"^\s*catch\b", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        var classified = new Regex(
+            @"^\s*catch\s*\(\s*Exception\s+ex\s*\)\s*when\s*\(\s*!AnalysisAbandon\.IsExpected\(",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        foreach (var (file, lines) in AnalysisSources())
+        {
+            if (!Path.GetFileName(file).StartsWith("DuckDbFactCollector.", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            for (var i = 0; i < lines.Length; i++)
+            {
+                if (opensCatch.IsMatch(lines[i]) && !classified.IsMatch(lines[i]))
+                {
+                    bare.Add($"{file}:{i + 1}: {lines[i].Trim()}");
+                }
+            }
+        }
+
+        Assert.True(bare.Count == 0,
+            "A fact-collector catch that does not classify swallows the abandonment the token was armed for, "
+            + "and the pass keeps collecting under a fired token:\n" + string.Join("\n", bare));
+
+        /* 27 collect methods guard their read this way; the number is stated so deleting one is a
+           decision. The other four have no catch at all and never had one — their reads propagate
+           straight to the pass, which is the same outcome by a shorter route. */
+        Assert.Equal(27, AnalysisSources()
+            .Where(s => Path.GetFileName(s.File).StartsWith("DuckDbFactCollector.", StringComparison.Ordinal))
+            .SelectMany(s => s.Lines)
+            .Count(line => classified.IsMatch(line)));
+    }
+
+    /// <summary>
+    /// The decision #2443 asked to be made explicitly rather than assumed: what a cancelled PERSIST
+    /// means. The insert batch has no transaction, every row shares one <c>analysis_time</c>, and the
+    /// latest-findings read takes the newest <c>analysis_time</c>. So a batch cut in half does not read
+    /// as truncated; it reads as a complete analysis that found fewer problems, and the server looks
+    /// HEALTHIER for having been abandoned. The lock and the connection open are therefore the last
+    /// abandonment points: before the first row, or not at all.
+    /// </summary>
+    [Fact]
+    public void TheFindingInsertIsAbandonedBeforeItStartsOrNotAtAll()
+    {
+        var store = File.ReadAllText(Path.Combine(AnalysisDirectory(), "FindingStore.cs"))
+            .Replace("\r\n", "\n", StringComparison.Ordinal);
+
+        var insertBatch = Between(store,
+            "public async Task<List<AnalysisFinding>> InsertFindingsAsync(",
+            "public async Task<List<AnalysisFinding>> SaveFindingsAsync(");
+
+        /* The abandonment points: both the lock wait and the connection open observe the pass token. */
+        Assert.Contains("_duckDb.AcquireReadLock(context.CancellationToken)", insertBatch, StringComparison.Ordinal);
+        Assert.Contains("await connection.OpenAsync(context.CancellationToken)", insertBatch, StringComparison.Ordinal);
+
+        /* And nothing after them does. A ThrowIfCancellationRequested between rows would MAKE the
+           partial set rather than prevent it, which is why there is none. */
+        Assert.DoesNotContain("ThrowIfCancellationRequested", insertBatch, StringComparison.Ordinal);
+
+        /* The row write states the decision where someone changing it will read it. */
+        Assert.Contains(ExemptionMarker,
+            Between(store, "/// Inserts one finding on an already-open connection", "private static async Task InsertFindingAsync("),
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The classifier's truth table. Both halves of the predicate are load-bearing and the TYPE half
+    /// especially so: since #2419 this token fires on an ordinary timeout, so it is signalled during
+    /// perfectly normal running, and a filter that asked only "has the token fired?" would relabel any
+    /// genuine fault landing after the budget elapsed as an abandonment — swallowing the one line of
+    /// evidence it left, at forty-odd catch sites at once.
+    /// </summary>
+    [Fact]
+    public void AnAbandonmentIsAFiredTokenAndACancellationShape_NeverOneWithoutTheOther()
+    {
+        var fired = new CancellationToken(canceled: true);
+
+        Assert.True(AnalysisAbandon.IsExpected(new OperationCanceledException(), fired));
+        Assert.True(AnalysisAbandon.IsExpected(new TaskCanceledException(), fired));
+
+        /* A fault that merely coincides with the budget expiring is still a fault. */
+        Assert.False(AnalysisAbandon.IsExpected(new InvalidOperationException("store"), fired));
+        Assert.False(AnalysisAbandon.IsExpected(new TimeoutException("deadline"), fired));
+
+        /* And a cancellation shape with nothing cancelled means something threw it for another
+           reason, which must keep its error. */
+        Assert.False(AnalysisAbandon.IsExpected(new OperationCanceledException(), CancellationToken.None));
+    }
+
+    /// <summary>
+    /// The Lite-only half of #2443, and the one place cancellation genuinely could not be replaced by
+    /// reporting. Every store read on the pass takes the read lock BEFORE opening its connection, and
+    /// <c>AcquireReadLock()</c> had no timeout and no token while its <c>AcquireWriteLock(TimeSpan?)</c>
+    /// sibling had one — so a pass queued behind a long archival sat in an uninterruptible
+    /// <c>EnterReadLock()</c> however carefully its reads were threaded.
+    ///
+    /// <para>Held behind a real write lock on another thread, which is what an archival looks like from
+    /// here. The old overload would block for the full hold; the token'd one gives up when asked.</para>
+    /// </summary>
+    [Fact]
+    public void TheReadLockWaitIsAbandonableWhileAWriterHoldsIt()
+    {
+        var initializer = new DuckDbInitializer(Path.Combine(Path.GetTempPath(), $"pm-lock-{Guid.NewGuid():N}.db"));
+
+        var writerHasIt = new ManualResetEventSlim(false);
+        var releaseWriter = new ManualResetEventSlim(false);
+
+        var writer = Task.Run(() =>
+        {
+            using var write = initializer.AcquireWriteLock();
+            writerHasIt.Set();
+            releaseWriter.Wait(TimeSpan.FromSeconds(30));
+        });
+
+        try
+        {
+            Assert.True(writerHasIt.Wait(TimeSpan.FromSeconds(5)), "the writer never took the lock");
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(250));
+            var elapsed = Stopwatch.StartNew();
+
+            Assert.Throws<OperationCanceledException>(() =>
+            {
+                using var read = initializer.AcquireReadLock(cts.Token);
+            });
+
+            /* Generously bounded — the assertion is "it gave up while the writer still held it",
+               not a latency measurement. The writer holds for up to 30s. */
+            Assert.True(elapsed.Elapsed < TimeSpan.FromSeconds(10),
+                $"the read lock gave up only after {elapsed.Elapsed.TotalSeconds:F1}s");
+        }
+        finally
+        {
+            releaseWriter.Set();
+            writer.Wait(TimeSpan.FromSeconds(30));
+        }
+
+        /* And once the writer is gone it is an ordinary read lock again, token or no token. */
+        using var after = initializer.AcquireReadLock(CancellationToken.None);
+        Assert.NotNull(after);
+    }
+
+    private static string Between(string source, string start, string end)
+    {
+        var from = source.IndexOf(start, StringComparison.Ordinal);
+        Assert.True(from >= 0, $"anchor not found: {start}");
+        var to = source.IndexOf(end, from, StringComparison.Ordinal);
+        Assert.True(to > from, $"anchor not found after {start}: {end}");
+        return source[from..to];
+    }
+
+    /// <summary>The declaration line a call at <paramref name="callLine"/> belongs to (scanning up).</summary>
+    private static int IndexOfDeclaration(string[] lines, int callLine)
+    {
+        for (var i = callLine; i >= 0; i--)
+        {
+            if (s_memberDeclaration.IsMatch(lines[i]))
+            {
+                return i;
+            }
+        }
+
+        return 0;
+    }
+
+    /// <summary>The contiguous <c>///</c> block immediately above a declaration, as one string.</summary>
+    private static string DocBlockAbove(string[] lines, int declarationLine)
+    {
+        var doc = new List<string>();
+        for (var i = declarationLine - 1; i >= 0 && lines[i].TrimStart().StartsWith("///", StringComparison.Ordinal); i--)
+        {
+            doc.Add(lines[i]);
+        }
+
+        return string.Join("\n", doc);
+    }
+
+    private static IEnumerable<(string File, string[] Lines)> AnalysisSources()
+    {
+        var files = Directory.GetFiles(AnalysisDirectory(), "*.cs", SearchOption.TopDirectoryOnly);
+        Assert.NotEmpty(files);
+
+        foreach (var file in files.OrderBy(f => f, StringComparer.Ordinal))
+        {
+            /* The working copy is CRLF; split on the LF so a line never carries a stray CR. */
+            yield return (Path.GetFileName(file),
+                File.ReadAllText(file).Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n'));
+        }
+    }
+
+    private static string AnalysisDirectory() => Path.Combine(RepoRoot(), "Lite", "Analysis");
+
+    private static string RepoRoot([CallerFilePath] string thisFile = "")
+    {
+        var dir = Path.GetDirectoryName(thisFile)!;
+        while (dir is not null && !File.Exists(Path.Combine(dir, "PerformanceMonitor.sln")) && !Directory.Exists(Path.Combine(dir, ".git")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        Assert.NotNull(dir);
+        return dir!;
+    }
+}

--- a/Lite/Analysis/AnalysisAbandon.cs
+++ b/Lite/Analysis/AnalysisAbandon.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Threading;
+
+namespace PerformanceMonitorLite.Analysis;
+
+/// <summary>
+/// Classifies whether an analysis-pass failure is the residue of an abandonment we asked for, so the
+/// pass's many catch sites can tell <i>unfinished because we called it off</i> from <i>unfinished
+/// because something broke</i> (#2443). Lite's counterpart to Darling's
+/// <c>AnalysisShutdown.IsExpectedAbandon</c>, and deliberately narrower than it.
+///
+/// <para>Both halves of the predicate are load-bearing, and the TYPE half especially so. Since #2419
+/// the pass token fires on an ordinary TIMEOUT as well as at shutdown, so it is signalled during
+/// perfectly normal running — a filter that asked only "has the token fired?" would relabel any
+/// genuine fault landing after the budget elapsed as an abandonment and swallow the one line of
+/// evidence it left. That is the same defect #2419's first review round caught, one layer further
+/// in.</para>
+///
+/// <para>The shape list is one entry long because that is what was MEASURED, not what was assumed.
+/// Darling's classifier also has to name a disposed data source and the 57P0x trio, because its
+/// store is a separate postmaster that can go away underneath an in-flight read; Lite's is an
+/// embedded file in this process. Against DuckDB.NET 1.5.5 a pre-cancelled token throws
+/// <see cref="OperationCanceledException"/> without touching the database, and a token fired
+/// mid-query reaches <c>duckdb_interrupt</c> through <c>DuckDBCommand.Cancel()</c> and surfaces as
+/// <see cref="OperationCanceledException"/> too — not as a <c>DuckDBException</c> anyone would have
+/// to pattern-match. A 2,790 ms query cancelled at 2,000 ms aborted at 2,004 ms, and both the
+/// interrupted connection and a fresh one were fully usable afterwards. So naming the one shape
+/// loses nothing the cancellation actually produces, and widening it would cost the fault
+/// evidence.</para>
+/// </summary>
+public static class AnalysisAbandon
+{
+    /// <summary>
+    /// True when this failure should be ABANDONED quietly rather than treated as a fault: the pass's
+    /// token has fired AND the exception is the shape an abandonment produces. Catch sites on the
+    /// pass use this in a <c>when</c> filter so the residue PROPAGATES — unwinding to the one line
+    /// <c>AnalysisService</c> logs for it — instead of being swallowed per collector.
+    /// </summary>
+    public static bool IsExpected(Exception ex, CancellationToken passToken) =>
+        passToken.IsCancellationRequested && ex is OperationCanceledException;
+}

--- a/Lite/Analysis/AnalysisService.cs
+++ b/Lite/Analysis/AnalysisService.cs
@@ -125,7 +125,7 @@ public class AnalysisService
 
             // 0. Check minimum data span — total history, not the analysis window.
             // A server with 100h of total history can be analyzed over a 4h window.
-            var dataSpanHours = await GetTotalDataSpanHoursAsync(context.ServerId);
+            var dataSpanHours = await GetTotalDataSpanHoursAsync(context.ServerId, context.CancellationToken);
             if (dataSpanHours < MinimumDataHours)
             {
                 var needed = MinimumDataHours >= 24
@@ -239,8 +239,11 @@ public class AnalysisService
 
             return findings;
         }
-        catch (OperationCanceledException ex) when (context.CancellationToken.IsCancellationRequested)
+        catch (Exception ex) when (AnalysisAbandon.IsExpected(ex, context.CancellationToken))
         {
+            /* #2443: the predicate moved to AnalysisAbandon.IsExpected, unchanged — signalled token
+               AND OperationCanceledException — because the store layer now needs the same judgement
+               at forty-odd catch sites, and two copies of it would drift. */
             /* #2412: the pass was abandoned because it outlived its budget (or the app is
                stopping), which is not a fault and must not read as one. Whatever this pass would
                have written is gone; the next scheduled pass recomputes it from the store.
@@ -384,13 +387,13 @@ public class AnalysisService
     /// </summary>
     /* Internal for AnalysisDataSpanTests (#1809): the span must survive an archive/reset, which is
        only observable with a real DuckDB + parquet fixture. */
-    internal async Task<double> GetTotalDataSpanHoursAsync(int serverId)
+    internal async Task<double> GetTotalDataSpanHoursAsync(int serverId, CancellationToken cancellationToken = default)
     {
         try
         {
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(cancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(cancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -400,14 +403,18 @@ WHERE server_id = $1";
 
             cmd.Parameters.Add(new DuckDBParameter { Value = serverId });
 
-            var result = await cmd.ExecuteScalarAsync();
+            var result = await cmd.ExecuteScalarAsync(cancellationToken);
             if (result == null || result is DBNull)
                 return 0;
 
             return Convert.ToDouble(result);
         }
-        catch
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, cancellationToken))
         {
+            /* A probe failure reads as "no data yet" — EXCEPT an abandonment, which must not be
+               allowed to masquerade as a 0-hour history (#2443). That would turn a cancelled pass
+               into an insufficient-data SKIP, which is a different and far calmer-looking answer
+               than the one the caller is about to log. */
             return 0;
         }
     }

--- a/Lite/Analysis/AnomalyDetector.cs
+++ b/Lite/Analysis/AnomalyDetector.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using DuckDB.NET.Data;
 using PerformanceMonitor.Analysis;
@@ -79,7 +80,7 @@ public class AnomalyDetector
         var anomalies = new List<Fact>();
 
         // Check if baseline period has any data at all — if not, skip all anomaly detection.
-        if (!await HasBaselineDataAsync(context.ServerId))
+        if (!await HasBaselineDataAsync(context.ServerId, context.CancellationToken))
             return anomalies;
 
         // Existing detection methods (upgraded to time-bucketed baselines)
@@ -108,9 +109,9 @@ public class AnomalyDetector
     {
         try
         {
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             // Growth: biggest day-over-day table grower (indexes rolled up) over threshold.
             using (var cmd = connection.CreateCommand())
@@ -135,8 +136,8 @@ ORDER BY growth_mb DESC LIMIT 1";
                 cmd.Parameters.Add(new DuckDBParameter { Value = ObjectGrowthMbThreshold });
                 cmd.Parameters.Add(new DuckDBParameter { Value = ObjectGrowthPctThreshold });
 
-                using var reader = await cmd.ExecuteReaderAsync();
-                if (await reader.ReadAsync())
+                using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+                if (await reader.ReadAsync(context.CancellationToken))
                 {
                     var db = reader.GetString(0);
                     var gSchema = reader.IsDBNull(1) ? null : reader.GetValue(1)?.ToString();
@@ -185,8 +186,8 @@ ORDER BY ms_delta DESC LIMIT 1";
                 cmd.Parameters.Add(new DuckDBParameter { Value = context.ServerId });
                 cmd.Parameters.Add(new DuckDBParameter { Value = ObjectLockWaitMsDeltaThreshold });
 
-                using var reader = await cmd.ExecuteReaderAsync();
-                if (await reader.ReadAsync())
+                using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+                if (await reader.ReadAsync(context.CancellationToken))
                 {
                     var db = reader.GetString(0);
                     var cSchema = reader.IsDBNull(1) ? null : reader.GetValue(1)?.ToString();
@@ -218,7 +219,7 @@ ORDER BY ms_delta DESC LIMIT 1";
                 }
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
         {
             AppLogger.Error("AnomalyDetector", $"Object stats anomaly detection failed: {ex.Message}");
         }
@@ -228,13 +229,13 @@ ORDER BY ms_delta DESC LIMIT 1";
     /// Checks if the server has enough historical data for meaningful baselines.
     /// Uses wait_stats as canary — if waits are collected, other data is too.
     /// </summary>
-    private async Task<bool> HasBaselineDataAsync(int serverId)
+    private async Task<bool> HasBaselineDataAsync(int serverId, CancellationToken cancellationToken)
     {
         try
         {
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(cancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(cancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -245,10 +246,16 @@ SELECT (SELECT COUNT(*) FROM v_wait_stats
             cmd.Parameters.Add(new DuckDBParameter { Value = serverId });
             cmd.Parameters.Add(new DuckDBParameter { Value = DateTime.UtcNow.AddDays(-30) });
 
-            var count = Convert.ToInt64(await cmd.ExecuteScalarAsync() ?? 0);
+            var count = Convert.ToInt64(await cmd.ExecuteScalarAsync(cancellationToken) ?? 0);
             return count > 0;
         }
-        catch { return false; }
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, cancellationToken))
+        {
+            /* No baseline data reads as "skip anomaly detection", which is right — but an
+               abandonment is NOT that answer, and swallowing it here would let the pass go on
+               through nine detectors under a token that had already fired (#2443). */
+            return false;
+        }
     }
 
     /// <summary>
@@ -259,16 +266,16 @@ SELECT (SELECT COUNT(*) FROM v_wait_stats
         try
         {
             var baseline = await _baselineProvider.GetBaselineAsync(
-                context.ServerId, MetricNames.Cpu, context.TimeRangeStart);
+                context.ServerId, MetricNames.Cpu, context.TimeRangeStart, context.CancellationToken);
 
             if (baseline.SampleCount == 0) return;
             // No effectiveStdDev<=0 early return — an untrustworthy/zero-dispersion baseline falls
             // back to the absolute bar (below) rather than going silent.
             var effectiveStdDev = baseline.EffectiveStdDev;
 
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -286,8 +293,8 @@ AND   collection_time >= $2 AND collection_time < $3";
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeStart });
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var peakCpu = reader.IsDBNull(0) ? 0.0 : Convert.ToDouble(reader.GetValue(0));
             var avgCpu = reader.IsDBNull(1) ? 0.0 : Convert.ToDouble(reader.GetValue(1));
@@ -326,7 +333,7 @@ AND   collection_time >= $2 AND collection_time < $3";
                 Metadata = metadata
             });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
         {
             AppLogger.Error("AnomalyDetector", $"CPU anomaly detection failed: {ex.Message}");
         }
@@ -346,11 +353,11 @@ AND   collection_time >= $2 AND collection_time < $3";
         try
         {
             var baseline = await _baselineProvider.GetBaselineAsync(
-                context.ServerId, MetricNames.WaitMsPerSec, context.TimeRangeStart);
+                context.ServerId, MetricNames.WaitMsPerSec, context.TimeRangeStart, context.CancellationToken);
 
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             // Current window: all-types wait ms/sec per collection (interval via LAG, never an assumed
             // cadence — mirrors the WaitMsPerSec baseline), then PEAK across collections (matching the
@@ -378,8 +385,8 @@ FROM per_collection";
                 rateCmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeStart });
                 rateCmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
-                using var rateReader = await rateCmd.ExecuteReaderAsync();
-                if (!await rateReader.ReadAsync()) return;
+                using var rateReader = await rateCmd.ExecuteReaderAsync(context.CancellationToken);
+                if (!await rateReader.ReadAsync(context.CancellationToken)) return;
                 peakRate = rateReader.IsDBNull(0) ? 0.0 : Convert.ToDouble(rateReader.GetValue(0));
                 totalWaitMs = rateReader.IsDBNull(1) ? 0.0 : Convert.ToDouble(rateReader.GetValue(1));
                 collectionCount = rateReader.IsDBNull(2) ? 0L : Convert.ToInt64(rateReader.GetValue(2));
@@ -447,8 +454,8 @@ LIMIT 6";
                 contribCmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeStart });
                 contribCmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
-                using var contribReader = await contribCmd.ExecuteReaderAsync();
-                while (await contribReader.ReadAsync())
+                using var contribReader = await contribCmd.ExecuteReaderAsync(context.CancellationToken);
+                while (await contribReader.ReadAsync(context.CancellationToken))
                 {
                     var waitType = contribReader.GetString(0);
                     metadata[$"contrib_{waitType}"] = Convert.ToDouble(contribReader.GetValue(1));
@@ -464,7 +471,7 @@ LIMIT 6";
                 Metadata = metadata
             });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
         {
             AppLogger.Error("AnomalyDetector", $"Wait anomaly detection failed: {ex.Message}");
         }
@@ -479,13 +486,13 @@ LIMIT 6";
         try
         {
             var blockingBaseline = await _baselineProvider.GetBaselineAsync(
-                context.ServerId, MetricNames.Blocking, context.TimeRangeStart);
+                context.ServerId, MetricNames.Blocking, context.TimeRangeStart, context.CancellationToken);
             var deadlockBaseline = await _baselineProvider.GetBaselineAsync(
-                context.ServerId, MetricNames.Deadlock, context.TimeRangeStart);
+                context.ServerId, MetricNames.Deadlock, context.TimeRangeStart, context.CancellationToken);
 
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
             /* current_blocking: prefer the blocked-process-report; fall back to the always-on DMV
@@ -505,8 +512,8 @@ SELECT
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeStart });
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var currentBlocking = Convert.ToInt64(reader.GetValue(0));
             var currentDeadlocks = Convert.ToInt64(reader.GetValue(1));
@@ -577,7 +584,7 @@ SELECT
                 });
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
         {
             AppLogger.Error("AnomalyDetector", $"Blocking anomaly detection failed: {ex.Message}");
         }
@@ -591,14 +598,14 @@ SELECT
         try
         {
             var baseline = await _baselineProvider.GetBaselineAsync(
-                context.ServerId, MetricNames.IoLatency, context.TimeRangeStart);
+                context.ServerId, MetricNames.IoLatency, context.TimeRangeStart, context.CancellationToken);
 
             if (baseline.SampleCount == 0) return;
             var effectiveStdDev = baseline.EffectiveStdDev;
 
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -612,8 +619,8 @@ AND   (delta_reads > 0 OR delta_writes > 0)";
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeStart });
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var currentReadLat = reader.IsDBNull(0) ? 0.0 : Convert.ToDouble(reader.GetValue(0));
             var currentWriteLat = reader.IsDBNull(1) ? 0.0 : Convert.ToDouble(reader.GetValue(1));
@@ -678,7 +685,7 @@ AND   (delta_reads > 0 OR delta_writes > 0)";
                 });
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
         {
             AppLogger.Error("AnomalyDetector", $"I/O anomaly detection failed: {ex.Message}");
         }
@@ -692,14 +699,14 @@ AND   (delta_reads > 0 OR delta_writes > 0)";
         try
         {
             var baseline = await _baselineProvider.GetBaselineAsync(
-                context.ServerId, MetricNames.BatchRequests, context.TimeRangeStart);
+                context.ServerId, MetricNames.BatchRequests, context.TimeRangeStart, context.CancellationToken);
 
             if (baseline.SampleCount == 0) return;
             var effectiveStdDev = baseline.EffectiveStdDev;
 
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -715,8 +722,8 @@ AND   delta_cntr_value >= 0";
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeStart });
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var avgBatch = reader.IsDBNull(0) ? 0.0 : Convert.ToDouble(reader.GetValue(0));
             var peakBatch = reader.IsDBNull(1) ? 0.0 : Convert.ToDouble(reader.GetValue(1));
@@ -753,7 +760,7 @@ AND   delta_cntr_value >= 0";
                 Metadata = metadata
             });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
         {
             AppLogger.Error("AnomalyDetector", $"Batch request anomaly detection failed: {ex.Message}");
         }
@@ -767,14 +774,14 @@ AND   delta_cntr_value >= 0";
         try
         {
             var baseline = await _baselineProvider.GetBaselineAsync(
-                context.ServerId, MetricNames.SessionCount, context.TimeRangeStart);
+                context.ServerId, MetricNames.SessionCount, context.TimeRangeStart, context.CancellationToken);
 
             if (baseline.SampleCount == 0) return;
             var effectiveStdDev = baseline.EffectiveStdDev;
 
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -794,8 +801,8 @@ FROM per_collection";
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeStart });
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var avgConnections = reader.IsDBNull(0) ? 0.0 : Convert.ToDouble(reader.GetValue(0));
             var peakConnections = reader.IsDBNull(1) ? 0.0 : Convert.ToDouble(reader.GetValue(1));
@@ -832,7 +839,7 @@ FROM per_collection";
                 Metadata = metadata
             });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
         {
             AppLogger.Error("AnomalyDetector", $"Session anomaly detection failed: {ex.Message}");
         }
@@ -847,14 +854,14 @@ FROM per_collection";
         try
         {
             var baseline = await _baselineProvider.GetBaselineAsync(
-                context.ServerId, MetricNames.QueryDuration, context.TimeRangeStart);
+                context.ServerId, MetricNames.QueryDuration, context.TimeRangeStart, context.CancellationToken);
 
             if (baseline.SampleCount == 0) return;
             var effectiveStdDev = baseline.EffectiveStdDev;
 
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -876,8 +883,8 @@ FROM per_collection";
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeStart });
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var avgElapsed = reader.IsDBNull(0) ? 0.0 : Convert.ToDouble(reader.GetValue(0));
             var peakElapsed = reader.IsDBNull(1) ? 0.0 : Convert.ToDouble(reader.GetValue(1));
@@ -914,7 +921,7 @@ FROM per_collection";
                 Metadata = metadata
             });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
         {
             AppLogger.Error("AnomalyDetector", $"Query duration anomaly detection failed: {ex.Message}");
         }
@@ -930,14 +937,14 @@ FROM per_collection";
         try
         {
             var baseline = await _baselineProvider.GetBaselineAsync(
-                context.ServerId, MetricNames.Memory, context.TimeRangeStart);
+                context.ServerId, MetricNames.Memory, context.TimeRangeStart, context.CancellationToken);
 
             if (baseline.SampleCount == 0) return;
             var effectiveStdDev = baseline.EffectiveStdDev;
 
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -952,8 +959,8 @@ AND   target_server_memory_mb > 0";
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeStart });
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var avgPressure = reader.IsDBNull(0) ? 0.0 : Convert.ToDouble(reader.GetValue(0));
             var peakPressure = reader.IsDBNull(1) ? 0.0 : Convert.ToDouble(reader.GetValue(1));
@@ -990,7 +997,7 @@ AND   target_server_memory_mb > 0";
                 Metadata = metadata
             });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
         {
             AppLogger.Error("AnomalyDetector", $"Memory anomaly detection failed: {ex.Message}");
         }

--- a/Lite/Analysis/BaselineProvider.cs
+++ b/Lite/Analysis/BaselineProvider.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using DuckDB.NET.Data;
 using PerformanceMonitor.Analysis.Baselines;
@@ -116,14 +117,14 @@ public class BaselineProvider
     /// Returns the most specific bucket available, collapsing as needed.
     /// </summary>
     public async Task<BaselineBucket> GetBaselineAsync(
-        int serverId, string metricName, DateTime analysisTime)
+        int serverId, string metricName, DateTime analysisTime, CancellationToken cancellationToken = default)
     {
         WarnIfRetentionUndercutsBaselineWindow(metricName);
 
         var hourOfDay = analysisTime.Hour;
         var dayOfWeek = (int)analysisTime.DayOfWeek; // Sunday=0
 
-        var baselines = await GetOrComputeBaselinesAsync(serverId, metricName, analysisTime);
+        var baselines = await GetOrComputeBaselinesAsync(serverId, metricName, analysisTime, cancellationToken);
         if (baselines == null || baselines.Count == 0)
             return BaselineBucket.Empty;
 
@@ -142,7 +143,7 @@ public class BaselineProvider
     public void ClearCache() => _cache.Clear();
 
     private async Task<Dictionary<(int HourOfDay, int DayOfWeek), BaselineBucket>?> GetOrComputeBaselinesAsync(
-        int serverId, string metricName, DateTime analysisTime)
+        int serverId, string metricName, DateTime analysisTime, CancellationToken cancellationToken)
     {
         var cacheKey = $"{serverId}:{metricName}";
         var roundedHour = new DateTime(analysisTime.Year, analysisTime.Month, analysisTime.Day, analysisTime.Hour, 0, 0);
@@ -154,7 +155,7 @@ public class BaselineProvider
             return cached.Buckets;
         }
 
-        var buckets = await ComputeBaselinesAsync(serverId, metricName, analysisTime);
+        var buckets = await ComputeBaselinesAsync(serverId, metricName, analysisTime, cancellationToken);
 
         _cache[cacheKey] = new CachedBaseline
         {
@@ -167,7 +168,7 @@ public class BaselineProvider
     }
 
     private async Task<Dictionary<(int HourOfDay, int DayOfWeek), BaselineBucket>?> ComputeBaselinesAsync(
-        int serverId, string metricName, DateTime analysisTime)
+        int serverId, string metricName, DateTime analysisTime, CancellationToken cancellationToken)
     {
         var query = GetBaselineQuery(metricName);
         if (query == null) return null;
@@ -177,9 +178,9 @@ public class BaselineProvider
 
         try
         {
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(cancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(cancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = query;
@@ -189,13 +190,13 @@ public class BaselineProvider
 
             var buckets = new Dictionary<(int, int), BaselineBucket>();
 
-            using var reader = await cmd.ExecuteReaderAsync();
+            using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
             /* #1743: the robust-scaffold metrics return eight columns (…, median_val, mad_val)
                and carry sentinel tier rows — every Lite arm except the two event-family ones,
                which keep the six-column classical shape (detected by column count) and whose
                buckets read Median=0/Mad=0, degrading the robust path to the classical one. */
             var hasRobustColumns = reader.FieldCount >= 8;
-            while (await reader.ReadAsync())
+            while (await reader.ReadAsync(cancellationToken))
             {
                 var hour = Convert.ToInt32(reader.GetValue(0));
                 var dow = Convert.ToInt32(reader.GetValue(1));
@@ -230,8 +231,12 @@ public class BaselineProvider
 
             return buckets;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, cancellationToken))
         {
+            /* #2443: a baseline that could not be computed leaves its metric with no anomaly
+               detection, which is worth an ERROR. An abandoned one is not that — it is the pass we
+               called off, and five of the seven lines #2299 was filed about came from exactly this
+               catch on the Darling twin. */
             AppLogger.Error("BaselineProvider", $"Failed to compute baselines for {metricName}: {ex.Message}");
             return null;
         }

--- a/Lite/Analysis/BlockingPairRowQuery.cs
+++ b/Lite/Analysis/BlockingPairRowQuery.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Numerics;
+using System.Threading;
 using System.Threading.Tasks;
 using DuckDB.NET.Data;
 using PerformanceMonitor.Analysis;
@@ -101,8 +102,15 @@ AND blocking_spid <> 0";
     /// fragments as the blocked-process-report queries, against v_dmv_blocking_snapshots, so <see cref="Read"/>
     /// maps it unchanged. Takes a command factory so the caller's connection (a LockedConnection in the viewer,
     /// a raw DuckDBConnection in the collectors) runs it on the read lock it already holds.
+    ///
+    /// <para>#2443: the token is required, not defaulted. Three callers share this fetch and two of
+    /// them are on the analysis pass; a default would have let either keep passing nothing while the
+    /// signature claimed the read was abandonable. The viewer's call is the one that legitimately has
+    /// no pass to abandon, and it says so at its own call site rather than here.</para>
     /// </summary>
-    internal static async Task AppendDmvSnapshotRowsAsync(Func<DuckDBCommand> createCommand, List<BlockingPairRow> rows, int serverId, DateTime start, DateTime end)
+    internal static async Task AppendDmvSnapshotRowsAsync(
+        Func<DuckDBCommand> createCommand, List<BlockingPairRow> rows, int serverId, DateTime start, DateTime end,
+        CancellationToken cancellationToken)
     {
         var dmv = new List<BlockingPairRow>();
         using (var cmd = createCommand())
@@ -123,8 +131,8 @@ LIMIT 5000";
             cmd.Parameters.Add(new DuckDBParameter { Value = start });
             cmd.Parameters.Add(new DuckDBParameter { Value = end });
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
+            using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
                 dmv.Add(Read(reader));
         }
 

--- a/Lite/Analysis/DrillDownCollector.Blocking.cs
+++ b/Lite/Analysis/DrillDownCollector.Blocking.cs
@@ -18,9 +18,9 @@ public partial class DrillDownCollector
 {
     private async Task CollectTopDeadlocks(AnalysisFinding finding, AnalysisContext context)
     {
-        using var readLock = _duckDb.AcquireReadLock();
+        using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
         using var connection = _duckDb.CreateConnection();
-        await connection.OpenAsync();
+        await connection.OpenAsync(context.CancellationToken);
 
         using var cmd = connection.CreateCommand();
         cmd.CommandText = @"
@@ -37,8 +37,8 @@ LIMIT 3";
         cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             /* #1140: parse the involved objects from the graph for the dedup fingerprint + a readable
                Objects field. The raw graph XML is NOT surfaced (it would bloat the alert detail). */
@@ -59,9 +59,9 @@ LIMIT 3";
 
     private async Task CollectTopBlockingChains(AnalysisFinding finding, AnalysisContext context)
     {
-        using var readLock = _duckDb.AcquireReadLock();
+        using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
         using var connection = _duckDb.CreateConnection();
-        await connection.OpenAsync();
+        await connection.OpenAsync(context.CancellationToken);
 
         using var cmd = connection.CreateCommand();
         /* BPR + always-on DMV blocking snapshot, so the flat top-blocking list isn't empty when the
@@ -98,8 +98,8 @@ LIMIT 5";
         cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             items.Add(new
             {
@@ -126,9 +126,9 @@ LIMIT 5";
     /// </summary>
     private async Task CollectReconstructedBlockingChains(AnalysisFinding finding, AnalysisContext context)
     {
-        using var readLock = _duckDb.AcquireReadLock();
+        using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
         using var connection = _duckDb.CreateConnection();
-        await connection.OpenAsync();
+        await connection.OpenAsync(context.CancellationToken);
 
         using var cmd = connection.CreateCommand();
         // SpidFilter keeps Lite's drill-down, fact collector, and viewer fetch in lockstep on the apex
@@ -153,16 +153,17 @@ LIMIT 5000";
         cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
         var rows = new List<BlockingPairRow>();
-        using (var reader = await cmd.ExecuteReaderAsync())
+        using (var reader = await cmd.ExecuteReaderAsync(context.CancellationToken))
         {
-            while (await reader.ReadAsync())
+            while (await reader.ReadAsync(context.CancellationToken))
                 rows.Add(BlockingPairRowQuery.Read(reader));
         }
 
         // Always-on DMV blocking snapshot fallback. Merge BEFORE the empty check so DMV-only blocking
         // (blocked-process-report unavailable, e.g. AWS RDS) still reconstructs.
         await BlockingPairRowQuery.AppendDmvSnapshotRowsAsync(
-            connection.CreateCommand, rows, context.ServerId, context.TimeRangeStart, context.TimeRangeEnd);
+            connection.CreateCommand, rows, context.ServerId, context.TimeRangeStart, context.TimeRangeEnd,
+            context.CancellationToken);
 
         if (rows.Count == 0) return;
 
@@ -199,9 +200,9 @@ LIMIT 5000";
 
     private async Task CollectLockModeBreakdown(AnalysisFinding finding, AnalysisContext context)
     {
-        using var readLock = _duckDb.AcquireReadLock();
+        using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
         using var connection = _duckDb.CreateConnection();
-        await connection.OpenAsync();
+        await connection.OpenAsync(context.CancellationToken);
 
         using var cmd = connection.CreateCommand();
         cmd.CommandText = @"
@@ -221,8 +222,8 @@ LIMIT 10";
         cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             items.Add(new
             {

--- a/Lite/Analysis/DrillDownCollector.Config.cs
+++ b/Lite/Analysis/DrillDownCollector.Config.cs
@@ -18,9 +18,9 @@ public partial class DrillDownCollector
 {
     private async Task CollectConfigIssues(AnalysisFinding finding, AnalysisContext context)
     {
-        using var readLock = _duckDb.AcquireReadLock();
+        using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
         using var connection = _duckDb.CreateConnection();
-        await connection.OpenAsync();
+        await connection.OpenAsync(context.CancellationToken);
 
         using var cmd = connection.CreateCommand();
         cmd.CommandText = @"
@@ -36,8 +36,8 @@ ORDER BY database_name";
         cmd.Parameters.Add(new DuckDBParameter { Value = context.ServerId });
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             var issues = new List<string>();
             if (!reader.IsDBNull(2) && reader.GetBoolean(2)) issues.Add("auto_shrink ON");

--- a/Lite/Analysis/DrillDownCollector.Plans.cs
+++ b/Lite/Analysis/DrillDownCollector.Plans.cs
@@ -37,9 +37,9 @@ public partial class DrillDownCollector
         string? planHandle = null;
         try
         {
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -54,11 +54,16 @@ LIMIT 1";
             cmd.Parameters.Add(new DuckDBParameter { Value = context.ServerId });
             cmd.Parameters.Add(new DuckDBParameter { Value = queryHash });
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (await reader.ReadAsync() && !reader.IsDBNull(0))
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (await reader.ReadAsync(context.CancellationToken) && !reader.IsDBNull(0))
                 planHandle = reader.GetString(0);
         }
-        catch { return; }
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
+        {
+            /* No plan_handle for this hash — the fetch below has nothing to ask for. An abandonment
+               is NOT swallowed here (#2443). */
+            return;
+        }
 
         if (string.IsNullOrEmpty(planHandle)) return;
 
@@ -128,10 +133,10 @@ LIMIT 1";
         {
             var planXmls = new List<string>();
 
-            using (var readLock = _duckDb.AcquireReadLock())
+            using (var readLock = _duckDb.AcquireReadLock(context.CancellationToken))
             using (var connection = _duckDb.CreateConnection())
             {
-                await connection.OpenAsync();
+                await connection.OpenAsync(context.CancellationToken);
 
                 using var cmd = connection.CreateCommand();
                 cmd.CommandText = @"
@@ -147,8 +152,8 @@ LIMIT 10";
                 cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeStart });
                 cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
-                using var reader = await cmd.ExecuteReaderAsync();
-                while (await reader.ReadAsync())
+                using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+                while (await reader.ReadAsync(context.CancellationToken))
                 {
                     if (!reader.IsDBNull(0))
                         planXmls.Add(reader.GetString(0));
@@ -188,9 +193,10 @@ LIMIT 10";
                     .ToList();
             }
         }
-        catch
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
         {
             // Plan read/parse can fail on malformed XML — skip, the detail is best-effort.
+            // An abandonment is NOT swallowed here (#2443).
         }
     }
 }

--- a/Lite/Analysis/DrillDownCollector.Plans.cs
+++ b/Lite/Analysis/DrillDownCollector.Plans.cs
@@ -63,7 +63,7 @@ LIMIT 1";
         if (string.IsNullOrEmpty(planHandle)) return;
 
         // Fetch plan XML live from SQL Server
-        var planXml = await _planFetcher.FetchPlanXmlAsync(context.ServerId, planHandle);
+        var planXml = await _planFetcher.FetchPlanXmlAsync(context.ServerId, planHandle, context.CancellationToken);
         if (string.IsNullOrEmpty(planXml)) return;
 
         try

--- a/Lite/Analysis/DrillDownCollector.Queries.cs
+++ b/Lite/Analysis/DrillDownCollector.Queries.cs
@@ -19,9 +19,9 @@ public partial class DrillDownCollector
     private async Task CollectQueriesAtSpike(AnalysisFinding finding, AnalysisContext context)
     {
         // Find the peak CPU time, then get queries active within 2 minutes of it
-        using var readLock = _duckDb.AcquireReadLock();
+        using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
         using var connection = _duckDb.CreateConnection();
-        await connection.OpenAsync();
+        await connection.OpenAsync(context.CancellationToken);
 
         // Step 1: Find when the spike occurred
         using var peakCmd = connection.CreateCommand();
@@ -38,9 +38,9 @@ LIMIT 1";
 
         DateTime? peakTime = null;
         int peakCpu = 0;
-        using (var peakReader = await peakCmd.ExecuteReaderAsync())
+        using (var peakReader = await peakCmd.ExecuteReaderAsync(context.CancellationToken))
         {
-            if (await peakReader.ReadAsync())
+            if (await peakReader.ReadAsync(context.CancellationToken))
             {
                 peakTime = peakReader.GetDateTime(0);
                 peakCpu = peakReader.GetInt32(1);
@@ -69,9 +69,9 @@ LIMIT 5";
         queryCmd.Parameters.Add(new DuckDBParameter { Value = peakTime.Value.AddMinutes(2) });
 
         var items = new List<object>();
-        using (var reader = await queryCmd.ExecuteReaderAsync())
+        using (var reader = await queryCmd.ExecuteReaderAsync(context.CancellationToken))
         {
-            while (await reader.ReadAsync())
+            while (await reader.ReadAsync(context.CancellationToken))
             {
                 items.Add(new
                 {
@@ -103,9 +103,9 @@ LIMIT 5";
 
     private async Task CollectTopCpuQueries(AnalysisFinding finding, AnalysisContext context)
     {
-        using var readLock = _duckDb.AcquireReadLock();
+        using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
         using var connection = _duckDb.CreateConnection();
-        await connection.OpenAsync();
+        await connection.OpenAsync(context.CancellationToken);
 
         using var cmd = connection.CreateCommand();
         cmd.CommandText = @"
@@ -127,8 +127,8 @@ LIMIT 5";
         cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             items.Add(new
             {
@@ -148,9 +148,9 @@ LIMIT 5";
 
     private async Task CollectTopSpillingQueries(AnalysisFinding finding, AnalysisContext context)
     {
-        using var readLock = _duckDb.AcquireReadLock();
+        using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
         using var connection = _duckDb.CreateConnection();
-        await connection.OpenAsync();
+        await connection.OpenAsync(context.CancellationToken);
 
         using var cmd = connection.CreateCommand();
         cmd.CommandText = @"
@@ -170,8 +170,8 @@ LIMIT 5";
         cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             items.Add(new
             {
@@ -193,9 +193,9 @@ LIMIT 5";
     /// </summary>
     private async Task CollectParameterSensitiveQueries(AnalysisFinding finding, AnalysisContext context)
     {
-        using var readLock = _duckDb.AcquireReadLock();
+        using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
         using var connection = _duckDb.CreateConnection();
-        await connection.OpenAsync();
+        await connection.OpenAsync(context.CancellationToken);
 
         using var cmd = connection.CreateCommand();
         cmd.CommandText = @"
@@ -251,8 +251,8 @@ LIMIT 5";
         cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             items.Add(new
             {
@@ -281,9 +281,9 @@ LIMIT 5";
     /// </summary>
     private async Task CollectRegressedQueries(AnalysisFinding finding, AnalysisContext context)
     {
-        using var readLock = _duckDb.AcquireReadLock();
+        using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
         using var connection = _duckDb.CreateConnection();
-        await connection.OpenAsync();
+        await connection.OpenAsync(context.CancellationToken);
 
         using var cmd = connection.CreateCommand();
         cmd.CommandText = @"
@@ -489,8 +489,8 @@ LIMIT 5";
         cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             items.Add(new
             {
@@ -527,9 +527,9 @@ LIMIT 5";
         var queryHash = finding.RootFactKey.Replace("BAD_ACTOR_", "");
         if (string.IsNullOrEmpty(queryHash)) return;
 
-        using var readLock = _duckDb.AcquireReadLock();
+        using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
         using var connection = _duckDb.CreateConnection();
-        await connection.OpenAsync();
+        await connection.OpenAsync(context.CancellationToken);
 
         using var cmd = connection.CreateCommand();
         cmd.CommandText = @"
@@ -561,8 +561,8 @@ GROUP BY database_name, query_hash";
         cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
         cmd.Parameters.Add(new DuckDBParameter { Value = queryHash });
 
-        using var reader = await cmd.ExecuteReaderAsync();
-        if (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        if (await reader.ReadAsync(context.CancellationToken))
         {
             finding.DrillDown!["bad_actor_query"] = new
             {
@@ -583,9 +583,9 @@ GROUP BY database_name, query_hash";
 
     private async Task CollectPendingGrants(AnalysisFinding finding, AnalysisContext context)
     {
-        using var readLock = _duckDb.AcquireReadLock();
+        using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
         using var connection = _duckDb.CreateConnection();
-        await connection.OpenAsync();
+        await connection.OpenAsync(context.CancellationToken);
 
         using var cmd = connection.CreateCommand();
         cmd.CommandText = @"
@@ -605,8 +605,8 @@ LIMIT 5";
         cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             items.Add(new
             {

--- a/Lite/Analysis/DrillDownCollector.Storage.cs
+++ b/Lite/Analysis/DrillDownCollector.Storage.cs
@@ -18,9 +18,9 @@ public partial class DrillDownCollector
 {
     private async Task CollectFileLatencyBreakdown(AnalysisFinding finding, AnalysisContext context)
     {
-        using var readLock = _duckDb.AcquireReadLock();
+        using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
         using var connection = _duckDb.CreateConnection();
-        await connection.OpenAsync();
+        await connection.OpenAsync(context.CancellationToken);
 
         using var cmd = connection.CreateCommand();
         cmd.CommandText = @"
@@ -41,8 +41,8 @@ LIMIT 10";
         cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             items.Add(new
             {
@@ -69,9 +69,9 @@ LIMIT 10";
     /// </summary>
     private async Task CollectAutogrowthPercentFiles(AnalysisFinding finding, AnalysisContext context)
     {
-        using var readLock = _duckDb.AcquireReadLock();
+        using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
         using var connection = _duckDb.CreateConnection();
-        await connection.OpenAsync();
+        await connection.OpenAsync(context.CancellationToken);
 
         using var cmd = connection.CreateCommand();
         cmd.CommandText = @"
@@ -93,8 +93,8 @@ LIMIT 50";
         cmd.Parameters.Add(new DuckDBParameter { Value = context.ServerId });
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             var database = reader.IsDBNull(0) ? "" : reader.GetString(0);
             var fileType = reader.IsDBNull(1) ? "" : reader.GetString(1);
@@ -122,9 +122,9 @@ LIMIT 50";
 
     private async Task CollectTempDbBreakdown(AnalysisFinding finding, AnalysisContext context)
     {
-        using var readLock = _duckDb.AcquireReadLock();
+        using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
         using var connection = _duckDb.CreateConnection();
-        await connection.OpenAsync();
+        await connection.OpenAsync(context.CancellationToken);
 
         using var cmd = connection.CreateCommand();
         cmd.CommandText = @"
@@ -140,8 +140,8 @@ LIMIT 5";
         cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
         var items = new List<object>();
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             items.Add(new
             {

--- a/Lite/Analysis/DrillDownCollector.cs
+++ b/Lite/Analysis/DrillDownCollector.cs
@@ -41,6 +41,11 @@ public partial class DrillDownCollector
     {
         foreach (var finding in findings)
         {
+            /* #2443: between findings is the natural abandon point — the per-finding catch below
+               deliberately does NOT swallow an abandonment, so this throw (and any residue from a
+               drill-down mid-read) unwinds the pass to the service's single Information line. */
+            context.CancellationToken.ThrowIfCancellationRequested();
+
             try
             {
                 finding.DrillDown = new Dictionary<string, object>();
@@ -124,7 +129,7 @@ public partial class DrillDownCollector
                 if (finding.DrillDown.Count == 0)
                     finding.DrillDown = null;
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
             {
                 AppLogger.Error("DrillDownCollector",
                     $"Drill-down failed for {finding.StoryPath}: {ex.GetType().Name}: {ex.Message}");

--- a/Lite/Analysis/DuckDbFactCollector.Activity.cs
+++ b/Lite/Analysis/DuckDbFactCollector.Activity.cs
@@ -22,9 +22,9 @@ public partial class DuckDbFactCollector
     {
         try
         {
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -61,8 +61,8 @@ LIMIT 5";
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeStart });
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            while (await reader.ReadAsync(context.CancellationToken))
             {
                 var dbName = reader.IsDBNull(0) ? "" : reader.GetString(0);
                 var queryHash = reader.IsDBNull(1) ? "" : reader.GetString(1);
@@ -100,7 +100,10 @@ LIMIT 5";
                 });
             }
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     /// <summary>
@@ -110,9 +113,9 @@ LIMIT 5";
     {
         try
         {
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -133,8 +136,8 @@ AND   collection_time <= $3";
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeStart });
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var totalSnapshots = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
             if (totalSnapshots == 0) return;
@@ -164,7 +167,10 @@ AND   collection_time <= $3";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     /// <summary>
@@ -174,9 +180,9 @@ AND   collection_time <= $3";
     {
         try
         {
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -194,8 +200,8 @@ AND   collection_time <= $3";
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeStart });
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var runningCount = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
             if (runningCount == 0) return;
@@ -219,7 +225,10 @@ AND   collection_time <= $3";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     /// <summary>
@@ -229,9 +238,9 @@ AND   collection_time <= $3";
     {
         try
         {
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -256,8 +265,8 @@ FROM latest WHERE rn = 1";
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeStart });
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var totalConns = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
             if (totalConns == 0) return;
@@ -285,7 +294,10 @@ FROM latest WHERE rn = 1";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
 }

--- a/Lite/Analysis/DuckDbFactCollector.Config.cs
+++ b/Lite/Analysis/DuckDbFactCollector.Config.cs
@@ -19,9 +19,9 @@ public partial class DuckDbFactCollector
     /// </summary>
     private async Task CollectServerConfigFactsAsync(AnalysisContext context, List<Fact> facts)
     {
-        using var readLock = _duckDb.AcquireReadLock();
+        using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
         using var connection = _duckDb.CreateConnection();
-        await connection.OpenAsync();
+        await connection.OpenAsync(context.CancellationToken);
 
         using var cmd = connection.CreateCommand();
         // Latest value PER configuration_name (ROW_NUMBER, not LIMIT N): server_config accumulates
@@ -57,9 +57,9 @@ WHERE rn = 1";
         double? maxMemoryMb = null;
         double? minMemoryMb = null;
 
-        using (var reader = await cmd.ExecuteReaderAsync())
+        using (var reader = await cmd.ExecuteReaderAsync(context.CancellationToken))
         {
-            while (await reader.ReadAsync())
+            while (await reader.ReadAsync(context.CancellationToken))
             {
                 var configName = reader.GetString(0);
                 var value = Convert.ToDouble(reader.GetValue(1));
@@ -110,9 +110,9 @@ WHERE rn = 1";
     {
         try
         {
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -125,8 +125,8 @@ LIMIT 1";
 
             cmd.Parameters.Add(new DuckDBParameter { Value = context.ServerId });
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var edition = reader.IsDBNull(0) ? 0 : Convert.ToInt32(reader.GetValue(0));
             var majorVersion = reader.IsDBNull(1) ? 0 : Convert.ToInt32(reader.GetValue(1));
@@ -136,7 +136,10 @@ LIMIT 1";
             if (majorVersion > 0)
                 facts.Add(new Fact { Source = "config", Key = "SERVER_MAJOR_VERSION", Value = majorVersion, ServerId = context.ServerId });
         }
-        catch { /* Columns may not exist yet (pre-migration) */ }
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
+        {
+            /* Columns may not exist yet (pre-migration). An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     /// <summary>
@@ -147,9 +150,9 @@ LIMIT 1";
     {
         try
         {
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -178,8 +181,8 @@ AND database_name NOT IN ('master', 'msdb', 'model', 'tempdb')";
 
             cmd.Parameters.Add(new DuckDBParameter { Value = context.ServerId });
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var dbCount = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
             if (dbCount == 0) return;
@@ -215,7 +218,10 @@ AND database_name NOT IN ('master', 'msdb', 'model', 'tempdb')";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     /// <summary>
@@ -225,9 +231,9 @@ AND database_name NOT IN ('master', 'msdb', 'model', 'tempdb')";
     {
         try
         {
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -244,11 +250,11 @@ ORDER BY trace_flag";
 
             cmd.Parameters.Add(new DuckDBParameter { Value = context.ServerId });
 
-            using var reader = await cmd.ExecuteReaderAsync();
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
             var metadata = new Dictionary<string, double>();
             var flagCount = 0;
 
-            while (await reader.ReadAsync())
+            while (await reader.ReadAsync(context.CancellationToken))
             {
                 var flag = Convert.ToInt32(reader.GetValue(0));
                 metadata[$"TF_{flag}"] = 1;
@@ -268,7 +274,10 @@ ORDER BY trace_flag";
                 Metadata = metadata
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     /// <summary>
@@ -279,9 +288,9 @@ ORDER BY trace_flag";
     {
         try
         {
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -295,8 +304,8 @@ LIMIT 1";
 
             cmd.Parameters.Add(new DuckDBParameter { Value = context.ServerId });
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var cpuCount = reader.IsDBNull(0) ? 0 : Convert.ToInt32(reader.GetValue(0));
             var htRatio = reader.IsDBNull(1) ? 0 : Convert.ToInt32(reader.GetValue(1));
@@ -333,7 +342,10 @@ LIMIT 1";
             // emitted (noise control).
             FactCollectorHelpers.EmitServerHealthFacts(context, facts, edition, physicalMemMb, lpim, ifi, dumpCount);
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
 }

--- a/Lite/Analysis/DuckDbFactCollector.QueryPerf.cs
+++ b/Lite/Analysis/DuckDbFactCollector.QueryPerf.cs
@@ -20,9 +20,9 @@ public partial class DuckDbFactCollector
     {
         try
         {
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -42,8 +42,8 @@ AND   delta_execution_count > 0";
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeStart });
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var totalSpills = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
             var highDopQueries = reader.IsDBNull(1) ? 0L : ToInt64(reader.GetValue(1));
@@ -85,7 +85,10 @@ AND   delta_execution_count > 0";
                 });
             }
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     /// <summary>
@@ -99,9 +102,9 @@ AND   delta_execution_count > 0";
     {
         try
         {
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -157,8 +160,8 @@ LIMIT 20";
             var worstGrantRatio = 0.0;
             var worstSpillDivergence = 0;
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            while (await reader.ReadAsync(context.CancellationToken))
             {
                 // Rows arrive ordered by worker_ratio DESC — the first row is the worst offender.
                 if (offenderCount == 0)
@@ -192,7 +195,10 @@ LIMIT 20";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     /// <summary>
@@ -207,9 +213,9 @@ LIMIT 20";
     {
         try
         {
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -370,8 +376,8 @@ LIMIT 20";
             var worstLatestForced = 0;
             var worstForceFailures = 0L;
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            while (await reader.ReadAsync(context.CancellationToken))
             {
                 // Rows arrive ordered by regression_factor DESC — the first row is the worst offender.
                 if (offenderCount == 0)
@@ -415,7 +421,10 @@ LIMIT 20";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     /// <summary>
@@ -425,9 +434,9 @@ LIMIT 20";
     {
         try
         {
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -447,8 +456,8 @@ AND   delta_execution_count > 0";
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeStart });
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var distinctProcs = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
             var totalExecs = reader.IsDBNull(1) ? 0L : ToInt64(reader.GetValue(1));
@@ -475,7 +484,10 @@ AND   delta_execution_count > 0";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     /// <summary>
@@ -491,10 +503,10 @@ AND   delta_execution_count > 0";
         {
             var planXmls = new List<string>();
 
-            using (var readLock = _duckDb.AcquireReadLock())
+            using (var readLock = _duckDb.AcquireReadLock(context.CancellationToken))
             using (var connection = _duckDb.CreateConnection())
             {
-                await connection.OpenAsync();
+                await connection.OpenAsync(context.CancellationToken);
 
                 using var command = connection.CreateCommand();
                 command.CommandText = @"
@@ -510,8 +522,8 @@ LIMIT 10";
                 command.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeStart });
                 command.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
-                using var reader = await command.ExecuteReaderAsync();
-                while (await reader.ReadAsync())
+                using var reader = await command.ExecuteReaderAsync(context.CancellationToken);
+                while (await reader.ReadAsync(context.CancellationToken))
                 {
                     if (!reader.IsDBNull(0))
                         planXmls.Add(reader.GetString(0));
@@ -556,9 +568,10 @@ LIMIT 10";
                 });
             }
         }
-        catch
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
         {
             // query_stats / plan parse may be unavailable — skip, the advisory is best-effort.
+            // An abandonment is NOT swallowed here (#2443).
         }
     }
 

--- a/Lite/Analysis/DuckDbFactCollector.Resources.cs
+++ b/Lite/Analysis/DuckDbFactCollector.Resources.cs
@@ -20,9 +20,9 @@ public partial class DuckDbFactCollector
     {
         try
         {
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -36,8 +36,8 @@ LIMIT 1";
             cmd.Parameters.Add(new DuckDBParameter { Value = context.ServerId });
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var totalPhysical = reader.IsDBNull(0) ? 0.0 : Convert.ToDouble(reader.GetValue(0));
             var bufferPool = reader.IsDBNull(1) ? 0.0 : Convert.ToDouble(reader.GetValue(1));
@@ -50,7 +50,10 @@ LIMIT 1";
             if (targetMemory > 0)
                 facts.Add(new Fact { Source = "memory", Key = "MEMORY_TARGET_MB", Value = targetMemory, ServerId = context.ServerId });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     /// <summary>
@@ -70,9 +73,9 @@ LIMIT 1";
     {
         try
         {
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -88,8 +91,8 @@ LIMIT 1";
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeStart });
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var totalRunnable = reader.IsDBNull(0) ? 0.0 : Convert.ToDouble(reader.GetValue(0));
             var runnableWarning = reader.IsDBNull(1) ? 0.0 : Convert.ToDouble(reader.GetValue(1));
@@ -107,7 +110,10 @@ LIMIT 1";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     /// <summary>
@@ -118,9 +124,9 @@ LIMIT 1";
     {
         try
         {
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -139,8 +145,8 @@ AND   collection_time <= $3";
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeStart });
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var maxWaiters = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
             var avgWaiters = reader.IsDBNull(1) ? 0.0 : Convert.ToDouble(reader.GetValue(1));
@@ -167,7 +173,10 @@ AND   collection_time <= $3";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     /// <summary>
@@ -177,9 +186,9 @@ AND   collection_time <= $3";
     {
         try
         {
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -198,12 +207,12 @@ LIMIT 10";
             cmd.Parameters.Add(new DuckDBParameter { Value = context.ServerId });
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
-            using var reader = await cmd.ExecuteReaderAsync();
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
             var metadata = new Dictionary<string, double>();
             var totalMb = 0.0;
             var clerkCount = 0;
 
-            while (await reader.ReadAsync())
+            while (await reader.ReadAsync(context.CancellationToken))
             {
                 var clerkType = reader.GetString(0);
                 var memoryMb = Convert.ToDouble(reader.GetValue(1));
@@ -226,7 +235,10 @@ LIMIT 10";
                 Metadata = metadata
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     /// <summary>
@@ -237,9 +249,9 @@ LIMIT 10";
     {
         try
         {
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -258,8 +270,8 @@ AND   collection_time <= $3";
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeStart });
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var avgSqlCpu = reader.IsDBNull(0) ? 0.0 : Convert.ToDouble(reader.GetValue(0));
             var maxSqlCpu = reader.IsDBNull(1) ? 0.0 : Convert.ToDouble(reader.GetValue(1));
@@ -303,7 +315,10 @@ AND   collection_time <= $3";
                 });
             }
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     /// <summary>
@@ -314,9 +329,9 @@ AND   collection_time <= $3";
     {
         try
         {
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -336,8 +351,8 @@ FROM latest WHERE rn = 1";
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeStart });
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            while (await reader.ReadAsync(context.CancellationToken))
             {
                 var counterName = reader.GetString(0);
                 var cntrValue = reader.IsDBNull(1) ? 0L : ToInt64(reader.GetValue(1));
@@ -370,7 +385,10 @@ FROM latest WHERE rn = 1";
                 });
             }
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     /// <summary>
@@ -388,9 +406,9 @@ FROM latest WHERE rn = 1";
     {
         try
         {
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -412,8 +430,8 @@ WHERE rnk = 1";
             cmd.Parameters.Add(new DuckDBParameter { Value = context.ServerId });
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             // SUM(INTEGER) widens to HUGEINT — DuckDB hands it back boxed as BigInteger, which
             // Convert.ToDouble cannot take (no IConvertible); read every aggregate through the
@@ -444,7 +462,10 @@ WHERE rnk = 1";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     /// <summary>
@@ -463,9 +484,9 @@ WHERE rnk = 1";
     {
         try
         {
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -482,8 +503,8 @@ AND   collection_time <= $3";
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeStart });
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var pressureEventCount = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
             var maxProcess = reader.IsDBNull(1) ? 0.0 : Convert.ToDouble(reader.GetValue(1));
@@ -508,7 +529,10 @@ AND   collection_time <= $3";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
 }

--- a/Lite/Analysis/DuckDbFactCollector.Storage.cs
+++ b/Lite/Analysis/DuckDbFactCollector.Storage.cs
@@ -20,9 +20,9 @@ public partial class DuckDbFactCollector
     {
         try
         {
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -41,14 +41,17 @@ WHERE rn = 1";
             cmd.Parameters.Add(new DuckDBParameter { Value = context.ServerId });
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var totalSize = reader.IsDBNull(0) ? 0.0 : Convert.ToDouble(reader.GetValue(0));
             if (totalSize > 0)
                 facts.Add(new Fact { Source = "config", Key = "DATABASE_TOTAL_SIZE_MB", Value = totalSize, ServerId = context.ServerId });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     /// <summary>
@@ -59,9 +62,9 @@ WHERE rn = 1";
     {
         try
         {
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -80,8 +83,8 @@ AND   (delta_reads > 0 OR delta_writes > 0)";
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeStart });
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var totalStallReadMs = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
             var totalReads = reader.IsDBNull(1) ? 0L : ToInt64(reader.GetValue(1));
@@ -124,7 +127,10 @@ AND   (delta_reads > 0 OR delta_writes > 0)";
                 });
             }
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     /// <summary>
@@ -135,9 +141,9 @@ AND   (delta_reads > 0 OR delta_writes > 0)";
     {
         try
         {
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -157,8 +163,8 @@ AND   collection_time <= $3";
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeStart });
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var maxReserved = reader.IsDBNull(0) ? 0.0 : Convert.ToDouble(reader.GetValue(0));
             var maxUserObj = reader.IsDBNull(1) ? 0.0 : Convert.ToDouble(reader.GetValue(1));
@@ -191,7 +197,10 @@ AND   collection_time <= $3";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     /// <summary>
@@ -206,9 +215,9 @@ AND   collection_time <= $3";
     {
         try
         {
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -229,8 +238,8 @@ AND   database_name NOT IN ('master', 'msdb', 'model', 'tempdb')";
 
             cmd.Parameters.Add(new DuckDBParameter { Value = context.ServerId });
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var fileCount = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
             if (fileCount == 0) return;
@@ -250,7 +259,10 @@ AND   database_name NOT IN ('master', 'msdb', 'model', 'tempdb')";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
     /// <summary>
@@ -260,9 +272,9 @@ AND   database_name NOT IN ('master', 'msdb', 'model', 'tempdb')";
     {
         try
         {
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
@@ -285,8 +297,8 @@ FROM latest WHERE rn = 1";
             cmd.Parameters.Add(new DuckDBParameter { Value = context.ServerId });
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
-            using var reader = await cmd.ExecuteReaderAsync();
-            if (!await reader.ReadAsync()) return;
+            using var reader = await cmd.ExecuteReaderAsync(context.CancellationToken);
+            if (!await reader.ReadAsync(context.CancellationToken)) return;
 
             var minFreePct = reader.IsDBNull(0) ? 1.0 : Convert.ToDouble(reader.GetValue(0));
             var minFreeMb = reader.IsDBNull(1) ? 0.0 : Convert.ToDouble(reader.GetValue(1));
@@ -312,6 +324,9 @@ FROM latest WHERE rn = 1";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 }

--- a/Lite/Analysis/DuckDbFactCollector.Waits.cs
+++ b/Lite/Analysis/DuckDbFactCollector.Waits.cs
@@ -18,9 +18,9 @@ public partial class DuckDbFactCollector
     /// </summary>
     private async Task CollectWaitStatsFactsAsync(AnalysisContext context, List<Fact> facts)
     {
-        using var readLock = _duckDb.AcquireReadLock();
+        using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
         using var connection = _duckDb.CreateConnection();
-        await connection.OpenAsync();
+        await connection.OpenAsync(context.CancellationToken);
 
         using var command = connection.CreateCommand();
         command.CommandText = @"
@@ -41,8 +41,8 @@ ORDER BY SUM(delta_wait_time_ms) DESC";
         command.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeStart });
         command.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
-        using var reader = await command.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await command.ExecuteReaderAsync(context.CancellationToken);
+        while (await reader.ReadAsync(context.CancellationToken))
         {
             var waitType = reader.GetString(0);
             var waitingTasks = reader.IsDBNull(1) ? 0L : ToInt64(reader.GetValue(1));
@@ -80,9 +80,9 @@ ORDER BY SUM(delta_wait_time_ms) DESC";
     /// </summary>
     private async Task CollectBlockingFactsAsync(AnalysisContext context, List<Fact> facts)
     {
-        using var readLock = _duckDb.AcquireReadLock();
+        using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
         using var connection = _duckDb.CreateConnection();
-        await connection.OpenAsync();
+        await connection.OpenAsync(context.CancellationToken);
 
         using var command = connection.CreateCommand();
         command.CommandText = @"
@@ -101,8 +101,8 @@ AND   collection_time <= $3";
         command.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeStart });
         command.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
-        using var reader = await command.ExecuteReaderAsync();
-        if (!await reader.ReadAsync()) return;
+        using var reader = await command.ExecuteReaderAsync(context.CancellationToken);
+        if (!await reader.ReadAsync(context.CancellationToken)) return;
 
         var eventCount = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
         if (eventCount <= 0) return;
@@ -141,9 +141,9 @@ AND   collection_time <= $3";
     /// </summary>
     private async Task CollectDeadlockFactsAsync(AnalysisContext context, List<Fact> facts)
     {
-        using var readLock = _duckDb.AcquireReadLock();
+        using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
         using var connection = _duckDb.CreateConnection();
-        await connection.OpenAsync();
+        await connection.OpenAsync(context.CancellationToken);
 
         using var command = connection.CreateCommand();
         command.CommandText = @"
@@ -157,8 +157,8 @@ AND   collection_time <= $3";
         command.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeStart });
         command.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
-        using var reader = await command.ExecuteReaderAsync();
-        if (!await reader.ReadAsync()) return;
+        using var reader = await command.ExecuteReaderAsync(context.CancellationToken);
+        if (!await reader.ReadAsync(context.CancellationToken)) return;
 
         var deadlockCount = reader.IsDBNull(0) ? 0L : ToInt64(reader.GetValue(0));
         if (deadlockCount <= 0) return;
@@ -194,9 +194,9 @@ AND   collection_time <= $3";
 
         try
         {
-            using var readLock = _duckDb.AcquireReadLock();
+            using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
             using var connection = _duckDb.CreateConnection();
-            await connection.OpenAsync();
+            await connection.OpenAsync(context.CancellationToken);
 
             using var command = connection.CreateCommand();
             // SpidFilter keeps this in lockstep with the drill-down + viewer fetch on the apex
@@ -222,16 +222,17 @@ LIMIT 5000";
             command.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeEnd });
 
             var rows = new List<BlockingPairRow>();
-            using (var reader = await command.ExecuteReaderAsync())
+            using (var reader = await command.ExecuteReaderAsync(context.CancellationToken))
             {
-                while (await reader.ReadAsync())
+                while (await reader.ReadAsync(context.CancellationToken))
                     rows.Add(BlockingPairRowQuery.Read(reader));
             }
 
             // Always-on DMV blocking snapshot fallback (works when the blocked-process-report XE is empty,
             // e.g. AWS RDS). Merge BEFORE the empty check so DMV-only blocking still produces facts.
             await BlockingPairRowQuery.AppendDmvSnapshotRowsAsync(
-                connection.CreateCommand, rows, context.ServerId, context.TimeRangeStart, context.TimeRangeEnd);
+                connection.CreateCommand, rows, context.ServerId, context.TimeRangeStart, context.TimeRangeEnd,
+                context.CancellationToken);
 
             if (rows.Count == 0) return;
 
@@ -262,7 +263,10 @@ LIMIT 5000";
                 }
             });
         }
-        catch { /* Table may not exist or have no data */ }
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
+        {
+            /* Table may not exist or have no data. An abandonment is NOT swallowed here (#2443). */
+        }
     }
 
 }

--- a/Lite/Analysis/FindingStore.cs
+++ b/Lite/Analysis/FindingStore.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using DuckDB.NET.Data;
 using PerformanceMonitor.Analysis;
@@ -52,11 +53,11 @@ public class FindingStore
         /* One read lock + one connection for the mute-filter read only. Released before the caller
            enriches + builds actions; InsertFindingsAsync then re-acquires for the batched insert.
            The lock is NoRecursion, so the helper below operates on the passed connection. */
-        using var readLock = _duckDb.AcquireReadLock();
+        using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
         using var connection = _duckDb.CreateConnection();
-        await connection.OpenAsync();
+        await connection.OpenAsync(context.CancellationToken);
 
-        var mutedHashes = await GetMutedHashesAsync(connection, context.ServerId);
+        var mutedHashes = await GetMutedHashesAsync(connection, context.ServerId, context.CancellationToken);
 
         foreach (var story in stories)
         {
@@ -101,6 +102,21 @@ public class FindingStore
     /// as <c>remediation_action_json</c> via the shared <see cref="AlertContextSerializer"/>, so a Lite
     /// finding's persisted action round-trips byte-identically to a Darling / Dashboard one. Returns the
     /// same list for caller convenience; the in-memory findings are unchanged.
+    ///
+    /// <para>#2443: the read lock and the connection open are the LAST cancellation points on this
+    /// pass, and that is a decision rather than an oversight. Past them the batch runs to completion,
+    /// because the third outcome — a half-written finding set — is worse than the one the pass
+    /// already reports. There is no transaction here, every row in a batch shares one
+    /// <c>analysis_time</c>, and <see cref="GetLatestFindingsAsync"/> reads the newest
+    /// <c>analysis_time</c> — so a batch cut in half does not read as truncated, it reads as a
+    /// complete analysis that found fewer problems. The server would look HEALTHIER for having been
+    /// abandoned, with nothing marking the set incomplete. Cancelling before the first row costs this
+    /// cycle's findings and says so; cancelling after it silently changes what the store means.</para>
+    ///
+    /// <para>The tail is affordable to finish: N small INSERTs into an embedded file in this process.
+    /// It is not where a pass wedges. Same call the Darling twin makes, and the same call
+    /// <c>AnalysisService</c> made a layer up in #2419 — "the post-enrichment tail carries no check
+    /// on purpose" — restated at the write it protects.</para>
     /// </summary>
     public async Task<List<AnalysisFinding>> InsertFindingsAsync(
         List<AnalysisFinding> findings, AnalysisContext context)
@@ -109,10 +125,12 @@ public class FindingStore
             return findings;
 
         /* One read lock + one connection for the whole batch, reused for every insert. */
-        using var readLock = _duckDb.AcquireReadLock();
+        using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
         using var connection = _duckDb.CreateConnection();
-        await connection.OpenAsync();
+        await connection.OpenAsync(context.CancellationToken);
 
+        /* No token check between rows: see the note above. Once the first row is written this batch
+           is finishing. */
         foreach (var finding in findings)
             await InsertFindingAsync(connection, finding);
 
@@ -135,7 +153,11 @@ public class FindingStore
     }
 
     /// <summary>
-    /// Returns the most recent findings for a server within the given time range.
+    /// Returns the most recent findings for a server within the given time range.    ///
+    /// <para>#2443 exempt: off the analysis pass. This surface serves the viewer, the MCP and the
+    /// retention sweep — lifetimes with no per-pass budget and no wedged analysis to abandon — so
+    /// its store calls take no pass token. Threading one here would mean inventing a caller that
+    /// does not exist. Matches the Darling twin's PgFindingStore exactly.</para>
     /// </summary>
     public async Task<List<AnalysisFinding>> GetRecentFindingsAsync(
         int serverId, int hoursBack = 24, int limit = 100)
@@ -198,7 +220,11 @@ LIMIT $3";
     }
 
     /// <summary>
-    /// Returns the latest analysis run's findings for a server (most recent analysis_time).
+    /// Returns the latest analysis run's findings for a server (most recent analysis_time).    ///
+    /// <para>#2443 exempt: off the analysis pass. This surface serves the viewer, the MCP and the
+    /// retention sweep — lifetimes with no per-pass budget and no wedged analysis to abandon — so
+    /// its store calls take no pass token. Threading one here would mean inventing a caller that
+    /// does not exist. Matches the Darling twin's PgFindingStore exactly.</para>
     /// </summary>
     public async Task<List<AnalysisFinding>> GetLatestFindingsAsync(int serverId)
     {
@@ -259,7 +285,11 @@ ORDER BY severity DESC";
     }
 
     /// <summary>
-    /// Mutes a story pattern so it won't appear in future analysis runs.
+    /// Mutes a story pattern so it won't appear in future analysis runs.    ///
+    /// <para>#2443 exempt: off the analysis pass. This surface serves the viewer, the MCP and the
+    /// retention sweep — lifetimes with no per-pass budget and no wedged analysis to abandon — so
+    /// its store calls take no pass token. Threading one here would mean inventing a caller that
+    /// does not exist. Matches the Darling twin's PgFindingStore exactly.</para>
     /// </summary>
     public async Task MuteStoryAsync(int serverId, string storyPathHash, string storyPath, string? reason = null)
     {
@@ -285,7 +315,11 @@ VALUES ($1, $2, $3, $4, $5, $6)";
     }
 
     /// <summary>
-    /// Cleans up old findings beyond the retention period.
+    /// Cleans up old findings beyond the retention period.    ///
+    /// <para>#2443 exempt: off the analysis pass. This surface serves the viewer, the MCP and the
+    /// retention sweep — lifetimes with no per-pass budget and no wedged analysis to abandon — so
+    /// its store calls take no pass token. Threading one here would mean inventing a caller that
+    /// does not exist. Matches the Darling twin's PgFindingStore exactly.</para>
     /// </summary>
     public async Task CleanupOldFindingsAsync(int retentionDays = 30)
     {
@@ -304,7 +338,8 @@ VALUES ($1, $2, $3, $4, $5, $6)";
     /// lock and connection (NoRecursion lock — do not re-acquire here). Used by
     /// FilterMutedFindingsAsync so the mute-filter read reuses that phase's connection.
     /// </summary>
-    private static async Task<HashSet<string>> GetMutedHashesAsync(DuckDBConnection connection, int serverId)
+    private static async Task<HashSet<string>> GetMutedHashesAsync(
+        DuckDBConnection connection, int serverId, CancellationToken cancellationToken)
     {
         var hashes = new HashSet<string>();
 
@@ -317,8 +352,8 @@ WHERE server_id = $1 OR server_id IS NULL OR server_id = 0";
 
         cmd.Parameters.Add(new DuckDBParameter { Value = serverId });
 
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        using var reader = await cmd.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
             hashes.Add(reader.GetString(0));
 
         return hashes;
@@ -328,6 +363,13 @@ WHERE server_id = $1 OR server_id IS NULL OR server_id = 0";
     /// Inserts one finding on an already-open connection. The caller owns the read lock
     /// and connection, so a batch of inserts in one InsertFindingsAsync call shares a
     /// single lock acquisition and connection.
+    ///
+    /// <para>#2443 exempt: this write deliberately takes no token. Cancelling inside a single-row
+    /// INSERT buys nothing — the row is microseconds of work in-process — and costs a definite
+    /// answer about whether it landed: DuckDB's cancel is <c>duckdb_interrupt</c>, so an interrupted
+    /// INSERT can leave a row that did commit, in a set nothing marks as partial.
+    /// <see cref="InsertFindingsAsync"/> carries the full reasoning and the abandonment point that
+    /// replaces this one.</para>
     /// </summary>
     private static async Task InsertFindingAsync(DuckDBConnection connection, AnalysisFinding finding)
     {

--- a/Lite/Analysis/FindingStore.cs
+++ b/Lite/Analysis/FindingStore.cs
@@ -153,7 +153,8 @@ public class FindingStore
     }
 
     /// <summary>
-    /// Returns the most recent findings for a server within the given time range.    ///
+    /// Returns the most recent findings for a server within the given time range.
+    ///
     /// <para>#2443 exempt: off the analysis pass. This surface serves the viewer, the MCP and the
     /// retention sweep — lifetimes with no per-pass budget and no wedged analysis to abandon — so
     /// its store calls take no pass token. Threading one here would mean inventing a caller that
@@ -220,7 +221,8 @@ LIMIT $3";
     }
 
     /// <summary>
-    /// Returns the latest analysis run's findings for a server (most recent analysis_time).    ///
+    /// Returns the latest analysis run's findings for a server (most recent analysis_time).
+    ///
     /// <para>#2443 exempt: off the analysis pass. This surface serves the viewer, the MCP and the
     /// retention sweep — lifetimes with no per-pass budget and no wedged analysis to abandon — so
     /// its store calls take no pass token. Threading one here would mean inventing a caller that
@@ -285,7 +287,8 @@ ORDER BY severity DESC";
     }
 
     /// <summary>
-    /// Mutes a story pattern so it won't appear in future analysis runs.    ///
+    /// Mutes a story pattern so it won't appear in future analysis runs.
+    ///
     /// <para>#2443 exempt: off the analysis pass. This surface serves the viewer, the MCP and the
     /// retention sweep — lifetimes with no per-pass budget and no wedged analysis to abandon — so
     /// its store calls take no pass token. Threading one here would mean inventing a caller that
@@ -315,7 +318,8 @@ VALUES ($1, $2, $3, $4, $5, $6)";
     }
 
     /// <summary>
-    /// Cleans up old findings beyond the retention period.    ///
+    /// Cleans up old findings beyond the retention period.
+    ///
     /// <para>#2443 exempt: off the analysis pass. This surface serves the viewer, the MCP and the
     /// retention sweep — lifetimes with no per-pass budget and no wedged analysis to abandon — so
     /// its store calls take no pass token. Threading one here would mean inventing a caller that

--- a/Lite/Analysis/SqlPlanFetcher.cs
+++ b/Lite/Analysis/SqlPlanFetcher.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
 using PerformanceMonitor.Analysis;
@@ -20,7 +21,7 @@ public class SqlPlanFetcher : IPlanFetcher
         _serverManager = serverManager;
     }
 
-    public async Task<string?> FetchPlanXmlAsync(int serverId, string planHandle)
+    public async Task<string?> FetchPlanXmlAsync(int serverId, string planHandle, CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(planHandle)) return null;
 
@@ -43,7 +44,7 @@ public class SqlPlanFetcher : IPlanFetcher
             };
 
             await using var connection = new SqlConnection(builder.ConnectionString);
-            await connection.OpenAsync();
+            await connection.OpenAsync(cancellationToken);
 
             await using var cmd = new SqlCommand(@"
 SET NOCOUNT ON;
@@ -53,7 +54,7 @@ FROM sys.dm_exec_query_plan(CONVERT(varbinary(64), @plan_handle, 1))", connectio
             cmd.CommandTimeout = 15;
             cmd.Parameters.AddWithValue("@plan_handle", planHandle);
 
-            var result = await cmd.ExecuteScalarAsync();
+            var result = await cmd.ExecuteScalarAsync(cancellationToken);
             if (result == null || result is DBNull) return null;
 
             return result.ToString();

--- a/Lite/Analysis/SqlPlanFetcher.cs
+++ b/Lite/Analysis/SqlPlanFetcher.cs
@@ -59,8 +59,15 @@ FROM sys.dm_exec_query_plan(CONVERT(varbinary(64), @plan_handle, 1))", connectio
 
             return result.ToString();
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
+            /* #2443: review caught this, and it is a real behaviour gap rather than a tidiness one.
+               Lite arms a genuine per-pass budget (#2412), so the token this method now takes can and
+               does fire mid-fetch on a healthy running app. An unconditional catch would log
+               "Failed to fetch plan for handle …: The operation was canceled." as an ERROR for work
+               we ourselves called off, AND swallow it, so the pass would carry on enriching under a
+               fired token instead of unwinding to AnalysisService's one quiet line. Same arm the
+               Darling twin's PgPlanFetcher carries for the identical call shape. */
             AppLogger.Error("SqlPlanFetcher",
                 $"Failed to fetch plan for handle {planHandle}: {ex.Message}");
             return null;

--- a/Lite/Database/DuckDbInitializer.cs
+++ b/Lite/Database/DuckDbInitializer.cs
@@ -31,11 +31,38 @@ public class DuckDbInitializer
     /// If the current thread already owns a read lock (e.g., leaked by an unhandled exception),
     /// returns a no-op disposable to allow the operation to proceed.
     /// </summary>
-    public IDisposable AcquireReadLock()
+    public IDisposable AcquireReadLock() => AcquireReadLock(CancellationToken.None);
+
+    /// <summary>
+    /// The same read lock, abandonable (#2443). <see cref="AcquireWriteLock"/> has taken a timeout
+    /// since it was written and this one took nothing, which left a real hole in the analysis budget:
+    /// every store read on the pass takes this lock BEFORE it opens its connection, so a pass queued
+    /// behind a long archival or a compaction sat in an uninterruptible <c>EnterReadLock()</c> however
+    /// carefully its reads were threaded. Cancellation reached the reads and stopped at the door.
+    ///
+    /// <para>A token rather than a timeout, because a timeout would need a NUMBER and there is no
+    /// honest one to pick — the right budget for waiting on this lock is exactly the caller's remaining
+    /// budget, which the caller already holds. A poll is the only way to say that to
+    /// <see cref="ReaderWriterLockSlim"/>, which has no token-taking overload; the interval is only
+    /// reached under contention, since an uncontended <c>TryEnterReadLock</c> returns immediately.
+    /// <see cref="CancellationToken.None"/> takes the original uninterruptible path, so the fourteen
+    /// callers outside the analysis pass are unchanged rather than quietly re-timed.</para>
+    /// </summary>
+    public IDisposable AcquireReadLock(CancellationToken cancellationToken)
     {
         try
         {
-            s_dbLock.EnterReadLock();
+            if (!cancellationToken.CanBeCanceled)
+            {
+                s_dbLock.EnterReadLock();
+            }
+            else
+            {
+                while (!s_dbLock.TryEnterReadLock(ReadLockPollInterval))
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+            }
         }
         catch (LockRecursionException)
         {
@@ -46,6 +73,14 @@ public class DuckDbInitializer
         }
         return new LockReleaser(s_dbLock, write: false);
     }
+
+    /// <summary>
+    /// How long a cancellable read-lock wait blocks before re-checking its token. Only reached under
+    /// contention, so it costs nothing on the normal path; 50 ms keeps the worst-case overshoot far
+    /// below the smallest budget anyone would set while leaving the wait almost entirely in the kernel
+    /// rather than spinning.
+    /// </summary>
+    private static readonly TimeSpan ReadLockPollInterval = TimeSpan.FromMilliseconds(50);
 
     /// <summary>
     /// Acquires an exclusive write lock on the database. Blocks until all readers finish.

--- a/Lite/Services/LocalDataService.Blocking.cs
+++ b/Lite/Services/LocalDataService.Blocking.cs
@@ -539,8 +539,12 @@ LIMIT 5000";
 
         // Always-on DMV blocking snapshot: merge in the fallback rows so the viewer works even when the
         // blocked-process-report XE captured nothing (threshold unset / AWS RDS). Same connection/lock.
+        /* #2443: CancellationToken.None because the viewer genuinely has no pass to abandon — this
+           read serves a person waiting at a grid, not an analysis pass with a budget or a service
+           stop. Stated here rather than defaulted in the shared method, so the exception belongs to
+           the caller that actually has it. */
         await PerformanceMonitorLite.Analysis.BlockingPairRowQuery.AppendDmvSnapshotRowsAsync(
-            connection.CreateCommand, rows, serverId, start, end);
+            connection.CreateCommand, rows, serverId, start, end, System.Threading.CancellationToken.None);
 
         return rows;
     }

--- a/PerformanceMonitor.Analysis/IPlanFetcher.cs
+++ b/PerformanceMonitor.Analysis/IPlanFetcher.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace PerformanceMonitor.Analysis;
@@ -14,6 +15,13 @@ public interface IPlanFetcher
     /// <summary>
     /// Fetches the execution plan XML for a given plan_handle.
     /// Returns null if the plan is no longer in cache.
+    ///
+    /// <para>#2443: the token is REQUIRED rather than defaulted, and that is deliberate. This is the
+    /// one call on the analysis pass that opens a session on a MONITORED server rather than on the
+    /// monitoring store, so it is the one an abandoned pass most needs to be able to let go of. A
+    /// defaulted parameter would let a call site keep passing nothing while the signature claimed
+    /// otherwise; requiring it makes every implementer and every caller name the token it abandons
+    /// under.</para>
     /// </summary>
-    Task<string?> FetchPlanXmlAsync(int serverId, string planHandle);
+    Task<string?> FetchPlanXmlAsync(int serverId, string planHandle, CancellationToken cancellationToken);
 }

--- a/deprecated/Dashboard/Analysis/SqlServerDrillDownCollector.Plans.cs
+++ b/deprecated/Dashboard/Analysis/SqlServerDrillDownCollector.Plans.cs
@@ -61,7 +61,7 @@ ORDER BY collection_time DESC;";
         if (string.IsNullOrEmpty(planHandle)) return;
 
         // Fetch plan XML live from SQL Server
-        var planXml = await _planFetcher.FetchPlanXmlAsync(context.ServerId, planHandle);
+        var planXml = await _planFetcher.FetchPlanXmlAsync(context.ServerId, planHandle, context.CancellationToken);
         if (string.IsNullOrEmpty(planXml)) return;
 
         try

--- a/deprecated/Dashboard/Analysis/SqlServerPlanFetcher.cs
+++ b/deprecated/Dashboard/Analysis/SqlServerPlanFetcher.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
 using PerformanceMonitor.Analysis;
@@ -21,7 +22,7 @@ public class SqlServerPlanFetcher : IPlanFetcher
         _connectionString = connectionString;
     }
 
-    public async Task<string?> FetchPlanXmlAsync(int serverId, string planHandle)
+    public async Task<string?> FetchPlanXmlAsync(int serverId, string planHandle, CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(planHandle)) return null;
 
@@ -34,7 +35,7 @@ public class SqlServerPlanFetcher : IPlanFetcher
             };
 
             await using var connection = new SqlConnection(builder.ConnectionString);
-            await connection.OpenAsync();
+            await connection.OpenAsync(cancellationToken);
 
             await using var cmd = new SqlCommand(@"
 SET NOCOUNT ON;
@@ -44,7 +45,7 @@ FROM sys.dm_exec_query_plan(CONVERT(varbinary(64), @plan_handle, 1));", connecti
             cmd.CommandTimeout = 15;
             cmd.Parameters.AddWithValue("@plan_handle", planHandle);
 
-            var result = await cmd.ExecuteScalarAsync();
+            var result = await cmd.ExecuteScalarAsync(cancellationToken);
             if (result == null || result is DBNull) return null;
 
             return result.ToString();


### PR DESCRIPTION
Closes the other half of #2443. Darling is #2449; this branch sits on top of it so it compiles, and the diff narrows to Lite's own commits the moment #2449 merges. **Merge #2449 first.**

> Reviewers: the first four commits here belong to #2449 and are already reviewed there. Lite's work is `bff0bea9` onward.

## What was wrong

#2419 armed a per-pass budget and put a `ThrowIfCancellationRequested` ahead of every store-touching stage, which closed the user-visible defect in #2412 — a wedged server became loudly stuck instead of silently skipped forever. Its diff touched **no store file**. So abandonment happened between stages: a collector that had already started ran to completion, holding the read lock and the connection of a pass that had stopped waiting for it.

Re-derived count on `dev`: **203 untokened async store calls across 17 files in `Lite/Analysis/`** — `ExecuteReaderAsync` 65, `ReadAsync` 65, `OpenAsync` 67, `ExecuteScalarAsync` 3, `ExecuteNonQueryAsync` 3. (The issue estimated ~138. Two of the 203 are `SqlPlanFetcher`'s SqlClient calls, which #2449 already threads; the DuckDB side is 201.) Plus **66 `AcquireReadLock()` calls in the same files**, which turn out to matter more than any of them.

## The lock was the real hole

`AcquireWriteLock` has taken a `TimeSpan?` since it was written; `AcquireReadLock` took nothing and blocked in `EnterReadLock()` until it got in. And the **order** of every store read on this pass is: take the lock, *then* open the connection. So a pass queued behind a long archival or a compaction was uninterruptible no matter how carefully its reads were threaded — the token would have reached the reads and stopped at the door. This is the item #2443 called out as "Lite-only, small, and the one place where the reporting genuinely cannot be replaced by cancellation", and threading the reads without it would have produced a pass abandonable everywhere except where it was actually stuck.

It takes **a token, not a timeout**, and that is the choice rather than a detail: a timeout needs a NUMBER, and the right budget for waiting on this lock is exactly the caller's remaining budget — which the caller already holds and nothing in `DuckDbInitializer` can know. `ReaderWriterLockSlim` has no token-taking overload, so a 50 ms poll is the only way to say it; the interval is only reached under contention, and `CancellationToken.None` takes the original `EnterReadLock()` path unchanged, so the fourteen callers outside the analysis pass are not quietly re-timed.

## DuckDB cancellation, measured rather than assumed

#2419 recorded that a token cancelled at 2 s aborted a 15,233 ms query at 2,004 ms. What it did not record is **what that throws**, and the whole classifier depends on it — the worry was a `DuckDBException` needing its own pattern-match. Measured against DuckDB.NET 1.5.5 on net10.0:

| | result |
|---|---|
| pre-cancelled token, `ExecuteScalarAsync(ct)` | `TaskCanceledException`, database never touched |
| token fired mid-query, `ExecuteReaderAsync(ct)` | **`System.OperationCanceledException`** — 2,790 ms query aborted at **2,004 ms** |
| `ReadAsync(ct)`, token fired mid-loop | observed, stops at the next row |
| the interrupted connection afterwards | fully usable |
| a fresh connection to the same file afterwards | fully usable |

So `duckdb_interrupt` reaches .NET as a plain `OperationCanceledException` and there is nothing else to name. `AnalysisAbandon.IsExpected` is one shape long **because that is what was measured**, not because it was assumed — and widening it would cost fault evidence for nothing.

## Threading the reads alone would have accomplished almost nothing

The fact collector's 27 per-query catches are bare `catch { }` **on purpose** — a missing table degrades to "no facts", never an exception — so a fired token would have been caught 27 times and the pass would have carried on to the next collector each time. (#2419's per-collector checkpoint bounds that to one wasted attempt per collector: much better than nothing, and still 27 of them.)

The nine `AnomalyDetector` catches are worse, because they do not swallow — they log `AppLogger.Error`. Unfiltered, an ordinary budget expiry would have produced **nine ERROR lines** describing nine detectors that "failed". `BaselineProvider`'s is the same shape, and is the one that produced five of the seven lines #2299 was filed about on the Darling side.

So all 40-odd now classify through `AnalysisAbandon.IsExpected`, and an abandonment propagates to the single line `AnalysisService` logs for it. Catch bodies and comments are unchanged; the only thing that stops being caught is the one thing we asked for.

`AnalysisAbandon` exists because #2419's inline predicate was right for one site and forty copies of a two-clause predicate is how the clauses drift. Both halves stay load-bearing, and the TYPE half especially: this token fires on an ordinary timeout, so it is signalled during normal running, and a filter asking only "has the token fired?" would relabel any fault landing after the budget as an abandonment — #2419's own first review finding, at forty sites instead of one.

## What cancellation means, per caller

| Caller | Cancellation abandons | Threaded? |
|---|---|---|
| `DuckDbFactCollector.*` | a read (and its read lock) | yes — 93 |
| `DrillDownCollector.*` | a read, plus a live plan fetch on a **monitored** server | yes — 53 |
| `AnomalyDetector` / `BaselineProvider` | a read | yes — 36 |
| `FindingStore.FilterMutedFindingsAsync` | a read of the mute registry | yes |
| `FindingStore.InsertFinding*` | a **write** | **no, deliberately** |

### A partial persist cannot happen on the cancellation path

Identical to the Darling twin's decision, reached the same way — a divergence here would be a parity bug, not a local choice. The lock and the connection open are the last abandonment points; past them the batch finishes.

There is no transaction, every row in a batch shares one `analysis_time`, and `GetLatestFindingsAsync` takes the newest `analysis_time` — so a batch cut in half **does not read as truncated**. It reads as a complete analysis that found fewer problems, and the server looks *healthier* for having been abandoned. Cancelling inside a row would be worse: `duckdb_interrupt` can leave a row that did commit, in a set nothing marks as partial — an ambiguous commit for microseconds of in-process work. **A partial set is still reachable from a store *fault* mid-batch**; that predates this work and is filed as #2448 against both SKUs.

## The 15 exemptions

Four read-back surfaces (the recommendations reader, the viewer's latest-run findings, the MCP mute verb, the retention sweep) plus the finding INSERT — the same five the Darling twin exempts, for the same two reasons. Each is exempt **by method name in the test** and carries a `#2443 exempt` note in its own doc comment, with a second test asserting the reverse direction.

## The test

`Lite.Tests/AnalysisPassTokenThreadingTests`, six tests. `AcquireReadLock()` sits on the forbidden list *beside* the ADO calls rather than in a check of its own, deliberately: the lock and the reads are one property, and splitting them into two tests would let half of it be reverted quietly.

Two are behavioural. The read-lock test holds a real write lock on another thread — what an archival looks like from here — and asserts the read side gives up when asked. Reverted, it does not fail, it **hangs** until the writer lets go, which is the defect stated as precisely as a test can state it.

## Verification

- Full solution builds clean on macOS (`EnableWindowsTargeting`), 0 errors, no new warnings. Each of the five Lite commits builds clean on its own, checked individually.
- `Lite.Tests` is `net10.0-windows` and cannot run on macOS, so the new test file was compiled into a `net10.0` xUnit harness together with the **real** `Lite/Analysis/AnalysisAbandon.cs` and `Lite/Database/DuckDbInitializer.cs` sources (one harness-only stub for the single service-layer symbol `DuckDbInitializer` reaches for — a pure hash on a legacy re-key path that nothing under test calls). **6/6 pass.** With `Lite/Analysis` reverted, the four source pins go red; with the pre-change `EnterReadLock()` spliced back in, the read-lock test hangs rather than passing. CI is the arbiter for the rest of the suite.
- The DuckDB cancellation numbers above come from a separate throwaway probe against DuckDB.NET 1.5.5, not from repeating #2419's note.

## Deferred

- #2448 — a batch that fails mid-insert leaves a truncated set that reads as a complete one. Both SKUs, pre-existing, unreachable from cancellation after this.
- `FindingStore.InsertFindingsAsync` takes a **read** lock for a write, and has since it was written. Out of scope for a token sweep and not touched here; filed separately.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
