### PR TITLE
Retire the last private copy of BraceBalanced, and correct the comment that said it was not one

### DIFF
--- a/Darling/Darling.Tests/ViewerScopedPaintGuardTests.cs
+++ b/Darling/Darling.Tests/ViewerScopedPaintGuardTests.cs
@@ -206,7 +206,7 @@ public sealed class ViewerScopedPaintGuardTests
 
                 Assert.True(open >= 0, $"a scope verify in {site.Method} has no block body");
 
-                var consequence = BraceBalanced(body, open);
+                var consequence = CSharpSourceWalker.BraceBalanced(body, open);
 
                 Assert.Matches(new Regex(@"\breturn\s*;"), consequence);
 
@@ -387,7 +387,7 @@ public sealed class ViewerScopedPaintGuardTests
 
         if (stripped[i] == '{')
         {
-            return BraceBalanced(stripped, i);
+            return CSharpSourceWalker.BraceBalanced(stripped, i);
         }
 
         Assert.True(
@@ -411,38 +411,14 @@ public sealed class ViewerScopedPaintGuardTests
         return i;
     }
 
-    /// <summary>
-    /// The brace-balanced span opening at <paramref name="open"/>. Brace MATCHING only — the literal- and
-    /// comment-aware walk that makes counting braces safe at all is <see cref="CSharpSourceWalker"/>'s, and
-    /// every caller here reads through <see cref="Stripped"/>, so a brace inside a string or a comment is
-    /// blanked before this sees it. #2913 consolidated that walk out of five copies; this is not a sixth.
-    /// </summary>
-    private static string BraceBalanced(string code, int open)
-    {
-        var depth = 0;
-
-        for (var i = open; i < code.Length; i++)
-        {
-            if (code[i] == '{')
-            {
-                depth++;
-            }
-            else if (code[i] == '}')
-            {
-                depth--;
-
-                if (depth == 0)
-                {
-                    return code[open..(i + 1)];
-                }
-            }
-        }
-
-        return code[open..];
-    }
-
     private static readonly Dictionary<string, string> s_stripped = new(StringComparer.Ordinal);
 
