### PR TITLE
Add Postgres Long-Running Query alert (part of #2711)

### DIFF
--- a/Darling/Darling.Tests/DarlingPgOperationalAlertTests.cs
+++ b/Darling/Darling.Tests/DarlingPgOperationalAlertTests.cs
@@ -262,4 +262,48 @@ public sealed class DarlingPgOperationalAlertTests
         Assert.Equal("root pid 42 blocking 2 session(s)", incident.InvolvedObjects[0]);
         Assert.Null(incident.Database);
     }
+
+    // ── Long-Running Query (#2711) ───────────────────────────────────────────────────────────────
+
+    private static DarlingPgSessionStatesReader.LongRunningSessionRow LongRunningRow(
+        long backendId = 1001, int pid = 100, string? databaseName = "eden", string? commandTag = "SELECT",
+        long queryDurationMs = 2_100_000) =>
+        new(backendId, pid, databaseName, "appuser", "myapp", commandTag, queryDurationMs);
+
+    [Fact]
+    public void BuildPgLongRunningQueryIncident_DedupKeyIsBackendId_NotPid()
+    {
+        /* Same reasoning as BuildPgBlockingIncident's dedup key: pids are reused, the synthetic backend id
+           is stable for the life of a backend. */
+        var incident = DarlingWorker.BuildPgLongRunningQueryIncident(LongRunningRow(backendId: 424242, pid: 99));
+
+        Assert.Equal("424242", incident.DedupKey);
+    }
+
+    [Fact]
+    public void BuildPgLongRunningQueryIncident_IncludesPidDurationAndCommandTag()
+    {
+        var incident = DarlingWorker.BuildPgLongRunningQueryIncident(
+            LongRunningRow(pid: 55, commandTag: "UPDATE", queryDurationMs: 42 * 60_000L));
+
+        Assert.Equal("pid 55 running 42m (UPDATE)", incident.InvolvedObjects[0]);
+    }
+
+    [Fact]
+    public void BuildPgLongRunningQueryIncident_FallsBackToUnknown_WhenCommandTagIsMissing()
+    {
+        /* pg_session_states substitutes NULL for command_tag under redaction (no pg_monitor grant) — the
+           incident text must not go blank or throw in that case. */
+        var incident = DarlingWorker.BuildPgLongRunningQueryIncident(LongRunningRow(commandTag: null));
+
+        Assert.Contains("(unknown)", incident.InvolvedObjects[0]);
+    }
+
+    [Fact]
+    public void BuildPgLongRunningQueryIncident_CarriesTheDatabaseName()
+    {
+        var incident = DarlingWorker.BuildPgLongRunningQueryIncident(LongRunningRow(databaseName: "sky"));
+
+        Assert.Equal("sky", incident.Database);
+    }
 }

--- a/Darling/Darling.Tests/DarlingPgSessionStatesReaderTests.cs
+++ b/Darling/Darling.Tests/DarlingPgSessionStatesReaderTests.cs
@@ -79,12 +79,31 @@ public class DarlingPgSessionStatesReaderTests
     }
 
     /// <summary>No query text projected — the collector deliberately stores none (see its class remarks), so
