### PR TITLE
Status-bar size read must not hold an unlocked DuckDB connection (#2594)

### DIFF
--- a/Lite.Tests/StatusBarSizeReadLockTests.cs
+++ b/Lite.Tests/StatusBarSizeReadLockTests.cs
@@ -35,7 +35,7 @@ public class StatusBarSizeReadLockTests
     private static readonly TimeSpan WriteLockHold = TimeSpan.FromSeconds(10);
 
     [Fact]
-    public void GetUsedDataSizeMb_WhenTheWriteLockIsHeld_GivesUpInsteadOfBlocking()
+    public async Task GetUsedDataSizeMb_WhenTheWriteLockIsHeld_GivesUpInsteadOfBlocking()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), "pmlite-statusbar-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(tempDir);
@@ -62,7 +62,7 @@ public class StatusBarSizeReadLockTests
             stopwatch.Stop();
 
             release.Set();
-            holder.Wait(TimeSpan.FromSeconds(15));
+            await holder.WaitAsync(TimeSpan.FromSeconds(15));
 
             /* Null, not a number: the caller renders the file size alone in this state, which is the
                degraded answer this is choosing on purpose. */

--- a/Lite.Tests/StatusBarSizeReadLockTests.cs
+++ b/Lite.Tests/StatusBarSizeReadLockTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using PerformanceMonitorLite.Database;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// Pins the status bar's used-size read against the two ways it can be wrong (#2594).
+///
+/// <para><b>It must not open a connection without the lock.</b> This was the one PERIODIC connection site
+/// in <see cref="DuckDbInitializer"/> that did — driven by the dashboard's 30-second
+/// <c>DispatcherTimer</c>, so a live handle sat on the database file at arbitrary moments, including
+/// moments the archival path may be deleting and recreating it.</para>
+///
+/// <para><b>And it must not block the dashboard to get it.</b> The obvious fix — take the read lock like
+/// every other read — runs on the dispatcher thread, so a size figure nobody is reading would freeze the
+/// window behind a long archival. So the contract is specifically a BOUNDED attempt: acquire if free,
+/// give up quickly otherwise, and let the caller render the file size alone. Asserting only "it takes a
+/// lock" would pass a fix that hangs the UI, which is why this test measures the time.</para>
+/// </summary>
+public class StatusBarSizeReadLockTests
+{
+    /// <summary>
+    /// Generous against the 100 ms budget rather than tight: this asserts the read GAVE UP rather than
+    /// waited, and a CI machine under load can overshoot a 100 ms timeout considerably without the
+    /// behaviour being wrong. The distinction being drawn is against a wait for the full hold below,
+    /// which is an order of magnitude larger.
+    /// </summary>
+    private static readonly TimeSpan GaveUpCeiling = TimeSpan.FromSeconds(2);
+
+    private static readonly TimeSpan WriteLockHold = TimeSpan.FromSeconds(10);
+
+    [Fact]
+    public void GetUsedDataSizeMb_WhenTheWriteLockIsHeld_GivesUpInsteadOfBlocking()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "pmlite-statusbar-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var initializer = new DuckDbInitializer(Path.Combine(tempDir, "test.duckdb"));
+
+            var lockHeld = new ManualResetEventSlim(false);
+            var release = new ManualResetEventSlim(false);
+
+            /* The write lock is thread-affine, so it has to be taken and released on its own thread. */
+            var holder = Task.Run(() =>
+            {
+                using var writeLock = initializer.AcquireWriteLock();
+                lockHeld.Set();
+                release.Wait(WriteLockHold);
+            });
+
+            Assert.True(lockHeld.Wait(TimeSpan.FromSeconds(5)), "the write lock was never acquired");
+
+            var stopwatch = Stopwatch.StartNew();
+            var used = initializer.GetUsedDataSizeMb();
+            stopwatch.Stop();
+
+            release.Set();
+            holder.Wait(TimeSpan.FromSeconds(15));
+
+            /* Null, not a number: the caller renders the file size alone in this state, which is the
+               degraded answer this is choosing on purpose. */
+            Assert.Null(used);
+
+            Assert.True(
+                stopwatch.Elapsed < GaveUpCeiling,
+                $"the status-bar size read waited {stopwatch.Elapsed.TotalMilliseconds:F0} ms for the write " +
+                "lock. It runs on the dispatcher thread and must give up rather than block the window.");
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch (IOException)
+            {
+                /* A leftover temp directory is not worth failing a passing test over. */
+            }
+        }
+    }
+}

--- a/Lite/Database/DuckDbInitializer.cs
+++ b/Lite/Database/DuckDbInitializer.cs
@@ -148,6 +148,48 @@ public class DuckDbInitializer
     private static readonly TimeSpan ReadLockPollInterval = TimeSpan.FromMilliseconds(50);
 
     /// <summary>
