### PR TITLE
Point alert-settings MCP tools at the Darling Viewer for webhook/SMTP config

### DIFF
--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpAlertTools.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpAlertTools.cs
@@ -41,7 +41,10 @@ namespace PerformanceMonitor.Darling.Service.Mcp;
 /// row carrying its server), or name a server to scope to it. get_alert_settings reports the single global
 /// alert-settings row the service hot-swaps in (the viewer's Settings-window desired state); SMTP/webhook
 /// delivery credentials are managed separately and are not exposed here (the least-privilege mcp role cannot
-/// read the secret columns anyway).</para>
+/// read the secret columns anyway) — configure them in the standalone PerformanceMonitor Darling Viewer app's
+/// Settings window (Notifications section), pointed at this store's connection string. The Viewer's Postgres
+/// connection is not hardcoded to localhost, so it can configure a remote headless box exactly as well as a
+/// local one.</para>
 ///
 /// <para><b>Writes route through the EXISTING authority, never a parallel copy.</b> update_alert_settings is a
 /// PARTIAL update of the single <c>config_alert_settings</c> row (id=1) — the caller reads via get_alert_settings,
@@ -124,7 +127,7 @@ public sealed class DarlingMcpAlertTools
         }
     }
 
-    [McpServerTool(Name = "get_alert_settings"), Description("Gets the current alert configuration the service is using: which alerts are enabled and their thresholds (CPU, blocking, deadlocks, poison waits, long-running queries/jobs, tempdb, low disk, failed jobs, database state, Availability Group health, connection loss), the cooldown, excluded databases, the deadlock/blocking delivery mode, and the scheduled-analysis cadence. This is the single global settings row the service hot-swaps in. SMTP/webhook delivery credentials are managed separately and are not reported here.")]
+    [McpServerTool(Name = "get_alert_settings"), Description("Gets the current alert configuration the service is using: which alerts are enabled and their thresholds (CPU, blocking, deadlocks, poison waits, long-running queries/jobs, tempdb, low disk, failed jobs, database state, Availability Group health, connection loss), the cooldown, excluded databases, the deadlock/blocking delivery mode, and the scheduled-analysis cadence. This is the single global settings row the service hot-swaps in. SMTP/webhook delivery credentials are managed separately and are not reported here — configure them in the standalone Darling Viewer app's Settings window (Notifications section), which connects to this store (including remotely, not just localhost) rather than requiring desktop access to this specific box.")]
     public static async Task<string> GetAlertSettings(
         NpgsqlDataSource postgres)
     {
@@ -319,7 +322,10 @@ public sealed class DarlingMcpAlertTools
         "the Viewer's Settings window enforces — thresholds in range, cpu.mode 'sql'|'total', delivery.mode " +
         "'Summary'|'PerEvent', counts within their bounds; an out-of-range value or an unknown field returns " +
         "{status:\"invalid\", ...} and writes NOTHING. On success the running service hot-reloads the change within " +
-        "one collection sweep. SMTP/webhook delivery credentials are managed separately and cannot be set here. " +
+        "one collection sweep. SMTP/webhook delivery credentials are managed separately and cannot be set here " +
+        "— configure them in the standalone Darling Viewer app's Settings window (Notifications section), which " +
+        "connects to this store (including remotely, not just localhost) rather than requiring desktop access to " +
+        "this specific box. " +
         "Returns {status:\"updated\", updated_fields:[...], settings:{...}} with the full new settings, or " +
         "{status:\"unavailable\"} when the settings row has not been seeded yet.")]
     public static async Task<string> UpdateAlertSettings(


### PR DESCRIPTION
Closes #2709.

`get_alert_settings`, `update_alert_settings`, and the class-level doc comment on `DarlingMcpAlertTools` all said SMTP/webhook delivery credentials are "managed separately" with no pointer to what that means. As #2709 documents, the mechanism already fully works — the standalone Darling Viewer app's Settings window (Notifications section) writes `config.config_notification`, its Postgres connection isn't hardcoded to localhost so it can configure a remote headless box, and the running service hot-swaps the change in with no restart. It just wasn't discoverable from the MCP surface an operator (or an agent working on their behalf) would actually consult first.

## Change

Extended the two tool descriptions and the class doc comment with a one-clause pointer to the Viewer's Settings window and its remote-connection capability. No behavior change — descriptions only.

Scoped to just the MCP tool descriptions (the issue's option 1) since that's what the issue title names directly and is the highest-leverage single change; didn't touch `darling.exe --help` (option 2) since every existing help line maps to a real implemented verb and this is a docs-only fix, or add a new doc file (option 3) since the pointer fits cleanly inline.

## Test plan

- [x] `dotnet build` (project + full solution) clean, 0 errors
- No test pins the exact description text (checked), so no test changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)