### PR TITLE
Release 3.6.0

### DIFF
--- a/Darling/PerformanceMonitor.Darling.Service/PerformanceMonitor.Darling.Service.csproj
+++ b/Darling/PerformanceMonitor.Darling.Service/PerformanceMonitor.Darling.Service.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <RootNamespace>PerformanceMonitor.Darling.Service</RootNamespace>
     <AssemblyName>PerformanceMonitor.Darling.Service</AssemblyName>
-    <Version>3.5.0</Version>
+    <Version>3.6.0</Version>
     <!-- #2113: <Version> is the ONE hand-set version. AssemblyVersion / FileVersion /
          InformationalVersion derive from it at build time - the 3.4.0 release bumped only
          <Version> and shipped binaries still STAMPED 3.3.0.0, because four hand-maintained

--- a/Darling/PerformanceMonitor.Darling.Viewer/PerformanceMonitor.Darling.Viewer.csproj
+++ b/Darling/PerformanceMonitor.Darling.Viewer/PerformanceMonitor.Darling.Viewer.csproj
@@ -15,7 +15,7 @@
          hooks go unhandled. It is a harmless no-op for the co-located (non-Velopack) viewer that
          ships inside the service zip. -->
     <StartupObject>PerformanceMonitor.Darling.Viewer.Program</StartupObject>
-    <Version>3.5.0</Version>
+    <Version>3.6.0</Version>
     <!-- #2113: <Version> is the ONE hand-set version. AssemblyVersion / FileVersion /
          InformationalVersion derive from it at build time - the 3.4.0 release bumped only
          <Version> and shipped binaries still STAMPED 3.3.0.0, because four hand-maintained

--- a/Lite/PerformanceMonitorLite.csproj
+++ b/Lite/PerformanceMonitorLite.csproj
@@ -18,7 +18,7 @@
     <AssemblyName>PerformanceMonitorLite</AssemblyName>
     <RootNamespace>PerformanceMonitorLite</RootNamespace>
     <Product>SQL Server Performance Monitor Lite</Product>
-    <Version>3.5.0</Version>
+    <Version>3.6.0</Version>
     <!-- #2113: <Version> is the ONE hand-set version. AssemblyVersion / FileVersion /
          InformationalVersion derive from it at build time - the 3.4.0 release bumped only
          <Version> and shipped binaries still STAMPED 3.3.0.0, because four hand-maintained

--- a/deprecated/Dashboard/Dashboard.csproj
+++ b/deprecated/Dashboard/Dashboard.csproj
@@ -7,7 +7,7 @@
     <StartupObject>PerformanceMonitorDashboard.Program</StartupObject>
     <AssemblyName>PerformanceMonitorDashboard</AssemblyName>
     <Product>SQL Server Performance Monitor Dashboard</Product>
-    <Version>3.5.0</Version>
+    <Version>3.6.0</Version>
     <AssemblyVersion>3.3.0.0</AssemblyVersion>
     <FileVersion>3.3.0.0</FileVersion>
     <InformationalVersion>3.3.0</InformationalVersion>


### PR DESCRIPTION
Version bump and CHANGELOG close-out for **3.6.0** (UAT release).

## What lands

- `<Version>` 3.5.0 → 3.6.0 in the three shipping products and the deprecated Dashboard the version-bump gate checks.
- CHANGELOG `[Unreleased]` → `[3.6.0] - 2026-08-27`, fresh empty Unreleased above.

## Scope since 3.5.0

194 merges. Store schema **v79 → v104** — 25 migration rungs, and the full upgrade path was verified end to end against a real v3.5.0 store (climbed to v104, matched the constant, re-ran clean/idempotent, every new table and column present).

Headlines:
- **PostgreSQL parity** — configuration collection and change history (#2658), deadlock capture from the server log (#2661), all four trend reads (#2663), PG18 support (#2655), the major-version persistence that lets a read explain a version-absent column (#2653), and multi-role store exposure (#2665).
- **Ten PostgreSQL MCP tools that shipped unreachable are now registered** (#2659), with a reflection pin so it cannot recur.
- **Opt-in GCF output format** for MCP results (#2286, external contribution) — 29.7% fewer tokens on real payloads.

## On plan capture (#2538)

Ships as built and tested to the limit the fleet allows: proven end to end on a self-hosted target (20 real plans captured, stored, read back), RDS transport parse pinned against real captured bytes, AWS calls covered by faked-client tests. The untested hop is a plan travelling out of a live Aurora log blob — loading `auto_explain` there needs a parameter-group change and reboot not available on this fleet. This is a fleet constraint, not a product limitation; `pg_plan_capture_readiness` reports the outstanding prerequisites on any managed target that does have them.

## Release mechanics

This PR to `dev` carries the bump. The `dev` → `main` PR after it is where `check-version-bump` verifies 3.6.0 > 3.5.0; merge that **not squashed**, then publish the release, which triggers the build and stops at the SignPath approval gate.