### PR TITLE
Window the server-local MCP reads in the requested server's own UTC offset

### DIFF
--- a/Lite.Tests/AsOfWindowAnchorTests.cs
+++ b/Lite.Tests/AsOfWindowAnchorTests.cs
@@ -31,10 +31,9 @@ namespace PerformanceMonitorLite.Tests;
 /// bounds. A helper-only test would pass with the plumbing missing, which is exactly the shape of bug the
 /// #2213 review found four of.</para>
 /// </summary>
-/* The server-local half below reads ServerTimeHelper.UtcOffsetMinutes, a process-wide mutable static that a
-   sibling class SETS for its duration. xUnit runs test classes in parallel, so this joins the collection the
-   other offset-reading classes already use rather than racing them into a window hours away from its rows. */
-[Collection("server-time-helper")]
+/* Runs fully parallel: every read exercised here now takes its UTC offset from the store per server_id, so
+   nothing in this class reads or writes ServerTimeHelper's process-wide static and a sibling class setting it
+   cannot move a window out from under a seeded row. */
 public sealed class AsOfWindowAnchorTests : IClassFixture<SharedDuckDbFixture>, IDisposable
 {
     /* Outside every default window on the surface (the widest default is 24 hours). The two windows are
@@ -191,42 +190,40 @@ public sealed class AsOfWindowAnchorTests : IClassFixture<SharedDuckDbFixture>, 
     /// Two families, two time bases, one instant — a bug here would shift the window by the monitored
     /// server's offset and still look plausible.
     ///
-    /// <para><b>The offset is SET, not read</b> (review catch). Reading whatever
-    /// <c>ServerTimeHelper.UtcOffsetMinutes</c> happens to be means running at 0 on any normal machine, and
-    /// at 0 a correct conversion and no conversion at all produce identical results — the test would pass
-    /// vacuously for exactly the bug its own summary names. UTC+5:30 is used because a half-hour offset also
-    /// catches an implementation that rounds to whole hours. Saved and restored, and this class shares the
-    /// <c>server-time-helper</c> collection so the write cannot land under a sibling class mid-read.</para>
+    /// <para><b>A non-zero offset is required, not incidental.</b> At offset 0 a correct conversion and no
+    /// conversion at all produce identical results, so the test would pass vacuously for exactly the bug its
+    /// own summary names. UTC+5:30 is used because a half-hour offset also catches an implementation that
+    /// rounds to whole hours.</para>
+    ///
+    /// <para><b>The offset is SEEDED, not set on the static.</b> It used to be assigned to
+    /// <c>ServerTimeHelper.UtcOffsetMinutes</c>, which made this test the thing that HID a second defect: the
+    /// tool took its window from that static rather than from the server it had resolved, and handing the
+    /// static the right answer first meant the coupling never showed. The offset now travels the way the
+    /// production path supplies it — a collected <c>server_properties.utc_offset_minutes</c> for this
+    /// server_id — and the static is left alone. <c>McpServerLocalOffsetTests</c> owns the per-server
+    /// contract; this test is back to being only about the anchor.</para>
     /// </summary>
     [Fact]
     public async Task TheAnchorAlsoMoves_AServerLocalWindow()
     {
-        var savedOffset = ServerTimeHelper.UtcOffsetMinutes;
-        try
-        {
-            ServerTimeHelper.UtcOffsetMinutes = 330; // UTC+5:30
+        const int offset = 330; // UTC+5:30
+        await SeedServerOffsetAsync(offset);
 
-            var now = DateTime.UtcNow;
-            var incident = now.AddHours(-30);
+        var now = DateTime.UtcNow;
+        var incident = now.AddHours(-30);
 
-            /* sample_time is the monitored server's LOCAL wall clock, so the fixture is seeded in that base —
-               the read's window is server-local and the anchor arrives in UTC, and the point of the test is
-               that the conversion between them happens exactly once. */
-            var offset = ServerTimeHelper.UtcOffsetMinutes;
-            await SeedCpuAsync(incident.AddMinutes(offset), 91);
-            await SeedCpuAsync(now.AddMinutes(-10).AddMinutes(offset), 12);
+        /* sample_time is the monitored server's LOCAL wall clock, so the fixture is seeded in that base —
+           the read's window is server-local and the anchor arrives in UTC, and the point of the test is
+           that the conversion between them happens exactly once. */
+        await SeedCpuAsync(incident.AddMinutes(offset), 91);
+        await SeedCpuAsync(now.AddMinutes(-10).AddMinutes(offset), 12);
 
-            var anchored = await McpCpuTools.GetCpuUtilization(
-                _dataService, _serverManager, "TestServer", 4, incident.AddMinutes(30).ToString("o"));
-            Assert.Equal(new[] { 91 }, SqlCpuIn(anchored));
+        var anchored = await McpCpuTools.GetCpuUtilization(
+            _dataService, _serverManager, "TestServer", 4, incident.AddMinutes(30).ToString("o"));
+        Assert.Equal(new[] { 91 }, SqlCpuIn(anchored));
 
-            var live = await McpCpuTools.GetCpuUtilization(_dataService, _serverManager, "TestServer");
-            Assert.Equal(new[] { 12 }, SqlCpuIn(live));
-        }
-        finally
-        {
-            ServerTimeHelper.UtcOffsetMinutes = savedOffset;
-        }
+        var live = await McpCpuTools.GetCpuUtilization(_dataService, _serverManager, "TestServer");
+        Assert.Equal(new[] { 12 }, SqlCpuIn(live));
     }
 
     // ── helpers ──
@@ -293,6 +290,29 @@ public sealed class AsOfWindowAnchorTests : IClassFixture<SharedDuckDbFixture>, 
         P(_serverId);
         P(at);
         P(sqlCpu);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    /// <summary>
+    /// The collected <c>server_properties.utc_offset_minutes</c> a server-local read resolves this server's
+    /// window from. The NOT NULL edition/hardware columns are filled with values nothing here reads.
+    /// </summary>
+    private async Task SeedServerOffsetAsync(int utcOffsetMinutes)
+    {
+        using var readLock = _duckDb.AcquireReadLock();
+        var conn = await SeedConnectionAsync();
+
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = @"INSERT INTO server_properties
+            (collection_id, collection_time, server_id, server_name,
+             edition, product_version, product_level, engine_edition,
+             cpu_count, hyperthread_ratio, physical_memory_mb, utc_offset_minutes)
+            VALUES ($1, $2, $3, 'TestServer', 'Developer Edition', '16.0.4150.1', 'RTM', 3, 8, 1, 16384, $4)";
+        void P(object v) => cmd.Parameters.Add(new DuckDBParameter { Value = v });
+        P(_nextId--);
+        P(DateTime.UtcNow);
+        P(_serverId);
+        P(utcOffsetMinutes);
         await cmd.ExecuteNonQueryAsync();
     }
 }

