### PR TITLE
A fresh store never seeds, so the control plane silently overrides darling.json

### DIFF
--- a/Darling/Darling.Tests/ConfigSeedStatementArityTests.cs
+++ b/Darling/Darling.Tests/ConfigSeedStatementArityTests.cs
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// The config-store seed statements agree with themselves: as many values as columns, and every
+/// parameter the command supplies is actually referenced by the SQL.
+///
+/// <para>Written after a live first-run failed with <c>42601: INSERT has more target columns than
+/// expressions</c>. <c>config_service</c> named sixteen columns and supplied fifteen values, because
+/// <c>$12</c> was bound on the command and never written into the VALUES list. Every subsequent value
+/// shifted one column left, so <c>'seed'</c> landed on <c>updated_at</c> and <c>updated_by</c> had
+/// nothing at all.</para>
+///
+/// <para><b>What that cost, which is why this is worth a pin.</b> The seed is how a FRESH store learns
+/// the file's settings. It failed, the service logged it and carried on with the file config — and then
+/// the control plane, which is authoritative after first contact, answered from an unseeded row where
+/// every toggle is false. So <c>web.enabled</c> and <c>mcp.enabled</c> were true in darling.json, false
+/// in the store, the store won, and neither endpoint ever listened. On a container deployment that is
+/// the entire first-run experience, and nothing in the suite noticed because no test drives the seed
+/// against an empty store.</para>
+///
+/// <para>Checked by parsing the shipped source rather than by executing it: the seed methods are private
+/// and reaching them needs a live store, which is exactly why this went unpinned. Arity is a property of
+/// the text, so the text is what gets read.</para>
+/// </summary>
+public sealed class ConfigSeedStatementArityTests
+{
+    private static readonly Regex Insert = new(
+        @"INSERT\s+INTO\s+(?<table>[a-z_.]+)\s*\((?<cols>[^)]*)\)\s*VALUES\s*\((?<vals>[^)]*)\)",
+        RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled);
+
+    [Fact]
+    public void EverySeedInsert_SuppliesExactlyAsManyValuesAsColumns()
+    {
+        var source = File.ReadAllText(ProviderPath());
+        var problems = new List<string>();
+        var seen = 0;
+
+        foreach (Match m in Insert.Matches(source))
+        {
+            var table = m.Groups["table"].Value;
+            var cols = Split(m.Groups["cols"].Value);
+            var vals = Split(m.Groups["vals"].Value);
+            seen++;
+
+            if (cols.Length != vals.Length)
+            {
+                problems.Add(
+                    $"{table}: {cols.Length} columns but {vals.Length} values" +
+                    $" — first unmatched column is '{cols.ElementAtOrDefault(Math.Min(vals.Length, cols.Length - 1))}'");
+            }
+        }
+
+        /* A regex that stops matching passes for free, which is the failure this whole file is about. */
+        Assert.True(seen >= 4, $"only {seen} seed INSERTs were parsed — the scan broke, not the SQL");
+
+        Assert.True(problems.Count == 0,
+            "a seed INSERT disagrees with itself, which fails at RUN time as 42601 and leaves a fresh "
+          + "store unseeded — after which the control plane answers from defaults and the file's "
+          + "settings are silently overridden:" + Environment.NewLine + string.Join(Environment.NewLine, problems));
+    }
+
+    [Fact]
+    public void EverySeedInsert_ReferencesEveryParameterItBinds()
+    {
+        var source = File.ReadAllText(ProviderPath());
+        var problems = new List<string>();
+
+        foreach (Match m in Insert.Matches(source))
+        {
+            var table = m.Groups["table"].Value;
+            var used = Regex.Matches(m.Groups["vals"].Value, @"\$(\d+)")
+                .Select(x => int.Parse(x.Groups[1].Value))
+                .ToHashSet();
+
+            if (used.Count == 0)
+            {
+                continue;
+            }
+
+            /*
+                Positional binding means the parameters are $1..$max with no gaps. A hole is not a
+                cosmetic gap: it means a value the caller computed is silently dropped, and every
+                parameter after the hole lands on the wrong column.
+            */
+            var missing = Enumerable.Range(1, used.Max()).Where(n => !used.Contains(n)).ToArray();
+            if (missing.Length > 0)
+            {
+                problems.Add($"{table}: binds up to ${used.Max()} but never references " +
+                    string.Join(", ", missing.Select(n => "$" + n)));
+            }
+        }
+
+        Assert.True(problems.Count == 0,
+            "a seed INSERT skips a positional parameter, so a supplied value is dropped and the ones "
+          + "after it shift onto the wrong columns:" + Environment.NewLine + string.Join(Environment.NewLine, problems));
+    }
+
+    private static string[] Split(string list) =>
+        list.Split(',')
+            .Select(x => x.Trim())
+            .Where(x => x.Length > 0)
+            .ToArray();
+
+    private static string ProviderPath() =>
+        Path.Combine(RepoRoot(), "Darling", "PerformanceMonitor.Darling.Service", "StoreConfigProvider.cs");
+
+    private static string RepoRoot([CallerFilePath] string thisFile = "")
+    {
+        var dir = Path.GetDirectoryName(thisFile)!;
+        while (dir is not null && !File.Exists(Path.Combine(dir, "PerformanceMonitor.sln")) && !Directory.Exists(Path.Combine(dir, ".git")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        Assert.NotNull(dir);
+        return dir!;
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Service/StoreConfigProvider.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/StoreConfigProvider.cs
@@ -335,7 +335,7 @@ public sealed class StoreConfigProvider
            so the worker's post-seed baseline read reflects the seeded state and triggers no spurious reload. */
         using var command = new NpgsqlCommand(@"
 INSERT INTO config_service (id, paused, capture_plans, query_store_backfill_enabled, query_store_text_budget_mb, max_concurrent_sweeps, plan_xml_compression, mcp_enabled, mcp_port, web_enabled, web_port, plan_content_retention_days, compose_statement_timeout_seconds, config_version, updated_at, updated_by)
-VALUES (1, FALSE, $1, $7, $8, $9, $10, $2, $3, $4, $5, $11, 0, $6, 'seed')
+VALUES (1, FALSE, $1, $7, $8, $9, $10, $2, $3, $4, $5, $11, $12, 0, $6, 'seed')
 ON CONFLICT (id) DO NOTHING", connection);
         command.Parameters.AddWithValue(config.CapturePlans);
         command.Parameters.AddWithValue(config.Mcp.Enabled);


### PR DESCRIPTION
Found by running the shipped nightly container against a live Azure SQL Database — not by reading code. This is the first-run path of every container deployment.

## What happens

```
Could not seed the config store from darling.json — running on the file config;
the store will seed on a later start: 42601: INSERT has more target columns than expressions
```

`config_service` names **sixteen** columns and supplies **fifteen** values. `$12` is bound on the command and never written into the `VALUES` list, so everything after it shifts one column left — `'seed'` lands on `updated_at`, and `updated_by` gets nothing:

| column | got |
|---|---|
| `compose_statement_timeout_seconds` | `0` |
| `config_version` | `$6` |
| `updated_at` | `'seed'` |
| `updated_by` | *nothing* |

## Why it has been shipping unnoticed

The failure is **caught and logged**, and the service carries on with the file config. That looks survivable. It isn't, because of what runs next: the control plane is authoritative after first contact, and it was answering from a row that had never been written — where every toggle is `false`.

So on a fresh store:

```
Web dashboard configuration disagrees across the two planes and the CONTROL PLANE WINS:
  enabled is true in darling.json (web.enabled) but false in config.config_service.web_enabled
MCP configuration disagrees ... enabled is true in darling.json (mcp.enabled) but false ...
```

Both endpoints then never listen. Verified: `curl` to `:5153` and `:5152` returns nothing at all. **A container user who sets `enabled: true` gets no web dashboard and no MCP, and the only clue is one logged line that says the config will "seed on a later start" — it will not, because the statement is malformed, not racing.**

The control-plane-wins behaviour is correct and deliberate. The bug is that it was deciding from a row the seed failed to write.

## The fix

`$12` restored to the `VALUES` list. Sixteen columns, sixteen values, and the mapping becomes coherent — `compose_statement_timeout_seconds ← $12`, `config_version ← 0`, `updated_at ← $6`, `updated_by ← 'seed'`.

## The pin, and why it reads text

No test drives the seed against an empty store, because the seed methods are `private` and reaching them needs a live one — which is exactly how this went unpinned. Arity is a property of the text, so the text is what gets read:

1. **Every seed INSERT supplies as many values as it names columns.**
2. **Every seed INSERT references every positional parameter it binds.** This catches the precise shape here: a hole in `$1..$max` silently drops a computed value and shifts everything after it onto the wrong column.

Covers all four seed statements, and asserts it parsed at least four — a regex that stops matching fails rather than passing for free.

## Verification

- Pin **green** on the fix, **red** on the bug, naming `updated_by` as the first unmatched column.
- Independently, both statements prepared against a live Postgres: the old one reproduces `42601`, the fixed one prepares.
- Service and test projects build clean.