### PR TITLE
Make the PostgreSQL verification rig reproducible

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,3 +20,10 @@
 # A captured PostgreSQL log is a FIXTURE of real bytes: the parser keys on the exact line endings
 # and the tab-indented continuation, so line-ending normalisation would change what it is evidence of.
 Darling/Darling.Tests/Fixtures/auto_explain_real_block.txt -text
+
+# The PostgreSQL verification rig runs INSIDE Linux containers. A Dockerfile whose RUN lines carry a
+# trailing CR breaks the shell that executes them, and the seed is fed to psql in the container the same
+# way - so these keep LF regardless of the repo-wide eol=crlf default.
+tools/pg-verification-rig/Dockerfile text eol=lf
+tools/pg-verification-rig/*.yml text eol=lf
+tools/pg-verification-rig/*.sql text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -16,3 +16,7 @@
 *.parquet binary
 *.zip binary
 *.duckdb binary
+
+# A captured PostgreSQL log is a FIXTURE of real bytes: the parser keys on the exact line endings
+# and the tab-indented continuation, so line-ending normalisation would change what it is evidence of.
+Darling/Darling.Tests/Fixtures/auto_explain_real_block.txt -text

--- a/Darling/Darling.Tests/Darling.Tests.csproj
+++ b/Darling/Darling.Tests/Darling.Tests.csproj
@@ -33,6 +33,11 @@
     <None Include="Fixtures\SystemHealth\*.xml" CopyToOutputDirectory="PreserveNewest" />
     <!-- Deadlock graph parser/layout golden samples (real sql2025 captures + synthetic edge cases). -->
     <None Include="Fixtures\Deadlocks\*.xml" CopyToOutputDirectory="PreserveNewest" />
+    <!-- #2538: a REAL auto_explain block, captured from a PostgreSQL container with auto_explain
+         loaded. Real rather than hand-written because the parser's whole job is the log's exact
+         shape - the tab-indented continuation, the %Q query id in the prefix, the JSON body - and a
+         fixture I typed would agree with whatever I believed that shape was. -->
+    <None Include="Fixtures\auto_explain_real_block.log" CopyToOutputDirectory="PreserveNewest" />
     <!-- The SHIPPED bring-your-own-Postgres provisioning script, copied beside the test binary so
          ProvisionRolesAclDriftTests can parse the REAL file (never a stale second copy) from
          AppContext.BaseDirectory, with no repo-root path walking. Same Link+copy delivery the Service

--- a/Darling/Darling.Tests/Darling.Tests.csproj
+++ b/Darling/Darling.Tests/Darling.Tests.csproj
@@ -36,8 +36,9 @@
     <!-- #2538: a REAL auto_explain block, captured from a PostgreSQL container with auto_explain
          loaded. Real rather than hand-written because the parser's whole job is the log's exact
          shape - the tab-indented continuation, the %Q query id in the prefix, the JSON body - and a
-         fixture I typed would agree with whatever I believed that shape was. -->
-    <None Include="Fixtures\auto_explain_real_block.log" CopyToOutputDirectory="PreserveNewest" />
+         fixture I typed would agree with whatever I believed that shape was. 
+         Named .txt rather than .log because *.log is gitignored - correctly, and a fixture is not a log. -->
+    <None Include="Fixtures\auto_explain_real_block.txt" CopyToOutputDirectory="PreserveNewest" />
     <!-- The SHIPPED bring-your-own-Postgres provisioning script, copied beside the test binary so
          ProvisionRolesAclDriftTests can parse the REAL file (never a stale second copy) from
          AppContext.BaseDirectory, with no repo-root path walking. Same Link+copy delivery the Service

--- a/Darling/Darling.Tests/Fixtures/auto_explain_real_block.txt
+++ b/Darling/Darling.Tests/Fixtures/auto_explain_real_block.txt
@@ -1,0 +1,45 @@
+2026-08-26 15:35:52.410 UTC [3448] -2849973824032797391 LOG:  duration: 0.040 ms  plan:
+	{
+	  "Query Text": "\nSET auto_explain.log_min_duration = 0;\nSET auto_explain.log_format = json;\nSELECT count(*) FROM t13 WHERE status = 'ACME Holdings Ltd' AND amount > 4321.55;\n",
+	  "Plan": {
+	    "Node Type": "Aggregate",
+	    "Strategy": "Plain",
+	    "Partial Mode": "Simple",
+	    "Parallel Aware": false,
+	    "Async Capable": false,
+	    "Startup Cost": 7.58,
+	    "Total Cost": 7.59,
+	    "Plan Rows": 1,
+	    "Plan Width": 8,
+	    "Plans": [
+	      {
+	        "Node Type": "Index Scan",
+	        "Parent Relationship": "Outer",
+	        "Parallel Aware": false,
+	        "Async Capable": false,
+	        "Scan Direction": "Forward",
+	        "Index Name": "t13_status",
+	        "Relation Name": "t13",
+	        "Alias": "t13",
+	        "Startup Cost": 0.29,
+	        "Total Cost": 7.57,
+	        "Plan Rows": 1,
+	        "Plan Width": 0,
+	        "Index Cond": "(status = 'ACME Holdings Ltd'::text)",
+	        "Filter": "(amount > 4321.55)"
+	      }
+	    ]
+	  }
+	}
+2026-08-26 15:35:55.576 UTC [3408] 0 ERROR:  function aurora_stat_statements(boolean) does not exist at character 70
+2026-08-26 15:35:55.576 UTC [3408] 0 HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+2026-08-26 15:35:55.576 UTC [3408] 0 STATEMENT:  
+	SELECT
+	    s.queryid AS queryid,
+	    s.query AS query_text
+	FROM aurora_stat_statements(true) AS s
+	WHERE s.queryid IS NOT NULL
+	AND   s.query IS NOT NULL
+	AND   s.toplevel
+	ORDER BY s.total_exec_time DESC
+	LIMIT $1

--- a/Darling/Darling.Tests/RdsPlanIngestionFromRealLogTests.cs
+++ b/Darling/Darling.Tests/RdsPlanIngestionFromRealLogTests.cs
@@ -42,7 +42,7 @@ namespace Darling.Tests;
 public sealed class RdsPlanIngestionFromRealLogTests
 {
     private static string RealLog =>
-        File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures", "auto_explain_real_block.log"));
+        File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures", "auto_explain_real_block.txt"));
 
     [Fact]
     public void TheRealBlockParses_WithItsQueryIdAndDuration()

--- a/Darling/Darling.Tests/RdsPlanIngestionFromRealLogTests.cs
+++ b/Darling/Darling.Tests/RdsPlanIngestionFromRealLogTests.cs
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.IO;
+using System.Linq;
+using PerformanceMonitor.Collectors;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #2538: the RDS plan-capture path, exercised against a REAL <c>auto_explain</c> block.
+///
+/// <para>
+/// The Aurora half of that issue cannot be proven end to end by anyone here — it needs
+/// <c>auto_explain</c> in the cluster's <c>shared_preload_libraries</c>, which is a static parameter and a
+/// reboot on a cluster nobody on this side controls. What CAN be proven, and is what actually breaks, is
+/// the parse: the log's exact shape.
+/// </para>
+///
+/// <para>
+/// So the fixture is a real block captured from a PostgreSQL container with <c>auto_explain</c> loaded,
+/// <c>log_format=json</c> and <c>%Q</c> in <c>log_line_prefix</c> — the same configuration the collector
+/// requires of a managed target. Real rather than hand-written, because a fixture I typed would agree with
+/// whatever I believed the shape to be, and the two earlier defects on this path were both about the shape
+/// being different from the belief.
+/// </para>
+///
+/// <para>
+/// The block was produced by a query carrying deliberately customer-shaped values —
+/// <c>status = 'ACME Holdings Ltd'</c> and <c>amount &gt; 4321.55</c> — because the redaction is the part
+/// with real consequences. A plan capture that ships a customer's literals into the monitoring store is a
+/// data-handling incident, not a bug.
+/// </para>
+/// </summary>
+public sealed class RdsPlanIngestionFromRealLogTests
+{
+    private static string RealLog =>
+        File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures", "auto_explain_real_block.log"));
+
+    [Fact]
+    public void TheRealBlockParses_WithItsQueryIdAndDuration()
+    {
+        var plans = PgPlanLogParser.Extract(RealLog);
+
+        var plan = Assert.Single(plans);
+        Assert.Equal(-2849973824032797391L, plan.QueryId);
+        Assert.Equal(0.040, plan.DurationMs, 3);
+        Assert.False(string.IsNullOrWhiteSpace(plan.PlanJson));
+    }
+
+    /// <summary>
+    /// The queryid is what makes a captured plan joinable to anything. It arrives from <c>%Q</c> in
+    /// <c>log_line_prefix</c>, which is the one prerequisite an operator is most likely to miss — and
+    /// without it the plan is an orphan. It is also a signed 64-bit value, so this asserts the exact one
+    /// rather than that a number was found.
+    /// </summary>
+    [Fact]
+    public void TheQueryIdSurvivesAsASigned64BitValue()
+    {
+        var plan = Assert.Single(PgPlanLogParser.Extract(RealLog));
+
+        Assert.True(plan.QueryId < 0, "The captured id is negative; a parser that lost the sign would still 'work' and join to nothing.");
+        Assert.NotEqual((long)(double)plan.QueryId, plan.QueryId);
+    }
+
+    /// <summary>
+    /// The part with consequences: the customer's values must not reach the store.
+    ///
+    /// <para>The block's plan carries <c>"Index Cond": "(status = 'ACME Holdings Ltd'::text)"</c> and
+    /// <c>"Filter": "(amount &gt; 4321.55)"</c> — a quoted literal and a bare number in a condition, which
+    /// are the two shapes the redaction handles differently. Both must be gone from what is stored.</para>
+    /// </summary>
+    [Fact]
+    public void CustomerLiteralsAreRedactedOutOfTheStoredPlan()
+    {
+        var plan = Assert.Single(PgPlanLogParser.Extract(RealLog));
+
+        Assert.Contains("ACME Holdings Ltd", RealLog, StringComparison.Ordinal);
+        Assert.Contains("4321.55", RealLog, StringComparison.Ordinal);
+
+        Assert.DoesNotContain("ACME Holdings Ltd", plan.PlanJson, StringComparison.Ordinal);
+        Assert.DoesNotContain("4321.55", plan.PlanJson, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Redaction removes the VALUES, not the shape. A plan stripped of its node types and relation names
+    /// would be safe and useless, and the whole point of capturing plans is reading them.
+    /// </summary>
+    [Fact]
+    public void TheShapeOfThePlanSurvivesRedaction()
+    {
+        var plan = Assert.Single(PgPlanLogParser.Extract(RealLog));
+
+        Assert.Contains("Node Type", plan.PlanJson, StringComparison.Ordinal);
+        Assert.Contains("Total Cost", plan.PlanJson, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The same parser serves both transports — <c>pg_read_file</c> on a self-hosted target and the RDS
+    /// log API on a managed one (#2616 gave it one home before it got a second caller). This asserts the
+    /// managed path's own entry point produces the identical result from the identical bytes, because a
+    /// second parser is exactly how the two routes would drift into disagreeing about a customer literal.
+    /// </summary>
+    [Fact]
+    public void BothTransportsParseTheSameBytesTheSameWay()
+    {
+        var viaExtract = Assert.Single(PgPlanLogParser.Extract(RealLog));
+
+        var viaBlock = PgPlanLogParser.FromBlock(
+            viaExtract.QueryId,
+            viaExtract.DurationMs,
+            RawPlanJsonOf(RealLog));
+
+        Assert.NotNull(viaBlock);
+        Assert.Equal(viaExtract.QueryId, viaBlock!.Value.QueryId);
+        Assert.Equal(viaExtract.PlanJson, viaBlock.Value.PlanJson);
+    }
+
+    /// <summary>The plan body as the file route hands it over: the tab-indented lines, de-indented.</summary>
+    private static string RawPlanJsonOf(string log)
+    {
+        var lines = log.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+        var body = lines.SkipWhile(l => !l.StartsWith("\t", StringComparison.Ordinal))
+                        .TakeWhile(l => l.StartsWith("\t", StringComparison.Ordinal))
+                        .Select(l => l[1..]);
+
+        return string.Join("\n", body);
+    }
+}

--- a/tools/pg-verification-rig/Dockerfile
+++ b/tools/pg-verification-rig/Dockerfile
@@ -1,0 +1,17 @@
+# A PostgreSQL TARGET with every instrument this product reads, for verifying collectors against a real
+# self-hosted server (#2622, #2623, #2625, #2629, #2630 were all found this way).
+#
+# The extensions come from the PGDG apt repository as PACKAGES. Building them from source is the obvious
+# approach and the wrong one: it turns a two-minute image into a twenty-minute one and pins you to whatever
+# compiler flags you guessed, when Debian already ships them built against this exact server.
+ARG PG_MAJOR=17
+FROM postgres:${PG_MAJOR}
+ARG PG_MAJOR
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      postgresql-${PG_MAJOR}-pg-wait-sampling \
+      postgresql-${PG_MAJOR}-pg-stat-kcache \
+      postgresql-${PG_MAJOR}-pg-qualstats \
+      postgresql-${PG_MAJOR}-hypopg \
+ && rm -rf /var/lib/apt/lists/*

--- a/tools/pg-verification-rig/README.md
+++ b/tools/pg-verification-rig/README.md
@@ -1,0 +1,60 @@
+# PostgreSQL verification rig
+
+A realistic self-hosted PostgreSQL **target**, plus a store, so the Darling service can be pointed at
+something that behaves like a customer's server.
+
+```bash
+docker compose up -d --build
+docker compose exec -T target psql -U postgres -d appdb -v ON_ERROR_STOP=1 < seed.sql
+# -> tables 40 | indexes 160 | tables_over_the_size_floor 40
+```
+
+Target on **55432** (`postgres` / `targetpw`, database `appdb`), store on **55441**
+(`darling` / `storepw`). Point a `darling.json` at both and run `--validate-config`; it should report
+**23 of 24 PostgreSQL collectors apply**, skipping only `pg_wait_stats` — Aurora's own wait
+instrumentation, which has no vanilla equivalent.
+
+## Why this exists
+
+Eight defects were found in a single day by running the **real service** against this and reading what it
+stored. Not one was reachable from CI, from a small container, or from the Aurora fleet:
+
+| | |
+|---|---|
+| #2622 | three collectors wrote fewer payload values than they declared — every row rejected, for three schema versions |
+| #2623 | a per-database collector failing in *some* databases reported SUCCESS with no note, which is what hid #2622 |
+| #2617 | `pg_index_bloat` had never returned a row |
+| #2625 | self-hosted PostgreSQL had no top-queries answer at all |
+| #2629 | nine collectors were readable only from the Windows Viewer |
+| #2630 | `pg_wait_sampling` was 100% `ClientRead` — idle clients drowning every real event |
+
+## The two things that make it work
+
+**Scale.** Several collectors have size floors — `pg_column_stats` needs `relpages >= 128`, `pg_index_bloat`
+measures only indexes worth measuring — so below them a healthy collector and a broken one both return
+nothing. `seed.sql` exists to clear them. A two-table container finds nothing, which is exactly why those
+defects survived long enough to be found here.
+
+**Every instrument loaded.** `pg_stat_statements`, `pg_wait_sampling`, `pg_stat_kcache`, `pg_qualstats`,
+`pgstattuple`, `pg_buffercache`, `hypopg`, and `auto_explain` configured the way plan capture requires.
+
+## Things that cost real time to learn
+
+- **`shared_preload_libraries` must be set on the command line**, not with `ALTER SYSTEM`. It is a
+  list-valued GUC and `ALTER SYSTEM` quotes the whole list as a single name, after which the server will
+  not start.
+- **`%Q` in `log_line_prefix` is the one people miss.** Without the query id in the prefix, captured plans
+  are orphans that join to nothing — `pg_plan_capture_readiness` checks for exactly this.
+- **`pg_qualstats.sample_rate` defaults to 1%**, so a short verification run records almost nothing. Set
+  to 1 here.
+- **Extensions come from PGDG packages, not from source.** Building them turns a two-minute image into a
+  twenty-minute one, against a compiler configuration you guessed.
+- **`pg_read_file`'s ACL is `postgres=X/postgres`.** The `pg_read_server_files` role does *not* carry
+  EXECUTE; a superuser must grant it explicitly. That grant also exposes `pg_hba.conf`, which is why the
+  plan-capture collector reports its absence as a grant the operator must choose to give.
+
+## Reproducing the Aurora-only paths
+
+You cannot, from here, and that is fine. `pg_wait_stats` and the RDS log API need a managed target. Their
+parsing is covered by tests against real captured output instead — see
+`Darling.Tests/Fixtures/auto_explain_real_block.txt`, which was captured from this rig.

--- a/tools/pg-verification-rig/docker-compose.yml
+++ b/tools/pg-verification-rig/docker-compose.yml
@@ -1,0 +1,59 @@
+# The PostgreSQL verification rig: a realistic self-hosted TARGET plus a store, so the Darling service can
+# be pointed at something that behaves like a customer's server rather than like a two-table container.
+#
+#   docker compose up -d --build
+#   psql -h localhost -p 55432 -U postgres -d appdb -f seed.sql     # 40 tables, 160 indexes
+#
+# Then point a darling.json at the target on 55432 and the store on 55441. --validate-config should report
+# 23 of 24 PostgreSQL collectors applying. The one skip is pg_wait_stats, which reads Aurora own wait
+# instrumentation and has no vanilla equivalent - pg_wait_sampling answers the same question here.
+#
+# WHY THE SCALE MATTERS. Several collectors have size floors - pg_column_stats needs relpages >= 128,
+# pg_index_bloat only measures indexes worth measuring - so below the floor a healthy collector and a
+# broken one both return nothing. seed.sql exists to clear them. A two-table container finds nothing, and
+# that is exactly why these defects survived to be found here.
+
+name: pm-pg-verification-rig
+
+services:
+  target:
+    build:
+      context: .
+      args:
+        PG_MAJOR: ${PG_MAJOR:-17}
+    restart: unless-stopped
+    environment:
+      POSTGRES_PASSWORD: targetpw
+      POSTGRES_DB: appdb
+    ports:
+      - "55432:5432"
+    command:
+      # shared_preload_libraries MUST be set on the command line, not with ALTER SYSTEM: it is a
+      # list-valued GUC, and ALTER SYSTEM quotes the whole list as one name, which stops the server
+      # from starting. Measured the hard way.
+      - postgres
+      - -c
+      - shared_preload_libraries=pg_stat_statements,pg_wait_sampling,pg_stat_kcache,pg_qualstats,auto_explain
+      # auto_explain, configured the way plan capture requires. %Q is the one people miss: without the
+      # query id in the prefix, captured plans join to nothing.
+      - -c
+      - auto_explain.log_min_duration=50
+      - -c
+      - auto_explain.log_format=json
+      - -c
+      - logging_collector=on
+      - -c
+      - log_line_prefix=%m [%p] %Q 
+      # Sample every predicate rather than the default 1%, so a short verification run records something.
+      - -c
+      - pg_qualstats.sample_rate=1
+
+  store:
+    image: postgres:17
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: darling
+      POSTGRES_DB: darling
+      POSTGRES_PASSWORD: storepw
+    ports:
+      - "55441:5432"

--- a/tools/pg-verification-rig/seed.sql
+++ b/tools/pg-verification-rig/seed.sql
@@ -1,0 +1,82 @@
+/*
+ * Enough schema and data to clear the collectors' size floors.
+ *
+ * This is not a benchmark and the shape of the data does not matter. What matters is the SCALE, because
+ * several collectors deliberately ignore small objects and below their floors a healthy collector and a
+ * broken one are indistinguishable:
+ *
+ *   pg_column_stats     relpages >= 128   (a ~1 MB floor; below it, no rows and no way to tell why)
+ *   pg_index_bloat      measures the largest indexes per cycle, budgeted
+ *   pg_buffer_usage     reports what is resident, which needs something to have been read
+ *   pg_predicate_stats  needs predicates actually executed
+ *
+ * Four defects were found by running the real service against this and reading what it stored.
+ */
+
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+CREATE EXTENSION IF NOT EXISTS pg_wait_sampling;
+CREATE EXTENSION IF NOT EXISTS pg_stat_kcache;
+CREATE EXTENSION IF NOT EXISTS pg_qualstats;
+CREATE EXTENSION IF NOT EXISTS pgstattuple;
+CREATE EXTENSION IF NOT EXISTS pg_buffercache;
+CREATE EXTENSION IF NOT EXISTS hypopg;
+
+DO $seed$
+DECLARE
+    i int;
+BEGIN
+    FOR i IN 1..40 LOOP
+        EXECUTE format($fmt$
+            CREATE TABLE IF NOT EXISTS t%1$s (
+                id      bigserial PRIMARY KEY,
+                ref     integer,
+                status  text,
+                amount  numeric(12,2),
+                note    text,
+                created timestamptz DEFAULT now()
+            )$fmt$, i);
+
+        /* ~20k rows puts every table comfortably past the 128-page floor. */
+        EXECUTE format($fmt$
+            INSERT INTO t%1$s (ref, status, amount, note)
+            SELECT
+                (random() * 1000)::int,
+                (ARRAY['new','open','closed','void'])[1 + (random() * 3)::int],
+                (random() * 10000)::numeric(12,2),
+                repeat('x', 40)
+            FROM generate_series(1, 20000)
+            ON CONFLICT DO NOTHING$fmt$, i);
+
+        /* Three secondary indexes each: 40 tables x (1 pk + 3) = 160 indexes. */
+        EXECUTE format('CREATE INDEX IF NOT EXISTS t%1$s_ref ON t%1$s (ref)', i);
+        EXECUTE format('CREATE INDEX IF NOT EXISTS t%1$s_status ON t%1$s (status)', i);
+        EXECUTE format('CREATE INDEX IF NOT EXISTS t%1$s_created ON t%1$s (created)', i);
+
+        /* ANALYZE, or pg_stats has nothing to report and pg_column_stats looks broken. */
+        EXECUTE format('ANALYZE t%1$s', i);
+    END LOOP;
+END
+$seed$;
+
+/* Some executed predicates, so pg_qualstats and pg_stat_statements have something to have seen.
+   Deliberately includes an UNINDEXED column (amount) so there is a real index candidate for
+   test_hypothetical_index to find. */
+DO $work$
+DECLARE
+    i int;
+    n bigint;
+BEGIN
+    FOR i IN 1..40 LOOP
+        EXECUTE format('SELECT count(*) FROM t%1$s WHERE status = ''open''', i) INTO n;
+        EXECUTE format('SELECT count(*) FROM t%1$s WHERE amount > 5000', i) INTO n;
+        EXECUTE format('SELECT count(*) FROM t%1$s WHERE ref BETWEEN 100 AND 200', i) INTO n;
+    END LOOP;
+END
+$work$;
+
+/* expr AS alias, not the T-SQL alias = expr this codebase uses everywhere else: PostgreSQL parses the
+   latter as a comparison and fails on the unknown column. */
+SELECT
+    (SELECT count(*) FROM pg_stat_user_tables)  AS tables,
+    (SELECT count(*) FROM pg_stat_user_indexes) AS indexes,
+    (SELECT count(*) FROM pg_class WHERE relkind = 'r' AND relpages >= 128) AS tables_over_the_size_floor;


