### PR TITLE
Add project skills for build, duckdb, maintenance, and release

### DIFF
--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: build
+description: Build and locate the PerformanceMonitor executables
+argument-hint: [lite|darling|viewer|dashboard|installer]
+disable-model-invocation: false
+---
+
+# Build PerformanceMonitor
+
+Build a component of PerformanceMonitor and report the result. All paths are relative to the repository root.
+
+## Arguments
+
+`$ARGUMENTS` specifies which component to build:
+
+| Argument | Project | Output TFM |
+|---|---|---|
+| `lite` | `Lite/PerformanceMonitorLite.csproj` | `net10.0-windows` |
+| `darling` or `service` | `Darling/PerformanceMonitor.Darling.Service/PerformanceMonitor.Darling.Service.csproj` | `net10.0` |
+| `viewer` | `Darling/PerformanceMonitor.Darling.Viewer/PerformanceMonitor.Darling.Viewer.csproj` | `net10.0-windows` |
+| `dashboard` or `full` | `deprecated/Dashboard/Dashboard.csproj` | DEPRECATED since v3.3.0 |
+| `installer` | `deprecated/Installer/PerformanceMonitorInstaller.csproj` | DEPRECATED since v3.3.0 |
+| (empty) | build whatever is in the current working directory, or ask | |
+
+Lite, the Darling service, and the Darling Viewer are the shipping artifacts. The full Dashboard and the CLI Installer moved to `deprecated/` in v3.3.0. They still build and their tests still run in CI, but they ship no release artifacts and get bug-fix support only.
+
+## Steps
+
+1. Map `$ARGUMENTS` to the project path above.
+2. Run `dotnet build <path>`, Debug configuration by default.
+3. Report the result:
+   - **success**: show the output path (e.g. `Lite/bin/Debug/net10.0-windows/`) and the executable name
+   - **failure**: show the error messages clearly and suggest fixes
+4. Do NOT automatically launch the executable. Just say where it is.
+
+## Notes
+
+- Use `dotnet build` with paths relative to the repository root. Do NOT `cd` into directories.
+- If the build fails because the exe is locked by a running instance, kill it (`taskkill /F /PID <pid>`) and rebuild.
+- If a project path cannot be determined, run `git ls-files "*.csproj"` to list the real projects. Stale `bin/` and `obj/` folders are left behind at the old top-level `Dashboard/` and `Installer/` paths and are not projects.

--- a/.claude/skills/duckdb/SKILL.md
+++ b/.claude/skills/duckdb/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: duckdb
+description: Query the Lite app's DuckDB database safely while the collector is running
+argument-hint: [SQL query or description of what to look up]
+disable-model-invocation: false
+---
+
+# Query Lite's DuckDB Database
+
+Safely query the PerformanceMonitor Lite DuckDB database using Python. This skill exists because DuckDB only allows one read-write connection at a time. When Lite is running (collecting data), it holds the write connection. External readers MUST connect in read-only mode.
+
+## Database Location
+
+Since the #1832 fix (data moved OUT of Velopack's install root, which Setup.exe deletes), the store lives at:
+```
+%LOCALAPPDATA%\PerformanceMonitorLite-Data\monitor.duckdb
+```
+Builds from BEFORE that fix (3.3.0 and earlier) keep it at the old path, and the file only moves when a fixed build first runs:
+```
+%LOCALAPPDATA%\PerformanceMonitorLite\monitor.duckdb
+```
+**Check the -Data path first; fall back to the old path if it does not exist.**
+
+## How to Query (ALWAYS use this pattern)
+
+Use Python with the `duckdb` module. **ALWAYS connect in read-only mode.**
+
+```python
+python -c "
+import duckdb, os
+la = os.environ['LOCALAPPDATA']
+p = la + '/PerformanceMonitorLite-Data/monitor.duckdb'
+if not os.path.exists(p):
+    p = la + '/PerformanceMonitorLite/monitor.duckdb'
+con = duckdb.connect(p, read_only=True)
+result = con.execute('YOUR SQL HERE').fetchall()
+for row in result:
+    print(row)
+con.close()
+"
+```
+
+## CRITICAL RULES
+
+1. **ALWAYS use `read_only=True`** -- without this, the connection will be blocked by Lite's write lock and hang or fail
+2. **NEVER use `duckdb.connect()` without `read_only=True`** -- the default is read-write which WILL conflict with the running app
+3. **Use forward slashes** in the path (Python on Windows handles this fine)
+4. **Close the connection** when done -- don't leave read locks dangling
+5. **Use Python** -- duckdb 1.4.4 is installed
+
+## Common Queries
+
+List all tables:
+```sql
+SELECT table_name FROM information_schema.tables WHERE table_schema = 'main' ORDER BY table_name;
+```
+
+List columns for a table:
+```sql
+SELECT column_name, data_type FROM information_schema.columns WHERE table_name = 'TABLE_NAME' ORDER BY ordinal_position;
+```
+
+List all views:
+```sql
+SELECT table_name FROM information_schema.tables WHERE table_type = 'VIEW' ORDER BY table_name;
+```
+
+Row counts:
+```sql
+SELECT table_name, estimated_size FROM duckdb_tables() ORDER BY estimated_size DESC;
+```
+
+## DuckDB vs SQL Server Syntax Notes
+
+- String concatenation: `||` (not `+`)
+- ILIKE for case-insensitive LIKE
+- `EPOCH_MS(timestamp_col)` to convert to epoch
+- `strftime('%Y-%m-%d %H:%M:%S', ts)` for formatting
+- No `TOP N` -- use `LIMIT N` instead
+- `EXCLUDE` clause: `SELECT * EXCLUDE (col1, col2) FROM table`
+

