### PR TITLE
Detach plan_correction from the sequential body, generalizing #2701

### DIFF
--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -5033,12 +5033,15 @@ LIMIT 1";
            dictionary already generalizes. A held gate here means a previous detached tick for THIS
            collector on THIS server has not finished — skip is safe because every collector detached this
            way is picked specifically for having no wall-clock-derived window (plan_correction re-reads
-           the live DMV set whole on every pass, so a skip just re-reads it, possibly refreshed, next time). */
+           the live DMV set whole on every pass, so a skip just re-reads it, possibly refreshed, next time).
+           NotGated (mirroring QueryStoreServerGate's) collapses this to a single null check below — a
+           future third collector needs only its own IsXCollector check added to this one condition,
+           never a second one to keep in sync. */
         using var detachedGate = IsPlanCorrectionCollector(collectorName)
             ? _detachedCollectorGates.GetOrAdd((runtime.ServerId, collectorName), static _ => new DetachedCollectorGate()).TryAcquire()
-            : null;
+            : DetachedCollectorGate.NotGated;
 
-        if (IsPlanCorrectionCollector(collectorName) && detachedGate is null)
+        if (detachedGate is null)
         {
             _logger.LogInformation(
                 "  [{Server}] {Collector} skipped this tick — a previous detached run has not finished (#2717). " +

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -2129,6 +2129,16 @@ public sealed class DarlingWorker : BackgroundService
     private readonly ConcurrentDictionary<int, QueryStoreServerGate> _queryStoreGates = new();
 
     /// <summary>
+    /// #2717: one <see cref="DetachedCollectorGate"/> per (server, collector) for every collector fired
+    /// detached from <see cref="RunDueCollectorsAsync"/>'s sequential body other than query_store (which
+    /// keeps its own <see cref="_queryStoreGates"/> because it has a second, orthogonal job — mutual
+    /// exclusion against the separate first-contact backfill loop — that a generic gate does not need to
+    /// solve). Keyed by collector name as well as server id so two DIFFERENT detached collectors on the
+    /// same server never contend for one slot.
+    /// </summary>
+    private readonly ConcurrentDictionary<(int ServerId, string CollectorName), DetachedCollectorGate> _detachedCollectorGates = new();
+
+    /// <summary>
     /// #2219: whether this is the PostgreSQL statement-stats collector, whose success is what triggers a text
     /// refresh. Compared against the collector's OWN declared name rather than a literal, so renaming it cannot
     /// silently unhook the text path — the same reasoning as <see cref="IsQueryStoreCollector"/>.
@@ -2143,6 +2153,15 @@ public sealed class DarlingWorker : BackgroundService
     /// </summary>
     internal static bool IsQueryStoreCollector(string collectorName) =>
         string.Equals(collectorName, QueryStoreCollector.Instance.Name, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// #2717: whether a dispatched collector name is plan_correction — the second collector detached from
+    /// the sequential body for the same bimodal-cost reason query_store was in #2701. Compared against the
+    /// collector's OWN declared name rather than a literal, for the same renaming-safety reason as
+    /// <see cref="IsQueryStoreCollector"/>.
+    /// </summary>
+    internal static bool IsPlanCorrectionCollector(string collectorName) =>
+        string.Equals(collectorName, PlanCorrectionCollector.Instance.Name, StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// #2219: refreshes this PostgreSQL server's statement text if it is due, and swallows everything if not.
@@ -4255,11 +4274,22 @@ LIMIT 1", connection);
                    overlapping — and query_store's own window is watermark-driven (#1960), so a detached run
                    that outlives this sweep resumes correctly from its own gate rather than dropping rows.
                    RunOneAsync's catch-all already contains every fault but cancellation, so
-                   RunDetachedQueryStoreAsync exists only to keep a shutdown-time
-                   OperationCanceledException from surfacing as an unobserved task exception. */
-                if (IsQueryStoreCollector(name))
+                   RunDetachedAsync exists only to keep a shutdown-time OperationCanceledException from
+                   surfacing as an unobserved task exception. */
+                /* #2717: plan_correction gets the identical treatment for the identical reason. Its own
+                   SQL is already correctly seek-based (#2687) and averages ~1 second, but on a server
+                   whose Query Store carries the same leaflogix-class distinct-plan-population signature
+                   already root-caused for query_store on multi-03/AYR, it can spike to 20+ seconds — the
+                   same bimodal shape, just a smaller worst case. Detached the same way, through the
+                   generic DetachedCollectorGate (#2717) rather than query_store's own gate, which has an
+                   orthogonal second job (excluding the backfill loop) this collector does not share.
+                   plan_correction's recommendation-set read is DMV-driven with no persisted watermark, but
+                   sys.dm_db_tuning_recommendations is re-read whole on every successful pass regardless —
+                   a skipped tick simply re-reads the same (or since-refreshed) live set next time, the
+                   same "defers, does not drop" property #1960 gives query_store's watermark. */
+                if (IsQueryStoreCollector(name) || IsPlanCorrectionCollector(name))
                 {
-                    _ = RunDetachedQueryStoreAsync(server, runner, name, cancellationToken);
+                    _ = RunDetachedAsync(server, runner, name, cancellationToken);
                 }
                 else
                 {
@@ -4996,6 +5026,27 @@ LIMIT 1";
             return 0;
         }
 
+        /* #2717: the generic sibling of the gate above, for collectors detached from the sequential body
+           for the same bimodal-cost reason as query_store but with no second loop to exclude — see
+           DetachedCollectorGate's own doc comment. Keyed by (server, collector name), so a future third
+           collector detached this way needs only its own IsXCollector check added to this condition; the
+           dictionary already generalizes. A held gate here means a previous detached tick for THIS
+           collector on THIS server has not finished — skip is safe because every collector detached this
+           way is picked specifically for having no wall-clock-derived window (plan_correction re-reads
+           the live DMV set whole on every pass, so a skip just re-reads it, possibly refreshed, next time). */
+        using var detachedGate = IsPlanCorrectionCollector(collectorName)
+            ? _detachedCollectorGates.GetOrAdd((runtime.ServerId, collectorName), static _ => new DetachedCollectorGate()).TryAcquire()
+            : null;
+
+        if (IsPlanCorrectionCollector(collectorName) && detachedGate is null)
+        {
+            _logger.LogInformation(
+                "  [{Server}] {Collector} skipped this tick — a previous detached run has not finished (#2717). " +
+                "Re-reads the live set next tick; no rows are lost.",
+                server.Config.DisplayName, collectorName);
+            return 0;
+        }
+
         try
         {
             var result = await run(runner, runtime, cancellationToken);
@@ -5196,13 +5247,14 @@ LIMIT 1";
     }
 
     /// <summary>
-    /// #2700: fire-and-forget wrapper around <see cref="RunOneAsync"/> for query_store, the one collector
-    /// split off <see cref="RunDueCollectorsAsync"/>'s sequential body — see that call site for why.
-    /// RunOneAsync's own catch-all already contains every fault but cancellation, so this wrapper exists
-    /// only to keep a shutdown-time <see cref="OperationCanceledException"/> from surfacing as an
-    /// unobserved task exception, the same containment every other fire-and-track body in this file gets.
+    /// #2717 generalized this from query_store's own name (<c>RunDetachedQueryStoreAsync</c>): shared by
+    /// every collector fired detached from <see cref="RunDueCollectorsAsync"/>'s sequential body — see
+    /// the two call sites for why each one qualifies. <see cref="RunOneAsync"/>'s own catch-all already
+    /// contains every fault but cancellation, so this wrapper exists only to keep a shutdown-time
+    /// <see cref="OperationCanceledException"/> from surfacing as an unobserved task exception, the same
+    /// containment every other fire-and-track body in this file gets.
     /// </summary>
-    private async Task RunDetachedQueryStoreAsync(
+    private async Task RunDetachedAsync(
         ServerLoopState server, DarlingCollectorRunner runner, string collectorName, CancellationToken cancellationToken)
     {
         try
@@ -5211,8 +5263,11 @@ LIMIT 1";
         }
         catch (OperationCanceledException)
         {
-            /* Shutdown — expected, and safe to abandon: query_store's window is watermark-driven (#1960),
-               so an in-flight run dropped here resumes from the same boundary on the next start. */
+            /* Shutdown — expected, and safe to abandon: every collector detached this way is picked
+               specifically for having no wall-clock-derived window (query_store's is watermark-driven,
+               #1960; plan_correction re-reads the live DMV set whole on every pass), so a run dropped
+               here resumes correctly — from the same watermark, or by re-reading the current set — on
+               the next start. */
         }
     }
 

--- a/Lite.Tests/DetachedCollectorGateTests.cs
+++ b/Lite.Tests/DetachedCollectorGateTests.cs
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using PerformanceMonitor.Common;
+using Xunit;
+
+namespace Lite.Tests;
+
+/// <summary>
+/// Pins the #2717 gate: the generic per-(server, collector) single-flight exclusion used by every collector
+/// detached from Darling's sequential per-server body for a bimodal, data-driven cost tail — query_store first
+/// (#2701), plan_correction second (#2717). Same shape as <see cref="QueryStoreServerGate"/> and the same two
+/// properties matter: it EXCLUDES, and it never WAITS — a blocking acquire here would let one server's slow
+/// detached run stall the caller that keyed the dictionary, recreating the #2148 wedge this whole family of
+/// gates exists to avoid.
+/// </summary>
+public sealed class DetachedCollectorGateTests
+{
+    /// <summary>THE POINT: a second acquirer is refused while the first holds the gate.</summary>
+    [Fact]
+    public void ASecondAcquirerIsRefusedWhileTheFirstHoldsIt()
+    {
+        var gate = new DetachedCollectorGate();
+
+        using var first = gate.TryAcquire();
+
+        Assert.NotNull(first);
+        Assert.Null(gate.TryAcquire());
+        Assert.True(gate.IsHeld);
+    }
+
+    /// <summary>
+    /// Releasing hands the gate to the next caller. A gate that could only be taken once would permanently stop
+    /// the detached collector on that server — and it would look like "that collector has no data" rather than
+    /// like a bug.
+    /// </summary>
+    [Fact]
+    public void ReleasingLetsTheNextTickIn()
+    {
+        var gate = new DetachedCollectorGate();
+
+        var first = gate.TryAcquire();
+        Assert.NotNull(first);
+        first!.Dispose();
+
+        Assert.False(gate.IsHeld);
+        using var second = gate.TryAcquire();
+        Assert.NotNull(second);
+    }
+
+    /// <summary>
+    /// It never blocks. Asserted as elapsed time against a HELD gate, because the failure this guards is a
+    /// blocking acquire silently replacing the try-acquire — which would still pass an exclusion-only test
+    /// while reintroducing a fleet stall (one server's still-running detached tick would freeze the whole
+    /// per-server foreach that keyed the dictionary, which is the exact per-body sequential-await problem
+    /// #2701/#2717 detach collectors to avoid in the first place).
+    /// </summary>
+    [Fact]
+    public void ARefusedAcquireReturnsImmediatelyRatherThanWaiting()
+    {
+        var gate = new DetachedCollectorGate();
+        using var held = gate.TryAcquire();
+
+        var started = Environment.TickCount64;
+        for (var i = 0; i < 1_000; i++)
+        {
+            Assert.Null(gate.TryAcquire());
+        }
+
+        Assert.True(Environment.TickCount64 - started < 1_000,
+            "a thousand refused acquires must not block — a blocking acquire here stalls the caller's whole sweep");
+    }
+
+    /// <summary>
+    /// Double-dispose must not release a gate a DIFFERENT tick has since taken. Without idempotence, "this
+    /// tick's own detached run disposes twice, the next tick acquires in between" leaves two detached runs of
+    /// the SAME collector against the SAME server in flight at once — the exact condition the gate exists to
+    /// prevent, reached through a stray extra Dispose rather than through missing exclusion.
+    /// </summary>
+    [Fact]
+    public void DisposingALeaseTwiceCannotReleaseSomebodyElsesHold()
+    {
+        var gate = new DetachedCollectorGate();
+
+        var firstTick = gate.TryAcquire();
+        Assert.NotNull(firstTick);
+        firstTick!.Dispose();
+
+        var secondTick = gate.TryAcquire();
+        Assert.NotNull(secondTick);
+
+        firstTick.Dispose();                 /* the stray second dispose */
+
+        Assert.True(gate.IsHeld, "the second tick's hold must survive the first tick's double-dispose");
+        Assert.Null(gate.TryAcquire());
+        secondTick!.Dispose();
+    }
+
+    /// <summary>
+    /// Under real contention exactly ONE holder exists at a time. Two overlapping detached runs of the same
+    /// collector against the same server is precisely the field risk this gate exists to prevent (doubled
+    /// transient load on a server already in its worst-case cost tail), so the concurrent-holder count is
+    /// asserted directly rather than inferred.
+    /// </summary>
+    [Fact]
+    public async Task UnderContentionOnlyOneHolderEverExistsAtOnce()
+    {
+        var gate = new DetachedCollectorGate();
+        var concurrent = 0;
+        var maxObserved = 0;
+        var acquisitions = 0;
+
+        await Task.WhenAll(Enumerable.Range(0, 8).Select(_ => Task.Run(() =>
+        {
+            for (var i = 0; i < 2_000; i++)
+            {
+                using var lease = gate.TryAcquire();
+                if (lease is null)
+                {
+                    continue;
+                }
+
+                Interlocked.Increment(ref acquisitions);
+                var now = Interlocked.Increment(ref concurrent);
+                InterlockedMax(ref maxObserved, now);
+                Interlocked.Decrement(ref concurrent);
+            }
+        })));
+
+        Assert.True(acquisitions > 0, "the contention loop must have actually acquired the gate at least once");
+        Assert.Equal(1, maxObserved);
+    }
+
+    private static void InterlockedMax(ref int target, int candidate)
+    {
+        int initial;
+        do
+        {
+            initial = Volatile.Read(ref target);
+            if (candidate <= initial)
+            {
+                return;
+            }
+        }
+        while (Interlocked.CompareExchange(ref target, candidate, initial) != initial);
+    }
+}

--- a/Lite.Tests/DetachedCollectorGateTests.cs
+++ b/Lite.Tests/DetachedCollectorGateTests.cs
@@ -7,7 +7,9 @@
  */
 
 using System;
+using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using PerformanceMonitor.Common;
@@ -152,5 +154,72 @@ public sealed class DetachedCollectorGateTests
             }
         }
         while (Interlocked.CompareExchange(ref target, candidate, initial) != initial);
+    }
+
+    /// <summary>
+    /// <c>NotGated</c> is a distinct, non-null, safely re-disposable sentinel — same reasoning as
+    /// <see cref="QueryStoreServerGate.NotGated"/>, which this mirrors. It is what lets a call site decide
+    /// "am I gated?" and "did I get the gate?" in one expression while keeping <c>null</c> meaning only
+    /// "skip" — conflating the two would silently skip a collector nobody meant to gate.
+    /// </summary>
+    [Fact]
+    public void NotGatedIsANonNullNoOpSentinel()
+    {
+        Assert.NotNull(DetachedCollectorGate.NotGated);
+
+        DetachedCollectorGate.NotGated.Dispose();
+        DetachedCollectorGate.NotGated.Dispose();
+
+        /* Still usable afterwards: it is a shared singleton every non-gated collector run disposes. */
+        Assert.NotNull(DetachedCollectorGate.NotGated);
+        Assert.Same(DetachedCollectorGate.NotGated, DetachedCollectorGate.NotGated);
+    }
+
+    /* ──────────────── the WIRING, pinned at the source ────────────────
+
+       Behavioral coverage cannot reach this: a call site that re-tests IsPlanCorrectionCollector in a second
+       `if` instead of using NotGated builds and passes every test above, and only drifts from its sibling gate
+       the day a third collector is added to one check and not the other — exactly the review nit on #2720.
+       So the call site is asserted textually, per the QueryStoreServerGateTests idiom. */
+
+    private static string ReadRepoFile(string relativePath, [CallerFilePath] string thisFile = "")
+    {
+        var dir = Path.GetDirectoryName(thisFile)!;
+        var parts = relativePath.Split('/');
+        while (dir is not null && !File.Exists(Path.Combine(new[] { dir }.Concat(parts).ToArray())))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        Assert.NotNull(dir);
+        return File.ReadAllText(Path.Combine(new[] { dir! }.Concat(parts).ToArray()));
+    }
+
+    /// <summary>
+    /// DARLING: the gate-acquisition call site uses <c>NotGated</c> rather than re-testing
+    /// IsPlanCorrectionCollector in a second condition — tested by asserting the predicate appears exactly
+    /// once at that call site. Two occurrences is the regression: it means "not gated" and "gate busy" are
+    /// being told apart by re-testing the predicate instead of by the sentinel, which is precisely the
+    /// two-sites-must-stay-in-sync failure mode NotGated exists to remove.
+    /// </summary>
+    [Fact]
+    public void Darling_GateAcquisitionTestsThePredicateExactlyOnce()
+    {
+        var worker = ReadRepoFile("Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs");
+
+        Assert.Contains("DetachedCollectorGate.NotGated", worker, StringComparison.Ordinal);
+        Assert.Equal(1, CountOccurrences(worker, "IsPlanCorrectionCollector(collectorName)"));
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        for (var i = haystack.IndexOf(needle, StringComparison.Ordinal); i >= 0;
+             i = haystack.IndexOf(needle, i + needle.Length, StringComparison.Ordinal))
+        {
+            count++;
+        }
+
+        return count;
     }
 }

--- a/PerformanceMonitor.Common/DetachedCollectorGate.cs
+++ b/PerformanceMonitor.Common/DetachedCollectorGate.cs
@@ -25,7 +25,7 @@ namespace PerformanceMonitor.Common;
 /// awaiting it in the sequential foreach, single-flighted per server so a still-running previous tick
 /// skips rather than overlaps.</para>
 ///
-/// <para><b>#2717 is the second.</b> <c>plan_correction</c> (1-minute cadence, a <c>PerItemWallClockBudget</c>
+/// <para><b>#2717 is the second.</b> <c>plan_correction</c> (5-minute cadence, a <c>PerItemWallClockBudget</c>
 /// of 120 seconds set by #2673 for exactly this tail-risk) showed the identical shape on a fleet server:
 /// average ~1 second, occasional 21-second spike, 97% of that spike attributable to one database
 /// independently confirmed to carry the same distinct-plan-population signature already root-caused

--- a/PerformanceMonitor.Common/DetachedCollectorGate.cs
+++ b/PerformanceMonitor.Common/DetachedCollectorGate.cs
@@ -73,6 +73,27 @@ public sealed class DetachedCollectorGate
     public IDisposable? TryAcquire() =>
         Interlocked.CompareExchange(ref _taken, 1, 0) == 0 ? new Lease(this) : null;
 
+    /// <summary>
+    /// A lease that guards nothing, for a caller whose collector is not gated at all.
+    ///
+    /// <para>Exists so <c>null</c> from <see cref="TryAcquire"/> keeps exactly ONE meaning — "a previous
+    /// detached run holds this (server, collector) slot, skip" — at a call site that decides whether to
+    /// gate and whether it got the gate in the same expression. Without it, "not gated" and "gate busy"
+    /// would both be null and every such site would need to re-test the predicate to tell a skip from a
+    /// pass-through; getting that wrong silently skips a collector nobody meant to gate. Same reasoning as
+    /// <see cref="QueryStoreServerGate.NotGated"/>, which this mirrors.</para>
+    /// </summary>
+    public static IDisposable NotGated { get; } = new NoOpLease();
+
+    private sealed class NoOpLease : IDisposable
+    {
+        public void Dispose()
+        {
+            /* Nothing held, nothing to release — and safe to dispose repeatedly, since it is a shared
+               singleton that every non-gated collector run disposes. */
+        }
+    }
+
     private sealed class Lease : IDisposable
     {
         private DetachedCollectorGate? _gate;

--- a/PerformanceMonitor.Common/DetachedCollectorGate.cs
+++ b/PerformanceMonitor.Common/DetachedCollectorGate.cs
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Threading;
+
+namespace PerformanceMonitor.Common;
+
+/// <summary>
+/// Per-(server, collector) single-flight gate for a collector detached from the sequential per-server
+/// body (Darling's <c>RunDueCollectorsAsync</c>) because its cost is BIMODAL — a fast common case with an
+/// occasional heavy-tailed run driven by data volume on the monitored server, not by anything this
+/// project's own query does wrong.
+///
+/// <para><b>#2701 was the first instance.</b> <c>query_store</c> (5-minute cadence) could spike from its
+/// normal 5-35s to 100-230+ seconds on a server accumulating an abnormally large distinct-plan population
+/// (the leaflogix-class decimal-parameter-instability signature). Awaited inline in the sequential body,
+/// that spike blocked every OTHER due collector for the same server and could push the whole server's
+/// sweep past its 60-second budget (BODY_OVERRUN). The fix was to detach it: fire the collector without
+/// awaiting it in the sequential foreach, single-flighted per server so a still-running previous tick
+/// skips rather than overlaps.</para>
+///
+/// <para><b>#2717 is the second.</b> <c>plan_correction</c> (1-minute cadence, a <c>PerItemWallClockBudget</c>
+/// of 120 seconds set by #2673 for exactly this tail-risk) showed the identical shape on a fleet server:
+/// average ~1 second, occasional 21-second spike, 97% of that spike attributable to one database
+/// independently confirmed to carry the same distinct-plan-population signature already root-caused
+/// elsewhere in the fleet. The query itself is already correctly seek-based (#2687) — the cost is
+/// proportional to real catalog size on an already-affected database, not a tunable defect, so the fix here
+/// is the same one #2701 already proved: stop letting one collector's data-driven tail block every other due
+/// collector on the same server.</para>
+///
+/// <para><b>Deliberately generic, and deliberately NOT <see cref="QueryStoreServerGate"/>.</b> That type's
+/// mutual exclusion is between TWO SPECIFIC loops (the per-tick collection and the separate first-contact
+/// backfill) — an orthogonal concern this type does not need to solve. Reusing it for a second collector
+/// would make its own doc comments wrong about what it protects. Keyed by (server, collector name) so two
+/// DIFFERENT detached collectors on the same server never share a gate — the only case that actually needs
+/// excluding is two overlapping runs of the SAME collector against the SAME server, which risks doubling
+/// transient load on a server already in its worst-case tail and writing overlapping rows for the same
+/// window. That is a target-load and store-write concern, not a data-race one: each run opens its own
+/// connection and each written row is independent, so a caller that skips on a busy gate loses nothing
+/// that the next tick's row will not carry.</para>
+///
+/// <para>Never blocks: <see cref="TryAcquire"/> only, exactly like <see cref="QueryStoreServerGate"/>. A
+/// collector whose gate is held simply skips this tick. Only add a collector to this gate's usage sites
+/// if a skipped tick is provably safe for it — a watermark-driven, aggregate, or otherwise idempotent
+/// window where a miss defers work rather than losing it. A collector whose window is wall-clock derived
+/// must not be detached this way.</para>
+/// </summary>
+public sealed class DetachedCollectorGate
+{
+    /* Same CompareExchange-flag shape as QueryStoreServerGate and for the same reason: this gate never
+       waits, so a SemaphoreSlim would buy blocking/async-wait machinery nothing here ever uses, at the
+       cost of a kernel-backed object per (server, collector) pair that nothing disposes (the registry is
+       never pruned, by design — one gate per pair lives for the process). */
+    private int _taken;
+
+    /// <summary>
+    /// True while a detached run holds this (server, collector) slot. Diagnostic only — never branch on
+    /// it and then acquire, which is a race; use <see cref="TryAcquire"/>, whose result IS the decision.
+    /// </summary>
+    public bool IsHeld => Volatile.Read(ref _taken) == 1;
+
+    /// <summary>
+    /// Takes the slot if it is free, returning a lease to release it — or <c>null</c> when a previous
+    /// detached run still holds it, which the caller must treat as "skip this tick for this collector on
+    /// this server".
+    /// </summary>
+    public IDisposable? TryAcquire() =>
+        Interlocked.CompareExchange(ref _taken, 1, 0) == 0 ? new Lease(this) : null;
+
+    private sealed class Lease : IDisposable
+    {
+        private DetachedCollectorGate? _gate;
+
+        internal Lease(DetachedCollectorGate gate) => _gate = gate;
+
+        /// <summary>
+        /// Releases once and only once. Idempotent, and the release is Interlocked, for the same reason
+        /// as <see cref="QueryStoreServerGate"/>'s lease: the acquiring tick and its detached continuation
+        /// dispose on different threads, and a double-release must never clear a flag a DIFFERENT tick
+        /// has since taken.
+        /// </summary>
+        public void Dispose() => Interlocked.Exchange(ref _gate, null)?.Release();
+    }
+
+    private void Release() => Volatile.Write(ref _taken, 0);
+}


### PR DESCRIPTION
Fixes #2717.

## Problem

Erik flagged plan_correction's Collector Cost Regression on one fleet server (217,072 ms/day, 3.4x its 14-day baseline) and asked for further perf tuning beyond #2687/#2688.

**Investigation found plan_correction's own SQL has no further tuning headroom.** It's already correctly seek-based post-#2687 (avg 1057ms). But `get_collection_health` shows a max of 21,351ms, with 97% of that (20,755ms) attributable to one database. Checked `collect.query_store_plan_map` directly for that database: **36,232 distinct plan_ids, 28,260 distinct digests** — the identical leaflogix-class decimal-parameter-instability signature already root-caused for query_store on other servers earlier tonight. This is a data-volume problem downstream of an already-tracked app-side bug, not a query-shape defect in plan_correction.

**The actual actionable finding:** plan_correction's cost shape (avg ~1s, occasional 20+s spike depending on the affected server) is exactly the bimodal shape #2701 fixed for `query_store` (avg 5-35s, occasional 100-230s spike) — which caused query_store to block every other due collector sharing its per-server sequential body and risk BODY_OVERRUN. **#2701's fix applies only to query_store.** plan_correction was still awaited inline in `RunDueCollectorsAsync`, still able to block other collectors on an affected server for the duration of its own spike.

## Fix

Generalizes #2701's detach pattern instead of duplicating it for a second collector:

- `DetachedCollectorGate` (new, `PerformanceMonitor.Common`): a collector-agnostic sibling of `QueryStoreServerGate`, same CompareExchange-flag single-flight shape, never blocks. `QueryStoreServerGate` itself is untouched — it has an orthogonal second job (mutual exclusion against the separate first-contact backfill loop) this type doesn't need to solve.
- `_detachedCollectorGates` in `DarlingWorker`: keyed by `(int ServerId, string CollectorName)`, so a future third collector detached this way needs only its own `IsXCollector` check — the dictionary already generalizes.
- `IsPlanCorrectionCollector` mirrors `IsQueryStoreCollector`'s renaming-safety pattern (compared against the collector's own declared `Name`).
- `RunDetachedQueryStoreAsync` renamed `RunDetachedAsync` and shared by both detached collectors rather than duplicated — its body (contain a shutdown-time `OperationCanceledException`) was already fully generic.
- `RunOneAsync` gates plan_correction through the new generic gate the same way it already gated query_store through its own.

plan_correction is safe to detach for the same reason query_store is: its window isn't wall-clock derived. It re-reads `sys.dm_db_tuning_recommendations` whole on every successful pass (no persisted watermark to invalidate), so a skipped tick just re-reads the current — possibly since-refreshed — live set next time. No rows are lost, only deferred.

## Test plan

- [x] `dotnet build` (project + full solution) clean, 0 errors, no new warnings
- [x] `DetachedCollectorGateTests.cs` added, mirroring `QueryStoreServerGateTests.cs`'s five properties (exclusion, release-lets-next-in, never-blocks, double-dispose-safety, single-holder-under-contention)
- Could not run `Lite.Tests`/`Darling.Tests` locally (net10.0-windows, this Mac lacks the WindowsDesktop runtime) — verified all 14 assertions pass against the real, shipped `DetachedCollectorGate` type via a throwaway `net10.0` console harness referencing the actual project (not a retyped copy), per this repo's documented macOS verification practice. Relying on CI for the full xUnit run.
- [x] First CI run caught two real issues, both fixed: a real fleet-tenant identifier that had leaked into a code comment (`FleetIdentifierScrubTests`, since this repo is public — replaced with generic language) and a stacked doc-comment block left over from renaming `RunDetachedQueryStoreAsync` to `RunDetachedAsync` (`DocCommentHygieneTests`). Commit amended and force-pushed to a branch nothing else was based on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)