### PR TITLE
Add Postgres Deadlocks and Blocking alerts (part of #2711)

### DIFF
--- a/Darling/Darling.Tests/DarlingPgOperationalAlertTests.cs
+++ b/Darling/Darling.Tests/DarlingPgOperationalAlertTests.cs
@@ -171,6 +171,25 @@ public sealed class DarlingPgOperationalAlertTests
     }
 
     [Fact]
+    public void BuildPgBlockingIncident_GivesTheVanishedBlockerSentinelAUniqueDedupKey_NotABareZero()
+    {
+        /* IncidentCooldown.BuildKeys does incidents.Select(i => i.DedupKey).Distinct() to build one
+           cooldown key per fingerprint — two genuinely distinct sentinel (RootBackendId == 0) incidents
+           sharing the literal key "0" would collapse into one cooldown slot downstream, even though
+           WorstPgBlockingChainPerRoot correctly kept both as separate list entries (review finding this
+           test pins). */
+        var capturedAt = new DateTime(2026, 8, 31, 1, 2, 3, DateTimeKind.Utc);
+        var incidentA = DarlingWorker.BuildPgBlockingIncident(
+            BlockingRow(rootBackendId: 0, rootPid: 111, capturedAt: capturedAt));
+        var incidentB = DarlingWorker.BuildPgBlockingIncident(
+            BlockingRow(rootBackendId: 0, rootPid: 222, capturedAt: capturedAt));
+
+        Assert.NotEqual(incidentA.DedupKey, incidentB.DedupKey);
+        Assert.NotEqual("0", incidentA.DedupKey);
+        Assert.NotEqual("0", incidentB.DedupKey);
+    }
+
+    [Fact]
     public void BuildPgBlockingIncident_IncludesDatabaseRootPidVictimCountAndQuery()
     {
         var incident = DarlingWorker.BuildPgBlockingIncident(

--- a/Darling/Darling.Tests/DarlingPgOperationalAlertTests.cs
+++ b/Darling/Darling.Tests/DarlingPgOperationalAlertTests.cs
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using PerformanceMonitor.Darling.Service;
+using PerformanceMonitor.Darling.Storage;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #2711: the pure, testable seams behind the Postgres Deadlocks/Blocking alerts —
+/// <see cref="DarlingWorker.BuildPgDeadlockIncident"/>, <see cref="DarlingWorker.WorstPgBlockingChainPerRoot"/>,
+/// and <see cref="DarlingWorker.BuildPgBlockingIncident"/>. The gating itself (fire/clear, edge-triggering,
+/// immunity to re-firing on an unrefreshed data point) is <c>RollingCountAlertGate</c>'s job and is already
+/// exhaustively pinned in <c>Lite.Tests/RollingCountAlertGateTests.cs</c>; these tests cover the mapping and
+/// dedup logic layered on top of it that is genuinely new here.
+/// </summary>
+public sealed class DarlingPgOperationalAlertTests
+{
+    private static DarlingPgDeadlockReader.PgDeadlockRow DeadlockRow(
+        string hash, string? victimStatement = "SELECT 1", int victimPid = 111, int participantCount = 2) =>
+        new(
+            OccurredAtUtc: new DateTime(2026, 8, 31, 0, 0, 0, DateTimeKind.Utc),
+            VictimPid: victimPid,
+            ParticipantCount: participantCount,
+            DeadlockHash: hash,
+            LockModes: null,
+            Resources: null,
+            VictimStatement: victimStatement,
+            TimesSeen: 1);
+
+    private static DarlingPgBlockingReader.PgBlockingChainRow BlockingRow(
+        long rootBackendId,
+        int rootPid = 200,
+        int totalVictims = 3,
+        string[]? databases = null,
+        string? rootQuery = "SELECT * FROM t",
+        DateTime? capturedAt = null) =>
+        new(
+            CapturedAt: capturedAt ?? new DateTime(2026, 8, 31, 0, 0, 0, DateTimeKind.Utc),
+            RootBackendId: rootBackendId,
+            RootPid: rootPid,
+            Databases: databases ?? new[] { "eden" },
+            RootUsername: "app",
+            RootApplicationName: "webapi",
+            RootState: "active",
+            RootQuery: rootQuery,
+            RootIsIdleInTransaction: false,
+            RootXactDurationMs: 5000,
+            RootQueryDurationMs: 5000,
+            TotalVictims: totalVictims,
+            DirectVictims: totalVictims,
+            MaxDepth: 1,
+            WorstVictimWaitMs: 4000,
+            WorstVictimQuery: "SELECT 2",
+            SamplesAsRoot: 1,
+            QueryTextMayBeTruncated: false,
+            ChainMayBeTruncated: false);
+
+    [Fact]
+    public void BuildPgDeadlockIncident_UsesDeadlockHashAsDedupKey_AndVictimStatementAsDetail()
+    {
+        var incident = DarlingWorker.BuildPgDeadlockIncident(DeadlockRow("hash-1", victimStatement: "DELETE FROM t"));
+
+        Assert.Equal("hash-1", incident.DedupKey);
+        Assert.Single(incident.InvolvedObjects);
+        Assert.Equal("DELETE FROM t", incident.InvolvedObjects[0]);
+    }
+
+    [Fact]
+    public void BuildPgDeadlockIncident_FallsBackToPidAndParticipantCount_WhenVictimStatementIsMissing()
+    {
+        var incident = DarlingWorker.BuildPgDeadlockIncident(
+            DeadlockRow("hash-2", victimStatement: null, victimPid: 555, participantCount: 3));
+
+        Assert.Equal("victim pid 555, 3 participant(s)", incident.InvolvedObjects[0]);
+    }
+
+    [Fact]
+    public void BuildPgDeadlockIncident_FallsBackOnWhitespaceStatement_NotJustNull()
+    {
+        var incident = DarlingWorker.BuildPgDeadlockIncident(
+            DeadlockRow("hash-3", victimStatement: "   ", victimPid: 7, participantCount: 2));
+
+        Assert.StartsWith("victim pid 7,", incident.InvolvedObjects[0]);
+    }
+
+    [Fact]
+    public void WorstPgBlockingChainPerRoot_CollapsesRepeatedSamplesOfTheSameRoot_ToOneEntry()
+    {
+        /* The defensive case this exists for (mirroring tonight's #2704/#2708 lesson): the SAME persistent
+           blocker sampled across several sweep cycles within the rolling window must not inflate the count
+           past "one blocking situation" just because it was still there the next time anyone looked. */
+        var rows = new[]
+        {
+            BlockingRow(rootBackendId: 100, capturedAt: new DateTime(2026, 8, 31, 0, 5, 0, DateTimeKind.Utc)),
+            BlockingRow(rootBackendId: 100, capturedAt: new DateTime(2026, 8, 31, 0, 10, 0, DateTimeKind.Utc)),
+            BlockingRow(rootBackendId: 100, capturedAt: new DateTime(2026, 8, 31, 0, 15, 0, DateTimeKind.Utc)),
+        };
+
+        var worst = DarlingWorker.WorstPgBlockingChainPerRoot(rows);
+
+        Assert.Single(worst);
+        Assert.Equal(100, worst[0].RootBackendId);
+    }
+
+    [Fact]
+    public void WorstPgBlockingChainPerRoot_KeepsDistinctRootsSeparate()
+    {
+        var rows = new[]
+        {
+            BlockingRow(rootBackendId: 100),
+            BlockingRow(rootBackendId: 200),
+            BlockingRow(rootBackendId: 100), // a repeat sample of the first root
+        };
+
+        var worst = DarlingWorker.WorstPgBlockingChainPerRoot(rows);
+
+        Assert.Equal(2, worst.Count);
+        Assert.Contains(worst, r => r.RootBackendId == 100);
+        Assert.Contains(worst, r => r.RootBackendId == 200);
+    }
+
+    [Fact]
+    public void WorstPgBlockingChainPerRoot_KeepsTheFirstSampleAsTheReaderAlreadyOrderedItWorstFirst()
+    {
+        /* GetPgBlockingChainsAsync orders worst-first (widest chain, then deepest, then most recent) — this
+           helper must not re-sort, only dedupe, or it would silently discard that ordering. */
+        var worstSample = BlockingRow(rootBackendId: 100, totalVictims: 9);
+        var laterButSmallerSample = BlockingRow(rootBackendId: 100, totalVictims: 1);
+        var rows = new[] { worstSample, laterButSmallerSample };
+
+        var worst = DarlingWorker.WorstPgBlockingChainPerRoot(rows);
+
+        Assert.Single(worst);
+        Assert.Equal(9, worst[0].TotalVictims);
+    }
+
+    [Fact]
+    public void BuildPgBlockingIncident_DedupKeyIsRootBackendId_NotPid()
+    {
+        /* Backend id, not pid, is the dedup key on purpose — pids are reused, backend id is stable for the
+           life of a backend (see the collector's own doc comment). */
+        var incident = DarlingWorker.BuildPgBlockingIncident(BlockingRow(rootBackendId: 424242, rootPid: 99));
+
+        Assert.Equal("424242", incident.DedupKey);
+    }
+
+    [Fact]
+    public void BuildPgBlockingIncident_IncludesDatabaseRootPidVictimCountAndQuery()
+    {
+        var incident = DarlingWorker.BuildPgBlockingIncident(
+            BlockingRow(rootBackendId: 1, rootPid: 42, totalVictims: 5, databases: new[] { "eden" }, rootQuery: "SELECT * FROM x"));
+
+        Assert.Equal("root pid 42 blocking 5 session(s) in [eden]: SELECT * FROM x", incident.InvolvedObjects[0]);
+        Assert.Equal("eden", incident.Database);
+    }
+
+    [Fact]
+    public void BuildPgBlockingIncident_OmitsTrailingQueryClause_WhenRootQueryIsMissing()
+    {
+        var incident = DarlingWorker.BuildPgBlockingIncident(
+            BlockingRow(rootBackendId: 1, rootPid: 42, totalVictims: 2, databases: new[] { "eden" }, rootQuery: null));
+
+        Assert.Equal("root pid 42 blocking 2 session(s) in [eden]", incident.InvolvedObjects[0]);
+    }
+
+    [Fact]
+    public void BuildPgBlockingIncident_OmitsDatabaseClause_WhenNoDatabasesResolved()
+    {
+        var incident = DarlingWorker.BuildPgBlockingIncident(
+            BlockingRow(rootBackendId: 1, rootPid: 42, totalVictims: 2, databases: Array.Empty<string>(), rootQuery: null));
+
+        Assert.Equal("root pid 42 blocking 2 session(s)", incident.InvolvedObjects[0]);
+        Assert.Null(incident.Database);
+    }
+}

--- a/Darling/Darling.Tests/DarlingPgOperationalAlertTests.cs
+++ b/Darling/Darling.Tests/DarlingPgOperationalAlertTests.cs
@@ -128,6 +128,24 @@ public sealed class DarlingPgOperationalAlertTests
     }
 
     [Fact]
+    public void WorstPgBlockingChainPerRoot_NeverCollapsesTheVanishedBlockerSentinel_EvenAcrossUnrelatedIncidents()
+    {
+        /* RootBackendId == 0 is PgBlockingCollector's coalesce(blocker.backend_id, 0) sentinel — the root's
+           own row had already left pg_stat_activity by capture time. Two GENUINELY DIFFERENT blocking
+           situations that both happen to hit this case in the same window must both survive; a plain
+           GroupBy-by-RootBackendId would wrongly merge them (the review finding this test pins). */
+        var unrelatedIncidentOne = BlockingRow(rootBackendId: 0, rootPid: 111, databases: new[] { "eden" });
+        var unrelatedIncidentTwo = BlockingRow(rootBackendId: 0, rootPid: 222, databases: new[] { "sky" });
+        var rows = new[] { unrelatedIncidentOne, unrelatedIncidentTwo };
+
+        var worst = DarlingWorker.WorstPgBlockingChainPerRoot(rows);
+
+        Assert.Equal(2, worst.Count);
+        Assert.Contains(worst, r => r.RootPid == 111);
+        Assert.Contains(worst, r => r.RootPid == 222);
+    }
+
+    [Fact]
     public void WorstPgBlockingChainPerRoot_KeepsTheFirstSampleAsTheReaderAlreadyOrderedItWorstFirst()
     {
         /* GetPgBlockingChainsAsync orders worst-first (widest chain, then deepest, then most recent) — this
@@ -169,6 +187,30 @@ public sealed class DarlingPgOperationalAlertTests
             BlockingRow(rootBackendId: 1, rootPid: 42, totalVictims: 2, databases: new[] { "eden" }, rootQuery: null));
 
         Assert.Equal("root pid 42 blocking 2 session(s) in [eden]", incident.InvolvedObjects[0]);
+    }
+
+    [Fact]
+    public void BuildPgBlockingIncident_CollapsesMultiLineRootQuery_ToASingleLinePreview()
+    {
+        /* Every other query-text field this codebase puts on an AlertIncident goes through
+           AlertContextBuilders.TruncateText first (review finding this test pins) — Postgres root queries
+           are commonly multi-line formatted DML with no length cap of their own. */
+        var incident = DarlingWorker.BuildPgBlockingIncident(
+            BlockingRow(rootBackendId: 1, rootPid: 42, totalVictims: 1, databases: Array.Empty<string>(),
+                rootQuery: "UPDATE t\nSET x = 1\nWHERE y = 2"));
+
+        Assert.DoesNotContain('\n', incident.InvolvedObjects[0]);
+        Assert.Contains("UPDATE t SET x = 1 WHERE y = 2", incident.InvolvedObjects[0]);
+    }
+
+    [Fact]
+    public void BuildPgDeadlockIncident_CollapsesMultiLineVictimStatement_ToASingleLinePreview()
+    {
+        var incident = DarlingWorker.BuildPgDeadlockIncident(
+            DeadlockRow("hash-4", victimStatement: "DELETE FROM t\nWHERE id = 1"));
+
+        Assert.DoesNotContain('\n', incident.InvolvedObjects[0]);
+        Assert.Equal("DELETE FROM t WHERE id = 1", incident.InvolvedObjects[0]);
     }
 
     [Fact]

--- a/Darling/Darling.Tests/DarlingPgOperationalAlertTests.cs
+++ b/Darling/Darling.Tests/DarlingPgOperationalAlertTests.cs
@@ -128,12 +128,33 @@ public sealed class DarlingPgOperationalAlertTests
     }
 
     [Fact]
