### PR TITLE
Promote alert Involved Objects/Database to top-level Datadog-parity tags

### DIFF
--- a/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml
@@ -820,7 +820,7 @@
                 </TextBlock>
                 <TextBlock Margin="20,4,0,0" TextWrapping="Wrap" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}">
                     <Run Text="Automation placeholders — the first two substitute RAW JSON values (use them unquoted, e.g. &quot;context&quot;: {{context_json}}): "/>
-                    <Run FontFamily="Consolas" Text="{}{{context_json}} {{incidents_json}} {{dedup_key}}"/>
+                    <Run FontFamily="Consolas" Text="{}{{context_json}} {{incidents_json}} {{dedup_key}} {{resource_name}} {{database}}"/>
                 </TextBlock>
                 <TextBlock Margin="20,6,0,0" TextWrapping="Wrap" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}">
                     <Run FontWeight="SemiBold" Text="Example — re-run a GitHub Actions workflow when an alert fires:"/>

--- a/Lite.Tests/AlertIncidentRenderTests.cs
+++ b/Lite.Tests/AlertIncidentRenderTests.cs
@@ -164,4 +164,21 @@ public class AlertIncidentRenderTests
         Assert.DoesNotContain("\"name\":\"Resource\"", teams);
         Assert.DoesNotContain("Resource:", slack);
     }
+
+    /// <summary>
+    /// Review catch (#2710): a caller can pass a blank display object through
+    /// <see cref="AlertFingerprint.ForKey"/> without going through the object-filtering
+    /// <see cref="AlertFingerprint.ForObjects"/> callers get — the joined resource_name must not
+    /// render as a labeled-but-empty tag in that case, the exact failure the design otherwise avoids
+    /// by omitting the tag entirely on a null.
+    /// </summary>
+    [Fact]
+    public void ResourceName_Absent_WhenInvolvedObjectsIsBlank()
+    {
+        var ctx = new AlertContext();
+        AlertIncidentRenderer.Apply(ctx, new[] { new AlertIncident("k", new[] { "" }) });
+
+        var teams = WebhookAlertService.BuildTeamsPayload("Low Disk Space", "S1", "5%", "10%", Branding, context: ctx);
+        Assert.DoesNotContain("\"name\":\"Resource\"", teams);
+    }
 }

--- a/Lite.Tests/AlertIncidentRenderTests.cs
+++ b/Lite.Tests/AlertIncidentRenderTests.cs
@@ -126,4 +126,42 @@ public class AlertIncidentRenderTests
         Assert.Contains("fingerprint-abc", html);
         Assert.Contains("fingerprint-abc", plain);
     }
+
+    /// <summary>
+    /// #2710: the Datadog-parity resource_name/env tags — promoted to the LEAD section/fields
+    /// (not just nested inside the per-incident "Incident" item #1140 already renders), so a
+    /// reader/automation scanning only the top-level facts sees what the alert is about, matching
+    /// Datadog's <c>resource_name:</c> tag. First incident wins on a multi-incident alert, same
+    /// anchor <c>DerivePagerDutyDedupKey</c> already uses.
+    /// </summary>
+    [Fact]
+    public void ResourceNameAndDatabase_PromotedToTopLevel_OnTeamsAndSlack()
+    {
+        var ctx = new AlertContext();
+        AlertIncidentRenderer.Apply(ctx, new[]
+        {
+            new AlertIncident("k1", new[] { "SalesDB.dbo.Orders" }, Database: "SalesDB"),
+            new AlertIncident("k2", new[] { "OtherDb.dbo.Widgets" }, Database: "OtherDb"),
+        });
+
+        var teams = WebhookAlertService.BuildTeamsPayload("Deadlocks Detected", "S1", "2", "n/a", Branding, context: ctx);
+        using var teamsDoc = System.Text.Json.JsonDocument.Parse(teams);
+        var leadFacts = teamsDoc.RootElement.GetProperty("sections")[0].GetProperty("facts").EnumerateArray().ToList();
+        Assert.Contains(leadFacts, f => f.GetProperty("name").GetString() == "Resource" && f.GetProperty("value").GetString() == "SalesDB.dbo.Orders");
+        Assert.Contains(leadFacts, f => f.GetProperty("name").GetString() == "Database" && f.GetProperty("value").GetString() == "SalesDB");
+
+        var slack = WebhookAlertService.BuildSlackPayload("Deadlocks Detected", "S1", "2", "n/a", Branding, context: ctx);
+        Assert.Contains("*Resource:*\\nSalesDB.dbo.Orders", slack);
+        Assert.Contains("*Database:*\\nSalesDB", slack);
+    }
+
+    [Fact]
+    public void ResourceNameAndDatabase_Absent_WhenAlertHasNoIncident()
+    {
+        var teams = WebhookAlertService.BuildTeamsPayload("High CPU", "S1", "97%", "90%", Branding);
+        var slack = WebhookAlertService.BuildSlackPayload("High CPU", "S1", "97%", "90%", Branding);
+
+        Assert.DoesNotContain("\"name\":\"Resource\"", teams);
+        Assert.DoesNotContain("Resource:", slack);
+    }
 }

