### PR TITLE
Say which gate turned a request away, without letting a scanner fill the log (#2479)

### DIFF
--- a/Darling/Darling.Tests/DarlingHttpRefusalLogTests.cs
+++ b/Darling/Darling.Tests/DarlingHttpRefusalLogTests.cs
@@ -346,6 +346,23 @@ public class DarlingHttpRefusalLogTests
     }
 
     /// <summary>
+    /// The verb agrees with the status code.
+    ///
+    /// <para>Review catch on #2479: not every gate rejection ends in a 4xx. The web dashboard answers an
+    /// in-CIDR request with a WRONG <c>?token=</c> using a 200 and the login page, deliberately — and
+    /// "refused a request … with 200" is self-contradictory on its face, misleading anyone reading the log
+    /// cold or filtering for denials on status.</para>
+    /// </summary>
+    [Theory]
+    [InlineData(400, "refused")]
+    [InlineData(401, "refused")]
+    [InlineData(403, "refused")]
+    [InlineData(200, "did not authorize")]
+    [InlineData(302, "did not authorize")]
+    public void TheOutcomeVerb_AgreesWithTheStatusCode(int statusCode, string expected) =>
+        Assert.Equal(expected, DarlingHttpRefusalLog.DescribeOutcome(statusCode));
+
+    /// <summary>
     /// Every refusal site on both hosts reports. This is the half that decays: a gate added later is a
     /// gate that refuses silently again, and no behavioural test can see one that does not exist yet.
     /// </summary>

