### PR TITLE
Stop the size-triggered reset deleting the store under a collection (#2594)

### DIFF
--- a/Lite.Tests/CollectionResetGateTests.cs
+++ b/Lite.Tests/CollectionResetGateTests.cs
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using PerformanceMonitorLite.Database;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// The gate that stops a size-triggered reset deleting the database out from under a running collection
+/// (#2594).
+///
+/// <para><b>The field failure this encodes.</b> Opening a server tab calls
+/// <c>RunAllCollectorsForServerAsync</c> on a bare <c>Task.Run</c>, sequenced against nothing. When the store
+/// crossed 512 MB while such a collection was running, the reset deleted and recreated <c>monitor.duckdb</c>
+/// underneath it — <c>index_object_stats</c> was five seconds into a fifty-five second run — and the
+/// collection's final <c>collection_log</c> insert failed with <c>Table with name collection_log does not
+/// exist</c>. Nothing was lost on disk and a restart cleared it, which is the signature of stale in-process
+/// state rather than a damaged store.</para>
+///
+/// <para>These run serially: the gate is process-wide static state, so concurrent tests would see each
+/// other's registrations.</para>
+/// </summary>
+[Collection("CollectionResetGate")]
+public class CollectionResetGateTests : IDisposable
+{
+    public CollectionResetGateTests() => CollectionResetGate.ResetForTests();
+
+    public void Dispose() => CollectionResetGate.ResetForTests();
+
+    [Fact]
+    public async Task AReset_DoesNotStartWhileACollectionIsRunning()
+    {
+        using var collection = await CollectionResetGate.BeginCollectionAsync();
+
+        Assert.Equal(1, CollectionResetGate.CollectionsInFlight);
+
+        /* The whole point: the reset must not get the gate here. It waits for the drain timeout and then
+           defers, which the caller reports and retries on the next archival check. */
+        var reset = await WithShortDrain(() => CollectionResetGate.TryBeginResetAsync());
+
+        Assert.Null(reset);
+    }
+
+    [Fact]
+    public async Task AReset_ProceedsOnceTheCollectionFinishes()
+    {
+        var collection = await CollectionResetGate.BeginCollectionAsync();
+        collection.Dispose();
+
+        Assert.Equal(0, CollectionResetGate.CollectionsInFlight);
+
+        using var reset = await CollectionResetGate.TryBeginResetAsync();
+
+        Assert.NotNull(reset);
+    }
+
+    [Fact]
+    public async Task AResetWaits_RatherThanFailingImmediately_WhenACollectionEndsShortly()
+    {
+        var collection = await CollectionResetGate.BeginCollectionAsync();
+
+        /* Released while the reset is already waiting, which is the ordinary case: a collection finishes
+           and the reset proceeds without anyone retrying. */
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(300));
+            collection.Dispose();
+        });
+
+        var stopwatch = Stopwatch.StartNew();
+        using var reset = await CollectionResetGate.TryBeginResetAsync();
+        stopwatch.Stop();
+
+        Assert.NotNull(reset);
+        Assert.True(
+            stopwatch.Elapsed >= TimeSpan.FromMilliseconds(200),
+            $"the reset returned in {stopwatch.ElapsedMilliseconds} ms, so it did not actually wait for the "
+            + "collection to finish.");
+    }
+
+    /// <summary>
+    /// A collection arriving mid-reset must wait, not start against a database that is about to be deleted.
+    /// This is the other half of the race and the half that is easy to forget: gating only the reset leaves
+    /// the tab-open path free to start one millisecond before the file disappears.
+    /// </summary>
+    [Fact]
+    public async Task ACollection_DoesNotStartWhileAResetIsRunning()
+    {
+        var reset = await CollectionResetGate.TryBeginResetAsync();
+        Assert.NotNull(reset);
+
+        var started = CollectionResetGate.BeginCollectionAsync();
+
+        var raced = await Task.WhenAny(started, Task.Delay(TimeSpan.FromMilliseconds(400)));
+        Assert.NotSame(started, raced);
+
+        reset!.Dispose();
+
+        using var collection = await started.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(1, CollectionResetGate.CollectionsInFlight);
+    }
+
+    /// <summary>
+    /// Collections must NOT serialise against each other. The background sweep and a tab-open sweep run
+    /// concurrently by design, and turning that into a queue would be a behaviour change wearing a bug fix.
+    /// </summary>
+    [Fact]
+    public async Task Collections_RunConcurrentlyWithEachOther()
+    {
+        using var first = await CollectionResetGate.BeginCollectionAsync();
+
+        var second = CollectionResetGate.BeginCollectionAsync().WaitAsync(TimeSpan.FromSeconds(2));
+
+        using var acquired = await second;
+
+        Assert.Equal(2, CollectionResetGate.CollectionsInFlight);
+    }
+
+    [Fact]
+    public async Task DisposingACollectionTwice_DoesNotDriveTheCounterNegative()
+    {
+        var collection = await CollectionResetGate.BeginCollectionAsync();
+        collection.Dispose();
+        collection.Dispose();
+
+        Assert.Equal(0, CollectionResetGate.CollectionsInFlight);
+
+        /* A negative counter would let a reset run while a real collection was still writing. */
+        using var other = await CollectionResetGate.BeginCollectionAsync();
+        Assert.Equal(1, CollectionResetGate.CollectionsInFlight);
+    }
+
+    /// <summary>
+    /// The production drain timeout is three minutes, which no test should sit through. This shortens the
+    /// wait by racing the call rather than by making the timeout configurable — a knob that exists only for
+    /// tests is a knob somebody eventually sets in production.
+    /// </summary>
+    private static async Task<IDisposable?> WithShortDrain(Func<Task<IDisposable?>> attempt)
+    {
+        var call = attempt();
+        var finished = await Task.WhenAny(call, Task.Delay(TimeSpan.FromMilliseconds(500)));
+
+        if (finished == call)
+        {
+            return await call;
+        }
+
+        /* Still draining after the grace period, which is the assertion the caller wants: it did not take
+           the gate. The underlying call abandons itself when the collection scope is disposed in teardown. */
+        return null;
+    }
+}
+
+[CollectionDefinition("CollectionResetGate", DisableParallelization = true)]
+public sealed class CollectionResetGateCollection
+{
+}

