### PR TITLE
Part of #2894

### DIFF
--- a/Darling/Darling.Tests/MigrationDataMovingRungCensusPins.cs
+++ b/Darling/Darling.Tests/MigrationDataMovingRungCensusPins.cs
@@ -476,6 +476,34 @@ public sealed class MigrationDataMovingRungCensusPins
             StripComments(
                 "/* deliberately does not trap the cancel */\n"
                 + "DO $$ BEGIN NULL; EXCEPTION WHEN SQLSTATE '57014' THEN NULL; END $$;"));
+
+        /* Control 4: the token is bounded, so a longer digit run or a longer identifier that merely
+           CONTAINS it is not a finding (#2975 review). Both halves matter: without this the pattern
+           could be loosened back to a substring search and every assertion above would still pass,
+           while a rung with an unrelated 57014 in it would fail the build accused of trapping a
+           cancel. Each condition spelling is asserted here too, so the boundaries cannot be shown
+           harmless by only ever being tested on the one shape control 1 uses. */
+        foreach (var traps in new[]
+                 {
+                     "EXCEPTION WHEN query_canceled THEN NULL;",
+                     "EXCEPTION WHEN OTHERS OR query_canceled THEN NULL;",
+                     "EXCEPTION WHEN query_canceled OR OTHERS THEN NULL;",
+                     "EXCEPTION WHEN SQLSTATE '57014' THEN NULL;",
+                 })
+        {
+            Assert.Matches(s_cancelTrap, traps);
+        }
+
+        foreach (var innocent in new[]
+                 {
+                     "INSERT INTO collect.t (n) VALUES (5701400);",
+                     "ALTER TABLE collect.t ADD COLUMN port int NOT NULL DEFAULT 157014;",
+                     "UPDATE collect.t SET rows_collected = 570140 WHERE id = 1;",
+                     "ALTER TABLE collect.t ADD COLUMN my_query_canceled_flag boolean;",
+                 })
+        {
+            Assert.DoesNotMatch(s_cancelTrap, innocent);
+        }
     }
 
     private sealed record DeclaredRung(int Version, bool SetsTheFloor, string Why);
@@ -518,13 +546,24 @@ public sealed class MigrationDataMovingRungCensusPins
         Opts);
 
     /// <summary>
-    /// The cancel condition, by either spelling PostgreSQL accepts for it. Deliberately a bare TOKEN
-    /// search rather than an attempt to parse a handler's condition list: a rung's executable SQL has no
+    /// The cancel condition, by either spelling PostgreSQL accepts for it. Deliberately a TOKEN search
+    /// rather than an attempt to parse a handler's condition list: a rung's executable SQL has no
     /// legitimate reason to name its own cancellation at all, so anything that does is worth a human
     /// look, and a token cannot be defeated by a condition list spelled in an order the pattern did not
-    /// anticipate (<c>WHEN OTHERS OR query_canceled</c>, <c>WHEN SQLSTATE '57014'</c>).
+    /// anticipate (<c>WHEN OTHERS OR query_canceled</c>, <c>WHEN query_canceled OR OTHERS</c>,
+    /// <c>WHEN SQLSTATE '57014'</c>).
+    ///
+    /// <para><b>The word boundaries are load-bearing in the FALSE-POSITIVE direction</b> (#2975 review).
+    /// Without them <c>57014</c> matches inside any longer digit run and <c>query_canceled</c> inside any
+    /// longer identifier, so a rung carrying an unrelated numeric literal or a column named for the
+    /// condition would fail the build with a message accusing it of trapping a cancel. Measured against
+    /// both forms: the boundaries cost nothing on any of the five real spellings — the quotes around
+    /// <c>'57014'</c> are non-word characters, so the boundary is already satisfied there — and they turn
+    /// <c>5701400</c>, <c>157014</c>, <c>570140</c> and <c>my_query_canceled_flag</c> from findings into
+    /// misses. A pin that fires on those is a pin that gets deleted, which is the same argument the
+    /// <c>CREATE INDEX</c> same-rung exemption above rests on.</para>
     /// </summary>