-    public void WorstPgBlockingChainPerRoot_NeverCollapsesTheVanishedBlockerSentinel_EvenAcrossUnrelatedIncidents()
+    public void WorstPgBlockingChainPerRoot_CollapsesRepeatedSamplesOfTheSameSentinelRoot_ToOneEntry()
+    {
+        /* The re-fire-class regression review caught: deduping the vanished-blocker sentinel (RootBackendId
+           == 0) by RootPid must still collapse repeated samples of the SAME persisting vanished-root block
+           — otherwise RollingCountAlertGate's watermark climbs every sweep and the alert re-fires every
+           cooldown for one ongoing incident (the #1091/#2704/#2708 class this design exists to avoid). */
+        var rows = new[]
+        {
+            BlockingRow(rootBackendId: 0, rootPid: 777, capturedAt: new DateTime(2026, 8, 31, 0, 5, 0, DateTimeKind.Utc)),
+            BlockingRow(rootBackendId: 0, rootPid: 777, capturedAt: new DateTime(2026, 8, 31, 0, 10, 0, DateTimeKind.Utc)),
+            BlockingRow(rootBackendId: 0, rootPid: 777, capturedAt: new DateTime(2026, 8, 31, 0, 15, 0, DateTimeKind.Utc)),
+        };
+
+        var worst = DarlingWorker.WorstPgBlockingChainPerRoot(rows);
+
+        Assert.Single(worst);
+        Assert.Equal(777, worst[0].RootPid);
+    }
+
+    [Fact]
+    public void WorstPgBlockingChainPerRoot_KeepsDifferentSentinelPidsSeparate()
     {
         /* RootBackendId == 0 is PgBlockingCollector's coalesce(blocker.backend_id, 0) sentinel — the root's
            own row had already left pg_stat_activity by capture time. Two GENUINELY DIFFERENT blocking
-           situations that both happen to hit this case in the same window must both survive; a plain
-           GroupBy-by-RootBackendId would wrongly merge them (the review finding this test pins). */
+           situations that both happen to hit this case in the same window (different pids) must both
+           survive; a plain GroupBy-by-RootBackendId would wrongly merge them (the review finding this test
+           pins) — dedup for the sentinel case is by RootPid instead, so different pids stay distinct. */
         var unrelatedIncidentOne = BlockingRow(rootBackendId: 0, rootPid: 111, databases: new[] { "eden" });
         var unrelatedIncidentTwo = BlockingRow(rootBackendId: 0, rootPid: 222, databases: new[] { "sky" });
         var rows = new[] { unrelatedIncidentOne, unrelatedIncidentTwo };

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -3184,7 +3184,18 @@ public sealed class DarlingWorker : BackgroundService
     /// </summary>
     internal static AlertIncident BuildPgBlockingIncident(DarlingPgBlockingReader.PgBlockingChainRow row) =>
         new(
-            row.RootBackendId.ToString(CultureInfo.InvariantCulture),
+            /* The vanished-blocker sentinel (RootBackendId == 0, see WorstPgBlockingChainPerRoot's doc
+               comment) needs a DedupKey too, not just a place in the list: IncidentCooldown.BuildKeys
+               (PerformanceMonitor.Notifications/IncidentCooldown.cs) does incidents.Select(i =>
+               i.DedupKey).Distinct() to build one cooldown key per fingerprint, so two genuinely distinct
+               sentinel incidents both keyed "0" would collapse into one cooldown slot downstream — an
+               unrelated PRIOR vanished-root incident's cooldown silently suppressing a genuinely NEW one's
+               delivery, even though WorstPgBlockingChainPerRoot correctly kept both as separate list
+               entries. Folding in RootPid and CapturedAt makes the sentinel case's key unique per incident
+               the same way a real backend id already is on its own. */
+            row.RootBackendId == 0
+                ? string.Create(CultureInfo.InvariantCulture, $"0-pid{row.RootPid}-{row.CapturedAt:O}")
+                : row.RootBackendId.ToString(CultureInfo.InvariantCulture),
             new[]
             {
                 $"root pid {row.RootPid} blocking {row.TotalVictims} session(s)"

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -3127,9 +3127,15 @@ public sealed class DarlingWorker : BackgroundService
             row.DeadlockHash,
             new[]
             {
+                /* AlertContextBuilders.TruncateText, not the raw statement: every other query-text field
+                   this codebase puts on an AlertIncident (Blocked Query/Blocking Query/Victim SQL/Query,
+                   AlertContextBuilders.cs:80,82,165,491,561) goes through it first, and deadlock victim
+                   statements are commonly multi-line formatted DML with no SQL-Server-style length cap —
+                   without this, a multi-line statement breaks the one-line-per-incident rendering and an
+                   unbounded one can bloat the stored context past what Slack/Teams will accept. */
                 string.IsNullOrWhiteSpace(row.VictimStatement)
                     ? $"victim pid {row.VictimPid}, {row.ParticipantCount} participant(s)"
-                    : row.VictimStatement!,
+                    : AlertContextBuilders.TruncateText(row.VictimStatement!),
             });
 
     /// <summary>
@@ -3138,15 +3144,37 @@ public sealed class DarlingWorker : BackgroundService
     /// <see cref="BuildPgDeadlockIncident"/>.
     /// <para><see cref="DarlingPgBlockingReader.GetPgBlockingChainsAsync"/> returns one row per (capture,
     /// root) ordered worst-first (widest chain, then deepest, then most recent) — see that method's own
-    /// doc comment — so grouping by root and taking each group's FIRST row keeps the worst sample the
-    /// window saw for that blocker, without needing to re-sort. Without this dedup, a single persistent
-    /// blocker sampled every cycle for the whole rolling window would inflate the alert's count far past
-    /// what an operator would call "how many blocking situations", since blocking here is sampled state,
-    /// not an engine-recorded event log (same caveat the collector's own doc comment carries).</para>
+    /// doc comment — so keeping the FIRST row seen per root keeps the worst sample the window saw for that
+    /// blocker, without needing to re-sort. Without this dedup, a single persistent blocker sampled every
+    /// cycle for the whole rolling window would inflate the alert's count far past what an operator would
+    /// call "how many blocking situations", since blocking here is sampled state, not an engine-recorded
+    /// event log (same caveat the collector's own doc comment carries).</para>
+    /// <para><b><c>RootBackendId == 0</c> is the vanished-blocker sentinel and is NEVER deduped against
+    /// another zero.</b> <c>PgBlockingCollector</c> writes <c>coalesce(blocker.backend_id, 0)</c> when the
+    /// root's own row had already left <c>pg_stat_activity</c> by capture time, and
+    /// <c>DarlingPgBlockingReader</c>'s own <c>recurrence</c> CTE already excludes
+    /// <c>blocking_backend_id &lt;&gt; 0</c> for the identical reason: grouping on the sentinel would count
+    /// unrelated one-off incidents in different captures as repeat appearances of one backend. A plain
+    /// GroupBy-by-RootBackendId would collapse two genuinely different vanished-root blocking situations
+    /// into one entry and merge their fingerprints — a real undercounting bug review caught before this
+    /// was reused as an alert count rather than a display grouping.</para>
     /// </summary>
     internal static List<DarlingPgBlockingReader.PgBlockingChainRow> WorstPgBlockingChainPerRoot(
-        IReadOnlyList<DarlingPgBlockingReader.PgBlockingChainRow> rows) =>
-        rows.GroupBy(r => r.RootBackendId).Select(g => g.First()).ToList();
+        IReadOnlyList<DarlingPgBlockingReader.PgBlockingChainRow> rows)
+    {
+        var result = new List<DarlingPgBlockingReader.PgBlockingChainRow>();
+        var seenRootBackendIds = new HashSet<long>();
+
+        foreach (var row in rows)
+        {
+            if (row.RootBackendId == 0 || seenRootBackendIds.Add(row.RootBackendId))
+            {
+                result.Add(row);
+            }
+        }
+
+        return result;
+    }
 
     /// <summary>
     /// Pure mapping, pulled out of <see cref="EvaluatePgBlockingAsync"/> for the same testability reason as
@@ -3161,7 +3189,11 @@ public sealed class DarlingWorker : BackgroundService
             {
                 $"root pid {row.RootPid} blocking {row.TotalVictims} session(s)"
                     + (row.Databases.Length > 0 ? $" in [{string.Join(", ", row.Databases)}]" : string.Empty)
-                    + (string.IsNullOrWhiteSpace(row.RootQuery) ? string.Empty : $": {row.RootQuery}"),
+                    /* AlertContextBuilders.TruncateText — same reasoning as BuildPgDeadlockIncident's
+                       VictimStatement: root queries are commonly multi-line and otherwise unbounded. */
+                    + (string.IsNullOrWhiteSpace(row.RootQuery)
+                        ? string.Empty
+                        : $": {AlertContextBuilders.TruncateText(row.RootQuery!)}"),
             },
             Database: row.Databases.Length > 0 ? row.Databases[0] : null);
 

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -441,6 +441,32 @@ public sealed class DarlingWorker : BackgroundService
 
     private readonly ConcurrentDictionary<string, DateTime> _lastPostgresAlert = new(StringComparer.Ordinal);
 
