### PR TITLE
Fetch PostgreSQL server logs from the RDS API (#2538)

### DIFF
--- a/Darling/Darling.Tests/RdsEndpointTests.cs
+++ b/Darling/Darling.Tests/RdsEndpointTests.cs
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using PerformanceMonitor.Darling.Service.Targets;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Endpoint parsing for the RDS log-download route (#2538). All fixtures are synthetic — the shapes come
+/// from AWS's documented endpoint formats, not from any fleet.
+/// </summary>
+public class RdsEndpointTests
+{
+    [Theory]
+    [InlineData("alpha.abc123xyz.us-east-1.rds.amazonaws.com", "alpha", "us-east-1", RdsEndpointKind.Instance)]
+    [InlineData("beta-01.c9ukews.eu-west-2.rds.amazonaws.com", "beta-01", "eu-west-2", RdsEndpointKind.Instance)]
+    [InlineData("gamma.cluster-abc123.us-east-2.rds.amazonaws.com", "gamma", "us-east-2", RdsEndpointKind.ClusterWriter)]
+    [InlineData("gamma.cluster-ro-abc123.us-east-2.rds.amazonaws.com", "gamma", "us-east-2", RdsEndpointKind.ClusterReader)]
+    [InlineData("gamma.cluster-custom-abc.ap-southeast-2.rds.amazonaws.com", "gamma", "ap-southeast-2", RdsEndpointKind.ClusterCustom)]
+    public void ItReadsTheIdentifierRegionAndShape(string host, string id, string region, RdsEndpointKind kind)
+    {
+        var parsed = RdsEndpoint.TryParse(host);
+
+        Assert.NotNull(parsed);
+        Assert.Equal(id, parsed!.Value.Identifier);
+        Assert.Equal(region, parsed.Value.Region);
+        Assert.Equal(kind, parsed.Value.Kind);
+    }
+
+    /// <summary>
+    /// <b>The distinction the whole route depends on.</b> <c>DownloadDBLogFilePortion</c> takes an INSTANCE
+    /// identifier. Reading a cluster endpoint as one yields <c>DBInstanceNotFound</c> against a perfectly
+    /// healthy cluster — a confusing way to fail, and one that would look like a permissions problem.
+    /// </summary>
+    [Fact]
+    public void AClusterEndpointIsNotMistakenForAnInstance()
+    {
+        var cluster = RdsEndpoint.TryParse("shared.cluster-abc123.us-east-1.rds.amazonaws.com");
+        var instance = RdsEndpoint.TryParse("shared.abc123.us-east-1.rds.amazonaws.com");
+
+        Assert.Equal(RdsEndpointKind.ClusterWriter, cluster!.Value.Kind);
+        Assert.Equal(RdsEndpointKind.Instance, instance!.Value.Kind);
+
+        /* Same name, same region — only the second label separates them, which is why it is matched
+           exactly while the suffix is matched loosely. */
+        Assert.Equal(cluster.Value.Identifier, instance.Value.Identifier);
+    }
+
+    /// <summary>
+    /// Non-RDS hosts return null rather than throwing. That is an ordinary answer — a self-hosted server, a
+    /// pooler, or an IP — and the caller falls back to the <c>pg_read_file</c> route.
+    /// </summary>
+    [Theory]
+    [InlineData("localhost")]
+    [InlineData("10.0.0.5")]
+    [InlineData("db.internal.example.com")]
+    [InlineData("pgbouncer.svc.cluster.local")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void ANonRdsHostIsNotAnError(string? host)
+    {
+        Assert.Null(RdsEndpoint.TryParse(host));
+    }
+
+    /// <summary>
+    /// The suffix is matched loosely so China and GovCloud parse. Pinning <c>.rds.amazonaws.com</c> exactly
+    /// would silently refuse a valid endpoint in either partition, and refusing to parse looks identical to
+    /// "this is not RDS" — so the failure would present as the wrong route being chosen.
+    /// </summary>
+    [Theory]
+    [InlineData("delta.abc123.cn-north-1.rds.amazonaws.com.cn", "cn-north-1")]
+    [InlineData("delta.cluster-abc.us-gov-west-1.rds.amazonaws.com", "us-gov-west-1")]
+    public void OtherPartitionsParse(string host, string region)
+    {
+        var parsed = RdsEndpoint.TryParse(host);
+
+        Assert.NotNull(parsed);
+        Assert.Equal(region, parsed!.Value.Region);
+    }
+}

--- a/Darling/Darling.Tests/RdsLogSourceTests.cs
+++ b/Darling/Darling.Tests/RdsLogSourceTests.cs
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.RDS;
+using Amazon.RDS.Model;
+using PerformanceMonitor.Darling.Service.Targets;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// The RDS log transport (#2538), against a fake client. No AWS call is made and none is needed: what is
+/// worth pinning is the DECISION-MAKING — which identifier gets used, which endpoints are refused, and
+/// whether the resume marker advances — and all of that is ours rather than the SDK's.
+/// </summary>
+public class RdsLogSourceTests
+{
+    private sealed class FakeRds : AmazonRDSClient
+    {
+        public FakeRds() : base(new Amazon.Runtime.BasicAWSCredentials("a", "b"),
+            Amazon.RegionEndpoint.USEast1) { }
+
+        public List<DownloadDBLogFilePortionRequest> Downloads { get; } = new();
+        public string? WriterId { get; init; }
+        public string LogName { get; init; } = "error/postgresql.log.2026-08-25-18";
+        public string? NextMarker { get; set; } = "MARKER-1";
+
+        public override Task<DescribeDBClustersResponse> DescribeDBClustersAsync(
+            DescribeDBClustersRequest request, CancellationToken cancellationToken = default)
+            => Task.FromResult(new DescribeDBClustersResponse
+            {
+                DBClusters = new List<DBCluster>
+                {
+                    new()
+                    {
+                        DBClusterMembers = new List<DBClusterMember>
+                        {
+                            new() { DBInstanceIdentifier = "reader-1", IsClusterWriter = false },
+                            new() { DBInstanceIdentifier = WriterId ?? "writer-1", IsClusterWriter = true },
+                        },
+                    },
+                },
+            });
+
+        public override Task<DescribeDBLogFilesResponse> DescribeDBLogFilesAsync(
+            DescribeDBLogFilesRequest request, CancellationToken cancellationToken = default)
+            => Task.FromResult(new DescribeDBLogFilesResponse
+            {
+                DescribeDBLogFiles = new List<DescribeDBLogFilesDetails>
+                {
+                    new() { LogFileName = "error/postgresql.log.2026-08-09-01", LastWritten = 1000 },
+                    new() { LogFileName = LogName, LastWritten = 9999 },
+                },
+            });
+
+        public override Task<DownloadDBLogFilePortionResponse> DownloadDBLogFilePortionAsync(
+            DownloadDBLogFilePortionRequest request, CancellationToken cancellationToken = default)
+        {
+            Downloads.Add(request);
+            return Task.FromResult(new DownloadDBLogFilePortionResponse
+            {
+                LogFileData = "log body",
+                Marker = NextMarker,
+                AdditionalDataPending = false,
+            });
+        }
+    }
+
+    private static (RdsLogSource Source, FakeRds Client) Build(FakeRds? client = null)
+    {
+        var fake = client ?? new FakeRds();
+        return (new RdsLogSource(_ => fake), fake);
+    }
+
+    /// <summary>
+    /// A cluster endpoint is resolved to its WRITER. <c>DownloadDBLogFilePortion</c> takes an instance
+    /// identifier, so passing the cluster name through would fail with <c>DBInstanceNotFound</c> against a
+    /// perfectly healthy cluster — which reads like a permissions problem and is not one.
+    /// </summary>
+    [Fact]
+    public async Task AClusterEndpointResolvesToItsWriter()
+    {
+        var (source, client) = Build(new FakeRds { WriterId = "prod-writer" });
+
+        await source.ReadNewestAsync("shared.cluster-abc123.us-east-1.rds.amazonaws.com");
+
+        Assert.Single(client.Downloads);
+        Assert.Equal("prod-writer", client.Downloads[0].DBInstanceIdentifier);
+    }
+
+    /// <summary>An instance endpoint is used directly — no cluster lookup to get wrong.</summary>
+    [Fact]
+    public async Task AnInstanceEndpointIsUsedAsIs()
+    {
+        var (source, client) = Build();
+
+        await source.ReadNewestAsync("solo.abc123.us-east-1.rds.amazonaws.com");
+
+        Assert.Equal("solo", client.Downloads[0].DBInstanceIdentifier);
+    }
+
+    /// <summary>
+    /// Reader and custom endpoints are REFUSED, with a reason. They round-robin across replicas, so the
+    /// instance behind one is not stable between calls — plans pulled through one would be attributed to
+    /// whichever replica happened to answer, which is worse than having none.
+    /// </summary>
+    [Theory]
+    [InlineData("shared.cluster-ro-abc123.us-east-1.rds.amazonaws.com")]
+    [InlineData("shared.cluster-custom-abc.us-east-1.rds.amazonaws.com")]
+    public async Task ReaderAndCustomEndpointsAreRefused(string host)
+    {
+        var (source, client) = Build();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => source.ReadNewestAsync(host));
+
+        Assert.Contains("does not resolve to a stable instance", ex.Message, StringComparison.Ordinal);
+        Assert.Empty(client.Downloads);
+    }
+
+    /// <summary>
+    /// The newest file is chosen by LAST-WRITTEN, not by name. RDS filenames embed a date and sorting them
+    /// as text puts <c>2026-08-09</c> after <c>2026-08-25</c>, which would pin the collector to a stale log
+    /// forever without ever erroring.
+    /// </summary>
+    [Fact]
+    public async Task TheNewestLogIsChosenByTimeNotByName()
+    {
+        var (source, client) = Build();
+
+        await source.ReadNewestAsync("solo.abc123.us-east-1.rds.amazonaws.com");
+
+        Assert.Equal("error/postgresql.log.2026-08-25-18", client.Downloads[0].LogFileName);
+    }
+
+    /// <summary>
+    /// First read asks for a bounded TAIL; the next resumes from the marker. Without the tail, a first read
+    /// against a rotated multi-GB log would pull all of it across the network — #2565 measured 772 MB in
+    /// twenty seconds at capture-everything.
+    /// </summary>
+    [Fact]
+    public async Task FirstReadIsBounded_ThenItResumesFromTheMarker()
+    {
+        var (source, client) = Build();
+
+        await source.ReadNewestAsync("solo.abc123.us-east-1.rds.amazonaws.com");
+        await source.ReadNewestAsync("solo.abc123.us-east-1.rds.amazonaws.com");
+
+        Assert.Null(client.Downloads[0].Marker);
+        Assert.True(client.Downloads[0].NumberOfLines > 0);
+
+        Assert.Equal("MARKER-1", client.Downloads[1].Marker);
+        Assert.Equal(0, client.Downloads[1].NumberOfLines);
+    }
+
+    /// <summary>A non-RDS host is not this transport's problem: null, so the caller uses pg_read_file.</summary>
+    [Fact]
+    public async Task ANonRdsHostReturnsNull()
+    {
+        var (source, client) = Build();
+
+        Assert.Null(await source.ReadNewestAsync("db.internal.example.com"));
+        Assert.Empty(client.Downloads);
+    }
+}

--- a/Darling/Darling.Tests/packages.lock.json
+++ b/Darling/Darling.Tests/packages.lock.json
@@ -11,6 +11,11 @@
           "xunit.v3.mtp-v1": "[3.2.2]"
         }
       },