--- a/Lite/Database/CollectionResetGate.cs
+++ b/Lite/Database/CollectionResetGate.cs
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PerformanceMonitorLite.Database;
+
+/// <summary>
+/// Keeps the size-triggered database reset from deleting <c>monitor.duckdb</c> out from under a collection
+/// that is still running (#2594).
+///
+/// <para><b>Why this is not the existing read/write lock.</b> <see cref="DuckDbInitializer.AcquireReadLock()"/>
+/// is a <see cref="ReaderWriterLockSlim"/>, which is thread-affine and cannot be held across an <c>await</c> —
+/// and a collection is almost entirely awaits. Holding it for a collection's lifetime would also block the
+/// alert and mute stores, which take the write lock for their own reasons, for as long as the slowest
+/// collector runs. Measured in the field: <c>index_object_stats</c> across thirteen databases took
+/// <b>55 seconds</b> on one server, so that is the scale of stall it would introduce.</para>
+///
+/// <para><b>What actually went wrong.</b> Two things start collections and only one of them was sequenced.
+/// <c>CollectionBackgroundService</c> runs collect-then-archive in a strict loop, so the reset cannot land
+/// mid-cycle there. But <c>MainWindow.ConnectToServer</c> — opening a server tab — calls
+/// <c>RunAllCollectorsForServerAsync</c> on a bare <c>Task.Run</c>, unsequenced against anything. When the
+/// store crossed its 512 MB threshold while such a collection was in flight, the reset deleted and recreated
+/// the database underneath it; the collection kept writing through connections that predated the reset and
+/// its final <c>collection_log</c> insert failed with <c>Table with name collection_log does not exist</c>.
+/// Nothing was lost on disk and a restart cleared it, which is exactly the signature of stale in-process
+/// state rather than a damaged store.</para>
+///
+/// <para><b>The shape.</b> Collections are concurrent with each other and only excluded by a reset, so this
+/// is a many-readers/one-writer gate built on <see cref="SemaphoreSlim"/> rather than a mutex: collections
+/// do not serialise against one another, which would be a behaviour change nobody asked for.</para>
+/// </summary>
+public static class CollectionResetGate
+{
+    /// <summary>
+    /// Held for the whole of a reset, and momentarily by a collection as it registers. A collection that
+    /// arrives during a reset waits here rather than starting against a database about to be deleted.
+    /// </summary>
+    private static readonly SemaphoreSlim s_resetExclusive = new(1, 1);
+
+    private static int s_collectionsInFlight;
+
+    /// <summary>How long the reset waits for in-flight collections to finish before giving up for this tick.</summary>
+    private static readonly TimeSpan DrainTimeout = TimeSpan.FromMinutes(3);
+
+    /// <summary>How often the drain wait re-checks. Short enough not to add meaningful latency to a reset.</summary>
+    private static readonly TimeSpan DrainPollInterval = TimeSpan.FromMilliseconds(100);
+
+    /// <summary>Collections currently registered. Exposed for tests and diagnostics.</summary>
+    public static int CollectionsInFlight => Volatile.Read(ref s_collectionsInFlight);
+
+    /// <summary>
+    /// Registers a collection. Dispose the result when the collection is finished — including its
+    /// <c>collection_log</c> write, which is the last thing it does and the write that failed in the field.
+    /// </summary>
+    public static async Task<IDisposable> BeginCollectionAsync(CancellationToken cancellationToken = default)
+    {
+        /* Taken and released immediately rather than held: it exists to make "a reset is running" a state a
+           starting collection cannot slip past, not to serialise collections against each other. */
+        await s_resetExclusive.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            Interlocked.Increment(ref s_collectionsInFlight);
+        }
+        finally
+        {
+            s_resetExclusive.Release();
+        }
+
+        return new CollectionScope();
+    }
+
+    /// <summary>
+    /// Takes the gate for a destructive reset, waiting for in-flight collections to drain.
+    ///
+    /// <para>Returns null when a collection is still running after <see cref="DrainTimeout"/>. That is a
+    /// deferral, not a failure: the reset is size-triggered, the store is a few megabytes over a soft
+    /// threshold, and the next tick will try again. Deleting the file on time matters far less than not
+    /// deleting it underneath a running collector.</para>
+    /// </summary>
+    public static async Task<IDisposable?> TryBeginResetAsync(CancellationToken cancellationToken = default)
+    {
+        if (!await s_resetExclusive.WaitAsync(TimeSpan.Zero, cancellationToken).ConfigureAwait(false))
+        {
+            /* Another reset holds it. Nothing to do — that one will finish the work this one wanted. */
+            return null;
+        }
+
+        var deadline = DateTime.UtcNow + DrainTimeout;
+
+        while (Volatile.Read(ref s_collectionsInFlight) > 0)
+        {
+            if (DateTime.UtcNow >= deadline || cancellationToken.IsCancellationRequested)
+            {
+                s_resetExclusive.Release();
+                return null;
+            }
+
+            await Task.Delay(DrainPollInterval, cancellationToken).ConfigureAwait(false);
+        }
+
+        return new ResetScope();
+    }
+
+    /// <summary>Test seam: drops any state a failed test left behind.</summary>
+    internal static void ResetForTests()
+    {
+        Volatile.Write(ref s_collectionsInFlight, 0);
+
+        while (s_resetExclusive.CurrentCount == 0)
+        {
+            s_resetExclusive.Release();
+        }
+    }
+
+    private sealed class CollectionScope : IDisposable
+    {
+        private int _disposed;
+
+        public void Dispose()
+        {
+            /* Idempotent: a double dispose would drive the counter negative and let a reset run while a
+               collection is still writing, which is the whole failure this type exists to prevent. */
+            if (Interlocked.Exchange(ref _disposed, 1) == 0)
+            {
+                Interlocked.Decrement(ref s_collectionsInFlight);
+            }
+        }
+    }
+
+    private sealed class ResetScope : IDisposable
+    {
+        private int _disposed;
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) == 0)
+            {
+                s_resetExclusive.Release();
+            }
+        }
+    }
+}

