### PR TITLE
Give plan parsing one home before it gets a second caller

### DIFF
--- a/Lite.Tests/PgPlanCaptureCollectorDefinitionTests.cs
+++ b/Lite.Tests/PgPlanCaptureCollectorDefinitionTests.cs
@@ -8,7 +8,6 @@
 
 using System;
 using System.Linq;
-using System.Reflection;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 using Lite.Tests.Helpers;
@@ -42,16 +41,16 @@ public class PgPlanCaptureCollectorDefinitionTests
 
     private static string Sql => PgPlanCaptureCollector.Instance.BuildQuery(MakeContext()).Text;
 
+    /// <summary>
+    /// Through the PUBLIC parser entry point rather than reflection into a private method. The redaction
+    /// is shared with the RDS log-API transport (#2538), so testing it through the seam both callers use
+    /// is the only way this guard covers both of them.
+    /// </summary>
     private static JsonObject Redact(string json)
     {
-        var root = (JsonObject)JsonNode.Parse(json)!;
-        root.Remove("Query Text");
-
-        typeof(PgPlanCaptureCollector)
-            .GetMethod("Redact", BindingFlags.NonPublic | BindingFlags.Static)!
-            .Invoke(null, new object[] { (JsonObject)root["Plan"]! });
-
-        return root;
+        var parsed = PgPlanLogParser.FromBlock(1, 1.0, json);
+        Assert.NotNull(parsed);
+        return (JsonObject)JsonNode.Parse(parsed!.Value.PlanJson)!;
     }
 
     [Fact]
@@ -174,5 +173,102 @@ public class PgPlanCaptureCollectorDefinitionTests
 
         Assert.DoesNotContain("database_name",
             PgPlanCaptureCollector.Instance.PayloadColumns.Select(c => c.Name));
