### PR TITLE
Part of #2874

### DIFF
--- a/Darling/Darling.Tests/AlertPassCommandTimeoutTests.cs
+++ b/Darling/Darling.Tests/AlertPassCommandTimeoutTests.cs
@@ -135,10 +135,6 @@ public sealed class AlertPassCommandTimeoutTests
         @"new\s+(?:[A-Za-z_][A-Za-z0-9_]*\s*\.\s*)*NpgsqlCommand\s*\(|\.CreateCommand\s*\(|\.CreateCommand\s*[,);]",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
-    private static readonly Regex s_setsTimeout = new(
-        @"CommandTimeout\s*=",
-        RegexOptions.Compiled | RegexOptions.CultureInvariant);
-
     /// <summary>
     /// A member name followed by an optional generic argument list and then its parameter list.
     ///
@@ -285,10 +281,16 @@ public sealed class AlertPassCommandTimeoutTests
     /// The scanner above is what forty-five sites' correctness is asserted through, so its own blind
     /// spots are worth pinning: a false positive here fails a green build on correct code.
     ///
-    /// <para>Both cases are shapes that actually occur. The first is the <c>CreateCommand</c> site
+    /// <para>The first three are shapes that actually occur. The first is the <c>CreateCommand</c> site
     /// with an interposed explanatory comment containing a semicolon — the exact gap where this
     /// codebase's style puts one. The second is the verbatim-SQL construction, where the deadline sits
     /// twenty-odd lines below the opening and past any fixed line window.</para>
+    ///
+    /// <para>The last three are the layouts a single two-statement window over RAW text cannot report: an
+    /// untimed command in a <c>using (...)</c> whose one-statement body lets the deadline behind the block
+    /// stand in, an untimed construction directly ahead of a timed one, and a deadline merely SPELLED in a
+    /// comment. The first two are why the initializer is read from the CONSTRUCTION and only an assignment
+    /// from the statement span; the third is why both are read from STRIPPED source.</para>
     /// </summary>
     [Theory]
     [InlineData(
@@ -303,6 +305,17 @@ public sealed class AlertPassCommandTimeoutTests
         "var command = _postgres.CreateCommand(Sql);\n"
         + "await command.ExecuteNonQueryAsync();\n",
         false)]
+    [InlineData(
+        "using (var untimed = new NpgsqlCommand(Sql, connection))\n"
+        + "{\n"
+        + "    await untimed.ExecuteNonQueryAsync(cancellationToken);\n"
+        + "}\n"
+        + "using var next = new NpgsqlCommand(OtherSql, connection) { CommandTimeout = 10 };\n",
+        false)]
+    [InlineData(
+        "using var untimed = new NpgsqlCommand(Sql, connection);\n"
+        + "using var next = new NpgsqlCommand(OtherSql, connection) { CommandTimeout = 10 };\n",
+        false)]
     /* A comment that NAMES a deadline is not one. This case was green before the value regex moved onto
        the stripped span: the construction match excluded comments while the deadline test did not, so
        prose could satisfy it. False-negative direction - it reported success on the defect. */
@@ -310,6 +323,17 @@ public sealed class AlertPassCommandTimeoutTests
         "var command = new NpgsqlCommand(Sql, connection);\n"
         + "/* no deadline needed here; CommandTimeout = 10 is applied by the caller. */\n"
         + "await command.ExecuteNonQueryAsync();\n",
+        false)]
+    /* The sibling spelled as an ASSIGNMENT rather than an initializer. Every other sibling fixture in this
+       family used the initializer form, which has no leading dot and so never reached the assignment regex -
+       while the assignment spelling is the dominant one in this codebase. Found in review. */
+    [InlineData(
+        "using (var untimed = connection.CreateCommand())\n"
+        + "{\n"
+        + "    using var sibling = connection.CreateCommand();\n"
+        + "    sibling.CommandTimeout = 10;\n"
+        + "    await untimed.ExecuteNonQueryAsync(cancellationToken);\n"
+        + "}\n",
         false)]
     public void TheScanner_SeesADeadlineThroughCommentsAndVerbatimSql(string source, bool expectedTimed)
     {
@@ -319,9 +343,7 @@ public sealed class AlertPassCommandTimeoutTests
         var ctor = s_commandCtor.Match(code);
         Assert.True(ctor.Success, "the fixture did not contain a command construction");
 
-        var span = CSharpSourceWalker.StatementSpanFrom(code, ctor.Index, statements: 2);
-
-        Assert.Equal(expectedTimed, s_setsTimeout.IsMatch(span));
+        Assert.Equal(expectedTimed, CommandDeadlineScanner.SetsAnExplicitDeadline(code, ctor.Index));
     }
 
     /* The literal- and comment-aware walk this pin used to carry lives in CSharpSourceWalker as of
@@ -447,8 +469,9 @@ public sealed class AlertPassCommandTimeoutTests
     /// <para>Matched over <see cref="CSharpSourceWalker.StripCommentsAndStrings"/>'s output so a
     /// construction named in PROSE is not counted as a site — these files carry long explanatory
     /// comments about the commands beside them, and a mention would arrive as a false offender on
-    /// correct code. Spans are then cut from the ORIGINAL text, which is sound because the strip is
-    /// length-preserving; that is the same stripped-walk/raw-span split the shared walker uses.</para>
+    /// correct code. The DEADLINE is matched over that same stripped text rather than the original: a
+    /// deadline merely spelled in one of those explanatory comments is not a deadline, and reading raw text
+    /// there lets the comment about a deadline stand in for the deadline itself.</para>
     ///
     /// <para>Scan to the END OF THE STATEMENT, not a fixed number of lines. A line window cannot work
     /// here and the first draft of this pin proved it: these sites embed verbatim SQL, so the
@@ -489,9 +512,7 @@ public sealed class AlertPassCommandTimeoutTests
         {
             total++;
 
-            var span = CSharpSourceWalker.StatementSpanFrom(code, ctor.Index, statements: 2);
-
-            if (!s_setsTimeout.IsMatch(span))
+            if (!CommandDeadlineScanner.SetsAnExplicitDeadline(code, ctor.Index))
             {
                 /* Reported as the line in the FILE, not an offset into the scanned region, so a member
                    scope's offender is as navigable as a whole-file scope's. */