+    /* #2711: Postgres Deadlocks/Blocking, mirroring AlertEngine's own field shape for the SQL Server
+       versions of these two alerts (RollingCountAlertGate + a watermark + an active flag + a
+       last-fired stamp) rather than the simpler single-timestamp cooldown the three Tier 0 predictors
+       above use. Deadlocks and blocking are ROLLING-WINDOW COUNTS (the same event can sit in the
+       window for the whole hour it takes to age out), which is exactly the shape #1091 fixed for SQL
+       Server: a plain "still above threshold" check re-fires the SAME already-reported event every
+       cooldown. RollingCountAlertGate is the shared, engine-agnostic fix for that, already proven and
+       already living in PerformanceMonitor.Alerting - reusing it here is what keeps this immune to the
+       #2704/#2708 class of bug (a cooldown timer with no memory of which data point it last fired on)
+       from day one, instead of needing its own follow-up fix later. */
+    private readonly ConcurrentDictionary<string, DateTime> _lastPgDeadlockAlert = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, bool> _activePgDeadlockAlert = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, int> _lastAlertedPgDeadlockCount = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, DateTime> _lastPgBlockingAlert = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, bool> _activePgBlockingAlert = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, int> _lastAlertedPgBlockingCount = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Held for the same reason <see cref="_alertDeliverer"/> is: the Postgres Deadlocks/Blocking alerts
+    /// (#2711) need to write a resolution history row on the active→inactive transition, exactly like
+    /// <see cref="BuildAlertEngine"/>'s <c>resolutionCallback</c> does for the SQL Server families - a
+    /// resolution has no send channel (<see cref="AlertResolution"/>'s own doc comment), so it goes
+    /// straight to history rather than through <see cref="_alertDeliverer"/>.
+    /// </summary>
+    private PgAlertHistoryStore? _historyStore;
+
     private int _alertCooldownMinutes = 15;
 
     /* #1560: the live MCP enable/port seam — published to the MCP host's supervisor at startup and on
@@ -1172,6 +1198,11 @@ public sealed class DarlingWorker : BackgroundService
            lands in the same history and obeys the same mute rules as an engine-emitted one — the point
            of reusing it rather than building a second delivery path. */
         _alertDeliverer = deliverer;
