### PR TITLE
Fix Poison Wait alert re-firing on an unrefreshed wait_stats row

### DIFF
--- a/Darling/Darling.Tests/AlertEngineTests.cs
+++ b/Darling/Darling.Tests/AlertEngineTests.cs
@@ -1007,6 +1007,52 @@ public sealed class AlertEngineTests
         Assert.Equal("SRV-A: Poison wait avg below threshold", resolution.Message); /* :330 */
     }
 
+    [Fact]
+    public async Task PoisonWait_DoesNotRefire_OnTheSameCollectionTime_EvenAfterCooldownElapses()
+    {
+        /* The read adapter's own "newest row within 10 minutes" window can hand back the SAME
+           wait_stats row across multiple sweeps when the collector's delivered cadence lags the
+           alert cooldown — observed live as byte-identical "Poison Wait" alerts ~5-7 minutes
+           apart on the same server. Cooldown elapsing is not proof a fresh observation exists;
+           re-firing on an unrefreshed collection_time reports the same event twice. */
+        var h = new Harness();
+        h.Settings.PoisonWaitEnabled = true;
+        var engine = h.Build();
+
+        var firstCollection = new DateTime(2026, 8, 31, 6, 0, 0, DateTimeKind.Utc);
+        h.Adapter.PoisonWaits.Add(new PoisonWaitDelta
+        {
+            WaitType = "RESOURCE_SEMAPHORE_QUERY_COMPILE",
+            DeltaMs = 113997,
+            DeltaTasks = 134,
+            AvgMsPerWait = 850.7,
+            CollectionTime = firstCollection
+        });
+        await engine.EvaluateServerAsync(Harness.Snapshot());
+        Assert.Single(h.Deliverer.Outcomes);
+
+        /* Cooldown (5 min default) elapses, but the collector has not produced a new row yet —
+           the adapter still hands back the identical collection_time. Must NOT re-fire. */
+        h.Now = h.Now.AddMinutes(6);
+        await engine.EvaluateServerAsync(Harness.Snapshot());
+        Assert.Single(h.Deliverer.Outcomes);
+
+        /* A genuinely new collection — even with the identical wait-type/value shape — is a
+           fresh observation of the condition and must fire. */
+        h.Now = h.Now.AddMinutes(6);
+        h.Adapter.PoisonWaits.Clear();
+        h.Adapter.PoisonWaits.Add(new PoisonWaitDelta
+        {
+            WaitType = "RESOURCE_SEMAPHORE_QUERY_COMPILE",
+            DeltaMs = 113997,
+            DeltaTasks = 134,
+            AvgMsPerWait = 850.7,
+            CollectionTime = firstCollection.AddMinutes(7)
+        });
+        await engine.EvaluateServerAsync(Harness.Snapshot());
+        Assert.Equal(2, h.Deliverer.Outcomes.Count);
+    }
+
     /* ---------------- long-running queries ---------------- */
 
     [Fact]

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingAlertReadAdapter.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingAlertReadAdapter.cs
@@ -292,7 +292,8 @@ SELECT
     delta_waiting_tasks AS delta_tasks,
     CASE WHEN delta_waiting_tasks > 0
     THEN CAST(delta_wait_time_ms AS DOUBLE PRECISION) / delta_waiting_tasks
-    ELSE 0 END AS avg_ms_per_wait
+    ELSE 0 END AS avg_ms_per_wait,
+    collection_time
 FROM wait_stats
 WHERE server_id = $1
 AND wait_type IN ('THREADPOOL', 'RESOURCE_SEMAPHORE', 'RESOURCE_SEMAPHORE_QUERY_COMPILE')
@@ -321,7 +322,8 @@ LIMIT 3";
                     WaitType = reader.GetString(0),
                     DeltaMs = reader.IsDBNull(1) ? 0 : reader.GetInt64(1),
                     DeltaTasks = reader.IsDBNull(2) ? 0 : reader.GetInt64(2),
-                    AvgMsPerWait = reader.IsDBNull(3) ? 0 : reader.GetDouble(3)
+                    AvgMsPerWait = reader.IsDBNull(3) ? 0 : reader.GetDouble(3),
+                    CollectionTime = reader.GetDateTime(4)
                 });
             }
         }