-    private static readonly Regex s_cancelTrap = new(@"query_canceled|57014", Opts);
+    private static readonly Regex s_cancelTrap = new(@"\bquery_canceled\b|\b57014\b", Opts);
 
     /// <summary>Any plpgsql exception handler, used only as this scan's own liveness control.</summary>
     private static readonly Regex s_exceptionHandler = new(@"\bEXCEPTION\b[\s\S]{0,40}?\bWHEN\b", Opts);

--- a/Darling/Darling.Tests/MigrationDataMovingRungCensusPins.cs
+++ b/Darling/Darling.Tests/MigrationDataMovingRungCensusPins.cs
@@ -412,6 +412,72 @@ public sealed class MigrationDataMovingRungCensusPins
             "DO $$ BEGIN EXECUTE format('CREATE INDEX %I ON %I (a)', 'ix', 'old'); END $$;");
     }
 
+    /// <summary>
+    /// #2894 residual 2: no rung may trap its OWN cancellation. This is the one rung shape that defeats
+    /// <c>PgMigrations.MigrationCommandTimeoutSeconds</c> SILENTLY, and it is one word from a shape the
+    /// ladder already contains.
+    ///
+    /// <para><b>Why this is a defect and not a style preference, measured on PostgreSQL 17.11.</b>
+    /// <c>WHEN OTHERS</c> deliberately does not match <c>query_canceled</c>, which is what makes V23's
+    /// <c>DO</c> block safe: cancelled mid-<c>create_hypertable</c>, its handler does not run, 57014
+    /// propagates, and the applier fails the rung and stamps nothing. Naming the condition instead
+    /// reverses every part of that. A <c>DO</c> block whose handler is <c>WHEN query_canceled</c> and
+    /// whose body was cancelled at its 2 s budget returned to the applier as SUCCESS; the applier
+    /// committed the rung and would have stamped its version, while the body's own write never happened.
+    /// So the store ends up permanently recorded at a version whose rung did nothing — which is exactly
+    /// the property <c>MigrationLockWaitTimeoutSeconds</c>' expiry split rests on ("a stamp of N proves
+    /// rung N and everything below it committed"), and it fails silently in the one direction nothing
+    /// downstream can detect.</para>
+    ///
+    /// <para><b>Green here has to mean something.</b> The ladder contains zero occurrences of either
+    /// spelling today, so the assertion alone would pass against a scan that had stopped scanning, or
+    /// against a comment stripper that had eaten the executable text. Three controls, each failing for a
+    /// different reason: the pattern fires on a rung that DOES trap the cancel; the ladder still holds a
+    /// real exception handler for the scan to be looking at (V23's, and after stripping it is the
+    /// handler rather than the sentence in V23's own comment describing it); and a rung carrying the
+    /// token in executable text is still found when a comment sits beside it.</para>
+    /// </summary>
+    [Fact]
+    public void NoRungTrapsItsOwnCancellation()
+    {
+        var offenders = PgMigrations.Scripts
+            .Where(m => s_cancelTrap.IsMatch(StripComments(m.Sql)))
+            .Select(m => $"V{m.Version.ToString(CultureInfo.InvariantCulture)} ({m.Name})")
+            .ToList();
+
+        Assert.True(
+            offenders.Count == 0,
+            "Rung(s) name their own cancellation condition: "
+            + string.Join(", ", offenders)
+            + ". A plpgsql handler that matches query_canceled (or SQLSTATE '57014') CATCHES the cancel "
+            + "MigrationCommandTimeoutSeconds sends, unlike WHEN OTHERS, which does not match it. "
+            + "Measured: the applier then sees the rung SUCCEED, commits it and stamps its version while "
+            + "the rung's work never happened, leaving the store permanently stamped at a version it "
+            + "never really reached — and the lock-wait expiry split reads that stamp as proof. Let the "
+            + "cancel out (WHEN OTHERS, or no handler), or if a rung genuinely must observe its own "
+            + "cancellation, re-raise it and re-derive both budgets in the same commit.");
+
+        /* Control 1: the pattern fires on the shape. Without it, a pattern that matched nothing at all
+           would read as a clean ladder. */
+        Assert.Matches(
+            s_cancelTrap,
+            "DO $$ BEGIN PERFORM pg_sleep(600); EXCEPTION WHEN query_canceled THEN NULL; END $$;");
+
+        /* Control 2: the scan is reading executable plpgsql, not an empty string. V23 is the ladder's
+           only exception handler and its own comment ALSO names WHEN OTHERS, so this is asserted on the
+           stripped text — which is the same delivery the assertion above uses. */
+        Assert.Contains(
+            PgMigrations.Scripts,
+            m => s_exceptionHandler.IsMatch(StripComments(m.Sql)));
+
+        /* Control 3: stripping comments must not blind the scan to executable text beside them. */
+        Assert.Matches(
+            s_cancelTrap,
+            StripComments(
+                "/* deliberately does not trap the cancel */\n"
+                + "DO $$ BEGIN NULL; EXCEPTION WHEN SQLSTATE '57014' THEN NULL; END $$;"));
+    }
+
     private sealed record DeclaredRung(int Version, bool SetsTheFloor, string Why);
 
     /// <summary>One data-moving statement: which rung, which shape, which table, and who created it.</summary>