--- a/Lite.Tests/GenericWebhookTests.cs
+++ b/Lite.Tests/GenericWebhookTests.cs
@@ -362,6 +362,42 @@ public class GenericWebhookTests
         Assert.Equal("SRV:High CPU", JsonDocument.Parse(byName).RootElement.GetProperty("dedup").GetString());
     }
 
+    /* ---------------- Datadog-parity tags (#2710) ---------------- */
+
+    [Fact]
+    public void ResourceNameAndDatabaseTokens_UseTheFirstIncident_SameAnchorAsDedupKey()
+    {
+        const string template = """{"resource": "{{resource_name}}", "db": "{{database}}"}""";
+
+        /* TwoIncidentContext's first incident (aa11/db1.dbo.t1) carries no Database — resource_name
+           still resolves, database stays empty (not the literal word "null"). */
+        var payload = WebhookAlertService.BuildGenericPayload(
+            "Deadlocks Detected", "SRV", "2", "0", Branding, context: TwoIncidentContext(), bodyTemplate: template);
+        var root = JsonDocument.Parse(payload).RootElement;
+        Assert.Equal("db1.dbo.t1", root.GetProperty("resource").GetString());
+        Assert.Equal("", root.GetProperty("db").GetString());
+
+        /* An incident that DOES carry a Database populates both. */
+        var withDb = new AlertContext();
+        AlertIncidentRenderer.Apply(withDb, new[] { new AlertIncident("k1", new[] { "SalesDB.dbo.Orders" }, Database: "SalesDB") });
+        var dbPayload = WebhookAlertService.BuildGenericPayload(
+            "Deadlocks Detected", "SRV", "2", "0", Branding, context: withDb, bodyTemplate: template);
+        var dbRoot = JsonDocument.Parse(dbPayload).RootElement;
+        Assert.Equal("SalesDB.dbo.Orders", dbRoot.GetProperty("resource").GetString());
+        Assert.Equal("SalesDB", dbRoot.GetProperty("db").GetString());
+    }
+
+    [Fact]
+    public void ResourceNameAndDatabaseTokens_AreEmptyStrings_WhenTheAlertCarriesNoIncident()
+    {
+        const string template = """{"resource": "{{resource_name}}", "db": "{{database}}"}""";
+        var payload = Build("High CPU", "SRV", template: template);
+
+        var root = JsonDocument.Parse(payload).RootElement;
+        Assert.Equal("", root.GetProperty("resource").GetString());
+        Assert.Equal("", root.GetProperty("db").GetString());
+    }
+
     [Fact]
     public void ContextJsonToken_RedactsRemediationTsql_LikeEveryOtherChannel()
     {

--- a/Lite.Tests/PagerDutyWebhookTests.cs
+++ b/Lite.Tests/PagerDutyWebhookTests.cs
@@ -191,6 +191,40 @@ public class PagerDutyWebhookTests
         Assert.True(customDetails.TryGetProperty("Blocking Chain — Blocking SPID", out _));
     }
 
+    /* ---------------- Datadog-parity tags (#2710) ---------------- */
+
+    [Fact]
+    public void BuildPagerDutyPayload_Incident_AddsResourceAndDatabaseToCustomDetails()
+    {
+        var context = new AlertContext();
+        AlertIncidentRenderer.Apply(context, new[]
+        {
+            new AlertIncident("k1", new[] { "SalesDB.dbo.Orders" }, Database: "SalesDB"),
+            new AlertIncident("k2", new[] { "OtherDb.dbo.Widgets" }, Database: "OtherDb"),
+        });
+
+        var payload = WebhookAlertService.BuildPagerDutyPayload(
+            "Deadlocks Detected", "SRV1", "2", "n/a", Branding, "key", context: context);
+
+        var customDetails = JsonDocument.Parse(payload).RootElement.GetProperty("payload").GetProperty("custom_details");
+
+        /* First incident wins, the same anchor DerivePagerDutyDedupKey already uses. */
+        Assert.Equal("SalesDB.dbo.Orders", customDetails.GetProperty("Resource").GetString());
+        Assert.Equal("SalesDB", customDetails.GetProperty("Database").GetString());
+    }
+
+    [Fact]
+    public void BuildPagerDutyPayload_NoIncident_OmitsResourceAndDatabase()
+    {
+        var payload = WebhookAlertService.BuildPagerDutyPayload(
+            "High CPU", "SRV1", "97%", "90%", Branding, "key");
+
+        var customDetails = JsonDocument.Parse(payload).RootElement.GetProperty("payload").GetProperty("custom_details");
+
+        Assert.False(customDetails.TryGetProperty("Resource", out _));
+        Assert.False(customDetails.TryGetProperty("Database", out _));
+    }
+
     /* ---------------- EU region endpoint ---------------- */
 
     [Fact]

