### PR TITLE
Order the latest-CPU reads on the hypertable's partition column instead of sample_time

### DIFF
--- a/Darling/Darling.Tests/DarlingFleetReaderTests.cs
+++ b/Darling/Darling.Tests/DarlingFleetReaderTests.cs
@@ -86,7 +86,9 @@ public sealed class DarlingFleetReaderSqlTests
     public void LatestSnapshotReads_AreDistinctOnPerServer()
     {
         Assert.Contains("DISTINCT ON (server_id)", DarlingFleetReader.FleetCpuSql, StringComparison.Ordinal);
-        Assert.Contains("ORDER BY server_id, sample_time DESC", DarlingFleetReader.FleetCpuSql, StringComparison.Ordinal);
+        /* collection_time leads, matching FleetMemorySql; sample_time is the within-batch tiebreak. For the
+           frame, not the cost - LatestCpuReadShapeSqlTests and the constant's own doc carry both halves. */
+        Assert.Contains("ORDER BY server_id, collection_time DESC, sample_time DESC", DarlingFleetReader.FleetCpuSql, StringComparison.Ordinal);
         Assert.Contains("DISTINCT ON (server_id)", DarlingFleetReader.FleetMemorySql, StringComparison.Ordinal);
         Assert.Contains("DISTINCT ON (server_id)", DarlingFleetReader.FleetThreadsSql, StringComparison.Ordinal);
     }

--- a/Darling/Darling.Tests/DarlingMcpHealthToolsTests.cs
+++ b/Darling/Darling.Tests/DarlingMcpHealthToolsTests.cs
@@ -99,7 +99,9 @@ public sealed class DarlingMcpHealthToolsSurfaceAndSqlTests
     public void ServerSummarySql_LatestCpuMemory_HourWindowBlockingDeadlock()
     {
         Assert.Contains("FROM v_cpu_utilization_stats", Reader.ServerSummaryCpuSql, StringComparison.Ordinal);
-        Assert.Contains("ORDER BY sample_time DESC", Reader.ServerSummaryCpuSql, StringComparison.Ordinal);
+        /* Partition column first, sample_time as the tiebreak — LatestCpuReadShapeSqlTests carries the
+           reasoning and the tree-wide guard. */
+        Assert.Contains("ORDER BY collection_time DESC, sample_time DESC", Reader.ServerSummaryCpuSql, StringComparison.Ordinal);
         Assert.Contains("LIMIT 1", Reader.ServerSummaryCpuSql, StringComparison.Ordinal);
 
         Assert.Contains("total_server_memory_mb", Reader.ServerSummaryMemorySql, StringComparison.Ordinal);

--- a/Darling/Darling.Tests/LatestCpuReadShapeTests.cs
+++ b/Darling/Darling.Tests/LatestCpuReadShapeTests.cs
@@ -280,6 +280,7 @@ LIMIT 1";
         await connection.OpenAsync(cancellationToken);
         await PgMigrations.MigrateAsync(connection, cancellationToken);
 
+        var bodySucceeded = false;
         try
         {
             await DeleteSentinelsAsync(connection, cancellationToken);
@@ -317,10 +318,15 @@ LIMIT 1";
                    with a broken oracle would still fail here. */
                 Assert.Equal((10, 20), shipped);
             }
+
+            bodySucceeded = true;
         }
         finally
         {
-            await DeleteSentinelsAsync(connection, CancellationToken.None);
+            /* #1794/#1902: teardown gets its own freshly-opened connection, because the body's is the one
+               thing the failure being reported may have destroyed — and a throw from finally would
+               replace the body's exception with connection noise. */
+            await LiveStoreCleanup.RunAsync(connectionString!, bodySucceeded, DeleteSentinelsAsync);
         }
     }
 
@@ -336,6 +342,7 @@ LIMIT 1";
         await connection.OpenAsync(cancellationToken);
         await PgMigrations.MigrateAsync(connection, cancellationToken);
 
+        var bodySucceeded = false;
         try
         {
             await DeleteSentinelsAsync(connection, cancellationToken);
@@ -355,10 +362,15 @@ LIMIT 1";
                proving the predicate is well-formed and the empty result above is not a typo. */
             Assert.Null(await ReadAsync(connection, TrapSql, FirstServerId, cancellationToken));
             Assert.Equal((55, 66), await ReadAsync(connection, TrapSql, FirstServerId - 1, cancellationToken));
+
+            bodySucceeded = true;
         }
         finally
         {
-            await DeleteSentinelsAsync(connection, CancellationToken.None);
+            /* #1794/#1902: teardown gets its own freshly-opened connection, because the body's is the one
+               thing the failure being reported may have destroyed — and a throw from finally would
+               replace the body's exception with connection noise. */
+            await LiveStoreCleanup.RunAsync(connectionString!, bodySucceeded, DeleteSentinelsAsync);
         }
     }
 
@@ -374,6 +386,7 @@ LIMIT 1";
         await connection.OpenAsync(cancellationToken);
         await PgMigrations.MigrateAsync(connection, cancellationToken);
 
+        var bodySucceeded = false;
         try
         {
             await DeleteSentinelsAsync(connection, cancellationToken);
@@ -397,10 +410,15 @@ LIMIT 1";
             /* The newest sample in the batch is minutesAgo == 0; an unsorted tied group returns one of the
                others, up to 29 minutes stale. */
             Assert.Equal((0, 0), await ReadAsync(connection, DarlingWorker.LatestCpuSql, FirstServerId, cancellationToken));
+
+            bodySucceeded = true;
         }
         finally
         {
-            await DeleteSentinelsAsync(connection, CancellationToken.None);
+            /* #1794/#1902: teardown gets its own freshly-opened connection, because the body's is the one
+               thing the failure being reported may have destroyed — and a throw from finally would
+               replace the body's exception with connection noise. */
+            await LiveStoreCleanup.RunAsync(connectionString!, bodySucceeded, DeleteSentinelsAsync);
         }
     }
 