### PR DESCRIPTION
Eight defects were found in one day by running the **real service** against a PostgreSQL target with every instrument loaded and enough data to clear the collectors' size floors. Not one was reachable from CI, from a small container, or from the Aurora fleet — and the rig that found them existed only as shell history.

```bash
docker compose up -d --build
docker compose exec -T target psql -U postgres -d appdb -v ON_ERROR_STOP=1 < seed.sql
# -> tables 40 | indexes 160 | tables_over_the_size_floor 40
```

## The two things that make it work

**Scale.** `pg_column_stats` ignores tables under 128 pages, `pg_index_bloat` measures only indexes worth measuring, `pg_buffer_usage` needs something to have been read. Below those floors a healthy collector and a broken one both return nothing — which is precisely how three collectors shipped rejecting every row they produced, for three schema versions. `seed.sql` clears the floors so that an empty result means something.

**Every instrument.** `pg_stat_statements`, `pg_wait_sampling`, `pg_stat_kcache`, `pg_qualstats`, `pgstattuple`, `pg_buffercache`, `hypopg`, and `auto_explain` configured the way plan capture actually requires — including `%Q` in `log_line_prefix`, the prerequisite people miss and the one that turns every captured plan into an orphan when absent.

## Things that cost real time, now written down

- **`shared_preload_libraries` on the command line, never `ALTER SYSTEM`** — it is a list-valued GUC and `ALTER SYSTEM` quotes the whole list as one name, after which the server will not start.
- **Extensions from PGDG packages, not source** — building them turns a two-minute image into a twenty-minute one, against compiler settings you guessed.
- **`pg_qualstats.sample_rate` defaults to 1%**, so a short run records almost nothing.
- **`pg_read_file`'s ACL is `postgres=X/postgres`** — `pg_read_server_files` does not carry EXECUTE.

## Stood up from nothing to verify it

Fresh build, fresh volumes. The seed reports 40 tables / 160 indexes / 40 over the floor, and `--validate-config` reports **23 of 24** PostgreSQL collectors applying — up from 22 before #2625, with the single skip being `pg_wait_stats`, correctly, since it reads Aurora's own instrumentation.

Running it also caught a bug in the file I had just written: the seed's summary line used this codebase's T-SQL `alias = expr` house style, which PostgreSQL parses as a comparison and rejects.

The rig files are pinned `eol=lf`: they run inside Linux containers, and a Dockerfile whose `RUN` lines carry a trailing CR breaks the shell executing them.