### PR TITLE
Scrub the last fleet identifier from main

### DIFF
--- a/Darling/Darling.Tests/DarlingPeerDisclosureTests.cs
+++ b/Darling/Darling.Tests/DarlingPeerDisclosureTests.cs
@@ -382,7 +382,7 @@ public sealed class DarlingPeerDisclosureTests
     {
         var rows = new List<DarlingDataReader.ServerListRow>
         {
-            new(1, "prod-sql-use1-beta-01", "ayr", 16, new DateTime(2026, 8, 19, 12, 0, 0, DateTimeKind.Utc)),
+            new(1, "prod-sql-use1-beta-01", "omega", 16, new DateTime(2026, 8, 19, 12, 0, 0, DateTimeKind.Utc)),
         };
 
         return JsonDocument
@@ -410,7 +410,7 @@ public sealed class DarlingPeerDisclosureTests
         /* The existing payload is untouched — the disclosure is additive here too. */
         var server = Assert.Single(root.GetProperty("servers").EnumerateArray());
         Assert.Equal("prod-sql-use1-beta-01", server.GetProperty("server_name").GetString());
-        Assert.Equal("ayr", server.GetProperty("display_name").GetString());
+        Assert.Equal("omega", server.GetProperty("display_name").GetString());
     }
 
     [Fact]

--- a/Darling/Darling.Tests/StatementSplitTimingTests.cs
+++ b/Darling/Darling.Tests/StatementSplitTimingTests.cs
@@ -76,7 +76,7 @@ public sealed class StatementSplitTimingTests
 
     /// <summary>
     /// #2312: the separate plan-XML and text fetches run INSIDE the driver's <c>sql:</c> stopwatch but are
-    /// their own queries against the Query Store catalogs — on ayr-01 a 0-row closed-only cycle still cost
+    /// their own queries against the Query Store catalogs — on omega-01 a 0-row closed-only cycle still cost
     /// 298s and the blended number could not say where. They must come out of drain exactly like the
     /// watermark phase, or drain silently absorbs the one cost this investigation needs isolated.
     /// </summary>

--- a/PerformanceMonitor.Collectors/CollectorContext.cs
+++ b/PerformanceMonitor.Collectors/CollectorContext.cs
@@ -250,7 +250,7 @@ public sealed class CollectorContext
     /// runs one (Darling; Lite has no separate fetch and leaves it zero). The fetch is INSIDE the driver's
     /// per-item <c>sql:</c> stopwatch but is neither open nor drain — it is its own query against
     /// <c>sys.query_store_plan</c>, and on a database with a huge Query Store catalog it can dominate the
-    /// whole item (ayr-01: a 0-row closed-only cycle still cost 298s, and the blended number could not say
+    /// whole item (omega-01: a 0-row closed-only cycle still cost 298s, and the blended number could not say
     /// where). Measured so drain stops absorbing it, exactly the #2164 argument one seam further down.
     /// </summary>
     public long PerItemPlanFetchMs { get; set; }


### PR DESCRIPTION
`main` is the repo's default branch and is swept separately from `dev`. The two have genuinely divergent history, so the identifier scrubs merged to dev ([#2900], [#2903]) never reached it — four locations on `main` still named a real tenant server.

## What changed

| file | was | now |
|---|---|---|
| `Darling.Tests/DarlingPeerDisclosureTests.cs:385` | `display_name` fixture | `omega` |
| `Darling.Tests/DarlingPeerDisclosureTests.cs:413` | matching assert | `omega` |
| `Darling.Tests/StatementSplitTimingTests.cs:79` | short name in comment | `omega-01` |
| `PerformanceMonitor.Collectors/CollectorContext.cs:253` | short name in comment | `omega-01` |

`omega` is not a fresh choice — it is the slug [#2900] reconciled this server onto, it is already in `FleetIdentifierScrubTests.SyntheticSlugs`, and **these four lines now match `origin/dev` byte-for-byte** (verified by diffing slug usage per file). Every measurement in the touched comments is unchanged.

Line endings preserved per file (CRLF counts asserted before/after).

Same precedent as 26a4e149, "Scrub fleet identifiers from main, which is what the repo shows by default".

## Why a PR and not a direct commit

26a4e149 went straight onto `main`. This is the same change shape, but a PR leaves the diff reviewable and revertable, and there is no rush now that the issue/PR-body exposure is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)