### PR TITLE
Part of #2874

### DIFF
--- a/Darling/Darling.Tests/ControlPlaneReloadDurabilityTests.cs
+++ b/Darling/Darling.Tests/ControlPlaneReloadDurabilityTests.cs
@@ -214,10 +214,18 @@ public sealed class ControlPlaneReloadDurabilityTests
     /// rather than exercised. It is a WIRING invariant, and wiring is invisible to a logic test.
     ///
     /// <para>Asserted structurally, not by string equality: the assignment to <c>_lastConfigVersion</c>
-    /// must sit INSIDE the braces of the <c>if (await ReloadFromStoreAsync(...))</c> that guards it. A
-    /// scan for "does the assignment appear after the call" would pass on the defect the moment someone
-    /// moved the call one line up, which is exactly the count-invariant relocation this sweep keeps
-    /// finding.</para>
+    /// must sit INSIDE the braces of the <c>if (appliedVersion.HasValue)</c> that guards it, and the
+    /// <c>appliedVersion</c> it reads must come from the <c>ReloadFromStoreAsync</c> call immediately
+    /// above. A scan for "does the assignment appear after the call" would pass on the defect the moment
+    /// someone moved the call one line up, which is exactly the count-invariant relocation this sweep
+    /// keeps finding.</para>
+    ///
+    /// <para>It also pins WHICH version is stamped, not merely that one is. The version of this fix that
+    /// #2946 shipped stamped <c>configVersion.Value</c> — the beacon's own earlier read — while
+    /// <c>ReloadFromStoreAsync</c> re-reads <c>config_version</c> inside <c>LoadViewAsync</c>, so a write
+    /// landing between the two left the watermark behind a config that was already live. This test froze
+    /// that imprecision until review caught it, which is why the negative against the outer read is here
+    /// and is positive-controlled.</para>
     /// </summary>
     [Fact]
     public void TheConfigVersionWatermark_AdvancesOnlyInsideTheReloadSuccessBranch()


### PR DESCRIPTION
Part of #2874. The one inline review nit on #2959, which merged before the fix landed.

`TheConfigVersionWatermark_AdvancesOnlyInsideTheReloadSuccessBranch`'s doc comment still described the pre-#2959 call shape — *"must sit INSIDE the braces of the `if (await ReloadFromStoreAsync(...))` that guards it"* — while the call site is now `var appliedVersion = await ReloadFromStoreAsync(...); if (appliedVersion.HasValue) { … }`. The regex the test actually runs was already correct; only the prose above it was stale, which is the kind of comment that misleads the next reader trying to work out what the test pins.

Updated to the current shape, and the second paragraph records **why the negative against the outer read exists**: the version #2946 shipped stamped `configVersion.Value`, this test froze that imprecision, and review is what caught it. Stating that in the pin is what stops the negative from looking like belt-and-braces and being dropped.

Comment-only change to a test file. 120 tests, 0 failed. No `CHANGELOG.md` entry, per the standing rule that lanes do not write that file.
