### PR TITLE
Correct §3.4's coverage claims, including a gap it blames on the web

### DIFF
--- a/docs/uat-onboarding.md
+++ b/docs/uat-onboarding.md
@@ -497,15 +497,26 @@ exclusion list — 92 read endpoints out of 111 tools — and these are the excl
 
 The pages are Fleet Overview, per-server, Alert History, Availability Groups and Custom Views. The per-server
 page carries twelve sub-tabs — Overview, Wait Stats, CPU, Memory, Blocking, File I/O, Queries, Configuration,
-Config Changes, Activity, System Events and Collection Health — reaching 71 of the 92 read endpoints, against
+Config Changes, Activity, System Events and Collection Health — reaching 72 of the 92 read endpoints, against
 the viewer's nineteen top-level per-server tabs (65 counting their inner tabs). So most of what the viewer
 shows is now here, and what is not divides into three groups.
 
-**Reads that exist but no web page shows.** The eight `get_pg_*` PostgreSQL reads, because `/api/fleet`'s card
-carries the SQL Server `engine_edition` and no target-engine discriminator, so the browser cannot tell a
-PostgreSQL target from a SQL Server one — a PostgreSQL panel would render on every SQL Server, permanently
-empty. Also `get_database_scoped_config`, whose `databases[].settings[]` shape the table renderer cannot draw,
-and `get_store_metrics`, which is store-wide and has no per-server home.
+**Reads that exist but no web page shows.** `get_database_scoped_config`, whose `databases[].settings[]` shape
+the table renderer cannot draw, and `get_store_metrics`, which is store-wide and has no per-server home.
+
+Also `get_query_trend` — one query's per-collection history, keyed on a **required** `query_hash`. The web has
+no per-query drill-down to select one from, so the read is unreachable there. The viewer does: double-clicking
+a row in Top Queries opens that query's history window. This is a genuine web gap rather than a boundary, and
+it is tracked separately.
+
+**The eight `get_pg_*` PostgreSQL reads are NOT a web gap, and this section used to say they were.** Neither
+surface shows them: the WPF viewer has no PostgreSQL screens either, so a PostgreSQL target is readable only
+through MCP, on both SKUs. The web has an additional obstacle on top of that — `/api/fleet`'s card carries the
+SQL Server `engine_edition` and no target-engine discriminator, so a browser cannot tell a PostgreSQL target
+from a SQL Server one and a PostgreSQL panel would render empty on every SQL Server — but fixing only that
+would not give you a screen, because there is no PostgreSQL screen on either side to reach. If you are
+evaluating this for PostgreSQL monitoring, know that up front: the collection and the reads are real and the
+graphical surfaces are not.
 
 **Data with no read endpoint at all** — **this list is now empty.** It used to hold ten viewer surfaces
 (Query Store regressions, the query heatmap, three of the four Performance Trends charts, the


### PR DESCRIPTION
Measured the web dashboard's coverage against the WPF viewer before cutting the release. Three things in §3.4 were wrong.

## 1. The PostgreSQL gap is not a web gap

§3.4 listed the eight `get_pg_*` reads under *"reads that exist but no web page shows"*, with a web-specific cause: `/api/fleet`'s card carries no target-engine discriminator.

That obstacle is real. It is not the reason there is no PostgreSQL screen. **The WPF viewer has no PostgreSQL screens either** — grepping the pg store tables (`pg_autovacuum_stats`, `pg_wait_stats`, `pg_replication_slots`, `pg_io_stats`) returns **zero files** in both the viewer and `wwwroot`. A PostgreSQL target is readable only through MCP, on both SKUs.

So fixing the discriminator would give the browser somewhere to put a screen that does not exist on either side. Anyone evaluating this product for PostgreSQL monitoring should learn that here, not by hunting for the tab.

## 2. `get_query_trend` was missing from the list entirely

One query's per-collection history, keyed on a **required** `query_hash` + `database_name`. The web has no per-query drill-down to select a query from, so the read is unreachable there. The viewer reaches it by double-clicking a row in Top Queries, which opens `QueryStatsHistoryWindow`.

That is a genuine gap, not a product boundary. It matters because the section says the *no-endpoint* list is now empty — true, and easy to read as "coverage is complete" when a read **with** an endpoint is still unreachable for want of UI. Tracked separately rather than quietly folded into a boundary list.

## 3. The count was off by one

"71 of the 92" is **72**. `audit_config` was missed.

I checked specifically that it is *fetched* and not merely mentioned — it appears as a Configuration-tab panel and a custom-view template. That distinction is not pedantic: `get_wait_types` appears in `server-tabs.js` **only inside a comment explaining why it is deliberately not read**, and my first pass at this counted it as reached because of that comment. A count that cannot tell a fetch from a mention is one that drifts.

## What is unchanged

The rest of §3.4 holds. Of 92 endpoints the web reaches 72; of the 20 it does not, three are served through dedicated endpoints (`/api/fleet` → `GetFleetOverviewAsync`, `/api/ag` → `GetAgHealthAsync`, and `list_servers` is redundant against the fleet payload — verified in `DarlingWebEndpoints.cs`), and the remainder are the documented exclusions plus the two corrections above.