### PR TITLE
Explain the memory-collector UTC choice inline instead of pointing at a reverted fix

### DIFF
--- a/PerformanceMonitor.Collectors/MemoryPressureEventsCollector.cs
+++ b/PerformanceMonitor.Collectors/MemoryPressureEventsCollector.cs
@@ -36,10 +36,19 @@ SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
 DECLARE
     @ms_ticks bigint,
-    /* SYSUTCDATETIME(), not SYSDATETIME() -- see CpuUtilizationCollector's identical fix for the full
-       explanation: @now is the base for a STORED sample_time, and every naive timestamp in the store is
-       UTC, so the local-time version sat one UTC offset behind the collection_time written by the same
-       run. Same defect, same ring-buffer arithmetic, same fix. */
+    /* SYSUTCDATETIME(), not SYSDATETIME(): @now is the base for a STORED sample_time, and both readers of
+       memory_pressure_events.sample_time treat it as naive UTC -- Darling passes it to
+       ViewerTimeHelper.ForDisplay, which takes naive-UTC input, and Lite windows it with the UTC-based
+       GetTimeRange and adds UtcOffsetMinutes when plotting. A local clock here therefore put the whole
+       memory-pressure series one UTC offset away from every other lane: measured at exactly 4h behind the
+       collection_time written by the same collector run, on 42 of 42 us-east-2 servers, with the collector
+       reporting SUCCESS throughout (#2932).
+
+       Not the same answer as CpuUtilizationCollector, which shares this ring-buffer arithmetic and
+       deliberately KEEPS SYSDATETIME(): its sample_time is documented as the monitored server's local wall
+       clock and #1262 de-skews it in SQL per collection batch, so UTC there would break that correction and
+       Lite's server-local window. The frame is a property of each column's readers, not of the store, and
+       CollectorTimestampFrameTests pins both directions. */
     @now datetime2(7) = SYSUTCDATETIME();
 
 SELECT @ms_ticks = dosi.ms_ticks FROM sys.dm_os_sys_info AS dosi;


### PR DESCRIPTION
Comment-only follow-up to #2947.

#2947's comment said *"see CpuUtilizationCollector's identical fix"*. Review narrowed that PR and reverted the CPU collector back to `SYSDATETIME()`, so the pointer now sends a reader to a local clock still in place — to wonder whether the CPU column was supposed to change too, or whether the comment is stale. The review bot caught it; #2947 merged at `11c9b7e0`, one commit short of the correction, so the stale pointer is on `dev`.

The reasoning is now inline and names what it prevents: which readers assume naive UTC (Darling's `ViewerTimeHelper.ForDisplay`, Lite's UTC-based `GetTimeRange` plus its plot-time `UtcOffsetMinutes`), the measured offset (4 h behind the same run's `collection_time`, 42 of 42 us-east-2 servers, collector reporting SUCCESS throughout, #2932), and why `CpuUtilizationCollector` deliberately keeps its local clock under #1262 — with a pointer to `CollectorTimestampFrameTests`, where both directions are pinned.

The pre-existing `#2749`/`#2755` references are untouched: those point at fixes that landed, which is the shape CONTRIBUTING asks for.

**Scope:** comment text only. No behaviour change, no `CommandTimeout`/clock change, no test change. The comment sits inside the verbatim SQL, matching that file's existing style and the placement of the comment it replaces — `MemoryPressureEventsCollector` has no verbatim parity contract (only WaitStats, SpinlockStats, SessionSummaryStats, CpuSchedulerStats, Ag, LatchStats and PlanCacheStats do), which #2947's green run already demonstrated.

**No CHANGELOG entry** — entries now go to the coordinator's inbox rather than the file.