### PR TITLE
Pin the plan parser against a real auto_explain block

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,3 +16,7 @@
 *.parquet binary
 *.zip binary
 *.duckdb binary
+
+# A captured PostgreSQL log is a FIXTURE of real bytes: the parser keys on the exact line endings
+# and the tab-indented continuation, so line-ending normalisation would change what it is evidence of.
+Darling/Darling.Tests/Fixtures/auto_explain_real_block.txt -text

--- a/Darling/Darling.Tests/Darling.Tests.csproj
+++ b/Darling/Darling.Tests/Darling.Tests.csproj
@@ -33,6 +33,11 @@
     <None Include="Fixtures\SystemHealth\*.xml" CopyToOutputDirectory="PreserveNewest" />
     <!-- Deadlock graph parser/layout golden samples (real sql2025 captures + synthetic edge cases). -->
     <None Include="Fixtures\Deadlocks\*.xml" CopyToOutputDirectory="PreserveNewest" />
+    <!-- #2538: a REAL auto_explain block, captured from a PostgreSQL container with auto_explain
+         loaded. Real rather than hand-written because the parser's whole job is the log's exact
+         shape - the tab-indented continuation, the %Q query id in the prefix, the JSON body - and a
+         fixture I typed would agree with whatever I believed that shape was. -->
+    <None Include="Fixtures\auto_explain_real_block.log" CopyToOutputDirectory="PreserveNewest" />
     <!-- The SHIPPED bring-your-own-Postgres provisioning script, copied beside the test binary so
          ProvisionRolesAclDriftTests can parse the REAL file (never a stale second copy) from
          AppContext.BaseDirectory, with no repo-root path walking. Same Link+copy delivery the Service

--- a/Darling/Darling.Tests/Darling.Tests.csproj
+++ b/Darling/Darling.Tests/Darling.Tests.csproj
@@ -36,8 +36,9 @@
     <!-- #2538: a REAL auto_explain block, captured from a PostgreSQL container with auto_explain
          loaded. Real rather than hand-written because the parser's whole job is the log's exact
          shape - the tab-indented continuation, the %Q query id in the prefix, the JSON body - and a
-         fixture I typed would agree with whatever I believed that shape was. -->
-    <None Include="Fixtures\auto_explain_real_block.log" CopyToOutputDirectory="PreserveNewest" />
+         fixture I typed would agree with whatever I believed that shape was. 
+         Named .txt rather than .log because *.log is gitignored - correctly, and a fixture is not a log. -->
+    <None Include="Fixtures\auto_explain_real_block.txt" CopyToOutputDirectory="PreserveNewest" />
     <!-- The SHIPPED bring-your-own-Postgres provisioning script, copied beside the test binary so
          ProvisionRolesAclDriftTests can parse the REAL file (never a stale second copy) from
          AppContext.BaseDirectory, with no repo-root path walking. Same Link+copy delivery the Service

--- a/Darling/Darling.Tests/Fixtures/auto_explain_real_block.txt
+++ b/Darling/Darling.Tests/Fixtures/auto_explain_real_block.txt
@@ -1,0 +1,45 @@
+2026-08-26 15:35:52.410 UTC [3448] -2849973824032797391 LOG:  duration: 0.040 ms  plan:
+	{
+	  "Query Text": "\nSET auto_explain.log_min_duration = 0;\nSET auto_explain.log_format = json;\nSELECT count(*) FROM t13 WHERE status = 'ACME Holdings Ltd' AND amount > 4321.55;\n",
+	  "Plan": {
+	    "Node Type": "Aggregate",
+	    "Strategy": "Plain",
+	    "Partial Mode": "Simple",
+	    "Parallel Aware": false,
+	    "Async Capable": false,
+	    "Startup Cost": 7.58,
+	    "Total Cost": 7.59,
+	    "Plan Rows": 1,
+	    "Plan Width": 8,
+	    "Plans": [
+	      {
+	        "Node Type": "Index Scan",
+	        "Parent Relationship": "Outer",
+	        "Parallel Aware": false,
+	        "Async Capable": false,
+	        "Scan Direction": "Forward",
+	        "Index Name": "t13_status",
+	        "Relation Name": "t13",
+	        "Alias": "t13",
+	        "Startup Cost": 0.29,
+	        "Total Cost": 7.57,
+	        "Plan Rows": 1,
+	        "Plan Width": 0,
+	        "Index Cond": "(status = 'ACME Holdings Ltd'::text)",
+	        "Filter": "(amount > 4321.55)"
+	      }
+	    ]
+	  }
+	}
+2026-08-26 15:35:55.576 UTC [3408] 0 ERROR:  function aurora_stat_statements(boolean) does not exist at character 70
+2026-08-26 15:35:55.576 UTC [3408] 0 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+2026-08-26 15:35:55.576 UTC [3408] 0 STATEMENT:  
+	SELECT
+	    s.queryid AS queryid,
+	    s.query AS query_text
+	FROM aurora_stat_statements(true) AS s
+	WHERE s.queryid IS NOT NULL
+	AND   s.query IS NOT NULL
+	AND   s.toplevel
+	ORDER BY s.total_exec_time DESC
+	LIMIT $1

