### PR TITLE
Bind store window bounds instead of comparing naive UTC to now()

### DIFF
--- a/Darling/Darling.Tests/BaselineSupplyTests.cs
+++ b/Darling/Darling.Tests/BaselineSupplyTests.cs
@@ -318,8 +318,17 @@ public class BaselineSupplyTests
         /* And the coverage side is read RAW, never clamped: it is the thing being measured, not a bound. */
         Assert.Contains($"(SELECT min(bucket) FROM collect.{TimescaleSupport.QueryStatsBaselineView}) AS coverage_oldest", sql, StringComparison.Ordinal);
 
-        /* The need is bounded by this tier's own retention, not by anything shorter. */
-        Assert.Contains($"INTERVAL '{TimescaleSupport.BaselineRetentionInterval}'", sql, StringComparison.Ordinal);
+        /* The need is bounded by this tier's own retention, and the bound arrives as a PARAMETER. It used to
+           be spelled `now()::timestamp - INTERVAL '35 days'` here, which is LOCALTIMESTAMP arithmetic: the
+           horizon rendered in the store session's zone, clamped by GREATEST against a naive-UTC
+           min(collection_time). The caller passes BaselineRetentionSpan off the service clock instead, so
+           what this can still assert about the SQL is that the local clock is gone and the bound is bound.
+           The horizon's VALUE stays pinned by BaselineRetention_CoversTheBaselineWindow_OrNumber1757Returns
+           (which holds the string and the TimeSpan equal), and the absence of a bare clock in any store
+           predicate by StoreSqlClockDisciplineTests. */
+        Assert.Contains("$1)) AS need_from", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("now()", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("LOCALTIMESTAMP", sql, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/Darling/Darling.Tests/CSharpSourceWalker.cs
+++ b/Darling/Darling.Tests/CSharpSourceWalker.cs
@@ -7,6 +7,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Text;
 
 namespace Darling.Tests;
@@ -78,7 +79,7 @@ internal static class CSharpSourceWalker
         ArgumentNullException.ThrowIfNull(text);
 
         var code = new bool[text.Length];
-        ScanCode(text, 0, code, null);
+        ScanCode(text, 0, code, null, null);
 
         return code;
     }
@@ -100,6 +101,45 @@ internal static class CSharpSourceWalker
         }
 
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Every string literal's BODY, in source order: the offset its text starts at, and that text with
+    /// interpolation holes blanked to spaces. The mirror image of <see cref="StripCommentsAndStrings"/> —
+    /// that one keeps the code and discards the literals, this one keeps the literals — built on the same
+    /// walk, so a delimiter one of them understands cannot desynchronise the other.
+    ///
+    /// <para>Holes are blanked rather than dropped because a scanner reading SQL out of a literal is asking
+    /// about the SQL, and eliding <c>{filter}</c> to nothing welds the tokens either side of it into one
+    /// word that neither the source nor the database ever contains. A space is the only substitution that
+    /// changes no adjacency.</para>
+    ///
+    /// <para>Literals nested inside an interpolation hole are yielded too, because the walk recurses through
+    /// the hole: a query assembled one clause at a time is still a query.</para>
+    /// </summary>
+    internal static IEnumerable<(int Start, string Text)> StringLiteralBodies(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+
+        var code = new bool[text.Length];
+        var bodies = new List<(int Start, int End)>();
+        ScanCode(text, 0, code, null, bodies);
+
+        var result = new List<(int Start, string Text)>(bodies.Count);
+
+        foreach (var (start, end) in bodies)
+        {
+            var sb = new StringBuilder(end - start);
+
+            for (var i = start; i < end; i++)
+            {
+                sb.Append(code[i] ? ' ' : text[i]);
+            }
+
+            result.Add((start, sb.ToString()));
+        }
+
+        return result;
     }
 
     /// <summary>
@@ -403,7 +443,7 @@ internal static class CSharpSourceWalker
     /// that literal's interpolation hole, and the scan RETURNS at the hole's closing brace run or at its
     /// top-level format-specifier colon without consuming either — the caller owns those delimiters.
     /// </summary>
-    private static int ScanCode(string text, int i, bool[] code, Frame? hole)
+    private static int ScanCode(string text, int i, bool[] code, Frame? hole, List<(int Start, int End)>? bodies)
     {
         var depth = 0;
 
@@ -461,7 +501,15 @@ internal static class CSharpSourceWalker
             if (TryReadOpener(text, i, out var frame, out var bodyStart))
             {
                 /* A QuoteRun of zero is the empty string `""`, which has no body to walk. */
-                i = frame.QuoteRun == 0 ? bodyStart : ScanLiteral(text, bodyStart, code, frame);
+                if (frame.QuoteRun == 0)
+                {
+                    bodies?.Add((bodyStart, bodyStart));
+                    i = bodyStart;
+                    continue;
+                }
+
+                i = ScanLiteral(text, bodyStart, code, frame, bodies, out var bodyEnd);
+                bodies?.Add((bodyStart, bodyEnd));
                 continue;
             }
 
@@ -484,9 +532,11 @@ internal static class CSharpSourceWalker
     /// <summary>
     /// Walks a literal's body from <paramref name="i"/> — which is the first character AFTER the opening
     /// delimiter — marking any interpolation holes it contains as code. Returns the index just past the
-    /// closing delimiter.
+    /// closing delimiter, and reports through <paramref name="bodyEnd"/> where the body itself stopped, so a
+    /// caller collecting literal TEXT does not have to re-derive the delimiter's length per flavour.
     /// </summary>
-    private static int ScanLiteral(string text, int i, bool[] code, Frame frame)
+    private static int ScanLiteral(
+        string text, int i, bool[] code, Frame frame, List<(int Start, int End)>? bodies, out int bodyEnd)
     {
         while (i < text.Length)
         {
@@ -500,6 +550,7 @@ internal static class CSharpSourceWalker
 
                     if (run >= frame.QuoteRun)
                     {
+                        bodyEnd = i;
                         return i + run;
                     }
 
@@ -516,6 +567,7 @@ internal static class CSharpSourceWalker
                         continue;
                     }
 
+                    bodyEnd = i;
                     return i + 1;
                 }
 
@@ -524,12 +576,14 @@ internal static class CSharpSourceWalker
                     continue;
 
                 case LiteralKind.Regular when c == '"':
+                    bodyEnd = i;
                     return i + 1;
 
                 /* A non-verbatim string cannot span lines, so a newline means the opener was mis-read or the
                    file is malformed. Ending here bounds the damage to one line instead of to the next quote
                    anywhere in the file. */
                 case LiteralKind.Regular when c == '\n':
+                    bodyEnd = i;
                     return i;
             }
 
@@ -547,7 +601,7 @@ internal static class CSharpSourceWalker
                         continue;
                     }
 
-                    i = ScanHole(text, i + 1, code, frame);
+                    i = ScanHole(text, i + 1, code, frame, bodies);
                     continue;
                 }
 
@@ -555,7 +609,7 @@ internal static class CSharpSourceWalker
                    literal text — `{{typeParams}}` inside a `$$"""..."""` is one hole, not two braces. */
                 if (run >= frame.Dollars)
                 {
-                    i = ScanHole(text, i + frame.Dollars, code, frame);
+                    i = ScanHole(text, i + frame.Dollars, code, frame, bodies);
                     continue;
                 }
 
@@ -574,6 +628,7 @@ internal static class CSharpSourceWalker
             i++;
         }
 
+        bodyEnd = i;
         return i;
     }
 
@@ -582,9 +637,9 @@ internal static class CSharpSourceWalker
     /// just past its closing brace run. The expression is code; the closing braces and any format specifier
     /// are not.
     /// </summary>