--- a/.claude/skills/maintenance/SKILL.md
+++ b/.claude/skills/maintenance/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: maintenance
+description: Quarterly maintenance pass (every 1-3 months) — dependency/security audit, build health, and repo hygiene for PerformanceMonitor and PerformanceStudio
+argument-hint: [optional: deps | build | all]
+disable-model-invocation: false
+---
+
+# Routine Maintenance Pass
+
+A repeatable every-1-3-months health check for the .NET desktop + SQL-monitoring repos
+(PerformanceMonitor = WPF, PerformanceStudio = Avalonia; same dependency/build/release shape).
+`$ARGUMENTS` optionally scopes it (`deps`, `build`, or `all` — default `all`).
+
+Work top to bottom. Do read-only scans first and report findings; make fixes on a feature
+branch/worktree (branch protection: never commit to `dev`/`main`), build + test, then PR to `dev`.
+Low-risk patch/minor bumps can go in one PR; majors and anything release-critical get their own.
+
+## A. Dependencies & Security
+
+> **Scope — scan every project, not just the solution.** A repo's `.sln` may not list every project. PerformanceStudio's `PlanViewer.sln` omits `server/PlanShare.csproj` and the SSMS VSIX (`PlanViewer.Ssms`, `PlanViewer.Ssms.Installer`), so the `dotnet list <Solution>.sln …` scans and the solution build all silently skip them. Run the checks against those projects too. The net472 VSIX is old-style, so `dotnet list` is unreliable on it — read its `<PackageReference>`s by hand (its `Microsoft.VSSDK.BuildTools` is intentionally held on the 17.x line; 18.x is un-restorable from nuget.org and targets VS 18, not VS 2022). Where the `.sln` covers all projects, the solution is enough.
+
+1. **Outdated packages.** `dotnet list <Solution>.sln package --outdated`
+   - Take low-risk **patch/minor** bumps (Microsoft.Extensions.*, Test.Sdk, etc.).
+   - **Majors get their own effort** — especially the update framework (Velopack: bump the library AND the `vpk` CLI pin in the release workflow — `.github/workflows/release.yml` for PerformanceStudio — together; validate the in-app + Setup.exe update path) and anything release-critical.
+   - **Engine-wrapped bindings** (e.g. DuckDB.NET) trail the native engine — bump when the binding catches up, and validate behavior (for DuckDB run `tools/CompactionRepro` re: the parquet-COPY memory-limit floor before changing the version).
+   - After version edits, **if the repo uses lock files** (`packages.lock.json` — PerformanceMonitor does; PerformanceStudio does not), regenerate them: `dotnet restore <Solution>.sln --force-evaluate` (CI restores `--locked-mode`).
+
+2. **Vulnerable packages (security).** `dotnet list <Solution>.sln package --vulnerable --include-transitive`
+   - Must be **zero**. Any hit (incl. transitive) is urgent — bump or pin to a fixed version. This catches CVEs the `--outdated` check does not.
+   - **Code-level pass, not just packages:** run the `security-review` skill/agent on the diff since the last maintenance pass. These apps have real attack surface beyond their dependencies — PerformanceStudio's MCP server opens a local network listener, both store DB credentials (Windows Credential Manager), and both parse untrusted input (e.g. execution-plan XML). Triage anything it flags.
+     - **Calibrate severity to the deployment.** PerformanceStudio runs on a single-user personal laptop, and its MCP tools are strictly read-only (no arbitrary SQL, no writes/config changes). So loopback-bound / opt-in / local-IPC findings — the MCP listener, the named-pipe single-instance server — are **Low/informational here, not High**: there's no other local user or attacker to exploit them, and read-only tools can at most leak data they already return. Reserve High for *remotely reachable* vectors (e.g. a missing `Host`/`Origin` check that allows DNS rebinding) or credential disclosure. This calibration would change only if Studio shipped the MCP server enabled-by-default or ran on a shared/multi-user host. Don't re-raise the same local-IPC findings at High each pass.
+
+3. **Deprecated packages.** `dotnet list <Solution>.sln package --deprecated` — replace anything abandoned.
+
+4. **Framework / runtime currency.** Confirm the TFM is on a **supported, released** .NET (do NOT move to a preview). Take the latest servicing patch of the current major. WPF/Avalonia track the runtime/their own NuGet — check both.
+
+5. **CI tool & action pins.** In `.github/workflows/*.yml`: confirm `uses:` actions are on current majors, and that any `dotnet tool install` is **version-pinned to match its library** (e.g. `vpk --version` must equal the Velopack PackageReference). Bump GitHub Actions that are behind / deprecated.
+
+6. **Dependabot (optional — not a finding).** Two separate features: *security alerts* (passive CVE notifications that close the gap between manual `--vulnerable` passes — mild value) and *version-update PRs* (automated bump PRs — redundant and noisy once you do periodic manual sweeps). For PerformanceStudio, Erik relies on the manual passes; treat Dependabot as **optional and do not report it as a finding**. If alerts are ever wanted they're a one-toggle enable (repo Settings → Code security, no config file); the version-update PRs aren't wanted.
+
+## B. Code & Build Health
+
+7. **Zero-warning build.** Build the whole solution and capture warnings — the standard is **0**:
+   ```
+   dotnet build <Solution>.sln -c Debug --nologo 2>&1 | Select-String ": warning "
+   ```
+   - Kill the running app(s) first OR build in a worktree — a running Dashboard/Lite/Studio locks its `bin` DLLs (MSB3021). Note: an incremental no-op build emits no warnings; force a clean compile of any project you're checking.
+   - Fix each warning honestly (don't add to `NoWarn` to silence). Remove dead code (e.g. an unused test seam → CS0649).
+
+8. **NoWarn review.** Scan each csproj `<NoWarn>`: every suppressed rule should have a reason (these repos keep inline comments). Remove suppressions that no longer fire; don't let the list grow silently. Most existing CA suppressions are intentional high-count ones — leave those.
+
+9. **Stale markers.** `grep -rE "\b(TODO|FIXME|HACK|XXX)\b" --include=*.cs` — resolve or file an issue; a `// TODO: restore to X` next to a non-X value may mean the comment is the leftover (ask before flipping).
+
+10. **Git repo hygiene.**
+    - **Line endings / `.gitattributes`.** If the repo has no `.gitattributes`, line endings drift (CRLF/LF mixed, `core.autocrlf=false`) and bulk edits balloon diffs. Add one and run a **dedicated** `git add --renormalize .` commit (its own PR, when no other work is in flight — it touches nearly every file).
+    - **Stale branches & worktrees.** `git worktree list` — remove leftover worktrees (anything under `.claude/worktrees/` or other agent/isolation worktrees) with `git worktree remove`. Then `git fetch --prune` to drop stale remote-tracking refs, and audit: `git branch --merged origin/dev` (local branches already in dev — safe to delete) and `git branch -r` (remote branches from closed/merged PRs). Delete merged/dead branches; **keep intentionally-parked ones** (note which and why — e.g. a blocked-upgrade branch like `upgrade/avalonia-12`). For branches *you didn't create*, surface and confirm before deleting rather than assuming abandoned. Confirm open PRs are still wanted.
+
+## C. App data & runtime hygiene (lighter)
+
+11. **Retention / archive end-to-end.** Confirm the app's data retention/purge and (Lite) parquet archiving actually prune old data, and logs rotate. A new time-series table must be registered for retention/archive or it grows forever.
+
+12. **Perf regression spot-check.** Re-run the UI-latency-under-load harness if available; watch known hot spots (e.g. the Lite Blocking tab render hitch). Quick collector-health pass.
+
+## D. Release & platform currency (lighter)
+
+13. **Release infra freshness.** Test servers online/patched; signing cert (SignPath) not near expiry; cloud creds (`az`/`aws`) valid; the `release-checklist` skill still accurate.
+    - **Cross-platform publish smoke.** `dotnet publish` the desktop app for the non-Windows runtimes it ships (PerformanceStudio: `linux-x64`, `osx-arm64`/`osx-x64`) and confirm each still produces a runnable app. The Avalonia/SkiaSharp native pins are fragile — the Linux `SkiaSharp.NativeAssets.Linux` pin exists to guard GitHub issue #139 — and a Windows-only build won't catch a broken Linux/macOS runtime.
+
+14. **SQL Server / cloud drift + bundled tools.** New SQL Server CU/version, new DMVs/columns, Azure SQL DB / RDS changes (cloud collector paths have a bug history); refresh bundled community procs (sp_WhoIsActive, sp_BlitzLock, sp_HealthParser, sp_HumanEventsBlockViewer).
+
+## Output
+
+Report per section: ✅ clean / ⚠️ findings (with the fix made or recommended). Group merged PRs and
+"parked" items (e.g. a major bump deferred) so the next pass knows where things stand.

--- a/.claude/skills/release-checklist/SKILL.md
+++ b/.claude/skills/release-checklist/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: release-checklist
+description: Pre-release checklist for PerformanceMonitor — version bumps, changelog, cloud testing, and validation (Lite + Darling; Full Dashboard and CLI Installer are deprecated and out of this process)
+argument-hint: [version]
+disable-model-invocation: false
+---
+
+# Pre-Release Checklist
+
+Run through the full release prep checklist for PerformanceMonitor. `$ARGUMENTS` is the target version (e.g., `3.3.0`).
+
+> **Scope (since v3.3.0):** the Full Dashboard and the CLI Installer are DEPRECATED and OUT of this process — they ship no release artifacts and get no live install/upgrade testing here. They still build and their test suites still run in CI on the release event, and their csprojs still get version bumps (below). The release artifacts are: Lite (zip + Velopack Setup.exe), the Darling service zip, and the Darling Viewer Setup.exe.
+
+## Checklist
+
+Work through each step in order. Report status as you go. If a step fails, stop and report.
+
+### 1. Version Bumps
+
+Bump `<Version>`, `<AssemblyVersion>`, `<FileVersion>`, and `<InformationalVersion>` in all 6 csproj files:
+- `Lite/PerformanceMonitorLite.csproj`
+- `Darling/PerformanceMonitor.Darling.Service/PerformanceMonitor.Darling.Service.csproj` (carries the Version/AssemblyVersion/FileVersion triplet, no InformationalVersion)
+- `Darling/PerformanceMonitor.Darling.Viewer/PerformanceMonitor.Darling.Viewer.csproj` (same triplet)
+- `deprecated/Dashboard/Dashboard.csproj` — still bumped even though deprecated: the `check-version-bump` workflow reads THIS file
+- `deprecated/Installer/PerformanceMonitorInstaller.csproj` — still bumped for consistency (CI builds it on release events)
+- `deprecated/Installer.Core/Installer.Core.csproj` — same
+
+The `check-version-bump` workflow only reads `Dashboard.csproj`, so the other five are on THIS checklist to catch — nothing in CI enforces them.
+
+Verify no other files contain hardcoded version strings that need updating.
+
+### 2. CHANGELOG
+
+Ensure `CHANGELOG.md` has an entry for the new version with:
+- **Important** section if there are store/schema changes or breaking changes (Darling store migrations, PG runtime upgrades with offline windows, operator actions required post-upgrade)
+- **Added** section for new features
+- **Changed** section for behavior changes
+- **Fixed** section for bug fixes
+- Reference links at the bottom for all issue numbers
+
+If a week of parallel PRs left duplicate section headers in `[Unreleased]` (two `### Fixed` blocks from keep-both merges), consolidate them at cut time with a content-preserving script that VERIFIES the entry-line multiset is unchanged — never re-sort by hand (a 242-line silent reorder shipped that way once).
+
+If the previous version's changelog entry is missing, add that too.
+
+### 2b. README Sync
+
+Cross-reference `README.md` against the changelog and ensure all user-facing changes are reflected:
+- **Lite collector table**: New collectors added, count updated
+- **Lite/Darling tab lists**: New tabs listed
+- **Edition comparison table**: Collector counts, feature rows updated
+- **Managed platform support table**: New platform behaviors documented
+- **Permissions section**: Updated if new grants are needed
+- **Deprecation callout**: still accurate about what ships and what doesn't
+
+Do NOT add internal/implementation changes — only user-facing features and behavior.
+
+### 3. Upgrade Scripts — Schema Change Audit (conditional)
+
+Applies ONLY when `install/` or `upgrades/` changed since the last release (the deprecated Dashboard edition remains on bug-fix support, so its schema discipline still holds when it IS touched):
+
+1. All schema changes MUST go through the `upgrades/{from}-to-{to}/` folder — never ad hoc, never baked into base install scripts. View-only changes flow through `CREATE OR ALTER` re-runs and need no upgrade script.
+2. **List all .sql files in the upgrade folder and compare against `upgrade.txt`** — every script must be listed or it won't run (PR #608 shipped a script not listed in `upgrade.txt`).
+3. Verify each script uses `IF NOT EXISTS` checks for idempotency, and that any column additions in `01_install_database.sql` CREATE TABLE blocks have corresponding ALTER TABLE scripts in the upgrade folder.
+
+### 4. Build Verification
+
+Run a FULL rebuild and check the warnings line, not just errors:
+```
+dotnet build PerformanceMonitor.sln -c Debug -t:Rebuild
+```
+All projects must succeed with **0 Warning(s) / 0 Error(s)** — the repo's bar is zero-warning, test projects included (they sit outside the WarningsAsErrors gate, so a warm incremental build can hide a warning a Rebuild surfaces).
+
+(The deprecated Installer/Dashboard test suites run in CI on the release event with the CI's own filter; they are no longer run from this checklist.)
+
+### 5. Cloud Platform Testing (shared collector layer — test via DARLING)
+
+**This step is never skipped for a release** (defer within the release window is OK; skip is not). Lite and Darling share the collector layer (`PerformanceMonitor.Collectors`), so the cloud-specific collector paths — Azure SQL DB edition detection, the master/database-level fallbacks, RDS capability skips — are exercised once, **through Darling**, which is headless and fully scriptable (no GUI clicking). Lite is covered by the shared code plus its unit suites; run a Lite-side pass too only when a LITE-specific cloud behavior shipped this release (connection-alert flows, webhook delivery, UI surfacing of cloud rows — their authoritative validation is `Lite.Tests/AzureMasterFallbackTests` + `ConnectionEdgeDetectorTests` and the alert-policy suites).
+
+Spin up temporary instances with the Azure CLI (`az`) and AWS CLI (`aws`):
+
+**Azure SQL DB:** (export `SQL_TEST_PASSWORD` with a freshly generated throwaway password before running these; never hardcode one)
+1. Create a resource group, logical server, and 2+ databases. **Use a region geographically close to the machine running the collector** -- cross-country latency causes collector timeouts. From US East that is eastus or eastus2:
+   ```
+   az group create --name rg-release-test --location eastus2
+   az sql server create --name pm-release-test --resource-group rg-release-test --location eastus2 --admin-user sqladmin --admin-password "$SQL_TEST_PASSWORD"
+   az sql server firewall-rule create --resource-group rg-release-test --server pm-release-test --name AllowAll --start-ip-address 0.0.0.0 --end-ip-address 255.255.255.255
+   az sql db create --resource-group rg-release-test --server pm-release-test --name testdb1 --edition GeneralPurpose --compute-model Serverless --family Gen5 --capacity 1 --auto-pause-delay 60 --min-capacity 0.5 --max-size 1GB
+   ```
+2. Add the Azure logical server to a Darling instance (a local scratch service or an existing dogfooding instance) and let it collect 2+ cycles.
+3. Verify against the store (psql or the web dashboard):
+   - `database_size_stats` / size collectors cover ALL databases, not just master (the #1631 fallback class)
+   - server row shows engine edition 5 and collectors inapplicable to Azure SQL DB are SKIPPED as not-applicable, not erroring
+   - `collection_log` clean for the cloud server across the cycles
+   - the serverless DB's 60s auto-pause + resume (error 40613 transients) does not wedge collection — rows resume after the pause without a service restart
+4. Firewall churn: DELETE the allow rule, wait 3–5 minutes, re-add it. Collection must resume on its own without restarting the service. (CAVEAT, verified v3.2.0: a bare rule-deletion often does NOT sever an actively-collecting client — connection pooling keeps the open connection alive and Azure gates only NEW connections — so treat a no-outage result as inconclusive rather than a pass; the recovery logic's authoritative validation is the unit suites.)
+5. Clean up: `az group delete --name rg-release-test --yes --no-wait`
+
+**AWS RDS:**
+1. Create an RDS SQL Server instance. **Use us-east-1** — cross-country latency to us-west-2 causes collector timeouts:
+   ```
+   aws rds create-db-instance --db-instance-identifier pm-release-test --db-instance-class db.t3.xlarge --engine sqlserver-ee --master-username admin --master-user-password "$SQL_TEST_PASSWORD" --allocated-storage 20 --region us-east-1
+   ```
+2. **Network reachability is NOT automatic** (bit on v3.3.0: the fresh instance answered "server was not found" until fixed). Verify `PubliclyAccessible` is true, and open 1433 on the instance's security group — the account-default SG has no public inbound:
+   ```
+   aws rds describe-db-instances --db-instance-identifier pm-release-test --region us-east-1 --query 'DBInstances[0].[PubliclyAccessible,VpcSecurityGroups[0].VpcSecurityGroupId]' --output text
+   aws ec2 authorize-security-group-ingress --group-id <sg-id> --protocol tcp --port 1433 --cidr 0.0.0.0/0 --region us-east-1
+   ```
+3. Add the RDS endpoint to the same Darling instance (`encrypt_mode` Mandatory + `trust_server_certificate` true — RDS serves its own CA), let it collect 2+ cycles.
+4. Verify: the Agent-surface collectors (`running_jobs`, `job_history`, `agent_status`) short-circuit as capability skips (0 rows at ~0ms, no errors); everything else lands rows; `collection_log` clean.
+5. Clean up — the instance AND the SG hole (it is usually the account-DEFAULT security group; leaving 1433/0.0.0.0/0 on it is a standing exposure for anything else in that VPC):
+   ```
+   aws rds delete-db-instance --db-instance-identifier pm-release-test --skip-final-snapshot --region us-east-1
+   aws ec2 revoke-security-group-ingress --group-id <sg-id> --protocol tcp --port 1433 --cidr 0.0.0.0/0 --region us-east-1
+   ```
+
+Success criteria: no collector errors in the store's `collection_log` for either cloud server, all applicable collectors landing rows, capability skips recorded as skips rather than failures.
+
+### 6. Lite Collector Validation
+
+Check Lite's latest dev build thoroughly:
+- Review the Lite error log at `%LOCALAPPDATA%\PerformanceMonitorLite\logs\` for any errors
+- Launch Lite, connect to at least one server, and monitor collector health
+- Check for collector failures in the Collection Health tab
+- Verify data is populating correctly in all tabs
+
+### 7. Smoke Test New Features
+
+Quick click-through of any new features or significant changes listed in the changelog — Lite, the Darling web dashboard, and the Darling Viewer.
+
+### 8. Desktop App Upgrade — Velopack Setup.exe + single-instance handoff
+
+Covers the **desktop apps' own** upgrade via Velopack (`*-Setup.exe`) for **Lite** and the **Darling Viewer**. Test the upgrade over a **running** prior version:
+
+1. Install the prior release's Setup.exe, launch the app, and **minimize it to the tray** (leave it running).
+2. Run the new release's Setup.exe (and separately test Help → About → download → restart). Confirm the **new** version actually runs afterward — not the stale in-memory one.
+3. **Single-instance upgrade handoff (#1148):** with the old version running in the tray, launch the new build → expect the *"A previous version is still running — close it and continue?"* prompt → old closes → new takes over. A same-version relaunch should just surface the running window (no prompt). An older build launched over a newer one should surface the newer (no eviction).
+4. **Elevated case:** run the old version **as administrator**, launch the new one non-elevated → expect the *"Restart as administrator"* prompt; elevating completes the takeover. A *same-version* elevated instance should just surface (no UAC).
+5. Confirm Lite never closes the Darling Viewer and vice-versa (scoped by exe name).
+
+Local proxy without a release: bump `<Version>`, rebuild, run over the old build → expect the close-and-takeover prompt. The decision logic is unit-tested (`Lite.Tests/SingleInstanceDecisionTests`); this step validates the live Win32/Velopack seam (`SingleInstanceCoordinator` / `ProcessInspector` in `PerformanceMonitor.Ui`). When the seam saw no changes since the prior release, a quick post-publish regression pass is acceptable instead of a pre-cut gate. Design: `plans/single-instance-upgrade-handoff.md`.
+
+### 9. Nightly Build Verification
+
+Before cutting the release, verify the nightly build has been clean:
+- Check that the most recent nightly build completed successfully (GitHub Actions) — verify the gated legs BY NAME (`build`, `Darling PostgreSQL tests`); a green wrapper exit code is not evidence, and the nightly publishes assets even when the test leg fails
+- Confirm no community bug reports against the nightly in the last 24-48 hours
+- If any issues were reported and fixed, wait for a new clean nightly before proceeding
+
+### 10. Commit and PR
+
+- Do the version-bump + changelog commits on a branch off `dev` (e.g. `release/v{version}`) — NEVER commit directly to `dev` or `main` (branch protection)
+- Push the branch and merge it into `dev` first (open that PR with base `dev`)
+- Then open the release PR **from `dev` to `main`** — the head MUST be `dev`. `check-pr-branch.yml` rejects any PR to `main` whose head is not `dev`, so a `release/*` → `main` PR fails CI (the "all jobs failed" email)
+- At release-PR merge time, dev must equal the sha the field validation ran against (or the delta must be explicitly accepted)
+
+### 11. Tag and Release
+
+After PR is merged to main:
+```
+git checkout main && git pull
+git tag v{version}
+git push origin v{version}
+```
+
+Then create the GitHub Release from the tag — `build.yml` triggers on `release: [published]` only (NOT `created`, and NOT on tag push alone). Publish a real release; do **not** use `--draft` (a draft fires only `created`, so the build/sign workflow won't run):
+```
+gh release create v{version} --title "v{version}" --notes "See CHANGELOG.md for details."
+```
+
+The build workflow will then run, compile all artifacts, sign them (if SignPath is configured), and attach them to the release. Monitor at https://github.com/erikdarlingdata/PerformanceMonitor/actions
+
+SignPath blocks on **four** approval requests as of v3.3.0: **Lite** (zip), **Darling** (service + viewer apphost exes), **Lite (Velopack)**, and **Darling Viewer (Velopack)** — the Dashboard/Installer signing steps left with their artifacts. The `Darling` artifact-configuration slug on signpath.io signs the two apphost exes (`PerformanceMonitor.Darling.Service.exe` at the root and `viewer/PerformanceMonitor.Darling.Viewer.exe`) and leaves the `PerformanceMonitor.*` / third-party dlls and `pg-runtime.zip` alone; if it ever goes missing the single `Sign Darling` step fails the release. The Darling zip (`PerformanceMonitorDarling-{version}.zip` — service at root with `pg-runtime.zip` beside the exe, viewer in `viewer\`) joins the release assets; the pg-runtime build downloads ~340MB on a cold cache (cached across re-releases on the fetch script's content hash). Verify the Darling zip is attached and listed in `SHA256SUMS.txt`, alongside the Lite zip/Setup.exe and the Viewer Setup.exe.
+
+## Notes
+
+- Always test BEFORE merging PRs
+- Test across the supported SQL Server version range (2016 through 2025). A machine with local instances for this lists them in the repo local CLAUDE.md, along with any that hold real data and must not be written to. Connect via pre-configured sqlcmd contexts so no credentials appear in this file or in any command it runs.
+- **NEVER use Express edition** for cloud test instances — Express does not support SQL Agent, and several collectors need Agent surface area
+- Azure CLI (`az`) and AWS CLI (`aws`) are both available for creating/destroying test instances
+- Always clean up cloud test resources after testing to avoid charges

--- a/.claude/skills/release-checklist/SKILL.md
+++ b/.claude/skills/release-checklist/SKILL.md
@@ -95,8 +95,8 @@ Spin up temporary instances with the Azure CLI (`az`) and AWS CLI (`aws`):
 4. Firewall churn: DELETE the allow rule, wait 3–5 minutes, re-add it. Collection must resume on its own without restarting the service. (CAVEAT, verified v3.2.0: a bare rule-deletion often does NOT sever an actively-collecting client — connection pooling keeps the open connection alive and Azure gates only NEW connections — so treat a no-outage result as inconclusive rather than a pass; the recovery logic's authoritative validation is the unit suites.)
 5. Clean up: `az group delete --name rg-release-test --yes --no-wait`
 
-**AWS RDS:**
-1. Create an RDS SQL Server instance. **Use us-east-1** — cross-country latency to us-west-2 causes collector timeouts:
+**AWS RDS:** (same `SQL_TEST_PASSWORD` throwaway as above)
+1. Create an RDS SQL Server instance. **Use a region geographically close to the machine running the collector** -- cross-country latency causes collector timeouts. From US East that is us-east-1:
    ```
    aws rds create-db-instance --db-instance-identifier pm-release-test --db-instance-class db.t3.xlarge --engine sqlserver-ee --master-username admin --master-user-password "$SQL_TEST_PASSWORD" --allocated-storage 20 --region us-east-1
    ```

--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,8 @@ PerformanceMonitor_Install_*.txt
 
 # Internal development files (not for public release)
 .internal/
-.claude/
+.claude/*
+!.claude/skills/
 CLAUDE.md
 AGENTS.md
 Dashboard/todo.md


### PR DESCRIPTION
## What

Moves four skills out of the personal `~/.claude/skills` directory into `.claude/skills` so they travel with the repo. Personal skills are machine-local, and cloud sessions do not read them at all, so a skill living only in `~/.claude/skills` is unavailable to every session outside the one machine it was written on.

`.gitignore` goes from `.claude/` to `.claude/*` plus `!.claude/skills/`, which exposes skills and nothing else. `settings.local.json`, `commands/`, and `worktrees/` stay ignored.

| Skill | Purpose |
|---|---|
| `release-checklist` | Pre-release checklist |
| `build` | Build a component, report where the exe landed |
| `duckdb` | Read-only query against Lite's DuckDB store |
| `maintenance` | Quarterly dependency, build, and hygiene pass |

## Credentials removed

`release-checklist` contained the lab `sa` password and a reused Azure/AWS admin password in plaintext. This repo is public, so both are gone:

- Cloud instance creation now takes `"$SQL_TEST_PASSWORD"`, a throwaway generated per run.
- The local SQL instance inventory, and the rule that sql2022 and sql2025 hold real monitoring data, moved to the untracked local `CLAUDE.md`. Those VMs exist on a single machine, so the committed procedure stays machine-neutral.

## Portability

- `%LOCALAPPDATA%` replaces absolute `C:\Users\...` paths. `duckdb` resolves the store through `os.environ['LOCALAPPDATA']`.
- `build` uses repo-relative paths instead of `C:\GitHub\PerformanceMonitor\`.
- Region guidance reads "close to the machine running the collector" instead of being hardcoded to US East for one developer's timezone.
- `maintenance/skill.md` renamed to `SKILL.md`. It resolved on Windows but would not have on the case-sensitive filesystem a cloud session runs on.

## Drive-by fix

`build` was stale. It pointed at `Dashboard/Dashboard.csproj`, which has been `bin`/`obj` leftovers since v3.3.0 moved Dashboard and Installer to `deprecated/`, and it did not know Darling exists. The argument table is rebuilt from `git ls-files "*.csproj"` with correct paths and target frameworks, now covering the Darling service and Viewer, with the deprecated projects labeled.

## Test plan

- [x] `git check-ignore` confirms `.claude/skills` is tracked while `settings.local.json`, `commands/`, and `worktrees/` stay ignored
- [x] Credential scan clean across every committed skill
- [x] No absolute paths or single-machine assumptions remain
- [x] Frontmatter `name` parses on every `SKILL.md`
- [ ] Clone on a second machine and confirm the four skills list in `/skills`

Docs and config only. No product code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EbYty5EYQwd4YGTDcJfEkE