--- a/Darling/Darling.Tests/RdsPlanIngestionFromRealLogTests.cs
+++ b/Darling/Darling.Tests/RdsPlanIngestionFromRealLogTests.cs
@@ -42,7 +42,7 @@ namespace Darling.Tests;
 public sealed class RdsPlanIngestionFromRealLogTests
 {
     private static string RealLog =>
-        File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures", "auto_explain_real_block.log"));
+        File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures", "auto_explain_real_block.txt"));
 
     [Fact]
     public void TheRealBlockParses_WithItsQueryIdAndDuration()

--- a/Darling/Darling.Tests/RdsPlanIngestionFromRealLogTests.cs
+++ b/Darling/Darling.Tests/RdsPlanIngestionFromRealLogTests.cs
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.IO;
+using System.Linq;
+using PerformanceMonitor.Collectors;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #2538: the RDS plan-capture path, exercised against a REAL <c>auto_explain</c> block.
+///
+/// <para>
+/// The Aurora half of that issue cannot be proven end to end by anyone here — it needs
+/// <c>auto_explain</c> in the cluster's <c>shared_preload_libraries</c>, which is a static parameter and a
+/// reboot on a cluster nobody on this side controls. What CAN be proven, and is what actually breaks, is
+/// the parse: the log's exact shape.
+/// </para>
+///
+/// <para>
+/// So the fixture is a real block captured from a PostgreSQL container with <c>auto_explain</c> loaded,
+/// <c>log_format=json</c> and <c>%Q</c> in <c>log_line_prefix</c> — the same configuration the collector
+/// requires of a managed target. Real rather than hand-written, because a fixture I typed would agree with
+/// whatever I believed the shape to be, and the two earlier defects on this path were both about the shape
+/// being different from the belief.
+/// </para>
+///
+/// <para>
+/// The block was produced by a query carrying deliberately customer-shaped values —
+/// <c>status = 'ACME Holdings Ltd'</c> and <c>amount &gt; 4321.55</c> — because the redaction is the part
+/// with real consequences. A plan capture that ships a customer's literals into the monitoring store is a
+/// data-handling incident, not a bug.
+/// </para>
+/// </summary>
+public sealed class RdsPlanIngestionFromRealLogTests
+{
+    private static string RealLog =>
+        File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures", "auto_explain_real_block.log"));
+
+    [Fact]
+    public void TheRealBlockParses_WithItsQueryIdAndDuration()
+    {
+        var plans = PgPlanLogParser.Extract(RealLog);
+
+        var plan = Assert.Single(plans);
+        Assert.Equal(-2849973824032797391L, plan.QueryId);
+        Assert.Equal(0.040, plan.DurationMs, 3);
+        Assert.False(string.IsNullOrWhiteSpace(plan.PlanJson));
+    }
+
+    /// <summary>
+    /// The queryid is what makes a captured plan joinable to anything. It arrives from <c>%Q</c> in
+    /// <c>log_line_prefix</c>, which is the one prerequisite an operator is most likely to miss — and
+    /// without it the plan is an orphan. It is also a signed 64-bit value, so this asserts the exact one
+    /// rather than that a number was found.
+    /// </summary>
+    [Fact]
+    public void TheQueryIdSurvivesAsASigned64BitValue()
+    {
+        var plan = Assert.Single(PgPlanLogParser.Extract(RealLog));
+
+        Assert.True(plan.QueryId < 0, "The captured id is negative; a parser that lost the sign would still 'work' and join to nothing.");
+        Assert.NotEqual((long)(double)plan.QueryId, plan.QueryId);
+    }
+
+    /// <summary>
+    /// The part with consequences: the customer's values must not reach the store.
+    ///
+    /// <para>The block's plan carries <c>"Index Cond": "(status = 'ACME Holdings Ltd'::text)"</c> and
+    /// <c>"Filter": "(amount &gt; 4321.55)"</c> — a quoted literal and a bare number in a condition, which
+    /// are the two shapes the redaction handles differently. Both must be gone from what is stored.</para>
+    /// </summary>
+    [Fact]
+    public void CustomerLiteralsAreRedactedOutOfTheStoredPlan()
+    {
+        var plan = Assert.Single(PgPlanLogParser.Extract(RealLog));
+
+        Assert.Contains("ACME Holdings Ltd", RealLog, StringComparison.Ordinal);
+        Assert.Contains("4321.55", RealLog, StringComparison.Ordinal);
+
+        Assert.DoesNotContain("ACME Holdings Ltd", plan.PlanJson, StringComparison.Ordinal);
+        Assert.DoesNotContain("4321.55", plan.PlanJson, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Redaction removes the VALUES, not the shape. A plan stripped of its node types and relation names
+    /// would be safe and useless, and the whole point of capturing plans is reading them.
+    /// </summary>
+    [Fact]
+    public void TheShapeOfThePlanSurvivesRedaction()
+    {
+        var plan = Assert.Single(PgPlanLogParser.Extract(RealLog));
+
+        Assert.Contains("Node Type", plan.PlanJson, StringComparison.Ordinal);
+        Assert.Contains("Total Cost", plan.PlanJson, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The same parser serves both transports — <c>pg_read_file</c> on a self-hosted target and the RDS
+    /// log API on a managed one (#2616 gave it one home before it got a second caller). This asserts the
+    /// managed path's own entry point produces the identical result from the identical bytes, because a
+    /// second parser is exactly how the two routes would drift into disagreeing about a customer literal.
+    /// </summary>
+    [Fact]
+    public void BothTransportsParseTheSameBytesTheSameWay()
+    {
+        var viaExtract = Assert.Single(PgPlanLogParser.Extract(RealLog));
+
+        var viaBlock = PgPlanLogParser.FromBlock(
+            viaExtract.QueryId,
+            viaExtract.DurationMs,
+            RawPlanJsonOf(RealLog));
+
+        Assert.NotNull(viaBlock);
+        Assert.Equal(viaExtract.QueryId, viaBlock!.Value.QueryId);
+        Assert.Equal(viaExtract.PlanJson, viaBlock.Value.PlanJson);
+    }
+
+    /// <summary>The plan body as the file route hands it over: the tab-indented lines, de-indented.</summary>
+    private static string RawPlanJsonOf(string log)
+    {
+        var lines = log.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+        var body = lines.SkipWhile(l => !l.StartsWith("\t", StringComparison.Ordinal))
+                        .TakeWhile(l => l.StartsWith("\t", StringComparison.Ordinal))
+                        .Select(l => l[1..]);
+
+        return string.Join("\n", body);
+    }
+}


### PR DESCRIPTION
Refs #2538.

The Aurora half of plan capture **cannot be proven end to end by anyone here** — it needs `auto_explain` in the cluster's `shared_preload_libraries`, a static parameter requiring a reboot on a cluster nobody on this side controls. That is settled, so the coverage has to come from somewhere else.

What actually breaks on this path is the **parse** — the log's exact shape — and that can be captured.

## A real block, not a written one

The fixture is a real `auto_explain` block from a PostgreSQL container running the configuration a managed target needs: `auto_explain` loaded, `log_format=json`, `%Q` in `log_line_prefix`.

Real rather than hand-written, because a fixture I typed would agree with whatever I believed the shape to be — and both earlier defects on this path were exactly that, the shape differing from the belief.

## The assertion with consequences

The query behind it carries deliberately customer-shaped values:

```
status = 'ACME Holdings Ltd'   ->  "Index Cond": "(status = 'ACME Holdings Ltd'::text)"
amount  > 4321.55              ->  "Filter": "(amount > 4321.55)"
```

A quoted literal and a bare number in a condition field — the two shapes redaction treats differently. The test asserts both are **present in the log and absent from the stored plan**.

Until now nothing proved the redaction against output PostgreSQL actually produced. A plan capture that ships a customer's literals into the monitoring store is a data-handling incident rather than a bug.

## Also pinned

- The **queryid survives as a signed 64-bit value**. The captured one is negative and would not survive a double round-trip, so a parser losing either the sign or the precision would still "work" and join to nothing.
- The plan's **shape survives** redaction — a plan stripped of node types would be safe and useless.
- **Both transports produce identical output from identical bytes.** #2616 gave the parser one home before it got a second caller; this is what stops `pg_read_file` and the RDS log API drifting into disagreeing about a customer literal.

## Two packaging traps, both caught before merge

`*.log` is gitignored — correctly — so the first push landed the test without the file it reads. And `.gitattributes` normalises text to CRLF, which for a fixture of real bytes changes what it is evidence of. It is `.txt` and marked `-text`; the staged blob is 1,597 bytes with no CRLF.