### PR TITLE
Check the .NET runtimes before installing, instead of after (#2479)

### DIFF
--- a/Darling/Darling.Tests/DarlingRuntimePreflightTests.cs
+++ b/Darling/Darling.Tests/DarlingRuntimePreflightTests.cs
@@ -1,0 +1,343 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// <c>install-darling.ps1</c>'s .NET runtime gate (#2479, item 1).
+///
+/// <para><b>The gap.</b> Both shipped binaries are framework-dependent publishes.
+/// <c>PerformanceMonitor.Darling.Service.exe</c> names <c>Microsoft.AspNetCore.App</c> in its
+/// runtimeconfig.json — unconditionally, because <c>ModelContextProtocol.AspNetCore</c> brings the
+/// framework reference in transitively, so turning <c>mcp.enabled</c> and <c>web.enabled</c> off does not
+/// remove it — and the co-located <c>viewer\</c> publish names <c>Microsoft.WindowsDesktop.App</c>. A stock
+/// Windows Server image has neither. What the operator saw was the .NET host's own "You must install .NET"
+/// error, emitted by the step-2 pre-flight, which then reported "the config is invalid or a server is
+/// unreachable" — a diagnosis that is not merely unhelpful but points at the wrong file.</para>
+///
+/// <para><b>Why the tests are split the way they are.</b> Everything structural — the ordering, the
+/// fail-versus-warn verdict, which switch governs the gate — is pinned by reading the script, the same way
+/// this project pins every other PowerShell invariant it cannot compile
+/// (<c>DarlingInstallLocationTests</c>, <c>DarlingFirewallCheckTests</c>). The version BOUNDARY is not:
+/// deciding whether <c>1.10.0</c> is a .NET 10 runtime is a computation on a string, its failure mode is a
+/// gate that reports success on a box with no runtime at all — strictly worse than no gate, because it
+/// looks like the check ran — and no source-parsing assertion can see it. So that one is executed against
+/// the function as it ships, under <c>powershell.exe</c> (Windows PowerShell 5.1), which is what Windows
+/// Server hands an operator by default.</para>
+/// </summary>
+public class DarlingRuntimePreflightTests
+{
+    private static string InstallScript => ReadRepoFile(Path.Combine("Darling", "tools", "install-darling.ps1"));
+
+    /// <summary>
+    /// The gate must run before the script invokes the service exe at all.
+    ///
+    /// <para>This is the ordering that matters most and the one the defect turned on: the step-2 pre-flight
+    /// is the first thing to RUN <c>PerformanceMonitor.Darling.Service.exe</c>, so on a box with no ASP.NET
+    /// Core runtime it is the pre-flight that surfaces the host error, and the pre-flight's own failure
+    /// message blames the config or an unreachable server. Running the runtime check afterwards would leave
+    /// that wrong diagnosis as the operator's first and loudest signal.</para>
+    /// </summary>
+    [Fact]
+    public void RuntimeGate_RunsBeforeTheServiceExeIsEverInvoked()
+    {
+        var script = InstallScript;
+
+        var gate = script.IndexOf("# -- 1c. Refuse an install the .NET runtimes on this box cannot run", StringComparison.Ordinal);
+        Assert.True(gate >= 0, "install-darling.ps1 no longer gates on the .NET runtimes (#2479)");
+
+        foreach (var (marker, what) in new[]
+        {
+            ("& $serviceExe --test-connection", "the --test-connection pre-flight, which is what surfaces the raw host error today"),
+            ("Copy-Item $samplePath $configPath", "copying darling.sample.json to darling.json"),
+            ("New-EventLog -LogName Application", "registering the Event Log source"),
+            ("& sc.exe create $serviceName", "creating the service"),
+            ("Start-Service -Name $serviceName", "starting the service"),
+        })
+        {
+            var at = script.IndexOf(marker, StringComparison.Ordinal);
+            Assert.True(at >= 0, $"install-darling.ps1 no longer contains {what} ('{marker}')");
+            Assert.True(gate < at, $"the .NET runtime gate must run BEFORE {what} (#2479)");
+        }
+
+        /* And after the install-location guard, which is a pure string decision that costs nothing. There
+           is no point telling somebody to install a runtime for a folder that will be refused anyway. */
+        var location = script.IndexOf("if ($underProfile -or $networkKind) {", StringComparison.Ordinal);
+        Assert.True(location >= 0, "install-darling.ps1 no longer guards the install location (#2187)");
+        Assert.True(location < gate, "the install-location guard is free and must still run first (#2187)");
+    }
+
+    /// <summary>
+    /// The gate has to name the runtime, the version, and where to get it — that triple is the entire
+    /// value of the check, and any one of them missing sends the operator to a search engine.
+    /// </summary>
+    [Fact]
+    public void RuntimeGate_NamesBothFrameworks_TheVersion_AndWhereToGetIt()
+    {
+        var script = InstallScript;
+
+        foreach (var (marker, what) in new[]
+        {
+            ("Microsoft.AspNetCore.App", "the ASP.NET Core shared framework the SERVICE needs"),
+            ("Microsoft.WindowsDesktop.App", "the Desktop shared framework the VIEWER needs"),
+            ("$dotnetMajor = 10", "the required .NET major version"),
+            ("https://dotnet.microsoft.com/download/dotnet/10.0", "where to download both runtimes"),
+            ("ASP.NET Core Runtime $dotnetMajor.0 is not installed", "the refusal naming the missing runtime by its installer's name"),
+            (".NET Desktop Runtime $dotnetMajor.0 is not installed", "the warning naming the missing runtime by its installer's name"),
+        })
+        {
+            Assert.True(
+                script.IndexOf(marker, StringComparison.Ordinal) >= 0,
+                $"install-darling.ps1 no longer states {what} ('{marker}') (#2479)");
+        }
+    }
+
+    /// <summary>
+    /// A missing ASP.NET Core runtime is a refusal; a missing Desktop runtime is a warning that continues.
+    ///
+    /// <para>The asymmetry is the decision, not an oversight. Without ASP.NET Core the thing being
+    /// installed cannot start, so proceeding is never right. Without the Desktop runtime only the viewer
+    /// cannot start, and a headless collector host nobody ever opens a window on is a legitimate
+    /// deployment — refusing it would strand an install that works. Flipping either verdict is a product
+    /// decision and should break this test.</para>
+    /// </summary>
+    [Fact]
+    public void RuntimeGate_RefusesOnAspNetCore_ButOnlyWarnsOnDesktop()
+    {
+        var script = InstallScript;
+
+        var aspNet = ExtractBracedBlock(script, "if (-not (Test-FrameworkMajorPresent $aspNetVersions $dotnetMajor)) {");
+        Assert.Contains("Fail @\"", aspNet, StringComparison.Ordinal);
+        Assert.Contains("Nothing was installed or changed.", aspNet, StringComparison.Ordinal);
+
+        var desktop = ExtractBracedBlock(script, "if (-not (Test-FrameworkMajorPresent $desktopVersions $dotnetMajor)) {");
+        Assert.DoesNotContain("Fail ", desktop, StringComparison.Ordinal);
+        Assert.DoesNotContain("exit ", desktop, StringComparison.Ordinal);
+        Assert.Contains("WARNING", desktop, StringComparison.Ordinal);
+        Assert.Contains("this install continues", desktop, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The gate rides the existing <c>-SkipPreflight</c> switch rather than adding a second one. One
+    /// documented escape hatch for "this script cannot see my box", not two — and the refusal message has
+    /// to say which switch that is, or a false refusal is a dead end.
+    /// </summary>
+    [Fact]
+    public void RuntimeGate_IsGovernedByTheExistingSkipPreflightSwitch()
+    {
+        var script = InstallScript;
+
+        var gate = script.IndexOf("# -- 1c. Refuse an install the .NET runtimes on this box cannot run", StringComparison.Ordinal);
+        Assert.True(gate >= 0, "install-darling.ps1 no longer gates on the .NET runtimes (#2479)");
+
+        var guard = script.IndexOf("if (-not $SkipPreflight) {", gate, StringComparison.Ordinal);
+        Assert.True(guard >= 0, "the .NET runtime gate is no longer governed by -SkipPreflight (#2479)");
+
+        var body = ExtractBracedBlockAt(script, script.IndexOf('{', guard), out _);
+        Assert.Contains("Get-InstalledFrameworkVersions 'Microsoft.AspNetCore.App'", body, StringComparison.Ordinal);
+        Assert.Contains("Get-InstalledFrameworkVersions 'Microsoft.WindowsDesktop.App'", body, StringComparison.Ordinal);
+
+        /* No parallel switch. The param block is the whole contract the operator reads from -? output. */
+        var param = ExtractBracedBlock(script, "param(");
+        Assert.DoesNotContain("SkipRuntime", param, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("SkipDotnet", param, StringComparison.OrdinalIgnoreCase);
+
+        /* A gate with no named way out is a dead end on the one box where it is wrong. */
+        Assert.Contains("-SkipPreflight, which skips", script, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The boundary, executed rather than read.
+    ///
+    /// <para><c>1.10.0</c> and <c>110.0.0</c> both contain the characters <c>10.</c> and neither is .NET 10.
+    /// A <c>-like '10.*'</c> or a bare <c>-match '10\.'</c> gets them wrong in the direction that costs
+    /// most: the gate reports success, the install proceeds, and the operator gets the raw host error the
+    /// gate exists to replace — now with a green line above it claiming the runtime is present.</para>
+    ///
+    /// <para>Run under <c>powershell.exe</c> (Windows PowerShell 5.1) deliberately, which pins 5.1
+    /// compatibility of the function's syntax at the same time.</para>
+    /// </summary>
+    [Fact]
+    public void TestFrameworkMajorPresent_DecidesTheBoundary_AsShipped()
+    {
+        var cases = new (string Versions, bool Expected)[]
+        {
+            /* What a box with the runtime actually looks like: one or more full version folders. */
+            ("@('10.0.11')", true),
+            ("@('10.0.0')", true),
+            ("@('9.0.14','10.0.11')", true),
+            /* Preview and RC folder names are still .NET 10, and refusing them would refuse a box that runs. */
+            ("@('10.0.0-preview.7.25380.108')", true),
+            ("@('10.0.0-rc.2.25451.107')", true),
+            /* The wrong major. Roll-forward crosses patch and minor by default, never major, so an 11 does
+               not satisfy a net10.0 app any more than a 9 does. */
+            ("@('9.0.14')", false),
+            ("@('8.0.20','9.0.14')", false),
+            ("@('11.0.0')", false),
+            /* The false-pass cases. A text-prefix test says true to every one of these. */
+            ("@('1.10.0')", false),
+            ("@('110.0.0')", false),
+            ("@('0.10.0','1.10.5')", false),
+            /* ...and must still find the real one when it is sitting next to them. */
+            ("@('1.10.0','110.0.0','10.0.11')", true),
+            /* Nothing installed, and junk in the folder. Neither is a runtime. */
+            ("@()", false),
+            ("@('')", false),
+            ("@('   ')", false),
+            ("@('not-a-version')", false),
+        };
+
+        var probe = new StringBuilder();
+        probe.AppendLine(ExtractFunction(InstallScript, "Test-FrameworkMajorPresent"));
+        foreach (var (versions, _) in cases)
+        {
+            probe.AppendLine($"if (Test-FrameworkMajorPresent {versions} 10) {{ 'True' }} else {{ 'False' }}");
+        }
+
+        var answers = RunWindowsPowerShell(probe.ToString());
+        Assert.Equal(cases.Length, answers.Count);
+
+        var wrong = new List<string>();
+        for (var i = 0; i < cases.Length; i++)
+        {
+            var (versions, expected) = cases[i];
+            if (!string.Equals(answers[i], expected.ToString(), StringComparison.Ordinal))
+            {
+                wrong.Add($"major-present({versions}, 10) returned {answers[i]}, expected {expected}");
+            }
+        }
+
+        Assert.True(wrong.Count == 0, "install-darling.ps1's runtime version boundary is wrong:\n  " + string.Join("\n  ", wrong));
+    }
+
+    /// <summary>
+    /// The "what did you find" line, executed. An operator staring at a refusal needs to know whether the
+    /// box has the wrong major or nothing at all, and an empty string there reads as a formatting bug.
+    /// </summary>
+    [Fact]
+    public void FormatFrameworkVersionList_SaysNothing_WhenNothingIsInstalled()
+    {
+        var probe = new StringBuilder();
+        probe.AppendLine(ExtractFunction(InstallScript, "Format-FrameworkVersionList"));
+        probe.AppendLine("Format-FrameworkVersionList @()");
+        probe.AppendLine("Format-FrameworkVersionList @('9.0.14','8.0.20','9.0.14')");
+
+        var answers = RunWindowsPowerShell(probe.ToString());
+
+        Assert.Equal(2, answers.Count);
+        Assert.Equal("nothing", answers[0]);
+        Assert.Equal("8.0.20, 9.0.14", answers[1]);
+    }
+
+    /// <summary>Runs a script under Windows PowerShell 5.1 and returns its non-blank output lines — the
+    /// same idiom <c>DarlingInstallLocationTests</c> uses to execute an extracted function as it ships.</summary>
+    private static List<string> RunWindowsPowerShell(string script)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"darling-2479-{Guid.NewGuid():N}.ps1");
+        File.WriteAllText(path, script);
+        try
+        {
+            using var process = Process.Start(new ProcessStartInfo("powershell.exe", $"-NoProfile -ExecutionPolicy Bypass -File \"{path}\"")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            });
+            Assert.NotNull(process);
+
+            var stdout = process!.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            process.WaitForExit(60_000);
+
+            Assert.True(string.IsNullOrWhiteSpace(stderr), $"powershell.exe reported an error running the extracted function:\n{stderr}");
+
+            var lines = new List<string>();
+            foreach (var line in stdout.Split('\n'))
+            {
+                var trimmed = line.Trim();
+                if (trimmed.Length > 0) { lines.Add(trimmed); }
+            }
+
+            return lines;
+        }
+        finally
+        {
+            try { File.Delete(path); } catch (IOException) { /* best-effort */ }
+        }
+    }
+
+    /// <summary>Returns the full <c>function NAME(...) { ... }</c> definition text from the script.</summary>
+    private static string ExtractFunction(string script, string name)
+    {
+        var start = script.IndexOf("function " + name, StringComparison.Ordinal);
+        Assert.True(start >= 0, $"install-darling.ps1 no longer defines {name} (#2479)");
+
+        ExtractBracedBlockAt(script, script.IndexOf('{', start), out var end);
+        return script.Substring(start, end - start + 1);
+    }
+
+    private static string ExtractBracedBlock(string script, string header)
+    {
+        var start = script.IndexOf(header, StringComparison.Ordinal);
+        Assert.True(start >= 0, $"expected '{header}' in install-darling.ps1");
+        return ExtractBracedBlockAt(script, script.IndexOf('{', start), out _);
+    }
+
+    private static string ExtractBracedBlockAt(string script, int open, out int end)
+    {
+        Assert.True(open >= 0, "expected an opening brace");
+
+        var depth = 0;
+        for (var i = open; i < script.Length; i++)
+        {
+            if (script[i] == '{') { depth++; }
+            else if (script[i] == '}')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    end = i;
+                    return script.Substring(open + 1, i - open - 1);
+                }
+            }
+        }
+
+        Assert.Fail("unbalanced braces while extracting a block from install-darling.ps1");
+        end = -1;
+        return string.Empty;
+    }
+
+    /// <summary>Walks up from the test output directory to the repo root (the directory holding
+    /// <c>PerformanceMonitor.sln</c>).</summary>
+    private static string ReadRepoFile(string relativePath)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        for (var i = 0; i < 10 && directory is not null; i++)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "PerformanceMonitor.sln")))
+            {
+                var path = Path.Combine(directory.FullName, relativePath);
+                Assert.True(File.Exists(path), $"expected {path} to exist");
+                return File.ReadAllText(path);
+            }
+
+            directory = directory.Parent;
+        }
+
+        Assert.Fail("could not find the repo root (the directory holding PerformanceMonitor.sln)");
+        return string.Empty;
+    }
+}

