### PR TITLE
Reprint a lost endpoint token, and say when a network block can change (#2479)

### DIFF
--- a/Darling/Darling.Tests/DarlingPrintEndpointTokenTests.cs
+++ b/Darling/Darling.Tests/DarlingPrintEndpointTokenTests.cs
@@ -239,8 +239,8 @@ public class DarlingPrintEndpointTokenTests
     /// <summary>Both verbs are dispatched from Program.cs behind the Windows guard the DPAPI material
     /// requires — a verb that is classified but never dispatched is #1581 the other way round.</summary>
     [Theory]
-    [InlineData("IsPrintMcpTokenVerb", "PrintMcpTokenAsync", "--print-mcp-token requires Windows")]
-    [InlineData("IsPrintWebTokenVerb", "PrintWebTokenAsync", "--print-web-token requires Windows")]
+    [InlineData("IsPrintMcpTokenVerb", "PrintMcpToken", "--print-mcp-token requires Windows")]
+    [InlineData("IsPrintWebTokenVerb", "PrintWebToken", "--print-web-token requires Windows")]
     public void ProgramDispatchesBothVerbs_BehindTheWindowsGuard(string classifier, string entryPoint, string guard)
     {
         var source = ReadSource(Path.Combine("Darling", "PerformanceMonitor.Darling.Service", "Program.cs"));

--- a/Darling/Darling.Tests/DarlingPrintEndpointTokenTests.cs
+++ b/Darling/Darling.Tests/DarlingPrintEndpointTokenTests.cs
@@ -1,0 +1,355 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using PerformanceMonitor.Darling.Service;
+using PerformanceMonitor.Darling.Service.Hosting;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Reprinting an endpoint's access token (#2479, item 2).
+///
+/// <para><b>The gap.</b> <c>--configure-network</c> shows each generated token's plaintext exactly once.
+/// Lose it and the only path was regeneration, which invalidates every client already configured against
+/// it — so one mislaid token during UAT meant re-onboarding every consumer of that endpoint. An
+/// unrecoverable mistake made out of a recoverable one.</para>
+///
+/// <para><b>What it discloses, and what the elevation gate is not.</b> Nothing new. The token is a
+/// <c>DarlingSecrets</c> blob: DPAPI at <c>LocalMachine</c> scope, with an entropy constant compiled into
+/// an open-source binary — so any process on the box can decrypt it, and the entropy is not a secret
+/// because it is published. And <c>darling.json</c> deliberately grants INTERACTIVE read, because the
+/// Viewer and these very CLI verbs are run by the interactive operator. So an ordinary logged-on
+/// NON-administrator can already read and decrypt the blob in four lines of PowerShell. The gate is worth
+/// having for what it actually does — consistency with the other "(run elevated)" endpoint verbs, and
+/// making a reprint a deliberate act rather than something a script picks up in passing — and the refusal
+/// message says so rather than implying a boundary that is not there. The token's protection is the file's
+/// ACL, and it always was.</para>
+/// </summary>
+public class DarlingPrintEndpointTokenTests
+{
+    [Theory]
+    [InlineData("--print-mcp-token", true)]
+    [InlineData("--PRINT-MCP-TOKEN", true)]
+    [InlineData("--print-web-token", false)]
+    [InlineData("--print-viewer-connection", false)]
+    [InlineData("--nonsense", false)]
+    public void IsPrintMcpTokenVerb_RecognizesOnlyItsOwnVerb_CaseInsensitively(string arg, bool expected) =>
+        Assert.Equal(expected, DarlingCliCommands.IsPrintMcpTokenVerb(arg));
+
+    [Theory]
+    [InlineData("--print-web-token", true)]
+    [InlineData("--PRINT-WEB-TOKEN", true)]
+    [InlineData("--print-mcp-token", false)]
+    [InlineData("--nonsense", false)]
+    public void IsPrintWebTokenVerb_RecognizesOnlyItsOwnVerb_CaseInsensitively(string arg, bool expected) =>
+        Assert.Equal(expected, DarlingCliCommands.IsPrintWebTokenVerb(arg));
+
+    /// <summary>The #1581 trap: a verb with a dispatch block and help text that <c>IsKnownVerb</c> never
+    /// learned classifies as an unknown option, and its dispatch is unreachable.</summary>
+    [Fact]
+    public void IsKnownVerb_ReachesBothTokenVerbs()
+    {
+        Assert.True(DarlingCliCommands.IsKnownVerb("--print-mcp-token"));
+        Assert.True(DarlingCliCommands.IsKnownVerb("--print-web-token"));
+    }
+
+    /// <summary>Both are listed, and both carry the elevated marker the other endpoint verbs use — an
+    /// operator should not have to discover the requirement by being refused.</summary>
+    [Fact]
+    public void UsageText_ListsBothVerbs_AndMarksThemElevated()
+    {
+        var usage = DarlingCliCommands.UsageText();
+
+        foreach (var verb in new[] { "--print-mcp-token", "--print-web-token" })
+        {
+            var at = usage.IndexOf(verb, StringComparison.Ordinal);
+            Assert.True(at >= 0, $"{verb} is not in the help text");
+
+            var line = usage[at..];
+            var end = line.IndexOf('\n');
+            line = end > 0 ? line[..end] : line;
+            Assert.Contains("run elevated", line, StringComparison.Ordinal);
+        }
+    }
+
+    /// <summary>
+    /// Not elevated: refuse, print nothing to STDOUT, and be honest about what the gate is.
+    ///
+    /// <para>The empty STDOUT is the assertion that matters. A refusal that still writes the token is not a
+    /// refusal, and a redirect (<c>… &gt; token.txt</c>) would capture it while the operator read the
+    /// error on their terminal and believed nothing had happened.</para>
+    /// </summary>
+    [Fact]
+    public void NotElevated_RefusesWithoutPrintingAnything_AndDoesNotOverclaimTheGate()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        var exit = DarlingCliCommands.PrintEndpointToken(
+            "mcp", "MCP bearer", "--print-mcp-token", "clients send it as a header",
+            elevated: false, configured: true, () => "s3cret-token-value", output, error);
+
+        Assert.Equal(1, exit);
+        Assert.Equal(string.Empty, output.ToString());
+        Assert.DoesNotContain("s3cret-token-value", error.ToString(), StringComparison.Ordinal);
+
+        var message = error.ToString();
+        Assert.Contains("ELEVATED", message, StringComparison.Ordinal);
+
+        /* The honesty clause. If this ever starts reading as "the token is protected by elevation", the
+           operator stops guarding the thing that actually protects it. */
+        Assert.Contains("INTERACTIVE read", message, StringComparison.Ordinal);
+        Assert.Contains("LocalMachine", message, StringComparison.Ordinal);
+        Assert.Contains("ACL", message, StringComparison.Ordinal);
+    }
+
+    /// <summary>Elevated with nothing configured: say there is no token and name the verb that makes one,
+    /// rather than printing a blank line that reads as an empty token.</summary>
+    [Fact]
+    public void Elevated_WithNoNetworkBlock_SaysSo_AndPrintsNothing()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        var exit = DarlingCliCommands.PrintEndpointToken(
+            "web", "web dashboard access", "--print-web-token", "presented via ?token=",
+            elevated: true, configured: false, () => null, output, error);
+
+        Assert.Equal(1, exit);
+        Assert.Equal(string.Empty, output.ToString());
+        Assert.Contains("web.network", error.ToString(), StringComparison.Ordinal);
+        Assert.Contains("--configure-network", error.ToString(), StringComparison.Ordinal);
+    }
+
+    /// <summary>A configured block whose token resolves empty is not a token — printing a blank line would
+    /// have the operator paste nothing into a client and wonder why it is refused.</summary>
+    [Fact]
+    public void Elevated_WithAnEmptyToken_RefusesRatherThanPrintingABlankLine()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        var exit = DarlingCliCommands.PrintEndpointToken(
+            "mcp", "MCP bearer", "--print-mcp-token", "clients send it as a header",
+            elevated: true, configured: true, () => "", output, error);
+
+        Assert.Equal(1, exit);
+        Assert.Equal(string.Empty, output.ToString());
+    }
+
+    /// <summary>
+    /// A DPAPI blob only decrypts on the machine that produced it, so a darling.json copied from another
+    /// host carries a token this box can never read. Saying that is the difference between a five-minute
+    /// fix and an afternoon.
+    /// </summary>
+    [Fact]
+    public void Elevated_WhenTheBlobCannotBeDecrypted_ExplainsWhy_AndPrintsNothing()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        var exit = DarlingCliCommands.PrintEndpointToken(
+            "mcp", "MCP bearer", "--print-mcp-token", "clients send it as a header",
+            elevated: true, configured: true,
+            () => throw new System.Security.Cryptography.CryptographicException("Key not valid for use in specified state."),
+            output, error);
+
+        Assert.Equal(1, exit);
+        Assert.Equal(string.Empty, output.ToString());
+        Assert.Contains("only decrypts on the machine that produced it", error.ToString(), StringComparison.Ordinal);
+        Assert.Contains("--configure-network", error.ToString(), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The success path, and the split that makes it usable: STDOUT is the token and NOTHING else, so
+    /// <c>… &gt; token.txt</c> and <c>… | clip</c> both produce a pasteable value; every warning is on
+    /// STDERR, so the redirect cannot swallow it; and the token appears on STDERR nowhere at all.
+    /// </summary>
+    [Fact]
+    public void Elevated_PrintsTheTokenOnStdoutAlone_WithEveryWarningOnStderr()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        var exit = DarlingCliCommands.PrintEndpointToken(
+            "mcp", "MCP bearer", "--print-mcp-token", "Authorization: Bearer <token>",
+            elevated: true, configured: true, () => "abc123TOKEN", output, error);
+
+        Assert.Equal(0, exit);
+        Assert.Equal("abc123TOKEN" + Environment.NewLine, output.ToString());
+
+        var warnings = error.ToString();
+        Assert.DoesNotContain("abc123TOKEN", warnings, StringComparison.Ordinal);
+        Assert.Contains("WARNING", warnings, StringComparison.Ordinal);
+        Assert.Contains("--print-mcp-token > token.txt", warnings, StringComparison.Ordinal);
+        Assert.Contains("| clip", warnings, StringComparison.Ordinal);
+
+        /* Reprinting is not the answer to a LEAK, and the one moment an operator reads this text is the
+           moment that distinction matters. */
+        Assert.Contains("LEAKED", warnings, StringComparison.Ordinal);
+        Assert.Contains("--configure-network", warnings, StringComparison.Ordinal);
+    }
+
+    /// <summary>Both verbs are dispatched from Program.cs behind the Windows guard the DPAPI material
+    /// requires — a verb that is classified but never dispatched is #1581 the other way round.</summary>
+    [Theory]
+    [InlineData("IsPrintMcpTokenVerb", "PrintMcpTokenAsync", "--print-mcp-token requires Windows")]
+    [InlineData("IsPrintWebTokenVerb", "PrintWebTokenAsync", "--print-web-token requires Windows")]
+    public void ProgramDispatchesBothVerbs_BehindTheWindowsGuard(string classifier, string entryPoint, string guard)
+    {
+        var source = ReadSource(Path.Combine("Darling", "PerformanceMonitor.Darling.Service", "Program.cs"));
+
+        Assert.Contains($"DarlingCliCommands.{classifier}(args[0])", source, StringComparison.Ordinal);
+        Assert.Contains($"DarlingCliCommands.{entryPoint}(", source, StringComparison.Ordinal);
+        Assert.Contains(guard, source, StringComparison.Ordinal);
+    }
+
+    private static string ReadSource(string relative, [CallerFilePath] string thisFile = "")
+    {
+        var dir = Path.GetDirectoryName(thisFile)!;
+        while (dir is not null && !File.Exists(Path.Combine(dir, relative)))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        Assert.False(dir is null, $"could not locate {relative} from the test source path");
+        return File.ReadAllText(Path.Combine(dir!, relative));
+    }
+}
+
+/// <summary>
+/// The network block's lifetime, said out loud at every start (#2479, item 6).
+///
+/// <para><b>The trap.</b> <c>mcp.network</c> / <c>web.network</c> are loaded ONCE and held for the process
+/// lifetime by design — exposure should require touching the host, and the DPAPI token is LocalMachine-scoped
+/// so it could not live in the store anyway. That design is right and is not changing. What it produced was
+/// "I enabled it and it is still loopback-bound" in another costume, because nothing said the value froze
+/// when the process started.</para>
+///
+/// <para>#2389/#2411 fixed the seed-versus-store confusion by making the split VISIBLE rather than by
+/// removing it, and #2414 did the same for the firewall port. This is that treatment applied to the third
+/// face of the same object — no hot reload, just an endpoint that states what it read and when it can
+/// change.</para>
+/// </summary>
+public class DarlingNetworkBlockLifetimeTests
+{
+    [Fact]
+    public void TheThreeStates_ReadDifferently_AndEachNamesTheKeyAndTheRestart()
+    {
+        var absent = DarlingHostBinding.DescribeNetworkBlockLifetime("mcp", "MCP", blockConfigured: false, exposed: false, null, null);
+        var loopback = DarlingHostBinding.DescribeNetworkBlockLifetime("mcp", "MCP", blockConfigured: true, exposed: false, null, null);
+        var exposed = DarlingHostBinding.DescribeNetworkBlockLifetime("mcp", "MCP", blockConfigured: true, exposed: true, "10.0.0.7", "10.0.0.0/24");
+
+        Assert.NotEqual(absent, loopback);
+        Assert.NotEqual(loopback, exposed);
+        Assert.NotEqual(absent, exposed);
+
+        foreach (var report in new[] { absent, loopback, exposed })
+        {
+            Assert.Contains("mcp.network", report, StringComparison.Ordinal);
+            Assert.Contains("RESTART", report, StringComparison.Ordinal);
+
+            /* And the other half, or "cannot change until restart" reads as "this endpoint is immovable" —
+               which is false, and would have an operator restart the service to do something the control
+               plane already does live. */
+            Assert.Contains("config.config_service.mcp_enabled", report, StringComparison.Ordinal);
+            Assert.Contains("--enable-mcp", report, StringComparison.Ordinal);
+        }
+    }
+
+    /// <summary>
+    /// Only the state that IS a call to action gets one. An endpoint already serving the LAN exactly as
+    /// configured is the likeliest state, and telling that operator to restart is where a start-up line
+    /// spends its credibility — the same reasoning that made <c>DescribeToggleOverride</c>'s consequence
+    /// clause state-specific.
+    /// </summary>
+    [Fact]
+    public void OnlyTheLoopbackWithABlock_TellsYouToRestart()
+    {
+        var exposed = DarlingHostBinding.DescribeNetworkBlockLifetime("web", "Web dashboard", true, true, "10.0.0.7", "10.0.0.0/24");
+        var loopback = DarlingHostBinding.DescribeNetworkBlockLifetime("web", "Web dashboard", true, false, null, null);
+        var absent = DarlingHostBinding.DescribeNetworkBlockLifetime("web", "Web dashboard", false, false, null, null);
+
+        Assert.Contains("restart the service", loopback, StringComparison.Ordinal);
+        Assert.DoesNotContain("restart the service", exposed, StringComparison.Ordinal);
+        Assert.DoesNotContain("restart the service", absent, StringComparison.Ordinal);
+
+        /* The loopback-with-a-block state must also point at the reason already logged rather than
+           repeating it in different words. */
+        Assert.Contains("why the exposure was refused", loopback, StringComparison.Ordinal);
+    }
+
+    /// <summary>The exposed line quotes what this process is actually bound to, so an operator comparing it
+    /// against the file can see at a glance whether the file has moved underneath it.</summary>
+    [Fact]
+    public void TheExposedLine_QuotesTheAddressAndCidrItIsHolding()
+    {
+        var report = DarlingHostBinding.DescribeNetworkBlockLifetime("mcp", "MCP", true, true, "10.197.53.214", "10.197.0.0/16");
+
+        Assert.Contains("10.197.53.214", report, StringComparison.Ordinal);
+        Assert.Contains("10.197.0.0/16", report, StringComparison.Ordinal);
+        Assert.Contains("FIXED for the lifetime of this process", report, StringComparison.Ordinal);
+    }
+
+    /// <summary>The section name threads through everything, so the MCP and web wordings cannot drift —
+    /// the same reason <c>DescribeToggleOverride</c> takes one rather than existing twice.</summary>
+    [Fact]
+    public void TheSectionName_ThreadsThroughEveryKeyItNames()
+    {
+        var web = DarlingHostBinding.DescribeNetworkBlockLifetime("web", "Web dashboard", true, false, null, null);
+
+        Assert.Contains("web.network", web, StringComparison.Ordinal);
+        Assert.Contains("config.config_service.web_enabled", web, StringComparison.Ordinal);
+        Assert.Contains("--enable-web", web, StringComparison.Ordinal);
+        Assert.DoesNotContain("mcp", web, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Both hosts say it, and say it in BOTH bind modes. The loopback start line was the one that never
+    /// mentioned the network block at all, and loopback-when-you-expected-LAN is precisely the state being
+    /// diagnosed — so a call sitting inside the network-mode branch would miss every operator who needs it.
+    /// </summary>
+    [Theory]
+    [InlineData("DarlingMcpHostService.cs")]
+    [InlineData("DarlingWebHostService.cs")]
+    public void EachHost_ReportsTheLifetime_InBothBindModes(string fileName)
+    {
+        var source = ReadHostSource(fileName);
+
+        var call = source.IndexOf("DarlingHostBinding.DescribeNetworkBlockLifetime(", StringComparison.Ordinal);
+        Assert.True(call >= 0, $"{fileName} no longer states its network block's lifetime at start-up (#2479)");
+
+        /* It must sit AFTER the mode-specific start lines rather than inside either of them. The tell is
+           that the nearest enclosing brace context is the start-up block, not the if/else — asserted here
+           the cheap way: the call is after BOTH branches' log statements. */
+        var loopbackLine = source.IndexOf("(loopback only)", StringComparison.Ordinal);
+        var exposedLine = source.IndexOf("loopback also bound", StringComparison.Ordinal);
+
+        Assert.True(loopbackLine >= 0, $"{fileName}'s loopback start line is gone — this pin needs rewriting");
+        Assert.True(exposedLine >= 0, $"{fileName}'s LAN start line is gone — this pin needs rewriting");
+        Assert.True(call > loopbackLine, $"{fileName} states the lifetime only in network mode — the loopback case is the one that needed it");
+        Assert.True(call > exposedLine, $"{fileName} states the lifetime before its LAN start line");
+    }
+
+    private static string ReadHostSource(string fileName, [CallerFilePath] string thisFile = "")
+    {
+        var relative = Path.Combine("Darling", "PerformanceMonitor.Darling.Service", "Mcp", fileName);
+        var dir = Path.GetDirectoryName(thisFile)!;
+        while (dir is not null && !File.Exists(Path.Combine(dir, relative)))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        Assert.False(dir is null, $"could not locate {relative} from the test source path");
+        return File.ReadAllText(Path.Combine(dir!, relative));
+    }
+}

--- a/Darling/Darling.Tests/DarlingPrintEndpointTokenTests.cs
+++ b/Darling/Darling.Tests/DarlingPrintEndpointTokenTests.cs
@@ -170,6 +170,43 @@ public class DarlingPrintEndpointTokenTests
     }
 
     /// <summary>
+    /// A NON-DPAPI resolve failure must not be diagnosed as a DPAPI one.
+    ///
+    /// <para>Review catch on #2479. <c>ResolveToken</c> also resolves <c>env:</c> and <c>file:</c> secret
+    /// references, and those fail with an <see cref="InvalidOperationException"/> whose message already
+    /// names the missing variable or the unreadable path. Appending "a DPAPI blob only decrypts on the
+    /// machine that produced it — regenerate it with --configure-network" to THOSE is a false diagnosis
+    /// pointing at a destructive fix: regenerating invalidates every client configured against the token,
+    /// when the actual repair is to set the environment variable or correct the path. The token is fine.</para>
+    /// </summary>
+    [Fact]
+    public void Elevated_WhenAnEnvOrFileReferenceFails_DoesNotBlameDpapi_OrSuggestRegenerating()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        var exit = DarlingCliCommands.PrintEndpointToken(
+            "mcp", "MCP bearer", "--print-mcp-token", "clients send it as a header",
+            elevated: true, configured: true,
+            () => throw new InvalidOperationException(
+                "mcp.network.token references environment variable 'DARLING_MCP_TOKEN', which is not set (or empty)."),
+            output, error);
+
+        var message = error.ToString();
+
+        Assert.Equal(1, exit);
+        Assert.Equal(string.Empty, output.ToString());
+
+        /* The real cause survives... */
+        Assert.Contains("DARLING_MCP_TOKEN", message, StringComparison.Ordinal);
+
+        /* ...and the DPAPI story, with its destructive remedy, does not appear at all. */
+        Assert.DoesNotContain("DPAPI", message, StringComparison.Ordinal);
+        Assert.DoesNotContain("--configure-network", message, StringComparison.Ordinal);
+        Assert.Contains("does not need regenerating", message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// The success path, and the split that makes it usable: STDOUT is the token and NOTHING else, so
     /// <c>… &gt; token.txt</c> and <c>… | clip</c> both produce a pasteable value; every warning is on
     /// STDERR, so the redirect cannot swallow it; and the token appears on STDERR nowhere at all.

--- a/Darling/Darling.Tests/DarlingPrintEndpointTokenTests.cs
+++ b/Darling/Darling.Tests/DarlingPrintEndpointTokenTests.cs
@@ -340,6 +340,33 @@ public class DarlingNetworkBlockLifetimeTests
         Assert.True(call > exposedLine, $"{fileName} states the lifetime before its LAN start line");
     }
 
+    /// <summary>
+    /// The lifetime report reads the network block NULL-SAFELY.
+    ///
+    /// <para>Review catch on #2479, and the exact shape of defect this project keeps finding: a call site
+    /// that never learned a concept the code around it already knew. <c>config.Mcp.Network</c> is
+    /// <c>McpNetworkConfig?</c> and is null on the DEFAULT secure config — no <c>mcp.network</c> block at
+    /// all — which is precisely the state this line exists to describe. The dereferences inside
+    /// <c>if (networkMode)</c> are safe because the bind resolution has already proven a block exists;
+    /// this one runs unconditionally. A bare <c>.IsConfigured</c> throws on every start of an un-exposed
+    /// server, is swallowed by the surrounding catch, and retry-fails forever because the config never
+    /// changes between attempts — so the feature that explains loopback-only would have been the thing
+    /// keeping the endpoint from starting at all.</para>
+    /// </summary>
+    [Theory]
+    [InlineData("DarlingMcpHostService.cs", "config.Mcp.Network")]
+    [InlineData("DarlingWebHostService.cs", "config.Web.Network")]
+    public void TheLifetimeReport_ReadsTheNetworkBlockNullSafely(string fileName, string accessor)
+    {
+        var source = ReadHostSource(fileName);
+
+        var call = source.IndexOf("DarlingHostBinding.DescribeNetworkBlockLifetime(", StringComparison.Ordinal);
+        Assert.True(call >= 0, $"{fileName} no longer states its network block's lifetime at start-up (#2479)");
+
+        var arguments = source[call..Math.Min(source.Length, call + 400)];
+        Assert.Contains($"{accessor}?.IsConfigured ?? false", arguments, StringComparison.Ordinal);
+    }
+
     private static string ReadHostSource(string fileName, [CallerFilePath] string thisFile = "")
     {
         var relative = Path.Combine("Darling", "PerformanceMonitor.Darling.Service", "Mcp", fileName);

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingCliCommands.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingCliCommands.cs
@@ -76,6 +76,16 @@ public static class DarlingCliCommands
     public static bool IsPrintViewerConnectionVerb(string arg) =>
         string.Equals(arg, "--print-viewer-connection", StringComparison.OrdinalIgnoreCase);
 
+    /// <summary>The verb <see cref="PrintMcpTokenAsync"/> handles — reprint the MCP bearer token (#2479, item 2).</summary>
+    public static bool IsPrintMcpTokenVerb(string arg) =>
+        string.Equals(arg, "--print-mcp-token", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>The verb <see cref="PrintWebTokenAsync"/> handles — reprint the web dashboard access token.
+    /// The issue asked for the MCP half; both tokens have the identical unrecoverable-loss problem and the
+    /// identical DPAPI shape, so shipping one and not the other would leave half a fix behind.</summary>
+    public static bool IsPrintWebTokenVerb(string arg) =>
+        string.Equals(arg, "--print-web-token", StringComparison.OrdinalIgnoreCase);
+
     /// <summary>The verb <see cref="ExportViewerConfigAsync"/> handles — write a COMPLETE viewer darling.json +
     /// server.crt + README.txt an operator copies to the viewer machine as-is (#1953).</summary>
     public static bool IsExportViewerConfigVerb(string arg) =>
@@ -158,6 +168,8 @@ public static class DarlingCliCommands
         IsEncryptPasswordVerb(arg)
         || IsValidateConfigVerb(arg)
         || IsPrintViewerConnectionVerb(arg)
+        || IsPrintMcpTokenVerb(arg)
+        || IsPrintWebTokenVerb(arg)
         || IsExportViewerConfigVerb(arg)
         || IsConfigureNetworkVerb(arg)
         || IsConfigureFirewallVerb(arg)
@@ -232,6 +244,8 @@ public static class DarlingCliCommands
         "  PerformanceMonitor.Darling.Service.exe --test-connection   Validate darling.json and probe every configured server." + Environment.NewLine +
         "  PerformanceMonitor.Darling.Service.exe --encrypt-password  Encrypt a SQL-auth password for darling.json (reads stdin)." + Environment.NewLine +
         "  PerformanceMonitor.Darling.Service.exe --print-viewer-connection   Print a remote-viewer connection string (managed store)." + Environment.NewLine +
+        "  PerformanceMonitor.Darling.Service.exe --print-mcp-token   Reprint the MCP bearer token from darling.json (run elevated; writes a LIVE token to stdout)." + Environment.NewLine +
+        "  PerformanceMonitor.Darling.Service.exe --print-web-token   Reprint the web dashboard access token from darling.json (run elevated; writes a LIVE token to stdout)." + Environment.NewLine +
         "  PerformanceMonitor.Darling.Service.exe --export-viewer-config [dir] [--config <path>]  Write a ready-to-copy viewer folder (darling.json + server.crt + README.txt)." + Environment.NewLine +
         "  PerformanceMonitor.Darling.Service.exe --configure-network Interactive LAN-exposure wizard." + Environment.NewLine +
         "  PerformanceMonitor.Darling.Service.exe --configure-firewall  Create/remove the scoped firewall rules to match darling.json (run elevated)." + Environment.NewLine +
@@ -415,6 +429,177 @@ public static class DarlingCliCommands
             output.WriteLine(certificate);
         }
 
+        return 0;
+    }
+
+    /* ---------------------------------------------------------------------------------------------------
+       REPRINTING AN ENDPOINT TOKEN (#2479, item 2).
+
+       --configure-network shows each generated token's plaintext exactly once. Lose it and the only path
+       was regeneration, which invalidates every client already configured against it - so one mislaid
+       token during UAT meant re-onboarding every consumer of that endpoint. That is an unrecoverable
+       mistake made out of a recoverable one, and the recovery costs nothing to provide.
+
+       WHAT THIS DISCLOSES, checked rather than assumed. Nothing new. darling.json stores the token as a
+       DarlingSecrets blob: DPAPI, DataProtectionScope.LocalMachine, with the entropy constant
+       "PerformanceMonitor.Darling.v1" compiled into an OPEN-SOURCE binary. LocalMachine scope means any
+       process on this box can Unprotect it, and the entropy is not a secret because it is published in
+       this repository. So the whole of this verb is four lines of PowerShell to anyone holding the file.
+
+       WHICH IS WHY THE ELEVATION GATE IS NOT A CONFIDENTIALITY BOUNDARY, and this comment says so rather
+       than letting the code imply otherwise. install-darling.ps1 and DarlingFileSecurity deliberately grant
+       INTERACTIVE *read* on darling.json - the Viewer and these very CLI verbs are run by the interactive
+       operator - so an ordinary logged-on user who is NOT an administrator can already read the blob and
+       decrypt it. The gate is worth having for what it actually does: it keeps the verb consistent with the
+       other endpoint verbs that carry "(run elevated)", it stops a script or a shared shell picking a live
+       credential up in passing, and it makes reprinting a deliberate act. The token's real protection is
+       the file's ACL, and it always was.
+
+       Emission follows --print-viewer-connection's posture exactly (D8): every warning on STDERR, ahead of
+       any STDOUT payload, so redirecting STDOUT to an ACL'd file or the clipboard captures the token
+       WITHOUT swallowing the warning. The field report on that verb watched a live password scroll past
+       and only then saw the redirect advice, which is precisely backwards.
+       --------------------------------------------------------------------------------------------------- */
+
+    /// <summary>Reprints the MCP bearer token from <c>mcp.network</c>. See the block above for the
+    /// disclosure analysis. Returns 0 when a token was printed, 1 otherwise.</summary>
+    [SupportedOSPlatform("windows")]
+    public static int PrintMcpTokenAsync(string? configPath, TextWriter output, TextWriter error)
+    {
+        DarlingConfig config;
+        try
+        {
+            config = DarlingConfig.Load(configPath);
+        }
+        catch (Exception ex)
+        {
+            error.WriteLine($"Could not load configuration: {ex.Message}");
+            return 1;
+        }
+
+        var network = config.Mcp.Network;
+        return PrintEndpointToken(
+            "mcp",
+            "MCP bearer",
+            "--print-mcp-token",
+            "Remote MCP clients send it as the header:  Authorization: Bearer <token>",
+            IsElevated(),
+            network is not null && network.IsConfigured,
+            () => network!.ResolveToken(out _),
+            output,
+            error);
+    }
+
+    /// <summary>Reprints the web dashboard access token from <c>web.network</c>. Returns 0 when a token was
+    /// printed, 1 otherwise.</summary>
+    [SupportedOSPlatform("windows")]
+    public static int PrintWebTokenAsync(string? configPath, TextWriter output, TextWriter error)
+    {
+        DarlingConfig config;
+        try
+        {
+            config = DarlingConfig.Load(configPath);
+        }
+        catch (Exception ex)
+        {
+            error.WriteLine($"Could not load configuration: {ex.Message}");
+            return 1;
+        }
+
+        var network = config.Web.Network;
+        return PrintEndpointToken(
+            "web",
+            "web dashboard access",
+            "--print-web-token",
+            "A remote browser presents it once via ?token=... and gets a session cookie back.",
+            IsElevated(),
+            network is not null && network.IsConfigured,
+            () => network!.ResolveToken(out _),
+            output,
+            error);
+    }
+
+    /// <summary>
+    /// The shared body. Split out so the elevation refusal, the disclosure warning and the redirect advice
+    /// are written once and cannot drift between the two endpoints - the same reason
+    /// <c>DescribeToggleOverride</c> takes a section name rather than existing twice.
+    ///
+    /// <para><paramref name="elevated"/> is passed IN rather than measured here, the same way the pure alert
+    /// gates take <c>nowUtc</c>: it makes both branches - the refusal and the disclosure - drivable in a test
+    /// on any runner, elevated or not. A verb whose refusal path is only exercised when the CI agent happens
+    /// to be unprivileged is a refusal nobody has checked.</para>
+    /// </summary>
+    internal static int PrintEndpointToken(
+        string section,
+        string tokenName,
+        string verb,
+        string howClientsPresentIt,
+        bool elevated,
+        bool configured,
+        Func<string?> resolveToken,
+        TextWriter output,
+        TextWriter error)
+    {
+        if (!elevated)
+        {
+            error.WriteLine($"{verb} needs an ELEVATED PowerShell.");
+            error.WriteLine();
+            error.WriteLine("It reprints a live credential, so it is a deliberate act rather than something a script or a");
+            error.WriteLine("shared shell picks up in passing.");
+            error.WriteLine();
+            error.WriteLine("Be clear about what this gate is NOT, though: darling.json grants INTERACTIVE read on purpose");
+            error.WriteLine("(the Viewer and these CLI verbs are run by the interactive operator), and the token is DPAPI-");
+            error.WriteLine("protected at LocalMachine scope with an entropy constant published in this project's source.");
+            error.WriteLine("Anyone who can log on to this box interactively can already decrypt it without this verb. The");
+            error.WriteLine("token's protection is the FILE'S ACL - keep darling.json restricted, and run --harden-files if");
+            error.WriteLine("you are not sure it still is.");
+            return 1;
+        }
+
+        if (!configured)
+        {
+            error.WriteLine($"darling.json has no {section}.network block, so there is no {tokenName} token to print.");
+            error.WriteLine($"Run --configure-network to create one (it generates the token and shows it once).");
+            return 1;
+        }
+
+        string? token;
+        try
+        {
+            token = resolveToken();
+        }
+        catch (Exception ex)
+        {
+            error.WriteLine($"Could not read the {tokenName} token: {ex.Message}");
+            error.WriteLine(
+                $"A DPAPI blob only decrypts on the machine that produced it, so a {section}.network.encryptedToken "
+                + "copied from another host can never be read here - regenerate it with --configure-network.");
+            return 1;
+        }
+
+        if (string.IsNullOrEmpty(token))
+        {
+            error.WriteLine($"{section}.network is configured but carries no token, so this endpoint is not LAN-exposed.");
+            error.WriteLine("Run --configure-network to generate one.");
+            return 1;
+        }
+
+        /* Every stderr line before the payload (D8), so a STDOUT redirect keeps the token and still shows
+           the warning. */
+        error.WriteLine();
+        error.WriteLine(
+            $"WARNING: the {tokenName} token below is written to STDOUT as PLAINTEXT. It gates ALL network access to "
+            + $"this endpoint. Redirect it to an ACL'd file or pipe it to the clipboard; do not leave it in shell "
+            + "scrollback, CI logs, or a screenshare.");
+        error.WriteLine($"  Example (file):      PerformanceMonitor.Darling.Service.exe {verb} > token.txt");
+        error.WriteLine($"  Example (clipboard): PerformanceMonitor.Darling.Service.exe {verb} | clip");
+        error.WriteLine($"  {howClientsPresentIt}");
+        error.WriteLine(
+            "  If this token has actually LEAKED, reprinting it is not the fix: --configure-network generates a new "
+            + "one, which invalidates every client already configured against the old one.");
+        error.WriteLine();
+
+        output.WriteLine(token);
         return 0;
     }
 

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingCliCommands.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingCliCommands.cs
@@ -76,11 +76,11 @@ public static class DarlingCliCommands
     public static bool IsPrintViewerConnectionVerb(string arg) =>
         string.Equals(arg, "--print-viewer-connection", StringComparison.OrdinalIgnoreCase);
 
-    /// <summary>The verb <see cref="PrintMcpTokenAsync"/> handles — reprint the MCP bearer token (#2479, item 2).</summary>
+    /// <summary>The verb <see cref="PrintMcpToken"/> handles — reprint the MCP bearer token (#2479, item 2).</summary>
     public static bool IsPrintMcpTokenVerb(string arg) =>
         string.Equals(arg, "--print-mcp-token", StringComparison.OrdinalIgnoreCase);
 
-    /// <summary>The verb <see cref="PrintWebTokenAsync"/> handles — reprint the web dashboard access token.
+    /// <summary>The verb <see cref="PrintWebToken"/> handles — reprint the web dashboard access token.
     /// The issue asked for the MCP half; both tokens have the identical unrecoverable-loss problem and the
     /// identical DPAPI shape, so shipping one and not the other would leave half a fix behind.</summary>
     public static bool IsPrintWebTokenVerb(string arg) =>
@@ -462,9 +462,14 @@ public static class DarlingCliCommands
        --------------------------------------------------------------------------------------------------- */
 
     /// <summary>Reprints the MCP bearer token from <c>mcp.network</c>. See the block above for the
-    /// disclosure analysis. Returns 0 when a token was printed, 1 otherwise.</summary>
+    /// disclosure analysis. Returns 0 when a token was printed, 1 otherwise.
+    ///
+    /// <para>No <c>Async</c> suffix, deliberately: this reads one file and decrypts one blob, with nothing
+    /// to await. It follows <c>HardenFiles</c> rather than the <c>PrintViewerConnectionAsync</c> directly
+    /// above, which really is async - naming a synchronous method <c>…Async</c> invites a caller to await
+    /// something that never yields (review catch on #2479).</para></summary>
     [SupportedOSPlatform("windows")]
-    public static int PrintMcpTokenAsync(string? configPath, TextWriter output, TextWriter error)
+    public static int PrintMcpToken(string? configPath, TextWriter output, TextWriter error)
     {
         DarlingConfig config;
         try
@@ -493,7 +498,7 @@ public static class DarlingCliCommands
     /// <summary>Reprints the web dashboard access token from <c>web.network</c>. Returns 0 when a token was
     /// printed, 1 otherwise.</summary>
     [SupportedOSPlatform("windows")]
-    public static int PrintWebTokenAsync(string? configPath, TextWriter output, TextWriter error)
+    public static int PrintWebToken(string? configPath, TextWriter output, TextWriter error)
     {
         DarlingConfig config;
         try

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingCliCommands.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingCliCommands.cs
@@ -568,12 +568,28 @@ public static class DarlingCliCommands
         {
             token = resolveToken();
         }
-        catch (Exception ex)
+        catch (System.Security.Cryptography.CryptographicException ex)
         {
+            /* The DPAPI cause, and ONLY the DPAPI cause. ResolveToken also resolves env: and file: secret
+               references, and those fail with an InvalidOperationException whose message already names the
+               missing variable or the unreadable path (review catch on #2479). Appending "a DPAPI blob only
+               decrypts on the machine that produced it - regenerate it" to THOSE would be a false diagnosis
+               pointing at a destructive fix: regenerating invalidates every configured client, when the
+               actual repair is to set the environment variable or correct the path. So the advice is gated
+               on the exception that earns it, and the arm below reports what it actually knows. */
             error.WriteLine($"Could not read the {tokenName} token: {ex.Message}");
             error.WriteLine(
                 $"A DPAPI blob only decrypts on the machine that produced it, so a {section}.network.encryptedToken "
                 + "copied from another host can never be read here - regenerate it with --configure-network.");
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            error.WriteLine($"Could not read the {tokenName} token: {ex.Message}");
+            error.WriteLine(
+                $"That is what {section}.network resolved to. Fix the source it names (an env: reference needs "
+                + "the variable set in THIS shell; a file: reference needs a path this account can read), then "
+                + "re-run - the token itself is fine and does not need regenerating.");
             return 1;
         }
 

--- a/Darling/PerformanceMonitor.Darling.Service/Hosting/DarlingHostBinding.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Hosting/DarlingHostBinding.cs
@@ -397,4 +397,82 @@ internal static class DarlingHostBinding
             + "is unreachable from the LAN after this, re-run --configure-firewall once the store is up: it resolves "
             + "the effective port and moves the rule.";
     }
+
+    /* ---------------------------------------------------------------------------------------------------
+       WHERE the network block came from, and when it can change (#2479, item 6). The other half of the same
+       split #2389 made visible. A network block is loaded ONCE, at start-up, and held for the process
+       lifetime by design: exposure should require touching the host, and the DPAPI token is LocalMachine-
+       scoped so it could not live in the store anyway. That is the right design and it is not going to
+       change -- but it produces the "I enabled it and it is still loopback-bound" trap in another costume,
+       because nothing said the value was frozen the moment the process started.
+
+       #2389/#2411 fixed the seed-versus-store confusion by making the split VISIBLE rather than by removing
+       it, and #2414 did the same one layer down for the firewall port. This is that treatment applied to
+       the third face of the same object: the endpoint states plainly, at every start, whether a network
+       block was read from the file, what it decided, and that editing darling.json now changes nothing
+       until a restart. Said in BOTH modes on purpose -- the loopback line was the one that carried no
+       mention of the block at all, and loopback-when-you-expected-LAN is precisely the state an operator
+       is trying to diagnose.
+       --------------------------------------------------------------------------------------------------- */
+
+    /// <summary>
+    /// PURE: the one-line start-up statement of where <c>{section}.network</c> came from and when it can
+    /// change. <paramref name="section"/> is the darling.json object name and the CLI verb suffix at once
+    /// ("mcp" -&gt; mcp.network / --enable-mcp), which is what keeps the two hosts' wordings from drifting.
+    ///
+    /// <para>Three states, three different consequences, and only the true one is emitted. A single line
+    /// claiming "restart to apply" would be wrong for an endpoint already serving the LAN exactly as
+    /// configured, which is the likeliest state and the one where a spurious call to action costs the most
+    /// credibility.</para>
+    /// </summary>
+    /// <param name="section">"mcp" or "web" - the darling.json object name.</param>
+    /// <param name="surface">"MCP" or "Web dashboard" - how the log names this endpoint elsewhere.</param>
+    /// <param name="blockConfigured">A <c>{section}.network</c> block was present in the file.</param>
+    /// <param name="exposed">This endpoint actually bound a LAN address as a result.</param>
+    /// <param name="listen">The bound address, when exposed.</param>
+    /// <param name="allowFrom">The source CIDR, when exposed.</param>
+    internal static string DescribeNetworkBlockLifetime(
+        string section,
+        string surface,
+        bool blockConfigured,
+        bool exposed,
+        string? listen,
+        string? allowFrom)
+    {
+        /* Common to all three: what CAN be changed without a restart, so naming what cannot does not read
+           as "this endpoint is immovable". The control plane really does stop and rebind this server
+           live -- it just cannot touch these three fields. */
+        var storeHalf =
+            $" The control plane still owns whether this endpoint runs and on which port "
+            + $"(config.config_service.{section}_enabled / {section}_port, moved by --enable-{section} / "
+            + $"--disable-{section} or the Viewer's Settings, and applied without a restart) - it simply "
+            + "cannot move where this binds, who may reach it, or what token it requires.";
+
+        if (!blockConfigured)
+        {
+            return $"{surface} network exposure: darling.json has no {section}.network block, so this endpoint is "
+                + "loopback-only. Adding one is a FILE edit that takes effect on the next service RESTART; there "
+                + "is no store setting and no Viewer control that can expose it."
+                + storeHalf;
+        }
+
+        if (exposed)
+        {
+            return $"{surface} network exposure: {section}.network was read from darling.json at start-up and is "
+                + $"FIXED for the lifetime of this process - LAN-bound on {listen} for {allowFrom}, behind the "
+                + "configured token, until the service is RESTARTED. Editing darling.json now changes nothing "
+                + "until then."
+                + storeHalf;
+        }
+
+        /* The trap, named. An operator who edited the block and restarted nothing sees this and has their
+           answer; one who DID restart is pointed at the fail-closed reason already logged above rather than
+           being told the same thing twice in different words. */
+        return $"{surface} network exposure: darling.json DEFINES {section}.network, but this endpoint is bound "
+            + "loopback-only. That block was read at start-up and is FIXED for the lifetime of this process, so "
+            + "editing darling.json now changes nothing until the service is RESTARTED. If you just edited it to "
+            + $"expose this endpoint, restart the service; if you already restarted, the {section}.network line "
+            + "logged above says why the exposure was refused."
+            + storeHalf;
+    }
 }

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpHostService.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpHostService.cs
@@ -750,11 +750,19 @@ public sealed class DarlingMcpHostService : BackgroundService
 
             /* #2479 item 6: the network block is read ONCE and held for the process lifetime by design.
                Say so at every start, in BOTH modes - the loopback line above never mentioned the block at
-               all, and loopback-when-you-expected-LAN is exactly the state being diagnosed. */
+               all, and loopback-when-you-expected-LAN is exactly the state being diagnosed.
+
+               The null-conditional is load-bearing, not defensive. config.Mcp.Network is McpNetworkConfig?
+               and is NULL on the default secure config - no mcp.network block at all - which is exactly the
+               state this line exists to describe. The dereferences at 313/317 are safe because they sit
+               inside if (networkMode), where the bind resolution has already proven a block exists; this
+               one runs unconditionally, so a bare .IsConfigured throws on every start of an un-exposed
+               server, gets swallowed by the catch below, and retry-fails forever because the config never
+               changes. Review catch on #2479. */
             _logger.LogInformation(
                 "{Report}",
                 DarlingHostBinding.DescribeNetworkBlockLifetime(
-                    "mcp", "MCP", config.Mcp.Network.IsConfigured, networkMode,
+                    "mcp", "MCP", config.Mcp.Network?.IsConfigured ?? false, networkMode,
                     networkMode ? primaryBind.ToString() : null,
                     networkMode ? allowedCidr.ToString() : null));
 

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpHostService.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpHostService.cs
@@ -748,6 +748,16 @@ public sealed class DarlingMcpHostService : BackgroundService
                     effectivePort, origin);
             }
 