--- a/Lite.Tests/McpServerLocalOffsetTests.cs
+++ b/Lite.Tests/McpServerLocalOffsetTests.cs
@@ -1,0 +1,332 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using DuckDB.NET.Data;
+using PerformanceMonitorLite.Database;
+using PerformanceMonitorLite.Mcp;
+using PerformanceMonitorLite.Models;
+using PerformanceMonitorLite.Services;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// The two MCP reads whose window is expressed in the MONITORED SERVER'S local wall clock —
+/// <c>get_cpu_utilization</c> (<c>cpu_utilization_stats.sample_time</c>, #1262's contract) and
+/// <c>get_default_trace_events</c> (<c>default_trace_events.event_time</c>) — must window in the offset of
+/// the server they were ASKED about.
+///
+/// <para><b>The bug this class exists for.</b> Both windows used to be built from
+/// <c>ServerTimeHelper.UtcOffsetMinutes</c>, process-wide state written only by the WPF tab paths. An MCP
+/// tool resolves its own <c>server_id</c> from <c>server_name</c> and never touches that static, so the
+/// window came from whichever server the desktop last selected — or from the Lite HOST's own timezone when
+/// no tab had ever been opened, which is not any monitored server's offset at all. The two halves of one
+/// predicate named two different servers, and the failure is SILENT: a <c>sample_time</c> compared against
+/// the wrong clock matches nothing, so a wrong answer arrives shaped exactly like "no data".</para>
+///
+/// <para><b>Why the assertion is an invariance, not a value.</b> Pinning one expected window would pass
+/// against the old code whenever the static happened to hold the right server — which is what
+/// <c>AsOfWindowAnchorTests.TheAnchorAlsoMoves_AServerLocalWindow</c> did by SETTING the static to the
+/// offset it then seeded against. So the contract here is stated as independence: the same two reads are
+/// run under four different values of the static, including two that are a real server's offset and one
+/// that is neither's, and every run must return each server its OWN rows. The old code cannot satisfy that
+/// for more than one of the four.</para>
+/// </summary>
+/* Writes ServerTimeHelper.UtcOffsetMinutes, a process-wide mutable static. xUnit runs test classes in
+   parallel, so this joins the collection the other offset-touching classes use rather than racing them. */
+[Collection("server-time-helper")]
+public sealed class McpServerLocalOffsetTests : IClassFixture<SharedDuckDbFixture>, IDisposable
+{
+    /* UTC-8 and UTC+5:30 — 13.5 hours apart, so a window built with the wrong server's offset cannot
+       accidentally still contain the right server's row (the default window is 4 hours). One offset is a
+       HALF hour so an implementation that rounds to whole hours is caught too. */
+    private const int PacificOffset = -480;
+    private const int IndiaOffset = 330;
+
+    /* Told apart by CONTENT, not by row count: a read that returns the other server's row cannot look
+       right. */
+    private const int PacificCpu = 41;
+    private const int IndiaCpu = 77;
+    private const string PacificEventText = "pacific-memory-change";
+    private const string IndiaEventText = "india-memory-change";
+
+    private readonly string _tempDir;
+    private readonly DuckDbInitializer _duckDb;
+    private readonly LocalDataService _dataService;
+    private readonly ServerManager _serverManager;
+    private readonly int _pacificId;
+    private readonly int _indiaId;
+    private readonly int _noOffsetId;
+    private long _nextId = -1;
+    private DuckDBConnection? _seedConn;
+
+    public McpServerLocalOffsetTests(SharedDuckDbFixture fixture)
+    {
+        fixture.ResetData();
+        _duckDb = fixture.DuckDb;
+
+        _tempDir = Path.Combine(Path.GetTempPath(), "McpOffsetTests_" + Guid.NewGuid().ToString("N")[..8]);
+        var configDir = Path.Combine(_tempDir, "config");
+        Directory.CreateDirectory(configDir);
+
+        _dataService = new LocalDataService(_duckDb);
+        _serverManager = new ServerManager(configDir);
+
+        /* Names that are not substrings of one another: ServerResolver falls back to a Contains match, so an
+           overlapping pair would let a resolution succeed for the wrong server and the test pass vacuously. */
+        _pacificId = Register("PacificSrv");
+        _indiaId = Register("IndiaSrv");
+        _noOffsetId = Register("UncollectedSrv");
+    }
+
+    private int Register(string name)
+    {
+        var server = new ServerConnection { ServerName = name, DisplayName = name };
+        _serverManager.AddServer(server);
+
+        /* The DERIVED id, not a literal: seeding under a hand-picked number makes every read return nothing
+           and the whole class pass for the wrong reason. */
+        return RemoteCollectorService.GetDeterministicHashCode(
+            RemoteCollectorService.GetServerNameForStorage(server));
+    }
+
+    public void Dispose()
+    {
+        _seedConn?.Dispose();
+        try { if (Directory.Exists(_tempDir)) Directory.Delete(_tempDir, recursive: true); }
+        catch (IOException) { /* best-effort cleanup */ }
+        catch (UnauthorizedAccessException) { /* best-effort cleanup */ }
+    }
+
+    /// <summary>
+    /// The contract, stated as independence from the desktop static: whatever
+    /// <c>ServerTimeHelper.UtcOffsetMinutes</c> holds — one server's offset, the other's, UTC, or an offset
+    /// belonging to neither — each MCP read returns the rows of the server it was asked about.
+    /// </summary>
+    [Theory]
+    [InlineData(PacificOffset)]  // the UI last selected the OTHER server
+    [InlineData(IndiaOffset)]    // ... and the other way round
+    [InlineData(0)]              // no tab ever opened, on a UTC host
+    [InlineData(720)]            // an offset belonging to neither server
+    public async Task AServerLocalRead_UsesTheRequestedServersOffset_WhateverTheDesktopStaticHolds(int desktopStatic)
+    {
+        var savedOffset = ServerTimeHelper.UtcOffsetMinutes;
+        try
+        {
+            ServerTimeHelper.UtcOffsetMinutes = desktopStatic;
+
+            var eventUtc = Truncate(DateTime.UtcNow.AddMinutes(-20));
+
+            await SeedServerOffsetAsync(_pacificId, "PacificSrv", PacificOffset);
+            await SeedServerOffsetAsync(_indiaId, "IndiaSrv", IndiaOffset);
+
+            /* Both rows record the SAME instant, each stamped on its own server's wall clock — which is
+               exactly what the collectors store. Their raw column values sit 13.5 hours apart. */
+            await SeedCpuAsync(_pacificId, "PacificSrv", eventUtc.AddMinutes(PacificOffset), PacificCpu);
+            await SeedCpuAsync(_indiaId, "IndiaSrv", eventUtc.AddMinutes(IndiaOffset), IndiaCpu);
+            await SeedDefaultTraceAsync(_pacificId, "PacificSrv", eventUtc.AddMinutes(PacificOffset), PacificEventText);
+            await SeedDefaultTraceAsync(_indiaId, "IndiaSrv", eventUtc.AddMinutes(IndiaOffset), IndiaEventText);
+
+            var pacificCpu = await McpCpuTools.GetCpuUtilization(_dataService, _serverManager, "PacificSrv");
+            var indiaCpu = await McpCpuTools.GetCpuUtilization(_dataService, _serverManager, "IndiaSrv");
+
+            Assert.Equal(new[] { PacificCpu }, SqlCpuIn(pacificCpu));
+            Assert.Equal(new[] { IndiaCpu }, SqlCpuIn(indiaCpu));
+
+            var pacificEvents = await McpDefaultTraceTools.GetDefaultTraceEvents(_dataService, _serverManager, "PacificSrv");
+            var indiaEvents = await McpDefaultTraceTools.GetDefaultTraceEvents(_dataService, _serverManager, "IndiaSrv");
+
+            Assert.Equal(new[] { PacificEventText }, EventTextIn(pacificEvents));
+            Assert.Equal(new[] { IndiaEventText }, EventTextIn(indiaEvents));
+
+            /* The SECOND use of the offset in the Default Trace read: each row's server-local event_time is
+               de-skewed back to naive UTC. Both servers recorded one instant, so both must come back AT that
+               instant despite their stored values being 13.5 hours apart — which only holds if the window
+               and the de-skew used the same per-server value. A fix that threaded the offset into the window
+               and left the de-skew on the static would still pass every assertion above this one. */
+            Assert.Equal(eventUtc, Assert.Single(EventTimesIn(pacificEvents)), TimeSpan.FromMinutes(1));
+            Assert.Equal(eventUtc, Assert.Single(EventTimesIn(indiaEvents)), TimeSpan.FromMinutes(1));
+        }
+        finally
+        {
+            ServerTimeHelper.UtcOffsetMinutes = savedOffset;
+        }
+    }
+
+    /// <summary>
+    /// A server whose offset the store does not hold is REFUSED, not answered against a guess. Both
+    /// candidate guesses (UTC, or the desktop static) would produce an answer indistinguishable from a
+    /// correct one, which is the failure the threading exists to remove — the same reasoning #2495 applied
+    /// to an unusable <c>as_of</c>. Rows ARE seeded for this server, so the refusal is provably about the
+    /// missing offset and not about missing data.
+    /// </summary>
+    [Fact]
+    public async Task AServerWithNoCollectedOffset_IsRefused_RatherThanWindowedOnAGuess()
+    {
+        var savedOffset = ServerTimeHelper.UtcOffsetMinutes;
+        try
+        {
+            ServerTimeHelper.UtcOffsetMinutes = IndiaOffset;
+
+            var eventUtc = Truncate(DateTime.UtcNow.AddMinutes(-20));
+            await SeedCpuAsync(_noOffsetId, "UncollectedSrv", eventUtc.AddMinutes(IndiaOffset), IndiaCpu);
+            await SeedDefaultTraceAsync(_noOffsetId, "UncollectedSrv", eventUtc.AddMinutes(IndiaOffset), IndiaEventText);
+
+            Assert.Null(await _dataService.GetServerUtcOffsetMinutesAsync(_noOffsetId));
+
+            var cpu = await McpCpuTools.GetCpuUtilization(_dataService, _serverManager, "UncollectedSrv");
+            using (var doc = JsonDocument.Parse(cpu))
+            {
+                Assert.Equal("unavailable", doc.RootElement.GetProperty("status").GetString());
+                Assert.False(doc.RootElement.TryGetProperty("samples", out _));
+            }
+
+            var events = await McpDefaultTraceTools.GetDefaultTraceEvents(_dataService, _serverManager, "UncollectedSrv");
+            using (var doc = JsonDocument.Parse(events))
+            {
+                Assert.Equal("unavailable", doc.RootElement.GetProperty("status").GetString());
+                Assert.False(doc.RootElement.TryGetProperty("events", out _));
+            }
+        }
+        finally
+        {
+            ServerTimeHelper.UtcOffsetMinutes = savedOffset;
+        }
+    }
+
+    /// <summary>
+    /// A NULL <c>utc_offset_minutes</c> from a pre-v42 snapshot must not mask a newer row that has one.
+    /// Ordering by <c>collection_time DESC</c> alone would take the NULL and refuse a server the store can
+    /// in fact place.
+    /// </summary>
+    [Fact]
+    public async Task ANullOffsetOnANewerSnapshot_DoesNotMaskTheOffsetTheStoreHas()
+    {
+        await SeedServerOffsetAsync(_pacificId, "PacificSrv", PacificOffset, DateTime.UtcNow.AddDays(-2));
+        await SeedServerOffsetAsync(_pacificId, "PacificSrv", null, DateTime.UtcNow);
+
+        Assert.Equal(PacificOffset, await _dataService.GetServerUtcOffsetMinutesAsync(_pacificId));
+    }
+
+    // ── helpers ──
+
+    private static DateTime Truncate(DateTime t) =>
+        new(t.Year, t.Month, t.Day, t.Hour, t.Minute, t.Second, DateTimeKind.Unspecified);
+
+    /* Returns an empty set rather than throwing when the tool answered a STATUS instead of data, so a
+       window built on the wrong offset fails as "expected [77], got []" instead of as a parse error. */
+    private static int[] SqlCpuIn(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.TryGetProperty("samples", out var samples)
+            ? samples.EnumerateArray().Select(s => s.GetProperty("sql_server_cpu").GetInt32()).ToArray()
+            : [];
+    }
+
+    private static string[] EventTextIn(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.TryGetProperty("events", out var events)
+            ? events.EnumerateArray().Select(e => e.GetProperty("text_data").GetString()!).ToArray()
+            : [];
+    }
+
+    private static DateTime[] EventTimesIn(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.TryGetProperty("events", out var events)
+            ? events.EnumerateArray().Select(e => DateTime.Parse(
+                e.GetProperty("event_time").GetString()!,
+                System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.RoundtripKind)).ToArray()
+            : [];
+    }
+
+    private async Task<DuckDBConnection> SeedConnectionAsync()
+    {
+        if (_seedConn is null)
+        {
+            _seedConn = _duckDb.CreateConnection();
+            await _seedConn.OpenAsync();
+        }
+        return _seedConn;
+    }
+
+    /// <summary>
+    /// One server_properties snapshot carrying (or deliberately omitting) this server's UTC offset. The
+    /// NOT NULL hardware/edition columns are filled with values nothing here reads.
+    /// </summary>
+    private async Task SeedServerOffsetAsync(int serverId, string serverName, int? utcOffsetMinutes, DateTime? collectionTime = null)
+    {
+        using var readLock = _duckDb.AcquireReadLock();
+        var conn = await SeedConnectionAsync();
+
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = @"INSERT INTO server_properties
+            (collection_id, collection_time, server_id, server_name,
+             edition, product_version, product_level, engine_edition,
+             cpu_count, hyperthread_ratio, physical_memory_mb, utc_offset_minutes)
+            VALUES ($1, $2, $3, $4, 'Developer Edition', '16.0.4150.1', 'RTM', 3, 8, 1, 16384, $5)";
+        void P(object v) => cmd.Parameters.Add(new DuckDBParameter { Value = v });
+        P(_nextId--);
+        P(collectionTime ?? DateTime.UtcNow);
+        P(serverId);
+        P(serverName);
+        P((object?)utcOffsetMinutes ?? DBNull.Value);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private async Task SeedCpuAsync(int serverId, string serverName, DateTime sampleTimeServerLocal, int sqlCpu)
+    {
+        using var readLock = _duckDb.AcquireReadLock();
+        var conn = await SeedConnectionAsync();
+
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = @"INSERT INTO cpu_utilization_stats
+            (collection_id, collection_time, server_id, server_name, sample_time,
+             sqlserver_cpu_utilization, other_process_cpu_utilization)
+            VALUES ($1, $2, $3, $4, $5, $6, 0)";
+        void P(object v) => cmd.Parameters.Add(new DuckDBParameter { Value = v });
+        P(_nextId--);
+        P(DateTime.UtcNow);
+        P(serverId);
+        P(serverName);
+        P(sampleTimeServerLocal);
+        P(sqlCpu);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    /// <summary>
+    /// One significant Default Trace event ("Server Memory Change" clears
+    /// <c>DefaultTraceEventSignificance</c> with no severity), stamped on the server's LOCAL wall clock the
+    /// way the collector stores <c>ft.StartTime</c>.
+    /// </summary>
+    private async Task SeedDefaultTraceAsync(int serverId, string serverName, DateTime eventTimeServerLocal, string textData)
+    {
+        using var readLock = _duckDb.AcquireReadLock();
+        var conn = await SeedConnectionAsync();
+
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = @"INSERT INTO default_trace_events
+            (default_trace_event_id, collection_time, server_id, server_name, event_time, event_name, text_data)
+            VALUES ($1, $2, $3, $4, $5, 'Server Memory Change', $6)";
+        void P(object v) => cmd.Parameters.Add(new DuckDBParameter { Value = v });
+        P(_nextId--);
+        P(DateTime.UtcNow);
+        P(serverId);
+        P(serverName);
+        P(eventTimeServerLocal);
+        P(textData);
+        await cmd.ExecuteNonQueryAsync();
+    }
+}

--- a/Lite.Tests/McpServerLocalOffsetTests.cs
+++ b/Lite.Tests/McpServerLocalOffsetTests.cs
@@ -164,14 +164,23 @@ public sealed class McpServerLocalOffsetTests : IClassFixture<SharedDuckDbFixtur
     }
 
     /// <summary>
-    /// A server whose offset the store does not hold is REFUSED, not answered against a guess. Both
-    /// candidate guesses (UTC, or the desktop static) would produce an answer indistinguishable from a
-    /// correct one, which is the failure the threading exists to remove — the same reasoning #2495 applied
-    /// to an unusable <c>as_of</c>. Rows ARE seeded for this server, so the refusal is provably about the
-    /// missing offset and not about missing data.
+    /// A server whose offset the store does not hold falls back to a FIXED POINT (UTC), never to the desktop
+    /// static. The distinction is the whole seam: 0 gives two identical MCP calls the same window whatever
+    /// the desktop is doing, while the static gives them whichever server a tab last selected.
+    ///
+    /// <para><b>Why a fallback rather than a refusal here.</b> A refusal would fire on the state every
+    /// server passes through on its first cycle — <c>server_properties</c> is an on-load collector — and it
+    /// would fire ahead of the read, pre-empting the two answers that outrank any window:
+    /// <c>not_collected</c> for an engine that cannot run the collector at all, and the read's own
+    /// <c>empty</c> when nothing has been collected. <c>EngineCapabilityMissTests</c> pins both and names
+    /// the failure mode: rendering "we do not know" as "this will never work" is the same defect wearing the
+    /// fix's clothes.</para>
+    ///
+    /// <para>Seeded AT UTC with the static parked on UTC+5:30, so the two candidate fallbacks disagree by
+    /// 5.5 hours and the row is only found by the right one.</para>
     /// </summary>
     [Fact]
-    public async Task AServerWithNoCollectedOffset_IsRefused_RatherThanWindowedOnAGuess()
+    public async Task AServerWithNoCollectedOffset_FallsBackToUtc_NotToTheDesktopStatic()
     {
         var savedOffset = ServerTimeHelper.UtcOffsetMinutes;
         try
@@ -179,24 +188,40 @@ public sealed class McpServerLocalOffsetTests : IClassFixture<SharedDuckDbFixtur
             ServerTimeHelper.UtcOffsetMinutes = IndiaOffset;
 
             var eventUtc = Truncate(DateTime.UtcNow.AddMinutes(-20));
-            await SeedCpuAsync(_noOffsetId, "UncollectedSrv", eventUtc.AddMinutes(IndiaOffset), IndiaCpu);
-            await SeedDefaultTraceAsync(_noOffsetId, "UncollectedSrv", eventUtc.AddMinutes(IndiaOffset), IndiaEventText);
+            await SeedCpuAsync(_noOffsetId, "UncollectedSrv", eventUtc, IndiaCpu);
+            await SeedDefaultTraceAsync(_noOffsetId, "UncollectedSrv", eventUtc, IndiaEventText);
 
             Assert.Null(await _dataService.GetServerUtcOffsetMinutesAsync(_noOffsetId));
 
             var cpu = await McpCpuTools.GetCpuUtilization(_dataService, _serverManager, "UncollectedSrv");
-            using (var doc = JsonDocument.Parse(cpu))
-            {
-                Assert.Equal("unavailable", doc.RootElement.GetProperty("status").GetString());
-                Assert.False(doc.RootElement.TryGetProperty("samples", out _));
-            }
+            Assert.Equal(new[] { IndiaCpu }, SqlCpuIn(cpu));
 
             var events = await McpDefaultTraceTools.GetDefaultTraceEvents(_dataService, _serverManager, "UncollectedSrv");
-            using (var doc = JsonDocument.Parse(events))
-            {
-                Assert.Equal("unavailable", doc.RootElement.GetProperty("status").GetString());
-                Assert.False(doc.RootElement.TryGetProperty("events", out _));
-            }
+            Assert.Equal(new[] { IndiaEventText }, EventTextIn(events));
+        }
+        finally
+        {
+            ServerTimeHelper.UtcOffsetMinutes = savedOffset;
+        }
+    }
+
+    /// <summary>
+    /// The fallback must not pre-empt the miss explanations that outrank it. A server with a registry row,
+    /// no collected offset and no server-local rows still reaches the read's own <c>empty</c> — the state
+    /// every server is in before its first collection completes. <c>EngineCapabilityMissTests</c> owns the
+    /// engine-edition half of this contract; this asserts the offset seam does not step in front of it.
+    /// </summary>
+    [Fact]
+    public async Task AServerWithNeitherOffsetNorRows_StillReachesTheReadsOwnMiss()
+    {
+        var savedOffset = ServerTimeHelper.UtcOffsetMinutes;
+        try
+        {
+            ServerTimeHelper.UtcOffsetMinutes = IndiaOffset;
+
+            var events = await McpDefaultTraceTools.GetDefaultTraceEvents(_dataService, _serverManager, "UncollectedSrv");
+            using var doc = JsonDocument.Parse(events);
+            Assert.Equal("empty", doc.RootElement.GetProperty("status").GetString());
         }
         finally
         {
@@ -206,8 +231,8 @@ public sealed class McpServerLocalOffsetTests : IClassFixture<SharedDuckDbFixtur
 
     /// <summary>
     /// A NULL <c>utc_offset_minutes</c> from a pre-v42 snapshot must not mask a newer row that has one.
-    /// Ordering by <c>collection_time DESC</c> alone would take the NULL and refuse a server the store can
-    /// in fact place.
+    /// Ordering by <c>collection_time DESC</c> alone would take the NULL and fall back to UTC for a server
+    /// the store can in fact place — a skewed window built from data that was right there.
     /// </summary>
     [Fact]
     public async Task ANullOffsetOnANewerSnapshot_DoesNotMaskTheOffsetTheStoreHas()

--- a/Lite/Mcp/McpCpuTools.cs
+++ b/Lite/Mcp/McpCpuTools.cs
@@ -27,9 +27,7 @@ public sealed class McpCpuTools
 
             /* sample_time is THIS server's local wall clock (#1262), so the window needs THIS server's
                offset — not the desktop tab's. See McpServerLocalWindow. */
-            var (utcOffsetMinutes, offsetError) =
-                await McpServerLocalWindow.OffsetOrErrorAsync(dataService, resolved.ServerId, resolved.ServerName);
-            if (offsetError != null) return offsetError;
+            var utcOffsetMinutes = await McpServerLocalWindow.OffsetForAsync(dataService, resolved.ServerId);
 
             var rows = await dataService.GetCpuUtilizationAsync(
                 resolved.ServerId, hours_back, asOfUtc: windowEnd, utcOffsetMinutes: utcOffsetMinutes);

--- a/Lite/Mcp/McpCpuTools.cs
+++ b/Lite/Mcp/McpCpuTools.cs
@@ -25,7 +25,14 @@ public sealed class McpCpuTools
             var hoursError = McpHelpers.ValidateWindow(hours_back, as_of, out var windowEnd);
             if (hoursError != null) return hoursError;
 
-            var rows = await dataService.GetCpuUtilizationAsync(resolved.ServerId, hours_back, asOfUtc: windowEnd);
+            /* sample_time is THIS server's local wall clock (#1262), so the window needs THIS server's
+               offset — not the desktop tab's. See McpServerLocalWindow. */
+            var (utcOffsetMinutes, offsetError) =
+                await McpServerLocalWindow.OffsetOrErrorAsync(dataService, resolved.ServerId, resolved.ServerName);
+            if (offsetError != null) return offsetError;
+
+            var rows = await dataService.GetCpuUtilizationAsync(
+                resolved.ServerId, hours_back, asOfUtc: windowEnd, utcOffsetMinutes: utcOffsetMinutes);
             if (rows.Count == 0)
             {
                 return await McpEngineCapability.NotCollectedStatusAsync(dataService, resolved.ServerId, resolved.ServerName, "cpu_utilization")

--- a/Lite/Mcp/McpDefaultTraceTools.cs
+++ b/Lite/Mcp/McpDefaultTraceTools.cs
@@ -37,9 +37,7 @@ public sealed class McpDefaultTraceTools
             /* Default Trace event_time is THIS server's local wall clock, so the window — and the de-skew
                that puts each returned event_time back into UTC — need THIS server's offset, not the desktop
                tab's. See McpServerLocalWindow. */
-            var (utcOffsetMinutes, offsetError) =
-                await McpServerLocalWindow.OffsetOrErrorAsync(dataService, resolved.ServerId, resolved.ServerName);
-            if (offsetError != null) return offsetError;
+            var utcOffsetMinutes = await McpServerLocalWindow.OffsetForAsync(dataService, resolved.ServerId);
 
             var rows = await dataService.GetDefaultTraceEventsAsync(
                 resolved.ServerId, hours_back, asOfUtc: windowEnd, utcOffsetMinutes: utcOffsetMinutes);

--- a/Lite/Mcp/McpDefaultTraceTools.cs
+++ b/Lite/Mcp/McpDefaultTraceTools.cs
@@ -34,7 +34,15 @@ public sealed class McpDefaultTraceTools
             var validation = McpHelpers.ValidateWindow(hours_back, as_of, out var windowEnd) ?? McpHelpers.ValidateTop(limit);
             if (validation != null) return validation;
 
-            var rows = await dataService.GetDefaultTraceEventsAsync(resolved.ServerId, hours_back, asOfUtc: windowEnd);
+            /* Default Trace event_time is THIS server's local wall clock, so the window — and the de-skew
+               that puts each returned event_time back into UTC — need THIS server's offset, not the desktop
+               tab's. See McpServerLocalWindow. */
+            var (utcOffsetMinutes, offsetError) =
+                await McpServerLocalWindow.OffsetOrErrorAsync(dataService, resolved.ServerId, resolved.ServerName);
+            if (offsetError != null) return offsetError;
+
+            var rows = await dataService.GetDefaultTraceEventsAsync(
+                resolved.ServerId, hours_back, asOfUtc: windowEnd, utcOffsetMinutes: utcOffsetMinutes);
             if (rows.Count == 0)
                 return await McpEngineCapability.NotCollectedStatusAsync(dataService, resolved.ServerId, resolved.ServerName, "default_trace_events")
                     ?? McpHelpers.Status("empty", "No significant default trace events found in the requested time range.");

--- a/Lite/Mcp/McpServerLocalWindow.cs
+++ b/Lite/Mcp/McpServerLocalWindow.cs
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using PerformanceMonitor.Common;
+using PerformanceMonitorLite.Services;
+
+namespace PerformanceMonitorLite.Mcp;
+
+/// <summary>
+/// Supplies the UTC offset for the MCP reads whose window is expressed in the MONITORED SERVER'S local wall
+/// clock rather than in UTC — <c>get_cpu_utilization</c> (<c>cpu_utilization_stats.sample_time</c>) and
+/// <c>get_default_trace_events</c> (<c>default_trace_events.event_time</c>). Every other MCP read windows on
+/// <c>collection_time</c>, which is naive UTC, and needs nothing from here.
+///
+/// <para><b>Why an MCP tool cannot use the desktop's offset.</b> <c>ServerTimeHelper.UtcOffsetMinutes</c> is
+/// process-wide state written only by the WPF tab paths, so it holds whichever server the UI last selected —
+/// or, with no tab ever opened, the LITE HOST's own offset, which belongs to no monitored server at all. An
+/// MCP tool picks its <c>server_id</c> from <c>server_name</c> independently of that, so reading the static
+/// lets the window and the server_id name two different servers. The result is a shifted or empty answer and
+/// no error: <c>sample_time</c> compared against the wrong clock simply matches nothing, which reads as "no
+/// data" rather than as a fault.</para>
+/// </summary>
+internal static class McpServerLocalWindow
+{
+    /// <summary>
+    /// This server's own offset, or a ready-to-return status when the store does not hold one. Mirrors
+    /// <see cref="ServerResolver.ResolveOrError"/>'s shape: <c>var (offset, error) = await ...; if (error
+    /// != null) return error;</c>. <c>OffsetMinutes</c> is not meaningful whenever <c>Error</c> is set.
+    ///
+    /// <para><b>Why a status and not a fallback.</b> The two candidate fallbacks — 0, or the desktop
+    /// static — are both guesses about a real server's clock, and a guess here produces an answer that
+    /// cannot be told apart from a correct one. That is the same reasoning that made #2495 refuse an
+    /// unusable <c>as_of</c> instead of quietly answering as of now. <c>unavailable</c> rather than
+    /// <c>not_collected</c>: the offset IS collected on this engine — <c>server_properties</c> is enabled by
+    /// default and writes it on load — so the honest reading is "supported here, not retrievable yet", and
+    /// the message names the collector so an operator has somewhere to go.</para>
+    /// </summary>
+    public static async Task<(int OffsetMinutes, string? Error)> OffsetOrErrorAsync(
+        LocalDataService dataService,
+        int serverId,
+        string serverName)
+    {
+        var offset = await dataService.GetServerUtcOffsetMinutesAsync(serverId);
+
+        return offset is { } minutes
+            ? (minutes, null)
+            : (0, McpHelpers.Status(
+                "unavailable",
+                $"No UTC offset has been collected for '{serverName}', and this read's window is expressed in that "
+                + "server's local wall clock, so it cannot be built. Run the server_properties collector for this "
+                + "server (it runs on load) and retry."));
+    }
+}

--- a/Lite/Mcp/McpServerLocalWindow.cs
+++ b/Lite/Mcp/McpServerLocalWindow.cs
@@ -6,7 +6,6 @@
  * Licensed under the MIT License. See LICENSE file in the project root for full license information.
  */
 
-using PerformanceMonitor.Common;
 using PerformanceMonitorLite.Services;
 
 namespace PerformanceMonitorLite.Mcp;
@@ -28,31 +27,29 @@ namespace PerformanceMonitorLite.Mcp;
 internal static class McpServerLocalWindow
 {
     /// <summary>
-    /// This server's own offset, or a ready-to-return status when the store does not hold one. Mirrors
-    /// <see cref="ServerResolver.ResolveOrError"/>'s shape: <c>var (offset, error) = await ...; if (error
-    /// != null) return error;</c>. <c>OffsetMinutes</c> is not meaningful whenever <c>Error</c> is set.
+    /// This server's collected offset, or 0 when the store holds none.
     ///
-    /// <para><b>Why a status and not a fallback.</b> The two candidate fallbacks — 0, or the desktop
-    /// static — are both guesses about a real server's clock, and a guess here produces an answer that
-    /// cannot be told apart from a correct one. That is the same reasoning that made #2495 refuse an
-    /// unusable <c>as_of</c> instead of quietly answering as of now. <c>unavailable</c> rather than
-    /// <c>not_collected</c>: the offset IS collected on this engine — <c>server_properties</c> is enabled by
-    /// default and writes it on load — so the honest reading is "supported here, not retrievable yet", and
-    /// the message names the collector so an operator has somewhere to go.</para>
+    /// <para><b>Why 0 and not the desktop static.</b> 0 is a fixed point: two identical MCP calls get the
+    /// same window from it no matter what the desktop is doing, which is the property this whole seam exists
+    /// to restore. Falling back to the static would reinstate exactly the coupling being removed, and would
+    /// do it on the least visible path.</para>
+    ///
+    /// <para><b>Why a fallback and not a refusal.</b> A refusal here would fire on the state every server
+    /// passes through on its first cycle — <c>server_properties</c> is an on-load collector, so a server has
+    /// no stored offset until it has completed one — and it would fire BEFORE the read, pre-empting the two
+    /// answers that are more fundamental than any window: <c>not_collected</c> when the engine cannot run
+    /// this collector at all (#2511), and the read's own <c>empty</c> when nothing has been collected yet.
+    /// <c>EngineCapabilityMissTests</c> pins both, and names the failure mode precisely: rendering "we do not
+    /// know" as "this will never work" is the same defect wearing the fix's clothes. A server with no offset
+    /// almost always has no server-local rows either, so the read reaches those explanations on its own.</para>
+    ///
+    /// <para><b>The residual, stated rather than hidden.</b> A server that has server-local ROWS but no
+    /// stored offset — data collected before schema v42 added the column, with no <c>server_properties</c>
+    /// collection since — gets a UTC window over a server-local column, so its answer is skewed by the
+    /// server's true offset. That is the pre-existing behaviour for that server rather than a new one, it is
+    /// self-correcting on the next on-load collection, and it is no longer contingent on which tab the
+    /// desktop last had open.</para>
     /// </summary>
-    public static async Task<(int OffsetMinutes, string? Error)> OffsetOrErrorAsync(
-        LocalDataService dataService,
-        int serverId,
-        string serverName)
-    {
-        var offset = await dataService.GetServerUtcOffsetMinutesAsync(serverId);
-
-        return offset is { } minutes
-            ? (minutes, null)
-            : (0, McpHelpers.Status(
-                "unavailable",
-                $"No UTC offset has been collected for '{serverName}', and this read's window is expressed in that "
-                + "server's local wall clock, so it cannot be built. Run the server_properties collector for this "
-                + "server (it runs on load) and retry."));
-    }
+    public static async Task<int> OffsetForAsync(LocalDataService dataService, int serverId)
+        => await dataService.GetServerUtcOffsetMinutesAsync(serverId) ?? 0;
 }

--- a/Lite/Services/LocalDataService.Cpu.cs
+++ b/Lite/Services/LocalDataService.Cpu.cs
@@ -19,13 +19,21 @@ public partial class LocalDataService
     /// Gets CPU utilization data for charting.
     /// Note: sample_time is stored in server local time (from SYSDATETIME()), not UTC.
     /// </summary>
-    public async Task<List<CpuUtilizationRow>> GetCpuUtilizationAsync(int serverId, int hoursBack = 4, DateTime? fromDate = null, DateTime? toDate = null, DateTime? asOfUtc = null)
+    /// <param name="utcOffsetMinutes">
+    /// <paramref name="serverId"/>'s OWN UTC offset, which is what the server-local window has to be
+    /// expressed in. <c>null</c> means "use the desktop UI's selected-tab offset"
+    /// (<see cref="ServerTimeHelper.UtcOffsetMinutes"/>) — correct for the WPF tab that set it and for
+    /// nobody else. Any caller that picks its own <paramref name="serverId"/> (every MCP tool does) must
+    /// pass that server's offset, or the window and the server_id name two different servers and the read
+    /// comes back shifted or empty with no error.
+    /// </param>
+    public async Task<List<CpuUtilizationRow>> GetCpuUtilizationAsync(int serverId, int hoursBack = 4, DateTime? fromDate = null, DateTime? toDate = null, DateTime? asOfUtc = null, int? utcOffsetMinutes = null)
     {
         using var connection = await OpenConnectionAsync();
         using var command = connection.CreateCommand();
 
         /* sample_time is in server local time, not UTC */
-        var (startTime, endTime) = GetTimeRangeServerLocal(hoursBack, fromDate, toDate, asOfUtc);
+        var (startTime, endTime) = GetTimeRangeServerLocal(hoursBack, fromDate, toDate, asOfUtc, utcOffsetMinutes ?? ServerTimeHelper.UtcOffsetMinutes);
 
         command.CommandText = @"
 SELECT

--- a/Lite/Services/LocalDataService.ServerInfo.cs
+++ b/Lite/Services/LocalDataService.ServerInfo.cs
@@ -58,6 +58,40 @@ LIMIT 1";
     }
 
     /// <summary>
+    /// One server's OWN UTC offset in minutes, for the reads whose window is expressed in that server's
+    /// local wall clock (<c>cpu_utilization_stats.sample_time</c>, <c>default_trace_events.event_time</c>).
+    /// <c>null</c> when the store holds no offset for it.
+    ///
+    /// <para><b>Why the STORE and not the live probe.</b> <c>ServerManager</c> also learns an offset — its
+    /// detection query selects <c>DATEDIFF(MINUTE, GETUTCDATE(), GETDATE())</c> — but that value only
+    /// exists once something has opened a connection to that server, and is keyed by the registry's own
+    /// string id. <c>server_properties.utc_offset_minutes</c> is the same fact, collected, keyed by the
+    /// numeric <c>server_id</c> these reads already filter on, and available to a caller that has connected
+    /// to nothing.</para>
+    ///
+    /// <para>Skips NULL offsets rather than taking the newest row blindly: the column arrived in schema v42
+    /// and is nullable, so a store migrated from earlier holds pre-v42 snapshots that predate it. Ordering
+    /// by <c>collection_time DESC</c> alone would let one of those mask an offset the store does have.</para>
+    /// </summary>
+    public async Task<int?> GetServerUtcOffsetMinutesAsync(int serverId)
+    {
+        using var connection = await OpenConnectionAsync();
+        using var command = connection.CreateCommand();
+        command.CommandText = @"
+SELECT utc_offset_minutes
+FROM v_server_properties
+WHERE server_id = $1
+AND   utc_offset_minutes IS NOT NULL
+ORDER BY collection_time DESC
+LIMIT 1";
+
+        command.Parameters.Add(new DuckDBParameter { Value = serverId });
+
+        var scalar = await command.ExecuteScalarAsync();
+        return scalar is null or DBNull ? null : Convert.ToInt32(scalar);
+    }
+
+    /// <summary>
     /// Gets the latest database size stats (file sizes, volume space).
     /// </summary>
     public async Task<List<DatabaseSizeStatsRow>> GetLatestDatabaseSizeStatsAsync(int serverId)

--- a/Lite/Services/LocalDataService.ServerInfo.cs
+++ b/Lite/Services/LocalDataService.ServerInfo.cs
@@ -60,7 +60,8 @@ LIMIT 1";
     /// <summary>
     /// One server's OWN UTC offset in minutes, for the reads whose window is expressed in that server's
     /// local wall clock (<c>cpu_utilization_stats.sample_time</c>, <c>default_trace_events.event_time</c>).
-    /// <c>null</c> when the store holds no offset for it.
+    /// <c>null</c> when the store holds no offset for it — callers decide what an unknown offset means, and
+    /// <see cref="Mcp.McpServerLocalWindow"/> holds that decision for the MCP surface.
     ///
     /// <para><b>Why the STORE and not the live probe.</b> <c>ServerManager</c> also learns an offset — its
     /// detection query selects <c>DATEDIFF(MINUTE, GETUTCDATE(), GETDATE())</c> — but that value only

--- a/Lite/Services/LocalDataService.SystemEvents.cs
+++ b/Lite/Services/LocalDataService.SystemEvents.cs
@@ -35,9 +35,9 @@ namespace PerformanceMonitorLite.Services;
  * ServerTimeHelper.FormatServerTime (naive-UTC -> display) exactly like the deadlock / blocked-process grids.
  * The Default Trace event_time is the monitored server's LOCAL StartTime (ft.StartTime, stored raw) — that
  * read windows on the server-LOCAL bounds from GetTimeRangeServerLocal and de-skews each row's server-local
- * event_time to naive-UTC (subtract the connected server's UtcOffsetMinutes) BEFORE the row VM, so a Default
- * Trace row and a system_health row from the same instant render the same wall-clock time and a merged
- * System Events timeline sorts consistently.
+ * event_time to naive-UTC (subtract THAT server's utc offset, the one the caller passed alongside its
+ * server_id) BEFORE the row VM, so a Default Trace row and a system_health row from the same instant render
+ * the same wall-clock time and a merged System Events timeline sorts consistently.
  */
 
 /// <summary>Shared render of a naive-UTC event timestamp for the System Events grids — the same
@@ -630,13 +630,21 @@ QUALIFY ROW_NUMBER() OVER (PARTITION BY database_id ORDER BY collection_time DES
     /// Significant Default Trace events for the window, newest first, from the v_default_trace_events archive
     /// view. The Default Trace StartTime is the monitored server's LOCAL wall clock (ft.StartTime, stored
     /// raw), so this windows on the server-LOCAL bounds from <see cref="GetTimeRangeServerLocal"/> and
-    /// de-skews each row's server-local event_time to naive-UTC (subtracting the connected server's
-    /// <see cref="ServerTimeHelper.UtcOffsetMinutes"/>) BEFORE the row VM, so the returned timestamps share
+    /// de-skews each row's server-local event_time to naive-UTC (subtracting that server's UTC offset)
+    /// BEFORE the row VM, so the returned timestamps share
     /// the same UTC frame as the system_health rows and render/sort consistently on the tab. #1319: the
     /// global database filter is pushed into SQL on <c>database_name</c>. The ErrorLog severity gate is
     /// applied on read via the shared <see cref="DefaultTraceEventSignificance"/>.
     /// </summary>
-    public async Task<List<DefaultTraceEventRow>> GetDefaultTraceEventsAsync(int serverId, int hoursBack = 24, DateTime? fromDate = null, DateTime? toDate = null, IReadOnlyList<string>? databaseNames = null, DateTime? asOfUtc = null)
+    /// <param name="utcOffsetMinutes">
+    /// <paramref name="serverId"/>'s OWN UTC offset. Used TWICE here — to build the server-local window and
+    /// to de-skew each returned row — and both uses read the one resolved value, so the bounds and the
+    /// timestamps can never disagree about which server's clock they are in. <c>null</c> means "use the
+    /// desktop UI's selected-tab offset" (<see cref="ServerTimeHelper.UtcOffsetMinutes"/>); see
+    /// <see cref="LocalDataService.GetCpuUtilizationAsync"/> for why a caller that picks its own
+    /// <paramref name="serverId"/> must not take that default.
+    /// </param>
+    public async Task<List<DefaultTraceEventRow>> GetDefaultTraceEventsAsync(int serverId, int hoursBack = 24, DateTime? fromDate = null, DateTime? toDate = null, IReadOnlyList<string>? databaseNames = null, DateTime? asOfUtc = null, int? utcOffsetMinutes = null)
     {
         using var _q = TimeQuery("GetDefaultTraceEventsAsync", "v_default_trace_events significant-set read");
         using var connection = await OpenConnectionAsync();
@@ -644,7 +652,8 @@ QUALIFY ROW_NUMBER() OVER (PARTITION BY database_id ORDER BY collection_time DES
 
         /* Default Trace event_time is server-LOCAL, so window on server-local bounds (the same helper the
            CPU/sample_time reads use). Bind db filter params immediately after the 3 fixed params ($4+). */
-        var (startTime, endTime) = GetTimeRangeServerLocal(hoursBack, fromDate, toDate, asOfUtc);
+        var offset = utcOffsetMinutes ?? ServerTimeHelper.UtcOffsetMinutes;
+        var (startTime, endTime) = GetTimeRangeServerLocal(hoursBack, fromDate, toDate, asOfUtc, offset);
         var dbClause = BuildDbInClause(databaseNames, "database_name", 4, out var dbValues);
 
         command.CommandText = @"
@@ -673,8 +682,6 @@ ORDER BY event_time DESC";
         command.Parameters.Add(new DuckDBParameter { Value = endTime });
         foreach (var db in dbValues)
             command.Parameters.Add(new DuckDBParameter { Value = db });
-
-        var offset = ServerTimeHelper.UtcOffsetMinutes;
 
         var rows = new List<DefaultTraceEventRow>();
         using var reader = await command.ExecuteReaderAsync();

--- a/Lite/Services/LocalDataService.cs
+++ b/Lite/Services/LocalDataService.cs
@@ -137,11 +137,18 @@ public partial class LocalDataService
     /// <summary>
     /// Gets the time range in server local time (for tables like cpu_utilization_stats.sample_time).
     /// </summary>
-    private static (DateTime startTime, DateTime endTime) GetTimeRangeServerLocal(int hoursBack, DateTime? fromDate, DateTime? toDate, DateTime? asOfUtc = null)
+    /// <param name="utcOffsetMinutes">
+    /// The UTC offset of the server whose rows this window will select — the same server as the
+    /// <c>server_id</c> in the predicate beside it. REQUIRED rather than defaulted: an offset and a
+    /// server_id are two halves of one question, and taking the offset from ambient state is how they came
+    /// to name two different servers. A caller with no server-specific offset to give has to say so at the
+    /// call site instead of inheriting one silently.
+    /// </param>
+    private static (DateTime startTime, DateTime endTime) GetTimeRangeServerLocal(int hoursBack, DateTime? fromDate, DateTime? toDate, DateTime? asOfUtc, int utcOffsetMinutes)
     {
         /* The anchor arrives in UTC (see GetTimeRange) and is carried into server-local here, so both
            families answer the same instant even though they window on differently-based columns. */
-        var serverNow = (asOfUtc ?? DateTime.UtcNow).AddMinutes(ServerTimeHelper.UtcOffsetMinutes);
+        var serverNow = (asOfUtc ?? DateTime.UtcNow).AddMinutes(utcOffsetMinutes);
 
         if (fromDate.HasValue && toDate.HasValue)
         {


### PR DESCRIPTION
`get_cpu_utilization` and `get_default_trace_events` window on columns that hold the monitored server's LOCAL wall clock — `cpu_utilization_stats.sample_time` (#1262's contract, pinned by `CollectorTimestampFrameTests`) and `default_trace_events.event_time` — so their bounds have to be expressed in that server's UTC offset. Both took that offset from `ServerTimeHelper.UtcOffsetMinutes`, process-wide state whose only writers are the WPF tab paths (`MainWindow.xaml.cs` on tab selection, `ServerTab.xaml.cs` on construction), while resolving their own `server_id` from `server_name` through `ServerResolver`. The two halves of one predicate could therefore name two different servers: over MCP the window came from whichever server the desktop last selected, or — with no tab ever opened — from the Lite HOST's own timezone, which is not any monitored server's offset at all. A `sample_time` compared against the wrong clock matches nothing, so the answer arrived shifted or empty with no error, shaped exactly like "no data".

## The change

`GetTimeRangeServerLocal` takes the offset as a **required** parameter and reads no ambient state. An offset and a `server_id` are two halves of one question, so a default there is what let them drift apart; a caller with no server-specific offset now has to say so at the call site.

Both readers (`GetCpuUtilizationAsync`, `GetDefaultTraceEventsAsync`) accept an optional per-server offset and fall back to the static only when a caller passes none — which is every desktop call site, so **UI behaviour is unchanged and no UI call site is touched**. The MCP tools resolve the offset for the server they actually resolved, via a new `LocalDataService.GetServerUtcOffsetMinutesAsync` reading the collected `server_properties.utc_offset_minutes`.

That column rather than `ServerManager`'s live probe: the probe's value only exists once something has opened a connection to that server and is keyed by the registry's string id, while the stored column is the same fact keyed by the numeric `server_id` these reads already filter on, and is available to a caller that has connected to nothing. It skips NULL offsets rather than taking the newest row blindly — the column arrived in schema v42 and is nullable, so a migrated store holds pre-v42 snapshots that predate it and one of those would otherwise mask an offset the store does have.

The Default Trace read uses the offset a **second** time, to de-skew each returned `event_time` back to naive UTC. Both uses now read one resolved value, so the bounds and the timestamps cannot disagree about whose clock they are in.

## What an unknown offset does

`server_properties` is an on-load collector, so a server has no stored offset until it has completed one cycle. An unknown offset falls back to **0**, and the read proceeds.

Not the desktop static: that is the coupling being removed, and falling back to it would reinstate it on the least visible path. 0 is a fixed point, so two identical MCP calls get the same window whatever the desktop is doing.

Not a refusal either, which is what the first revision of this PR did and what CI caught. Refusing fired ahead of the read and pre-empted the two answers that outrank any window — `not_collected` for an engine that cannot run the collector at all (#2511), and the read's own `empty` when nothing has been collected. An Azure SQL Database server got a generic "run the server_properties collector" instead of the message explaining it has no default trace. `EngineCapabilityMissTests` pins both and names the failure mode exactly: rendering "we do not know" as "this will never work" is the same defect wearing the fix's clothes, and it is the state every server passes through on its first cycle. A server with no offset almost always has no server-local rows either, so the read reaches those explanations on its own.

**The residual, stated rather than hidden.** A server holding server-local ROWS but no stored offset — data collected before v42 added the column, with no `server_properties` collection since — gets a UTC window over a server-local column, so its answer is skewed by the server's true offset. That is its pre-existing behaviour rather than a new one, it self-corrects on the next on-load collection, and it is no longer contingent on which tab the desktop last had open. It is documented on `McpServerLocalWindow` beside the fallback.

## Tests

`AsOfWindowAnchorTests.TheAnchorAlsoMoves_AServerLocalWindow` was **masking** this: it assigned the static the offset it then seeded against, so the tool taking its window from the static rather than from the server it resolved never showed. It now seeds the offset the way production supplies it and leaves the static alone. With nothing in that class touching the static any more, it no longer needs the `server-time-helper` collection and runs fully parallel again.

`McpServerLocalOffsetTests` owns the per-server contract, and states it as **invariance** rather than as an expected window — a pinned window passes against the old code whenever the static happens to hold the right server, which is exactly how the masking happened. Two servers 13.5 hours apart (UTC-8 and UTC+5:30, one a half-hour offset so whole-hour rounding is caught), both reads run under four values of the static including one belonging to neither server, and every run must return each server its own rows. It also asserts both servers' events come back at the same UTC instant despite their stored values sitting 13.5 hours apart, which is what pins the de-skew: a fix that threaded the offset into the window and left the de-skew on the static passes every other assertion.

## Verification

`Lite` and `Lite.Tests` compile clean on macOS with `-p:EnableWindowsTargeting=true` (0 errors; the warnings are pre-existing in files this PR does not touch). `Lite.Tests` targets `net10.0-windows` and **cannot run** here — `Microsoft.WindowsDesktop.App` is absent — so CI is the arbiter for the xUnit tests above.

Fail-first was therefore demonstrated locally at the level that *can* run: a throwaway `net10.0` harness splices the **shipped text** of `GetTimeRangeServerLocal` out of both `origin/dev` and this branch (extracted by script, not retyped), together with the shipped CPU query literal, and runs both against a real DuckDB holding the new test's fixture. `origin/dev`'s helper returns the wrong server's window on **6 of 8** reads — and returns it as an empty set, not an error — while this branch's is correct on all 8. The two it gets right are the two where the static happens to hold the requested server's offset, which is the masking restated as a measurement.

That harness covers the window arithmetic and the SQL predicate. It does **not** cover the MCP wiring, the Default Trace de-skew, or the unknown-offset fallback; those are covered only by the xUnit tests CI runs.
