### PR TITLE
Fix PgBlocking alerts: dedup by root before LIMIT, not after

### DIFF
--- a/Darling/Darling.Tests/DarlingPgBlockingReaderTests.cs
+++ b/Darling/Darling.Tests/DarlingPgBlockingReaderTests.cs
@@ -416,7 +416,7 @@ public class DarlingPgBlockingReaderTests
             "query_text_may_be_truncated", "chain_may_be_truncated",
         ];
 
-        var finalSelectStart = DedupedByRootSql.LastIndexOf("SELECT\n", StringComparison.Ordinal);
+        var finalSelectStart = DedupedByRootSql.LastIndexOf("SELECT", StringComparison.Ordinal);
         Assert.True(finalSelectStart >= 0, "expected a final SELECT projecting the deduped rows");
         var finalSelect = DedupedByRootSql[finalSelectStart..];
 
@@ -508,6 +508,7 @@ public sealed class PgBlockingChainsDedupedByRootLivePostgresTests
 
         await using var postgres = NpgsqlDataSource.Create(cs!);
 
+        var bodySucceeded = false;
         try
         {
             var now = DateTime.UtcNow;
@@ -550,10 +551,14 @@ public sealed class PgBlockingChainsDedupedByRootLivePostgresTests
             Assert.Equal(2, deduped.Count);
             Assert.Contains(deduped, row => row.RootBackendId == RootABackendId && row.TotalVictims == 3);
             Assert.Contains(deduped, row => row.RootBackendId == RootBBackendId && row.TotalVictims == 1);
+            bodySucceeded = true;
         }
         finally
         {
-            await DeleteRowsAsync(connection, ct);
+            await LiveStoreCleanup.RunAsync(cs!, bodySucceeded, async (cleanup, cleanupCt) =>
+            {
+                await DeleteRowsAsync(cleanup, cleanupCt);
+            });
         }
     }
 

--- a/Darling/Darling.Tests/DarlingPgBlockingReaderTests.cs
+++ b/Darling/Darling.Tests/DarlingPgBlockingReaderTests.cs
@@ -7,8 +7,13 @@
  */
 
 using System;
+using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Npgsql;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Darling.Service.Mcp;
 using PerformanceMonitor.Darling.Storage;
 using Xunit;
@@ -351,5 +356,235 @@ public class DarlingPgBlockingReaderTests
         /* All six answers distinct — a collapsed branch is the failure this test exists for. */
         var all = new[] { idle, aborted, active, unknown, other };
         Assert.Equal(all.Length, all.Distinct(StringComparer.Ordinal).Count());