--- a/Lite/Services/ArchiveService.cs
+++ b/Lite/Services/ArchiveService.cs
@@ -578,6 +578,26 @@ COPY (
             return;
         }
 
+        /* Wait for in-flight collections before deleting the database (#2594). The write lock below does NOT
+           exclude them: the collection path takes no lock at all, so a reset could delete monitor.duckdb
+           underneath a collector that was still writing - which is what happened in the field, via a
+           tab-open collection that is sequenced against nothing.
+
+           Null means a collection outlasted the drain timeout, and the right response is to DEFER. This is
+           size-triggered, the store is a little over a soft threshold, and the next tick will try again;
+           resetting on schedule matters far less than not resetting under a live collector. */
+        var resetScope = await CollectionResetGate.TryBeginResetAsync();
+
+        if (resetScope is null)
+        {
+            _logger?.LogInformation(
+                "Database reset deferred: {InFlight} collection(s) still running. It will be retried on the " +
+                "next archival check.",
+                CollectionResetGate.CollectionsInFlight);
+            s_archiveLock.Release();
+            return;
+        }
+
         IsArchiving = true;
         var preserveDir = Path.Combine(Path.GetTempPath(), $"pm_preserve_{Guid.NewGuid():N}");
         var preservedFiles = new Dictionary<string, string>();
@@ -730,6 +750,7 @@ COPY (
         finally
         {
             IsArchiving = false;
+            resetScope.Dispose();
             s_archiveLock.Release();
         }
     }

