### PR TITLE
Part of #2874

### DIFF
--- a/Darling/Darling.Tests/CollectionSweepCommandTimeoutTests.cs
+++ b/Darling/Darling.Tests/CollectionSweepCommandTimeoutTests.cs
@@ -188,20 +188,6 @@ public sealed class CollectionSweepCommandTimeoutTests
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     /// <summary>
-    /// The deadline, judged over STRIPPED source like the construction scan above it — the two halves of
-    /// one question should not disagree about what counts as code.
-    ///
-    /// <para>Stripping the VALUE span is not unconditionally right for every pin in this family: one whose
-    /// value regex has to see inside a string LITERAL would be broken by it. It is right for this one
-    /// because the pattern targets an assignment in code, and the failure it closes is a false CLEAN — a
-    /// comment in the two-statement window spelling <c>command.CommandTimeout =</c> would certify an
-    /// untimed site, at a line where no edit could ever fix it.</para>
-    /// </summary>
-    private static readonly Regex s_setsTimeout = new(
-        @"CommandTimeout\s*=",
-        RegexOptions.Compiled | RegexOptions.CultureInvariant);
-
-    /// <summary>
     /// The store's command FACTORY, as the receiver reads immediately behind a <c>CreateCommand</c>:
     /// <c>_postgres</c> is the worker's and the ingestor's field, <c>postgres</c> the
     /// <c>NpgsqlDataSource</c> the static helpers take as a parameter. The optional <c>!</c> is the
@@ -263,7 +249,8 @@ public sealed class CollectionSweepCommandTimeoutTests
     /// <c>NpgsqlBinaryImporter.Timeout</c>, matched on the property rather than on a variable name so a
     /// site that calls its importer something other than <c>importer</c> still counts.
     ///
-    /// <para>Judged over STRIPPED source, for the reason on <see cref="s_setsTimeout"/> and with the same
+    /// <para>Judged over STRIPPED source, for the reason on
+    /// <see cref="CommandDeadlineScanner.SetsAnExplicitDeadline"/> and with the same
     /// justification: it targets code, not a literal. The leading dot is what made this one's
     /// comment-immunity fixture pass for the wrong reason until the fixture was corrected — see
     /// <see cref="TheCopyScanner_SeesTheImporterDeadlineWithoutBorrowingANeighbours"/>.</para>
@@ -295,12 +282,15 @@ public sealed class CollectionSweepCommandTimeoutTests
             {
                 total++;
 
-                /* Two statements, for the reason #2810's pin records: the CreateCommand shape's method
-                   result cannot take an object initializer, so its deadline is the statement AFTER the
-                   construction. The span is walked literal- and comment-aware, which is load-bearing
-                   rather than defensive here — these members embed verbatim SQL carrying both semicolons
-                   and quote characters. */
-                if (!SetsTheSweepDeadline(code, ctor.Index))
+                /* The shared judgement (#2938), which asks in two halves: an initializer is read from the
+                   CONSTRUCTION span, an assignment from the two-statement span and only when it NAMES the
+                   variable bound here. Both halves are load-bearing for this pin — the CreateCommand
+                   shape cannot take an initializer, so its deadline is the statement after the
+                   construction, and all thirteen of these sites are answered by the name-bound half. The
+                   spans are walked literal- and comment-aware, which is load-bearing rather than
+                   defensive here: these members embed verbatim SQL carrying both semicolons and quote
+                   characters. */
+                if (!CommandDeadlineScanner.SetsAnExplicitDeadline(code, ctor.Index))
                 {
                     offenders.Add($"{file} {member} +{LineOf(code, ctor.Index)}");
                 }
@@ -530,7 +520,8 @@ public sealed class CollectionSweepCommandTimeoutTests
     /// The deadline scan reads CODE, not prose — the positive control for judging the value span over
     /// stripped source, and the command half of the fixture
     /// <see cref="TheCopyScanner_SeesTheImporterDeadlineWithoutBorrowingANeighbours"/> is for the COPY
-    /// half. Without it the fix to <see cref="s_setsTimeout"/> would have no witness at all.
+    /// half. Without it the stripped-source half of
+    /// <see cref="CommandDeadlineScanner.SetsAnExplicitDeadline"/> would have no witness at all.
     ///
     /// <para>The first two fixtures are the failure being closed, and the comment is written the way
     /// someone documenting the absence of a deadline actually writes it — quoting the assignment. Over raw
@@ -566,18 +557,50 @@ public sealed class CollectionSweepCommandTimeoutTests
         var ctor = s_commandCtor.Match(code);
 
         Assert.True(ctor.Success, "the fixture did not contain a command construction");
-        Assert.Equal(expectedTimed, SetsTheSweepDeadline(code, ctor.Index));
+        Assert.Equal(expectedTimed, CommandDeadlineScanner.SetsAnExplicitDeadline(code, ctor.Index));
     }
 
     /// <summary>
