### PR TITLE
Make a finding batch commit whole or not at all (#2448)

### DIFF
--- a/Darling/Darling.Tests/AnalysisPassTokenThreadingTests.cs
+++ b/Darling/Darling.Tests/AnalysisPassTokenThreadingTests.cs
@@ -256,13 +256,19 @@ public sealed class AnalysisPassTokenThreadingTests
 
     /// <summary>
     /// The decision this issue asked to be made explicitly rather than assumed: what a cancelled PERSIST
-    /// means. The insert batch has no transaction (per-row failure isolation is deliberate — one bad row
-    /// logs and the batch continues), every row shares one <c>analysis_time</c>, and the latest-findings
-    /// read keys on <c>MAX(analysis_time)</c>. So a batch cut in half does not read as truncated; it reads
-    /// as a complete analysis that found fewer problems, and the server looks HEALTHIER for having been
-    /// abandoned. That is a third outcome, distinct from the timeout and the shutdown the classifier names,
-    /// and it must not exist. The connection open is therefore the last abandonment point: before the first
-    /// row, or not at all.
+    /// means. Every row shares one <c>analysis_time</c> and the latest-findings read keys on
+    /// <c>MAX(analysis_time)</c>, so a batch cut in half does not read as truncated; it reads as a
+    /// complete analysis that found fewer problems, and the server looks HEALTHIER for having been
+    /// abandoned. That is a third outcome, distinct from the timeout and the shutdown the classifier
+    /// names, and it must not exist. The connection open is therefore the last abandonment point: before
+    /// the first row, or not at all.
+    ///
+    /// <para>#2448 closed the other half of that. #2443 could only reason about the CANCELLATION path,
+    /// and the same truncated set was still reachable from an ordinary store fault mid-batch, where no
+    /// amount of token discipline reaches. The batch is now one transaction, so it is all-or-nothing
+    /// against a fault as well — which is why the between-rows assertion below is still right, but no
+    /// longer the only thing standing between a store fault and a set that understates a server. Both
+    /// halves are pinned here because they are one property.</para>
     /// </summary>
     [Fact]
     public void TheFindingInsertIsAbandonedBeforeItStartsOrNotAtAll()
@@ -278,6 +284,19 @@ public sealed class AnalysisPassTokenThreadingTests
            set rather than prevent it, which is why there is none. */
         var insertBatch = Between(store, "public async Task<List<AnalysisFinding>> InsertFindingsAsync(", "public async Task<List<AnalysisFinding>> SaveFindingsAsync(");
         Assert.DoesNotContain("ThrowIfCancellationRequested", insertBatch, StringComparison.Ordinal);
+
+        /* #2448: the batch is one transaction, and the rows are enlisted in it. Both halves are pinned
+           because either alone is silently useless — a transaction the rows do not join commits nothing
+           of theirs, and enlisting in a transaction nobody commits writes nothing at all. */
+        Assert.Contains("await connection.BeginTransactionAsync();", insertBatch, StringComparison.Ordinal);
+        Assert.Contains("await transaction.CommitAsync();", insertBatch, StringComparison.Ordinal);
+        Assert.Contains("new NpgsqlCommand(InsertFindingSql, connection, transaction)", store, StringComparison.Ordinal);
+
+        /* And the row write must not swallow. A per-row catch inside a transaction is worse than useless:
+           PostgreSQL refuses every later statement once one fails (25P02), so it buys N-k ERROR lines for
+           one event and a CommitAsync that returns normally having written nothing. */
+        var rowWrite = Between(store, "private async Task InsertFindingAsync(", "private static AnalysisFinding ReadFinding(");
+        Assert.DoesNotContain("catch", rowWrite, StringComparison.Ordinal);
 
         /* The row write states the decision where someone changing it will read it. */
         Assert.Contains(ExemptionMarker, Between(store, "/// Inserts one finding on an already-open connection", "private async Task InsertFindingAsync("), StringComparison.Ordinal);

--- a/Darling/Darling.Tests/DarlingAnalysisStoreTests.cs
+++ b/Darling/Darling.Tests/DarlingAnalysisStoreTests.cs
@@ -587,9 +587,12 @@ VALUES ($1, $2, $3, $4, $5, $6)", connection);
             var doomed = await store.FilterMutedFindingsAsync(PartialBatchStories(faultAtRow: 3), context);
             Assert.Equal(5, doomed.Count);
 
-            /* The store never throws to the pass (the class's error discipline); the loss reaches
-               the caller as one logged line, not as an exception. */
-            await store.InsertFindingsAsync(doomed, context);
+            /* It THROWS rather than degrading, which is the one place this store departs from its
+               own no-throw discipline and is deliberate: swallowing a total rollback returns the
+               same list a full success returns, so DarlingAnalysisService would set LastAnalysisTime,
+               fire AnalysisCompleted and log "Analysis complete - 5 finding(s)" over a store holding
+               none of them. That is this very defect moved one layer out. */
+            await Assert.ThrowsAsync<PostgresException>(() => store.InsertFindingsAsync(doomed, context));
 
             /* The assertion #2448 exists for: not "fewer rows", NO rows. A partial set here would
                be indistinguishable from a healthy server. */

--- a/Darling/Darling.Tests/DarlingAnalysisStoreTests.cs
+++ b/Darling/Darling.Tests/DarlingAnalysisStoreTests.cs
@@ -53,6 +53,11 @@ public sealed class DarlingAnalysisStoreTests
     private const int GlobalReaderServerId = -929292;
     private const int GlobalOtherServerId = -939393;
 
+    /* #2448's fixture, kept off every other test's server so the "nothing was persisted" assertion
+       cannot be satisfied by another test's cleanup or broken by its rows. */
+    private const int PartialBatchServerId = -646464;
+    private const string PartialBatchServerName = "analysis-store-partial-batch";
+
     /// <summary>
     /// Every v_&lt;table&gt; view the V4 migration must create: the fourteen the ported fact
     /// collectors read plus the three Lite's drill-down/storage collectors also read
@@ -522,6 +527,120 @@ VALUES ($1, $2, $3, $4, $5, $6)", connection);
     {
         using var cleanup = new NpgsqlCommand(
             $"DELETE FROM analysis_muted WHERE story_path_hash IN ('{GlobalNullHash}', '{LegacyZeroHash}', '{OtherServerHash}', '{GlobalSurvivorHash}');", connection);
+        await cleanup.ExecuteNonQueryAsync(ct);
+    }
+
+    /* ---------------- gated: #2448 — a faulted batch persists nothing ---------------- */
+
+    /// <summary>
+    /// #2448: a finding batch that faults partway through must persist NOTHING, not the rows that
+    /// happened to land first.
+    ///
+    /// <para>The damage this prevents is invisible by construction, which is why it is worth a live
+    /// test rather than a source pin. Every row in a batch shares one <c>analysis_time</c> and
+    /// <see cref="PgFindingStore.GetLatestFindingsSql"/> keys on <c>MAX(analysis_time)</c>, so four
+    /// committed rows of an intended forty do not read as a truncated set — they read as a complete
+    /// analysis that found four problems. The server looks HEALTHIER for the store having failed,
+    /// and nothing anywhere says otherwise.</para>
+    ///
+    /// <para>The fault is induced with a NUL byte in <c>story_text</c>, which PostgreSQL rejects as
+    /// 22021 (<c>invalid byte sequence for encoding "UTF8": 0x00</c>). That is the realistic
+    /// per-row fault on this table — it carries no primary key, no CHECK and no foreign key, and
+    /// every NOT NULL column maps to a non-nullable property with a default — so it is also the
+    /// exact case the old per-row catch was there to survive. It should not survive: publishing the
+    /// other rows as a complete analysis is the wrong answer, and it is the answer this test
+    /// forbids.</para>
+    ///
+    /// <para>Reverted, the batch commits its first two rows and this fails on
+    /// <c>Assert.Empty</c> — the truncated set stated exactly.</para>
+    /// </summary>
+    [Fact]
+    public async Task AFaultedBatch_PersistsNothing_RatherThanATruncatedSetThatReadsAsComplete()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the live partial-persist test.");
+
+        using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await PgMigrations.MigrateAsync(connection, TestContext.Current.CancellationToken);
+        await DeletePartialBatchRowsAsync(connection, TestContext.Current.CancellationToken);
+
+        await using var postgres = NpgsqlDataSource.Create(connectionString!);
+        var store = new PgFindingStore(postgres);
+
+        var bodySucceeded = false;
+        try
+        {
+            var windowEnd = TruncateToSeconds(DateTime.UtcNow);
+            var context = new AnalysisContext
+            {
+                ServerId = PartialBatchServerId,
+                ServerName = PartialBatchServerName,
+                TimeRangeStart = windowEnd.AddHours(-4),
+                TimeRangeEnd = windowEnd,
+                ServerUtcOffset = TimeSpan.Zero
+            };
+
+            /* Row 3 of 5 faults, so rows 1-2 are already durable at the moment it does — under
+               autocommit they stay durable, which is the whole defect. */
+            var doomed = await store.FilterMutedFindingsAsync(PartialBatchStories(faultAtRow: 3), context);
+            Assert.Equal(5, doomed.Count);
+
+            /* The store never throws to the pass (the class's error discipline); the loss reaches
+               the caller as one logged line, not as an exception. */
+            await store.InsertFindingsAsync(doomed, context);
+
+            /* The assertion #2448 exists for: not "fewer rows", NO rows. A partial set here would
+               be indistinguishable from a healthy server. */
+            Assert.Empty(await store.GetRecentFindingsAsync(PartialBatchServerId));
+
+            /* And the rollback is not the store simply refusing to write: the same batch without
+               the poisoned row commits in full, through the same code path. */
+            var clean = await store.FilterMutedFindingsAsync(PartialBatchStories(faultAtRow: null), context);
+            await store.InsertFindingsAsync(clean, context);
+            Assert.Equal(5, (await store.GetRecentFindingsAsync(PartialBatchServerId)).Count);
+
+            bodySucceeded = true;
+        }
+        finally
+        {
+            await LiveStoreCleanup.RunAsync(connectionString!, bodySucceeded, async (cleanup, cleanupCt) =>
+                await DeletePartialBatchRowsAsync(cleanup, cleanupCt));
+        }
+    }
+
+    /// <summary>
+    /// Five stories a pass would produce, optionally with a NUL byte in the story text of one of
+    /// them — <paramref name="faultAtRow"/> is 1-based, or null for a batch that must commit whole.
+    /// </summary>
+    private static List<AnalysisStory> PartialBatchStories(int? faultAtRow)
+    {
+        var stories = new List<AnalysisStory>();
+
+        for (var row = 1; row <= 5; row++)
+        {
+            stories.Add(new AnalysisStory
+            {
+                Severity = 1.0,
+                Confidence = 0.9,
+                Category = "waits",
+                StoryPath = $"PARTIAL_BATCH_{row}",
+                StoryPathHash = $"an1-partial-batch-{row}",
+                StoryText = row == faultAtRow ? "log flush detail\0truncated here" : $"row {row} of a five-finding pass",
+                RootFactKey = "WRITELOG",
+                RootFactValue = row,
+                FactCount = 1
+            });
+        }
+
+        return stories;
+    }
+
+    private static async Task DeletePartialBatchRowsAsync(NpgsqlConnection connection, System.Threading.CancellationToken ct)
+    {
+        using var cleanup = new NpgsqlCommand(
+            $"DELETE FROM analysis_findings WHERE server_id = {PartialBatchServerId};", connection);
         await cleanup.ExecuteNonQueryAsync(ct);
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgFindingStore.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgFindingStore.cs
@@ -64,9 +64,16 @@ public sealed record MutedStory(
 /// </para>
 ///
 /// <para>
-/// Error discipline mirrors the Dashboard twin: no public method throws — writes log and
-/// degrade, reads log and return empty. The mute-hash read fails OPEN (an unreadable mute
-/// registry lets findings through rather than suppressing them), exactly like both twins.
+/// Error discipline mirrors the Dashboard twin: reads log and return empty, and the mute-hash read
+/// fails OPEN (an unreadable mute registry lets findings through rather than suppressing them),
+/// exactly like both twins. <see cref="InsertFindingsAsync"/> is the ONE exception, and #2448 is
+/// why: "log and degrade" needs something to degrade TO, and once the batch became all-or-nothing
+/// there is nothing between "all persisted" and "none persisted". Swallowing the second would let
+/// <c>DarlingAnalysisService</c> set LastAnalysisTime, fire AnalysisCompleted and log "Analysis
+/// complete — N finding(s)" over a store holding none of them, which is #2448's own misreading
+/// moved one layer out and made louder. So it logs the detail only it can know and rethrows, and
+/// the pass reports itself failed — which is what the Lite twin has always done, by never catching
+/// at all.
 /// </para>
 /// </summary>
 public sealed class PgFindingStore
@@ -251,6 +258,15 @@ VALUES ($1, $2, $3, $4, $5, $6)";
     /// nothing, so reaching the commit is not evidence that anything was written. That is the other
     /// reason the row write must not swallow.</para>
     ///
+    /// <para>It is also the one write here that THROWS, against the class's own no-throw discipline,
+    /// and that follows from the transaction rather than sitting beside it. A swallowed rollback returns
+    /// the same list a full success returns, so the caller cannot tell them apart and announces a
+    /// complete analysis for a set the store does not have. Before the transaction that line was only a
+    /// little wrong — most rows had landed — and now it would be entirely wrong, which is the same
+    /// defect this method exists to remove, one layer further out. The single ERROR line below carries
+    /// the part only this method knows (which row, or that it was the commit); the pass adds its own
+    /// outcome line and reports itself failed.</para>
+    ///
     /// <para>#2443: the connection open is still the LAST cancellation point on this pass, unchanged
     /// by the above. Past it the batch runs to completion, and cancelling before the first row costs
     /// this cycle's findings and says so in the line the pass already logs. This is the same call
@@ -315,6 +331,11 @@ VALUES ($1, $2, $3, $4, $5, $6)";
                     "[PgFindingStore] InsertFindingsAsync failed at row {Row} of {Count} and the batch was rolled back — this analysis persisted NO findings, deliberately: a partial set would have read as a complete analysis that found fewer problems. {Message}",
                     row, findings.Count, ex.Message);
             }
