### PR TITLE
Collapse the sidebar dot onto the status the Overview card renders (#2458)

### DIFF
--- a/Lite.Tests/LiteOverviewCardExplainsItselfTests.cs
+++ b/Lite.Tests/LiteOverviewCardExplainsItselfTests.cs
@@ -196,6 +196,12 @@ public sealed class LiteOverviewCardExplainsItselfTests
     /// makes them incapable of disagreeing rather than merely observed not to. The viewer arrived at the same
     /// collapse over two review rounds on #2429, each of which found a different flag pair where two independent
     /// readings contradicted each other.
+    ///
+    /// <para>Since #2458 the ladder is <c>ServerCardStatusRules.Classify</c> rather than a member of this class,
+    /// and the count below spans the sidebar's file too. The reason is the shape of what this pin missed: it
+    /// counted one literal in ONE file, which was true and stayed true while a fourth copy of the same ladder sat
+    /// in <c>Lite/Models/ServerConnection.cs</c> driving the sidebar dot. A pin scoped to one file cannot see the
+    /// duplicate it exists to forbid.</para>
     /// </summary>
     [Fact]
     public void TheCardStatus_IsTheOnlyPlaceTheStatusFlagsAreRead()
@@ -213,15 +219,26 @@ public sealed class LiteOverviewCardExplainsItselfTests
         Assert.Contains("Offline", offlineAndErroring.StatusTooltip, StringComparison.Ordinal);
 
         var source = ReadRepoFile(Path.Combine("Lite", "Services", "LocalDataService.Overview.cs"));
-        Assert.Contains("public ServerCardStatus CardStatus => IsOnline switch", source, StringComparison.Ordinal);
-        Assert.Contains("public string StatusDisplay => CardStatus switch", source, StringComparison.Ordinal);
+        Assert.Contains(
+            "public static ServerCardStatus Classify(bool? isOnline, bool hasCollectorErrors) => isOnline switch",
+            source, StringComparison.Ordinal);
+        Assert.Contains(
+            "public ServerCardStatus CardStatus => ServerCardStatusRules.Classify(IsOnline, HasCollectorErrors);",
+            source, StringComparison.Ordinal);
+        Assert.Contains("public string StatusDisplay => CardStatus.Word();", source, StringComparison.Ordinal);
         Assert.Contains("public SolidColorBrush StatusBrush => MakeBrush(CardStatus switch", source, StringComparison.Ordinal);
-        Assert.Contains("private string StatusHeadline => CardStatus switch", source, StringComparison.Ordinal);
+        Assert.Contains("private string StatusHeadline => CardStatus.Headline();", source, StringComparison.Ordinal);
 
-        /* And exactly one switch on the flag itself. This is the assertion behind the claim in
-           ServerCardStatus's doc comment; without it the claim is prose that review has to re-check by hand,
-           which is how it came to overstate what was true in the first place (raised on #2451). */
-        Assert.Equal(1, CountOccurrences(source, "IsOnline switch"));
+        /* And exactly one switch on the flag itself, counted across BOTH files that render it. This is the
+           assertion behind the claim in ServerCardStatus's doc comment; without it the claim is prose that
+           review has to re-check by hand, which is how it came to overstate what was true in the first place
+           (raised on #2451). The literal moved with the ladder — it is now the classifier's own parameter
+           list — and the card may not switch on the property again. The sidebar's file is scanned for either
+           casing, because the copy #2458 removed was the property-cased one. */
+        var sidebar = ReadRepoFile(Path.Combine("Lite", "Models", "ServerConnection.cs"));
+        Assert.Equal(1, CountOccurrences(source, "isOnline switch"));
+        Assert.Equal(0, CountOccurrences(source, "IsOnline switch"));
+        Assert.Equal(0, CountOccurrences(sidebar, "sOnline switch"));
     }
 
     /// <summary>

