### PR TITLE
Decide, per site, whether the repair pass can be abandoned at the lock (#2465)

### DIFF
--- a/Lite.Tests/QueryStoreSliceRepairTests.cs
+++ b/Lite.Tests/QueryStoreSliceRepairTests.cs
@@ -344,10 +344,63 @@ public sealed class QueryStoreSliceRepairTests : IClassFixture<SharedDuckDbFixtu
 
         /* And the REWRITE stays under the read lock: writing a temp sibling nothing can see yet must not take
            the UI's exclusivity for the whole of a large archive rewrite. */
-        Assert.Contains("using (_duckDb.AcquireReadLock())", source, StringComparison.Ordinal);
-        var readLock = source.IndexOf("using (_duckDb.AcquireReadLock())", StringComparison.Ordinal);
+        Assert.Contains("using (_duckDb.AcquireReadLock(cancellationToken))", source, StringComparison.Ordinal);
+        var readLock = source.IndexOf("using (_duckDb.AcquireReadLock(cancellationToken))", StringComparison.Ordinal);
         var copyToTemp = source.IndexOf("COMPRESSION ZSTD)\";", StringComparison.Ordinal);
         Assert.True(copyToTemp > readLock, "the rewrite-to-temp belongs under the read lock, not the write lock");
+    }
+
+    /// <summary>
+    /// Source guard: no lock acquisition in this service is silent about cancellation (#2465).
+    ///
+    /// <para>The sibling test above pins WHICH lock each phase takes. This one pins whether the phase can be
+    /// ABANDONED while it waits for it, which is a separate property and the one CA2016 was pointing at: every
+    /// method here holds a token, and every one of them takes the lock BEFORE it opens its connection, so a
+    /// no-arg <c>AcquireReadLock()</c> leaves the token stopped at the door — abandonable everywhere except
+    /// where the pass is actually stuck, which is the exact defect #2454 closed for the analysis pass.</para>
+    ///
+    /// <para>A source guard rather than a behavioral one because what is being pinned is a DECISION, not a
+    /// behavior: three sites forward the token and two decline it, and on the shipped caller
+    /// (<c>MainWindow</c> fires the repair un-awaited with no token) both spellings run identically today.
+    /// Nothing observable separates them, and that is precisely why they need pinning — a later edit that
+    /// "tidied" the two declines into forwards, or blanket-suppressed the rule, would cost nothing at runtime
+    /// and quietly convert five stated decisions back into an unknown.</para>
+    ///
+    /// <para>The declines are pinned WITH their reason, because a bare <c>CancellationToken.None</c> is the
+    /// oversight the analyzer complained about with an extra token typed in.</para>
+    /// </summary>
+    [Fact]
+    public void EveryLockAcquisition_SaysWhetherItCanBeAbandoned()
+    {
+        var source = File.ReadAllText(SourcePath("Lite", "Services", "QueryStoreSliceRepairService.cs"));
+
+        /* Not one silent acquisition left. This is the assertion that goes red on the pre-#2465 file. */
+        Assert.Empty(Regex.Matches(source, @"_duckDb\.AcquireReadLock\(\)"));
+
+        /* Three FORWARD it: the marker read, the survey, and the archive rewrite-to-temp. Each abandons into
+           a state the next launch reproduces for free, so there is nothing to protect by waiting. */
+        Assert.Equal(3, Regex.Matches(source, @"_duckDb\.AcquireReadLock\(cancellationToken\)").Count);
+
+        /* Two DECLINE it, and both are the marker write — the only thing here that records work already done
+           and irreversible, where abandoning costs the next launch the whole survey to learn nothing. */
+        var declined = Regex.Matches(source, @"_duckDb\.AcquireReadLock\(CancellationToken\.None\)");
+        Assert.Equal(2, declined.Count);
+
+        foreach (Match site in declined)
+        {
+            var reason = source[Math.Max(0, site.Index - 1500)..site.Index];
+            Assert.Contains("#2465", reason, StringComparison.Ordinal);
+            Assert.Contains("marker", reason, StringComparison.Ordinal);
+        }
+
+        /* And each decline is WHOLE. A lock that will not be abandoned in front of a write that will be is
+           worse than either choice made consistently, so the open and both statements decline too. */
+        Assert.Equal(2, Regex.Matches(source, @"await connection\.OpenAsync\(CancellationToken\.None\);").Count);
+        Assert.Equal(2, Regex.Matches(source, @"await MarkRepairedAsync\(connection, [^;]*CancellationToken\.None\);").Count);
+
+        /* The write locks stay out of this: AcquireWriteLock has no token-taking overload, so there is no
+           decision to state at those two. Their timeout question is #2463's, not this test's. */
+        Assert.Equal(2, Regex.Matches(source, @"_duckDb\.AcquireWriteLock\(\)").Count);
     }
 
     /* ─────────────────────────── helpers ─────────────────────────── */