--- a/Darling/Darling.Tests/LatestCpuReadShapeTests.cs
+++ b/Darling/Darling.Tests/LatestCpuReadShapeTests.cs
@@ -1,0 +1,463 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+using PerformanceMonitor.Darling.Service;
+using PerformanceMonitor.Darling.Storage;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Darling reads the newest CPU sample for one server in three places, and both halves of the shape they
+/// share are load-bearing, so both are pinned — across the whole tree rather than per constant, because the
+/// defect this guards was three copies of one query and nothing stopping a fourth.
+///
+/// <para><b>Order on the partition column.</b> <c>cpu_utilization_stats</c> is a hypertable partitioned on
+/// <c>collection_time</c>: <c>TimescaleSupport.CreateHypertableSql</c> takes the definition's
+/// <c>PrefixTimeColumnName</c> and <c>CpuUtilizationCollector</c> keeps the <c>collection_time</c> default, so
+/// <c>sample_time</c> is an ordinary payload column with neither an index nor partition affinity. Ordering on
+/// the dimension earns TimescaleDB's ORDERED ChunkAppend, which walks chunks newest-first and stops at the
+/// first that yields a row; ordering on <c>sample_time</c> appends every chunk and top-N sorts the server's
+/// whole retained history to return one row. Measured against a seeded thirty-chunk store: 47,752 rows and
+/// 839 buffers per call versus 6 buffers, and the alert sweep makes this call once per server per tick.</para>
+///
+/// <para><b>Carry no store-clock predicate.</b> <c>sample_time</c> is the monitored server's LOCAL wall clock
+/// on the ring-buffer arm (#1262, pinned by <see cref="CollectorTimestampFrameTests"/>) and naive UTC on the
+/// Azure SQL DB arm, so the obvious-looking <c>sample_time &gt; now() - INTERVAL '1 hour'</c> compares two
+/// clock frames. It returns ZERO rows for every server behind the store's clock, and zero rows here reads as
+/// "this server has no CPU data" rather than as a failure — no exception, no log line, CPU alerting silently
+/// off. <see cref="LatestCpuReadShapeLivePostgresTests"/> demonstrates that against seeded data instead of
+/// arguing it from the shape.</para>
+/// </summary>
+public sealed class LatestCpuReadShapeSqlTests
+{
+    /// <summary>The required ordering: the partition column first, <c>sample_time</c> only as the
+    /// within-batch tiebreak.</summary>
+    private const string RequiredOrdering = "ORDER BY collection_time DESC, sample_time DESC";
+
+    /// <summary>
+    /// The number of latest-CPU reads in <c>Darling/</c> — the alert sweep's, the viewer's server-summary
+    /// card, and the MCP health reader's. A hard floor rather than an exact count so adding a fourth read is
+    /// allowed; what is not allowed is the scan silently finding NOTHING and passing vacuously, which is the
+    /// only way this whole class could stop guarding without going red.
+    /// </summary>
+    private const int KnownLatestCpuReadCount = 3;
+
+    [Fact]
+    public void EveryLatestCpuRead_OrdersOnThePartitionColumnWithASampleTimeTiebreak()
+    {
+        var reads = LatestCpuReads();
+
+        Assert.True(
+            reads.Count >= KnownLatestCpuReadCount,
+            $"Found {reads.Count} latest-CPU read(s) under Darling/, expected at least "
+            + $"{KnownLatestCpuReadCount}. The scan below is the enforcement, so finding nothing is a broken "
+            + "scan rather than a clean tree — fix the extraction, do not lower the floor.");
+
+        foreach (var (where, sql) in reads)
+        {
+            Assert.Contains(RequiredOrdering, sql, StringComparison.Ordinal);
+
+            /* sample_time must not be the LEADING sort key by any route: that is the shape being replaced,
+               and it costs the server's whole retained history plus a sort to return one row. */
+            Assert.False(
+                Regex.IsMatch(sql, @"ORDER\s+BY\s+sample_time"),
+                $"{where}: orders on sample_time, which has no index and is not the partition column. "
+                + $"Use \"{RequiredOrdering}\" — see DarlingWorker.LatestCpuSql.");
+        }
+    }
+
+    [Fact]
+    public void EveryLatestCpuRead_ComparesNoColumnToAStoreClock()
+    {
+        var reads = LatestCpuReads();
+
+        Assert.True(reads.Count >= KnownLatestCpuReadCount, "broken scan — see the ordering test's message.");
+
+        foreach (var (where, sql) in reads)
+        {
+            /* now() / CURRENT_TIMESTAMP / LOCALTIMESTAMP are all the STORE's clock, and none of them shares a
+               frame with sample_time. A bound on collection_time WOULD be frame-correct, but it buys nothing
+               once the ordering prunes to one chunk, and it drops a server that has stopped reporting out of
+               alerting altogether — so these reads carry no time predicate at all and the guard is absolute
+               rather than per-column. */
+            foreach (var clock in new[] { "now(", "CURRENT_TIMESTAMP", "LOCALTIMESTAMP" })
+            {
+                Assert.False(
+                    sql.Contains(clock, StringComparison.OrdinalIgnoreCase),
+                    $"{where}: compares a column to the store clock ({clock}). sample_time is the monitored "
+                    + "server's local wall clock, so that returns zero rows — read as \"no CPU data\", not as "
+                    + "an error — for every server behind the store. See DarlingWorker.LatestCpuSql.");
+            }
+        }
+    }
+
+    [Fact]
+    public void LatestCpuSql_ReadsTheRawTableForOneServerAndReturnsOneRow()
+    {
+        Assert.Contains("FROM cpu_utilization_stats", DarlingWorker.LatestCpuSql, StringComparison.Ordinal);
+        Assert.Contains("WHERE server_id = $1", DarlingWorker.LatestCpuSql, StringComparison.Ordinal);
+        Assert.Contains("LIMIT 1", DarlingWorker.LatestCpuSql, StringComparison.Ordinal);
+        Assert.Contains(RequiredOrdering, DarlingWorker.LatestCpuSql, StringComparison.Ordinal);
+        Assert.Contains(
+            "SELECT sqlserver_cpu_utilization, other_process_cpu_utilization",
+            DarlingWorker.LatestCpuSql,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The scan's own positive control. The extraction below is the enforcement mechanism, so a change that
+    /// quietly stops it matching would disarm both tests above while leaving them green; this pins that it
+    /// finds the shape it is looking for and rejects the two it must not confuse with it.
+    /// </summary>
+    [Theory]
+    /* A latest-row read: table, LIMIT 1, and the ordering under test. */
+    [InlineData(true, "const string S = @\"\nSELECT a FROM cpu_utilization_stats\nWHERE server_id = $1\nORDER BY collection_time DESC, sample_time DESC\nLIMIT 1\";")]
+    /* The v_ passthrough view counts too — the viewer and MCP reads go through it. */
+    [InlineData(true, "const string S = @\"\nSELECT a FROM v_cpu_utilization_stats\nWHERE server_id = $1\nORDER BY collection_time DESC, sample_time DESC\nLIMIT 1\";")]
+    /* A WINDOWED read is a different query under different rules — it legitimately bounds collection_time,
+       and bounding is the correct answer there — so the second parameter must keep it out rather than
+       dragging it under the no-predicate rule. */
+    [InlineData(false, "const string S = @\"\nSELECT a FROM cpu_utilization_stats\nWHERE server_id = $1\nAND collection_time >= $2\nORDER BY collection_time\";")]
+    /* The shape that made this discriminator necessary: PgAnomalyDetector.CpuWindowSql picks the PEAK
+       sample inside a bounded window, so it is a windowed read that happens to LIMIT 1 and orders on the
+       CPU value rather than on time. A LIMIT-1-only rule pulled it in and demanded a fix it does not
+       need. */
+    [InlineData(false, "const string S = @\"\nSELECT (SELECT collection_time FROM v_cpu_utilization_stats\nWHERE server_id = $1 AND collection_time >= $2 AND collection_time < $3\nORDER BY sqlserver_cpu_utilization DESC LIMIT 1) AS peak_time\nFROM v_cpu_utilization_stats\nWHERE server_id = $1\";")]
+    /* A different table entirely. */
+    [InlineData(false, "const string S = @\"\nSELECT a FROM memory_stats\nWHERE server_id = $1\nORDER BY collection_time DESC\nLIMIT 1\";")]
+    public void TheScanFindsLatestRowCpuReadsAndNothingElse(bool expected, string source)
+    {
+        Assert.Equal(expected, ExtractLatestCpuReads(source, "synthetic").Count == 1);
+    }
+
+    /// <summary>
+    /// Every latest-CPU read under <c>Darling/</c>, as (location, SQL) pairs. Reads the SOURCE TREE rather
+    /// than the constants so it reaches the WPF viewer without this net10.0-windows test assembly having to
+    /// resolve a WPF project reference, and so a fourth copy anywhere under Darling/ is covered the moment it
+    /// is written. This test project is skipped: it holds the replaced shape and the trap predicate on purpose,
+    /// as the oracle and the positive control the live tests compare against.
+    /// </summary>
+    private static List<(string Where, string Sql)> LatestCpuReads()
+    {
+        var darling = Path.Combine(RepoRoot(), "Darling");
+        var found = new List<(string, string)>();
+
+        foreach (var file in Directory.EnumerateFiles(darling, "*.cs", SearchOption.AllDirectories))
+        {
+            var segments = file.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            if (segments.Contains("bin") || segments.Contains("obj") || segments.Contains("Darling.Tests"))
+            {
+                continue;
+            }
+
+            found.AddRange(ExtractLatestCpuReads(File.ReadAllText(file), Path.GetFileName(file)));
+        }
+
+        return found;
+    }
+
+    /// <summary>
+    /// One file's latest-row CPU reads. Comment spans go first (this codebase's SQL carries its reasoning in
+    /// <c>/* ... */</c> blocks that quote the very predicates matched here), then each mention of the table is
+    /// taken out to the end of its verbatim literal and kept only if that span is a LATEST-row read:
+    /// <c>LIMIT 1</c> and <c>$1</c> as its only parameter.
+    ///
+    /// <para>The single-parameter test is what separates this class from a WINDOWED read. A windowed read
+    /// takes its bounds as <c>$2</c>/<c>$3</c> and bounding <c>collection_time</c> is the right answer there;
+    /// <c>PgAnomalyDetector.CpuWindowSql</c> is one, and a <c>LIMIT 1</c>-only rule swept it in and demanded a
+    /// change it does not need. Both directions are pinned by
+    /// <see cref="TheScanFindsLatestRowCpuReadsAndNothingElse"/>.</para>
+    /// </summary>
+    private static List<(string Where, string Sql)> ExtractLatestCpuReads(string text, string where)
+    {
+        var code = Regex.Replace(text, @"/\*.*?\*/", " ", RegexOptions.Singleline);
+        code = Regex.Replace(code, @"//[^\r\n]*", " ");
+
+        var reads = new List<(string, string)>();
+        foreach (Match match in Regex.Matches(code, @"FROM\s+v?_?cpu_utilization_stats\b"))
+        {
+            /* The end of the enclosing verbatim literal. A read that somehow lacks one is not a SQL literal
+               and is left alone rather than guessed at. */
+            var close = code.IndexOf("\";", match.Index, StringComparison.Ordinal);
+            if (close < 0)
+            {
+                continue;
+            }
+
+            var span = code[match.Index..close];
+            if (span.Contains("LIMIT 1", StringComparison.Ordinal)
+                && !span.Contains("$2", StringComparison.Ordinal))
+            {
+                reads.Add((where, span));
+            }
+        }
+
+        return reads;
+    }
+
+    private static string RepoRoot([CallerFilePath] string thisFile = "")
+    {
+        var dir = Path.GetDirectoryName(thisFile)!;
+        while (dir is not null
+               && !File.Exists(Path.Combine(dir, "PerformanceMonitor.sln"))
+               && !Directory.Exists(Path.Combine(dir, ".git")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        Assert.NotNull(dir);
+        return dir!;
+    }
+}
+
+/// <summary>
+/// Gated (DARLING_TEST_PG) live round-trips for the latest-CPU read against the real hypertable. Serialized
+/// through the "live-postgres" collection; uses negative sentinel server_ids and cleans up in finally, the
+/// same contract as the sibling live suites.
+///
+/// <para>What a shape pin cannot show is that the shipped ordering returns the SAME ROW the unbounded
+/// <c>sample_time</c> order returned, for servers whose local clock sits at different offsets from the
+/// store's. These seed exactly that: two servers behind UTC, two ahead (one on a half-hour offset), and one
+/// in the store's own frame — that last being the single case a broken frame comparison still passes, so it
+/// is here as the control rather than as the whole test.</para>
+/// </summary>
+[Collection("live-postgres")]
+public sealed class LatestCpuReadShapeLivePostgresTests
+{
+    /// <summary>Sentinel ids, negative so they cannot collide with a real registry entry.</summary>
+    private const int FirstServerId = -9151;
+
+    /// <summary>Offsets from UTC for the seeded servers, in minutes: behind, behind, at, ahead on a half
+    /// hour, ahead.</summary>
+    private static readonly int[] s_offsetMinutes = { -420, -240, 0, 330, 600 };
+
+    /// <summary>The unbounded <c>sample_time</c> order, kept as the oracle the shipped read must match
+    /// row-for-row. Slow by construction — it appends every chunk and sorts — which is why it is the oracle
+    /// and not the read.</summary>
+    private const string OracleSql = @"
+SELECT sqlserver_cpu_utilization, other_process_cpu_utilization
+FROM cpu_utilization_stats
+WHERE server_id = $1
+ORDER BY sample_time DESC
+LIMIT 1";
+
+    /// <summary>The predicate that looks like the fix and is not. Anchored on <c>now() AT TIME ZONE 'UTC'</c>
+    /// so the assertion does not itself depend on the store session's TimeZone, and still empty for a server
+    /// behind the store.</summary>
+    private const string TrapSql = @"
+SELECT sqlserver_cpu_utilization, other_process_cpu_utilization
+FROM cpu_utilization_stats
+WHERE server_id = $1
+AND   sample_time > (now() AT TIME ZONE 'UTC') - INTERVAL '1 hour'
+ORDER BY sample_time DESC
+LIMIT 1";
+
+    [Fact]
+    public async Task LatestCpuRead_ReturnsTheOracleRow_AtEveryUtcOffset_AgainstDevPostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the live latest-CPU read test.");
+
+        var cancellationToken = TestContext.Current.CancellationToken;
+        using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+        await PgMigrations.MigrateAsync(connection, cancellationToken);
+
+        try
+        {
+            await DeleteSentinelsAsync(connection, cancellationToken);
+
+            /* Three polls per server one minute apart, each carrying one new ring-buffer sample: the steady
+               state at the collector's one-minute frequency. The CPU values carry the poll ordinal so the row
+               that comes back is identifiable rather than merely equal to the oracle's. */
+            var newestUtc = TruncateToSeconds(DateTime.UtcNow);
+            for (var i = 0; i < s_offsetMinutes.Length; i++)
+            {
+                for (var poll = 0; poll < 3; poll++)
+                {
+                    var collectionTime = newestUtc.AddMinutes(-poll);
+                    await InsertSampleAsync(
+                        connection,
+                        FirstServerId - i,
+                        collectionTime,
+                        collectionTime.AddMinutes(s_offsetMinutes[i]),
+                        sqlCpu: 10 - poll,
+                        otherCpu: 20 - poll,
+                        cancellationToken);
+                }
+            }
+
+            for (var i = 0; i < s_offsetMinutes.Length; i++)
+            {
+                var serverId = FirstServerId - i;
+                var shipped = await ReadAsync(connection, DarlingWorker.LatestCpuSql, serverId, cancellationToken);
+                var oracle = await ReadAsync(connection, OracleSql, serverId, cancellationToken);
+
+                Assert.NotNull(shipped);
+                Assert.Equal(oracle, shipped);
+
+                /* Not merely agreement with the oracle — the newest poll's own values, so a shape that agreed
+                   with a broken oracle would still fail here. */
+                Assert.Equal((10, 20), shipped);
+            }
+        }
+        finally
+        {
+            await DeleteSentinelsAsync(connection, CancellationToken.None);
+        }
+    }
+
+    [Fact]
+    public async Task TheSampleTimePredicate_LosesEveryServerBehindTheStoresClock_AgainstDevPostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the live latest-CPU trap test.");
+
+        var cancellationToken = TestContext.Current.CancellationToken;
+        using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+        await PgMigrations.MigrateAsync(connection, cancellationToken);
+
+        try
+        {
+            await DeleteSentinelsAsync(connection, cancellationToken);
+
+            var newestUtc = TruncateToSeconds(DateTime.UtcNow);
+
+            /* One server behind the store by more than the window, one in the store's own frame. */
+            await InsertSampleAsync(connection, FirstServerId, newestUtc, newestUtc.AddHours(-6), 33, 44, cancellationToken);
+            await InsertSampleAsync(connection, FirstServerId - 1, newestUtc, newestUtc, 55, 66, cancellationToken);
+
+            /* The shipped read is indifferent to the offset: both servers report. */
+            Assert.Equal((33, 44), await ReadAsync(connection, DarlingWorker.LatestCpuSql, FirstServerId, cancellationToken));
+            Assert.Equal((55, 66), await ReadAsync(connection, DarlingWorker.LatestCpuSql, FirstServerId - 1, cancellationToken));
+
+            /* The predicate loses the server behind the store entirely, and not as an error — as an empty
+               result the alert engine reads as "no CPU data". The same-frame server is the positive control
+               proving the predicate is well-formed and the empty result above is not a typo. */
+            Assert.Null(await ReadAsync(connection, TrapSql, FirstServerId, cancellationToken));
+            Assert.Equal((55, 66), await ReadAsync(connection, TrapSql, FirstServerId - 1, cancellationToken));
+        }
+        finally
+        {
+            await DeleteSentinelsAsync(connection, CancellationToken.None);
+        }
+    }
+
+    [Fact]
+    public async Task LatestCpuRead_PicksTheNewestSampleInsideOneBatch_AgainstDevPostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the live latest-CPU tiebreak test.");
+
+        var cancellationToken = TestContext.Current.CancellationToken;
+        using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+        await PgMigrations.MigrateAsync(connection, cancellationToken);
+
+        try
+        {
+            await DeleteSentinelsAsync(connection, cancellationToken);
+
+            /* One poll catching up on a ring-buffer backlog: thirty samples under ONE collection_time. They
+               go in NEWEST-sample-first, so heap order runs opposite to sample order and a scan of the tied
+               group hands back the OLDEST sample unless the tiebreak sorts it. */
+            var collectionTime = TruncateToSeconds(DateTime.UtcNow);
+            for (var minutesAgo = 0; minutesAgo < 30; minutesAgo++)
+            {
+                await InsertSampleAsync(
+                    connection,
+                    FirstServerId,
+                    collectionTime,
+                    collectionTime.AddHours(-4).AddMinutes(-minutesAgo),
+                    sqlCpu: minutesAgo,
+                    otherCpu: minutesAgo,
+                    cancellationToken);
+            }
+
+            /* The newest sample in the batch is minutesAgo == 0; an unsorted tied group returns one of the
+               others, up to 29 minutes stale. */
+            Assert.Equal((0, 0), await ReadAsync(connection, DarlingWorker.LatestCpuSql, FirstServerId, cancellationToken));
+        }
+        finally
+        {
+            await DeleteSentinelsAsync(connection, CancellationToken.None);
+        }
+    }
+
+    private static async Task<(int SqlCpu, int OtherCpu)?> ReadAsync(
+        NpgsqlConnection connection, string sql, int serverId, CancellationToken cancellationToken)
+    {
+        using var command = new NpgsqlCommand(sql, connection) { CommandTimeout = LiveReadTimeoutSeconds };
+        command.Parameters.AddWithValue(serverId);
+
+        using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken))
+        {
+            return null;
+        }
+
+        return (reader.GetInt32(0), reader.GetInt32(1));
+    }
+
+    private static async Task InsertSampleAsync(
+        NpgsqlConnection connection,
+        int serverId,
+        DateTime collectionTimeUtc,
+        DateTime sampleTime,
+        int sqlCpu,
+        int otherCpu,
+        CancellationToken cancellationToken)
+    {
+        using var command = new NpgsqlCommand(@"
+INSERT INTO cpu_utilization_stats
+    (collection_id, collection_time, server_id, server_name,
+     sample_time, sqlserver_cpu_utilization, other_process_cpu_utilization)
+VALUES ($1, $2, $3, $4, $5, $6, $7)", connection) { CommandTimeout = LiveReadTimeoutSeconds };
+        command.Parameters.AddWithValue((long)Math.Abs(serverId));
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTimeUtc, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(serverId);
+        command.Parameters.AddWithValue(string.Create(CultureInfo.InvariantCulture, $"sentinel{serverId}"));
+        command.Parameters.AddWithValue(DateTime.SpecifyKind(sampleTime, DateTimeKind.Unspecified));
+        command.Parameters.AddWithValue(sqlCpu);
+        command.Parameters.AddWithValue(otherCpu);
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    private static async Task DeleteSentinelsAsync(NpgsqlConnection connection, CancellationToken cancellationToken)
+    {
+        var lowest = FirstServerId - s_offsetMinutes.Length;
+        using var cleanup = new NpgsqlCommand(
+            string.Create(
+                CultureInfo.InvariantCulture,
+                $"DELETE FROM cpu_utilization_stats WHERE server_id <= {FirstServerId} AND server_id >= {lowest};"),
+            connection) { CommandTimeout = LiveReadTimeoutSeconds };
+        await cleanup.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    /// <summary>Every command in this class is a sentinel-scoped seed, read or cleanup against a dev store —
+    /// seconds of work. Sixty is slack for a cold container, not a budget.</summary>
+    private const int LiveReadTimeoutSeconds = 60;
+
+    private static DateTime TruncateToSeconds(DateTime value) =>
+        DateTime.SpecifyKind(new DateTime(value.Ticks - (value.Ticks % TimeSpan.TicksPerSecond)), DateTimeKind.Unspecified);
+}

--- a/Darling/Darling.Tests/LatestCpuReadShapeTests.cs
+++ b/Darling/Darling.Tests/LatestCpuReadShapeTests.cs
@@ -46,17 +46,24 @@ namespace Darling.Tests;
 /// </summary>
 public sealed class LatestCpuReadShapeSqlTests
 {
-    /// <summary>The required ordering: the partition column first, <c>sample_time</c> only as the
-    /// within-batch tiebreak.</summary>
-    private const string RequiredOrdering = "ORDER BY collection_time DESC, sample_time DESC";
+    /// <summary>The required ordering, as the substring common to the per-server reads
+    /// (<c>ORDER BY collection_time DESC, ...</c>) and the fleet-wide one
+    /// (<c>ORDER BY server_id, collection_time DESC, ...</c>): the partition column ahead of
+    /// <c>sample_time</c>, which is only the within-batch tiebreak.</summary>
+    private const string RequiredOrdering = "collection_time DESC, sample_time DESC";
 
     /// <summary>
-    /// The number of latest-CPU reads in <c>Darling/</c> — the alert sweep's, the viewer's server-summary
-    /// card, and the MCP health reader's. A hard floor rather than an exact count so adding a fourth read is
-    /// allowed; what is not allowed is the scan silently finding NOTHING and passing vacuously, which is the
-    /// only way this whole class could stop guarding without going red.
+    /// The number of latest-CPU reads in <c>Darling/</c>: the alert sweep's, the viewer's server-summary
+    /// card, the MCP health reader's, and the MCP fleet reader's per-server-newest <c>DISTINCT ON</c>. A hard
+    /// floor rather than an exact count so adding a fifth read is allowed; what is not allowed is the scan
+    /// silently finding NOTHING and passing vacuously, which is the only way this whole class could stop
+    /// guarding without going red.
+    ///
+    /// <para>It was 3 while the extraction keyed on <c>LIMIT 1</c> alone, and the fleet read — the only one
+    /// of the four with no <c>server_id</c> filter, so the one where a mis-framed bound would take the whole
+    /// fleet — was the copy the guard could not see.</para>
     /// </summary>
-    private const int KnownLatestCpuReadCount = 3;
+    private const int KnownLatestCpuReadCount = 4;
 
     [Fact]
     public void EveryLatestCpuRead_OrdersOnThePartitionColumnWithASampleTimeTiebreak()
@@ -75,10 +82,14 @@ public sealed class LatestCpuReadShapeSqlTests
 
             /* sample_time must not be the LEADING sort key by any route: that is the shape being replaced,
                and it costs the server's whole retained history plus a sort to return one row. */
+            /* sample_time must not be the leading TIME key by any route - not on its own, and not behind
+               the fleet read's server_id. That is the shape being replaced, and it is also the shape that
+               invites a bound on a local-clock column. */
             Assert.False(
-                Regex.IsMatch(sql, @"ORDER\s+BY\s+sample_time"),
-                $"{where}: orders on sample_time, which has no index and is not the partition column. "
-                + $"Use \"{RequiredOrdering}\" — see DarlingWorker.LatestCpuSql.");
+                Regex.IsMatch(sql, @"ORDER\s+BY\s+(?:server_id\s*,\s*)?sample_time"),
+                $"{where}: leads its ordering on sample_time, which has no index, is not the partition "
+                + $"column, and is not in the store's clock frame. Put \"{RequiredOrdering}\" ahead of it "
+                + "— see DarlingWorker.LatestCpuSql.");
         }
     }
 