--- a/Lite.Tests/LiteSidebarDotRendersTheCardStatusTests.cs
+++ b/Lite.Tests/LiteSidebarDotRendersTheCardStatusTests.cs
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using PerformanceMonitorLite.Models;
+using PerformanceMonitorLite.Services;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// #2458: the sidebar row's status dot stops deriving its own copy of the four-word status ladder.
+///
+/// <para><b>What was wrong.</b> <c>ServerConnection.DotStatus</c> computed "Unknown"/"Online"/"Warning"/"Offline"
+/// from its own <c>(IsOnline, HasCollectorErrors)</c> pair — the same ladder the Overview card derives, on a
+/// different type, on a different surface, from a different instance of the same flags. The two could therefore
+/// say different things about one server and nothing would notice. #2451 collapsed the card's five renderings onto
+/// <see cref="ServerCardStatus"/> for exactly this reason and pinned the collapse — but the pin counted one literal
+/// in one file, and this fourth copy was in a file that scan never opened.</para>
+///
+/// <para><b>What is pinned here.</b> That the two surfaces agree BY CONSTRUCTION rather than by observation — both
+/// render <see cref="ServerCardStatusRules"/> — and that the dot now says what it means. The dot is the thing a
+/// reader points at first, which is @ehaar's #2422 complaint one surface over from where it was reported.</para>
+///
+/// <para><b>What is deliberately NOT here.</b> Collection freshness. #2457 kept it out of the status word and gave
+/// it its own banded row on the card, because folding it in recreates the #2429/#2422 conflation of a stale
+/// collection with a failing one. <see cref="TheDot_CannotBandFreshnessEvenByAccident"/> holds that line at the
+/// classifier's signature, and the tooltip tells the reader where the freshness answer actually lives.</para>
+/// </summary>
+public sealed class LiteSidebarDotRendersTheCardStatusTests
+{
+    private static ServerConnection Connection(bool? isOnline, bool? hasCollectorErrors) =>
+        new() { ServerName = "srv", IsOnline = isOnline, HasCollectorErrors = hasCollectorErrors };
+
+    private static ServerSummaryItem Card(bool? isOnline, bool hasCollectorErrors) =>
+        new() { ServerName = "srv", IsOnline = isOnline, HasCollectorErrors = hasCollectorErrors };
+
+    /// <summary>
+    /// The defect itself: the sidebar and the card, handed the same flags, land on the same state and the same
+    /// word. Sampled over every reachable combination rather than the happy one, because the pairs that drifted on
+    /// #2429 and #2451 were both edge combinations nobody looked at.
+    /// </summary>
+    [Fact]
+    public void TheDot_AndTheCard_RenderOneLadder()
+    {
+        foreach (var isOnline in new bool?[] { true, false, null })
+        {
+            foreach (var hasErrors in new[] { true, false })
+            {
+                var dot = Connection(isOnline, hasErrors);
+                var card = Card(isOnline, hasErrors);
+
+                Assert.Equal(card.CardStatus, dot.CardStatus);
+                Assert.Equal(card.StatusDisplay, dot.DotStatus);
+                Assert.StartsWith(dot.DotTooltip.Split('\n')[0], card.StatusTooltip, StringComparison.Ordinal);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The four words are unchanged, so the sidebar's DataTriggers keep painting the dot they always did. This is
+    /// the compatibility half of the collapse: <c>Word()</c> feeds a XAML <c>DataTrigger Value=</c> match, and a
+    /// word that stopped matching would fall through to the muted default rather than fail anything.
+    /// </summary>
+    [Fact]
+    public void TheDotWords_AreTheOnesTheSidebarPaints()
+    {
+        Assert.Equal("Online", Connection(true, false).DotStatus);
+        Assert.Equal("Warning", Connection(true, true).DotStatus);
+        Assert.Equal("Offline", Connection(false, false).DotStatus);
+        Assert.Equal("Unknown", Connection(null, false).DotStatus);
+
+        /* An offline server's collector-error marker must not turn its dot amber — the flags resolve in order. */
+        Assert.Equal("Offline", Connection(false, true).DotStatus);
+
+        /* HasCollectorErrors is nullable on this type only. Null means nobody has established collector health,
+           which is not the same claim as "collectors are failing" — the string ladder folded it to Online and
+           that reading is kept. */
+        Assert.Equal("Online", Connection(true, null).DotStatus);
+
+        var xaml = ReadRepoFile(Path.Combine("Lite", "MainWindow.xaml"));
+        foreach (var word in new[] { "Online", "Offline", "Warning" })
+        {
+            Assert.Contains(
+                "<DataTrigger Binding=\"{Binding Server.Connection.DotStatus}\" Value=\"" + word + "\">",
+                xaml, StringComparison.Ordinal);
+        }
+    }
+
+    /// <summary>
+    /// The dot says what it means, in the card's words. The first line is byte-for-byte the card's, because that
+    /// is the whole argument for doing every surface: a reader moving between them meets one vocabulary rather
+    /// than three levels of helpfulness.
+    /// </summary>
+    [Fact]
+    public void TheDotTooltip_OpensOnTheSentenceTheCardOpensOn()
+    {
+        Assert.StartsWith("Online — the last connection check succeeded", Connection(true, false).DotTooltip, StringComparison.Ordinal);
+        Assert.StartsWith("Warning — one or more collectors are failing on this server", Connection(true, true).DotTooltip, StringComparison.Ordinal);
+        Assert.StartsWith("Offline — the last connection check failed", Connection(false, false).DotTooltip, StringComparison.Ordinal);
+        Assert.StartsWith("Unknown — this server has not been connection-checked yet", Connection(null, false).DotTooltip, StringComparison.Ordinal);
+
+        /* And it ends on the gesture THIS surface supports. The card's line names the card; naming a single click
+           on either would be naming a no-op, since both handlers act only on a double-click. */
+        Assert.EndsWith("Double-click the row to open this server's tab", Connection(true, false).DotTooltip, StringComparison.Ordinal);
+        Assert.EndsWith("Double-click the card to open this server's tab", Card(true, false).StatusTooltip, StringComparison.Ordinal);
+
+        var xaml = ReadRepoFile(Path.Combine("Lite", "MainWindow.xaml"));
+        Assert.Contains("MouseDoubleClick=\"ServerListView_MouseDoubleClick\"", xaml, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The dot actually carries the tooltip. Removing the attribute compiles perfectly clean and silently returns
+    /// the sidebar to a coloured circle that will not say what it means, which is why this reads XAML — no
+    /// assertion about a C# object can reach into an element's attributes.
+    /// </summary>
+    [Fact]
+    public void TheSidebarDot_IsBoundToItsTooltip()
+    {
+        var xaml = ReadRepoFile(Path.Combine("Lite", "MainWindow.xaml"));
+
+        var at = xaml.IndexOf("{Binding Server.Connection.DotStatus}", StringComparison.Ordinal);
+        Assert.True(at > 0, "the sidebar status dot is gone — find where it moved before editing this test");
+
+        /* Walk back to the Ellipse that owns those triggers and assert the ToolTip is on the element itself. */
+        var open = xaml.LastIndexOf("<Ellipse ", at, StringComparison.Ordinal);
+        Assert.True(open > 0, "the sidebar status dot is no longer an Ellipse");
+
+        var element = xaml[open..xaml.IndexOf(">", open, StringComparison.Ordinal)];
+        Assert.Contains("ToolTip=\"{Binding Server.Connection.DotTooltip}\"", element, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// #2457 kept collection freshness out of the status word on purpose, and this dot is the surface where that
+    /// separation is easiest to lose: <c>ServerConnection</c> carries no last-collection time, so a green dot here
+    /// is a connection answer being read somewhere that offers no freshness answer at all.
+    ///
+    /// <para>Two things hold the line. The classifier takes exactly two arguments, so freshness cannot be folded in
+    /// without changing a signature this test names — the failure mode being guarded is a plausible, well-meant
+    /// edit, not a typo. And the tooltip tells the reader where the freshness answer lives instead of leaving them
+    /// to infer it from a colour, which is the #2429/#2422 conflation in miniature.</para>
+    /// </summary>
+    [Fact]
+    public void TheDot_CannotBandFreshnessEvenByAccident()
+    {
+        const string disclaimer =
+            "It reports the connection check only, not collection freshness — the Overview card's Last Collect row bands that.";
+
+        foreach (var isOnline in new bool?[] { true, false, null })
+        {
+            Assert.Contains(disclaimer, Connection(isOnline, false).DotTooltip, StringComparison.Ordinal);
+        }
+
+        var rules = ReadRepoFile(Path.Combine("Lite", "Services", "LocalDataService.Overview.cs"));
+        Assert.Contains(
+            "public static ServerCardStatus Classify(bool? isOnline, bool hasCollectorErrors) => isOnline switch",
+            rules, StringComparison.Ordinal);
+
+        /* And the sidebar has nothing to band it FROM, which is why unifying the ladder was the whole of #2458 and
+           plumbing a collection time to this surface was split off. If that ever changes, this assertion is the
+           place the decision gets made rather than discovered. */
+        var sidebar = ReadRepoFile(Path.Combine("Lite", "Models", "ServerConnection.cs"));
+        Assert.DoesNotContain("LastCollection", sidebar, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The pin that would actually have caught this one. #2451 counted the literal <c>"IsOnline switch"</c>
+    /// at exactly one occurrence, in exactly one file — and the fourth copy it existed to forbid was already
+    /// sitting in ANOTHER file, written as a chain of <c>if</c> statements rather than a switch. It evaded
+    /// that pin on both axes at once, and went on evading it through #2451 and #2457.
+    ///
+    /// <para>So the invariant is not "one switch". It is that the four words are WRITTEN once. Scanning for
+    /// them as string literals is syntax-agnostic: an <c>if</c> chain, a switch, a dictionary and a ternary
+    /// all have to spell them, and none of them can spell them here any more. Comments are stripped first
+    /// because <c>DotStatus</c>'s own doc comment legitimately names all four while the code writes none.</para>
+    /// </summary>
+    [Fact]
+    public void TheFourWords_AreWrittenInExactlyOnePlace()
+    {
+        var sidebar = WithoutComments(ReadRepoFile(Path.Combine("Lite", "Models", "ServerConnection.cs")));
+
+        foreach (var word in new[] { "Online", "Warning", "Offline", "Unknown" })
+        {
+            Assert.DoesNotContain("\"" + word + "\"", sidebar, StringComparison.Ordinal);
+        }
+
+        /* And they are written in the one function both surfaces render. */
+        var rules = ReadRepoFile(Path.Combine("Lite", "Services", "LocalDataService.Overview.cs"));
+        Assert.Contains(
+            "public static string Word(this ServerCardStatus status) => status switch",
+            rules, StringComparison.Ordinal);
+    }
+
+    /// <summary>Drops line comments so a literal scan is neither defeated nor falsely tripped by prose.
+    /// <c>ServerConnection.cs</c> carries exactly one block comment — the licence header at the top — so
+    /// dropping <c>//</c>-prefixed lines is sufficient and cannot eat a string literal.</summary>
+    private static string WithoutComments(string source) =>
+        string.Join("\n", source.Split('\n').Where(line => !line.TrimStart().StartsWith("//", StringComparison.Ordinal)));
+
+    /// <summary>Locates a repo file by walking up from this file's compile-time path — the same helper
+    /// <c>LiteOverviewCardExplainsItselfTests</c> uses, and for the same reason: the assertions above are about
+    /// text that lives in files, not about objects.</summary>
+    private static string ReadRepoFile(string relative, [CallerFilePath] string thisFile = "")
+    {
+        for (var dir = new DirectoryInfo(Path.GetDirectoryName(thisFile)!); dir is not null; dir = dir.Parent)
+        {
+            var candidate = Path.Combine(dir.FullName, relative);
+            if (File.Exists(candidate))
+            {
+                return File.ReadAllText(candidate).Replace("\r\n", "\n", StringComparison.Ordinal);
+            }
+        }
+
+        throw new FileNotFoundException($"Could not locate {relative} walking up from {thisFile}");
+    }
+}

--- a/Lite/MainWindow.xaml
+++ b/Lite/MainWindow.xaml
@@ -65,8 +65,11 @@
                             <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
 
-                        <!-- Status dot (collection freshness) + the muted-bell silence indicator
-                             (#2031: a silenced server must not look healthy-quiet). -->
+                        <!-- Status dot (the CONNECTION check, not collection freshness — this label said
+                             "collection freshness" until #2458, copied from the Darling viewer where it is
+                             true; here IsOnline comes from ServerManager.GetConnectionStatus and the dot's
+                             own tooltip now says so) + the muted-bell silence indicator (#2031: a silenced
+                             server must not look healthy-quiet). -->
                         <StackPanel Grid.Column="0" Grid.RowSpan="2"
                                     Orientation="Horizontal" VerticalAlignment="Center">
                             <!-- #2458: the dot renders the same ServerCardStatus the Overview card does, and

--- a/Lite/MainWindow.xaml
+++ b/Lite/MainWindow.xaml
@@ -69,8 +69,16 @@
                              (#2031: a silenced server must not look healthy-quiet). -->
                         <StackPanel Grid.Column="0" Grid.RowSpan="2"
                                     Orientation="Horizontal" VerticalAlignment="Center">
+                            <!-- #2458: the dot renders the same ServerCardStatus the Overview card does, and
+                                 carries the same first line the card's tooltip opens on. It was a coloured
+                                 circle deriving its own copy of the four-word ladder, so the sidebar and the
+                                 card could disagree about one server; and it is the thing a reader points at
+                                 first, which is #2422's complaint one surface over. The tooltip also says what
+                                 the dot is NOT about: #2457 kept collection freshness on its own banded row on
+                                 the card, and this row has no such band. -->
                             <Ellipse Width="10" Height="10"
                                      Margin="0,0,8,0"
+                                     ToolTip="{Binding Server.Connection.DotTooltip}"
                                      VerticalAlignment="Center">
                                 <Ellipse.Style>
                                     <Style TargetType="Ellipse">

--- a/Lite/Models/ServerConnection.cs
+++ b/Lite/Models/ServerConnection.cs
@@ -192,21 +192,53 @@ public class ServerConnection : INotifyPropertyChanged
     public bool? HasCollectorErrors { get; set; }
 
     /// <summary>
+    /// The sidebar row's status, as a VALUE — the same <see cref="ServerCardStatus"/> the Overview card
+    /// renders (#2458). This row used to derive its own copy of the four-word ladder from this same flag
+    /// pair, on a different type, on a different surface: the sidebar and the card could therefore say
+    /// different things about one server and nothing would notice. Both now read
+    /// <see cref="ServerCardStatusRules.Classify"/>, which is the collapse #2429 argued for — with one
+    /// discriminant there is no flag combination left for the renderings to disagree about.
+    ///
+    /// <para><c>HasCollectorErrors</c> is <c>bool?</c> here and <c>bool</c> on the card, so "not yet
+    /// determined" folds to false. That is the string ladder's own reading, kept deliberately rather than
+    /// inherited by accident: a server whose collector health nobody has established yet is not a server
+    /// reporting failing collectors, and painting it amber would say it was.</para>
+    /// </summary>
+    [JsonIgnore]
+    public ServerCardStatus CardStatus => ServerCardStatusRules.Classify(IsOnline, HasCollectorErrors == true);
+
+    /// <summary>
     /// Computed dot status for the sidebar indicator. One of: "Unknown", "Online", "Warning", "Offline".
     /// Drives the Ellipse fill via DataTrigger in MainWindow.xaml.
     /// </summary>
     [JsonIgnore]
-    public string DotStatus
-    {
-        get
-        {
-            if (IsOnline == true)
-                return HasCollectorErrors == true ? "Warning" : "Online";
-            if (IsOnline == false)
-                return "Offline";
-            return "Unknown"; // null — not yet checked
-        }
-    }
+    public string DotStatus => CardStatus.Word();
+
+    /// <summary>
+    /// What the dot means, for the ToolTip the sidebar Ellipse carries (#2458, answering #2422 one surface
+    /// over). The dot is the thing a reader points at first, and until now it was a coloured circle with no
+    /// way to ask what it meant — the same complaint #2429 answered on the viewer's card and #2451 on Lite's.
+    /// The first line is <see cref="ServerCardStatusRules.Headline"/>, so it is word-for-word what the
+    /// Overview card says for that state.
+    ///
+    /// <para>The middle line is the one this surface specifically needs. #2457 deliberately kept collection
+    /// freshness OUT of the status word and gave it its own banded row on the card; the sidebar has no such
+    /// row and <see cref="ServerConnection"/> carries no last-collection time to build one from, so a green
+    /// dot here is a connection answer being read in a place that offers no freshness answer at all. Saying
+    /// so — and naming where the freshness answer lives — is what stops the reader inferring one from the
+    /// other, which is the #2429/#2422 conflation in miniature.</para>
+    /// </summary>
+    [JsonIgnore]
+    public string DotTooltip => string.Join("\n",
+        CardStatus.Headline(),
+        "It reports the connection check only, not collection freshness — the Overview card's Last Collect row bands that.",
+        DotTooltipAction);
+
+    /// <summary>The line the sidebar dot's tooltip ends on — the gesture the ROW actually supports.
+    /// <c>ServerListView_MouseDoubleClick</c> connects; a single click only selects, so naming one would be
+    /// naming a no-op. Same sentence as the Overview card's closing line with the noun the reader is
+    /// pointing at, because the point of doing every surface is that they share a vocabulary.</summary>
+    private const string DotTooltipAction = "Double-click the row to open this server's tab";
 
     /// <summary>
     /// Display-only property for showing status in UI.

--- a/Lite/Services/LocalDataService.Overview.cs
+++ b/Lite/Services/LocalDataService.Overview.cs
@@ -158,8 +158,10 @@ public sealed class ServerTagPill
 /// (<see cref="ServerSummaryItem.CardBorderBrush"/>), the offline overlay
 /// (<see cref="ServerSummaryItem.IsOffline"/>) and the first line of its tooltip
 /// (<see cref="ServerSummaryItem.StatusTooltip"/>) are all renderings OF THIS — the
-/// (<c>IsOnline</c>, <c>HasCollectorErrors</c>) pair is read here and nowhere else, so no two of them can land
-/// on different answers for the same card. The Darling viewer's twin (<c>ServerCardStatus</c> there) exists
+/// (<c>IsOnline</c>, <c>HasCollectorErrors</c>) pair is read by <see cref="ServerCardStatusRules.Classify"/>
+/// and nowhere else in Lite, so no two of them can land on different answers for the same server — including
+/// the sidebar row's dot, which carried its own copy of this ladder until #2458 and could therefore disagree
+/// with the card about a server both of them were showing. The Darling viewer's twin exists
 /// because two review passes on #2429 each found a flag combination where two independent readings disagreed;
 /// the word and the colour here already carried their own copy of the ladder, and the tooltip would have been
 /// a third.
@@ -192,6 +194,57 @@ public enum ServerCardStatus
     /// <summary>The server has not been connection-checked yet (<c>IsOnline</c> is null): a card built before
     /// the first check completed, not a dead server.</summary>
     Unknown,
+}
+
+/// <summary>
+/// The ladder itself, in ONE function, plus the two renderings every surface shares. #2451 collapsed the
+/// Overview card's word, colour, border, overlay and tooltip onto <see cref="ServerCardStatus"/>; #2458 found
+/// the sidebar row's dot (<c>ServerConnection.DotStatus</c>) deriving the same four words from its own copy of
+/// the same flag pair, on a different type, on a different surface — so the sidebar and the card could say
+/// different things about one server and nothing would notice. They now read this.
+///
+/// <para><b>The word is a CONNECTION word on both surfaces, and that is deliberate.</b> #2457 kept collection
+/// freshness out of it — freshness bands its own row on the card, in its own vocabulary — because #2429 found
+/// the Darling viewer rendering one amber word for a stale collection AND for a metric breach with nothing
+/// telling them apart, which is the card @ehaar wrote in about in #2422. So nothing here takes a freshness
+/// argument, and it must not grow one: a green dot means the last connection check succeeded and says nothing
+/// about whether anything is being collected. <see cref="Headline"/> is where the reader is told that.</para>
+/// </summary>
+public static class ServerCardStatusRules
+{
+    /// <summary>The (<c>IsOnline</c>, <c>HasCollectorErrors</c>) pair, resolved. The only reader of that pair
+    /// in Lite — which is an assertion in <c>LiteOverviewCardExplainsItselfTests</c> rather than a claim in
+    /// prose, because the prose version came to overstate what was true and had to be caught by review on
+    /// #2451.</summary>
+    public static ServerCardStatus Classify(bool? isOnline, bool hasCollectorErrors) => isOnline switch
+    {
+        true when hasCollectorErrors => ServerCardStatus.CollectorErrors,
+        true => ServerCardStatus.Online,
+        false => ServerCardStatus.Offline,
+        _ => ServerCardStatus.Unknown
+    };
+
+    /// <summary>The four words. They are also the DataTrigger values the sidebar keys its dot colour off in
+    /// <c>Lite/MainWindow.xaml</c>, so a fifth word added here would silently fall through to the muted
+    /// default dot rather than fail anything.</summary>
+    public static string Word(this ServerCardStatus status) => status switch
+    {
+        ServerCardStatus.CollectorErrors => "Warning",
+        ServerCardStatus.Online => "Online",
+        ServerCardStatus.Offline => "Offline",
+        _ => "Unknown"
+    };
+
+    /// <summary>What the word means, in words — the first line of whichever tooltip renders it. Every arm names
+    /// the connection check or the collectors explicitly, because the complaint in #2422 was precisely that a
+    /// word and a colour left the reader guessing which axis they were about.</summary>
+    public static string Headline(this ServerCardStatus status) => status switch
+    {
+        ServerCardStatus.CollectorErrors => "Warning — one or more collectors are failing on this server",
+        ServerCardStatus.Online => "Online — the last connection check succeeded",
+        ServerCardStatus.Offline => "Offline — the last connection check failed",
+        _ => "Unknown — this server has not been connection-checked yet",
+    };
 }
 
 public class ServerSummaryItem
@@ -341,7 +394,8 @@ public class ServerSummaryItem
     private static string Minutes(TimeSpan span) =>
         $"{span.TotalMinutes:0.#} minute{(Math.Abs(span.TotalMinutes - 1) < 0.001 ? "" : "s")}";
 
-    /* Connection status. This is the ONE place the (IsOnline, HasCollectorErrors) pair is read; the word, the
+    /* Connection status. The (IsOnline, HasCollectorErrors) pair is resolved by ServerCardStatusRules.Classify
+       and nowhere else in Lite — the sidebar row's dot carried its own copy until #2458 — and the word, the
        colour and the tooltip's first line all render the result. See ServerCardStatus.
 
        Collection freshness is deliberately NOT one of the states here, and that is option 2 in #2452 being
@@ -350,21 +404,9 @@ public class ServerSummaryItem
        one specific thing. Folding freshness in would make one amber word mean two unrelated failures, which
        is the conflation #2429 spent four review rounds untangling on the viewer and the reason #2422 was
        written. Freshness is a third axis: it bands its own row, and the tooltip names it there. */
-    public ServerCardStatus CardStatus => IsOnline switch
-    {
-        true when HasCollectorErrors => ServerCardStatus.CollectorErrors,
-        true => ServerCardStatus.Online,
-        false => ServerCardStatus.Offline,
-        _ => ServerCardStatus.Unknown
-    };
+    public ServerCardStatus CardStatus => ServerCardStatusRules.Classify(IsOnline, HasCollectorErrors);
 
-    public string StatusDisplay => CardStatus switch
-    {
-        ServerCardStatus.CollectorErrors => "Warning",
-        ServerCardStatus.Online => "Online",
-        ServerCardStatus.Offline => "Offline",
-        _ => "Unknown"
-    };
+    public string StatusDisplay => CardStatus.Word();
     public SolidColorBrush StatusBrush => MakeBrush(CardStatus switch
     {
         ServerCardStatus.CollectorErrors => "#FFD54F",  // amber — connected but collectors failing
@@ -431,16 +473,11 @@ public class ServerSummaryItem
        the metrics at all. Fusing the two into one clause would reproduce the ambiguity in prose, so the
        tooltip keeps them on separate lines: what the status word means, then what the rows say. */
 
-    /// <summary>What the status word means, in words — the tooltip's first line. Switches on
+    /// <summary>What the status word means, in words — the tooltip's first line. Renders
     /// <see cref="CardStatus"/>, the same discriminant <see cref="StatusDisplay"/> renders, so a tooltip that
-    /// hangs off a word can never contradict it.</summary>
-    private string StatusHeadline => CardStatus switch
-    {
-        ServerCardStatus.CollectorErrors => "Warning — one or more collectors are failing on this server",
-        ServerCardStatus.Online => "Online — the last connection check succeeded",
-        ServerCardStatus.Offline => "Offline — the last connection check failed",
-        _ => "Unknown — this server has not been connection-checked yet",
-    };
+    /// hangs off a word can never contradict it — and since #2458 it is the SAME sentence the sidebar dot
+    /// shows for that state, so a reader moving between the two surfaces meets one vocabulary.</summary>
+    private string StatusHeadline => CardStatus.Headline();
 
     /// <summary>
     /// The metric rows that are not green, in the card's OWN display strings — "CPU 96% (SQL 90%), Deadlocks 2".


### PR DESCRIPTION
Fixes #2458. Part 2 of #2452; part 1 was #2457, and the type this collapses onto arrived in #2451.

## The last copy of the ladder

`Lite/Models/ServerConnection.cs:199` computed `"Unknown"/"Online"/"Warning"/"Offline"` from its own `(IsOnline, HasCollectorErrors)` pair — the same four-word ladder the Overview card derives, on a different type, on a different surface, from a different instance of the same flags. The sidebar and the card could say different things about one server and nothing would notice. That is the drift #2429 collapsed the viewer's card for and #2451 collapsed Lite's; this was the fourth copy, and #2451's own PR body named it as the next place it could go wrong.

**It is the last of them in Lite, and not the last of them anywhere** — an earlier draft of this description said otherwise and review was right to correct it. See the last section.

## The collapse is the ladder, not the return type

The change that would have looked like a fix and wasn't: give `ServerConnection` a `CardStatus => IsOnline switch { … }` and have `DotStatus` render it. That is still a second ladder — the same flag pair read in a second place, just typed better — and it can still drift from the card's.

So the ladder itself moved into one function:

```csharp
public static class ServerCardStatusRules
{
    public static ServerCardStatus Classify(bool? isOnline, bool hasCollectorErrors) => isOnline switch { … };
    public static string Word(this ServerCardStatus status) => status switch { … };
    public static string Headline(this ServerCardStatus status) => status switch { … };
}
```

`ServerSummaryItem.CardStatus` and `ServerConnection.CardStatus` both call `Classify`. `StatusDisplay` and `DotStatus` are both `CardStatus.Word()`; `StatusHeadline` and the first line of `DotTooltip` are both `CardStatus.Headline()`. The card's brushes stay where they are — hex colours are the card's business, and the sidebar paints its dot from theme resources through XAML `DataTrigger`s — but they still switch on `CardStatus` rather than on the flags, exactly as #2451 left them.

`HasCollectorErrors` is `bool?` on `ServerConnection` and `bool` on the card, so "not yet determined" folds to false. That is the string ladder's own reading, kept deliberately rather than inherited by accident: a server whose collector health nobody has established is not a server reporting failing collectors, and painting it amber would say it was.

## The dot says what it means, and says what it is not about

The sidebar `Ellipse` gets the tooltip the card's dot got in #2451, opening on the same sentence word for word. It is the thing a reader points at first, which is @ehaar's #2422 complaint one surface over from where it was reported.

```
Online — the last connection check succeeded
It reports the connection check only, not collection freshness — the Overview card's Last Collect row bands that.
Double-click the row to open this server's tab
```

The middle line is what this surface specifically needs, and it is #2457's separation being preserved rather than restated. #2457 kept collection freshness **out** of the status word and gave it its own banded row on the card, because folding it in recreates the #2429/#2422 conflation of a stale collection with a failing one. The sidebar has no such row and `ServerConnection` carries no last-collection time to build one from — so a green dot here is a connection answer being read somewhere that offers no freshness answer at all. Naming that, and naming where the freshness answer lives, is what stops a reader inferring one from the other.

`Classify` takes two arguments and `TheDot_CannotBandFreshnessEvenByAccident` pins that signature, so freshness cannot be folded in without changing a line a test names. The failure mode being guarded is a plausible, well-meant edit, not a typo.

The closing line names the gesture **this** surface supports: `ServerListView_MouseDoubleClick` connects, a single click only selects. Same sentence as the card's with the noun the reader is pointing at.

## The pin moved with the ladder, and got wider — because of how it missed this

#2451 wrote `Assert.Equal(1, CountOccurrences(source, "IsOnline switch"))` specifically so a second copy could not reappear. It was true, it stayed true, and the copy it existed to forbid was **already there**:

- it was in **another file**, which the scan never opened; and
- it was written as a chain of `if` statements, not a `switch`, so even a repo-wide scan for that literal would have found nothing.

It evaded the pin on both axes at once, and went on evading it through #2451 and #2457. Loosening it was never on the table; it needed to be pointed at the right invariant.

The count now spans both files and pins the classifier's own parameter list:

```csharp
Assert.Equal(1, CountOccurrences(source, "isOnline switch"));
Assert.Equal(0, CountOccurrences(source, "IsOnline switch"));
Assert.Equal(0, CountOccurrences(sidebar, "sOnline switch"));
```

and `TheFourWords_AreWrittenInExactlyOnePlace` holds the invariant the count was standing in for, syntax-agnostically: the four words are string literals that appear in exactly one function, and none of them is written in `ServerConnection.cs` any more. An `if` chain, a switch, a dictionary and a ternary all have to spell them. Comments are stripped first, because `DotStatus`'s own doc comment legitimately names all four while the code writes none.

## Verification

`Lite.Tests` targets `net10.0-windows` and cannot run on macOS, so the logic was run for real anyway: a throwaway `net10.0` harness **splices `ServerCardStatus`, `ServerCardStatusRules`, `ServerSummaryItem` and the `ServerConnection` members straight out of the shipped files** (a generator reads the source and emits them — never retyped) behind a `System.Windows.Media` shim, with a real project reference to `PerformanceMonitor.Common`. **35 checks, 0 failures**, including every reachable `(IsOnline, HasCollectorErrors)` combination agreeing between the two surfaces on state, on word, and on the tooltip's first line.

Against `dev` that harness **does not compile at all**, because none of the members exist there — so the comparison runs as the identically-expressible subset with the new members reached reflectively:

| | dev | this branch |
|---|---|---|
| the reflective subset | **7 passed / 6 failed** | **13 / 0** |
| the source + XAML scan | **5 passed / 13 failed** | **18 / 0** |

**The 7 that pass on both sides are the controls, and they are the ones a wrong fix breaks first.** Six of them are the two ladders agreeing on every flag combination *today* — which is the honest shape of this defect: it is drift potential, not a live disagreement. That is precisely why the assertions separating the branches are about construction rather than about output, and why a behavioural test alone could never have justified this change.

The seventh control is #2457's: a card whose collection stopped four hours ago still reads a green "Online", so this is not option 2 sneaking in through the sidebar.

The XAML half has to text-scan for the reason #2429 gave — a `ToolTip` attribute lives where no assertion about a C# object can reach it, and removing it compiles perfectly clean.

Whole solution builds, 0 errors. CHANGELOG deliberately untouched — #2395 is an open release-prep PR that owns that file for 3.5.1.

## Two things noted and not fixed here

**The Darling viewer has a fifth copy, and its two surfaces already disagree.** Raised by review, verified, and it is worse than duplication. `DarlingServer.DotStatus` (`Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.cs:116`) derives the same four words from its own flag pair, bound the same way Lite's was. Both it and the viewer's Overview card are stamped from the **same** `ClassifyFreshness(LastCollectionTime, nowUtc)` call — and they answer differently for a never-collected server:

| | viewer sidebar dot | viewer Overview card |
|---|---|---|
| `ServerFreshness.NeverCollected` | `IsOnline = null` → `"Unknown"` → **grey muted dot** | `AwaitingFirstCollection = true` → **"Awaiting first collection", amber** |

That is on `dev` today, not a latent risk. It is a different app, a different `ServerCardStatus` (five members, `Stale` where Lite has `CollectorErrors`), and a different vocabulary decision — the viewer's word is freshness-derived where Lite's is connection-derived — so folding it in here would mean picking that vocabulary inside a Lite PR. Filed separately.

**`Lite/Mcp/McpDiscoveryTools.cs:28` renders a third vocabulary for the same axis** — `"Online"/"Offline"/"Status not checked"` — off `ConnectionStatus.IsOnline`. It is a different type, it never reads collector health so it has no "Warning" state at all, and MCP text is a consumer API whose words downstream automation may key on. Changing them is a decision, not a cleanup, so it is left alone rather than folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
