### PR TITLE
Three trend tools told the two SKUs' users different stories (#2485)

### DIFF
--- a/Darling/Darling.Tests/DarlingTrendEmptyTests.cs
+++ b/Darling/Darling.Tests/DarlingTrendEmptyTests.cs
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+using PerformanceMonitor.Collectors;
+using PerformanceMonitor.Darling.Service.Mcp;
+using PerformanceMonitor.Darling.Storage;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// The three windowed trends whose empty answer used to be one sentence covering two opposite states
+/// (#2485): get_memory_trend, get_file_io_trend and get_query_duration_trend all returned
+/// <c>Status("unavailable", "No … trend data available.")</c> whatever the reason. "Unavailable" sounds
+/// specific and says nothing: a server that collected fine and was quiet in this window needs the window
+/// widened, and a server the collector has never touched needs somebody to look at collection — and
+/// widening will never fill that one.
+///
+/// <para>These are the three where Lite returned a BARE empty array while Darling returned an envelope, so
+/// the same tool name gave two different answers depending on which SKU the client was pointed at. Both
+/// SKUs now return the same two sentences word for word.</para>
+///
+/// <para>Gated on DARLING_TEST_PG like every other live class.</para>
+/// </summary>
+[Collection("live-postgres")]
+public sealed class DarlingTrendEmptyTests
+{
+    private const int ServerId = -949555;
+    private const string ServerName = "trend-empty";
+    private const string Db = "AppDb";
+
+    private static string? ConnectionString => Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+
+    [Fact]
+    public async Task AllThreeTrends_SeparateAQuietWindowFromANeverCollectedServer_AgainstDevPostgres()
+    {
+        var cs = ConnectionString;
+        Assert.SkipWhen(string.IsNullOrEmpty(cs),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the live trend-empty test.");
+
+        var ct = TestContext.Current.CancellationToken;
+        using var connection = new NpgsqlConnection(cs);
+        await connection.OpenAsync(ct);
+        await PgMigrations.MigrateAsync(connection, ct);
+        await DeleteRowsAsync(connection, ct);
+
+        await using var postgres = NpgsqlDataSource.Create(cs!);
+        var bodySucceeded = false;
+
+        try
+        {
+            await DarlingMcpTestData.RegisterServerAsync(connection, ServerId, ServerName, ct);
+
+            /* ── never collected: not an empty window, a server nothing has been stored for ── */
+            AssertNeverCollected(await DarlingMcpTrendTools.GetMemoryTrend(postgres, ServerName, 4));
+            AssertNeverCollected(await DarlingMcpTrendTools.GetFileIoTrend(postgres, ServerName, 4));
+            AssertNeverCollected(await DarlingMcpTrendTools.GetQueryDurationTrend(postgres, ServerName, 4));
+
+            /* ── collected, but everything outside the window: a genuinely quiet window ── */
+            var old = HoursAgo(48);
+            await SeedMemoryAsync(connection, ct, old);
+            await SeedFileIoAsync(connection, ct, old);
+            await SeedQueryAsync(connection, ct, old);
+
+            AssertQuietWindow(await DarlingMcpTrendTools.GetMemoryTrend(postgres, ServerName, 1));
+            AssertQuietWindow(await DarlingMcpTrendTools.GetFileIoTrend(postgres, ServerName, 1));
+            AssertQuietWindow(await DarlingMcpTrendTools.GetQueryDurationTrend(postgres, ServerName, 1));
+
+            /* ── inside the window: the trend payload, envelope gone ── */
+            var recent = MinutesAgo(10);
+            await SeedMemoryAsync(connection, ct, recent);
+            await SeedFileIoAsync(connection, ct, recent);
+            await SeedQueryAsync(connection, ct, recent);
+
+            foreach (var payload in new[]
+                     {
+                         await DarlingMcpTrendTools.GetMemoryTrend(postgres, ServerName, 4),
+                         await DarlingMcpTrendTools.GetFileIoTrend(postgres, ServerName, 4),
+                         await DarlingMcpTrendTools.GetQueryDurationTrend(postgres, ServerName, 4),
+                     })
+            {
+                var root = JsonDocument.Parse(payload).RootElement;
+                Assert.False(root.TryGetProperty("status", out _));
+                Assert.True(root.GetProperty("trend").GetArrayLength() > 0);
+            }
+
+            bodySucceeded = true;
+        }
+        finally
+        {
+            await LiveStoreCleanup.RunAsync(cs!, bodySucceeded, async (cleanup, cleanupCt) =>
+                await DeleteRowsAsync(cleanup, cleanupCt));
+        }
+    }
+
+    /// <summary>
+    /// The probe has to walk the SAME relation its trend walks, and this is derived from the SQL rather
+    /// than restated: the relation is pulled out of the probe and looked for in the trend. It is not a
+    /// formality — get_query_duration_trend reads the BASE <c>query_stats</c> table because a V38+ store's
+    /// <c>v_query_stats</c> is the payload-RESOLVING view, so a probe that reached for the view out of
+    /// habit would be asking about a different relation from the one the read returns nothing from.
+    /// </summary>
+    [Fact]
+    public void EachProbe_WalksTheSameRelationAsItsTrend()
+    {
+        AssertSameRelation(DarlingTrendReader.HasAnyMemoryStatSql, DarlingTrendReader.MemoryTrendSql);
+        AssertSameRelation(DarlingTrendReader.HasAnyFileIoStatSql, DarlingTrendReader.FileIoLatencyTrendSql);
+        AssertSameRelation(DarlingTrendReader.HasAnyQueryStatSql, DarlingTrendReader.QueryDurationTrendSql);
+
+        /* And each stops at the first row: it runs on a path that already found nothing, and its only job
+           is to pick which of the two sentences is true. */
+        Assert.Contains("LIMIT 1", DarlingTrendReader.HasAnyMemoryStatSql, StringComparison.Ordinal);
+        Assert.Contains("LIMIT 1", DarlingTrendReader.HasAnyFileIoStatSql, StringComparison.Ordinal);
+        Assert.Contains("LIMIT 1", DarlingTrendReader.HasAnyQueryStatSql, StringComparison.Ordinal);
+    }
+
+    private static void AssertSameRelation(string probeSql, string trendSql)
+    {
+        var relation = Regex.Match(probeSql, @"FROM\s+(\S+)").Groups[1].Value;
+        Assert.False(string.IsNullOrEmpty(relation), "the probe must name a relation");
+        Assert.Contains("FROM " + relation, trendSql, StringComparison.Ordinal);
+    }
+
+    /// <summary>Nothing has ever been stored for this server: NOT an empty window, and widening it would
+    /// never help.</summary>
+    private static void AssertNeverCollected(string payload)
+    {
+        var root = JsonDocument.Parse(payload).RootElement;
+        Assert.Equal("unavailable", root.GetProperty("status").GetString());
+        var text = root.GetProperty("message").GetString()!;
+        Assert.Contains("EVER", text, StringComparison.Ordinal);
+        Assert.Contains("not an empty window", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("widen hours_back", text, StringComparison.Ordinal);
+    }
+
+    /// <summary>The server collected and this window is simply quiet — the opposite next move, and it must
+    /// not share wording with the case above.</summary>
+    private static void AssertQuietWindow(string payload)
+    {
+        var root = JsonDocument.Parse(payload).RootElement;
+        Assert.Equal("empty", root.GetProperty("status").GetString());
+        var text = root.GetProperty("message").GetString()!;
+        Assert.Contains("widen hours_back", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("EVER", text, StringComparison.Ordinal);
+    }
+
+    private static DateTime MinutesAgo(int minutes) =>
+        DarlingMcpTestData.TruncateToSeconds(DateTime.UtcNow.AddMinutes(-minutes));
+
+    private static DateTime HoursAgo(int hours) =>
+        DarlingMcpTestData.TruncateToSeconds(DateTime.UtcNow.AddHours(-hours));
+
+    private static async Task SeedMemoryAsync(NpgsqlConnection connection, CancellationToken ct, DateTime t) =>
+        await DarlingMcpTestData.ExecAsync(connection, ct, @"
+INSERT INTO memory_stats
+    (collection_id, collection_time, server_id, server_name,
+     total_server_memory_mb, target_server_memory_mb, buffer_pool_mb, plan_cache_mb)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+            CollectionIdGenerator.Next(), DarlingMcpTestData.Naive(t), ServerId, ServerName,
+            40000m, 49152m, 35000m, 5000m);
+
+    /* delta_reads above zero on purpose: the trend's top_files CTE requires read or write activity, so a
+       row with zero deltas would leave the window empty for a reason that has nothing to do with #2485. */
+    private static async Task SeedFileIoAsync(NpgsqlConnection connection, CancellationToken ct, DateTime t) =>
+        await DarlingMcpTestData.ExecAsync(connection, ct, @"
+INSERT INTO file_io_stats
+    (collection_id, collection_time, server_id, server_name, database_name, file_name, file_type,
+     physical_name, size_mb, delta_reads, delta_writes, delta_read_bytes, delta_write_bytes,
+     delta_stall_read_ms, delta_stall_write_ms)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)",
+            CollectionIdGenerator.Next(), DarlingMcpTestData.Naive(t), ServerId, ServerName, Db,
+            "app.mdf", "ROWS", "D:\\app.mdf", 100000m, 500L, 200L, 4096000L, 1024000L, 2500L, 400L);
+
+    private static async Task SeedQueryAsync(NpgsqlConnection connection, CancellationToken ct, DateTime t) =>
+        await DarlingMcpTestData.ExecAsync(connection, ct, @"
+INSERT INTO query_stats
+    (collection_id, collection_time, server_id, server_name, database_name, query_hash, query_plan_hash,
+     sql_handle, plan_handle, query_text, delta_execution_count, delta_worker_time, delta_elapsed_time,
+     delta_logical_reads, delta_logical_writes, delta_physical_reads, delta_rows, delta_spills,
+     min_dop, max_dop)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)",
+            CollectionIdGenerator.Next(), DarlingMcpTestData.Naive(t), ServerId, ServerName, Db,
+            "0xEMPTYTRENDHASH", "0xPLANHASH", "0xSQLH", "0xPLANH", "SELECT * FROM Orders",
+            10L, 10000L, 20000L, 5000L, 0L, 50L, 1000L, 0L, 1, 4);
+
+    private static async Task DeleteRowsAsync(NpgsqlConnection connection, CancellationToken ct)
+    {
+        await DarlingMcpTestData.ExecAsync(connection, ct, "DELETE FROM memory_stats WHERE server_id = $1", ServerId);
+        await DarlingMcpTestData.ExecAsync(connection, ct, "DELETE FROM file_io_stats WHERE server_id = $1", ServerId);
+        await DarlingMcpTestData.ExecAsync(connection, ct, "DELETE FROM query_stats WHERE server_id = $1", ServerId);
+        await DarlingMcpTestData.ExecAsync(connection, ct, "DELETE FROM servers WHERE server_id = $1", ServerId);
+        await DarlingMcpTestData.ExecAsync(connection, ct, "DELETE FROM config_monitored_servers WHERE server_id = $1", ServerId);
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpInstructions.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpInstructions.cs
@@ -161,11 +161,11 @@ internal static class DarlingMcpInstructions
 
         | Tool | Purpose | Key Parameters |
         |------|---------|----------------|
-        | `get_memory_trend` | Memory usage over time: total / target server memory, buffer pool, plan cache | `server_name`, `hours_back` (default 24) |
+        | `get_memory_trend` | Memory usage over time: total / target server memory, buffer pool, plan cache. An empty result distinguishes a quiet window (`empty`, widen `hours_back`) from a server nothing has ever been collected for (`unavailable`, collection is not running) | `server_name`, `hours_back` (default 24) |
         | `get_perfmon_trend` | A single performance counter's value + delta over time (summed across instances) | `counter_name` (required), `server_name`, `hours_back` (default 24) |
-        | `get_file_io_trend` | Per-database file I/O read/write latency over time (top-10 busiest files) | `server_name`, `hours_back` (default 24) |
+        | `get_file_io_trend` | Per-database file I/O read/write latency over time (top-10 busiest files). An empty result distinguishes a quiet window (`empty`, widen `hours_back`) from a server nothing has ever been collected for (`unavailable`, collection is not running) | `server_name`, `hours_back` (default 24) |
         | `get_query_trend` | One query's per-collection history (deltas, avg cpu/elapsed, DOP) by query_hash | `query_hash` (required), `database_name` (required), `server_name`, `hours_back` (default 24) |
-        | `get_query_duration_trend` | Overall query elapsed-ms/sec + executions/sec across all queries over time | `server_name`, `hours_back` (default 24) |
+        | `get_query_duration_trend` | Overall query elapsed-ms/sec + executions/sec across all queries over time. An empty result distinguishes a quiet window (`empty`, widen `hours_back`) from a server nothing has ever been collected for (`unavailable`, collection is not running) | `server_name`, `hours_back` (default 24) |
 
         ### System-health parse-on-read tools
 

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpTrendTools.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpTrendTools.cs
@@ -34,9 +34,10 @@ namespace PerformanceMonitor.Darling.Service.Mcp;
 /// windowed BOTH-sides on the naive-UTC <c>collection_time</c>, byte-identical to the viewer's proven
 /// chart reads. get_perfmon_trend reproduces Lite's miss vocabulary (the intentionally-uncollected Page
 /// Life Expectancy special-case + the collected-counters hint); get_query_trend reproduces Lite's per-key
-/// "empty" miss; the three unkeyed trends return the #1224 "unavailable" miss on an empty window, matching
-/// the merged get_tempdb_trend sibling. A response-shape change here must land in Lite's Mcp*Tools too, and
-/// vice versa.
+/// "empty" miss; the three unkeyed trends now distinguish the two kinds of nothing (#2485) rather than
+/// collapsing both into one "unavailable" — a quiet window answers "empty" and tells the caller to widen
+/// it, while a server the collector has never sampled answers "unavailable" and says so outright. A
+/// response-shape change here must land in Lite's Mcp*Tools too, and vice versa.
 /// </para>
 /// </summary>
 [McpServerToolType]

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpTrendTools.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpTrendTools.cs
@@ -59,7 +59,22 @@ public sealed class DarlingMcpTrendTools
             var now = DateTime.UtcNow;
             var points = await DarlingTrendReader.GetMemoryTrendAsync(postgres, resolved.ServerId, now.AddHours(-hours_back), now);
             if (points.Count == 0)
-                return McpHelpers.Status("unavailable", "No memory trend data available.");
+            {
+                /*
+                    "No memory trend data available" was true of two opposite states and told the caller
+                    neither. A server that collected fine and was simply quiet in THIS window wants the
+                    window widened; a server the collector has never touched wants somebody to go look at
+                    collection, and widening will never fill it. Probed only here, on the path that already
+                    found nothing, against the SAME source the trend read.
+                */
+                return await DarlingTrendReader.HasAnyMemoryStatAsync(postgres, resolved.ServerId)
+                    ? McpHelpers.Status(
+                        "empty",
+                        $"No memory samples recorded for {resolved.ServerName} in the last {hours_back} hour(s). This server HAS collected memory stats before, so this window is genuinely quiet rather than broken — widen hours_back to find the most recent samples.")
+                    : McpHelpers.Status(
+                        "unavailable",
+                        $"No memory stats have EVER been recorded for {resolved.ServerName}. This is not an empty window — the memory_stats collector has stored nothing at all for this server. Check that collection is running and that the server is enabled; get_memory_stats will be equally empty until it does.");
+            }
 
             var result = points.Select(p => new
             {
@@ -182,7 +197,19 @@ public sealed class DarlingMcpTrendTools
             var now = DateTime.UtcNow;
             var points = await DarlingTrendReader.GetFileIoLatencyTrendAsync(postgres, resolved.ServerId, now.AddHours(-hours_back), now);
             if (points.Count == 0)
-                return McpHelpers.Status("unavailable", "No I/O trend data available.");
+            {
+                /* Same two states as the memory trend, same probe discipline. The quiet-window sentence
+                   carries one extra clause the others do not need: this read's top_files CTE requires
+                   delta_reads or delta_writes above zero, so a genuinely idle file set is empty here even
+                   on a server whose file_io_stats collector ran every cycle. */
+                return await DarlingTrendReader.HasAnyFileIoStatAsync(postgres, resolved.ServerId)
+                    ? McpHelpers.Status(
+                        "empty",
+                        $"No file I/O samples recorded for {resolved.ServerName} in the last {hours_back} hour(s). This server HAS collected file I/O stats before, so this window is genuinely quiet rather than broken — widen hours_back, or read it as no measurable read or write activity on any file in this window.")
+                    : McpHelpers.Status(
+                        "unavailable",
+                        $"No file I/O stats have EVER been recorded for {resolved.ServerName}. This is not an empty window — the file_io_stats collector has stored nothing at all for this server. Check that collection is running and that the server is enabled; get_file_io_stats will be equally empty until it does.");
+            }
 
             var result = points.Select(p => new
             {
@@ -307,7 +334,19 @@ public sealed class DarlingMcpTrendTools
             var now = DateTime.UtcNow;
             var points = await DarlingTrendReader.GetQueryDurationTrendAsync(postgres, resolved.ServerId, now.AddHours(-hours_back), now);
             if (points.Count == 0)
-                return McpHelpers.Status("unavailable", "No query duration trend data available.");
+            {
+                /* Same two states again. The probe reads the BASE query_stats table because this trend
+                   does — v_query_stats is the payload-resolving view on a V38+ store, and probing a
+                   different relation from the one the read walks is how an existence probe ends up
+                   reporting the wrong branch. */
+                return await DarlingTrendReader.HasAnyQueryStatAsync(postgres, resolved.ServerId)
+                    ? McpHelpers.Status(
+                        "empty",
+                        $"No query samples recorded for {resolved.ServerName} in the last {hours_back} hour(s). This server HAS collected query stats before, so this window is genuinely quiet rather than broken — widen hours_back to find the most recent samples.")
+                    : McpHelpers.Status(
+                        "unavailable",
+                        $"No query stats have EVER been recorded for {resolved.ServerName}. This is not an empty window — the query_stats collector has stored nothing at all for this server. Check that collection is running and that the server is enabled; get_top_queries_by_cpu will be equally empty until it does.");
+            }
 
             var result = points.Select(p => new
             {

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingTrendReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingTrendReader.cs
@@ -494,4 +494,69 @@ internal static class DarlingTrendReader
 
         return items;
     }
+
+    /* ─────────── "which nothing is this?" probes for the three windowed trends ─────────── */
+
+    /// <summary>
+    /// Whether this server has EVER recorded a memory sample, ignoring any window.
+    /// <para>Exists so an empty memory trend can say WHICH kind of nothing it found. "No memory trend data
+    /// available" is true both of a quiet window and of a server the collector has never touched, and those
+    /// want opposite responses from the caller — widen the window, versus go find out why collection is not
+    /// running. Reads <c>v_memory_stats</c>, the same source <see cref="MemoryTrendSql"/> reads, so it can
+    /// never report "collected" for rows the trend cannot see. LIMIT 1, so it stops at the first row.</para>
+    /// </summary>
+    public const string HasAnyMemoryStatSql = """
+        SELECT 1
+        FROM v_memory_stats
+        WHERE server_id = $1
+        LIMIT 1
+        """;
+
+    /// <summary>Whether this server has EVER recorded a file I/O sample. Reads <c>v_file_io_stats</c>, the
+    /// same source <see cref="FileIoLatencyTrendSql"/> reads. See <see cref="HasAnyMemoryStatSql"/>.</summary>
+    public const string HasAnyFileIoStatSql = """
+        SELECT 1
+        FROM v_file_io_stats
+        WHERE server_id = $1
+        LIMIT 1
+        """;
+
+    /// <summary>
+    /// Whether this server has EVER recorded a query-stats sample.
+    /// <para>Reads the BASE <c>query_stats</c> table, deliberately, because <see cref="QueryDurationTrendSql"/>
+    /// does: on a V38+ store <c>v_query_stats</c> is the payload-RESOLVING view, not a passthrough, and the
+    /// duration trend projects no text so it never needs it. Probing the view here would be probing a
+    /// different relation from the one the read walks — the exact way an existence probe reports the wrong
+    /// branch in the case it exists to get right.</para>
+    /// </summary>
+    public const string HasAnyQueryStatSql = """
+        SELECT 1
+        FROM query_stats
+        WHERE server_id = $1
+        LIMIT 1
+        """;
+
+    /// <summary>Runs <see cref="HasAnyMemoryStatSql"/>.</summary>
+    public static Task<bool> HasAnyMemoryStatAsync(
+        NpgsqlDataSource postgres, int serverId, CancellationToken cancellationToken = default)
+        => HasAnySampleAsync(postgres, HasAnyMemoryStatSql, serverId, cancellationToken);
+
+    /// <summary>Runs <see cref="HasAnyFileIoStatSql"/>.</summary>
+    public static Task<bool> HasAnyFileIoStatAsync(
+        NpgsqlDataSource postgres, int serverId, CancellationToken cancellationToken = default)
+        => HasAnySampleAsync(postgres, HasAnyFileIoStatSql, serverId, cancellationToken);
+
+    /// <summary>Runs <see cref="HasAnyQueryStatSql"/>.</summary>
+    public static Task<bool> HasAnyQueryStatAsync(
+        NpgsqlDataSource postgres, int serverId, CancellationToken cancellationToken = default)
+        => HasAnySampleAsync(postgres, HasAnyQueryStatSql, serverId, cancellationToken);
+
+    /// <summary>All three probes share one shape: a scalar that is null when no row qualifies.</summary>
+    private static async Task<bool> HasAnySampleAsync(
+        NpgsqlDataSource postgres, string sql, int serverId, CancellationToken cancellationToken)
+    {
+        await using var command = postgres.CreateCommand(sql);
+        DarlingMcpReadParameters.AddInt(command, serverId);
+        return await command.ExecuteScalarAsync(cancellationToken) is not null;
+    }
 }

--- a/Lite.Tests/TrendEmptyParityToolTests.cs
+++ b/Lite.Tests/TrendEmptyParityToolTests.cs
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using DuckDB.NET.Data;
+using PerformanceMonitorLite.Database;
+using PerformanceMonitorLite.Mcp;
+using PerformanceMonitorLite.Models;
+using PerformanceMonitorLite.Services;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// The three tools where the two SKUs disagreed (#2485): <c>get_memory_trend</c>, <c>get_file_io_trend</c>
+/// and <c>get_query_duration_trend</c> returned a BARE empty array on Lite while their Darling twins
+/// returned a status envelope. Same tool name, same client, two different answers depending on which SKU it
+/// was pointed at — a parity break independent of the issue's main point and arguably the more urgent half.
+///
+/// <para>Darling's envelope was not the target either. "No memory trend data available" is true both of a
+/// window that was simply quiet and of a server the collector has never touched, and those want opposite
+/// next moves — widen the window, versus go find out why collection is not running, which widening will
+/// never fix. Both SKUs now make that distinction, in the same two sentences.</para>
+/// </summary>
+public sealed class TrendEmptyParityToolTests : IClassFixture<SharedDuckDbFixture>, IDisposable
+{
+    private const string ServerName = "TrendEmptySrv";
+
+    private readonly DuckDbInitializer _duckDb;
+    private readonly string _configDir;
+    private readonly ServerManager _serverManager;
+    private readonly int _serverId;
+    private DuckDBConnection? _seedConn;
+    private long _nextId = 830000;
+
+    public TrendEmptyParityToolTests(SharedDuckDbFixture fixture)
+    {
+        fixture.ResetData();
+        _duckDb = fixture.DuckDb;
+
+        _configDir = Path.Combine(Path.GetTempPath(), "pmlite-trendempty-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_configDir);
+        _serverManager = new ServerManager(_configDir);
+
+        var server = new ServerConnection
+        {
+            Id = Guid.NewGuid().ToString(),
+            ServerName = ServerName,
+            IsEnabled = true,
+        };
+        _serverManager.AddServer(server);
+
+        /* Derived, not stored -- seeding under a hardcoded id would write rows the tool looks past. */
+        _serverId = RemoteCollectorService.GetDeterministicHashCode(
+            RemoteCollectorService.GetServerNameForStorage(server));
+    }
+
+    public void Dispose()
+    {
+        _seedConn?.Dispose();
+        try { Directory.Delete(_configDir, recursive: true); } catch (IOException) { /* temp dir */ }
+    }
+
+    [Fact]
+    public async Task MemoryTrend_NeverCollected_AndAQuietWindow_AreDifferentAnswers()
+    {
+        var service = new LocalDataService(_duckDb);
+
+        AssertNeverCollected(await McpMemoryTools.GetMemoryTrend(service, _serverManager, ServerName, 4));
+
+        await SeedMemoryAsync(DateTime.UtcNow.AddHours(-48));
+        AssertQuietWindow(await McpMemoryTools.GetMemoryTrend(service, _serverManager, ServerName, 1));
+
+        await SeedMemoryAsync(DateTime.UtcNow.AddMinutes(-10));
+        AssertPayload(await McpMemoryTools.GetMemoryTrend(service, _serverManager, ServerName, 4));
+    }
+
+    [Fact]
+    public async Task FileIoTrend_NeverCollected_AndAQuietWindow_AreDifferentAnswers()
+    {
+        var service = new LocalDataService(_duckDb);
+
+        AssertNeverCollected(await McpIoTools.GetFileIoTrend(service, _serverManager, ServerName, 4));
+
+        await SeedFileIoAsync(DateTime.UtcNow.AddHours(-48));
+        AssertQuietWindow(await McpIoTools.GetFileIoTrend(service, _serverManager, ServerName, 1));
+
+        await SeedFileIoAsync(DateTime.UtcNow.AddMinutes(-10));
+        AssertPayload(await McpIoTools.GetFileIoTrend(service, _serverManager, ServerName, 4));
+    }
+
+    [Fact]
+    public async Task QueryDurationTrend_NeverCollected_AndAQuietWindow_AreDifferentAnswers()
+    {
+        var service = new LocalDataService(_duckDb);
+
+        AssertNeverCollected(await McpQueryTools.GetQueryDurationTrend(service, _serverManager, ServerName, 4));
+
+        await SeedQueryAsync(DateTime.UtcNow.AddHours(-48));
+        AssertQuietWindow(await McpQueryTools.GetQueryDurationTrend(service, _serverManager, ServerName, 1));
+
+        await SeedQueryAsync(DateTime.UtcNow.AddMinutes(-10));
+        AssertPayload(await McpQueryTools.GetQueryDurationTrend(service, _serverManager, ServerName, 4));
+    }
+
+    /// <summary>Nothing has ever been stored for this server: NOT an empty window, and widening it would
+    /// never help.</summary>
+    private static void AssertNeverCollected(string payload)
+    {
+        var root = JsonDocument.Parse(payload).RootElement;
+        Assert.Equal("unavailable", root.GetProperty("status").GetString());
+        var text = root.GetProperty("message").GetString()!;
+        Assert.Contains("EVER", text, StringComparison.Ordinal);
+        Assert.Contains("not an empty window", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("widen hours_back", text, StringComparison.Ordinal);
+    }
+
+    /// <summary>The server collected and this window is simply quiet — the opposite next move, and it must
+    /// not share wording with the case above.</summary>
+    private static void AssertQuietWindow(string payload)
+    {
+        var root = JsonDocument.Parse(payload).RootElement;
+        Assert.Equal("empty", root.GetProperty("status").GetString());
+        var text = root.GetProperty("message").GetString()!;
+        Assert.Contains("widen hours_back", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("EVER", text, StringComparison.Ordinal);
+    }
+
+    private static void AssertPayload(string payload)
+    {
+        var root = JsonDocument.Parse(payload).RootElement;
+        Assert.False(root.TryGetProperty("status", out _));
+        Assert.True(root.GetProperty("trend").GetArrayLength() > 0);
+    }
+
+    private async Task<DuckDBConnection> SeedConnectionAsync()
+    {
+        if (_seedConn is null)
+        {
+            _seedConn = _duckDb.CreateConnection();
+            await _seedConn.OpenAsync();
+        }
+        return _seedConn;
+    }
+
+    private async Task SeedMemoryAsync(DateTime collectionTimeUtc)
+    {
+        using var readLock = _duckDb.AcquireReadLock();
+        var connection = await SeedConnectionAsync();
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = @"
+INSERT INTO memory_stats
+    (collection_id, collection_time, server_id, server_name,
+     total_physical_memory_mb, available_physical_memory_mb,
+     target_server_memory_mb, total_server_memory_mb, buffer_pool_mb, plan_cache_mb)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)";
+        cmd.Parameters.Add(new DuckDBParameter { Value = _nextId++ });
+        cmd.Parameters.Add(new DuckDBParameter { Value = DateTime.SpecifyKind(collectionTimeUtc, DateTimeKind.Unspecified) });
+        cmd.Parameters.Add(new DuckDBParameter { Value = _serverId });
+        cmd.Parameters.Add(new DuckDBParameter { Value = ServerName });
+        cmd.Parameters.Add(new DuckDBParameter { Value = 65536.0 });
+        cmd.Parameters.Add(new DuckDBParameter { Value = 8192.0 });
+        cmd.Parameters.Add(new DuckDBParameter { Value = 49152.0 });
+        cmd.Parameters.Add(new DuckDBParameter { Value = 40000.0 });
+        cmd.Parameters.Add(new DuckDBParameter { Value = 35000.0 });
+        cmd.Parameters.Add(new DuckDBParameter { Value = 5000.0 });
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    /* delta_reads above zero on purpose: the trend's top_files CTE requires read or write activity, so a
+       row with zero deltas would leave the window empty for a reason that has nothing to do with #2485. */
+    private async Task SeedFileIoAsync(DateTime collectionTimeUtc)
+    {
+        using var readLock = _duckDb.AcquireReadLock();
+        var connection = await SeedConnectionAsync();
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = @"
+INSERT INTO file_io_stats
+    (collection_id, collection_time, server_id, server_name,
+     database_name, file_name, file_type, size_mb,
+     num_of_reads, num_of_writes, read_bytes, write_bytes,
+     io_stall_read_ms, io_stall_write_ms,
+     delta_reads, delta_writes, delta_stall_read_ms, delta_stall_write_ms)
+VALUES ($1, $2, $3, $4, $5, $6, $7, 0,
+        $8, $9, 0, 0, $10, $11, $12, $13, $14, $15)";
+        cmd.Parameters.Add(new DuckDBParameter { Value = _nextId++ });
+        cmd.Parameters.Add(new DuckDBParameter { Value = DateTime.SpecifyKind(collectionTimeUtc, DateTimeKind.Unspecified) });
+        cmd.Parameters.Add(new DuckDBParameter { Value = _serverId });
+        cmd.Parameters.Add(new DuckDBParameter { Value = ServerName });
+        cmd.Parameters.Add(new DuckDBParameter { Value = "AppDb" });
+        cmd.Parameters.Add(new DuckDBParameter { Value = "app.mdf" });
+        cmd.Parameters.Add(new DuckDBParameter { Value = "ROWS" });
+        cmd.Parameters.Add(new DuckDBParameter { Value = 500L });
+        cmd.Parameters.Add(new DuckDBParameter { Value = 200L });
+        cmd.Parameters.Add(new DuckDBParameter { Value = 2500L });
+        cmd.Parameters.Add(new DuckDBParameter { Value = 400L });
+        cmd.Parameters.Add(new DuckDBParameter { Value = 500L });
+        cmd.Parameters.Add(new DuckDBParameter { Value = 200L });
+        cmd.Parameters.Add(new DuckDBParameter { Value = 2500L });
+        cmd.Parameters.Add(new DuckDBParameter { Value = 400L });
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private async Task SeedQueryAsync(DateTime collectionTimeUtc)
+    {
+        using var readLock = _duckDb.AcquireReadLock();
+        var connection = await SeedConnectionAsync();
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = @"
+INSERT INTO query_stats
+    (collection_id, collection_time, server_id, server_name, database_name,
+     query_hash, sql_handle, last_execution_time, delta_execution_count,
+     delta_worker_time, delta_elapsed_time, query_text)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)";
+        var naive = DateTime.SpecifyKind(collectionTimeUtc, DateTimeKind.Unspecified);
+        cmd.Parameters.Add(new DuckDBParameter { Value = _nextId++ });
+        cmd.Parameters.Add(new DuckDBParameter { Value = naive });
+        cmd.Parameters.Add(new DuckDBParameter { Value = _serverId });
+        cmd.Parameters.Add(new DuckDBParameter { Value = ServerName });
+        cmd.Parameters.Add(new DuckDBParameter { Value = "AppDb" });
+        cmd.Parameters.Add(new DuckDBParameter { Value = "0xEMPTYTRENDHASH" });
+        cmd.Parameters.Add(new DuckDBParameter { Value = "0xSQLH" });
+        cmd.Parameters.Add(new DuckDBParameter { Value = naive });
+        cmd.Parameters.Add(new DuckDBParameter { Value = 10L });
+        cmd.Parameters.Add(new DuckDBParameter { Value = 10000L });
+        cmd.Parameters.Add(new DuckDBParameter { Value = 20000L });
+        cmd.Parameters.Add(new DuckDBParameter { Value = "SELECT * FROM Orders" });
+        await cmd.ExecuteNonQueryAsync();
+    }
+}

--- a/Lite/Mcp/McpInstructions.cs
+++ b/Lite/Mcp/McpInstructions.cs
@@ -74,7 +74,7 @@ internal static class McpInstructions
         | `get_top_procedures_by_cpu` | Expensive stored procedures by CPU time, with the same `cpu_attribution` disclosure | `server_name`, `hours_back`, `top`, `database_name` |
         | `get_query_store_top` | Expensive queries from Query Store (persistent) | `server_name`, `hours_back`, `top`, `database_name` |
         | `get_query_trend` | Time-series for a specific query by query_hash | `query_hash` (required), `database_name` (required), `server_name`, `hours_back` |
-        | `get_query_duration_trend` | Average query duration over time (detect degradation) | `server_name`, `hours_back` |
+        | `get_query_duration_trend` | Average query duration over time (detect degradation). An empty result distinguishes a quiet window (`empty`, widen `hours_back`) from a server nothing has ever been collected for (`unavailable`, collection is not running) | `server_name`, `hours_back` |
 
         ### Blocking & Deadlock Tools
         | Tool | Purpose | Key Parameters |
@@ -91,7 +91,7 @@ internal static class McpInstructions
         | Tool | Purpose | Key Parameters |
         |------|---------|----------------|
         | `get_memory_stats` | Latest memory snapshot: physical, buffer pool, plan cache | `server_name` |
-        | `get_memory_trend` | Memory usage over time | `server_name`, `hours_back` |
+        | `get_memory_trend` | Memory usage over time. An empty result distinguishes a quiet window (`empty`, widen `hours_back`) from a server nothing has ever been collected for (`unavailable`, collection is not running) | `server_name`, `hours_back` |
         | `get_memory_clerks` | Top memory consumers by clerk type | `server_name` |
         | `get_memory_grants` | Active/recent memory grants (detect grant pressure) | `server_name`, `hours_back` (default 1), `limit` |
         | `get_resource_semaphore` | Latest resource-semaphore snapshot: workspace memory vs target/max ceiling, waiter/timeout/forced-grant pressure | `server_name`, `hours_back` (default 24) |
@@ -101,7 +101,7 @@ internal static class McpInstructions
         | Tool | Purpose | Key Parameters |
         |------|---------|----------------|
         | `get_file_io_stats` | Latest file I/O stats per database file with latency | `server_name` |
-        | `get_file_io_trend` | I/O latency trend over time per database | `server_name`, `hours_back` |
+        | `get_file_io_trend` | I/O latency trend over time per database. An empty result distinguishes a quiet window (`empty`, widen `hours_back`) from a server nothing has ever been collected for (`unavailable`, collection is not running) | `server_name`, `hours_back` |
 
         ### TempDB Tools
         | Tool | Purpose | Key Parameters |

--- a/Lite/Mcp/McpIoTools.cs
+++ b/Lite/Mcp/McpIoTools.cs
@@ -71,6 +71,22 @@ public sealed class McpIoTools
             if (hoursError != null) return hoursError;
 
             var points = await dataService.GetFileIoLatencyTrendAsync(resolved.ServerId, hours_back);
+
+            if (points.Count == 0)
+            {
+                /* Same two states as the memory trend, same probe discipline, same words as Darling's twin.
+                   The quiet-window sentence carries one extra clause the others do not need: this read's
+                   top_files CTE requires delta_reads or delta_writes above zero, so a genuinely idle file
+                   set is empty here even on a server whose file_io_stats collector ran every cycle. */
+                return await dataService.HasAnyFileIoStatAsync(resolved.ServerId)
+                    ? McpHelpers.Status(
+                        "empty",
+                        $"No file I/O samples recorded for {resolved.ServerName} in the last {hours_back} hour(s). This server HAS collected file I/O stats before, so this window is genuinely quiet rather than broken — widen hours_back, or read it as no measurable read or write activity on any file in this window.")
+                    : McpHelpers.Status(
+                        "unavailable",
+                        $"No file I/O stats have EVER been recorded for {resolved.ServerName}. This is not an empty window — the file_io_stats collector has stored nothing at all for this server. Check that collection is running and that the server is enabled; get_file_io_stats will be equally empty until it does.");
+            }
+
             var result = points.Select(p => new
             {
                 time = p.CollectionTime.ToString("o"),

--- a/Lite/Mcp/McpMemoryTools.cs
+++ b/Lite/Mcp/McpMemoryTools.cs
@@ -63,6 +63,26 @@ public sealed class McpMemoryTools
             if (hoursError != null) return hoursError;
 
             var points = await dataService.GetMemoryTrendAsync(resolved.ServerId, hours_back);
+
+            if (points.Count == 0)
+            {
+                /*
+                    A bare empty array here told an MCP client nothing at all -- and Darling's twin already
+                    returned a status envelope, so the same tool name gave two different answers depending
+                    on which SKU it was pointed at. Both now make the same distinction in the same words: a
+                    server that collected fine and was quiet in THIS window wants the window widened, while
+                    a server the collector has never touched wants somebody to go look at collection, and
+                    widening will never fill it. Probed only here, against the SAME source the trend read.
+                */
+                return await dataService.HasAnyMemoryStatAsync(resolved.ServerId)
+                    ? McpHelpers.Status(
+                        "empty",
+                        $"No memory samples recorded for {resolved.ServerName} in the last {hours_back} hour(s). This server HAS collected memory stats before, so this window is genuinely quiet rather than broken — widen hours_back to find the most recent samples.")
+                    : McpHelpers.Status(
+                        "unavailable",
+                        $"No memory stats have EVER been recorded for {resolved.ServerName}. This is not an empty window — the memory_stats collector has stored nothing at all for this server. Check that collection is running and that the server is enabled; get_memory_stats will be equally empty until it does.");
+            }
+
             var result = points.Select(p => new
             {
                 time = p.CollectionTime.ToString("o"),

--- a/Lite/Mcp/McpQueryTools.cs
+++ b/Lite/Mcp/McpQueryTools.cs
@@ -286,6 +286,21 @@ public sealed class McpQueryTools
             if (hoursError != null) return hoursError;
 
             var points = await dataService.GetQueryDurationTrendAsync(resolved.ServerId, hours_back);
+
+            if (points.Count == 0)
+            {
+                /* Same two states again, same words as Darling's twin. The probe reads v_query_stats
+                   because THIS trend does; Darling's probes the base table because ITS trend does. Each
+                   probe follows its own read — what the caller sees is one sentence, not two. */
+                return await dataService.HasAnyQueryStatAsync(resolved.ServerId)
+                    ? McpHelpers.Status(
+                        "empty",
+                        $"No query samples recorded for {resolved.ServerName} in the last {hours_back} hour(s). This server HAS collected query stats before, so this window is genuinely quiet rather than broken — widen hours_back to find the most recent samples.")
+                    : McpHelpers.Status(
+                        "unavailable",
+                        $"No query stats have EVER been recorded for {resolved.ServerName}. This is not an empty window — the query_stats collector has stored nothing at all for this server. Check that collection is running and that the server is enabled; get_top_queries_by_cpu will be equally empty until it does.");
+            }
+
             var result = points.Select(p => new
             {
                 time = p.CollectionTime.ToString("o"),

--- a/Lite/Services/LocalDataService.FileIo.cs
+++ b/Lite/Services/LocalDataService.FileIo.cs
@@ -135,6 +135,28 @@ ORDER BY f.collection_time, f.database_name, f.file_name";
     }
 
     /// <summary>
+    /// Whether this server has EVER recorded a file I/O sample, ignoring any window.
+    /// <para>Lets an empty I/O trend say WHICH kind of nothing it found — see
+    /// <c>LocalDataService.HasAnyMemoryStatAsync</c> for the reasoning. Reads <c>v_file_io_stats</c>, the
+    /// same source <see cref="GetFileIoLatencyTrendAsync"/> reads. Darling's twin is
+    /// <c>DarlingTrendReader.HasAnyFileIoStatAsync</c>.</para>
+    /// </summary>
+    public async Task<bool> HasAnyFileIoStatAsync(int serverId)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        command.CommandText = @"
+SELECT 1
+FROM v_file_io_stats
+WHERE server_id = $1
+LIMIT 1";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        return await command.ExecuteScalarAsync() is not null and not DBNull;
+    }
+
+    /// <summary>
     /// Gets file I/O throughput trend data (MB/s) broken down by file for charting.
     /// Uses LAG() window function to compute collection interval for per-second calculation.
     /// </summary>

--- a/Lite/Services/LocalDataService.Memory.cs
+++ b/Lite/Services/LocalDataService.Memory.cs
@@ -109,6 +109,31 @@ ORDER BY collection_time";
     }
 
     /// <summary>
+    /// Whether this server has EVER recorded a memory sample, ignoring any window.
+    /// <para>Lets an empty memory trend say WHICH kind of nothing it found. "No memory trend data" is true
+    /// both of a quiet window and of a server the collector has never touched, and those want opposite
+    /// responses — widen the window, versus go find out why collection is not running. Reads
+    /// <c>v_memory_stats</c>, the same source <see cref="GetMemoryTrendAsync"/> reads, so it can never
+    /// report "collected" for rows the trend cannot see. Darling's twin is
+    /// <c>DarlingTrendReader.HasAnyMemoryStatAsync</c>; the two must stay in step so a user moving between
+    /// the SKUs is not told a different story about the same state.</para>
+    /// </summary>
+    public async Task<bool> HasAnyMemoryStatAsync(int serverId)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        command.CommandText = @"
+SELECT 1
+FROM v_memory_stats
+WHERE server_id = $1
+LIMIT 1";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        return await command.ExecuteScalarAsync() is not null and not DBNull;
+    }
+
+    /// <summary>
     /// Gets the distinct memory clerk types collected for a server, ordered by total memory descending.
     /// </summary>
     public async Task<List<string>> GetDistinctMemoryClerkTypesAsync(int serverId, int hoursBack = 24, DateTime? fromDate = null, DateTime? toDate = null)

--- a/Lite/Services/LocalDataService.QueryStats.cs
+++ b/Lite/Services/LocalDataService.QueryStats.cs
@@ -1158,6 +1158,30 @@ ORDER BY collection_time";
     }
 
     /// <summary>
+    /// Whether this server has EVER recorded a query-stats sample, ignoring any window.
+    /// <para>Lets an empty query-duration trend say WHICH kind of nothing it found — see
+    /// <c>LocalDataService.HasAnyMemoryStatAsync</c> for the reasoning. Reads <c>v_query_stats</c>, the
+    /// same source <see cref="GetQueryDurationTrendAsync"/> reads here. Darling's twin probes the BASE
+    /// <c>query_stats</c> table instead, because ITS duration trend does — on a Darling store
+    /// <c>v_query_stats</c> is the payload-resolving view rather than a passthrough. Each probe follows
+    /// its own read; the SENTENCES the two SKUs return are identical, which is what the caller sees.</para>
+    /// </summary>
+    public async Task<bool> HasAnyQueryStatAsync(int serverId)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+
+        command.CommandText = @"
+SELECT 1
+FROM v_query_stats
+WHERE server_id = $1
+LIMIT 1";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        return await command.ExecuteScalarAsync() is not null and not DBNull;
+    }
+
+    /// <summary>
     /// Gets procedure duration trend — elapsed time per second per collection snapshot.
     /// </summary>
     public async Task<List<QueryTrendPoint>> GetProcedureDurationTrendAsync(int serverId, int hoursBack = 24, DateTime? fromDate = null, DateTime? toDate = null, IReadOnlyList<string>? databaseNames = null)


### PR DESCRIPTION
Closes part of #2485 — the SKU-divergence half, which the issue calls "arguably the more urgent".

## What was wrong

`get_file_io_trend`, `get_memory_trend` and `get_query_duration_trend` returned a **bare empty array on Lite** while their **Darling twins returned a status envelope**. Same tool name, same client, two different answers depending on which SKU it was pointed at.

Darling's envelope was not the target either. All three returned `Status("unavailable", "No … trend data available.")` whatever the reason. That sentence is true of a window that was simply quiet **and** of a server the collector has never touched, and those want opposite next moves — widen the window, versus go find out why collection is not running, which widening will never fix. `"unavailable"` sounds specific and says neither.

## What the two branches now say

Both SKUs, word for word:

| Situation | status | message |
|---|---|---|
| Collected before, this window quiet | `empty` | "No memory samples recorded for X in the last N hour(s). This server **HAS collected** memory stats before, so this window is genuinely quiet rather than broken — **widen hours_back** to find the most recent samples." |
| Nothing ever stored | `unavailable` | "No memory stats have **EVER** been recorded for X. This is **not an empty window** — the memory_stats collector has stored nothing at all for this server. Check that collection is running …" |

The branch is a `LIMIT 1` existence probe run **only** on the path that already found nothing. The two sentences share no wording, pinned in both directions on both SKUs.

The file I/O `empty` sentence carries one clause the other two do not: that read's `top_files` CTE requires `delta_reads` or `delta_writes` above zero, so a genuinely idle file set is empty here even on a server whose collector ran every cycle — the message says so rather than implying the window was too narrow.

## The probe-source decision, which is the real review surface

Each probe walks **the same relation its own read walks**, and here that means the two SKUs' probes deliberately name *different* relations:

- Darling's `get_query_duration_trend` reads the **base `query_stats` table** on purpose — on a V38+ store `v_query_stats` is the payload-**resolving** view and the trend projects no text — so `HasAnyQueryStatSql` reads `query_stats`.
- Lite's reads `v_query_stats`, so its probe reads `v_query_stats`.

A probe reaching for the view out of habit on the Darling side would be asking about a relation the read never walks. `DarlingTrendEmptyTests.EachProbe_WalksTheSameRelationAsItsTrend` **derives** this rather than restating it: it pulls the relation out of the probe SQL with a regex and asserts the trend SQL names the same one. The sentences the caller sees are identical regardless.

## How I verified

- `PerformanceMonitor.Darling.Service`, `Lite`, `Darling.Tests` and `Lite.Tests` all build clean on macOS (0 errors).
- `DarlingTrendEmptyTests` — one gated-live test (cleanup through `LiveStoreCleanup.RunAsync`) walking never-collected → quiet-window → payload for all three tools, plus the **ungated** derived relation pin.
- `TrendEmptyParityToolTests` — 3 Lite tests over `SharedDuckDbFixture`, one per tool, seeded under the **derived** server id, walking the same three states.
- The existing pin in `DarlingMcpTrendToolsLivePostgresTests` (after `DeleteRowsAsync`, memory and query-duration trends must return `unavailable`) still holds: that teardown removes every row, so the probe correctly reports never-collected.

## What I could NOT verify

- **Neither suite ran locally.** Both target `net10.0-windows`; built on macOS, run in CI.
- **No live store was queried.** The `v_query_stats`-is-not-a-passthrough claim comes from reading `PgMigrations` V51 and `PgSchemaGenerator.PayloadResolvingViews`, not from querying a real store.
- **The web panels were not exercised.** Darling already returned an envelope for all three, so the web shape is unchanged — only the wording is better — but no browser rendered it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