--- a/Darling/Darling.Tests/DarlingHttpRefusalLogTests.cs
+++ b/Darling/Darling.Tests/DarlingHttpRefusalLogTests.cs
@@ -1,0 +1,385 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Runtime.CompilerServices;
+using PerformanceMonitor.Darling.Service.Hosting;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Rejected HTTP requests get a rate-limited WARN naming the gate that refused them (#2479, item 5).
+///
+/// <para><b>The gap.</b> All five refusal sites across the MCP and web listeners were a bare
+/// <c>StatusCode = …; return;</c>. So "is my token wrong, or my CIDR wrong?" was answerable only from the
+/// client, which sees one opaque status code and cannot tell a Host-allowlist 400 from a malformed
+/// request, or a CIDR 403 from anything else — while the person who can fix either is on the server, and
+/// the server said nothing.</para>
+///
+/// <para><b>Why the policy is tested this hard.</b> The rate limit is not a nicety here. These ports are
+/// LAN-exposed on purpose, so an unthrottled line per refusal makes the service log a denial-of-service
+/// target: a scanner fills the file an operator debugs from, and the log stops being readable exactly when
+/// it matters. Equally, a limiter tuned the other way is worthless — if a tester's own first refusal waits
+/// out a window, the feature has not shipped. Both halves are measured below rather than asserted about.</para>
+/// </summary>
+public class DarlingHttpRefusalLogTests
+{
+    private static readonly DateTime T0 = new(2026, 8, 21, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly TimeSpan Window = TimeSpan.FromMinutes(10);
+
+    /// <summary>
+    /// The tester's own first refusal is never delayed. A limiter that makes the operator wait out a
+    /// window before their answer appears has not fixed anything.
+    /// </summary>
+    [Fact]
+    public void FirstSighting_LogsImmediately_ForEveryGate()
+    {
+        var log = new DarlingHttpRefusalLog(Window, 16);
+
+        foreach (DarlingRefusalGate gate in Enum.GetValues<DarlingRefusalGate>())
+        {
+            Assert.True(log.Observe(gate, "10.0.0.5", T0).Log, $"the first {gate} refusal must be logged at once");
+        }
+    }
+
+    /// <summary>
+    /// Repeats fold, and the count rides out on the next line that does emit — so the volume is visible
+    /// without being written. And the count resets once reported, or every later line over-reports.
+    /// </summary>
+    [Fact]
+    public void RepeatsFold_AndTheSuppressedCountRidesTheNextLine()
+    {
+        var log = new DarlingHttpRefusalLog(Window, 16);
+        Assert.True(log.Observe(DarlingRefusalGate.Token, "10.0.0.5", T0).Log);
+
+        for (var i = 1; i <= 500; i++)
+        {
+            Assert.False(
+                log.Observe(DarlingRefusalGate.Token, "10.0.0.5", T0.AddSeconds(i)).Log,
+                "a repeat inside the window must not produce a line");
+        }
+
+        var next = log.Observe(DarlingRefusalGate.Token, "10.0.0.5", T0.Add(Window).AddSeconds(1));
+        Assert.True(next.Log);
+        Assert.Equal(500, next.SuppressedSinceLastLog);
+
+        var after = log.Observe(DarlingRefusalGate.Token, "10.0.0.5", T0.Add(Window).AddSeconds(2));
+        Assert.False(after.Log);
+        Assert.Equal(0, after.SuppressedSinceLastLog);
+    }
+
+    /// <summary>
+    /// A different gate is a different key, so iterating stays responsive: fix the token, now fail the
+    /// CIDR check, and the new answer appears at once instead of behind the old gate's window.
+    /// </summary>
+    [Fact]
+    public void ADifferentGate_FromTheSameSource_LogsAtOnce()
+    {
+        var log = new DarlingHttpRefusalLog(Window, 16);
+
+        Assert.True(log.Observe(DarlingRefusalGate.Token, "10.0.0.5", T0).Log);
+        Assert.True(log.Observe(DarlingRefusalGate.SourceCidr, "10.0.0.5", T0.AddSeconds(1)).Log);
+        Assert.True(log.Observe(DarlingRefusalGate.HostAllowlist, "10.0.0.5", T0.AddSeconds(2)).Log);
+    }
+
+    /// <summary>
+    /// Per SOURCE, not per gate alone. Keyed per gate only, one scanner's line wins the window and hides
+    /// the tester's own refusal completely — the failure this exists to fix, reintroduced by the fix.
+    /// </summary>
+    [Fact]
+    public void OneNoisySource_DoesNotHideAnother()
+    {
+        var log = new DarlingHttpRefusalLog(Window, 16);
+
+        for (var i = 0; i < 100; i++)
+        {
+            log.Observe(DarlingRefusalGate.Token, "203.0.113.9", T0.AddSeconds(i));
+        }
+
+        Assert.True(
+            log.Observe(DarlingRefusalGate.Token, "10.0.0.5", T0.AddSeconds(101)).Log,
+            "the tester's first refusal must survive a noisy neighbour on the same gate");
+    }
+
+    /// <summary>
+    /// The ceiling, measured rather than asserted about: an hour of 30 refusals per second from a few
+    /// hundred sources — 108,000 refused requests — must not be able to fill the log, and the tracked
+    /// state must stay inside the cap.
+    /// </summary>
+    [Fact]
+    public void AScanner_CannotFillTheLog()
+    {
+        var log = new DarlingHttpRefusalLog(Window, 16);
+        var random = new Random(1);
+        var lines = 0;
+
+        for (var second = 0; second < 3600; second++)
+        {
+            for (var burst = 0; burst < 10; burst++)
+            {
+                var source = $"203.0.113.{random.Next(1, 255)}:{random.Next(1, 10)}";
+                foreach (DarlingRefusalGate gate in Enum.GetValues<DarlingRefusalGate>())
+                {
+                    if (log.Observe(gate, source, T0.AddSeconds(second)).Log)
+                    {
+                        lines++;
+                    }
+                }
+            }
+        }
+
+        Assert.True(lines < 400, $"108,000 refused requests produced {lines} log lines — the ceiling is not holding");
+        Assert.True(
+            log.TrackedCount <= 16 + Enum.GetValues<DarlingRefusalGate>().Length,
+            $"tracked entries grew to {log.TrackedCount} — the per-source map is unbounded");
+    }
+
+    /// <summary>
+    /// Overflow is ANNOUNCED. Past the cap a source still gets a line, and that line says it speaks for
+    /// several sources — because "this port is being scanned" is the more urgent fact, and silently
+    /// dropping the surplus would leave the operator reading a log that looks quiet.
+    /// </summary>
+    [Fact]
+    public void PastTheCap_TheLineSaysItSpeaksForSeveralSources()
+    {
+        var log = new DarlingHttpRefusalLog(Window, 2);
+
+        var first = log.Observe(DarlingRefusalGate.Token, "a", T0);
+        var second = log.Observe(DarlingRefusalGate.Token, "b", T0);
+        Assert.True(first.Log);
+        Assert.False(first.Aggregated);
+        Assert.True(second.Log);
+        Assert.False(second.Aggregated);
+
+        var overflow = log.Observe(DarlingRefusalGate.Token, "c", T0);
+        Assert.True(overflow.Log, "a source past the cap must still be reported, not silently dropped");
+        Assert.True(overflow.Aggregated, "and the line must say it is speaking for more than one source");
+    }
+
+    /// <summary>
+    /// Eviction is keyed on LAST SEEN, not last logged. Keyed on last logged, a source still being refused
+    /// every second would be dropped at the two-window horizon and re-log as a fresh first sighting —
+    /// turning the rate limit into a rate multiplier, which is worse than no limit because it looks like
+    /// one is working.
+    /// </summary>
+    [Fact]
+    public void AContinuouslyRefusedSource_IsNeverEvictedIntoAFreshFirstSighting()
+    {
+        var log = new DarlingHttpRefusalLog(Window, 2);
+
+        var lines = 0;
+        var everyLaterLineReportedItsFolds = true;
+        for (var half = 0; half <= 50; half++)
+        {
+            var decision = log.Observe(DarlingRefusalGate.Token, "a", T0.AddSeconds(half * 30));
+            if (!decision.Log)
+            {
+                continue;
+            }
+
+            lines++;
+            if (lines > 1 && decision.SuppressedSinceLastLog == 0)
+            {
+                everyLaterLineReportedItsFolds = false;
+            }
+        }
+
+        /* 25 minutes at 2 refusals a minute: one line per 10-minute window, and not one more. */
+        Assert.Equal(3, lines);
+        Assert.True(everyLaterLineReportedItsFolds, "a later line reported nothing folded — it re-armed as a first sighting");
+        Assert.Equal(1, log.TrackedCount);
+    }
+
+    /// <summary>And silence does free the budget again, or a finished scan holds the slots forever.</summary>
+    [Fact]
+    public void ASourceSilentForTwoWindows_IsForgotten()
+    {
+        var log = new DarlingHttpRefusalLog(Window, 2);
+        log.Observe(DarlingRefusalGate.Token, "a", T0);
+        log.Observe(DarlingRefusalGate.Token, "b", T0);
+
+        var later = log.Observe(DarlingRefusalGate.Token, "c", T0.AddMinutes(21));
+        Assert.True(later.Log);
+        Assert.False(later.Aggregated, "the budget should have been freed by eviction");
+    }
+
+    /// <summary>A remote address ASP.NET Core cannot report is a real state (the CIDR gate fails closed on
+    /// it), so it needs a stable key rather than an exception. IPv4-mapped IPv6 is unwrapped so one client
+    /// is one key.</summary>
+    [Fact]
+    public void SourceDescription_HandlesTheAddressesTheGatesActuallySee()
+    {
+        Assert.Equal("unknown", DarlingHttpRefusalLog.DescribeSource(null));
+        Assert.Equal("10.0.0.5", DarlingHttpRefusalLog.DescribeSource(IPAddress.Parse("10.0.0.5")));
+        Assert.Equal("10.0.0.5", DarlingHttpRefusalLog.DescribeSource(IPAddress.Parse("::ffff:10.0.0.5")));
+        Assert.Equal("::1", DarlingHttpRefusalLog.DescribeSource(IPAddress.IPv6Loopback));
+    }
+
+    /// <summary>
+    /// A log file is a text file. The Host header is attacker-supplied and the only request-derived value
+    /// echoed into a line, so a header carrying CR/LF must not be able to forge entries — and a megabyte
+    /// header must not become a megabyte of log.
+    /// </summary>
+    [Fact]
+    public void AHostHeader_CannotForgeLogLines()
+    {
+        var forged = DarlingHttpRefusalLog.Sanitize("evil\r\n2026-08-21 12:00:00 WARN  Everything is fine");
+        Assert.DoesNotContain('\r', forged);
+        Assert.DoesNotContain('\n', forged);
+
+        Assert.True(DarlingHttpRefusalLog.Sanitize(new string('x', 5000)).Length <= DarlingHttpRefusalLog.MaxEchoedLength + 1);
+        Assert.Equal("(none)", DarlingHttpRefusalLog.Sanitize(null));
+        Assert.Equal("(none)", DarlingHttpRefusalLog.Sanitize(""));
+
+        /* And an ordinary hostname survives unchanged, or the line stops being useful. */
+        Assert.Equal("darling.example.com", DarlingHttpRefusalLog.Sanitize("darling.example.com"));
+        Assert.Equal("10.197.53.214:5152", DarlingHttpRefusalLog.Sanitize("10.197.53.214:5152"));
+    }
+
+    /// <summary>Every gate is named the way an operator would have to name it to fix it — the CIDR gate
+    /// by its config key, not by "403".</summary>
+    [Fact]
+    public void EveryGate_IsNamedInTermsTheOperatorCanActOn()
+    {
+        foreach (DarlingRefusalGate gate in Enum.GetValues<DarlingRefusalGate>())
+        {
+            var described = DarlingHttpRefusalLog.Describe(gate);
+            Assert.False(string.IsNullOrWhiteSpace(described));
+            Assert.NotEqual(gate.ToString(), described);
+        }
+
+        Assert.Contains("allowFrom", DarlingHttpRefusalLog.Describe(DarlingRefusalGate.SourceCidr), StringComparison.Ordinal);
+        Assert.Contains("Host header", DarlingHttpRefusalLog.Describe(DarlingRefusalGate.HostAllowlist), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Every refusal site on both hosts reports. This is the half that decays: a gate added later is a
+    /// gate that refuses silently again, and no behavioural test can see one that does not exist yet.
+    /// </summary>
+    [Theory]
+    [InlineData("DarlingMcpHostService.cs")]
+    [InlineData("DarlingWebHostService.cs")]
+    public void EveryRefusalSite_ReportsBeforeItRefuses(string fileName)
+    {
+        var source = ReadHostSource(fileName);
+
+        var unreported = new List<string>();
+        var at = 0;
+        var found = 0;
+        const string Marker = "context.Response.StatusCode = StatusCodes.Status4";
+        while ((at = source.IndexOf(Marker, at, StringComparison.Ordinal)) >= 0)
+        {
+            found++;
+
+            /* Report sits immediately above the status assignment at every site, so a short lookback is
+               both sufficient and specific — long enough to span the call's arguments, short enough that
+               a neighbouring site's Report cannot satisfy this one. */
+            var from = Math.Max(0, at - 1200);
+            if (!source[from..at].Contains("refusals.Report(", StringComparison.Ordinal))
+            {
+                unreported.Add(source.Substring(at, Math.Min(72, source.Length - at)));
+            }
+
+            at += Marker.Length;
+        }
+
+        Assert.True(found > 0, $"{fileName} no longer refuses anything with a 4xx — this pin needs rewriting");
+        Assert.True(
+            unreported.Count == 0,
+            $"{fileName} has refusal sites that log nothing (#2479):\n  " + string.Join("\n  ", unreported));
+    }
+
+    /// <summary>
+    /// The token, any prefix of it, and its length are never logged. A refusal may say whether a
+    /// credential was PRESENTED; it may never say anything about its value.
+    /// </summary>
+    [Theory]
+    [InlineData("DarlingMcpHostService.cs")]
+    [InlineData("DarlingWebHostService.cs")]
+    public void NoRefusalLine_CanCarryTheToken(string fileName)
+    {
+        var source = ReadHostSource(fileName);
+
+        var at = 0;
+        var calls = 0;
+        while ((at = source.IndexOf("refusals.Report(", at, StringComparison.Ordinal)) >= 0)
+        {
+            calls++;
+            var arguments = ArgumentsAt(source, source.IndexOf('(', at));
+
+            foreach (var forbidden in new[] { "bearerToken", "accessToken", "presentedToken", ", token", "{token}", ".Length" })
+            {
+                Assert.False(
+                    arguments.Contains(forbidden, StringComparison.Ordinal),
+                    $"{fileName}: a refusal line passes '{forbidden}' into the log — the token's value, "
+                    + "prefix and length are all off limits (#2479)");
+            }
+
+            at += "refusals.Report(".Length;
+        }
+
+        Assert.True(calls >= 3, $"{fileName} reports only {calls} refusals — expected every gate to report");
+    }
+
+    /// <summary>
+    /// The budget is per started server, not process-wide static: a rebind (a control-plane port change,
+    /// or a restart of a listener that failed to bind) must start with a clean budget rather than
+    /// inheriting the previous listener's scan and swallowing the first refusals of the new one.
+    /// </summary>
+    [Theory]
+    [InlineData("DarlingMcpHostService.cs")]
+    [InlineData("DarlingWebHostService.cs")]
+    public void TheBudget_IsPerStartedServer_NotProcessWide(string fileName)
+    {
+        var source = ReadHostSource(fileName);
+
+        var built = source.IndexOf("_app = builder.Build();", StringComparison.Ordinal);
+        var created = source.IndexOf("var refusals = new DarlingHttpRefusalLog();", StringComparison.Ordinal);
+
+        Assert.True(built >= 0, $"{fileName} no longer builds a host — this pin needs rewriting");
+        Assert.True(created > built, $"{fileName} must create its refusal log with the server it belongs to (#2479)");
+        Assert.DoesNotContain("static readonly DarlingHttpRefusalLog", source, StringComparison.Ordinal);
+    }
+
+    /// <summary>The argument list of the call whose '(' is at <paramref name="open"/>.</summary>
+    private static string ArgumentsAt(string source, int open)
+    {
+        Assert.True(open >= 0, "expected a call");
+
+        var depth = 0;
+        for (var i = open; i < source.Length; i++)
+        {
+            if (source[i] == '(') { depth++; }
+            else if (source[i] == ')')
+            {
+                depth--;
+                if (depth == 0) { return source[(open + 1)..i]; }
+            }
+        }
+
+        Assert.Fail("unbalanced parentheses while reading a refusal report call");
+        return string.Empty;
+    }
+
+    private static string ReadHostSource(string fileName, [CallerFilePath] string thisFile = "")
+    {
+        var relative = Path.Combine("Darling", "PerformanceMonitor.Darling.Service", "Mcp", fileName);
+        var dir = Path.GetDirectoryName(thisFile)!;
+        while (dir is not null && !File.Exists(Path.Combine(dir, relative)))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        Assert.False(dir is null, $"could not locate {relative} from the test source path");
+        return File.ReadAllText(Path.Combine(dir!, relative));
+    }
+}

--- a/Darling/Darling.Tests/DarlingHttpRefusalLogTests.cs
+++ b/Darling/Darling.Tests/DarlingHttpRefusalLogTests.cs
@@ -12,6 +12,7 @@ using System.IO;
 using System.Net;
 using System.Runtime.CompilerServices;
 using PerformanceMonitor.Darling.Service.Hosting;
+using PerformanceMonitor.Darling.Service.Mcp;
 using Xunit;
 
 namespace Darling.Tests;
@@ -307,6 +308,41 @@ public class DarlingHttpRefusalLogTests
 
         Assert.Contains("allowFrom", DarlingHttpRefusalLog.Describe(DarlingRefusalGate.SourceCidr), StringComparison.Ordinal);
         Assert.Contains("Host header", DarlingHttpRefusalLog.Describe(DarlingRefusalGate.HostAllowlist), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A bearer refusal distinguishes THREE client states, not two.
+    ///
+    /// <para>Review catch on #2479. <c>ExtractBearerToken</c> answers null for both "no header" and "a
+    /// header that is not a well-formed Bearer", so a refusal line built on it alone told an operator that
+    /// nothing was presented while their client was sending <c>Authorization: Basic …</c> every second —
+    /// collapsing exactly the ambiguity this feature exists to resolve. Each state is a different next
+    /// step: no token configured, token configured wrong, or the wrong token.</para>
+    /// </summary>
+    [Theory]
+    /* Nothing sent at all. */
+    [InlineData(null, "no 'Authorization: Bearer <token>' header was presented")]
+    [InlineData("", "no 'Authorization: Bearer <token>' header was presented")]
+    [InlineData("   ", "no 'Authorization: Bearer <token>' header was presented")]
+    /* Something WAS sent, in the wrong shape. Each of these used to read as "nothing was presented". */
+    [InlineData("Basic dXNlcjpwYXNz", "an Authorization header WAS presented but is not a 'Bearer <token>'")]
+    [InlineData("abc123", "an Authorization header WAS presented but is not a 'Bearer <token>'")]
+    [InlineData("Bearer ", "an Authorization header WAS presented but is not a 'Bearer <token>'")]
+    [InlineData("Bearer    ", "an Authorization header WAS presented but is not a 'Bearer <token>'")]
+    /* A well-formed Bearer that simply does not match — including the case-insensitive scheme. */
+    [InlineData("Bearer wrong-token", "does not match mcp.network.encryptedToken")]
+    [InlineData("bearer wrong-token", "does not match mcp.network.encryptedToken")]
+    public void ABearerRefusal_TellsNoTokenFromAMalformedOne_FromAWrongOne(string? header, string expected)
+    {
+        var described = DarlingMcpHostService.DescribeBearerRefusal(header);
+
+        Assert.Contains(expected, described, StringComparison.Ordinal);
+
+        /* And it can never carry the value, because it only ever reads the header's SHAPE. */
+        if (header is not null && header.Contains("wrong-token", StringComparison.Ordinal))
+        {
+            Assert.DoesNotContain("wrong-token", described, StringComparison.Ordinal);
+        }
     }
 
     /// <summary>

--- a/Darling/Darling.Tests/DarlingHttpRefusalLogTests.cs
+++ b/Darling/Darling.Tests/DarlingHttpRefusalLogTests.cs
@@ -166,6 +166,54 @@ public class DarlingHttpRefusalLogTests
     }
 
     /// <summary>
+    /// The aggregate bucket folds MANY DIFFERENT addresses, so its suppression clause must not claim they
+    /// were repeats from one.
+    ///
+    /// <para>Review catch on #2479: <c>PastTheCap_…</c> above only exercises the FIRST overflow, before any
+    /// folding has happened on the aggregate — so the wording that ships with the folded count was
+    /// untested, and it said "from this source". That is false in the direction that matters. An operator
+    /// reading "400 further refusals from this source" goes looking for one busy client; what is actually
+    /// happening is a broad scan, which is the thing the aggregate bucket exists to tell them.</para>
+    /// </summary>
+    [Fact]
+    public void TheAggregateSuppressionClause_DoesNotClaimTheyCameFromOneSource()
+    {
+        var log = new DarlingHttpRefusalLog(Window, 2);
+
+        /* Fill the per-source budget, then push the overflow through one gate from many addresses. */
+        log.Observe(DarlingRefusalGate.Token, "10.0.0.1", T0);
+        log.Observe(DarlingRefusalGate.Token, "10.0.0.2", T0);
+
+        var firstOverflow = log.Observe(DarlingRefusalGate.Token, "203.0.113.1", T0);
+        Assert.True(firstOverflow.Log);
+        Assert.True(firstOverflow.Aggregated);
+
+        for (var i = 2; i <= 400; i++)
+        {
+            Assert.False(log.Observe(DarlingRefusalGate.Token, $"203.0.113.{i}", T0.AddSeconds(i)).Log);
+        }
+
+        var next = log.Observe(DarlingRefusalGate.Token, "203.0.113.401", T0.Add(Window).AddSeconds(1));
+        Assert.True(next.Log);
+        Assert.True(next.Aggregated);
+        Assert.Equal(399, next.SuppressedSinceLastLog);
+
+        var clause = DarlingHttpRefusalLog.DescribeSuppression(next, Window);
+        Assert.Contains("399", clause, StringComparison.Ordinal);
+        Assert.Contains("from other sources", clause, StringComparison.Ordinal);
+        Assert.DoesNotContain("from this source", clause, StringComparison.Ordinal);
+
+        /* And the per-source wording is still right where it IS one source. */
+        var perSource = log.Observe(DarlingRefusalGate.Token, "10.0.0.1", T0.Add(Window).AddSeconds(2));
+        Assert.True(perSource.Log);
+        Assert.False(perSource.Aggregated);
+        Assert.Contains(
+            "from this source",
+            DarlingHttpRefusalLog.DescribeSuppression(perSource with { SuppressedSinceLastLog = 7 }, Window),
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// Eviction is keyed on LAST SEEN, not last logged. Keyed on last logged, a source still being refused
     /// every second would be dropped at the two-window horizon and re-log as a fresh first sighting —
     /// turning the rate limit into a rate multiplier, which is worse than no limit because it looks like

--- a/Darling/PerformanceMonitor.Darling.Service/Hosting/DarlingHttpRefusalLog.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Hosting/DarlingHttpRefusalLog.cs
@@ -225,6 +225,18 @@ internal sealed class DarlingHttpRefusalLog
         get { lock (_sync) { return _perSource.Count + _perGate.Count; } }
     }
 
+    /// <summary>
+    /// What actually happened, so the verb agrees with the status code (review catch on #2479).
+    ///
+    /// <para>Not every gate rejection ends in a 4xx. The web dashboard answers an in-CIDR request carrying
+    /// a WRONG <c>?token=</c> with a 200 and the login page — deliberately, and it is exactly the state an
+    /// operator asks about when a token they pasted did not work, which is why it is logged at all. But
+    /// "refused a request … with 200" is self-contradictory on its face, and it would mislead anyone
+    /// reading the log cold or filtering it for denials on status.</para>
+    /// </summary>
+    internal static string DescribeOutcome(int statusCode) =>
+        statusCode >= 400 ? "refused" : "did not authorize";
+
     /// <summary>The gate, named the way an operator would have to name it to fix it.</summary>
     internal static string Describe(DarlingRefusalGate gate) => gate switch
     {
@@ -330,8 +342,9 @@ internal sealed class DarlingHttpRefusalLog
             : string.Empty;
 
         logger.LogWarning(
-            "{Surface} refused a request from {Source} with {Status}: the {Gate} gate rejected it — {Reason}.{Suppressed}{Scope}",
+            "{Surface} {Outcome} a request from {Source} (HTTP {Status}): the {Gate} gate rejected it — {Reason}.{Suppressed}{Scope}",
             surface,
+            DescribeOutcome(statusCode),
             source,
             statusCode,
             Describe(gate),

--- a/Darling/PerformanceMonitor.Darling.Service/Hosting/DarlingHttpRefusalLog.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Hosting/DarlingHttpRefusalLog.cs
@@ -1,0 +1,331 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Net;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace PerformanceMonitor.Darling.Service.Hosting;
+
+/// <summary>Which gate turned a request away. Naming it is the whole point (#2479, item 5).</summary>
+internal enum DarlingRefusalGate
+{
+    /// <summary>The Host-header allowlist / DNS-rebinding guard. 400, both bind modes.</summary>
+    HostAllowlist,
+
+    /// <summary>The access token — the MCP bearer header, or the web dashboard's <c>?token=</c>.</summary>
+    Token,
+
+    /// <summary>The in-app source-address allowlist built from <c>network.allowFrom</c>. 403.</summary>
+    SourceCidr,
+}
+
+/// <summary>
+/// One rate-limited WARN per refused request, saying which gate refused it (#2479, item 5).
+///
+/// <para><b>The gap.</b> A 401, 403 or 400 on either listener left NOTHING in the service log — every
+/// refusal site was a bare <c>StatusCode = …; return;</c>. So "is my token wrong, or my CIDR wrong?" was
+/// answerable only from the client, which sees one opaque status code and cannot tell a Host-allowlist 400
+/// from a malformed request, or a CIDR 403 from anything else. The person who can FIX either of those is
+/// on the server, and the server said nothing.</para>
+///
+/// <para><b>Why the rate limit is not optional.</b> These listeners are LAN-exposed on purpose. An exposed
+/// port meets a scanner eventually, and an unthrottled line per refusal turns that into a log-filling
+/// denial of service against the very file an operator debugs from — the log stops being readable exactly
+/// when it matters. So a refusal is logged at most once per <see cref="DefaultWindow"/> per
+/// (gate, source address), and the number suppressed since the last line rides along on the next one, so
+/// the volume is visible without being written.</para>
+///
+/// <para><b>Why per-SOURCE and not per-gate alone.</b> Per-gate is a smaller key set and it is wrong: one
+/// scanner's line would win the window and hide the tester's own refusal completely, which is the failure
+/// this exists to fix, reintroduced by the fix for it. Keyed per source, the tester's FIRST refusal is
+/// always logged immediately — first sighting never waits — and only their repeats are folded, which cost
+/// nothing to lose because a second identical refusal carries no information the first did not.</para>
+///
+/// <para><b>Why there is a cap, and what it costs.</b> A per-source map is unbounded by construction on an
+/// exposed port. Past <see cref="DefaultMaxTrackedSources"/> distinct sources in a window, further sources
+/// fold into one per-gate aggregate bucket that says so, which bounds both memory and log volume to
+/// (cap + gate count) entries and one line per gate per window. The accepted cost: under an active scan
+/// the per-source slots may be taken, and a tester arriving mid-scan lands in the aggregate. That is
+/// visible rather than silent — the line says the per-source budget is full — and if the port is being
+/// scanned, that IS the more urgent thing for the operator to know.</para>
+///
+/// <para><b>What is never logged.</b> The token, any prefix of it, and its length. A refusal reports
+/// whether a credential was PRESENTED, never anything about its value. Attacker-controlled text that does
+/// reach the log (the Host header) goes through <see cref="Sanitize"/> first: a log file is a text file,
+/// and a header carrying CR/LF would otherwise forge log lines.</para>
+/// </summary>
+internal sealed class DarlingHttpRefusalLog
+{
+    /// <summary>
+    /// How long one (gate, source) stays folded after a line is written.
+    ///
+    /// <para>Long on purpose. The first sighting of a (gate, source) is ALWAYS logged immediately, so a
+    /// tester never waits for their answer; the window only governs REPEATS, and a second identical
+    /// refusal from the same address through the same gate tells nobody anything. A tester who fixes their
+    /// token and now fails the CIDR check instead trips a different gate, which is a different key, which
+    /// logs at once — so iterating stays responsive while a fixed fault stays quiet.</para>
+    /// </summary>
+    internal static readonly TimeSpan DefaultWindow = TimeSpan.FromMinutes(10);
+
+    /// <summary>Distinct sources tracked before new ones fold into the per-gate aggregate.</summary>
+    internal const int DefaultMaxTrackedSources = 16;
+
+    /// <summary>Longest a Host header is echoed into the log.</summary>
+    internal const int MaxEchoedLength = 64;
+
+    /// <summary>Stands in for a remote address ASP.NET Core could not give us. It is a real state (a
+    /// Unix-socket or in-process transport) and the CIDR gate fails closed on it, so it needs a key.</summary>
+    internal const string UnknownSource = "unknown";
+
+    private readonly TimeSpan _window;
+    private readonly int _maxTrackedSources;
+
+    /* A plain Dictionary under a lock rather than a ConcurrentDictionary: the decision reads AND writes
+       several fields together (last-logged, last-seen, the suppressed counter) and has to consult Count
+       against the cap in the same breath, which a concurrent map cannot make atomic without a lock anyway.
+       Contention is a non-issue because this is only ever reached on a REFUSED request. */
+    private readonly object _sync = new();
+    private readonly Dictionary<string, Entry> _perSource = new(StringComparer.Ordinal);
+    private readonly Dictionary<DarlingRefusalGate, Entry> _perGate = new();
+
+    public DarlingHttpRefusalLog(TimeSpan? window = null, int? maxTrackedSources = null)
+    {
+        _window = window ?? DefaultWindow;
+        _maxTrackedSources = maxTrackedSources ?? DefaultMaxTrackedSources;
+    }
+
+    /// <summary>Whether this refusal should be written, and what the line owes the reader.</summary>
+    /// <param name="Log">Write a line for this refusal.</param>
+    /// <param name="SuppressedSinceLastLog">Refusals folded into silence since the last line for this key.
+    /// Reported ON the next line, so the volume is visible without being written.</param>
+    /// <param name="Aggregated">This line speaks for the per-gate aggregate rather than one source,
+    /// because the per-source budget was full.</param>
+    internal readonly record struct Decision(bool Log, int SuppressedSinceLastLog, bool Aggregated);
+
+    /// <summary>
+    /// Records one refusal and decides whether it earns a log line. Pure with respect to the clock — the
+    /// caller passes <paramref name="nowUtc"/> — so the whole policy is testable without a host, a socket
+    /// or a wait.
+    /// </summary>
+    public Decision Observe(DarlingRefusalGate gate, string? source, DateTime nowUtc)
+    {
+        var key = string.Concat(
+            gate.ToString(),
+            "|",
+            string.IsNullOrWhiteSpace(source) ? UnknownSource : source);
+
+        lock (_sync)
+        {
+            Evict(nowUtc);
+
+            if (_perSource.TryGetValue(key, out var tracked))
+            {
+                return Fold(tracked, nowUtc, aggregated: false);
+            }
+
+            if (_perSource.Count < _maxTrackedSources)
+            {
+                /* First sighting: logged immediately and unconditionally. This is the line the operator is
+                   waiting for, and making it wait for a window would be the whole feature failing. */
+                _perSource[key] = new Entry { LastLoggedUtc = nowUtc, LastSeenUtc = nowUtc, Suppressed = 0 };
+                return new Decision(Log: true, SuppressedSinceLastLog: 0, Aggregated: false);
+            }
+
+            if (!_perGate.TryGetValue(gate, out var aggregate))
+            {
+                _perGate[gate] = new Entry { LastLoggedUtc = nowUtc, LastSeenUtc = nowUtc, Suppressed = 0 };
+                return new Decision(Log: true, SuppressedSinceLastLog: 0, Aggregated: true);
+            }
+
+            return Fold(aggregate, nowUtc, aggregated: true);
+        }
+    }
+
+    private Decision Fold(Entry entry, DateTime nowUtc, bool aggregated)
+    {
+        entry.LastSeenUtc = nowUtc;
+
+        if (nowUtc - entry.LastLoggedUtc < _window)
+        {
+            entry.Suppressed++;
+            return new Decision(Log: false, SuppressedSinceLastLog: 0, Aggregated: aggregated);
+        }
+
+        var suppressed = entry.Suppressed;
+        entry.Suppressed = 0;
+        entry.LastLoggedUtc = nowUtc;
+        return new Decision(Log: true, SuppressedSinceLastLog: suppressed, Aggregated: aggregated);
+    }
+
+    /* Two windows of silence and a source is forgotten, which is what frees the per-source budget again
+       after a scan stops. Keyed on LAST SEEN rather than last logged: an address still being refused every
+       second must not be evicted mid-window and then re-log as a first sighting, which would turn the
+       rate limit into a rate multiplier. */
+    private void Evict(DateTime nowUtc)
+    {
+        var horizon = nowUtc - (_window + _window);
+
+        List<string>? staleSources = null;
+        foreach (var pair in _perSource)
+        {
+            if (pair.Value.LastSeenUtc < horizon)
+            {
+                (staleSources ??= new List<string>()).Add(pair.Key);
+            }
+        }
+
+        if (staleSources is not null)
+        {
+            foreach (var stale in staleSources)
+            {
+                _perSource.Remove(stale);
+            }
+        }
+
+        List<DarlingRefusalGate>? staleGates = null;
+        foreach (var pair in _perGate)
+        {
+            if (pair.Value.LastSeenUtc < horizon)
+            {
+                (staleGates ??= new List<DarlingRefusalGate>()).Add(pair.Key);
+            }
+        }
+
+        if (staleGates is not null)
+        {
+            foreach (var stale in staleGates)
+            {
+                _perGate.Remove(stale);
+            }
+        }
+    }
+
+    /* Mutable, and only ever touched under _sync. LastLoggedUtc drives the window; LastSeenUtc drives
+       eviction; Suppressed is what the next line owes the reader. */
+    private sealed class Entry
+    {
+        public DateTime LastLoggedUtc;
+        public DateTime LastSeenUtc;
+        public int Suppressed;
+    }
+
+    /// <summary>Entries tracked right now — for the tests, which assert that the cap and the eviction
+    /// actually bound this rather than trusting that they do.</summary>
+    internal int TrackedCount
+    {
+        get { lock (_sync) { return _perSource.Count + _perGate.Count; } }
+    }
+
+    /// <summary>The gate, named the way an operator would have to name it to fix it.</summary>
+    internal static string Describe(DarlingRefusalGate gate) => gate switch
+    {
+        DarlingRefusalGate.HostAllowlist => "Host header allowlist",
+        DarlingRefusalGate.Token => "access token",
+        DarlingRefusalGate.SourceCidr => "source address allowlist (network.allowFrom)",
+        _ => gate.ToString(),
+    };
+
+    /// <summary>The remote address as a log key and a log value, or <see cref="UnknownSource"/>.</summary>
+    internal static string DescribeSource(IPAddress? remote)
+    {
+        if (remote is null)
+        {
+            return UnknownSource;
+        }
+
+        var ip = remote.IsIPv4MappedToIPv6 ? remote.MapToIPv4() : remote;
+        return ip.ToString();
+    }
+
+    /// <summary>
+    /// Makes attacker-supplied text safe to put in a log line: control characters become '.', and the
+    /// result is truncated.
+    ///
+    /// <para>CR and LF are the ones that matter. A log file is a text file and a reader — human or
+    /// otherwise — splits it on newlines, so a Host header carrying <c>\r\n</c> could forge whole log
+    /// entries. Truncation bounds the other half of the problem: a megabyte header should not become a
+    /// megabyte of log.</para>
+    /// </summary>
+    internal static string Sanitize(string? value, int maxLength = MaxEchoedLength)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return "(none)";
+        }
+
+        var take = Math.Min(value.Length, maxLength);
+        var builder = new StringBuilder(take + 1);
+        for (var i = 0; i < take; i++)
+        {
+            var c = value[i];
+            builder.Append(c < ' ' || c == (char)0x7F ? '.' : c);
+        }
+
+        if (value.Length > maxLength)
+        {
+            builder.Append('…');
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>The " (N more suppressed…)" clause, or empty when this is the first or only line.</summary>
+    internal static string DescribeSuppression(Decision decision, TimeSpan window)
+    {
+        if (decision.SuppressedSinceLastLog <= 0)
+        {
+            return string.Empty;
+        }
+
+        return string.Format(
+            CultureInfo.InvariantCulture,
+            " {0} further refusal(s) from this source were not logged in the last {1} minute(s).",
+            decision.SuppressedSinceLastLog,
+            (int)Math.Round(window.TotalMinutes));
+    }
+
+    /// <summary>
+    /// Observes one refusal and writes the WARN if it earns one. Both hosts call this, so the wording,
+    /// the rate limit and the redaction rules cannot drift between them.
+    /// </summary>
+    public void Report(
+        ILogger logger,
+        string surface,
+        DarlingRefusalGate gate,
+        int statusCode,
+        IPAddress? remote,
+        string reason,
+        DateTime nowUtc)
+    {
+        var source = DescribeSource(remote);
+        var decision = Observe(gate, source, nowUtc);
+        if (!decision.Log)
+        {
+            return;
+        }
+
+        var scope = decision.Aggregated
+            ? " (speaking for several sources — the per-source log budget is full, which usually means this "
+                + "port is being scanned)"
+            : string.Empty;
+
+        logger.LogWarning(
+            "{Surface} refused a request from {Source} with {Status}: the {Gate} gate rejected it — {Reason}.{Suppressed}{Scope}",
+            surface,
+            source,
+            statusCode,
+            Describe(gate),
+            reason,
+            DescribeSuppression(decision, _window),
+            scope);
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Service/Hosting/DarlingHttpRefusalLog.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Hosting/DarlingHttpRefusalLog.cs
@@ -278,7 +278,16 @@ internal sealed class DarlingHttpRefusalLog
         return builder.ToString();
     }
 
-    /// <summary>The " (N more suppressed…)" clause, or empty when this is the first or only line.</summary>
+    /// <summary>
+    /// The "N more were suppressed" clause, or empty when this is the first or only line.
+    ///
+    /// <para>The wording branches on <see cref="Decision.Aggregated"/> because the two buckets fold
+    /// different things, and saying so wrongly is worse than saying nothing. A per-source entry folds
+    /// repeats from ONE address. The aggregate entry folds the cap overflow, which is by definition many
+    /// DIFFERENT addresses through one gate — so "N further refusals from this source" would be actively
+    /// false there, and false in the direction that matters: an operator reading it would go looking for
+    /// one busy client when what is happening is a broad scan. Review catch on #2479.</para>
+    /// </summary>
     internal static string DescribeSuppression(Decision decision, TimeSpan window)
     {
         if (decision.SuppressedSinceLastLog <= 0)
@@ -288,7 +297,9 @@ internal sealed class DarlingHttpRefusalLog
 
         return string.Format(
             CultureInfo.InvariantCulture,
-            " {0} further refusal(s) from this source were not logged in the last {1} minute(s).",
+            decision.Aggregated
+                ? " {0} further refusal(s) through this gate, from other sources, were not logged in the last {1} minute(s)."
+                : " {0} further refusal(s) from this source were not logged in the last {1} minute(s).",
             decision.SuppressedSinceLastLog,
             (int)Math.Round(window.TotalMinutes));
     }

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpHostService.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpHostService.cs
@@ -731,16 +731,22 @@ public sealed class DarlingMcpHostService : BackgroundService
 
                     if (!IsBearerTokenAuthorized(authorization, token))
                     {
-                        /* Presented-or-not, never the value. Which of the two it is IS the operator's next
-                           step - an absent header is a client that was never configured, a wrong one is a
-                           token that does not match mcp.network.encryptedToken - and neither statement
-                           says anything about what the token is. */
+                        /* THREE client states, never the token's value. Each one is a different next step
+                           for the operator, which is the whole point of logging this at all:
+
+                             no header            -> a client that was never configured with a token
+                             header, not a Bearer -> a client configured wrong (Basic, a bare token, an
+                                                     empty "Bearer ") - it IS sending something
+                             a Bearer that misses -> a token that does not match this endpoint's
+
+                           Review catch on #2479: ExtractBearerToken returns null for the first TWO, so
+                           testing only it reported "nothing was presented" about a client that presented
+                           a malformed header - collapsing precisely the ambiguity this exists to resolve.
+                           None of the three says anything about what the token IS. */
                         refusals.Report(
                             _logger, "MCP", DarlingRefusalGate.Token, StatusCodes.Status401Unauthorized,
                             context.Connection.RemoteIpAddress,
-                            ExtractBearerToken(authorization) is null
-                                ? "no 'Authorization: Bearer <token>' header was presented"
-                                : "the presented bearer token does not match mcp.network.encryptedToken",
+                            DescribeBearerRefusal(authorization),
                             DateTime.UtcNow);
                         context.Response.StatusCode = StatusCodes.Status401Unauthorized;
                         context.Response.Headers.WWWAuthenticate = "Bearer";
@@ -934,6 +940,33 @@ public sealed class DarlingMcpHostService : BackgroundService
 
         var token = value.Substring(prefix.Length).Trim();
         return string.IsNullOrEmpty(token) ? null : token;
+    }
+
+    /// <summary>
+    /// PURE: why a bearer check refused, in the operator's terms — three states, not two (#2479).
+    ///
+    /// <para><see cref="ExtractBearerToken"/> answers null for BOTH "no header" and "a header that is not a
+    /// well-formed Bearer", so a refusal line built on it alone tells an operator nothing was presented
+    /// while their client is sending <c>Authorization: Basic …</c> every second. Those are different
+    /// faults with different fixes — one client has no token configured, the other has it configured
+    /// wrong — and telling them apart is the reason this line exists.</para>
+    ///
+    /// <para>Says nothing about the token's value, and cannot: it reads only the header's SHAPE.</para>
+    /// </summary>
+    internal static string DescribeBearerRefusal(string? authorizationHeaderValue)
+    {
+        if (string.IsNullOrWhiteSpace(authorizationHeaderValue))
+        {
+            return "no 'Authorization: Bearer <token>' header was presented";
+        }
+
+        if (ExtractBearerToken(authorizationHeaderValue) is null)
+        {
+            return "an Authorization header WAS presented but is not a 'Bearer <token>' "
+                + "(wrong scheme, or an empty token after 'Bearer')";
+        }
+
+        return "the presented bearer token does not match mcp.network.encryptedToken";
     }
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpHostService.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpHostService.cs
@@ -721,7 +721,15 @@ public sealed class DarlingMcpHostService : BackgroundService
 
                 _app.Use(async (context, next) =>
                 {
-                    if (!IsBearerTokenAuthorized(context.Request.Headers.Authorization.ToString(), token))
+                    /* Materialized once: StringValues.ToString() allocates, and the refusal path below needs
+                       the same header again to tell "no credential" from "wrong credential" (review catch on
+                       #2479). IsBearerTokenAuthorized keeps taking the raw header rather than returning what
+                       it parsed - its signature is pinned by DarlingMcpHostTests and DarlingHostBindingTests,
+                       and threading a result type through it to save one parse on an ALREADY-REFUSED request
+                       is not a trade worth making. */
+                    var authorization = context.Request.Headers.Authorization.ToString();
+
+                    if (!IsBearerTokenAuthorized(authorization, token))
                     {
                         /* Presented-or-not, never the value. Which of the two it is IS the operator's next
                            step - an absent header is a client that was never configured, a wrong one is a
@@ -730,7 +738,7 @@ public sealed class DarlingMcpHostService : BackgroundService
                         refusals.Report(
                             _logger, "MCP", DarlingRefusalGate.Token, StatusCodes.Status401Unauthorized,
                             context.Connection.RemoteIpAddress,
-                            ExtractBearerToken(context.Request.Headers.Authorization.ToString()) is null
+                            ExtractBearerToken(authorization) is null
                                 ? "no 'Authorization: Bearer <token>' header was presented"
                                 : "the presented bearer token does not match mcp.network.encryptedToken",
                             DateTime.UtcNow);

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpHostService.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpHostService.cs
@@ -672,6 +672,14 @@ public sealed class DarlingMcpHostService : BackgroundService
 
             _app = builder.Build();
 
+            /* #2479 item 5: every gate below used to refuse silently, so "is my token wrong or my CIDR
+               wrong" was answerable only from the client, which sees one opaque status code. One log per
+               refusal is rate-limited per (gate, source) because this port is LAN-exposed on purpose and
+               an exposed port meets a scanner eventually - see DarlingHttpRefusalLog for the shape and
+               what it deliberately never writes. Created here, per started server, so a rebind starts
+               with a clean budget rather than inheriting the previous listener's scan. */
+            var refusals = new DarlingHttpRefusalLog();
+
             /* DNS-rebinding guard (#1648) — the FIRST middleware, in BOTH modes, mirroring the web host's
                #1576 fix. The loopback bind is tokenless by design (the network gates below install only in
                network mode), so a browser ON this host that loads attacker content could be rebound to
@@ -686,6 +694,12 @@ public sealed class DarlingMcpHostService : BackgroundService
             {
                 if (!DarlingHostBinding.IsAllowedHost(context.Request.Host.Host, networkListenIp))
                 {
+                    refusals.Report(
+                        _logger, "MCP", DarlingRefusalGate.HostAllowlist, StatusCodes.Status400BadRequest,
+                        context.Connection.RemoteIpAddress,
+                        $"the Host header '{DarlingHttpRefusalLog.Sanitize(context.Request.Host.Host)}' is not an address this endpoint binds"
+                        + " (a loopback name/IP, or mcp.network.listen when LAN-exposed)",
+                        DateTime.UtcNow);
                     context.Response.StatusCode = StatusCodes.Status400BadRequest;
                     return;
                 }
@@ -709,6 +723,17 @@ public sealed class DarlingMcpHostService : BackgroundService
                 {
                     if (!IsBearerTokenAuthorized(context.Request.Headers.Authorization.ToString(), token))
                     {
+                        /* Presented-or-not, never the value. Which of the two it is IS the operator's next
+                           step - an absent header is a client that was never configured, a wrong one is a
+                           token that does not match mcp.network.encryptedToken - and neither statement
+                           says anything about what the token is. */
+                        refusals.Report(
+                            _logger, "MCP", DarlingRefusalGate.Token, StatusCodes.Status401Unauthorized,
+                            context.Connection.RemoteIpAddress,
+                            ExtractBearerToken(context.Request.Headers.Authorization.ToString()) is null
+                                ? "no 'Authorization: Bearer <token>' header was presented"
+                                : "the presented bearer token does not match mcp.network.encryptedToken",
+                            DateTime.UtcNow);
                         context.Response.StatusCode = StatusCodes.Status401Unauthorized;
                         context.Response.Headers.WWWAuthenticate = "Bearer";
                         return;
@@ -721,6 +746,11 @@ public sealed class DarlingMcpHostService : BackgroundService
                 {
                     if (!IsRemoteAddressAllowed(context.Connection.RemoteIpAddress, cidr))
                     {
+                        refusals.Report(
+                            _logger, "MCP", DarlingRefusalGate.SourceCidr, StatusCodes.Status403Forbidden,
+                            context.Connection.RemoteIpAddress,
+                            $"its address is outside mcp.network.allowFrom ({cidr})",
+                            DateTime.UtcNow);
                         context.Response.StatusCode = StatusCodes.Status403Forbidden;
                         return;
                     }

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingWebHostService.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingWebHostService.cs
@@ -428,6 +428,11 @@ public sealed class DarlingWebHostService : BackgroundService
 
             _app = builder.Build();
 
+            /* #2479 item 5: the gates below used to refuse silently. Rate-limited per (gate, source),
+               because this port is LAN-exposed on purpose - see DarlingHttpRefusalLog. Created per
+               started server so a rebind starts with a clean budget. */
+            var refusals = new DarlingHttpRefusalLog();
+
             /* Pipeline order: the Host-allowlist middleware runs FIRST on EVERY request (both modes) as the
                DNS-rebinding guard, then (network mode only) the auth middleware, then DarlingWebEndpoints.MapAll
                -> UseDefaultFiles -> UseStaticFiles. WebApplication auto-inserts UseRouting at the head and
@@ -446,6 +451,12 @@ public sealed class DarlingWebHostService : BackgroundService
             {
                 if (!IsAllowedHost(context.Request.Host.Host, networkListenIp))
                 {
+                    refusals.Report(
+                        _logger, "Web dashboard", DarlingRefusalGate.HostAllowlist, StatusCodes.Status400BadRequest,
+                        context.Connection.RemoteIpAddress,
+                        $"the Host header '{DarlingHttpRefusalLog.Sanitize(context.Request.Host.Host)}' is not an address this endpoint binds"
+                        + " (a loopback name/IP, or web.network.listen when LAN-exposed)",
+                        DateTime.UtcNow);
                     context.Response.StatusCode = StatusCodes.Status400BadRequest;
                     return;
                 }
@@ -468,8 +479,8 @@ public sealed class DarlingWebHostService : BackgroundService
                     var remote = context.Connection.RemoteIpAddress;
                     var hasValidCookie = TryValidateSessionCookie(
                         context.Request.Cookies[SessionCookieName], signingKey, DateTimeOffset.UtcNow);
-                    var hasValidToken = DarlingHostBinding.FixedTimeTokenEquals(
-                        context.Request.Query["token"].ToString(), token);
+                    var presentedToken = context.Request.Query["token"].ToString();
+                    var hasValidToken = DarlingHostBinding.FixedTimeTokenEquals(presentedToken, token);
 
                     switch (DecideWebAuth(remote, cidr, hasValidCookie, hasValidToken))
                     {
@@ -485,10 +496,34 @@ public sealed class DarlingWebHostService : BackgroundService
                             return;
 
                         case WebAuthAction.Forbid:
+                            /* The ONLY 403 this host produces: an out-of-CIDR remote, or one whose address
+                               ASP.NET Core could not report (which fails closed). A wrong credential from
+                               inside the CIDR is ShowLogin, not this - see below. */
+                            refusals.Report(
+                                _logger, "Web dashboard", DarlingRefusalGate.SourceCidr, StatusCodes.Status403Forbidden,
+                                remote,
+                                remote is null
+                                    ? "its source address could not be determined, which fails closed"
+                                    : $"its address is outside web.network.allowFrom ({cidr})",
+                                DateTime.UtcNow);
                             context.Response.StatusCode = StatusCodes.Status403Forbidden;
                             return;
 
                         default: /* ShowLogin */
+                            /* A 200 rather than a 401, so this is not a "rejected request" by status - and
+                               it is exactly the state an operator asks about when a ?token= they pasted did
+                               not work. Logged ONLY when a token was actually presented and did not match:
+                               a first visit with no token is the normal path to the login page and logging
+                               it would make every bookmark a warning. */
+                            if (!string.IsNullOrEmpty(presentedToken))
+                            {
+                                refusals.Report(
+                                    _logger, "Web dashboard", DarlingRefusalGate.Token, StatusCodes.Status200OK,
+                                    remote,
+                                    "the presented ?token= does not match web.network.encryptedToken, so the login page was served instead",
+                                    DateTime.UtcNow);
+                            }
+
                             await WriteLoginPageAsync(context);
                             return;
                     }


### PR DESCRIPTION
Item **5** of #2479.

## The gap

All five refusal sites across the two listeners were a bare `StatusCode = …; return;`:

| Host | Gate | Status | Logged before |
|---|---|---|---|
| MCP | Host header allowlist (DNS-rebinding guard) | 400 | nothing |
| MCP | bearer token | 401 | nothing |
| MCP | source CIDR (`mcp.network.allowFrom`) | 403 | nothing |
| Web | Host header allowlist | 400 | nothing |
| Web | source CIDR (`web.network.allowFrom`) | 403 | nothing |

So *"is my token wrong, or my CIDR wrong?"* was answerable only from the client — which sees one opaque status code and cannot tell a Host-allowlist 400 from a malformed request, or a CIDR 403 from anything else. The person who can fix either is on the server, and the server said nothing.

Each gate now emits a WARN naming itself and the config key that governs it.

**The web host's `ShowLogin` path is included too**, even though it answers **200** rather than 401 — but only when a token was actually *presented and did not match*. That is precisely the state an operator asks about when a `?token=` they pasted did not work, and the status code hides it. A first visit with no token is the normal route to the login page, so logging that would make every bookmark a warning.

Out of scope on purpose: `DarlingWebEndpoints`' validation 400s and the CSRF 415 already return a body that explains itself to the client. This is about the gates that refuse *silently, before any handler*.

## The rate limit, and why it is shaped this way

This is the load-bearing half, so it is measured rather than asserted about.

- **Key is (gate, source address), and a first sighting always logs immediately.** A limiter that makes the tester wait out a window before their own answer appears has not shipped anything. Only *repeats* fold — 10 minutes — which costs nothing, because a second identical refusal from the same address through the same gate carries no information the first did not. Fix the token and now fail the CIDR check, and that is a different key, which logs at once.
- **Per source, not per gate alone.** Per-gate is a smaller key set and it is wrong: one scanner's line would win the window and hide the tester's refusal completely — this defect reintroduced by the fix for it.
- **Which makes the map unbounded, so there is a cap.** Past 16 distinct sources in a window, further sources fold into one per-gate aggregate that **says so** ("speaking for several sources — the per-source log budget is full, which usually means this port is being scanned"). Bounds memory and volume to `cap + gate count` entries and one line per gate per window.
- **The accepted cost, stated rather than discovered:** under an active scan the per-source slots may be taken and a tester arriving mid-scan lands in the aggregate. That is visible rather than silent, and if the port is being scanned, that is the more urgent thing for the operator to know.
- **Eviction is keyed on last SEEN, not last logged.** Keyed on last logged, a source still being refused every second would be dropped at the two-window horizon and re-log as a fresh first sighting — turning the rate limit into a rate *multiplier*, which is worse than no limit because it looks like one is working.
- **The budget belongs to the started server, not the process**, so a rebind starts clean rather than inheriting the previous listener's scan and swallowing the new one's first refusals.

**Measured ceiling: 108,000 refused requests over an hour (30/s across three gates from a few hundred sources) produce 100 log lines and 19 tracked entries.**

## What is never logged

The token, any prefix of it, and its length. A line may say whether a credential was **presented** — an absent `Authorization` header is a client that was never configured; a wrong one is a token that does not match `mcp.network.encryptedToken`, and each points at a different next step — and nothing about its value. Pinned per call site rather than trusted.

The Host header is the only request-derived value echoed, and it goes through a sanitizer first. A log file is a text file: a header carrying `\r\n` would otherwise forge whole log entries.

## Verification

- **Ran the shipped `DarlingHttpRefusalLog.cs`** — `<Compile Include>`'d into a throwaway `net10.0` console harness, since `Darling.Tests` is `net10.0-windows` and cannot run on macOS. **26/26 assertions pass**, including the 108,000-request scan ceiling, the first-sighting-is-immediate guarantee, the noisy-neighbour case, the cap announcement, the last-seen eviction invariant, and the log-injection cases.
- **Simulated both structural pins against the real host files**: MCP has 3 of 3 4xx sites reported, Web 2 of 2, 6 `Report` calls total, no forbidden token identifier in any argument list.
- **Re-checked the existing `HostHeaderGuardTests` assertions against the edited files** — `FirstMiddlewareAfterBuild` still finds `IsAllowedHost(context.Request.Host.Host` and `Status400BadRequest` in the first middleware, and the guard still precedes `if (networkMode)` and `MapMcp`. Adding lines inside that lambda was the one thing that could have broken them.
- Service and `Darling.Tests` both build clean, 0 errors.
- Against `dev` the whole test class fails to **compile** — `DarlingHttpRefusalLog` does not exist there.
- **Not verified:** no request has been pushed through a live Kestrel host, so the exact rendered line and the interaction with the file/Event Log sinks are unexercised. Manual check on a box: with `mcp.network` exposed, `curl -H "Authorization: Bearer wrong" http://<ip>:5152/` should produce one WARN naming the access-token gate, and a second identical curl within ten minutes should produce none.

## Onboarding

Makes `docs/uat-onboarding.md` §4.4 *"When it says enabled and still will not connect"* substantially unnecessary — the section exists because the server-side answer had to be reconstructed from the client's status code. The tell it teaches (401 = token, 403 = CIDR, 400 = Host) is now stated in the service log at the moment it happens, naming the config key. §5's *"the things that will actually bite you"* entry on the same subject can go the same way. The gate list is still worth keeping as a reference table; the "you can only tell from the client" framing is what stops being true.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
