### PR TITLE
Exclude build output by path segment, so two source scans read the same set on every platform

### DIFF
--- a/Darling/Darling.Tests/DocCommentHygieneTests.cs
+++ b/Darling/Darling.Tests/DocCommentHygieneTests.cs
@@ -266,6 +266,115 @@ public sealed class DocCommentHygieneTests
     }
 
     /// <summary>
+    /// <see cref="HasBuildOutputSegment"/> reaches the same verdict for a path written with either
+    /// separator, so the set both rules read is a property of the tree and not of the machine that ran
+    /// them.
+    ///
+    /// <para><b>Why every path here is written out by hand.</b> <see cref="Path.Combine"/> emits the
+    /// HOST's separator, so a case built with it exercises whichever flavour the runner happens to use and
+    /// says nothing about the other — a filter recognising only <c>\</c> passes such a case on Windows
+    /// while scanning every generated file on a macOS or Linux run, which is the asymmetry this pin is for.
+    /// Each case below carries its separators literally and appears in both flavours, so whichever
+    /// platform runs this asserts both.</para>
+    ///
+    /// <para>The negatives are the other half of the claim: excluding by whole segment is what keeps a
+    /// directory merely NAMED like build output inside the scanned set.</para>
+    /// </summary>
+    [Theory]
+    /* Generated output, the reason the filter exists: .AssemblyInfo.cs and .g.cs land here during a build. */
+    [InlineData(true, "Darling/Darling.Tests/bin/Debug/net10.0/Darling.Tests.AssemblyInfo.cs")]
+    [InlineData(true, @"Darling\Darling.Tests\bin\Debug\net10.0\Darling.Tests.AssemblyInfo.cs")]
+    [InlineData(true, "Darling/Darling.Tests/obj/Debug/net10.0/Darling.Tests.g.cs")]
+    [InlineData(true, @"Darling\Darling.Tests\obj\Debug\net10.0\Darling.Tests.g.cs")]
+    /* Windows paths are case-insensitive and so is this rule. */
+    [InlineData(true, "Darling/Darling.Tests/BIN/Debug/Generated.cs")]
+    [InlineData(true, @"Darling\Darling.Tests\OBJ\Debug\Generated.cs")]
+    /* Ordinary source — the set the two rules exist to read. */
+    [InlineData(false, "Darling/Darling.Tests/DocCommentHygieneTests.cs")]
+    [InlineData(false, @"Darling\Darling.Tests\DocCommentHygieneTests.cs")]
+    /* Segments, not substrings: every one of these CONTAINS "bin" or "obj" and is source. */
+    [InlineData(false, "Darling/PerformanceMonitor.Darling.Viewer/mybin/Thing.cs")]
+    [InlineData(false, @"Darling\PerformanceMonitor.Darling.Viewer\mybin\Thing.cs")]
+    [InlineData(false, "Darling/PerformanceMonitor.Darling.Viewer/obj-cache/Thing.cs")]
+    [InlineData(false, @"Darling\PerformanceMonitor.Darling.Viewer\obj-cache\Thing.cs")]
+    [InlineData(false, "Darling/PerformanceMonitor.Darling.Viewer/Objects/ObjectBrowser.cs")]
+    [InlineData(false, @"Darling\PerformanceMonitor.Darling.Viewer\Objects\ObjectBrowser.cs")]
+    public void BuildOutputIsRecognisedThroughEitherSeparator(bool excluded, string path)
+    {
+        Assert.True(
+            HasBuildOutputSegment(path) == excluded,
+            $"'{path}' should{(excluded ? " " : " NOT ")}be treated as build output. The verdict cannot " +
+            "depend on which separator the path is written with: both rules in this class read whatever " +
+            "this admits, so a separator-specific filter hands them a different set of files on Windows " +
+            "than on macOS or Linux, and the same commit is then guarded differently depending on who ran " +
+            "it. Compare whole path SEGMENTS against both separator characters.");
+    }
+
+    /// <summary>
+    /// A <c>bin</c> or <c>obj</c> directory ABOVE the scanned root leaves the tree scanned, because
+    /// <see cref="IsBuildOutput"/> judges each path relative to the root it was handed.
+    ///
+    /// <para>The failure direction is the silent one. An absolute-path test would classify every file in a
+    /// repository checked out under, say, <c>/opt/bin/</c> as build output, and both rules would report no
+    /// offenders having read nothing at all — which is indistinguishable from a clean tree.</para>
+    /// </summary>
+    [Fact]
+    public void ABuildDirectoryAboveTheRootDoesNotExcludeTheWholeTree()
+    {
+        Assert.False(
+            IsBuildOutput("/opt/bin/repo", "/opt/bin/repo/Darling/Darling.Tests/DocCommentHygieneTests.cs"),
+            "A source file was read as build output because a directory ABOVE the scanned root is called " +
+            "'bin'. Every file in the tree is excluded on that reading and both rules pass having scanned " +
+            "nothing, which looks exactly like a clean tree.");
+
+        Assert.True(
+            IsBuildOutput("/opt/bin/repo", "/opt/bin/repo/Darling/Darling.Tests/obj/Debug/Generated.cs"),
+            "Build output UNDER the scanned root was admitted as source, so relativising the path has " +
+            "gone too far and dropped the exclusion the walk needs.");
+    }
+
+    /// <summary>
+    /// <see cref="SourceFiles"/> applies the filter, so a <c>bin</c> or <c>obj</c> directory under the
+    /// scanned root is never read.
+    ///
+    /// <para>Separate from the two pins above, which judge the predicate on paths that need not exist.
+    /// This one walks a REAL directory tree, so it is the one that fails if the exclusion is ever detached
+    /// from the enumeration: a predicate nothing calls leaves both rules reading everything, and they pass
+    /// either way on a tree whose generated files happen to carry no doc comments.</para>
+    /// </summary>
+    [Fact]
+    public void SourceFilesDoesNotReadBuildOutputUnderTheRoot()
+    {
+        var root = Directory.CreateTempSubdirectory("darling-doc-hygiene-sourcefiles-");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(root.FullName, "bin", "Debug"));
+            Directory.CreateDirectory(Path.Combine(root.FullName, "obj", "Debug"));
+            /* A directory merely NAMED like build output, which has to stay in the scanned set. */
+            Directory.CreateDirectory(Path.Combine(root.FullName, "Objects"));
+
+            File.WriteAllText(Path.Combine(root.FullName, "Source.cs"), "// source");
+            File.WriteAllText(Path.Combine(root.FullName, "Objects", "ObjectBrowser.cs"), "// source");
+            File.WriteAllText(
+                Path.Combine(root.FullName, "bin", "Debug", "Thing.AssemblyInfo.cs"), "// generated");
+            File.WriteAllText(Path.Combine(root.FullName, "obj", "Debug", "Thing.g.cs"), "// generated");
+
+            /* Separators normalised for the comparison only: what this pin asserts is WHICH files came
+               back, and the platform-independence of the filter itself is asserted above. */
+            var scanned = SourceFiles(root.FullName)
+                .Select(f => Path.GetRelativePath(root.FullName, f).Replace('\\', '/'))
+                .OrderBy(f => f, StringComparer.Ordinal)
+                .ToArray();
+
+            Assert.Equal(new[] { "Objects/ObjectBrowser.cs", "Source.cs" }, scanned);
+        }
+        finally
+        {
+            root.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
     /// Every contiguous run of <c>///</c> lines, as the run's first line and the line of each
     /// <c>&lt;summary&gt;</c> opening and closing tag in it. A run ends at the first line that is neither a
     /// doc comment nor an attribute, which is what ties it to exactly one member: the declaration itself
@@ -356,14 +465,14 @@ public sealed class DocCommentHygieneTests
 
     /// <summary>
     /// Every <c>.cs</c> file under <paramref name="root"/> that is a source file rather than a build
-    /// output. Both rules scan the same set, so a path either rule should ignore is excluded in one place.
+    /// output. Both rules scan the same set, so a path either rule should ignore is excluded in one
+    /// place — and the same set wherever they run, which is <see cref="HasBuildOutputSegment"/>'s job.
     /// </summary>
     private static IEnumerable<string> SourceFiles(string root)
     {
         foreach (var file in Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories))
         {
-            if (file.Contains(@"\bin\", StringComparison.OrdinalIgnoreCase)
-                || file.Contains(@"\obj\", StringComparison.OrdinalIgnoreCase))
+            if (IsBuildOutput(root, file))
             {
                 continue;
             }
@@ -371,6 +480,38 @@ public sealed class DocCommentHygieneTests
             yield return file;
         }
     }
+
+    /// <summary>
+    /// True when <paramref name="path"/> is generated build output rather than source.
+    ///
+    /// <para>Judged RELATIVE to <paramref name="root"/> rather than on the absolute path, because the scan
+    /// walks a whole repository from wherever it is checked out: a directory ABOVE the root called
+    /// <c>bin</c> would otherwise classify every file in the tree as build output, and both rules would
+    /// then report no offenders because they had read nothing.</para>
+    /// </summary>
+    private static bool IsBuildOutput(string root, string path) =>
+        HasBuildOutputSegment(Path.GetRelativePath(root, path));
+
+    /// <summary>
+    /// True when any whole SEGMENT of <paramref name="path"/> is <c>bin</c> or <c>obj</c>, reading both
+    /// separator characters on every platform.
+    ///
+    /// <para><b>Both separators, not the host's.</b> A substring test for <c>\bin\</c> matches nothing
+    /// where the separator is <c>/</c> — macOS and Linux — so the two rules above would read every
+    /// generated <c>.AssemblyInfo.cs</c> and <c>.g.cs</c> there and skip them on Windows, and a guard whose
+    /// scope depends on the host is two guards. Splitting on
+    /// <see cref="Path.DirectorySeparatorChar"/> alone relocates that asymmetry rather than removing it: it
+    /// answers NO to a Windows-shaped path off Windows, which leaves the platform-independence pin below
+    /// unstatable in a form that means one thing everywhere. Splitting on both makes the verdict a property
+    /// of the path.</para>
+    ///
+    /// <para><b>Whole segments, not a substring.</b> <c>Objects</c>, <c>obj-cache</c> and <c>mybin</c> are
+    /// source directories, and a <c>Contains("obj")</c> would quietly stop scanning them.</para>
+    /// </summary>
+    private static bool HasBuildOutputSegment(string path) =>
+        path.Split('/', '\\')
+            .Any(s => string.Equals(s, "bin", StringComparison.OrdinalIgnoreCase)
+                      || string.Equals(s, "obj", StringComparison.OrdinalIgnoreCase));
 
     /// <summary>
     /// Walks up from the test output directory to the repo root — the directory holding

--- a/Darling/Darling.Tests/RollupCoverageRoutingTests.cs
+++ b/Darling/Darling.Tests/RollupCoverageRoutingTests.cs
@@ -356,10 +356,7 @@ public sealed class RollupCoverageRoutingTests
         var scanned = 0;
         foreach (var file in Directory.EnumerateFiles(Path.Combine(root!, "Darling"), "*.cs", SearchOption.AllDirectories))
         {
-            if (file.Contains(@"\bin\", StringComparison.OrdinalIgnoreCase)
-                || file.Contains(@"\obj\", StringComparison.OrdinalIgnoreCase)
-                /* The tests deliberately exercise the un-gated overload to prove the two agree. */
-                || file.Contains(@"\Darling.Tests\", StringComparison.OrdinalIgnoreCase))
+            if (IsExcludedFromScan(Path.GetRelativePath(root!, file)))
             {
                 continue;
             }
@@ -408,6 +405,53 @@ public sealed class RollupCoverageRoutingTests
             "And if this reader has a twin answering the same question elsewhere, gate BOTH or the two will " +
             "disagree:\n\n" +
             string.Join("\n", offenders));
+    }
+
+    /// <summary>
+    /// True when a path is generated build output, or the test project's own source. Compared as whole
+    /// path SEGMENTS against BOTH separator characters, so the scanned set is the same wherever this runs
+    /// and a directory merely named <c>Objects</c> stays in it.
+    ///
+    /// <para><b>Both separators.</b> A substring test for <c>\bin\</c> matches nothing where the separator
+    /// is <c>/</c>, so off Windows this scan would take in the generated <c>.AssemblyInfo.cs</c> under
+    /// <c>obj/</c> AND the test project — and then report the test project's deliberate un-gated calls as
+    /// production offenders, which is a guard whose verdict depends on who ran it.</para>
+    ///
+    /// <para><b>The test project is excluded</b> because it calls the un-gated overload on purpose, to
+    /// prove the coverage-aware ladder and the age-only one agree. The same call in production code routes
+    /// a window on no evidence, which is what this file forbids.</para>
+    /// </summary>
+    private static bool IsExcludedFromScan(string relativePath) =>
+        relativePath.Split('/', '\\')
+            .Any(s => string.Equals(s, "bin", StringComparison.OrdinalIgnoreCase)
+                      || string.Equals(s, "obj", StringComparison.OrdinalIgnoreCase)
+                      || string.Equals(s, "Darling.Tests", StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// <see cref="IsExcludedFromScan"/> reaches the same verdict for a path written with either separator.
+    /// The cases are written out rather than composed with <see cref="Path.Combine"/>, which emits only the
+    /// HOST's separator and so would leave one flavour unasserted wherever this ran.
+    /// </summary>
+    [Theory]
+    [InlineData(true, "Darling/Darling.Tests/RollupCoverageRoutingTests.cs")]
+    [InlineData(true, @"Darling\Darling.Tests\RollupCoverageRoutingTests.cs")]
+    [InlineData(true, "Darling/PerformanceMonitor.Darling.Storage/obj/Debug/net10.0/Generated.cs")]
+    [InlineData(true, @"Darling\PerformanceMonitor.Darling.Storage\obj\Debug\net10.0\Generated.cs")]
+    [InlineData(true, "Darling/PerformanceMonitor.Darling.Storage/bin/Debug/net10.0/Generated.cs")]
+    [InlineData(true, @"Darling\PerformanceMonitor.Darling.Storage\bin\Debug\net10.0\Generated.cs")]
+    [InlineData(false, "Darling/PerformanceMonitor.Darling.Storage/RetentionTierRouter.cs")]
+    [InlineData(false, @"Darling\PerformanceMonitor.Darling.Storage\RetentionTierRouter.cs")]
+    /* Segments, not substrings: source that merely CONTAINS an excluded name stays in the scan. */
+    [InlineData(false, "Darling/PerformanceMonitor.Darling.Storage/Objects/ObjectStore.cs")]
+    [InlineData(false, @"Darling\PerformanceMonitor.Darling.Storage\Objects\ObjectStore.cs")]
+    public void TheScanExclusionReadsBothSeparatorsTheSameWay(bool excluded, string relativePath)
+    {
+        Assert.True(
+            IsExcludedFromScan(relativePath) == excluded,
+            $"'{relativePath}' should{(excluded ? " " : " NOT ")}be excluded from the production scan. " +
+            "A separator-specific exclusion gives this guard a different set of files on Windows than on " +
+            "macOS or Linux: off Windows it would read the test project, whose un-gated calls are " +
+            "deliberate, and report them as production defects.");
     }
 
     /// <summary>


### PR DESCRIPTION
Two source-scanning guards in `Darling.Tests` excluded build output with `file.Contains(@"\bin\", StringComparison.OrdinalIgnoreCase)`. `Path.DirectorySeparatorChar` is `/` on macOS and Linux, so neither `Contains` ever matched there and the exclusion was Windows-only. Both now compare whole path SEGMENTS against both separator characters, so the verdict is a property of the path rather than of the host that read it.

`DocCommentHygieneTests` read the generated `.AssemblyInfo.cs`, `.g.cs` and `XunitAutoGeneratedEntryPoint.cs` under `obj/`, plus the `Link`+copy source fixtures staged under `bin/` — which it then reported twice, once at the source and once at the copy. Its own doc comment claimed both rules scan the same set; off Windows that set was 72 files larger than the one CI reads.

`RollupCoverageRoutingTests` is the same defect with a visible consequence: its `\Darling.Tests\` exclusion never matched either, so off Windows it scanned the test project — whose deliberate un-gated `RetentionTierRouter.Resolve` calls exist to prove the coverage-aware ladder matches the age-only one — and failed with 14 false offenders. Green in CI, red on every local run.

The fix relativises against the scanned root before splitting, so a `bin` directory ABOVE the checkout cannot exclude the whole tree and leave both rules passing having read nothing.

Three new pins:

- `BuildOutputIsRecognisedThroughEitherSeparator` asserts the verdict for 14 paths written with literal separators, each case present in both flavours. Written out rather than composed with `Path.Combine`, which emits only the host's separator — a case built that way exercises whichever flavour the runner happens to use and is silent about the other, so it would have passed on Windows against the broken filter.
- `ABuildDirectoryAboveTheRootDoesNotExcludeTheWholeTree` pins the relativisation.
- `SourceFilesDoesNotReadBuildOutputUnderTheRoot` walks a real temporary tree, so the filter cannot be detached from the enumeration without going red.

`TheScanExclusionReadsBothSeparatorsTheSameWay` does the same for the routing scan's exclusion.

**CI is unchanged, measured rather than assumed.** Over a built tree of 2185 `.cs` files, the substring and segment forms classify every single path identically on a Windows rendering — 72 excluded either way, 2113 scanned either way, zero disagreements — and the same holds for the routing scan's three-way exclusion. The two forms can only differ on a segment that CONTAINS `bin` or `obj` without being exactly it, and no directory in the tree does, so this is structural rather than incidental. On macOS the scanned set drops from 2185 to 2113.

Verified on macOS by compiling the two real test files into a throwaway `net10.0` xunit host staged outside the repository tree, with the host's own artifacts outside the scanned root so the measurement could not include them. Pre-fix 53 tests with 1 failure; post-fix 79 tests, 0 failed, 0 not run. A stacked-summary offender planted under `bin/Debug/` was reported pre-fix and invisible post-fix. Six mutations, one at a time, each asserted applied by anchor count and content hash and each caught by a different pin: host-separator-only split, call site reverted to the substring form, relativisation dropped, segment comparison loosened to a substring, and the last two repeated for the routing scan.

Related, not changed here: this predicate now has eleven implementations across `Darling.Tests` — six named `IsBuildOutput`, two named `HasBuildOutputSegment`, one written inline, and the two fixed here. They have already drifted in signature, in case sensitivity, and in whether they relativise.