+
+            /* And it must not be swallowed: see the note above. The caller announces a completed
+               analysis on the strength of this returning, so eating a total rollback would move the
+               #2448 misreading up a layer instead of removing it. */
+            throw;
         }
 
         return findings;

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgFindingStore.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgFindingStore.cs
@@ -271,6 +271,7 @@ VALUES ($1, $2, $3, $4, $5, $6)";
         }
 
         var row = 0;
+        var everyRowAccepted = false;
 
         try
         {
@@ -286,6 +287,7 @@ VALUES ($1, $2, $3, $4, $5, $6)";
                 await InsertFindingAsync(connection, transaction, finding);
             }
 
+            everyRowAccepted = true;
             await transaction.CommitAsync();
         }
         catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
@@ -293,10 +295,26 @@ VALUES ($1, $2, $3, $4, $5, $6)";
             /* The ONE line the batch is allowed to cost, and it states the loss rather than the
                mechanism: nothing was persisted, and that is the deliberate outcome. Naming the row
                is what turns "how often does this actually happen" into something the log can
-               answer — #2448 asked for that measurement and this is where it comes from. */
-            _logger?.LogError(
-                "[PgFindingStore] InsertFindingsAsync failed at row {Row} of {Count} and the batch was rolled back — this analysis persisted NO findings, deliberately: a partial set would have read as a complete analysis that found fewer problems. {Message}",
-                row, findings.Count, ex.Message);
+               answer — #2448 asked for that measurement and this is where it comes from.
+
+               Which is exactly why the commit gets its OWN line rather than sharing this one. After
+               the loop `row` sits at findings.Count, so a fault in CommitAsync — a blip, a
+               deadlock at commit, the store out of disk — would report "failed at row N of N" and
+               name the last finding as the bad one when every row had in fact been accepted and
+               only the commit failed. A diagnostic that exists to be counted must not miscount the
+               one case it cannot see from the row number. */
+            if (everyRowAccepted)
+            {
+                _logger?.LogError(
+                    "[PgFindingStore] InsertFindingsAsync had all {Count} row(s) accepted and then failed to COMMIT them, so the batch was rolled back — this analysis persisted NO findings, deliberately: a partial set would have read as a complete analysis that found fewer problems. {Message}",
+                    findings.Count, ex.Message);
+            }
+            else
+            {
+                _logger?.LogError(
+                    "[PgFindingStore] InsertFindingsAsync failed at row {Row} of {Count} and the batch was rolled back — this analysis persisted NO findings, deliberately: a partial set would have read as a complete analysis that found fewer problems. {Message}",
+                    row, findings.Count, ex.Message);
+            }
         }
 
         return findings;

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgFindingStore.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgFindingStore.cs
@@ -219,27 +219,43 @@ VALUES ($1, $2, $3, $4, $5, $6)";
 
     /// <summary>
     /// Inserts the (already mute-filtered, enriched, and action-attached) findings in one
