### PR TITLE
Say why Lite's finding writes take a read lock, and fix the ids that made it look wrong (#2455)

### DIFF
--- a/Lite.Tests/FindingStoreTests.cs
+++ b/Lite.Tests/FindingStoreTests.cs
@@ -565,6 +565,146 @@ VALUES ($1, $2, $3, $4, $5, $6)";
         await cmd.ExecuteNonQueryAsync();
     }
 
+    /// <summary>
+    /// #2455: two FindingStore instances must never issue the same id.
+    ///
+    /// <para>The filed defect was that <c>_nextId++</c> ran under a lock that admits concurrent
+    /// holders, and it was real. The bigger half is that <c>Interlocked.Increment</c> on that field
+    /// would not have fixed anything, because there is no shared field to make atomic: Lite builds
+    /// TWO stores — <c>AnalysisService</c> and <c>RecommendationsTab</c> — each seeding its own
+    /// counter from <c>DateTime.UtcNow.Ticks</c> at construction. Two built in the same timer tick
+    /// start from the same value and then walk the same range independently.</para>
+    ///
+    /// <para><c>finding_id</c> and <c>mute_id</c> are both PRIMARY KEY in DuckDB, so a collision is a
+    /// hard INSERT failure, and since #2448 made the batch atomic it costs the entire analysis rather
+    /// than one row.</para>
+    ///
+    /// <para>The two stores are constructed on adjacent lines and each issues 1,000 ids, so the old
+    /// per-instance seeds would have to differ by more than 1,000 ticks (100 microseconds) to avoid
+    /// overlapping — orders of magnitude more clock than two adjacent constructor calls consume. On
+    /// Windows, where this suite runs, the seeds are simply identical: the interrupt-timer granularity
+    /// behind <c>DateTime.UtcNow</c> is ~15.6 ms, which is ~156,000 ticks.</para>
+    /// </summary>
+    [Fact]
+    public async Task TwoFindingStoresNeverIssueTheSameId()
+    {
+        /* Adjacent on purpose: this is the case the old seeding could not survive. */
+        var analysisPass = new FindingStore(_duckDb);
+        var recommendationsTab = new FindingStore(_duckDb);
+
+        var context = TestDataSeeder.CreateTestContext();
+        var stories = ManyStories(1000);
+
+        var fromPass = await analysisPass.FilterMutedFindingsAsync(stories, context);
+        var fromTab = await recommendationsTab.FilterMutedFindingsAsync(stories, context);
+
+        Assert.Equal(1000, fromPass.Count);
+        Assert.Equal(1000, fromTab.Count);
+
+        var ids = new HashSet<long>();
+        foreach (var finding in fromPass)
+            Assert.True(ids.Add(finding.FindingId), $"the analysis pass reissued {finding.FindingId}");
+        foreach (var finding in fromTab)
+            Assert.True(ids.Add(finding.FindingId), $"the second store reissued {finding.FindingId}");
+
+        Assert.Equal(2000, ids.Count);
+    }
+
+    /// <summary>
+    /// #2455: the read lock around the three WRITE paths is deliberate, and the reason has to stay
+    /// written down.
+    ///
+    /// <para>An unexplained read-lock-to-write reads as a bug on every inspection, and the obvious
+    /// "fix" — swapping in <c>AcquireWriteLock</c> — is the one change that would actually cost
+    /// something: it serializes every finding batch against every UI read for the length of the batch,
+    /// and #2443 had just made the read-lock WAIT abandonable precisely so the analysis pass could
+    /// yield to a long archival rather than become the thing archival waits on.</para>
+    ///
+    /// <para>The lock coordinates everyone against MAINTENANCE (CHECKPOINT, archive DELETEs,
+    /// compaction), which takes the exclusive write lock; a held read lock blocks
+    /// <c>EnterWriteLock</c>, so holding one is how a write says "not while I am in flight". That is
+    /// the only exclusion these paths need — concurrency between writers is DuckDB's own job. So this
+    /// pins the choice AND its explanation together: changing the lock should be a decision someone
+    /// makes against the stated reason, not a tidy-up.</para>
+    /// </summary>
+    [Fact]
+    public void TheWritePathsTakeAReadLockOnPurpose_AndSayWhy()
+    {
+        var source = File.ReadAllText(FindingStoreSourcePath()).Replace("\r\n", "\n", StringComparison.Ordinal);
+
+        /* The choice. The write lock is not banned outright — it is banned from these three without a
+           reason, which is what a failing test forces someone to supply. */
+        Assert.DoesNotContain("AcquireWriteLock", source, StringComparison.Ordinal);
+        Assert.Equal(6, CountOf(source, "_duckDb.AcquireReadLock("));
+
+        /* The explanation, at the class and at each write site — whichever one a reader lands on. */
+        Assert.Contains("The read lock around the WRITES is deliberate (#2455)", source, StringComparison.Ordinal);
+        Assert.Contains("A READ lock", Between(source, "public async Task<List<AnalysisFinding>> InsertFindingsAsync(", "public async Task<List<AnalysisFinding>> SaveFindingsAsync("), StringComparison.Ordinal);
+        Assert.Contains("see the class note (#2455)", Between(source, "public async Task MuteStoryAsync(", "await cmd.ExecuteNonQueryAsync();"), StringComparison.Ordinal);
+        Assert.Contains("see the class note (#2455)", Between(source, "public async Task CleanupOldFindingsAsync(", "await cmd.ExecuteNonQueryAsync();"), StringComparison.Ordinal);
+
+        /* And the reason the shared lock is SUFFICIENT: no read-modify-write is left under it. */
+        Assert.DoesNotContain("private long _nextId", source, StringComparison.Ordinal);
+        Assert.Contains("FindingId = NextId(),", source, StringComparison.Ordinal);
+        Assert.Contains("Value = NextId() }", source, StringComparison.Ordinal);
+        Assert.Contains("CollectionIdGenerator.Next()", source, StringComparison.Ordinal);
+    }
+
+    private static string FindingStoreSourcePath()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Lite", "Analysis", "FindingStore.cs")))
+            dir = dir.Parent;
+
+        Assert.NotNull(dir);
+        return Path.Combine(dir!.FullName, "Lite", "Analysis", "FindingStore.cs");
+    }
+
+    private static string Between(string source, string start, string end)
+    {
+        var from = source.IndexOf(start, StringComparison.Ordinal);
+        Assert.True(from >= 0, $"anchor not found: {start}");
+        var to = source.IndexOf(end, from, StringComparison.Ordinal);
+        Assert.True(to > from, $"anchor not found after {start}: {end}");
+        return source[from..to];
+    }
+
+    private static int CountOf(string source, string needle)
+    {
+        var count = 0;
+        var at = 0;
+        while ((at = source.IndexOf(needle, at, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            at += needle.Length;
+        }
+
+        return count;
+    }
+
+    private static System.Collections.Generic.List<AnalysisStory> ManyStories(int count)
+    {
+        var stories = new System.Collections.Generic.List<AnalysisStory>(count);
+
+        for (var i = 0; i < count; i++)
+        {
+            stories.Add(new AnalysisStory
+            {
+                RootFactKey = "WRITELOG",
+                RootFactValue = i,
+                Severity = 1.0,
+                Confidence = 1.0,
+                Category = "waits",
+                StoryPath = $"WRITELOG_{i}",
+                StoryPathHash = $"id-collision-{i}",
+                StoryText = $"story {i}",
+                FactCount = 1
+            });
+        }
+
+        return stories;
+    }
+
     private static System.Collections.Generic.List<AnalysisStory> CreateTestStories()
     {
         return

--- a/Lite/Analysis/FindingStore.cs
+++ b/Lite/Analysis/FindingStore.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DuckDB.NET.Data;
 using PerformanceMonitor.Analysis;
+using PerformanceMonitor.Collectors;
 using PerformanceMonitor.Notifications;
 using PerformanceMonitorLite.Database;
 
@@ -23,17 +24,69 @@ namespace PerformanceMonitorLite.Analysis;
 /// Recommendations reader can render the copy-paste command byte-identically to the Darling viewer.
 /// <see cref="SaveFindingsAsync"/> remains as a single-pass convenience wrapper (no action attached).
 /// </para>
+///
+/// <para>
+/// <b>The read lock around the WRITES is deliberate (#2455).</b> It is the first thing in this file
+/// that looks like a bug, so it is answered here rather than left to cost every reader the same five
+/// minutes. <see cref="InsertFindingsAsync"/> INSERTs, <see cref="MuteStoryAsync"/> INSERTs and
+/// <see cref="CleanupOldFindingsAsync"/> DELETEs, and all three hold
+/// <c>DuckDbInitializer.AcquireReadLock</c>. That lock is not a table lock and does not claim "I am
+/// reading": it coordinates everyone against MAINTENANCE — CHECKPOINT, archive DELETEs, compaction —
+/// which take the exclusive write lock and reorganize the file underneath whatever is running. A held
+/// read lock blocks <c>EnterWriteLock</c>, so holding one IS how a write says "not while I am in
+/// flight", and that is the only exclusion these three need. Concurrency between writers is DuckDB's
+/// own job and it does it: two connections appending to <c>analysis_findings</c> in concurrent
+/// transactions both commit, and the retention DELETE overlaps an insert batch cleanly — both
+/// measured on DuckDB.NET 1.5.5 rather than assumed.
+/// </para>
+///
+/// <para>
+/// Taking the write lock instead would be a real cost for a benefit nobody has shown a need for: it
+/// would serialize every finding batch against every UI read for the length of the batch, and #2443
+/// had just made the read-lock WAIT abandonable so the analysis pass could yield to a long archival.
+/// Turning the pass into the thing archival and the UI queue behind reverses that. What a SHARED lock
+/// genuinely cannot protect is a read-modify-write, because it admits concurrent holders — which is
+/// why the ids below do not use one.
+/// </para>
+///
+/// <para>
+/// One thing this store does NOT settle, so a reader who checks the neighbours is not misled twice:
+/// <c>DuckDbAlertHistoryStore</c> and <c>DuckDbMuteRuleStore</c> take the WRITE lock for the same
+/// species of ordinary write, and <c>LocalDataService.OpenWriteConnectionAsync</c> states that as the
+/// house rule in its own doc comment. Two conventions, and this file follows the cheaper one. Which
+/// is right for the other eleven call sites is #2463 — a question about the lock model rather than
+/// about these three methods, and deliberately not answered here.
+/// </para>
 /// </summary>
 public class FindingStore
 {
     private readonly DuckDbInitializer _duckDb;
-    private long _nextId;
 
     public FindingStore(DuckDbInitializer duckDb)
     {
         _duckDb = duckDb;
-        _nextId = DateTime.UtcNow.Ticks;
     }
+
+    /// <summary>
+    /// #2455: finding and mute ids come from the shared process-wide
+    /// <see cref="CollectionIdGenerator"/> rather than a per-instance counter.
+    ///
+    /// <para>The <c>_nextId++</c> this replaces was seeded from <c>DateTime.UtcNow.Ticks</c> per
+    /// INSTANCE and unprotected twice over. The increment is a read-modify-write under a lock that
+    /// admits concurrent holders, which is the half that was filed — but <c>Interlocked.Increment</c>
+    /// on the field would not have fixed the worse half: Lite constructs TWO of these, one in
+    /// <c>AnalysisService</c> and one in <c>RecommendationsTab</c>, and two instances built inside the
+    /// same timer tick start from the SAME value and then hand out the same ids independently, with no
+    /// shared state to make atomic. <c>finding_id</c> and <c>mute_id</c> are both PRIMARY KEY in
+    /// DuckDB, so a collision is a hard INSERT failure — and since #2448 made the batch atomic, one
+    /// such row costs the whole analysis rather than itself.</para>
+    ///
+    /// <para>The generator is process-wide and <c>Interlocked</c>-incremented, and it is what the
+    /// Darling twin's <c>PgFindingStore</c> has always used — whose own class doc names "the twins'
+    /// per-instance tick counters" as the thing it deliberately moved away from. So this closes a
+    /// stated parity gap rather than inventing a mechanism.</para>
+    /// </summary>
+    private static long NextId() => CollectionIdGenerator.Next();
 
     /// <summary>
     /// Mute-filters the stories and materializes the SURVIVING findings WITHOUT inserting them
@@ -70,7 +123,7 @@ public class FindingStore
 
             survivors.Add(new AnalysisFinding
             {
-                FindingId = _nextId++,
+                FindingId = NextId(),
                 AnalysisTime = analysisTime,
                 ServerId = context.ServerId,
                 ServerName = context.ServerName,
@@ -124,7 +177,9 @@ public class FindingStore
         if (findings.Count == 0)
             return findings;
 
-        /* One read lock + one connection for the whole batch, reused for every insert. */
+        /* One read lock + one connection for the whole batch, reused for every insert. A READ lock
+           around a WRITE is deliberate — it excludes compaction/archival, which is the only exclusion
+           this needs; see the class note (#2455). */
         using var readLock = _duckDb.AcquireReadLock(context.CancellationToken);
         using var connection = _duckDb.CreateConnection();
         await connection.OpenAsync(context.CancellationToken);
@@ -296,6 +351,9 @@ ORDER BY severity DESC";
     /// </summary>
     public async Task MuteStoryAsync(int serverId, string storyPathHash, string storyPath, string? reason = null)
     {
+        /* Read lock around an INSERT: deliberate, see the class note (#2455). It admits concurrent
+           holders, which is exactly why the mute_id below comes from the shared generator and not
+           from per-instance state this lock could not have protected. */
         using var readLock = _duckDb.AcquireReadLock();
         using var connection = _duckDb.CreateConnection();
         await connection.OpenAsync();
@@ -305,7 +363,7 @@ ORDER BY severity DESC";
 INSERT INTO analysis_muted (mute_id, server_id, story_path_hash, story_path, muted_date, reason)
 VALUES ($1, $2, $3, $4, $5, $6)";
 
-        cmd.Parameters.Add(new DuckDBParameter { Value = _nextId++ });
+        cmd.Parameters.Add(new DuckDBParameter { Value = NextId() });
         // serverId 0 is the MCP "mute across all servers" sentinel; persist it as NULL, the
         // canonical global marker every reader filters on (legacy 0 rows are still honored).
         cmd.Parameters.Add(new DuckDBParameter { Value = serverId == 0 ? (object)DBNull.Value : serverId });
@@ -327,6 +385,9 @@ VALUES ($1, $2, $3, $4, $5, $6)";
     /// </summary>
     public async Task CleanupOldFindingsAsync(int retentionDays = 30)
     {
+        /* Read lock around a DELETE: deliberate, see the class note (#2455). The rows it removes are
+           older than the retention cutoff and an insert batch only ever writes rows stamped now, so
+           the sweep and a pass overlap on disjoint rows — measured, not assumed. */
         using var readLock = _duckDb.AcquireReadLock();
         using var connection = _duckDb.CreateConnection();
         await connection.OpenAsync();

--- a/Lite/Analysis/FindingStore.cs
+++ b/Lite/Analysis/FindingStore.cs
@@ -35,9 +35,11 @@ namespace PerformanceMonitorLite.Analysis;
 /// which take the exclusive write lock and reorganize the file underneath whatever is running. A held
 /// read lock blocks <c>EnterWriteLock</c>, so holding one IS how a write says "not while I am in
 /// flight", and that is the only exclusion these three need. Concurrency between writers is DuckDB's
-/// own job and it does it: two connections appending to <c>analysis_findings</c> in concurrent
-/// transactions both commit, and the retention DELETE overlaps an insert batch cleanly — both
-/// measured on DuckDB.NET 1.5.5 rather than assumed.
+/// own job and it does it: two connections writing to <c>analysis_findings</c> at the same time both
+/// succeed, and the retention DELETE overlaps an insert batch cleanly on disjoint rows — both
+/// measured on DuckDB.NET 1.5.5 rather than assumed, and measured with each batch wrapped in a
+/// transaction, which is the longer-held and therefore stronger case (and the shape #2448 gives
+/// them).
 /// </para>
 ///
 /// <para>


### PR DESCRIPTION
Closes #2455. Lite only — Darling's `PgFindingStore` has neither a lock nor a per-instance counter, so there is no twin to keep in step.

Two separable things, decided separately as the issue asked.

## 1. The read lock is correct, and now says so

**Verified rather than inherited.** The lock is not a table lock and does not claim "I am reading": `DuckDbInitializer.s_dbLock` coordinates everyone against MAINTENANCE — CHECKPOINT, archive DELETEs, compaction — which take the exclusive write lock and reorganize the file underneath whatever is running. A held read lock blocks `EnterWriteLock`, so holding one **is** how a write says "not while I am in flight", and that is the only exclusion an INSERT batch, a mute INSERT or a retention DELETE needs.

Measured on DuckDB.NET 1.5.5 rather than reasoned about:

| | result |
|---|---|
| two connections appending to `analysis_findings` in concurrent transactions | both commit |
| the retention DELETE overlapping an insert batch (disjoint rows) | both commit — 20 old purged, 10 new kept |
| a held READ lock vs. `TryEnterWriteLock(300 ms)` | writer refused for the full attempt — compaction is excluded |
| a held READ lock vs. a second reader | admitted — the lock serializes nothing *between* writers |

So the filer's assessment holds on the axis that matters, and the cost of "fixing" it is real: `AcquireWriteLock` would serialize every finding batch against every UI read for the length of the batch, and #2443 had just made the read-lock *wait* abandonable specifically so the analysis pass could yield to a long archival. Turning the pass into the thing archival queues behind reverses the change immediately before it.

**The fix for the lock is therefore the sentence, not the lock.** It is written at the class, where someone looking for the rule will look, and again in one line at each of the three write sites — because whichever one a reader lands on is where they form the wrong impression. A test pins the choice and the explanation *together*, so swapping in `AcquireWriteLock` becomes a decision made against a stated reason rather than a tidy-up.

## 2. `_nextId++` is a real race, and the filed fix would not have fixed it

This is the part worth reading. The issue proposed `Interlocked.Increment` "if the id generator is meant to be shared". **`Interlocked` on that field would have fixed nothing, because there is no shared field to make atomic.**

Lite constructs **two** `FindingStore`s:

- `Lite/Analysis/AnalysisService.cs:66` — the analysis pass, which draws `finding_id`
- `Lite/Controls/RecommendationsTab.xaml.cs:75` — the viewer, which draws `mute_id`

Each seeds its **own** `_nextId` from `DateTime.UtcNow.Ticks` at construction, so two instances built inside the same timer tick start from the same value and then walk the same range independently, with no common state between them to protect. On Windows — where this suite runs and where Lite ships — that is not a narrow window: the interrupt-timer granularity behind `DateTime.UtcNow` is ~15.6 ms, about 156,000 ticks, so the two seeds are simply **identical**.

`finding_id` and `mute_id` are both `PRIMARY KEY` in DuckDB, so a collision is a hard INSERT failure rather than a duplicate row — and since #2448 made the batch atomic, one such row now costs the **whole analysis** instead of itself. Measured:

```
two per-instance counters seeded in one tick issue the SAME id -- both = 639229104000000000
and the second INSERT is a hard failure -- Constraint Error: Duplicate key "finding_id: 639229104000000000"
one process-wide Interlocked counter cannot -- 639229104000000001 != 639229104000000002
```

So ids come from the shared process-wide `CollectionIdGenerator`, which is `Interlocked` and is **what the Darling twin has always used** — `PgFindingStore`'s own class doc names "the twins' per-instance tick counters" as the thing it deliberately moved away from. This closes a parity gap that was already written down rather than inventing a mechanism.

It is also what lets the shared lock stay shared. The one thing a lock admitting concurrent holders cannot protect is a read-modify-write; there is no longer one under it. The two halves of this PR are the same answer from opposite ends.

## The tests

Both verified red on `dev`:

- **`TwoFindingStoresNeverIssueTheSameId`** — behavioural, against a real DuckDB. Two stores constructed on adjacent lines, 1,000 ids each, all 2,000 distinct. The old seeds would have to differ by more than 1,000 ticks (100 µs) to avoid overlapping, which is orders of magnitude more clock than two adjacent constructor calls consume — and on Windows the seeds are identical outright. Reverted on macOS (a *finer* clock than CI's): `the second store reissued 639229300503372870`.
- **`TheWritePathsTakeAReadLockOnPurpose_AndSayWhy`** — pins the lock choice *and* its explanation, plus the id generator. Reverted: fails on the missing explanation.

## Verification

- Full solution builds clean on macOS (`EnableWindowsTargeting`): **0 errors**, 14 warnings, all pre-existing in untouched files.
- `Lite.Tests` is `net10.0-windows` and cannot run on macOS, so both tests were compiled into a `net10.0` xUnit shim against the **real shipped `FindingStore`** (`Lite/Database/**` + `Lite/Analysis/FindingStore.cs` compiled in) and run there: **2/2 pass on this branch, 2/2 fail on `dev`**. CI is the arbiter for the rest of the suite.
- Rebased onto `dev` at `8f692439`.

## Deferred — filed as #2463, not fixed here

The ruling surfaced that **the codebase has two conventions for locking a DuckDB write, and one of them is written down as the rule.** `LocalDataService.OpenWriteConnectionAsync`'s doc comment says *"Use for UPDATE/DELETE/INSERT operations that must not race with archival or compaction"* and takes the write lock; `DuckDbAlertHistoryStore` (6 sites) and `DuckDbMuteRuleStore` (5 sites) follow it for ordinary writes. `FindingStore` follows the cheaper one. `DuckDbMuteRuleStore.InsertAsync` writes `config_mute_rules` under a write lock while `MuteStoryAsync` writes `analysis_muted` under a read lock — same species, same store, opposite lock.

I think the read lock is right and the eleven write-lock sites are over-locking, but that is a judgement about three files I did not measure, and per the issue's own advice it should not ride in on a three-method change. The class note points at #2463 so the next reader who checks the neighbours is not misled a second time.

#2463 also records a **latent** hazard found in passing and confirmed *not* live: `ReaderWriterLockSlim` is thread-affine, `LockReleaser.Dispose` calls `ExitReadLock` unguarded, and every one of these locks is held across `await` — which is safe today only because DuckDB.NET 1.5.5's async completes synchronously (thread id `4, 4, 4, 4, 4` across `OpenAsync`, DDL, 200 `ExecuteNonQueryAsync` and a reader drain). It is stated as latent, with the measurement, rather than reported as a bug.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
