### PR TITLE
Remove OPTION(RECOMPILE) from plan_correction's zero-parameter DMV query

### DIFF
--- a/Lite.Tests/PlanCorrectionCollectorDefinitionTests.cs
+++ b/Lite.Tests/PlanCorrectionCollectorDefinitionTests.cs
@@ -179,6 +179,21 @@ public sealed class PlanCorrectionCollectorDefinitionTests
     }
 
     [Fact]
+    public void PayloadBody_DoesNotCarryRecompile()
+    {
+        /* #2759/#2760: both statements are static literal T-SQL with no runtime parameters, so
+           RECOMPILE has nothing to protect against parameter sniffing on, and
+           sys.dm_db_tuning_recommendations has no statistics — a cached plan's cardinality guess is
+           the same fixed heuristic a fresh compile produces. Live evidence on
+           prod-pos-use1-multi-45/Demo showed 4,237ms avg CPU against 381 logical reads and 18 rows: a
+           compile-cost signature paid per database, per server, every cycle, for no plan-quality
+           benefit. Caching the plan removes that cost fleet-wide with no functional change. */
+        var text = PlanCorrectionCollector.Instance.BuildQuery(Context(isAzureSqlDb: true)).Text;
+
+        Assert.DoesNotContain("OPTION(RECOMPILE)", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void QueryStoreJoins_AreLeft_SoAnAgedOutPlanCannotDropTheRecommendation()
     {
         /* Microsoft's Example 3 INNER JOINs sys.query_store_plan twice, which silently drops any

--- a/PerformanceMonitor.Collectors/PlanCorrectionCollector.cs
+++ b/PerformanceMonitor.Collectors/PlanCorrectionCollector.cs
@@ -123,8 +123,18 @@ public sealed class PlanCorrectionCollector : CollectorDefinitionBase<PlanCorrec
     /// its details JSON already shredded — hands the optimizer a real row count, and the final query
     /// nested-loop SEEKS each query_id/plan_id into the QS views instead of scanning them. SET NOCOUNT
     /// ON so the SELECT INTO emits no result set and the caller's reader takes the final SELECT as the
-    /// shipped rows; both statements carry OPTION(RECOMPILE); the #temp is scoped to this sp_executesql
-    /// and dropped explicitly.
+    /// shipped rows; the #temp is scoped to this sp_executesql and dropped explicitly.
+    /// </para>
+    ///
+    /// <para>
+    /// #2759/#2760: neither statement carries OPTION(RECOMPILE) anymore. Both are static literal T-SQL
+    /// with no runtime parameters — nothing here for RECOMPILE to protect against parameter sniffing —
+    /// and sys.dm_db_tuning_recommendations has no statistics (see below), so a cached plan's cardinality
+    /// guess is the same fixed heuristic a fresh compile would produce; there is no plan-quality benefit
+    /// to buy back. Live evidence on prod-pos-use1-multi-45/Demo: 5,004ms avg duration, 4,237ms avg CPU
+    /// (85%), 381 logical reads, 18 rows — a compile-cost signature, not an execution-cost one, on a
+    /// query that runs per database, per server, every cycle. Caching the plan removes that repeated
+    /// compile cost fleet-wide with no functional change.
     /// </para>
     ///
     /// <para>
@@ -242,8 +252,7 @@ CROSS APPLY
                 TRY_CAST(JSON_VALUE(dtr.details, '$.planForceDetails.recommendedPlanAbortedCount') AS bigint),
                 TRY_CAST(JSON_VALUE(dtr.details, '$.planForceDetails.recommendedPlanErrorCount') AS bigint)
             )
-) AS pfd
-OPTION(RECOMPILE);
+) AS pfd;
 
 SELECT
     force_last_good_plan_desired_state = o.desired_state_desc,
@@ -326,8 +335,7 @@ LEFT JOIN sys.query_store_query_text AS qsqt
 LEFT JOIN sys.query_store_plan AS qsp
   ON qsp.query_id = r.query_id
   AND qsp.plan_id = r.last_good_plan_id
-ORDER BY r.score DESC, r.recommendation_name
-OPTION(RECOMPILE);
+ORDER BY r.score DESC, r.recommendation_name;
 
 DROP TABLE #pm_plan_correction_recs;";
 


### PR DESCRIPTION
Fixes #2760, part of the #2759 fleet-wide collector cost investigation.

## Root cause

Both statements in `PlanCorrectionCollector.PayloadBodyText` carry `OPTION(RECOMPILE)`, but the query is static literal T-SQL with zero runtime parameters — nothing for RECOMPILE to protect against parameter sniffing on. `sys.dm_db_tuning_recommendations` has no statistics (per the collector's own doc comment), so a cached plan's cardinality guess is the same fixed heuristic a fresh compile would produce. RECOMPILE buys no plan-quality benefit here.

Live evidence on `prod-pos-use1-multi-45`/`Demo` (Query Store): 5,004ms avg duration, 4,237ms avg CPU (85% of duration), 381 logical reads, 18 rows — a compile-cost signature, not an execution-cost one, paid per database, per server, every 5-minute cycle.

## Fix

Remove `OPTION(RECOMPILE)` from both statements. Comment updated to explain why (per house style — comment the decision, not the mechanics).

## Verification

Built clean (`PerformanceMonitor.Collectors`, 0 errors/warnings). Verified against the real built assembly via a throwaway harness that RECOMPILE is gone and nothing else changed (staging temp-table drop, final drop, JSON_VALUE shredding, LEFT JOIN to `query_store_plan` all intact). New regression test `PayloadBody_DoesNotCarryRecompile`.