### PR TITLE
Judge the alert-pass deadline on stripped source (part of #2942)

### DIFF
--- a/Darling/Darling.Tests/AlertPassCommandTimeoutTests.cs
+++ b/Darling/Darling.Tests/AlertPassCommandTimeoutTests.cs
@@ -303,12 +303,23 @@ public sealed class AlertPassCommandTimeoutTests
         "var command = _postgres.CreateCommand(Sql);\n"
         + "await command.ExecuteNonQueryAsync();\n",
         false)]
+    /* A comment that NAMES a deadline is not one. This case was green before the value regex moved onto
+       the stripped span: the construction match excluded comments while the deadline test did not, so
+       prose could satisfy it. False-negative direction - it reported success on the defect. */
+    [InlineData(
+        "var command = new NpgsqlCommand(Sql, connection);\n"
+        + "/* no deadline needed here; CommandTimeout = 10 is applied by the caller. */\n"
+        + "await command.ExecuteNonQueryAsync();\n",
+        false)]
     public void TheScanner_SeesADeadlineThroughCommentsAndVerbatimSql(string source, bool expectedTimed)
     {
-        var ctor = s_commandCtor.Match(source);
+        /* Stripped, exactly as ScanForUntimedCommands does it - a fixture that walked the raw text would
+           pass while the shipped scan failed, which is how this defect survived its own theory. */
+        var code = CSharpSourceWalker.StripCommentsAndStrings(source);
+        var ctor = s_commandCtor.Match(code);
         Assert.True(ctor.Success, "the fixture did not contain a command construction");
 
-        var span = CSharpSourceWalker.StatementSpanFrom(source, ctor.Index, statements: 2);
+        var span = CSharpSourceWalker.StatementSpanFrom(code, ctor.Index, statements: 2);
 
         Assert.Equal(expectedTimed, s_setsTimeout.IsMatch(span));
     }


### PR DESCRIPTION
Part of #2942 — the **raw-span half**, which needs nothing from #2938 and so can land ahead of it. The two-span (`ConstructionSpanFrom`) half stays open until #2938 lands.

## The defect

`ScanForUntimedCommands` matched the **construction** regex over `StripCommentsAndStrings` output but tested the **value** regex against a span cut from the **raw** text — half stripped, half not, inside one method. A comment was therefore excluded from inventing a *site* but not from satisfying a *deadline*:

```
var command = new NpgsqlCommand(Sql, connection);
/* no deadline needed here; CommandTimeout = 10 is applied by the caller. */
```

read as **timed**. That is the false-negative direction — it reports success on the defect.

Found by #2874's group D in its own pin and confirmed here. My own doc comment described the stripped half and said nothing about the raw half, which is how I wrote it without noticing.

## Severity: real, currently masking nothing

Measured across all **46** alert-pass sites on `dev`, evaluating the deadline over the stripped span as well as the raw one: **0 masked**. So no current verdict changes and the earlier "46 sites, 0 untimed" census still holds under the stricter check. This is fixed because the *next* one would be invisible, not because something is broken today.

## Proven both directions

With the site untimed and a deadline-naming comment beside it, anchor count asserted first:

| | result |
|---|---|
| with the fix | offender named — `DarlingWorker.cs ReadLatestCpuAsync:4010` |
| **pre-fix, same mutation** | **8/8 green — the comment masks it entirely** |

## The theory was passing for the wrong reason too

`TheScanner_SeesADeadlineThroughCommentsAndVerbatimSql` walked the **raw** source, so a fixture would have passed while the shipped scan failed — which is how this defect survived a theory named for comments. The theory now strips before matching, exactly as the scan does, and carries the comment-naming-a-deadline case as its witness. The pre-existing cases still pass: the verbatim-SQL case's `CommandTimeout = 10` sits outside the literal, and the semicolons inside it are blanked, which is the desired behaviour.

## One caution, recorded at the line

Stripping literal **text** as well as comments is safe for *this* regex and only for it: the deadline is always code (`CommandTimeout = <expr>`), never a value inside a string. A pin whose value regex must see literal contents would be broken by this change, so it should not be applied family-wide by reflex. Relevant to whoever takes the same fix for the other pins.

## Not verified

- `Darling.Tests` is `net10.0-windows` and cannot run on macOS; executed in a throwaway `net10.0` xunit host (8 tests green, plus the mutation pair above). Expected suite delta **+1** (one new `[InlineData]`). CI is the arbiter.
- No production code changes at all — test-only.

**No CHANGELOG entry** — reported to the coordinator's inbox instead.