+            /* #2479 item 6: the network block is read ONCE and held for the process lifetime by design.
+               Say so at every start, in BOTH modes - the loopback line above never mentioned the block at
+               all, and loopback-when-you-expected-LAN is exactly the state being diagnosed. */
+            _logger.LogInformation(
+                "{Report}",
+                DarlingHostBinding.DescribeNetworkBlockLifetime(
+                    "mcp", "MCP", config.Mcp.Network.IsConfigured, networkMode,
+                    networkMode ? primaryBind.ToString() : null,
+                    networkMode ? allowedCidr.ToString() : null));
+
             /* StartAsync, not RunAsync (#1560): the supervisor loop owns the wait — the app keeps
                serving until StopServerAsync (toggle-off, port change, or shutdown). */
             await _app.StartAsync(stoppingToken);

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingWebHostService.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingWebHostService.cs
@@ -516,6 +516,16 @@ public sealed class DarlingWebHostService : BackgroundService
                     effectivePort, origin);
             }
 
+            /* #2479 item 6: the network block is read ONCE and held for the process lifetime by design.
+               Say so at every start, in BOTH modes - the loopback line above never mentioned the block at
+               all, and loopback-when-you-expected-LAN is exactly the state being diagnosed. */
+            _logger.LogInformation(
+                "{Report}",
+                DarlingHostBinding.DescribeNetworkBlockLifetime(
+                    "web", "Web dashboard", config.Web.Network.IsConfigured, networkMode,
+                    networkMode ? primaryBind.ToString() : null,
+                    networkMode ? allowedCidr.ToString() : null));
+
             /* StartAsync, not RunAsync: the supervisor loop owns the wait — the app keeps serving until
                StopServerAsync (toggle-off, port change, or shutdown). */
             await _app.StartAsync(stoppingToken);

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingWebHostService.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingWebHostService.cs
@@ -522,7 +522,7 @@ public sealed class DarlingWebHostService : BackgroundService
             _logger.LogInformation(
                 "{Report}",
                 DarlingHostBinding.DescribeNetworkBlockLifetime(
-                    "web", "Web dashboard", config.Web.Network.IsConfigured, networkMode,
+                    "web", "Web dashboard", config.Web.Network?.IsConfigured ?? false, networkMode,
                     networkMode ? primaryBind.ToString() : null,
                     networkMode ? allowedCidr.ToString() : null));
 