--- a/Darling/README.md
+++ b/Darling/README.md
@@ -37,7 +37,16 @@ Nothing is installed on the monitored SQL Servers by either edition beyond two l
 - **Windows** for the service host (Windows-service lifetime, DPAPI password protection) and for the viewer (WPF). Monitored servers can be SQL Server 2016–2025, Azure SQL Managed Instance, AWS RDS for SQL Server, or Azure SQL Database.
 - **A PostgreSQL store — bundled or your own.** In managed mode (the shipped default, see [Managed Bundled PostgreSQL](#managed-bundled-postgresql)) the service runs its own bundled PostgreSQL 18 + TimescaleDB and no database provisioning is needed. To bring your own instead, PostgreSQL 16 or newer is recommended (developed and validated against PostgreSQL 18) with a database and a login the service can create tables in — and if that store has TimescaleDB, size its background workers before you rely on compression, because the stock PostgreSQL defaults cannot run the policies (see [Background workers](#background-workers-sizing-an-unmanaged-store-and-what-happens-if-you-dont)).
 - **TimescaleDB is optional and auto-adopted.** If the extension is installed (or pre-created by an administrator) in the store database, the service detects it at startup and automatically converts the collector tables to hypertables with compression; without it, the service runs in plain-PostgreSQL mode, which is fully supported. No configuration flag either way.
-- **.NET 10** to build and run.
+- **Two .NET 10 runtimes on the host**, from <https://dotnet.microsoft.com/download/dotnet/10.0>. Both
+  shipped binaries are framework-dependent, and a stock Windows Server image has neither:
+  - **ASP.NET Core Runtime 10** for the service. Required unconditionally — the MCP package brings the
+    ASP.NET Core framework reference in transitively, so it is needed whether or not you ever enable MCP
+    or the web dashboard.
+  - **.NET Desktop Runtime 10** for the viewer (WPF). Not needed on a headless collector host, and not
+    needed for a remote seat installed from the viewer's own `Setup.exe`, which is self-contained.
+
+  `install-darling.ps1` checks both before it installs anything: it refuses when ASP.NET Core is missing
+  and warns when the Desktop runtime is. The .NET 10 SDK covers both if you are building from source.
 
 Build from the repository root:
 

--- a/Darling/tools/install-darling.ps1
+++ b/Darling/tools/install-darling.ps1
@@ -15,6 +15,10 @@ C:\PerformanceMonitorDarling). What it does, in order:
      that is neither you nor an administrator, and a profile folder grants nothing to it, so the
      service installs cleanly and then dies at the bundled PostgreSQL's first step (#2185, #2187).
      Extract to a machine-scoped local path such as C:\PerformanceMonitorDarling instead.
+  1c. REFUSES an install when the ASP.NET Core Runtime 10 is missing, and WARNS when the .NET Desktop
+     Runtime 10 is (#2479). Both shipped binaries are framework-dependent; a stock Windows Server image
+     has neither runtime, and the failure is the .NET host's own "You must install .NET" error with
+     nothing of ours on it. Part of the pre-flight, so -SkipPreflight skips it.
   2. Optional pre-flight: runs `--test-connection` and shows the per-server PASS/FAIL lines
      (continue-or-abort prompt on failure; -SkipPreflight to skip).
   3. Registers the Windows Event Log source 'PerformanceMonitor Darling' (requires elevation —
@@ -38,7 +42,8 @@ C:\PerformanceMonitorDarling). What it does, in order:
 Uninstall with uninstall-darling.ps1 (same folder).
 
 .PARAMETER SkipPreflight
-Skip the --test-connection pre-flight gate.
+Skip BOTH pre-flight gates: the .NET runtime check (1c) and the --test-connection probe (2). The runtime
+check is the escape hatch for a private or xcopy runtime layout this script cannot see.
 
 .PARAMETER NoShortcuts
 Do not create the viewer shortcuts.
@@ -63,6 +68,12 @@ $serviceExe = Join-Path $root 'PerformanceMonitor.Darling.Service.exe'
 $viewerExe = Join-Path $root 'viewer\PerformanceMonitor.Darling.Viewer.exe'
 $configPath = Join-Path $root 'darling.json'
 $samplePath = Join-Path $root 'darling.sample.json'
+
+# The .NET major both shipped binaries are built against, and the one page that offers every installer
+# for it. Kept beside the other script-scope facts so a framework bump is one edit, and deliberately the
+# SAME url the UAT onboarding prints - a tester who reads both should not be sent to two places.
+$dotnetMajor = 10
+$dotnetDownloadUrl = 'https://dotnet.microsoft.com/download/dotnet/10.0'
 
 function Fail([string]$message) { Write-Host "ERROR: $message" -ForegroundColor Red; exit 1 }
 
@@ -164,6 +175,96 @@ function Get-NetworkPathKind([string]$path) {
     if ($psDrive -and -not [string]::IsNullOrWhiteSpace($psDrive.DisplayRoot)) { return 'mapped drive' }
 
     return $null
+}
+
+# Every place the .NET host looks for a shared framework, in the order it looks. Used by the runtime gate
+# at 1c, which has to answer "can these binaries start at all" on a box where dotnet.exe may not exist.
+function Get-DotnetRootCandidates {
+    $roots = New-Object 'System.Collections.Generic.List[string]'
+
+    # DOTNET_ROOT wins here because it wins for the host: an operator who redirected the runtime is not
+    # someone whose install should be refused for looking in the wrong place.
+    foreach ($fromEnv in @($env:DOTNET_ROOT, ${env:DOTNET_ROOT_X64})) {
+        if (-not [string]::IsNullOrWhiteSpace($fromEnv)) { $roots.Add($fromEnv) }
+    }
+
+    # Where the official installers record themselves. The key is HKLM:\SOFTWARE\dotnet - NOT under
+    # Microsoft\ - and reading it is what finds an install that was pointed somewhere other than
+    # Program Files. Its absence proves nothing, so the default location below is checked regardless.
+    try {
+        $recorded = (Get-ItemProperty -Path 'HKLM:\SOFTWARE\dotnet\Setup\InstalledVersions\x64' -Name 'InstallLocation' -ErrorAction Stop).InstallLocation
+        if (-not [string]::IsNullOrWhiteSpace($recorded)) { $roots.Add($recorded) }
+    }
+    catch {
+        # No registry entry, or an unreadable one. Fall through.
+    }
+
+    foreach ($programFiles in @($env:ProgramW6432, $env:ProgramFiles)) {
+        if (-not [string]::IsNullOrWhiteSpace($programFiles)) { $roots.Add((Join-Path $programFiles 'dotnet')) }
+    }
+
+    return $roots
+}
+
+# The version folder names present for one shared framework, e.g. '10.0.11' for Microsoft.AspNetCore.App.
+# Returns an empty list when the framework is not installed anywhere this can see.
+function Get-InstalledFrameworkVersions([string]$frameworkName) {
+    $versions = New-Object 'System.Collections.Generic.List[string]'
+
+    foreach ($dotnetRoot in (Get-DotnetRootCandidates)) {
+        $frameworkDir = Join-Path (Join-Path $dotnetRoot 'shared') $frameworkName
+        if (-not (Test-Path -LiteralPath $frameworkDir)) { continue }
+        foreach ($child in @(Get-ChildItem -LiteralPath $frameworkDir -Directory -ErrorAction SilentlyContinue)) {
+            $versions.Add($child.Name)
+        }
+    }
+
+    # `dotnet --list-runtimes` is the authoritative answer and sees layouts the three guesses above do
+    # not, but it is a SUPPLEMENT rather than the primary check: a box with neither runtime installed
+    # frequently has no dotnet.exe on it at all, and that is precisely the box this gate exists for.
+    $muxer = Get-Command 'dotnet' -CommandType Application -ErrorAction SilentlyContinue
+    if ($muxer) {
+        try {
+            foreach ($line in @(& $muxer.Source --list-runtimes 2>$null)) {
+                if ($line -match ('^' + [Regex]::Escape($frameworkName) + '\s+(\S+)\s')) { $versions.Add($Matches[1]) }
+            }
+        }
+        catch {
+            # A dotnet.exe that cannot list its own runtimes tells us nothing the directory scan did not.
+        }
+    }
+
+    return $versions
+}
+
+# True when at least one of $versions is a build of major version $major.
+#
+# The test is on the PARSED leading integer, never a text prefix. '1.10.0' and '110.0.0' both contain the
+# characters '10.' and neither one is .NET 10, so a -like '10.*' or a bare -match '10\.' waves a box
+# through with no runtime on it and hands the operator back the raw host error this gate exists to
+# replace - the worse of the two failures, because it looks like the check ran.
+#
+# MAJOR is the right granularity because it is the granularity the host rolls forward at: a net10.0 app
+# rolls forward across patch and minor by default but never across major, so any 10.x satisfies these
+# binaries and an 11.x does not.
+function Test-FrameworkMajorPresent([string[]]$versions, [int]$major) {
+    if ($null -eq $versions) { return $false }
+
+    foreach ($version in $versions) {
+        if ([string]::IsNullOrWhiteSpace($version)) { continue }
+        if ($version -match '^\s*(\d+)(?:\.|$)') {
+            if ([int]$Matches[1] -eq $major) { return $true }
+        }
+    }
+
+    return $false
+}
+
+# What the gate says it found. 'nothing' rather than an empty string, because a blank there reads as a
+# formatting bug and sends the operator looking in the wrong place.
+function Format-FrameworkVersionList([string[]]$versions) {
+    if ($null -eq $versions -or $versions.Count -eq 0) { return 'nothing' }
+    return (($versions | Sort-Object -Unique) -join ', ')
 }
 
 # -- 1. Environment checks ------------------------------------------------------------------------
@@ -287,6 +388,74 @@ Nothing was installed or changed.
     Write-Host 'this is a question. If it has NOT been, the service will stop working the moment it restarts.' -ForegroundColor Yellow
     $answer = Read-Host 'Point the service at this folder anyway? [y/N]'
     if ($answer -notmatch '^[Yy]') { exit 4 }
+}
+
+# -- 1c. Refuse an install the .NET runtimes on this box cannot run (#2479) ------------------------
+# The first thing a new operator hits and the least self-explanatory. Both shipped binaries are
+# FRAMEWORK-DEPENDENT publishes, so both name a shared framework in their runtimeconfig.json and neither
+# carries one:
+#
+#   PerformanceMonitor.Darling.Service.exe -> Microsoft.NETCore.App + Microsoft.AspNetCore.App
+#   viewer\PerformanceMonitor.Darling.Viewer.exe -> Microsoft.NETCore.App + Microsoft.WindowsDesktop.App
+#
+# ASP.NET Core is required UNCONDITIONALLY, which is the part nobody expects: the MCP tools reference
+# ModelContextProtocol.AspNetCore, which brings the Microsoft.AspNetCore.App framework reference in
+# transitively, so the framework is named in the runtimeconfig whether or not mcp.enabled and
+# web.enabled are ever turned on. Setting them false does not make the requirement go away.
+#
+# A stock Windows Server image has neither runtime. Without this gate the operator's first signal is the
+# .NET host's own error - "You must install .NET to run this application" - printed BY THE PRE-FLIGHT AT
+# STEP 2, which then reports "the config is invalid or a server is unreachable" and offers to install
+# anyway. That diagnosis is not merely unhelpful, it is wrong, and it points at the config file. So this
+# has to run before step 2 touches the exe at all.
+#
+# Governed by -SkipPreflight rather than a switch of its own, because it is the same kind of gate: a
+# question asked before anything is created, answered from the operator's machine, and worth bypassing
+# only when the operator knows something this script cannot see.
+if (-not $SkipPreflight) {
+    $aspNetVersions = @(Get-InstalledFrameworkVersions 'Microsoft.AspNetCore.App')
+    $desktopVersions = @(Get-InstalledFrameworkVersions 'Microsoft.WindowsDesktop.App')
+
+    if (-not (Test-FrameworkMajorPresent $aspNetVersions $dotnetMajor)) {
+        Fail @"
+The ASP.NET Core Runtime $dotnetMajor.0 is not installed, and the service cannot start without it.
+
+  Need:  ASP.NET Core Runtime $dotnetMajor.0 (x64). The Hosting Bundle contains it and also works.
+  Found: $(Format-FrameworkVersionList $aspNetVersions)
+  Get:   $dotnetDownloadUrl
+
+This is required whether or not you ever enable MCP or the web dashboard - the MCP package brings the
+ASP.NET Core framework reference in transitively, so the service names it at startup either way.
+
+Install it and run this script again. Nothing was installed or changed.
+
+If this machine DOES have it in a layout this check cannot see, re-run with -SkipPreflight, which skips
+this gate and the --test-connection probe together.
+"@
+    }
+
+    # A WARNING and not a refusal, and the asymmetry is deliberate. A missing ASP.NET Core runtime means
+    # the thing being installed cannot run; a missing Desktop runtime means only that the viewer cannot,
+    # and a headless collector host that nobody ever opens a window on is a legitimate deployment. What
+    # it must not do is stay quiet, because this script creates Desktop and Start Menu shortcuts a few
+    # steps from here and a tester will double-click one.
+    #
+    # Scoped to the co-located viewer\ folder on purpose: the remote-seat viewer installed from the
+    # Velopack Setup.exe is a SELF-CONTAINED publish and needs no Desktop runtime at all, so this is a
+    # statement about this box, not about every seat.
+    if (-not (Test-FrameworkMajorPresent $desktopVersions $dotnetMajor)) {
+        Write-Host ''
+        Write-Host "WARNING: the .NET Desktop Runtime $dotnetMajor.0 is not installed." -ForegroundColor Yellow
+        Write-Host "  Found: $(Format-FrameworkVersionList $desktopVersions)" -ForegroundColor Yellow
+        Write-Host "  Get:   $dotnetDownloadUrl" -ForegroundColor Yellow
+        Write-Host ''
+        Write-Host 'The SERVICE does not need it and this install continues. The bundled viewer does: the Desktop and' -ForegroundColor Yellow
+        Write-Host 'Start Menu shortcuts this script creates will fail with the .NET host error until it is installed.' -ForegroundColor Yellow
+        Write-Host ''
+    }
+    else {
+        Write-Host "Runtime check passed (ASP.NET Core $dotnetMajor and .NET Desktop $dotnetMajor present)." -ForegroundColor Green
+    }
 }
 
 if (-not (Test-Path $configPath)) {


### PR DESCRIPTION
Item 1 of #2479, and the one a UAT tester hits first.

## What was wrong

Both shipped binaries are **framework-dependent** publishes, so both name a shared framework in their `runtimeconfig.json` and neither carries one. Verified against the actual build output rather than the summary:

```
PerformanceMonitor.Darling.Service.runtimeconfig.json
  "frameworks": [ Microsoft.NETCore.App 10.0.0, Microsoft.AspNetCore.App 10.0.0 ]
```

and `PerformanceMonitor.Darling.Viewer.csproj` is `net10.0-windows` + `UseWPF=true`, published into the zip's `viewer\` folder by `dotnet publish ... -c Release -o publish/DarlingViewer` — no `--self-contained` — so it takes `Microsoft.WindowsDesktop.App` from the box.

The ASP.NET Core requirement is **unconditional**. `ModelContextProtocol.AspNetCore` brings the framework reference in transitively, so the framework is named whether or not `mcp.enabled` and `web.enabled` are ever turned on. Setting them false does not remove it.

A stock Windows Server image has neither runtime, and what the operator got was worse than nothing: the step-2 pre-flight is the first thing that *runs* the service exe, so it is the pre-flight that surfaces the .NET host's `You must install .NET to run this application` — and the script then reports

> `Pre-flight FAILED (exit N) - the config is invalid or a server is unreachable.`
> `Install anyway? A monitoring service may legitimately be installed while a target is down. [y/N]`

That diagnosis is not merely unhelpful; it points at the wrong file.

## What this does

A new step **1c**, after the install-location guard (a pure string decision that costs nothing, and there is no point telling somebody to install a runtime for a folder about to be refused) and **before** step 2 touches the exe:

- **Missing ASP.NET Core 10 → refusal**, naming the runtime, the version, what was found instead, and <https://dotnet.microsoft.com/download/dotnet/10.0>. The service cannot start without it, so proceeding is never right.
- **Missing Desktop 10 → warning that continues.** A headless collector host nobody opens a window on is a legitimate deployment. But it must not be silent: this script creates Desktop and Start Menu shortcuts a few steps later and a tester will double-click one. Scoped to the co-located `viewer\` folder on purpose — the remote-seat viewer from the Velopack `Setup.exe` is self-contained and needs no Desktop runtime at all.

Detection resolves the dotnet root the way the host does — `DOTNET_ROOT`, then `HKLM:\SOFTWARE\dotnet`'s recorded `InstallLocation`, then Program Files — and enumerates `shared\<framework>\<version>`. `dotnet --list-runtimes` is folded in as a **supplement**, not the primary check: a box with neither runtime installed frequently has no `dotnet.exe` on it at all, which is precisely the box this gate exists for.

It rides the existing `-SkipPreflight` switch rather than adding a second one, and the refusal names it. A check that can be wrong about a private runtime layout needs one documented way past it, not a dead end.

`Darling/README.md`'s `- **.NET 10** to build and run.` is replaced with the two runtimes, which one each binary needs, and the note that ASP.NET Core is not conditional on MCP.

## The boundary, and why it is executed rather than read

`1.10.0` and `110.0.0` both contain the characters `10.` and neither is .NET 10. A `-like '10.*'` gets both wrong in the direction that costs most: the gate reports success, the install proceeds, and the operator gets back the raw host error this gate exists to replace — now with a green line above it claiming the runtime is present. So the test is on the parsed leading integer. Major is the right granularity because it is what the host rolls forward at: any 10.x satisfies a `net10.0` app and an 11.x does not.

## Verification

- **Executed the shipped function**, extracted from `install-darling.ps1` exactly as the test does, over all 16 boundary cases plus the two `Format-FrameworkVersionList` cases. All 18 match. Run in a `mcr.microsoft.com/powershell` container (PowerShell 7 on Linux) because macOS has no PowerShell — the functions use no 7-only syntax, and `DarlingRuntimePreflightTests` re-runs the identical probe under `powershell.exe` (5.1) on the Windows CI job, which is the host that matters.
- `Darling.Tests` builds clean, 0 errors.
- Every new assertion fails against `dev`: none of `Microsoft.AspNetCore.App`, `Microsoft.WindowsDesktop.App`, `$dotnetMajor = 10`, `dotnet/10.0` or `Test-FrameworkMajorPresent` exists in `dev`'s `install-darling.ps1`.
- **Not verified:** the check has not been run against a real Windows Server with a runtime genuinely absent. Manual verification note for whoever does: on a box with only the Desktop runtime, `.\install-darling.ps1` should refuse before probing any SQL Server and name ASP.NET Core; with only ASP.NET Core it should warn about the shortcuts and continue.

## Onboarding

Makes the second bullet of `docs/uat-onboarding.md` §1.1 Prerequisites (#2476) stop needing to say *"`install-darling.ps1` does **not** check for them, and a missing runtime surfaces as the raw .NET host error."* The section should still list both runtimes — installing them first is still faster than being refused — but the workaround sentence goes.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