-    /// batched pass on a single connection. Each row persists its BUILT
+    /// batched pass on a single connection, inside ONE transaction. Each row persists its BUILT
     /// <see cref="AnalysisFinding.Remediation"/> as <c>remediation_action_json</c> via the
     /// shared <see cref="AlertContextSerializer"/>, so a Darling finding's persisted action
     /// round-trips byte-identically to a Dashboard one. Returns the same list for caller
     /// convenience; the in-memory findings are unchanged.
     ///
-    /// <para>#2443: the connection open is the LAST cancellation point on this pass, and that is a
-    /// decision rather than an oversight. Past it the batch runs to completion, because the third
-    /// outcome — a half-written finding set — is worse than either of the two the classifier already
-    /// names. There is no transaction here (per-row failure isolation is deliberate: one bad row
-    /// logs and the batch continues), every row in a batch shares one <c>analysis_time</c>, and
-    /// <see cref="PgFindingStore.GetLatestFindingsSql"/> keys on <c>MAX(analysis_time)</c> — so a
-    /// batch cut in half does not read as truncated, it reads as a complete analysis that found
-    /// fewer problems. The server would look HEALTHIER for having been abandoned, with nothing
-    /// marking the set incomplete. Cancelling before the first row costs this cycle's findings and
-    /// says so; cancelling after it silently changes what the store means.</para>
+    /// <para>#2448: the transaction is what makes this method's promise true, and it is the whole
+    /// reason for the shape. A finding set is one indivisible statement about a server: every row
+    /// shares one <c>analysis_time</c>, and <see cref="PgFindingStore.GetLatestFindingsSql"/> keys
+    /// on <c>MAX(analysis_time)</c>. So a batch that lands four of forty rows before the store
+    /// faults does NOT read as truncated — it reads as a complete analysis that found four
+    /// problems, and the server looks HEALTHIER for the store having failed. Rolling the batch back
+    /// instead leaves the PREVIOUS pass as the newest complete set: stale, stamped with its own
+    /// older <c>analysis_time</c>, and incapable of misleading anyone.</para>
     ///
-    /// <para>The tail is affordable to finish: N small INSERTs against the LOCAL managed store on
-    /// loopback, not against a monitored server. It is not where a pass wedges. This is the same
-    /// call <c>DarlingAnalysisService</c> made one layer up in #2299 — "the post-enrichment tail
-    /// carries no check" — restated at the write it protects.</para>
+    /// <para>This replaces per-row failure isolation, which was deliberate and is deliberately gone.
+    /// It could not have survived the transaction on both SKUs anyway — PostgreSQL refuses every
+    /// later statement in a transaction once one fails (25P02) and only <c>SAVEPOINT</c> escapes
+    /// that, which DuckDB 1.5.5 does not parse, so keeping it here alone would be exactly the
+    /// Lite/Darling drift this store has spent its life removing. It also should not survive on its
+    /// own merits: a batch that silently drops row 5 and commits the other 39 is this same defect at
+    /// row granularity, a set claiming 39 problems when the analysis found 40. One failure now ends
+    /// the batch and costs ONE log line naming the count — #2299's shape — instead of a line per
+    /// remaining row and a set nothing marks as partial.</para>
+    ///
+    /// <para>Measured rather than assumed, because "the batch is small" is the load-bearing claim: a
+    /// busy production server persists ~10 rows per pass, as small INSERTs against the LOCAL managed
+    /// store on loopback. Worth knowing when reading the loop below: <c>CommitAsync</c> on an
+    /// already-aborted transaction RETURNS NORMALLY on both Npgsql and DuckDB.NET while committing
+    /// nothing, so reaching the commit is not evidence that anything was written. That is the other
+    /// reason the row write must not swallow.</para>
+    ///
+    /// <para>#2443: the connection open is still the LAST cancellation point on this pass, unchanged
+    /// by the above. Past it the batch runs to completion, and cancelling before the first row costs
+    /// this cycle's findings and says so in the line the pass already logs. This is the same call
+    /// <c>DarlingAnalysisService</c> made one layer up in #2299 — "the post-enrichment tail carries
+    /// no check" — restated at the write it protects.</para>
     /// </summary>
     public async Task<List<AnalysisFinding>> InsertFindingsAsync(
         List<AnalysisFinding> findings, AnalysisContext context)
