### PR TITLE
Say which DuckDB lock a write takes, and why both answers were right (#2463)

### DIFF
--- a/Lite.Tests/DuckDbLockModelTests.cs
+++ b/Lite.Tests/DuckDbLockModelTests.cs
@@ -1,0 +1,217 @@
+﻿/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using DuckDB.NET.Data;
+using Xunit;
+
+namespace Lite.Tests;
+
+/// <summary>
+/// #2463: the lock MODEL, rather than any one caller's use of it.
+///
+/// <para>Lite had two conventions for locking a DuckDB write and only one of them was written down.
+/// The resolution is that they are answers to two different questions — the read lock excludes
+/// MAINTENANCE, the write lock additionally excludes OTHER WRITERS OF THE SAME ROWS — and the axis
+/// belongs to DuckDB's optimistic concurrency control rather than to anything in
+/// <c>DuckDbInitializer</c>. These tests pin the two facts that rule rests on, and pin that it is
+/// stated where a caller will actually find it.</para>
+///
+/// <para>Only one of the three can be red on <c>dev</c>, and that is honest rather than a gap: the
+/// other two pin properties that are ALREADY TRUE and whose value is that they announce when they stop
+/// being true. A test for a fact is a tripwire, not a regression test, and writing one that fails today
+/// would mean breaking the thing first.</para>
+/// </summary>
+public sealed class DuckDbLockModelTests
+{
+    /// <summary>
+    /// The premise the whole store layer rests on: DuckDB.NET's async completes SYNCHRONOUSLY, so a lock
+    /// entered before an <c>await</c> is still owned by the entering thread when it is released after one.
+    ///
+    /// <para><b>This is a tripwire on the driver, not a test of our code.</b>
+    /// <see cref="ReaderWriterLockSlim"/> is thread-affine — <c>ExitReadLock</c> throws from a thread that
+    /// did not enter — and Lite holds that lock across <c>await</c> at every store call site (66 in
+    /// <c>Lite/Analysis</c> alone per #2443), on a pass that runs under <c>Task.Run</c> with no
+    /// <c>SynchronizationContext</c>, where a continuation is free to resume anywhere. Nothing in our
+    /// code makes that safe. What makes it safe is that no await here ever yields, so no continuation is
+    /// ever scheduled.</para>
+    ///
+    /// <para>If a DuckDB.NET bump makes any of these genuinely asynchronous this goes red, and the
+    /// paragraph on <c>DuckDbInitializer.LockReleaser</c> says what to do about it — including why
+    /// guarding <c>Dispose</c> with <c>IsReadLockHeld</c> is the wrong answer, which the test below
+    /// measures.</para>
+    ///
+    /// <para>The insert loop is long on purpose. A single moved continuation could land back on the same
+    /// pool thread by chance; two hundred of them landing there is not chance.</para>
+    /// </summary>
+    [Fact]
+    public async Task DuckDbAsyncStillCompletesOnTheCallingThread()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"pm-2463-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            /* Task.Run, so there is no SynchronizationContext to pin the continuations for us --
+               the same shape the analysis pass runs in. */
+            await Task.Run(async () =>
+            {
+                var entered = Environment.CurrentManagedThreadId;
+
+                using var connection = new DuckDBConnection($"Data Source={Path.Combine(dir, "lockmodel.duckdb")}");
+                await connection.OpenAsync();
+                Assert.Equal(entered, Environment.CurrentManagedThreadId);
+
+                using (var ddl = connection.CreateCommand())
+                {
+                    ddl.CommandText = "CREATE TABLE t (v INTEGER)";
+                    await ddl.ExecuteNonQueryAsync();
+                }
+                Assert.Equal(entered, Environment.CurrentManagedThreadId);
+
+                for (var i = 0; i < 200; i++)
+                {
+                    using var insert = connection.CreateCommand();
+                    insert.CommandText = $"INSERT INTO t VALUES ({i})";
+                    await insert.ExecuteNonQueryAsync();
+                }
+                Assert.Equal(entered, Environment.CurrentManagedThreadId);
+
+                using (var read = connection.CreateCommand())
+                {
+                    read.CommandText = "SELECT v FROM t";
+                    using var reader = await read.ExecuteReaderAsync();
+                    while (await reader.ReadAsync())
+                    {
+                    }
+                }
+
+                Assert.Equal(entered, Environment.CurrentManagedThreadId);
+            });
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Why <c>LockReleaser.Dispose</c> is NOT guarded with <c>IsReadLockHeld</c>, kept as an executable
+    /// measurement because "the obvious fix is worse" is exactly the claim a later reader will doubt.
+    ///
+    /// <para>The guard looks free: skip the exit when this thread did not enter, and the
+    /// <see cref="SynchronizationLockException"/> goes away. What actually goes away is the diagnosis.
+    /// The entry the ORIGINAL thread took is still held, nothing will ever release it, and every
+    /// maintenance operation in the process — CHECKPOINT, archival, compaction — blocks on it for the
+    /// life of the app. An exception is loud, attributable and survivable; a leaked reader is none of
+    /// those.</para>
+    /// </summary>
+    [Fact]
+    public void GuardingTheReleaserWouldTradeAnExceptionForAPermanentlyWedgedLock()
+    {
+        using var rwLock = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
+        rwLock.EnterReadLock();
+        try
+        {
+            /* What the guard would see on a continuation that resumed elsewhere. */
+            var guardWouldSkip = RunOnAnotherThread(() => !rwLock.IsReadLockHeld);
+            Assert.True(guardWouldSkip, "a foreign thread does not observe the entry, so the guard skips the exit");
+
+            /* What it is being offered instead of: loud and attributable. */
+            var thrown = RunOnAnotherThread<Type?>(() =>
+            {
+                try
+                {
+                    rwLock.ExitReadLock();
+                    return null;
+                }
+                catch (Exception ex)
+                {
+                    return ex.GetType();
+                }
+            });
+            Assert.Equal(typeof(SynchronizationLockException), thrown);
+
+            /* And what skipping costs: the entry is still held and maintenance cannot get in. */
+            Assert.Equal(1, rwLock.CurrentReadCount);
+            var maintenanceGotIn = RunOnAnotherThread(() =>
+            {
+                if (!rwLock.TryEnterWriteLock(TimeSpan.FromMilliseconds(250)))
+                    return false;
+                rwLock.ExitWriteLock();
+                return true;
+            });
+            Assert.False(maintenanceGotIn, "the leaked read entry blocks every maintenance writer, permanently");
+        }
+        finally
+        {
+            rwLock.ExitReadLock();
+        }
+    }
+
+    /// <summary>
+    /// The rule is stated where a caller will find it, and the doc comment that used to be read as the
+    /// house rule no longer is. This is the one here that goes red on <c>dev</c>.
+    ///
+    /// <para>A source pin because what #2463 produced is a WRITTEN RULE — no call site changed, so there
+    /// is no behavior to assert. The thing that can regress is the sentence, and it regresses by being
+    /// deleted or by drifting back to "use the write lock for INSERT", which is the phrasing that made
+    /// eleven callers look like a house rule and <c>FindingStore</c> look like a bug.</para>
+    /// </summary>
+    [Fact]
+    public void TheLockRuleIsWrittenWhereEveryCallerAlreadyLooks()
+    {
+        var initializer = ParitySource.ReadFile("Lite/Database/DuckDbInitializer.cs");
+
+        /* The rule itself, on the lock it governs. */
+        Assert.Contains("WHAT IT MUST EXCLUDE, NOT BY WHETHER IT READS OR", initializer, StringComparison.Ordinal);
+        Assert.Contains("#2463", initializer, StringComparison.Ordinal);
+
+        /* The measurement that makes it a rule rather than an opinion: DuckDB fails, rather than
+           queues, the loser of a write-write collision -- and an append cannot collide. */
+        Assert.Contains("Conflict on update!", initializer, StringComparison.Ordinal);
+        Assert.Contains("Conflict on tuple deletion!", initializer, StringComparison.Ordinal);
+
+        /* And the latent thread-affinity hazard, with the reason its obvious mitigation is refused. */
+        Assert.Contains("IsReadLockHeld", initializer, StringComparison.Ordinal);
+        Assert.Contains("bug amplifier", initializer, StringComparison.Ordinal);
+
+        /* LocalDataService must no longer read as the house rule for the whole app. */
+        var localData = ParitySource.ReadFile("Lite/Services/LocalDataService.cs");
+        Assert.DoesNotContain(
+            "Use for UPDATE/DELETE/INSERT operations that must not race with archival or compaction.",
+            localData,
+            StringComparison.Ordinal);
+        Assert.Contains("#2463", localData, StringComparison.Ordinal);
+
+        /* Every store on either side of the split points at the one rule, so whichever a reader lands
+           on first is where they find it. */
+        foreach (var file in new[]
+                 {
+                     "Lite/Analysis/FindingStore.cs",
+                     "Lite/Services/DuckDbAlertHistoryStore.cs",
+                     "Lite/Services/DuckDbMuteRuleStore.cs",
+                 })
+        {
+            var source = ParitySource.ReadFile(file);
+            Assert.Contains("#2463", source, StringComparison.Ordinal);
+            Assert.Contains("DuckDbInitializer.s_dbLock", source, StringComparison.Ordinal);
+        }
+    }
+
+    private static T RunOnAnotherThread<T>(Func<T> body)
+    {
+        var result = default(T)!;
+        var thread = new Thread(() => result = body());
+        thread.Start();
+        Assert.True(thread.Join(TimeSpan.FromSeconds(10)), "the probe thread did not finish");
+        return result;
+    }
+}

--- a/Lite/Analysis/FindingStore.cs
+++ b/Lite/Analysis/FindingStore.cs
@@ -53,12 +53,14 @@ namespace PerformanceMonitorLite.Analysis;
 /// </para>
 ///
 /// <para>
-/// One thing this store does NOT settle, so a reader who checks the neighbours is not misled twice:
-/// <c>DuckDbAlertHistoryStore</c> and <c>DuckDbMuteRuleStore</c> take the WRITE lock for the same
-/// species of ordinary write, and <c>LocalDataService.OpenWriteConnectionAsync</c> states that as the
-/// house rule in its own doc comment. Two conventions, and this file follows the cheaper one. Which
-/// is right for the other eleven call sites is #2463 — a question about the lock model rather than
-/// about these three methods, and deliberately not answered here.
+/// A reader who checks the neighbours will find <c>DuckDbAlertHistoryStore</c> and
+/// <c>DuckDbMuteRuleStore</c> taking the WRITE lock, and should not conclude that one of the two is
+/// wrong. #2463 settled it: the lock is chosen by what a statement must EXCLUDE, not by whether it
+/// reads or writes, and the rule with its measurements is on <c>DuckDbInitializer.s_dbLock</c>. The
+/// short of it is that these three are on the correct side of it — <see cref="InsertFindingsAsync"/>
+/// and <see cref="MuteStoryAsync"/> APPEND new rows, which DuckDB lets run concurrently, and
+/// <see cref="CleanupOldFindingsAsync"/>'s retention DELETE is disjoint from them. What the write lock
+/// buys is exclusion of another writer of the SAME rows, and nothing else writes these tables.
 /// </para>
 /// </summary>
 public class FindingStore

--- a/Lite/Database/DuckDbInitializer.cs
+++ b/Lite/Database/DuckDbInitializer.cs
@@ -19,9 +19,74 @@ public class DuckDbInitializer
     private readonly ILogger<DuckDbInitializer>? _logger;
 
     /// <summary>
-    /// Coordinates UI readers with maintenance writers (CHECKPOINT, archive DELETEs, compaction).
-    /// Read locks allow unlimited concurrent UI queries. Write locks are exclusive and wait
-    /// for all readers to finish before proceeding.
+    /// Coordinates every DuckDB caller in the process against MAINTENANCE — CHECKPOINT, the archive
+    /// export and its DELETEs, compaction, the in-place parquet swap, schema migration — each of which
+    /// reorganizes the database file, or the paths under it, while other statements are running. Read
+    /// locks allow unlimited concurrent holders. Write locks are exclusive and wait for every reader to
+    /// drain first.
+    ///
+    /// <para>ONE lock for the whole process, deliberately: Lite constructs several
+    /// <see cref="DuckDbInitializer"/> instances over the same file (MainWindow,
+    /// DatabaseStateOverridesWindow, DuckDbAlertHistoryStore), and making it per-instance would trade a
+    /// slow test suite for a real data race.</para>
+    ///
+    /// <para><b>WHICH LOCK A CALLER TAKES IS DECIDED BY WHAT IT MUST EXCLUDE, NOT BY WHETHER IT READS OR
+    /// WRITES (#2463).</b> That one sentence is the rule, and it is written here because the answer had
+    /// drifted into looking like two rival conventions: <c>FindingStore</c>'s three write paths take the
+    /// READ lock (#2455/#2464), while <c>DuckDbAlertHistoryStore</c> (6), <c>DuckDbMuteRuleStore</c> (5)
+    /// and the fourteen callers of <c>LocalDataService.OpenWriteConnectionAsync</c> take the WRITE lock —
+    /// twenty-five sites against three, with no note anywhere saying why either was right. They are not
+    /// two answers to one question. They are answers to two questions, and the axis that separates them
+    /// belongs to DuckDB rather than to anything in this file.</para>
+    ///
+    /// <para><b>Take the READ lock when all you need is "the file must not be reorganized under me."</b>
+    /// That covers every ordinary statement, SELECT and INSERT alike. It is shared, so it costs other
+    /// readers nothing, and a held read lock blocks <c>EnterWriteLock</c> — which means holding one IS how
+    /// a write says "not while I am in flight", and is the whole of the exclusion an append needs.</para>
+    ///
+    /// <para><b>Take the WRITE lock when you need one of two stronger things.</b> (1) <b>You ARE the
+    /// maintenance</b> — you reorganize the file or the paths under it. <c>ArchiveService</c>,
+    /// <c>RemoteCollectorService</c>'s post-collection CHECKPOINT, this class's own re-key, and
+    /// <c>QueryStoreSliceRepairService</c>'s hot collapse and file promotion. Never in question. (2)
+    /// <b>Your statement can COLLIDE with another writer of the same rows.</b> DuckDB's concurrency
+    /// control is optimistic: it does not queue the second writer, it FAILS it. An UPDATE, an upsert, or
+    /// a delete-then-reinsert compound can lose that race; an append of new rows cannot. So the write
+    /// lock buys serialization exactly where DuckDB would otherwise hand somebody an exception.</para>
+    ///
+    /// <para>Measured on DuckDB.NET 1.5.5 with the two transactions strictly interleaved — the second
+    /// statement runs while the first transaction is still open and uncommitted, which is the only
+    /// arrangement that measures anything (let the connections merely start together and one commits
+    /// before the other begins, and every case reads as "both committed"):</para>
+    ///
+    /// <list type="table">
+    /// <item><description>two APPENDS of brand-new rows — <b>both commit</b></description></item>
+    /// <item><description>a retention DELETE overlapping a disjoint append — <b>both commit</b></description></item>
+    /// <item><description>two UPDATEs of the same row — second fails, <c>Conflict on update!</c></description></item>
+    /// <item><description>two upserts of the same key — second fails, <c>Conflict on update!</c></description></item>
+    /// <item><description>two delete-all-then-reinsert compounds — second fails, <c>Conflict on tuple deletion!</c></description></item>
+    /// </list>
+    ///
+    /// <para><b>That rule describes the code as it stands, with two known exceptions</b>, both appends
+    /// holding the write lock: <c>DuckDbAlertHistoryStore.RecordAlertAsync</c> (an INSERT into
+    /// <c>config_alert_log</c>) and <c>DuckDbMuteRuleStore.InsertAsync</c> (an INSERT of a fresh rule id).
+    /// Neither can collide, so by clause (2) neither needs exclusivity. They are left alone on purpose:
+    /// each is one method on a store whose siblings genuinely do need it, both are operator- or
+    /// alert-frequency rather than hot, and making two of eleven different would cost more in legibility
+    /// than it recovers in lock time. Recorded as over-locked so the next reader knows it was seen.</para>
+    ///
+    /// <para>It also answers the pair that made the split look like a contradiction.
+    /// <c>DuckDbMuteRuleStore.InsertAsync</c> writing <c>config_mute_rules</c> under a write lock and
+    /// <c>FindingStore.MuteStoryAsync</c> writing <c>analysis_muted</c> under a read lock are NOT the same
+    /// species: nothing but the analysis pass ever writes <c>analysis_muted</c>, while
+    /// <c>config_mute_rules</c> is UPDATEd by an operator and DELETEd by a timer-driven expiry purge that
+    /// can be running at the same moment.</para>
+    ///
+    /// <para><b>The WAIT is a separate question from the lock.</b> <c>AcquireWriteLock()</c> with no
+    /// timeout waits behind an archival for however long the archival takes. Eleven current callers do
+    /// that, and can: they are alert-sweep and mute-CRUD paths whose failures are caught, logged and
+    /// non-fatal. <c>LocalDataService.OpenWriteConnectionAsync</c> is the one that cannot, because it is on
+    /// the path the UI thread awaits, so it passes 5 seconds and #2208's maintenance block treats the
+    /// timeout as "skip this cycle". If you are adding a caller, decide which of those two you are.</para>
     /// </summary>
     private static readonly ReaderWriterLockSlim s_dbLock = new(LockRecursionPolicy.NoRecursion);
 
@@ -109,6 +174,35 @@ public class DuckDbInitializer
         public void Dispose() { }
     }
 
