### PR TITLE
Bump BlackwellSystems.Gcf to 0.2.1

### DIFF
--- a/Darling/Darling.Tests/packages.lock.json
+++ b/Darling/Darling.Tests/packages.lock.json
@@ -692,7 +692,7 @@
         "dependencies": {
           "AWSSDK.PI": "[4.0.100.11, )",
           "AWSSDK.RDS": "[4.0.104.4, )",
-          "BlackwellSystems.Gcf": "[0.2.0, )",
+          "BlackwellSystems.Gcf": "[0.2.1, )",
           "Microsoft.Data.SqlClient": "[7.0.2, )",
           "Microsoft.Extensions.Hosting": "[10.0.11, )",
           "Microsoft.Extensions.Hosting.WindowsServices": "[10.0.11, )",
@@ -775,9 +775,9 @@
       },
       "BlackwellSystems.Gcf": {
         "type": "CentralTransitive",
-        "requested": "[0.2.0, )",
-        "resolved": "0.2.0",
-        "contentHash": "HnL0i5xnmNDxv0j4kqGTgUxZ+uTEuRtM4S31NYS/XdL1kaQ77TfknqpW0yUALyt4KJRmzVKXgI2CmqdhvMQ9cA=="
+        "requested": "[0.2.1, )",
+        "resolved": "0.2.1",
+        "contentHash": "reYZPIgRpPctAOEVOhaZguOT4eSxv4hKCiFjiTJOdZuZViPEaWghz3DyW3MGSbxuzBFSwnLjxkiSB2X9S+93VA=="
       },
       "CredentialManagement": {
         "type": "CentralTransitive",

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageVersion Include="AWSSDK.PI" Version="4.0.100.11" />
     <PackageVersion Include="AWSSDK.RDS" Version="4.0.104.4" />
-    <PackageVersion Include="BlackwellSystems.Gcf" Version="0.2.0" />
+    <PackageVersion Include="BlackwellSystems.Gcf" Version="0.2.1" />
     <PackageVersion Include="CredentialManagement" Version="1.0.2" />
     <PackageVersion Include="DuckDB.NET.Bindings.Full" Version="1.5.5" />
     <PackageVersion Include="DuckDB.NET.Data" Version="1.5.5" />


### PR DESCRIPTION
Puts Monitor on the same GCF build PerformanceStudio took in erikdarlingdata/PerformanceStudio#501, instead of leaving it a patch behind on 0.2.0.

## What 0.2.1 changes

A decoder fix: a quoted key containing `[` alongside an array value now round-trips.

Nothing here depended on the broken case, and it was never a correctness risk. `GcfOutput` decodes every wire and compares it against the input before substituting, so a key that failed to round-trip made the result fall back to JSON rather than emit a bad wire. The bug cost compression on those shapes; it could not corrupt one.

## Scope

Only the two Gcf entries move. Regenerating the lock with `--force-evaluate` also pruned unrelated `System.Security.Cryptography.ProtectedData` and `System.Diagnostics.EventLog` entries across two lock files; that churn was reverted. `dotnet restore --locked-mode` (what `build.yml:286` runs) accepts the committed lock as it stands, so there is nothing stale to clean up here, and a dependency bump is the wrong PR to do it in.

## Verified

- `dotnet restore Darling/Darling.Tests/Darling.Tests.csproj --locked-mode` passes.
- `dotnet build` clean.
- `dotnet run --project Darling/Darling.Tests` (the invocation `build.yml:332` uses): **6901 total, 0 errors, 0 failed, 296 skipped** — the skips are the live-Postgres tests that need `DARLING_TEST_PG`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nD83xZyWPzKWhs7Gg9Vyq