@@ -254,20 +270,33 @@ VALUES ($1, $2, $3, $4, $5, $6)";
             return findings;
         }
 
+        var row = 0;
+
         try
         {
             await using var connection = await _postgres.OpenConnectionAsync(context.CancellationToken);
 
-            /* No token check between rows: see the note above. Once the first row is written this
-               batch is finishing. */
+            /* #2448: one transaction for the whole set — the batch commits complete or not at all.
+               No token check between rows: see the note above. */
+            await using var transaction = await connection.BeginTransactionAsync();
+
             foreach (var finding in findings)
             {
-                await InsertFindingAsync(connection, finding);
+                row++;
+                await InsertFindingAsync(connection, transaction, finding);
             }
+
+            await transaction.CommitAsync();
         }
         catch (Exception ex) when (!AnalysisShutdown.IsExpectedAbandon(ex, context.CancellationToken))
         {
-            _logger?.LogError("[PgFindingStore] InsertFindingsAsync failed: {Message}", ex.Message);
+            /* The ONE line the batch is allowed to cost, and it states the loss rather than the
+               mechanism: nothing was persisted, and that is the deliberate outcome. Naming the row
+               is what turns "how often does this actually happen" into something the log can
+               answer — #2448 asked for that measurement and this is where it comes from. */
+            _logger?.LogError(
+                "[PgFindingStore] InsertFindingsAsync failed at row {Row} of {Count} and the batch was rolled back — this analysis persisted NO findings, deliberately: a partial set would have read as a complete analysis that found fewer problems. {Message}",
+                row, findings.Count, ex.Message);
         }
 
         return findings;
@@ -518,66 +547,70 @@ VALUES ($1, $2, $3, $4, $5, $6)";
     }
 
     /// <summary>
-    /// Inserts one finding on an already-open connection (the caller owns it, so a batch
-    /// shares a single connection). Per-row failure isolation like the Dashboard twin: one
-    /// bad row logs and the batch continues.
+    /// Inserts one finding on an already-open connection, enlisted in the batch's transaction (the
+    /// caller owns both, so a batch shares a single connection and a single transaction).
+    ///
+    /// <para>#2448: this throws rather than logging and continuing, which is the reverse of the
+    /// Dashboard twin's per-row isolation and is the point. Once one row has failed, PostgreSQL
+    /// refuses every later statement in the transaction (25P02), so "continue" would mean N-k more
+    /// ERROR lines for one event and a <c>CommitAsync</c> that returns normally having written
+    /// nothing. Letting it out gives <see cref="InsertFindingsAsync"/> the single line and the
+    /// rollback. The isolation is barely reachable here in any case — the table carries no primary
+    /// key, no CHECK and no foreign key, and every NOT NULL column maps to a non-nullable property
+    /// with a default — which leaves data-shape failures such as a NUL byte in a text column
+    /// (22021) as the realistic per-row fault, and one of those in a batch of ten is exactly the
+    /// case where publishing the other nine as a complete analysis is the wrong answer.</para>
     ///
     /// <para>#2443 exempt: this write deliberately takes no token. Cancelling inside a single-row
     /// INSERT buys nothing — the row is milliseconds of work on loopback — and costs the one thing
     /// worth having: a definite answer about whether it committed. Npgsql's cancel is a request to
-    /// the server, so a cancelled <c>ExecuteNonQueryAsync</c> can leave a row that did land, in a
-    /// set nothing marks as partial. <see cref="InsertFindingsAsync"/> carries the full reasoning
-    /// and the abandonment point that replaces this one.</para>
+    /// the server, so a cancelled <c>ExecuteNonQueryAsync</c> can leave a row that did land.
+    /// <see cref="InsertFindingsAsync"/> carries the full reasoning and the abandonment point that
+    /// replaces this one.</para>
     /// </summary>
