### PR TITLE
Fixes #2953

### DIFF
--- a/Darling/Darling.Tests/CollectorRuntimeStateTests.cs
+++ b/Darling/Darling.Tests/CollectorRuntimeStateTests.cs
@@ -1,0 +1,369 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using PerformanceMonitor.Darling.Service;
+using PerformanceMonitor.Darling.Service.Mcp;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #2953: the collector's startup verdict, and the one health surface that reports it without reading the
+/// store. Three things are pinned, in ascending order of how much they matter.
+///
+/// <para>The SEAM (<see cref="CollectorRuntimeState"/>) behaves like its two siblings — null until published,
+/// then one coherent immutable snapshot.</para>
+///
+/// <para>The MAPPING (<see cref="DarlingWebEndpoints.DescribePing"/>) turns that verdict into a status code
+/// and a body, four states, no state answering healthy that is not.</para>
+///
+/// <para>The CENSUS is the pin that actually protects the fix. A stand-down in the worker's startup path
+/// <c>return</c>s, which completes the worker task successfully — the host stays up, both Kestrel hosts keep
+/// serving, and on Windows the service keeps reporting Running — so a collection-blocking exit that forgets
+/// to publish is invisible on every automated surface and silently restores the exact defect this closes.
+/// The compiler cannot catch that, so it is asserted structurally over the source.</para>
+/// </summary>
+public sealed class CollectorRuntimeStateTests
+{
+    // ── The seam ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void CollectorRuntimeState_UnpublishedReadsNull_ThenLatestCoherentSnapshot()
+    {
+        var state = new CollectorRuntimeState();
+
+        /* Pre-publish: the worker has not reached a verdict, which a reader renders as "starting" rather
+           than as either healthy or broken. */
+        Assert.Null(state.Read());
+
+        state.PublishRetrying(CollectorRuntimeState.StartupStep.Store, "Connection refused", attempt: 3, attempts: 25);
+        var retrying = state.Read();
+        Assert.NotNull(retrying);
+        Assert.Equal(CollectorRuntimeState.CollectorPhase.Retrying, retrying!.Phase);
+        Assert.Equal(CollectorRuntimeState.StartupStep.Store, retrying.Step);
+        Assert.Equal("Connection refused", retrying.Detail);
+        Assert.Equal(3, retrying.Attempt);
+        Assert.Equal(25, retrying.Attempts);
+
+        /* Each publish swaps ONE immutable snapshot reference, so a reader can never see a phase from one
+           publish carrying an attempt count from another. */
+        state.PublishStopped(CollectorRuntimeState.StartupStep.Store, "relation \"x\" does not exist");
+        var stopped = state.Read();
+        Assert.NotNull(stopped);
+        Assert.NotSame(retrying, stopped);
+        Assert.Equal(CollectorRuntimeState.CollectorPhase.Stopped, stopped!.Phase);
+        Assert.Equal("relation \"x\" does not exist", stopped.Detail);
+        /* The attempt fields carry nothing outside Retrying rather than the last retry's numbers — a
+           terminal verdict that reported "attempt 3 of 25" would read as still trying. */
+        Assert.Equal(0, stopped.Attempt);
+        Assert.Equal(0, stopped.Attempts);
+
+        state.PublishCollecting();
+        var collecting = state.Read();
+        Assert.NotNull(collecting);
+        Assert.Equal(CollectorRuntimeState.CollectorPhase.Collecting, collecting!.Phase);
+        Assert.Null(collecting.Step);
+        Assert.Null(collecting.Detail);
+    }
+
+    /// <summary>Every publish stamps UTC, because the ping body reports it as an instant and a local-time
+    /// stamp serialized with an offset (or worse, without one) is a wrong instant to whoever reads it.</summary>
+    [Fact]
+    public void EveryPublish_StampsUtc()
+    {
+        var state = new CollectorRuntimeState();
+
+        foreach (var publish in new Action[]
+        {
+            () => state.PublishRetrying(CollectorRuntimeState.StartupStep.Configuration, "locked", 1, 25),
+            () => state.PublishStopped(CollectorRuntimeState.StartupStep.Configuration, "not found"),
+            state.PublishCollecting,
+        })
+        {
+            publish();
+            Assert.Equal(DateTimeKind.Utc, state.Read()!.AsOfUtc.Kind);
+        }
+    }
+
+    // ── The mapping ───────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The whole four-state table, code and word together. The pairing is the point: the CODE is what a load
+    /// balancer or uptime check reads without parsing a body, so a state that is not collecting and answers
+    /// 200 is the original defect however good its body is.
+    /// </summary>
+    [Fact]
+    public void DescribePing_CoversTheWholeTable()
+    {
+        /* Unpublished — the ordinary first seconds of a start. 200, because a check that alarmed here would
+           alarm on every service restart, and this state is bounded: a terminal stand-down publishes
+           Stopped before it returns, so a dead collector cannot come to rest here. */
+        var starting = DarlingWebEndpoints.DescribePing(null);
+        Assert.Equal(200, starting.HttpStatus);
+        Assert.Equal("starting", starting.Status);
+        Assert.False(starting.Collecting);
+        Assert.Null(starting.SinceUtc);
+
+        var collectingAt = new DateTime(2026, 9, 4, 20, 11, 3, DateTimeKind.Utc);
+        var collecting = DarlingWebEndpoints.DescribePing(new CollectorRuntimeState.Snapshot(
+            CollectorRuntimeState.CollectorPhase.Collecting, null, null, 0, 0, collectingAt));
+        Assert.Equal(200, collecting.HttpStatus);
+        Assert.Equal("ok", collecting.Status);
+        Assert.True(collecting.Collecting);
+        Assert.Equal(collectingAt, collecting.SinceUtc);
+        Assert.Null(collecting.Step);
+        Assert.Null(collecting.Attempt);
+        Assert.Null(collecting.Detail);
+
+        var retrying = DarlingWebEndpoints.DescribePing(new CollectorRuntimeState.Snapshot(
+            CollectorRuntimeState.CollectorPhase.Retrying, CollectorRuntimeState.StartupStep.Store,
+            "Connection refused", 3, 25, DateTime.UtcNow));
+        Assert.Equal(503, retrying.HttpStatus);
+        Assert.Equal("degraded", retrying.Status);
+        Assert.False(retrying.Collecting);
+        Assert.Equal("store", retrying.Step);
+        Assert.Equal(3, retrying.Attempt);
+        Assert.Equal(25, retrying.Attempts);
+        Assert.Equal("Connection refused", retrying.Detail);
+
+        var stopped = DarlingWebEndpoints.DescribePing(new CollectorRuntimeState.Snapshot(
+            CollectorRuntimeState.CollectorPhase.Stopped, CollectorRuntimeState.StartupStep.Store,
+            "42P01: relation does not exist", 0, 0, DateTime.UtcNow));
+        Assert.Equal(503, stopped.HttpStatus);
+        Assert.Equal("stopped", stopped.Status);
+        Assert.False(stopped.Collecting);
+        Assert.Equal("store", stopped.Step);
+        Assert.Equal("42P01: relation does not exist", stopped.Detail);
+        /* No attempt fields on a terminal verdict — see the seam pin above. */
+        Assert.Null(stopped.Attempt);
+        Assert.Null(stopped.Attempts);
+    }
+
+    /// <summary>The two non-collecting phases are the ones the issue is about, and NEITHER may answer 200 for
+    /// any step — a per-step exemption is how "the store is down" would quietly become healthy again.</summary>
+    [Theory]
+    [InlineData(CollectorRuntimeState.CollectorPhase.Retrying, CollectorRuntimeState.StartupStep.Configuration, "configuration")]
+    [InlineData(CollectorRuntimeState.CollectorPhase.Retrying, CollectorRuntimeState.StartupStep.ManagedStore, "managed_store")]
+    [InlineData(CollectorRuntimeState.CollectorPhase.Retrying, CollectorRuntimeState.StartupStep.Store, "store")]
+    [InlineData(CollectorRuntimeState.CollectorPhase.Stopped, CollectorRuntimeState.StartupStep.Configuration, "configuration")]
+    [InlineData(CollectorRuntimeState.CollectorPhase.Stopped, CollectorRuntimeState.StartupStep.ManagedStore, "managed_store")]
+    [InlineData(CollectorRuntimeState.CollectorPhase.Stopped, CollectorRuntimeState.StartupStep.Store, "store")]
+    public void NoNonCollectingPhase_EverAnswersHealthy(
+        CollectorRuntimeState.CollectorPhase phase, CollectorRuntimeState.StartupStep step, string wireStep)
+    {
+        var report = DarlingWebEndpoints.DescribePing(
+            new CollectorRuntimeState.Snapshot(phase, step, "why", 1, 25, DateTime.UtcNow));
+
+        Assert.Equal(503, report.HttpStatus);
+        Assert.False(report.Collecting);
+        Assert.NotEqual("ok", report.Status);
+        Assert.Equal(wireStep, report.Step);
+    }
+
+    /// <summary>
+    /// The healthy body still says <c>status: ok</c>, and the states that have no attempt count or no failure
+    /// omit those fields rather than sending nulls a check has to know to ignore. Both halves are the
+    /// compatibility contract: an existing check asserting <c>status: ok</c> keeps passing, and only stops
+    /// passing when collection genuinely is not running.
+    /// </summary>
+    [Fact]
+    public void TheBody_KeepsStatusOkForHealthy_AndOmitsWhatDoesNotApply()
+    {
+        var healthy = JsonSerializer.Serialize(
+            DarlingWebEndpoints.DescribePing(new CollectorRuntimeState.Snapshot(
+                CollectorRuntimeState.CollectorPhase.Collecting, null, null, 0, 0, DateTime.UtcNow)),
+            DarlingWebEndpoints.PingJsonOptions);
+
+        Assert.Contains("\"status\":\"ok\"", healthy, StringComparison.Ordinal);
+        Assert.Contains("\"collecting\":true", healthy, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"step\"", healthy, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"attempt\"", healthy, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"detail\"", healthy, StringComparison.Ordinal);
+        /* HttpStatus is the verdict in the status LINE; repeating it in the body would invite a check to
+           read one and ignore the other. */
+        Assert.DoesNotContain("HttpStatus", healthy, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"httpStatus\"", healthy, StringComparison.Ordinal);
+
+        var down = JsonSerializer.Serialize(
+            DarlingWebEndpoints.DescribePing(new CollectorRuntimeState.Snapshot(
+                CollectorRuntimeState.CollectorPhase.Stopped, CollectorRuntimeState.StartupStep.Store,
+                "Connection refused", 0, 0, DateTime.UtcNow)),
+            DarlingWebEndpoints.PingJsonOptions);
+
+        Assert.Contains("\"status\":\"stopped\"", down, StringComparison.Ordinal);
+        Assert.Contains("\"collecting\":false", down, StringComparison.Ordinal);
+        Assert.Contains("\"step\":\"store\"", down, StringComparison.Ordinal);
+        Assert.Contains("\"detail\":\"Connection refused\"", down, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"attempt\"", down, StringComparison.Ordinal);
+
+        /* The instant is serialized as UTC with its Z, so a monitor's "how long has this been down" is not
+           read against the service host's local offset. */
+        Assert.Contains("Z\"", down, StringComparison.Ordinal);
+    }
+
+    // ── The census ────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Every collection-blocking <c>return</c> in the worker's startup path publishes a verdict first.
+    ///
+    /// <para>Source-parsed, and that is the only way this can be asserted: the exits are inside a
+    /// <c>BackgroundService</c>'s startup, reached only by a real config load, a real managed-Postgres
+    /// bootstrap and a real store connection, and the symptom of missing one is that a surface stays
+    /// SILENT — there is no exception to catch and no exit code to read.</para>
+    ///
+    /// <para>The region is self-anchoring rather than a line range: it runs from <c>ExecuteAsync</c>'s body
+    /// to the <c>PublishCollecting()</c> call, which is by definition the point at which collection starts,
+    /// so a new startup step lands inside the pin the day it is written. Cancellation is the one allowed
+    /// silent exit — it means the service is stopping, not that the collector failed.</para>
+    /// </summary>
+    [Fact]
+    public void EveryCollectionBlockingExitInTheStartupPath_PublishesAVerdictFirst()
+    {
+        var code = CSharpSourceWalker.StripCommentsAndStrings(
+            File.ReadAllText(Path.Combine(ServiceDirectory(), "DarlingWorker.cs")));
+
+        var regions = new List<(string Name, string Body)>
+        {
+            ("ExecuteAsync", MethodBody(code, "Task ExecuteAsync(CancellationToken stoppingToken)")),
+            /* RunCollectionLoopAsync's STARTUP prologue only: everything up to the publish that says
+               collection began. Past that point a return is a shutdown, not a stand-down. */
+            ("RunCollectionLoopAsync prologue", PrologueOf(MethodBody(code, "Task RunCollectionLoopAsync("))),
+        };
+
+        foreach (var (name, body) in regions)
+        {
+            Assert.True(body.Length > 0, $"could not locate {name} in DarlingWorker.cs");
+
+            var exits = Regex.Matches(body, @"\breturn\s*;").ToList();
+            Assert.True(exits.Count > 0, $"expected collection-blocking exits in {name}; found none");
+
+            foreach (var exit in exits)
+            {
+                var window = body[Math.Max(0, exit.Index - PublishWindow)..exit.Index];
+
+                /* Cancellation is the allowed silent exit. Matched on the catch/filter text in the window
+                   rather than allowlisted by position, so moving the block does not silence the pin. */
+                if (window.Contains("OperationCanceledException", StringComparison.Ordinal)
+                    && !window.Contains("LogCritical", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                Assert.True(
+                    window.Contains("_collectorState.Publish", StringComparison.Ordinal),
+                    $"a return in {name} at offset {exit.Index} stands collection down without publishing a "
+                    + "verdict to CollectorRuntimeState. That return completes the worker task SUCCESSFULLY - the "
+                    + "host stays up, both Kestrel hosts keep serving, and on Windows the service keeps reporting "
+                    + "Running - so /api/ping would answer healthy while collection never starts, which is exactly "
+                    + "the defect #2953 closed. Publish PublishStopped (or PublishRetrying, on a retry arm) before "
+                    + "returning, or - if this exit is a shutdown rather than a stand-down - make that visible in "
+                    + "the catch it sits in.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// The three retry arms report the cap they are actually counting against. An attempt total in the ping
+    /// body that does not match <see cref="StartupFailureTriage.Attempts"/> is a body that lies about how
+    /// much time is left, on the one surface an operator consults to decide whether to wait.
+    /// </summary>
+    [Fact]
+    public void EveryRetryPublish_ReportsTheTriagesOwnAttemptCap()
+    {
+        var code = CSharpSourceWalker.StripCommentsAndStrings(
+            File.ReadAllText(Path.Combine(ServiceDirectory(), "DarlingWorker.cs")));
+
+        var calls = Regex.Matches(code, @"_collectorState\.PublishRetrying\((?<args>[^)]*)\)").ToList();
+        Assert.True(
+            calls.Count == 3,
+            $"expected a retry publish on each of the three collection-blocking startup steps (config load, "
+            + $"managed-Postgres bootstrap, store connect/migrate); found {calls.Count}.");
+
+        foreach (var call in calls)
+        {
+            Assert.Contains("StartupFailureTriage.Attempts", call.Groups["args"].Value, StringComparison.Ordinal);
+        }
+
+        /* And a terminal verdict on each of those three plus the two config gates that never reach a retry
+           at all (an all-fatal Validate, and postgres.managed on a non-Windows host). */
+        var terminal = Regex.Matches(code, @"_collectorState\.PublishStopped\(").Count;
+        Assert.True(
+            terminal == 5,
+            $"expected a terminal verdict at the config-load, config-validate, managed-mode-platform, "
+            + $"managed-bootstrap and store-connect stand-downs; found {terminal}.");
+
+        /* Exactly one publish clears the failure phases, and it is the one that says collection started. */
+        Assert.Equal(1, Regex.Matches(code, @"_collectorState\.PublishCollecting\(").Count);
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────────────────
+
+    /// <summary>How far back of a <c>return</c> the verdict may be published. Wide enough for the critical
+    /// log line that precedes it (templates run long here) and narrow enough that a publish in a sibling
+    /// catch arm cannot satisfy a neighbour.</summary>
+    private const int PublishWindow = 700;
+
+    /// <summary>The brace-balanced body of the method whose signature contains <paramref name="signature"/>,
+    /// over comment/literal-stripped source. The signature must occur EXACTLY once: the declaration and a
+    /// recursive or forwarding call read alike to IndexOf, and locating the call instead would silently scan
+    /// a region with no exits in it and pass by finding nothing.</summary>
+    private static string MethodBody(string code, string signature)
+    {
+        var occurrences = Regex.Matches(code, Regex.Escape(signature)).Count;
+        Assert.True(
+            occurrences == 1,
+            $"'{signature}' occurs {occurrences} time(s) in DarlingWorker.cs; the pin needs exactly one so it "
+            + "anchors on the declaration rather than a call site.");
+
+        var at = code.IndexOf(signature, StringComparison.Ordinal);
+        var open = code.IndexOf('{', at);
+        Assert.True(open > at, $"no body found for '{signature}'");
+
+        return CSharpSourceWalker.BraceBalanced(code, open);
+    }
+
+    /// <summary>Everything before the publish that says collection started — the startup prologue, where a
+    /// <c>return</c> means collection never begins rather than that it is ending.</summary>
+    private static string PrologueOf(string body)
+    {
+        var at = body.IndexOf("_collectorState.PublishCollecting(", StringComparison.Ordinal);
+        Assert.True(at > 0, "RunCollectionLoopAsync no longer publishes that collection started");
+
+        return body[..at];
+    }
+
+    private static string ServiceDirectory()
+    {
+        var dir = Path.Combine(RepoRoot(), "Darling", "PerformanceMonitor.Darling.Service");
+
+        Assert.True(Directory.Exists(dir), $"service project directory not found: {dir}");
+
+        return dir;
+    }
+
+    private static string RepoRoot([CallerFilePath] string thisFile = "")
+    {
+        var dir = Path.GetDirectoryName(thisFile)!;
+        while (dir is not null
+               && !File.Exists(Path.Combine(dir, "PerformanceMonitor.sln"))
+               && !Directory.Exists(Path.Combine(dir, ".git")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        Assert.NotNull(dir);
+        return dir!;
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWebEndpoints.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWebEndpoints.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using System.Net;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -87,14 +88,130 @@ public static class DarlingWebEndpoints
     private const int DefaultFleetHours = 1;
 
     /// <summary>
+    /// What <c>GET /api/ping</c> answers, as an object rather than a literal (#2953). <c>HttpStatus</c> is not
+    /// serialized — it is the same verdict expressed in the one field a load balancer or uptime check reads
+    /// without parsing a body.
+    /// </summary>
+    /// <param name="HttpStatus">200 while nothing is known to be wrong with collection, 503 once something is.</param>
+    /// <param name="Status">The machine-readable state: <c>ok</c>, <c>starting</c>, <c>degraded</c> or <c>stopped</c>.</param>
+    /// <param name="Collecting">The same answer as one bit, for a check that wants no string comparison at all.</param>
+    /// <param name="Step">Which startup step failed (<c>configuration</c>, <c>managed_store</c>, <c>store</c>); omitted otherwise.</param>
+    /// <param name="Attempt">The retry in flight and the cap it counts against; both omitted outside <c>degraded</c>.</param>
+    /// <param name="Attempts">The attempt cap the retry budget allows.</param>
+    /// <param name="Detail">The failure message, as the service's own log line reports it; omitted when there is none.</param>
+    /// <param name="SinceUtc">When this state began — collection start, or when the failure was last observed.</param>
+    internal sealed record PingReport(
+        [property: JsonIgnore] int HttpStatus,
+        [property: JsonPropertyName("status")] string Status,
+        [property: JsonPropertyName("collecting")] bool Collecting,
+        [property: JsonPropertyName("step")] string? Step,
+        [property: JsonPropertyName("attempt")] int? Attempt,
+        [property: JsonPropertyName("attempts")] int? Attempts,
+        [property: JsonPropertyName("detail")] string? Detail,
+        [property: JsonPropertyName("since")] DateTime? SinceUtc);
+
+    /// <summary>Omits the null members so each ping state carries only the fields that mean something in it —
+    /// a <c>degraded</c> body has an attempt count and an <c>ok</c> body does not, rather than every body
+    /// carrying nulls a check has to know to ignore.</summary>
+    internal static readonly JsonSerializerOptions PingJsonOptions = new()
+    {
+        WriteIndented = false,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    /// <summary>
+    /// Turns the collector's published verdict into the ping response (#2953). Pure over the snapshot so the
+    /// whole four-state table is unit-pinned without a server or a store, exactly as
+    /// <c>DarlingWebHostService.DecideWebAction</c> pins the supervisor's.
+    ///
+    /// <para><b>The four states, and how an external monitor tells them apart.</b> The status CODE separates
+    /// "collection is not a known problem" from "collection is not running", because that is the only field a
+    /// load balancer or an uptime check reads without parsing JSON; the <c>status</c> string then separates the
+    /// four:</para>
+    /// <list type="bullet">
+    /// <item><description><b>200 <c>ok</c></b> — the collection loop started. Byte-compatible with what this
+    /// route always answered for the healthy case, so an existing check that asserts <c>status: ok</c> keeps
+    /// passing and only stops passing when something is genuinely wrong.</description></item>
+    /// <item><description><b>200 <c>starting</c></b> — the worker has not reached a verdict yet. 200 rather than
+    /// 503 deliberately: this is the ordinary state for the first seconds of every service start, and a check
+    /// that alarmed here would alarm on every restart. It is bounded — the worker publishes one of the other
+    /// three, and a terminal stand-down publishes <c>stopped</c> before it returns, so this cannot be where a
+    /// dead collector comes to rest.</description></item>
+    /// <item><description><b>503 <c>degraded</c></b> — a collection-blocking startup step failed transiently and
+    /// is being retried. 503 because collection is not happening; self-clearing because the failure was
+    /// classified retryable, so within <c>StartupFailureTriage.RetryBudget</c> this becomes <c>ok</c> or
+    /// <c>stopped</c>.</description></item>
+    /// <item><description><b>503 <c>stopped</c></b> — a collection-blocking startup step failed terminally.
+    /// Collection does not start for the life of this process; <c>detail</c> carries what the critical log line
+    /// says, and the fix is to correct that and restart. This is the state the whole issue is about: it used to
+    /// answer <c>200 ok</c>.</description></item>
+    /// </list>
+    ///
+    /// <para><b>Why 503 and not 200-with-a-body.</b> The reporting failure is that automation was told the
+    /// service was fine — and automation reads the code. A body-only signal would leave every existing uptime
+    /// check exactly as wrong as it is now. The cost is that a load balancer health-checking this route pulls
+    /// the host from rotation during a store outage, which is the correct verdict for an API whose data all
+    /// comes from that store; the dashboard's static surface and its other routes are untouched, so a human can
+    /// still open the UI directly and read the reason out of this body.</para>
+    /// </summary>
+    internal static PingReport DescribePing(CollectorRuntimeState.Snapshot? snapshot)
+    {
+        if (snapshot is null)
+        {
+            return new PingReport(StatusCodes.Status200OK, "starting", false, null, null, null, null, null);
+        }
+
+        return snapshot.Phase switch
+        {
+            CollectorRuntimeState.CollectorPhase.Collecting =>
+                new PingReport(StatusCodes.Status200OK, "ok", true, null, null, null, null, snapshot.AsOfUtc),
+
+            CollectorRuntimeState.CollectorPhase.Retrying =>
+                new PingReport(
+                    StatusCodes.Status503ServiceUnavailable, "degraded", false, DescribeStartupStep(snapshot.Step),
+                    snapshot.Attempt, snapshot.Attempts, snapshot.Detail, snapshot.AsOfUtc),
+
+            CollectorRuntimeState.CollectorPhase.Stopped =>
+                new PingReport(
+                    StatusCodes.Status503ServiceUnavailable, "stopped", false, DescribeStartupStep(snapshot.Step),
+                    null, null, snapshot.Detail, snapshot.AsOfUtc),
+
+            /* Default-deny to the loudest answer: a phase this method does not know about is a phase whose
+               health it cannot vouch for, and the whole point of the route is that it does not report healthy
+               on a state it has not reasoned about. */
+            _ => new PingReport(
+                StatusCodes.Status503ServiceUnavailable, "stopped", false, DescribeStartupStep(snapshot.Step),
+                null, null, snapshot.Detail, snapshot.AsOfUtc),
+        };
+    }
+
+    /// <summary>The wire name for a startup step — snake_case like the store's own identifiers, and an explicit
+    /// map rather than the enum name so renaming the enum cannot silently change a public response field.</summary>
+    private static string? DescribeStartupStep(CollectorRuntimeState.StartupStep? step)
+        => step switch
+        {
+            CollectorRuntimeState.StartupStep.Configuration => "configuration",
+            CollectorRuntimeState.StartupStep.ManagedStore => "managed_store",
+            CollectorRuntimeState.StartupStep.Store => "store",
+            _ => null,
+        };
+
+    /// <summary>
     /// Maps the web dashboard's HTTP endpoints onto <paramref name="app"/>, reading from <paramref name="postgres"/>
     /// (the VIEWER-role store pool). Called ONCE from the web host's pipeline, after the auth middleware and before
     /// the static files. Every route lives under <c>/api/*</c> so the SPA's static surface never collides.
     /// </summary>
-    public static void MapAll(WebApplication app, NpgsqlDataSource postgres)
+    public static void MapAll(WebApplication app, NpgsqlDataSource postgres, CollectorRuntimeState collector)
     {
-        /* Liveness probe (Builder 1's stub, kept): proves the host is up and the pipeline reaches the API. */
-        app.MapGet("/api/ping", () => Results.Json(new { status = "ok" }));
+        /* Liveness AND collection state (#2953). The one health surface that does not read the store, which
+           makes it the only one that can answer when the store IS the problem — so it reports the collector's
+           actual verdict instead of a hardcoded "ok". See DescribePing for the four states and their status
+           codes, and CollectorRuntimeState for why that verdict is an in-process field rather than a row. */
+        app.MapGet("/api/ping", () =>
+        {
+            var report = DescribePing(collector.Read());
+            return Results.Json(report, PingJsonOptions, statusCode: report.HttpStatus);
+        });
 
         /* The four analysis-READ tools take a DarlingAnalysisService; the web host does not register one, so
            build it once here from the same VIEWER-role pool (its read methods — fact collection, period compare,

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -544,13 +544,23 @@ public sealed class DarlingWorker : BackgroundService
        encrypted_password SELECT-carve fails that whole read). */
     private readonly MonitoredServerRegistryState _registryState;
 
-    public DarlingWorker(ILogger<DarlingWorker> logger, ILoggerFactory loggerFactory, McpRuntimeState mcpState, WebRuntimeState webState, MonitoredServerRegistryState registryState)
+    /* #2953: the collector's own startup verdict, published to the web host so /api/ping can report whether
+       collection is actually running WITHOUT reading the store. The other three seams carry control-plane
+       values the store is the authority for; this one carries the one fact the store cannot be asked about,
+       because the failure it reports is the store being unreachable. Every collection-blocking exit below
+       publishes before it returns — a stand-down that completes the worker task successfully, leaves the host
+       up and the Windows service reporting Running, and diagnoses itself only in a file log, is otherwise
+       indistinguishable from a healthy service on every automated surface there is. */
+    private readonly CollectorRuntimeState _collectorState;
+
+    public DarlingWorker(ILogger<DarlingWorker> logger, ILoggerFactory loggerFactory, McpRuntimeState mcpState, WebRuntimeState webState, MonitoredServerRegistryState registryState, CollectorRuntimeState collectorState)
     {
         _logger = logger;
         _loggerFactory = loggerFactory;
         _mcpState = mcpState;
         _webState = webState;
         _registryState = registryState;
+        _collectorState = collectorState;
     }
 
     private sealed class ServerLoopState
@@ -739,11 +749,14 @@ public sealed class DarlingWorker : BackgroundService
                     "or unreadable one does not and is not retried.",
                     ex.Message, attempt, StartupFailureTriage.Attempts,
                     (int)StartupFailureTriage.RetryDelay.TotalSeconds);
+                _collectorState.PublishRetrying(
+                    CollectorRuntimeState.StartupStep.Configuration, ex.Message, attempt, StartupFailureTriage.Attempts);
                 await Task.Delay(StartupFailureTriage.RetryDelay, stoppingToken);
             }
             catch (Exception ex)
             {
                 _logger.LogCritical("Cannot load configuration: {Message}", ex.Message);
+                _collectorState.PublishStopped(CollectorRuntimeState.StartupStep.Configuration, ex.Message);
                 return;
             }
         }
@@ -761,6 +774,12 @@ public sealed class DarlingWorker : BackgroundService
             {
                 _logger.LogCritical("Configuration problem: {Problem}", problem);
             }
+
+            /* #2953: every problem, joined, rather than the first — Validate is all-fatal and reports the whole
+               set, so a ping body carrying one of several would send an operator to fix a config that still
+               does not start. */
+            _collectorState.PublishStopped(
+                CollectorRuntimeState.StartupStep.Configuration, string.Join("; ", problems));
             return;
         }
 
@@ -807,6 +826,10 @@ public sealed class DarlingWorker : BackgroundService
                 _logger.LogCritical(
                     "postgres.managed = true requires Windows (the bundled runtime and the DPAPI-protected credential); " +
                     "set postgres.managed = false and point postgres.connectionString at your own PostgreSQL instead.");
+                _collectorState.PublishStopped(
+                    CollectorRuntimeState.StartupStep.ManagedStore,
+                    "postgres.managed = true requires Windows; set postgres.managed = false and point "
+                    + "postgres.connectionString at your own PostgreSQL instead.");
                 return;
             }
 
@@ -853,11 +876,14 @@ public sealed class DarlingWorker : BackgroundService
                         "not retried.",
                         ex.Message, attempt, StartupFailureTriage.Attempts,
                         (int)StartupFailureTriage.RetryDelay.TotalSeconds);
+                    _collectorState.PublishRetrying(
+                        CollectorRuntimeState.StartupStep.ManagedStore, ex.Message, attempt, StartupFailureTriage.Attempts);
                     await Task.Delay(StartupFailureTriage.RetryDelay, stoppingToken);
                 }
                 catch (Exception ex)
                 {
                     _logger.LogCritical("Managed Postgres bootstrap failed: {Message}", ex.Message);
+                    _collectorState.PublishStopped(CollectorRuntimeState.StartupStep.ManagedStore, ex.Message);
                     return;
                 }
             }
@@ -1124,11 +1150,17 @@ public sealed class DarlingWorker : BackgroundService
                     "and collection does not start.",
                     ex.Message, attempt, StartupFailureTriage.Attempts,
                     (int)StartupFailureTriage.RetryDelay.TotalSeconds);
+                _collectorState.PublishRetrying(
+                    CollectorRuntimeState.StartupStep.Store, ex.Message, attempt, StartupFailureTriage.Attempts);
                 await Task.Delay(StartupFailureTriage.RetryDelay, stoppingToken);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 _logger.LogCritical("Cannot reach or migrate the Postgres store: {Message}", ex.Message);
+                /* #2953: AFTER the critical line, deliberately. The log line is the diagnosis of record and
+                   predates this seam; publishing first would put a new call between the failure and the one
+                   message an operator greps for. */
+                _collectorState.PublishStopped(CollectorRuntimeState.StartupStep.Store, ex.Message);
                 return;
             }
         }
@@ -1524,6 +1556,12 @@ public sealed class DarlingWorker : BackgroundService
         }
 
         _logger.LogInformation("PerformanceMonitor Darling collection loop started");
+        /* #2953: the one publish that clears the failure phases. Set HERE — the last statement before the
+           sweep loop's first iteration — and not re-published per cycle: this seam answers "did collection
+           start", which is the question no other surface could answer without the store. Whether the CURRENT
+           sweep is succeeding is collection_log's question, and by this point collection_log exists to be
+           asked. */
+        _collectorState.PublishCollecting();
 
         while (!stoppingToken.IsCancellationRequested)
         {

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/CollectorRuntimeState.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/CollectorRuntimeState.cs
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+
+namespace PerformanceMonitor.Darling.Service.Mcp;
+
+/// <summary>
+/// The collector's own startup verdict, published by the WORKER and readable WITHOUT touching the store
+/// (#2953). The third seam of the <see cref="McpRuntimeState"/> / <see cref="WebRuntimeState"/> family, and
+/// the one whose whole reason for existing is that it answers when the store cannot.
+///
+/// <para><b>The signal this replaces was a literal.</b> Every surface that could tell an operator
+/// "collection is not running" reached the store to find out — <c>get_fleet_overview</c>, <c>/api/fleet</c>
+/// and the Viewer's fleet grid all funnel into <c>DarlingFleetReader</c>'s reads — so with the store
+/// unreachable they fail or come back empty, which reads as a UI or permissions fault rather than as the
+/// store being down. The one surface that did not read the store, <c>/api/ping</c>, answered a hardcoded
+/// <c>"ok"</c>, so it could not report anything either. That mattered more than it sounds: the
+/// stand-down at the end of <c>DarlingWorker</c>'s startup steps <c>return</c>s, which completes the
+/// worker task SUCCESSFULLY — the host stays up, both Kestrel hosts keep serving, and on Windows the
+/// service keeps reporting Running, so SCM recovery never fires because nothing crashed. The only
+/// diagnosis was one <c>LogCritical</c> line in a rolling file log, and the service registers no console
+/// log provider, so that line prints nowhere visible even when run interactively.</para>
+///
+/// <para><b>Why an in-process field is the right store-free read.</b> The alternative — a row, a file, a
+/// heartbeat table — is a thing that can itself be unavailable, and the failure being reported is
+/// precisely "the durable store is unavailable". A volatile reference in the same process as the worker
+/// and both hosts has no failure mode of its own, and both existing seams already prove the shape carries
+/// worker state to a Kestrel host correctly.</para>
+///
+/// <para><b>A STARTUP verdict, and deliberately not a liveness heartbeat.</b>
+/// <see cref="CollectorPhase.Collecting"/> means the collection loop STARTED, not that the current sweep
+/// succeeded — the phase is set once, where the loop logs that it began, and is not re-published per
+/// cycle. A store outage that begins after that point leaves this reading
+/// <see cref="CollectorPhase.Collecting"/>, and that is the honest division of labour: once the store has
+/// been reachable at least once, <c>collection_log</c> exists and the self-alert engine polls it, so the
+/// later outage has a surface that can already report it. What had no surface at all is the window before
+/// the first successful store interaction, which is exactly the window this covers.</para>
+///
+/// <para><b>Null until the worker publishes, matching both siblings rather than carrying an explicit
+/// starting value.</b> An unpublished read means the worker has not yet reached a verdict — ordinary for
+/// the first seconds of a start, and the state a reader should render as "starting" rather than as either
+/// healthy or broken. Every collection-blocking exit publishes
+/// <see cref="CollectorPhase.Stopped"/> before returning, so a terminal stand-down can never be mistaken
+/// for a slow start; the one exit that stays silent is cancellation, which means the service is stopping
+/// and is not a collector fault.</para>
+///
+/// <para>Thread-safety: one writer (the worker's startup path, then nothing), many readers (the web host's
+/// request threads). State is swapped as one immutable record reference, so a reader always sees a
+/// coherent snapshot — never a phase from one publish with an attempt count from another.</para>
+/// </summary>
+public sealed class CollectorRuntimeState
+{
+    /// <summary>
+    /// Where the collector is relative to having started collecting. Four values because that is what a
+    /// reader has to be able to tell apart: fine, not yet, failing but recovering on its own, and failed
+    /// until somebody intervenes. Collapsing the last two would put a two-second store restart and a
+    /// migration rung that can never apply behind the same word.
+    /// </summary>
+    public enum CollectorPhase
+    {
+        /// <summary>A collection-blocking startup step failed with something
+        /// <c>StartupFailureTriage.IsRetryable</c> accepted, and is being retried on its budget. Transient
+        /// by classification: this becomes <see cref="Collecting"/> or <see cref="Stopped"/> within
+        /// <c>StartupFailureTriage.RetryBudget</c>.</summary>
+        Retrying,
+
+        /// <summary>A collection-blocking startup step failed terminally. Collection does not start for
+        /// the life of this process and no amount of waiting changes that — the process must be restarted
+        /// after fixing whatever <see cref="Snapshot.Detail"/> names.</summary>
+        Stopped,
+
+        /// <summary>The collection loop started. See the class remarks for why this is not a claim about
+        /// the current sweep.</summary>
+        Collecting,
+    }
+
+    /// <summary>
+    /// Which of the collection-blocking startup steps a <see cref="CollectorPhase.Retrying"/> or
+    /// <see cref="CollectorPhase.Stopped"/> phase is about — the same three sites
+    /// <c>StartupFailureTriage</c> classifies for, named so a reader can say WHERE the start stopped
+    /// without parsing the message.
+    /// </summary>
+    public enum StartupStep
+    {
+        /// <summary>Loading or validating <c>darling.json</c>.</summary>
+        Configuration,
+
+        /// <summary>Bootstrapping the bundled managed PostgreSQL (Windows, <c>postgres.managed = true</c>).</summary>
+        ManagedStore,
+
+        /// <summary>Opening the store connection and applying the migration ladder.</summary>
+        Store,
+    }
+
+    /// <summary>
+    /// A coherent published snapshot; null until the worker first publishes.
+    /// </summary>
+    /// <param name="Phase">Where the collector is relative to having started collecting.</param>
+    /// <param name="Step">The startup step the phase is about; null for
+    /// <see cref="CollectorPhase.Collecting"/>, which is not about a step.</param>
+    /// <param name="Detail">The failure's message, as the critical/warning log line reports it; null for
+    /// <see cref="CollectorPhase.Collecting"/>.</param>
+    /// <param name="Attempt">Which attempt is in flight, and how many the budget allows — both zero
+    /// outside <see cref="CollectorPhase.Retrying"/>, where an attempt number is the only one of the two
+    /// caps a reader can be shown (the wall-clock budget can end the retrying earlier).</param>
+    /// <param name="Attempts">The attempt cap the retry budget allows.</param>
+    /// <param name="AsOfUtc">When this phase was published — for
+    /// <see cref="CollectorPhase.Collecting"/> that is when collection started, and for the two failure
+    /// phases it is when the failure was last observed.</param>
+    public sealed record Snapshot(
+        CollectorPhase Phase,
+        StartupStep? Step,
+        string? Detail,
+        int Attempt,
+        int Attempts,
+        DateTime AsOfUtc);
+
+    private volatile Snapshot? _current;
+
+    /// <summary>Publishes a classified-transient failure of <paramref name="step"/> that is being retried
+    /// (worker only; called from each retry arm alongside its warning line).</summary>
+    public void PublishRetrying(StartupStep step, string detail, int attempt, int attempts)
+        => _current = new Snapshot(CollectorPhase.Retrying, step, detail, attempt, attempts, DateTime.UtcNow);
+
+    /// <summary>Publishes a terminal failure of <paramref name="step"/> (worker only; called from each
+    /// collection-blocking exit, before the <c>return</c> — after the critical line, so a throw here could
+    /// never cost the operator the log line).</summary>
+    public void PublishStopped(StartupStep step, string detail)
+        => _current = new Snapshot(CollectorPhase.Stopped, step, detail, 0, 0, DateTime.UtcNow);
+
+    /// <summary>Publishes that the collection loop started (worker only; called once, where the loop logs
+    /// that it began).</summary>
+    public void PublishCollecting()
+        => _current = new Snapshot(CollectorPhase.Collecting, null, null, 0, 0, DateTime.UtcNow);
+
+    /// <summary>The latest published snapshot, or null when the worker has not reached a verdict yet.</summary>
+    public Snapshot? Read() => _current;
+}

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingWebHostService.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingWebHostService.cs
@@ -75,6 +75,11 @@ public sealed class DarlingWebHostService : BackgroundService
 {
     private readonly ILogger<DarlingWebHostService> _logger;
     private readonly WebRuntimeState _state;
+
+    /// <summary>#2953: the collector's startup verdict, published by the worker and reported by
+    /// <c>/api/ping</c>. Held rather than resolved per request so the route stays a field read — the whole
+    /// point of that endpoint is that it answers without depending on anything that can be down.</summary>
+    private readonly CollectorRuntimeState _collectorState;
     private WebApplication? _app;
     private NpgsqlDataSource? _appDataSource;
 
@@ -104,10 +109,11 @@ public sealed class DarlingWebHostService : BackgroundService
     internal static readonly TimeSpan SessionLifetime = TimeSpan.FromHours(12);
     private const int SigningKeyBytes = 32;
 
-    public DarlingWebHostService(ILogger<DarlingWebHostService> logger, WebRuntimeState state)
+    public DarlingWebHostService(ILogger<DarlingWebHostService> logger, WebRuntimeState state, CollectorRuntimeState collectorState)
     {
         _logger = logger;
         _state = state;
+        _collectorState = collectorState;
     }
 
     /// <summary>The supervisor's per-tick verdict — pure over (running, runningPort, enabled, desiredPort) so a
@@ -875,7 +881,7 @@ public sealed class DarlingWebHostService : BackgroundService
                 });
             }
 