-    private static int ScanHole(string text, int i, bool[] code, Frame frame)
+    private static int ScanHole(string text, int i, bool[] code, Frame frame, List<(int Start, int End)>? bodies)
     {
-        i = ScanCode(text, i, code, frame);
+        i = ScanCode(text, i, code, frame, bodies);
 
         if (i < text.Length && text[i] == ':')
         {

--- a/Darling/Darling.Tests/DarlingManagedPostgresTests.cs
+++ b/Darling/Darling.Tests/DarlingManagedPostgresTests.cs
@@ -220,6 +220,38 @@ public sealed class DarlingManagedPostgresTests
     }
 
     /// <summary>
+    /// The v9 session-time-zone block: the belt behind
+    /// <c>StoreSqlClockDisciplineTests</c>. The store's timestamp columns hold naive UTC while initdb takes
+    /// <c>timezone</c> from the host OS, so on a Windows box outside UTC every comparison of a naive column
+    /// against <c>now()</c> has the naive side converted at the machine's local zone. Pinning UTC makes that
+    /// conversion the identity — for MANAGED stores only, which is why it is a backstop and not the fix.
+    ///
+    /// <para>Nothing else may ride in this block: it is appended after the v8 hardware check, whose
+    /// staleness test keys on the last fingerprint line in the text read before any of these appends. A
+    /// sizing line here would be both invisible to that check and able to override it.</para>
+    /// </summary>
+    [Fact]
+    public void TimeZoneConfAppend_PinsV9Marker_AndCarriesNothingButTheZone()
+    {
+        var block = DarlingManagedPostgres.BuildTimeZoneConfAppend();
+
+        Assert.Contains(DarlingManagedPostgres.ConfMarkerV9, block, StringComparison.Ordinal);
+        Assert.Contains("timezone = 'UTC'", block, StringComparison.Ordinal);
+
+        /* No fingerprint line, or the v8 staleness check silently stops checking. */
+        Assert.DoesNotContain(DarlingManagedPostgres.ConfHardwareFingerprintPrefix, block, StringComparison.Ordinal);
+
+        /* The blocks compose, they don't compete. */
+        Assert.DoesNotContain("shared_buffers", block, StringComparison.Ordinal);
+        Assert.DoesNotContain("maintenance_work_mem", block, StringComparison.Ordinal);
+        Assert.DoesNotContain("max_worker_processes", block, StringComparison.Ordinal);
+
+        /* `timezone`, not `log_timezone`: the session zone is what resolves a mixed timestamp/timestamptz
+           comparison. Setting only the log zone would change what the log says and nothing about the data. */
+        Assert.DoesNotContain("log_timezone", block, StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// The v7 compression-memory override (#1777) — the PROPAGATION half of the raised floor, and the only
     /// reason an EXISTING store adopts it. A store provisioned before #1777 carries a v3 block whose
     /// maintenance_work_mem was written under the old min(5% RAM, 1 GB) rule: on a 16 GB host that is the

--- a/Darling/Darling.Tests/StoreSqlClockDisciplineTests.cs
+++ b/Darling/Darling.Tests/StoreSqlClockDisciplineTests.cs
@@ -162,6 +162,9 @@ public sealed class StoreSqlClockDisciplineTests
             /* HAVING and a JOIN's ON are predicate contexts too. */
             "SELECT 1 FROM t GROUP BY a HAVING max(collection_time) > now() - interval '1 hour'",
             "SELECT 1 FROM a JOIN b ON b.collection_time > now() - interval '1 hour'",
+            /* Bare predicate FRAGMENTS — the shape these readers interpolate, with no statement keyword. */
+            "AND r.collection_time >= NOW() - INTERVAL '10 MINUTES'",
+            "AND   qs.collection_time > now() - interval '2 hours'",
         ];
 
         foreach (var sql in hazards)
@@ -194,6 +197,10 @@ public sealed class StoreSqlClockDisciplineTests
                did not strip these. */
             "SELECT 1 FROM t WHERE collection_time > $1 /* not now() - interval '2 hours': the session zone shifts it */",
             "SELECT 1 FROM t WHERE collection_time > $1 -- was now() - interval '2 hours'",
+            /* Fragments that are already right: the bound form, and the rescued spelling the viewer's
+               monitored-servers upsert actually ships. */
+            "AND r.collection_time >= $4",
+            "(now() AT TIME ZONE 'UTC'), (now() AT TIME ZONE 'UTC')",
         ];
 
         foreach (var sql in benign)
@@ -567,13 +574,31 @@ public sealed class StoreSqlClockDisciplineTests
 
     /* ---------------- text helpers ---------------- */
 
+    /// <summary>
+    /// Whether a literal is worth reading as SQL: a whole statement, OR a bare predicate FRAGMENT.
+    ///
+    /// <para>The fragment arm is not padding. These readers assemble filters as standalone literals and
+    /// interpolate them — <c>LocalDataService.WaitStats</c> builds five that way — so a fragment like
+    /// <c>"AND r.collection_time &gt;= NOW() - INTERVAL '10 MINUTES'"</c> carries no statement keyword at
+    /// all, and a statement-only filter skips the shape most likely to reintroduce this. A fragment is
+    /// recognised by carrying both a clock and a comparison, which is all the discriminator needs to judge
+    /// it.</para>
+    ///
+    /// <para>Known limit, stated rather than papered over: the scan reads ONE literal at a time, so a
+    /// predicate whose column sits in one literal and whose clock sits in another — welded together only by
+    /// concatenation — is outside it. No such split exists in the corpus today; the one fragment pairing a
+    /// clock with a column, <c>ViewerDataService.MonitoredServers</c>, already uses the rescued
+    /// <c>AT TIME ZONE 'UTC'</c> form. Catching it would mean resolving concatenation rather than reading
+    /// literals.</para>
+    /// </summary>
     private static bool LooksLikeSql(string body) =>
         body.Contains("SELECT ", StringComparison.OrdinalIgnoreCase)
         || body.Contains("INSERT ", StringComparison.OrdinalIgnoreCase)
         || body.Contains("UPDATE ", StringComparison.OrdinalIgnoreCase)
         || body.Contains("DELETE ", StringComparison.OrdinalIgnoreCase)
         || body.Contains("CREATE ", StringComparison.OrdinalIgnoreCase)
-        || body.Contains(" FROM ", StringComparison.OrdinalIgnoreCase);
+        || body.Contains(" FROM ", StringComparison.OrdinalIgnoreCase)
+        || (ClockRegex.IsMatch(body) && ComparisonRegex.IsMatch(body));
 
     /// <summary>Blanks SQL comments, preserving length so an offset still points where it did. The repo's SQL
     /// is heavily commented and those comments discuss <c>now()</c> constantly — including in the waiver this

--- a/Darling/Darling.Tests/StoreSqlClockDisciplineTests.cs
+++ b/Darling/Darling.Tests/StoreSqlClockDisciplineTests.cs
@@ -492,6 +492,16 @@ public sealed class StoreSqlClockDisciplineTests
            break inside a DDL literal. Left in, it would match every SQL literal that casts anything. */
         names.Remove("timestamp");
 
+        /* sample_time is EXCLUDED, and not because it is safe. It is the one name in the store whose frame
+           depends on the table: cpu_utilization_stats.sample_time is deliberately the MONITORED SERVER's
+           local wall clock (#1262 de-skews it per batch, Lite windows it through GetTimeRangeServerLocal),
+           while memory_pressure_events.sample_time must be UTC. CollectorTimestampFrameTests pins both,
+           per column, against the read path each protects — and its own remarks record that its first cut
+           was a store-wide "all naive timestamps are UTC" rule that would have forbidden the CPU
+           collector's intentional local clock. This scan keys on column NAMES, so it cannot tell those two
+           apart and must not claim to; that column's frame is that pin's business, not this one's. */
+        names.Remove("sample_time");
+
         return names;
     }
 