-    private async Task InsertFindingAsync(NpgsqlConnection connection, AnalysisFinding finding)
+    private async Task InsertFindingAsync(
+        NpgsqlConnection connection, NpgsqlTransaction transaction, AnalysisFinding finding)
     {
-        try
+        using var command = new NpgsqlCommand(InsertFindingSql, connection, transaction);
+        command.Parameters.AddWithValue(finding.FindingId);
+        command.Parameters.AddWithValue(AsNaive(finding.AnalysisTime));
+        command.Parameters.AddWithValue(finding.ServerId);
+        command.Parameters.AddWithValue(finding.ServerName);
+        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text, Value = (object?)finding.DatabaseName ?? DBNull.Value });
+        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Timestamp, Value = finding.TimeRangeStart is { } rangeStart ? AsNaive(rangeStart) : (object)DBNull.Value });
+        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Timestamp, Value = finding.TimeRangeEnd is { } rangeEnd ? AsNaive(rangeEnd) : (object)DBNull.Value });
+        command.Parameters.AddWithValue(finding.Severity);
+        command.Parameters.AddWithValue(finding.Confidence);
+        command.Parameters.AddWithValue(finding.Category);
+        command.Parameters.AddWithValue(finding.StoryPath);
+        command.Parameters.AddWithValue(finding.StoryPathHash);
+        command.Parameters.AddWithValue(finding.StoryText);
+        command.Parameters.AddWithValue(finding.RootFactKey);
+        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Double, Value = (object?)finding.RootFactValue ?? DBNull.Value });
+        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text, Value = (object?)finding.LeafFactKey ?? DBNull.Value });
+        command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Double, Value = (object?)finding.LeafFactValue ?? DBNull.Value });
+        command.Parameters.AddWithValue(finding.FactCount);
+        command.Parameters.Add(new NpgsqlParameter
         {
-            using var command = new NpgsqlCommand(InsertFindingSql, connection);
-            command.Parameters.AddWithValue(finding.FindingId);
-            command.Parameters.AddWithValue(AsNaive(finding.AnalysisTime));
-            command.Parameters.AddWithValue(finding.ServerId);
-            command.Parameters.AddWithValue(finding.ServerName);
-            command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text, Value = (object?)finding.DatabaseName ?? DBNull.Value });
-            command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Timestamp, Value = finding.TimeRangeStart is { } rangeStart ? AsNaive(rangeStart) : (object)DBNull.Value });
-            command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Timestamp, Value = finding.TimeRangeEnd is { } rangeEnd ? AsNaive(rangeEnd) : (object)DBNull.Value });
-            command.Parameters.AddWithValue(finding.Severity);
-            command.Parameters.AddWithValue(finding.Confidence);
-            command.Parameters.AddWithValue(finding.Category);
-            command.Parameters.AddWithValue(finding.StoryPath);
-            command.Parameters.AddWithValue(finding.StoryPathHash);
-            command.Parameters.AddWithValue(finding.StoryText);
-            command.Parameters.AddWithValue(finding.RootFactKey);
-            command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Double, Value = (object?)finding.RootFactValue ?? DBNull.Value });
-            command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Text, Value = (object?)finding.LeafFactKey ?? DBNull.Value });
-            command.Parameters.Add(new NpgsqlParameter { NpgsqlDbType = NpgsqlDbType.Double, Value = (object?)finding.LeafFactValue ?? DBNull.Value });
-            command.Parameters.AddWithValue(finding.FactCount);
-            command.Parameters.Add(new NpgsqlParameter
-            {
-                NpgsqlDbType = NpgsqlDbType.Text,
-                Value = string.IsNullOrEmpty(finding.IncidentId) ? (object)DBNull.Value : finding.IncidentId
-            });
-            /* D2: persist the BUILT action (mirrors the alert path's ContextJson) so the
-               Recommendations reader can drive Apply + consent from a stored finding. */
-            command.Parameters.Add(new NpgsqlParameter
-            {
-                NpgsqlDbType = NpgsqlDbType.Text,
-                Value = (object?)AlertContextSerializer.SerializeAction(finding.Remediation) ?? DBNull.Value
-            });
-            /* #2060: persist the CAPPED drill-down beside the built action — same D2 rationale
-               (the evidence rows exist only on the write path), same degrade-to-NULL discipline. */
-            command.Parameters.Add(new NpgsqlParameter
-            {
-                NpgsqlDbType = NpgsqlDbType.Text,
-                Value = (object?)DrillDownSerializer.Serialize(finding.DrillDown) ?? DBNull.Value
-            });
+            NpgsqlDbType = NpgsqlDbType.Text,
+            Value = string.IsNullOrEmpty(finding.IncidentId) ? (object)DBNull.Value : finding.IncidentId
+        });
+        /* D2: persist the BUILT action (mirrors the alert path's ContextJson) so the
+           Recommendations reader can drive Apply + consent from a stored finding. */
+        command.Parameters.Add(new NpgsqlParameter
+        {
+            NpgsqlDbType = NpgsqlDbType.Text,
+            Value = (object?)AlertContextSerializer.SerializeAction(finding.Remediation) ?? DBNull.Value
+        });
+        /* #2060: persist the CAPPED drill-down beside the built action — same D2 rationale
+           (the evidence rows exist only on the write path), same degrade-to-NULL discipline. */
+        command.Parameters.Add(new NpgsqlParameter
+        {
+            NpgsqlDbType = NpgsqlDbType.Text,
+            Value = (object?)DrillDownSerializer.Serialize(finding.DrillDown) ?? DBNull.Value
+        });
 
-            await command.ExecuteNonQueryAsync();
-        }
-        catch (Exception ex)
-        {
-            _logger?.LogError("[PgFindingStore] InsertFindingAsync failed: {Message}", ex.Message);
-        }
+        await command.ExecuteNonQueryAsync();
     }
 
     /// <summary>

--- a/Lite.Tests/AnalysisPassTokenThreadingTests.cs
+++ b/Lite.Tests/AnalysisPassTokenThreadingTests.cs
@@ -219,11 +219,17 @@ public sealed class AnalysisPassTokenThreadingTests
 
     /// <summary>
     /// The decision #2443 asked to be made explicitly rather than assumed: what a cancelled PERSIST
-    /// means. The insert batch has no transaction, every row shares one <c>analysis_time</c>, and the
-    /// latest-findings read takes the newest <c>analysis_time</c>. So a batch cut in half does not read
-    /// as truncated; it reads as a complete analysis that found fewer problems, and the server looks
-    /// HEALTHIER for having been abandoned. The lock and the connection open are therefore the last
-    /// abandonment points: before the first row, or not at all.
+    /// means. Every row shares one <c>analysis_time</c> and the latest-findings read takes the newest
+    /// <c>analysis_time</c>, so a batch cut in half does not read as truncated; it reads as a complete
+    /// analysis that found fewer problems, and the server looks HEALTHIER for having been abandoned.
+    /// The lock and the connection open are therefore the last abandonment points: before the first
+    /// row, or not at all.
+    ///
+    /// <para>#2448 closed the other half of that. #2443 could only reason about the CANCELLATION path,
+    /// and the same truncated set was still reachable from an ordinary store fault mid-batch, where no
+    /// amount of token discipline reaches. The batch is now one transaction, so it is all-or-nothing
+    /// against a fault as well. Deliberately the same answer as the Darling twin's, pinned the same
+    /// way, because a divergence here would be a parity bug rather than a local choice.</para>
     /// </summary>
     [Fact]
     public void TheFindingInsertIsAbandonedBeforeItStartsOrNotAtAll()
@@ -242,6 +248,13 @@ public sealed class AnalysisPassTokenThreadingTests
         /* And nothing after them does. A ThrowIfCancellationRequested between rows would MAKE the
            partial set rather than prevent it, which is why there is none. */
         Assert.DoesNotContain("ThrowIfCancellationRequested", insertBatch, StringComparison.Ordinal);
+
+        /* #2448: the batch is one transaction, and the rows are enlisted in it. Both halves are pinned
+           because either alone is silently useless — a transaction the rows do not join commits nothing
+           of theirs, and enlisting in a transaction nobody commits writes nothing at all. */
+        Assert.Contains("connection.BeginTransaction();", insertBatch, StringComparison.Ordinal);
+        Assert.Contains("transaction.Commit();", insertBatch, StringComparison.Ordinal);
+        Assert.Contains("cmd.Transaction = transaction;", store, StringComparison.Ordinal);
 
         /* The row write states the decision where someone changing it will read it. */
         Assert.Contains(ExemptionMarker,

--- a/Lite.Tests/FindingStoreTests.cs
+++ b/Lite.Tests/FindingStoreTests.cs
@@ -565,6 +565,94 @@ VALUES ($1, $2, $3, $4, $5, $6)";
         await cmd.ExecuteNonQueryAsync();
     }
 