--- a/Darling/Darling.Tests/AnalysisPassCommandTimeoutTests.cs
+++ b/Darling/Darling.Tests/AnalysisPassCommandTimeoutTests.cs
@@ -67,11 +67,7 @@ public sealed class AnalysisPassCommandTimeoutTests
        BOTH construction shapes, as the viewer's pin does - `.CreateCommand(` was absent from #2871's
        census and is how the two DMV-snapshot factories build their commands. */
     private static readonly Regex s_commandCtor = new(
-        @"new NpgsqlCommand\s*\(|\.CreateCommand\s*\(",
-        RegexOptions.Compiled | RegexOptions.CultureInvariant);
-
-    private static readonly Regex s_setsTimeout = new(
-        @"CommandTimeout\s*=",
+        @"new\s+(?:[A-Za-z_][A-Za-z0-9_]*\s*\.\s*)*NpgsqlCommand\s*\(|\.CreateCommand\s*\(",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     /// <summary>
@@ -102,28 +98,25 @@ public sealed class AnalysisPassCommandTimeoutTests
 
         foreach (var file in AnalysisSources())
         {
-            var lines = File.ReadAllLines(file);
+            var text = File.ReadAllText(file);
 
-            for (var i = 0; i < lines.Length; i++)
+            /* Both halves of the question are asked of STRIPPED text, which is character-aligned with its
+               input. This replaced a raw three-LINE window that could tell neither a construction from the
+               same words in a comment, nor this site's deadline from the next site's, nor a real deadline
+               from one merely spelled in prose. */
+            var code = CSharpSourceWalker.StripCommentsAndStrings(text);
+
+            foreach (Match ctor in s_commandCtor.Matches(code))
             {
-                if (!s_commandCtor.IsMatch(lines[i]))
-                {
-                    continue;
-                }
+                var line = text.Take(ctor.Index).Count(c => c == '\n') + 1;
 
-                /* The deadline may sit in the object initializer on the construction line or be
-                   assigned in the following statement — both spellings are in use here. */
-                var window = string.Join(
-                    "\n",
-                    lines.Skip(i).Take(Math.Min(3, lines.Length - i)));
-
-                if (s_setsTimeout.IsMatch(window))
+                if (CommandDeadlineScanner.SetsAnExplicitDeadline(code, ctor.Index))
                 {
                     covered++;
                 }
                 else
                 {
-                    missing.Add($"{Path.GetFileName(file)}:{i + 1}");
+                    missing.Add($"{Path.GetFileName(file)}:{line}");
                 }
             }
         }
@@ -286,25 +279,12 @@ public sealed class AnalysisPassCommandTimeoutTests
     public void TheCtorScan_SeesTheStampingFactory_AndNotTheMethodGroup(
         string source, bool expectedMatched, bool expectedTimed)
     {
-        var lines = source.Split('\n');
-        var matched = false;
-        var timed = false;
+        var code = CSharpSourceWalker.StripCommentsAndStrings(source);
+        var ctor = s_commandCtor.Match(code);
 
-        for (var i = 0; i < lines.Length; i++)
-        {
-            if (!s_commandCtor.IsMatch(lines[i]))
-            {
-                continue;
-            }
+        Assert.Equal(expectedMatched, ctor.Success);
 
-            matched = true;
-            var window = string.Join("\n", lines.Skip(i).Take(Math.Min(3, lines.Length - i)));
-            timed = s_setsTimeout.IsMatch(window);
-            break;
-        }
-
-        Assert.Equal(expectedMatched, matched);
-        Assert.Equal(expectedTimed, timed);
+        Assert.Equal(expectedTimed, ctor.Success && CommandDeadlineScanner.SetsAnExplicitDeadline(code, ctor.Index));
     }
 
     /* The literal- and comment-aware walk this pin used to carry lives in CSharpSourceWalker as of
@@ -312,6 +292,96 @@ public sealed class AnalysisPassCommandTimeoutTests
        with the literal text around them, so a call written inside an interpolation was invisible to every
        scan built on them. The reasoning that shaped the walk moved there with it, and
        CSharpSourceWalkerTests carries the witnesses. */
+
+    /// <summary>
+    /// Scanner blind spots, pinned - a false positive here fails a green build on correct code. The first
+    /// two are this assembly's real shapes; the next three are the layouts the raw three-line window this
+    /// scan replaced could not report, where the deadline it found belonged to the NEXT construction. The
+    /// last is why the span is not simply CUT at that next construction, which is the tempting one-line
+    /// version of the same rule: two constructions can legitimately share ONE deadline. The last two are the
+    /// value half of the same mistake: a deadline SPELLED in a comment or a literal is not a deadline, so the
+    /// span is judged over STRIPPED source - this codebase quotes code in its prose constantly.
+    /// </summary>
+    [Theory]
+    [InlineData(
+        "var command = new NpgsqlCommand(Sql, connection) { CommandTimeout = 45 };\n",
+        true)]
+    [InlineData(
+        "var command = connection.CreateCommand();\n"
+        + "/* a method result cannot take an initializer; set it here. */\n"
+        + "command.CommandTimeout = 45;\n",
+        true)]
+    [InlineData(
+        "using (var untimed = new NpgsqlCommand(Sql, connection))\n"
+        + "{\n"
+        + "    await untimed.ExecuteNonQueryAsync(cancellationToken);\n"
+        + "}\n"
+        + "using var next = new NpgsqlCommand(OtherSql, connection) { CommandTimeout = 45 };\n",
+        false)]
+    [InlineData(
+        "using var untimed = new NpgsqlCommand(Sql, connection);\n"
+        + "using var next = new NpgsqlCommand(OtherSql, connection) { CommandTimeout = 45 };\n",
+        false)]
+    [InlineData(
+        "using (var untimed = new NpgsqlCommand(Sql, connection))\n"
+        + "{\n"
+        + "    using var sibling = new NpgsqlCommand(OtherSql, connection) { CommandTimeout = 45 };\n"
+        + "    await untimed.ExecuteNonQueryAsync(cancellationToken);\n"
+        + "}\n",
+        false)]
+    [InlineData(
+        "await using var command = filtered\n"
+        + "    ? connection.CreateCommand(FilteredSql)\n"
+        + "    : connection.CreateCommand(AllSql);\n"
+        + "command.CommandTimeout = 45;\n",
+        true)]
+    [InlineData(
+        "using var command = connection.CreateCommand();\n"
+        + "/* the deadline used to be command.CommandTimeout = 10 here */\n"
+        + "await command.ExecuteNonQueryAsync(cancellationToken);\n",
+        false)]
+    [InlineData(
+        "using var command = connection.CreateCommand();\n"
+        + "var doc = \"command.CommandTimeout = 10\";\n",
+        false)]
+    /* The sibling spelled as an ASSIGNMENT rather than an initializer. Every other sibling fixture in this
+       family used the initializer form, which has no leading dot and so never reached the assignment regex -
+       while the assignment spelling is the dominant one in this codebase. Found in review. */
+    [InlineData(
+        "using (var untimed = connection.CreateCommand())\n"
+        + "{\n"
+        + "    using var sibling = connection.CreateCommand();\n"
+        + "    sibling.CommandTimeout = 10;\n"
+        + "    await untimed.ExecuteNonQueryAsync(cancellationToken);\n"
+        + "}\n",
+        false)]
+    public void TheScanner_JudgesTheSiteItself_NotItsNeighbours(string source, bool expectedTimed)
+    {
+        var code = CSharpSourceWalker.StripCommentsAndStrings(source);
+        var ctor = s_commandCtor.Match(code);
+
+        Assert.True(ctor.Success, "the fixture did not contain a command construction");
+
+        Assert.Equal(expectedTimed, CommandDeadlineScanner.SetsAnExplicitDeadline(code, ctor.Index));
+    }
+
+    /// <summary>
+    /// A construction written ONLY in a comment or a literal is not a construction. The scan reads
+    /// stripped text so it cannot report one: a phantom offender names a line where no edit can ever make
+    /// the build pass. The last case is a fifth construction shape the unqualified pattern could not see.
+    /// </summary>
+    [Theory]
+    [InlineData("var command = connection.CreateCommand();", true)]
+    [InlineData("/* these go through connection.CreateCommand() and leave nothing open. */", false)]
+    [InlineData("// TODO: replace with new NpgsqlCommand(Sql, connection)", false)]
+    [InlineData("var doc = \"using var c = new NpgsqlCommand(Sql, connection);\";", false)]
+    [InlineData("await using var command = new Npgsql.NpgsqlCommand(Sql, connection);", true)]
+    public void TheConstructionScan_ReadsCodeNotProse(string source, bool expectedSite)
+    {
+        var code = CSharpSourceWalker.StripCommentsAndStrings(source);
+
+        Assert.Equal(expectedSite, s_commandCtor.IsMatch(code));
+    }
 
     private static IEnumerable<string> AnalysisSources()
     {

--- a/Darling/Darling.Tests/CSharpSourceWalker.cs
+++ b/Darling/Darling.Tests/CSharpSourceWalker.cs
@@ -103,20 +103,36 @@ internal static class CSharpSourceWalker
     }
 
     /// <summary>
-    /// <para>The text from <paramref name="start"/> through the <paramref name="statements"/>'th <c>;</c>
-    /// that sits at bracket depth zero or below, or to the end of <paramref name="text"/> if there are
-    /// fewer. Only CODE characters are counted, so a semicolon or a bracket inside a comment or a literal
-    /// cannot end the span or unbalance the depth.</para>
+    /// <para>The text from <paramref name="start"/> through the <paramref name="statements"/>'th
+    /// statement-ending <c>;</c>, or through the end of the SCOPE that <paramref name="start"/> sits in,
+    /// whichever comes first. Only CODE characters are counted, so a semicolon or a bracket inside a
+    /// comment or a literal cannot end the span or unbalance the depth.</para>
     ///
-    /// <para>The span is cut from the ORIGINAL text rather than the stripped one, because the callers match
-    /// a value-bearing regex over it and want to see what is actually written there. It is the WALK that is
-    /// literal-aware, not the result.</para>
+    /// <para><b>The span is cut from whatever text it was handed, and every caller now hands it STRIPPED
+    /// source.</b> This once said the opposite - that the original was passed because a caller wants to see
+    /// what is actually written there - and that reasoning was wrong in the direction that matters. A caller
+    /// matching a value-bearing regex over a raw span accepts the value SPELLED in a comment: a site whose
+    /// deadline exists only in an explanatory note about the deadline reads as timed. Making the walk
+    /// literal-aware and then handing it raw text throws the awareness away at the last step.</para>
     ///
-    /// <para><b>Why depth <c>&lt;= 0</c> and not <c>== 0</c>.</b> An untimed command inside a
-    /// <c>using (...) { }</c> statement has the block's closing brace between it and the next command's
-    /// deadline. A depth counter that cannot go negative treats that <c>}</c> as still depth-zero, keeps
-    /// consuming past it, and reads the FOLLOWING command's deadline — calling the untimed site clean. That
-    /// is a false negative in a guard, and it is the shape this group's own tooling once got wrong.</para>
+    /// <para><b>A closing BRACE that was open before <paramref name="start"/> ends the span.</b> A statement
+    /// count alone cannot bound it. An untimed command inside a <c>using (...) { }</c> whose body holds a
+    /// single statement spends the two-statement window on that statement and on the statement AFTER the
+    /// block, so the FOLLOWING command's deadline satisfies the scan and the untimed site reads as clean;
+    /// the same leak runs out through the closing brace of any block a construction is the last statement of.
+    /// Both are false negatives in a guard, and a deadline written where the command is already out of scope
+    /// was never this command's deadline — so the scope, not a count, is what has to bound the span. A
+    /// parenthesis or a bracket is NOT a scope: it delimits an expression, and an expression that opened
+    /// before <paramref name="start"/> does not change which block the construction lives in.</para>
+    ///
+    /// <para><b>A statement header is followed into its embedded statement.</b> When the construction sits in
+    /// a <c>using (var command = ...)</c> header, the deadline is either in that header's initializer or in
+    /// the block the header governs — fourteen sites across the four projects these pins scan set it as the
+    /// block's first statement — and never after the block, where the command no longer exists. So the span
+    /// continues past the header's <c>)</c> into the embedded block and ends at its closing brace, counting
+    /// that block's own statements. Stopping at the header instead would report all fourteen as offenders.
+    /// When the header governs a BRACELESS single statement, that statement is the whole span for the same
+    /// reason: the scope ends with it.</para>
     ///
     /// <para>Comments are skipped for the mirror-image reason, and it is not hypothetical: the two-statement
     /// window exists for the <c>CreateCommand</c> shape, whose deadline is the statement AFTER the
@@ -133,6 +149,12 @@ internal static class CSharpSourceWalker
         var depth = 0;
         var seen = 0;
 
+        /* The depth the statements being counted live at: zero, or the embedded block's depth once a header
+           has been followed into one. `body` is that block's depth, and -1 until there is one. */
+        var floor = 0;
+        var body = -1;
+        var header = false;
+
         for (var i = start; i < text.Length; i++)
         {
             if (!code[i])
@@ -145,18 +167,197 @@ internal static class CSharpSourceWalker
             if (c is '(' or '[' or '{')
             {
                 depth++;
+
+                if (c == '{' && header && body < 0)
+                {
+                    body = depth;
+                    floor = depth;
+                }
+
+                continue;
             }
-            else if (c is ')' or ']' or '}')
+
+            if (c is ')' or ']' or '}')
             {
+                if (c == '}' && depth == body)
+                {
+                    return text[start..(i + 1)];
+                }
+
                 depth--;
+
+                if (depth >= 0)
+                {
+                    continue;
+                }
+
+                if (c == '}')
+                {
+                    return text[start..i];
+                }
+
+                /* A parenthesis or bracket that was open before `start` has closed. Neither ends the block, so
+                   the walk carries on at depth zero - but WHICH of the two it was decides how much further it
+                   may go, and the answer is in what comes next. A statement HEADER is followed by the statement
+                   it governs, so that statement is the rest of the span. An ARGUMENT LIST is followed by the
+                   rest of its own expression, and the construction it held is still an ordinary part of the
+                   statement it sits in, so the statement budget continues as normal. Conflating them costs a
+                   verdict either way: treat a header like an argument list and the span runs out of the scope
+                   the command lives in; treat an argument list like a header and a correctly-timed
+                   `Wrap(connection.CreateCommand())` is cut off before the assignment on the next line. */
+                depth = 0;
+                header = header || StartsAStatement(text, code, i + 1);
+
+                continue;
             }
-            else if (c == ';' && depth <= 0 && ++seen >= statements)
+
+            if (c != ';' || depth != floor)
+            {
+                continue;
+            }
+
+            if (header && body < 0)
+            {
+                /* A header whose embedded statement carries no braces - `using (...) await cmd.RunAsync();`.
+                   This semicolon ends that one statement, and the scope ends with it, so there is no next
+                   statement to look at. Without this the braced and braceless forms of the same `using` would
+                   be judged differently, which is the generality the brace stop above does not have on its
+                   own. */
+                return text[start..(i + 1)];
+            }
+
+            if (++seen >= statements)
             {
                 return text[start..(i + 1)];
             }
         }
 
         return text[start..];
+    }
+
+    /// <summary>
+    /// <para>The construction expression starting at <paramref name="start"/> — its argument list, and the
+    /// object or collection initializer attached to it, if there is one. Nothing else: this is the span that
+    /// belongs to the SITE rather than to its statement or to its scope.</para>
+    ///
+    /// <para><b>Why the scope bound on <see cref="StatementSpanFrom"/> is not enough on its own.</b> A scan
+    /// asking "was a deadline set here" over a span that reaches into the following statement — which the
+    /// <c>CreateCommand</c> shape needs, its deadline being an assignment rather than an initializer — will
+    /// accept the following construction's OWN initializer. So an untimed command directly followed by a
+    /// timed one reads as timed, and so does an untimed <c>using (...)</c> header whose block opens with a
+    /// timed sibling. That sibling is in the same scope and often in the very next statement, so neither a
+    /// statement count nor a scope bound can exclude it.</para>
+    ///
+    /// <para>Splitting the question is what excludes it. A value in a construction's initializer belongs to
+    /// THAT construction, so it is read from this span; a value assigned through a member access belongs to
+    /// whatever it was assigned to, so it is read from the surrounding statement span. Truncating the
+    /// statement span at the next construction instead is the tempting one-liner, and it is wrong: two
+    /// constructions can share one deadline, as the arms of the conditional in
+    /// <c>ViewerDataService.FinOps.Locking.cs</c> do, and truncating there reports the first arm as an
+    /// offender.</para>
+    /// </summary>
+    internal static string ConstructionSpanFrom(string text, int start)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+
+        var code = CodeMask(text);
+        var open = start;
+
+        /* The argument list has to be ATTACHED to the reference at `start`, so the walk to it may only cross
+           what a construction's head is made of: the `new` keyword, a qualified type or member name, and any
+           generic argument list. A scan that just looked for the next `(` would run out of the statement
+           entirely for a match that has no argument list - a bare `.CreateCommand` METHOD GROUP, which two of
+           these pins match deliberately - and return the NEXT construction's span, initializer included, so a
+           hand-off with no deadline of its own read as timed. */
+        while (open < text.Length
+               && (!code[open] || char.IsWhiteSpace(text[open]) || char.IsLetterOrDigit(text[open])
+                   || text[open] is '_' or '.' or '<' or '>'))
+        {
+            open++;
+        }
+
+        if (open >= text.Length || text[open] != '(')
+        {
+            /* No argument list attached: the reference itself is the whole span, and it cannot carry a
+               deadline. */
+            return text[start..open];
+        }
+
+        var end = ClosingIndex(text, code, open, '(', ')');
+
+        if (end < 0)
+        {
+            return text[start..];
+        }
+
+        var next = end + 1;
+
+        while (next < text.Length && (!code[next] || char.IsWhiteSpace(text[next])))
+        {
+            next++;
+        }
+
+        if (next >= text.Length || text[next] != '{')
+        {
+            return text[start..(end + 1)];
+        }
+
+        var brace = ClosingIndex(text, code, next, '{', '}');
+
+        return brace < 0 ? text[start..] : text[start..(brace + 1)];
+    }
+
+    /// <summary>
+    /// Whether the next CODE character from <paramref name="i"/> begins a STATEMENT rather than continuing an
+    /// expression. Only used to tell a statement header apart from an argument list once the closing
+    /// parenthesis of one of them has been passed, where the two want different amounts of the text that
+    /// follows. A statement can begin with a block, an identifier or a keyword; an expression continues with
+    /// punctuation or an operator, and a bare <c>;</c> ends the statement the expression was part of.
+    /// </summary>
+    private static bool StartsAStatement(string text, bool[] code, int i)
+    {
+        while (i < text.Length && (!code[i] || char.IsWhiteSpace(text[i])))
+        {
+            i++;
+        }
+
+        return i < text.Length
+               && (text[i] == '{' || text[i] == '_' || text[i] == '@' || char.IsLetter(text[i]));
+    }
+
+    /// <summary>
+    /// The index of the <paramref name="close"/> matching the <paramref name="open"/> delimiter at
+    /// <paramref name="from"/>, or -1 when they never balance. Only CODE characters count, so a delimiter in
+    /// prose or in a literal cannot unbalance the match — the same contract <see cref="BraceBalanced"/> gets
+    /// by being handed already-stripped text, reached the other way so this one holds whatever it is handed.
+    /// </summary>
+    private static int ClosingIndex(string text, bool[] code, int from, char open, char close)
+    {
+        var depth = 0;
+
+        for (var i = from; i < text.Length; i++)
+        {
+            if (!code[i])
+            {
+                continue;
+            }
+
+            if (text[i] == open)
+            {
+                depth++;
+            }
+            else if (text[i] == close)
+            {
+                depth--;
+
+                if (depth == 0)
+                {
+                    return i;
+                }
+            }
+        }
+
+        return -1;
     }
 
     /// <summary>