-    /// Whether the construction at <paramref name="at"/> carries a deadline, over the TWO statements from
-    /// it — the <c>CreateCommand</c> shape's result cannot take an object initializer, so its deadline is
-    /// the statement after the construction. <paramref name="code"/> is stripped source, so a
-    /// <c>CommandTimeout =</c> written in a comment or inside the member's verbatim SQL cannot certify an
-    /// untimed site.
+    /// <para>A deadline written on a NEIGHBOUR is not this site's deadline — the two false accepts the
+    /// shared judgement closes, and the reason this pin adopting it is a behaviour change rather than a
+    /// tidy-up. Both are invisible to a single bare <c>CommandTimeout\s*=</c> over the two-statement span,
+    /// which is what this pin asked before #2938.</para>
+    ///
+    /// <para>The first is the FOLLOWING construction's own initializer: an untimed command directly ahead
+    /// of a timed one sits inside the untimed one's statement window, so the window's deadline is real —
+    /// it just belongs to the next site. Reading initializers from the CONSTRUCTION span excludes it.</para>
+    ///
+    /// <para>The second is a SIBLING's assignment inside an untimed <c>using</c> header's block, which
+    /// spends both counted statements on the sibling. No statement count or scope bound can exclude that
+    /// one — it is in the same scope and in the very next statement — so only the NAME the assignment
+    /// qualifies can. That half is not hypothetical here: all thirteen census sites are answered by it,
+    /// two of them through receivers not called <c>command</c>.</para>
     /// </summary>
-    private static bool SetsTheSweepDeadline(string code, int at)
-        => s_setsTimeout.IsMatch(CSharpSourceWalker.StatementSpanFrom(code, at, statements: 2));
+    [Theory]
+    [InlineData(
+        "using var first = new NpgsqlCommand(A, connection);\n"
+        + "using var second = new NpgsqlCommand(B, connection) { CommandTimeout = 60 };\n",
+        false)]
+    [InlineData(
+        "using (var command = connection.CreateCommand())\n"
+        + "{\n"
+        + "    using var sibling = connection.CreateCommand();\n"
+        + "    sibling.CommandTimeout = 10;\n"
+        + "}\n",
+        false)]
+    [InlineData(
+        "using var command = new NpgsqlCommand(A, connection);\n"
+        + "command.CommandTimeout = ServiceCommandDeadlines.CollectionSweepSeconds;\n"
+        + "using var second = new NpgsqlCommand(B, connection);\n",
+        true)]
+    public void TheDeadlineScanner_DoesNotBorrowANeighboursDeadline(string source, bool expectedTimed)
+    {
+        var code = CSharpSourceWalker.StripCommentsAndStrings(source);
+        var ctor = s_commandCtor.Match(code);
+
+        Assert.True(ctor.Success, "the fixture did not contain a command construction");
+        Assert.Equal(expectedTimed, CommandDeadlineScanner.SetsAnExplicitDeadline(code, ctor.Index));
+    }
 
     /// <summary>
     /// The member extractor, pinned separately. It is the piece with no precedent in this sweep — every


### PR DESCRIPTION
The collection-sweep pin was asking the `#2874` family's deadline question its own way. `CommandDeadlineScanner` (#2938) is the shared judgement, and this pin kept a private `s_setsTimeout` and a `SetsTheSweepDeadline` wrapper instead. Same divergence #2913 fixed for `CSharpSourceWalker`: private copies of one judgement, already drifted, only some carrying the hardening.

**This does not close the family, and the inventory is worth stating exactly** — re-derived after merging `origin/dev`, which brought in #2940. Measured by `grep -l 'CommandDeadlineScanner.SetsAnExplicitDeadline' *.cs`, **six** pins had adopted the shared judgement before this change — `StorageCommandTimeoutTests`, `ViewerCommandTimeoutTests`, `AnalysisPassCommandTimeoutTests`, `FactCollectorCommandTimeoutTests`, `AlertPassCommandTimeoutTests` and `CommandPlaneCommandTimeoutTests` — and this makes **seven**.