+    /// <summary>
+    /// #2448: a finding batch that faults partway through must persist NOTHING, not the rows that
+    /// happened to land first.
+    ///
+    /// <para>The damage this prevents is invisible by construction, which is why it is worth a
+    /// behavioural test against a real DuckDB rather than a source pin. Every row in a batch shares
+    /// one <c>analysis_time</c> and <see cref="FindingStore.GetLatestFindingsAsync"/> reads the
+    /// newest <c>analysis_time</c>, so two committed rows of an intended five do not read as a
+    /// truncated set — they read as a complete analysis that found two problems. The server looks
+    /// HEALTHIER for the store having failed, and nothing anywhere says otherwise.</para>
+    ///
+    /// <para>The fault is a duplicate <c>finding_id</c>, which is the reachable per-row fault on
+    /// this table (<c>finding_id BIGINT PRIMARY KEY</c>) and not a contrivance: the ids come from
+    /// <c>_nextId++</c> seeded off <c>DateTime.UtcNow.Ticks</c>, so two stores in one process can
+    /// genuinely produce one — see #2455.</para>
+    ///
+    /// <para>Reverted, rows 1 and 2 commit before row 3 throws and this fails on
+    /// <c>Assert.Single</c> with three rows present — the truncated set stated exactly.</para>
+    /// </summary>
+    [Fact]
+    public async Task AFaultedBatch_PersistsNothing_RatherThanATruncatedSetThatReadsAsComplete()
+    {
+        const int serverId = -646464;
+        const long earlierPassId = 5_646_464L;
+
+        var store = new FindingStore(_duckDb);
+        var context = new AnalysisContext
+        {
+            ServerId = serverId,
+            ServerName = "partial-batch",
+            TimeRangeStart = DateTime.UtcNow.AddHours(-4),
+            TimeRangeEnd = DateTime.UtcNow
+        };
+
+        /* An earlier pass's row, and the id the doomed batch collides with. */
+        await store.InsertFindingsAsync(
+            [PartialBatchFinding(earlierPassId, serverId, "an earlier pass")], context);
+
+        /* Row 3 of 5 collides, so rows 1-2 have already run by the time it fails. */
+        var doomed = new List<AnalysisFinding>
+        {
+            PartialBatchFinding(earlierPassId + 1, serverId, "row 1"),
+            PartialBatchFinding(earlierPassId + 2, serverId, "row 2"),
+            PartialBatchFinding(earlierPassId, serverId, "row 3 - collides"),
+            PartialBatchFinding(earlierPassId + 3, serverId, "row 4"),
+            PartialBatchFinding(earlierPassId + 4, serverId, "row 5")
+        };
+
+        await Assert.ThrowsAsync<DuckDBException>(() => store.InsertFindingsAsync(doomed, context));
+
+        /* The assertion #2448 exists for: not "fewer rows", NO rows from the doomed batch. Only the
+           earlier pass survives, and it is still stamped with its own analysis_time — stale and
+           saying so, rather than fresh and understating the server. */
+        var persisted = await store.GetRecentFindingsAsync(serverId);
+        Assert.Equal(earlierPassId, Assert.Single(persisted).FindingId);
+
+        /* And the rollback is not the store simply refusing to write: the same five rows without
+           the collision commit in full, through the same code path. */
+        var clean = new List<AnalysisFinding>
+        {
+            PartialBatchFinding(earlierPassId + 10, serverId, "row 1"),
+            PartialBatchFinding(earlierPassId + 11, serverId, "row 2"),
+            PartialBatchFinding(earlierPassId + 12, serverId, "row 3"),
+            PartialBatchFinding(earlierPassId + 13, serverId, "row 4"),
+            PartialBatchFinding(earlierPassId + 14, serverId, "row 5")
+        };
+
+        await store.InsertFindingsAsync(clean, context);
+        Assert.Equal(6, (await store.GetRecentFindingsAsync(serverId)).Count);
+    }
+
+    private static AnalysisFinding PartialBatchFinding(long findingId, int serverId, string storyText) =>
+        new()
+        {
+            FindingId = findingId,
+            AnalysisTime = DateTime.UtcNow,
+            ServerId = serverId,
+            ServerName = "partial-batch",
+            Severity = 1.0,
+            Confidence = 0.9,
+            Category = "waits",
+            StoryPath = "WRITELOG",
+            StoryPathHash = "an1-partial-batch",
+            StoryText = storyText,
+            RootFactKey = "WRITELOG",
+            FactCount = 1
+        };
+
     private static System.Collections.Generic.List<AnalysisStory> CreateTestStories()
     {
         return

--- a/Lite/Analysis/FindingStore.cs
+++ b/Lite/Analysis/FindingStore.cs
@@ -103,20 +103,39 @@ public class FindingStore
     /// finding's persisted action round-trips byte-identically to a Darling / Dashboard one. Returns the
     /// same list for caller convenience; the in-memory findings are unchanged.
     ///
-    /// <para>#2443: the read lock and the connection open are the LAST cancellation points on this
-    /// pass, and that is a decision rather than an oversight. Past them the batch runs to completion,
-    /// because the third outcome — a half-written finding set — is worse than the one the pass
-    /// already reports. There is no transaction here, every row in a batch shares one
-    /// <c>analysis_time</c>, and <see cref="GetLatestFindingsAsync"/> reads the newest
-    /// <c>analysis_time</c> — so a batch cut in half does not read as truncated, it reads as a
-    /// complete analysis that found fewer problems. The server would look HEALTHIER for having been
-    /// abandoned, with nothing marking the set incomplete. Cancelling before the first row costs this
-    /// cycle's findings and says so; cancelling after it silently changes what the store means.</para>
+    /// <para>#2448: the transaction is what makes this method's promise true, and it is the whole
+    /// reason for the shape. A finding set is one indivisible statement about a server: every row
+    /// shares one <c>analysis_time</c>, and <see cref="GetLatestFindingsAsync"/> reads the newest
+    /// <c>analysis_time</c>. So a batch that lands four of forty rows before the store faults does
+    /// NOT read as truncated — it reads as a complete analysis that found four problems, and the
+    /// server looks HEALTHIER for the store having failed. Rolling the batch back instead leaves the
+    /// PREVIOUS pass as the newest complete set: stale, stamped with its own older
+    /// <c>analysis_time</c>, and incapable of misleading anyone. The rollback needs no explicit
+    /// call — a row that throws skips the commit and <c>DuckDBTransaction.Dispose</c> discards the
+    /// batch, measured on DuckDB.NET 1.5.5.</para>
     ///
-    /// <para>The tail is affordable to finish: N small INSERTs into an embedded file in this process.
-    /// It is not where a pass wedges. Same call the Darling twin makes, and the same call
-    /// <c>AnalysisService</c> made a layer up in #2419 — "the post-enrichment tail carries no check
-    /// on purpose" — restated at the write it protects.</para>
+    /// <para>Deliberately identical to the Darling twin, which reached it the same way; a divergence
+    /// here would be a parity bug rather than a local choice. Worth knowing when reading the loop:
+    /// once one statement in a DuckDB transaction fails, every later one is refused
+    /// ("TransactionContext Error: Current transaction is aborted") and there is no <c>SAVEPOINT</c>
+    /// to escape it — 1.5.5 does not parse the keyword — so per-row failure isolation is not
+    /// available inside a transaction on this engine even if it were wanted. It is not: a batch that
+    /// silently drops row 5 and commits the other 39 is this same defect at row granularity.
+    /// <c>Commit</c> on an already-aborted transaction also RETURNS NORMALLY while committing
+    /// nothing, on both this driver and Npgsql, so reaching the commit is never evidence of a
+    /// write.</para>
+    ///
+    /// <para>The batch is small enough for this to be free: a busy production server persists ~10
+    /// rows per pass, as small INSERTs into an embedded file in this process. Two passes on
+    /// different servers can hold open append transactions on this table at once — the read lock
+    /// admits concurrent holders — and both commit; measured, because widening the write window
+    /// under a shared lock is the one way this change could have cost something.</para>
+    ///
+    /// <para>#2443: the read lock and the connection open are still the LAST cancellation points on
+    /// this pass, unchanged by the above. Past them the batch runs to completion, and cancelling
+    /// before the first row costs this cycle's findings and says so. Same call the Darling twin
+    /// makes, and the same call <c>AnalysisService</c> made a layer up in #2419 — "the
+    /// post-enrichment tail carries no check on purpose" — restated at the write it protects.</para>
     /// </summary>
     public async Task<List<AnalysisFinding>> InsertFindingsAsync(
         List<AnalysisFinding> findings, AnalysisContext context)
@@ -129,10 +148,14 @@ public class FindingStore
         using var connection = _duckDb.CreateConnection();
         await connection.OpenAsync(context.CancellationToken);
 
-        /* No token check between rows: see the note above. Once the first row is written this batch
-           is finishing. */
+        /* #2448: one transaction for the whole set — the batch commits complete or not at all.
+           No token check between rows: see the note above. */
+        using var transaction = connection.BeginTransaction();
+
         foreach (var finding in findings)
-            await InsertFindingAsync(connection, finding);
+            await InsertFindingAsync(connection, transaction, finding);
+
+        transaction.Commit();
 
         return findings;
     }