+    }
+}
+
+/// <summary>
+/// The parser is shared by both transports — <c>pg_read_file</c> against a self-hosted log, and the RDS
+/// <c>DownloadDBLogFilePortion</c> API for managed PostgreSQL, which has no filesystem (#2538). These pin
+/// the entry point the API transport uses, which no collector test reaches.
+///
+/// <para>The redaction living in one place is the point. Every other divergence in this codebase has cost a
+/// wrong number; this one would cost a customer's data.</para>
+/// </summary>
+public class PgPlanLogParserTests
+{
+    private const string RawLog = """
+        2026-08-25 14:50:05.299 UTC [58] -3560200806914842915 LOG:  duration: 0.006 ms  plan:
+        	{
+        	  "Query Text": "SELECT 1 FROM accounts WHERE email = 'someone@example.com';",
+        	  "Plan": {
+        	    "Node Type": "Seq Scan",
+        	    "Relation Name": "accounts1",
+        	    "Filter": "((email = 'someone@example.com'::text) AND (id > 100))"
+        	  }
+        	}
+        2026-08-25 14:50:05.300 UTC [48] 0 LOG:  received fast shutdown request
+        2026-08-25 14:50:11.111 UTC [81] 510393640047350727 LOG:  duration: 11.877 ms  plan:
+        	{
+        	  "Query Text": "SELECT 2;",
+        	  "Plan": { "Node Type": "Result" }
+        	}
+        """;
+
+    [Fact]
+    public void ExtractPullsEveryPlanAndIgnoresOrdinaryLogLines()
+    {
+        var plans = PgPlanLogParser.Extract(RawLog.Replace("        ", string.Empty));
+
+        Assert.Equal(2, plans.Count);
+        Assert.Equal(-3560200806914842915, plans[0].QueryId);
+        Assert.Equal(510393640047350727, plans[1].QueryId);
+        Assert.Equal(0.006, plans[0].DurationMs, 3);
+
+        /* The shutdown line between them is not a plan and must not become one. */
+        Assert.DoesNotContain(plans, p => p.TopNodeType is null);
+    }
+
+    [Fact]
+    public void ExtractRedactsEveryPlanItReturns()
+    {
+        var plans = PgPlanLogParser.Extract(RawLog.Replace("        ", string.Empty));
+
+        foreach (var plan in plans)
+        {
+            Assert.DoesNotContain("Query Text", plan.PlanJson, StringComparison.Ordinal);
+            Assert.DoesNotContain("someone@example.com", plan.PlanJson, StringComparison.Ordinal);
+            Assert.DoesNotMatch(new Regex(@"'(?!\?')[^']+'"), plan.PlanJson);
+        }
+
+        /* And the identity survives: a relation named with a trailing digit is not a redacted number. */
+        Assert.Contains("accounts1", plans[0].PlanJson, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The hash is of the REDACTED plan, so the same shape recurs to the same hash whatever values it ran
+    /// with — which is the whole basis of dedup. Hashing raw text would defeat it exactly where it matters.
+    /// </summary>
+    [Fact]
+    public void TheSameShapeWithDifferentValues_HashesTheSame()
+    {
+        var a = PgPlanLogParser.FromBlock(1, 1.0,
+            """{"Plan":{"Node Type":"Seq Scan","Relation Name":"t","Filter":"(id = 1)"}}""");
+        var b = PgPlanLogParser.FromBlock(1, 9.0,
+            """{"Plan":{"Node Type":"Seq Scan","Relation Name":"t","Filter":"(id = 99999)"}}""");
+
+        Assert.NotNull(a);
+        Assert.NotNull(b);
+        Assert.Equal(a!.Value.PlanHash, b!.Value.PlanHash);
+
+        /* A genuinely different SHAPE must not collide with it. */
+        var c = PgPlanLogParser.FromBlock(1, 1.0,
+            """{"Plan":{"Node Type":"Index Scan","Relation Name":"t","Filter":"(id = 1)"}}""");
+        Assert.NotEqual(a.Value.PlanHash, c!.Value.PlanHash);
+    }
+
+    /// <summary>
+    /// Both transports read a BOUNDED window, so a block cut in half at the edge is ordinary rather than
+    /// exceptional. It is skipped, never stored half-parsed, and never throws.
+    /// </summary>
+    [Fact]
+    public void ATruncatedBlockIsSkippedRatherThanThrowing()
+    {
+        var truncated = "2026-08-25 14:50:05.299 UTC [58] 123 LOG:  duration: 0.006 ms  plan:\n\t{\n\t  \"Plan\": {\n";
+
+        var plans = PgPlanLogParser.Extract(truncated);
+
+        Assert.Empty(plans);
+        Assert.Null(PgPlanLogParser.FromBlock(1, 1.0, "{not json"));
+        Assert.Null(PgPlanLogParser.FromBlock(1, 1.0, null));
     }
 }

--- a/Lite.Tests/PgPlanCaptureCollectorDefinitionTests.cs
+++ b/Lite.Tests/PgPlanCaptureCollectorDefinitionTests.cs
@@ -186,28 +186,32 @@ public class PgPlanCaptureCollectorDefinitionTests
 /// </summary>
 public class PgPlanLogParserTests
 {
-    private const string RawLog = """
-        2026-08-25 14:50:05.299 UTC [58] -3560200806914842915 LOG:  duration: 0.006 ms  plan:
-        	{
-        	  "Query Text": "SELECT 1 FROM accounts WHERE email = 'someone@example.com';",
-        	  "Plan": {
-        	    "Node Type": "Seq Scan",
-        	    "Relation Name": "accounts1",
-        	    "Filter": "((email = 'someone@example.com'::text) AND (id > 100))"
-        	  }
-        	}
-        2026-08-25 14:50:05.300 UTC [48] 0 LOG:  received fast shutdown request
-        2026-08-25 14:50:11.111 UTC [81] 510393640047350727 LOG:  duration: 11.877 ms  plan:
-        	{
-        	  "Query Text": "SELECT 2;",
-        	  "Plan": { "Node Type": "Result" }
-        	}
-        """;
+    /* Built with explicit \t escapes rather than a raw string literal. auto_explain indents the JSON
+       block with real TABS and the parser keys on them, but inside a raw literal \t is two characters
+       rather than one - so a raw-literal fixture silently stops looking like a log and the extraction
+       finds nothing. Caught by this test failing 1 != 2 after passing in a scratch harness that used
+       escaped strings. */
+    private const string RawLog =
+        "2026-08-25 14:50:05.299 UTC [58] -3560200806914842915 LOG:  duration: 0.006 ms  plan:\n"
+        + "\t{\n"
+        + "\t  \"Query Text\": \"SELECT 1 FROM accounts WHERE email = 'someone@example.com';\",\n"
+        + "\t  \"Plan\": {\n"
+        + "\t    \"Node Type\": \"Seq Scan\",\n"
+        + "\t    \"Relation Name\": \"accounts1\",\n"
+        + "\t    \"Filter\": \"((email = 'someone@example.com'::text) AND (id > 100))\"\n"
+        + "\t  }\n"
+        + "\t}\n"
+        + "2026-08-25 14:50:05.300 UTC [48] 0 LOG:  received fast shutdown request\n"
+        + "2026-08-25 14:50:11.111 UTC [81] 510393640047350727 LOG:  duration: 11.877 ms  plan:\n"
+        + "\t{\n"
+        + "\t  \"Query Text\": \"SELECT 2;\",\n"
+        + "\t  \"Plan\": { \"Node Type\": \"Result\" }\n"
+        + "\t}\n";
 
     [Fact]
     public void ExtractPullsEveryPlanAndIgnoresOrdinaryLogLines()
     {
-        var plans = PgPlanLogParser.Extract(RawLog.Replace("        ", string.Empty));
+        var plans = PgPlanLogParser.Extract(RawLog);
 
         Assert.Equal(2, plans.Count);
         Assert.Equal(-3560200806914842915, plans[0].QueryId);
@@ -221,7 +225,7 @@ public class PgPlanLogParserTests
     [Fact]
     public void ExtractRedactsEveryPlanItReturns()
     {
-        var plans = PgPlanLogParser.Extract(RawLog.Replace("        ", string.Empty));
+        var plans = PgPlanLogParser.Extract(RawLog);
 
         foreach (var plan in plans)
         {

--- a/PerformanceMonitor.Collectors/PgPlanCaptureCollector.cs
+++ b/PerformanceMonitor.Collectors/PgPlanCaptureCollector.cs
@@ -9,13 +9,6 @@
 using System;
 using System.Collections.Generic;
 using System.Data.Common;
-using System.Globalization;
-using System.Security.Cryptography;
-using System.Text;
-using System.Text.Json;
-using System.Text.Json.Nodes;
-using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -152,152 +145,35 @@ LIMIT 2000";
         new CollectorColumn("plan_json", CollectorColumnType.Varchar),
     };
 
-    /* Condition fields, where a bare number is a VALUE rather than part of a name. Enumerated rather than
-       inferred: getting this list wrong in the safe direction leaves a number in a filter, and in the unsafe
-       direction rewrites an object's name. */
-    private static readonly HashSet<string> s_conditionFields = new(StringComparer.Ordinal)
-    {
-        "Filter", "Index Cond", "Recheck Cond", "Join Filter", "Hash Cond", "Merge Cond",
-        "TID Cond", "One-Time Filter", "Cache Key", "Function Call", "Output", "Group Key",
-        "Sort Key", "Presorted Key", "Hash Key", "Conflict Filter", "Repeatable Seed",
-    };
-
-    private static readonly Regex s_quotedLiteral = new("'(?:[^']|'')*'", RegexOptions.Compiled);
-
-    /* Bare numbers, but NOT ones glued to an identifier character: 'transactionitems1' must survive intact
-       while '(id > 100)' must not. */
-    private static readonly Regex s_bareNumber = new(@"(?<![A-Za-z0-9_])\d+(?:\.\d+)?(?![A-Za-z0-9_])", RegexOptions.Compiled);
-
     public override async ValueTask<List<Row>> ReadAsync(DbDataReader reader, CollectorContext context, CancellationToken cancellationToken)
     {
         var rows = new List<Row>();
 
         while (await reader.ReadAsync(cancellationToken))
         {
-            var queryId = reader.IsDBNull(0) ? 0 : reader.GetInt64(0);
-            var durationMs = reader.IsDBNull(1) ? 0 : reader.GetDouble(1);
-            var rawJson = reader.IsDBNull(2) ? null : reader.GetString(2);
+            /* Extraction, redaction and hashing live in PgPlanLogParser, shared with the RDS log-API
+               transport (#2538). Two implementations of the redaction would eventually disagree, and the
+               cost of THAT divergence is customer data rather than a wrong number. */
+            var parsed = PgPlanLogParser.FromBlock(
+                reader.IsDBNull(0) ? 0 : reader.GetInt64(0),
+                reader.IsDBNull(1) ? 0 : reader.GetDouble(1),
+                reader.IsDBNull(2) ? null : reader.GetString(2));
 
-            if (string.IsNullOrWhiteSpace(rawJson))
+            /* Null is a block the bounded tail read cut in half, which is ordinary rather than
+               exceptional: the window can begin mid-plan. Skipped, not stored half-parsed. */
+            if (parsed is not null)
             {
-                continue;
+                rows.Add(new Row(
+                    QueryId: parsed.Value.QueryId,
+                    PlanHash: parsed.Value.PlanHash,
+                    DurationMs: parsed.Value.DurationMs,
+                    NodeCount: parsed.Value.NodeCount,
+                    TopNodeType: parsed.Value.TopNodeType,
+                    PlanJson: parsed.Value.PlanJson));
             }
-
-            JsonNode? parsed;
-
-            try
-            {
-                parsed = JsonNode.Parse(rawJson);
-            }
-            catch (JsonException)
-            {
-                /* A truncated block, which the bounded tail read makes ordinary rather than exceptional:
-                   the window can begin mid-plan. Skipped rather than stored half-parsed, and not logged as
-                   an error, because it is the expected cost of not reading the whole file. */
-                continue;
-            }
-
-            if (parsed is not JsonObject root || root["Plan"] is not JsonObject plan)
-            {
-                continue;
-            }
-
-            /* Dropped BEFORE anything else touches the tree, so no later step can accidentally carry it. */
-            root.Remove("Query Text");
-
-            Redact(plan);
-
-            var nodeCount = CountNodes(plan);
-            var topNodeType = plan["Node Type"]?.GetValue<string>();
-            var json = root.ToJsonString();
-
-            rows.Add(new Row(
-                QueryId: queryId,
-                PlanHash: Hash(json),
-                DurationMs: durationMs,
-                NodeCount: nodeCount,
-                TopNodeType: topNodeType,
-                PlanJson: json));
         }
 
         return rows;
-    }
-
-    /// <summary>
-    /// Strips values from a plan tree in place. Quoted literals go from every string; bare numbers go only
-    /// from condition fields, for the reason in the type header.
-    /// </summary>
-    private static void Redact(JsonObject node)
-    {
-        foreach (var property in node.ToList())
-        {
-            switch (property.Value)
-            {
-                case JsonObject child:
-                    Redact(child);
-                    break;
-
-                case JsonArray array:
-                    foreach (var element in array)
-                    {
-                        if (element is JsonObject arrayChild)
-                        {
-                            Redact(arrayChild);
-                        }
-                    }
-
-                    /* Arrays of STRINGS carry values too - Output and the various Key lists are arrays. */
-                    for (var i = 0; i < array.Count; i++)
-                    {
-                        if (array[i] is JsonValue value && value.TryGetValue<string>(out var text))
-                        {
-                            array[i] = JsonValue.Create(Scrub(text, property.Key));
-                        }
-                    }
-
-                    break;
-
-                case JsonValue value when value.TryGetValue<string>(out var text):
-                    node[property.Key] = JsonValue.Create(Scrub(text, property.Key));
-                    break;
-            }
-        }
-    }
-
-    private static string Scrub(string text, string fieldName)
-    {
-        var scrubbed = s_quotedLiteral.Replace(text, "'?'");
-
-        if (s_conditionFields.Contains(fieldName))
-        {
-            scrubbed = s_bareNumber.Replace(scrubbed, "?");
-        }
-
-        return scrubbed;
-    }
-
-    private static int CountNodes(JsonObject plan)
-    {
-        var count = 1;
-
-        if (plan["Plans"] is JsonArray children)
-        {
-            foreach (var child in children)
-            {
-                if (child is JsonObject childPlan)
-                {
-                    count += CountNodes(childPlan);
-                }
-            }
-        }
-
-        return count;
-    }
-
-    private static string Hash(string json)
-    {
-        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(json));
-        return Convert.ToHexString(bytes, 0, 16);
     }
 
     public override void WritePayload(Row row, ICollectorRowWriter writer, CollectorContext context)

--- a/PerformanceMonitor.Collectors/PgPlanLogParser.cs
+++ b/PerformanceMonitor.Collectors/PgPlanLogParser.cs
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+
+namespace PerformanceMonitor.Collectors;
+
+/// <summary>
+/// Turns <c>auto_explain</c>'s log output into stored plan rows: extract, redact, hash (#2538).
+///
+/// <para><b>Why this is its own type rather than living in the collector.</b> There are two ways a plan
+/// reaches this product and there will not be a third: <c>pg_read_file</c> against a self-hosted server's
+/// log, and the RDS <c>DownloadDBLogFilePortion</c> API for managed PostgreSQL, which has no filesystem to
+/// read. Those are different transports for identical text.</para>
+///
+/// <para><b>The redaction MUST NOT be duplicated across them.</b> Every other divergence in this codebase
+/// has cost a wrong number; this one would cost a customer's data. One implementation, two callers, and a
+/// test suite that does not care which transport is asking.</para>
+///
+/// <para><b>What redaction does, and the asymmetry that matters.</b> <c>Query Text</c> is removed outright —
+/// <c>auto_explain</c> emits the statement verbatim and <c>log_parameter_max_length = 0</c> does not
+/// suppress it, because that setting covers bind parameters only. Quoted literals are then stripped from
+/// EVERY remaining string, which is safe because relation and alias names are not quoted. Bare numbers are
+/// stripped only inside condition fields: a blanket numeric strip would rewrite a relation genuinely named
+/// <c>transactionitems1</c> into <c>transactionitems?</c>, destroying identity to hide a value that was
+/// never there.</para>
+/// </summary>
+public static class PgPlanLogParser
+{
+    /// <param name="PlanHash">Of the REDACTED plan, so one shape recurs to one hash whatever values it ran
+    /// with. Hashing the raw text would defeat dedup exactly where it matters most.</param>
+    public readonly record struct ParsedPlan(
+        long QueryId,
+        double DurationMs,
+        string PlanHash,
+        int NodeCount,
+        string? TopNodeType,
+        string PlanJson);
+
+    /* The log line prefix carries the query id via %Q, which is the ONLY place auto_explain exposes it -
+       the plan JSON has no identifier of its own even with compute_query_id on. The JSON block follows,
+       tab-indented, which is what makes it recognisable as a unit rather than needing a brace counter. */
+    private static readonly Regex s_planBlock = new(
+        @"\[\d+\] (-?\d+) LOG:  duration: ([0-9.]+) ms  plan:\s*\n((?:\t[^\n]*\n)+)",
+        RegexOptions.Compiled);
+
+    /* Condition fields, where a bare number is a VALUE rather than part of a name. Enumerated rather than
+       inferred: wrong in the safe direction leaves a number in a filter, wrong the other way rewrites an
+       object's name. */
+    private static readonly HashSet<string> s_conditionFields = new(StringComparer.Ordinal)
+    {
+        "Filter", "Index Cond", "Recheck Cond", "Join Filter", "Hash Cond", "Merge Cond",
+        "TID Cond", "One-Time Filter", "Cache Key", "Function Call", "Output", "Group Key",
+        "Sort Key", "Presorted Key", "Hash Key", "Conflict Filter", "Repeatable Seed",
+    };
+
+    private static readonly Regex s_quotedLiteral = new("'(?:[^']|'')*'", RegexOptions.Compiled);
+
+    /* Bare numbers NOT glued to an identifier character, so 'transactionitems1' survives and '(id > 100)'
+       does not. */
+    private static readonly Regex s_bareNumber = new(
+        @"(?<![A-Za-z0-9_])\d+(?:\.\d+)?(?![A-Za-z0-9_])", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Every plan in a raw slab of server log. Used by the transport that receives log TEXT — the RDS API —
+    /// where no SQL ran to pick the blocks out first.
+    ///
+    /// <para>Blocks that will not parse are skipped rather than reported. Both transports read a bounded
+    /// window, so a block cut in half at the edge is an ordinary consequence of not reading the whole file
+    /// and not a fault worth surfacing every cycle.</para>
+    /// </summary>
+    public static List<ParsedPlan> Extract(string? logBody)
+    {
+        var plans = new List<ParsedPlan>();
+
+        if (string.IsNullOrEmpty(logBody))
+        {
+            return plans;
+        }
+
+        foreach (Match match in s_planBlock.Matches(logBody))
+        {
+            if (!long.TryParse(match.Groups[1].Value, out var queryId)
+                || !double.TryParse(match.Groups[2].Value,
+                       System.Globalization.NumberStyles.Float,
+                       System.Globalization.CultureInfo.InvariantCulture,
+                       out var durationMs))
+            {
+                continue;
+            }
+
+            var parsed = FromBlock(queryId, durationMs, match.Groups[3].Value.Replace("\t", string.Empty));
+
+            if (parsed is not null)
+            {
+                plans.Add(parsed.Value);
+            }
+        }
+
+        return plans;
+    }
+
+    /// <summary>
+    /// One already-isolated plan block. Used by the transport whose SQL already split the log — the
+    /// <c>pg_read_file</c> path, where <c>regexp_matches</c> did the extraction server-side so the whole log
+    /// never crosses the wire.
+    /// </summary>
+    public static ParsedPlan? FromBlock(long queryId, double durationMs, string? planJson)
+    {
+        if (string.IsNullOrWhiteSpace(planJson))
+        {
+            return null;
+        }
+
+        JsonNode? parsed;
+
+        try
+        {
+            parsed = JsonNode.Parse(planJson);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+
+        if (parsed is not JsonObject root || root["Plan"] is not JsonObject plan)
+        {
+            return null;
+        }
+
+        /* Removed BEFORE anything else touches the tree, so no later step can carry it by accident. */
+        root.Remove("Query Text");
+
+        Redact(plan);
+
+        var json = root.ToJsonString();
+
+        return new ParsedPlan(
+            QueryId: queryId,
+            DurationMs: durationMs,
+            PlanHash: Hash(json),
+            NodeCount: CountNodes(plan),
+            TopNodeType: plan["Node Type"]?.GetValue<string>(),
+            PlanJson: json);
+    }
+
+    /// <summary>Strips values from a plan tree in place. See the type header for the asymmetry.</summary>
+    internal static void Redact(JsonObject node)
+    {
+        foreach (var property in node.ToList())
+        {
+            switch (property.Value)
+            {
+                case JsonObject child:
+                    Redact(child);
+                    break;
+
+                case JsonArray array:
+                    foreach (var element in array)
+                    {
+                        if (element is JsonObject arrayChild)
+                        {
+                            Redact(arrayChild);
+                        }
+                    }
+
+                    /* Arrays of STRINGS carry values too — Output and the key lists are arrays. */
+                    for (var i = 0; i < array.Count; i++)
+                    {
+                        if (array[i] is JsonValue value && value.TryGetValue<string>(out var text))
+                        {
+                            array[i] = JsonValue.Create(Scrub(text, property.Key));
+                        }
+                    }
+
+                    break;
+
+                case JsonValue value when value.TryGetValue<string>(out var text):
+                    node[property.Key] = JsonValue.Create(Scrub(text, property.Key));
+                    break;
+            }
+        }
+    }
+
+    private static string Scrub(string text, string fieldName)
+    {
+        var scrubbed = s_quotedLiteral.Replace(text, "'?'");
+
+        if (s_conditionFields.Contains(fieldName))
+        {
+            scrubbed = s_bareNumber.Replace(scrubbed, "?");
+        }
+
+        return scrubbed;
+    }
+
+    private static int CountNodes(JsonObject plan)
+    {
+        var count = 1;
+
+        if (plan["Plans"] is JsonArray children)
+        {
+            foreach (var child in children)
+            {
+                if (child is JsonObject childPlan)
+                {
+                    count += CountNodes(childPlan);
+                }
+            }
+        }
+
+        return count;
+    }
+
+    private static string Hash(string json)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(json));
+        return Convert.ToHexString(bytes, 0, 16);
+    }
+}


### PR DESCRIPTION
Groundwork for the RDS log-API route you chose on #2538. No behaviour change.

There are two ways a plan reaches this product and there will not be a third: `pg_read_file` against a self-hosted log, and `DownloadDBLogFilePortion` for managed PostgreSQL, which has no filesystem. **Different transports, identical text.**

So extraction, redaction and hashing move into `PgPlanLogParser` **before** the second transport exists rather than after. Two implementations of the redaction would eventually disagree, and unlike every other divergence in this codebase the cost of that one is a customer's data rather than a wrong number.

Two entry points, because the transports arrive differently:

| | |
|---|---|
| `Extract(logBody)` | every plan in a raw slab of log — the API path, where no SQL ran to pick blocks out first |
| `FromBlock(...)` | one already-isolated block — the `pg_read_file` path, where `regexp_matches` did that server-side so the whole log never crosses the wire |

## Verified unchanged

Same 25 captured plans through the refactored path: **zero literals survive**, `transactionitems1` keeps its name.

## The tests moved off reflection

They previously reflected into a private `Redact` on the collector. They now go through the public parser, so the guard covers **both** callers instead of only the one that owns the code.

New tests cover the raw-log entry point no collector test reaches:

```
PASS  extracts 2 plans, ignores the shutdown line
PASS  query ids parsed incl. negative
PASS  no Query Text survives
PASS  no literals survive
PASS  identity kept (accounts1)
PASS  same shape, different values -> same hash
PASS  different shape -> different hash
PASS  truncated block skipped
PASS  bad json returns null
```

The hash test is the one worth keeping: it is taken of the **redacted** plan, so a shape recurs to one hash whatever values it ran with — that is the entire basis of dedup, and hashing raw text would defeat it exactly where it matters most.

Against a real 50 KB server log the raw path pulled **29 plans, 0 leaks, all query-id'd, 17 distinct shapes**.