@@ -450,6 +516,18 @@ public sealed class MigrationDataMovingRungCensusPins
     private static readonly Regex s_dynamicSql = new(
         @"\bEXECUTE\s+(?!FUNCTION\b|PROCEDURE\b)|\bformat\s*\(",
         Opts);
+
+    /// <summary>
+    /// The cancel condition, by either spelling PostgreSQL accepts for it. Deliberately a bare TOKEN
+    /// search rather than an attempt to parse a handler's condition list: a rung's executable SQL has no
+    /// legitimate reason to name its own cancellation at all, so anything that does is worth a human
+    /// look, and a token cannot be defeated by a condition list spelled in an order the pattern did not
+    /// anticipate (<c>WHEN OTHERS OR query_canceled</c>, <c>WHEN SQLSTATE '57014'</c>).
+    /// </summary>
+    private static readonly Regex s_cancelTrap = new(@"query_canceled|57014", Opts);
+
+    /// <summary>Any plpgsql exception handler, used only as this scan's own liveness control.</summary>
+    private static readonly Regex s_exceptionHandler = new(@"\bEXCEPTION\b[\s\S]{0,40}?\bWHEN\b", Opts);
 
     /// <summary>
     /// Shapes whose cost depends on WHOSE table it is: free when the rung created the table itself

