### PR TITLE
Log a denied XE session at Warn, not Error

### DIFF
--- a/Lite.Tests/XeSessionPermissionLogLevelTests.cs
+++ b/Lite.Tests/XeSessionPermissionLogLevelTests.cs
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// A denied XE session logs at Warn, not Error.
+///
+/// <para><b>Why this is worth pinning.</b> Declining to grant <c>ALTER ANY EVENT SESSION</c> is a
+/// least-privilege choice a customer is entitled to make (#1823), and the collector already treats it as
+/// one: it classifies the outcome as <c>PERMISSIONS</c> and flags the collector so the scheduler stops
+/// retrying it for the session. The logging did not agree. A field log from #2594 carried three consecutive
+/// <c>[ERROR]</c> lines — two from the XE layer, one from the collector — for a login that was simply not
+/// granted the permission, while every other permission denial in the same method logs at Warn. Someone
+/// reading that log reasonably concludes something is broken.</para>
+///
+/// <para>Anchored on the logger call adjacent to the permission test rather than on the message text, so a
+/// reworded message does not fail this and a level change does.</para>
+/// </summary>
+public class XeSessionPermissionLogLevelTests
+{
+    private static readonly string[] XeSources =
+    {
+        "RemoteCollectorService.Deadlocks.cs",
+        "RemoteCollectorService.BlockedProcessReport.cs",
+    };
+
+    [Fact]
+    public void ADeniedXeSession_LogsAtWarn_NotError()
+    {
+        foreach (var file in XeSources)
+        {
+            var source = ReadServiceSource(file);
+
+            var guards = Regex.Matches(
+                source,
+                @"if \(SqlServerPermissionErrors\.IsPermissionDenied\(ex\.Number\)\)\s*\{\s*AppLogger\.(\w+)\(",
+                RegexOptions.Singleline);
+
+            Assert.True(
+                guards.Count > 0,
+                $"{file} no longer routes a denied XE session through IsPermissionDenied, so a least-privilege "
+                + "login is back to logging as a fault.");
+
+            foreach (Match guard in guards)
+            {
+                Assert.Equal("Warn", guard.Groups[1].Value);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The Error arm must survive. Downgrading everything would hide a genuine XE failure — a session that
+    /// cannot start for a reason that is not permissions is exactly what #1086 made loud.
+    /// </summary>
+    [Fact]
+    public void AnXeFailureThatIsNotPermissions_StillLogsAtError()
+    {
+        foreach (var file in XeSources)
+        {
+            var source = ReadServiceSource(file);
+
+            Assert.Contains("AppLogger.Error(\"XeSession\"", source, StringComparison.Ordinal);
+        }
+    }
+
+    private static string ReadServiceSource(string fileName)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, "Lite", "Services")))
+        {
+            dir = dir.Parent;
+        }
+
+        Assert.NotNull(dir);
+
+        var path = Path.Combine(dir!.FullName, "Lite", "Services", fileName);
+        Assert.True(File.Exists(path), $"could not locate {fileName}");
+
+        return File.ReadAllText(path);
+    }
+}

--- a/Lite/Services/RemoteCollectorService.BlockedProcessReport.cs
+++ b/Lite/Services/RemoteCollectorService.BlockedProcessReport.cs
@@ -64,7 +64,17 @@ public partial class RemoteCollectorService
         }
         catch (SqlException ex)
         {
-            AppLogger.Error("XeSession", $"[{server.DisplayName}] Failed to ensure blocked process XE session: {ex.Message}");
+            /* Warn rather than Error when the server simply said no: a denied XE session is a least-privilege
+               posture (#1823), classified as PERMISSIONS upstream and retried no further this session.
+               Genuine failures still log at Error. */
+            if (SqlServerPermissionErrors.IsPermissionDenied(ex.Number))
+            {
+                AppLogger.Warn("XeSession", $"[{server.DisplayName}] Failed to ensure blocked process XE session: {ex.Message}");
+            }
+            else
+            {
+                AppLogger.Error("XeSession", $"[{server.DisplayName}] Failed to ensure blocked process XE session: {ex.Message}");
+            }
 
             /* Propagate so RunCollectorAsync marks the collector unhealthy instead
                of letting a zero-row ring-buffer read record SUCCESS (#1086) */
@@ -189,7 +199,17 @@ ALTER EVENT SESSION [{BlockedProcessXeSessionName}] ON SERVER STATE = START;", c
         }
         catch (SqlException ex)
         {
-            AppLogger.Error("XeSession", $"[{server.DisplayName}] Failed to create blocked process XE session: {ex.Message}");
+            /* Warn rather than Error when the server simply said no: a denied XE session is a least-privilege
+               posture (#1823), classified as PERMISSIONS upstream and retried no further this session.
+               Genuine failures still log at Error. */
+            if (SqlServerPermissionErrors.IsPermissionDenied(ex.Number))
+            {
+                AppLogger.Warn("XeSession", $"[{server.DisplayName}] Failed to create blocked process XE session: {ex.Message}");
+            }
+            else
+            {
+                AppLogger.Error("XeSession", $"[{server.DisplayName}] Failed to create blocked process XE session: {ex.Message}");
+            }
             throw;
         }
     }

