### PR TITLE
Make the store-clock scan see the project and the split column it was missing

### DIFF
--- a/Darling/Darling.Tests/StoreSqlClockDisciplineTests.cs
+++ b/Darling/Darling.Tests/StoreSqlClockDisciplineTests.cs
@@ -60,7 +60,7 @@ public sealed class StoreSqlClockDisciplineTests
 
     /// <summary>
     /// Column NAMES whose timestamp frame depends on which table they are in, so a name-keyed scan cannot
-    /// judge them and must not pretend to. Both are genuinely split:
+    /// judge them and must not pretend to. All three are genuinely split:
     ///
     /// <list type="bullet">
     /// <item><c>sample_time</c> — <c>cpu_utilization_stats.sample_time</c> is deliberately the MONITORED
@@ -69,7 +69,24 @@ public sealed class StoreSqlClockDisciplineTests
     /// <item><c>event_time</c> — <c>default_trace_events.event_time</c> is server-LOCAL (the .trc files
     /// store local time), while <c>system_health.event_time</c> is UTC. <c>ViewerSystemEventsTests</c> says
     /// it in one line: "system_health.event_time is UTC, default_trace.event_time is local".</item>
+    /// <item><c>last_execution_time</c> — THREE tables declare it and they do not agree.
+    /// <c>query_stats</c> and <c>procedure_stats</c> ship <c>sys.dm_exec_*_stats</c> DMV values verbatim, so
+    /// both are server-LOCAL; <c>QueryStatsCollector</c> states it outright about its sibling column —
+    /// "creation_time is in the monitored server's local time while collection times are UTC — comparing
+    /// them client-side is a timezone bug on every server that is not UTC" — and the Lite reads that window
+    /// on it correct for it explicitly, adding <c>$5 * INTERVAL '1' MINUTE</c> from the collected UTC offset.
+    /// <c>query_store_stats.last_execution_time</c> is naive UTC: Query Store returns
+    /// <c>datetimeoffset</c> and <c>QueryStoreCollector</c> normalizes through
+    /// <c>DateTimeOffset.UtcDateTime</c> before storing. So the same name is two frames across three tables,
+    /// and the analysis reads that window on it hit both.</item>
     /// </list>
+    ///
+    /// <para>Adding a name here REMOVES it from the discriminator, which is a real cost: a future bare clock
+    /// compared against <c>query_store_stats.last_execution_time</c> would go unflagged, and there the naive-UTC
+    /// bind this scan recommends would have been the right fix. That trade is taken deliberately, because the
+    /// alternative is worse — the scan would confidently prescribe the wrong fix on two tables out of three,
+    /// and a guard that names a defect and misdirects the repair is harder to recover from than one that
+    /// declines to judge.</para>
     ///
     /// <para><c>CollectorTimestampFrameTests</c> is the authority for these, pinning the frame PER COLUMN
     /// against the read path each one protects. Its own remarks record that ITS first cut was a store-wide
@@ -79,7 +96,7 @@ public sealed class StoreSqlClockDisciplineTests
     /// with a different fix (de-skew by the server's offset, not bind naive UTC), so it belongs to that pin.
     /// Add a name here only with the same kind of evidence: a documented split, per table.</para>
     /// </summary>
-    private static readonly string[] AmbiguousFrameColumns = ["sample_time", "event_time"];
+    private static readonly string[] AmbiguousFrameColumns = ["sample_time", "event_time", "last_execution_time"];
 
     /// <summary>
     /// The one bare <c>now()</c> left in the store's SQL, and it is waived on ARITHMETIC, not on being

--- a/Darling/Darling.Tests/StoreSqlClockDisciplineTests.cs
+++ b/Darling/Darling.Tests/StoreSqlClockDisciplineTests.cs
@@ -545,6 +545,13 @@ public sealed class StoreSqlClockDisciplineTests
     /// Both apps' store-side source: everything that composes SQL against a Darling (PostgreSQL) or Lite
     /// (DuckDB) store. The collectors are deliberately NOT here — their SQL runs against a monitored SQL
     /// Server, whose clock policy is a separate question with at least one deliberately local caller.