+        /* #2711: the Postgres Deadlocks/Blocking resolution path writes history directly (see
+           _historyStore's doc comment) - same instance the engine's own resolutionCallback closure
+           over historyStore uses, so a restart-time history read sees both engines' rows regardless of
+           which wrote them. */
+        _historyStore = historyStore;
         /* Same instance the engine binds, so a mute-rule reload mutes the PostgreSQL predictors on the next
            sweep exactly as it mutes every SQL Server family. */
         _isAlertMuted = muteRuleService.IsAlertMuted;
@@ -2855,7 +2886,284 @@ public sealed class DarlingWorker : BackgroundService
             _logger.LogError("[{Server}] PostgreSQL alert evaluation failed: {Message}",
                 runtime.Config.DisplayName, ex.Message);
         }
+
+        /* #2711: Deadlocks and Blocking, each independently failure-isolated (own try/catch inside),
+           so a broken read on one never costs the three predictors above or the other of this pair —
+           the same isolation AlertEngine gives its own CheckDeadlocksAsync/CheckBlockingAsync. */
+        await EvaluatePgDeadlocksAsync(runtime, snapshot, cancellationToken);
+        await EvaluatePgBlockingAsync(runtime, snapshot, cancellationToken);
     }
+
+    /// <summary>
+    /// The rolling-1-hour-window Postgres Deadlocks alert (#2711), reusing <see cref="RollingCountAlertGate"/>
+    /// (shared with SQL Server's AlertEngine — see the field doc comment on <see cref="_lastPgDeadlockAlert"/>)
+    /// so a deadlock already reported cannot re-fire merely because it is still inside the window, and a new
+    /// one arriving mid-cooldown is not lost.
+    /// <para>Metric names are the EXACT SQL Server strings ("Deadlocks Detected"/"Deadlocks Cleared") rather
+    /// than Postgres-prefixed ones — deliberately, for parity: a mute rule, a history filter, or a dashboard
+    /// built against "Deadlocks Detected" should not have to know or care which engine a server runs, and
+    /// server_id never collides across engines so there is no ambiguity in doing so.</para>
+    /// </summary>
+    private async Task EvaluatePgDeadlocksAsync(
+        ServerRuntime runtime, AlertServerSnapshot snapshot, CancellationToken cancellationToken)
+    {
+        if (_postgres is null || _alertDeliverer is null)
+        {
+            return;
+        }
+
+        const string metricName = "Deadlocks Detected";
+        var key = snapshot.ServerKey;
+
+        try
+        {
+            var now = DateTime.UtcNow;
+            var windowStart = now.AddHours(-AlertEngine.RollingCountWindowHours);
+
+            /* Already deduplicated by deadlock_hash (GROUP BY in DarlingPgDeadlockReader's own SQL) and
+               windowed on occurred_at, not collection_time — see that reader's doc comment for why
+               collection_time would put a report in the wrong window and move it every cycle. */
+            var rows = await DarlingPgDeadlockReader.GetDeadlocksAsync(
+                _postgres, runtime.ServerId, windowStart, now, limit: 50, cancellationToken);
+            var count = rows.Count;
+
+            var cooldown = TimeSpan.FromMinutes(Math.Max(1, _alertCooldownMinutes));
+            var watermark = _lastAlertedPgDeadlockCount.TryGetValue(key, out var wm) ? wm : 0;
+            var cooldownElapsed = !_lastPgDeadlockAlert.TryGetValue(key, out var last) || now - last >= cooldown;
+
+            var decision = RollingCountAlertGate.Evaluate(
+                count, PgDeadlockCountThreshold, watermark, cooldownElapsed, suppressed: false);
+            _lastAlertedPgDeadlockCount[key] = decision.Watermark;
+
+            var wasActive = _activePgDeadlockAlert.TryGetValue(key, out var activeBefore) && activeBefore;
+            _activePgDeadlockAlert[key] = decision.Active;
+
+            if (decision.Fire)
+            {
+                _lastPgDeadlockAlert[key] = now;
+
+                var muted = _isAlertMuted?.Invoke(new AlertMuteContext
+                {
+                    ServerName = snapshot.ServerName,
+                    MetricName = metricName,
+                }) ?? false;
+
+                await _alertDeliverer.DeliverAsync(
+                    new AlertOutcome(
+                        key,
+                        snapshot.ServerName,
+                        metricName,
+                        count.ToString(CultureInfo.InvariantCulture),
+                        PgDeadlockCountThreshold.ToString(CultureInfo.InvariantCulture),
+                        Context: new AlertContext
+                        {
+                            Incidents = rows.Select(BuildPgDeadlockIncident).ToList(),
+                        },
+                        DetailText: null,
+                        NumericCurrentValue: count,
+                        NumericThresholdValue: PgDeadlockCountThreshold,
+                        Muted: muted,
+                        Severity: null,
+                        ShortMessage: $"{count} deadlock(s) in the last hour"),
+                    cancellationToken);
+            }
+            else if (!decision.Active && wasActive)
+            {
+                await NotifyPgResolutionAsync(key, snapshot.ServerName, metricName, "Deadlocks Cleared",
+                    $"{snapshot.ServerName}: No deadlocks in the last hour");
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError("[{Server}] PostgreSQL deadlock alert evaluation failed: {Message}",
+                runtime.Config.DisplayName, ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// The rolling-1-hour-window Postgres Blocking alert (#2711). Counts DISTINCT root blockers, not raw
+    /// chain rows — <see cref="DarlingPgBlockingReader.GetPgBlockingChainsAsync"/> returns one row per
+    /// (capture, root), so a single persistent blocker sampled every cycle for an hour would otherwise
+    /// inflate the count far past what an operator would call "how many blocking situations". Same
+    /// <see cref="RollingCountAlertGate"/> reuse and parity-named metrics as
+    /// <see cref="EvaluatePgDeadlocksAsync"/> — see its doc comment for why.
+    /// </summary>
+    private async Task EvaluatePgBlockingAsync(
+        ServerRuntime runtime, AlertServerSnapshot snapshot, CancellationToken cancellationToken)
+    {
+        if (_postgres is null || _alertDeliverer is null)
+        {
+            return;
+        }
+
+        const string metricName = "Blocking Detected";
+        var key = snapshot.ServerKey;
+
+        try
+        {
+            var now = DateTime.UtcNow;
+            var windowStart = now.AddHours(-AlertEngine.RollingCountWindowHours);
+
+            var rows = await DarlingPgBlockingReader.GetPgBlockingChainsAsync(
+                _postgres, runtime.ServerId, windowStart, now, limit: 100, cancellationToken);
+
+            var worstPerRoot = WorstPgBlockingChainPerRoot(rows);
+            var count = worstPerRoot.Count;
+
+            var cooldown = TimeSpan.FromMinutes(Math.Max(1, _alertCooldownMinutes));
+            var watermark = _lastAlertedPgBlockingCount.TryGetValue(key, out var wm) ? wm : 0;
+            var cooldownElapsed = !_lastPgBlockingAlert.TryGetValue(key, out var last) || now - last >= cooldown;
+
+            var decision = RollingCountAlertGate.Evaluate(
+                count, PgBlockingCountThreshold, watermark, cooldownElapsed, suppressed: false);
+            _lastAlertedPgBlockingCount[key] = decision.Watermark;
+
+            var wasActive = _activePgBlockingAlert.TryGetValue(key, out var activeBefore) && activeBefore;
+            _activePgBlockingAlert[key] = decision.Active;
+
+            if (decision.Fire)
+            {
+                _lastPgBlockingAlert[key] = now;
+
+                var muted = _isAlertMuted?.Invoke(new AlertMuteContext
+                {
+                    ServerName = snapshot.ServerName,
+                    MetricName = metricName,
+                }) ?? false;
+
+                await _alertDeliverer.DeliverAsync(
+                    new AlertOutcome(
+                        key,
+                        snapshot.ServerName,
+                        metricName,
+                        count.ToString(CultureInfo.InvariantCulture),
+                        PgBlockingCountThreshold.ToString(CultureInfo.InvariantCulture),
+                        Context: new AlertContext
+                        {
+                            Incidents = worstPerRoot.Select(BuildPgBlockingIncident).ToList(),
+                        },
+                        DetailText: null,
+                        NumericCurrentValue: count,
+                        NumericThresholdValue: PgBlockingCountThreshold,
+                        Muted: muted,
+                        Severity: null,
+                        ShortMessage: $"{count} blocking session(s)"),
+                    cancellationToken);
+            }
+            else if (!decision.Active && wasActive)
+            {
+                await NotifyPgResolutionAsync(key, snapshot.ServerName, metricName, "Blocking Cleared",
+                    $"{snapshot.ServerName}: No active blocking");
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError("[{Server}] PostgreSQL blocking alert evaluation failed: {Message}",
+                runtime.Config.DisplayName, ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Writes a Postgres Deadlocks/Blocking resolution the same way <see cref="BuildAlertEngine"/>'s
+    /// <c>resolutionCallback</c> does for the SQL Server families: a log line via
+    /// <see cref="AlertFiringLog.Resolved"/> and a history row via
+    /// <see cref="DarlingSelfAlertEvaluator.BuildResolutionRecord"/> — never through
+    /// <see cref="_alertDeliverer"/>, because a resolution has no send channel
+    /// (<see cref="AlertResolution"/>'s own doc comment). Best-effort: a history-write failure here must
+    /// not be allowed to look like the alert itself failed, since the condition genuinely did clear.
+    /// </summary>
+    private async Task NotifyPgResolutionAsync(
+        string serverKey, string serverName, string metricName, string title, string message)
+    {
+        _logger.LogInformation("{Line}", AlertFiringLog.Resolved(serverName, metricName, message));
+
+        if (_historyStore is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await _historyStore.RecordAlertAsync(DarlingSelfAlertEvaluator.BuildResolutionRecord(
+                new AlertResolution(serverKey, serverName, metricName, title, message)));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("Could not record Postgres alert resolution for {Server}/{Metric}: {Message}",
+                serverName, metricName, ex.Message);
+        }
+    }
+
+    /// <summary>Rolling-window count threshold for the Postgres Deadlocks alert (#2711) — 1, matching SQL
+    /// Server's own observed default via <see cref="IAlertEngineSettings.DeadlockCountThreshold"/>. A
+    /// constant rather than a setting for this first cut, the same reasoning
+    /// <see cref="PostgresAlertEvaluator"/>'s own doc comment gives for its three thresholds: add
+    /// configuration when someone actually wants a different number, not speculatively.</summary>
+    private const int PgDeadlockCountThreshold = 1;
+
+    /// <summary>Rolling-window count threshold for the Postgres Blocking alert (#2711) — same reasoning
+    /// as <see cref="PgDeadlockCountThreshold"/>.</summary>
+    private const int PgBlockingCountThreshold = 1;
+
+    /// <summary>
+    /// Pure mapping, pulled out of <see cref="EvaluatePgDeadlocksAsync"/> so it is testable without a
+    /// Postgres connection or an <see cref="IAlertDeliverer"/> fake — the same "pure, testable seam"
+    /// reasoning <see cref="CadencePhaseOffset"/> already gets in this file. One <see cref="AlertIncident"/>
+    /// per distinct deadlock (rows arrive pre-deduplicated by <c>deadlock_hash</c>, see
+    /// <see cref="DarlingPgDeadlockReader.GetDeadlocksAsync"/>'s own doc comment), falling back to pid +
+    /// participant count when the victim's statement text was not resolvable (permissions, or a graph
+    /// shape the log parser did not recognise).
+    /// </summary>
+    internal static AlertIncident BuildPgDeadlockIncident(DarlingPgDeadlockReader.PgDeadlockRow row) =>
+        new(
+            row.DeadlockHash,
+            new[]
+            {
+                string.IsNullOrWhiteSpace(row.VictimStatement)
+                    ? $"victim pid {row.VictimPid}, {row.ParticipantCount} participant(s)"
+                    : row.VictimStatement!,
+            });
+
+    /// <summary>
+    /// Which root blocker each captured chain belongs to, worst sample first per root — pulled out of
+    /// <see cref="EvaluatePgBlockingAsync"/> for the same testability reason as
+    /// <see cref="BuildPgDeadlockIncident"/>.
+    /// <para><see cref="DarlingPgBlockingReader.GetPgBlockingChainsAsync"/> returns one row per (capture,
+    /// root) ordered worst-first (widest chain, then deepest, then most recent) — see that method's own
+    /// doc comment — so grouping by root and taking each group's FIRST row keeps the worst sample the
+    /// window saw for that blocker, without needing to re-sort. Without this dedup, a single persistent
+    /// blocker sampled every cycle for the whole rolling window would inflate the alert's count far past
+    /// what an operator would call "how many blocking situations", since blocking here is sampled state,
+    /// not an engine-recorded event log (same caveat the collector's own doc comment carries).</para>
+    /// </summary>
+    internal static List<DarlingPgBlockingReader.PgBlockingChainRow> WorstPgBlockingChainPerRoot(
+        IReadOnlyList<DarlingPgBlockingReader.PgBlockingChainRow> rows) =>
+        rows.GroupBy(r => r.RootBackendId).Select(g => g.First()).ToList();
+
+    /// <summary>
+    /// Pure mapping, pulled out of <see cref="EvaluatePgBlockingAsync"/> for the same testability reason as
+    /// <see cref="BuildPgDeadlockIncident"/>. The dedup key is the root's synthetic backend identity (stable
+    /// across samples of the same backend, unlike a reused pid — see the collector's own doc comment), not
+    /// the pid alone.
+    /// </summary>
+    internal static AlertIncident BuildPgBlockingIncident(DarlingPgBlockingReader.PgBlockingChainRow row) =>
+        new(
+            row.RootBackendId.ToString(CultureInfo.InvariantCulture),
+            new[]
+            {
+                $"root pid {row.RootPid} blocking {row.TotalVictims} session(s)"
+                    + (row.Databases.Length > 0 ? $" in [{string.Join(", ", row.Databases)}]" : string.Empty)
+                    + (string.IsNullOrWhiteSpace(row.RootQuery) ? string.Empty : $": {row.RootQuery}"),
+            },
+            Database: row.Databases.Length > 0 ? row.Databases[0] : null);
 
     /// <summary>
     /// The latest collected CPU sample for the snapshot — Lite's overview read

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -3083,7 +3083,11 @@ public sealed class DarlingWorker : BackgroundService
     private async Task NotifyPgResolutionAsync(
         string serverKey, string serverName, string metricName, string title, string message)
     {
-        _logger.LogInformation("{Line}", AlertFiringLog.Resolved(serverName, metricName, message));
+        /* title, not metricName: AlertFiringLog deliberately uses different strings for Fired ("Deadlocks
+           Detected") vs Resolved ("Deadlocks Cleared") so the pair is distinguishable without reading the
+           log level — every other call site (the resolutionCallback closure above,
+           DarlingSelfAlertEvaluator) passes the title-like value here. */
+        _logger.LogInformation("{Line}", AlertFiringLog.Resolved(serverName, title, message));
 
         if (_historyStore is null)
         {

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -3153,25 +3153,50 @@ public sealed class DarlingWorker : BackgroundService
     /// cycle for the whole rolling window would inflate the alert's count far past what an operator would
     /// call "how many blocking situations", since blocking here is sampled state, not an engine-recorded
     /// event log (same caveat the collector's own doc comment carries).</para>
-    /// <para><b><c>RootBackendId == 0</c> is the vanished-blocker sentinel and is NEVER deduped against
-    /// another zero.</b> <c>PgBlockingCollector</c> writes <c>coalesce(blocker.backend_id, 0)</c> when the
-    /// root's own row had already left <c>pg_stat_activity</c> by capture time, and
-    /// <c>DarlingPgBlockingReader</c>'s own <c>recurrence</c> CTE already excludes
-    /// <c>blocking_backend_id &lt;&gt; 0</c> for the identical reason: grouping on the sentinel would count
-    /// unrelated one-off incidents in different captures as repeat appearances of one backend. A plain
-    /// GroupBy-by-RootBackendId would collapse two genuinely different vanished-root blocking situations
-    /// into one entry and merge their fingerprints — a real undercounting bug review caught before this
-    /// was reused as an alert count rather than a display grouping.</para>
+    /// <para><b><c>RootBackendId == 0</c> is the vanished-blocker sentinel, and it needs its OWN identity to
+    /// dedupe against, not the raw backend id.</b> <c>PgBlockingCollector</c> writes
+    /// <c>coalesce(blocker.backend_id, 0)</c> when the root's own row had already left
+    /// <c>pg_stat_activity</c> by capture time, so every genuinely different vanished-root incident shares
+    /// the literal value 0 — <c>DarlingPgBlockingReader</c>'s own <c>recurrence</c> CTE excludes
+    /// <c>blocking_backend_id &lt;&gt; 0</c> for the identical reason. Two failure modes sit on either side
+    /// of this, and both were caught by review before shipping:
+    /// <list type="bullet">
+    /// <item>Grouping by the raw <c>RootBackendId</c> (as if 0 were a real id) collapses two UNRELATED
+    /// vanished-root incidents into one entry and merges their fingerprints — an undercount.</item>
+    /// <item>Never deduping sentinel rows at all re-introduces the #1091/#2704/#2708 re-fire class for
+    /// exactly this case: the SAME persisting vanished-root block, sampled every sweep, would add a new
+    /// list entry every cycle, so <see cref="RollingCountAlertGate"/>'s watermark keeps climbing and the
+    /// alert re-fires every cooldown for one ongoing incident.</item>
+    /// </list>
+    /// The fix is <c>RootPid</c> as the sentinel case's dedup identity — the same value
+    /// <see cref="BuildPgBlockingIncident"/> already folds into that case's <c>DedupKey</c> — which narrows
+    /// the risk to pid reuse inside one rolling 1-hour window, far smaller than either failure mode
+    /// above.</para>
     /// </summary>
     internal static List<DarlingPgBlockingReader.PgBlockingChainRow> WorstPgBlockingChainPerRoot(
         IReadOnlyList<DarlingPgBlockingReader.PgBlockingChainRow> rows)
     {
         var result = new List<DarlingPgBlockingReader.PgBlockingChainRow>();
-        var seenRootBackendIds = new HashSet<long>();
+        var seenRealBackendIds = new HashSet<long>();
+        var seenSentinelPids = new HashSet<int>();
 
         foreach (var row in rows)
         {
-            if (row.RootBackendId == 0 || seenRootBackendIds.Add(row.RootBackendId))
+            /* Never deduping the sentinel at all (an earlier version of this method) traded one bug for
+               another: the SAME persisting vanished-root block, sampled every sweep, would then add a NEW
+               list entry every cycle — RollingCountAlertGate's watermark keeps climbing as long as the
+               count keeps climbing, re-firing "Blocking Detected" every cooldown for what is one ongoing
+               incident (exactly the #1091/#2704/#2708 class this whole design exists to be immune to,
+               reintroduced specifically for this case). Deduping the sentinel by RootPid instead is the
+               narrower, correct trade: BuildPgBlockingIncident already treats RootPid as the sentinel
+               case's usable identity (it is folded into that case's DedupKey below), and pid reuse inside
+               one rolling 1-hour window is a far smaller risk than guaranteed re-alerting on every sweep
+               for any persisting vanished-root block. */
+            var isNew = row.RootBackendId == 0
+                ? seenSentinelPids.Add(row.RootPid)
+                : seenRealBackendIds.Add(row.RootBackendId);
+
+            if (isNew)
             {
                 result.Add(row);
             }


### PR DESCRIPTION
Part of #2711.

## What this adds

Postgres Deadlocks and Blocking alerts, the two "straightforward" items from #2711's per-alert-type breakdown — the underlying telemetry was already collected (`pg_deadlocks`, `pg_blocking_edges`), nothing evaluated it into an alert.

## Design

- **Reuses `RollingCountAlertGate`** (`PerformanceMonitor.Alerting`) for the fire/clear edge-trigger — the same shared, already-tested primitive `AlertEngine` uses for the SQL Server versions of these two alerts. This is deliberate: these are rolling-window counts, and #1091 already proved that a plain "still above threshold" check re-fires the SAME already-reported event every cooldown until it ages out of the window.
- **Reuses the existing read side** — `DarlingPgDeadlockReader.GetDeadlocksAsync` (already dedupes by `deadlock_hash`) and `DarlingPgBlockingReader.GetPgBlockingChainsAsync` (already assembles chains worst-first). No new SQL.
- **Kept alongside `AlertEngine`, not inside it** — same reasoning `PostgresAlertEvaluator`'s own doc comment gives for the three existing Tier 0 predictors.
- **Kept at the simpler state shape** the three existing Postgres predictors already use (in-process `ConcurrentDictionary`s in `DarlingWorker`, not `IAlertStateStore`/`IncidentOccurrenceAccumulator`) — proportionate to a first cut, matching existing precedent rather than porting `AlertEngine`'s full machinery. **Known limitation, not fixed here:** unlike `AlertEngine`'s watermarks (seeded from `IAlertStateStore` on startup), these dictionaries — and the three existing Postgres predictors' — don't survive a service restart, so a condition still active across a restart can re-fire once. Filed as #2716, scoped to all five Postgres alerts uniformly rather than just these two, since it's a pre-existing property of the Postgres alert path, not something specific to this PR.
- **Metric names are the exact SQL Server strings** ("Deadlocks Detected"/"Deadlocks Cleared", "Blocking Detected"/"Blocking Cleared") rather than Postgres-prefixed ones — the whole point is parity. `server_id` never collides across engines, so there's no ambiguity.
- **Blocking counts distinct root blockers, not raw chain rows** — the reader returns one row per (capture, root), so a single persistent blocker sampled every cycle for an hour would otherwise inflate the count. `WorstPgBlockingChainPerRoot` dedupes to one (the worst) sample per root — by `RootBackendId` normally, and by `RootPid` for the vanished-blocker sentinel (`RootBackendId == 0`), since the sentinel value itself can't distinguish unrelated incidents (review caught two failure modes here in turn: merging unrelated sentinel incidents, then over-correcting into never deduping a persisting one — both fixed, see commit history).

## Explicitly out of scope (remains open under #2711)

High CPU, Long-Running Query, and Poison Wait — per Erik's explicit narrowing to Deadlocks + Blocking for this pass.

## Test plan

- [x] `dotnet build` (project + `Darling.Tests`) clean, 0 new errors/warnings
- [x] `DarlingPgOperationalAlertTests.cs` covers `BuildPgDeadlockIncident`, `WorstPgBlockingChainPerRoot`, `BuildPgBlockingIncident` — including the sentinel collision/re-fire cases review caught
- [x] Confirmed via CI's Windows `build` job log: `Darling.Tests` total went from 6379 (pre-PR) to 6394 (+15, matching every test added across this PR's commits), 0 failed
- `RollingCountAlertGate` itself is already exhaustively tested in `Lite.Tests/RollingCountAlertGateTests.cs` — not re-tested here

## Follow-ups filed during review

- #2714 — `GetPgBlockingChainsAsync`'s severity-ordered `LIMIT` applies before dedup (rare edge case, reviewer's own framing)
- #2716 — Postgres alert watermarks (all five, not just this PR's two) don't survive a service restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)