+    /// <summary>
+    /// Every source this pin reads arrives through here, with comments and string literals blanked. Brace
+    /// matching over the result is <see cref="CSharpSourceWalker.BraceBalanced"/>'s — this file keeps no walk
+    /// of its own — and the blanking is the precondition that makes it correct: a brace in prose or in a
+    /// literal is gone before the walk can count it.
+    /// </summary>
     private static string Stripped(string path)
     {
         if (s_stripped.TryGetValue(path, out var cached))


### PR DESCRIPTION
`ViewerScopedPaintGuardTests` declared a private `BraceBalanced`, and its doc comment asserted "#2913 consolidated that walk out of five copies; this is not a sixth." #2927 moved the helper into `CSharpSourceWalker` and pointed the other viewer call sites at it — `ViewerFleetTimerFanOutPositionTests:311`, `ViewerFleetTimerGuardTests:498` and `:617` — which made the claim false. This was the last private copy: a copy whose comment said it was not one.

The copy is deleted, both call sites read `CSharpSourceWalker.BraceBalanced`, and the doc comment moves to `Stripped`, which is where this file discharges the walk's precondition.

## The two implementations were compared, not assumed equivalent

#2927 settled its own two copies by running them against every offset of the viewer project rather than by reading them, because they were already textually apart. Same method here.

Normalising only the parameter name (`code` → `text`) and the accessibility, the diff is one line: the shared version carries `ArgumentNullException.ThrowIfNull(text)` and the copy did not. Both used the expanded decrement, so there was no fused-condition divergence of the kind #2927 found.

Behaviourally they agree at **every offset of 872 source files — 14,619,467 positions, zero differences** (190 viewer sources at 2,844,172 positions, then Lite and `Darling.Tests` at 11,775,295). The comparison ran the *shipped* shared method, compiled from its own file, against the copy's *shipped bytes*, extracted programmatically rather than retyped.

Eight edge cases outside that corpus were compared separately, and exactly one diverges: on a null input the shared version raises `ArgumentNullException` where the copy raised `NullReferenceException`. **The shared behaviour is kept**, and neither call site can reach it — both pass a non-null `string` derived from `Stripped`. Out-of-range `open`, an empty string, unbalanced braces, an extra closing brace and a start offset that is not a brace all behave identically.

## The redirect is load-bearing

Breaking the shared `BraceBalanced` turns two of this pin's five facts red (`EveryVerifysConsequence_IsAReturnThatPaintsNothing`, `EveryPaintAfterTheRead_SitsBelowAVerifyOnItsOwnPath`) along with the five tests at the other three call sites. So these two sites genuinely execute the shared walk now, rather than passing either way.

## The pin is still falsifiable

Green is not the deliverable. All **nine** mutations documented in #2929 were re-applied, one at a time. Each one compiles, each turns **exactly one** test red, and each reports the message #2929 claims for it:

| Mutation | Byte delta | Fact that goes red |
| --- | --- | --- |
| Inline the raw tab read back into the method | +122 | `TheScope_IsReadThroughOneExpressionAndNotInlined` |
| Invert the verify's `!=` to `==` | 0 | `TheVerify_ComparesAFreshReadAgainstTheCapturedScope` |
| Swap the verify's `return;` for a log line | +77 | `EveryVerifysConsequence_IsAReturnThatPaintsNothing` |
| **Move** the verify below the empty-result clear | **0** | `EveryPaintAfterTheRead…` — *paints before the captured scope is re-verified* |
| Delete the error path's verify in the second site | -307 | `EveryPaintAfterTheRead…` — *nearest verify on the other side of a catch* |
| Delete `MainTabs_SelectionChanged`'s call | -314 | `TheScopeChangingControl_StillIssuesItsOwnReRead` |
| Delete the success-path verify in Lite's twin | -291 | `EveryPaintAfterTheRead…` — *paints before the captured scope is re-verified* |
| Swap Lite's verify `return;` for a no-op | +6 | `EveryVerifysConsequence_IsAReturnThatPaintsNothing` |
| Drop `LoadAsync` from Lite's combo handler | +30 | `TheScopeChangingControl_StillIssuesItsOwnReRead` |

That covers all five facts, and both distinct failure messages of the one fact that has two. The pure move is confirmed pure: `MainWindow.ServerManagement.cs` stays at **40,277 bytes**, the same figure #2929 recorded, so no count-based control could see it and the offset comparison is what catches it.

Every mutation asserted its anchor unique before applying, asserted the old anchor gone and the new text present afterwards, and asserted the suite actually moved — a mutation that compiles but leaves the suite green proves as little as one that does not compile. Each mutated source was **compiled**, not merely syntax-checked: the Viewer and Lite projects both build on this host with `EnableWindowsTargeting`. Restores were byte-and-copy with `mtime` bumped explicitly, since `copy2` preserves it and MSBuild will then keep a mutated assembly, and green was re-asserted in the **rebuilt assembly** after each one.

## Verification

`Darling.Tests` is `net10.0-windows` and cannot run here, so the real files — `ViewerScopedPaintGuardTests`, `CSharpSourceWalker` and its tests, both fleet-timer pins and `DocCommentHygieneTests`, by absolute path, no copies — were compiled into a throwaway `net10.0` xunit host named `Darling.Tests`, staged under a `bin/` segment inside the tree so the pins that walk up from `AppContext.BaseDirectory` find this checkout's `PerformanceMonitor.sln` and nothing else. **41 tests, 0 failed, 0 not run**; dropping this one file from the host takes it to 36, so the five facts are demonstrably discovered and executed rather than assumed.

## Not verified

No Windows run and no live Viewer run; CI is the arbiter for the full suite. The 41-test host covers six files, so it cannot see a pin that landed on `dev` outside them — the full `Darling.Tests` project does compile against rebased `dev` with 0 errors. `CSharpSourceWalker.cs` is **not** modified by this change; #2938 is changing its `StatementSpanFrom` and owns it. No open PR touches `ViewerScopedPaintGuardTests.cs`.

No schema-version change and no migration rung.