--- a/Darling/Darling.Tests/StoreSqlClockDisciplineTests.cs
+++ b/Darling/Darling.Tests/StoreSqlClockDisciplineTests.cs
@@ -1,0 +1,638 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// No store-side SQL literal may compare a naive collector timestamp column against a BARE clock function.
+/// Every timestamp column in both stores is <c>timestamp without time zone</c> holding naive UTC — measured,
+/// there is not one <c>timestamptz</c> column in the schema — while <c>now()</c> is <c>timestamptz</c>. The
+/// mixed comparison is not an error: PostgreSQL resolves it by converting the NAIVE side at the store
+/// SESSION's TimeZone, which initdb takes from the host OS and which
+/// <c>DarlingManagedPostgres.BuildConfAppend</c> does not pin, so a managed store on a Windows host inherits
+/// the machine's local zone and a bring-your-own store inherits whatever it was built with.
+///
+/// <para><b>The measurement.</b> On <c>timescale/timescaledb:latest-pg17</c> seeded one row per 52 seconds,
+/// <c>WHERE collection_time &gt; now() - interval '1 hour'</c> returned 66 rows under
+/// <c>TimeZone='UTC'</c> and 343 under <c>TimeZone='America/New_York'</c> — the same one-hour predicate
+/// silently spanning five. West of UTC a window widens and grades stale data; east of UTC it narrows and can
+/// return nothing at all, which is the direction that matters, because two of the sites this pin was written
+/// for are alert reads and an alert that returns no rows never fires.</para>
+///
+/// <para><b>Why a source pin.</b> Every store anyone develops or tests against runs UTC, so the defect is
+/// invisible in CI, invisible in a live-store probe, and invisible in review — the query reads exactly like
+/// what it was meant to say. <see cref="PgReadKindDisciplineTests"/> already holds the C# BIND side of this
+/// same discipline (a <c>Kind=Utc</c> DateTime makes Npgsql infer timestamptz); this holds the SQL LITERAL
+/// side, which that scan cannot see.</para>
+///
+/// <para><b>What it does not claim.</b> It flags comparisons and clamps, not writes: a bare clock in a
+/// <c>SET</c>, a <c>VALUES</c> row or a projection is a different defect shape (a local-time value stored,
+/// rather than a window skewed) and Lite has several that are inert today because nothing reads those
+/// columns back. Widening this to the write side is a separate change with a data-migration question
+/// attached, so it is deliberately out of scope here rather than silently allowlisted.</para>
+/// </summary>
+public sealed class StoreSqlClockDisciplineTests
+{
+    /* Floors, so the scan cannot pass by finding nothing. Measured on dev at the time of writing: 563 files,
+       19,604 string literals, 1,626 of them SQL-shaped, 58 naive timestamp column names. Set well below
+       those so ordinary growth never trips them, but high enough that a broken glob or a desynchronised
+       literal walk fails instead of reporting a clean bill of health. The column-vocabulary floor is the one
+       that matters most: the discriminator needs those names, and a DDL scrape that quietly returned four of
+       them would make every offender below invisible while still reporting thousands of literals scanned. */
+    private const int MinimumFilesScanned = 200;
+    private const int MinimumLiteralsScanned = 12_000;
+    private const int MinimumSqlLiteralsScanned = 1_200;
+    private const int MinimumTimestampColumnsKnown = 40;
+
+    /// <summary>
+    /// The one bare <c>now()</c> left in the store's SQL, and it is waived on ARITHMETIC, not on being
+    /// harmless: across UTC-12..UTC+14 its 48-hour window delivers 34–60 hours, 34h still covers the refresh
+    /// cadence (startup, then riding the 24-hour purge) and 60h is still inside the 4-day raw retention. The
+    /// query's own remarks carry the derivation and the two numbers that have to keep holding.
+    /// </summary>
+    private static readonly HashSet<string> Waived = new(StringComparer.Ordinal)
+    {
+        "DarlingModuleMap.cs:RefreshSql",
+    };
+
+    [Fact]
+    public void NoStoreSqlComparesANaiveTimestampToABareClock()
+    {
+        var columns = NaiveTimestampColumns();
+
+        Assert.True(
+            columns.Count >= MinimumTimestampColumnsKnown,
+            $"only {columns.Count} naive timestamp column names were scraped from the store DDL (floor "
+            + $"{MinimumTimestampColumnsKnown}) — the discriminator is blind without them, so this scan "
+            + "would pass vacuously. Check the DDL globs below.");
+
+        /* collection_time is the column every windowed read is written against; naming it explicitly means a
+           scrape that collects 40 obscure names and misses the load-bearing one still fails. */
+        Assert.Contains("collection_time", columns);
+
+        var files = 0;
+        var literals = 0;
+        var sqlLiterals = 0;
+        var offenders = new List<string>();
+
+        foreach (var path in StoreSourceFiles())
+        {
+            files++;
+            var text = File.ReadAllText(path);
+            var name = Path.GetFileName(path);
+
+            foreach (var (start, body) in CSharpSourceWalker.StringLiteralBodies(text))
+            {
+                literals++;
+
+                if (!LooksLikeSql(body))
+                {
+                    continue;
+                }
+
+                sqlLiterals++;
+
+                foreach (var finding in MixedClockComparisons(body, columns))
+                {
+                    var member = EnclosingMember(text, start);
+
+                    if (Waived.Contains(name + ":" + member))
+                    {
+                        continue;
+                    }
+
+                    offenders.Add($"{name}:{member} — {finding}");
+                }
+            }
+        }
+
+        Assert.True(files >= MinimumFilesScanned, $"scanned only {files} store source files (floor {MinimumFilesScanned})");
+        Assert.True(literals >= MinimumLiteralsScanned, $"scanned only {literals} string literals (floor {MinimumLiteralsScanned})");
+        Assert.True(sqlLiterals >= MinimumSqlLiteralsScanned, $"scanned only {sqlLiterals} SQL literals (floor {MinimumSqlLiteralsScanned})");
+
+        Assert.True(
+            offenders.Count == 0,
+            "store SQL compares a naive collector timestamp against a bare clock function:"
+            + Environment.NewLine + string.Join(Environment.NewLine, offenders) + Environment.NewLine
+            + "The store session's TimeZone shifts the naive side, so the window widens west of UTC and can "
+            + "return nothing east of it. Bind the bound as a Kind-Unspecified DateTime parameter computed "
+            + "from DateTime.UtcNow (the clock that stamped collection_time), the way every other windowed "
+            + "read here does.");
+    }
+
+    /// <summary>
+    /// The discriminator, pinned in BOTH directions against literals written for the purpose. A scan like the
+    /// one above is only worth its runtime if it flags the thing it names and leaves everything else alone;
+    /// each positive here is a form that shipped in this repo, and each negative is a form the corpus
+    /// contains and must not be dragged in with them.
+    /// </summary>
+    [Fact]
+    public void TheDiscriminator_FlagsTheHazard_AndNothingElse()
+    {
+        var columns = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "collection_time", "updated_at", "last_seen" };
+
+        string[] hazards =
+        [
+            /* The four spellings named in the rule. */
+            "SELECT 1 FROM query_store_stats AS qs WHERE qs.server_id = $1 AND qs.collection_time > now() - interval '2 hours'",
+            "SELECT 1 FROM t WHERE collection_time >= CURRENT_TIMESTAMP - interval '2 days'",
+            "SELECT 1 FROM t WHERE collection_time >= LOCALTIMESTAMP - interval '10 minutes'",
+            "SELECT 1 FROM t WHERE collection_time > now()::timestamp - interval '1 hour'",
+            /* Column on the RIGHT of the operator. */
+            "SELECT 1 FROM t WHERE now() - interval '1 hour' < collection_time",
+            /* The clamp shape: no comparison operator anywhere, GREATEST does the comparing. */
+            "SELECT time_bucket('1 hour', GREATEST((SELECT min(collection_time) FROM collect.query_stats), now()::timestamp - INTERVAL '35 days')) AS need_from",
+            "SELECT LEAST(max(collection_time), now()) FROM t",
+            /* BETWEEN, and a qualified alias. */
+            "SELECT 1 FROM t AS x WHERE x.collection_time BETWEEN now() - interval '1 day' AND now()",
+            /* HAVING and a JOIN's ON are predicate contexts too. */
+            "SELECT 1 FROM t GROUP BY a HAVING max(collection_time) > now() - interval '1 hour'",
+            "SELECT 1 FROM a JOIN b ON b.collection_time > now() - interval '1 hour'",
+        ];
+
+        foreach (var sql in hazards)
+        {
+            Assert.True(
+                MixedClockComparisons(sql, columns).Any(),
+                "the discriminator MISSED a hazard it is named for: " + sql);
+        }
+
+        string[] benign =
+        [
+            /* The fix: the bound is a parameter. */
+            "SELECT 1 FROM query_store_stats AS qs WHERE qs.server_id = $1 AND qs.collection_time > $2",
+            "SELECT time_bucket('1 hour', GREATEST((SELECT min(collection_time) FROM collect.query_stats), $1)) AS need_from",
+            /* The other legitimate spelling — both sides naive UTC. Rescued whether or not it is parenthesised
+               and whether or not the timestamptz cast is written out. */
+            "SELECT 1 FROM t WHERE collection_time > (now() AT TIME ZONE 'UTC') - interval '2 hours'",
+            "SELECT 1 FROM t WHERE collection_time > now() AT TIME ZONE 'UTC' - interval '2 hours'",
+            "SELECT 1 FROM t WHERE collection_time > now()::timestamptz AT TIME ZONE 'UTC' - interval '2 hours'",
+            /* WRITES, not comparisons — the deliberate scope boundary. Lite ships all three shapes. */
+            "UPDATE config_database_state_expected SET expected_state = 'ONLINE', updated_at = now()::TIMESTAMP WHERE server_id = $1",
+            "INSERT INTO t (server_id, updated_at) SELECT $1, now()::TIMESTAMP FROM database_states WHERE collection_time = $2",
+            "INSERT INTO t (completed_at, rows_removed) VALUES (CURRENT_TIMESTAMP, 4)",
+            "INSERT INTO t (a, updated_at) SELECT $1, now() ON CONFLICT (a) DO UPDATE SET updated_at = now()",
+            /* A clock with no naive column anywhere near it: TimescaleDB's own catalog is timestamptz, and its
+               scheduler takes a timestamptz. Both ship in TimescaleSupport. */
+            "SELECT alter_job($1::integer, next_start => now())",
+            "SELECT j.hypertable_name FROM timescaledb_information.jobs AS j WHERE j.next_start < now()",
+            /* The clock is spelled only in a SQL comment. Four wrong counts were produced here by scans that
+               did not strip these. */
+            "SELECT 1 FROM t WHERE collection_time > $1 /* not now() - interval '2 hours': the session zone shifts it */",
+            "SELECT 1 FROM t WHERE collection_time > $1 -- was now() - interval '2 hours'",
+        ];
+
+        foreach (var sql in benign)
+        {
+            Assert.False(
+                MixedClockComparisons(sql, columns).Any(),
+                "the discriminator FLAGGED a benign form: " + sql
+                    + " => " + string.Join("; ", MixedClockComparisons(sql, columns)));
+        }
+    }
+
+    /* ---------------- the discriminator ---------------- */
+
+    /// <summary>Bare clock reads. A store-local <c>now()::timestamp</c> is the same hazard spelled as a cast,
+    /// so the cast is matched as part of the occurrence rather than left to look like a rescue — but the
+    /// <c>\b</c> after it is load-bearing: without it the optional cast eats the first eleven characters of
+    /// <c>::timestamptz</c>, the rescue that follows no longer sits at the match's end, and
+    /// <c>now()::timestamptz AT TIME ZONE 'UTC'</c> — a CORRECT form — reads as an offender.</summary>
+    private static readonly Regex ClockRegex = new(
+        @"\b(?:now\s*\(\s*\)|current_timestamp|localtimestamp|statement_timestamp\s*\(\s*\)|transaction_timestamp\s*\(\s*\)|clock_timestamp\s*\(\s*\))(?:\s*::\s*timestamp\b)?",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary><c>AT TIME ZONE 'UTC'</c> immediately after the clock makes both sides naive UTC. It binds
+    /// tighter than the arithmetic that follows, so the unparenthesised form is equally safe.</summary>
+    private static readonly Regex RescueRegex = new(
+        @"\G\s*(?:::\s*timestamptz\s*)?at\s+time\s+zone\s+'utc'",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static readonly Regex ComparisonRegex = new(
+        @"(?:>=|<=|<>|!=|>|<|=|\bbetween\b)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary>Keywords that open a PREDICATE. A clock reached from one of these is being compared; a clock
+    /// reached from <c>SET</c>, <c>SELECT</c> or <c>VALUES</c> is being stored, which is a different defect
+    /// and not this pin's business.</summary>
+    private static readonly HashSet<string> PredicateOpeners = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "WHERE", "AND", "OR", "HAVING", "ON", "WHEN", "THEN", "ELSE",
+    };
+
+    private static readonly HashSet<string> SpanBoundaries = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "WHERE", "AND", "OR", "HAVING", "ON", "WHEN", "THEN", "ELSE", "SELECT", "SET", "VALUES",
+        "ORDER", "GROUP", "LIMIT", "OFFSET", "RETURNING", "INSERT", "UPDATE", "DELETE", "FROM",
+        "JOIN", "UNION", "EXCEPT", "INTERSECT", "CONFLICT", "DO", "AS", "BY", "INTO",
+    };
+
+    /// <summary>Clamp functions: they compare their arguments without any operator being written, so the
+    /// predicate walk cannot see them. <c>BaselineBackfillProbeSql</c> was exactly this shape.</summary>
+    private static readonly Regex ClampRegex = new(
+        @"\b(?:greatest|least)\s*\(", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary>
+    /// Every place <paramref name="sql"/> puts a bare clock in a comparison or a clamp with one of
+    /// <paramref name="columns"/>. Internal so the corpus scan and the control pin share one implementation
+    /// — a copy would let the controls certify behaviour the corpus scan does not have.
+    /// </summary>
+    internal static IEnumerable<string> MixedClockComparisons(string sql, ISet<string> columns)
+    {
+        ArgumentNullException.ThrowIfNull(sql);
+        ArgumentNullException.ThrowIfNull(columns);
+
+        var text = StripSqlComments(sql);
+        var findings = new List<string>();
+
+        foreach (Match clock in ClockRegex.Matches(text))
+        {
+            if (RescueRegex.Match(text, clock.Index + clock.Length).Success)
+            {
+                continue;
+            }
+
+            var span = ClampArgumentsAround(text, clock.Index) ?? PredicateSpanAround(text, clock.Index);
+
+            if (span is null || !MentionsColumn(span, columns))
+            {
+                continue;
+            }
+
+            findings.Add(Collapse(span));
+        }
+
+        return findings;
+    }
+
+    /// <summary>The innermost <c>GREATEST</c>/<c>LEAST</c> argument list containing <paramref name="index"/>,
+    /// or null when the clock is not inside one.</summary>
+    private static string? ClampArgumentsAround(string text, int index)
+    {
+        foreach (Match clamp in ClampRegex.Matches(text))
+        {
+            var open = clamp.Index + clamp.Length - 1;
+
+            if (open >= index)
+            {
+                continue;
+            }
+
+            var depth = 0;
+
+            for (var i = open; i < text.Length; i++)
+            {
+                if (text[i] == '(')
+                {
+                    depth++;
+                }
+                else if (text[i] == ')')
+                {
+                    depth--;
+
+                    if (depth == 0)
+                    {
+                        if (index < i)
+                        {
+                            return text[open..(i + 1)];
+                        }
+
+                        break;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// The predicate <paramref name="index"/> sits in: outward to the nearest boundary keyword, an
+    /// unbalanced parenthesis, or a comma at this depth. Returns null unless the predicate was OPENED by a
+    /// boolean keyword and actually contains a comparison — that pair is what separates
+    /// <c>WHERE col = now()</c> from <c>SET col = now()</c>.
+    /// </summary>
+    private static string? PredicateSpanAround(string text, int index)
+    {
+        var (left, opener) = WalkLeft(text, index);
+        var right = WalkRight(text, index);
+
+        if (opener is null || !PredicateOpeners.Contains(opener))
+        {
+            return null;
+        }
+
+        var span = text[left..right];
+
+        return ComparisonRegex.IsMatch(span) ? span : null;
+    }
+
+    private static (int Start, string? Opener) WalkLeft(string text, int index)
+    {
+        var depth = 0;
+        var i = index;
+
+        while (i > 0)
+        {
+            var c = text[i - 1];
+
+            if (c == ')')
+            {
+                depth++;
+            }
+            else if (c == '(')
+            {
+                if (depth == 0)
+                {
+                    return (i, null);
+                }
+
+                depth--;
+            }
+            else if (depth == 0 && (c == ',' || c == ';'))
+            {
+                return (i, null);
+            }
+            else if (depth == 0 && char.IsLetter(c))
+            {
+                var end = i;
+                var start = end;
+
+                while (start > 0 && (char.IsLetterOrDigit(text[start - 1]) || text[start - 1] == '_'))
+                {
+                    start--;
+                }
+
+                var word = text[start..end];
+
+                if (SpanBoundaries.Contains(word))
+                {
+                    return (end, word);
+                }
+
+                i = start;
+                continue;
+            }
+
+            i--;
+        }
+
+        return (0, null);
+    }
+
+    private static int WalkRight(string text, int index)
+    {
+        var depth = 0;
+        var i = index;
+
+        while (i < text.Length)
+        {
+            var c = text[i];
+
+            if (c == '(')
+            {
+                depth++;
+            }
+            else if (c == ')')
+            {
+                if (depth == 0)
+                {
+                    return i;
+                }
+
+                depth--;
+            }
+            else if (depth == 0 && (c == ',' || c == ';'))
+            {
+                return i;
+            }
+            else if (depth == 0 && char.IsLetter(c))
+            {
+                var start = i;
+                var end = start;
+
+                while (end < text.Length && (char.IsLetterOrDigit(text[end]) || text[end] == '_'))
+                {
+                    end++;
+                }
+
+                var word = text[start..end];
+
+                if (SpanBoundaries.Contains(word) && start != index)
+                {
+                    return start;
+                }
+
+                i = end;
+                continue;
+            }
+
+            i++;
+        }
+
+        return text.Length;
+    }
+
+    private static bool MentionsColumn(string span, ISet<string> columns)
+    {
+        foreach (Match word in Regex.Matches(span, @"[A-Za-z_][A-Za-z0-9_]*"))
+        {
+            if (columns.Contains(word.Value))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /* ---------------- corpus ---------------- */
+
+    /// <summary>
+    /// Column names declared <c>timestamp</c> / <c>TIMESTAMP</c> (never <c>timestamptz</c>) by either store's
+    /// DDL. Scraped from the DDL's own literals rather than listed here, so a column added by a new migration
+    /// rung is covered the day it lands — and read through the literal walk, so a name written in a comment
+    /// cannot enter the vocabulary.
+    /// </summary>
+    private static HashSet<string> NaiveTimestampColumns([CallerFilePath] string thisFile = "")
+    {
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        var declaration = new Regex(
+            @"(?:^|[(,])\s*(?<name>[A-Za-z_][A-Za-z0-9_]*)\s+timestamp\b(?!\s*(?:with|tz))",
+            RegexOptions.IgnoreCase | RegexOptions.Multiline);
+
+        foreach (var path in DdlFiles(thisFile))
+        {
+            var text = File.ReadAllText(path);
+
+            foreach (var (_, body) in CSharpSourceWalker.StringLiteralBodies(text))
+            {
+                foreach (Match match in declaration.Matches(body))
+                {
+                    names.Add(match.Groups["name"].Value);
+                }
+            }
+        }
+
+        /* `timestamp` is the type keyword, not a column; it turns up when a cast is written across a line
+           break inside a DDL literal. Left in, it would match every SQL literal that casts anything. */
+        names.Remove("timestamp");
+
+        return names;
+    }
+
+    private static IEnumerable<string> DdlFiles(string thisFile)
+    {
+        foreach (var dir in new[] { StorageDir(thisFile), LiteDir(thisFile, "Database") })
+        {
+            foreach (var path in Directory.EnumerateFiles(dir, "*.cs", SearchOption.AllDirectories))
+            {
+                yield return path;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Both apps' store-side source: everything that composes SQL against a Darling (PostgreSQL) or Lite
+    /// (DuckDB) store. The collectors are deliberately NOT here — their SQL runs against a monitored SQL
+    /// Server, whose clock policy is a separate question with at least one deliberately local caller.
+    /// </summary>
+    private static IEnumerable<string> StoreSourceFiles([CallerFilePath] string thisFile = "")
+    {
+        var roots = new[]
+        {
+            StorageDir(thisFile),
+            ServiceDir(thisFile),
+            ViewerDir(thisFile),
+            LiteDir(thisFile, "Services"),
+            LiteDir(thisFile, "Database"),
+            LiteDir(thisFile, "Analysis"),
+        };
+
+        foreach (var root in roots)
+        {
+            foreach (var path in Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories))
+            {
+                if (path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                    || path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                yield return path;
+            }
+        }
+    }
+
+    private static string DarlingDir(string thisFile) =>
+        Path.GetFullPath(Path.Combine(Path.GetDirectoryName(thisFile)!, ".."));
+
+    private static string StorageDir(string thisFile) =>
+        Directory.Exists(Path.Combine(DarlingDir(thisFile), "PerformanceMonitor.Darling.Storage"))
+            ? Path.Combine(DarlingDir(thisFile), "PerformanceMonitor.Darling.Storage")
+            : throw new DirectoryNotFoundException("Darling Storage project not found from " + thisFile);
+
+    private static string ServiceDir(string thisFile) =>
+        Path.Combine(DarlingDir(thisFile), "PerformanceMonitor.Darling.Service");
+
+    private static string ViewerDir(string thisFile) =>
+        Path.Combine(DarlingDir(thisFile), "PerformanceMonitor.Darling.Viewer");
+
+    private static string LiteDir(string thisFile, string leaf) =>
+        Path.GetFullPath(Path.Combine(DarlingDir(thisFile), "..", "Lite", leaf));
+
+    /* ---------------- text helpers ---------------- */
+
+    private static bool LooksLikeSql(string body) =>
+        body.Contains("SELECT ", StringComparison.OrdinalIgnoreCase)
+        || body.Contains("INSERT ", StringComparison.OrdinalIgnoreCase)
+        || body.Contains("UPDATE ", StringComparison.OrdinalIgnoreCase)
+        || body.Contains("DELETE ", StringComparison.OrdinalIgnoreCase)
+        || body.Contains("CREATE ", StringComparison.OrdinalIgnoreCase)
+        || body.Contains(" FROM ", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Blanks SQL comments, preserving length so an offset still points where it did. The repo's SQL
+    /// is heavily commented and those comments discuss <c>now()</c> constantly — including in the waiver this
+    /// pin allows — so a scan that skips this step measures the prose.</summary>
+    private static string StripSqlComments(string sql)
+    {
+        var sb = new StringBuilder(sql);
+
+        for (var i = 0; i < sb.Length - 1; i++)
+        {
+            if (sb[i] == '-' && sb[i + 1] == '-')
+            {
+                while (i < sb.Length && sb[i] != '\n')
+                {
+                    sb[i++] = ' ';
+                }
+
+                continue;
+            }
+
+            if (sb[i] == '/' && sb[i + 1] == '*')
+            {
+                var close = sql.IndexOf("*/", i + 2, StringComparison.Ordinal);
+                var end = close < 0 ? sb.Length : close + 2;
+
+                while (i < end)
+                {
+                    if (sb[i] != '\n')
+                    {
+                        sb[i] = ' ';
+                    }
+
+                    i++;
+                }
+
+                i--;
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>The member a literal belongs to, for the waiver key and the failure message: the nearest
+    /// declaration above it.</summary>
+    private static string EnclosingMember(string text, int offset)
+    {
+        var head = text[..Math.Min(offset, text.Length)];
+
+        var matches = Regex.Matches(
+            head,
+            @"(?:const\s+string|static\s+string|string)\s+(?<name>[A-Za-z_][A-Za-z0-9_]*)\s*(?:=|=>)|(?<name2>[A-Za-z_][A-Za-z0-9_]*)\s*\([^)]*\)\s*(?:=>|\{)");
+
+        for (var i = matches.Count - 1; i >= 0; i--)
+        {
+            var name = matches[i].Groups["name"].Success ? matches[i].Groups["name"].Value : matches[i].Groups["name2"].Value;
+
+            if (!string.IsNullOrEmpty(name))
+            {
+                return name;
+            }
+        }
+
+        return "<unknown>";
+    }
+
+    private static string Collapse(string span)
+    {
+        var one = Regex.Replace(span.Trim(), @"\s+", " ");
+
+        return one.Length <= 160 ? one : one[..160] + "…";
+    }
+}

--- a/Darling/Darling.Tests/StoreSqlClockDisciplineTests.cs
+++ b/Darling/Darling.Tests/StoreSqlClockDisciplineTests.cs
@@ -48,7 +48,7 @@ namespace Darling.Tests;
 public sealed class StoreSqlClockDisciplineTests
 {
     /* Floors, so the scan cannot pass by finding nothing. Measured on dev at the time of writing: 563 files,
-       19,604 string literals, 1,626 of them SQL-shaped, 58 naive timestamp column names. Set well below
+       19,604 string literals, 1,627 of them SQL-shaped, 56 naive timestamp column names. Set well below
        those so ordinary growth never trips them, but high enough that a broken glob or a desynchronised
        literal walk fails instead of reporting a clean bill of health. The column-vocabulary floor is the one
        that matters most: the discriminator needs those names, and a DDL scrape that quietly returned four of
@@ -57,6 +57,29 @@ public sealed class StoreSqlClockDisciplineTests
     private const int MinimumLiteralsScanned = 12_000;
     private const int MinimumSqlLiteralsScanned = 1_200;
     private const int MinimumTimestampColumnsKnown = 40;
+
+    /// <summary>
+    /// Column NAMES whose timestamp frame depends on which table they are in, so a name-keyed scan cannot
+    /// judge them and must not pretend to. Both are genuinely split:
+    ///
+    /// <list type="bullet">
+    /// <item><c>sample_time</c> — <c>cpu_utilization_stats.sample_time</c> is deliberately the MONITORED
+    /// SERVER's local wall clock (#1262 de-skews it per batch; Lite windows it through
+    /// <c>GetTimeRangeServerLocal</c>), while <c>memory_pressure_events.sample_time</c> must be UTC.</item>
+    /// <item><c>event_time</c> — <c>default_trace_events.event_time</c> is server-LOCAL (the .trc files
+    /// store local time), while <c>system_health.event_time</c> is UTC. <c>ViewerSystemEventsTests</c> says
+    /// it in one line: "system_health.event_time is UTC, default_trace.event_time is local".</item>
+    /// </list>
+    ///
+    /// <para><c>CollectorTimestampFrameTests</c> is the authority for these, pinning the frame PER COLUMN
+    /// against the read path each one protects. Its own remarks record that ITS first cut was a store-wide
+    /// "all naive timestamps are UTC" rule that would have forbidden the CPU collector's intentional local
+    /// clock — which is exactly the mistake a scan like this one makes if it assumes a name implies a
+    /// frame. A server-local column compared against a bare clock is still a defect, but a DIFFERENT one
+    /// with a different fix (de-skew by the server's offset, not bind naive UTC), so it belongs to that pin.
+    /// Add a name here only with the same kind of evidence: a documented split, per table.</para>
+    /// </summary>
+    private static readonly string[] AmbiguousFrameColumns = ["sample_time", "event_time"];
 
     /// <summary>
     /// The one bare <c>now()</c> left in the store's SQL, and it is waived on ARITHMETIC, not on being
@@ -499,15 +522,10 @@ public sealed class StoreSqlClockDisciplineTests
            break inside a DDL literal. Left in, it would match every SQL literal that casts anything. */
         names.Remove("timestamp");
 
-        /* sample_time is EXCLUDED, and not because it is safe. It is the one name in the store whose frame
-           depends on the table: cpu_utilization_stats.sample_time is deliberately the MONITORED SERVER's
-           local wall clock (#1262 de-skews it per batch, Lite windows it through GetTimeRangeServerLocal),
-           while memory_pressure_events.sample_time must be UTC. CollectorTimestampFrameTests pins both,
-           per column, against the read path each protects — and its own remarks record that its first cut
-           was a store-wide "all naive timestamps are UTC" rule that would have forbidden the CPU
-           collector's intentional local clock. This scan keys on column NAMES, so it cannot tell those two
-           apart and must not claim to; that column's frame is that pin's business, not this one's. */
-        names.Remove("sample_time");
+        foreach (var ambiguous in AmbiguousFrameColumns)
+        {
+            names.Remove(ambiguous);
+        }
 
         return names;
     }

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingAlertReadAdapter.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingAlertReadAdapter.cs
@@ -1047,6 +1047,10 @@ ORDER BY l.database_name";
         return items;
     }
 
+    /// <summary>How far back <see cref="ForcePlanFailuresSql"/> looks for a plan's two most recent
+    /// collections. Bound as a parameter rather than written into the SQL — see that query's remarks.</summary>
+    internal static readonly TimeSpan ForcePlanFailureWindow = TimeSpan.FromHours(2);
+
     /// <summary>
     /// Forced plans whose failure counter ROSE between the two most recent collections that carried the
     /// plan (#2157). $1 server_id.
@@ -1062,19 +1066,15 @@ ORDER BY l.database_name";
     /// <c>timestamp without time zone</c> holding naive UTC and <c>now()</c> is <c>timestamptz</c>, so the
     /// mixed comparison makes PostgreSQL convert the naive side at the store SESSION's TimeZone — which
     /// initdb takes from the host OS, and which BuildConfAppend does not pin. Measured on
-    /// timescaledb:latest-pg17 seeded one row per 52s, a one-hour window returned 66 rows under
-    /// <c>TimeZone='UTC'</c> and 343 under <c>'America/New_York'</c>: the same predicate silently spanning
-    /// five hours. East of UTC it narrows instead and can return nothing, which for THIS read means the
-    /// forced-plan-failure alert never fires. The bound is the service clock's, which is also the clock that
+    /// timescaledb:latest-pg17 seeded one row per 52s, a one-hour window returned 70 rows under
+    /// <c>TimeZone='UTC'</c> and 347 under <c>'America/New_York'</c>: the same predicate silently spanning
+    /// five hours. East of UTC it narrows instead: at <c>'Pacific/Kiritimati'</c> this read returns NOTHING,
+    /// so the forced-plan-failure alert never fires there at all. The bound is the service clock's, which is also the clock that
     /// stamped <c>collection_time</c>, so the two cannot disagree about what "two hours ago" means.</para>
     ///
     /// <para>The <c>&gt;</c> comparison is what makes this a delta read: equal counters are silence, and a
     /// LOWER counter (unforce/re-force reset) is silence too rather than a negative delta.</para>
     /// </summary>
-    /// <summary>How far back <see cref="ForcePlanFailuresSql"/> looks for a plan's two most recent
-    /// collections. Bound as a parameter rather than written into the SQL — see that query's remarks.</summary>
-    internal static readonly TimeSpan ForcePlanFailureWindow = TimeSpan.FromHours(2);
-
     public const string ForcePlanFailuresSql = @"
 WITH per_collection AS (
     SELECT

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingAlertReadAdapter.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingAlertReadAdapter.cs
@@ -1057,9 +1057,24 @@ ORDER BY l.database_name";
     /// the hypertable scan; a plan not collected within it is by definition not failing right now, and
     /// Query Store's own flush cadence (900s) means an active plan appears several times inside it.</para>
     ///
+    /// <para>The window's lower bound is BOUND as <c>$2</c> from <see cref="NaiveUtcNow"/>, never spelled
+    /// <c>now() - interval '2 hours'</c> in the SQL. <c>collection_time</c> is
+    /// <c>timestamp without time zone</c> holding naive UTC and <c>now()</c> is <c>timestamptz</c>, so the
+    /// mixed comparison makes PostgreSQL convert the naive side at the store SESSION's TimeZone — which
+    /// initdb takes from the host OS, and which BuildConfAppend does not pin. Measured on
+    /// timescaledb:latest-pg17 seeded one row per 52s, a one-hour window returned 66 rows under
+    /// <c>TimeZone='UTC'</c> and 343 under <c>'America/New_York'</c>: the same predicate silently spanning
+    /// five hours. East of UTC it narrows instead and can return nothing, which for THIS read means the
+    /// forced-plan-failure alert never fires. The bound is the service clock's, which is also the clock that
+    /// stamped <c>collection_time</c>, so the two cannot disagree about what "two hours ago" means.</para>
+    ///
     /// <para>The <c>&gt;</c> comparison is what makes this a delta read: equal counters are silence, and a
     /// LOWER counter (unforce/re-force reset) is silence too rather than a negative delta.</para>
     /// </summary>
+    /// <summary>How far back <see cref="ForcePlanFailuresSql"/> looks for a plan's two most recent
+    /// collections. Bound as a parameter rather than written into the SQL — see that query's remarks.</summary>
+    internal static readonly TimeSpan ForcePlanFailureWindow = TimeSpan.FromHours(2);
+
     public const string ForcePlanFailuresSql = @"
 WITH per_collection AS (
     SELECT
@@ -1073,7 +1088,7 @@ WITH per_collection AS (
         MAX(COALESCE(qs.last_force_failure_reason, '')) AS reason
     FROM query_store_stats AS qs
     WHERE qs.server_id = $1
-    AND   qs.collection_time > now() - interval '2 hours'
+    AND   qs.collection_time > $2
     GROUP BY qs.database_name, qs.query_id, qs.plan_id, qs.collection_time
 ),
 ranked AS (
@@ -1110,6 +1125,7 @@ ORDER BY n.database_name, n.query_id, n.plan_id";
         await using var connection = await _postgres.OpenConnectionAsync(cancellationToken);
         using var command = new NpgsqlCommand(ForcePlanFailuresSql, connection) { CommandTimeout = AlertPassCommandTimeoutSeconds };
         command.Parameters.AddWithValue(serverId);
+        command.Parameters.AddWithValue(NaiveUtcNow() - ForcePlanFailureWindow);
 
         using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingManagedPostgres.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingManagedPostgres.cs
@@ -201,6 +201,26 @@ public sealed class DarlingManagedPostgres
     public const string ConfMarkerV8 = "# Managed by PerformanceMonitor Darling (v8 hardware sizing) -- do not remove this block";
 
     /// <summary>
+    /// DEFENCE IN DEPTH for the naive-UTC/timestamptz split, not the fix for it. Every timestamp column in
+    /// the store is <c>timestamp without time zone</c> holding naive UTC, but initdb takes
+    /// <c>timezone</c> from the host OS — so a managed store on a Windows box in New York runs its sessions
+    /// at <c>America/New_York</c>, and anything that compares a naive column against <c>now()</c> has the
+    /// naive side converted at that zone. Pinning the session zone to UTC makes that conversion the identity
+    /// it was always assumed to be, and makes <c>timestamptz::text</c> (TimescaleDB's catalog views, psql
+    /// output) render on the same clock as the collected data instead of four hours off it.
+    ///
+    /// <para>It does NOT replace binding those bounds as parameters: it reaches MANAGED stores only, and a
+    /// bring-your-own store keeps whatever zone its owner built it with. <c>StoreSqlClockDisciplineTests</c>
+    /// is what actually holds the predicates; this is the belt behind it.</para>
+    ///
+    /// <para><c>timezone</c> is a SIGHUP-context setting and this append runs before pg_ctl start, so it
+    /// takes effect on the very start that writes it — the log-rotation story, not the shared_buffers one.
+    /// Existing clusters gain it by the marker being absent, which is what carries this to the stores
+    /// already in the field rather than only to a fresh initdb.</para>
+    /// </summary>
+    public const string ConfMarkerV9 = "# Managed by PerformanceMonitor Darling (v9 session time zone) -- do not remove this block";
+
+    /// <summary>
     /// Prefix of the v8 fingerprint line — the record of what the sizing beneath it was derived FROM,
     /// which is the whole mechanism: a marker can only say "a block exists", a fingerprint says "a block
     /// exists FOR THIS MACHINE". Compared by <see cref="ConfHasCurrentHardwareFingerprint"/> against the
@@ -757,6 +777,22 @@ public sealed class DarlingManagedPostgres
         builder.Append("maintenance_work_mem = ").Append(settings.MaintenanceWorkMemMb).Append("MB\n");
         builder.Append("timescaledb.max_background_workers = ").Append(workers.MaxBackgroundWorkers).Append('\n');
         builder.Append("max_worker_processes = ").Append(workers.MaxWorkerProcesses).Append('\n');
+        return builder.ToString();
+    }
+
+    /* ===================== v9 session time zone ===================== */
+
+    /// <summary>
+    /// The v9 block: pin the cluster's session <c>timezone</c> to UTC. See <see cref="ConfMarkerV9"/> for
+    /// why, and for what this deliberately does not cover. Appended last and carrying no fingerprint line,
+    /// so the v8 staleness check's invariant about what it reads is untouched.
+    /// </summary>
+    public static string BuildTimeZoneConfAppend()
+    {
+        var builder = new StringBuilder();
+        builder.Append('\n');
+        builder.Append(ConfMarkerV9).Append('\n');
+        builder.Append("timezone = 'UTC'\n");
         return builder.ToString();
     }
 
@@ -1323,6 +1359,17 @@ public sealed class DarlingManagedPostgres
             _logger.LogInformation(
                 "Appended v8 hardware sizing to postgresql.conf (host RAM {RamMb} MB, {Hypertables} hypertables -> effective_cache_size {EffectiveCache}MB, maintenance_work_mem {Maintenance}MB, timescaledb.max_background_workers {BgWorkers}, max_worker_processes {WorkerProcesses}; shared_buffers and work_mem deliberately NOT re-derived, see #2845)",
                 v8QuantizedRam / (1024L * 1024L), hypertableCount, v8Settings.EffectiveCacheSizeMb, v8Settings.MaintenanceWorkMemMb, v8Workers.MaxBackgroundWorkers, v8Workers.MaxWorkerProcesses);
+        }
+
+        /* Checked independently of v1-v8, and placed AFTER v8 on purpose: v8 keys on the last fingerprint
+           line in the text it read at the top of this method, so a block appended before it must not carry
+           one. This block carries only `timezone`, but sitting last means the ordering cannot be broken by
+           editing it. Effective on this start (SIGHUP-context, appended before pg_ctl start). */
+        if (!conf.Contains(ConfMarkerV9, StringComparison.Ordinal))
+        {
+            File.AppendAllText(confPath, BuildTimeZoneConfAppend());
+            _logger.LogInformation(
+                "Appended v9 session time zone to postgresql.conf (timezone = 'UTC'): the store's timestamp columns hold naive UTC, so a host-derived session zone would shift any comparison against now() and render timestamptz output on a different clock than the collected data.");
         }
     }
 

--- a/Darling/PerformanceMonitor.Darling.Storage/DarlingModuleMap.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/DarlingModuleMap.cs
@@ -48,8 +48,18 @@ public static class DarlingModuleMap
     /// two days of procedure_stats — well inside its 4-day raw retention, so no handle is missed between runs.
     /// ACCUMULATES: a handle that stops appearing keeps its last-known attribution forever (no delete). DISTINCT ON
     /// keeps the most-recent row per handle; the ON CONFLICT only advances a row (never regresses last_seen), so a
-    /// stale run can't overwrite a fresher attribution. <c>now()</c> is fine here — this is runtime maintenance, not
-    /// the deterministic compiler.
+    /// stale run can't overwrite a fresher attribution.
+    ///
+    /// <para><c>now()</c> IS LEFT BARE HERE, alone in the store's SQL, and it survives on margin rather than on
+    /// being harmless. <c>collection_time</c> is naive UTC and <c>now()</c> is <c>timestamptz</c>, so the store
+    /// session's TimeZone shifts this bound like any other: across the real offset range (UTC-12..UTC+14) the
+    /// 48-hour window delivers between 34 and 60 hours. Both ends are safe for THIS query and only because of
+    /// the two numbers either side of it — 34h still covers the refresh cadence (startup, then riding the 24h
+    /// purge) so no handle is missed between runs, and 60h is still inside
+    /// <c>TimescaleSupport.RawRetentionInterval</c> (4 days) so the widened end scans nothing that has been
+    /// dropped. The map also ACCUMULATES, so a wider window only re-reads rows it already has. Shorten the
+    /// cadence past 34h or the raw retention past 60h and this has to become a bound parameter like every other
+    /// windowed read; it is not a licence for the next one.</para>
     ///
     /// <para>The <c>ORDER BY</c> its DISTINCT ON requires also happens to be a deterministic ascending order
     /// on the conflict key, so concurrent refreshes take these row locks in the same relative order and the

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -500,8 +500,14 @@ WITH NO DATA";
                 DateTime? coverageOldest = null;
                 DateTime? needFrom = null;
                 using (var probe = new NpgsqlCommand(probeSql, connection) { CommandTimeout = SetupTimeoutSeconds })
-                await using (var reader = await probe.ExecuteReaderAsync(cancellationToken))
                 {
+                    /* Kind-Unspecified so Npgsql sends `timestamp`, not `timestamptz`: the horizon is
+                       compared against collection_time, which is naive UTC. */
+                    probe.Parameters.AddWithValue(
+                        DateTime.SpecifyKind(DateTime.UtcNow - BaselineRetentionSpan, DateTimeKind.Unspecified));
+
+                    await using var reader = await probe.ExecuteReaderAsync(cancellationToken);
+
                     if (await reader.ReadAsync(cancellationToken))
                     {
                         sourceOldest = reader.IsDBNull(0) ? null : reader.GetDateTime(0);
@@ -735,6 +741,16 @@ WITH NO DATA";
     /// <para>This is the same predicate shape the retention arming uses (<c>MeasureRetentionCoverageAsync</c>) over
     /// the same pair of relations, deliberately: what we backfill and what unblocks arming cannot be allowed
     /// to drift apart.</para>
+    ///
+    /// <para>THE HORIZON IS BOUND AS <c>$1</c>, not computed in the SQL. <c>now()::timestamp</c> is
+    /// effectively <c>LOCALTIMESTAMP</c> — it renders the clock in the store session's TimeZone, which
+    /// initdb takes from the host OS — while <c>min(collection_time)</c> is naive UTC. Both sides are
+    /// <c>timestamp</c>, so PostgreSQL raises nothing and <c>GREATEST</c> simply picks between two values on
+    /// different clocks: on a store whose host sits east of UTC the horizon moves LATER and the gate
+    /// under-asks for coverage, leaving the baseline tier permanently short of the window #1757 needs, and
+    /// west of UTC it over-asks and materializes buckets the tier's own retention policy then drops. The
+    /// caller passes <see cref="BaselineRetentionSpan"/> off the service clock, the same clock that stamped
+    /// every <c>collection_time</c> it is compared against.</para>
     /// </summary>
     public static string BaselineBackfillProbeSql(string view, string source)
         => $@"
@@ -743,7 +759,7 @@ SELECT
     (SELECT min(bucket) FROM collect.{view}) AS coverage_oldest,
     time_bucket('1 hour', GREATEST(
         (SELECT min(collection_time) FROM collect.{source}),
-        now()::timestamp - INTERVAL '{BaselineRetentionInterval}')) AS need_from";
+        $1)) AS need_from";
 
     /// <summary>
     /// Drops a baseline relation ONLY when it is a plain fallback view and NOT a continuous aggregate — the

--- a/Lite/Services/LocalDataService.ForcePlanFailures.cs
+++ b/Lite/Services/LocalDataService.ForcePlanFailures.cs
@@ -21,6 +21,10 @@ namespace PerformanceMonitorLite.Services;
 /// </summary>
 public sealed partial class LocalDataService
 {
+    /// <summary>How far back <see cref="ForcePlanFailuresSql"/> looks for a plan's two most recent
+    /// collections. Bound as a parameter rather than written into the SQL — see that query's remarks.</summary>
+    internal static readonly TimeSpan ForcePlanFailureWindow = TimeSpan.FromHours(2);
+
     /// <summary>
     /// Forced plans whose failure counter ROSE between the two most recent collections that carried the
     /// plan. $1 server_id.
@@ -41,10 +45,6 @@ public sealed partial class LocalDataService
     /// Darling's twin carries the same bound for the same reason; keeping the two shape-for-shape is what
     /// stops the apps disagreeing about what counts as a new failure.</para>
     /// </summary>
-    /// <summary>How far back <see cref="ForcePlanFailuresSql"/> looks for a plan's two most recent
-    /// collections. Bound as a parameter rather than written into the SQL — see that query's remarks.</summary>
-    internal static readonly TimeSpan ForcePlanFailureWindow = TimeSpan.FromHours(2);
-
     public const string ForcePlanFailuresSql = @"
 WITH per_collection AS (
     SELECT

--- a/Lite/Services/LocalDataService.ForcePlanFailures.cs
+++ b/Lite/Services/LocalDataService.ForcePlanFailures.cs
@@ -6,6 +6,7 @@
  * Licensed under the MIT License. See LICENSE file in the project root for full license information.
  */
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using DuckDB.NET.Data;
@@ -32,7 +33,18 @@ public sealed partial class LocalDataService
     ///
     /// <para>The <c>&gt;</c> is what makes this a delta read — equal counters are silence, and a LOWER
     /// counter (an unforce/re-force reset) is silence rather than a negative delta.</para>
+    ///
+    /// <para>The window's lower bound is BOUND as <c>$2</c>, not written <c>now() - INTERVAL '2 hours'</c>.
+    /// <c>collection_time</c> is a naive-UTC <c>TIMESTAMP</c> and <c>now()</c> is <c>TIMESTAMP WITH TIME
+    /// ZONE</c>, so the mixed comparison resolves the naive side in the session's TimeZone — which DuckDB
+    /// takes from the host — and the window silently widens west of UTC and narrows to nothing east of it.
+    /// Darling's twin carries the same bound for the same reason; keeping the two shape-for-shape is what
+    /// stops the apps disagreeing about what counts as a new failure.</para>
     /// </summary>
+    /// <summary>How far back <see cref="ForcePlanFailuresSql"/> looks for a plan's two most recent
+    /// collections. Bound as a parameter rather than written into the SQL — see that query's remarks.</summary>
+    internal static readonly TimeSpan ForcePlanFailureWindow = TimeSpan.FromHours(2);
+
     public const string ForcePlanFailuresSql = @"
 WITH per_collection AS (
     SELECT
@@ -46,7 +58,7 @@ WITH per_collection AS (
         MAX(COALESCE(qs.last_force_failure_reason, '')) AS reason
     FROM v_query_store_stats AS qs
     WHERE qs.server_id = $1
-    AND   qs.collection_time > now() - INTERVAL '2 hours'
+    AND   qs.collection_time > $2
     GROUP BY qs.database_name, qs.query_id, qs.plan_id, qs.collection_time
 ),
 ranked AS (
@@ -81,6 +93,7 @@ ORDER BY n.database_name, n.query_id, n.plan_id";
         using var command = connection.CreateCommand();
         command.CommandText = ForcePlanFailuresSql;
         command.Parameters.Add(new DuckDBParameter { Value = serverId });
+        command.Parameters.Add(new DuckDBParameter { Value = DateTime.UtcNow - ForcePlanFailureWindow });
 
         var items = new List<ForcePlanFailureInfo>();
         using var reader = await command.ExecuteReaderAsync();

--- a/Lite/Services/LocalDataService.WaitStats.cs
+++ b/Lite/Services/LocalDataService.WaitStats.cs
@@ -599,6 +599,10 @@ LIMIT 2000";
         return items;
     }
 
+    /// <summary>How fresh the latest snapshot must be for its sessions to count as still running. Bound as
+    /// <c>$4</c> rather than written into the SQL — see the bind site.</summary>
+    private static readonly TimeSpan LatestSnapshotFreshness = TimeSpan.FromMinutes(10);
+
     /// <summary>
     /// Gets long-running queries from the latest collection snapshot.
     /// Returns sessions whose total elapsed time exceeds the given threshold.
@@ -652,7 +656,7 @@ LIMIT 2000";
                 FROM v_query_snapshots AS r
                 WHERE r.server_id = $1
                     AND r.collection_time = (SELECT MAX(vqs.collection_time) FROM v_query_snapshots AS vqs WHERE vqs.server_id = $1)
-                    AND r.collection_time >= NOW() - INTERVAL '10 MINUTES'
+                    AND r.collection_time >= $4
                     AND r.session_id > 50
                     {spServerDiagnosticsFilter}
                     {waitForFilter}
@@ -666,6 +670,11 @@ LIMIT 2000";
         command.Parameters.Add(new DuckDBParameter { Value = serverId });
         command.Parameters.Add(new DuckDBParameter { Value = thresholdMs });
         command.Parameters.Add(new DuckDBParameter { Value = maxResults });
+        /* $4 is the snapshot-freshness floor, bound rather than spelled `NOW() - INTERVAL '10 MINUTES'`:
+           collection_time is a naive-UTC TIMESTAMP, NOW() is TIMESTAMP WITH TIME ZONE, and the mixed
+           comparison resolves the naive side in the host's TimeZone. East of UTC the floor lands in the
+           future and this read returns nothing, so the long-running-query alert never fires at all. */
+        command.Parameters.Add(new DuckDBParameter { Value = DateTime.UtcNow - LatestSnapshotFreshness });
 
         var items = new List<LongRunningQueryInfo>();
         using var reader = await command.ExecuteReaderAsync();


### PR DESCRIPTION
Every timestamp column in both stores is `timestamp without time zone` holding naive UTC — measured, there is not one `timestamptz` column in either schema. `now()` is `timestamptz`. PostgreSQL resolves the mixed comparison by converting the NAIVE side at the store session's `TimeZone`, which `initdb` takes from the host OS and which `BuildConfAppend` does not pin, so a window silently widens west of UTC and inverts to nothing east of it. Nothing raises an error, and every store anyone develops or tests against runs UTC, which is why these read as correct in review.

## Measured, running the shipped query strings

`timescale/timescaledb:latest-pg17` (17.11) seeded one row per 52 seconds, and DuckDB 1.5.5 (the pinned version) seeded the same way:

| | UTC | America/New_York | Pacific/Kiritimati |
|---|---|---|---|
| `collection_time > now() - interval '1 hour'` | 70 rows | **347** | **0** |
| same window bound as `$1` | 70 | 70 | 70 |
| `ForcePlanFailuresSql` before | 1 row | 1 | **0 — alert dead** |
| `ForcePlanFailuresSql` after | 1 | 1 | 1 |
| `BaselineBackfillProbeSql` `need_from` before | 01:00 | −4h | **+14h** |
| `BaselineBackfillProbeSql` `need_from` after | 01:00 | 01:00 | 01:00 |
| Lite 10-minute freshness floor before (DuckDB) | 12 rows | **289** | **0 — alert dead** |
| Lite 10-minute freshness floor after (DuckDB) | 12 | 12 | 12 |

## The fix, and why parameters rather than `AT TIME ZONE 'UTC'`

Both spellings are correct. Binding a Kind-Unspecified `DateTime` from `DateTime.UtcNow` wins on four counts:

- It is already the house convention. `NaiveUtcNow()` exists in four service files — including 79 lines below the offending predicate in `DarlingAlertReadAdapter`, which was the only windowed read in its own file not using it — and `PgReadKindDisciplineTests` already enforces the C# *bind* half of exactly this rule. This PR holds the SQL *literal* half, which that scan cannot see.
- The bound is then the same clock that stamped `collection_time` (`DarlingCollectorRunner` writes `DateTime.UtcNow` through `SpecifyKind(..., Unspecified)`), so the two sides cannot disagree about what "two hours ago" means.
- It is one spelling for both stores. DuckDB's `AT TIME ZONE` needs ICU; a parameter does not.
- It makes the guard's rule absolute — *no* bare clock in a store-side comparison — rather than "a bare clock, but only in the blessed spelling". The blessed spelling also has a precedence trap: `now() AT TIME ZONE 'UTC' - interval '2 hours'` is correct only because `AT TIME ZONE` binds tighter than `-`, which is something you have to know.

Four predicates now bind their bound. The fifth, `DarlingModuleMap.RefreshSql`, keeps its bare `now()`: across UTC-12..UTC+14 its 48-hour window delivers 34–60 hours, which stays above the 24-hour refresh cadence (so no handle is missed between runs) and inside the 4-day raw retention (so the widened end scans nothing dropped). It is waived by arithmetic, not by being harmless; the query's remarks carry the derivation and the two numbers that have to keep holding, and the guard records it as its single exception.

`Lite/Services/LocalDataService.WaitStats.cs` was not in the original report — a span-level scan of the whole store-side literal corpus found it. It is the long-running-query alert's snapshot-freshness floor, and it fails in the same direction as the Darling alert.

**And this one was already diagnosed in the repo.** `DarlingAlertReadAdapter.LongRunningQueriesSqlTemplate` is that same query ported to Postgres, and its doc comment has said all along:

> Lite's long-running-query read with the two PG dialect adjustments: DuckDB's bare `NOW() - INTERVAL '10 MINUTES'` becomes the parameterized naive-UTC $4 (a bare `now()` is timestamptz — wrong basis against naive-UTC timestamp columns)

So the defect was identified, correctly explained, and fixed on the Darling side at the moment of the port — and the Lite original it was ported *from* kept it. That is the strongest argument in this PR for a class-level guard rather than four fixes: the knowledge was already here, written down next to the fix, and it still did not propagate. (`$4` is also the parameter number Darling's twin uses, so the two now match.)

## The guard

`StoreSqlClockDisciplineTests` holds the class rather than the four instances: no store-side SQL literal may compare a naive collector timestamp column against a bare `now()` / `CURRENT_TIMESTAMP` / `LOCALTIMESTAMP` / `now()::timestamp`.

- Reads literals through `CSharpSourceWalker`, which gains a `StringLiteralBodies` entry point rather than a sixth private lexer (#2913's lesson) — additive, and the mirror image of the existing `StripCommentsAndStrings`.
- Strips SQL comments inside each literal before matching. The repo's SQL discusses `now()` constantly, including in the waiver this pin allows.
- Scrapes its naive-column vocabulary from the DDL's own literals, so a column added by a new rung is covered the day it lands. `sample_time` is deliberately **excluded**: it is the one column name whose frame depends on the table (`cpu_utilization_stats.sample_time` is intentionally the monitored server's local clock per #1262, `memory_pressure_events.sample_time` must be UTC), and `CollectorTimestampFrameTests` already pins both per column — its own remarks record that *its* first cut was a store-wide "all naive timestamps are UTC" rule that would have forbidden the CPU collector's intentional local clock. A name-keyed scan cannot tell those two apart and must not claim to.
- Floors on what it scanned — 563 files, 19,604 literals, 1,626 SQL-shaped, 58 column names — so it cannot pass vacuously. The column floor is the load-bearing one: a scrape returning four names would hide every offender while still reporting thousands of literals.
- Accepts bare predicate **fragments**, not just whole statements — these readers interpolate standalone filter literals (five in `LocalDataService.WaitStats` alone), so `"AND r.collection_time >= NOW() - INTERVAL '10 MINUTES'"` has no statement keyword and a statement-only filter walks past the shape most likely to reintroduce this. Proven both ways: that fragment as a mutation is caught with the arm and **missed without it**. The limit it does not reach is stated in the source — one literal at a time, so a predicate welded from two literals by concatenation is out of scope, and no such split exists today.
- Discriminator pinned in **both** directions against 12 hazard forms and 15 benign ones. The benign set is the part that took the work: `SET col = now()`, `VALUES (CURRENT_TIMESTAMP)`, `alter_job(..., next_start => now())`, TimescaleDB's genuinely-`timestamptz` catalog views, and a clock spelled only in a comment all appear in the corpus and must not be dragged in. One of those controls caught a real bug in the detector's own regex, where the optional `::timestamp` ate the first eleven characters of `::timestamptz` and made a *correct* `now()::timestamptz AT TIME ZONE 'UTC'` read as an offender.

Mutation-tested: reverting each of the four fixes turns it red, and neutering the waiver key exposes the module-map site — so the allowlist is what suppresses that one, not a blind spot in the detector.

## Scope boundary, stated rather than allowlisted

The guard flags comparisons and clamps, not writes. Lite has six bare-clock *writes* (`now()::TIMESTAMP` into `config_database_state_expected.updated_at`, `server_tags.created_at`, and `CURRENT_TIMESTAMP` into the repair-marker tables). Those store local wall time in naive-UTC columns, which is a different defect shape — and all of them are inert today: none of those columns is read back or compared anywhere, and the one ordering use (`ORDER BY attempted_at`) is offset-invariant. `collector_state.updated_at`, which *is* compared against `MAX(collection_time)`, is written from `DateTime.UtcNow` and is correct. Widening the guard to the write side would need six allowlist entries that misrepresent them as blessed, plus a data-migration question for existing stores, so it is deliberately out of scope here rather than quietly waived.

## Defence in depth

`DarlingManagedPostgres` gains a v9 conf block pinning `timezone = 'UTC'`. Verified above: with the session pinned, even the un-fixed bare form returns the right answer. It rides the established versioned-marker mechanism, so existing field stores gain it on their next service-owned start rather than only a fresh `initdb`; `timezone` is SIGHUP-context and the append runs before `pg_ctl start`, so it is effective on that start. It is placed after the v8 hardware check and carries no fingerprint line, preserving v8's documented invariant about the text it reads.

This is a backstop, not the fix: it reaches managed stores only, and a bring-your-own store keeps whatever zone its owner built it with. The predicates are what actually hold.

## Verification scope

The Windows-only suites cannot run on macOS. What ran here: all four projects plus `Lite.Tests` compile with `EnableWindowsTargeting`; the new guard's real source compiled into a `net10.0` harness against the actual `CSharpSourceWalker` and executed (2/2, plus the five mutations); the shipped `ForcePlanFailuresSql` and `BaselineBackfillProbeSql` executed through Npgsql against live PostgreSQL 17.11 under three session zones; DuckDB 1.5.5 probed for the Lite half. Not run locally: the xUnit suites themselves — CI is the arbiter for those.

No CHANGELOG entry in this PR; the entry text is reported to the coordinating session for consolidation.