--- a/Lite/Services/QueryStoreSliceRepairService.cs
+++ b/Lite/Services/QueryStoreSliceRepairService.cs
@@ -41,6 +41,22 @@ namespace PerformanceMonitorLite.Services;
 /// #1832's data-root move already established. A button was considered and rejected: a repair gated behind UI
 /// discovery leaves the users least equipped to find it holding wrong numbers permanently. See
 /// <see cref="RepairOnStartupAsync"/> for the once-only marker and the retry-on-partial behavior.</para>
+///
+/// <para><b>What cancellation means here (#2465).</b> Every entry point takes a token, and every one of them
+/// takes the DATABASE LOCK BEFORE it opens its connection — so a token that does not reach
+/// <c>AcquireReadLock</c> stops at the door, which is the hole #2454 found on the analysis pass and the one
+/// the analyzer surfaced here the moment that overload existed. The five acquisitions are split by what
+/// abandoning COSTS, not by whether the site reads or writes. The marker read, the survey and the archive
+/// rewrite-to-temp FORWARD it: each abandons into a state the next launch reproduces for free — a question
+/// re-asked, a survey re-run, an original file left untouched by construction. The two marker WRITES take
+/// <see cref="CancellationToken.None"/>: they record work that is already done and cannot be undone, and
+/// dropping the record does not undo it either — it only makes the next launch pay the whole survey again to
+/// rediscover there is nothing left to do. Every site states its own choice at the site.</para>
+///
+/// <para>The two <c>AcquireWriteLock</c> acquisitions are deliberately untouched by that, and not merely
+/// because CA2016 cannot see them (there is no token-taking overload). They are the genuinely
+/// maintenance-shaped acquisitions — the hot-table mutation with its CHECKPOINT, and the instant a live
+/// path's bytes are replaced — which is the one category #2463 does not put in question.</para>
 /// </summary>
 public sealed class QueryStoreSliceRepairService
 {
@@ -186,10 +202,17 @@ public sealed class QueryStoreSliceRepairService
     /// </summary>
     internal const string MarkerTable = "query_store_slice_repair";
 
-    /// <summary>True when a completed repair has already been recorded for this store.</summary>
+    /// <summary>
+    /// True when a completed repair has already been recorded for this store.
+    ///
+    /// <para>#2465 forwards the token to the LOCK as well as to the reads. This method asks a question and
+    /// writes nothing, so abandoning it costs nothing at all — the next launch asks it again — and there is
+    /// no reason for a caller holding a fired token to sit in an uninterruptible <c>EnterReadLock()</c>
+    /// behind an archival to learn an answer it has stopped wanting.</para>
+    /// </summary>
     public async Task<bool> AlreadyRepairedAsync(CancellationToken cancellationToken = default)
     {
-        using var readLock = _duckDb.AcquireReadLock();
+        using var readLock = _duckDb.AcquireReadLock(cancellationToken);
         using var connection = _duckDb.CreateConnection();
         await connection.OpenAsync(cancellationToken);
 
@@ -246,11 +269,21 @@ public sealed class QueryStoreSliceRepairService
             if (!survey.HasWork && survey.Unreadable.Count == 0)
             {
                 /* Nothing to do — a fresh store, or one that only ever ran fixed builds. Record it so the
-                   survey does not run on every launch forever. */
-                using var readLock = _duckDb.AcquireReadLock();
+                   survey does not run on every launch forever.
+
+                   #2465: CancellationToken.None, and all the way through — the lock, the open and both
+                   statements. The survey immediately above ran under the token and RETURNED, so the token is
+                   known unfired a moment ago and forwarding here would buy an abandonment window microseconds
+                   wide. What that window would cost is the sentence directly above it: drop the marker and the
+                   survey runs again on the next launch, and the survey is the expensive thing this service has
+                   — a full GROUP BY over the hot table plus a read_parquet of every monthly archive file.
+                   None reaches the statements too rather than stopping at the lock, because "this write
+                   completes once started" contradicted three lines later would be worse than either choice
+                   made whole. */
+                using var readLock = _duckDb.AcquireReadLock(CancellationToken.None);
                 using var connection = _duckDb.CreateConnection();
-                await connection.OpenAsync(cancellationToken);
-                await MarkRepairedAsync(connection, 0, cancellationToken);
+                await connection.OpenAsync(CancellationToken.None);
+                await MarkRepairedAsync(connection, 0, CancellationToken.None);
                 return;
             }
 
@@ -265,10 +298,17 @@ public sealed class QueryStoreSliceRepairService
 
             if (result.FullyRepaired)
             {
-                using var readLock = _duckDb.AcquireReadLock();
+                /* #2465: CancellationToken.None, for the reason above and one more that is only true here.
+                   The repair is DONE — the hot table is collapsed and committed, every affected archive file
+                   has been rewritten and swapped — and none of that is undone by abandoning its record.
+                   Dropping the marker does not stop a repair; it only makes the next launch pay the full
+                   survey to rediscover that there is nothing left to repair. That makes this the one place in
+                   the file where abandoning loses something the next launch does not get back for free, and
+                   what it is protecting is two statements and one row. */
+                using var readLock = _duckDb.AcquireReadLock(CancellationToken.None);
                 using var connection = _duckDb.CreateConnection();
-                await connection.OpenAsync(cancellationToken);
-                await MarkRepairedAsync(connection, result.RowsRemoved, cancellationToken);
+                await connection.OpenAsync(CancellationToken.None);
+                await MarkRepairedAsync(connection, result.RowsRemoved, CancellationToken.None);
 
                 _logger?.LogInformation("#1912 one-time Query Store repair complete: {Rows} row(s) collapsed", result.RowsRemoved);
             }
@@ -289,9 +329,18 @@ public sealed class QueryStoreSliceRepairService
         }
     }
 