+    ///
+    /// <para>The two analysis projects are BOTH roots, and the pairing is the point: they are ports of one
+    /// another (<c>PgFactCollector</c> / <c>DuckDbFactCollector</c>, <c>PgDrillDownCollector</c> /
+    /// <c>DrillDownCollector</c>) composing the same windowed reads against the two stores, so covering one
+    /// and not the other leaves the scan blind on whichever side the next port lands. Darling's analysis
+    /// project carries 225 <c>collection_time</c> references across its SQL literals — the exact corpus this
+    /// scan exists to judge.</para>
     /// </summary>
     private static IEnumerable<string> StoreSourceFiles([CallerFilePath] string thisFile = "")
     {
@@ -553,6 +560,7 @@ public sealed class StoreSqlClockDisciplineTests
             StorageDir(thisFile),
             ServiceDir(thisFile),
             ViewerDir(thisFile),
+            AnalysisDir(thisFile),
             LiteDir(thisFile, "Services"),
             LiteDir(thisFile, "Database"),
             LiteDir(thisFile, "Analysis"),
@@ -586,6 +594,9 @@ public sealed class StoreSqlClockDisciplineTests
 
     private static string ViewerDir(string thisFile) =>
         Path.Combine(DarlingDir(thisFile), "PerformanceMonitor.Darling.Viewer");
+
+    private static string AnalysisDir(string thisFile) =>
+        Path.Combine(DarlingDir(thisFile), "PerformanceMonitor.Darling.Analysis");
 
     private static string LiteDir(string thisFile, string leaf) =>
         Path.GetFullPath(Path.Combine(DarlingDir(thisFile), "..", "Lite", leaf));


### PR DESCRIPTION
Two things `StoreSqlClockDisciplineTests` claims to judge and does not: a project it never reads, and a column name whose frame it cannot know.

## 1. `PerformanceMonitor.Darling.Analysis` was not a root

`StoreSourceFiles` listed `Lite/Analysis` but not its Darling twin. Those two projects are ports of one another — `PgFactCollector`/`DuckDbFactCollector`, `PgDrillDownCollector`/`DrillDownCollector` — composing the same windowed reads against the two stores, so the scan judged one side of every pair and not the other.

Measured, comment-stripped so doc-comment mentions cannot inflate it: all **225** `collection_time` references in `PerformanceMonitor.Darling.Analysis` sit **inside SQL string literals**, across 13 files. That is exactly the corpus the scan reads.

The gap is load-bearing, not cosmetic. One deliberate `collection_time >= now() - interval '1 hour'` planted in a SQL literal in that project:

| | with the root | without the root |
|---|---|---|
| clean tree | 2 passed | 2 passed |
| offender planted | **1 failed** — names the file and the predicate | **2 passed — offender invisible** |

There is no offender there today: zero `now()` / `current_timestamp` / `localtimestamp` occurrences in its comment-stripped source, against a positive control of 225 `collection_time` hits in the same stripped corpus, so the scan reads a real body of SQL rather than an empty one. The three `Minimum*Scanned` floors only move up when a root is added, so widening cannot make the scan pass vacuously.

## 2. `last_execution_time` is two frames, and was being judged as one

Three store tables declare it, and they do not agree:

| table | frame | why |
|---|---|---|
| `query_stats` | server-LOCAL | ships `sys.dm_exec_query_stats` verbatim |
| `procedure_stats` | server-LOCAL | ships `sys.dm_exec_procedure_stats` verbatim |
| `query_store_stats` | naive UTC | Query Store returns `datetimeoffset`; the collector normalizes through `DateTimeOffset.UtcDateTime` before storing |

`QueryStatsCollector` states the frame outright about its sibling column — "creation_time is in the monitored server's local time while collection times are UTC — comparing them client-side is a timezone bug on every server that is not UTC" — and the Lite reads that window on `last_execution_time` correct for it explicitly, adding `$5 * INTERVAL '1' MINUTE` from the collected UTC offset. So the split is documented on both sides already; only the scan didn't know.

Scraped from the DDL as one name, it was judged as if uniformly naive UTC, so the scan's prescribed repair — bind naive UTC — was the wrong fix on two tables out of three.

**The trade is stated in the doc rather than hidden.** Adding a name to `AmbiguousFrameColumns` removes it from the discriminator, so a future bare clock against `query_store_stats.last_execution_time` now goes unflagged, and there the naive-UTC bind *would* have been right. That cost is taken deliberately: a guard that names a defect and misdirects the repair is harder to recover from than one that declines to judge. It is the same reasoning the existing two entries carry, applied consistently.

Behaviour change, measured both directions with the same planted-offender method:

| planted predicate | before | after |
|---|---|---|
| `collection_time >= now() - ...` (unambiguous) | flagged | **still flagged** — the removal did not blunt the scan generally |
| `last_execution_time >= now() - ...` (ambiguous) | flagged, with the wrong fix | **declines to judge** |

## Verified

The suite is `net10.0-windows` and cannot execute on macOS, so the shipped test source was compiled into a `net10.0` shim harness — `StoreSqlClockDisciplineTests.cs` and `CSharpSourceWalker.cs` in place, so `[CallerFilePath]` resolves to the real repo. Every row in the tables above is a run of that harness. `Darling.Tests` builds clean with `-p:EnableWindowsTargeting=true`.