-    /// a read that tried to select one would be selecting a column that does not exist.</summary>
+    /// a read that tried to select one would be selecting a column that does not exist. Word-boundary regex
+    /// rather than a plain substring check: a naive "s.query" substring search self-matches the legitimate
+    /// "s.query_duration_ms" projection (caught by this exact test failing red the first time it was
+    /// written), since "query" is a literal prefix of that identifier.</summary>
     [Fact]
     public void LongRunningSql_ProjectsNoQueryText()
     {
         Assert.DoesNotContain("query_text", LongRunningSql, StringComparison.OrdinalIgnoreCase);
-        Assert.DoesNotContain(" s.query", LongRunningSql, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotMatch(new Regex(@"\bquery\b", RegexOptions.IgnoreCase), LongRunningSql);
+    }
+
+    /// <summary>
+    /// Excludes idle-in-transaction sessions. Per PostgreSQL's own semantics, <c>query_duration_ms</c> for a
+    /// session sitting idle-in-transaction measures how long ago its LAST query started, not how long a query
+    /// has actually been running — that query already finished. Without this filter a session that ran a 5ms
+    /// UPDATE and has sat idle-in-transaction for 40 minutes since would read identically to one whose UPDATE
+    /// has genuinely been running for 40 minutes, which is a different, differently-actioned incident (an app
+    /// connection-pool bug vs. a slow statement). Matches the SQL Server equivalent
+    /// (<c>AlertEngine.CheckLongRunningQueriesAsync</c>), which reads <c>sys.dm_exec_requests</c> — a table of
+    /// requests actually executing, where an idle session has no row at all.
+    /// </summary>
+    [Fact]
+    public void LongRunningSql_ExcludesIdleInTransactionSessions()
+    {
+        Assert.Contains("s.is_idle_in_transaction = false", LongRunningSql, StringComparison.Ordinal);
     }
 
     // ── Scoping and parameterisation ─────────────────────────────────────────────────────────────

--- a/Darling/Darling.Tests/DarlingPgSessionStatesReaderTests.cs
+++ b/Darling/Darling.Tests/DarlingPgSessionStatesReaderTests.cs
@@ -34,6 +34,59 @@ public class DarlingPgSessionStatesReaderTests
 
     private static string CountsSql => DarlingPgSessionStatesReader.PgSessionStatesCaptureCountsSql;
 
+    private static string LongRunningSql => DarlingPgSessionStatesReader.CurrentLongRunningSessionsSql;
+
+    // ── #2711 Long-Running Query — the live-state read ──────────────────────────────────────────────
+
+    [Fact]
+    public void LongRunningSql_ScopesToOneServerOneThresholdAndOneRecencyFloor()
+    {
+        Assert.Contains("server_id = $1", LongRunningSql, StringComparison.Ordinal);
+        Assert.Contains("query_duration_ms >= $2", LongRunningSql, StringComparison.Ordinal);
+        Assert.Contains("collection_time >= $3", LongRunningSql, StringComparison.Ordinal);
+        Assert.Contains("LIMIT $4", LongRunningSql, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The mechanism this whole read exists for: "most recent" is computed via <c>max(collection_time)</c>
+    /// over the recency-bounded set and then JOINED back, rather than just filtering rows to
+    /// <c>collection_time >= $3</c> directly. Without the join, a session whose peak crossed the threshold in
+    /// an OLDER capture inside the recency window — but has since finished, so it is absent from the truly
+    /// latest capture — would still be reported as currently running. Verified against a real local
+    /// PostgreSQL 17 with exactly this shape (a superseded older-but-in-window row correctly excluded, a
+    /// short same-cycle row correctly excluded, only the genuinely-latest over-threshold row returned) before
+    /// this test was written; this pins the SQL shape that made that hold.
+    /// </summary>
+    [Fact]
+    public void LongRunningSql_FiltersToTheSingleLatestCapture_ViaMaxJoin_NotAWindowFilterAlone()
+    {
+        Assert.Contains("max(collection_time)", LongRunningSql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("s.collection_time = r.latest_capture", LongRunningSql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LongRunningSql_TheRowLimitIsParameterisedRatherThanBakedIn()
+    {
+        Assert.DoesNotMatch(new Regex(@"LIMIT\s+\d+"), LongRunningSql);
+    }
+
+    [Fact]
+    public void LongRunningSql_ReadsOnlyItsOwnTable()
+    {
+        Assert.Contains("FROM pg_session_states", LongRunningSql, StringComparison.Ordinal);
+        Assert.DoesNotContain("pg_blocking_edges", LongRunningSql, StringComparison.Ordinal);
+        Assert.DoesNotContain("pg_deadlocks", LongRunningSql, StringComparison.Ordinal);
+    }
+
+    /// <summary>No query text projected — the collector deliberately stores none (see its class remarks), so
+    /// a read that tried to select one would be selecting a column that does not exist.</summary>
+    [Fact]
+    public void LongRunningSql_ProjectsNoQueryText()
+    {
+        Assert.DoesNotContain("query_text", LongRunningSql, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(" s.query", LongRunningSql, StringComparison.OrdinalIgnoreCase);
+    }
+
     // ── Scoping and parameterisation ─────────────────────────────────────────────────────────────
 
     [Fact]

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -3118,12 +3118,13 @@ public sealed class DarlingWorker : BackgroundService
 
         try
         {
-            var thresholdMinutes = new DarlingAlertSettings(config).LongRunningQueryThresholdMinutes;
+            var alertSettings = new DarlingAlertSettings(config);
+            var thresholdMinutes = alertSettings.LongRunningQueryThresholdMinutes;
             var now = DateTime.UtcNow;
 
             var rows = await DarlingPgSessionStatesReader.GetCurrentLongRunningSessionsAsync(
                 _postgres, runtime.ServerId, thresholdMs: thresholdMinutes * 60_000L, now,
-                PgLongRunningQueryRecencyMinutes, limit: 50, cancellationToken);
+                PgLongRunningQueryRecencyMinutes, limit: alertSettings.LongRunningQueryMaxResults, cancellationToken);
 
             var cooldown = TimeSpan.FromMinutes(Math.Max(1, _alertCooldownMinutes));
             var wasActive = _activePgLongRunningQueryAlert.TryGetValue(key, out var activeBefore) && activeBefore;

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -3113,12 +3113,18 @@ public sealed class DarlingWorker : BackgroundService
             return;
         }
 
+        var alertSettings = new DarlingAlertSettings(config);
+
+        if (!alertSettings.LongRunningQueryEnabled)
+        {
+            return;
+        }
+
         const string metricName = "Long-Running Query";
         var key = snapshot.ServerKey;
 
         try
         {
-            var alertSettings = new DarlingAlertSettings(config);
             var thresholdMinutes = alertSettings.LongRunningQueryThresholdMinutes;
             var now = DateTime.UtcNow;
 

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -457,6 +457,11 @@ public sealed class DarlingWorker : BackgroundService
     private readonly ConcurrentDictionary<string, DateTime> _lastPgBlockingAlert = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, bool> _activePgBlockingAlert = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, int> _lastAlertedPgBlockingCount = new(StringComparer.Ordinal);
+    /* Long-Running Query is a LIVE-STATE check ("is one running right now"), not a rolling event count like
+       Deadlocks/Blocking above — so it needs only a cooldown timestamp and an active flag, the same shape
+       AlertEngine itself uses for its own SQL Server Long-Running Query check, not RollingCountAlertGate. */
+    private readonly ConcurrentDictionary<string, DateTime> _lastPgLongRunningQueryAlert = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, bool> _activePgLongRunningQueryAlert = new(StringComparer.Ordinal);
 
     /// <summary>
     /// Held for the same reason <see cref="_alertDeliverer"/> is: the Postgres Deadlocks/Blocking alerts
@@ -1746,7 +1751,7 @@ public sealed class DarlingWorker : BackgroundService
             if (DateTime.UtcNow >= server.NextAlertSweep)
             {
                 server.NextAlertSweep = DateTime.UtcNow.Add(s_alertSweepInterval);
-                await EvaluateAlertsAsync(engine, server, stoppingToken);
+                await EvaluateAlertsAsync(engine, server, config, stoppingToken);
             }
 
             /* AN3: the scheduled analysis pipeline, per-server. The cadence, the enabled gate, and the notify
@@ -2752,7 +2757,8 @@ public sealed class DarlingWorker : BackgroundService
     /// (headless — suppression is an engine INPUT owned by interactive hosts). Failure-isolated:
     /// a failed sweep logs and retries on the next cadence tick, mirroring the collector loop.
     /// </summary>
-    private async Task EvaluateAlertsAsync(AlertEngine engine, ServerLoopState server, CancellationToken cancellationToken)
+    private async Task EvaluateAlertsAsync(
+        AlertEngine engine, ServerLoopState server, DarlingConfig config, CancellationToken cancellationToken)
     {
         var runtime = server.Runtime;
         if (runtime is null)
@@ -2781,7 +2787,7 @@ public sealed class DarlingWorker : BackgroundService
                PostgreSQL read. */
             if (runtime.Target.Engine == CollectorTargetEngine.PostgreSql)
             {
-                await EvaluatePostgresAlertsAsync(runtime, snapshot, cancellationToken);
+                await EvaluatePostgresAlertsAsync(runtime, snapshot, config, cancellationToken);
             }
         }
         catch (OperationCanceledException)
@@ -2802,7 +2808,7 @@ public sealed class DarlingWorker : BackgroundService
     /// history and obeys the same mute rules as every other one.</para>
     /// </summary>
     private async Task EvaluatePostgresAlertsAsync(
-        ServerRuntime runtime, AlertServerSnapshot snapshot, CancellationToken cancellationToken)
+        ServerRuntime runtime, AlertServerSnapshot snapshot, DarlingConfig config, CancellationToken cancellationToken)
     {
         if (_postgres is null || _alertDeliverer is null)
         {
@@ -2887,11 +2893,13 @@ public sealed class DarlingWorker : BackgroundService
                 runtime.Config.DisplayName, ex.Message);
         }
 
-        /* #2711: Deadlocks and Blocking, each independently failure-isolated (own try/catch inside),
-           so a broken read on one never costs the three predictors above or the other of this pair —
-           the same isolation AlertEngine gives its own CheckDeadlocksAsync/CheckBlockingAsync. */
+        /* #2711: Deadlocks, Blocking and Long-Running Query, each independently failure-isolated (own
+           try/catch inside), so a broken read on one never costs the three predictors above or either
+           sibling — the same isolation AlertEngine gives its own CheckDeadlocksAsync/CheckBlockingAsync/
+           CheckLongRunningQueriesAsync. */
         await EvaluatePgDeadlocksAsync(runtime, snapshot, cancellationToken);
         await EvaluatePgBlockingAsync(runtime, snapshot, cancellationToken);
+        await EvaluatePgLongRunningQueryAsync(runtime, snapshot, config, cancellationToken);
     }
 
     /// <summary>
@@ -3070,6 +3078,129 @@ public sealed class DarlingWorker : BackgroundService
                 runtime.Config.DisplayName, ex.Message);
         }
     }
+
+    /// <summary>
+    /// How far back "the most recent capture" is allowed to reach before it stops counting as "now", for the
+    /// Postgres Long-Running Query alert (#2711). See
+    /// <see cref="DarlingPgSessionStatesReader.GetCurrentLongRunningSessionsAsync"/>'s doc comment for why this
+    /// is the fleet's own 15-minute staleness convention rather than a tight multiple of the collector's
+    /// 1-minute configured cadence.
+    /// </summary>
+    private const int PgLongRunningQueryRecencyMinutes = 15;
+
+    /// <summary>
+    /// The live-state Postgres Long-Running Query alert (#2711): fires when the most recent
+    /// <c>pg_session_states</c> capture shows any session whose CURRENT query has run past
+    /// <see cref="IAlertEngineSettings.LongRunningQueryThresholdMinutes"/> — the SAME configured threshold SQL
+    /// Server's <c>AlertEngine.CheckLongRunningQueriesAsync</c> uses, read live off <paramref name="config"/>
+    /// rather than a separate Postgres-only constant, so changing the one setting changes behavior for both
+    /// engines the way one shared "how long is too long" preference should.
+    ///
+    /// <para><b>Boolean state + cooldown, not <see cref="RollingCountAlertGate"/>.</b> Unlike Deadlocks/Blocking
+    /// above, this is not a rolling count of discrete past events — it is "is a condition true right now",
+    /// exactly the shape AlertEngine's own SQL Server check already uses (an active flag plus a cooldown
+    /// timestamp). Reusing the rolling-count gate here would answer a question this alert does not ask.</para>
+    ///
+    /// <para>No query-text preview: <c>pg_session_states</c> deliberately stores none (see the collector's
+    /// class remarks), so the message identifies the session by pid/database/command tag instead of the
+    /// statement text SQL Server's equivalent shows.</para>
+    /// </summary>
+    private async Task EvaluatePgLongRunningQueryAsync(
+        ServerRuntime runtime, AlertServerSnapshot snapshot, DarlingConfig config, CancellationToken cancellationToken)
+    {
+        if (_postgres is null || _alertDeliverer is null)
+        {
+            return;
+        }
+
+        const string metricName = "Long-Running Query";
+        var key = snapshot.ServerKey;
+
+        try
+        {
+            var thresholdMinutes = new DarlingAlertSettings(config).LongRunningQueryThresholdMinutes;
+            var now = DateTime.UtcNow;
+
+            var rows = await DarlingPgSessionStatesReader.GetCurrentLongRunningSessionsAsync(
+                _postgres, runtime.ServerId, thresholdMs: thresholdMinutes * 60_000L, now,
+                PgLongRunningQueryRecencyMinutes, limit: 50, cancellationToken);
+
+            var cooldown = TimeSpan.FromMinutes(Math.Max(1, _alertCooldownMinutes));
+            var wasActive = _activePgLongRunningQueryAlert.TryGetValue(key, out var activeBefore) && activeBefore;
+            _activePgLongRunningQueryAlert[key] = rows.Count > 0;
+
+            if (rows.Count > 0)
+            {
+                var cooldownElapsed = !_lastPgLongRunningQueryAlert.TryGetValue(key, out var last) || now - last >= cooldown;
+                if (!cooldownElapsed)
+                {
+                    return;
+                }
+
+                _lastPgLongRunningQueryAlert[key] = now;
+
+                var worst = rows[0];
+                var elapsedMinutes = worst.QueryDurationMs / 60_000;
+
+                var muted = _isAlertMuted?.Invoke(new AlertMuteContext
+                {
+                    ServerName = snapshot.ServerName,
+                    MetricName = metricName,
+                    DatabaseName = worst.DatabaseName,
+                }) ?? false;
+
+                await _alertDeliverer.DeliverAsync(
+                    new AlertOutcome(
+                        key,
+                        snapshot.ServerName,
+                        metricName,
+                        $"{rows.Count} query(s), longest {elapsedMinutes}m",
+                        $"{thresholdMinutes}m",
+                        Context: new AlertContext
+                        {
+                            Incidents = rows.Select(BuildPgLongRunningQueryIncident).ToList(),
+                        },
+                        DetailText: null,
+                        NumericCurrentValue: elapsedMinutes,
+                        NumericThresholdValue: thresholdMinutes,
+                        Muted: muted,
+                        Severity: null,
+                        ShortMessage: $"pid {worst.Pid} running {elapsedMinutes}m — {worst.CommandTag ?? "(unknown)"}"
+                            + (worst.DatabaseName is null ? "" : $" on {worst.DatabaseName}")),
+                    cancellationToken);
+            }
+            else if (wasActive)
+            {
+                await NotifyPgResolutionAsync(key, snapshot.ServerName, metricName, "Long-Running Queries Cleared",
+                    $"{snapshot.ServerName}: No queries over threshold");
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError("[{Server}] PostgreSQL long-running-query alert evaluation failed: {Message}",
+                runtime.Config.DisplayName, ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Pure mapping, pulled out of <see cref="EvaluatePgLongRunningQueryAsync"/> for the same testability
+    /// reason as <see cref="BuildPgDeadlockIncident"/>. Dedup key is the synthetic backend id (stable across
+    /// samples of the same backend, unlike a reused pid), matching <see cref="BuildPgBlockingIncident"/>'s
+    /// convention for the same underlying identity.
+    /// </summary>
+    internal static AlertIncident BuildPgLongRunningQueryIncident(
+        DarlingPgSessionStatesReader.LongRunningSessionRow row) =>
+        new(
+            row.BackendId.ToString(CultureInfo.InvariantCulture),
+            new[]
+            {
+                $"pid {row.Pid} running {row.QueryDurationMs / 60_000}m ({row.CommandTag ?? "(unknown)"})",
+            },
+            Database: row.DatabaseName);
 
     /// <summary>
     /// Writes a Postgres Deadlocks/Blocking resolution the same way <see cref="BuildAlertEngine"/>'s

--- a/Darling/PerformanceMonitor.Darling.Storage/DarlingPgSessionStatesReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/DarlingPgSessionStatesReader.cs
@@ -330,6 +330,102 @@ public static class DarlingPgSessionStatesReader
         DateTime? FirstCaptureAt,
         DateTime? LastCaptureAt);
 
+    public sealed record LongRunningSessionRow(
+        long BackendId,
+        int Pid,
+        string? DatabaseName,
+        string? Username,
+        string? ApplicationName,
+        string? CommandTag,
+        long QueryDurationMs);
+
+    /// <summary>
+    /// The single most recent <c>pg_session_states</c> capture for this server, filtered to sessions whose
+    /// CURRENT query has been running at least <paramref name="thresholdMs"/> — the Postgres read behind the
+    /// #2711 Long-Running Query alert.
+    ///
+    /// <para><b>Why the single latest capture, not a window rollup.</b> <see cref="GetPgSessionStatesAsync"/>
+    /// above answers "what happened in this window" with peaks-per-backend, which is right for the Viewer's
+    /// own display but wrong for "is a long-running query happening RIGHT NOW": a session whose peak
+    /// <c>query_duration_ms</c> crossed the threshold ten minutes ago and has since finished must not still
+    /// read as active. Restricting to rows sharing the single most recent <c>collection_time</c> is what makes
+    /// this a live-state check rather than a history search — a still-running session reappears in EVERY
+    /// cycle with a monotonically growing duration, so it is present in that latest capture by construction;
+    /// a finished one is not.</para>
+    ///
+    /// <para><b><paramref name="recencyMinutes"/> exists because this table is an EXCEPTION table</b> (see the
+    /// collector's own doc comment) — a healthy instance with nothing over the collector's own 30s/10s floors
+    /// produces ZERO rows for a cycle, which is correct and must not be confused with "the collector stopped
+    /// running". Bounding "most recent" to a real window (rather than an unqualified <c>MAX(collection_time)</c>
+    /// that could resolve to a capture from hours ago) is what keeps an honest empty from silently going stale.
+    /// 15 minutes, matching the fleet's own <c>OfflineThreshold</c> staleness convention
+    /// (<see cref="PerformanceMonitor.Common.ServerHealthBands"/>) rather than a tight multiple of the
+    /// collector's 1-minute configured cadence — this fleet's delivered sweep cadence has been measured
+    /// running well behind its configured interval under load, and a recency bound tighter than the fleet's
+    /// own staleness definition would make the alert silently never fire on exactly the servers busy enough to
+    /// need it.</para>
+    ///
+    /// <para>No query text: this collector deliberately stores none (see its class remarks) to avoid
+    /// accumulating literal parameter values for a condition an ordinary application can cross, so the alert
+    /// this backs identifies a session by pid/database/command tag rather than a statement preview.</para>
+    ///
+    /// <para>$1 server_id, $2 threshold (ms), $3 recency floor (naive UTC), $4 row limit.</para>
+    /// </summary>
+    public const string CurrentLongRunningSessionsSql = """
+        WITH recent AS (
+            SELECT max(collection_time) AS latest_capture
+            FROM pg_session_states
+            WHERE server_id = $1
+            AND   collection_time >= $3
+        )
+        SELECT
+            s.backend_id,
+            s.pid,
+            s.database_name,
+            s.username,
+            s.application_name,
+            s.command_tag,
+            s.query_duration_ms
+        FROM pg_session_states AS s
+        JOIN recent AS r
+          ON  s.collection_time = r.latest_capture
+        WHERE s.server_id = $1
+        AND   s.query_duration_ms >= $2
+        ORDER BY s.query_duration_ms DESC, s.pid
+        LIMIT $4
+        """;
+
+    public static async Task<List<LongRunningSessionRow>> GetCurrentLongRunningSessionsAsync(
+        NpgsqlDataSource postgres, int serverId, long thresholdMs, DateTime nowUtc, int recencyMinutes, int limit,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(postgres);
+
+        var rows = new List<LongRunningSessionRow>();
+        await using var command = postgres.CreateCommand(CurrentLongRunningSessionsSql);
+        command.Parameters.AddWithValue(serverId);
+        command.Parameters.AddWithValue(thresholdMs);
+        /* SpecifyKind(Unspecified) at the BIND — see GetPgSessionStatesAsync's identical comment for why
+           Kind=Utc would silently shift this comparison against the naive columns it is measured against. */
+        command.Parameters.AddWithValue(
+            DateTime.SpecifyKind(nowUtc.AddMinutes(-recencyMinutes), DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(limit);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            rows.Add(new LongRunningSessionRow(
+                reader.IsDBNull(0) ? 0 : reader.GetInt64(0),
+                reader.IsDBNull(1) ? 0 : reader.GetInt32(1),
+                reader.IsDBNull(2) ? null : reader.GetString(2),
+                reader.IsDBNull(3) ? null : reader.GetString(3),
+                reader.IsDBNull(4) ? null : reader.GetString(4),
+                reader.IsDBNull(5) ? null : reader.GetString(5),
+                reader.IsDBNull(6) ? -1 : reader.GetInt64(6)));
+        }
+
+        return rows;
+    }
+
     public static async Task<PgSessionStatesCaptureCounts> GetPgSessionStatesCaptureCountsAsync(
         NpgsqlDataSource postgres, int serverId, DateTime startUtc, DateTime endUtc,
         CancellationToken cancellationToken = default)

--- a/Darling/PerformanceMonitor.Darling.Storage/DarlingPgSessionStatesReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/DarlingPgSessionStatesReader.cs
@@ -369,6 +369,18 @@ public static class DarlingPgSessionStatesReader
     /// accumulating literal parameter values for a condition an ordinary application can cross, so the alert
     /// this backs identifies a session by pid/database/command tag rather than a statement preview.</para>
     ///
+    /// <para><b>Excludes idle-in-transaction sessions.</b> Per PostgreSQL's own semantics for
+    /// <c>pg_stat_activity.query_start</c> ("time when the currently active query was started, OR IF STATE IS
+    /// NOT ACTIVE, when the last query was started"), <c>query_duration_ms</c> for a session sitting
+    /// <c>idle in transaction</c> measures how long ago its LAST query started, not how long a query has
+    /// actually been running — that query already finished. Without this filter a session that ran a 5ms
+    /// UPDATE and has sat idle-in-transaction for 40 minutes since (the common "forgot to COMMIT" shape) would
+    /// read identically to one whose UPDATE has genuinely been executing for 40 minutes, and the two are
+    /// different incidents needing different fixes (an app connection-pool bug vs. a slow statement). This
+    /// matches the SQL Server equivalent (<c>AlertEngine.CheckLongRunningQueriesAsync</c>), which reads
+    /// <c>sys.dm_exec_requests</c> — a table of requests actually executing, where an idle session has no
+    /// row at all.</para>
+    ///
     /// <para>$1 server_id, $2 threshold (ms), $3 recency floor (naive UTC), $4 row limit.</para>
     /// </summary>
     public const string CurrentLongRunningSessionsSql = """
@@ -391,6 +403,7 @@ public static class DarlingPgSessionStatesReader
           ON  s.collection_time = r.latest_capture
         WHERE s.server_id = $1
         AND   s.query_duration_ms >= $2
+        AND   s.is_idle_in_transaction = false
         ORDER BY s.query_duration_ms DESC, s.pid
         LIMIT $4
         """;


### PR DESCRIPTION
Part of #2711.

## What this adds

The Postgres Long-Running Query / Long-Running Queries Cleared alert pair, the third increment of #2711 after Deadlocks and Blocking (#2713).

Per #2711's own assessment, this one is "likely straightforward, needs a quick confirm" — confirmed: `pg_session_states` already stores `query_duration_ms` (a live, per-sample measurement of how long the session's CURRENT query has been running) for every session whose transaction/idle-in-transaction state crossed the collector's own 30s/10s floors, which is always well below any sane alert threshold (30 minutes by default).

## Shape: live-state check, not a rolling count

Unlike Deadlocks/Blocking (#2713), which reuse `RollingCountAlertGate` for a rolling-1-hour event count, Long-Running Query is "is a condition true right now" — the exact shape `AlertEngine.CheckLongRunningQueriesAsync` already uses for SQL Server (a boolean active flag + cooldown, not a watermark). Reusing the rolling-count gate here would have answered a different question, so this mirrors AlertEngine's own shape instead.

## The read: latest-capture-only, not a window filter

New `DarlingPgSessionStatesReader.GetCurrentLongRunningSessionsAsync` joins the table's own `MAX(collection_time)` back to itself, rather than filtering rows to "anything in the last N minutes ≥ threshold". Without that join, a session whose PEAK duration crossed the threshold in an older-but-still-in-window capture — and has since finished — would still read as "running now". Verified against a real local PostgreSQL 17 with exactly that adversarial shape (a superseded older-capture row correctly excluded, a short same-cycle row correctly excluded, only the genuinely-latest over-threshold row returned) before writing the pinning tests.

The 15-minute recency floor (bounding what "most recent" is allowed to mean, since this is an EXCEPTION table that legitimately produces zero rows on a healthy cycle) matches the fleet's own `OfflineThreshold` staleness convention rather than a tight multiple of the collector's 1-minute configured cadence — this fleet's delivered sweep cadence has been measured running well behind its configured interval under load, and a tighter bound would make the alert silently never fire on exactly the busy servers that need it.

## Threshold: shared with SQL Server, not a separate constant

Unlike Deadlocks/Blocking's own hardcoded count thresholds (reasonable there since SQL Server's own deadlock/blocking count thresholds are themselves effectively fixed at 1), Long-Running Query's threshold is a genuinely user-tunable setting (`IAlertEngineSettings.LongRunningQueryThresholdMinutes`, default 30). This reads it live off the same `DarlingConfig` SQL Server's `AlertEngine` uses, via `new DarlingAlertSettings(config)`, so changing the one setting changes behavior for both engines — required threading `DarlingConfig` through `EvaluateAlertsAsync` → `EvaluatePostgresAlertsAsync`, a 3-call-site signature change.

## What's different from SQL Server's version

No query-text preview. `pg_session_states` deliberately stores no raw query text (see the collector's own class remarks — it fires on a duration floor an ordinary application can cross, so storing literal SQL there would mean routinely accumulating user data to answer a question that doesn't need it). The alert identifies a session by pid/database/command tag instead of a statement preview.

## Test plan

- [x] `dotnet build` (project + full solution) clean, 0 warnings, 0 errors
- [x] Verified `BuildPgLongRunningQueryIncident` (pure mapping) via reflection against the real built assembly — 5/5 checks pass (dedup key, message text, null-command_tag fallback, database passthrough, integer-minute truncation)
- [x] Verified the actual shipped SQL string (spliced from the built assembly, not retyped) against a real local PostgreSQL 17 container, proving the latest-capture-only join excludes a superseded older-window row and a below-threshold same-cycle row while returning the genuinely-current over-threshold one
- [x] Added `Darling.Tests` coverage: SQL-shape pins (`DarlingPgSessionStatesReaderTests.cs`) and pure-mapping tests (`DarlingPgOperationalAlertTests.cs`) — could not run `Darling.Tests` locally (macOS lacks the Windows Desktop runtime the `net10.0-windows` TFM needs); relying on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)