--- a/Lite/Services/LocalDataService.WaitStats.cs
+++ b/Lite/Services/LocalDataService.WaitStats.cs
@@ -323,7 +323,8 @@ SELECT
     delta_waiting_tasks AS delta_tasks,
     CASE WHEN delta_waiting_tasks > 0
     THEN CAST(delta_wait_time_ms AS DOUBLE PRECISION) / delta_waiting_tasks
-    ELSE 0 END AS avg_ms_per_wait
+    ELSE 0 END AS avg_ms_per_wait,
+    collection_time
 FROM v_wait_stats
 WHERE server_id = $1
 AND wait_type IN ('THREADPOOL', 'RESOURCE_SEMAPHORE', 'RESOURCE_SEMAPHORE_QUERY_COMPILE')
@@ -344,7 +345,8 @@ LIMIT 3";
                 WaitType = reader.GetString(0),
                 DeltaMs = reader.IsDBNull(1) ? 0 : reader.GetInt64(1),
                 DeltaTasks = reader.IsDBNull(2) ? 0 : reader.GetInt64(2),
-                AvgMsPerWait = reader.IsDBNull(3) ? 0 : reader.GetDouble(3)
+                AvgMsPerWait = reader.IsDBNull(3) ? 0 : reader.GetDouble(3),
+                CollectionTime = reader.GetDateTime(4)
             });
         }
 

--- a/PerformanceMonitor.Alerting/AlertEngine.cs
+++ b/PerformanceMonitor.Alerting/AlertEngine.cs
@@ -116,6 +116,17 @@ public sealed class AlertEngine
     private readonly ConcurrentDictionary<string, DateTime> _lastBlockingWaitAlert = new();
     private readonly ConcurrentDictionary<string, DateTime> _lastDeadlockAlert = new();
     private readonly ConcurrentDictionary<string, DateTime> _lastPoisonWaitAlert = new();
+
+    /* The collection_time of the wait_stats row(s) last actually fired on. Read adapters answer
+       "what's the newest poison-wait row within the last 10 minutes", which is independent of
+       whether it is NEW since the previous ask — at fleet load the collector's delivered cadence
+       can lag the alert cooldown (PerformanceMonitor's own dogfooding on prod-pos-use2-monitor-01
+       caught byte-identical duplicate alerts ~5-7 minutes apart), so the cooldown elapsing is not
+       proof a fresh observation exists. Poison wait is deliberately NOT level-triggered like CPU
+       (which resamples live every sweep): a delta is one collector cycle's computation, and
+       reading it twice is the same event surfacing twice, not two observations of a standing
+       condition. Gate re-fire on BOTH the cooldown AND a newer collection_time than last fired. */
+    private readonly ConcurrentDictionary<string, DateTime> _lastPoisonWaitCollectionTime = new();
     private readonly ConcurrentDictionary<string, DateTime> _lastLongRunningQueryAlert = new();
     private readonly ConcurrentDictionary<string, DateTime> _lastTempDbSpaceAlert = new();
     private readonly ConcurrentDictionary<string, DateTime> _lastLowDiskAlert = new();