+    /// <summary>
+    /// Counts the split slices waiting in the hot table and in every archive file. Reads only; writes nothing.
+    ///
+    /// <para>#2465 forwards the token to the LOCK. This is the longest read the service has — a full GROUP BY
+    /// over <c>query_store_stats</c> and then a <c>read_parquet</c> of every monthly archive file — and the
+    /// lock is taken before any of it starts, so a survey queued behind an archival is precisely the pass that
+    /// is "abandonable everywhere except where it is actually stuck". Abandoning costs the survey and nothing
+    /// else: the marker is withheld, and the next launch redoes it.</para>
+    /// </summary>
     public async Task<Survey> SurveyAsync(CancellationToken cancellationToken = default)
     {
-        using var readLock = _duckDb.AcquireReadLock();
+        using var readLock = _duckDb.AcquireReadLock(cancellationToken);
         using var connection = _duckDb.CreateConnection();
         await connection.OpenAsync(cancellationToken);
 
@@ -489,8 +538,15 @@ HAVING COUNT(*) > 1";
         long rewrittenExecutions;
 
         /* READ LOCK: everything up to and including verification. The original is only read; the only thing
-           written is the temp sibling, which nothing else knows about yet. */
-        using (_duckDb.AcquireReadLock())
+           written is the temp sibling, which nothing else knows about yet.
+
+           #2465 forwards the token, to the lock as well as to the reads. This phase is the expensive one — a
+           COPY across a whole monthly parquet — and abandoning it lands in a state the design already
+           handles rather than a new one: the original is untouched by construction, the marker is withheld,
+           and the next launch retries a repair the pre-fix signature makes idempotent. A cancelled COPY
+           strands the same temp sibling a FAILED one does, and the retry's COPY overwrites it; the archive
+           glob does not match the .repair-tmp suffix, so a stranded one is never read as an archive file. */
+        using (_duckDb.AcquireReadLock(cancellationToken))
         {
             using var connection = _duckDb.CreateConnection();
             await connection.OpenAsync(cancellationToken);


### PR DESCRIPTION
Closes #2465. Lite only — Darling has no `QueryStoreSliceRepairService` and no lock of this shape, so there is no twin to keep in step.

## The twenty are five

`20` warning lines, `5` distinct call sites. Each is reported four times: MSBuild builds the WPF project twice (the real `PerformanceMonitorLite.csproj` and its generated `_wpftmp` pass) and each emits the warning in the log and again in the summary block. All five are `AcquireReadLock()`; the two `AcquireWriteLock()` acquisitions are invisible to CA2016 because that method has no token-taking overload.

## Why the analyzer is right rather than pedantic

Every method in this service takes the **database lock before it opens its connection**. So a token that reaches the reads and not the lock is a token that stops at the door — the exact hole #2454 found on the analysis pass, where threading the reads alone would have produced a pass abandonable everywhere except where it was actually stuck. A startup repair queued behind a long archival has the same shape.

It is also worth saying plainly that **nothing observable separates the two spellings today**: `MainWindow.xaml.cs:193` fires this un-awaited with no token, so `cancellationToken` is `default` at all five sites and `CanBeCanceled` is false, which takes `AcquireReadLock`'s original uninterruptible path either way. That is the reason these need *deciding and pinning* rather than a reason they do not matter — the decision is entirely in what the code says, and a silent no-arg call is indistinguishable from an oversight.

## The five, decided one at a time

The split is by **what abandoning costs**, not by whether the site reads or writes.

| Site | Choice | Why |
|---|---|---|
| `AlreadyRepairedAsync` | **forward** | Asks a question, writes nothing. No reason to sit in an uninterruptible `EnterReadLock()` for an answer the caller has stopped wanting. |
| `SurveyAsync` | **forward** | The longest read here — a full `GROUP BY` over `query_store_stats` plus a `read_parquet` of every monthly archive file. This is the one that should yield to an archival rather than queue behind it. |
| `RewriteArchiveFileAsync` (rewrite-to-temp) | **forward** | The expensive phase, and abandoning it lands in a state the design already handles: the original is untouched by construction, the marker is withheld, and the next launch retries a repair the pre-fix signature makes idempotent. A cancelled `COPY` strands the same `.repair-tmp` sibling a *failed* one does, the retry's `COPY` overwrites it, and the archive glob does not match that suffix so a stranded one is never read as an archive file. |
| `RepairOnStartupAsync` (no-work marker) | **`None`, with the reason** | The marker's whole job is the sentence already above it in the source: *"Record it so the survey does not run on every launch forever."* Dropping it makes the survey run again — the expensive thing this service has. |
| `RepairOnStartupAsync` (post-repair marker) | **`None`, with the reason** | The repair is **done** — hot table collapsed and committed, every affected archive file rewritten and swapped — and abandoning the record undoes none of it. It only makes the next launch pay the full survey to rediscover there is nothing left to repair. |

**3 forwarded, 2 `CancellationToken.None` with a comment saying why**, matching the convention #2454 set for its fourteen off-pass callers.

A detail that decided both declines: reaching either marker write **proves the token was unfired a moment earlier**, because `SurveyAsync` (or the entire `RepairAsync`) just returned under it. Forwarding there would buy an abandonment window microseconds wide, and what it would risk in that window is the record of work that cannot be redone for free.

### The declines go all the way through

`CancellationToken.None` reaches the lock, the `OpenAsync` and both statements — not just the lock. #2454's `InsertFindingsAsync` declines only *past* the lock and the open, and it is right to: what it must not cut is a multi-row batch that would read as a complete analysis that found fewer problems. The marker write has no such shape — it is `CREATE TABLE IF NOT EXISTS` plus one row, and a cut between them leaves an empty marker table that `AlreadyRepairedAsync` correctly reads as "not repaired". What it must not lose is the *record*, so the decline covers the whole write. A lock that will not be abandoned in front of a write that will be is worse than either choice made whole.

## Not suppressed, and the write locks are not swept in

No `#pragma`, no `.editorconfig` entry, no file-scoped suppression — per the issue, that converts a list of decidable items into a permanent unknown.

The two `AcquireWriteLock()` sites are left exactly as they are, and not merely because CA2016 cannot see them. They are the genuinely maintenance-shaped acquisitions — the hot-table mutation with its CHECKPOINT, and the instant a live path's bytes are replaced — which is the one category #2463 explicitly does not put in question. Their no-timeout behaviour is #2463's, and #2463 rules on it.

While in the file: the two marker writes are **writes taking a read lock**, which is the same shape #2455/#2464 ruled correct. Nothing about their locking changed here.

## Verification

- **The build is the check.** Full-solution rebuild on macOS (`EnableWindowsTargeting`, `-t:Rebuild` so the analyzer actually re-runs — an incremental build reports zero because it skips the compile):

  | | CA2016 lines | solution warning summary | errors |
  |---|---|---|---|
  | `dev` | **20** | 30 | 0 |
  | this branch | **0** | 20 | 0 |

  Warning code sets are otherwise identical (`CA1720` ×8, `xUnit1031` ×2, `xUnit2031` ×30 on both). One new warning was introduced and fixed before commit: the first draft of the pin used `Assert.Equal(0, …Count)` and drew `xUnit2013`.

- `Lite.Tests` is `net10.0-windows` and cannot run on macOS, so **the real `Lite.Tests/QueryStoreSliceRepairTests.cs`** was compiled into a `net10.0` xUnit shim together with the **real shipped sources** — `Lite/Database/*.cs`, `Lite/Services/QueryStoreSliceRepairService.cs`, `ArchiveService.cs`, `ParquetCompaction.cs`, the real `SharedDuckDbFixture`, and a `ProjectReference` to `PerformanceMonitor.Collectors` — with one harness-only stub for the single service-layer symbol `DuckDbInitializer` reaches for (`RemoteCollectorService.GetDeterministicHashCode`, a pure hash on a legacy re-key path nothing under test calls). That is the same single stub #2454's Lite harness needed.

  **10/10 pass on this branch. 2/10 fail on `dev`**, against a real DuckDB:

  ```
  EveryLockAcquisition_SaysWhetherItCanBeAbandoned [FAIL]
    Assert.Empty() Failure: Collection was not empty
    Collection: [_duckDb.AcquireReadLock(), _duckDb.AcquireReadLock(), _duckDb.AcquireReadLock(),
                 _duckDb.AcquireReadLock(), _duckDb.AcquireReadLock()]

  EveryMutatingPhase_SitsInsideAWriteLockScope [FAIL]
    Not found: "using (_duckDb.AcquireReadLock(cancellationToken))"
  ```

  The second is the pre-existing structural pin, whose anchor for the rewrite-to-temp lock moved with the token — updated deliberately, not incidentally, and it still asserts the same property.

- Rebased onto `dev` at `9d1337a5` and every check above re-run after: still 0 CA2016, still 10/10 here and 2/10 on `dev`.
- CI is the arbiter for the rest of the suite.

## The new test

`EveryLockAcquisition_SaysWhetherItCanBeAbandoned` sits beside the existing `EveryMutatingPhase_SitsInsideAWriteLockScope` in the same class, deliberately: one pins **which** lock each phase takes, the other pins whether the phase can be **abandoned while it waits for it**. Two properties, and splitting them across files would let either be reverted without the other noticing.

It asserts zero silent acquisitions, three forwards, two declines, that each decline carries `#2465` and the word `marker` in the preceding source, that each decline is whole (the `OpenAsync` and both statements decline too), and that the write-lock count is still two.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


---

**Related:** #2469 answers #2463, and agrees with the call made here — the two `AcquireWriteLock` sites in this file are maintenance-shaped (clause 1 of the rule it states), and the two marker writes taking a read lock are appends, which is clause-correct too. Neither PR touches the other's files; they can merge in either order.
