### PR TITLE
Defer the deadline scanner's adopter roster to the pin that asserts it

### DIFF
--- a/Darling/Darling.Tests/CommandDeadlineScanner.cs
+++ b/Darling/Darling.Tests/CommandDeadlineScanner.cs
@@ -12,13 +12,19 @@ using System.Text.RegularExpressions;
 namespace Darling.Tests;
 
 /// <summary>
-/// <para>Decides whether the command constructed at a given offset had its deadline chosen on purpose (#2874).
-/// Five command-timeout pins ask that question - <c>.Storage</c>, <c>.Viewer</c>, <c>.Analysis</c>,
-/// <c>PgFactCollector</c> and the alert pass - and they used to ask it five identical ways. This is the one
-/// implementation they share, the same treatment <see cref="CSharpSourceWalker"/> gave the five copies of the
-/// source walk in #2913 and <c>IlCallSiteScanner</c> gave the five copies of the IL walk in #2898. The walk
-/// copies had already drifted by the time they were consolidated, and only one of them carried the hardening
-/// the others needed; a judgement duplicated five ways would drift the same way.</para>
+/// <para>Decides whether the command constructed at a given offset had its deadline chosen on purpose
+/// (#2874). Every <c>*CommandTimeoutTests</c> pin that asks that question asks it here; each used to carry
+/// its own identical copy of the rule. This is the one implementation they share, the same treatment
+/// <see cref="CSharpSourceWalker"/> gave the five copies of the source walk in #2913 and
+/// <c>IlCallSiteScanner</c> gave the five copies of the IL walk in #2898. Those copies had already drifted
+/// by the time they were consolidated, and only one of them carried the hardening the others needed; a
+/// judgement duplicated once per pin would drift the same way.</para>
+///
+/// <para><b>Which pins ask it here, and which deliberately do not, is asserted rather than listed.</b>
+/// <see cref="CommandDeadlineScannerAdoptionTests"/> re-derives the adopting set from the tree and declares
+/// the abstainers beside it, so a pin that quietly stops calling this - and a new pin that arrives with its
+/// own private copy of the rule - both fail the build. It is the authoritative roster, and it carries the
+/// reason a roster in prose is not: a list here would have nothing checking it.</para>
 ///
 /// <para><b>The question is asked in two halves, because there are two places a deadline can legitimately be
 /// written and each has a different neighbour problem.</b> An initializer belongs to the construction it is
@@ -77,8 +83,9 @@ internal static class CommandDeadlineScanner
     /// and <c>sibling.CommandTimeout = 10;</c> spends both counted statements on the sibling, and the outer
     /// command reads as timed. Every fixture in this family used to exercise that sibling through an object
     /// INITIALIZER, which has no leading dot and so never reached this regex - while the assignment spelling
-    /// it missed is the dominant one, 112 of the MCP surface's 119 sites. Found in review, not by the
-    /// fixtures.</para>
+    /// it missed is the dominant one on the read surfaces these pins scan. That surface's census lives on
+    /// <see cref="McpReadCommandTimeoutTests"/>, not here, for the same reason the adopter roster does. Found
+    /// in review, not by the fixtures.</para>
     /// </summary>
     private static Regex Assigns(string bound) => new(
         @"(?<![A-Za-z0-9_])" + Regex.Escape(bound) + @"\s*[!?]?\s*\.\s*CommandTimeout\s*=",

--- a/Darling/Darling.Tests/CommandDeadlineScannerAdoptionTests.cs
+++ b/Darling/Darling.Tests/CommandDeadlineScannerAdoptionTests.cs
@@ -23,8 +23,8 @@ namespace Darling.Tests;
 /// judgement and described five pins as asking it; #2940 made it six, #2966 seven, #2972 nine. Every one of
 /// those drifts was invisible, because a count written in a doc comment has nothing checking it. The
 /// enumerated LIST beside the count rotted the same way, which is the worse half: a reader looking for the
-/// adopters found four names and no hint that others existed. So the set is written down once, here, and
-/// the build re-derives it from the tree.</para>
+/// adopters found the pins named at extraction time and no hint that others had joined. So the set is
+/// written down once, here, and the build re-derives it from the tree.</para>
 ///
 /// <para><b>Both halves are declared, and the second is what earns this test.</b> Listing the adopters
 /// catches a pin that quietly STOPS calling the scanner. Listing the abstainers catches the likelier case:


### PR DESCRIPTION
`CommandDeadlineScanner`'s class summary opened with a count of the pins routing through it and a roster of their names. Nothing checked either one. The count was written five in #2938, six in #2940, seven in #2966 and nine in #2972; the roster never moved at all, which is the worse half — a reader looking for the adopters found the names as of extraction and no hint that others had joined.

`CommandDeadlineScannerAdoptionTests` already re-derives the adopting set from the tree and declares the deliberate abstainers beside it, so any `*CommandTimeoutTests.cs` landing in neither list fails the build. The summary now points there and states nothing countable itself, so there is no figure left to go stale a fourth time.

Two other figures go with it.

The `Assigns` doc argued that the name qualification is load-bearing rather than defensive by quoting "112 of the MCP surface's 119 sites" in the present tense. That numerator no longer holds: every command site in `McpReadCommandTimeoutTests`' scope — `Mcp/` recursively plus `CustomViewStore.cs` and `DarlingWebEndpoints.cs`, 126 of them today — is assignment-spelled. The claim keeps its point and hands the census back to the pin that maintains it.

The adoption pin's own rationale counted the names in the roster it replaced. That figure described a list this change removes, so it goes too.

Deliberately unchanged: `IlCallSiteScannerTests`' "two of the five pins" counts #2898's IL-walk duplicators, and `CSharpSourceWalker`'s "five copies" counts what #2913 consolidated. Different censuses from this one.

## Verification

`Darling.Tests` compiles on macOS with `-p:EnableWindowsTargeting=true`: 0 errors, 38 pre-existing analyzer warnings, 4.3 s.

The real `CommandDeadlineScanner.cs`, `CommandDeadlineScannerAdoptionTests.cs`, `DocCommentHygieneTests.cs`, `CSharpSourceWalkerTests.cs` and `CSharpSourceWalker.cs` were compiled by absolute path into a throwaway `net10.0` xunit.v3 host staged outside the repo tree: 50 tests, `Failed: 0`, `Not Run: 0`. Test counts moved 24 → 25 → 50 across builds with a distinct output-assembly hash each time, so no run reported a previous binary's results.

Red-first, one mutation at a time. A planted second `<summary>` opening in `CommandDeadlineScanner.cs` (anchor count 1, content hash `a20e3a2d` → `5bddb6f2`) failed both `DocCommentHygieneTests` rules by name — which is simultaneously the proof that the hygiene scan reaches this file, since it enumerated 2191 `.cs` files including it. Dropping `ViewerCommandTimeoutTests.cs` from `s_adopters` (anchor count 1, `e7ebfbf7` → `095ad86d`) failed the adoption pin, so the authority this comment now defers to is enforced rather than decorative. Both mutations restored byte-exact, with the tree clean afterwards.

No project sets `GenerateDocumentationFile`, so CS1574 cannot fire on a wrong cref. Both crefs this change adds — `CommandDeadlineScannerAdoptionTests` and `McpReadCommandTimeoutTests` — were verified by grep and are each already crefed elsewhere in the same project.
