### PR TITLE
Name the settings the viewer lost, and stop one of them costing the rest (#2456)

### DIFF
--- a/Darling/Darling.Tests/ViewerSettingsMemberRecoveryTests.cs
+++ b/Darling/Darling.Tests/ViewerSettingsMemberRecoveryTests.cs
@@ -290,6 +290,63 @@ public sealed class ViewerSettingsMemberRecoveryTests : IDisposable
         Assert.Contains("line 2", read.Problem!, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// A hand-named member recovers like any other. Review raised the narrow identifier match as a diacritic
+    /// edge case; measuring System.Text.Json showed it is wider and far more ordinary than that — STJ writes
+    /// the DOT form for every name needing no escaping, so <c>$.alert-cpu-threshold</c>,
+    /// <c>$.dollar$sign</c> and <c>$.サーバー</c> all arrive that way, and only a name like
+    /// <c>$['with space']</c> gets bracket-quoted.
+    ///
+    /// <para>A hyphenated key is an ordinary thing to find in a settings file. The narrow form captured
+    /// <c>alert</c> out of it, found no such member, and fell back to whole-file <c>Unreadable</c> — safe,
+    /// and silently short of the per-member recovery, for exactly the settings someone had to name by hand.
+    /// Pinned with the two names that actually differ between the forms rather than with the diacritic,
+    /// because those are the ones a settings file is likely to contain.</para>
+    /// </summary>
+    [Fact]
+    public void AHandNamedMemberRecoversLikeAnyOther()
+    {
+        File.WriteAllText(SettingsPath, @"{
+  ""alert-cpu-threshold"": ""ninety"",
+  ""dollar$sign"": ""also not a number"",
+  ""Fine"": 22
+}");
+
+        var read = SettingsFileGuard.ReadObject<HandNamed>(SettingsPath);
+
+        Assert.Equal(
+            new[] { "alert-cpu-threshold", "dollar$sign" },
+            read.UnreadableMembers!.Select(m => m.Member));
+        Assert.Equal(22, read.Value!.Fine);
+    }
+
+    /// <summary>And the boundary that must NOT move with it: a bracket-quoted path is still refused, because
+    /// the reader has no business editing a document it cannot name a member in unambiguously.</summary>
+    [Fact]
+    public void ABracketQuotedPathIsStillRefused()
+    {
+        File.WriteAllText(SettingsPath, @"{ ""with space"": ""not a number"" }");
+
+        var read = SettingsFileGuard.ReadObject<HandNamed>(SettingsPath);
+
+        Assert.Equal(SettingsFileState.Unreadable, read.State);
+        Assert.Null(read.Value);
+        Assert.True(read.UnreadableMembers is null or { Count: 0 });
+    }
+
+    /// <summary>Members System.Text.Json renders in its dot form despite not being C# identifiers, plus one
+    /// it bracket-quotes. Local to the test: these exist to cover the path shapes, not to model a setting.</summary>
+    private sealed class HandNamed
+    {
+        [JsonPropertyName("alert-cpu-threshold")] public int Hyphenated { get; set; } = 80;
+
+        [JsonPropertyName("dollar$sign")] public int Dollar { get; set; } = 1;
+
+        [JsonPropertyName("with space")] public int Spaced { get; set; } = 2;
+
+        public int Fine { get; set; } = 3;
+    }
+
     /// <summary>A type with a member System.Text.Json reports as <c>$['weird.name']</c> — a path the reader
     /// deliberately will not edit a document on. Local to this test because it exists to reach a branch, not
     /// to model anything the viewer stores.</summary>

--- a/Darling/Darling.Tests/ViewerSettingsMemberRecoveryTests.cs
+++ b/Darling/Darling.Tests/ViewerSettingsMemberRecoveryTests.cs
@@ -252,8 +252,10 @@ public sealed class ViewerSettingsMemberRecoveryTests : IDisposable
     }
 
     /// <summary>
-    /// The invariant, and the combination review found that broke it: <c>UnreadableMembers</c> is non-empty
-    /// if and only if <c>Value</c> is non-null.
+    /// The invariant, and the combination review found that broke it: a non-empty
+    /// <c>UnreadableMembers</c> always comes with a non-null <c>Value</c>. One direction only — an ordinary
+    /// readable file has a value and no members, which <see cref="ReadObject_SaysNothingAboutAHealthyFile"/>
+    /// covers.
     ///
     /// <para>The reader can drop one member successfully and THEN meet a fault it cannot attribute — a path
     /// like <c>$['weird.name']</c>, which System.Text.Json bracket-quotes for a property name that is not a

--- a/Darling/Darling.Tests/ViewerSettingsMemberRecoveryTests.cs
+++ b/Darling/Darling.Tests/ViewerSettingsMemberRecoveryTests.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text.Json.Serialization;
 using PerformanceMonitor.Common;
 using PerformanceMonitor.Darling.Viewer;
 using Xunit;
@@ -248,6 +249,53 @@ public sealed class ViewerSettingsMemberRecoveryTests : IDisposable
         Assert.True(read.UnreadableMembers is null or { Count: 0 });
         Assert.Null(read.Problem);
         Assert.Equal(91, read.Value!.AlertCpuThreshold);
+    }
+
+    /// <summary>
+    /// The invariant, and the combination review found that broke it: <c>UnreadableMembers</c> is non-empty
+    /// if and only if <c>Value</c> is non-null.
+    ///
+    /// <para>The reader can drop one member successfully and THEN meet a fault it cannot attribute — a path
+    /// like <c>$['weird.name']</c>, which System.Text.Json bracket-quotes for a property name that is not a
+    /// bare identifier. Before the fix that returned a null value carrying a member list, and the viewer's
+    /// dialog routes on the list: it would have said "these settings could not be read… everything else in
+    /// their file loaded normally" about a file where NOTHING loaded and every setting reverted. An
+    /// overstatement in exactly the place this issue exists to remove one.</para>
+    ///
+    /// <para>The fixture uses a local type because no viewer setting has a name like that today, which is
+    /// what made this latent rather than live. That is the reason to pin it rather than to leave it: the
+    /// first property that needs a converter throwing <c>ArgumentException</c> — an enum, a DateTime — makes
+    /// it reachable with no warning, and the failure is a confident lie rather than a crash.</para>
+    /// </summary>
+    [Fact]
+    public void APartialRecoveryThatCannotFinish_ReportsNoMembersAtAll()
+    {
+        File.WriteAllText(SettingsPath, @"{
+  ""Fine"": ""not a number"",
+  ""weird.name"": ""not a number either""
+}");
+
+        var read = SettingsFileGuard.ReadObject<AwkwardlyNamed>(SettingsPath);
+
+        Assert.Equal(SettingsFileState.Unreadable, read.State);
+        Assert.Null(read.Value);
+        Assert.True(read.UnreadableMembers is null or { Count: 0 },
+            "A read that recovered nothing must not name the members it managed to drop on the way.");
+
+        /* And the message is the FIRST failure's, whose line and position are against the file the user has
+           rather than against a re-serialized copy of it. */
+        Assert.Contains("line 2", read.Problem!, StringComparison.Ordinal);
+    }
+
+    /// <summary>A type with a member System.Text.Json reports as <c>$['weird.name']</c> — a path the reader
+    /// deliberately will not edit a document on. Local to this test because it exists to reach a branch, not
+    /// to model anything the viewer stores.</summary>
+    private sealed class AwkwardlyNamed
+    {
+        [JsonPropertyName("weird.name")]
+        public int Weird { get; set; } = 7;
+
+        public int Fine { get; set; } = 3;
     }
 
     // ── What the STORES do with it ────────────────────────────────────────────────────────────────

--- a/Darling/Darling.Tests/ViewerSettingsMemberRecoveryTests.cs
+++ b/Darling/Darling.Tests/ViewerSettingsMemberRecoveryTests.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using PerformanceMonitor.Common;
 using PerformanceMonitor.Darling.Viewer;
@@ -298,6 +299,67 @@ public sealed class ViewerSettingsMemberRecoveryTests : IDisposable
         public int Weird { get; set; } = 7;
 
         public int Fine { get; set; } = 3;
+    }
+
+    /// <summary>
+    /// The recovery borrows the caller's leniency, so the two reads inside it cannot judge the same file by
+    /// different standards — the "one judge, not two" property the whole design rests on.
+    ///
+    /// <para>Review found the seam. The retry deserializes with the caller's
+    /// <see cref="JsonSerializerOptions"/>, but dropping a member re-parses the text, and a bare
+    /// <c>JsonNode.Parse</c> runs with trailing commas and comments DISALLOWED however lenient the caller
+    /// is. So for a caller that permits them, the deserialize would reach the bad member and the re-parse
+    /// would throw on the very same text — and the recovery would quietly bail to whole-file Unreadable,
+    /// giving up the per-member repair on exactly the files it was written for. Silent, because it falls
+    /// back to the old behaviour rather than crashing.</para>
+    ///
+    /// <para>Not hypothetical in this repo: <c>ViewerSettings</c> reads darling.json with
+    /// <c>AllowTrailingCommas</c> and <c>ReadCommentHandling.Skip</c> because that file is JSONC, and seven
+    /// call sites here set those options. None of the three viewer stores does today, which is what made it
+    /// dormant — and <see cref="SettingsFileGuard.ReadObject{T}"/> is a general-purpose Common API, so the
+    /// next caller is as likely to be lenient as strict.</para>
+    /// </summary>
+    [Fact]
+    public void TheRecoveryBorrowsTheCallersLeniency_SoBothOfItsReadsAgree()
+    {
+        var lenient = new JsonSerializerOptions
+        {
+            AllowTrailingCommas = true,
+            ReadCommentHandling = JsonCommentHandling.Skip,
+        };
+
+        /* A file the LENIENT deserialize is perfectly happy with except for one member's value: a comment
+           and a trailing comma, both of which a strict re-parse rejects outright. */
+        File.WriteAllText(SettingsPath, @"{
+  // the operator left a note here
+  ""AlertCpuThreshold"": ""ninety"",
+  ""AlertCooldownMinutes"": 22,
+}");
+
+        var read = SettingsFileGuard.ReadObject<ViewerAppSettings>(SettingsPath, lenient);
+
+        Assert.Equal(new[] { "AlertCpuThreshold" }, read.UnreadableMembers!.Select(m => m.Member));
+        Assert.NotNull(read.Value);
+        Assert.Equal(22, read.Value!.AlertCooldownMinutes);
+    }
+
+    /// <summary>And the control: the SAME file under STRICT options is a document fault, not a member one.
+    /// Without this the test above would pass on a reader that had simply been made permanently lenient,
+    /// which would be a different defect — every strict caller silently accepting JSONC.</summary>
+    [Fact]
+    public void TheSameFileUnderStrictOptionsIsStillADocumentFault()
+    {
+        File.WriteAllText(SettingsPath, @"{
+  // the operator left a note here
+  ""AlertCpuThreshold"": ""ninety"",
+  ""AlertCooldownMinutes"": 22,
+}");
+
+        var read = SettingsFileGuard.ReadObject<ViewerAppSettings>(SettingsPath);
+
+        Assert.Equal(SettingsFileState.Unreadable, read.State);
+        Assert.Null(read.Value);
+        Assert.True(read.UnreadableMembers is null or { Count: 0 });
     }
 
     // ── What the STORES do with it ────────────────────────────────────────────────────────────────

