### PR TITLE
Say which seat this viewer has, once, instead of one refusal at a time (#2479)

### DIFF
--- a/Darling/Darling.Tests/ViewerSeatIndicatorTests.cs
+++ b/Darling/Darling.Tests/ViewerSeatIndicatorTests.cs
@@ -1,0 +1,254 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
+using PerformanceMonitor.Darling.Viewer;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// The global read-only seat indicator (#2479, items 3 and 4).
+///
+/// <para><b>What it replaces.</b> #2400 asked why a viewer on a jumpbox refuses "Current Active Queries",
+/// and #2403 answered by rewriting the individual refusals — four better messages, and the same discovery
+/// model: you learn your seat at the moment a write is denied. The probe has existed since V8 and its
+/// answer was never shown anywhere you could look on purpose.</para>
+///
+/// <para><b>The half these tests exist to protect.</b> <c>DetectReadOnlyAsync</c> fails safe to read-only
+/// for an unexpected RESPONSE but raises <see cref="ViewerStoreUnreachableException"/> for a failure to
+/// REACH the store — a split #2117 built deliberately, because collapsing them told an operator whose
+/// service was simply down to go and change a database role. A status field is exactly where that
+/// distinction gets quietly re-collapsed, so both the state machine and the connect flow's arms are
+/// pinned.</para>
+/// </summary>
+public class ViewerSeatIndicatorTests
+{
+    /// <summary>
+    /// Four states, four distinct labels, and "unreachable" must never read as "read-only" — the whole
+    /// point of keeping <see cref="ViewerStoreUnreachableException"/> a separate arm.
+    /// </summary>
+    [Fact]
+    public void EveryState_HasItsOwnLabel_AndUnreachableNeverReadsAsReadOnly()
+    {
+        var texts = new List<string>();
+        foreach (ViewerSeatState state in Enum.GetValues<ViewerSeatState>())
+        {
+            var text = ViewerSeatIndicator.Text(state);
+            Assert.StartsWith("Seat:", text, StringComparison.Ordinal);
+            texts.Add(text);
+        }
+
+        Assert.Equal(texts.Count, new HashSet<string>(texts, StringComparer.Ordinal).Count);
+
+        Assert.Equal("Seat: read-only", ViewerSeatIndicator.Text(ViewerSeatState.ReadOnly));
+        Assert.Equal("Seat: read-write", ViewerSeatIndicator.Text(ViewerSeatState.ReadWrite));
+        Assert.DoesNotContain("read-only", ViewerSeatIndicator.Text(ViewerSeatState.Unreachable), StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The unreachable tooltip must actively DENY the read-only reading, and must not send the operator
+    /// at a role. Nothing about the seat was measured, so nothing about the seat is claimed.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void UnreachableToolTip_DeniesTheReadOnlyReading_AndNamesNoRole(bool storeIsOnThisMachine)
+    {
+        var tip = ViewerSeatIndicator.ToolTip(ViewerSeatState.Unreachable, storeIsOnThisMachine);
+
+        Assert.Contains("NOT a read-only seat", tip, StringComparison.Ordinal);
+        Assert.DoesNotContain("connectAs", tip, StringComparison.Ordinal);
+        Assert.DoesNotContain("network.role", tip, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The read-only tooltip is where #2479 item 4's answer lives: the seat is read-only BY DESIGN on a
+    /// remote seat, because <c>postgres.network.role</c> defaults to the restricted role while local
+    /// <c>postgres.connectAs</c> defaults to <c>admin</c>. Both defaults are named in both placements —
+    /// a tooltip that names only the likely one is wrong exactly when the operator most needs it.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ReadOnlyToolTip_NamesBothDefaults_WhatIsBlocked_AndHowToChangeIt(bool storeIsOnThisMachine)
+    {
+        var tip = ViewerSeatIndicator.ToolTip(ViewerSeatState.ReadOnly, storeIsOnThisMachine);
+
+        Assert.Contains("postgres.network.role", tip, StringComparison.Ordinal);
+        Assert.Contains("defaults to \"viewer\"", tip, StringComparison.Ordinal);
+        Assert.Contains("postgres.connectAs", tip, StringComparison.Ordinal);
+        Assert.Contains("defaults to \"admin\"", tip, StringComparison.Ordinal);
+
+        /* The #2400 misconception, answered before it is formed: the blocked write is a row in the
+           MONITORING store, and the monitored server is never written to at all. */
+        Assert.Contains("Nothing is ever written to a monitored SQL Server", tip, StringComparison.Ordinal);
+        Assert.Contains("MONITORING store", tip, StringComparison.Ordinal);
+
+        Assert.Contains("To change it:", tip, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// <c>StoreIsOnThisMachine</c> may only ORDER the two sentences, never claim which default decided
+    /// this seat. A non-loopback store host does not prove a remote seat (#2279 — a bring-your-own store
+    /// on another host, reached from the service host, reads identically), so the likelier default leads
+    /// and both are stated.
+    /// </summary>
+    [Fact]
+    public void StoreLocation_OnlyOrdersTheTwoDefaults_AndClaimsNeither()
+    {
+        var remote = ViewerSeatIndicator.ToolTip(ViewerSeatState.ReadOnly, storeIsOnThisMachine: false);
+        var local = ViewerSeatIndicator.ToolTip(ViewerSeatState.ReadOnly, storeIsOnThisMachine: true);
+
+        Assert.True(
+            remote.IndexOf("postgres.network.role", StringComparison.Ordinal)
+            < remote.IndexOf("postgres.connectAs", StringComparison.Ordinal),
+            "a store that is not on this machine should lead with the network-role default");
+
+        Assert.True(
+            local.IndexOf("postgres.connectAs", StringComparison.Ordinal)
+            < local.IndexOf("postgres.network.role", StringComparison.Ordinal),
+            "a store on this machine should lead with the connectAs default");
+
+        Assert.Contains("The store is not on this machine", remote, StringComparison.Ordinal);
+        Assert.Contains("The store is on this machine", local, StringComparison.Ordinal);
+    }
+
+    /// <summary>Every state answers with something. A blank tooltip on the one field an operator now
+    /// hovers first is the silence this change exists to end.</summary>
+    [Fact]
+    public void EveryState_HasANonEmptyToolTip_InBothPlacements()
+    {
+        foreach (ViewerSeatState state in Enum.GetValues<ViewerSeatState>())
+        {
+            Assert.False(string.IsNullOrWhiteSpace(ViewerSeatIndicator.ToolTip(state, true)), $"{state} / local");
+            Assert.False(string.IsNullOrWhiteSpace(ViewerSeatIndicator.ToolTip(state, false)), $"{state} / remote");
+        }
+    }
+
+    /// <summary>
+    /// The connect flow must publish a seat state on every arm that leaves <c>OnLoaded</c>, and the
+    /// unreachable arms must publish <c>Unreachable</c> rather than <c>ReadOnly</c>.
+    ///
+    /// <para>This is the structural half, and it is the one that decays: the pure helper cannot be wrong
+    /// about a state nobody sets, and a later refactor that adds an early return or reroutes the catch is
+    /// exactly how the field silently goes stale — showing the previous verdict, which is worse than
+    /// showing none.</para>
+    /// </summary>
+    [Fact]
+    public void ConnectFlow_PublishesASeatState_OnEveryArm_AndNeverCollapsesUnreachableIntoReadOnly()
+    {
+        var source = ReadSource(Path.Combine("Darling", "PerformanceMonitor.Darling.Viewer", "MainWindow.xaml.cs"));
+
+        /* The verdict arm sits with the probe, so the two cannot drift apart. */
+        var probe = source.IndexOf("await _dataService.DetectReadOnlyAsync();", StringComparison.Ordinal);
+        Assert.True(probe >= 0, "the viewer no longer probes the seat at connect");
+        Assert.Contains(
+            "ApplySeatState(_dataService.IsReadOnly ? ViewerSeatState.ReadOnly : ViewerSeatState.ReadWrite);",
+            source,
+            StringComparison.Ordinal);
+
+        /* The store-unreachable arm. Its body must set Unreachable and must not mention ReadOnly at all —
+           #2117's split, re-asserted at the surface that would otherwise quietly undo it. */
+        var arm = source.IndexOf("catch (ViewerStoreUnreachableException ex)", StringComparison.Ordinal);
+        Assert.True(arm >= 0, "the viewer no longer distinguishes an unreachable store at connect (#2117)");
+
+        var armBody = BlockAfter(source, arm);
+        Assert.Contains("ApplySeatState(ViewerSeatState.Unreachable);", armBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("ViewerSeatState.ReadOnly", armBody, StringComparison.Ordinal);
+
+        /* Every ApplySeatState call must precede its arm's return, or the field never changes. */
+        foreach (var state in new[] { "Unknown", "Unreachable", "ReadOnly" })
+        {
+            Assert.Contains($"ViewerSeatState.{state}", source, StringComparison.Ordinal);
+        }
+    }
+
+    /// <summary>
+    /// The field exists in the status bar, is named, and the column count matches the number of fields.
+    /// A <c>TextBlock</c> at <c>Grid.Column="5"</c> with only five columns defined silently stacks on top
+    /// of column 4, which is the kind of thing that ships looking fine in a screenshot.
+    /// </summary>
+    [Fact]
+    public void StatusBar_CarriesTheSeatField_AndHasAColumnForEveryField()
+    {
+        var xaml = ReadSource(Path.Combine("Darling", "PerformanceMonitor.Darling.Viewer", "MainWindow.xaml"));
+
+        var bar = xaml.IndexOf("<Grid Grid.Row=\"1\" Margin=\"0,8,0,0\">", StringComparison.Ordinal);
+        Assert.True(bar >= 0, "the viewer's status bar grid is gone or was renamed");
+
+        var body = xaml[bar..];
+        var end = body.IndexOf("</Grid>", StringComparison.Ordinal);
+        body = end > 0 ? body[..end] : body;
+
+        Assert.Contains("x:Name=\"SeatText\"", body, StringComparison.Ordinal);
+        Assert.Contains("Text=\"Seat: --\"", body, StringComparison.Ordinal);
+
+        var columns = Count(body, "<ColumnDefinition ");
+        var fields = Count(body, "<TextBlock ");
+        Assert.True(
+            columns == fields,
+            $"the status bar defines {columns} columns for {fields} fields — a field without a column stacks on its neighbour");
+
+        /* The seat is the first fixed field, right of the message area: it describes THIS CONNECTION
+           rather than the fleet, and it is the answer #2479 exists to make findable. */
+        Assert.True(
+            body.IndexOf("x:Name=\"SeatText\"", StringComparison.Ordinal)
+            < body.IndexOf("x:Name=\"CollectorHealthText\"", StringComparison.Ordinal),
+            "the seat field should lead the fixed status fields");
+    }
+
+    private static int Count(string haystack, string needle)
+    {
+        var n = 0;
+        var at = 0;
+        while ((at = haystack.IndexOf(needle, at, StringComparison.Ordinal)) >= 0)
+        {
+            n++;
+            at += needle.Length;
+        }
+
+        return n;
+    }
+
+    /// <summary>The brace-balanced block that opens after <paramref name="from"/>.</summary>
+    private static string BlockAfter(string source, int from)
+    {
+        var open = source.IndexOf('{', from);
+        Assert.True(open >= 0, "expected a block");
+
+        var depth = 0;
+        for (var i = open; i < source.Length; i++)
+        {
+            if (source[i] == '{') { depth++; }
+            else if (source[i] == '}')
+            {
+                depth--;
+                if (depth == 0) { return source[open..(i + 1)]; }
+            }
+        }
+
+        Assert.Fail("unbalanced braces while reading the connect flow");
+        return string.Empty;
+    }
+
+    private static string ReadSource(string relative, [CallerFilePath] string thisFile = "")
+    {
+        var dir = Path.GetDirectoryName(thisFile)!;
+        while (dir is not null && !File.Exists(Path.Combine(dir, relative)))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        Assert.False(dir is null, $"could not locate {relative} from the test source path");
+        return File.ReadAllText(Path.Combine(dir!, relative));
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
@@ -1377,8 +1377,14 @@
         </Border>
 
         <!-- Multi-field status bar (ported from Lite, adapted to what the viewer knows): general status,
-             collector health across all servers (from collection freshness), store database size, overall
-             collection status, and server count. -->
+             which SEAT this viewer holds, collector health across all servers (from collection freshness),
+             store database size, overall collection status, and server count.
+
+             SeatText sits first among the fixed fields, immediately right of the message area, because it
+             is the only one that describes THIS CONNECTION rather than the fleet, and #2479 exists because
+             the answer was previously discoverable only by tripping a refusal. Its text, colour and tooltip
+             are all set from ViewerSeatIndicator in the connect flow; the XAML holds only the not-probed-yet
+             state, which is what an operator sees if the window opens before OnLoaded finishes. -->
         <Grid Grid.Row="1" Margin="0,8,0,0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
@@ -1386,12 +1392,14 @@
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
             <TextBlock Grid.Column="0" x:Name="StatusText" FontSize="12" Foreground="{DynamicResource ForegroundMutedBrush}" VerticalAlignment="Center"/>
-            <TextBlock Grid.Column="1" x:Name="CollectorHealthText" FontSize="12" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="16,0" VerticalAlignment="Center"/>
-            <TextBlock Grid.Column="2" x:Name="DatabaseSizeText" Text="Database: --" FontSize="12" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="16,0" VerticalAlignment="Center"/>
-            <TextBlock Grid.Column="3" x:Name="CollectionStatusText" Text="Collection: --" FontSize="12" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="16,0" VerticalAlignment="Center"/>
-            <TextBlock Grid.Column="4" x:Name="ServerCountText" Text="Servers: 0" FontSize="12" Foreground="{DynamicResource ForegroundMutedBrush}" VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="1" x:Name="SeatText" Text="Seat: --" FontSize="12" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="16,0" VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="2" x:Name="CollectorHealthText" FontSize="12" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="16,0" VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="3" x:Name="DatabaseSizeText" Text="Database: --" FontSize="12" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="16,0" VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="4" x:Name="CollectionStatusText" Text="Collection: --" FontSize="12" Foreground="{DynamicResource ForegroundMutedBrush}" Margin="16,0" VerticalAlignment="Center"/>
+            <TextBlock Grid.Column="5" x:Name="ServerCountText" Text="Servers: 0" FontSize="12" Foreground="{DynamicResource ForegroundMutedBrush}" VerticalAlignment="Center"/>
         </Grid>
     </Grid>
 </Window>

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
@@ -916,12 +916,23 @@ public partial class MainWindow : Window
     {
         SeatText.Text = ViewerSeatIndicator.Text(state);
         SeatText.ToolTip = ViewerSeatIndicator.ToolTip(state, _dataService?.StoreIsOnThisMachine ?? true);
-        SeatText.Foreground = state switch
-        {
-            ViewerSeatState.Unreachable => (System.Windows.Media.Brush)FindResource("ErrorBrush"),
-            ViewerSeatState.ReadOnly => (System.Windows.Media.Brush)FindResource("WarningBrush"),
-            _ => (System.Windows.Media.Brush)FindResource("ForegroundMutedBrush"),
-        };
+
+        /* TryFindResource rather than the hard FindResource the sibling status fields use, and the reason is
+           the call site rather than doubt about the keys: all three brushes exist in all three shipped
+           themes, but ApplySeatState is called from INSIDE the catch that handles an unreachable store. A
+           ResourceReferenceKeyNotFoundException thrown from a catch block is unhandled, so a missing key in
+           some future theme would turn "the service is down" into "the viewer crashed" - the one moment the
+           viewer most needs to stay up and explain itself. Falling back to the muted foreground costs a
+           colour and nothing else. */
+        SeatText.Foreground =
+            (state switch
+            {
+                ViewerSeatState.Unreachable => TryFindResource("ErrorBrush"),
+                ViewerSeatState.ReadOnly => TryFindResource("WarningBrush"),
+                _ => TryFindResource("ForegroundMutedBrush"),
+            } as System.Windows.Media.Brush)
+            ?? TryFindResource("ForegroundMutedBrush") as System.Windows.Media.Brush
+            ?? SeatText.Foreground;
     }
 
     private async Task LoadServersAsync(bool preserveSelection = false)

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
@@ -376,6 +376,9 @@ public partial class MainWindow : Window
             var storeVersion = await _dataService.GetStoreSchemaVersionAsync();
             if (storeVersion is int version && version < ViewerDataService.RequiredStoreSchemaVersion)
             {
+                /* The store answered, so this is not Unreachable — but the seat probe never ran, so the
+                   field stays at "Seat: --" rather than claiming a verdict nothing measured (#2479). */
+                ApplySeatState(ViewerSeatState.Unknown);
                 ShowConnectionFailure(
                     $"The Darling store is at schema v{version}, but this viewer needs v{ViewerDataService.RequiredStoreSchemaVersion}. " +
                     "Update or restart the Darling service so it migrates the store, then reopen the viewer.");
@@ -387,9 +390,18 @@ public partial class MainWindow : Window
                probe fails safe to read-only; the write surfaces gate on ViewerDataService.IsReadOnly and
                the write paths translate a live 42501 into a friendly message as a backstop. */
             await _dataService.DetectReadOnlyAsync();
+
+            /* #2479 items 3+4: publish the verdict ONCE, globally, instead of letting it be discovered a
+               dialog at a time. Same probe, same fail-safe — this only makes the answer visible before a
+               write is attempted, which is the whole of #2400. */
+            ApplySeatState(_dataService.IsReadOnly ? ViewerSeatState.ReadOnly : ViewerSeatState.ReadWrite);
         }
         catch (ViewerStoreUnreachableException ex)
         {
+            /* NOT ReadOnly. #2117 built this arm precisely so an unreachable store stops being misread as
+               a read-only seat, and a status field that collapsed them would undo it in the one place an
+               operator now looks first — sending them to fix a role they never needed to touch. */
+            ApplySeatState(ViewerSeatState.Unreachable);
             ViewerLogger.Error("App", "Darling store unreachable", ex);
             ShowConnectionFailure(ex.Message);
             return;
@@ -398,6 +410,7 @@ public partial class MainWindow : Window
         {
             /* Reachable but the first connection failed for another reason (e.g. authentication, or the
                configured database does not exist) — show it rather than dead-ending on a blank window. */
+            ApplySeatState(ViewerSeatState.Unreachable);
             ViewerLogger.Error("App", "Darling store connection failed", ex);
             ShowConnectionFailure($"Couldn't connect to the Darling store: {ex.Message}");
             return;
@@ -883,6 +896,33 @@ public partial class MainWindow : Window
         ServerCountText.Text = _fleet.IsSearching
             ? $"Servers: {_fleet.VisibleServerCount} of {_fleet.TotalCount}"
             : $"Servers: {_fleet.TotalCount}";
+
+    /// <summary>
+    /// The status bar's "Seat:" field (#2479, items 3 and 4) — text, colour and the tooltip that explains
+    /// WHY, in one place so no caller can set half of it.
+    ///
+    /// <para>The colours are the existing status-bar vocabulary, not a new one:
+    /// <c>ErrorBrush</c> for a store that cannot be reached (the same severity <c>CollectorHealthText</c>
+    /// gives an erroring collector), <c>WarningBrush</c> for a read-only seat — visible, because a tester
+    /// who does not notice it is back to discovering the seat one refusal at a time, but not alarming,
+    /// because on a remote seat it is the correct and expected default — and the muted foreground for
+    /// read-write and for not-yet-probed, which are the unremarkable states.</para>
+    ///
+    /// <para><see cref="ViewerDataService.StoreIsOnThisMachine"/> only ORDERS the two sentences in the
+    /// tooltip by which default is likelier to have decided this seat. It cannot claim which one did: a
+    /// non-loopback store host does not prove a remote seat (#2279), so the tooltip names both.</para>
+    /// </summary>
+    private void ApplySeatState(ViewerSeatState state)
+    {
+        SeatText.Text = ViewerSeatIndicator.Text(state);
+        SeatText.ToolTip = ViewerSeatIndicator.ToolTip(state, _dataService?.StoreIsOnThisMachine ?? true);
+        SeatText.Foreground = state switch
+        {
+            ViewerSeatState.Unreachable => (System.Windows.Media.Brush)FindResource("ErrorBrush"),
+            ViewerSeatState.ReadOnly => (System.Windows.Media.Brush)FindResource("WarningBrush"),
+            _ => (System.Windows.Media.Brush)FindResource("ForegroundMutedBrush"),
+        };
+    }
 
     private async Task LoadServersAsync(bool preserveSelection = false)
     {

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerSeatIndicator.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerSeatIndicator.cs
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// Which seat this viewer is connected with, as one status-bar field (#2479, items 3 and 4).
+///
+/// <para><b>Why this exists.</b> #2400 asked why "Current Active Queries" refuses on a read-write-looking
+/// connection, and #2403 answered it by rewriting the individual refusals. That improved every refusal and
+/// left the question intact: you still discover your seat one surface at a time, at the moment a write is
+/// denied, which is the worst moment to learn it. The viewer has known the answer since V8 — one
+/// <c>has_table_privilege</c> probe at connect — and never showed it anywhere you could look on purpose.</para>
+///
+/// <para><b>Why it matters more in UAT than it did before.</b> The two defaults are deliberately opposite:
+/// a local seat takes <c>postgres.connectAs</c>, which defaults to <c>admin</c> (read-write), while a seat
+/// reached over the LAN takes <c>postgres.network.role</c>, which defaults to <c>viewer</c> (read-only). A
+/// UAT tester connecting from their own desktop is the second case by construction, so the read-only seat
+/// is the EXPECTED default rather than a misconfiguration — and nothing in the product said so.</para>
+///
+/// <para><b>Unreachable is its own state, not a read-only verdict.</b> <c>DetectReadOnlyAsync</c> fails safe
+/// to read-only for an unexpected RESPONSE, but raises <see cref="ViewerStoreUnreachableException"/> for a
+/// failure to REACH the store — a distinction #2117 built deliberately and this field must not undo. A
+/// status line claiming "read-only" when the service is simply down would send an operator to fix a role
+/// they do not need to touch. So the state machine carries four values and the two failures never share
+/// one.</para>
+/// </summary>
+internal enum ViewerSeatState
+{
+    /// <summary>Not probed yet. The field's initial value, and where a schema-skew refusal leaves it —
+    /// the store answered, but the seat question was never asked, so nothing is claimed about it.</summary>
+    Unknown,
+
+    /// <summary>The store could not be reached, so there is no seat to report. Never collapsed into
+    /// <see cref="ReadOnly"/>: see the type remarks.</summary>
+    Unreachable,
+
+    /// <summary>The probe said this connection cannot write the operator-config tables — either the
+    /// restricted role, or a response that could not be read as a yes (the V8 fail-safe).</summary>
+    ReadOnly,
+
+    /// <summary>The probe said this connection can write the operator-config tables.</summary>
+    ReadWrite,
+}
+
+/// <summary>The status-bar text and tooltip for a <see cref="ViewerSeatState"/>. Pure, so the wording is
+/// pinned by tests rather than by reading a XAML file.</summary>
+internal static class ViewerSeatIndicator
+{
+    /// <summary>
+    /// The status-bar field. Prefixed "Seat:" to match the other four fields ("Collectors:", "Database:",
+    /// "Collection:", "Servers:"), which is what makes it findable without a legend.
+    /// </summary>
+    public static string Text(ViewerSeatState state) => state switch
+    {
+        ViewerSeatState.ReadOnly => "Seat: read-only",
+        ViewerSeatState.ReadWrite => "Seat: read-write",
+        ViewerSeatState.Unreachable => "Seat: not connected",
+        _ => "Seat: --",
+    };
+
+    /// <summary>
+    /// The tooltip, which is where the ANSWER lives rather than in a doc.
+    ///
+    /// <para><paramref name="storeIsOnThisMachine"/> orders the two defaults by which one is likelier to
+    /// have decided this seat; it never claims which one DID. A non-loopback store host does not prove a
+    /// remote seat — a bring-your-own store on another host reached from the service host reads
+    /// identically — so the wording says the role arrived in the connection string and then names both
+    /// defaults, which is true either way.</para>
+    /// </summary>
+    public static string ToolTip(ViewerSeatState state, bool storeIsOnThisMachine) => state switch
+    {
+        ViewerSeatState.ReadOnly => ReadOnlyToolTip(storeIsOnThisMachine),
+        ViewerSeatState.ReadWrite => ReadWriteToolTip,
+        ViewerSeatState.Unreachable => UnreachableToolTip,
+        _ => UnknownToolTip,
+    };
+
+    internal const string LocalDefaultSentence =
+        "A seat on the service host connects as postgres.connectAs, which defaults to \"admin\" — read-write.";
+
+    internal const string NetworkDefaultSentence =
+        "A seat reached over the LAN connects as postgres.network.role, which defaults to \"viewer\" — read-only.";
+
+    /* Said in full on the read-only tooltip because it is the actual #2400 question. The refusals say it
+       per-dialog already; a reader who has not tripped one yet has no way to know a "write" here is a row
+       in the MONITORING store rather than something aimed at their SQL Server. */
+    internal const string NothingIsWrittenSentence =
+        "Nothing is ever written to a monitored SQL Server. The actions a read-only seat cannot take "
+        + "(Refresh on Current Active Queries, Get Actual Plan, Purge Now, Generate now, dismissing an "
+        + "alert, editing mute rules, adding a server) work by enqueueing a request for the service in the "
+        + "MONITORING store, and that row is the write a read-only seat cannot make.";
+
+    private static string ReadOnlyToolTip(bool storeIsOnThisMachine)
+    {
+        /* Order by likelihood, claim neither. The likelier default goes first so the sentence that
+           explains THIS seat is the one the reader hits first. */
+        var defaults = storeIsOnThisMachine
+            ? LocalDefaultSentence + " " + NetworkDefaultSentence
+            : NetworkDefaultSentence + " " + LocalDefaultSentence;
+
+        var where = storeIsOnThisMachine
+            ? "The store is on this machine."
+            : "The store is not on this machine, so the role came from the connection string the service handed out.";
+
+        return "This viewer is connected with a read-only role, so write affordances are hidden or disabled."
+            + Environment.NewLine + Environment.NewLine
+            + where + " " + defaults
+            + " The two defaults are deliberately opposite — the local seat is the operator's, the remote "
+            + "seat is a laptop — so a remote seat being read-only is the expected default, not a fault."
+            + Environment.NewLine + Environment.NewLine
+            + NothingIsWrittenSentence
+            + Environment.NewLine + Environment.NewLine
+            + "To change it: set postgres.network.role to \"admin\" on the SERVICE host and restart the "
+            + "service (then re-run --export-viewer-config) for a LAN seat, or set postgres.connectAs to "
+            + "\"admin\" and restart the viewer for a seat on the service host.";
+    }
+
+    /* static readonly rather than const so the paragraph breaks come from Environment.NewLine, exactly as
+       the read-only tooltip's do. A const cannot call it, and two tooltips breaking lines two different
+       ways is the kind of drift nobody notices until a test pins one of them. */
+    internal static readonly string ReadWriteToolTip =
+        "This viewer is connected with a read-write role, so it can enqueue requests for the service "
+        + "(Refresh on Current Active Queries, Get Actual Plan, Purge Now, adding a server, editing mute "
+        + "rules) by writing to the MONITORING store."
+        + Environment.NewLine + Environment.NewLine
+        + "Nothing is ever written to a monitored SQL Server. The service reads those under the same "
+        + "least-privilege login the collectors use."
+        + Environment.NewLine + Environment.NewLine
+        + LocalDefaultSentence + " " + NetworkDefaultSentence;
+
+    /* Deliberately says nothing about the seat. The probe never ran, so there is no verdict to report,
+       and the full-window message already carries the diagnosis and the connection details. */
+    internal const string UnreachableToolTip =
+        "The Darling store could not be reached, so this viewer has not probed which seat it has. This is "
+        + "NOT a read-only seat — it is no connection at all. See the message on the main panel for the "
+        + "store address it tried and why it failed.";
+
+    internal const string UnknownToolTip =
+        "This viewer has not probed which seat it has yet.";
+}


### PR DESCRIPTION
Items **3 and 4** of #2479, shipped together because they are one user experience.

## The gap

#2400 asked why a viewer on a jumpbox refuses "Current Active Queries". #2403 answered it by rewriting the individual refusals — four better messages, and the same discovery model: **you learn your seat at the moment a write is denied**, which is the worst moment to learn it. The viewer has known the answer since V8 (one `has_table_privilege('config_mute_rules','INSERT')` probe at connect, `ViewerDataService.DetectReadOnlyAsync`) and never showed it anywhere you could look on purpose.

Item 4 is why this gets *worse* in UAT rather than better. The two defaults are deliberately opposite:

| Seat | Setting | Default | Result |
|---|---|---|---|
| Local, on the service host | `postgres.connectAs` | `admin` | read-write |
| Remote, over the LAN | `postgres.network.role` | `viewer` | **read-only** |

A UAT tester connecting from their own desktop is the second row **by construction**, so the read-only seat is the expected default rather than a misconfiguration — and nothing in the product said so.

## What this adds

A `Seat:` field in the status bar, first among the fixed fields because it is the only one describing *this connection* rather than the fleet. The whole answer is in its tooltip: what a "write" means here (a row in the **monitoring store**, never anything sent at a monitored SQL Server), which config key decided it, that the two defaults are opposite on purpose, and how to change it. Same probe, same V8 fail-safe — this only makes the verdict visible before a write is attempted.

## Unreachable is its own state, and never collapses into read-only

`DetectReadOnlyAsync` fails safe to read-only for an unexpected *response* but raises `ViewerStoreUnreachableException` for a failure to *reach* the store. #2117 built that split deliberately, because collapsing them told an operator whose service was simply down to go and change a database role. A status field is exactly where that gets quietly re-collapsed, so:

- the state machine carries four values — `Unknown`, `Unreachable`, `ReadOnly`, `ReadWrite`;
- the unreachable tooltip **actively denies** the read-only reading ("This is NOT a read-only seat — it is no connection at all") and names no role at all, so it cannot send anyone at `connectAs`;
- the schema-skew arm, which *did* reach the store but never asked the seat question, leaves the field at `Seat: --` rather than claiming a verdict nothing measured.

The `catch (ViewerStoreUnreachableException)` arm's body is pinned to contain `ViewerSeatState.Unreachable` and to contain no `ViewerSeatState.ReadOnly` at all.

## Honest about what it can and cannot know

`StoreIsOnThisMachine` only **orders** the two sentences by which default is likelier to have decided this seat. It cannot claim which one did — a non-loopback store host does not prove a remote seat (#2279: a bring-your-own store on another host, reached from the service host, reads identically), so the likelier default leads and **both are always stated**.

Colours reuse the status bar's existing vocabulary rather than inventing one: `ErrorBrush` for an unreachable store (the same severity an erroring collector gets from `CollectorHealthText`), `WarningBrush` for a read-only seat — visible, because a tester who does not notice it is back to discovering the seat one refusal at a time, but not alarming, because on a remote seat it is correct — and the muted foreground for read-write and not-yet-probed.

## Verification

- **Ran the shipped `ViewerSeatIndicator.cs` itself.** `Darling.Tests` is `net10.0-windows` and cannot run on macOS, so the file — which has no WPF dependency — was `<Compile Include>`'d into a throwaway `net10.0` console harness and all 33 assertions executed against the real source: 33/33 pass, including that the four labels are distinct, that the unreachable label and tooltip contain no read-only claim, that both defaults are named in both placements, and that the ordering flips with `StoreIsOnThisMachine` while neither is claimed.
- Viewer and `Darling.Tests` both build clean, 0 errors.
- Status bar counted from the file: **6 column definitions, 6 fields**, `SeatText` ahead of `CollectorHealthText`.
- Against `dev` the whole test class fails to **compile** — `ViewerSeatIndicator` and `ViewerSeatState` do not exist there.
- **Not verified:** nothing has been run in a live WPF window, so the field's rendered width, its colour against all three themes, and multi-line tooltip wrapping are unexercised. Manual check for a reviewer with the viewer open: connect a remote (`viewer`-role) seat and confirm `Seat: read-only` in the warning colour with the tooltip naming `postgres.network.role`; stop the service and reconnect, and confirm `Seat: not connected` rather than `Seat: read-only`.

## Onboarding

Makes `docs/uat-onboarding.md` §2.3's *"How to tell which seat you have"* subsection unnecessary (#2476) — the paragraph beginning **"There is no global banner — it shows up per surface"**, along with its Settings-window recipe and the list of per-surface tells. §2.3's table of the two defaults, the "nothing is written to your monitored SQL Server" explanation and the "How to change it" recipe are all now in the tooltip too, so that section can shrink to a pointer at the status bar; keeping the prose is still reasonable, but it stops being the only place the answer exists.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