-            DarlingWebEndpoints.MapAll(_app, postgres);
+            DarlingWebEndpoints.MapAll(_app, postgres, _collectorState);
             _app.UseDefaultFiles();
             _app.UseStaticFiles();
 

--- a/Darling/PerformanceMonitor.Darling.Service/Program.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Program.cs
@@ -407,6 +407,12 @@ builder.Services.AddSingleton<WebRuntimeState>();
    deliberately denied. */
 builder.Services.AddSingleton<MonitoredServerRegistryState>();
 
+/* #2953: the collector's startup verdict — the worker publishes it, the web host's /api/ping reads it, and
+   neither touches the store to do so. A singleton for the same reason the three above are: the publisher and
+   the reader are separate hosted services in one process, and the answer has to survive being asked at any
+   moment rather than being computed on demand from something that might be down. */
+builder.Services.AddSingleton<CollectorRuntimeState>();
+
 builder.Services.AddHostedService<DarlingWorker>();
 
 /* AN4: the analysis MCP tools over Streamable HTTP — registered always, self-gating on

--- a/docs/uat-onboarding.md
+++ b/docs/uat-onboarding.md
@@ -479,7 +479,22 @@ the store holds AG data; the `#/ag` route works regardless.) Or, scriptably:
 Invoke-RestMethod http://localhost:5153/api/ping
 ```
 
-**Proof:** `status : ok`.
+**Proof:** `status : ok`, and `collecting : True`.
+
+`/api/ping` is the only health surface that does not read the store, so it is the only one that can tell you
+the store is the problem — it reports the collector's own startup verdict, in four states:
+
+| HTTP | `status` | What it means |
+|---|---|---|
+| 200 | `ok` | The collection loop started. |
+| 200 | `starting` | The service is still bootstrapping and has not reached a verdict. Normal for the first seconds of a start. |
+| 503 | `degraded` | A startup step failed transiently and is being retried — `step`, `attempt`, `attempts` and `detail` say which and why. Clears itself, or becomes `stopped`. |
+| 503 | `stopped` | A startup step failed terminally. **Collection will not start until the service is restarted**, and `detail` carries the reason the log's critical line gives. |
+
+Point an uptime check at this route and alert on the status code: the two 503 states are the ones where the
+service is up, the dashboard still answers, the Windows service still reports **Running**, and nothing is
+being collected. Note that `Invoke-RestMethod` THROWS on a 503, which is the behaviour you want from a
+scripted check — catch it and read `$_.ErrorDetails.Message` for the body.
 
 ### 3.4 What it will not do
 


### PR DESCRIPTION
`/api/ping` was `app.MapGet("/api/ping", () => Results.Json(new { status = "ok" }))` — a literal, no store touch, no runtime state, no conditions. It answered `"ok"` while collection had never started. Every other health surface (`get_fleet_overview`, `/api/fleet`, the Viewer fleet grid) reads the store to find out, which is why none of them can report that the store is the problem.

### The seam

`Mcp/CollectorRuntimeState.cs` is the third member of the `McpRuntimeState` / `WebRuntimeState` family, same shape: one immutable snapshot swapped through a `volatile` field, null until the worker publishes. The other two carry control-plane values the store is the authority for; this one carries the one fact the store cannot be asked about, because the failure it reports is the store being unreachable. In-process rather than a row or a file for the same reason: a durable witness has its own failure mode, and that failure mode is exactly the condition being reported.

It is a **startup** verdict, not a liveness heartbeat. `Collecting` is published once, where the collection loop logs that it began, and is not re-published per cycle — a store outage that begins after that point leaves this reading `Collecting`. That is the division of labour rather than a gap: once the store has been reachable once, `collection_log` exists and the self-alert engine polls it, so the later outage already has a surface. The window with no surface at all was the one before the first successful store interaction.

### What `/api/ping` answers

| HTTP | `status` | When |
|---|---|---|
| 200 | `ok` | The collection loop started. `{"status":"ok","collecting":true,"since":"…"}` |
| 200 | `starting` | The worker has not reached a verdict. Ordinary for the first seconds of a start, and bounded — every terminal exit publishes `stopped` before returning, so a dead collector cannot come to rest here. 200 because a check that alarmed here would alarm on every restart. |
| 503 | `degraded` | A startup step failed transiently and is on #2936's retry budget. Carries `step`, `attempt`, `attempts`, `detail`. Self-clearing: becomes `ok` or `stopped` inside `StartupFailureTriage.RetryBudget`. |
| 503 | `stopped` | A startup step failed terminally. Collection does not start for the life of the process; `detail` is what the critical log line says. This is the state that used to answer `200 ok`. |

The status **code** carries the verdict because that is the field a load balancer or uptime check reads without parsing a body — a body-only signal would leave every existing check as wrong as it is now. The healthy body still says `status: ok`, so an existing check keeps passing and only stops passing when collection genuinely is not running. Null members are omitted, so a `degraded` body has an attempt count and an `ok` body does not.

The cost is that a load balancer health-checking this route pulls the host from rotation during a store outage. That is the correct verdict for an API whose data all comes from that store, and the dashboard's static surface and its other routes are untouched — `GET /` still answered 200 in every state below, so a human can read the reason out of this body directly.

### Where it is published

Nine call sites in `DarlingWorker`, all in the startup path: a retry publish beside each of the three retry warnings #2936 added, a terminal publish at each of the five collection-blocking stand-downs (config load, config validate, `postgres.managed` on a non-Windows host, managed bootstrap, store connect/migrate), and the one `PublishCollecting()`. Cancellation stays silent — it means the service is stopping, not that the collector failed.

Those `return`s complete the worker task **successfully**, so the host stays up, both Kestrel hosts keep serving, and on Windows the service keeps reporting Running. A stand-down that forgets to publish is therefore invisible on every automated surface and silently restores the whole defect, which the compiler cannot catch — so `EveryCollectionBlockingExitInTheStartupPath_PublishesAVerdictFirst` asserts it structurally over the source, across a **self-anchoring** region (`ExecuteAsync`'s brace-balanced body, plus `RunCollectionLoopAsync` up to the publish that says collection began) so a startup step added later joins the pin the day it is written.

### Not in this change, with reasons

**The Viewer needs no fourth arm — it already has one.** #2117 built `ViewerStoreUnreachableException` and `ViewerSeatState.Unreachable` as their own arm of the connect ladder (`MainWindow.xaml.cs:399`), with their own message and a seat state that deliberately does not collapse into `ReadOnly`. The gate has six arms, one of which is store-unreachable. Nothing to add. Worth stating for whoever reads the issue: the Viewer has **no HTTP transport at all** — no `HttpClient` anywhere in the project — so it cannot read this seam. A store-free "is the collector running" read from the Viewer means adding an HTTP dependency, a port discovery story and a network-mode auth story to a WPF app, which is a feature and not a fourth arm.

**`DarlingSelfAlertEvaluator` is not hoisted above the migrate.** Its constructor is I/O-free — four collaborators and nine `Func` seams, all assignment, no `NpgsqlDataSource`, no store read — so the construction genuinely is hoistable. Hoisting it does not produce an alert, though: the evaluator has no startup-failure condition to raise, and its delivery tail would run above `StoreConfigProvider.ApplyToConfig`, on `darling.json`'s alert settings rather than the store's, with an empty mute set (`muteRuleService.LoadAsync` has not run) and no history row (`RecordAlertAsync` swallows the write). Those are three semantics to decide deliberately, not a reorder. The store-free status surface is the part that stands alone.

### Verification

Exercised against `timescale/timescaledb:latest-pg17` (PostgreSQL 17.11), BYO mode, loopback dashboard, all four states observed:

- **Store down at start** — `503 degraded step=store attempt=1..24 of 25 detail="Failed to connect to 127.0.0.1:5953"`, then `503 stopped` at t+130s, matching the critical line exactly. Process still alive, `GET /` still 200.
- **Store brought up mid-retry** — `degraded attempt=4` at t+21s, `200 ok collecting=true` at t+24s.
- **A genuinely failing rung** — a login without CREATE on the target database: `503 stopped detail="3F000: no schema has been selected to create in"`, **zero** retry warnings. Terminal reads differently from transient by the `status` word and by the absence of the attempt fields.
- **Config validate** — `503 stopped step=configuration detail="servers must contain at least one entry."`, all problems joined, since `Validate` is all-fatal and reports the whole set.
- **Pre-publish** — `200 {"status":"starting","collecting":false}`, caught on a 200 ms poll before the worker's first publish.

Seven `[Fact]`/`[Theory]` methods (12 cases). Each proven red first by a distinct mutation, one at a time, each asserted applied by anchor count **and** SHA-256 — including one deliberately equal-length mutation (`managed_store` → `managedxstore`) where the hash is the only witness.
