### PR TITLE
Mirror Darling's raised dedup-site total in Lite's parity guard (Fixes #2835)

### DIFF
--- a/Lite.Tests/QueryStoreSliceTieBreakSourceTests.cs
+++ b/Lite.Tests/QueryStoreSliceTieBreakSourceTests.cs
@@ -127,10 +127,12 @@ public sealed class QueryStoreSliceTieBreakSourceTests
         var darlingSource = File.ReadAllText(darlingGuard);
 
         /* Darling declares its own total the same way this file does. If that guard is deleted or stops
-           asserting a total, this fails rather than silently becoming a one-sided check. */
+           asserting a total, this fails rather than silently becoming a one-sided check. The literal below
+           MIRRORS Darling's declared total: raising one without the other is what broke dev on #2830, so
+           bump both in the same commit. */
         var declared = Regex.Match(darlingSource, @"Assert\.Equal\((?<total>\d+), total\);");
         Assert.True(declared.Success, "Darling's guard no longer declares a total dedup-site count.");
-        Assert.Equal(12, int.Parse(declared.Groups["total"].Value, System.Globalization.CultureInfo.InvariantCulture));
+        Assert.Equal(18, int.Parse(declared.Groups["total"].Value, System.Globalization.CultureInfo.InvariantCulture));
 
         /* And it must still enumerate its files rather than globbing, for the same reason this one does. */
         Assert.Contains("DedupSites", darlingSource, StringComparison.Ordinal);


### PR DESCRIPTION
Fixes #2835.

`dev` does not build. #2830 raised Darling's declared dedup-site total 12 → 18 in `ccbaa7a`; Lite's parity guard cross-checks that number against a literal of its own and still expected 12, so the first nightly after the merge failed with `Expected: 12, Actual: 18` and produced no artifact.

## The change

One literal, `Lite.Tests/QueryStoreSliceTieBreakSourceTests.cs:133`, plus three comment lines recording that the two literals must move together.

## Verification

`Lite.Tests` is `net10.0-windows` and cannot run on macOS, so I verified by executing the assertion's own logic against the real source rather than asserting it looks right:

```
Darling declared total   = 18   (regex the test itself uses)
Lite cross-check expects = 18
MATCH: True
Darling contains DedupSites: True
```

Also confirmed there is no reverse cross-check in Darling's guard, and Lite's own total (8, its own sites) is untouched.

CRLF preserved — 153 CRLF / 153 LF before and after, no renormalisation.

## Not a guard defect

The parity check did its job: it caught real drift between the two apps, which is the failure class it was written for. The comment now says the two literals mirror each other and why, so the next bump moves both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MX6HyjsuDCs15qGB2rh4Gy