### PR TITLE
Ask whether the blocking collectors ran, not whether they found anything

### DIFF
--- a/Darling/Darling.Tests/DarlingBlockingStatsReadTests.cs
+++ b/Darling/Darling.Tests/DarlingBlockingStatsReadTests.cs
@@ -63,11 +63,27 @@ public sealed class DarlingBlockingStatsReadTests
         {
             await DarlingMcpTestData.RegisterServerAsync(connection, ServerId, ServerName, ct);
 
-            /* ── nothing captured at all: NOT a clean bill of health ── */
+            /* ── collectors never ran: NOT a clean bill of health ── */
             var never = await DarlingMcpDataTools.GetBlockingStats(dataSource, ServerName, 24);
             var neverDoc = JsonDocument.Parse(never);
             Assert.Equal("unavailable", neverDoc.RootElement.GetProperty("status").GetString());
             Assert.Contains("NOT a clean bill of health", neverDoc.RootElement.GetProperty("message").GetString()!, StringComparison.Ordinal);
+
+            /*
+                ── the healthy-server case, which the first design got backwards ──
+                A collector that RAN and saw nothing, with no blocking or deadlock rows anywhere. This is
+                the ordinary state of a well-behaved server, and it must read as a clear window. An
+                event-existence probe answers no here -- there are no rows to find -- and would tell a
+                healthy server its collection is broken, sending someone to fix what is working.
+            */
+            await SeedCollectorRunAsync(connection, ct, "blocked_process_report", MinutesAgo(20));
+
+            var healthy = await DarlingMcpDataTools.GetBlockingStats(dataSource, ServerName, 24);
+            var healthyDoc = JsonDocument.Parse(healthy);
+            Assert.Equal("empty", healthyDoc.RootElement.GetProperty("status").GetString());
+            var healthyText = healthyDoc.RootElement.GetProperty("message").GetString()!;
+            Assert.Contains("genuinely clear", healthyText, StringComparison.Ordinal);
+            Assert.DoesNotContain("NEVER", healthyText, StringComparison.Ordinal);
 
             /*
                 ── the regression this file exists for ──
@@ -113,6 +129,17 @@ public sealed class DarlingBlockingStatsReadTests
     private static DateTime HoursAgo(int hours) =>
         DarlingMcpTestData.TruncateToSeconds(DateTime.UtcNow.AddHours(-hours));
 
+    /// <summary>A SUCCESSFUL collector run that found nothing — the denominator the verdict rests on.</summary>
+    private static async Task SeedCollectorRunAsync(
+        NpgsqlConnection connection, CancellationToken ct, string collector, DateTime at) =>
+        await DarlingMcpTestData.ExecAsync(connection, ct, @"
+INSERT INTO collection_log
+    (log_id, server_id, server_name, collector_name, collection_time,
+     duration_ms, status, error_message, rows_collected, sql_duration_ms, duckdb_duration_ms)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)",
+            CollectionIdGenerator.Next(), ServerId, ServerName, collector,
+            DarlingMcpTestData.Naive(at), 100, "SUCCESS", null, 0, 80, 20);
+
     private static async Task SeedDeadlockAsync(NpgsqlConnection connection, CancellationToken ct, DateTime at) =>
         await DarlingMcpTestData.ExecAsync(connection, ct,
             "INSERT INTO deadlocks (deadlock_id, collection_time, server_id, server_name, deadlock_time, victim_process_id, victim_sql_text, deadlock_graph_xml) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
@@ -122,6 +149,7 @@ public sealed class DarlingBlockingStatsReadTests
     private static async Task DeleteRowsAsync(NpgsqlConnection connection, CancellationToken ct)
     {
         await DarlingMcpTestData.ExecAsync(connection, ct, "DELETE FROM deadlocks WHERE server_id = $1", ServerId);
+        await DarlingMcpTestData.ExecAsync(connection, ct, "DELETE FROM collection_log WHERE server_id = $1", ServerId);
         await DarlingMcpTestData.ExecAsync(connection, ct, "DELETE FROM servers WHERE server_id = $1", ServerId);
         await DarlingMcpTestData.ExecAsync(connection, ct, "DELETE FROM config_monitored_servers WHERE server_id = $1", ServerId);
     }

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingBlockingTrendReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingBlockingTrendReader.cs
@@ -168,12 +168,14 @@ internal static class DarlingBlockingTrendReader
     /// server whose collectors have run before has a GAP in this window (widen it, or go look at collection
     /// health), while one that has never run them is not collecting blocking at all. Both are "not an
     /// all-clear" and they want different next moves. LIMIT 1, so it stops at the first row.</para>
-    /// <para>NOT the same question as the neighbouring <c>DarlingDataReader.HasAnyBlockingCaptureAsync</c>,
-    /// which asks whether an EVENT was ever captured. That one is right for get_blocking_stats, whose
-    /// verdict is about severity; it is wrong here, because a server that has been collected perfectly for
-    /// months and simply never blocked has no event rows and would be reported as never captured — the
-    /// reassuring-answer failure this read exists to prevent, inverted. Hence "collector run", not
-    /// "capture": the denominator is whether we LOOKED, not whether we found something.</para>
+    /// <para>NOT the same question as asking whether an EVENT was ever captured. A server collected
+    /// perfectly for months that simply never blocked has no event rows, and an event-existence probe
+    /// reports it as never captured — the reassuring-answer failure inverted, sending someone to fix
+    /// collection that is working. Hence "collector run", not "capture": the denominator is whether we
+    /// LOOKED, not whether we found something.</para>
+    /// <para>This applies to get_blocking_stats too, which originally used an event-existence probe on the
+    /// grounds that its verdict is about severity. That reasoning does not survive contact with a healthy
+    /// server: zero severity is the NORMAL state, so the same false alarm fires. It uses these.</para>
     /// </summary>
     public const string HasAnyBlockingCollectorRunSql = """
         SELECT 1

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpDataTools.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpDataTools.cs
@@ -1219,19 +1219,26 @@ public sealed class DarlingMcpDataTools
             if (blocking.Count == 0 && deadlocks.Count == 0)
             {
                 /*
-                    Same trap as the waits trend, and the reassuring answer is again the wrong one: an
-                    operator told "no blocking" stops looking. Both capture paths are checked, because
-                    either alone can be off on a given server -- reporting calm while the only source that
-                    would have shown it was never collected is the failure this avoids.
+                    The denominator is whether we LOOKED, not whether we ever FOUND anything. Blocking and
+                    deadlocks are edge tables: a server collected perfectly for months that simply never
+                    blocked has no rows at all, so asking "was an event ever captured" answers no and
+                    reports a healthy server as uncollected -- the reassuring-answer failure inverted, and
+                    a false alarm sends someone to fix collection that is working.
+
+                    So this asks collection_log for a SUCCESSFUL run of either capture path. Both are
+                    checked because either can be off alone, and the deadlock collector is separate from
+                    both -- the verdict covers its series too.
                 */
-                var everCaptured = await DarlingDataReader.HasAnyBlockingCaptureAsync(postgres, resolved.ServerId);
-                return everCaptured
+                var everRan =
+                    await DarlingBlockingTrendReader.HasAnyBlockingCollectorRunAsync(postgres, resolved.ServerId)
+                    || await DarlingBlockingTrendReader.HasAnyDeadlockCollectorRunAsync(postgres, resolved.ServerId);
+                return everRan
                     ? McpHelpers.Status(
                         "empty",
-                        $"No blocking or deadlocks recorded for {resolved.ServerName} in the last {Math.Abs(hours_back)} hour(s). This server HAS captured blocking before, so the window is genuinely clear.")
+                        $"No blocking or deadlocks recorded for {resolved.ServerName} in the last {Math.Abs(hours_back)} hour(s). The blocking collectors HAVE run successfully for this server, so the window is genuinely clear rather than blind.")
                     : McpHelpers.Status(
                         "unavailable",
-                        $"No blocking has EVER been captured for {resolved.ServerName}, so this is NOT a clean bill of health — there is nothing to read. Blocked-process reports need the XE session running, or the DMV blocking snapshot collector enabled; check those before concluding this server does not block.");
+                        $"The blocking collectors have NEVER run successfully for {resolved.ServerName}, so this is NOT a clean bill of health — nothing looked. Blocked-process reports need the XE session running, or the DMV blocking snapshot collector enabled; check those before concluding this server does not block.");
             }
 
             return JsonSerializer.Serialize(new

--- a/Lite/Mcp/McpHealthTools.cs
+++ b/Lite/Mcp/McpHealthTools.cs
@@ -418,15 +418,19 @@ public sealed class McpHealthTools
 
             if (blocking.Count == 0 && deadlocks.Count == 0)
             {
-                /* The reassuring answer is the wrong one -- same words as Darling's twin. */
-                var everCaptured = await dataService.HasAnyBlockingCaptureAsync(resolved.ServerId);
-                return everCaptured
+                /* The denominator is whether we LOOKED, not whether we ever FOUND anything: these are
+                   edge tables, and a healthy server that never blocked has no rows to find. Same words
+                   as Darling's twin. */
+                var everRan =
+                    await dataService.HasAnyBlockingCollectorRunAsync(resolved.ServerId)
+                    || await dataService.HasAnyDeadlockCollectorRunAsync(resolved.ServerId);
+                return everRan
                     ? McpHelpers.Status(
                         "empty",
-                        $"No blocking or deadlocks recorded for {resolved.ServerName} in the last {hours} hour(s). This server HAS captured blocking before, so the window is genuinely clear.")
+                        $"No blocking or deadlocks recorded for {resolved.ServerName} in the last {hours} hour(s). The blocking collectors HAVE run successfully for this server, so the window is genuinely clear rather than blind.")
                     : McpHelpers.Status(
                         "unavailable",
-                        $"No blocking has EVER been captured for {resolved.ServerName}, so this is NOT a clean bill of health — there is nothing to read. Blocked-process reports need the XE session running, or the DMV blocking snapshot collector enabled; check those before concluding this server does not block.");
+                        $"The blocking collectors have NEVER run successfully for {resolved.ServerName}, so this is NOT a clean bill of health — nothing looked. Blocked-process reports need the XE session running, or the DMV blocking snapshot collector enabled; check those before concluding this server does not block.");
             }
 
             return JsonSerializer.Serialize(new


### PR DESCRIPTION
Follow-up to my own #2497, prompted by the design in #2500.

## The bug

`get_blocking_stats` used an **event-existence** probe: had a blocking or deadlock row ever been stored for this server?

That is wrong on an edge table. A server collected perfectly for months that simply **never blocked** has no rows at all — so the probe answers no, and the read tells a healthy server:

> …so this is NOT a clean bill of health — there is nothing to read. Blocked-process reports need the XE session running…

A false alarm that sends someone to fix collection that is working. It is the reassuring-answer failure **inverted**, and I built the probe reasoning carefully about capture paths while never asking what it says about a server with nothing to capture.

## The correction, including a note that defended the mistake

#2500 got this right for the trends and left a note saying the event probe was nonetheless correct *for `get_blocking_stats`*, because that verdict is about severity rather than occurrence. That reasoning does not survive contact with a healthy server: **zero severity is the normal state**, so the same false alarm fires. The note is corrected along with the code, because a wrong rationale sitting next to the right implementation is how the mistake comes back.

The denominator is now whether we **looked**: a successful run of either blocking capture path, or of the deadlock collector, in `collection_log`. Both paths, because either can be off alone; deadlocks included, because the verdict covers that series too.

## Verification

`DarlingBlockingStatsReadTests` now pins the case the first design got backwards:

- A collector that **ran and saw nothing**, with no event rows anywhere → `empty`, "genuinely clear", and asserts the message does **not** say `NEVER`. This is the ordinary state of a well-behaved server, and it is precisely the state the original probe could not describe.
- Collectors never ran → `unavailable`, "NOT a clean bill of health".
- Deadlock outside the window with no blocking rows → still a clear *window*, not never-captured.

Messages stay byte-identical across both SKUs. Service, Lite and both test projects build clean.