--- a/Darling/PerformanceMonitor.Darling.Service/Program.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Program.cs
@@ -93,6 +93,33 @@ if (args.Length > 0 && DarlingCliCommands.IsPrintViewerConnectionVerb(args[0]))
     return await DarlingCliCommands.PrintViewerConnectionAsync(configPath, Console.Out, Console.Error, CancellationToken.None);
 }
 
+/* CLI verbs: --print-mcp-token / --print-web-token (#2479 item 2) — reprint an endpoint's access token from
+   darling.json. --configure-network shows each generated token once; losing it used to leave regeneration as
+   the only path, which invalidates every client already configured against it. The verbs refuse when not
+   elevated, and both are Windows-only for the same reason --print-viewer-connection is: the token is a DPAPI
+   blob. The reasoning about what this does and does NOT disclose lives with the implementation. */
+if (args.Length > 0 && DarlingCliCommands.IsPrintMcpTokenVerb(args[0]))
+{
+    if (!OperatingSystem.IsWindows())
+    {
+        Console.Error.WriteLine("--print-mcp-token requires Windows (DPAPI).");
+        return 1;
+    }
+
+    return DarlingCliCommands.PrintMcpTokenAsync(args.Length > 1 ? args[1] : null, Console.Out, Console.Error);
+}
+
+if (args.Length > 0 && DarlingCliCommands.IsPrintWebTokenVerb(args[0]))
+{
+    if (!OperatingSystem.IsWindows())
+    {
+        Console.Error.WriteLine("--print-web-token requires Windows (DPAPI).");
+        return 1;
+    }
+
+    return DarlingCliCommands.PrintWebTokenAsync(args.Length > 1 ? args[1] : null, Console.Out, Console.Error);
+}
+
 /* CLI verb: --export-viewer-config (#1953) — write the viewer machine's whole handoff folder (a complete
    darling.json with "managed": false and the resolved connection string, the store's server.crt beside it, and
    a README.txt documenting every field) instead of making the operator hand-merge --print-viewer-connection's

--- a/Darling/PerformanceMonitor.Darling.Service/Program.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Program.cs
@@ -106,7 +106,7 @@ if (args.Length > 0 && DarlingCliCommands.IsPrintMcpTokenVerb(args[0]))
         return 1;
     }
 
-    return DarlingCliCommands.PrintMcpTokenAsync(args.Length > 1 ? args[1] : null, Console.Out, Console.Error);
+    return DarlingCliCommands.PrintMcpToken(args.Length > 1 ? args[1] : null, Console.Out, Console.Error);
 }
 
 if (args.Length > 0 && DarlingCliCommands.IsPrintWebTokenVerb(args[0]))
@@ -117,7 +117,7 @@ if (args.Length > 0 && DarlingCliCommands.IsPrintWebTokenVerb(args[0]))
         return 1;
     }
 
-    return DarlingCliCommands.PrintWebTokenAsync(args.Length > 1 ? args[1] : null, Console.Out, Console.Error);
+    return DarlingCliCommands.PrintWebToken(args.Length > 1 ? args[1] : null, Console.Out, Console.Error);
 }
 
 /* CLI verb: --export-viewer-config (#1953) — write the viewer machine's whole handoff folder (a complete

--- a/Darling/README.md
+++ b/Darling/README.md
@@ -1141,6 +1141,8 @@ Add a `network` block to `mcp` (managed mode; `mcp.enabled` must be `true`):
 
 When `listen` is a network address **and** a token is present **and** `allowFrom` is a valid CIDR, the MCP host binds that interface behind two gates: a **required bearer token** (checked first, constant-time, no loopback exemption) and an **in-app CIDR check** on the remote address (loopback is always allowed, so local clients keep working). Any missing precondition keeps MCP loopback-only. Prefer `encryptedToken` (a DPAPI blob from `--encrypt-password`); a plaintext `token` works for dev but is warned. Set the same scoped firewall rule for the MCP port:
 
+**Lost the token?** `--print-mcp-token` (elevated) reprints it from `darling.json` — `--print-web-token` does the same for the dashboard. Both write the live token to **STDOUT** with every warning on STDERR, so `... --print-mcp-token | clip` captures the value and still shows the warning. This discloses nothing new: the blob is DPAPI at `LocalMachine` scope with an entropy constant published in this repository, and `darling.json` grants `INTERACTIVE` read by design (see [Security & Least-Privilege Roles](#security--least-privilege-roles)), so anyone who can log on to the host interactively could already decrypt it. The elevation requirement makes reprinting a deliberate act; the token's actual protection is the file's ACL. If the token has **leaked** rather than been mislaid, reprinting is not the fix — `--configure-network` generates a new one, and every client configured against the old one must be updated.
+
 ```
 New-NetFirewallRule -DisplayName "Darling MCP" -Direction Inbound -Action Allow -Protocol TCP -LocalPort 5152 -RemoteAddress 192.168.1.0/24
 ```


### PR DESCRIPTION
Items **2 and 6** of #2479. Both come down to the service knowing something and not saying it.

---

## Item 2 — `--print-mcp-token` / `--print-web-token`

`--configure-network` shows each generated token's plaintext exactly once. Lose it and the only path was regeneration, which invalidates every client already configured against it — so one mislaid token during UAT meant re-onboarding every consumer of that endpoint. An unrecoverable mistake made out of a recoverable one.

### The security reasoning, checked — and it is stronger than the issue states

The issue's claim was *"the token is already DPAPI-decryptable in-process on that box, so an admin on the host gains nothing they could not already get."* That holds, and the real position is broader:

- The token is a `DarlingSecrets` blob: **DPAPI at `DataProtectionScope.LocalMachine`**, entropy `"PerformanceMonitor.Darling.v1"` — a constant compiled into an **open-source** binary (`DarlingSecrets.cs:27`). LocalMachine scope means *any process on the box* can `Unprotect` it, and the entropy is not a secret because it is published in this repository. `DarlingCliCommands.cs:2191-2194` already says as much: read access to `darling.json` **is** the secret.
- **`darling.json` grants `INTERACTIVE` read deliberately** — `DarlingWorker.cs:737` and `DarlingFileSecurity.HardenFile(path, allowInteractiveRead: true)`, mirrored by `install-darling.ps1` — because the Viewer and these very CLI verbs are run by the interactive operator. `Darling/README.md`'s principal model states it outright: *"`INTERACTIVE` == the operator, so the admin/viewer credentials are readable by the Viewer with zero configuration."*

So an ordinary logged-on **non-administrator** can already read and decrypt the blob in about four lines of PowerShell. Shipping the verb discloses nothing new to anyone.

**Which means the elevation gate is not a confidentiality boundary, and the code says so rather than implying one.** It is still worth having for what it actually does — consistency with the other verbs carrying `(run elevated)`, and making a reprint a deliberate act rather than something a script or a shared shell picks up in passing — and the refusal message spends five lines saying that the token's real protection is the file's ACL, with a pointer at `--harden-files`. An operator who believes elevation is protecting the token stops guarding the thing that is.

Worth flagging for the record: `--print-viewer-connection` prints a live **database password** to stdout and is *not* elevation-gated. That asymmetry is now real. I have not changed it — it would break existing runbooks and is outside this issue — but it is the obvious next question.

### Both verbs, not one

The issue names *"an MCP or web token"*. They have the identical loss problem, the identical DPAPI shape and adjacent config blocks; shipping one would leave half a fix behind.

### Emission

Follows `--print-viewer-connection`'s posture exactly (D8): **stdout is the token and nothing else**, so `> token.txt` and `| clip` both yield a pasteable value, and every warning is on **stderr ahead of the payload** so a redirect cannot swallow it. The warning also separates the two cases that look alike: reprinting recovers a **mislaid** token and is *not* the answer to a **leaked** one, where `--configure-network` generates a new one and every configured client must be updated.

Elevation is passed **in** rather than measured inside the shared body, the way the pure alert gates take `nowUtc`. That makes the refusal path drivable on any runner — a refusal only exercised when the CI agent happens to be unprivileged is a refusal nobody has checked.

---

## Item 6 — saying when a network block can change

`mcp.network` / `web.network` are loaded once and held for the process lifetime **by design**: exposure should require touching the host, and a LocalMachine-scoped DPAPI token could not live in the store anyway. **No hot reload here** — that design is right and is not changing.

But it produces "I enabled it and it is still loopback-bound" in another costume, because nothing said the value froze the moment the process started. #2389/#2411 fixed the seed-versus-store confusion by making the split **visible** rather than by removing it, and #2414 did the same one layer down for the firewall port. This is that treatment applied to the third face of the same object.

**The specific gap:** the network-mode start line already carried `listen/allowFrom/token from darling.json mcp.network (file-only, restart-only)`. The **loopback** line carried nothing about the block at all — and loopback-when-you-expected-LAN is precisely the state an operator is diagnosing. So the new line is emitted in **both** modes.

Three states, three consequences, only the true one emitted:

> `MCP network exposure: mcp.network was read from darling.json at start-up and is FIXED for the lifetime of this process - LAN-bound on 10.197.53.214 for 10.197.0.0/16, behind the configured token, until the service is RESTARTED. Editing darling.json now changes nothing until then. The control plane still owns whether this endpoint runs and on which port (config.config_service.mcp_enabled / mcp_port, moved by --enable-mcp / --disable-mcp or the Viewer's Settings, and applied without a restart) - it simply cannot move where this binds, who may reach it, or what token it requires.`

> `MCP network exposure: darling.json DEFINES mcp.network, but this endpoint is bound loopback-only. That block was read at start-up and is FIXED for the lifetime of this process, so editing darling.json now changes nothing until the service is RESTARTED. If you just edited it to expose this endpoint, restart the service; if you already restarted, the mcp.network line logged above says why the exposure was refused. […]`

> `MCP network exposure: darling.json has no mcp.network block, so this endpoint is loopback-only. Adding one is a FILE edit that takes effect on the next service RESTART; there is no store setting and no Viewer control that can expose it. […]`

Only the trap state gets a **call to action**. An endpoint already serving the LAN exactly as configured is the likeliest state, and telling that operator to restart is where a start-up line spends its credibility — the same reasoning that made `DescribeToggleOverride`'s consequence clause state-specific. And all three name the half the control plane **does** own without a restart, or "cannot change until restart" reads as "this endpoint is immovable" and sends someone to restart the service for something `--enable-mcp` already does live.

---

## Verification

- **Ran both new pure surfaces against the real service assembly** — a throwaway `net10.0` console with a `ProjectReference` to `PerformanceMonitor.Darling.Service`, borrowing the friend-assembly name so it reaches the same internals `Darling.Tests` does. **28/28 checks pass**, covering all five `PrintEndpointToken` branches (not elevated / no block / empty token / decrypt failure / success) and all three lifetime states. The critical invariants: **stdout is empty on every refusal path**, and the token appears on stderr in none of them.
- Service and `Darling.Tests` both build clean, 0 errors.
- **Checked the pins the new verbs could break:** `IsKnownVerb_ReachesEveryVerbClassifierOnTheClass` derives `--print-mcp-token` / `--print-web-token` correctly from the classifier names via `VerbLiteralFor`, and both new help lines are pure ASCII for `UsageText_ListsTheKeyVerbs_AndIsAscii`.
- Against `dev` the whole test file fails to **compile** — none of these members exist there.
- **Not verified:** nothing has run on a real Windows host, so the actual elevated round-trip through a DPAPI blob and the rendered start-up log lines are unexercised. Manual checks: `--print-mcp-token` from a non-elevated shell should refuse with empty stdout; from an elevated one, `... --print-mcp-token > t.txt` should leave exactly the token in `t.txt` with the warning on the terminal. Restarting the service should show one `MCP network exposure:` line whichever mode it comes up in.
- **Deliberately not done:** `postgres.network` is restart-only in the same way and gets no equivalent line — the issue names `mcp.network` and `web.network`, and the store already logs `Fix postgres.network and restart to expose the store` on a degrade. Worth a follow-up if the store's silent-when-healthy case turns out to bite the same way.

## Onboarding

- **Item 2** removes the need for `docs/uat-onboarding.md` §4.2's warning that the MCP token is shown once and is otherwise unrecoverable, and the matching line in §3.2 for the web token. The "save it now" advice is still good; the "or else re-onboard every client" consequence stops being true for a token that is merely mislaid.
- **Item 6** makes §4.4's *"When it says enabled and still will not connect"* and §3.5's restart caveat unnecessary as *instructions* — the service now says it at every start, in the mode where it matters. §0's "the file is a first-run seed / the network block is the opposite" framing is still worth keeping; it is the conceptual model, and the log line is the runtime reminder of it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