--- a/Darling/PerformanceMonitor.Darling.Storage/PgMigrations.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/PgMigrations.cs
@@ -4013,6 +4013,36 @@ CREATE TABLE IF NOT EXISTS darling_schema_version (
     /// <c>migrate_data =&gt; true</c>, which rewrites every existing row into chunks; on a long-collected /
     /// many-server store that can exceed 30s. Mirrors <see cref="TimescaleSupport"/>'s runtime-conversion
     /// budget. Harmless for the DDL-only migrations — they finish in milliseconds regardless.
+    ///
+    /// <para><b>Per RUNG, not per statement.</b> <see cref="MigrateLockedAsync"/> issues one
+    /// <c>NpgsqlCommand</c> carrying a rung's entire SQL, so V39's two <c>CREATE INDEX</c>es share one
+    /// budget instead of getting one each. That is the unit
+    /// <see cref="MigrationLockWaitTimeoutSeconds"/>' floor is counted in.</para>
+    ///
+    /// <para><b>The cancel it sends IS honoured, on every rung this ladder has.</b> Client-side bounds
+    /// are only requests, so this was measured rather than assumed, against a seeded PostgreSQL 17.11 /
+    /// TimescaleDB 2.29.2 store carrying 13.5 million rows and 90 chunks in each of the four
+    /// floor-setting rungs' targets (unbounded there: V22 6.08 s, V39 4.28 s, V104 10.57 s, V23 25.61 s).
+    /// At a 1 s and a 2 s budget all four abort within 50 ms of it, from inside <c>IO/DataFileRead</c> and
+    /// <c>IO/BuffileRead</c> waits; the backend leaves <c>pg_stat_activity</c> inside 0.4 s, the rung's
+    /// transaction rolls back whole and the connection stays usable. The realistic overrun was run at this
+    /// constant's real value through this applier — a rung parked behind a peer's table lock, which is
+    /// what a second instance collecting into the same store produces: V22 sat in <c>Lock/relation</c> for
+    /// the entire budget and ended at 300.06 s, nothing applied and nothing stamped. So the floor in
+    /// <see cref="MigrationLockWaitTimeoutSeconds"/> is a ceiling on real holds as well, one budget per
+    /// rung.</para>
+    ///
+    /// <para><b>What it bounds is SILENCE, not wall clock — which is why #2894's residual is a
+    /// rung-SHAPE question and not a missing mechanism.</b> Npgsql implements this as a socket READ
+    /// timeout, and every message the backend sends restarts it. Matched pair, same statement and the same
+    /// 40 s of work both times: emitting one <c>RAISE NOTICE</c> a second it ran to completion in 40.18 s
+    /// and a 5 s budget never fired at all, while silent it was cancelled at 5.02 s. A rung is therefore
+    /// bounded at this many seconds of BACKEND SILENCE. Today's ladder is quiet — no rung contains a
+    /// <c>LOOP</c>, and V23's is its only <c>RAISE</c>, in an exception handler that runs only when the
+    /// rung is already failing — so the whole exposure is the two messages <c>create_hypertable</c> emits
+    /// itself, both inside the first 3 s, which offsets V23's real ceiling to 303 s while V22, V39 and
+    /// V104 are cancelled at 300.05 s. A rung that instrumented its own progress, the natural way to write
+    /// a long data move, would not be cancelled at all.</para>
     /// </summary>
     private const int MigrationCommandTimeoutSeconds = 300;
 
@@ -4073,7 +4103,12 @@ CREATE TABLE IF NOT EXISTS darling_schema_version (
     /// <c>BackgroundService</c>, so the service reports Running before the first migration statement runs. The
     /// value therefore comes from the failure ASYMMETRY: too short and the waiter throws into
     /// <c>DarlingWorker</c>'s <c>LogCritical</c>-and-return, which takes that instance out of the collection
-    /// loop entirely with no retry until an operator restarts it; too long and it only delays its own first
+    /// loop entirely until an operator restarts it. #2936's retry loop around that call does not save it,
+    /// and deliberately so: <c>StartupFailureTriage</c> does classify the expiry's bare
+    /// <see cref="TimeoutException"/> as retryable, but gates the retries on a 120 s WALL-CLOCK budget —
+    /// an order of magnitude under a single spend of this constant, precisely so 25 attempts cannot become
+    /// ten hours — so the first expiry has already exhausted it and lands in the terminal arm. One expiry
+    /// is terminal by design, not by omission. Too long and it only delays its own first
     /// cycle, because its MCP and web surfaces start independently and are already serving. Waiting is the
     /// cheap direction, so this errs long — but stays FINITE, so a genuinely wedged holder still produces a
     /// readable deadline instead of the silent hang #2874 exists to stop.</para>
@@ -4092,19 +4127,38 @@ CREATE TABLE IF NOT EXISTS darling_schema_version (
     /// of a lock it had nothing to do with. Never proceeding without a POSITIVE version match is what keeps
     /// this from being "give up and collect anyway".</para>
     ///
-    /// <para><b>What still bounds a rung that overruns its own budget: nothing available here, measured
-    /// rather than assumed.</b> <see cref="MigrationCommandTimeoutSeconds"/> is client-side — it sends a
-    /// cancel request, and a backend in a phase that does not reach an interrupt check keeps going, so the
-    /// lower bound above is a floor on LEGITIMATE holds and not a ceiling on real ones. Both server-side
-    /// alternatives were tried on PostgreSQL 17.11 and neither has the right shape. <c>statement_timeout</c>
-    /// is per STATEMENT, not per transaction — three one-second statements all survive a two-second setting
-    /// — so it would bound V39's two <c>CREATE INDEX</c>es at one budget EACH, making the ladder's floor
-    /// five multiples instead of four and spending this constant's entire margin to buy a bound that still
-    /// is not per-rung. <c>transaction_timeout</c> has exactly the right unit, since each rung is one
-    /// transaction, but it is PostgreSQL 17+ against readers here that gate as low as 13, and it ends the
-    /// session with FATAL rather than failing the statement. So the holder stays unbounded, and this budget
-    /// is deliberately NOT sized to cover an unbounded holder — the waiter is instead made independent of
-    /// whether it was covered, which is the part that was reachable.</para>
+    /// <para><b>What bounds a rung that overruns its own budget: that budget does, and the residual is a
+    /// rung SHAPE rather than a missing mechanism.</b> <see cref="MigrationCommandTimeoutSeconds"/> is
+    /// client-side, so whether it BINDS was measured rather than reasoned about — see that constant: the
+    /// cancel it sends is honoured by all four floor-setting rungs within 50 ms of the budget, from inside
+    /// I/O waits and from a full-budget <c>Lock/relation</c> wait, so the floor above is a ceiling on real
+    /// holds too. What it does not bound is a rung that keeps TALKING, because Npgsql restarts the timeout
+    /// on every backend message. Two rung shapes opt out of it and both are one line of plpgsql from V23's
+    /// existing <c>DO</c> block. A <c>RAISE</c> inside a <c>LOOP</c> is never cancelled and holds this lock
+    /// for as long as it runs — loud, because the waiter says so, and caught anyway by the census above
+    /// whenever such a rung also moves data. An <c>EXCEPTION WHEN query_canceled</c> is the silent one:
+    /// <c>OTHERS</c> deliberately does not match a cancel, but naming the condition does, and measured, the
+    /// applier then saw SUCCESS, committed the rung and stamped the version while the rung's own work never
+    /// happened. That destroys the "a stamp of N proves rung N committed" property the expiry split above
+    /// rests on, and permanently, so <c>MigrationDataMovingRungCensusPins</c> fails the build on the shape
+    /// rather than leaving it to be rediscovered.</para>
+    ///
+    /// <para><b>Three mechanisms considered instead of that pin, and why none of them is built.</b> A
+    /// watchdog cancelling the migrate backend out of band buys nothing measurable:
+    /// <c>pg_cancel_backend</c> stopped the same four rungs at 2.01-2.03 s and
+    /// <c>pg_terminate_backend</c> at 2.01-2.05 s, against this applier's own 2.04-2.07 s on the identical
+    /// rungs, because all three arrive through the same <c>CHECK_FOR_INTERRUPTS</c> — nothing one can stop
+    /// is beyond the others. Terminate is worse than merely redundant: it reports <c>57P01</c>, which
+    /// <c>StartupFailureTriage</c> holds retryable, so it would turn a rung that can never apply into one
+    /// that is retried. Splitting the expensive rungs so each statement gets its own budget helps exactly
+    /// one of the four — V22, V23 and V104 are each a single statement — and pays for that by raising this
+    /// floor from four multiples to five. Both server-side timeouts have the wrong unit or the wrong
+    /// reach: <c>statement_timeout</c> is per STATEMENT, not per transaction — three one-second statements
+    /// all survive a two-second setting — so it would bound V39's two <c>CREATE INDEX</c>es at one budget
+    /// EACH, making the ladder's floor five multiples instead of four and spending this constant's entire
+    /// margin to buy a bound that still is not per-rung. <c>transaction_timeout</c> has exactly the right
+    /// unit, since each rung is one transaction, but it is PostgreSQL 17+ against readers here that gate
+    /// as low as 13, and it ends the session with FATAL rather than failing the statement.</para>
     ///
     /// <para>A multiple rather than a literal so the two budgets cannot drift apart if the rung bound moves.
     /// #2894 recorded two ways the wait still dies, and both are now narrowed rather than closed. A fifth
@@ -4113,12 +4167,15 @@ CREATE TABLE IF NOT EXISTS darling_schema_version (
     /// above, so a new one arrives carrying this derivation in a failure message instead of arriving
     /// silently. It resolves each statement's TARGET rather than counting keywords, because an index on a
     /// table the same rung creates is free and 130 of this ladder's 134 <c>CREATE INDEX</c> statements are
-    /// that shape. A rung needing longer than its own bound is still not bounded, per the paragraph above;
-    /// what changed is that its victim no longer dies undiagnosed, and no longer dies at all when it had
-    /// nothing to apply. The refinement deliberately NOT built is extending this budget whenever the stamp
-    /// table is seen to advance, which would make a slow-but-progressing holder unable to strand a waiter
-    /// at all: it costs a catalog probe and a read per poll on the store being migrated, to buy a case that
-    /// needs a single rung to exceed five minutes on a ladder measured at 0.301 s.</para>
+    /// that shape. A rung needing longer than its own bound turns out to be bounded after all, per the two
+    /// paragraphs above — one <see cref="MigrationCommandTimeoutSeconds"/> per rung, honoured, plus V23's
+    /// 3 s of <c>create_hypertable</c> chatter — and what is left of that residual is the rung shape that
+    /// opts out of the bound silently, which is pinned. Its victim also no longer dies undiagnosed, and no
+    /// longer dies at all when it had nothing to apply. The refinement deliberately NOT built is
+    /// extending this budget whenever the stamp table is seen to advance, which would make a
+    /// slow-but-progressing holder unable to strand a waiter at all: it costs a catalog probe and a read
+    /// per poll on the store being migrated, to buy a case that needs a single rung to exceed five minutes
+    /// on a ladder measured at 0.301 s.</para>
     /// </summary>
     private const int MigrationLockWaitTimeoutSeconds = 5 * MigrationCommandTimeoutSeconds;
 


### PR DESCRIPTION
Closes the last residual of #2894 by measuring it rather than building for it. `MigrationCommandTimeoutSeconds` (300 s) turns out to bound the migration-lock HOLDER after all — the question #2935 left open — and the part of it that does not bound is a rung SHAPE, not a missing mechanism. Doc comments carry the measurement; one pin covers the shape that escapes the bound silently. No SQL, no runtime path, no schema bump.

## Can a rung exceed its own 300 s? Not by ignoring the cancel — that was measured, not reasoned about

`CommandTimeout` is a client-side cancel REQUEST, so whether it BINDS is an empirical question. Rig: `timescale/timescaledb:latest-pg17` (PostgreSQL 17.11 / TimescaleDB 2.29.2), the real 109-rung ladder applied through the real `MigrateAsync` (0.303 s on an empty store), then the four floor-setting rungs' targets converted to hypertables the way the runtime does and seeded to 13.5 M rows / 90 chunks each — ~14.7 GB, with `maintenance_work_mem` squeezed to force the external sorts a cold busy store does. Unbounded durations there: **V22 6.08 s, V39 4.28 s, V104 10.57 s, V23 25.61 s**.

Each rung then applied through the applier's exact command shape — one `NpgsqlCommand` carrying the whole rung SQL, in its own transaction — at a scaled budget:

| rung | budget 1 s | budget 2 s | D/T at 2 s | wait state at the last sample before it vanished |
|---|---|---|---|---|
| V22 | 1.04 s | 2.05 s | 3.0x | `IO/DataFileRead` |
| V39 | 1.05 s | 2.04 s | 2.1x | none (sampled in `IO/DataFileRead` mid-run) |
| V104 | 1.05 s | 2.05 s | 5.2x | none |
| V23 | 1.06 s | 2.07 s | 12.4x | `IO/BuffileRead` |

Every one aborts within ~50 ms of the budget; a second connection polling `pg_stat_activity` every 150 ms shows the backend gone inside 0.4 s; the transaction rolls back whole and the client connection stays usable. Two of the four were in an I/O wait at the instant the cancel landed, which is the phase a client-side bound is most often assumed not to reach.

**The realistic overrun was then run at the real constant through the real applier.** A rung parked behind a peer's table lock is what a second instance collecting into the same store produces — `CREATE INDEX` needs `ShareLock`, an open `INSERT` holds `RowExclusiveLock`. V22 sat in `Lock/relation` for the entire budget (1944 samples, continuous) and **gave up at 300.06 s**, nothing applied and nothing stamped. So the lock-wait floor is a ceiling on real holds too, one budget per rung.

## What it actually bounds is SILENCE, and that is where the residual lives

Npgsql implements `CommandTimeout` as a socket READ timeout: every backend message restarts it. Matched pair, same statement and the same 40 s of work both times, same 5 s budget —

- one `RAISE NOTICE` per second: **ran to completion at 40.18 s, the budget never fired**
- silent: **cancelled at 5.02 s**

That also explains the only deviation in the table above: V23 overshoots by exactly 3.00 s at both a 5 s and a 15 s budget, and 3.00 s is when `create_hypertable`'s own last message arrives. Rollback cost 0.00 s, so it is the read timer restarting, not cleanup.

Today's ladder is quiet — **no rung contains a `LOOP`**, and V23's is its only `RAISE`, inside an exception handler that runs only when the rung is already failing. So V23's real ceiling is 303 s and the other three are 300.05 s. A rung that instrumented its own progress would not be cancelled at all.

## The pin: no rung may trap its own cancellation

`WHEN OTHERS` deliberately does not match `query_canceled`, which is exactly what makes V23's `DO` block safe. Naming the condition reverses it, and the consequence is the silent one:

| handler | applier saw | committed | the rung's own work |
|---|---|---|---|
| `WHEN OTHERS` | `NpgsqlException` <- `TimeoutException` | no | not done, not stamped |
| `WHEN query_canceled` | **SUCCESS** | **yes** | **not done — stamped anyway** |

So a rung one keyword from a shape the ladder already contains leaves the store permanently stamped at a version whose rung did nothing — destroying the "a stamp of N proves rung N committed" property `MigrationLockWaitTimeoutSeconds`' expiry split reads. `MigrationDataMovingRungCensusPins.NoRungTrapsItsOwnCancellation` fails the build on it: a token search over every rung's comment-stripped shipped SQL, deliberately not an attempt to parse a condition list, since `WHEN OTHERS OR query_canceled` and `WHEN SQLSTATE '57014'` are both the same defect and a rung's executable SQL has no legitimate reason to name its own cancellation. Zero occurrences today.

The tokens are word-bounded, and that is load-bearing in the FALSE-POSITIVE direction: unbounded, `57014` matches inside any longer digit run and `query_canceled` inside any longer identifier, so a rung carrying an unrelated numeric literal or a column named for the condition would fail the build accused of trapping a cancel. Measured against both forms, the boundaries cost nothing on any of the five real condition spellings — the quotes around `'57014'` already satisfy them — and turn `5701400`, `157014`, `570140` and `my_query_canceled_flag` from findings into misses.

Four controls, each red for a different reason: the pattern fires on a rung that does trap the cancel; the ladder still holds a real exception handler for the scan to be looking at (V23's — and after stripping it is the handler rather than the sentence in V23's own comment describing it, which is why stripping is not cosmetic here); a rung carrying the token in executable text is still found with a comment beside it; and each of the five condition spellings matches while each of the four innocent literals does not, so the pattern cannot be loosened back to a substring search with every other assertion still passing.

## The three mechanisms NOT built, each declined on a measurement

- **A `pg_cancel_backend` / `pg_terminate_backend` watchdog buys nothing.** Signalled at t+2 s against an infinite `CommandTimeout`, `pg_cancel_backend` stopped the same four rungs at 2.01-2.03 s and `pg_terminate_backend` at 2.01-2.05 s — against this applier's own 2.04-2.07 s on the identical rungs. All three arrive through the same `CHECK_FOR_INTERRUPTS`, so nothing one can stop is beyond the others. Terminate is worse than redundant: it reports `57P01`, which `StartupFailureTriage` holds retryable, turning a rung that can never apply into one that is retried.
- **Splitting the expensive rungs for a per-statement budget helps one of four.** V22, V23 and V104 are each a single statement. It buys that by raising the floor here from four multiples to five.
- **Server-side timeouts still have the wrong unit or reach**, unchanged from #2935: `statement_timeout` is per statement, `transaction_timeout` is 17+ and FATALs the session.

## Two stale claims corrected

- **`#2894`'s "no retry" is no longer the mechanism.** #2936 added a retry loop around this `MigrateAsync` call, and `StartupFailureTriage` does classify the expiry's bare `TimeoutException` as retryable — but gates retries on a **120 s wall-clock budget**, an order of magnitude under one spend of a 1500 s wait, deliberately so 25 attempts cannot become ten hours. The first expiry has already exhausted it and lands in the terminal arm. Same outcome, and it matters that the reason is by design rather than by omission, because "no retry" invites adding one.
- **"The holder stays unbounded" was too pessimistic**, and the paragraph asserting it is replaced by what was measured.

## Not changed, deliberately

`MigrationLockWaitTimeoutSeconds` stays `5 * MigrationCommandTimeoutSeconds` and the census keeps its four floor-setting rungs, so `TheLockWaitMultiple_IsOneMoreThanTheFloorContributingRungCount` still derives `5 == 4 + 1` and needed no new reasoning: this changes what is known about whether the rung bound BINDS, not how many rungs spend it or what the floor is counted in.

## Verification

Eleven mutations through `redproof.sh`, one at a time, each asserted applied by anchor count AND sha256 before/after, each confirmed to move behaviour, tree byte-clean after every restore: planting `WHEN query_canceled` and `WHEN SQLSTATE '57014'` into a real rung (both caught); neutering the pattern (the pattern control fires); an over-eager comment stripper (the liveness control fires); the token in a rung COMMENT only (**stays green** — the precision direction); planting `predates this rung` inside the `2864` slice and removing the `2864` anchor (both fire); and `= 1500` and `6 *` on the lock-wait constant (the derived-form pin fires on each), re-proving that coupling is still live after this edit. Loosening the word-bounded pattern back to a substring search fires the fourth control, so the hardening is itself pinned. Every mutation touching the pin file was re-run after the hardening; one refused to apply on a stale anchor rather than proving nothing silently, which is the anchor control doing its job.

Test count in `MigrationDataMovingRungCensusPins`: **27 -> 28**.

`CollectionLogDrainForensicsStoreTests`' anchor re-verified: `2864` still resolves (one occurrence, line 2412), the edited doc comment sits inside the slice — asserted positively, not assumed — both `DoesNotContain` assertions hold, and the planted-phrase control proves they can still fail.

`Darling.Tests` compiles clean (`-p:EnableWindowsTargeting=true`, 0 errors, 0 warnings in either touched file); the 28 cases ran in a throwaway `net10.0` host compiling the real pin file, and CI is the arbiter.

Container `pg2894holder` on port 5694, torn down.

### Not verified

No production store — this adds no SQL and no runtime path. The rig is local NVMe, so the absolute rung durations are floors, which is the point of taking the bound from the constant rather than from timings. The "phase that never reaches an interrupt check" could not be produced on this rig, which is itself evidence about how reachable it is; the measurement shows only that no phase of these four rungs is one. `transaction_timeout` was not re-measured, being quoted from #2935.