--- a/Darling/Darling.Tests/ViewerSettingsMemberRecoveryTests.cs
+++ b/Darling/Darling.Tests/ViewerSettingsMemberRecoveryTests.cs
@@ -1,0 +1,344 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.Darling.Viewer;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #2456. #2444 gave Lite a reader that checks a value's <c>ValueKind</c> before it calls a getter, so one
+/// badly-shaped setting costs its own setting and the startup dialog names every key it could not read. The
+/// viewer had the same complaint one level up and a different mechanism: it round-trips a WHOLE object, so
+/// the deserialize fails before any property exists — it could name the file and the parse position and
+/// nothing else, and one bad member cost every setting in the file.
+///
+/// <para><b>Per-property reads were the wrong answer here, and the reason is not the typing.</b> Lite's
+/// settings.json is built key by key on BOTH sides — #2441 made every writer mutate one
+/// <c>JsonObject</c> — so a per-key read is symmetric with a per-key write. These files are a whole-object
+/// round trip on both sides. Converting only the READ half to hand-written properties would break that
+/// symmetry, and a property added to <see cref="ViewerAppSettings"/> afterwards would still be serialized
+/// on save and silently never read back. That is a worse defect than the one being fixed and an invisible
+/// one. So the fix names the member the deserializer stopped on, drops it, and runs the SAME deserialize
+/// again — which recovers the whole set rather than the first one, and keeps the round trip intact.</para>
+///
+/// <para><b>The dangerous half is what it refuses to recover</b>, and
+/// <see cref="ReadObject_LeavesAnArrayRootedRegistryAllOrNothing"/> is the control for it. The registry of
+/// monitored servers is a root JSON array; "drop the element that would not deserialize" there means
+/// silently deleting a server the operator added, which is the data loss #2434 exists to prevent wearing a
+/// repair's clothes. Only a top-level member of a root OBJECT is ever dropped.</para>
+/// </summary>
+public sealed class ViewerSettingsMemberRecoveryTests : IDisposable
+{
+    private readonly string _directory =
+        Path.Combine(Path.GetTempPath(), $"viewer-settings-members-{Guid.NewGuid():N}");
+
+    public ViewerSettingsMemberRecoveryTests() => Directory.CreateDirectory(_directory);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_directory))
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+    }
+
+    private string SettingsPath => Path.Combine(_directory, "viewer-settings.json");
+
+    private string RegistryPath => Path.Combine(_directory, "viewer-servers.json");
+
+    private string[] QuarantineCopies(string ofFile) =>
+        Directory.GetFiles(_directory)
+            .Where(f => f.StartsWith(ofFile + SettingsFileGuard.QuarantineInfix, StringComparison.Ordinal))
+            .ToArray();
+
+    // ── What the reader can now say ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The defect, and the whole of the issue's title. One member holds a string where an int belongs. On
+    /// dev that costs every setting in the file and the message can only say "line 3, position 30". Here it
+    /// names <c>AlertCpuThreshold</c>, and the eight settings around it — including the ones AFTER the bad
+    /// one, which is where the old ordering-dependent loss was worst — keep the values the file gave them.
+    /// </summary>
+    [Fact]
+    public void ReadObject_NamesTheSettingItCouldNotRead_AndKeepsEveryOtherOne()
+    {
+        File.WriteAllText(SettingsPath, @"{
+  ""AlertsEnabled"": false,
+  ""AlertCpuThreshold"": ""ninety"",
+  ""SmtpServer"": ""mail.example.com"",
+  ""AlertCooldownMinutes"": 22
+}");
+
+        var read = SettingsFileGuard.ReadObject<ViewerAppSettings>(SettingsPath);
+
+        Assert.Equal(SettingsFileState.Unreadable, read.State);
+        Assert.NotNull(read.Value);
+        Assert.NotNull(read.UnreadableMembers);
+        Assert.Equal(new[] { "AlertCpuThreshold" }, read.UnreadableMembers!.Select(m => m.Member));
+
+        /* Both sides of the bad member survive. The setting before it, and the two after it — which is the
+           half the single try/catch could never have delivered, because it threw and stopped reading. */
+        Assert.False(read.Value!.AlertsEnabled);
+        Assert.Equal("mail.example.com", read.Value.SmtpServer);
+        Assert.Equal(22, read.Value.AlertCooldownMinutes);
+
+        /* And the one it could not read is at its own default, not at some neighbour's value. */
+        Assert.Equal(80, read.Value.AlertCpuThreshold);
+    }
+
+    /// <summary>
+    /// The whole set, not the first one. <c>JsonException.Path</c> names ONE member — measured: a file with
+    /// two bad members reports only whichever the reader met first — so "which settings were lost" needs
+    /// the retry, not just the path. Someone who hand-edited one line has one mistake; someone who pasted a
+    /// block has several, and stopping at the first means fixing, restarting, and finding the next.
+    /// </summary>
+    [Fact]
+    public void ReadObject_NamesEverySettingItCouldNotRead_NotJustTheFirst()
+    {
+        File.WriteAllText(SettingsPath, @"{
+  ""McpEnabled"": ""yes"",
+  ""AlertCpuThreshold"": ""ninety"",
+  ""SmtpPort"": [ 25 ],
+  ""AlertCooldownMinutes"": 22
+}");
+
+        var read = SettingsFileGuard.ReadObject<ViewerAppSettings>(SettingsPath);
+
+        Assert.Equal(
+            new[] { "McpEnabled", "AlertCpuThreshold", "SmtpPort" },
+            read.UnreadableMembers!.Select(m => m.Member));
+        Assert.Equal(22, read.Value!.AlertCooldownMinutes);
+
+        /* The summary is the line the log and the dialog render, so it names them rather than counting
+           them — a count is what sends someone off to proofread an eighty-key file. */
+        Assert.Contains("McpEnabled", read.Problem!, StringComparison.Ordinal);
+        Assert.Contains("AlertCpuThreshold", read.Problem!, StringComparison.Ordinal);
+        Assert.Contains("SmtpPort", read.Problem!, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A bad ELEMENT inside a list-valued setting costs that setting and nothing else. The exception's path
+    /// is <c>$.AlertExcludedDatabases[1]</c>, so the reader takes the top-level member off the front of it
+    /// and drops the whole list — coarse on purpose: editing an operator's list down to the elements that
+    /// happened to parse would be a repair nobody asked for.
+    /// </summary>
+    [Fact]
+    public void ReadObject_DropsTheWholeListWhenOneElementIsWrong()
+    {
+        File.WriteAllText(SettingsPath, @"{
+  ""AlertExcludedDatabases"": [ ""tempdb"", 7 ],
+  ""AlertCooldownMinutes"": 22
+}");
+
+        var read = SettingsFileGuard.ReadObject<ViewerAppSettings>(SettingsPath);
+
+        Assert.Equal(new[] { "AlertExcludedDatabases" }, read.UnreadableMembers!.Select(m => m.Member));
+        Assert.Empty(read.Value!.AlertExcludedDatabases);
+        Assert.Equal(22, read.Value.AlertCooldownMinutes);
+    }
+
+    /// <summary>
+    /// A DOCUMENT fault is unchanged, and has to be: there is no member to name, nothing was read, and
+    /// every setting really is at its default. The message says where the parse stopped, which is what it
+    /// could always say and is the right answer here. Reporting a member list for this case would be the
+    /// overstatement the issue warns about.
+    /// </summary>
+    [Fact]
+    public void ReadObject_LeavesADocumentFaultAllOrNothing()
+    {
+        File.WriteAllText(SettingsPath, @"{
+  ""AlertsEnabled"": true,
+  ""AlertCpuThreshold"": 91,
+}");
+
+        var read = SettingsFileGuard.ReadObject<ViewerAppSettings>(SettingsPath);
+
+        Assert.Equal(SettingsFileState.Unreadable, read.State);
+        Assert.Null(read.Value);
+        Assert.True(read.UnreadableMembers is null or { Count: 0 });
+        Assert.Contains("line 4", read.Problem!, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// THE control, and the mistake that was one line away. The viewer's server registry is a root JSON
+    /// ARRAY, and a bad entry's path is <c>$[1]</c> — recovering it would mean deleting a monitored server
+    /// from the operator's registry and calling it a repair. That is the exact class of loss #2434 was
+    /// filed about. The registry stays all-or-nothing, and the count is asserted so a future widening of
+    /// the recovery cannot silently start editing it.
+    /// </summary>
+    [Fact]
+    public void ReadObject_LeavesAnArrayRootedRegistryAllOrNothing()
+    {
+        File.WriteAllText(RegistryPath, @"[
+  { ""ServerName"": ""SQL2022"", ""DisplayName"": ""Prod"" },
+  { ""ServerName"": 7 }
+]");
+
+        var read = SettingsFileGuard.ReadObject<List<ViewerServerEntry>>(RegistryPath);
+
+        Assert.Equal(SettingsFileState.Unreadable, read.State);
+        Assert.Null(read.Value);
+        Assert.True(read.UnreadableMembers is null or { Count: 0 });
+    }
+
+    /// <summary>The control that keeps every assertion above meaningful: a healthy file is Readable, reports
+    /// nothing, and is not touched. The first thing a recovery that fires too eagerly breaks.</summary>
+    [Fact]
+    public void ReadObject_SaysNothingAboutAHealthyFile()
+    {
+        File.WriteAllText(SettingsPath, @"{ ""AlertCpuThreshold"": 91, ""AlertsEnabled"": false }");
+
+        var read = SettingsFileGuard.ReadObject<ViewerAppSettings>(SettingsPath);
+
+        Assert.Equal(SettingsFileState.Readable, read.State);
+        Assert.True(read.UnreadableMembers is null or { Count: 0 });
+        Assert.Null(read.Problem);
+        Assert.Equal(91, read.Value!.AlertCpuThreshold);
+    }
+
+    // ── What the STORES do with it ────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The store surfaces the names, which is what the startup dialog reads. And the settings that DID load
+    /// are the file's, not defaults — the load is no longer all-or-nothing even though the state still says
+    /// the file could not be read, which it could not, as written.
+    /// </summary>
+    [Fact]
+    public void Load_SurfacesTheNamedSettings_AndKeepsTheRestOfTheFile()
+    {
+        File.WriteAllText(SettingsPath, @"{
+  ""AlertCpuThreshold"": ""ninety"",
+  ""ConnectionTimeoutSeconds"": 42
+}");
+
+        var store = new ViewerAppSettingsStore(SettingsPath);
+        var settings = store.Load();
+
+        Assert.Equal(SettingsFileState.Unreadable, store.LastLoadState);
+        Assert.Equal(new[] { "AlertCpuThreshold" }, store.LastLoadUnreadableMembers.Select(m => m.Member));
+        Assert.Equal(42, settings.ConnectionTimeoutSeconds);
+        Assert.Equal(80, settings.AlertCpuThreshold);
+    }
+
+    /// <summary>
+    /// The safety-critical one, and the reason the state stays <c>Unreadable</c> for a partially-recovered
+    /// file rather than becoming some third thing. The dropped member's original text exists nowhere but
+    /// that file, and the very next save replaces the file with the recovered object. If the permit had
+    /// been relaxed to "we read most of it, go ahead", the one setting the user actually got wrong would be
+    /// the one destroyed, with no copy — a strictly worse outcome than dev's, where nothing was recovered
+    /// and everything was copied aside.
+    /// </summary>
+    [Fact]
+    public void Save_StillCopiesAPartiallyRecoveredFileAside()
+    {
+        const string Original = @"{
+  ""AlertCpuThreshold"": ""ninety"",
+  ""ConnectionTimeoutSeconds"": 42
+}";
+        File.WriteAllText(SettingsPath, Original);
+
+        var store = new ViewerAppSettingsStore(SettingsPath);
+        var settings = store.Load();
+
+        Assert.True(store.Save(settings));
+
+        var copies = QuarantineCopies(SettingsPath);
+        Assert.Single(copies);
+        Assert.Equal(Original, File.ReadAllText(copies[0]));
+
+        /* And the rewritten file is the recovered settings, so the good half of the user's configuration
+           survived the round trip rather than being reset along with the bad member. */
+        var reopened = new ViewerAppSettingsStore(SettingsPath).Load();
+        Assert.Equal(42, reopened.ConnectionTimeoutSeconds);
+    }
+
+    /// <summary>
+    /// The category rather than the instance, in the shape #2439 established when writing exactly this kind
+    /// of guard turned up a THIRD store nobody had looked at. All three answer the same three questions;
+    /// a fourth store written without the member list fails here instead of shipping.
+    /// </summary>
+    [Fact]
+    public void EveryViewerSettingsStore_CanNameTheSettingsItLost()
+    {
+        foreach (var store in new[]
+                 {
+                     typeof(ViewerAppSettingsStore),
+                     typeof(ViewerPreferencesStore),
+                     typeof(ViewerServerStore),
+                 })
+        {
+            Assert.NotNull(store.GetProperty("LastLoadState"));
+            Assert.NotNull(store.GetProperty("LastLoadProblem"));
+            Assert.NotNull(store.GetProperty("LastLoadUnreadableMembers"));
+        }
+    }
+
+    // ── The dialog, which is what the issue is actually about ─────────────────────────────────────
+
+    private static string CodeBehind => ReadRepoFile(Path.Combine(
+        "Darling", "PerformanceMonitor.Darling.Viewer", "MainWindow.xaml.cs"));
+
+    /// <summary>
+    /// The two facts get two sentences. A file that could not be read at all costs every setting in it; a
+    /// file read after dropping named members costs only those. One list covering both would have to put an
+    /// overstatement in front of whichever case it was not describing — and the issue is explicit that an
+    /// overstated capability is worse than an admitted gap. Source-scanned because the routing is a
+    /// <c>MessageBox</c> string, which no assertion about an object can reach and which compiles perfectly
+    /// clean when it is wrong.
+    /// </summary>
+    [Fact]
+    public void TheStartupDialog_SaysWhichSettingsWereLost_WithoutClaimingTheWholeFile()
+    {
+        var source = CodeBehind;
+
+        Assert.Contains("_unreadableSettingsFiles", source, StringComparison.Ordinal);
+        Assert.Contains("_unreadableSettingsValues", source, StringComparison.Ordinal);
+
+        /* The all-or-nothing sentence and the named-settings sentence both exist, and each is written once. */
+        Assert.Equal(1, Occurrences(source, "so the settings they hold are at "));
+        Assert.Equal(1, Occurrences(source, "These individual settings could not be read"));
+        Assert.Contains("Everything else in their file loaded normally", source, StringComparison.Ordinal);
+
+        /* And the routing: a file with named members goes on the values list and nowhere else, so the two
+           sentences can never both describe the same file. */
+        Assert.Contains("if (members.Count > 0)", source, StringComparison.Ordinal);
+    }
+
+    private static int Occurrences(string haystack, string needle)
+    {
+        var count = 0;
+        for (var i = haystack.IndexOf(needle, StringComparison.Ordinal); i >= 0;
+             i = haystack.IndexOf(needle, i + needle.Length, StringComparison.Ordinal))
+        {
+            count++;
+        }
+
+        return count;
+    }
+
+    private static string ReadRepoFile(string relative, [CallerFilePath] string thisFile = "")
+    {
+        for (var dir = new DirectoryInfo(Path.GetDirectoryName(thisFile)!); dir is not null; dir = dir.Parent)
+        {
+            var candidate = Path.Combine(dir.FullName, relative);
+            if (File.Exists(candidate))
+            {
+                return File.ReadAllText(candidate);
+            }
+        }
+
+        throw new FileNotFoundException($"Could not locate {relative} walking up from {thisFile}");
+    }
+}

--- a/Darling/Darling.Tests/ViewerSettingsMemberRecoveryTests.cs
+++ b/Darling/Darling.Tests/ViewerSettingsMemberRecoveryTests.cs
@@ -129,6 +129,48 @@ public sealed class ViewerSettingsMemberRecoveryTests : IDisposable
     }
 
     /// <summary>
+    /// A member's problem carries no line or position, and that omission is a correctness fix rather than a
+    /// trim. Each retry runs over the document with the previous member removed, and removing it
+    /// re-serializes — so from the second member onward the exception's position describes the RE-SERIALIZED
+    /// text, not the file the user is about to open. Measured on the first draft of this change: three bad
+    /// members on lines 2, 3 and 4 reported "line 2, position 22", then "line 1, position 30" and "line 1,
+    /// position 14". A position that confidently names the wrong line is worse than none, and the member's
+    /// NAME is a better locator anyway.
+    ///
+    /// <para>The document fault keeps its position, in the same test, because there the parse position is
+    /// the only locator there is — and because a rule applied to both would have quietly taken it away.</para>
+    /// </summary>
+    [Fact]
+    public void AMemberProblemCarriesNoParsePosition_ThoughTheDocumentFaultStillDoes()
+    {
+        File.WriteAllText(SettingsPath, @"{
+  ""McpEnabled"": ""yes"",
+  ""AlertCpuThreshold"": ""ninety"",
+  ""SmtpPort"": [ 25 ]
+}");
+
+        var members = SettingsFileGuard.ReadObject<ViewerAppSettings>(SettingsPath);
+
+        Assert.Equal(3, members.UnreadableMembers!.Count);
+        foreach (var problem in members.UnreadableMembers!)
+        {
+            Assert.DoesNotContain("line ", problem.Problem, StringComparison.Ordinal);
+            Assert.DoesNotContain("position ", problem.Problem, StringComparison.Ordinal);
+        }
+
+        Assert.DoesNotContain("line ", members.Problem!, StringComparison.Ordinal);
+
+        File.WriteAllText(SettingsPath, @"{
+  ""AlertsEnabled"": true,
+  ""AlertCpuThreshold"": 91,
+}");
+
+        var document = SettingsFileGuard.ReadObject<ViewerAppSettings>(SettingsPath);
+
+        Assert.Contains("line 4, position 1", document.Problem!, StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// A bad ELEMENT inside a list-valued setting costs that setting and nothing else. The exception's path
     /// is <c>$.AlertExcludedDatabases[1]</c>, so the reader takes the top-level member off the front of it
     /// and drops the whole list — coarse on purpose: editing an operator's list down to the elements that

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
@@ -91,13 +91,22 @@ public partial class MainWindow : Window
     private readonly ViewerAppSettingsStore _appSettingsStore = new();
 
     /// <summary>
-    /// The per-user settings files that were on disk at startup and could not be read, each with why
-    /// (#2434). Collected in the constructor, where both stores are loaded, and reported once from
+    /// The per-user settings files that were on disk at startup and could not be read AT ALL, each with why
+    /// (#2434). Collected in the constructor, where all three stores are loaded, and reported once from
     /// <see cref="OnLoaded"/> — a dialog raised from the constructor has no window behind it. Empty on
     /// every ordinary run INCLUDING a first run: an absent file is not a problem, and saying so would make
     /// a warning out of the most normal thing the viewer ever does.
     /// </summary>
     private readonly List<string> _unreadableSettingsFiles = new();
+
+    /// <summary>
+    /// The individual SETTINGS that could not be read, per file, when the rest of that file loaded normally
+    /// (#2456). Kept apart from <see cref="_unreadableSettingsFiles"/> because the two need different
+    /// sentences: one says every setting in the file reverted, the other says these did and nothing else
+    /// did. Collapsing them would put an overstatement in front of whichever case was not being described,
+    /// and the whole complaint here was a dialog that could not say which settings were lost.
+    /// </summary>
+    private readonly List<string> _unreadableSettingsValues = new();
 
     /// <summary>
     /// The system-tray icon + minimize-to-tray behavior (ported from Lite's SystemTrayService, adapted for
@@ -172,19 +181,22 @@ public partial class MainWindow : Window
     {
         InitializeComponent();
         _preferences = _preferencesStore.Load();
-        NoteUnreadableSettingsFile(_preferencesStore.FilePath, _preferencesStore.LastLoadState, _preferencesStore.LastLoadProblem);
+        NoteUnreadableSettingsFile(_preferencesStore.FilePath, _preferencesStore.LastLoadState, _preferencesStore.LastLoadProblem,
+            _preferencesStore.LastLoadUnreadableMembers);
         /* The registry loads in its own field initializer, which has already run by the time the
            constructor body does, so its state is available here — and it is the one of the three worth
            surfacing most: a viewer that opens with no servers because it could not read viewer-servers.json
            looks exactly like a viewer nobody has configured yet. */
-        NoteUnreadableSettingsFile(_serverStore.FilePath, _serverStore.LastLoadState, _serverStore.LastLoadProblem);
+        NoteUnreadableSettingsFile(_serverStore.FilePath, _serverStore.LastLoadState, _serverStore.LastLoadProblem,
+            _serverStore.LastLoadUnreadableMembers);
         /* Seed the persisted app settings the viewer honors at runtime BEFORE any tab/chart renders: the CSV
            export separator (grid exports) and the Server/Local/UTC time-display mode (every timestamp render
            routes through ViewerTimeHelper, which reads CurrentDisplayMode). UiTimeContext is deliberately left
            at its identity default — Darling charts pre-convert their X through ForDisplay, so wiring it would
            double-convert on hover/crosshair. */
         var appSettings = _appSettingsStore.Load();
-        NoteUnreadableSettingsFile(_appSettingsStore.FilePath, _appSettingsStore.LastLoadState, _appSettingsStore.LastLoadProblem);
+        NoteUnreadableSettingsFile(_appSettingsStore.FilePath, _appSettingsStore.LastLoadState, _appSettingsStore.LastLoadProblem,
+            _appSettingsStore.LastLoadUnreadableMembers);
         ViewerExportSettings.Apply(appSettings);
         /* Seed the new-mute-rule default expiration preference so every MuteRuleEditDialog opens on it, and the
            dismiss/mute action-logging opt-in the Alerts tab honors. */
@@ -212,14 +224,35 @@ public partial class MainWindow : Window
         Closed += OnClosed;
     }
 
-    /// <summary>Records a settings file that is present and could not be read, for the one startup report.
-    /// Absent and readable both record nothing, which is the whole point of the three-way split.</summary>
-    private void NoteUnreadableSettingsFile(string filePath, SettingsFileState state, string? problem)
+    /// <summary>
+    /// Records a settings file that is present and could not be read, for the one startup report. Absent
+    /// and readable both record nothing, which is the whole point of the three-way split.
+    ///
+    /// <para>Since #2456 the state carries a fourth possibility inside <c>Unreadable</c>: the file was read
+    /// after dropping members the deserializer could not understand, and <paramref name="members"/> names
+    /// them. That goes on the other list, because it is a different claim — those settings reverted and the
+    /// rest of the file did not.</para>
+    /// </summary>
+    private void NoteUnreadableSettingsFile(
+        string filePath,
+        SettingsFileState state,
+        string? problem,
+        IReadOnlyList<SettingsMemberProblem> members)
     {
-        if (state == SettingsFileState.Unreadable)
+        if (state != SettingsFileState.Unreadable)
         {
-            _unreadableSettingsFiles.Add($"{System.IO.Path.GetFileName(filePath)} — {problem}");
+            return;
         }
+
+        var fileName = System.IO.Path.GetFileName(filePath);
+
+        if (members.Count > 0)
+        {
+            _unreadableSettingsValues.Add($"{fileName} — {string.Join(", ", members)}");
+            return;
+        }
+
+        _unreadableSettingsFiles.Add($"{fileName} — {problem}");
     }
 
     /// <summary>
@@ -235,22 +268,47 @@ public partial class MainWindow : Window
     /// <para>Raised from Loaded so it has a window behind it, and before the store connect below on
     /// purpose: it costs nothing when there is nothing to say, and the connection-failure overlay would
     /// otherwise bury the one message that explains why the settings changed.</para>
+    ///
+    /// <para>Two paragraphs rather than one list, because there are two different facts and #2456 is the
+    /// issue about telling them apart. A file that could not be read at all costs every setting in it; a
+    /// file that was read after dropping named members costs only those. One sentence covering both would
+    /// have to overstate one of them, and an overstated capability is worse than an admitted gap — which
+    /// is also why the second paragraph says the settings are NAMED rather than implying the list is
+    /// exhaustive of everything wrong with the file.</para>
     /// </summary>
     private void ReportUnreadableSettingsFiles()
     {
-        if (_unreadableSettingsFiles.Count == 0)
+        if (_unreadableSettingsFiles.Count == 0 && _unreadableSettingsValues.Count == 0)
         {
             return;
         }
 
-        MessageBox.Show(
-            "The viewer could not read these settings files, so the settings they hold are at their "
-            + "defaults for this session:\n\n"
-            + string.Join("\n", _unreadableSettingsFiles)
-            + "\n\nThey have been left exactly as they are. Fix the JSON and restart to get those settings "
-            + "back — or save from the Settings window, which copies an unreadable file aside as "
-            + "'.unreadable-<timestamp>' before replacing it.",
-            "Settings", MessageBoxButton.OK, MessageBoxImage.Warning);
+        var message = new System.Text.StringBuilder();
+
+        if (_unreadableSettingsFiles.Count > 0)
+        {
+            message
+                .Append("The viewer could not read these settings files, so the settings they hold are at ")
+                .Append("their defaults for this session:\n\n")
+                .AppendJoin('\n', _unreadableSettingsFiles)
+                .Append("\n\n");
+        }
+
+        if (_unreadableSettingsValues.Count > 0)
+        {
+            message
+                .Append("These individual settings could not be read and are at their defaults for this ")
+                .Append("session. Everything else in their file loaded normally:\n\n")
+                .AppendJoin('\n', _unreadableSettingsValues)
+                .Append("\n\n");
+        }
+
+        message
+            .Append("The files have been left exactly as they are. Fix the JSON and restart to get those ")
+            .Append("settings back — or save from the Settings window, which copies an unreadable file ")
+            .Append("aside as '.unreadable-<timestamp>' before replacing it.");
+
+        MessageBox.Show(message.ToString(), "Settings", MessageBoxButton.OK, MessageBoxImage.Warning);
     }
 
     private async void OnLoaded(object sender, RoutedEventArgs e)

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerAppSettings.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerAppSettings.cs
@@ -288,6 +288,15 @@ public sealed class ViewerAppSettingsStore
     /// error where there is one — or null when there was nothing wrong with it.</summary>
     public string? LastLoadProblem { get; private set; }
 
+    /// <summary>
+    /// The settings the last <see cref="Load"/> could not read, by NAME, and empty when there were none
+    /// (#2456). Non-empty means the rest of the file loaded normally and only these reverted to their
+    /// defaults — the distinction <see cref="LastLoadProblem"/> alone cannot make, and the reason the
+    /// startup dialog can now say which settings were lost instead of only where the parse stopped.
+    /// </summary>
+    public IReadOnlyList<SettingsMemberProblem> LastLoadUnreadableMembers { get; private set; } =
+        Array.Empty<SettingsMemberProblem>();
+
     /// <summary>%APPDATA%\PerformanceMonitorDarling\viewer-settings.json.</summary>
     public static string DefaultFilePath()
     {
@@ -307,6 +316,7 @@ public sealed class ViewerAppSettingsStore
         var read = ViewerSettingsFile.Load<ViewerAppSettings>(_filePath, LogSource, s_jsonOptions);
         LastLoadState = read.State;
         LastLoadProblem = read.Problem;
+        LastLoadUnreadableMembers = read.UnreadableMembers ?? Array.Empty<SettingsMemberProblem>();
         return read.Value!.Normalize();
     }
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerPreferences.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerPreferences.cs
@@ -117,6 +117,15 @@ public sealed class ViewerPreferencesStore
     /// <summary>Why the last <see cref="Load"/> could not read the file, or null when it could.</summary>
     public string? LastLoadProblem { get; private set; }
 
+    /// <summary>
+    /// The settings the last <see cref="Load"/> could not read, by NAME, and empty when there were none
+    /// (#2456). Non-empty means the rest of the file loaded normally and only these reverted to their
+    /// defaults — the distinction <see cref="LastLoadProblem"/> alone cannot make, and the reason the
+    /// startup dialog can now say which settings were lost instead of only where the parse stopped.
+    /// </summary>
+    public IReadOnlyList<SettingsMemberProblem> LastLoadUnreadableMembers { get; private set; } =
+        Array.Empty<SettingsMemberProblem>();
+
     /// <summary>%APPDATA%\PerformanceMonitorDarling\viewer-preferences.json.</summary>
     public static string DefaultFilePath()
     {
@@ -136,6 +145,7 @@ public sealed class ViewerPreferencesStore
         var read = ViewerSettingsFile.Load<ViewerPreferences>(_filePath, LogSource, s_jsonOptions);
         LastLoadState = read.State;
         LastLoadProblem = read.Problem;
+        LastLoadUnreadableMembers = read.UnreadableMembers ?? Array.Empty<SettingsMemberProblem>();
         return read.Value!.Normalize();
     }
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerStore.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerStore.cs
@@ -121,6 +121,16 @@ public sealed class ViewerServerStore
     public string? LastLoadProblem { get; private set; }
 
     /// <summary>
+    /// Present so all three stores answer the same three questions, and ALWAYS empty here — which is the
+    /// point rather than an oversight. The member recovery #2456 added only edits a root JSON object, and
+    /// this file's root is an array: dropping a bad element would silently delete a monitored server from
+    /// the operator's registry, which is the data loss #2434 exists to prevent wearing a repair's clothes.
+    /// The registry stays all-or-nothing, and the guard has a control test that pins it.
+    /// </summary>
+    public IReadOnlyList<SettingsMemberProblem> LastLoadUnreadableMembers { get; private set; } =
+        Array.Empty<SettingsMemberProblem>();
+
+    /// <summary>
     /// Whether the last write of the registry reached disk (#2434). Every mutator here ends in the same
     /// <see cref="Save"/>, and several of them keep return types that already mean something else —
     /// <c>ToggleFavorite</c> answers "is it favourite now", <c>ImportServersFromFile</c> answers with
@@ -386,6 +396,7 @@ public sealed class ViewerServerStore
         var read = ViewerSettingsFile.Load<List<ViewerServerEntry>>(_filePath, LogSource, s_jsonOptions);
         LastLoadState = read.State;
         LastLoadProblem = read.Problem;
+        LastLoadUnreadableMembers = read.UnreadableMembers ?? Array.Empty<SettingsMemberProblem>();
         return read.Value!;
     }
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerSettingsFile.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerSettingsFile.cs
@@ -83,10 +83,17 @@ internal static class ViewerSettingsFile
 
         if (read.State == SettingsFileState.Unreadable && FirstReportOf(filePath, read.Problem))
         {
+            /* Two different facts, so two different sentences. A file the reader could not use AT ALL costs
+               every setting in it; a file it read after dropping named members costs only those. Saying the
+               first when the second is true is the overstatement #2456 was filed to end — and saying the
+               second when the first is true would be worse, because it implies the rest survived. */
             ViewerLogger.Error(logSource,
-                $"'{filePath}' could not be read ({read.Problem}), so every setting it holds is at its " +
-                "default for this session. The file has not been changed; the next save copies it aside " +
-                "before replacing it.");
+                read.UnreadableMembers is { Count: > 0 }
+                    ? $"'{filePath}': {read.Problem}. Every other setting in the file loaded normally. " +
+                      "The file has not been changed; the next save copies it aside before replacing it."
+                    : $"'{filePath}' could not be read ({read.Problem}), so every setting it holds is at " +
+                      "its default for this session. The file has not been changed; the next save copies " +
+                      "it aside before replacing it.");
         }
 
         return read.Value is null ? read with { Value = new T() } : read;
@@ -122,9 +129,13 @@ internal static class ViewerSettingsFile
 
         if (permit.QuarantinedTo is not null)
         {
+            /* Deliberately does not claim WHAT the replacement is written from. Since #2456 that depends on
+               how much of the file the load recovered — everything but the named members, or nothing at all
+               — and this permit is asked at save time by a caller holding an object it did not necessarily
+               load. The one fact that matters here is true either way: the original bytes are in the copy. */
             ViewerLogger.Warn(logSource,
                 $"'{Path.GetFileName(filePath)}' could not be read ({permit.Problem}), so this save " +
-                "rewrites it from defaults. The unreadable original was copied to " +
+                "replaces it. The unreadable original was copied to " +
                 $"'{Path.GetFileName(permit.QuarantinedTo)}' first — the settings it held are recoverable " +
                 "from there.");
         }

--- a/PerformanceMonitor.Common/Services/SettingsFileGuard.cs
+++ b/PerformanceMonitor.Common/Services/SettingsFileGuard.cs
@@ -306,13 +306,24 @@ public static class SettingsFileGuard
     }
 
     /// <summary>
