### PR TITLE
Part of #2874

### DIFF
--- a/Darling/Darling.Tests/ControlPlaneReloadDurabilityTests.cs
+++ b/Darling/Darling.Tests/ControlPlaneReloadDurabilityTests.cs
@@ -225,46 +225,67 @@ public sealed class ControlPlaneReloadDurabilityTests
         var code = CSharpSourceWalker.StripCommentsAndStrings(SourceText("DarlingWorker.cs"));
 
         var guard = new Regex(
-            @"if\s*\(\s*await ReloadFromStoreAsync\s*\([^)]*\)\s*\)\s*\{",
+            @"var appliedVersion = await ReloadFromStoreAsync\s*\([^)]*\)\s*;\s*if\s*\(\s*appliedVersion\.HasValue\s*\)\s*\{",
             RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
         var match = guard.Match(code);
         Assert.True(
             match.Success,
-            "the reload beacon no longer guards on ReloadFromStoreAsync's result, so a reload that read "
-            + "nothing can record its config_version as applied and will never be retried");
+            "the reload beacon no longer guards on ReloadFromStoreAsync's applied version, so a reload "
+            + "that read nothing can record its config_version as applied and will never be retried");
 
         var branch = CSharpSourceWalker.BraceBalanced(code, code.IndexOf('{', match.Index + match.Length - 1));
 
-        Assert.Contains("_lastConfigVersion = configVersion.Value;", branch, StringComparison.Ordinal);
+        /* Stamped from the APPLIED version, not from the beacon's own earlier read. Review caught that the
+           first version of this fix used `configVersion.Value` — correct about ordering, imprecise about
+           WHICH version: LoadViewAsync re-reads config_version, so a write landing between the two makes
+           the applied view newer than the beacon saw, and the older stamp leaves the watermark behind a
+           live config. Self-healing rather than lossy, but the same class of imprecision as the defect
+           this class exists for, and the startup path already stamped it correctly. */
+        Assert.Contains("_lastConfigVersion = appliedVersion.Value;", branch, StringComparison.Ordinal);
 
-        /* And nowhere else in the beacon: exactly one assignment from the beacon's own local, so a second
-           one outside the branch cannot re-introduce the early advance alongside the correct one. */
+        /* The beacon's own outer read must NOT be what lands on the watermark anywhere — this is the
+           assertion that would have failed on the first version of the fix. */
+        Assert.Empty(Regex.Matches(code, @"_lastConfigVersion\s*=\s*configVersion\.Value\s*;"));
+
+        /* And exactly one assignment from the applied version, so a second one outside the branch cannot
+           re-introduce the early advance alongside the correct one. */
         Assert.Equal(
             1,
-            Regex.Matches(code, @"_lastConfigVersion\s*=\s*configVersion\.Value\s*;").Count);
+            Regex.Matches(code, @"_lastConfigVersion\s*=\s*appliedVersion\.Value\s*;").Count);
+
+        /* Positive control on the negative above, through the identical pattern: an assertion that can
+           only pass is not an assertion. */
+        Assert.Single(Regex.Matches(
+            "_lastConfigVersion = configVersion.Value;",
+            @"_lastConfigVersion\s*=\s*configVersion\.Value\s*;"));
 
         /* ReloadFromStoreAsync has to REPORT failure for the guard to mean anything — a method that
            always returned true would satisfy every assertion above, which is why the signature check is
            not the end of it. */