+    /// <summary>
+    /// Releases the lock entry its constructor was handed.
+    ///
+    /// <para><b>Thread affinity is a LATENT hazard here, and the obvious mitigation is worse than the
+    /// hazard (#2463).</b> <see cref="ReaderWriterLockSlim"/> is thread-affine: <c>ExitReadLock</c> throws
+    /// <see cref="SynchronizationLockException"/> when called from a thread that did not enter. Every one
+    /// of these locks is held across <c>await</c> — <c>AcquireReadLock</c>, then <c>OpenAsync</c>, then the
+    /// reads — and the analysis pass runs under <c>Task.Run</c> with no <c>SynchronizationContext</c>, so a
+    /// continuation is free to resume on a different pool thread. It does not, and the reason is measured
+    /// rather than lucky: <b>DuckDB.NET 1.5.5's async methods complete synchronously</b>, so no await ever
+    /// yields and the entering thread is always the exiting thread. Thread id across <c>OpenAsync</c>, a
+    /// DDL statement, 200 <c>ExecuteNonQueryAsync</c> calls and a reader drain: <c>4, 4, 4, 4, 4</c>.</para>
+    ///
+    /// <para><b>Do not "harden" this with an <c>IsReadLockHeld</c> guard.</b> It looks like the cheap fix
+    /// and it is a bug amplifier, measured: on a thread that did not enter, <c>IsReadLockHeld</c> is
+    /// <c>false</c>, so the guard SKIPS the exit — and the entry the original thread took is then held
+    /// forever. With it still held, <c>TryEnterWriteLock(400 ms)</c> fails. So the guard would convert a
+    /// loud, attributable <see cref="SynchronizationLockException"/> into a silently leaked reader that
+    /// permanently wedges every maintenance operation in the process: no CHECKPOINT, no archival, no
+    /// compaction, for the life of the app. Throwing is the better failure.</para>
+    ///
+    /// <para>A real fix would have to make the releaser not thread-affine at all — replacing
+    /// <see cref="ReaderWriterLockSlim"/> with something like a <c>SemaphoreSlim</c>, which would also
+    /// retire <see cref="AcquireReadLock(CancellationToken)"/>'s poll — and that is a change to the lock
+    /// primitive, not to this class. It is not worth doing while the premise holds. What would break the
+    /// premise is a DuckDB.NET release whose async genuinely yields, so
+    /// <c>DuckDbLockModelTests.DuckDbAsyncStillCompletesOnTheCallingThread</c> is a tripwire on exactly
+    /// that: if it goes red after a driver bump, this paragraph is where to start.</para>
+    /// </summary>
     private sealed class LockReleaser : IDisposable
     {
         private readonly ReaderWriterLockSlim _lock;

--- a/Lite/Services/DuckDbAlertHistoryStore.cs
+++ b/Lite/Services/DuckDbAlertHistoryStore.cs
@@ -21,6 +21,19 @@ namespace PerformanceMonitorLite.Services;
 /// GetLastAlertTimeAsync) — verbatim SQL, same DuckDbInitializer + App.DatabasePath
 /// fallback. The shared <c>string serverId</c> is parsed back to the DuckDB
 /// <c>INT</c> column before binding the $1 parameter (§4.1).
+///
+/// <para><b>The write lock on the six mutating methods is mostly earned, and once is not (#2463).</b>
+/// Said here because <c>FindingStore</c> next door writes under the READ lock and the difference looks
+/// like one of them is a bug. It is not: the rule is that the read lock excludes MAINTENANCE while the
+/// write lock additionally excludes OTHER WRITERS OF THE SAME ROWS, which matters because DuckDB's
+/// concurrency control fails the loser of a write-write collision instead of queueing it. The two
+/// watermark upserts, the incident-occurrence delete-then-reinsert, and the two
+/// <c>config_database_state_expected</c> UPDATEs all collide under that rule — the UPDATEs against
+/// <c>LocalDataService.GetDatabaseStateDeviationsAsync</c>'s #2208 maintenance block, which writes the
+/// same table. <see cref="RecordAlertAsync"/> is the exception: it APPENDS to <c>config_alert_log</c>
+/// and cannot collide, so it is over-locked and kept that way deliberately, because one method of six
+/// spelled differently costs more than the microseconds it saves on an alert-frequency write. Full rule
+/// and measurements on <c>DuckDbInitializer.s_dbLock</c>.</para>
 /// </summary>
 public sealed class DuckDbAlertHistoryStore : IAlertHistoryStore
 {

--- a/Lite/Services/DuckDbMuteRuleStore.cs
+++ b/Lite/Services/DuckDbMuteRuleStore.cs
@@ -23,6 +23,18 @@ namespace PerformanceMonitorLite.Services;
 /// try/catch + logging + in-memory cache (persist-then-cache ordering preserved).
 /// <see cref="LoadAllAsync"/> swallows errors and returns an empty set, matching
 /// the old LoadAsync ("start with empty rules if DB not ready").
+///
+/// <para><b>Four of the five write-lock sites are earned; <see cref="InsertAsync"/> is not (#2463).</b>
+/// Worth saying because <c>FindingStore.MuteStoryAsync</c> writes a mute row under the READ lock, and the
+/// pair reads as one convention contradicting another. It is not the same species of write.
+/// <c>config_mute_rules</c> is UPDATEd by an operator (<see cref="UpdateAsync"/>,
+/// <see cref="SetEnabledAsync"/>) and DELETEd by both the operator and a timer-driven expiry purge
+/// (<see cref="DeleteAsync"/>, <see cref="DeleteExpiredAsync"/>) that can be running at the same instant;
+/// DuckDB fails the loser of such a collision rather than queueing it, and the write lock is what stops
+/// that happening. Nothing but the analysis pass writes <c>analysis_muted</c>, so its append needs only
+/// the read lock. <see cref="InsertAsync"/> is an append too and by the rule needs only the read lock;
+/// it is left on the write lock so this store speaks with one voice. The rule and the measurements are
+/// on <c>DuckDbInitializer.s_dbLock</c>.</para>
 /// </summary>
 public sealed class DuckDbMuteRuleStore : IMuteRuleStore
 {

--- a/Lite/Services/LocalDataService.cs
+++ b/Lite/Services/LocalDataService.cs
@@ -53,9 +53,23 @@ public partial class LocalDataService
     }
 
     /// <summary>
-    /// Creates and opens a DuckDB connection wrapped in an exclusive write lock.
-    /// Use for UPDATE/DELETE/INSERT operations that must not race with archival or compaction.
-    /// A 5-second timeout prevents UI freeze if archival currently holds the lock.
+    /// Creates and opens a DuckDB connection wrapped in an exclusive write lock, with a 5-second timeout
+    /// so the UI thread cannot freeze behind an in-flight archival.
+    ///
+    /// <para><b>This doc comment used to say "use for UPDATE/DELETE/INSERT operations that must not race
+    /// with archival or compaction", and was read as the house rule for the whole app (#2463).</b> It is
+    /// not, and the INSERT in that sentence is the part that was wrong: excluding archival is what the
+    /// READ lock already does, since a held read lock blocks <c>EnterWriteLock</c>. What this method
+    /// additionally buys is exclusion of OTHER WRITERS, which an UPDATE or a DELETE needs — DuckDB's
+    /// optimistic concurrency fails the loser of a write-write collision rather than queueing it — and
+    /// which an append of new rows does not. The rule, with the measurements behind it, is on
+    /// <c>DuckDbInitializer.s_dbLock</c>; the fourteen callers here are UPDATE, DELETE and #2208's
+    /// multi-statement maintenance block, and all of them sit on the right side of it.</para>
+    ///
+    /// <para>The 5-second timeout is this method's own contribution and is not part of the lock rule:
+    /// every other write-lock caller in the app waits indefinitely, which they can afford and the UI
+    /// thread cannot. See <see cref="LocalDataService.GetDatabaseStateDeviationsAsync"/> for what a
+    /// caller does when it expires.</para>
     /// </summary>
     internal async Task<LockedConnection> OpenWriteConnectionAsync()
     {


### PR DESCRIPTION
Closes #2463. Lite only. **No behaviour changes anywhere** — `git diff` on the five modified sources adds zero executable lines; every added line is a doc comment. The only new code is one test file.

## Verifying the issue first

Mostly accurate, with one incomplete census and one prior ruling it did not account for.

| Claim | |
|---|---|
| `LocalDataService.OpenWriteConnectionAsync` doc states the house rule verbatim | ✅ |
| `DuckDbAlertHistoryStore` — 6 write-lock sites | ✅ |
| `DuckDbMuteRuleStore` — 5 write-lock sites | ✅ |
| `FindingStore` — 3 write paths on the read lock | ✅ |
| `LocalDataService` is the only caller passing a timeout (5 s) | ✅ |
| The maintenance-shaped set is not in question | ✅ |
| "**eleven** write sites" | ❌ **twenty-five.** `OpenWriteConnectionAsync` has 14 callers of its own the census missed — `LocalDataService.ServerTags.cs` ×8, `.DatabaseStates.cs` ×3, `.AlertHistory.cs` ×3 |
| "the read lock is right and the write-lock sites are over-locking" | ❌ mostly not — see below |

The prior ruling: **#2208 already decided this axis, in the opposite direction, off a measured failure.** `LocalDataService.GetDatabaseStateDeviationsAsync` moved *from* the read lock *to* the write lock, and says why at the site — an unrelated server-tags test timed out acquiring the write lock while this method held the read lock across four statements. So "unify on the read lock" would have reverted a deliberate ruling backed by an observed failure, on the strength of a measurement taken against a different file. That is precisely the "repo-wide convention altered without anyone deciding to" the issue was filed to prevent.

## The two conventions are answers to two different questions

The resolution is neither "unify" nor "state both and shrug". There is **one rule**, and it explains both sets:

> **Which lock a caller takes is decided by what it must EXCLUDE, not by whether it reads or writes.**
>
> The **read lock** excludes MAINTENANCE. A held read lock blocks `EnterWriteLock`, so holding one *is* how a statement says "not while the file is reorganized under me". That is the whole of what an append needs.
>
> The **write lock** additionally excludes OTHER WRITERS OF THE SAME ROWS. You need that because DuckDB's concurrency control is optimistic: it does not queue the second writer, it **fails** it.

Measured on DuckDB.NET 1.5.5, with the two transactions **strictly interleaved** — the second statement runs while the first transaction is still open and uncommitted:

| overlap | result |
|---|---|
| two APPENDS of brand-new rows | **both commit** |
| a retention DELETE overlapping a disjoint append | **both commit** |
| two UPDATEs of the same row | second fails — `TransactionContext Error: Conflict on update!` |
| two upserts of the same key | second fails — `Conflict on update!` |
| two delete-all-then-reinsert compounds | second fails — `Conflict on tuple deletion!` |

**The interleave is load-bearing.** My first pass let both connections merely start together, and every case came back "both committed" — a slow connection open lets one transaction commit before the other begins, so the probe measures nothing. That artefact is exactly how this reads as a tidiness complaint instead of a rule, and it is why the numbers above are reported with the barrier described.

## What the rule says about the actual call sites

It describes the code as it stands, with two named exceptions.

**Read lock, correct** — `FindingStore.InsertFindingsAsync` and `MuteStoryAsync` append new rows (#2464 moved their ids to the process-wide `CollectionIdGenerator`, so they cannot even collide on the key), and `CleanupOldFindingsAsync`'s retention DELETE is disjoint from them. Nothing else writes those tables.

**Write lock, earned** — the two watermark upserts, `SaveIncidentOccurrencesAsync`'s delete-then-reinsert, and the two `config_database_state_expected` UPDATEs (which collide with #2208's maintenance block, writing the same table); the mute store's UPDATEs and DELETEs, which race a timer-driven expiry purge; the 14 `OpenWriteConnectionAsync` callers, which are UPDATE, DELETE and #2208's compound.

**The pair that made this look like a contradiction resolves rather than persists.** The issue's headline example — `DuckDbMuteRuleStore.InsertAsync` writing `config_mute_rules` under a write lock while `FindingStore.MuteStoryAsync` writes `analysis_muted` under a read lock, *"same species of write, same store, opposite lock"* — turns out **not to be the same species**. Nothing but the analysis pass ever writes `analysis_muted`. `config_mute_rules` is UPDATEd by an operator and DELETEd by a timer that can be running at the same instant.

**Write lock, over-locked, and left that way** — two appends that cannot collide: `DuckDbAlertHistoryStore.RecordAlertAsync` and `DuckDbMuteRuleStore.InsertAsync`. Each is one method on a store whose siblings genuinely need the write lock, both are alert- or operator-frequency rather than hot, and making two of eleven spell it differently costs more in legibility than it recovers in lock time. **Recorded as over-locked** so the next reader knows it was seen and decided rather than missed. A rule that names its own two exceptions is more useful than one quietly enforced over them.

## Where it is written

On `DuckDbInitializer.s_dbLock` — the issue's own suggestion, and where every caller already looks. `LocalDataService.OpenWriteConnectionAsync` keeps its 5-second-timeout note (real, and its own contribution) and stops claiming to be the rule; the **INSERT** in its old sentence was the part that was wrong, since excluding archival is what the read lock already does. `FindingStore`'s #2464 paragraph said "which is right for the other eleven call sites is #2463 … deliberately not answered here" — that is now answered, so it says so. Both write-lock stores get a class note pointing at the same rule, so whichever a reader lands on first is where they find it.

## The latent hazard: not "documented and left"

`LockReleaser.Dispose` calls `ExitReadLock` unguarded across an `await`, safe today only because DuckDB.NET's async completes synchronously. Reproduced independently: thread id `4, 4, 4, 4, 4` across `OpenAsync`, DDL, 200 `ExecuteNonQueryAsync` and a reader drain.

**The cheap mitigation the issue floated is a bug amplifier, and that is measured rather than argued.** Guarding `Dispose` with `IsReadLockHeld`:

```
entered on main; IsReadLockHeld observed on ANOTHER thread = False   (the guard SKIPS the exit)
CurrentReadCount while still held = 1
ExitReadLock from another thread threw: SynchronizationLockException
with the read entry still held, TryEnterWriteLock(400ms) succeeded = False
```

A thread that did not enter sees `false`, so the guard skips the exit — and `ReaderWriterLockSlim` entries are per-thread, so the original thread's entry is then held **forever**. With it held, no writer can get in. The guard would trade a loud, attributable `SynchronizationLockException` for a silently leaked reader that permanently wedges every CHECKPOINT, archival and compaction for the life of the app. **Throwing is the better failure**, and the doc now says so rather than leaving the next reader to reach for the guard and make it worse.

A real fix has to make the releaser not thread-affine at all — replacing `ReaderWriterLockSlim`, which would also retire #2443's 50 ms poll. That is a change to the lock primitive, not to any caller, and it is not worth doing while the premise holds. So what ships is a **tripwire on the premise**: `DuckDbAsyncStillCompletesOnTheCallingThread` asserts the thread never moves across `OpenAsync`, DDL, 200 awaited inserts and a reader drain, under `Task.Run` with no `SynchronizationContext`. Two hundred awaits because one moved continuation could land back on the same pool thread by chance and two hundred could not. If a driver bump turns it red, the `LockReleaser` doc is the place to start.

## Verification

- Full-solution rebuild on macOS (`EnableWindowsTargeting`, `-t:Rebuild`): **0 errors**, 30 warnings, warning-code set byte-identical to `dev`'s (`CA1720` ×8, `CA2016` ×20, `xUnit1031` ×2, `xUnit2031` ×30). The 20 `CA2016` are #2465's, in a file this branch does not touch.
- `git diff -U0` on the five modified sources yields **zero added non-comment lines**.
- `Lite.Tests` is `net10.0-windows`, so the **real `Lite.Tests/DuckDbLockModelTests.cs`** was compiled into a `net10.0` xUnit shim with the **real `Lite.Tests/ParitySource.cs`** (no stubs needed) and run against both branches: **3/3 pass here, 1/3 fails on `dev`**:

  ```
  TheLockRuleIsWrittenWhereEveryCallerAlreadyLooks [FAIL]
    Not found: "WHAT IT MUST EXCLUDE, NOT BY WHETHER IT READS OR"
  ```

  **Only that one can be red, and the class doc says so.** The other two assert facts that are *already true* — the driver's synchrony, and what a guard would cost. A test for a fact is a tripwire, not a regression test; writing one that failed today would mean breaking the thing first.
- Rebased onto `dev` at `9d1337a5` and every check above re-run after.

## Deferred

- The two recorded over-locks are not changed. Changing them is a behaviour change on an unmeasured benefit, in the two files a reader is most likely to copy from.
- Replacing `ReaderWriterLockSlim` with a non-thread-affine primitive is left unfiled: it is a real option, it would retire #2443's poll, and it has no trigger yet. The tripwire is the trigger.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