@@ -128,6 +139,12 @@ public sealed class LatestCpuReadShapeSqlTests
     [Theory]
     /* A latest-row read: table, LIMIT 1, and the ordering under test. */
     [InlineData(true, "const string S = @\"\nSELECT a FROM cpu_utilization_stats\nWHERE server_id = $1\nORDER BY collection_time DESC, sample_time DESC\nLIMIT 1\";")]
+    /* The fleet-wide shape: newest-per-server via DISTINCT ON, so no LIMIT 1 and no $1 at all. Keying on
+       LIMIT 1 alone left this one invisible, which is how a fourth copy already existed under a guard whose
+       own doc worried about a fourth copy being added. */
+    [InlineData(true, "const string S = @\"\nSELECT DISTINCT ON (server_id)\n    server_id, a\nFROM v_cpu_utilization_stats\nORDER BY server_id, collection_time DESC, sample_time DESC\";")]
+    /* DISTINCT ON something OTHER than server_id is not a per-server-newest read. */
+    [InlineData(false, "const string S = @\"\nSELECT DISTINCT ON (database_name)\n    database_name, a\nFROM v_cpu_utilization_stats\nORDER BY database_name, collection_time DESC\";")]
     /* The v_ passthrough view counts too — the viewer and MCP reads go through it. */
     [InlineData(true, "const string S = @\"\nSELECT a FROM v_cpu_utilization_stats\nWHERE server_id = $1\nORDER BY collection_time DESC, sample_time DESC\nLIMIT 1\";")]
     /* A WINDOWED read is a different query under different rules — it legitimately bounds collection_time,
@@ -175,8 +192,9 @@ public sealed class LatestCpuReadShapeSqlTests
     /// <summary>
     /// One file's latest-row CPU reads. Comment spans go first (this codebase's SQL carries its reasoning in
     /// <c>/* ... */</c> blocks that quote the very predicates matched here), then each mention of the table is