-        var reload = code.IndexOf("private async Task<bool> ReloadFromStoreAsync(", StringComparison.Ordinal);
-        Assert.True(reload > 0, "ReloadFromStoreAsync no longer reports whether the reload applied");
+        var reload = code.IndexOf("private async Task<long?> ReloadFromStoreAsync(", StringComparison.Ordinal);
+        Assert.True(reload > 0, "ReloadFromStoreAsync no longer reports WHICH config_version it applied");
 
         var reloadBody = CSharpSourceWalker.BraceBalanced(code, code.IndexOf('{', code.IndexOf(')', reload)));
 
         /* The unreadable-view branch must return FALSE. This is the assertion that separates "the plumbing
            is shaped right" from "the plumbing carries the answer". */
         var nullBranch = new Regex(
-            @"if\s*\(\s*view is null\s*\)\s*\{[^}]*return false\s*;[^}]*\}",
+            @"if\s*\(\s*view is null\s*\)\s*\{[^}]*return null\s*;[^}]*\}",
             RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
         Assert.True(
             nullBranch.IsMatch(reloadBody),
-            "ReloadFromStoreAsync does not return false when LoadViewAsync could not read the store, so the "
+            "ReloadFromStoreAsync does not return null when LoadViewAsync could not read the store, so the "
             + "caller's guard always succeeds and the config_version watermark advances on a reload that "
             + "applied nothing — the original defect, reachable again through the new return value");
 
-        Assert.Equal(1, Regex.Matches(reloadBody, @"return false\s*;").Count);
+        Assert.Equal(1, Regex.Matches(reloadBody, @"return null\s*;").Count);
+
+        /* And what it returns on SUCCESS is the view's own version, so the watermark, the log line and the
+           applied config can never disagree. A method returning any other long would satisfy every
+           assertion above. */
+        Assert.Contains("return view.ConfigVersion;", reloadBody, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -1557,9 +1557,18 @@ public sealed class DarlingWorker : BackgroundService
                    re-enter or resume) because that path has no loop of its own and its failure is terminal.
                    This path already re-runs every tick by construction and its failure is recoverable, so
                    the only defect here was the ordering. */
-                if (await ReloadFromStoreAsync(configProvider, config, servers, muteRuleService, stoppingToken))
+                /* Stamped from the version the reload ACTUALLY applied, not from the beacon's own earlier
+                   read. ReloadFromStoreAsync re-reads config_version inside LoadViewAsync, so a write
+                   landing in the window between the two makes the applied view NEWER than
+                   configVersion.Value — and recording the older number would leave the watermark behind a
+                   config that is already live, costing one redundant idempotent re-apply on the next tick.
+                   Self-healing rather than lossy, but it is the same class of imprecision as the defect
+                   above ("the version recorded as applied must be the version that was applied"), and the
+                   startup path at :1179 already does it this way. */
+                var appliedVersion = await ReloadFromStoreAsync(configProvider, config, servers, muteRuleService, stoppingToken);
+                if (appliedVersion.HasValue)
                 {
-                    _lastConfigVersion = configVersion.Value;
+                    _lastConfigVersion = appliedVersion.Value;
 
                     /* #2170: the reload swapped the knob into the live config; move the gate to match. Safe
                        here by construction — top of the sweep, and narrowing never preempts a running body.
@@ -2601,9 +2610,10 @@ public sealed class DarlingWorker : BackgroundService
     /// schedule overrides, and reloads the mute-rule cache (F16). Store-unreachable is a no-op — the current
     /// live config stands, never worse than before.
     ///
-    /// <para><b>Returns whether the reload APPLIED</b>, so the caller can hold the <c>config_version</c>
-    /// watermark back on a failure instead of recording an unapplied version as done. The line between the
-    /// two is <c>LoadViewAsync</c>, and it is the right line because that call is the atomic gate: it reads
+    /// <para><b>Returns the <c>config_version</c> that was APPLIED</b>, or null when nothing was, so the
+    /// caller can both hold the watermark back on a failure and stamp the version the store actually
+    /// served rather than the one its own earlier beacon read saw. The line between applied and not is
+    /// <c>LoadViewAsync</c>, and it is the right line because that call is the atomic gate: it reads
     /// all five <c>config</c> rows under one try/catch and returns null if any of them throws, so either
     /// nothing was read or <c>ApplyToConfig</c> below has already swapped the whole view into the live
     /// config — a swap that cannot un-happen and that makes the version genuinely applied.</para>
@@ -2617,14 +2627,14 @@ public sealed class DarlingWorker : BackgroundService
     /// which is narrower than the version-discarding one this replaces rather than a new instance of
     /// it.</para>
     /// </summary>
-    private async Task<bool> ReloadFromStoreAsync(
+    private async Task<long?> ReloadFromStoreAsync(
         StoreConfigProvider provider, DarlingConfig config, List<ServerLoopState> servers,
         MuteRuleService muteRuleService, CancellationToken cancellationToken)
     {
         var view = await provider.LoadViewAsync(config, cancellationToken);
         if (view is null)
         {
-            return false;
+            return null;
         }
 
         StoreConfigProvider.ApplyToConfig(config, view);
@@ -2680,12 +2690,14 @@ public sealed class DarlingWorker : BackgroundService
         await muteRuleService.LoadAsync();
 
         /* view.ConfigVersion rather than _lastConfigVersion: the caller has not advanced the watermark yet
-           (that is now this method's return value), so the field still holds the PREVIOUS version here. */
+           (it advances from this method's RETURN value), so the field still holds the PREVIOUS version
+           here — and the returned version is this same one, so the log line and the watermark can never
+           disagree about what was applied. */
         _logger.LogInformation(
             "Control-plane reload applied (config_version {Version}, {Servers} monitored server(s), paused: {Paused})",
             view.ConfigVersion, servers.Count, _paused);
 
-        return true;
+        return view.ConfigVersion;
     }
 
     /// <summary>


### PR DESCRIPTION
Part of #2874. Acts on the review nit posted inline on #2946's own hunk, which was correct.

## The nit

#2946 fixed the ordering — the `config_version` watermark now advances only after the reload applies — but stamped it from `configVersion.Value`, the **beacon's own earlier read**. `ReloadFromStoreAsync` re-reads `config_version` inside `LoadViewAsync` → `ReadServiceRowAsync`, so a config write landing in the window between the two makes the applied view **newer** than the beacon saw, and the older stamp leaves the watermark behind a config that is already live.

Self-healing rather than lossy — the next 15 s tick re-detects a "change" and redundantly re-applies an already-current, idempotent view — so it is not a regression of the defect #2946 closed. But it is the same class of imprecision (*the version recorded as applied must be the version that was applied*), and the **startup path three hundred lines away already did it right**: `_lastConfigVersion = initialView.ConfigVersion;`.

## The change

`ReloadFromStoreAsync` returns the applied `config_version` (`long?`, null when nothing applied) instead of a `bool`, and the beacon stamps that. The watermark, the "Control-plane reload applied (config_version …)" log line and the applied config now all come from one value and cannot disagree.

## The pin had frozen the imprecise form

Worth stating plainly: `TheConfigVersionWatermark_AdvancesOnlyInsideTheReloadSuccessBranch` asserted `_lastConfigVersion = configVersion.Value;` appears exactly once — so it *pinned the nit* and would have resisted this correction. It now asserts the applied-version stamp, carries a **positive-controlled negative** against the outer read (the assertion that would have failed on #2946's version), and additionally requires `return view.ConfigVersion;` on the success path, since a method returning any other `long` satisfied every other assertion.

## Red-first

Four mutations, all RED on the intended assertion, each verified applied by byte delta and a unique-anchor check asserted before the result was read, each compiled, each restored from a byte copy, `pre-mutation dirty files: 0` per run:

| mutation | fails on |
|---|---|
| stamp from `configVersion.Value` again (the reviewed nit) | the applied-version `Contains` |
| return `0L` instead of `null` when nothing applied | the null-branch assertion |
| return something other than the applied version | `return view.ConfigVersion;` |
| advance the watermark outside the success branch | the guard shape |

119 tests, 0 failed. No `CHANGELOG.md` entry, per the standing rule that lanes do not write that file; the entry text is with the coordinator.

## Not verified

Source-parsed wiring pin, as with #2946: `ReloadFromStoreAsync` is private to a `BackgroundService` that needs a configured host, a store and a fleet to run. No production measurement — this is a correctness fix with no timing component. Windows suites ran only in a `net10.0` xunit shim over the real source files; CI is the arbiter.