-    /// A top-level member name in a <see cref="JsonException.Path"/>: <c>$.AlertCpuThreshold</c> and
-    /// <c>$.AlertExcludedDatabases[1]</c> both yield <c>AlertCpuThreshold</c> / <c>AlertExcludedDatabases</c>,
-    /// while <c>$</c> and <c>$[3].DisplayName</c> yield nothing. Anchored and deliberately narrow — see
-    /// <see cref="DeserializeWithMemberRecovery{T}"/>.
+    /// A top-level member name in a <see cref="JsonException.Path"/>: <c>$.AlertCpuThreshold</c>,
+    /// <c>$.AlertExcludedDatabases[1]</c> and <c>$.Nested.Deeper</c> all yield the first segment, while
+    /// <c>$</c>, <c>$[3].DisplayName</c> and <c>$['with space']</c> yield nothing — an array root and a
+    /// bracket-quoted name are both paths this reader must not edit a document on.
+    ///
+    /// <para><b>Everything up to the first <c>.</c> or <c>[</c>, not an ASCII identifier.</b> Review raised
+    /// the narrower form as a diacritic edge case; measuring System.Text.Json showed it is wider and more
+    /// ordinary than that. STJ writes the DOT form for every name that needs no escaping, which includes
+    /// <c>$.with-dash</c> and <c>$.dollar$sign</c> as well as <c>$.ServerNaïve</c> and <c>$.サーバー</c>; it
+    /// bracket-quotes only where it must, e.g. <c>$['with space']</c>. An identifier class would have
+    /// captured <c>with</c> out of <c>with-dash</c> — and a hyphenated key is an ordinary thing to find in a
+    /// settings file, not an exotic one. It failed SAFE (<see cref="WithoutMember"/> finds no such key and
+    /// the read falls back to whole-file <c>Unreadable</c>), so nothing was ever at risk; what it lost was
+    /// the per-member recovery, silently, for exactly the settings someone had to name by hand with
+    /// <c>JsonPropertyName</c>.</para>
     /// </summary>
     private static readonly Regex s_topLevelMember =