-    /// taken out to the end of its verbatim literal and kept only if that span is a LATEST-row read:
-    /// <c>LIMIT 1</c> and <c>$1</c> as its only parameter.
+    /// taken out to the end of its verbatim literal and kept if that span is a latest-row read in either
+    /// shape: per-server (<c>LIMIT 1</c> with <c>$1</c> as its only parameter) or fleet-wide
+    /// (<c>DISTINCT ON (server_id)</c>, which has neither).
     ///
     /// <para>The single-parameter test is what separates this class from a WINDOWED read. A windowed read
     /// takes its bounds as <c>$2</c>/<c>$3</c> and bounding <c>collection_time</c> is the right answer there;
@@ -192,17 +210,21 @@ public sealed class LatestCpuReadShapeSqlTests
         var reads = new List<(string, string)>();
         foreach (Match match in Regex.Matches(code, @"FROM\s+v?_?cpu_utilization_stats\b"))
         {
-            /* The end of the enclosing verbatim literal. A read that somehow lacks one is not a SQL literal
-               and is left alone rather than guessed at. */
+            /* The enclosing verbatim literal, both ends: DISTINCT ON and the select list sit BEFORE the
+               table name, so a forward-only span would miss the fleet shape entirely. A read that lacks
+               either end is not a SQL literal and is left alone rather than guessed at. */
             var close = code.IndexOf("\";", match.Index, StringComparison.Ordinal);
-            if (close < 0)
+            var open = code.LastIndexOf("@\"", match.Index, StringComparison.Ordinal);
+            if (close < 0 || open < 0)
             {
                 continue;
             }
 
-            var span = code[match.Index..close];
-            if (span.Contains("LIMIT 1", StringComparison.Ordinal)
-                && !span.Contains("$2", StringComparison.Ordinal))
+            var span = code[open..close];
+            var perServerNewest = span.Contains("LIMIT 1", StringComparison.Ordinal)
+                                  && !span.Contains("$2", StringComparison.Ordinal);
+            var fleetNewest = span.Contains("DISTINCT ON (server_id)", StringComparison.Ordinal);
+            if (perServerNewest || fleetNewest)
             {
                 reads.Add((where, span));
             }

--- a/Darling/Darling.Tests/ViewerW2aTests.cs
+++ b/Darling/Darling.Tests/ViewerW2aTests.cs
@@ -37,7 +37,10 @@ public sealed class ViewerOverviewSqlTests
         Assert.Contains("sqlserver_cpu_utilization", sql, StringComparison.Ordinal);
         Assert.Contains("other_process_cpu_utilization", sql, StringComparison.Ordinal);
         Assert.Contains("WHERE server_id = $1", sql, StringComparison.Ordinal);
-        Assert.Contains("ORDER BY sample_time DESC", sql, StringComparison.Ordinal);
+        /* The partition column leads, sample_time is the within-batch tiebreak — see
+           LatestCpuReadShapeSqlTests for why, and for the tree-wide guard that keeps all three
+           latest-CPU reads on this one shape. */
+        Assert.Contains("ORDER BY collection_time DESC, sample_time DESC", sql, StringComparison.Ordinal);
         Assert.Contains("LIMIT 1", sql, StringComparison.Ordinal);
     }
 

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -4061,7 +4061,48 @@ public sealed class DarlingWorker : BackgroundService
             Database: row.Databases.Length > 0 ? row.Databases[0] : null);
 
     /// <summary>
