### PR TITLE
Fix QUERY_HIGH_DOP firing on a stale lifetime max_dop

### DIFF
--- a/Darling/Darling.Tests/QueryHighDopStaleMaxDopLiveTests.cs
+++ b/Darling/Darling.Tests/QueryHighDopStaleMaxDopLiveTests.cs
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+using PerformanceMonitor.Analysis;
+using PerformanceMonitor.Collectors;
+using PerformanceMonitor.Darling.Analysis;
+using PerformanceMonitor.Darling.Storage;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Live-Postgres pins for #2705: QUERY_HIGH_DOP read <c>v_query_stats.max_dop</c> — a lifetime-max for
+/// the plan's time in cache, the same semantics <c>get_top_queries_by_cpu</c>'s own tool description has
+/// always warned about — with no guard, and fed it into a finding at full confidence. A plan compiled
+/// before <c>max degree of parallelism</c> was lowered keeps reporting its old, higher DOP until it is
+/// evicted or recompiled, so on a server now configured to MAXDOP 1 a cached max_dop of 16 is not a
+/// current problem; it is a stale high-water mark that predates the configuration change.
+///
+/// <para>Live rather than a string pin because the fix is a JOIN against <c>server_config</c> evaluated
+/// by the real Postgres engine — whether the CTE actually excludes the provably-impossible row, and
+/// whether the LEFT JOIN's NULL-safe fallback still counts the row when no <c>server_config</c> data
+/// exists at all, are both engine behavior a text assertion cannot see.</para>
+/// </summary>
+[Collection("live-postgres")]
+public sealed class QueryHighDopStaleMaxDopLiveTests
+{
+    private const int TestServerId = -270200;
+    private const string TestServerName = "StaleMaxDopSrv";
+    private const string Db = "StaleMaxDopDb";
+
+    private static DateTime TruncateToSeconds(DateTime t) =>
+        DateTime.SpecifyKind(new DateTime(t.Ticks - (t.Ticks % TimeSpan.TicksPerSecond)), DateTimeKind.Unspecified);
+
+    private static async Task<NpgsqlConnection> OpenWithSearchPathAsync(string connectionString, CancellationToken ct)
+    {
+        var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(ct);
+        await using var setPath = new NpgsqlCommand("SET search_path = " + PgSchemaGenerator.SearchPath, connection);
+        await setPath.ExecuteNonQueryAsync(ct);
+        return connection;
+    }
+
+    private static async Task SeedHighDopQueryStatsAsync(NpgsqlConnection c, DateTime t, CancellationToken ct)
+    {
+        await using var command = new NpgsqlCommand(@"
+INSERT INTO query_stats
+    (collection_id, collection_time, server_id, server_name, database_name, query_hash, query_plan_hash,
+     sql_handle, plan_handle, query_text, delta_execution_count, delta_worker_time, delta_elapsed_time,
+     delta_logical_reads, delta_logical_writes, delta_physical_reads, delta_rows, delta_spills,
+     min_dop, max_dop, min_worker_time, max_worker_time, min_elapsed_time, max_elapsed_time)
+VALUES
+    ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24)", c);
+        command.Parameters.AddWithValue(CollectionIdGenerator.Next());
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(t, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(TestServerId);
+        command.Parameters.AddWithValue(TestServerName);
+        command.Parameters.AddWithValue(Db);
+        command.Parameters.AddWithValue("0xHIGHDOPHASH");
+        command.Parameters.AddWithValue("0xHIGHDOPPLANHASH");
+        command.Parameters.AddWithValue("0xHIGHDOPSQLH");
+        command.Parameters.AddWithValue("0xHIGHDOPPLANH");
+        command.Parameters.AddWithValue("SELECT * FROM StaleMaxDopTable");
+        command.Parameters.AddWithValue(10L);      // delta_execution_count
+        command.Parameters.AddWithValue(10_000L);  // delta_worker_time
+        command.Parameters.AddWithValue(20_000L);  // delta_elapsed_time
+        command.Parameters.AddWithValue(500L);     // delta_logical_reads
+        command.Parameters.AddWithValue(0L);       // delta_logical_writes
+        command.Parameters.AddWithValue(5L);       // delta_physical_reads
+        command.Parameters.AddWithValue(100L);     // delta_rows
+        command.Parameters.AddWithValue(0L);       // delta_spills
+        command.Parameters.AddWithValue(1);        // min_dop
+        command.Parameters.AddWithValue(16);       // max_dop — the stale high-water mark
+        command.Parameters.AddWithValue(800L);     // min_worker_time
+        command.Parameters.AddWithValue(1500L);    // max_worker_time
+        command.Parameters.AddWithValue(1600L);    // min_elapsed_time
+        command.Parameters.AddWithValue(3000L);    // max_elapsed_time
+        await command.ExecuteNonQueryAsync(ct);
+    }
+
+    private static async Task SeedServerConfigMaxDopAsync(
+        NpgsqlConnection c, DateTime captureTime, long valueInUse, CancellationToken ct)
+    {
+        await using var command = new NpgsqlCommand(@"
+INSERT INTO server_config
+    (config_id, capture_time, server_id, server_name, configuration_name, value_configured, value_in_use,
+     is_dynamic, is_advanced)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)", c);
+        command.Parameters.AddWithValue(CollectionIdGenerator.Next());
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(captureTime, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(TestServerId);
+        command.Parameters.AddWithValue(TestServerName);
+        command.Parameters.AddWithValue("max degree of parallelism");
+        command.Parameters.AddWithValue(valueInUse);
+        command.Parameters.AddWithValue(valueInUse);
+        command.Parameters.AddWithValue(true);
+        command.Parameters.AddWithValue(false);
+        await command.ExecuteNonQueryAsync(ct);
+    }
+
+    private static async Task DeleteTestRowsAsync(NpgsqlConnection connection, CancellationToken ct)
+    {
+        await using (var command = new NpgsqlCommand("DELETE FROM query_stats WHERE server_id = $1", connection))
+        {
+            command.Parameters.AddWithValue(TestServerId);
+            await command.ExecuteNonQueryAsync(ct);
+        }
+
+        await using (var command = new NpgsqlCommand("DELETE FROM server_config WHERE server_id = $1", connection))
+        {
+            command.Parameters.AddWithValue(TestServerId);
+            await command.ExecuteNonQueryAsync(ct);
+        }
+    }
+
+    [Fact]
+    public async Task QueryHighDop_DoesNotFire_WhenMaxDopExceedsCurrentServerConfig()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the live #2705 stale-max_dop test.");
+
+        var ct = TestContext.Current.CancellationToken;
+        var bodySucceeded = false;
+
+        await using (var connection = new NpgsqlConnection(connectionString))
+        {
+            await connection.OpenAsync(ct);
+            await PgMigrations.MigrateAsync(connection, ct);
+        }
+
+        await using (var connection = await OpenWithSearchPathAsync(connectionString!, ct))
+        {
+            await DeleteTestRowsAsync(connection, ct);
+        }
+
+        try
+        {
+            var periodEnd = TruncateToSeconds(DateTime.UtcNow);
+            var periodStart = periodEnd.AddHours(-4);
+            var seedTime = periodEnd.AddMinutes(-30);
+            var context = new AnalysisContext
+            {
+                ServerId = TestServerId,
+                ServerName = TestServerName,
+                TimeRangeStart = periodStart,
+                TimeRangeEnd = periodEnd,
+                ServerUtcOffset = TimeSpan.Zero,
+            };
+
+            /* ── #2705, RED under the old query: the plan's lifetime max_dop (16) predates the server
+                  being reconfigured to MAXDOP 1, which makes DOP > 1 impossible right now. ── */
+            await using (var connection = await OpenWithSearchPathAsync(connectionString!, ct))
+            {
+                await SeedHighDopQueryStatsAsync(connection, seedTime, ct);
+                await SeedServerConfigMaxDopAsync(connection, seedTime.AddMinutes(5), valueInUse: 1, ct);
+            }
+
+            await using (var postgres = NpgsqlDataSource.Create(connectionString!))
+            {
+                var facts = await new PgFactCollector(postgres).CollectFactsAsync(context);
+                Assert.DoesNotContain(facts, f => f.Key == "QUERY_HIGH_DOP");
+            }
+
+            /* ── The unlimited case: current MAXDOP 0 makes no reading impossible, so the finding still
+                  fires exactly as before the fix. ── */
+            await using (var connection = await OpenWithSearchPathAsync(connectionString!, ct))
+            {
+                await DeleteTestRowsAsync(connection, ct);
+                await SeedHighDopQueryStatsAsync(connection, seedTime, ct);
+                await SeedServerConfigMaxDopAsync(connection, seedTime.AddMinutes(5), valueInUse: 0, ct);
+            }
+
+            await using (var postgres = NpgsqlDataSource.Create(connectionString!))
+            {
+                var facts = await new PgFactCollector(postgres).CollectFactsAsync(context);
+                var fact = Assert.Single(facts, f => f.Key == "QUERY_HIGH_DOP");
+                Assert.Equal(1.0, fact.Metadata["high_dop_query_count"]);
+            }
+
+            /* ── No server_config row at all (never collected, or a target this collector doesn't apply
+                  to): unknown current MAXDOP corroborates nothing, so the count is unchanged rather than
+                  manufacturing confidence either way — same "omit rather than invent" rule the CPU-
+                  attribution ratio already follows. ── */
+            await using (var connection = await OpenWithSearchPathAsync(connectionString!, ct))
+            {
+                await DeleteTestRowsAsync(connection, ct);
+                await SeedHighDopQueryStatsAsync(connection, seedTime, ct);
+            }
+
+            await using (var postgres = NpgsqlDataSource.Create(connectionString!))
+            {
+                var facts = await new PgFactCollector(postgres).CollectFactsAsync(context);
+                var fact = Assert.Single(facts, f => f.Key == "QUERY_HIGH_DOP");
+                Assert.Equal(1.0, fact.Metadata["high_dop_query_count"]);
+            }
+
+            bodySucceeded = true;
+        }
+        finally
+        {
+            await LiveStoreCleanup.RunAsync(connectionString!, bodySucceeded, DeleteTestRowsAsync);
+        }
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgFactCollector.QueryPerf.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgFactCollector.QueryPerf.cs
@@ -17,18 +17,41 @@ namespace PerformanceMonitor.Darling.Analysis;
 
 public sealed partial class PgFactCollector
 {
+    /* #2705: max_dop on v_query_stats is sys.dm_exec_query_stats' lifetime-max for the plan's time in
+       cache (QueryStatExtremes.cs's doctrine — same semantics as max/min_cpu_ms), so a plan compiled
+       before 'max degree of parallelism' was lowered keeps reporting the old higher DOP until it is
+       evicted or recompiled. get_top_queries_by_cpu's tool description has always carried this caveat
+       for a human reader; this fact collector had no equivalent guard and fed the raw lifetime value
+       into a QUERY_HIGH_DOP finding at full confidence. current_maxdop applies the same provable-tell
+       reasoning QueryStatExtremes uses for CPU/elapsed: a max_dop reading that EXCEEDS what the
+       server's current maxdop setting can produce right now is impossible under today's configuration,
+       so it provably predates whatever change set that configuration and must not be counted. A
+       current_maxdop of 0 (unlimited) or unknown (no server_config row yet) makes no configuration
+       impossible, so the count is unchanged in both of those cases. */
     public const string QueryStatsSql = @"
+WITH current_maxdop AS
+(
+    SELECT value_in_use
+    FROM server_config
+    WHERE server_id = $1
+    AND   configuration_name = 'max degree of parallelism'
+    ORDER BY capture_time DESC
+    LIMIT 1
+)
 SELECT
-    SUM(delta_spills) AS total_spills,
-    COUNT(CASE WHEN max_dop > 8 THEN 1 END) AS high_dop_queries,
-    COUNT(CASE WHEN delta_spills > 0 THEN 1 END) AS spilling_queries,
-    SUM(delta_execution_count) AS total_executions,
-    SUM(delta_worker_time) AS total_cpu_time_us
-FROM v_query_stats
-WHERE server_id = $1
-AND   collection_time >= $2
-AND   collection_time <= $3
-AND   delta_execution_count > 0";
+    SUM(v.delta_spills) AS total_spills,
+    COUNT(CASE WHEN v.max_dop > 8
+                AND (m.value_in_use IS NULL OR m.value_in_use = 0 OR v.max_dop <= m.value_in_use)
+               THEN 1 END) AS high_dop_queries,
+    COUNT(CASE WHEN v.delta_spills > 0 THEN 1 END) AS spilling_queries,
+    SUM(v.delta_execution_count) AS total_executions,
+    SUM(v.delta_worker_time) AS total_cpu_time_us
+FROM v_query_stats AS v
+LEFT JOIN current_maxdop AS m ON true
+WHERE v.server_id = $1
+AND   v.collection_time >= $2
+AND   v.collection_time <= $3
+AND   v.delta_execution_count > 0";
 
     /// <summary>
     /// Collects query-level aggregate facts from query_stats.


### PR DESCRIPTION
Fixes #2705.

## Problem

\`PgFactCollector.CollectQueryStatsFactsAsync\` counted \`v_query_stats.max_dop > 8\` unconditionally and fed the count into a \`QUERY_HIGH_DOP\` Fact at full confidence. \`max_dop\` is \`sys.dm_exec_query_stats\`' **lifetime-max** for the plan's time in cache — the exact semantics \`PerformanceMonitor.Common/QueryStatExtremes.cs\` (#2235) already documents for \`min/max_cpu_ms\`, and the same caveat \`get_top_queries_by_cpu\`'s tool description has always carried. A plan compiled before an operator lowered \`max degree of parallelism\` keeps reporting its old, higher DOP until evicted or recompiled — so on a server now configured to MAXDOP 1, a cached \`max_dop = 16\` is not a current problem, it's a stale high-water mark, and the finding fired anyway at severity 1.00.

## Fix

Same "provable tell" doctrine \`QueryStatExtremes\` already applies to CPU/elapsed: a \`max_dop\` reading that exceeds the server's **current** \`max degree of parallelism\` (from \`server_config\`) is impossible under today's configuration, so it provably predates whatever change set that config, and is excluded from the count. A current value of 0 (unlimited) or no \`server_config\` row at all proves nothing impossible, so those cases are unchanged.

## Test plan

- [x] \`dotnet build\` (Darling.Analysis + Darling.Tests) clean, 0 errors
- [x] **Verified against a real Postgres 17** (a throwaway console harness against a local docker container, referencing the shipped project directly — not a retyped copy of the SQL): reverting the fix reproduces the exact reported false positive (current maxdop=1, stale \`max_dop=16\` still fires \`QUERY_HIGH_DOP\`); restoring the fix suppresses that case while the maxdop=0 (unlimited) and unknown-\`server_config\` cases still fire exactly as before.
- [x] Added \`QueryHighDopStaleMaxDopLiveTests\` (live-Postgres, \`[Collection("live-postgres")]\`, skips without \`DARLING_TEST_PG\`) covering all three cases — this is the CI-executed version of the same three scenarios the local harness proved.
- [ ] Could not run \`Darling.Tests\` locally end-to-end (this Mac lacks the WindowsDesktop runtime the \`net10.0-windows\` TFM needs) — relying on the \"Darling PostgreSQL tests\" CI job, which runs against a live Postgres and is exactly the job this test is written for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)