--- a/Lite/Services/RemoteCollectorService.Deadlocks.cs
+++ b/Lite/Services/RemoteCollectorService.Deadlocks.cs
@@ -64,7 +64,17 @@ public partial class RemoteCollectorService
         }
         catch (SqlException ex)
         {
-            AppLogger.Error("XeSession", $"[{server.DisplayName}] Failed to ensure deadlock XE session: {ex.Message}");
+            /* Warn rather than Error when the server simply said no: a denied XE session is a least-privilege
+               posture (#1823), classified as PERMISSIONS upstream and retried no further this session.
+               Genuine failures still log at Error. */
+            if (SqlServerPermissionErrors.IsPermissionDenied(ex.Number))
+            {
+                AppLogger.Warn("XeSession", $"[{server.DisplayName}] Failed to ensure deadlock XE session: {ex.Message}");
+            }
+            else
+            {
+                AppLogger.Error("XeSession", $"[{server.DisplayName}] Failed to ensure deadlock XE session: {ex.Message}");
+            }
 
             /* Propagate so RunCollectorAsync marks the collector unhealthy instead
                of letting a zero-row ring-buffer read record SUCCESS (#1086) */
@@ -146,7 +156,17 @@ ALTER EVENT SESSION [{DeadlockXeSessionName}] ON SERVER STATE = START;", connect
         }
         catch (SqlException ex)
         {
-            AppLogger.Error("XeSession", $"[{server.DisplayName}] Failed to create deadlock XE session: {ex.Message}");
+            /* Warn rather than Error when the server simply said no: a denied XE session is a least-privilege
+               posture (#1823), classified as PERMISSIONS upstream and retried no further this session.
+               Genuine failures still log at Error. */
+            if (SqlServerPermissionErrors.IsPermissionDenied(ex.Number))
+            {
+                AppLogger.Warn("XeSession", $"[{server.DisplayName}] Failed to create deadlock XE session: {ex.Message}");
+            }
+            else
+            {
+                AppLogger.Error("XeSession", $"[{server.DisplayName}] Failed to create deadlock XE session: {ex.Message}");
+            }
             throw;
         }
     }

--- a/Lite/Services/RemoteCollectorService.cs
+++ b/Lite/Services/RemoteCollectorService.cs
@@ -631,7 +631,22 @@ public partial class RemoteCollectorService
                 ? "PERMISSIONS"
                 : "ERROR";
             xeSessionUnavailable = true;
-            AppLogger.Error("Collector", $"  [{server.DisplayName}] {collectorName} {ex.Message}");
+
+            /* Logged at the level the CLASSIFICATION implies, not always Error. A denied XE session is a
+               least-privilege choice a customer is entitled to make (#1823), and the arm above already
+               records it as PERMISSIONS and flags the collector so the scheduler stops retrying it for the
+               session. Logging that at Error made a deliberate posture read as a fault: a field log showed
+               three consecutive Error lines - two from the XE layer, one from here - for a login that was
+               simply not granted ALTER ANY EVENT SESSION, while every other permission denial in this method
+               logs at Warn. Only a genuine ERROR status stays at Error. */
+            if (status == "PERMISSIONS")
+            {
+                AppLogger.Warn("Collector", $"  [{server.DisplayName}] {collectorName} {ex.Message}");
+            }
+            else
+            {
+                AppLogger.Error("Collector", $"  [{server.DisplayName}] {collectorName} {ex.Message}");
+            }
         }
         catch (SqlException ex) when (ex.Number == 1222 && CollectorCatalog.YieldsOnLockTimeout(collectorName))
         {


### PR DESCRIPTION
Spotted in the #2594 reporter's log, unrelated to that bug's cause.

Their server refuses `deadlocks` and `blocked_process_report`:

```
[ERROR] [XeSession] [SERVER1] Failed to create deadlock XE session: User does not have permission to perform this action.
[ERROR] [XeSession] [SERVER1] Failed to ensure deadlock XE session: User does not have permission to perform this action.
[ERROR] [Collector]   [SERVER1] deadlocks Failed to ensure deadlock XE session: User does not have permission...
```

Three ERROR lines for a login that simply was not granted `ALTER ANY EVENT SESSION`.

**Nothing is actually wrong.** The collector already classifies this as `PERMISSIONS` and sets `IsPermissionRestricted`, so the scheduler stops retrying it for the session — that part works, and I checked before assuming otherwise. Declining that grant is a legitimate least-privilege posture (#1823). Only the log level disagreed, and every *other* permission denial in the same method logs at Warn.

All four XE session sites plus the collector arm now take the level from the classification. **The Error arm survives** — an XE session failing for a reason that is not permissions is exactly what #1086 made loud.

The pin anchors on the logger call adjacent to `IsPermissionDenied` rather than on message text, so a reworded message does not fail it and a level change does. Verified red against `dev`:

```
PASS  PATCHED
FAIL  dev (pre-fix)  -> no permission-guarded log
```