-    /// The latest collected CPU sample for the snapshot — Lite's overview read
+    /// The newest collected CPU sample for one server, the read that gates CPU alerting. $1 server_id.
+    ///
+    /// <para><b>Ordered on <c>collection_time</c>, the hypertable's own partition column.</b>
+    /// <c>TimescaleSupport.CreateHypertableSql</c> partitions every collector table on its
+    /// <c>PrefixTimeColumnName</c>, and <c>CpuUtilizationCollector</c> does not override the
+    /// <c>collection_time</c> default, so <c>sample_time</c> is an ordinary payload column carrying neither
+    /// an index nor partition affinity. Ordering on the dimension is what earns TimescaleDB's ORDERED
+    /// ChunkAppend: it walks chunks newest-first and stops at the first one that yields a row, so every older
+    /// chunk plans as <c>never executed</c> and the read costs the same against thirty chunks as against one,
+    /// compressed chunks included. Ordering on <c>sample_time</c> instead appends every chunk and top-N sorts
+    /// the server's whole retained history to return a single row — 47,752 rows and 839 buffers at thirty
+    /// one-day chunks, once per server per alert tick.</para>
+    ///
+    /// <para><b>The <c>sample_time</c> tiebreak is load-bearing, not decoration.</b> One poll writes up to 60
+    /// ring-buffer samples under a single <c>collection_time</c>, and without it the read returns whichever of
+    /// them the index reaches first — measured 59 minutes stale. The batch with the newest
+    /// <c>collection_time</c> is always the one holding the newest <c>sample_time</c>, because the collector's
+    /// watermark IS <c>sample_time</c>, so a poll only ever inserts samples above the previous high-water
+    /// mark.</para>
+    ///
+    /// <para><b>No time predicate, deliberately.</b> <c>sample_time</c> is the monitored server's LOCAL wall
+    /// clock on the ring-buffer arm and UTC on the Azure SQL DB arm — two frames in one column, pinned in both
+    /// directions by <c>CollectorTimestampFrameTests</c>. So <c>sample_time &gt; now() - INTERVAL '...'</c>
+    /// compares two different clocks and returns ZERO rows for every server behind the store's, which reads as
+    /// "this server has no CPU data" rather than as an error: no exception, no log line, CPU alerting simply
+    /// stops. <c>collection_time</c> IS naive UTC and a bound on it would be frame-correct, but it buys nothing
+    /// here — ordered append already touches one chunk — and costs two failure modes of its own. It drops a
+    /// server that has stopped reporting out of alerting entirely, and a bare <c>now()</c> is a
+    /// <c>timestamptz</c> whose comparison against a naive column is re-framed by the STORE session's own
+    /// TimeZone (measured: a 1-hour window becomes 4 hours on an <c>America/New_York</c> store, and would
+    /// invert east of UTC). An ORDER BY carries no clock frame at all. Internal so the shape and the
+    /// same-row-across-offsets behaviour are both pinned by test.</para>
+    /// </summary>
+    internal const string LatestCpuSql = @"
+SELECT sqlserver_cpu_utilization, other_process_cpu_utilization
+FROM cpu_utilization_stats
+WHERE server_id = $1
+ORDER BY collection_time DESC, sample_time DESC
+LIMIT 1";
+
+    /// <summary>
+    /// Runs <see cref="LatestCpuSql"/> and shapes it for the snapshot — Lite's overview read
     /// (LocalDataService.Overview.cs:37-51) against the raw PG table, and the
     /// ServerSummaryItem.TotalCpuPercent derivation (:140-141): total = SQL + (other ?? 0),
     /// null when there is no SQL sample (Azure SQL DB stores other as 0; Linux stores NULL).