+      "AWSSDK.Core": {
+        "type": "Transitive",
+        "resolved": "4.0.102.1",
+        "contentHash": "vsf+/o+S/euH/wG7bO1cha+OWaHvjgvpDeGFO6l3Vcdio9GlSfXkZDD2BogMuAJ+/jDyqqSgqmYVolPKV9ie/A=="
+      },
       "HarfBuzzSharp": {
         "type": "Transitive",
         "resolved": "8.3.1.1",
@@ -685,6 +690,7 @@
       "performancemonitor.darling.service": {
         "type": "Project",
         "dependencies": {
+          "AWSSDK.RDS": "[4.0.104.4, )",
           "Microsoft.Data.SqlClient": "[7.0.2, )",
           "Microsoft.Extensions.Hosting": "[10.0.11, )",
           "Microsoft.Extensions.Hosting.WindowsServices": "[10.0.11, )",
@@ -745,6 +751,15 @@
           "PerformanceMonitor.Common": "[1.0.0, )",
           "PerformanceMonitor.PlanAnalysis": "[1.0.0, )",
           "ScottPlot.WPF": "[5.1.59, )"
+        }
+      },
+      "AWSSDK.RDS": {
+        "type": "CentralTransitive",
+        "requested": "[4.0.104.4, )",
+        "resolved": "4.0.104.4",
+        "contentHash": "tAhUJwG6SnAFT0ZHL2n+z6c7EDmnpo5fPrZO4HZsBmVj4vV7k1/+j0zoe+wMLWKl8qRTk+gipUuz8LITk9rSyA==",
+        "dependencies": {
+          "AWSSDK.Core": "[4.0.102.1, 5.0.0)"
         }
       },
       "CredentialManagement": {

--- a/Darling/PerformanceMonitor.Darling.Service/PerformanceMonitor.Darling.Service.csproj
+++ b/Darling/PerformanceMonitor.Darling.Service/PerformanceMonitor.Darling.Service.csproj
@@ -21,6 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AWSSDK.RDS" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" />
     <PackageReference Include="Microsoft.Data.SqlClient" />

--- a/Darling/PerformanceMonitor.Darling.Service/Targets/RdsEndpoint.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Targets/RdsEndpoint.cs
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Text.RegularExpressions;
+
+namespace PerformanceMonitor.Darling.Service.Targets;
+
+/// <summary>
+/// What an RDS or Aurora endpoint hostname tells us, for the log-download route (#2538).
+///
+/// <para><b>Why this has to be parsed at all.</b> A target is a connection string. The RDS API needs a
+/// <c>DBInstanceIdentifier</c> and a region, and neither appears in a connection string — but both are
+/// encoded in the endpoint hostname AWS hands out. Asking an operator to configure them separately would
+/// mean two sources of truth for the same server, and the one they typed would eventually disagree with the
+/// one they connect to.</para>
+///
+/// <para><b>The cluster/instance distinction is the part that matters.</b>
+/// <c>DownloadDBLogFilePortion</c> takes an INSTANCE identifier. An Aurora CLUSTER endpoint
+/// (<c>…​.cluster-xxxx.…</c>) names a cluster, whose writer is whatever instance currently holds that role —
+/// so a cluster endpoint cannot be used directly and has to be resolved through the API first. Reading a
+/// cluster endpoint as an instance id yields <c>DBInstanceNotFound</c> against a perfectly healthy cluster,
+/// which is a confusing way to fail.</para>
+///
+/// <para><b>Reader endpoints are called out separately</b> (<c>.cluster-ro-</c>). They round-robin across
+/// replicas, so the instance behind one is not stable between calls — and plans captured from a reader are
+/// a different workload from the writer's, not a substitute for it.</para>
+/// </summary>
+public static class RdsEndpoint
+{
+    /// <param name="Identifier">The instance or cluster id, depending on <paramref name="Kind"/>.</param>
+    /// <param name="Region">From the hostname, so it always matches the endpoint actually connected to.</param>
+    public readonly record struct Parsed(string Identifier, string Region, RdsEndpointKind Kind);
+
+    /* Instance:    name.hash.region.rds.amazonaws.com
+       Cluster:     name.cluster-hash.region.rds.amazonaws.com
+       Reader:      name.cluster-ro-hash.region.rds.amazonaws.com
+       Custom:      name.cluster-custom-hash.region.rds.amazonaws.com
+
+       The suffix is matched loosely on purpose: commercial AWS, China (.com.cn) and GovCloud all differ
+       there, and pinning the exact tail would silently refuse to parse a perfectly valid GovCloud endpoint.
+       What must be exact is the SECOND label, because that is what separates a cluster from an instance. */
+    private static readonly Regex s_endpoint = new(
+        @"^(?<name>[a-z0-9][a-z0-9-]*)\.(?<second>cluster-ro-[a-z0-9]+|cluster-custom-[a-z0-9]+|cluster-[a-z0-9]+|[a-z0-9]+)\.(?<region>[a-z]{2}(?:-[a-z]+)+-\d)\.rds\.",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    /// <summary>
+    /// Null when the host is not an RDS endpoint at all — a self-hosted server, a proxy, or an IP. That is
+    /// an ordinary answer rather than an error: the caller falls back to the <c>pg_read_file</c> route.
+    /// </summary>
+    public static Parsed? TryParse(string? host)
+    {
+        if (string.IsNullOrWhiteSpace(host))
+        {
+            return null;
+        }
+
+        var match = s_endpoint.Match(host.Trim());
+
+        if (!match.Success)
+        {
+            return null;
+        }
+
+        var second = match.Groups["second"].Value;
+
+        var kind = second.StartsWith("cluster-ro-", StringComparison.OrdinalIgnoreCase)
+            ? RdsEndpointKind.ClusterReader
+            : second.StartsWith("cluster-custom-", StringComparison.OrdinalIgnoreCase)
+                ? RdsEndpointKind.ClusterCustom
+                : second.StartsWith("cluster-", StringComparison.OrdinalIgnoreCase)
+                    ? RdsEndpointKind.ClusterWriter
+                    : RdsEndpointKind.Instance;
+
+        return new Parsed(
+            Identifier: match.Groups["name"].Value,
+            Region: match.Groups["region"].Value.ToLowerInvariant(),
+            Kind: kind);
+    }
+}
+
+/// <summary>
+/// Which shape of endpoint was found. The distinction decides whether the identifier can be used with
+/// <c>DownloadDBLogFilePortion</c> directly or has to be resolved to a writer instance first.
+/// </summary>
+public enum RdsEndpointKind
+{
+    /// <summary>A DB instance. Its identifier IS the log-download identifier.</summary>
+    Instance,
+
+    /// <summary>An Aurora cluster writer endpoint. Names a cluster; the writer must be resolved.</summary>
+    ClusterWriter,
+
+    /// <summary>An Aurora reader endpoint. Round-robins across replicas, so no stable instance behind it.</summary>
+    ClusterReader,
+
+    /// <summary>A custom endpoint over a chosen subset of instances. Same resolution problem as a reader.</summary>
+    ClusterCustom,
+}

--- a/Darling/PerformanceMonitor.Darling.Service/Targets/RdsLogSource.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Targets/RdsLogSource.cs
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon;
+using Amazon.RDS;
+using Amazon.RDS.Model;
+
+namespace PerformanceMonitor.Darling.Service.Targets;
+
+/// <summary>
+/// Fetches PostgreSQL server-log text from the RDS API, for targets with no filesystem to read (#2538).
+///
+/// <para><b>Why this exists at all.</b> <c>auto_explain</c> writes plans to the server log and nowhere else.
+/// On a self-hosted server the collector reads that log with <c>pg_read_file</c>; on Aurora and RDS there is
+/// no filesystem, <c>pg_read_server_files</c> is not grantable, and the log is only reachable through
+/// <c>DownloadDBLogFilePortion</c>. Same text, different transport — which is exactly why the parsing and
+/// redaction were moved into <c>PgPlanLogParser</c> first.</para>
+///
+/// <para><b>This is the only code in the product that reaches a monitored target other than through a
+/// database connection.</b> It holds no credentials of its own: the SDK's default chain finds the EC2
+/// instance profile the service already runs under, which is how the monitoring hosts reach every other AWS
+/// API today. Nothing is stored, so nothing can leak from config — and a host with no role simply fails the
+/// call and the collector degrades, rather than the product asking anyone to paste keys into a file.</para>
+///
+/// <para><b>The marker is deliberately in memory rather than in the store.</b> RDS returns a position to
+/// resume from, and keeping it per-process means a restart re-reads a bounded tail instead of nothing.
+/// Re-reading is HARMLESS here and that is not luck: plan rows dedup on (queryid, plan_hash), so an
+/// overlapping window produces the same shapes rather than duplicates — the same property the
+/// <c>pg_read_file</c> route already relies on. Persisting the marker would buy nothing and add a schema
+/// rung that could disagree with reality after a log rotation.</para>
+/// </summary>
+public sealed class RdsLogSource
+{
+    /// <summary>
+    /// How much of a log file to take on the FIRST read of a target, before any marker exists. Bounded for
+    /// the same reason the file route reads a tail: #2565 measured 772 MB of log in twenty seconds at
+    /// capture-everything, and an unbounded first read would pull all of it across the network.
+    /// </summary>
+    private const int FirstReadLines = 10_000;
+
+    private readonly Dictionary<string, string> _markers = new(StringComparer.Ordinal);
+
+    private readonly Func<string, IAmazonRDS> _clientFactory;
+
+    public RdsLogSource(Func<string, IAmazonRDS>? clientFactory = null)
+        => _clientFactory = clientFactory
+            ?? (region => new AmazonRDSClient(RegionEndpoint.GetBySystemName(region)));
+
+    /// <param name="Text">Raw log text, to be handed to <c>PgPlanLogParser.Extract</c> unchanged.</param>
+    /// <param name="MoreAvailable">RDS had more than one call's worth. The caller decides whether to keep
+    /// pulling; this type does not loop, so one cycle cannot spend unbounded time on one target.</param>
+    public readonly record struct LogChunk(string Text, bool MoreAvailable);
+
+    /// <summary>
+    /// The newest PostgreSQL log file's unread portion, or null when this target is not RDS at all.
+    ///
+    /// <para>A cluster endpoint is resolved to its WRITER, because <c>DownloadDBLogFilePortion</c> takes an
+    /// instance identifier and because the writer is where the workload worth capturing runs. A READER
+    /// endpoint is refused rather than guessed at: it round-robins across replicas, so the instance behind
+    /// it is not stable between calls and plans captured through one would be attributed to whichever
+    /// replica answered.</para>
+    /// </summary>
+    public async Task<LogChunk?> ReadNewestAsync(string host, CancellationToken cancellationToken = default)
+    {
+        var endpoint = RdsEndpoint.TryParse(host);
+
+        if (endpoint is null)
+        {
+            return null;
+        }
+
+        var parsed = endpoint.Value;
+
+        if (parsed.Kind is RdsEndpointKind.ClusterReader or RdsEndpointKind.ClusterCustom)
+        {
+            throw new InvalidOperationException(
+                $"'{host}' is an Aurora {(parsed.Kind == RdsEndpointKind.ClusterReader ? "reader" : "custom")} "
+                + "endpoint, which does not resolve to a stable instance — it moves between replicas "
+                + "call to call. Point the target at the cluster writer endpoint or at a specific instance "
+                + "so captured plans belong to a server that can be named.");
+        }
+
+        using var client = _clientFactory(parsed.Region);
+
+        var instanceId = parsed.Kind == RdsEndpointKind.ClusterWriter
+            ? await ResolveWriterAsync(client, parsed.Identifier, cancellationToken)
+            : parsed.Identifier;
+
+        var newest = await NewestLogFileAsync(client, instanceId, cancellationToken);
+
+        if (newest is null)
+        {
+            return new LogChunk(string.Empty, false);
+        }
+
+        var key = instanceId + "|" + newest;
+        _markers.TryGetValue(key, out var marker);
+
+        var response = await client.DownloadDBLogFilePortionAsync(
+            new DownloadDBLogFilePortionRequest
+            {
+                DBInstanceIdentifier = instanceId,
+                LogFileName = newest,
+                /* "0" means from the start, which on a rotated multi-GB log is not what anyone wants on a
+                   first read. NumberOfLines with no marker asks RDS for the TAIL, matching the file
+                   route's bounded-tail behaviour. */
+                Marker = marker,
+                NumberOfLines = marker is null ? FirstReadLines : 0,
+            },
+            cancellationToken);
+
+        if (!string.IsNullOrEmpty(response.Marker))
+        {
+            /* Keyed by FILE as well as instance, so a log rotation starts a fresh marker instead of
+               resuming a new file at an old file's offset. */
+            _markers[key] = response.Marker;
+        }
+
+        /* AdditionalDataPending is bool? in the SDK. Treated as false when null: claiming more is
+               pending when the API did not say so would make a caller loop for data that is not there. */
+            return new LogChunk(response.LogFileData ?? string.Empty, response.AdditionalDataPending == true);
+    }
+
+    private static async Task<string> ResolveWriterAsync(
+        IAmazonRDS client, string clusterId, CancellationToken cancellationToken)
+    {
+        var clusters = await client.DescribeDBClustersAsync(
+            new DescribeDBClustersRequest { DBClusterIdentifier = clusterId }, cancellationToken);
+
+        var cluster = clusters.DBClusters.FirstOrDefault()
+            ?? throw new InvalidOperationException($"Aurora cluster '{clusterId}' was not found.");
+
+        var writer = cluster.DBClusterMembers.FirstOrDefault(m => m.IsClusterWriter == true)
+            ?? throw new InvalidOperationException(
+                $"Aurora cluster '{clusterId}' reports no writer. That is a real state during a failover, "
+                + "so this is worth retrying rather than treating as a configuration error.");
+
+        return writer.DBInstanceIdentifier;
+    }
+
+    /// <summary>
+    /// The newest PostgreSQL log file. Filtered by name because an instance's log list also carries
+    /// upgrade and other logs, and sorted by last-written rather than by name — the filename embeds a
+    /// timestamp, but sorting text would order 2026-08-9 after 2026-08-10.
+    /// </summary>
+    private static async Task<string?> NewestLogFileAsync(
+        IAmazonRDS client, string instanceId, CancellationToken cancellationToken)
+    {
+        var files = await client.DescribeDBLogFilesAsync(
+            new DescribeDBLogFilesRequest
+            {
+                DBInstanceIdentifier = instanceId,
+                FilenameContains = "postgresql",
+            },
+            cancellationToken);
+
+        return files.DescribeDBLogFiles
+            .OrderByDescending(f => f.LastWritten)
+            .Select(f => f.LogFileName)
+            .FirstOrDefault();
+    }
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="AWSSDK.RDS" Version="4.0.104.4" />
     <PackageVersion Include="CredentialManagement" Version="1.0.2" />
     <PackageVersion Include="DuckDB.NET.Bindings.Full" Version="1.5.5" />
     <PackageVersion Include="DuckDB.NET.Data" Version="1.5.5" />


### PR DESCRIPTION
The transport half of the route you chose on #2538. `auto_explain` writes plans to the server log and nowhere else; Aurora and RDS have no filesystem, `pg_read_server_files` is not grantable there, and `DownloadDBLogFilePortion` is the only way in.

Same text, different transport — which is why the parsing and redaction moved into `PgPlanLogParser` first (#2616). **Nothing in this PR re-derives redaction.**

## `RdsEndpoint` — a connection host is not an API identifier

Neither the instance id nor the region appears in a connection string, and asking an operator to configure them separately means two sources of truth for one server. Both are encoded in the endpoint AWS hands out.

**The cluster/instance distinction is load-bearing.** `DownloadDBLogFilePortion` takes an *instance* identifier, so passing a cluster endpoint through yields `DBInstanceNotFound` against a perfectly healthy cluster — which reads like a permissions problem and is not one.

The suffix is matched loosely so China and GovCloud parse. Refusing to parse a valid endpoint looks identical to "this is not RDS", so the failure would present as the wrong route being silently chosen.

## `RdsLogSource` — three decisions worth naming

**Cluster → writer.** Resolved through `DescribeDBClusters`, because that is where the workload worth capturing runs. A cluster reporting no writer is a real state during failover, so that says *retry* rather than *misconfigured*.

**Newest log by `LastWritten`, not by name.** The filename embeds a date, and sorting text puts `2026-08-09` after `2026-08-25` — that would pin the collector to a stale log **forever without ever erroring**, which is the failure mode I most wanted to avoid after today.

**Reader and custom endpoints are refused, with a reason.** They round-robin across replicas, so the instance behind one is not stable call to call — plans pulled through one would be attributed to whichever replica answered, which is worse than having none.

## Credentials: none held

The SDK's default chain finds the EC2 instance profile the service already runs under. Nothing is stored, so nothing can leak from config, and a host with no role simply fails the call and the collector degrades — rather than the product asking anyone to paste keys into a file.

## The marker is in memory on purpose

A restart re-reads a bounded tail. That is harmless, and **not by luck**: plan rows dedup on `(queryid, plan_hash)`, so an overlapping window yields the same shapes rather than duplicates — the property the `pg_read_file` route already depends on. Persisting it would add a schema rung that could disagree with reality after a log rotation.

First read asks for a bounded tail rather than `Marker = "0"`; #2565 measured **772 MB of log in twenty seconds** at capture-everything, and an unbounded first read would pull all of it across the network.

## Tested against a fake client

No AWS call is made and none is needed. What is worth pinning is ours, not the SDK's: which identifier gets used, which endpoints are refused, whether the newest log is chosen by time, and whether the marker advances between calls.

**Not yet wired to the collector** — this is the transport only. Next is deciding where it runs, since it is the one code path in the product that reaches a target other than through a database connection.