+    }
+
+    private static string DedupedByRootSql => DarlingPgBlockingReader.PgBlockingChainsDedupedByRootSql;
+
+    /// <summary>
+    /// #2714: <see cref="PgBlockingChainsSql"/> is unchanged — same candidate CTEs, same severity-ordered
+    /// LIMIT — proving the shared factoring didn't alter what the MCP tool and the Viewer's blocking grid
+    /// already ship. The behavioral fix lives entirely in the new, separate
+    /// <see cref="PgBlockingChainsDedupedByRootSql"/> query these callers do not use.
+    /// </summary>
+    [Fact]
+    public void ChainsSql_IsUnchangedByTheDedupRefactor()
+    {
+        Assert.StartsWith("WITH RECURSIVE", ChainsSql.TrimStart(), StringComparison.Ordinal);
+        Assert.EndsWith(
+            "ORDER BY s.total_victims DESC, s.max_depth DESC, d.collection_time DESC\nLIMIT $4",
+            ChainsSql, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// #2714: the dedup happens BEFORE the row-count LIMIT, not after — <c>DISTINCT ON</c> must appear
+    /// ahead of the final <c>LIMIT $4</c> in the query text, or this is the same bug re-typed. Also pins the
+    /// sentinel-aware partition key (root_backend_id = 0 falls back to root_pid, mirroring
+    /// <c>DarlingWorker.WorstPgBlockingChainPerRoot</c>'s own C# dedup identity) so the two layers of
+    /// defense-in-depth cannot silently disagree about what "the same root" means.
+    /// </summary>
+    [Fact]
+    public void DedupedByRootSql_DedupesBeforeLimit_UsingTheSameSentinelAwareRootIdentity()
+    {
+        var distinctOnIndex = DedupedByRootSql.IndexOf("DISTINCT ON (root_key)", StringComparison.Ordinal);
+        var limitIndex = DedupedByRootSql.LastIndexOf("LIMIT $4", StringComparison.Ordinal);
+
+        Assert.True(distinctOnIndex >= 0, "expected a DISTINCT ON (root_key) dedup step");
+        Assert.True(limitIndex >= 0, "expected a trailing LIMIT $4");
+        Assert.True(distinctOnIndex < limitIndex,
+            "DISTINCT ON must run BEFORE the row-count LIMIT, or this is #2714 re-typed");
+
+        Assert.Contains("WHEN root_backend_id = 0", DedupedByRootSql, StringComparison.Ordinal);
+        Assert.Contains("'pid:' || root_pid::text", DedupedByRootSql, StringComparison.Ordinal);
+        Assert.Contains("'bid:' || root_backend_id::text", DedupedByRootSql, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// #2714: the deduped query must select the exact same output columns, in the exact same order, as
+    /// <see cref="PgBlockingChainsSql"/> — <see cref="DarlingPgBlockingReader.MapChainRow"/> reads both by
+    /// ordinal, and a mismatch here is the exact "two lists that must agree, and nothing makes them" hazard
+    /// that method's own doc comment already warns about for the original query's projection.
+    /// </summary>
+    [Fact]
+    public void DedupedByRootSql_ProjectsTheSameColumnsInTheSameOrder_AsChainsSql()
+    {
+        string[] expectedColumns =
+        [
+            "captured_at", "root_backend_id", "root_pid", "databases", "root_username",
+            "root_application_name", "root_state", "root_query", "root_is_idle_in_transaction",
+            "root_xact_duration_ms", "root_query_duration_ms", "total_victims", "direct_victims",
+            "max_depth", "worst_victim_wait_ms", "worst_victim_query", "samples_as_root",
+            "query_text_may_be_truncated", "chain_may_be_truncated",
+        ];
+
+        var finalSelectStart = DedupedByRootSql.LastIndexOf("SELECT\n", StringComparison.Ordinal);
+        Assert.True(finalSelectStart >= 0, "expected a final SELECT projecting the deduped rows");
+        var finalSelect = DedupedByRootSql[finalSelectStart..];
+
+        var lastIndex = -1;
+        foreach (var column in expectedColumns)
+        {
+            var index = finalSelect.IndexOf(column, StringComparison.Ordinal);
+            Assert.True(index > lastIndex, $"expected '{column}' to appear, in order, in the final SELECT");
+            lastIndex = index;
+        }
+    }
+
+    /// <summary>
+    /// #2714: the wiring, not just the query shape. Neither <c>EvaluatePgBlockingAsync</c> nor
+    /// <c>WorstPgBlockingChainPerRoot</c> is otherwise exercised by a fast unit test — both talk to Postgres
+    /// directly and are covered only by the gated live test above — so nothing else would catch a future
+    /// edit quietly reverting the alert's call site back to the raw, pre-#2714
+    /// <see cref="DarlingPgBlockingReader.GetPgBlockingChainsAsync"/> without also reverting the query it
+    /// calls. Pinned at source, the same idiom <c>DatabaseMismatchTripwireTests</c> already uses for this
+    /// exact class of cross-artifact contract.
+    /// </summary>
+    [Fact]
+    public void EvaluatePgBlockingAsync_CallsTheDedupedByRootReader_NotTheRawOne()
+    {
+        var source = ReadWorkerSource();
+        var methodStart = source.IndexOf("private async Task EvaluatePgBlockingAsync(", StringComparison.Ordinal);
+        Assert.True(methodStart >= 0, "expected to find EvaluatePgBlockingAsync in DarlingWorker.cs");
+
+        var methodEnd = source.IndexOf("\n    private", methodStart + 1, StringComparison.Ordinal);
+        Assert.True(methodEnd > methodStart, "expected to find the next method after EvaluatePgBlockingAsync");
+        var body = source[methodStart..methodEnd];
+
+        Assert.Contains("DarlingPgBlockingReader.GetPgBlockingChainsDedupedByRootAsync", body, StringComparison.Ordinal);
+        Assert.DoesNotContain("DarlingPgBlockingReader.GetPgBlockingChainsAsync(", body, StringComparison.Ordinal);
+    }
+
+    private static string ReadWorkerSource([CallerFilePath] string thisFile = "")
+    {
+        var dir = Path.GetDirectoryName(thisFile)!;
+        var relative = Path.Combine("Darling", "PerformanceMonitor.Darling.Service", "DarlingWorker.cs");
+        while (dir is not null && !File.Exists(Path.Combine(dir, relative)))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        Assert.NotNull(dir);
+        return File.ReadAllText(Path.Combine(dir!, relative));
+    }
+}
+
+/// <summary>
+/// Gated (DARLING_TEST_PG) proof of #2714 against a real instance: a severe root sampled repeatedly across
+/// the window really does crowd a second, distinct root entirely out of <see cref="DarlingPgBlockingReader.
+/// PgBlockingChainsSql"/>'s severity-ordered LIMIT — proven RED here — and
+/// <see cref="DarlingPgBlockingReader.PgBlockingChainsDedupedByRootSql"/> keeps both roots under the exact
+/// same LIMIT, proven GREEN. The text pins above prove the query SHAPE; this proves the query DOES what the
+/// shape claims against PostgreSQL's actual planner and DISTINCT ON semantics, which no text assertion can.
+/// </summary>
+[Collection("live-postgres")]
+public sealed class PgBlockingChainsDedupedByRootLivePostgresTests
+{
+    private const string ServerName = "darling-pgblocking-dedup-e2e";
+    private static readonly int ServerId = ServerIdHelper.GetDeterministicHashCode(ServerName);
+
+    /* Root A: severe (3 victims/sample), sampled on 20 separate captures — enough to fill a LIMIT of 20 on
+       its own. Root B: distinct, less severe (1 victim), sampled ONCE, at a time no earlier than Root A's
+       samples, so recency cannot accidentally rescue it — only severity-before-dedup can, or #2714 is back. */
+    private const int RootABackendId = 900_001;
+    private const int RootAPid = 51_000;
+    private const int RootBBackendId = 900_002;
+    private const int RootBPid = 51_100;
+    private const int SampleCount = 20;
+    private const int LimitUnderTest = SampleCount;
+
+    private static string? ConnectionString => Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+
+    [Fact]
+    public async Task ASeverePersistentRoot_DoesNotCrowdADistinctRoot_OutOfTheDedupedRead()
+    {
+        var cs = ConnectionString;
+        Assert.SkipWhen(string.IsNullOrEmpty(cs),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the live #2714 dedup-before-limit test.");
+
+        var ct = TestContext.Current.CancellationToken;
+        using var connection = new NpgsqlConnection(cs);
+        await connection.OpenAsync(ct);
+        await PgMigrations.MigrateAsync(connection, ct);
+        await DeleteRowsAsync(connection, ct);
+
+        await using var postgres = NpgsqlDataSource.Create(cs!);
+
+        try
+        {
+            var now = DateTime.UtcNow;
+            var collectionId = 0L;
+
+            for (var i = 0; i < SampleCount; i++)
+            {
+                collectionId++;
+                var capturedAt = now.AddMinutes(-SampleCount + i);
+                for (var victim = 0; victim < 3; victim++)
+                {
+                    await PlantEdgeAsync(
+                        connection, collectionId, capturedAt, RootAPid, RootABackendId,
+                        blockedPid: RootAPid + 100 + victim, ct);
+                }
+            }
+
+            collectionId++;
+            await PlantEdgeAsync(
+                connection, collectionId, now, RootBPid, RootBBackendId, blockedPid: RootBPid + 100, ct);
+
+            var windowStart = now.AddHours(-2);
+            var windowEnd = now.AddMinutes(1);
+
+            /* RED: the pre-#2714 shape. Severity-ordered LIMIT, applied before any per-root dedup, spends
+               its whole budget on Root A's 20 equally-severe repeat samples and never reaches Root B at
+               all — not merely under-ranks it, DROPS it, so no downstream dedup step can recover it. */
+            var raw = await DarlingPgBlockingReader.GetPgBlockingChainsAsync(
+                postgres, ServerId, windowStart, windowEnd, LimitUnderTest, ct);
+
+            Assert.Equal(LimitUnderTest, raw.Count);
+            Assert.All(raw, row => Assert.Equal(RootABackendId, row.RootBackendId));
+            Assert.DoesNotContain(raw, row => row.RootBackendId == RootBBackendId);
+
+            /* GREEN: #2714's fix. Same LIMIT, but dedup-by-root runs BEFORE it, so the budget is spent on
+               root DIVERSITY — both roots survive even though Root A alone could have filled it twice over. */
+            var deduped = await DarlingPgBlockingReader.GetPgBlockingChainsDedupedByRootAsync(
+                postgres, ServerId, windowStart, windowEnd, LimitUnderTest, ct);
+
+            Assert.Equal(2, deduped.Count);
+            Assert.Contains(deduped, row => row.RootBackendId == RootABackendId && row.TotalVictims == 3);
+            Assert.Contains(deduped, row => row.RootBackendId == RootBBackendId && row.TotalVictims == 1);
+        }
+        finally
+        {
+            await DeleteRowsAsync(connection, ct);
+        }
+    }
+
+    private static async Task PlantEdgeAsync(
+        NpgsqlConnection connection, long collectionId, DateTime capturedAt, int blockingPid, int blockingBackendId,
+        int blockedPid, System.Threading.CancellationToken ct)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = """
+            INSERT INTO collect.pg_blocking_edges
+                (collection_id, collection_time, server_id, server_name, blocked_pid, blocking_pid,
+                 blocking_backend_id, database_name, blocked_query, blocking_query,
+                 query_text_may_be_truncated, blocking_is_idle_in_transaction)
+            VALUES
+                ($1, $2, $3, $4, $5, $6, $7, 'appdb', 'select victim', 'update root set x = 1', false, false)
+            """;
+        command.Parameters.AddWithValue(collectionId);
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(capturedAt, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(ServerId);
+        command.Parameters.AddWithValue(ServerName);
+        command.Parameters.AddWithValue(blockedPid);
+        command.Parameters.AddWithValue(blockingPid);
+        command.Parameters.AddWithValue((long)blockingBackendId);
+        await command.ExecuteNonQueryAsync(ct);
+    }
+
+    private static async Task DeleteRowsAsync(NpgsqlConnection connection, System.Threading.CancellationToken ct)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = "DELETE FROM collect.pg_blocking_edges WHERE server_id = $1";
+        command.Parameters.AddWithValue(ServerId);
+        await command.ExecuteNonQueryAsync(ct);
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -3008,7 +3008,13 @@ public sealed class DarlingWorker : BackgroundService
             var now = DateTime.UtcNow;
             var windowStart = now.AddHours(-AlertEngine.RollingCountWindowHours);
 
-            var rows = await DarlingPgBlockingReader.GetPgBlockingChainsAsync(
+            /* #2714: deduped-by-root BEFORE the row-count LIMIT, not the raw severity-ordered read — a
+               single severe root sampled repeatedly across the rolling window could otherwise occupy the
+               entire LIMIT budget with repeat samples of itself, pushing a second, genuinely distinct root
+               out of the top N before WorstPgBlockingChainPerRoot below ever saw it. That method's own
+               per-root dedup is kept regardless, as a no-op safety net now that SQL already hands it one
+               row per root — never the only thing standing between a real distinct root and an undercount. */
+            var rows = await DarlingPgBlockingReader.GetPgBlockingChainsDedupedByRootAsync(
                 _postgres, runtime.ServerId, windowStart, now, limit: 100, cancellationToken);
 
             var worstPerRoot = WorstPgBlockingChainPerRoot(rows);

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -2986,11 +2986,13 @@ public sealed class DarlingWorker : BackgroundService
 
     /// <summary>
     /// The rolling-1-hour-window Postgres Blocking alert (#2711). Counts DISTINCT root blockers, not raw
-    /// chain rows — <see cref="DarlingPgBlockingReader.GetPgBlockingChainsAsync"/> returns one row per
-    /// (capture, root), so a single persistent blocker sampled every cycle for an hour would otherwise
-    /// inflate the count far past what an operator would call "how many blocking situations". Same
-    /// <see cref="RollingCountAlertGate"/> reuse and parity-named metrics as
-    /// <see cref="EvaluatePgDeadlocksAsync"/> — see its doc comment for why.
+    /// chain rows — <see cref="DarlingPgBlockingReader.GetPgBlockingChainsDedupedByRootAsync"/> (#2714) already
+    /// dedupes by root INSIDE the query, before its own LIMIT, so a single persistent blocker sampled every
+    /// cycle for an hour cannot crowd a distinct root out of the row budget the way the raw, severity-ordered
+    /// <see cref="DarlingPgBlockingReader.GetPgBlockingChainsAsync"/> could. <see cref="WorstPgBlockingChainPerRoot"/>
+    /// below still runs — see its own doc comment for why a second, C#-side dedup remains worth keeping even
+    /// though the query no longer needs it to arrive at "one row per root". Same <see cref="RollingCountAlertGate"/>
+    /// reuse and parity-named metrics as <see cref="EvaluatePgDeadlocksAsync"/> — see its doc comment for why.
     /// </summary>
     private async Task EvaluatePgBlockingAsync(
         ServerRuntime runtime, AlertServerSnapshot snapshot, CancellationToken cancellationToken)
@@ -3152,13 +3154,17 @@ public sealed class DarlingWorker : BackgroundService
     /// Which root blocker each captured chain belongs to, worst sample first per root — pulled out of
     /// <see cref="EvaluatePgBlockingAsync"/> for the same testability reason as
     /// <see cref="BuildPgDeadlockIncident"/>.
-    /// <para><see cref="DarlingPgBlockingReader.GetPgBlockingChainsAsync"/> returns one row per (capture,
-    /// root) ordered worst-first (widest chain, then deepest, then most recent) — see that method's own
-    /// doc comment — so keeping the FIRST row seen per root keeps the worst sample the window saw for that
-    /// blocker, without needing to re-sort. Without this dedup, a single persistent blocker sampled every
-    /// cycle for the whole rolling window would inflate the alert's count far past what an operator would
-    /// call "how many blocking situations", since blocking here is sampled state, not an engine-recorded
-    /// event log (same caveat the collector's own doc comment carries).</para>
+    /// <para><see cref="EvaluatePgBlockingAsync"/> feeds this from
+    /// <see cref="DarlingPgBlockingReader.GetPgBlockingChainsDedupedByRootAsync"/> (#2714), which already
+    /// dedupes by root INSIDE the query, ordered worst-first (widest chain, then deepest, then most recent) —
+    /// see that method's own doc comment. So the rows arriving here are typically already at most one per
+    /// root, and this method's own
+    /// "keep the FIRST row seen per root" dedup is now a no-op safety net rather than the only thing standing
+    /// between a real distinct root and an undercount — kept because the sentinel-identity handling below
+    /// (<c>RootBackendId == 0</c>) is still load-bearing regardless of which reader supplies the rows, and
+    /// because nothing stops a future call site from wiring this to the raw, non-deduped
+    /// <see cref="DarlingPgBlockingReader.GetPgBlockingChainsAsync"/> again (guarded by
+    /// <c>EvaluatePgBlockingAsync_CallsTheDedupedByRootReader_NotTheRawOne</c>).</para>
     /// <para><b><c>RootBackendId == 0</c> is the vanished-blocker sentinel, and it needs its OWN identity to
     /// dedupe against, not the raw backend id.</b> <c>PgBlockingCollector</c> writes
     /// <c>coalesce(blocker.backend_id, 0)</c> when the root's own row had already left

--- a/Darling/PerformanceMonitor.Darling.Storage/DarlingPgBlockingReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/DarlingPgBlockingReader.cs
@@ -81,9 +81,15 @@ public static class DarlingPgBlockingReader
     /// error on the first call, not a compile-time one, which is why this was found by running the text
     /// against a real instance rather than by reading it.</para>
     ///
-    /// <para>$1 server_id, $2/$3 window (naive UTC), $4 row limit.</para>
+    /// <para>#2714: this is a complete SELECT statement (its own nested <c>WITH RECURSIVE</c>), factored out
+    /// so <see cref="PgBlockingChainsSql"/> (raw severity-ordered top-N — the MCP tool and the Viewer grid
+    /// both want to see an ongoing situation's repeated samples, not one row per root) and
+    /// <see cref="PgBlockingChainsDedupedByRootSql"/> (the alert-only variant that dedupes by root BEFORE the
+    /// row-count LIMIT) share ONE canonical copy of the CTE chain rather than two texts that can drift the
+    /// way the ladder-generator's fresh-store/upgrade pair once did. Embedded elsewhere by wrapping it in one
+    /// more set of parens as the body of an outer CTE.</para>
     /// </summary>
-    public const string PgBlockingChainsSql = """
+    private const string PgBlockingChainCandidatesSql = """
         WITH RECURSIVE edges AS (
             SELECT
                 collection_id,
@@ -272,16 +278,103 @@ public static class DarlingPgBlockingReader
           AND a.blocking_pid = d.blocking_pid
         LEFT JOIN recurrence AS c
           ON  c.blocking_backend_id = d.blocking_backend_id
-        ORDER BY s.total_victims DESC, s.max_depth DESC, d.collection_time DESC
+        """;
+
+    /// <para>$1 server_id, $2/$3 window (naive UTC), $4 row limit.</para>
+    public const string PgBlockingChainsSql = PgBlockingChainCandidatesSql +
+        "\nORDER BY s.total_victims DESC, s.max_depth DESC, d.collection_time DESC\nLIMIT $4";
+
+    /// <summary>
+    /// #2714: the same candidate rows as <see cref="PgBlockingChainsSql"/>, but deduped to ONE row per
+    /// distinct root — the same sentinel-aware identity <c>DarlingWorker.WorstPgBlockingChainPerRoot</c>
+    /// already applies in C# (a vanished root's own pid, since its backend id fell back to the shared
+    /// sentinel 0; the real backend id otherwise) — BEFORE the row-count LIMIT is applied, not after.
+    ///
+    /// <para><b>Why this needs to exist at all.</b> <see cref="PgBlockingChainsSql"/> orders candidate rows
+    /// by severity (<c>total_victims DESC, max_depth DESC, collection_time DESC</c>) and applies LIMIT
+    /// across the whole window BEFORE any caller dedupes by root. A single severe, persistent blocker
+    /// sampled on most cycles of a rolling hour can occupy the entire LIMIT budget with repeat samples of
+    /// itself, pushing every sample of a second, genuinely distinct — merely less severe — root out of the
+    /// top N and out of the alert entirely. Raising the LIMIT only narrows the window this can happen in; it
+    /// does not fix the "ordered by severity before dedup" shape. Deduping in SQL, before LIMIT, is the only
+    /// way the row budget is actually spent on root diversity rather than repeat samples of one root.</para>
+    ///
+    /// <para>Kept as a query, not just a bigger raw LIMIT: dedupes by keeping each root's OWN worst sample
+    /// (<c>DISTINCT ON</c> ordered the same worst-first way as <see cref="PgBlockingChainsSql"/>), so the
+    /// alert's downstream per-root dedup in C# becomes a no-op safety net rather than the only thing standing
+    /// between a real distinct root and an undercount.</para>
+    ///
+    /// <para>This is deliberately a SEPARATE query from <see cref="PgBlockingChainsSql"/> rather than a
+    /// parameter that changes its shape — the MCP tool and the Viewer's blocking grid both call the raw
+    /// severity-ordered form and want to see an ongoing situation's repeated samples across the window, not
+    /// collapse them to one row per root. Changing the shared query's contract would have silently changed
+    /// what those two already-shipped call sites display.</para>
+    /// </summary>
+    public const string PgBlockingChainsDedupedByRootSql =
+        "WITH candidates AS (\n" +
+        PgBlockingChainCandidatesSql +
+        "\n),\n" +
+        """
+        keyed AS (
+            SELECT
+                candidates.*,
+                CASE WHEN root_backend_id = 0
+                     THEN 'pid:' || root_pid::text
+                     ELSE 'bid:' || root_backend_id::text
+                END AS root_key
+            FROM candidates
+        ),
+        deduped AS (
+            SELECT DISTINCT ON (root_key) *
+            FROM keyed
+            ORDER BY root_key, total_victims DESC, max_depth DESC, captured_at DESC
+        )
+        SELECT
+            captured_at,
+            root_backend_id,
+            root_pid,
+            databases,
+            root_username,
+            root_application_name,
+            root_state,
+            root_query,
+            root_is_idle_in_transaction,
+            root_xact_duration_ms,
+            root_query_duration_ms,
+            total_victims,
+            direct_victims,
+            max_depth,
+            worst_victim_wait_ms,
+            worst_victim_query,
+            samples_as_root,
+            query_text_may_be_truncated,
+            chain_may_be_truncated
+        FROM deduped
+        ORDER BY total_victims DESC, max_depth DESC, captured_at DESC
         LIMIT $4
         """;
 
-    public static async Task<List<PgBlockingChainRow>> GetPgBlockingChainsAsync(
+    public static Task<List<PgBlockingChainRow>> GetPgBlockingChainsAsync(
         NpgsqlDataSource postgres, int serverId, DateTime startUtc, DateTime endUtc, int limit,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default) =>
+        RunPgBlockingChainsQueryAsync(
+            postgres, PgBlockingChainsSql, serverId, startUtc, endUtc, limit, cancellationToken);
+
+    /// <summary>#2714: dedup-by-root-before-LIMIT variant — see <see cref="PgBlockingChainsDedupedByRootSql"/>
+    /// for why this exists as a separate call rather than a flag on <see cref="GetPgBlockingChainsAsync"/>.
+    /// </summary>
+    public static Task<List<PgBlockingChainRow>> GetPgBlockingChainsDedupedByRootAsync(
+        NpgsqlDataSource postgres, int serverId, DateTime startUtc, DateTime endUtc, int limit,
+        CancellationToken cancellationToken = default) =>
+        RunPgBlockingChainsQueryAsync(
+            postgres, PgBlockingChainsDedupedByRootSql, serverId, startUtc, endUtc, limit, cancellationToken);
+
+    private static async Task<List<PgBlockingChainRow>> RunPgBlockingChainsQueryAsync(
+        NpgsqlDataSource postgres, string sql, int serverId, DateTime startUtc, DateTime endUtc, int limit,
+        CancellationToken cancellationToken)
     {
         var rows = new List<PgBlockingChainRow>();
-        await using var command = postgres.CreateCommand(PgBlockingChainsSql);
+        await using var command = postgres.CreateCommand(sql);
         command.Parameters.AddWithValue(serverId);
         /* SpecifyKind(Unspecified), not the bare value. Npgsql does not reject Kind=Utc — it infers
            timestamptz, and PostgreSQL then zone-shifts the window against the store's NAIVE timestamp


### PR DESCRIPTION
Closes #2714.

## Problem

`DarlingPgBlockingReader.GetPgBlockingChainsAsync`'s query orders candidate (capture, root) rows by severity (`total_victims DESC, max_depth DESC, collection_time DESC`) and applies `LIMIT` across the whole rolling window **before** `EvaluatePgBlockingAsync`'s `WorstPgBlockingChainPerRoot` (added in #2713) ever dedupes by root.

A single severe, persistent blocker sampled on most cycles of a rolling hour can occupy the entire `LIMIT` budget with repeat samples of itself, pushing every sample of a second, genuinely distinct — merely less severe — root out of the top N and out of the alert entirely. This isn't an under-ranking; the second root's samples never reach the dedup step at all, so no downstream logic can recover them.

## Fix

Added `PgBlockingChainsDedupedByRootSql` — a separate query built from the same CTE chain (factored into `PgBlockingChainCandidatesSql` so the raw and deduped queries share one canonical copy and cannot drift) that dedupes to one row per root, using the exact same sentinel-aware root identity `WorstPgBlockingChainPerRoot` already applies in C# (a vanished root's own pid when its backend id fell back to the shared sentinel 0; the real backend id otherwise) — **before** the row-count `LIMIT`.

`EvaluatePgBlockingAsync` now calls the new `GetPgBlockingChainsDedupedByRootAsync`. `GetPgBlockingChainsAsync` (and its `PgBlockingChainsSql`) is untouched — confirmed byte-identical text before/after the refactor — so the two other callers (the `get_pg_blocking` MCP tool and the Viewer's Postgres blocking grid), which want to see an ongoing situation's repeated samples across the window rather than collapse to one row per root, are unaffected.

## Verification

Against a real Postgres 17, with a synthetic scenario (Root A: 3 victims/sample, sampled 20 times; Root B: 1 victim, sampled once) and `LIMIT 20`:
- **Before the fix**: raw query returns all 20 rows for Root A, **zero** for Root B — bug reproduced.
- **After the fix**: deduped query returns exactly 2 rows, one per root.

Proved twice — once via raw SQL through psql, once through the actual C# `DarlingPgBlockingReader` methods (via a throwaway harness against a real migrated store, since `dotnet test` can't run the Windows-targeted suite on macOS).

## Tests

- `ChainsSql_IsUnchangedByTheDedupRefactor` — pins that the existing query's text didn't move.
- `DedupedByRootSql_DedupesBeforeLimit_UsingTheSameSentinelAwareRootIdentity` — pins `DISTINCT ON` appears before `LIMIT $4` in the new query text, and that the partition key matches `WorstPgBlockingChainPerRoot`'s sentinel handling.
- `DedupedByRootSql_ProjectsTheSameColumnsInTheSameOrder_AsChainsSql` — guards the ordinal-read hazard `MapChainRow`'s own doc comment already calls out.
- `EvaluatePgBlockingAsync_CallsTheDedupedByRootReader_NotTheRawOne` — source-pinned wiring check (this call site has no unit-test seam otherwise; confirmed red against the pre-fix source, green against the fix).
- `ASeverePersistentRoot_DoesNotCrowdADistinctRoot_OutOfTheDedupedRead` (gated `DARLING_TEST_PG`) — the live regression proof above, runnable in CI's `Darling PostgreSQL tests` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)