### PR TITLE
Band Lite's collection freshness, so a quiet server stops looking green (#2452)

### DIFF
--- a/Lite.Tests/ServerCollectionFreshnessTests.cs
+++ b/Lite.Tests/ServerCollectionFreshnessTests.cs
@@ -1,0 +1,382 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Windows.Media;
+using PerformanceMonitor.Common;
+using PerformanceMonitorLite.Services;
+using Xunit;
+
+namespace Lite.Tests;
+
+/// <summary>
+/// #2452: Lite's Overview card banded five metric rows and a status word, and none of them was collection
+/// FRESHNESS. A server could go quiet and stay green — the connection check still passing, no collector
+/// reporting an error, and the store taking no new rows for hours — while the card showed "Online" in green,
+/// a neutral border, and a "Last Collect" timestamp rendered in the plain foreground brush, where a reading
+/// from four hours ago looked exactly like one from four seconds ago.
+///
+/// <para><b>Freshness is a THIRD axis and these pins exist mostly to keep it one.</b> The card already
+/// answers two questions: did the last connection check succeed (<c>IsOnline</c>) and are any collectors
+/// erroring (<c>HasCollectorErrors</c>). "Has anything landed lately" is neither of those, and the way this
+/// goes wrong is well documented next door: #2429 found the Darling viewer says the same word, "Warning", for
+/// a stale collection AND for a metric breach, with nothing on the card telling them apart — the card @ehaar
+/// wrote in about in #2422. So <see cref="TheStatusWordIsNotToldAboutFreshness"/> and
+/// <see cref="EachAxisIsNamedOnTheCardWithoutBorrowingTheOthersWords"/> are the load-bearing tests here; the
+/// band arithmetic below is the shared classifier's and is pinned in <c>PerformanceMonitor.Common</c>.</para>
+///
+/// <para><b>The thresholds are read, never restated.</b> Every boundary case is built from
+/// <see cref="ServerHealthThresholds"/> rather than from the literals 2 and 15, so a test cannot pass while
+/// the card has quietly grown numbers of its own — which is the drift the shared class was created to end
+/// (#1562).</para>
+/// </summary>
+public class ServerCollectionFreshnessTests
+{
+    private static readonly DateTime Now = new(2026, 8, 21, 12, 0, 0, DateTimeKind.Utc);
+
+    /// <summary>A card in the state #2452 describes: reachable, nothing erroring, every metric calm. The
+    /// only variable is how long ago the newest collection_log row landed.</summary>
+    private static ServerSummaryItem QuietServer(TimeSpan? sinceLastCollection)
+    {
+        var card = new ServerSummaryItem
+        {
+            DisplayName = "sql-01",
+            ServerId = 1,
+            IsOnline = true,
+            HasCollectorErrors = false,
+            CpuPercent = 4,
+            OtherProcessCpuPercent = 1,
+            MemoryMb = 8192,
+            BlockingCount = 0,
+            DeadlockCount = 0,
+            LastCollectionTime = sinceLastCollection.HasValue ? Now - sinceLastCollection.Value : null,
+        };
+
+        card.ApplyCollectionFreshness(Now);
+        return card;
+    }
+
+    private static string Hex(SolidColorBrush brush) => brush.Color.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+    private const string Green = "#FF81C784";
+    private const string RowAmber = "#FFFFB74D";
+    private const string Red = "#FFE57373";
+    private const string StatusAmber = "#FFFFD54F";
+    private const string NeutralBorder = "#FF2A2D35";
+    private const string UnknownGrey = "#FF888888";
+
+    // ── The band itself, off the shared thresholds ────────────────────────────────────────────────────
+
+    [Fact]
+    public void ACollectionInsideTheCadenceIsFresh()
+    {
+        var card = QuietServer(ServerHealthThresholds.CollectorCadence);
+
+        Assert.Equal(ServerFreshness.Fresh, card.CollectionFreshness);
+        Assert.False(card.CollectionIsNotFresh);
+        Assert.Equal(Green, Hex(card.LastCollectionBrush));
+    }
+
+    [Fact]
+    public void PastTwiceTheCadenceTheRowGoesAmberAndSaysStale()
+    {
+        var card = QuietServer(ServerHealthThresholds.StaleThreshold + TimeSpan.FromSeconds(1));
+
+        Assert.Equal(ServerFreshness.Stale, card.CollectionFreshness);
+        Assert.Equal(RowAmber, Hex(card.LastCollectionBrush));
+        Assert.EndsWith(" (stale)", card.LastCollectionDisplay, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PastTheOfflineThresholdTheRowGoesRedAndSaysStopped()
+    {
+        var card = QuietServer(ServerHealthThresholds.OfflineThreshold + TimeSpan.FromSeconds(1));
+
+        Assert.Equal(ServerFreshness.Offline, card.CollectionFreshness);
+        Assert.Equal(Red, Hex(card.LastCollectionBrush));
+        Assert.EndsWith(" (stopped)", card.LastCollectionDisplay, StringComparison.Ordinal);
+    }
+
+    /// <summary>Exactly ON a threshold is still the lower band — the shared classifier compares with a strict
+    /// <c>&gt;</c>. Pinned because a card that re-derived the comparison is exactly how the two SKUs would
+    /// come to disagree by one tick, and nothing else would ever show it.</summary>
+    [Fact]
+    public void TheBoundariesAreTheSharedClassifiersAndAreInclusiveOfTheLowerBand()
+    {
+        Assert.Equal(ServerFreshness.Fresh, QuietServer(ServerHealthThresholds.StaleThreshold).CollectionFreshness);
+        Assert.Equal(ServerFreshness.Stale, QuietServer(ServerHealthThresholds.OfflineThreshold).CollectionFreshness);
+    }
+
+    /// <summary>A server that has never been collected is queued, not dead. Amber, never the red the
+    /// stopped band gets — the viewer learned this from a 24-server field report that went chasing a
+    /// phantom scheduler bug (<see cref="ServerFreshness.NeverCollected"/>).</summary>
+    [Fact]
+    public void NeverCollectedIsAmberRatherThanRed()
+    {
+        var card = QuietServer(null);
+
+        Assert.Equal(ServerFreshness.NeverCollected, card.CollectionFreshness);
+        Assert.Equal(RowAmber, Hex(card.LastCollectionBrush));
+        Assert.Equal("Never", card.LastCollectionDisplay);
+    }
+
+    /// <summary>An item nobody classified renders EXACTLY what dev's row rendered: the bare stamp, the
+    /// card's unknown grey, and no tooltip. Unreachable in the shipped app — every ServerSummaryItem is
+    /// built by GetServerSummaryAsync, which stamps the band — but a fixture or a new data path can produce
+    /// it, and a named "not classified" beats falling through onto a band that would be a guess.</summary>
+    [Fact]
+    public void AnUnclassifiedCardClaimsNothing()
+    {
+        var card = new ServerSummaryItem { LastCollectionTime = Now.AddHours(-4) };
+
+        Assert.Null(card.CollectionFreshness);
+        Assert.False(card.CollectionIsNotFresh);
+        Assert.Equal(UnknownGrey, Hex(card.LastCollectionBrush));
+        Assert.Null(card.CollectionFreshnessTooltip);
+        Assert.DoesNotContain("(", card.LastCollectionDisplay, StringComparison.Ordinal);
+    }
+
+    // ── The defect, and the conflation the fix must not create ────────────────────────────────────────
+
+    /// <summary>
+    /// The #2452 card itself. Everything the card used to answer still says the server is fine, because
+    /// those answers are still TRUE — the connection check really did succeed and no collector really is
+    /// erroring. What changes is that the card no longer looks calm: the border escalates and the row that
+    /// holds the evidence is red and says so.
+    /// </summary>
+    [Fact]
+    public void AServerThatWentQuietNoLongerLooksCalm()
+    {
+        var quiet = QuietServer(TimeSpan.FromHours(4));
+
+        /* Unchanged, and deliberately so: these two answer different questions and both are still yes. */
+        Assert.Equal("Online", quiet.StatusDisplay);
+        Assert.Equal(Green, Hex(quiet.StatusBrush));
+
+        /* Changed: the card now shows the third axis. */
+        Assert.Equal(StatusAmber, Hex(quiet.CardBorderBrush));
+        Assert.Equal(Red, Hex(quiet.LastCollectionBrush));
+        Assert.Contains("stopped", quiet.LastCollectionDisplay, StringComparison.Ordinal);
+        Assert.Contains("Collection has stopped", quiet.CollectionFreshnessTooltip!, StringComparison.Ordinal);
+
+        /* And #2451's card tooltip picks it up through the gate pattern, which is what option 1 in the
+           issue meant by "let the tooltip name it, the way it names CPU and Blocking today". */
+        Assert.Contains("Needs attention: Last collect ", quiet.StatusTooltip, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The invariant #2451 established for the metric rows, extended to this one: the tooltip names the Last
+    /// Collect row exactly when that row is not green. Asserted against the SHIPPED brush rather than against
+    /// a copy of the thresholds, so the clause and the colour cannot drift apart — a tooltip that named a
+    /// green row, or stayed silent about a red one, is the single thing this property exists to prevent.
+    /// </summary>
+    [Fact]
+    public void TheTooltipNamesTheCollectionRowExactlyWhenItIsNotGreen()
+    {
+        foreach (var age in new TimeSpan?[]
+                 {
+                     TimeSpan.FromSeconds(20),
+                     ServerHealthThresholds.StaleThreshold + TimeSpan.FromSeconds(1),
+                     TimeSpan.FromHours(4),
+                     null,
+                 })
+        {
+            var card = QuietServer(age);
+
+            Assert.Equal(
+                Hex(card.LastCollectionBrush) != Green,
+                card.StatusTooltip.Contains("Last collect ", StringComparison.Ordinal));
+        }
+    }
+
+    /// <summary>
+    /// Collection goes FIRST in the reason, ahead of the metrics. It is the row that says whether the other
+    /// four can be believed: a card whose collection stopped four hours ago is showing four-hour-old CPU,
+    /// and meeting "CPU 4%" before learning that is the wrong order to be told the two facts in.
+    /// </summary>
+    [Fact]
+    public void TheReasonLeadsWithCollectionWhenBothAxesAreInTrouble()
+    {
+        var card = QuietServer(TimeSpan.FromHours(4));
+        card.CpuPercent = 96;
+        card.OtherProcessCpuPercent = 0;
+        card.DeadlockCount = 2;
+
+        Assert.StartsWith("Last collect ", card.StatusReason, StringComparison.Ordinal);
+        Assert.Contains("CPU ", card.StatusReason, StringComparison.Ordinal);
+        Assert.Contains("Deadlocks ", card.StatusReason, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The same card while collection is current is the control: neutral border, green row. Without this the
+    /// test above would pass on a card that had simply been painted amber for everyone.
+    /// </summary>
+    [Fact]
+    public void ACalmCardWithCurrentCollectionStaysNeutral()
+    {
+        var healthy = QuietServer(TimeSpan.FromSeconds(20));
+
+        Assert.Equal(NeutralBorder, Hex(healthy.CardBorderBrush));
+        Assert.Equal(Green, Hex(healthy.LastCollectionBrush));
+    }
+
+    /// <summary>
+    /// The anti-conflation pin, and the reason option 2 in #2452 was turned down. Lite's status word is a
+    /// CONNECTION word — <c>IsOnline</c> comes from a live check that succeeds whether or not anything is
+    /// being collected, and "Warning" there already means collectors are erroring. If freshness were folded
+    /// into it, one amber word would mean two unrelated failures, which is precisely the viewer defect
+    /// #2429 found and #2422 reported. So a stale card's word and colour are byte-identical to a fresh
+    /// card's, and every difference is on the row that owns the axis.
+    /// </summary>
+    [Fact]
+    public void TheStatusWordIsNotToldAboutFreshness()
+    {
+        var fresh = QuietServer(TimeSpan.FromSeconds(20));
+        var stale = QuietServer(ServerHealthThresholds.StaleThreshold + TimeSpan.FromSeconds(1));
+        var stopped = QuietServer(TimeSpan.FromHours(4));
+
+        Assert.Equal(fresh.StatusDisplay, stale.StatusDisplay);
+        Assert.Equal(fresh.StatusDisplay, stopped.StatusDisplay);
+        Assert.Equal(Hex(fresh.StatusBrush), Hex(stale.StatusBrush));
+        Assert.Equal(Hex(fresh.StatusBrush), Hex(stopped.StatusBrush));
+    }
+
+    /// <summary>
+    /// Both directions of the split. A stale collection must not be describable as a metric problem, and a
+    /// metric breach must not be describable as a collection problem — the card carries both at once often
+    /// enough that only an adversarial pair proves the two vocabularies stayed apart.
+    /// </summary>
+    [Fact]
+    public void EachAxisIsNamedOnTheCardWithoutBorrowingTheOthersWords()
+    {
+        var stale = QuietServer(ServerHealthThresholds.StaleThreshold + TimeSpan.FromSeconds(1));
+        var tooltip = stale.CollectionFreshnessTooltip!;
+
+        Assert.Contains("Collection is stale", tooltip, StringComparison.Ordinal);
+        Assert.Contains("not about the server's metrics", tooltip, StringComparison.Ordinal);
+        /* The one word that means "collectors are erroring" on this card. Freshness may never claim it. */
+        Assert.DoesNotContain("Warning", tooltip, StringComparison.Ordinal);
+
+        /* A busy server whose collection is perfectly current: the border escalates for the METRIC, and the
+           collection row keeps saying collection is fine. */
+        var busy = QuietServer(TimeSpan.FromSeconds(20));
+        busy.CpuPercent = 96;
+        busy.OtherProcessCpuPercent = 0;
+
+        Assert.Equal(RowAmber, Hex(busy.CardBorderBrush));
+        Assert.Equal(Green, Hex(busy.LastCollectionBrush));
+        Assert.Contains("Collection is current", busy.CollectionFreshnessTooltip!, StringComparison.Ordinal);
+        Assert.DoesNotContain("Last collect ", busy.StatusTooltip, StringComparison.Ordinal);
+    }
+
+    /// <summary>The tooltip quotes the shared thresholds instead of restating them, so the sentence cannot
+    /// come to disagree with the band it is explaining.</summary>
+    [Fact]
+    public void TheTooltipQuotesTheSharedThresholds()
+    {
+        var stale = QuietServer(ServerHealthThresholds.StaleThreshold + TimeSpan.FromSeconds(1));
+        var stopped = QuietServer(ServerHealthThresholds.OfflineThreshold + TimeSpan.FromSeconds(1));
+
+        Assert.Contains(
+            $"{ServerHealthThresholds.StaleThreshold.TotalMinutes:0.#} minute",
+            stale.CollectionFreshnessTooltip!,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            $"{ServerHealthThresholds.OfflineThreshold.TotalMinutes:0.#} minute",
+            stopped.CollectionFreshnessTooltip!,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>The band is a pure function of (last collection, now): the same card classified against two
+    /// clocks lands in two bands. That is what makes the stamp testable without a store, and what keeps the
+    /// clock out of the card's property getters.</summary>
+    [Fact]
+    public void TheBandIsPureOverTheClockItIsGiven()
+    {
+        var card = new ServerSummaryItem { LastCollectionTime = Now };
+
+        card.ApplyCollectionFreshness(Now);
+        Assert.Equal(ServerFreshness.Fresh, card.CollectionFreshness);
+
+        card.ApplyCollectionFreshness(Now + ServerHealthThresholds.OfflineThreshold + TimeSpan.FromMinutes(1));
+        Assert.Equal(ServerFreshness.Offline, card.CollectionFreshness);
+    }
+
+    // ── Wiring: the half that lives in XAML, where no assertion about a C# object can reach it ─────────
+
+    /// <summary>
+    /// The Last Collect row has to actually BE bound to the band, and removing either binding compiles
+    /// perfectly clean — the properties would simply go unread and the row would render exactly as it did
+    /// on dev. <c>Background="Transparent"</c> is checked with them because a <c>TextBlock</c> with a null
+    /// Background hit-tests on its rendered glyphs alone, so without it the tooltip appears over the letters
+    /// and nowhere in the space around them (#2429 found this on the viewer's status line).
+    /// </summary>
+    [Fact]
+    public void TheCardsLastCollectRowIsBoundToTheBand()
+    {
+        var xaml = ParitySource.ReadFile("Lite/MainWindow.xaml");
+        var row = RowFour(xaml);
+
+        Assert.Contains("{Binding LastCollectionBrush}", row, StringComparison.Ordinal);
+        Assert.Contains("{Binding CollectionFreshnessTooltip}", row, StringComparison.Ordinal);
+        Assert.DoesNotContain("Foreground=\"{DynamicResource ForegroundBrush}\"", row, StringComparison.Ordinal);
+        Assert.Equal(2, CountOccurrences(row, "Background=\"Transparent\""));
+        Assert.Equal(2, CountOccurrences(row, "ToolTip=\"{Binding CollectionFreshnessTooltip}\""));
+    }
+
+    /// <summary>
+    /// The band is stamped at the ONE place a ServerSummaryItem is built, which is what stops the Overview
+    /// and the two MCP reads from getting different answers about the same server. It is pinned in the
+    /// source because deleting that single line compiles perfectly clean and silently returns every card to
+    /// dev's behaviour — no band, so a grey row and a neutral border. A property that nothing sets is the
+    /// failure mode this whole issue is about, one level up.
+    /// </summary>
+    [Fact]
+    public void EveryCardIsStampedWithItsBandWhereItIsBuilt()
+    {
+        var source = ParitySource.ReadFile("Lite/Services/LocalDataService.Overview.cs");
+
+        Assert.Equal(1, CountOccurrences(source, "new ServerSummaryItem"));
+        Assert.Equal(1, CountOccurrences(source, "ApplyCollectionFreshness(DateTime.UtcNow)"));
+
+        /* And the stamp is after the object is built: banding an object that has already been handed back
+           would band nothing, and the ordering is the half a count cannot see. */
+        Assert.True(
+            source.IndexOf("new ServerSummaryItem", StringComparison.Ordinal)
+                < source.IndexOf("ApplyCollectionFreshness(DateTime.UtcNow)", StringComparison.Ordinal),
+            "The freshness stamp no longer follows the summary it is meant to band.");
+    }
+
+    /// <summary>The two Grid.Row="4" TextBlocks of the Overview card template — the "Last Collect:" label
+    /// and its value. Sliced by the marker rather than by line numbers so an edit above the row does not
+    /// silently move the window this test reads.</summary>
+    private static string RowFour(string xaml)
+    {
+        const string marker = "Text=\"Last Collect:\"";
+        var start = xaml.IndexOf(marker, StringComparison.Ordinal);
+        Assert.True(start >= 0, "The Overview card no longer has a Last Collect row.");
+        Assert.Equal(start, xaml.LastIndexOf(marker, StringComparison.Ordinal));
+
+        var lineStart = xaml.LastIndexOf('<', start);
+        var end = xaml.IndexOf("</Grid>", start, StringComparison.Ordinal);
+        Assert.True(end > lineStart, "The Last Collect row is no longer inside the card's metric Grid.");
+        return xaml[lineStart..end];
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        for (var i = haystack.IndexOf(needle, StringComparison.Ordinal); i >= 0;
+             i = haystack.IndexOf(needle, i + needle.Length, StringComparison.Ordinal))
+        {
+            count++;
+        }
+
+        return count;
+    }
+}

--- a/Lite/MainWindow.xaml
+++ b/Lite/MainWindow.xaml
@@ -502,8 +502,16 @@
                                                         <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding BlockingDisplay}" Foreground="{Binding BlockingBrush}" FontWeight="SemiBold" Margin="8,2" HorizontalAlignment="Right"/>
                                                         <TextBlock Grid.Row="3" Grid.Column="0" Text="Deadlocks:" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,2"/>
                                                         <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding DeadlockDisplay}" Foreground="{Binding DeadlockBrush}" FontWeight="SemiBold" Margin="8,2" HorizontalAlignment="Right"/>
-                                                        <TextBlock Grid.Row="4" Grid.Column="0" Text="Last Collect:" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,2"/>
-                                                        <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding LastCollectionDisplay}" Foreground="{DynamicResource ForegroundBrush}" FontWeight="SemiBold" Margin="8,2" HorizontalAlignment="Right"/>
+                                                        <!-- Last Collect is a BANDED row (#2452): its brush comes from the shared
+                                                             ServerHealthClassifier, and it carries a tooltip that says the band is about
+                                                             collection stopping rather than about the server's metrics. Background="Transparent"
+                                                             on both cells is load-bearing, not decoration: a TextBlock with a null Background
+                                                             hit-tests on its rendered glyphs alone, so the tooltip would appear over the
+                                                             letters and nowhere in the space around them (#2429). -->
+                                                        <TextBlock Grid.Row="4" Grid.Column="0" Text="Last Collect:" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,2"
+                                                                   Background="Transparent" ToolTip="{Binding CollectionFreshnessTooltip}"/>
+                                                        <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding LastCollectionDisplay}" Foreground="{Binding LastCollectionBrush}" FontWeight="SemiBold" Margin="8,2" HorizontalAlignment="Right"
+                                                                   Background="Transparent" ToolTip="{Binding CollectionFreshnessTooltip}"/>
                                                     </Grid>
                                                 </StackPanel>
                                                 <!-- Offline overlay -->

--- a/Lite/Services/LocalDataService.Overview.cs
+++ b/Lite/Services/LocalDataService.Overview.cs
@@ -406,13 +406,18 @@ public class ServerSummaryItem
         DeadlocksAreElevated ? "#E57373" :
         BlockingIsElevated ? "#FFB74D" :
         CpuIsCritical ? "#FFB74D" :
+        CardStatus == ServerCardStatus.CollectorErrors ? "#FFD54F" :   // amber border when collectors are failing
         /* Collector errors and collector SILENCE are the same class of fault — the monitoring of this server
-           is not working — so they share one arm and one amber. Silence is the harder of the two to notice,
-           which is the whole of #2452: nothing on the card moved when a server went quiet. It stays amber
-           even for a stopped collection, because the red border belongs to a dark server and a red border
-           under a green "Online" word would be the loudest contradiction on the card; the row underneath
-           carries the severity in its own colour and its own word. */
-        CardStatus == ServerCardStatus.CollectorErrors || CollectionIsNotFresh ? "#FFD54F" :
+           is not working — so they get the same amber, on their own arm rather than folded into the one
+           above. Two named causes reading one colour is the honest shape here, and it keeps #2451's pin on
+           the CollectorErrors arm reading the discriminant it was written to pin.
+
+           Silence is the harder of the two to notice, which is the whole of #2452: nothing on this card
+           moved when a server went quiet. It stays amber even for a STOPPED collection, because the red
+           border belongs to a dark server and a red border under a green "Online" word would be the loudest
+           contradiction on the card; the row underneath carries the severity in its own colour and its own
+           word. */
+        CollectionIsNotFresh ? "#FFD54F" :
         "#2a2d35");
 
     /* ── The card explains itself (#2437 / #2422) ────────────────────────────────────────────────────

--- a/Lite/Services/LocalDataService.Overview.cs
+++ b/Lite/Services/LocalDataService.Overview.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Windows.Media;
 using DuckDB.NET.Data;
+using PerformanceMonitor.Common;
 
 namespace PerformanceMonitorLite.Services;
 
@@ -110,7 +111,7 @@ WHERE server_id = $1";
             }
         }
 
-        return new ServerSummaryItem
+        var summary = new ServerSummaryItem
         {
             DisplayName = displayName,
             ServerId = serverId,
@@ -121,6 +122,14 @@ WHERE server_id = $1";
             DeadlockCount = deadlockCount,
             LastCollectionTime = lastCollection
         };
+
+        /* Band the collection's freshness HERE and not at the Overview loader, because this is the one
+           place a ServerSummaryItem is built: the two MCP reads call this method too, and a band only the
+           Overview applied would be a fact that depended on which caller asked. The clock is handed in
+           rather than read inside the band, so the classification stays a pure function of
+           (last collection, now) — the shape the viewer's ApplyFreshness already has. */
+        summary.ApplyCollectionFreshness(DateTime.UtcNow);
+        return summary;
     }
 }
 
@@ -234,10 +243,113 @@ public class ServerSummaryItem
     public string MemoryDisplay => MemoryMb.HasValue ? $"{MemoryMb / 1024.0:F1} GB" : "--";
     public string BlockingDisplay => BlockingCount > 0 ? BlockingCount.ToString() : "0";
     public string DeadlockDisplay => DeadlockCount > 0 ? DeadlockCount.ToString() : "0";
-    public string LastCollectionDisplay => LastCollectionTime.HasValue ? ServerTimeHelper.FormatServerTime(LastCollectionTime, "HH:mm:ss") : "Never";
+
+    /// <summary>
+    /// How old the newest collection_log row for this server is, banded by the SHARED
+    /// <see cref="ServerHealthClassifier.ClassifyFreshness"/> — the same Fresh / Stale / Offline /
+    /// NeverCollected ladder the Darling viewer bands, off the same <see cref="ServerHealthThresholds"/>
+    /// numbers, so the two SKUs cannot drift on when a collection has gone quiet (#2452).
+    ///
+    /// <para>NULL means nobody classified it. <see cref="ApplyCollectionFreshness"/> always produces a band
+    /// and every ServerSummaryItem the app builds goes through it, so null is unreachable in the shipped
+    /// app; a hand-built item can still produce one, which is why it is a named "not classified" rather
+    /// than a fall-through onto a band that would be a guess. It renders as the card's existing unknown
+    /// grey with no band word — exactly what this row rendered before it had a band.</para>
+    /// </summary>
+    public ServerFreshness? CollectionFreshness { get; set; }
+
+    /// <summary>
+    /// Stamp <see cref="CollectionFreshness"/> from this card's own <see cref="LastCollectionTime"/>. Pure
+    /// over (last collection, now): both instants are UTC (the DuckDB store is naive UTC and
+    /// <paramref name="nowUtc"/> is <see cref="DateTime.UtcNow"/>), so the subtraction inside the classifier
+    /// is a true elapsed time regardless of Kind. Stamped rather than computed on read so the band cannot
+    /// change between the row's brush binding and the tooltip that explains it.
+    /// </summary>
+    public void ApplyCollectionFreshness(DateTime nowUtc) =>
+        CollectionFreshness = ServerHealthClassifier.ClassifyFreshness(LastCollectionTime, nowUtc);
+
+    /// <summary>
+    /// The Last Collect row. Names its band in words when the collection is not current, because a colour
+    /// alone is what this row already had against it: it was a bare "HH:mm:ss" in the plain foreground
+    /// brush, so a timestamp from four hours ago looked exactly like one from four seconds ago and nothing
+    /// on the card asked anyone to read it (#2452).
+    /// </summary>
+    public string LastCollectionDisplay
+    {
+        get
+        {
+            if (!LastCollectionTime.HasValue) return "Never";
+
+            var stamp = ServerTimeHelper.FormatServerTime(LastCollectionTime, "HH:mm:ss");
+            return CollectionFreshness switch
+            {
+                ServerFreshness.Stale => $"{stamp} (stale)",
+                ServerFreshness.Offline => $"{stamp} (stopped)",
+                _ => stamp,
+            };
+        }
+    }
+
+    /// <summary>
+    /// The Last Collect row's band brush — the row's own palette, alongside CPU / Blocking / Deadlocks,
+    /// rather than the neutral foreground it used to be painted in. NeverCollected is amber, never red: a
+    /// server that has not been collected yet is queued, not dead, and red there sent a 24-server field
+    /// report chasing a phantom scheduler bug on the viewer side (see
+    /// <see cref="ServerFreshness.NeverCollected"/>). An unclassified band gets the card's unknown grey.
+    /// </summary>
+    public SolidColorBrush LastCollectionBrush => MakeBrush(CollectionFreshness switch
+    {
+        ServerFreshness.Fresh => "#81C784",
+        ServerFreshness.Stale => "#FFB74D",
+        ServerFreshness.Offline => "#E57373",
+        ServerFreshness.NeverCollected => "#FFB74D",
+        _ => "#888888",
+    });
+
+    /// <summary>
+    /// What the Last Collect row's band MEANS, for the tooltip that row carries.
+    ///
+    /// <para>The second sentence is the point of the wording rather than padding. #2429 found the Darling
+    /// viewer says the same word — "Warning" — for a stale collection and for a metric breach, with nothing
+    /// on the card telling them apart; that was the card @ehaar wrote in about (#2422). So Lite says which
+    /// axis it is about, in words, on the row the band is on. It is deliberately NOT folded into the status
+    /// word: see the note on <see cref="CardStatus"/>.</para>
+    ///
+    /// <para>The thresholds are read from <see cref="ServerHealthThresholds"/> rather than typed, so the
+    /// sentence cannot come to disagree with the band it is explaining.</para>
+    /// </summary>
+    public string? CollectionFreshnessTooltip => CollectionFreshness switch
+    {
+        ServerFreshness.Fresh =>
+            $"Collection is current — something landed within the last {Minutes(ServerHealthThresholds.StaleThreshold)}.",
+        ServerFreshness.Stale =>
+            $"Collection is stale — nothing has landed for over {Minutes(ServerHealthThresholds.StaleThreshold)}.\n" +
+            "This is about collection stopping, not about the server's metrics: the connection check can " +
+            "still be passing and no collector reporting an error.",
+        ServerFreshness.Offline =>
+            $"Collection has stopped — nothing has landed for over {Minutes(ServerHealthThresholds.OfflineThreshold)}.\n" +
+            "This is about collection stopping, not about the server's metrics: the connection check can " +
+            "still be passing and no collector reporting an error.",
+        ServerFreshness.NeverCollected =>
+            "No collection has ever landed for this server.\n" +
+            "This is about collection, not about the server's metrics.",
+        _ => null,
+    };
+
+    /// <summary>Renders a threshold as "2 minutes" / "15 minutes" so the tooltip quotes the shared numbers
+    /// instead of restating them.</summary>
+    private static string Minutes(TimeSpan span) =>
+        $"{span.TotalMinutes:0.#} minute{(Math.Abs(span.TotalMinutes - 1) < 0.001 ? "" : "s")}";
 
     /* Connection status. This is the ONE place the (IsOnline, HasCollectorErrors) pair is read; the word, the
-       colour and the tooltip's first line all render the result. See ServerCardStatus. */
+       colour and the tooltip's first line all render the result. See ServerCardStatus.
+
+       Collection freshness is deliberately NOT one of the states here, and that is option 2 in #2452 being
+       turned down. This word is a CONNECTION word: IsOnline comes from ServerManager.GetConnectionStatus, a
+       live check that succeeds whether or not anything is being collected, and CollectorErrors already means
+       one specific thing. Folding freshness in would make one amber word mean two unrelated failures, which
+       is the conflation #2429 spent four review rounds untangling on the viewer and the reason #2422 was
+       written. Freshness is a third axis: it bands its own row, and the tooltip names it there. */
     public ServerCardStatus CardStatus => IsOnline switch
     {
         true when HasCollectorErrors => ServerCardStatus.CollectorErrors,
@@ -275,6 +387,13 @@ public class ServerSummaryItem
     private bool BlockingIsElevated => BlockingCount > 0;
     private bool DeadlocksAreElevated => DeadlockCount > 0;
 
+    /// <summary>The Last Collect row's gate — stale, stopped, or never started (#2452). Public because the
+    /// card border reads it too; the other three are private only because nothing outside needed them. Like
+    /// them it is the row's OWN "not green" test, so the border, the row brush and the tooltip cannot come
+    /// to disagree about whether this card's collection is in trouble.</summary>
+    public bool CollectionIsNotFresh =>
+        CollectionFreshness is ServerFreshness.Stale or ServerFreshness.Offline or ServerFreshness.NeverCollected;
+
     /* Color coding */
     public SolidColorBrush CpuBrush => MakeBrush(CpuIsCritical ? "#E57373" : CpuIsElevated ? "#FFB74D" : "#81C784");
     public SolidColorBrush BlockingBrush => MakeBrush(BlockingIsElevated ? "#FFB74D" : "#81C784");
@@ -287,7 +406,13 @@ public class ServerSummaryItem
         DeadlocksAreElevated ? "#E57373" :
         BlockingIsElevated ? "#FFB74D" :
         CpuIsCritical ? "#FFB74D" :
-        CardStatus == ServerCardStatus.CollectorErrors ? "#FFD54F" :   // amber border when collectors are failing
+        /* Collector errors and collector SILENCE are the same class of fault — the monitoring of this server
+           is not working — so they share one arm and one amber. Silence is the harder of the two to notice,
+           which is the whole of #2452: nothing on the card moved when a server went quiet. It stays amber
+           even for a stopped collection, because the red border belongs to a dark server and a red border
+           under a green "Online" word would be the loudest contradiction on the card; the row underneath
+           carries the severity in its own colour and its own word. */
+        CardStatus == ServerCardStatus.CollectorErrors || CollectionIsNotFresh ? "#FFD54F" :
         "#2a2d35");
 
     /* ── The card explains itself (#2437 / #2422) ────────────────────────────────────────────────────
@@ -321,12 +446,25 @@ public class ServerSummaryItem
     /// <para>Memory is absent deliberately: the Memory row carries no severity brush on this card, so there is
     /// no band to report. Inventing a threshold here would be the one thing this property exists to prevent —
     /// a tooltip asserting something the rows underneath it do not.</para>
+    ///
+    /// <para>Last Collect joined the list when it gained a band (#2452), and it goes FIRST. It is the row
+    /// that says whether the other four can be believed at all: a card whose collection stopped four hours
+    /// ago is showing four-hour-old CPU, and reading "CPU 4%" before learning that is the wrong order to
+    /// meet the two facts in. It quotes <see cref="LastCollectionDisplay"/> verbatim, like every other part
+    /// here, so the clause and the row cannot render different things — and because that display already
+    /// carries the band word, the clause says which axis it is about without borrowing a metric's
+    /// vocabulary.</para>
     /// </summary>
     public string StatusReason
     {
         get
         {
             var parts = new List<string>();
+
+            if (CollectionIsNotFresh)
+            {
+                parts.Add("Last collect " + LastCollectionDisplay);
+            }
 
             if (CpuIsElevated)
             {


### PR DESCRIPTION
Fixes #2452 (part 1). Part 2 is split out as #2458 — see the last section for why, and why the issue's reason for pairing them did not survive the implementation.

## The defect, and why it is reachable in shipped Lite

The Overview card carries five metric rows and a status word. None of them was collection freshness, so the state the issue describes — connection fine, nothing *erroring*, store taking no new rows for hours — rendered as a green **"Online"**, a neutral border, and a timestamp in the plain foreground brush where four hours ago looked exactly like four seconds ago.

The issue asks for a measurement: *whether Lite installs actually see collection stop without a collector erroring*. Lite's own source answers it without needing one, and the path is short:

- `RemoteCollectorService.RecordCollectorResult` treats `PERMISSIONS` as **not a failure** — deliberately, per its comment, because a permission denial is not transient. It sets `IsPermissionRestricted` and leaves `ConsecutiveErrors` alone.
- `IsCollectorPermissionRestricted` then `return`s out of `RunCollectorAsync` **before** `LogCollectionAsync`, so a restricted collector writes no `collection_log` row at all — not even a failed one.
- `GetHealthSummary` counts `ErroringCollectors` from `ConsecutiveErrors > 0`.

So a login that loses rights across the board stops the store dead with `ErroringCollectors` at **zero**, the connection check still passing, and every card green. `_collectorHealth` is in-memory too, so an app restart zeroes every streak while the store stays exactly as stale as the previous session left it.

## What changed, and the one thing that deliberately did not

**Option 1 from the issue**, sharing the thresholds rather than growing new ones.

`ServerHealthClassifier.ClassifyFreshness` out of `PerformanceMonitor.Common` — the same Fresh / Stale / Offline / NeverCollected ladder the Darling viewer bands, off the same `ServerHealthThresholds` numbers. Lite already referenced that project, so this cost one `using`. **No threshold is added to Lite**, and that is a claim about correctness rather than convenience: Lite's fastest configured collector in `collection_schedule.json` runs every minute, which is exactly the derivation `CollectorCadence` documents, so `StaleThreshold` is true here on its own terms rather than borrowed from a service with a different rhythm.

**Option 2 — folding freshness into the status word — is turned down, and the reason is written on `StatusDisplay`.** Lite's status word is a *connection* word (`IsOnline` is a live check, which succeeds whether or not anything is being collected) and its `"Warning"` already means one specific thing: collectors are erroring. #2429 found the viewer renders that same word for a stale collection **and** for a metric breach with nothing on the card telling them apart, which is the card @ehaar wrote in about in #2422. Reproducing that here would have traded one defect for the other.

So freshness bands its own row and names its own band there. What the card actually renders, printed from the shipped `ServerSummaryItem` spliced out of this branch:

| collection | status word | border | Last Collect row | card tooltip's middle line |
|---|---|---|---|---|
| current | `Online` green | neutral `#2A2D35` | `11:59:40` green | `Every metric on this card is inside its threshold` |
| stale (2m01s) | `Online` green | amber `#FFD54F` | `11:57:59 (stale)` amber | `Needs attention: Last collect 11:57:59 (stale)` |
| stopped (4h) | `Online` green | amber `#FFD54F` | `08:00:00 (stopped)` **red** | `Needs attention: Last collect 08:00:00 (stopped)` |
| never collected | `Online` green | amber `#FFD54F` | `Never` amber | `Needs attention: Last collect Never` |

and the Last Collect row carries its own tooltip, which is the part that answers the "do not reproduce the conflation" requirement literally:

> Collection is stale — nothing has landed for over 2 minutes.
> This is about collection stopping, not about the server's metrics: the connection check can still be passing and no collector reporting an error.

The status word staying green across all four rows is not an oversight — it is the point. `IsOnline` answers "did the last connection check succeed", and it did. **"Online" and "fresh" are different questions and the card now answers both, each in its own place, each in its own words.** The thresholds inside the tooltip are read from `ServerHealthThresholds` rather than typed, so the sentence cannot come to disagree with the band it is explaining.

### Three smaller decisions

**The border escalates, on its own arm reading the same amber as the collector-error one.** Collector errors and collector silence are one class of fault — the monitoring of this server is not working — and silence is the harder of the two to notice, which is the whole issue; a fix that left the card looking calm at a glance would have fixed a row nobody was asked to read. It stays **amber even for a stopped collection**: red belongs to the offline overlay, and a red border under a green "Online" would be the loudest contradiction on the card. The row underneath carries the severity in its own colour and its own word.

It is a separate arm rather than a clause on the collector-error one because #2451's `TheCardBorder_RendersTheSameDiscriminantTheWordDoes` pins that arm's source text — `CardStatus == ServerCardStatus.CollectorErrors ? "#FFD54F"` — and folding `|| CollectionIsNotFresh` in put the new clause between the discriminant and the colour, so the literal stopped appearing. That pin is a landed guard from another lane asserting something true and worth asserting, so the branch moved rather than the pin. Two named causes reading one colour is the better shape anyway: each arm gets its own line and its own reason.

**This was caught by running #2451's committed test class against this branch rather than waiting for CI to run it** — and CI then failed on that one test and nothing else, which is the whole argument for doing it that way. All 12 of #2451's tests pass on this branch now.

**`NeverCollected` is amber, never red.** A server that has not been collected yet is queued, not dead — the reasoning `ServerFreshness.NeverCollected` already carries from the viewer, where a red "Offline" on a merely-queued server sent a 24-server field report chasing a phantom scheduler bug.

**The band is stamped in `GetServerSummaryAsync`**, the one place a `ServerSummaryItem` is built, rather than at the Overview loader — the two MCP reads call that method too, and a band only the Overview applied would be a fact that depended on which caller asked. The clock is handed in rather than read inside the band, so the classification stays pure over (last collection, now). `null` means nobody classified it: unreachable in the app, reachable from a fixture, and it renders **exactly what dev rendered** — the bare stamp, the card's unknown grey, no tooltip.

`Background="Transparent"` on both row cells is load-bearing rather than decoration, as #2429 found: a `TextBlock` with a null `Background` hit-tests on its rendered glyphs alone, so the tooltip would have appeared over the letters and nowhere in the space around them.

## Verification

`Lite.Tests` targets `net10.0-windows` and cannot run on macOS, so the logic was run for real anyway: a throwaway `net10.0` harness **splices `ServerSummaryItem` straight out of the shipped file** (a generator reads the source and emits it — never retyped) behind a `System.Windows.Media` shim, with a real project reference to `PerformanceMonitor.Common` so the bands are the shipped classifier's. The table above is that harness's output.

| | dev | this branch |
|---|---|---|
| the full committed test file | **does not compile — 29 errors** | **16 passed / 0 failed** |
| the identically-expressible subset | **3 passed / 5 failed** | **8 passed / 0 failed** |

The absence is the finding rather than a measurement, so the subset runs identical bodies against both contracts. `ApplyCollectionFreshness` is invoked reflectively there — on dev there is genuinely nothing to stamp, which is the thing being measured, not a harness limit. The five that fail on dev are the quiet server's border, the row naming its band, the card tooltip naming the row, the XAML wiring, and the stamp itself. **The three that pass on both sides are the controls**, and they are the ones a wrong fix breaks first: a calm currently-collecting card keeps the neutral border (so this is not "paint every card amber"), the status word says the same thing for a stale card as for a fresh one (so this is not option 2 sneaking in), and a calm current card's tooltip still says nothing about collection.

`EveryCardIsStampedWithItsBandWhereItIsBuilt` is a source scan on purpose: deleting that one line compiles perfectly clean and silently returns every card to dev's behaviour, and a property nothing sets is this issue's own failure mode one level up. The XAML half has to text-scan for the same reason #2429 gave — a `ToolTip` attribute lives where no assertion about a C# object can reach it, and removing it compiles clean.

`dev` moved twice while this was open (#2451, then #2450/#2453). Rebased onto `88fe948f` and re-verified: whole solution builds 0 errors, and **28 cases green — this PR's 16 plus all 12 of #2451's**, run against the rebased tree. Not force-pushed, because the PR is `MERGEABLE`/`CLEAN` against that same `dev` and the rebase was for verification rather than for the merge.

Whole solution builds, 0 errors. CHANGELOG deliberately untouched — #2395 is an open release-prep PR that owns that file for 3.5.1.

## Part 2 is split out as #2458, not dropped

#2452's second half — `ServerConnection.DotStatus` being a fourth independent copy of the four-word ladder — is filed as #2458 rather than done here, and the issue's own reason for pairing them does not hold as this landed. It argued that "a freshness band would otherwise need writing twice". It is written **once**, on `ServerSummaryItem`, and the sidebar dot is untouched, so nothing is duplicated by leaving it.

The thing that *does* argue for splitting: the type `DotStatus` should collapse onto is `ServerCardStatus`, and in Lite that type arrives in **#2451**, which is still open. Doing it here would mean either duplicating that enum or stacking on an unmerged branch — and a stacked PR reports a meaningless green.

## #2451 landed while this was open, and it is what completes option 1

The issue's option 1 has two halves: band the row, **and** "let the tooltip name it, the way it names CPU and Blocking today". The second half needed a tooltip built from the card's own rows, which did not exist in Lite when #2452 was written. #2451 merged into `dev` mid-flight and brought one, so this branch was rebuilt on top of it rather than textually merged, and takes the whole option instead of half.

`CollectionIsNotFresh` joins `CpuIsElevated` / `BlockingIsElevated` / `DeadlocksAreElevated` in #2451's per-row concern gates, and `StatusReason` quotes `LastCollectionDisplay` **verbatim** exactly as it quotes `CpuDisplay` — which is the property that makes that whole design work, per its own comment: the clause and the row cannot render different things. Because the display already carries the band word, the clause names its axis without borrowing a metric's vocabulary.

It goes **first** in the reason. Collection is the row that says whether the other four can be believed at all: a card whose collection stopped four hours ago is showing four-hour-old CPU, and meeting "CPU 4%" before learning that is the wrong order to be told the two facts in.

`TheTooltipNamesTheCollectionRowExactlyWhenItIsNotGreen` extends #2451's own invariant to this row and asserts it against the **shipped brush** rather than a copy of the thresholds:

```csharp
Assert.Equal(
    Hex(card.LastCollectionBrush) != Green,
    card.StatusTooltip.Contains("Last collect ", StringComparison.Ordinal));
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
