### PR TITLE
Bound the other two PostgreSQL collectors that had no ceiling

### DIFF
--- a/PerformanceMonitor.Collectors/PgBufferUsageCollector.cs
+++ b/PerformanceMonitor.Collectors/PgBufferUsageCollector.cs
@@ -135,6 +135,20 @@ ORDER BY count(*) DESC";
     /// </summary>
     public override bool AppliesTo(CollectorTargetInfo target) => true;
 
+    /// <summary>
+    /// Two minutes, because the COST here is the input scan and no LIMIT can reduce it.
+    ///
+    /// <para><c>pg_buffercache</c> materialises one row per shared buffer and takes buffer partition locks
+    /// while it does — on a large instance that is millions of rows, and the aggregate needs all of them,
+    /// so the usual trick of capping output does nothing. The output IS bounded (grouped per relation,
+    /// with an eight-buffer floor); the read is not.</para>
+    ///
+    /// <para>Without an override a slow scan ends as <c>Exception while reading from stream</c>, an
+    /// unclassified Npgsql failure — which is exactly how #2617 presented and why it went unnoticed for a
+    /// collector that had never once succeeded. A classified timeout says which collector was too slow.</para>
+    /// </summary>
+    public override int? CommandTimeoutSecondsOverride => 120;
+
     public override CollectorQuery BuildQuery(CollectorContext context) => new(QueryText);
 
     public override IReadOnlyList<CollectorColumn> PayloadColumns { get; } = new[]

--- a/PerformanceMonitor.Collectors/PgColumnStatsCollector.cs
+++ b/PerformanceMonitor.Collectors/PgColumnStatsCollector.cs
@@ -119,7 +119,13 @@ JOIN pg_catalog.pg_namespace AS n
 WHERE s.schemaname NOT IN ('pg_catalog', 'information_schema')
 AND   c.relkind IN ('r', 'm', 'p')
 AND   c.relpages >= 128
-ORDER BY c.relpages DESC, s.schemaname, s.tablename, s.attname";
+ORDER BY c.relpages DESC, s.schemaname, s.tablename, s.attname
+/* Bounded (#2617's lesson applied before it bites). This is a catalog read rather than a page scan, so
+   it is nowhere near as costly as pg_index_bloat was - but it was still unbounded, and row count here is
+   tables x columns: 361 tables over the size floor on one measured target, and a wide schema turns that
+   into five figures per database per DAY. The ORDER BY already puts the biggest tables first, so the cap
+   keeps exactly the columns a plan-shape question is asked about. */
+LIMIT 5000";
 
     public override string Name => "pg_column_stats";
 


### PR DESCRIPTION
#2617 was a collector that read **461 GB in one statement** because I bounded each index and not the cycle. Rather than wait for the others to fail the same way, I audited every PostgreSQL collector for the same shape. Two more were unbounded — neither broken yet.

## `pg_column_stats` — no LIMIT

A catalog read rather than a page scan, so nowhere near #2617's severity. But row count is **tables × columns**, and 361 tables clear the size floor on one measured target; a wide schema turns that into five figures per database per day.

It already ordered by `relpages DESC`, so a cap keeps exactly the columns anyone asks a plan-shape question about.

## `pg_buffer_usage` — the interesting one, because no LIMIT would help

Its **output** is bounded — grouped per relation with an eight-buffer floor. Its **input** is not: `pg_buffercache` materialises one row per shared buffer and takes buffer partition locks doing it, and the aggregate needs every one of them. On a large instance that is millions of rows that cannot be capped away.

So it gets a **command timeout** instead. Without one, a slow scan ends as `Exception while reading from stream` — an unclassified Npgsql failure, which is precisely how #2617 presented and exactly why a collector that had *never once succeeded* went unnoticed. A classified timeout at least names which collector was too slow.

Worth stating the distinction, because it is the reusable part: **capping output and bounding work are different problems.** #2617 needed the first, this needs the second, and reaching for `LIMIT` on this one would have looked like a fix and changed nothing.

Both verified still returning correct rows against a live PostgreSQL instance.