@@ -364,20 +387,26 @@ WHERE server_id = $1 OR server_id IS NULL OR server_id = 0";
     }
 
     /// <summary>
-    /// Inserts one finding on an already-open connection. The caller owns the read lock
-    /// and connection, so a batch of inserts in one InsertFindingsAsync call shares a
-    /// single lock acquisition and connection.
+    /// Inserts one finding on an already-open connection, enlisted in the batch's transaction. The
+    /// caller owns the read lock, the connection and the transaction, so a batch of inserts in one
+    /// InsertFindingsAsync call shares a single lock acquisition, connection and transaction.
+    ///
+    /// <para>#2448: this throws rather than logging and continuing, and that is the point. Letting
+    /// it out skips the commit, so the batch is discarded and the pass logs its one line instead of
+    /// a line per remaining row for a single event. Continuing would not work here in any case —
+    /// DuckDB refuses every later statement once one has failed inside the transaction.</para>
     ///
     /// <para>#2443 exempt: this write deliberately takes no token. Cancelling inside a single-row
     /// INSERT buys nothing — the row is microseconds of work in-process — and costs a definite
     /// answer about whether it landed: DuckDB's cancel is <c>duckdb_interrupt</c>, so an interrupted
-    /// INSERT can leave a row that did commit, in a set nothing marks as partial.
-    /// <see cref="InsertFindingsAsync"/> carries the full reasoning and the abandonment point that
-    /// replaces this one.</para>
+    /// INSERT can leave a row that did commit. <see cref="InsertFindingsAsync"/> carries the full
+    /// reasoning and the abandonment point that replaces this one.</para>
     /// </summary>