@@ -860,7 +871,17 @@ public sealed class AlertEngine
             if (triggered.Count > 0)
             {
                 _activePoisonWaitAlert[key] = true;                                 /* :282 */
-                if (!suppressed && CooldownElapsed(_lastPoisonWaitAlert, key, now, alertCooldown)) /* :283 */
+
+                /* The read adapter's own window can hand back the SAME wait_stats row(s) across
+                   multiple sweeps when the collector lags the cooldown — see the field's own
+                   doc comment. Only a collection_time newer than the one last fired on counts as
+                   a fresh observation; a cooldown-elapsed re-ask against an unrefreshed row must
+                   wait for the NEXT sweep rather than re-fire on data it already reported. */
+                var newestCollectionTime = triggered.Max(w => w.CollectionTime);
+                bool hasFreshCollection = !_lastPoisonWaitCollectionTime.TryGetValue(key, out var lastCollectionTime)
+                    || newestCollectionTime > lastCollectionTime;
+
+                if (!suppressed && hasFreshCollection && CooldownElapsed(_lastPoisonWaitAlert, key, now, alertCooldown)) /* :283 */
                 {
                     var worst = triggered[0];                                       /* :285 */
                     var allWaitNames = string.Join(", ", triggered.ConvertAll(w => $"{w.WaitType} ({w.AvgMsPerWait:F0}ms)")); /* :286 */
@@ -870,6 +891,7 @@ public sealed class AlertEngine
                     var muteCtx = new AlertMuteContext { ServerName = serverName, MetricName = "Poison Wait", WaitType = worst.WaitType };
                     bool isMuted = _isAlertMuted(muteCtx);
                     _lastPoisonWaitAlert[key] = now;                                /* :294 */
+                    _lastPoisonWaitCollectionTime[key] = newestCollectionTime;
 
                     var poisonContext = AlertContextBuilders.BuildPoisonWaitContext(triggered); /* :307 */
                     var detailText = AlertContextBuilders.ContextToDetailText(poisonContext);   /* :308 */

--- a/PerformanceMonitor.Alerting/PoisonWaitDelta.cs
+++ b/PerformanceMonitor.Alerting/PoisonWaitDelta.cs
@@ -6,6 +6,8 @@
  * Licensed under the MIT License. See LICENSE file in the project root for full license information.
  */
 
+using System;
+
 namespace PerformanceMonitor.Alerting;
 
 /// <summary>
@@ -19,4 +21,14 @@ public class PoisonWaitDelta
     public long DeltaMs { get; set; }
     public long DeltaTasks { get; set; }
     public double AvgMsPerWait { get; set; }
+
+    /// <summary>
+    /// The wait_stats row's own collection_time — the collector's cadence, not the alert engine's.
+    /// AlertEngine keys its re-fire decision on this because the alert cooldown and the collector's
+    /// delivered cadence are independent clocks: at fleet load the collector can lag the cooldown,
+    /// and re-reading the SAME still-uncollected row is not a new observation of a standing
+    /// condition (unlike CPU, which is resampled every sweep) — it is the identical delta
+    /// computation surfacing twice.
+    /// </summary>
+    public DateTime CollectionTime { get; set; }
 }


### PR DESCRIPTION
Fixes #2703.

## Problem

\`AlertEngine.CheckPoisonWaitsAsync\` gates re-firing purely on wall-clock cooldown (\`CooldownElapsed\`). \`IAlertReadAdapter.GetPoisonWaitDeltasAsync\` always asks "what's the newest poison-wait \`wait_stats\` row within the last 10 minutes" (\`ORDER BY collection_time DESC LIMIT 3\`) — independent of whether that row is NEW since the last ask. When the collector's delivered cadence lags the alert cooldown (documented fleet behavior at load), the same still-unrefreshed row answers the question twice, and the engine fires again on data it already reported. Observed live: byte-identical \`RESOURCE_SEMAPHORE_QUERY_COMPILE\` alerts on the same server 6.5 minutes apart, same avg/delta/task values to the decimal.

This is unlike CPU's alert, which is correctly level-triggered (resampled live every sweep — an identical reading really is a fresh observation of a standing condition). A wait_stats delta is one collector cycle's computation; reading it twice is the same event, not two observations.

## Fix

- \`PoisonWaitDelta\` gains \`CollectionTime\` (the row's own \`collection_time\`).
- Both read-adapter implementations (Darling/Postgres, Lite/DuckDB) select and populate it — one added column in an already-parameterized query, no behavior change to what rows are selected.
- \`AlertEngine\` tracks the collection_time it last actually fired on, per server, in a new \`_lastPoisonWaitCollectionTime\` dictionary (mirroring the existing per-family cooldown dictionaries). Re-fire now requires BOTH cooldown elapsed AND a newer collection_time than last fired — a cooldown-elapsed re-ask against unrefreshed data waits for the next sweep instead of re-firing.

## Test plan

- [x] \`dotnet build\` (full solution) clean, 0 errors
- [x] New test \`PoisonWait_DoesNotRefire_OnTheSameCollectionTime_EvenAfterCooldownElapses\` in \`AlertEngineTests.cs\`: fires once, then asserts a cooldown-elapsed re-ask against the SAME collection_time does NOT re-fire, then asserts a genuinely new collection_time (same wait-type/value shape) DOES fire. Hand-traced against the new gating logic; `Darling.Tests` can't run on macOS (net10.0-windows) — relying on CI's \`Darling PostgreSQL tests\`/\`build\` jobs to actually execute it.
- [x] Existing \`PoisonWait_FiresWithWorstWaitNumerics_AndResolvesWhenGone\` and Lite's \`PoisonWait_ToastBody_UsesTheWorstWait\` unaffected — both fire only once per test, so the new gate is a no-op on their paths (empty tracking dictionary on first fire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)