@@ -4072,12 +4113,8 @@ public sealed class DarlingWorker : BackgroundService
         double? otherCpu = null;
 
         await using var connection = await _postgres!.OpenConnectionAsync(cancellationToken);
-        using var command = new NpgsqlCommand(@"
-SELECT sqlserver_cpu_utilization, other_process_cpu_utilization
-FROM cpu_utilization_stats
-WHERE server_id = $1
-ORDER BY sample_time DESC
-LIMIT 1", connection) { CommandTimeout = DarlingAlertReadAdapter.AlertPassCommandTimeoutSeconds };
+        using var command = new NpgsqlCommand(
+            LatestCpuSql, connection) { CommandTimeout = DarlingAlertReadAdapter.AlertPassCommandTimeoutSeconds };
         command.Parameters.AddWithValue(serverId);
 
         using var reader = await command.ExecuteReaderAsync(cancellationToken);

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingFleetReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingFleetReader.cs
@@ -112,14 +112,29 @@ SELECT id, name, parent_id, sort_order, colour
 FROM server_tags
 ORDER BY sort_order, lower(name)";
 
-    /// <summary>Latest SQL + other-process CPU per server (newest ring-buffer sample). $ none.</summary>
+    /// <summary>Latest SQL + other-process CPU per server (newest ring-buffer sample). $ none.
+    ///
+    /// <para>The <c>collection_time</c> key, matching <see cref="FleetMemorySql"/> below, is here for the
+    /// FRAME rather than for the cost. <c>sample_time</c> is the monitored server's local wall clock, so
+    /// leading on it invites the bound that looks like the obvious optimisation and returns zero rows for
+    /// every server behind the store — and this is the one CPU read with no <c>server_id</c> filter, so it
+    /// would take the whole fleet at once. Ordering carries no clock frame; see
+    /// <c>DarlingWorker.LatestCpuSql</c> for the full reasoning and
+    /// <c>LatestCpuReadShapeSqlTests</c> for the guard.</para>
+    ///
+    /// <para>It buys NO speed, and the doc says so rather than implying otherwise: <c>DISTINCT ON</c> with
+    /// <c>server_id</c> leading and no per-server <c>LIMIT</c> reads and sorts the whole relation whatever
+    /// the time key is (measured identical, 240,701 rows and 169 buffers either way at thirty chunks). The
+    /// per-server reads get ordered ChunkAppend from this same change because each has its own
+    /// <c>LIMIT 1</c>; this one would need a per-server lateral instead, which is a different query.</para>
+    /// </summary>
     public const string FleetCpuSql = @"
 SELECT DISTINCT ON (server_id)
     server_id,
     sqlserver_cpu_utilization,
     other_process_cpu_utilization
 FROM v_cpu_utilization_stats
-ORDER BY server_id, sample_time DESC";
+ORDER BY server_id, collection_time DESC, sample_time DESC";
 
     /// <summary>Latest total server memory + buffer pool (MB) per server. $ none.</summary>
     public const string FleetMemorySql = @"

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingHealthReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingHealthReader.cs
@@ -49,12 +49,16 @@ internal static class DarlingHealthReader
             CpuPercent is null && MemoryMb is null && LastCollectionTime is null;
     }
 