--- a/Darling/Darling.Tests/CSharpSourceWalkerTests.cs
+++ b/Darling/Darling.Tests/CSharpSourceWalkerTests.cs
@@ -355,6 +355,196 @@ public sealed class CSharpSourceWalkerTests
     }
 
     /// <summary>
+    /// <para>The span ends with the SCOPE it started in. Both fixtures are the shape the landed pins could
+    /// not report: an untimed construction whose two-statement window reaches a deadline set where the
+    /// command no longer exists — once out through the closing brace of the block a <c>using (...)</c> header
+    /// governs, once out through the closing brace of a plain block the construction is the last statement
+    /// of. The legacy walk is the positive control in both: it leaks, which is why the assertion that the
+    /// current walk does not is worth something.</para>
+    ///
+    /// <para>Reproduced against real merged code before this landed. <c>DarlingRetention.PurgeOneAsync</c>
+    /// lifts a TimescaleDB decompression rail through an untimed <c>using (...)</c> whose body holds one
+    /// statement, and the timed delete that follows it satisfied the scan. It was the ONLY site in the
+    /// repository the leak was actually hiding, and it sat outside every pin's reach — the count it was one of
+    /// moves with every command anyone adds, so the figure lives in the change log rather than here, where a
+    /// comment cannot keep it true.</para>
+    /// </summary>
+    [Fact]
+    public void AStatementSpanEndsWithTheScopeItStartedIn()
+    {
+        var throughAHeadersBlock = Lines(
+            """        using (var untimed = _dataSource.CreateCommand(Sql))""",
+            """        {""",
+            """            await untimed.ExecuteNonQueryAsync(cancellationToken);""",
+            """        }""",
+            """        timed.CommandTimeout = 5;""");
+
+        var throughAPlainBlock = Lines(
+            """        if (probe)""",
+            """        {""",
+            """            var untimed = _dataSource.CreateCommand(Sql);""",
+            """        }""",
+            """        timed.CommandTimeout = 5;""");
+
+        foreach (var fixture in new[] { throughAHeadersBlock, throughAPlainBlock })
+        {
+            var start = fixture.IndexOf(".CreateCommand(", StringComparison.Ordinal);
+
+            Assert.True(start > 0, "the fixture no longer contains a command construction");
+
+            Assert.Contains(
+                "CommandTimeout",
+                LegacyStatementSpanFrom(fixture, start, statements: 2),
+                StringComparison.Ordinal);
+
+            Assert.DoesNotContain(
+                "CommandTimeout",
+                CSharpSourceWalker.StatementSpanFrom(fixture, start, statements: 2),
+                StringComparison.Ordinal);
+        }
+    }
+
+    /// <summary>
+    /// The same bound for a header whose embedded statement carries NO braces. The brace stop cannot reach
+    /// this one — there is no block to end at — so the span ends with the embedded statement instead, and the
+    /// braced and braceless spellings of the same <c>using</c> are judged alike. The legacy walk is the
+    /// positive control: it runs on to the deadline set after the scope has closed.
+    /// </summary>
+    [Fact]
+    public void AStatementSpanEndsWithABracelessHeadersOwnStatement()
+    {
+        var fixture = Lines(
+            """        using (var untimed = _dataSource.CreateCommand(Sql))""",
+            """            await untimed.ExecuteNonQueryAsync(cancellationToken);""",
+            """        timed.CommandTimeout = 5;""");
+
+        var start = fixture.IndexOf(".CreateCommand(", StringComparison.Ordinal);
+
+        Assert.True(start > 0, "the fixture no longer contains a command construction");
+
+        Assert.Contains(
+            "CommandTimeout",
+            LegacyStatementSpanFrom(fixture, start, statements: 2),
+            StringComparison.Ordinal);
+
+        Assert.DoesNotContain(
+            "CommandTimeout",
+            CSharpSourceWalker.StatementSpanFrom(fixture, start, statements: 2),
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A closing parenthesis that was open before the start is NOT always a statement header. When the
+    /// construction sits in an ordinary argument list the expression simply continues, and the command is a
+    /// normal part of the statement it is in - so the statement budget has to continue with it. Ending the
+    /// span at the header rule instead cuts this fixture off before the assignment on the next line and
+    /// reports a correctly-timed command. Caught in review rather than by this file, which is why it is here.
+    /// </summary>
+    [Fact]
+    public void AStatementSpanTreatsAnArgumentListDifferentlyFromAStatementHeader()
+    {
+        var nested = Lines(
+            """        var command = Wrap(connection.CreateCommand());""",
+            """        command.CommandTimeout = 5;""");
+
+        var header = Lines(
+            """        using (var untimed = connection.CreateCommand())""",
+            """            await untimed.ExecuteNonQueryAsync(cancellationToken);""",
+            """        timed.CommandTimeout = 5;""");
+
+        Assert.Contains(
+            "CommandTimeout",
+            CSharpSourceWalker.StatementSpanFrom(nested, nested.IndexOf(".CreateCommand(", StringComparison.Ordinal), statements: 2),
+            StringComparison.Ordinal);
+
+        Assert.DoesNotContain(
+            "CommandTimeout",
+            CSharpSourceWalker.StatementSpanFrom(header, header.IndexOf(".CreateCommand(", StringComparison.Ordinal), statements: 2),
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The other side of the same bound, and the reason it is the SCOPE rather than the header: fourteen
+    /// sites across the four projects these pins scan construct their command in a <c>using (...)</c> header
+    /// and set its deadline as the block's first statement. A span that stopped at the header would report
+    /// every one of them, and a false positive fails a green build on correct code.
+    /// </summary>
+    [Fact]
+    public void AStatementSpanStillReachesADeadlineSetInsideTheBlockItsHeaderGoverns()
+    {
+        var fixture = Lines(
+            """        await using (var command = _dataSource.CreateCommand(Sql))""",
+            """        {""",
+            """            command.CommandTimeout = 5;""",
+            """        }""");
+
+        var start = fixture.IndexOf(".CreateCommand(", StringComparison.Ordinal);
+
+        Assert.True(start > 0, "the fixture no longer contains a command construction");
+
+        Assert.Contains(
+            "CommandTimeout",
+            CSharpSourceWalker.StatementSpanFrom(fixture, start, statements: 2),
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// <para><see cref="CSharpSourceWalker.ConstructionSpanFrom"/> covers the site and its initializer, and
+    /// stops. The third case is what it exists for: a deadline in the NEXT construction's initializer is not
+    /// this one's, and no statement count or scope bound can tell them apart because the neighbour is in the
+    /// same scope. The second case is the matching limit — an assignment is outside this span by design, and
+    /// the pins read it from the statement span instead.</para>
+    ///
+    /// <para>Two of these are the positive controls for the walk being literal- and comment-aware here too:
+    /// a semicolon inside verbatim SQL must not cut the argument list short, and a comment written between a
+    /// construction and its initializer must not detach them.</para>
+    ///
+    /// <para>The last is a bare <c>.CreateCommand</c> METHOD GROUP, which two pins in this family match on
+    /// purpose. It has NO argument list, so a scan that simply looked for the next <c>(</c> would leave the
+    /// statement and return the following construction's span, initializer included - a hand-off with no
+    /// deadline of its own reading as timed. The walk may only cross what a construction's head is made of,
+    /// so the span here is the reference alone and carries no deadline.</para>
+    /// </summary>
+    [Theory]
+    [InlineData("var c = new NpgsqlCommand(Sql, connection) { CommandTimeout = 5 };\n", true)]
+    [InlineData("var c = new NpgsqlCommand(Sql, connection);\nc.CommandTimeout = 5;\n", false)]
+    [InlineData(
+        "var c = _dataSource.CreateCommand(Sql);\n"
+        + "var d = new NpgsqlCommand(Sql, connection) { CommandTimeout = 5 };\n",
+        false)]
+    [InlineData("var c = new NpgsqlCommand(@\"SELECT 1; SELECT 2;\", connection) { CommandTimeout = 5 };\n", true)]
+    [InlineData("var c = new NpgsqlCommand(Sql, connection) /* set here; not below */ { CommandTimeout = 5 };\n", true)]
+    [InlineData(
+        "builder.Register(factory.CreateCommand, options);\n"
+        + "var other = new NpgsqlCommand(Sql, connection) { CommandTimeout = 5 };\n",
+        false)]
+    public void AConstructionSpanIsTheSiteAndItsInitializerAndNothingElse(string fixture, bool carriesTheDeadline)
+    {
+        var start = FirstConstruction(fixture);
+
+        Assert.True(start >= 0, "the fixture no longer contains a command construction");
+
+        Assert.Equal(
+            carriesTheDeadline,
+            CSharpSourceWalker.ConstructionSpanFrom(fixture, start).Contains("CommandTimeout", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The FIRST construction in <paramref name="fixture"/>, in whichever of the two shapes it is written.
+    /// First rather than any, because the neighbour case above needs the site that does NOT carry the
+    /// deadline.
+    /// </summary>
+    private static int FirstConstruction(string fixture)
+    {
+        var constructed = fixture.IndexOf("new NpgsqlCommand(", StringComparison.Ordinal);
+        var manufactured = fixture.IndexOf(".CreateCommand", StringComparison.Ordinal);
+
+        return constructed < 0 ? manufactured
+            : manufactured < 0 ? constructed
+            : Math.Min(constructed, manufactured);
+    }
+
+    /// <summary>
     /// A semicolon in a comment still cannot end a span, which is the assertion the three timeout pins lean
     /// on most: this codebase's style puts an explanatory comment in exactly the gap between a
     /// <c>CreateCommand</c> and its deadline, and a semicolon inside one would report a correctly-timed site

--- a/Darling/Darling.Tests/CommandDeadlineScanner.cs
+++ b/Darling/Darling.Tests/CommandDeadlineScanner.cs
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Text.RegularExpressions;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// <para>Decides whether the command constructed at a given offset had its deadline chosen on purpose (#2874).
+/// Five command-timeout pins ask that question - <c>.Storage</c>, <c>.Viewer</c>, <c>.Analysis</c>,
+/// <c>PgFactCollector</c> and the alert pass - and they used to ask it five identical ways. This is the one
+/// implementation they share, the same treatment <see cref="CSharpSourceWalker"/> gave the five copies of the
+/// source walk in #2913 and <c>IlCallSiteScanner</c> gave the five copies of the IL walk in #2898. The walk
+/// copies had already drifted by the time they were consolidated, and only one of them carried the hardening
+/// the others needed; a judgement duplicated five ways would drift the same way.</para>
+///
+/// <para><b>The question is asked in two halves, because there are two places a deadline can legitimately be
+/// written and each has a different neighbour problem.</b> An initializer belongs to the construction it is
+/// attached to, so it is read from the CONSTRUCTION span; read from the wider statement span it would accept
+/// the FOLLOWING construction's initializer, and an untimed command directly ahead of a timed one would pass.
+/// An assignment names its target, so it cannot be mistaken for a construction's own, and it is read from the
+/// statement span - which is where the <c>CreateCommand</c> shape has to put it, a method result being unable
+/// to take an initializer.</para>
+///
+/// <para><b>Both halves are asked of STRIPPED source.</b> A deadline merely SPELLED in a comment is not a
+/// deadline, and this codebase quotes code in its prose constantly: judged raw, a note explaining where the
+/// deadline used to be stands in for the deadline itself. Callers pass
+/// <see cref="CSharpSourceWalker.StripCommentsAndStrings"/>'s output, which is character-aligned with its
+/// input, so an offset taken from either means the same thing in both.</para>
+/// </summary>
+internal static class CommandDeadlineScanner
+{
+    /// <summary>
+    /// A deadline in a construction's own object initializer. Read against the CONSTRUCTION span only.
+    /// </summary>
+    private static readonly Regex s_setsTimeout = new(
+        @"CommandTimeout\s*=",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// A deadline assigned through a member access - <c>command.CommandTimeout = ...</c>, the only way a
+    /// <c>CreateCommand</c> result can carry one. Read against the statement span.
+    /// </summary>
+    private static readonly Regex s_assignsTimeout = new(
+        @"\.\s*CommandTimeout\s*=",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// Whether the command constructed at <paramref name="index"/> in already-STRIPPED
+    /// <paramref name="code"/> sets an explicit deadline.
+    /// </summary>
+    internal static bool SetsAnExplicitDeadline(string code, int index)
+    {
+        ArgumentNullException.ThrowIfNull(code);
+
+        if (s_setsTimeout.IsMatch(CSharpSourceWalker.ConstructionSpanFrom(code, index)))
+        {
+            return true;
+        }
+
+        var bound = BoundName(code, index);
+
+        if (bound is null)
+        {
+            /* Nothing was bound to the construction - it is returned, or passed straight into a call - so the
+               initializer was the only place a deadline could have been written. */
+            return false;
+        }
+
+        return Assigns(bound).IsMatch(CSharpSourceWalker.StatementSpanFrom(code, index, statements: 2));
+    }
+
+    /// <summary>
+    /// <para>An assignment to <c>CommandTimeout</c> through <paramref name="bound"/> specifically.</para>
+    ///
+    /// <para><b>The name is what makes this the site's own deadline rather than a neighbour's.</b> An
+    /// unqualified <c>\.CommandTimeout\s*=</c> over the statement span accepts a SIBLING's assignment: an
+    /// untimed <c>using (...)</c> header whose block opens with <c>using var sibling = conn.CreateCommand();</c>
+    /// and <c>sibling.CommandTimeout = 10;</c> spends both counted statements on the sibling, and the outer
+    /// command reads as timed. Every fixture in this family used to exercise that sibling through an object
+    /// INITIALIZER, which has no leading dot and so never reached this regex - while the assignment spelling
+    /// it missed is the dominant one, 112 of the MCP surface's 119 sites. Found in review, not by the
+    /// fixtures.</para>
+    /// </summary>
+    private static Regex Assigns(string bound) => new(
+        @"(?<![A-Za-z0-9_])" + Regex.Escape(bound) + @"\s*[!?]?\s*\.\s*CommandTimeout\s*=",
+        RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// <para>The identifier the construction at <paramref name="index"/> is bound to, or null when it is not
+    /// bound to one.</para>
+    ///
+    /// <para>Taken as the identifier before the FIRST <c>=</c> of the statement the construction sits in,
+    /// which is the binder in every shape here and in none of the shapes that have no binder: a declaration
+    /// (<c>using var c = ...</c>), a header declaration (<c>using (var c = ...)</c>) and a field assignment
+    /// all put it there, while <c>return new ...</c> and <c>Wrap(conn.CreateCommand())</c> have no <c>=</c> at
+    /// all. FIRST rather than last so a conditional whose arms are each a construction still resolves to the
+    /// one variable they share - the shape in <c>ViewerDataService.FinOps.Locking.cs</c> - and comparison and
+    /// lambda operators are skipped so <c>x == null ? ... : ...</c> does not look like a binder.</para>
+    /// </summary>
+    private static string? BoundName(string code, int index)
+    {
+        var from = index;
+
+        while (from > 0 && code[from - 1] is not (';' or '{' or '}'))
+        {
+            from--;
+        }
+
+        for (var i = from; i < index; i++)
+        {
+            if (code[i] != '=')
+            {
+                continue;
+            }
+
+            if (i + 1 < code.Length && code[i + 1] is '=' or '>')
+            {
+                i++;
+                continue;
+            }
+
+            if (i > from && code[i - 1] is '=' or '!' or '<' or '>' or '+' or '-' or '*' or '/' or '|' or '&' or '^' or '%')
+            {
+                continue;
+            }
+
+            var end = i - 1;
+
+            while (end >= from && char.IsWhiteSpace(code[end]))
+            {
+                end--;
+            }
+
+            var start = end;
+
+            while (start >= from && (char.IsLetterOrDigit(code[start]) || code[start] == '_'))
+            {
+                start--;
+            }
+
+            return end > start ? code[(start + 1)..(end + 1)] : null;
+        }
+
+        return null;
+    }
+}

--- a/Darling/Darling.Tests/FactCollectorCommandTimeoutTests.cs
+++ b/Darling/Darling.Tests/FactCollectorCommandTimeoutTests.cs
@@ -50,11 +50,7 @@ public sealed class FactCollectorCommandTimeoutTests
     /// half of them.
     /// </summary>
     private static readonly Regex s_commandCtor = new(
-        @"new NpgsqlCommand\(",
-        RegexOptions.Compiled | RegexOptions.CultureInvariant);
-
-    private static readonly Regex s_setsTimeout = new(
-        @"CommandTimeout\s*=",
+        @"new\s+(?:[A-Za-z_][A-Za-z0-9_]*\s*\.\s*)*NpgsqlCommand\s*\(|\.CreateCommand\s*\(",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     [Fact]
@@ -65,29 +61,25 @@ public sealed class FactCollectorCommandTimeoutTests
 
         foreach (var file in FactCollectorSources())
         {
-            var lines = File.ReadAllLines(file);
+            var text = File.ReadAllText(file);
 
-            for (var i = 0; i < lines.Length; i++)
+            /* Both halves of the question are asked of STRIPPED text, which is character-aligned with its
+               input. This replaced a raw three-LINE window that could tell neither a construction from the
+               same words in a comment, nor this site's deadline from the next site's, nor a real deadline
+               from one merely spelled in prose. */
+            var code = CSharpSourceWalker.StripCommentsAndStrings(text);
+
+            foreach (Match ctor in s_commandCtor.Matches(code))
             {
-                if (!s_commandCtor.IsMatch(lines[i]))
-                {
-                    continue;
-                }
+                var line = text.Take(ctor.Index).Count(c => c == '\n') + 1;
 
-                /* The initializer may wrap, so the deadline counts if it appears on the construction
-                   line or in the statement that follows it — both are in use across this codebase
-                   (PgPlanFetcher uses the initializer, PgDrillDownCollector assigns afterwards). */
-                var window = string.Join(
-                    "\n",
-                    lines.Skip(i).Take(Math.Min(3, lines.Length - i)));
-
-                if (s_setsTimeout.IsMatch(window))
+                if (CommandDeadlineScanner.SetsAnExplicitDeadline(code, ctor.Index))
                 {
                     covered++;
                 }
                 else
                 {
-                    missing.Add($"{Path.GetFileName(file)}:{i + 1}");
+                    missing.Add($"{Path.GetFileName(file)}:{line}");
                 }
             }
         }
@@ -135,6 +127,96 @@ public sealed class FactCollectorCommandTimeoutTests
             $"The deadline ({PgFactCollector.FactCommandTimeoutSeconds}s) must leave at least half of "
             + $"the {AnalysisPassBudgetSeconds}s analysis pass for the other twenty-nine collect "
             + "methods. One read that stalls must not cost a server every other fact.");
+    }
+
+    /// <summary>
+    /// Scanner blind spots, pinned - a false positive here fails a green build on correct code. The first
+    /// two are this assembly's real shapes; the next three are the layouts the raw three-line window this
+    /// scan replaced could not report, where the deadline it found belonged to the NEXT construction. The
+    /// last is why the span is not simply CUT at that next construction, which is the tempting one-line
+    /// version of the same rule: two constructions can legitimately share ONE deadline. The last two are the
+    /// value half of the same mistake: a deadline SPELLED in a comment or a literal is not a deadline, so the
+    /// span is judged over STRIPPED source - this codebase quotes code in its prose constantly.
+    /// </summary>
+    [Theory]
+    [InlineData(
+        "var command = new NpgsqlCommand(Sql, connection) { CommandTimeout = 45 };\n",
+        true)]
+    [InlineData(
+        "var command = connection.CreateCommand();\n"
+        + "/* a method result cannot take an initializer; set it here. */\n"
+        + "command.CommandTimeout = 45;\n",
+        true)]
+    [InlineData(
+        "using (var untimed = new NpgsqlCommand(Sql, connection))\n"
+        + "{\n"
+        + "    await untimed.ExecuteNonQueryAsync(cancellationToken);\n"
+        + "}\n"
+        + "using var next = new NpgsqlCommand(OtherSql, connection) { CommandTimeout = 45 };\n",
+        false)]
+    [InlineData(
+        "using var untimed = new NpgsqlCommand(Sql, connection);\n"
+        + "using var next = new NpgsqlCommand(OtherSql, connection) { CommandTimeout = 45 };\n",
+        false)]
+    [InlineData(
+        "using (var untimed = new NpgsqlCommand(Sql, connection))\n"
+        + "{\n"
+        + "    using var sibling = new NpgsqlCommand(OtherSql, connection) { CommandTimeout = 45 };\n"
+        + "    await untimed.ExecuteNonQueryAsync(cancellationToken);\n"
+        + "}\n",
+        false)]
+    [InlineData(
+        "await using var command = filtered\n"
+        + "    ? connection.CreateCommand(FilteredSql)\n"
+        + "    : connection.CreateCommand(AllSql);\n"
+        + "command.CommandTimeout = 45;\n",
+        true)]
+    [InlineData(
+        "using var command = connection.CreateCommand();\n"
+        + "/* the deadline used to be command.CommandTimeout = 10 here */\n"
+        + "await command.ExecuteNonQueryAsync(cancellationToken);\n",
+        false)]
+    [InlineData(
+        "using var command = connection.CreateCommand();\n"
+        + "var doc = \"command.CommandTimeout = 10\";\n",
+        false)]
+    /* The sibling spelled as an ASSIGNMENT rather than an initializer. Every other sibling fixture in this
+       family used the initializer form, which has no leading dot and so never reached the assignment regex -
+       while the assignment spelling is the dominant one in this codebase. Found in review. */
+    [InlineData(
+        "using (var untimed = connection.CreateCommand())\n"
+        + "{\n"
+        + "    using var sibling = connection.CreateCommand();\n"
+        + "    sibling.CommandTimeout = 10;\n"
+        + "    await untimed.ExecuteNonQueryAsync(cancellationToken);\n"
+        + "}\n",
+        false)]
+    public void TheScanner_JudgesTheSiteItself_NotItsNeighbours(string source, bool expectedTimed)
+    {
+        var code = CSharpSourceWalker.StripCommentsAndStrings(source);
+        var ctor = s_commandCtor.Match(code);
+
+        Assert.True(ctor.Success, "the fixture did not contain a command construction");
+
+        Assert.Equal(expectedTimed, CommandDeadlineScanner.SetsAnExplicitDeadline(code, ctor.Index));
+    }
+
+    /// <summary>
+    /// A construction written ONLY in a comment or a literal is not a construction. The scan reads
+    /// stripped text so it cannot report one: a phantom offender names a line where no edit can ever make
+    /// the build pass. The last case is a fifth construction shape the unqualified pattern could not see.
+    /// </summary>
+    [Theory]
+    [InlineData("var command = connection.CreateCommand();", true)]
+    [InlineData("/* these go through connection.CreateCommand() and leave nothing open. */", false)]
+    [InlineData("// TODO: replace with new NpgsqlCommand(Sql, connection)", false)]
+    [InlineData("var doc = \"using var c = new NpgsqlCommand(Sql, connection);\";", false)]
+    [InlineData("await using var command = new Npgsql.NpgsqlCommand(Sql, connection);", true)]
+    public void TheConstructionScan_ReadsCodeNotProse(string source, bool expectedSite)
+    {
+        var code = CSharpSourceWalker.StripCommentsAndStrings(source);
+
+        Assert.Equal(expectedSite, s_commandCtor.IsMatch(code));
     }
 
     private static IEnumerable<string> FactCollectorSources()

--- a/Darling/Darling.Tests/StorageCommandTimeoutTests.cs
+++ b/Darling/Darling.Tests/StorageCommandTimeoutTests.cs
@@ -47,11 +47,7 @@ public sealed class StorageCommandTimeoutTests
     /// (367 of its 371 sites were untimed), and 50 of this project's 70 were that shape.
     /// </summary>
     private static readonly Regex s_commandCtor = new(
-        @"new NpgsqlCommand\s*\(|\.CreateCommand\s*\(",
-        RegexOptions.Compiled | RegexOptions.CultureInvariant);
-
-    private static readonly Regex s_setsTimeout = new(
-        @"CommandTimeout\s*=",
+        @"new\s+(?:[A-Za-z_][A-Za-z0-9_]*\s*\.\s*)*NpgsqlCommand\s*\(|\.CreateCommand\s*\(",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     [Fact]
@@ -64,13 +60,19 @@ public sealed class StorageCommandTimeoutTests
         {
             var text = File.ReadAllText(path);
 
-            foreach (Match ctor in s_commandCtor.Matches(text))
+            /* Both halves of the question are asked of STRIPPED text, which is character-aligned with its
+               input so an offset means the same thing in either. A construction written only in a comment or
+               a literal is not a construction - reported raw it is a phantom offender at a line no edit can
+               fix, already observed once in this family on a bare CreateCommand method group inside a block
+               comment. And a deadline merely SPELLED in a comment is not a deadline: judged raw, a note
+               explaining where the deadline used to be stands in for the deadline. */
+            var code = CSharpSourceWalker.StripCommentsAndStrings(text);
+
+            foreach (Match ctor in s_commandCtor.Matches(code))
             {
                 total++;
 
-                var span = CSharpSourceWalker.StatementSpanFrom(text, ctor.Index, statements: 2);
-
-                if (!s_setsTimeout.IsMatch(span))
+                if (!CommandDeadlineScanner.SetsAnExplicitDeadline(code, ctor.Index))
                 {
                     var line = text.Take(ctor.Index).Count(c => c == '\n') + 1;
                     offenders.Add($"{Path.GetFileName(path)}:{line}");
@@ -122,8 +124,35 @@ public sealed class StorageCommandTimeoutTests
     /// site, as it must. A scanner whose depth counter cannot go negative treats the block's closing
     /// <c>}</c> as still depth-zero, keeps consuming past it, and reads the FOLLOWING command's
     /// deadline — calling the untimed site clean. That is how two Python scanners each missed the real
-    /// <c>QueryStoreSliceRepair</c> rail-lift during this change; the <c>depth &lt;= 0</c> walker below
+    /// <c>QueryStoreSliceRepair</c> rail-lift during this change; the scope-bounded walker below
     /// reports it.</para>
+    ///
+    /// <para><b>The last two cases are the same leak in the layouts a statement COUNT cannot bound.</b>
+    /// Give the block above a single body statement and the two-statement window spends its budget on that
+    /// statement and on the one AFTER the block, so the following command's initializer satisfies the scan
+    /// and the untimed site is reported clean. Give the construction no header at all and make it the last
+    /// statement of its block, and the window reaches past the closing brace to a deadline set where this
+    /// command no longer exists. Both were silent until the span stopped at the end of the scope the
+    /// construction sits in rather than after a fixed number of semicolons.</para>
+    ///
+    /// <para><b>The final two cases are the neighbour no scope bound can exclude</b>, because the sibling is
+    /// in the same scope: an untimed construction directly followed by a timed one, and an untimed
+    /// <c>using (...)</c> header whose block opens with a timed sibling. In both the deadline the scan finds
+    /// belongs to the NEXT construction, which is why the span is cut at the next construction rather than
+    /// only at the end of the scope. The following statement stays reachable, which the first case above
+    /// needs: a <c>CreateCommand</c> deadline is an assignment, and an assignment is not a construction.</para>
+    ///
+    /// <para><b>A deadline SPELLED in a comment or a literal is not a deadline.</b> The span is judged over
+    /// STRIPPED source for the same reason the construction scan enumerates over it: this codebase quotes
+    /// code in its prose constantly, and a scan that reads raw text lets an explanatory comment about a
+    /// deadline stand in for the deadline itself. That is the value half of the same mistake - right span,
+    /// wrong text.</para>
+    ///
+    /// <para><b>The last case is why the span is not simply CUT at the next construction</b>, which is the
+    /// tempting one-line version of that rule. It is real code — the conditional in
+    /// <c>ViewerDataService.FinOps.Locking.cs</c> — where TWO constructions share ONE deadline, so cutting at
+    /// the second reports the first as an offender. Reading the initializer from the construction and the
+    /// assignment from the statement span gets both this and the two cases above right.</para>
     /// </summary>
     [Theory]
     [InlineData(
@@ -146,14 +175,64 @@ public sealed class StorageCommandTimeoutTests
         + "}\n"
         + "using var next = new NpgsqlCommand(OtherSql, connection) { CommandTimeout = 10 };\n",
         false)]
+    [InlineData(
+        "using (var untimed = new NpgsqlCommand(\"SELECT 1\", connection))\n"
+        + "{\n"
+        + "    await untimed.ExecuteNonQueryAsync(cancellationToken);\n"
+        + "}\n"
+        + "using var next = new NpgsqlCommand(OtherSql, connection) { CommandTimeout = 10 };\n",
+        false)]
+    [InlineData(
+        "if (probe)\n"
+        + "{\n"
+        + "    using var untimed = new NpgsqlCommand(\"SELECT 1\", connection);\n"
+        + "}\n"
+        + "using var next = new NpgsqlCommand(OtherSql, connection) { CommandTimeout = 10 };\n",
+        false)]
+    [InlineData(
+        "using var untimed = new NpgsqlCommand(Sql, connection);\n"
+        + "using var next = new NpgsqlCommand(OtherSql, connection) { CommandTimeout = 10 };\n",
+        false)]
+    [InlineData(
+        "using (var untimed = new NpgsqlCommand(Sql, connection))\n"
+        + "{\n"
+        + "    using var sibling = new NpgsqlCommand(OtherSql, connection) { CommandTimeout = 10 };\n"
+        + "    await untimed.ExecuteNonQueryAsync(cancellationToken);\n"
+        + "}\n",
+        false)]
+    [InlineData(
+        "await using var command = databaseName == null\n"
+        + "    ? _dataSource.CreateCommand(IndexLockingAllSql)\n"
+        + "    : _dataSource.CreateCommand(IndexLockingByDbSql);\n"
+        + "command.CommandTimeout = StorageCommandDeadlines.McpReadSeconds;\n",
+        true)]
+    [InlineData(
+        "using var command = connection.CreateCommand();\n"
+        + "/* the deadline used to be command.CommandTimeout = 10 here */\n"
+        + "await command.ExecuteNonQueryAsync(cancellationToken);\n",
+        false)]
+    [InlineData(
+        "using var command = connection.CreateCommand();\n"
+        + "var doc = \"command.CommandTimeout = 10\";\n",
+        false)]
+    /* The sibling spelled as an ASSIGNMENT rather than an initializer. Every other sibling fixture in this
+       family used the initializer form, which has no leading dot and so never reached the assignment regex -
+       while the assignment spelling is the dominant one in this codebase. Found in review. */
+    [InlineData(
+        "using (var untimed = connection.CreateCommand())\n"
+        + "{\n"
+        + "    using var sibling = connection.CreateCommand();\n"
+        + "    sibling.CommandTimeout = 10;\n"
+        + "    await untimed.ExecuteNonQueryAsync(cancellationToken);\n"
+        + "}\n",
+        false)]
     public void TheScanner_JudgesTheSiteItself_NotItsNeighbours(string source, bool expectedTimed)
     {
-        var ctor = s_commandCtor.Match(source);
+        var code = CSharpSourceWalker.StripCommentsAndStrings(source);
+        var ctor = s_commandCtor.Match(code);
         Assert.True(ctor.Success, "the fixture did not contain a command construction");
 
-        var span = CSharpSourceWalker.StatementSpanFrom(source, ctor.Index, statements: 2);
-
-        Assert.Equal(expectedTimed, s_setsTimeout.IsMatch(span));
+        Assert.Equal(expectedTimed, CommandDeadlineScanner.SetsAnExplicitDeadline(code, ctor.Index));
     }
 
     /* The literal- and comment-aware walk this pin used to carry lives in CSharpSourceWalker as of
@@ -161,6 +240,31 @@ public sealed class StorageCommandTimeoutTests
        with the literal text around them, so a call written inside an interpolation was invisible to every
        scan built on them. The reasoning that shaped the walk moved there with it, and
        CSharpSourceWalkerTests carries the witnesses. */
+
+    /// <summary>
+    /// <para>A construction written ONLY in a comment or a literal is not a construction. The scan reads
+    /// stripped text so it cannot report one: a phantom offender names a line where no edit can ever make
+    /// the build pass, which is worse than a miss because it cannot be acted on. Not hypothetical — an
+    /// earlier census in this family reported a bare <c>CreateCommand</c> method group that turned out to
+    /// be the phrase in running prose inside a block comment.</para>
+    ///
+    /// <para>The last case is a FIFTH construction shape, <c>new Npgsql.NpgsqlCommand(</c>, which the
+    /// unqualified pattern could not see at all. None exists in this project today; one exists elsewhere in
+    /// the solution, so the shape is real and a pattern blind to it would report a clean sweep over a site
+    /// it never looked at.</para>
+    /// </summary>
+    [Theory]
+    [InlineData("var command = _postgres.CreateCommand(Sql);", true)]
+    [InlineData("/* these go through _postgres.CreateCommand(Sql) and leave nothing open. */", false)]
+    [InlineData("// TODO: replace with new NpgsqlCommand(Sql, connection)", false)]
+    [InlineData("var doc = \"await using var c = _postgres.CreateCommand(Sql);\";", false)]
+    [InlineData("await using var command = new Npgsql.NpgsqlCommand(Sql, connection);", true)]
+    public void TheConstructionScan_ReadsCodeNotProse(string source, bool expectedSite)
+    {
+        var code = CSharpSourceWalker.StripCommentsAndStrings(source);
+
+        Assert.Equal(expectedSite, s_commandCtor.IsMatch(code));
+    }
 
     private static IEnumerable<string> StorageSources()
     {

--- a/Darling/Darling.Tests/ViewerCommandTimeoutTests.cs
+++ b/Darling/Darling.Tests/ViewerCommandTimeoutTests.cs
@@ -45,11 +45,7 @@ public sealed class ViewerCommandTimeoutTests
     /// here it is 191 of the 193 sites.
     /// </summary>
     private static readonly Regex s_commandCtor = new(
-        @"new NpgsqlCommand\s*\(|\.CreateCommand\s*\(",
-        RegexOptions.Compiled | RegexOptions.CultureInvariant);
-
-    private static readonly Regex s_setsTimeout = new(
-        @"CommandTimeout\s*=",
+        @"new\s+(?:[A-Za-z_][A-Za-z0-9_]*\s*\.\s*)*NpgsqlCommand\s*\(|\.CreateCommand\s*\(",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     /// <summary>
@@ -71,13 +67,17 @@ public sealed class ViewerCommandTimeoutTests
         {
             var text = File.ReadAllText(path);
 
-            foreach (Match ctor in s_commandCtor.Matches(text))
+            /* Both halves of the question are asked of STRIPPED text, which is character-aligned with its
+               input so an offset means the same thing in either. A construction named only in prose is not a
+               construction, and a deadline merely SPELLED in a comment is not a deadline - judged raw, a note
+               explaining where the deadline used to be stands in for the deadline. */
+            var code = CSharpSourceWalker.StripCommentsAndStrings(text);
+
+            foreach (Match ctor in s_commandCtor.Matches(code))
             {
                 total++;
 
-                var span = CSharpSourceWalker.StatementSpanFrom(text, ctor.Index, statements: 2);
-
-                if (!s_setsTimeout.IsMatch(span))
+                if (!CommandDeadlineScanner.SetsAnExplicitDeadline(code, ctor.Index))
                 {
                     var line = text.Take(ctor.Index).Count(c => c == '\n') + 1;
                     offenders.Add($"{Path.GetFileName(path)}:{line}");
@@ -208,11 +208,16 @@ public sealed class ViewerCommandTimeoutTests
     ///
     /// <para>The fourth case is the shape this group's own tooling got wrong on <c>.Storage</c>: an
     /// untimed command inside a <c>using (...) { }</c> STATEMENT, with the block's closing brace
-    /// between it and the next command's deadline. A scanner whose depth counter cannot go negative
-    /// treats that <c>}</c> as still depth-zero, keeps consuming past it, and reads the FOLLOWING
-    /// command's deadline — calling the untimed site clean. The <c>depth &lt;= 0</c> walker below
-    /// reports it. The fifth is this project's real shape: the timed factory lambda that replaced the
-    /// method-group hand-off, which must read as TIMED.</para>
+    /// between it and the next command's deadline. The fifth is this project's real shape: the timed
+    /// factory lambda that replaced the method-group hand-off, which must read as TIMED.</para>
+    ///
+    /// <para><b>The last three are the layouts the landed scan could not report</b>, and they are why the
+    /// question is asked in two halves. Give the block above ONE body statement and the two-statement window
+    /// spends its budget on that statement and on the statement after the block; put the timed command in the
+    /// very next statement, or as the untimed header's own first body statement, and the deadline the scan
+    /// finds belongs to the neighbour outright. The initializer is therefore read from the CONSTRUCTION span
+    /// and only the assignment from the statement span. Cutting the statement span at the next construction
+    /// instead would fail the SECOND case above, where two constructions legitimately share one deadline.</para>
     /// </summary>
     [Theory]
     [InlineData(
@@ -245,14 +250,51 @@ public sealed class ViewerCommandTimeoutTests
         + "    return command;\n"
         + "},\n",
         true)]
+    [InlineData(
+        "using (var untimed = new NpgsqlCommand(\"SELECT 1\", connection))\n"
+        + "{\n"
+        + "    await untimed.ExecuteNonQueryAsync(cancellationToken);\n"
+        + "}\n"
+        + "using var next = new NpgsqlCommand(OtherSql, connection) { CommandTimeout = 10 };\n",
+        false)]
+    [InlineData(
+        "using var untimed = new NpgsqlCommand(Sql, connection);\n"
+        + "using var next = new NpgsqlCommand(OtherSql, connection) { CommandTimeout = 10 };\n",
+        false)]
+    [InlineData(
+        "using (var untimed = new NpgsqlCommand(Sql, connection))\n"
+        + "{\n"
+        + "    using var sibling = new NpgsqlCommand(OtherSql, connection) { CommandTimeout = 10 };\n"
+        + "    await untimed.ExecuteNonQueryAsync(cancellationToken);\n"
+        + "}\n",
+        false)]
+    [InlineData(
+        "using var command = connection.CreateCommand();\n"
+        + "/* the deadline used to be command.CommandTimeout = 10 here */\n"
+        + "await command.ExecuteNonQueryAsync(cancellationToken);\n",
+        false)]
+    [InlineData(
+        "using var command = connection.CreateCommand();\n"
+        + "var doc = \"command.CommandTimeout = 10\";\n",
+        false)]
+    /* The sibling spelled as an ASSIGNMENT rather than an initializer. Every other sibling fixture in this
+       family used the initializer form, which has no leading dot and so never reached the assignment regex -
+       while the assignment spelling is the dominant one in this codebase. Found in review. */
+    [InlineData(
+        "using (var untimed = connection.CreateCommand())\n"
+        + "{\n"
+        + "    using var sibling = connection.CreateCommand();\n"
+        + "    sibling.CommandTimeout = 10;\n"
+        + "    await untimed.ExecuteNonQueryAsync(cancellationToken);\n"
+        + "}\n",
+        false)]
     public void TheScanner_JudgesTheSiteItself_NotItsNeighbours(string source, bool expectedTimed)
     {
-        var ctor = s_commandCtor.Match(source);
+        var code = CSharpSourceWalker.StripCommentsAndStrings(source);
+        var ctor = s_commandCtor.Match(code);
         Assert.True(ctor.Success, "the fixture did not contain a command construction");
 
-        var span = CSharpSourceWalker.StatementSpanFrom(source, ctor.Index, statements: 2);
-
-        Assert.Equal(expectedTimed, s_setsTimeout.IsMatch(span));
+        Assert.Equal(expectedTimed, CommandDeadlineScanner.SetsAnExplicitDeadline(code, ctor.Index));
     }
 
     /// <summary>
@@ -278,6 +320,31 @@ public sealed class ViewerCommandTimeoutTests
        with the literal text around them, so a call written inside an interpolation was invisible to every
        scan built on them. The reasoning that shaped the walk moved there with it, and
        CSharpSourceWalkerTests carries the witnesses. */
+
+    /// <summary>
+    /// <para>A construction written ONLY in a comment or a literal is not a construction. The scan reads
+    /// stripped text so it cannot report one: a phantom offender names a line where no edit can ever make
+    /// the build pass, which is worse than a miss because it cannot be acted on. Not hypothetical — an
+    /// earlier census in this family reported a bare <c>CreateCommand</c> method group that turned out to
+    /// be the phrase in running prose inside a block comment.</para>
+    ///
+    /// <para>The last case is a FIFTH construction shape, <c>new Npgsql.NpgsqlCommand(</c>, which the
+    /// unqualified pattern could not see at all. None exists in this project today; one exists elsewhere in
+    /// the solution, so the shape is real and a pattern blind to it would report a clean sweep over a site
+    /// it never looked at.</para>
+    /// </summary>
+    [Theory]
+    [InlineData("var command = _dataSource.CreateCommand(Sql);", true)]
+    [InlineData("/* these go through _dataSource.CreateCommand(Sql) and leave nothing open. */", false)]
+    [InlineData("// TODO: replace with new NpgsqlCommand(Sql, connection)", false)]
+    [InlineData("var doc = \"await using var c = _dataSource.CreateCommand(Sql);\";", false)]
+    [InlineData("await using var command = new Npgsql.NpgsqlCommand(Sql, connection);", true)]
+    public void TheConstructionScan_ReadsCodeNotProse(string source, bool expectedSite)
+    {
+        var code = CSharpSourceWalker.StripCommentsAndStrings(source);
+
+        Assert.Equal(expectedSite, s_commandCtor.IsMatch(code));
+    }
 
     private static IEnumerable<string> ViewerSources()
     {

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingRetention.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingRetention.cs
@@ -958,7 +958,8 @@ public static class DarlingRetention
                purge deliberately is. Lift it for this connection only. On a store without the extension
                the qualified name is accepted as a placeholder GUC, so this is safe everywhere. */
             using (var lift = new NpgsqlCommand(
-                "SET timescaledb.max_tuples_decompressed_per_dml_transaction = 0", connection))
+                "SET timescaledb.max_tuples_decompressed_per_dml_transaction = 0",
+                connection) { CommandTimeout = DeleteTimeoutSeconds })
             {
                 await lift.ExecuteNonQueryAsync(cancellationToken);
             }


### PR DESCRIPTION
## A retention command was inheriting the 30 s default, and the pins that exist to say so could not see it

`DarlingRetention.PurgeOneAsync` lifts a TimescaleDB decompression rail before a batched purge:

```csharp
using (var lift = new NpgsqlCommand(
    "SET timescaledb.max_tuples_decompressed_per_dml_transaction = 0", connection))
{
    await lift.ExecuteNonQueryAsync(cancellationToken);
}

using var command = new NpgsqlCommand(deleteSql, connection) { CommandTimeout = DeleteTimeoutSeconds };
```

The `lift` command set no deadline, so it ran on Npgsql's undocumented 30 s default — the defect class #2874 exists to eliminate. Four of that file's five constructions already carried `DeleteTimeoutSeconds`; this one was missed, and the scan reported it clean because the two-statement window reached past the block's closing brace and found the initializer on the `delete` behind it. It now carries `DeleteTimeoutSeconds`.

It is the only such site in the repository's command constructions, and it sits outside every #2874 pin's scan scope — so **no pin's published figure was false**, but the class was live in shipped code rather than theoretical.

## Three independent blind spots let it hide

All three are the same mistake: the scan answering about something other than the construction it is pointing at.

### 1. The span ran out of the scope it started in (false negative)

`CSharpSourceWalker.StatementSpanFrom` let its bracket depth go negative and keep counting semicolons. A construction in a `using (...)` header whose block body holds ONE statement spends the two-statement window on that statement and on the statement AFTER the block, so the FOLLOWING command's initializer satisfies the scan. The same leak runs out through the closing brace of any block a construction is the last statement of.

Reproduced against #2935's branch, one mutation at a time, each restored byte-identically:

- deadline removed from a `using (...)` block followed by a timed construction — `Total: 6, Failed: 0`, **silent**
- deadline removed from the trailing `using var`, nothing timed after it — `1 storage command(s) inherit Npgsql's 30s default ... PgMigrations.cs:4370`, fires

The pin was directional: it saw an untimed site only when no timed construction followed within two statements. `TheScanner_JudgesTheSiteItself_NotItsNeighbours`, written to prevent exactly this, had no case with a one-statement body.

The span now ends with the SCOPE it started in. A closing BRACE that was open beforehand ends it; a parenthesis or bracket does not, because it delimits an expression and an expression that opened earlier does not change which block the construction lives in.

**It still follows a statement header into the block — or the braceless statement — that header governs**, and that half is load-bearing. Fourteen sites across the scanned projects set the deadline as that block's FIRST statement. Stopping at the header, the smaller change, reports every one of them; confirmed by mutation, which fails four pins on real code.

Judging only the construction and its initializer, the other candidate, is worse: **all 193** viewer sites and 51 of `.Storage`'s 124 set the deadline in the following statement, because a `CreateCommand` result cannot take an initializer. That is what the two-statement allowance exists for.

### 2. The neighbour no scope bound can exclude (false negative)

Two layouts survive the scope fix, because the sibling is in the same scope: an untimed construction directly ahead of a timed one, and an untimed `using (...)` header whose block OPENS with a timed sibling.

Both are closed by asking the question in two halves. A new `ConstructionSpanFrom` returns the site and its own object initializer, and the bare `CommandTimeout =` pattern is read from THAT and nothing wider. Only a MEMBER assignment — `command.CommandTimeout = ...`, the one placement a `CreateCommand` result allows — is read from the surrounding statement span. A value in an initializer belongs to the construction it is attached to; a value assigned through a member access belongs to whatever it names.

Cutting the statement span at the next construction instead is the tempting one-liner, and it is wrong. Two constructions can share one deadline — the conditional in `ViewerDataService.FinOps.Locking.cs` does — and cutting there reports the first arm as an offender. That shape was **already a pinned case in the viewer pin**, so the one-liner would have turned an existing green case red. It is now a case in all five pins.

### 3. Both sides of the question read RAW source (false positive *and* false negative)

The scans matched raw text when enumerating constructions, so a construction named in a comment or a string was reportable as an untimed site at a line where no edit could ever fix it. Demonstrated on real code: with a construction named in a comment in `StorageVersion.cs`, the landed pin reports `StorageVersion.cs:19` — a comment — and the fixed pin reports nothing.

**The mirror of it is worse, and the two-part rule above does not close it on its own**: the *deadline* check also read raw text, so a deadline merely SPELLED in a comment satisfied a site that had none. Reproduced against this branch before fixing it — a block comment `/* the deadline used to be command.CommandTimeout = 10 here */`, a line comment, and a string literal all read as timed; all three now read untimed, and both legitimate controls (a real assignment with a comment in the gap, and an initializer) still read timed.

Both halves now route through one stripped `code` per file. The doc remarks that used to justify cutting spans from the ORIGINAL text — in the walker and in every pin — now say what the code does instead; those remarks were the thing that would otherwise let this be re-introduced, because a walk made literal-aware and then handed raw text throws the awareness away at the last step.

This codebase quotes code in its prose constantly, so both directions were live. **Not one phantom sits inside any pin's scan scope**, which is the figure that means something — a repo-wide count would go stale on the next commit, and this change itself adds more of them to the test suite.

The defects also interact: a phantom planted next to a timed statement is itself hidden by the over-wide window.

## All five scans, not just the two that were reported

`.Analysis` and `PgFactCollector` judged a site by joining the next three RAW source lines, which can neither tell a construction from the same words in a comment nor tell this site's deadline from the next site's. The alert pass, consolidated to a single scan helper by #2934, judged a single raw span. All now use the same two-part rule over stripped source.

The clearest evidence is one run, one file, two pins: with an untimed construction planted immediately ahead of a timed one in `PgFactCollector.Activity.cs`, the landed three-line pin says clean while the migrated scan reports `PgFactCollector.Activity.cs:61`. Both pins read that exact file.

All five also take the alert pass's fully-qualified construction pattern — `new\s+(?:[A-Za-z_][A-Za-z0-9_]*\s*\.\s*)*NpgsqlCommand\s*\(` — which is strictly more general than the `Npgsql.`-only form and sees a construction qualified by any namespace. There is one qualified occurrence in the solution, in `DarlingWorker.TryRefreshPgStatementTextAsync`, a member the merged collection-sweep census enlists — so that census counts 13 where 14 constructions exist. It is already timed, and whether a monitored-target read belongs in that budget is that group's call, so it is flagged rather than changed here.

## Every figure, re-measured after the fix

Counts are as measured at this head; `dev` adds command sites steadily, so the load-bearing claim is the last two columns rather than the first. Every figure below is the SHIPPED judgement, not a stand-in for it — the measuring tool compiles `CommandDeadlineScanner` itself.

| scope | sites | timed | newly reported | phantoms in scope |
|---|---|---|---|---|
| `.Storage` | 127 | 127 | 0 | 0 |
| `.Viewer` | 193 | 193 | 0 | 0 |
| `.Analysis` | 73 | 73 | 0 | 0 |
| `PgFactCollector.*.cs` | 32 | 32 | 0 | 0 |
| alert pass (6 files) | 45 | 45 | 0 | 0 |
| MCP read surface | 126 | 126 | 0 | 0 |
| whole repository | 1,862 | — | 1 (fixed here) | none in any scope |

The MCP read surface is the densest population of the affected shape — **112 of its 119 `Mcp/` sites place the deadline in a following statement**, structurally, because `.CreateCommand(` returns a command. It measures clean under four independent rules: the landed span, the scope-bounded span, the shipped two-part rule, and a deliberately stricter control that additionally requires the assignment to name the identifier the construction was bound to. That control resolves 119 of 119 names, so the shipped rule's one residual — an assignment on a different variable inside the window — is empirically empty there.

## Two pins in the family are NOT fixed by this

Stated plainly, because the headline would otherwise overreach. Five pins route through the shared judgement: `.Storage`, `.Viewer`, `.Analysis`, `PgFactCollector` and the alert pass. Two do not, and both still reproduce blind spots this closes elsewhere:

- **`CollectionSweepCommandTimeoutTests`** still cuts its span from RAW member source and matches an unqualified value regex over it, so a deadline spelled in a comment satisfies a site, and a sibling's assignment satisfies one too. Untouched here on purpose — it is another group's just-landed pin and its census constant is a scope judgement I should not make unilaterally.
- **`StoreSelfMetricsTimeoutTests`** is a whole-file count-equality pin over one file, not a per-site scan at all. Relocating a deadline from one command to another leaves its counts invariant, so it cannot see a move. All five of that file's sites currently carry the initializer, so it reports truthfully today.

Adopting the shared judgement in either is a one-line change now that it exists.

## What this does NOT establish

**The enumeration is regex-based, and that is a design limit, not an oversight.** These pins find a construction by matching its written form, so a construction whose TYPE NAME is not at the site is invisible to them however the pattern is widened. Target-typed `new` is exactly that shape: in `return new(...)` or `=> new(...)` the type lives in the member's return type, and in `= new(...)` it lives on the declaration. No pattern over the construction site can see it.

So the claim this PR supports is "every construction these patterns can see is judged correctly", not "every construction is judged". The gap is bounded rather than open, though — measured, not assumed:

- **2,755** target-typed `new(...)` sites in the repository, over stripped source so prose cannot contribute
- **327** of them sit in a file that names a command type at all
- **22** have a command type within 3,000 characters, a deliberately generous stand-in for "in the same member"
- **all 22 read by hand: none constructs a command.** Eleven are in test files no pin scans; the other eleven are records, singletons and collections — `CommandPlan`, `AlertHistoryRecord`, `PlanForceActionRecord`, `MonitoredServerRow`, `PlanDimRecompression.Result`, the two target-provider singletons, a `ConcurrentDictionary` and a `List<string>`

**So the shape is a footnote today, not a hole** — but it is a footnote a widened regex cannot keep true, and the next command written as `return new(...)` would be invisible to every pin. Closing it properly needs the target type resolved, which is a different tool from this one.

Two other things worth stating plainly. The `.CreateCommand` bare method group is matched by the pins that assert it is ABSENT and not by the five that judge deadlines, because a method group has no argument list for either pattern to anchor on. And the two-statement allowance is a syntactic claim — the construction's own statement plus the one after it — not a tuned window; it is now bounded by scope on one side and by the construction span on the other, so its size is no longer what decides a verdict.

### 4. A match with no argument list ran away (false negative)

Caught in review on this branch, and it was mine: two pins match a bare `.CreateCommand` METHOD GROUP on purpose, and `ConstructionSpanFrom` assumed its start was followed by the construction's own `(`. A method group has none, so the scan walked out of the statement, found the NEXT construction's parentheses, and returned that span with its initializer — a hand-off with no deadline of its own reading as timed.

Reproduced before fixing: `builder.Register(factory.CreateCommand, options);` followed by a timed construction read as timed, as did the `Func<NpgsqlCommand> f = connection.CreateCommand;` form. The walk to the opening parenthesis may now only cross what a construction's head is made of — the `new` keyword, a qualified name, generic arguments — so a match with nothing attached spans the reference alone and carries no deadline. Both hand-off forms now read untimed; both legitimate called forms still read timed.

### 5. A header and an argument list are not the same closing parenthesis (false positive)

Also caught in review, also mine, and introduced by the fix for the braceless case above. Once the span may end at a header's embedded statement, it has to know a header's `)` from an argument list's. It did not, so `Wrap(connection.CreateCommand())` — a construction nested in an ordinary call — had its span cut off before the assignment on the next line, reporting a correctly-timed command.

The two are told apart by what follows the parenthesis: a statement header is followed by the statement it governs, an argument list by the rest of its own expression. Reproduced before fixing (both the plain and the `.Inner` member-access form read as untimed), and both directions are now pinned — conflating them fails the new argument-list witness, and never recognising a header fails the braceless and scope witnesses **plus the landed witnesses in `McpReadCommandTimeoutTests` and `CollectionSweepCommandTimeoutTests`**, so the header path is load-bearing for two other groups' pins as well.

**Two of the five defects here were mine, both found by review rather than by my own mutations.** The pattern in both: a bound added for one shape changed the verdict for a shape I had already reasoned about and stopped re-checking. The fifteen-case matrix in the walker's tests now covers all of them together rather than one at a time.

### 6. The assignment half never checked WHICH command it named (false negative)

The last one, and the sharpest: `\.CommandTimeout\s*=` over the statement span accepts a SIBLING's assignment. An untimed `using (...)` header whose block opens with `using var sibling = conn.CreateCommand();` and `sibling.CommandTimeout = 10;` spends both counted statements on the sibling, and the outer command reads as timed.

Every sibling fixture in this family — mine included — exercised the sibling through an object INITIALIZER, which has no leading dot and so never reached that regex. The assignment spelling it missed is the dominant one: **112 of the MCP surface's 119 sites**. So the hole sat precisely where the fixtures did not look.

The assignment must now name the identifier the construction was bound to, taken as the identifier before the FIRST `=` of the construction's statement — the binder in a declaration, a header declaration and a field assignment alike, and absent exactly where there is no binder (`return new ...`, `Wrap(conn.CreateCommand())`), where the initializer is then the only place a deadline could be. First rather than last so a conditional whose arms are each a construction still resolves to the one variable they share.

Dropping the qualification fails the new witness in all five pins. And the shipped judgement now measures **zero offenders in every scope**, the viewer's 193 included — the conditional in `ViewerDataService.FinOps.Locking.cs` resolves correctly, which an earlier and cruder name walk of my own did not.

## One judgement, shared

Review also pointed out that the two regexes and the judgement they feed were copy-pasted byte-for-byte into all five pins — the same duplication `CSharpSourceWalker` was extracted to end in #2913 (five copies of the source walk, already drifted, only one of them hardened) and `BraceBalanced` in #2923/#2927. Fair, and paid down here rather than left to drift: `CommandDeadlineScanner` owns both regexes and the two-part judgement, and all five pins call it. Neutering one regex in that one file now fails **17 tests across all five pins**, which is the evidence that they genuinely share it.

`CSharpSourceWalker` stays generic — it walks C# source and knows nothing about deadlines. The domain judgement lives in its own type, which is the pattern `IlCallSiteScanner` already set for the IL walk.

## Verification

Every guard proved red first, one mutation at a time, each asserted applied and compiling, each moving the behaviour under test, each restored by copy with a dirty-file count logged. Each mutation killed a different set:

- removing the plain-block stop, the entered-block stop, the header follow-through, and the braceless-header stop each fail a different walker witness; the header-only variant fails four pins on real code
- `ConstructionSpanFrom` returning the whole statement span fails every neighbour witness across all five pins; dropping the initializer fails the verbatim-SQL and comment-gap controls
- neutering either half of the two-part judgement fails a different set of cases, so both halves are independently pinned in every pin
- reading raw text instead of stripped fails the prose cases on the construction side and the comment-deadline cases on the value side; narrowing the pattern fails the qualified-shape case

End to end on real code, same planted mutation both sides: `dev` reports `Failed: 0`, the fix reports `PgMigrations.cs:4144`.

`DarlingRetentionTests` slices `DarlingRetention.cs` by string anchor, once by a fixed character window and once brace-matched from inside the method this change edits. Both anchors still resolve, both still hold, and a planted-phrase control confirms each can still fail.

`Darling.Tests` is `net10.0-windows` and cannot run on macOS, so CI is the arbiter. Locally, the real test files compiled by absolute path into a `net10.0` xunit host staged inside the repo tree run **254** tests against **195** for the same harness on `dev`, with the same single pre-existing failure on both sides (`LivePostgresCollectionHygieneTests`, which fails identically without this change).