-        new(@"^\$\.([A-Za-z_][A-Za-z0-9_]*)", RegexOptions.CultureInvariant);
+        new(@"^\$\.([^.\[]+)", RegexOptions.CultureInvariant);
 
     /// <summary>A file cannot lose more members than it has; the cap is a termination guard, not a policy.</summary>
     private const int MaxDroppedMembers = 500;

--- a/PerformanceMonitor.Common/Services/SettingsFileGuard.cs
+++ b/PerformanceMonitor.Common/Services/SettingsFileGuard.cs
@@ -393,7 +393,7 @@ public static class SettingsFileGuard
             firstProblem ??= Describe(failure);
 
             var member = TopLevelMember(failure);
-            var without = member is null ? null : WithoutMember(current, member);
+            var without = member is null ? null : WithoutMember(current, member, options);
 
             if (member is null || without is null)
             {
@@ -457,12 +457,34 @@ public static class SettingsFileGuard
     /// The same JSON with one top-level member removed, or null when the root is not an object, the member
     /// is not actually there, or the text will not re-parse. The existence check is what makes the retry
     /// loop terminate: a pass that removed nothing would fail identically forever.
+    ///
+    /// <para><b>The parse borrows the caller's leniency, and it has to.</b> Review found the seam: the retry
+    /// loop deserializes with the caller's <see cref="JsonSerializerOptions"/>, so a caller that allows
+    /// trailing commas or comments has a file the DESERIALIZE accepts — while a bare
+    /// <see cref="JsonNode.Parse(string, JsonNodeOptions?, JsonDocumentOptions)"/> here runs with both
+    /// disallowed and throws on the very same text. The recovery would then bail to whole-file Unreadable
+    /// and silently give up the per-member repair, on files it was written for.</para>
+    ///
+    /// <para>Dormant today — none of the three viewer stores passes permissive options — and not hypothetical
+    /// either: <c>ViewerSettings</c> reads darling.json with <c>AllowTrailingCommas</c> and
+    /// <c>ReadCommentHandling.Skip</c> because that file is JSONC, so the next caller of this general-purpose
+    /// API is as likely to be lenient as strict. This is also the one place the "one judge, not two" claim
+    /// this recovery rests on could have quietly become false, which is why the mapping is here and pinned
+    /// rather than left to match by luck.</para>
     /// </summary>
-    private static string? WithoutMember(string text, string member)
+    private static string? WithoutMember(string text, string member, JsonSerializerOptions? options)
     {
         try
         {
-            if (JsonNode.Parse(text) is not JsonObject root || !root.Remove(member))
+            var documentOptions = new JsonDocumentOptions
+            {
+                AllowTrailingCommas = options?.AllowTrailingCommas ?? false,
+                CommentHandling = options?.ReadCommentHandling ?? JsonCommentHandling.Disallow,
+                MaxDepth = options?.MaxDepth ?? 0,
+            };
+
+            if (JsonNode.Parse(text, nodeOptions: null, documentOptions) is not JsonObject root
+                || !root.Remove(member))
             {
                 return null;
             }

--- a/PerformanceMonitor.Common/Services/SettingsFileGuard.cs
+++ b/PerformanceMonitor.Common/Services/SettingsFileGuard.cs
@@ -380,7 +380,8 @@ public static class SettingsFileGuard
                 return new SettingsObjectRead<T>(SettingsFileState.Unreadable, null, Describe(failure), dropped);
             }
 
-            (dropped ??= new List<SettingsMemberProblem>()).Add(new SettingsMemberProblem(member, Describe(failure)));
+            (dropped ??= new List<SettingsMemberProblem>()).Add(
+                new SettingsMemberProblem(member, DescribeMemberValue(failure)));
             current = without;
         }
 
@@ -389,6 +390,22 @@ public static class SettingsFileGuard
         return new SettingsObjectRead<T>(SettingsFileState.Unreadable, null,
             "the file holds more unreadable settings than this reader will drop", dropped);
     }