+    /// The read lock for a caller that would rather have NO answer than wait for one — returns null if
+    /// the lock is not free within <paramref name="timeout"/>, instead of blocking.
+    ///
+    /// <para>This exists for the status bar (#2594). Every other read here takes the lock and waits,
+    /// which is right when the caller needs the data; the status-bar size figure is cosmetic, refreshed
+    /// on a 30-second UI timer, and runs on the dispatcher thread — so waiting on a lock held by a long
+    /// archival would freeze the window to render a number nobody is reading. The two honest options for
+    /// that caller are "skip the lock" and "skip the read", and skipping the lock is how a connection
+    /// ends up open against a file the reset path deletes.</para>
+    ///
+    /// <para>A timeout rather than a token here, unlike <see cref="AcquireReadLock(CancellationToken)"/>,
+    /// because this caller genuinely has a number to pick: it is bounded by what a UI thread may spend,
+    /// not by a caller's remaining budget.</para>
+    /// </summary>
+    public IDisposable? TryAcquireReadLock(TimeSpan timeout)
+    {
+        try
+        {
+            if (!s_dbLock.TryEnterReadLock(timeout))
+            {
+                return null;
+            }
+        }
+        catch (LockRecursionException)
+        {
+            /* Already held by this thread — same reasoning as AcquireReadLock: we are protected, so
+               hand back a no-op rather than reporting a failure the caller cannot act on. */
+            return NoOpDisposable.Instance;
+        }
+
+        return new LockReleaser(s_dbLock, write: false);
+    }
+
+    /// <summary>
+    /// How long the status bar will wait for the read lock before giving up and reporting no used-size
+    /// figure. Short on purpose: this runs on the dispatcher thread, and the caller already renders the
+    /// file size alone when this returns null, so the degraded answer is a smaller status bar rather
+    /// than a stalled window.
+    /// </summary>
+    private static readonly TimeSpan StatusBarReadLockTimeout = TimeSpan.FromMilliseconds(100);
+
+    /// <summary>
     /// Acquires an exclusive write lock on the database. Blocks until all readers finish.
     /// Dispose the returned object to release the lock.
     /// When a timeout is specified, throws <see cref="TimeoutException"/> if the lock
@@ -1696,6 +1738,17 @@ QUALIFY ROW_NUMBER() OVER (PARTITION BY {dedupKey} ORDER BY collection_time DESC
     /// </summary>
     public double? GetUsedDataSizeMb()
     {
+        /* Under the read lock (#2594). This was the one periodic connection site that opened without it,
+           on the UI's 30-second timer, which put a live handle on the database file at moments the
+           archival path may be deleting and recreating it. Bounded rather than blocking - see
+           StatusBarReadLockTimeout for why this caller may give up where others may not. */
+        using var readLock = TryAcquireReadLock(StatusBarReadLockTimeout);
+
+        if (readLock is null)
+        {
+            return null;
+        }
+
         try
         {
             using var connection = CreateConnection();


### PR DESCRIPTION
Addresses one concrete gap found while investigating #2594. **It does not close that issue** — the diagnosis there still depends on the reporter's `Database files deleted, reinitializing` timestamp — but this is worth fixing whatever that answer turns out to be.

## The gap

`DuckDbInitializer.GetUsedDataSizeMb` opens a DuckDB connection **without taking the read lock**:

```csharp
using var connection = CreateConnection();
connection.Open();
using var cmd = connection.CreateCommand();
cmd.CommandText = "SELECT (used_blocks * block_size)::BIGINT FROM pragma_database_size()";
```

Every other read in that class takes the lock first. This one is also the only **periodic** unlocked site: it is called from `UpdateStatusBar()`, driven by a `DispatcherTimer` with a 30-second interval (`MainWindow.xaml.cs:125`), to render the "Database: X / Y MB" figure. So while the dashboard is open, a live handle lands on the database file every 30 seconds — including at moments the archival path may be deleting and recreating it.

A bare `catch { }` returning null means it reports nothing when it fails, so this has been invisible.

## Why the obvious fix is wrong

Taking `AcquireReadLock()` like every other read would run on the **dispatcher thread**. A long archival holds the write lock, and the window would freeze while waiting to draw a number nobody is reading.

So the contract is a **bounded** attempt — a new `TryAcquireReadLock(TimeSpan)` that returns null instead of waiting. The status bar gives up after 100 ms and the caller renders the file size alone, which it already does when this returns null. The degraded answer is a smaller status bar, not a stalled window.

`TryAcquireReadLock` takes a timeout rather than a cancellation token, unlike `AcquireReadLock(CancellationToken)`. That asymmetry is deliberate and documented: the token exists there because the right budget is the caller's remaining budget, and this caller genuinely has a number to pick — what a UI thread may spend.

## The red run is on purpose

The first commit on this branch is **the test alone**, so the pin is demonstrated failing rather than asserted to fail. Lite's test project is `net10.0-windows` and cannot run on this host, so CI is the only place that demonstration can happen.

Expect the first run to fail `GetUsedDataSizeMb_WhenTheWriteLockIsHeld_GivesUpInsteadOfBlocking`: the current code never consults the lock, so it opens its connection and returns a size where the test expects null. The fix commit follows.

The test asserts **both** halves — that the read gives up, and that it gives up quickly. Asserting only "it takes a lock" would pass a fix that hangs the UI.

## Still open, deliberately not touched here

`CreateArchiveViewsAsync` is a second unlocked connection site, and unlike this one it is unlocked **on purpose** — `ArchiveService.cs:193` says "Refresh archive views outside write lock — view creation is fast and safe". That is an assertion rather than a proof, and it is a bigger call than this PR. Flagging it rather than widening the change.
