### PR TITLE
Give the catch-up horizon one home, because the copies of it went stale (refs #2468)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,6 +111,15 @@ jobs:
               # colors. A Darling-theme-only edit is exactly the drift that guard exists to catch,
               # so it has to reach the suite.
               - 'Darling/PerformanceMonitor.Darling.Viewer/Themes/*.xaml'
+              # Same reason again, and a whole tree this time: WatermarkPolicyTests'
+              # TheCatchUpHorizon_IsWrittenDownInExactlyOnePlace (#2468) scans the Darling SERVICE for
+              # comments that restate the catch-up horizon's number instead of pointing at
+              # WatermarkPolicy.MaxCatchup. Three of the twelve sites it was written for live here, so a
+              # Darling-only PR reintroducing one would fire `darling` but not `lite` and skip the step
+              # that runs the guard — caught a day later by the nightly, which is exactly the silent
+              # drift the pin exists to close. The cost is that Darling service PRs now also run the Lite
+              # suite; that is the same trade the `darling` filter already takes for Lite/**/*.xaml.
+              - 'Darling/PerformanceMonitor.Darling.Service/**/!(*.md)'
             installer:
               - 'deprecated/Installer/**/!(*.md)'
               - 'deprecated/Installer.Tests/**/!(*.md)'

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
@@ -417,7 +417,7 @@ public sealed class DarlingCollectorRunner
                            documented first-run window, per database. No clamp is applied HERE because
                            this branch also serves the XE ring-buffer collectors (deadlocks / BPR),
                            where flooring a stale watermark would WRONGLY truncate legitimate catch-up
-                           — those sources roll past 24h on their own. query_store also reaches this
+                           — those sources roll past the catch-up horizon on their own. query_store also
                            branch on Azure SQL DB (#1836) and does need the bound, so it applies
                            WatermarkPolicy.ClampCatchup inside its own cutoff computation: the clamp
                            travels with the collector that needs it instead of with the path. */
@@ -738,7 +738,7 @@ public sealed class DarlingCollectorRunner
 
                 var driverResult = await EnumeratedCollectorDriver.RunAsync<TRow>(
                     items,
-                    /* Per-database watermark refresh + the 24h catch-up clamp, computed INSIDE the loop —
+                    /* Per-database watermark refresh + the catch-up clamp, computed INSIDE the loop —
                        this is the per-item cutoff site the plan's LOUD FLAG requires the clamp to live at.
                        Only query_store (the sole enumeration collector with a per-database timestamp
                        watermark) reaches this; the two snapshot collectors are watermark-less. */

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -1237,7 +1237,7 @@ public sealed class DarlingWorker : BackgroundService
 
         /* #2022 phase 2: the Query Store backfill worker, on its own tick (see s_queryStoreBackfillInterval).
            Fills the two windows the live path discards by design — the 60-minute first-contact tail and
-           24h-clamped outage holes — newest-first, byte-budgeted, strictly BELOW the live path's floor, and
+           clamp-bounded outage holes — newest-first, byte-budgeted, strictly BELOW the live path's floor, and
            never past the raw tier's horizon. Plan capture reads the same live provider the runner does. */
         var queryStoreBackfill = new QueryStoreBackfill(postgres, runner, deltas, _logger, () => config.CapturePlans,
             () => StoreConfigProvider.ClampTextBudgetMb(config.QueryStoreTextBudgetMb));

--- a/Darling/PerformanceMonitor.Darling.Service/QueryStoreBackfill.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/QueryStoreBackfill.cs
@@ -25,7 +25,7 @@ namespace PerformanceMonitor.Darling.Service;
 /// live path never takes. Phase 1 made the LIVE path hole-free, but two bounded windows still
 /// discard history by design: first contact takes only the trailing 60 minutes of a ~30-day
 /// catalog, and post-outage catch-up is clamped to <see cref="WatermarkPolicy.MaxCatchup"/> (the
-/// #1556 incident fix, tightened to 1h by #2102) as a bounded, logged hole. One mechanism fills
+/// #1556 incident fix, tightened by #2102) as a bounded, logged hole. One mechanism fills
 /// both, and every slice of it windows at most <see cref="QueryStoreBackfillState.MaxSliceSpan"/>
 /// at a time (#2102 — the query's cost grows with window width, so an unchunked wide range on a
 /// big database re-times-out forever instead of draining):
@@ -40,7 +40,7 @@ namespace PerformanceMonitor.Darling.Service;
 /// is the #1960 design constraint: the two paths can never race for the same boundary.</para>
 ///
 /// <para><b>Clamp holes (post-outage).</b> An interior gap is invisible to MIN/MAX, so the runner
-/// records it at the moment the 24h clamp fires — (raw watermark, clamped floor), merged wider on
+/// records it at the moment the catch-up clamp fires — (raw watermark, clamped floor), merged wider on
 /// a repeat clamp — under this worker's own <c>collector_state</c> rows
 /// (<see cref="StateCollectorName"/>; deliberately NOT the definition's StateKeys machinery, so
 /// query_store itself still declares none). The worker services the hole newest-first and shrinks

--- a/Lite.Tests/WatermarkPolicyTests.cs
+++ b/Lite.Tests/WatermarkPolicyTests.cs
@@ -7,6 +7,11 @@
  */
 
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 using PerformanceMonitor.Collectors;
 using Xunit;
 
@@ -130,5 +135,102 @@ public sealed class WatermarkPolicyTests
     public void ReadFloor_OnDefault_IsNull()
     {
         Assert.Null(WatermarkPolicy.ReadFloor(default));
+    }
+
+    /// <summary>
+    /// The horizon's NUMBER lives in <see cref="WatermarkPolicy.MaxCatchup"/> and nowhere else.
+    ///
+    /// <para><b>Why this needed asserting.</b> #2102 moved the horizon from 24 hours to one. The constant
+    /// moved, the behaviour moved, and the operator-facing WARNINGs moved with it because they interpolate
+    /// <c>MaxCatchup.TotalHours</c> instead of restating it. What did not move were nine comments across five
+    /// files, each calling it "the 24h catch-up clamp". Nothing misbehaved, no test went red, and no log line
+    /// disagreed — so there was no instrument in this repo that could see it. It was found the way stale prose
+    /// always is: someone read the source, believed it, and reasoned from a 24-hour lever that had not existed
+    /// for months (#2468, filed on exactly that premise).</para>
+    ///
+    /// <para>So the assertion is not "the comments say 1h" — that is the same defect with a fresher number in
+    /// it, and it would go stale the next time the horizon moves. It is that no source discussing the clamp
+    /// states an hours figure at all. The number has one home, and prose has to point at it.</para>
+    /// </summary>
+    [Fact]
+    public void TheCatchUpHorizon_IsWrittenDownInExactlyOnePlace()
+    {
+        /* The concept, wherever it is named. "clamp fires" / "-clamped" / "clamp-bounded" are in the list
+           because the site in DarlingWorker that carried this defect named the clamp without ever using the
+           words "catch-up" — a trigger list built only from the obvious phrase would have missed it. */
+        const string mentions = @"catch-up|ClampCatchup|MaxCatchup|clamp fires|clamp-bounded|-clamped";
+
+        /* An hours figure in any spelling. Minutes are legitimate and common nearby (the 60-minute
+           first-run window, the 15-minute adaptive floor), so the pattern is deliberately hours-only. */
+        const string hours = @"\b\d+\s*-?\s*(h\b|hr\b|hrs\b|hours?\b|hour-)";
+
+        var offenders = new List<string>();
+
+        foreach (var file in ClampSources())
+        {
+            var text = File.ReadAllText(file).Replace("\r\n", "\n", StringComparison.Ordinal);
+
+            foreach (Match mention in Regex.Matches(text, mentions, RegexOptions.IgnoreCase))
+            {
+                /* A window rather than a line: these are wrapped block comments, and the figure and the
+                   concept routinely land on different lines. */
+                var from = Math.Max(0, mention.Index - 220);
+                var to = Math.Min(text.Length, mention.Index + 220);
+                var figure = Regex.Match(text[from..to], hours, RegexOptions.IgnoreCase);
+
+                if (figure.Success)
+                {
+                    offenders.Add($"{Path.GetFileName(file)}: '{figure.Value}' near '{mention.Value}'");
+                }
+            }
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            "the catch-up horizon's number belongs to WatermarkPolicy.MaxCatchup and nowhere else — " +
+            "name the concept and let the constant carry the figure: " + string.Join("; ", offenders.Distinct()));
+    }
+
+    /// <summary>Every shipped source that could describe the clamp: the shared collectors, the Darling
+    /// service's runners, and Lite's twin of them. <c>WatermarkPolicy.cs</c> is excluded because it is the
+    /// one place allowed to write the number down — including its own record of what the horizon used to
+    /// be, which is history worth keeping rather than prose that has gone stale.</summary>
+    private static IEnumerable<string> ClampSources([CallerFilePath] string thisFile = "")
+    {
+        var repo = new DirectoryInfo(Path.GetDirectoryName(thisFile)!);
+        while (repo is not null && !Directory.Exists(Path.Combine(repo.FullName, "PerformanceMonitor.Collectors")))
+        {
+            repo = repo.Parent;
+        }
+
+        Assert.True(repo is not null, $"could not locate the repo root walking up from {thisFile}");
+
+        var roots = new[]
+        {
+            Path.Combine(repo!.FullName, "PerformanceMonitor.Collectors"),
+            Path.Combine(repo.FullName, "Darling", "PerformanceMonitor.Darling.Service"),
+            Path.Combine(repo.FullName, "Lite", "Services"),
+        };
+
+        foreach (var root in roots)
+        {
+            Assert.True(Directory.Exists(root), $"{root} is gone — find where it moved before editing this test");
+
+            foreach (var file in Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories))
+            {
+                /* Skip build output. A local build drops generated .cs under obj/, and a scan that reads
+                   them is asserting about artifacts rather than about the source anyone will edit. */
+                if (file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                    || file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (!string.Equals(Path.GetFileName(file), "WatermarkPolicy.cs", StringComparison.Ordinal))
+                {
+                    yield return file;
+                }
+            }
+        }
     }
 }

--- a/Lite.Tests/WatermarkPolicyTests.cs
+++ b/Lite.Tests/WatermarkPolicyTests.cs
@@ -151,6 +151,20 @@ public sealed class WatermarkPolicyTests
     /// <para>So the assertion is not "the comments say 1h" — that is the same defect with a fresher number in
     /// it, and it would go stale the next time the horizon moves. It is that no source discussing the clamp
     /// states an hours figure at all. The number has one home, and prose has to point at it.</para>
+    ///
+    /// <para><b>If this fails on something that has nothing to do with the horizon, read this first.</b> The
+    /// trigger list is broader than the concept, on purpose and at a known cost. "catch-up" is ordinary English
+    /// in this codebase — the compression backlog catches up, a cold-start sweep body catches up, WAL replay
+    /// catches up — and none of those is <see cref="WatermarkPolicy.MaxCatchup"/>. A future comment that pairs
+    /// one of them with an unrelated hours figure inside the window will fail this test, and it will be a
+    /// SCOPE problem in the list below, not the horizon drifting. Fix it by narrowing the trigger, never by
+    /// widening the window's tolerance for figures.</para>
+    ///
+    /// <para>Narrowing to "catch-up clamp" is the obvious escape and it does not work: two of the twelve sites
+    /// this caught named the clamp without the word "clamp" adjacent ("roll past 24h on their own", two lines
+    /// under "legitimate catch-up"), and two more named it without the words "catch-up" at all
+    /// ("24h-clamped outage holes"). A precise trigger would have missed the ones that hide best. The false
+    /// positive is the price of that, and it is the cheaper failure — it is loud, and it is this paragraph.</para>
     /// </summary>
     [Fact]
     public void TheCatchUpHorizon_IsWrittenDownInExactlyOnePlace()

--- a/Lite.Tests/WatermarkPolicyTests.cs
+++ b/Lite.Tests/WatermarkPolicyTests.cs
@@ -209,21 +209,15 @@ public sealed class WatermarkPolicyTests
     /// service's runners, and Lite's twin of them. <c>WatermarkPolicy.cs</c> is excluded because it is the
     /// one place allowed to write the number down — including its own record of what the horizon used to
     /// be, which is history worth keeping rather than prose that has gone stale.</summary>
-    private static IEnumerable<string> ClampSources([CallerFilePath] string thisFile = "")
+    private static IEnumerable<string> ClampSources()
     {
-        var repo = new DirectoryInfo(Path.GetDirectoryName(thisFile)!);
-        while (repo is not null && !Directory.Exists(Path.Combine(repo.FullName, "PerformanceMonitor.Collectors")))
-        {
-            repo = repo.Parent;
-        }
-
-        Assert.True(repo is not null, $"could not locate the repo root walking up from {thisFile}");
+        var repo = RepoRoot();
 
         var roots = new[]
         {
-            Path.Combine(repo!.FullName, "PerformanceMonitor.Collectors"),
-            Path.Combine(repo.FullName, "Darling", "PerformanceMonitor.Darling.Service"),
-            Path.Combine(repo.FullName, "Lite", "Services"),
+            Path.Combine(repo, "PerformanceMonitor.Collectors"),
+            Path.Combine(repo, "Darling", "PerformanceMonitor.Darling.Service"),
+            Path.Combine(repo, "Lite", "Services"),
         };
 
         foreach (var root in roots)
@@ -246,5 +240,60 @@ public sealed class WatermarkPolicyTests
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// A guard that CI skips on the PRs it guards is a guard that has silently stopped guarding — the
+    /// same failure the horizon pin above exists to close, one layer out.
+    ///
+    /// <para>Raised by review on #2471. That pin lives in <c>Lite.Tests</c> and walks the Darling service
+    /// tree, but <c>build.yml</c>'s "Run Lite tests" step gates on <c>lite</c> / <c>core</c> / <c>root</c>.
+    /// <c>core</c> covers <c>PerformanceMonitor.Collectors</c> and <c>lite</c> covers <c>Lite/Services</c>,
+    /// so two of the three trees were fine — but <c>Darling/PerformanceMonitor.Darling.Service</c> belongs
+    /// only to <c>darling</c>, and three of the twelve sites the pin was written for live there. A
+    /// Darling-only PR reintroducing one would have fired <c>darling</c>, skipped this suite, and been
+    /// caught a day later by the nightly.</para>
+    ///
+    /// <para>So the filter entry is load-bearing, and a filter entry is exactly the kind of thing that gets
+    /// tidied away by someone trimming what looks like an over-broad path. It is asserted rather than
+    /// commented — <c>Darling.Tests</c>' CI-worker-sizing guards already set the precedent for a test
+    /// reading these workflows.</para>
+    /// </summary>
+    [Fact]
+    public void TheLiteSuite_RunsOnEveryTreeTheHorizonPinScans()
+    {
+        var yaml = File.ReadAllText(Path.Combine(RepoRoot(), ".github", "workflows", "build.yml"))
+            .Replace("\r\n", "\n", StringComparison.Ordinal);
+
+        var at = yaml.IndexOf("\n            lite:\n", StringComparison.Ordinal);
+        Assert.True(at > 0, "build.yml's 'lite' path filter is gone — find where it moved before editing this test");
+
+        /* The block runs to the next area key at the same indent; its own entries are indented deeper. */
+        var rest = yaml[(at + 1)..];
+        var next = Regex.Match(rest, "\n            [a-z_]+:\n");
+        var block = next.Success ? rest[..next.Index] : rest;
+
+        Assert.Contains("Darling/PerformanceMonitor.Darling.Service/**/!(*.md)", block, StringComparison.Ordinal);
+
+        /* The step that consumes it. If "Run Lite tests" ever stops reading `lite`, the entry above is
+           decoration and this test is the only thing that would notice. */
+        var step = yaml.IndexOf("name: Run Lite tests", StringComparison.Ordinal);
+        Assert.True(step > 0, "the 'Run Lite tests' step is gone — find where it moved before editing this test");
+        Assert.Contains("steps.filter.outputs.lite == 'true'", yaml[step..(step + 400)], StringComparison.Ordinal);
+    }
+
+    /// <summary>The repo root, located by walking up from this file's compile-time path — the same idiom
+    /// the other source-scanning suites use.</summary>
+    private static string RepoRoot([CallerFilePath] string thisFile = "")
+    {
+        for (var dir = new DirectoryInfo(Path.GetDirectoryName(thisFile)!); dir is not null; dir = dir.Parent)
+        {
+            if (Directory.Exists(Path.Combine(dir.FullName, "PerformanceMonitor.Collectors")))
+            {
+                return dir.FullName;
+            }
+        }
+
+        throw new DirectoryNotFoundException($"could not locate the repo root walking up from {thisFile}");
     }
 }

--- a/Lite/Services/CollectionBackgroundService.cs
+++ b/Lite/Services/CollectionBackgroundService.cs
@@ -233,7 +233,7 @@ public class CollectionBackgroundService : BackgroundService
     }
 
     /// <summary>#2058: fills the Query Store history the live path never takes — the 60-minute
-    /// first-contact tail and 24h-clamped outage holes — newest-first, strictly behind the live
+    /// first-contact tail and clamp-bounded outage holes — newest-first, strictly behind the live
     /// path's floor, never past the resolved query_store retention. See
     /// RemoteCollectorService.QueryStoreBackfill for the worker itself.</summary>
     private async Task RunQueryStoreBackfillIfDueAsync(CancellationToken stoppingToken)

--- a/Lite/Services/RemoteCollectorService.DefinitionRunner.cs
+++ b/Lite/Services/RemoteCollectorService.DefinitionRunner.cs
@@ -236,7 +236,7 @@ public partial class RemoteCollectorService
                            documented first-run window, per database. No clamp is applied HERE because
                            this branch also serves the XE ring-buffer collectors (deadlocks / BPR),
                            where flooring a stale watermark would WRONGLY truncate legitimate catch-up
-                           — those sources roll past 24h on their own. query_store also reaches this
+                           — those sources roll past the catch-up horizon on their own. query_store also
                            branch on Azure SQL DB (#1836) and does need the bound, so it applies
                            WatermarkPolicy.ClampCatchup inside its own cutoff computation: the clamp
                            travels with the collector that needs it instead of with the path. */
@@ -556,7 +556,7 @@ public partial class RemoteCollectorService
 
                 var driverResult = await EnumeratedCollectorDriver.RunAsync<TRow>(
                     items,
-                    /* Per-database watermark refresh + the 24h catch-up clamp, computed INSIDE the loop —
+                    /* Per-database watermark refresh + the catch-up clamp, computed INSIDE the loop —
                        this is the per-item cutoff site the plan's LOUD FLAG requires the clamp to live at.
                        Only query_store (the sole enumeration collector with a per-database timestamp
                        watermark) reaches this; the two snapshot collectors are watermark-less. */

--- a/PerformanceMonitor.Collectors/EnumeratedCollectorDriver.cs
+++ b/PerformanceMonitor.Collectors/EnumeratedCollectorDriver.cs
@@ -109,7 +109,7 @@ public sealed class CycleProbeFailures
 /// The driver owns only the control flow — iteration, cancellation, the per-item catch SHAPE, the
 /// per-item flush, and the interleaved SQL/storage timing. Everything app-specific stays in the
 /// caller's delegates: the SQL connection and per-item query (readItem), the storage engine
-/// (writeBatch), the host store's per-database watermark read and its 24h clamp (perItemWatermark),
+/// (writeBatch), the host store's per-database watermark read and its catch-up clamp (perItemWatermark),
 /// and the log text / display name (onItemComplete / onItemError). This is the seam the plan required:
 /// no app or collector semantics leak into the shared loop.
 /// </para>
@@ -429,7 +429,7 @@ public static class EnumeratedCollectorDriver
             var itemToken = itemBudget?.Token ?? cancellationToken;
             try
             {
-                /* Per-database watermark refresh (query_store): its cutoff — including the 24h catch-up
+                /* Per-database watermark refresh (query_store): its cutoff — including the catch-up
                    clamp — is computed HERE, inside the loop, so each database's commit advances only its
                    own watermark and an abort loses no other database's intervals. Inside the budget on
                    purpose: it is a store read, and a store that has stopped answering is exactly the kind

--- a/PerformanceMonitor.Collectors/QueryStoreCollector.cs
+++ b/PerformanceMonitor.Collectors/QueryStoreCollector.cs
@@ -392,7 +392,7 @@ END;
     /// <c>database_name</c> column, the same precedent the deadlocks / blocked_process_report XE
     /// collectors set. With this, each database's commit advances only its own watermark and an abort
     /// loses nothing. This also relocates query_store's cutoff computation into the per-item loop, which
-    /// is exactly where the 24h catch-up clamp (<see cref="WatermarkPolicy"/>) must be applied — and
+    /// is exactly where the catch-up clamp (<see cref="WatermarkPolicy"/>) must be applied — and
     /// since #1836 the clamp is applied by <see cref="BuildCutoffParameters"/> itself, so it holds on the
     /// Azure per-database path too, where the host reads this same per-database watermark but does not
     /// clamp (that branch is shared with the XE collectors, which must not be clamped).
@@ -1051,7 +1051,7 @@ OPTION(RECOMPILE);";
     /// newer than what this database already has are fetched. Falls back to 60 minutes back when the
     /// database has nothing stored yet.
     ///
-    /// <para>The 24h catch-up clamp (<see cref="WatermarkPolicy"/>) is applied HERE, in the definition,
+    /// <para>The catch-up clamp (<see cref="WatermarkPolicy"/>) is applied HERE, in the definition,
     /// rather than only in the host's enumeration loop (#1836). Query Store is the one
     /// unbounded-persisted source among the collectors — it retains ~30 days — so a service that was
     /// stopped for days must not come back and ask for the entire backlog in one cycle; that is the

--- a/PerformanceMonitor.Collectors/WatermarkPolicy.cs
+++ b/PerformanceMonitor.Collectors/WatermarkPolicy.cs
@@ -51,6 +51,15 @@ public static class WatermarkPolicy
     /// <see cref="QueryStoreBackfillState.MaxSliceSpan"/> so no path ever windows wider than the
     /// steady state the fleet proves (#2102). Everything older is the backfill worker's job.
     /// Exposed so a test pins the boundary.
+    ///
+    /// <para><b>This is the only place the horizon's number is written down, and that is now asserted</b>
+    /// (<c>TheCatchUpHorizon_IsWrittenDownInExactlyOnePlace</c>). #2102 moved it from 24 hours to one, and
+    /// every runner that applies the clamp carried a comment calling it "the 24h catch-up clamp". None of
+    /// them moved with it. Nothing misbehaved and nothing went red, because the operator-facing WARNINGs
+    /// interpolate <see cref="MaxCatchup"/> rather than restating it — so the stale prose was invisible to
+    /// every instrument the repo has, and it survived long enough for #2468 to be filed against a 24-hour
+    /// lever that had not existed for months. Those comments now name the concept and leave the number
+    /// here; the assertion is what stops the next move from doing this again.</para>
     /// </summary>
     public static readonly TimeSpan MaxCatchup = TimeSpan.FromHours(1);
 


### PR DESCRIPTION
Refs #2468 — and **this is not the fan-out fix**. #2468 stays open; the investigation is reported there. This is the correction that has to land before anyone judges it, because the lever the issue names does not exist.

## `MaxCatchup` is one hour, not twenty-four

#2102 moved `WatermarkPolicy.MaxCatchup` from 24 hours to one, for a measured reason still written down in its own remarks:

> a row cap is not a cost cap: the per-database query aggregates and sorts the WHOLE window before TOP or the byte budget can bound anything, so its cost grows with window width. A big database that missed one 60s cycle faced a wider window the next cycle, which cost more and timed out again — a self-sustaining spiral the 24h clamp sat far above and never interrupted.

The constant moved. The behaviour moved. The operator-facing WARNINGs moved with it, because they interpolate `MaxCatchup.TotalHours` rather than restating it. What did not move were **twelve comments across seven files**, eleven of which called it "the 24h catch-up clamp":

| file | |
|---|---|
| `PerformanceMonitor.Collectors/EnumeratedCollectorDriver.cs` | 2 |
| `PerformanceMonitor.Collectors/QueryStoreCollector.cs` | 2 |
| `Darling/…/DarlingCollectorRunner.cs` | 2 |
| `Darling/…/DarlingWorker.cs` | 1 |
| `Darling/…/QueryStoreBackfill.cs` | 2 |
| `Lite/Services/RemoteCollectorService.DefinitionRunner.cs` | 2 |
| `Lite/Services/CollectionBackgroundService.cs` | 1 |

## Why nothing caught it

Nothing misbehaved. No test went red. No log line disagreed — the logs were always right. **There was no instrument in this repo that could see it**, which is why it survived from #2102 through every PR since.

It was found the way stale prose always is: someone read the source and believed it. #2468 was filed on the premise that

> `WatermarkPolicy.ClampCatchup` allows a **24-hour catch-up** per database, so a stale watermark means one cycle reads up to a full day of runtime stats

read straight out of these comments and stated as an established fact. The real bound is **one hour** — twelve times a 5-minute cadence rather than two hundred and eighty-eight — which changes what the evidence in that issue can even mean, and therefore which of its four proposed fixes is right.

## The repair is not a fresher number

Changing "24h" to "1h" is the same defect with a newer figure in it, and it goes stale the next time the horizon moves. The number belongs to `MaxCatchup`; every comment that discusses the clamp now names the **concept** and points at the constant.

One of the twelve was already **correct** — `QueryStoreBackfill` said "tightened to 1h by #2102" — and it was changed too, because being right today is not the property being asserted.

`WatermarkPolicy`'s own remarks keep "the horizon was 24h until … #2102". That is history, not a stale claim, and excluding that one file is what makes it legal.

## The pin

`TheCatchUpHorizon_IsWrittenDownInExactlyOnePlace` scans every shipped `.cs` under `PerformanceMonitor.Collectors`, `Darling/PerformanceMonitor.Darling.Service` and `Lite/Services`, excluding `WatermarkPolicy.cs`, and fails if any text within 220 characters of the clamp being named carries an hours figure.

Three details are deliberate, and each is a way this pin could have been written uselessly:

- **The trigger list includes `-clamped` and `clamp fires`, not just `catch-up`.** The sites in `DarlingWorker` and `CollectionBackgroundService` named the clamp without ever using the words "catch-up" — a trigger list built from the obvious phrase would have missed exactly the two that hide best. (I wrote it that way first; the scan found them.)
- **It matches a window, not a line.** These are wrapped block comments and the figure and the concept routinely land on different lines.
- **It matches hours only.** Minutes are legitimate and common right beside it — the 60-minute first-run window, the 15-minute adaptive floor — so a looser pattern would have been noise.

It also skips `obj/` and `bin/`, because a local build drops generated `.cs` under those and a scan that reads them is asserting about artifacts rather than about source anyone will edit.

## The pin has to actually run — review found it did not

Raised on review, and it is the same failure as the one this PR is about, one layer out: **a guard CI skips on the changes it guards has silently stopped guarding.**

The pin lives in `Lite.Tests` and walks three trees. `build.yml`'s "Run Lite tests" step gates on `lite` / `core` / `root`:

| tree the pin scans | covered by | ok? |
|---|---|---|
| `PerformanceMonitor.Collectors` | `core` | yes |
| `Lite/Services` | `lite` | yes |
| `Darling/PerformanceMonitor.Darling.Service` | **`darling` only** | **no** |

**Three of the twelve sites this pin was written for live in that third tree.** A Darling-only PR putting "24h" back into `DarlingCollectorRunner` would have fired `darling`, skipped the Lite suite entirely, and been caught a day later by the unconditional nightly — which is to say the pin would have worked exactly as well as the comments it replaced.

The `lite` filter now carries `Darling/PerformanceMonitor.Darling.Service/**/!(*.md)`, for the same reason the entry directly above it already exists (`ThemeParityLiteDarlingTests` reads the Darling viewer's theme dictionaries). The cost is real and is written into the comment rather than left implicit — Darling service PRs now also run the Lite suite — and it is the same trade the `darling` filter already takes in the other direction for `Lite/**/*.xaml`.

And it is **asserted**, not commented, because a path filter that looks over-broad is exactly the line someone tidies away. `TheLiteSuite_RunsOnEveryTreeTheHorizonPinScans` parses the `lite` block out of `build.yml` and checks the entry is in it — *and* that "Run Lite tests" still consumes `lite` at all, because without that half the entry could quietly become decoration.

## Verification

`Lite.Tests` targets `net10.0-windows` and cannot run on macOS, so the scan was simulated in Python against both trees — with **both regexes read out of the shipped test file rather than retyped**, so the simulation cannot drift from the assertion it stands in for:

| | dev (`d2a457de`) | this branch |
|---|---|---|
| files scanned | 322 | 322 |
| clamp mentions found | 73 | 77 |
| **offenders** | **11** | **0** |

Whole solution builds, 0 errors. **No behaviour changes** — the only non-comment edits in the diff are the two new tests and the CI path filter. CHANGELOG untouched: #2395 is an open release-prep PR that owns that file for 3.5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