--- a/Lite/Windows/SettingsWindow.xaml
+++ b/Lite/Windows/SettingsWindow.xaml
@@ -649,7 +649,7 @@
                 </TextBlock>
                 <TextBlock Margin="20,4,0,0" TextWrapping="Wrap" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}">
                     <Run Text="Automation placeholders — the first two substitute RAW JSON values (use them unquoted, e.g. &quot;context&quot;: {{context_json}}): "/>
-                    <Run FontFamily="Consolas" Text="{}{{context_json}} {{incidents_json}} {{dedup_key}}"/>
+                    <Run FontFamily="Consolas" Text="{}{{context_json}} {{incidents_json}} {{dedup_key}} {{resource_name}} {{database}}"/>
                 </TextBlock>
                 <TextBlock Margin="20,6,0,0" TextWrapping="Wrap" FontSize="11" Foreground="{DynamicResource ForegroundMutedBrush}">
                     <Run FontWeight="SemiBold" Text="Example — re-run a GitHub Actions workflow when an alert fires:"/>

--- a/PerformanceMonitor.Notifications/WebhookAlertService.cs
+++ b/PerformanceMonitor.Notifications/WebhookAlertService.cs
@@ -310,6 +310,12 @@ public class WebhookAlertService
     /// the tag should look at first. Null when the alert carries no fingerprintable incident (alert
     /// type not wired to #1140's <see cref="AlertContext.Incidents"/>, or the objects were
     /// unresolved) — a top-level tag naming nothing would read worse than the tag being absent.
+    /// <see cref="AlertFingerprint.ForObjects"/>'s callers filter out blank objects before they ever
+    /// reach here, but a caller of the sibling <see cref="AlertFingerprint.ForKey"/> overload can pass
+    /// an unfiltered blank display object (review catch: <c>AlertContextBuilders.VolumeFreeSpaceIncidents</c>
+    /// / <c>AnomalousJobIncidents</c> pass the raw mount point / job name) — so the join is checked
+    /// for blank the same way <see cref="AlertFingerprint.ForKey"/> already checks <c>Database</c>,
+    /// rather than trusting every caller to have pre-filtered.
     /// </summary>
     private static string? DeriveResourceName(AlertContext? context)
     {
@@ -317,7 +323,11 @@ public class WebhookAlertService
             return null;
 
         var objects = incidents[0].InvolvedObjects;
-        return objects.Count > 0 ? string.Join(", ", objects) : null;
+        if (objects.Count == 0)
+            return null;
+
+        var joined = string.Join(", ", objects);
+        return string.IsNullOrWhiteSpace(joined) ? null : joined;
     }
 
     /// <summary>

--- a/PerformanceMonitor.Notifications/WebhookAlertService.cs
+++ b/PerformanceMonitor.Notifications/WebhookAlertService.cs
@@ -303,10 +303,6 @@ public class WebhookAlertService
     }
 
     /// <summary>
-    /// Builds an O365 MessageCard payload for Teams incoming webhooks.
-    /// The themeColor property renders as a colored accent bar at the top of the card.
-    /// </summary>
-    /// <summary>
     /// #2710: the Datadog-parity <c>resource_name</c> tag — the first incident's involved objects,
     /// joined. Mirrors the SAME "first incident is the correlation anchor" precedent
     /// <see cref="DerivePagerDutyDedupKey"/> already uses for an alert carrying more than one
@@ -335,6 +331,10 @@ public class WebhookAlertService
     private static string? DeriveResourceDatabase(AlertContext? context) =>
         context?.Incidents is { Count: > 0 } incidents ? incidents[0].Database : null;
 