+
+    /// <summary>
+    /// Why one member's value could not be read, deliberately WITHOUT the line and position
+    /// <see cref="Describe"/> renders.
+    ///
+    /// <para>That omission is a correctness fix, not a trim. Each retry runs over the document with the
+    /// previous member removed, and removing it re-serializes — so from the second member onward the
+    /// exception's line and position describe the RE-SERIALIZED text, not the file the user is about to
+    /// open. Measured: three bad members on lines 2, 3 and 4 reported "line 2, position 22", then
+    /// "line 1, position 30" and "line 1, position 14". A position that confidently names the wrong line is
+    /// worse than no position, and here there is a better locator anyway — the member's NAME, which is what
+    /// this whole reader exists to produce and what a reader will search their file for. The line and
+    /// position stay on the DOCUMENT fault, where the parse position is the only locator there is.</para>
+    /// </summary>
+    private static string DescribeMemberValue(JsonException failure) =>
+        WithoutPathSuffix(failure.Message).Trim();
 
     /// <summary>The member a <see cref="JsonException"/> stopped on, or null when it stopped on the document
     /// itself (<c>$</c>) or somewhere this reader will not edit.</summary>
@@ -433,7 +450,7 @@ public static class SettingsFileGuard
     private static string Summarize(List<SettingsMemberProblem> dropped) =>
         string.Format(
             CultureInfo.InvariantCulture,
-            "{0} setting{1} could not be read and {2} at {3} default: {4}",
+            "{0} setting{1} could not be read and {2} at {3} default{1}: {4}",
             dropped.Count,
             dropped.Count == 1 ? "" : "s",
             dropped.Count == 1 ? "is" : "are",

--- a/PerformanceMonitor.Common/Services/SettingsFileGuard.cs
+++ b/PerformanceMonitor.Common/Services/SettingsFileGuard.cs
@@ -70,14 +70,18 @@ public readonly record struct SettingsMemberProblem(string Member, string Proble
 /// empty (or null) means nothing in the file was usable, and the caller's own defaults are the whole
 /// answer.</para>
 ///
-/// <para><b>The invariant, because a caller reads one field and believes the other:</b>
-/// <c>UnreadableMembers</c> is non-empty if and only if <c>Value</c> is non-null. Review found the
-/// combination that broke it — a recovery that dropped one member and then hit a fault it could not
-/// attribute returned a null value WITH a member list, and the viewer's dialog routes on the list, so it
-/// would have said "everything else in their file loaded normally" about a file where nothing loaded at
-/// all. It is enforced at the one place that can enforce it (see
-/// <see cref="SettingsFileGuard.DeserializeWithMemberRecovery{T}"/>) rather than at each caller, because
-/// every caller that has to remember a rule is a caller that can forget it.</para>
+/// <para><b>The invariant, because a caller reads one field and believes the other:</b> a non-empty
+/// <c>UnreadableMembers</c> always comes with a non-null <c>Value</c>. One direction only, and stated that
+/// way deliberately — the reverse is false, because an ordinary <see cref="SettingsFileState.Readable"/>
+/// file has a value and no members at all, so an "if and only if" here would be a sentence a future
+/// <c>Debug.Assert</c> could fire on down the happy path.</para>
+///
+/// <para>Review found the combination that broke the direction that IS guaranteed: a recovery that dropped
+/// one member and then hit a fault it could not attribute returned a null value WITH a member list, and the
+/// viewer's dialog routes on the list — so it would have said "everything else in their file loaded
+/// normally" about a file where nothing loaded at all. It is enforced at the one place that can enforce it
+/// (see <see cref="SettingsFileGuard.DeserializeWithMemberRecovery{T}"/>) rather than at each caller,
+/// because every caller that has to remember a rule is a caller that can forget it.</para>
 /// </summary>
 public readonly record struct SettingsObjectRead<T>(
     SettingsFileState State,

--- a/PerformanceMonitor.Common/Services/SettingsFileGuard.cs
+++ b/PerformanceMonitor.Common/Services/SettingsFileGuard.cs
@@ -69,6 +69,15 @@ public readonly record struct SettingsMemberProblem(string Member, string Proble
 /// save must still copy it aside before replacing it. <c>UnreadableMembers</c> is what separates the two:
 /// empty (or null) means nothing in the file was usable, and the caller's own defaults are the whole
 /// answer.</para>
+///
+/// <para><b>The invariant, because a caller reads one field and believes the other:</b>
+/// <c>UnreadableMembers</c> is non-empty if and only if <c>Value</c> is non-null. Review found the
+/// combination that broke it — a recovery that dropped one member and then hit a fault it could not
+/// attribute returned a null value WITH a member list, and the viewer's dialog routes on the list, so it
+/// would have said "everything else in their file loaded normally" about a file where nothing loaded at
+/// all. It is enforced at the one place that can enforce it (see
+/// <see cref="SettingsFileGuard.DeserializeWithMemberRecovery{T}"/>) rather than at each caller, because
+/// every caller that has to remember a rule is a caller that can forget it.</para>
 /// </summary>
 public readonly record struct SettingsObjectRead<T>(
     SettingsFileState State,
@@ -342,6 +351,11 @@ public static class SettingsFileGuard
         List<SettingsMemberProblem>? dropped = null;
         var current = text;
 
+        /* The first failure's description, kept because it is the only one whose line and position are
+           against the file the user actually has: every later attempt runs over a re-serialized document.
+           It is what a whole-file failure reports, however many members had been dropped before it. */
+        string? firstProblem = null;
+
         for (var attempt = 0; attempt <= MaxDroppedMembers; attempt++)
         {
             JsonException failure;
@@ -354,8 +368,8 @@ public static class SettingsFileGuard
                    consequence of believing that is a file replaced from defaults. */
                 if (value is null)
                 {
-                    return new SettingsObjectRead<T>(SettingsFileState.Unreadable, null,
-                        "the file holds the JSON literal null rather than the settings it should", dropped);
+                    return Unreadable<T>(
+                        "the file holds the JSON literal null rather than the settings it should");
                 }
 
                 return dropped is null
@@ -369,15 +383,17 @@ public static class SettingsFileGuard
             catch (Exception ex) when (ex is NotSupportedException or ArgumentException)
             {
                 /* Not a member fault and carries no path to attribute one with. */
-                return new SettingsObjectRead<T>(SettingsFileState.Unreadable, null, Describe(ex), dropped);
+                return Unreadable<T>(firstProblem ?? Describe(ex));
             }
+
+            firstProblem ??= Describe(failure);
 
             var member = TopLevelMember(failure);
             var without = member is null ? null : WithoutMember(current, member);
 
             if (member is null || without is null)
             {
-                return new SettingsObjectRead<T>(SettingsFileState.Unreadable, null, Describe(failure), dropped);
+                return Unreadable<T>(firstProblem);
             }
 
             (dropped ??= new List<SettingsMemberProblem>()).Add(
@@ -387,9 +403,21 @@ public static class SettingsFileGuard
 
         /* Unreachable for any real file — every pass removes a member that was there — but a loop that
            edits its own input gets a bound rather than a proof. */
-        return new SettingsObjectRead<T>(SettingsFileState.Unreadable, null,
-            "the file holds more unreadable settings than this reader will drop", dropped);
+        return Unreadable<T>("the file holds more unreadable settings than this reader will drop");
     }
+
+    /// <summary>
+    /// A whole-file failure: no value, and deliberately NO member list even when members had already been
+    /// dropped before the reader hit something it could not attribute.
+    ///
+    /// <para>Discarding that partial list is the honest answer rather than a loss. The caller substitutes
+    /// its own defaults for a null value, so EVERY setting in the file reverts — and a list naming three of
+    /// them, next to a message built to mean "only these", would tell the reader the other eighty survived.
+    /// The named subset is worth nothing here anyway: it is a subset of "all of them". This is the one place
+    /// the <see cref="SettingsObjectRead{T}"/> invariant can be enforced, so it is enforced here.</para>
+    /// </summary>
+    private static SettingsObjectRead<T> Unreadable<T>(string? problem) where T : class =>
+        new(SettingsFileState.Unreadable, null, problem, null);
 
     /// <summary>
     /// Why one member's value could not be read, deliberately WITHOUT the line and position

--- a/PerformanceMonitor.Common/Services/SettingsFileGuard.cs
+++ b/PerformanceMonitor.Common/Services/SettingsFileGuard.cs
@@ -7,8 +7,11 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
@@ -47,15 +50,31 @@ public readonly record struct SettingsFileRead(
     string? Problem);
 
 /// <summary>
+/// One top-level member of a settings file whose VALUE the deserializer could not read, and what was wrong
+/// with it (#2456). Carried rather than thrown, because the whole point is that the reader gets to name it.
+/// </summary>
+public readonly record struct SettingsMemberProblem(string Member, string Problem)
+{
+    /// <summary>One line, ready to put in a log or a dialog.</summary>
+    public override string ToString() => $"{Member} ({Problem})";
+}
+
+/// <summary>
 /// The outcome of <see cref="SettingsFileGuard.ReadObject{T}"/>, for a store that round-trips a whole
-/// object rather than merging a document key by key. <c>Value</c> is non-null only for
-/// <see cref="SettingsFileState.Readable"/>; the caller supplies its own defaults for the other two
-/// states, and must tell them apart before deciding whether to say anything about it.
+/// object rather than merging a document key by key.
+///
+/// <para><c>Value</c> is non-null for <see cref="SettingsFileState.Readable"/> and for a file that was read
+/// after DROPPING members the deserializer could not understand — in which case the state is still
+/// <see cref="SettingsFileState.Unreadable"/>, because the file as written is exactly that, and the next
+/// save must still copy it aside before replacing it. <c>UnreadableMembers</c> is what separates the two:
+/// empty (or null) means nothing in the file was usable, and the caller's own defaults are the whole
+/// answer.</para>
 /// </summary>
 public readonly record struct SettingsObjectRead<T>(
     SettingsFileState State,
     T? Value,
-    string? Problem) where T : class;
+    string? Problem,
+    IReadOnlyList<SettingsMemberProblem>? UnreadableMembers = null) where T : class;
 
 /// <summary>
 /// The outcome of <see cref="SettingsFileGuard.RootForWrite"/>. <c>Problem</c> is null on the ordinary
@@ -255,6 +274,11 @@ public static class SettingsFileGuard
     /// every add, edit and favourite toggle. The typed deserialize is the right judge of whether the file
     /// says what this caller reads — for a settings object an array still fails, and for a
     /// <c>List&lt;T&gt;</c> an object still fails.</para>
+    ///
+    /// <para>When the deserialize fails on ONE member's value rather than on the document, that member is
+    /// named, dropped, and the read is attempted again — see
+    /// <see cref="DeserializeWithMemberRecovery{T}"/> for why that is the shape rather than per-property
+    /// reads (#2456).</para>
     /// </summary>
     public static SettingsObjectRead<T> ReadObject<T>(string settingsPath, JsonSerializerOptions? options = null)
         where T : class
@@ -265,23 +289,156 @@ public static class SettingsFileGuard
             return new SettingsObjectRead<T>(state, null, problem);
         }
 
+        return DeserializeWithMemberRecovery<T>(text!, options);
+    }
+
+    /// <summary>
+    /// A top-level member name in a <see cref="JsonException.Path"/>: <c>$.AlertCpuThreshold</c> and
+    /// <c>$.AlertExcludedDatabases[1]</c> both yield <c>AlertCpuThreshold</c> / <c>AlertExcludedDatabases</c>,
+    /// while <c>$</c> and <c>$[3].DisplayName</c> yield nothing. Anchored and deliberately narrow — see
+    /// <see cref="DeserializeWithMemberRecovery{T}"/>.
+    /// </summary>
+    private static readonly Regex s_topLevelMember =
+        new(@"^\$\.([A-Za-z_][A-Za-z0-9_]*)", RegexOptions.CultureInvariant);
+
+    /// <summary>A file cannot lose more members than it has; the cap is a termination guard, not a policy.</summary>
+    private const int MaxDroppedMembers = 500;
+
+    /// <summary>
+    /// Deserialize <typeparamref name="T"/>, and when the failure is one member's VALUE rather than the
+    /// document, name that member, drop it, and try again — so a badly-shaped setting costs exactly its own
+    /// setting and the read can say which ones it lost (#2456).
+    ///
+    /// <para><b>Why this shape and not per-property reads.</b> #2444 gave Lite a per-KEY reader, which works
+    /// there because Lite's settings.json is built key by key on BOTH sides: #2441 made every writer mutate
+    /// one <see cref="JsonObject"/>, so a per-key read is symmetric with a per-key write. These files are a
+    /// whole-object round trip on both sides, and converting only the READ half to hand-written properties
+    /// would break that symmetry: a property added to the settings class would still be serialized on save
+    /// and would silently never be read back. That is a worse defect than the one being fixed, and an
+    /// invisible one. Dropping the named member and re-running the SAME deserialize keeps the round trip
+    /// intact, so a new property is covered the day it is added.</para>
+    ///
+    /// <para><b>Why it is not two readers.</b> #2213 spent a review round on a two-pass classify where the
+    /// second pass judged the file by a different standard from the first. Every attempt here is
+    /// <see cref="JsonSerializer.Deserialize{T}(string, JsonSerializerOptions)"/> with the caller's own
+    /// options over the caller's own type. The only thing that changes between attempts is that one member
+    /// is gone, so the two passes cannot disagree about what "unreadable" means — there is only one judge.</para>
+    ///
+    /// <para><b>What it deliberately will not recover.</b> Only a top-level member of a root JSON OBJECT.
+    /// The viewer's server registry is a root ARRAY, and a bad element there has a path of
+    /// <c>$[3]</c> — dropping it would silently delete a monitored server from the operator's registry,
+    /// which is the data loss #2434 exists to prevent, dressed up as a repair. So an array-rooted file keeps
+    /// its all-or-nothing behaviour and says so, and
+    /// <c>ReadObject_LeavesAnArrayRootedRegistryAllOrNothing</c> is the control for exactly that mistake.</para>
+    ///
+    /// <para>The state stays <see cref="SettingsFileState.Unreadable"/> for a partially-recovered file, on
+    /// purpose. The file on disk is still the one that could not be read, so <see cref="PermitReplace{T}"/>
+    /// must still copy it aside before anything replaces it — the recovered values are in memory, and the
+    /// dropped members' original text exists nowhere else.</para>
+    /// </summary>
+    internal static SettingsObjectRead<T> DeserializeWithMemberRecovery<T>(string text, JsonSerializerOptions? options)
+        where T : class
+    {
+        List<SettingsMemberProblem>? dropped = null;
+        var current = text;
+
+        for (var attempt = 0; attempt <= MaxDroppedMembers; attempt++)
+        {
+            JsonException failure;
+            try
+            {
+                var value = JsonSerializer.Deserialize<T>(current, options);
+
+                /* The JSON literal null parses and deserializes to null. Reported, because it is the shape
+                   that reads as "nothing was configured" to a caller that only null-checks, and the
+                   consequence of believing that is a file replaced from defaults. */
+                if (value is null)
+                {
+                    return new SettingsObjectRead<T>(SettingsFileState.Unreadable, null,
+                        "the file holds the JSON literal null rather than the settings it should", dropped);
+                }
+
+                return dropped is null
+                    ? new SettingsObjectRead<T>(SettingsFileState.Readable, value, null)
+                    : new SettingsObjectRead<T>(SettingsFileState.Unreadable, value, Summarize(dropped), dropped);
+            }
+            catch (JsonException ex)
+            {
+                failure = ex;
+            }
+            catch (Exception ex) when (ex is NotSupportedException or ArgumentException)
+            {
+                /* Not a member fault and carries no path to attribute one with. */
+                return new SettingsObjectRead<T>(SettingsFileState.Unreadable, null, Describe(ex), dropped);
+            }
+
+            var member = TopLevelMember(failure);
+            var without = member is null ? null : WithoutMember(current, member);
+
+            if (member is null || without is null)
+            {
+                return new SettingsObjectRead<T>(SettingsFileState.Unreadable, null, Describe(failure), dropped);
+            }
+
+            (dropped ??= new List<SettingsMemberProblem>()).Add(new SettingsMemberProblem(member, Describe(failure)));
+            current = without;
+        }
+
+        /* Unreachable for any real file — every pass removes a member that was there — but a loop that
+           edits its own input gets a bound rather than a proof. */
+        return new SettingsObjectRead<T>(SettingsFileState.Unreadable, null,
+            "the file holds more unreadable settings than this reader will drop", dropped);
+    }
+
+    /// <summary>The member a <see cref="JsonException"/> stopped on, or null when it stopped on the document
+    /// itself (<c>$</c>) or somewhere this reader will not edit.</summary>
+    private static string? TopLevelMember(JsonException failure)
+    {
+        var path = failure.Path;
+        if (string.IsNullOrEmpty(path))
+        {
+            return null;
+        }
+
+        var match = s_topLevelMember.Match(path);
+        return match.Success ? match.Groups[1].Value : null;
+    }
+
+    /// <summary>
+    /// The same JSON with one top-level member removed, or null when the root is not an object, the member
+    /// is not actually there, or the text will not re-parse. The existence check is what makes the retry
+    /// loop terminate: a pass that removed nothing would fail identically forever.
+    /// </summary>
+    private static string? WithoutMember(string text, string member)
+    {
         try
         {
-            var value = JsonSerializer.Deserialize<T>(text!, options);
+            if (JsonNode.Parse(text) is not JsonObject root || !root.Remove(member))
+            {
+                return null;
+            }
 
-            /* The JSON literal null parses and deserializes to null. Reported, because it is the shape that
-               reads as "nothing was configured" to a caller that only null-checks, and the consequence of
-               believing that is a file replaced from defaults. */
-            return value is null
-                ? new SettingsObjectRead<T>(SettingsFileState.Unreadable, null,
-                    "the file holds the JSON literal null rather than the settings it should")
-                : new SettingsObjectRead<T>(SettingsFileState.Readable, value, null);
+            return root.ToJsonString();
         }
-        catch (Exception ex) when (ex is JsonException or NotSupportedException or ArgumentException)
+        catch (JsonException)
         {
-            return new SettingsObjectRead<T>(SettingsFileState.Unreadable, null, Describe(ex));
+            return null;
         }
     }
+
+    /// <summary>
+    /// The one-line <c>Problem</c> for a partially-recovered file. Names the members rather than counting
+    /// them: a count sends someone to proofread the whole file, which is the message #2444 replaced.
+    /// </summary>
+    private static string Summarize(List<SettingsMemberProblem> dropped) =>
+        string.Format(
+            CultureInfo.InvariantCulture,
+            "{0} setting{1} could not be read and {2} at {3} default: {4}",
+            dropped.Count,
+            dropped.Count == 1 ? "" : "s",
+            dropped.Count == 1 ? "is" : "are",
+            dropped.Count == 1 ? "its" : "their",
+            string.Join(", ", dropped.Select(d => d.ToString())));
 
     /// <summary>
     /// <see cref="RootForWrite"/>'s twin for a store that REPLACES the file instead of merging into it.


### PR DESCRIPTION
Fixes #2456.

## The gap, and why Lite's answer does not port

The viewer's startup dialog could name the file and the parse position and nothing else. That is not a wording problem: it round-trips a whole object, so when `JsonSerializer.Deserialize<T>` threw there was no property in existence to report — and **every** setting in the file reverted, not just the bad one.

**Option 1 — per-property reads, the shape #2444 gave Lite — is wrong here, and not for the reason the issue weighed.** The issue framed it as "is the settings object stable enough to be worth eighty-odd hand-written reads". The decisive problem is smaller and worse than the typing:

Lite's `settings.json` is built key by key on **both** sides — #2441 made all ten writers mutate one `JsonObject` opened once — so a per-key read is symmetric with a per-key write. These files are a whole-object round trip on both sides. Converting only the READ half to hand-written properties breaks that symmetry, and a property added to `ViewerAppSettings` afterwards would still be serialized on save and **silently never read back**. That is a worse defect than the one being fixed, and an invisible one; nothing in the compiler or the tests would notice. So the answer had to keep the round trip.

## What `JsonException` actually carries, measured

The issue said `JsonException.Path` "names one member at best". Measured against the shipped BCL rather than assumed, across every fault class these files can produce:

| file | `Path` | `LineNumber` |
|---|---|---|
| `"AlertCpuThreshold": "ninety"` | `$.AlertCpuThreshold` | 2 |
| `"McpEnabled": "true"` | `$.McpEnabled` | 1 |
| `"SmtpServer": 5` | `$.SmtpServer` | 1 |
| `"AlertExcludedDatabases": 5` | `$.AlertExcludedDatabases` | 1 |
| `"AlertExcludedDatabases": ["a", 2]` | `$.AlertExcludedDatabases[1]` | 1 |
| `"AlertCpuThreshold": 99999999999999` | `$.AlertCpuThreshold` | 1 |
| trailing comma | `$` | 2 |
| unbalanced brace | `$` | 2 |
| root is an array / a string | `$` | 0 |
| **two bad members** | `$.McpEnabled` **only** | 1 |

So it is stronger than "often carries": `Path == "$"` is exactly the discriminant between *the document is broken* and *one setting is the wrong shape*, every time. And the last row is the limit that matters — one member, never the set.

There is a small finding in that. **`SettingsFileGuard.Describe` had the member name in its hand and was deliberately throwing it away**: `WithoutPathSuffix` cuts ` Path: … | LineNumber: … ` off the message because it duplicates the line and position it has already rendered — and `Path` is the one part of that suffix that does not.

## The fix: name it, drop it, run the same deserialize again

`ReadObject<T>` now names the member the deserializer stopped on, removes it from the document, and retries. Two consequences, and the second is the issue's title:

- a badly-shaped setting costs **exactly its own setting** — the settings before *and* after it in the file survive, which the single `try` could never have delivered because it threw and stopped reading;
- the read reports **the whole set**, which `Path` alone cannot, because the retry is what surfaces the second and third.

**It is one judge, not two.** #2213 spent a review round on a two-pass classify whose second pass judged the file by a different standard from the first. Every attempt here is `JsonSerializer.Deserialize<T>` with the caller's own options over the caller's own type; the only thing that changes between attempts is that one member is gone.

Review found the one place that property could quietly become false, and it is worth naming rather than quietly fixing: dropping a member **re-parses** the text, and a bare `JsonNode.Parse` runs with trailing commas and comments disallowed however lenient the caller is. For a permissive caller the deserialize would reach the bad member and the re-parse would throw on the same text, so the recovery would bail to whole-file `Unreadable` — silently, because that is the pre-#2456 behaviour rather than a crash. Not hypothetical here: `darling.json` is JSONC, `ViewerSettings` reads it with `AllowTrailingCommas` + `ReadCommentHandling.Skip`, and seven call sites in the repo set those options. The re-parse now borrows the caller's leniency explicitly, and two tests pin both directions — the lenient file recovers its one member, and the **same file under strict options is still a document fault**, which is the control that stops the first passing on a reader made permanently lenient.

The member name is taken from the path's first segment, up to the first `.` or `[` — which is what the grammar delimits on. Review raised a narrower identifier match as a diacritic edge case; measuring STJ made it wider and more ordinary: the **dot** form is used for every name needing no escaping, so `$.with-dash` and `$.dollar$sign` arrive that way alongside `$.ServerNaïve` and `$.サーバー`, and only `$['with space']` is bracket-quoted. A hyphenated key is an ordinary thing to find in a settings file. It failed safe either way — the member lookup finds nothing and the read falls back — but it silently lost per-member recovery for exactly the settings someone had to name by hand. `ABracketQuotedPathIsStillRefused` is the boundary that must not move with it.

**Only a top-level member of a root JSON OBJECT is ever dropped**, and that restriction is the load-bearing half rather than a simplification. The viewer's server registry is a root **array**, and a bad entry's path is `$[1]` — "drop the element that would not deserialize" there means silently deleting a server the operator added, which is the data loss #2434 exists to prevent wearing a repair's clothes. `ReadObject_LeavesAnArrayRootedRegistryAllOrNothing` is the control for exactly that mistake, and `ViewerServerStore` says why in place, because a future widening of the recovery is the obvious next edit.

**The state stays `Unreadable` for a partially recovered file** rather than becoming some third thing, so `PermitReplace` still copies the original aside before the next save replaces it. The dropped member's original text exists nowhere else, and the very next save writes the recovered object over it; relaxing the permit would have destroyed the one setting the user actually got wrong, with no copy — strictly worse than dev, where nothing was recovered and everything was preserved. It also costs no new enum member, so nothing in Lite or the service has to learn a fourth state.

## The dialog gets two paragraphs, because there are two facts

```
The viewer could not read these settings files, so the settings they hold are at
their defaults for this session:

viewer-preferences.json — line 4, position 3: …

These individual settings could not be read and are at their defaults for this
session. Everything else in their file loaded normally:

viewer-settings.json — AlertCpuThreshold (The JSON value could not be converted to
                          System.Int32.), McpEnabled (…)

The files have been left exactly as they are. …
```

**A member's line is missing from that second paragraph on purpose, and finding out why is the one thing probing the shipped reader caught that reading it did not.** Each retry runs over the document with the previous member removed, and removing it re-serializes — so from the second member onward the exception's position describes the re-serialized text. Measured on a file whose three bad members sit on lines 2, 3 and 4: the first reported `line 2, position 22`, correctly, and the other two reported `line 1, position 30` and `line 1, position 14`. A position that confidently names the wrong line is worse than none, in a dialog whose whole job is to send someone to the right place in their file — and the member's NAME is the better locator anyway. The **document** fault keeps its position, where the parse position is the only locator there is, and one test asserts both halves so a rule applied to both cannot quietly take it away.

One list covering both would have to overstate whichever case it was not describing, and the issue is explicit that an overstated capability is worse than an admitted gap. The second paragraph says the settings are **named**, not that the list is exhaustive of everything wrong with the file — because a document fault after a recovered member is still a document fault, and lands in the first paragraph.

**The contract is enforced at the source, and review found the case that broke it.** a non-empty `UnreadableMembers` always comes with a non-null `Value` — one direction, because the reverse is false: an ordinary `Readable` file has a value and no members at all. The recovery could drop one member successfully and then meet a fault it could not attribute — a path like `$['weird.name']`, which System.Text.Json bracket-quotes for a property name that is not a bare identifier — and every such bail returned a null value while still carrying the member list collected on the way. `ViewerSettingsFile.Load` substitutes defaults for a null value, so *every* setting reverts, while `MainWindow` routes on the list and would have said "everything else in their file loaded normally" about a file where nothing loaded at all. Unreachable today (these types are all `bool`/`int`/`string`/`List<string>`), which is the argument for pinning it: the first property needing a converter that throws `ArgumentException` makes it reachable with no warning, and the failure is a confident lie rather than a crash. One `Unreadable<T>` helper is now the only way to build a whole-file failure and it carries no member list, so the invariant holds for every caller rather than being a rule each caller has to remember.

All three stores gained `LastLoadUnreadableMembers`, including the registry where it is **always empty** — that is the #2439 lesson taken literally: a guard listing two of the three stores is the scenario-shaped fix that issue was written to prevent.

## Verification

`Darling.Tests` targets `net10.0-windows` and cannot run on macOS, so the committed test file was compiled into a `net10.0` xUnit-shim harness against the **real** `ViewerSettingsFile.cs`, `ViewerAppSettings.cs`, `ViewerPreferences.cs`, `ViewerServerStore.cs`, `ViewerServerEntry.cs` and `ViewerLogger.cs` — compiled, not transcribed — plus real project references to `PerformanceMonitor.Common` and `PerformanceMonitor.Notifications`.

| | dev | this branch |
|---|---|---|
| the full committed test file | **does not compile — 8 errors** | **16 passed / 0 failed** |
| the identically-expressible subset | **4 passed / 6 failed** | **10 passed / 0 failed** |

`UnreadableMembers` does not exist on dev, so the subset asks the same questions through `Value`, `Problem` and reflection, which dev has. The six that fail on dev are: one bad setting costing the others, the problem naming the settings, a bad list element costing its own setting only, the store keeping the rest of the file, the three stores answering the member question, and the dialog.

**The four that pass on both sides are the controls**, and they are what a wrong fix breaks first: a document fault stays all-or-nothing and still says where the parse stopped; the array-rooted registry is never partially recovered; a healthy file is silent and untouched; and the unreadable original is still copied aside before a save replaces it.

Both review-driven cases were additionally checked the way the house asks — revert the fix, watch it go red, put the fix back, with every other case unmoved either way, so they are tests rather than assertions that happen to hold. `APartialRecoveryThatCannotFinish_ReportsNoMembersAtAll`, `TheRecoveryBorrowsTheCallersLeniency_SoBothOfItsReadsAgree` and `AHandNamedMemberRecoversLikeAnyOther` each go red alone against this branch without their fix.

The two landed suites this change sits under were run against the branch as well, since `ReadObject` is shared: **all 13 of #2439's `ViewerSettingsFileGuardTests`** pass (including `Load_ReportsUnreadable_WhenAValueHasTheWrongShape`, the one most exposed to the recovery), and **all 9 of Lite's `SettingsFileGuardTests`** pass — Lite reaches the guard through `Read`/`RootForWrite`, which this PR does not touch.

Whole solution builds, 0 errors. CHANGELOG deliberately untouched — #2395 is an open release-prep PR that owns that file for 3.5.1.

## #2453 merged while this was open, and the two types coexist

#2453 landed on `dev` and brought `PerformanceMonitor.Common.SettingsValueProblem` — `(Key, Problem)` — for Lite's per-key reader. This PR adds `SettingsMemberProblem` — `(Member, Problem)` — for the viewer's whole-object reader. Different names, different files, no collision; **rebased onto `88fe948f` and re-verified after it merged**: whole solution builds 0 errors, and all 31 cases green — this PR's 12, plus **all of #2439's `ViewerSettingsFileGuardTests`** run against the rebased branch because `ReadObject` is shared.

Whether they should become one type is a real question and deliberately not answered here. Unifying them would make the two readers look interchangeable when the whole finding above is that they are not — one is symmetric with a per-key write, the other with a whole-object one — and the decision is better made now that both can be read side by side on `dev`.

## Deliberately not in scope

The `.unreadable-<timestamp>` copy is still the only route back to a dropped setting's original text. A recovery that also told the user the *value* it could not read — rather than only the type it could not read it as — would be a better message, and it is one `Element.GetRawText()` away in `SettingsValue`'s Lite twin; it is not here because it means widening `SettingsMemberProblem` and deciding how much of a hand-pasted thousand-character value belongs in a `MessageBox`. Worth its own issue if the dialog gets read in anger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
