### PR TITLE
Derive the seed scanner's floor so it cannot decay

### DIFF
--- a/Darling/Darling.Tests/ConfigSeedStatementArityTests.cs
+++ b/Darling/Darling.Tests/ConfigSeedStatementArityTests.cs
@@ -66,8 +66,22 @@ public sealed class ConfigSeedStatementArityTests
             }
         }
 
-        /* A regex that stops matching passes for free, which is the failure this whole file is about. */
-        Assert.True(seen >= 4, $"only {seen} seed INSERTs were parsed — the scan broke, not the SQL");
+        /*
+            A regex that stops matching passes for free, which is the failure this whole file is about.
+            The floor is DERIVED from the file rather than a literal: `seen >= 4` was true of today's four
+            statements, and would have gone on being true the day a fifth was added and one stopped
+            parsing. Counting the INSERTs independently of the pattern that parses them means the two
+            have to agree, so a statement the pattern cannot read is a failure rather than an absence.
+
+            The specific way it could stop reading one: the column and value lists are captured with
+            [^)]*, so a future seed carrying a function call — COALESCE($1, 0) — closes the capture early
+            or fails the match outright. Loud is fine; silent is not, and this is what makes it loud.
+        */
+        var declared = Regex.Matches(source, @"INSERT\s+INTO\s+[a-z_.]+", RegexOptions.IgnoreCase).Count;
+        Assert.True(
+            seen == declared,
+            $"parsed {seen} seed INSERTs but the file declares {declared} — the pattern cannot read one of "
+          + "them (a parenthesis inside a column or value list will do it), so its arity is unchecked");
 
         Assert.True(problems.Count == 0,
             "a seed INSERT disagrees with itself, which fails at RUN time as 42601 and leaves a fresh "


### PR DESCRIPTION
Follow-up to the review nit on #2524.

## The nit, which was right

The column and value lists are captured with `[^)]*`. A future seed statement carrying a function call — `COALESCE($1, 0)` — closes the capture early or fails the match outright, and that statement's arity **silently stops being checked**.

That is the failure this file was written about, one level up: a guard that quietly stops reaching its target.

## What I had was worse than it looked

My anti-vacuity floor was `Assert.True(seen >= 4)`. True of today's four seed statements — and it would have gone on being true the day a fifth was added and one of the five stopped parsing. **A floor expressed as a literal decays precisely when the thing it guards grows**, and it decays in the passing direction.

## The fix

Count the `INSERT INTO`s independently of the pattern that parses them, and require the two to agree. A statement the pattern cannot read is then a failure rather than an absence, whatever the total, and adding a fifth seed raises the bar automatically instead of leaving it behind.

## Verified

Introduced the reviewer's exact case — a `COALESCE` in `config_service`'s `VALUES` list — and watched it go red, then restored:

```
Darling.Tests.ConfigSeedStatementArityTests.EverySeedInsert_SuppliesExactlyAsManyValuesAsColumns [FAIL]
Failed! - Failed: 1, Passed: 1
```

Green on the unmodified tree.