**Two holdouts remain and are NOT touched here**: `StragglerCommandTimeoutTests.cs` (private `s_setsTimeout` at line 100, used at line 548) and `McpReadCommandTimeoutTests.cs` (line 74, used at lines 158, 497, 505, 534 and 539). Both still carry exactly the single-span rule this change argues is unsound, so both plausibly hold the same live false-accept blind spots this fixed for the sweep. They are left for separate assessment rather than folded in: McpRead's surface is ~119 sites, so re-deriving its census is a scope call, not a rider on this one.

## This is a behaviour change, not a tidy-up

The private copy was a SINGLE span — a bare `CommandTimeout\s*=` over the two statements from the construction. The shared judgement asks in two halves, and each half closes a false ACCEPT the single span cannot see:

- **The following construction's own initializer.** An untimed command directly ahead of a timed one sits inside the untimed one's statement window, so the window's deadline is real — it just belongs to the next site. Reading initializers from the CONSTRUCTION span excludes it.
- **A sibling's assignment** inside an untimed `using` header's block, which spends both counted statements on the sibling. It is in the same scope and in the very next statement, so no statement count or scope bound can exclude it — only the NAME the assignment qualifies can.

Both arrive as permanent fixtures in `TheDeadlineScanner_DoesNotBorrowANeighboursDeadline`, with a positive control so the theory cannot pass by rejecting everything.

## The censuses were RE-DERIVED, not adjusted

The two-span rule is *stricter* in one direction: the assignment half requires name-qualification against the bound variable, so a site assigning `CommandTimeout` through a differently-named reference would newly report untimed. That would be a finding, not a number to tune — so both constants were re-derived by enumerating the real sources through the pin's own `s_sweepMembers`, `MemberBody` and `s_commandCtor`, and asking both rules at every site.

**`ExpectedSweepCommandSites` = 13, unchanged. `ExpectedCopyWriterSites` = 4, unchanged. Zero sites disagree between the old rule and the shared one**, so the offender list stays empty and nothing was reclassified.

All thirteen are answered by the **name-bound half**, none by the initializer half — so the stricter rule is not merely reachable for this pin's shapes, it is the only path that carries them. Two do it through receivers not called `command`: `isDue` and `upsert`, both `_postgres!.CreateCommand` sites in `TryRefreshPgStatementTextAsync`, which the `BoundName` walk resolves through a `using` header declaration and a plain declaration respectively.

## What deliberately did NOT change

The scanner holds no construction regex — it takes an offset the caller found — so adoption cannot narrow construction matching. `s_commandCtor` stays the pin's own, qualified `new Npgsql.NpgsqlCommand(` alternative and bare `.CreateCommand` method group included. Kept for the same reason: the twelve `(file, member)` pairs of member scoping, which exist because `.Service` spans budget regimes; the store-versus-target receiver classifier, which has no equivalent in the shared helper and which `.Storage` and `.Viewer` never needed; and the COPY half, whose `NpgsqlBinaryImporter.Timeout` is a different property on a different type that the scanner knows nothing about.

## Verification

Windows-only suite, so CI is the arbiter. Locally the REAL `.cs` files were compiled by absolute path into a throwaway `net10.0` xunit host with `AssemblyName=Darling.Tests`, staged inside the repo tree: **34 tests, 0 failed, 0 skipped, 0 not run**, up from 31 — the three added fixtures. The real `net10.0-windows` project also rebuilds with `EnableWindowsTargeting=true`: **0 errors**, and no doc-comment `cref` left dangling by the deleted regex.

Proved red first, one mutation at a time, each confirmed applied by anchor count and content hash and each confirmed to have relinked the assembly, so no green came from a stale binary:

- Reverting the judgement to the old single-span rule fails **both** new negative fixtures at `Expected: False, Actual: True` — the two false accepts, reproduced — while the census stays green, which is the same evidence that the thirteen real sites are unmoved.
- Breaking the receiver classifier's store factory fails `EverySweepBodyCommand_IsBuiltAgainstTheStore_NotAMonitoredTarget` and both of its unit fixtures.
- Breaking the COPY half's importer property reports all four writers as offenders, by name.
- Dropping one member from the scoping list moves the census to 12.

No `CHANGELOG.md` entry — that file is the coordinator's, and this entry is reported to them. No production code, no schema bump, no migration rung.

**Re-verified after merging `origin/dev`** (which brought #2940 and #2965): both censuses unchanged at 13 and 4, zero old-versus-new disagreements, 34 tests green, and the real project still rebuilds with 0 errors. `ServiceCommandDeadlines.CollectionSweepSeconds` is still 10 and `DarlingWorker.SweepWatchdogSeconds` still 60, so the band assertion is unaffected.
