### PR TITLE
Actually judge the alert-pass deadline on stripped source (repairs #2958)

### DIFF
--- a/Darling/Darling.Tests/AlertPassCommandTimeoutTests.cs
+++ b/Darling/Darling.Tests/AlertPassCommandTimeoutTests.cs
@@ -469,17 +469,33 @@ public sealed class AlertPassCommandTimeoutTests
     {
         var total = 0;
 
-        foreach (Match ctor in s_commandCtor.Matches(CSharpSourceWalker.StripCommentsAndStrings(text)))
+        /* ONE stripped copy, used for the construction match AND for the deadline test.
+
+           The value regex used to run over a span cut from the RAW text while the construction regex ran
+           over stripped output - half stripped, half not, in one method - so a comment was excluded from
+           inventing a SITE but not from satisfying a DEADLINE. a comment reading "no deadline here; CommandTimeout = 10 is set
+           by the caller" made an untimed command read clean, which is the false-negative
+           direction: it reports success on the defect. Found by #2874's group D in its own pin and
+           confirmed here; it masks nothing on the current tree (46 alert-pass sites, 0 affected, measured)
+           and is fixed because the next one would be invisible.
+
+           Stripping literal TEXT as well as comments is safe for THIS regex and only for this one: the
+           deadline is always code (`CommandTimeout = <expr>`), never a value inside a string. A pin whose
+           value regex must see literal contents would be broken by this line, so it is not a change to
+           make family-wide by reflex. Line numbers survive because the strip preserves newlines. */
+        var code = CSharpSourceWalker.StripCommentsAndStrings(text);
+
+        foreach (Match ctor in s_commandCtor.Matches(code))
         {
             total++;
 
-            var span = CSharpSourceWalker.StatementSpanFrom(text, ctor.Index, statements: 2);
+            var span = CSharpSourceWalker.StatementSpanFrom(code, ctor.Index, statements: 2);
 
             if (!s_setsTimeout.IsMatch(span))
             {
                 /* Reported as the line in the FILE, not an offset into the scanned region, so a member
                    scope's offender is as navigable as a whole-file scope's. */
-                offenders.Add($"{label}:{firstLine + LineOf(text, ctor.Index) - 1}");
+                offenders.Add($"{label}:{firstLine + LineOf(code, ctor.Index) - 1}");
             }
         }
 


### PR DESCRIPTION
**#2958 shipped only its fixture. This is the change that was supposed to land.**

## What went wrong

I applied the fix to `ScanForUntimedCommands`, built it, then red-proofed it with mutations. The mutation sequence ended in `git checkout -- .` to restore — and the fix **was not committed**, so that discarded it. I then added the fixture and committed, capturing only the fixture.

The diffstat was the tell: **13 insertions, 2 deletions** for a change that was supposed to include a 15-line explanatory comment plus three code edits. I read the number and didn't react to it.

This is the trap recorded in my own notes for this repo — commit before mutation testing, and verify content rather than diffstat. I had the pin and walked into it anyway.

## The state it left on `dev`

Worse than before the PR, in one specific way: `dev` now carries a fixture asserting that a comment naming a deadline is not a deadline, and a comment claiming the value regex "moved onto the stripped span" — while `ScanForUntimedCommands` still judges the value regex against a span cut from the **raw** text. So the theory passes, CI is green, and the shipped scan still accepts a comment. A misleading green rather than a silent gap.

## The fix

One stripped copy, used for both the construction match and the deadline test:

```
var code = CSharpSourceWalker.StripCommentsAndStrings(text);
foreach (Match ctor in s_commandCtor.Matches(code))
    var span = CSharpSourceWalker.StatementSpanFrom(code, ctor.Index, statements: 2);
```

Previously the construction regex ran over stripped output while the value regex ran over raw text — half stripped, half not, in one method — so a comment was excluded from inventing a *site* but not from satisfying a *deadline*.

## Proven, and this time the artifact was verified after the proof

Committed **before** mutating, so the restore could not eat it. Each mutation's anchor count asserted first:

| | result |
|---|---|
| site untimed + a comment naming a deadline, **with the fix** | offender named — `DarlingWorker.cs ReadLatestCpuAsync:4067` |
| same mutation, value regex back on the **raw** span | **8/8 green — masked entirely** |
| after `git checkout -- .` | fix still present (2 `StatementSpanFrom(code, …)` sites: fixture + scanner) |

That third row is the check I skipped last time and is why this PR exists.

## Severity, unchanged from #2958's claim

Measured across all **46** alert-pass sites: **0 masked** today. The census holds; this is fixed because the next one would be invisible.

## Scope caution, recorded at the line

Stripping literal **text** as well as comments is safe for *this* regex only — the deadline is always code, never a value inside a string. A pin whose value regex must see literal contents would break under it.

Test-only. No production change, no schema change, no version bump. **No CHANGELOG entry** — reported to the coordinator's inbox.
