### PR TITLE
Part of #2874

### DIFF
--- a/Darling/Darling.Tests/CommandDeadlineScanner.cs
+++ b/Darling/Darling.Tests/CommandDeadlineScanner.cs
@@ -44,14 +44,6 @@ internal static class CommandDeadlineScanner
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     /// <summary>
-    /// A deadline assigned through a member access - <c>command.CommandTimeout = ...</c>, the only way a
-    /// <c>CreateCommand</c> result can carry one. Read against the statement span.
-    /// </summary>
-    private static readonly Regex s_assignsTimeout = new(
-        @"\.\s*CommandTimeout\s*=",
-        RegexOptions.Compiled | RegexOptions.CultureInvariant);
-
-    /// <summary>
     /// Whether the command constructed at <paramref name="index"/> in already-STRIPPED
     /// <paramref name="code"/> sets an explicit deadline.
     /// </summary>


### PR DESCRIPTION
`s_assignsTimeout` in `Darling/Darling.Tests/CommandDeadlineScanner.cs` had no reader. `SetsAnExplicitDeadline` asks the initializer half through `s_setsTimeout` and the assignment half through the name-bound `Assigns(bound)` factory, which is the form that supersedes it — the unqualified spelling was left behind when #2938's review introduced the name binding.

It is also the exact shape `Assigns`' own doc comment identifies as wrong. Read over the statement span, an unqualified `\.CommandTimeout\s*=` accepts a *sibling's* assignment: an untimed `using (...)` header whose block opens with a timed sibling spends both counted statements on the sibling, and the outer command reads as timed. A working implementation of the bug the file documents is an invitation to reuse it, so this removes it rather than leaving it in place as a footnote.

**#2874 is closed (completed).** The `Part of` title keeps this grouped with the sweep's other PRs; it is tidy-up the sweep left behind, not part of any remaining work.

### Scope

Eight lines deleted from one file — the declaration and its `<summary>`. Nothing else changes; `System.Text.RegularExpressions` is still needed by `s_setsTimeout` and `Assigns`.

### Verification

- `s_assignsTimeout` occurs **once** in the repo: its own declaration. Cross-checked with three independent tools (ugrep, `/usr/bin/grep`, `git grep -F`), each positive-controlled against `s_setsTimeout` (14 source lines) so a zero could not be a bad pattern quietly reading as a clean result. Being `private`, it was also unreachable from outside the class by construction.
- No `<see cref="s_assignsTimeout"/>` anywhere, and no prose reference by name; that search was positive-controlled against `cref="CSharpSourceWalker` (21 matches).
- `Assigns`' doc comment refers to the unqualified *pattern*, never to the field by name, so it needs no rewording — with the working copy gone it reads as the description of a rejected alternative, which is what it always was.
- Worth recording for future cref-safety claims in this repo: `GenerateDocumentationFile` is not set anywhere, so **CS1574 cannot fire**. A deliberately dangling cref injected into this file produced the same 37 warnings as a clean build, which is why the textual search above is the load-bearing check rather than the compile.
- `dotnet build -p:EnableWindowsTargeting=true --no-incremental`: 0 errors, 37 warnings, and the normalized warning set is **byte-identical** to a baseline build of unmodified `dev`.
- All six pins that route through the scanner still compile: `AlertPass`, `AnalysisPass`, `CommandPlane`, `FactCollector`, `Storage`, `Viewer`.
- Those six compiled into a throwaway `net10.0` xunit host (`AssemblyName=Darling.Tests`) report `Total: 116, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0` both before and after, with an identical suite fingerprint. The rebuilt assembly was confirmed to no longer contain `s_assignsTimeout` while still containing `s_setsTimeout`, so the result is not a stale binary.