--- a/Lite/Services/RemoteCollectorService.cs
+++ b/Lite/Services/RemoteCollectorService.cs
@@ -357,6 +357,10 @@ public partial class RemoteCollectorService
     /// </summary>
     public async Task RunDueCollectorsAsync(CancellationToken cancellationToken = default)
     {
+        /* Registered for the whole sweep, including the collection_log write at the end of each collector -
+           that final write is the one that failed in the field when a reset landed mid-collection (#2594). */
+        using var collectionScope = await CollectionResetGate.BeginCollectionAsync(cancellationToken);
+
         var enabledServers = _serverManager.GetEnabledServers();
 
         if (enabledServers.Count == 0)
@@ -435,6 +439,11 @@ public partial class RemoteCollectorService
     /// </summary>
     public async Task RunAllCollectorsForServerAsync(ServerConnection server, CancellationToken cancellationToken = default)
     {
+        /* THE path from #2594. MainWindow.ConnectToServer calls this on a bare Task.Run when a server tab is
+           opened, so unlike the scheduled sweep it was sequenced against nothing at all - and it runs EVERY
+           collector for the server, which is how a 55-second index_object_stats came to straddle a reset. */
+        using var collectionScope = await CollectionResetGate.BeginCollectionAsync(cancellationToken);
+
         var enabledSchedules = _scheduleManager.GetSchedulesForServer(server.Id)
             .Where(s => s.Enabled)
             .ToList();


### PR DESCRIPTION
Fixes the race behind #2594.

## What was actually wrong

Two things start collections and **only one of them was sequenced**.

`CollectionBackgroundService` runs collect-then-archive in a strict loop, so a reset cannot land mid-cycle there — which is why the reporter's log initially looked impossible. The other driver is `MainWindow.ConnectToServer`, fired by opening a server tab:

```csharp
await Task.Run(() => _collectorService.RunAllCollectorsForServerAsync(server));
```

Sequenced against nothing, and it runs **every** collector for that server. The reporter's log is that path — one server walked through the full list in order, ending in `index_object_stats` across thirteen databases at **55 seconds**.

So: tab-open collection running → store crosses 512 MB → the background loop's reset deletes and recreates `monitor.duckdb` five seconds into that 55-second collector → its per-database writes continue through connections that predate the reset → the final `collection_log` insert fails with `Table with name collection_log does not exist`.

No data lost, cleared by a restart: stale in-process state, not a damaged store. Sporadic and unreproducible by navigation because the navigation is necessary but the size crossing is the coin flip.

**The existing write lock did not help**, and that is the part worth keeping in mind: `RemoteCollectorService` acquires exactly one lock in the entire file — the post-cycle `CHECKPOINT`. Collector data writes and `collection_log` inserts take none. The write lock excludes the UI, the alert store and the mute store, but not the one thing that runs for a minute at a time.

## Why not just take the read lock

Two reasons, both disqualifying:

1. `ReaderWriterLockSlim` is **thread-affine** and cannot be held across an `await`. A collection is almost entirely awaits.
2. Even if it could, holding it for a collection's lifetime would block the alert and mute stores — which take the write lock — for as long as the slowest collector. That is 55 seconds on the reporter's fleet.

So `CollectionResetGate` is a purpose-built many-collections/one-reset gate on `SemaphoreSlim`. **Collections still run concurrently with each other**, which is by design; turning that into a queue would be a behaviour change wearing a bug fix, and there is a test pinning it.

## Both directions are closed

- A reset **waits** for in-flight collections, and **defers** if they outlast the drain timeout. It is size-triggered and a few MB over a soft threshold — the next archival check retries. Resetting on time matters far less than not resetting under a live collector.
- A collection arriving **mid-reset waits**, rather than starting against a database about to be deleted. Gating only the reset would leave the tab-open path free to start a millisecond before the file disappears.

## Verification

The gate is pure C# with no WPF dependency, so I ran all eight scenarios directly rather than reasoning about them:

```
PASS  reset does NOT start while a collection runs
PASS  reset proceeds once the collection finishes
PASS  reset acquires when idle
PASS  collection does NOT start while a reset runs
PASS  collection proceeds once the reset finishes
PASS  collections do NOT serialise against each other
PASS  double dispose does not drive the counter negative
PASS  reset waits for the slow collector rather than deleting under it
```

Double-dispose is in there deliberately: a negative counter would let a reset run while a real collection was still writing, which is the exact failure this exists to prevent.

The xUnit tests are in a non-parallel collection — the gate is process-wide static state, so concurrent tests would see each other's registrations.