+    /// <summary>
+    /// Builds an O365 MessageCard payload for Teams incoming webhooks.
+    /// The themeColor property renders as a colored accent bar at the top of the card.
+    /// </summary>
     internal static string BuildTeamsPayload(
         string metricName,
         string serverName,

--- a/PerformanceMonitor.Notifications/WebhookAlertService.cs
+++ b/PerformanceMonitor.Notifications/WebhookAlertService.cs
@@ -306,6 +306,35 @@ public class WebhookAlertService
     /// Builds an O365 MessageCard payload for Teams incoming webhooks.
     /// The themeColor property renders as a colored accent bar at the top of the card.
     /// </summary>
+    /// <summary>
+    /// #2710: the Datadog-parity <c>resource_name</c> tag — the first incident's involved objects,
+    /// joined. Mirrors the SAME "first incident is the correlation anchor" precedent
+    /// <see cref="DerivePagerDutyDedupKey"/> already uses for an alert carrying more than one
+    /// fingerprint: whichever incident PagerDuty's dedup_key names is also the one a human reading
+    /// the tag should look at first. Null when the alert carries no fingerprintable incident (alert
+    /// type not wired to #1140's <see cref="AlertContext.Incidents"/>, or the objects were
+    /// unresolved) — a top-level tag naming nothing would read worse than the tag being absent.
+    /// </summary>
+    private static string? DeriveResourceName(AlertContext? context)
+    {
+        if (context?.Incidents is not { Count: > 0 } incidents)
+            return null;
+
+        var objects = incidents[0].InvolvedObjects;
+        return objects.Count > 0 ? string.Join(", ", objects) : null;
+    }
+
+    /// <summary>
+    /// #2710: the Datadog-parity <c>env</c>-adjacent database scope — the first incident's
+    /// <see cref="AlertIncident.Database"/>, the SAME incident <see cref="DeriveResourceName"/>
+    /// reads (kept as its own tag rather than folded into resource_name: per #2361's doc comment on
+    /// <see cref="AlertIncident.Database"/>, it is WHERE the resource lives, not what it is). Null on
+    /// every alert type <see cref="AlertIncident.Database"/> already documents as unscoped (a volume
+    /// or a job is not database-scoped) or with no incident at all.
+    /// </summary>
+    private static string? DeriveResourceDatabase(AlertContext? context) =>
+        context?.Incidents is { Count: > 0 } incidents ? incidents[0].Database : null;
+
     internal static string BuildTeamsPayload(
         string metricName,
         string serverName,
@@ -330,6 +359,12 @@ public class WebhookAlertService
         else
         {
             facts.Add(new { name = "Server", value = serverName });
+            var resourceName = DeriveResourceName(context);
+            if (resourceName is not null)
+                facts.Add(new { name = "Resource", value = resourceName });
+            var database = DeriveResourceDatabase(context);
+            if (!string.IsNullOrEmpty(database))
+                facts.Add(new { name = "Database", value = database });
             facts.Add(new { name = "Current Value", value = currentValue });
             facts.Add(new { name = "Threshold", value = thresholdValue });
             facts.Add(new { name = "Time (UTC)", value = utcNow.ToString("yyyy-MM-dd HH:mm:ss") });
@@ -504,6 +539,12 @@ public class WebhookAlertService
         else
         {
             fields.Add(new { type = "mrkdwn", text = $"*Server:*\n{serverName}" });
+            var resourceName = DeriveResourceName(context);
+            if (resourceName is not null)
+                fields.Add(new { type = "mrkdwn", text = $"*Resource:*\n{resourceName}" });
+            var database = DeriveResourceDatabase(context);
+            if (!string.IsNullOrEmpty(database))
+                fields.Add(new { type = "mrkdwn", text = $"*Database:*\n{database}" });
             fields.Add(new { type = "mrkdwn", text = $"*Current Value:*\n{currentValue}" });
             fields.Add(new { type = "mrkdwn", text = $"*Threshold:*\n{thresholdValue}" });
             fields.Add(new { type = "mrkdwn", text = $"*Time (UTC):*\n{utcNow:yyyy-MM-dd HH:mm:ss}" });
@@ -665,6 +706,13 @@ public class WebhookAlertService
     /// A template that quotes a raw token anyway produces malformed JSON and is caught by the caller's
     /// well-formedness check, surfacing as a config error rather than a silent bad post.
     /// </para>
+    /// <para>
+    /// #2710: <c>{{resource_name}}</c> / <c>{{database}}</c> are ordinary escaped strings, empty when the
+    /// alert carries no fingerprintable incident — a template author already has the same data via
+    /// <c>{{incidents_json}}</c>, but these two save hand-parsing JSON for the common case of one
+    /// Datadog-shaped <c>resource_name:</c> tag. Same "first incident" derivation as every other channel
+    /// here (<see cref="DeriveResourceName"/> / <see cref="DeriveResourceDatabase"/>).
+    /// </para>
     /// </summary>
     internal static string BuildGenericPayload(
         string metricName,
@@ -708,6 +756,8 @@ public class WebhookAlertService
             ["context_json"] = context is null ? "{}" : AlertContextSerializer.Serialize(RedactForWebhook(context)),
             ["incidents_json"] = AlertContextSerializer.SerializeIncidents(context),
             ["dedup_key"] = EscapeForJson(dedupKey),
+            ["resource_name"] = EscapeForJson(DeriveResourceName(context) ?? ""),
+            ["database"] = EscapeForJson(DeriveResourceDatabase(context) ?? ""),
         };
 
         /* Single pass: a MatchEvaluator's output is NOT re-scanned, so a value that itself contains the
@@ -720,7 +770,7 @@ public class WebhookAlertService
     /* context_json before context: alternation is ordered, and while the closing \}\} would force a
        backtrack to the right answer anyway, longest-first means correctness never leans on it. */
     private static readonly System.Text.RegularExpressions.Regex s_genericPlaceholders =
-        new(@"\{\{(metric|server|value|threshold|severity|context_json|incidents_json|dedup_key|context|timestamp)\}\}",
+        new(@"\{\{(metric|server|value|threshold|severity|context_json|incidents_json|dedup_key|resource_name|database|context|timestamp)\}\}",
             System.Text.RegularExpressions.RegexOptions.Compiled);
 
     /// <summary>
@@ -1151,6 +1201,17 @@ public class WebhookAlertService
             details["Sent by"] = branding.EditionName;
             return details;
         }
+
+        /* #2710: Datadog-parity tags, added before the empty-Details early return so an alert type
+           that ever carries Incidents without a matching Details item (none do today — Apply and
+           BuildDeadlockContext always render one alongside — but nothing enforces that pairing)
+           still gets them. */
+        var resourceName = DeriveResourceName(context);
+        if (resourceName is not null)
+            details["Resource"] = resourceName;
+        var database = DeriveResourceDatabase(context);
+        if (!string.IsNullOrEmpty(database))
+            details["Database"] = database;
 
         if (context?.Details is null || context.Details.Count == 0)
         {


### PR DESCRIPTION
Part of #2710. Scoped to option 3 from that issue's sketch: the tagging half only. The linked triage-artifact half stays open — it's blocked on the unresolved authentication question the issue raised for the Darling web service, which is a separate design decision.

## What changed

Slack/Teams/PagerDuty/generic-webhook alerts already carry the first `#1140` incident's `InvolvedObjects`/`Database` — but only nested inside a per-incident detail item ("Dedup Key"/"Involved Objects" fields on an "Incident"/"Deadlock N of M" card), never as a top-level, clearly-labeled tag the way Datadog's `resource_name:`/`env:` convention does.

Added two small pure helpers (`DeriveResourceName`/`DeriveResourceDatabase`) that pick the **first incident** — the same "first incident is the correlation anchor" precedent `DerivePagerDutyDedupKey` already uses for a multi-incident alert — and promoted them:

- **Teams**: new `Resource`/`Database` facts in the lead section, right after `Server`.
- **Slack**: same, in the lead section's fields.
- **PagerDuty**: `custom_details.Resource`/`Database`.
- **Generic webhook**: two new tokens, `{{resource_name}}`/`{{database}}` — ordinary escaped strings (empty string, not the literal word "null", when the alert carries no incident), documented alongside `{{dedup_key}}` in both Settings windows' placeholder reference (Lite and Darling Viewer).

Absent entirely (no tag, not an empty one) on Teams/Slack/PagerDuty when the alert has no fingerprintable incident — a top-level tag naming nothing would read worse than the tag being absent, per the existing `AlertIncidentRenderer.BuildItem` precedent for `(unresolved)` involved-objects.

## Verification

Built the project + full solution clean. Since `Lite.Tests`/`Darling.Tests` build but cannot run on macOS, ran a throwaway `net10.0` console harness (`AssemblyName=Lite.Tests` to pick up the existing `InternalsVisibleTo`) against the real shipped `WebhookAlertService` before writing the xUnit tests — confirmed real Teams/Slack/PagerDuty/generic payloads for: a two-incident context (first incident wins), an incident with no `Database` set (Resource present, Database fact correctly omitted), and no incident at all (both tags absent/empty as appropriate). All 15 checks passed against the actual build before any test was written into the suite.

Added xUnit tests pinning the same behavior: `AlertIncidentRenderTests.cs` (Teams/Slack), `PagerDutyWebhookTests.cs`, `GenericWebhookTests.cs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)