-    private static async Task InsertFindingAsync(DuckDBConnection connection, AnalysisFinding finding)
+    private static async Task InsertFindingAsync(
+        DuckDBConnection connection, DuckDBTransaction transaction, AnalysisFinding finding)
     {
         using var cmd = connection.CreateCommand();
+        cmd.Transaction = transaction;
         cmd.CommandText = @"
 INSERT INTO analysis_findings
     (finding_id, analysis_time, server_id, server_name, database_name,

--- a/Lite/Analysis/FindingStore.cs
+++ b/Lite/Analysis/FindingStore.cs
@@ -6,6 +6,7 @@ using DuckDB.NET.Data;
 using PerformanceMonitor.Analysis;
 using PerformanceMonitor.Notifications;
 using PerformanceMonitorLite.Database;
+using PerformanceMonitorLite.Services;
 
 namespace PerformanceMonitorLite.Analysis;
 
@@ -152,10 +153,40 @@ public class FindingStore
            No token check between rows: see the note above. */
         using var transaction = connection.BeginTransaction();
 
-        foreach (var finding in findings)
-            await InsertFindingAsync(connection, transaction, finding);
+        var row = 0;
+        var everyRowAccepted = false;
 
-        transaction.Commit();
+        try
+        {
+            foreach (var finding in findings)
+            {
+                row++;
+                await InsertFindingAsync(connection, transaction, finding);
+            }
+
+            everyRowAccepted = true;
+            transaction.Commit();
+        }
+        catch (Exception ex) when (!AnalysisAbandon.IsExpected(ex, context.CancellationToken))
+        {
+            /* #2448: the same line the Darling twin logs, for the same reason and in the same two
+               shapes. Without it a Lite operator gets only AnalysisService's generic "Analysis failed
+               for {server}", which cannot answer the question the issue said should decide this —
+               how often a batch actually fails partway — because it does not say a batch was even
+               involved, let alone which row.
+
+               The commit gets its own branch because `row` sits at findings.Count once the loop ends,
+               so sharing one line would report "failed at row N of N" for a commit fault and name the
+               last finding as the bad one when every row had in fact been accepted.
+
+               Logged and RETHROWN, not swallowed: letting it out is what stops AnalysisService
+               announcing a completed analysis for a set the store does not have, and it is the
+               behaviour this store has always had. Only the diagnostic is new. */
+            AppLogger.Error("AnalysisService", everyRowAccepted
+                ? $"Finding batch for {context.ServerName} had all {findings.Count} row(s) accepted and then failed to COMMIT them, so the batch was rolled back — this analysis persisted NO findings, deliberately: a partial set would have read as a complete analysis that found fewer problems. {ex.Message}"
+                : $"Finding batch for {context.ServerName} failed at row {row} of {findings.Count} and was rolled back — this analysis persisted NO findings, deliberately: a partial set would have read as a complete analysis that found fewer problems. {ex.Message}");
+            throw;
+        }
 
         return findings;
     }


### PR DESCRIPTION
Closes #2448. Both SKUs, one commit each.

## The option, and why

**Option 1 — one transaction per batch.** Both stores. Option 3 (collapse the ERROR burst) falls out of it rather than being bolted on. Option 2 was rejected and option "do nothing" was not defensible; both reasons are below.

### The measurement the issue asked for

The issue said the thing to measure is how often a batch fails partway, and that `collection_log` cannot show it. That is true, and it was the wrong measurement to wait for — it would have taken a fault landing in a specific tail on the dogfood fleet, and until then the answer would have been "not yet". So the numbers that actually decide are the ones about **cost** and about **whether the fix is buildable identically on both engines**, and those can be taken today.

**Batch size — ~10 rows.** Read off the dogfood store: `prod-sql-use2-multi-37` at `analysis_time 2026-08-21T16:39:03` persisted the contiguous `finding_id` block `639229059608319080`–`089`. Ten rows, on a busy production server with nine co-fired findings. So the transaction spans ten small INSERTs on loopback (Darling) or into an embedded file in-process (Lite). There is nothing to weigh against here.

**DuckDB.NET 1.5.5 and Npgsql 10.0.3, measured on real engines** (DuckDB embedded; PostgreSQL 17.10):

| | DuckDB 1.5.5 | Npgsql / PG 17.10 |
|---|---|---|
| transaction + commit | works | works |
| a failed row inside the transaction | aborts it — every later statement refused (`TransactionContext Error: Current transaction is aborted`) | aborts it — `25P02 current transaction is aborted, commands ignored` |
| `SAVEPOINT` | **not parsed** — `Parser Error: syntax error at or near "SAVEPOINT"` | supported |
| `Commit()` on an already-aborted transaction | **returns normally, commits nothing** | **returns normally, commits nothing** |
| rollback / dispose after the abort | discards the whole batch | discards the whole batch |
| two concurrent append transactions, same table, two connections | both commit | n/a |

Two of those changed the design rather than confirming it, so they are worth reading twice.

**DuckDB has no `SAVEPOINT`.** That is what settles the per-row question. Per-row failure isolation cannot exist inside a transaction on DuckDB at all, so preserving it on Darling with savepoints would have been a fix in one SKU and not the other — exactly the drift this repo has spent a day removing. It also should not survive on its own merits: a batch that silently drops row 5 and commits the other 39 is #2448 at row granularity, a set claiming 39 problems when the analysis found 40.

**`Commit` on an aborted transaction returns normally on BOTH drivers, having written nothing.** So "reaching the commit" is never evidence of a write. A per-row catch inside a transaction would have logged N−k rows' worth of ERRORs, then reached a commit that looked like success and persisted zero rows — strictly worse than what is there now. This is the second, independent reason the row write must not swallow, and it is stated at the code.

**Concurrency was checked before widening the window**, because Lite's batch runs under a *read* lock, which admits concurrent holders (#2455), so two servers' passes can genuinely overlap on this table. Two open append transactions on one DuckDB table from two connections both commit. Nothing to pay.

### Why not option 2 (stamp completeness)

It fixes the silence, but every reader has to learn the new rule — the viewer's Recommendations tab, `get_analysis_findings`, the alert routing, `GetLatestFindings`, `GetRecentFindings` — plus a migration rung on the Darling ladder and a DuckDB schema bump on Lite. Any reader that did not learn it keeps the behaviour being fixed, and a marker written *last* is itself a write that can fail, which flags complete sets as partial. The transaction requires no reader to learn anything, and a rolled-back batch leaves the PREVIOUS pass as the newest complete set — stale, stamped with its own older `analysis_time`, and incapable of misleading anyone. That is a strictly better answer than a fresh set annotated as untrustworthy.

### Why not "do nothing"

The window is not negligible, and the reason is the part I would not have guessed before running it. Darling's per-row catch means the batch **continues** past the failure, so the damaged set is not "the rows before the fault" — it is *every row except the bad ones*. The reverted test persists **four of five rows** and reports failure. A store fault that kills the connection does produce the truncated tail the issue describes, but a data-shape fault produces a near-complete set that is even harder to disbelieve. Neither is rare enough to be worth arguing about once the fix costs ten rows of transaction.

## What changed

Both stores: `InsertFindingsAsync` opens one transaction, enlists every row in it, and commits. The per-row `try`/`catch` in Darling's `InsertFindingAsync` is gone (Lite never had one), so one failure ends the batch and costs **one** log line naming the row and the count — which is option 3, delivered by the same change.

`InsertFindingsAsync` still never throws on Darling (the class's error discipline is unchanged) and still throws on Lite (its shape is unchanged); each SKU's existing posture is preserved exactly. The #2443 abandonment decision is untouched: the connection open — and on Lite the read-lock wait — is still the last cancellation point, and there is still no between-rows token check.

**The issue described the two stores as "same shape" and they were not**, which is worth recording: Darling caught per row and continued, Lite has never caught at all, so a fault at row 5 already ended Lite's batch there. Lite had the quieter half of the same defect — rows 1–4 stayed durable under the new `analysis_time` while the pass reported failure — and gains the fix with no change to error handling at all.

## The tests

Both behavioural, both against a real engine, both verified red on `dev`:

- **Lite** (`FindingStoreTests`) — real DuckDB. Fault induced with a duplicate `finding_id`, which is the reachable per-row fault on that table and not a contrivance: the ids come from `_nextId++` seeded off `DateTime.UtcNow.Ticks`, so two stores in one process can genuinely produce one (#2455). Reverted: **3 rows where 1 was expected**.
- **Darling** (`DarlingAnalysisStoreTests`, `[Collection("live-postgres")]`) — fault induced with a NUL byte in `story_text`, which PostgreSQL rejects as `22021`. That is the realistic per-row fault on a table carrying no primary key, no CHECK and no foreign key whose NOT NULL columns all map to non-nullable properties with defaults. Reverted: **4 of 5 rows persisted**.

Both then commit the same batch *clean* through the same path, so neither assertion can be satisfied by a store that has simply stopped writing.

The #2443 pins in both `AnalysisPassTokenThreadingTests` gain the transaction — begin, commit, and the rows' enlistment are pinned separately, because either half alone is silently useless — plus, on Darling, `Assert.DoesNotContain("catch", rowWrite)`. Their prose said "the insert batch has no transaction"; that claim is now false and is rewritten rather than left to mislead.

## Verification

- Full solution builds clean on macOS (`EnableWindowsTargeting`): **0 errors**, 24 warnings, all pre-existing in untouched files. Each commit builds on its own.
- `Lite.Tests` / `Darling.Tests` are `net10.0-windows` and cannot run on macOS, so **both new tests were compiled into a `net10.0` xUnit shim against the real shipped `FindingStore` / `PgFindingStore`** (Lite's `Lite/Database/**` + `Lite/Analysis/FindingStore.cs` compiled in; one stub for the single legacy symbol `DuckDbInitializer` reaches outside `Lite/Database`, which the finding path never touches) and run on macOS against embedded DuckDB and a local PostgreSQL 17.10. **2/2 pass on this branch, 2/2 fail on `dev`**, with the failure messages quoted above. CI is the arbiter for the rest of the suites.
- Every source pin the Windows-only suites make about these two files was replicated by hand and re-checked after the rebase — including `AnalysisShutdownResidueTests`' `Assert.Equal(2, Count(findingStore, contextFilter))`, which is unchanged: the catch removed was a bare one, not a filtered one.
- Rebased onto `dev` at `8f692439` and everything above re-run after.

## Deferred

**The #2443 cancellation decision is now re-openable, and deliberately not re-opened here.** #2449 withheld the token from the batch because cancelling mid-batch would have *made* the partial set. With the transaction it would roll one back instead, so mid-batch cancellation is now safe and would let a wedged pass drop its store work sooner. That is a different question from this one, the pinned rationale for the absent check is now half-expired, and re-deciding it inside a fault-handling PR is how a settled decision gets changed without anyone noticing. Say the word and I will file it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>