-    /// <summary>Latest SQL-process CPU for one server (newest ring-buffer sample). $1 server_id.</summary>
+    /// <summary>Latest SQL-process CPU for one server (newest ring-buffer sample). $1 server_id.
+    /// Same shape and same reasoning as <c>DarlingWorker.LatestCpuSql</c>: ordered on the hypertable's
+    /// <c>collection_time</c> partition column so ordered ChunkAppend stops at the newest chunk, with
+    /// <c>sample_time</c> as the within-batch tiebreak, and no time predicate because <c>sample_time</c> is
+    /// the monitored server's local wall clock.</summary>
     public const string ServerSummaryCpuSql = @"
 SELECT sqlserver_cpu_utilization
 FROM v_cpu_utilization_stats
 WHERE server_id = $1
-ORDER BY sample_time DESC
+ORDER BY collection_time DESC, sample_time DESC
 LIMIT 1";
 
     /// <summary>Latest total server memory (MB) for one server. $1 server_id.</summary>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Overview.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Overview.cs
@@ -46,12 +46,18 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// </summary>
 public sealed partial class ViewerDataService
 {
-    /// <summary>Latest SQL + other-process CPU for one server (newest ring-buffer sample). $1 server_id.</summary>
+    /// <summary>Latest SQL + other-process CPU for one server (newest ring-buffer sample). $1 server_id.
+    /// Ordered on <c>collection_time</c> — the hypertable's partition column, which earns TimescaleDB's
+    /// ordered ChunkAppend and so touches ONE chunk instead of appending and top-N sorting the server's whole
+    /// retained history — with <c>sample_time</c> as the within-batch tiebreak. Carries no time predicate:
+    /// <c>sample_time</c> is the monitored server's local wall clock, so bounding on it against store time
+    /// returns zero rows for any server behind the store. Full reasoning on
+    /// <c>DarlingWorker.LatestCpuSql</c>.</summary>
     public const string ServerSummaryCpuSql = @"
 SELECT sqlserver_cpu_utilization, other_process_cpu_utilization
 FROM v_cpu_utilization_stats
 WHERE server_id = $1
-ORDER BY sample_time DESC
+ORDER BY collection_time DESC, sample_time DESC
 LIMIT 1";
 
     /// <summary>Latest total server memory + buffer pool (MB) for one server. $1 server_id.</summary>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Memory.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Memory.cs
@@ -35,13 +35,14 @@ namespace PerformanceMonitor.Darling.Viewer;
 ///
 /// <para>First cut: all four sub-tabs (re)load on Memory-tab activation (Lite's full-refresh branch);
 /// Lite's sub-tab-only timer optimization is deferred, so the sub-TabControl has no SelectionChanged
-/// handler. <b>Pressure-event time:</b> like CPU's <c>sample_time</c>, the pressure <c>sample_time</c> is
-/// the monitored server's LOCAL wall clock, but the per-batch de-skew the CPU read uses (#1262) assumes the
-/// newest sample is ~1 minute old — true for the dense CPU ring buffer, NOT for the sparse resource-monitor
-/// ring buffer — so it does not transfer. The pressure chart therefore windows AND plots on raw
-/// <c>sample_time</c> through <see cref="ViewerTimeHelper.ForDisplay"/>: bars stay inside the X range and
-/// internally consistent (both bounds and bars share the one clock); for a non-UTC server the whole
-/// standalone chart shifts by the server's UTC offset. A reliable pressure-time de-skew is deferred.</para>
+/// handler. <b>Pressure-event time:</b> unlike CPU's <c>sample_time</c>, which is the monitored server's
+/// LOCAL wall clock and needs the per-batch de-skew (#1262), the pressure <c>sample_time</c> is naive UTC —
+/// <c>MemoryPressureEventsCollector</c> stamps it from <c>SYSUTCDATETIME()</c> and
+/// <c>CollectorTimestampFrameTests</c> pins that it must. So the chart windows AND plots on raw
+/// <c>sample_time</c> through <see cref="ViewerTimeHelper.ForDisplay"/>, which takes naive-UTC input, and
+/// needs no de-skew of its own: the CPU read's correction assumes the newest sample is ~1 minute old, true
+/// for the dense CPU ring buffer and not for the sparse resource-monitor one, and would be wrong here even
+/// if the frame called for it.</para>
 /// </summary>
 public partial class ViewerServerTab
 {


### PR DESCRIPTION
`cpu_utilization_stats` is a TimescaleDB hypertable partitioned on `collection_time` — `TimescaleSupport.CreateHypertableSql` takes each collector definition's `PrefixTimeColumnName`, and `CpuUtilizationCollector` never overrides the `collection_time` default, so `sample_time` is an ordinary payload column carrying neither an index nor partition affinity. The three reads that want a server's newest CPU sample all ordered on `sample_time`, so each appended every chunk and top-N sorted the server's entire retained history to return a single row. The alert sweep's copy does that once per server per 30-second tick, which is what gates CPU alerting.

Ordering on the dimension instead, with `sample_time` demoted to the within-batch tiebreak, earns TimescaleDB's ordered `ChunkAppend`: it walks chunks newest-first and stops at the first one that yields a row, so every older chunk plans as `never executed` and the cost stops scaling with chunk count.

Measured on a store seeded to thirty one-day chunks and 47,752 rows per server, five synthetic servers spanning UTC-7 to UTC+10, with 28 of 30 chunks compressed as production has them:

| | rows read | buffers | execution | end-to-end per call |
|---|---|---|---|---|
| `ORDER BY sample_time DESC` | 47,752 | 87 (839 uncompressed) | 5.1 ms | 3.27 ms |
| `ORDER BY collection_time DESC, sample_time DESC` | 27 | 6 | 0.34 ms | 1.08 ms |

The residual 1.08 ms is almost entirely planning, which thirty chunks cost either way.

## No time predicate, deliberately

`AND sample_time > now() - interval '1 hour'` is the obvious-looking fix and it is a trap in two independent ways.

`sample_time` is the monitored server's **local wall clock** on the ring-buffer arm — `SYSDATETIME()`, an intentional convention that `CollectorTimestampFrameTests` pins in both directions — and naive UTC on the Azure SQL DB arm, which reads `sys.dm_db_resource_stats.end_time`. Two frames in one column, neither of them the store's. Measured against the seeded fleet on a UTC store, that predicate returns **zero rows for every server behind the store's clock** and a meaninglessly wide window for every server ahead of it:

| server offset | rows in a "1 hour" `sample_time` window |
|---|---|
| UTC-7 | **0** |
| UTC-4 | **0** |
| UTC | 66 |
| UTC+5:30 | 447 |
| UTC+10 | 759 |

Zero rows here is not an error. It reads as "this server has no CPU data" — no exception, no log line, CPU alerting silently off for the whole US fleet.

`collection_time` **is** naive UTC and a bound on it would be frame-correct, but it buys nothing once the ordering already touches one chunk, and it costs two failure modes of its own: it drops a server that has stopped reporting out of alerting entirely, and a bare `now()` is a `timestamptz` whose comparison against a naive column is re-framed by the *store session's* own `TimeZone`. Measured: the same one-hour `collection_time` window returns 66 rows on a UTC store and 343 on an `America/New_York` one, and would invert east of UTC. An `ORDER BY` carries no clock frame at all, which is why this is a pure ordering change.

## The tiebreak

One poll writes up to 60 ring-buffer samples under a single `collection_time`. Ordering on `collection_time` alone returns whichever of them the index reaches first — measured 59 minutes stale against a seeded backlog, with an unrelated CPU value. `LatestCpuRead_PicksTheNewestSampleInsideOneBatch_AgainstDevPostgres` fails on the real hypertable when the tiebreak is dropped.

The newest `collection_time` always holds the newest `sample_time` because the collector's watermark **is** `sample_time`, so a poll only ever inserts samples above the previous high-water mark.

## Scope

Three reads change: the alert sweep's `DarlingWorker.LatestCpuSql` (hoisted from an inline literal so its shape and behaviour are both testable), `ViewerDataService.ServerSummaryCpuSql`, and `DarlingHealthReader.ServerSummaryCpuSql`. All three measure identically.

`DarlingFleetReader.FleetCpuSql` moves onto the same ordering, but **for the frame, not the cost, and the constant's own doc says so**. It is `DISTINCT ON (server_id)` with `server_id` leading and no per-server `LIMIT`, so it reads and sorts the whole relation whatever the time key is — measured 240,701 rows and 169 buffers either way at thirty chunks. What the change buys is that this read, the only CPU read with no `server_id` filter, stops leading on a local-clock column and stops being the odd one out against `FleetMemorySql` directly below it, which already leads on `collection_time`. Bounding `sample_time` here would take the whole fleet at once. The cost fix would be a per-server lateral, which is a different query and out of scope.

That read was also invisible to the first cut of the shape guard, which keyed on `LIMIT 1` with a lone `$1` — neither of which the fleet read has. The extraction now recognises the `DISTINCT ON (server_id)` shape, spans backward to the start of the literal so the select list is in scope, and rejects `sample_time` sitting behind a leading `server_id`.

**Lite is deliberately untouched**, and that is a decision rather than an oversight. `Lite/Services/LocalDataService.Overview.cs` carries the same `ORDER BY sample_time DESC LIMIT 1` shape, and its DuckDB index `idx_cpu_time` does lead on `collection_time`, so the ordering is unhelpful there too. But DuckDB has no chunks to prune, Lite reads one server's overview card on demand rather than every server every 30 seconds, and Lite's CPU window goes through `GetTimeRangeServerLocal`, which reads a process-global `ServerTimeHelper.UtcOffsetMinutes` written only by desktop tab selection. That global has its own defect on the MCP path, and changing Lite's CPU ordering while it is unresolved would tangle two changes. The shape guard is scoped to `Darling/` for the same reason: extending it to a place this PR is not fixing would only make it red.

`ViewerServerTab.Memory`'s frame note is corrected: it still described the memory-pressure `sample_time` as the monitored server's local wall clock with a de-skew "deferred", which inverted the contract after that collector moved to `SYSUTCDATETIME()`. `CollectorTimestampFrameTests` asserts the UTC direction, so the comment argued against the pin — in the one file someone auditing this class would open.

## Tests

`LatestCpuReadShapeTests` adds 12 tests. The shape guards scan the `Darling/` source tree rather than referencing the constants, so they reach the WPF viewer without this test assembly resolving a WPF project reference, and a fourth copy is covered the moment it is written. A hard floor on the count makes a scan that finds nothing go red instead of passing vacuously, and the extraction handles both C# literal spellings, because 127 files under `Darling/` write SQL as a raw string rather than a verbatim one and a `@"`-only scan was blind to exactly the future copy the guard exists to catch. Its discriminator — `LIMIT 1` with `$1` as the only parameter, or `DISTINCT ON (server_id)` — is pinned in both directions, including against `PgAnomalyDetector.CpuWindowSql`, a windowed peak-CPU read that a `LIMIT 1`-only rule swept in and demanded a change it does not need, and against a `DISTINCT ON` keyed on something other than `server_id`.

Three gated live round-trips seed sentinel servers at UTC-7, UTC-4, UTC, UTC+5:30 and UTC+10 and assert the shipped read returns the same row the unbounded `sample_time` order returns, and the newest poll's own values rather than merely agreeing with the oracle. One of them is the trap itself, with a same-frame server as the positive control proving the empty result is the frame mismatch and not a malformed predicate.

`ViewerOverviewSqlTests` and `DarlingMcpHealthToolsSurfaceAndSqlTests` each pinned the replaced ordering on the read they cover, and are updated to the new one. The three live tests take their teardown through `LiveStoreCleanup.RunAsync` rather than the body's own connection, per the `LiveCleanupConversionRatchetTests` convention: the body's connection is the one thing the failure being reported may have destroyed, and a throw from `finally` replaces the body's exception with connection noise.

Nine mutations were run through `redproof.sh`: reverting each of the two changed orderings, dropping the tiebreak, adding the trap predicate, and stripping `ReadLatestCpuAsync`'s `CommandTimeout`, putting the live teardown back on the body's connection, reverting the fleet read, and rewriting the alert read as a raw string literal with the replaced ordering were each caught - the last two by the widened extraction itself, which is the positive control that it reaches the `DISTINCT ON` and raw-string shapes on the real tree rather than only in a fixture; breaking the windowed peak read stayed green as the positive control that the scan excludes it. Every mutation asserted a `sha256` change on the file, so a same-length substitution could not pass as applied.
