### PR TITLE
Name Darling's findings-retention horizon at its two cleanup defaults

### DIFF
--- a/Darling/Darling.Tests/FindingsRetentionDefaultWiringPinTests.cs
+++ b/Darling/Darling.Tests/FindingsRetentionDefaultWiringPinTests.cs
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.Darling.Analysis;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// The Darling half of the findings-retention pin: that the two cleanup defaults in
+/// <c>PerformanceMonitor.Darling.Analysis</c> NAME the shared horizon rather than repeating its value.
+///
+/// <para>Nothing else can carry this claim. <see cref="FindingsRetentionCrossSkuPinTests"/> pins the two
+/// editions' constants equal, and the worker's daily sweep passes the horizon in explicitly — so a default
+/// reverted to a bare <c>30</c> leaves every value correct, every behavioural assertion passing, and,
+/// because the constant it replaced reads 30 today, byte-identical IL. Source text is the only artifact
+/// that distinguishes the two states.</para>
+///
+/// <para>The pair below is deliberate. The source pin catches the revert; the reflection pin states the
+/// weaker but independent claim that the default a caller actually receives is the shared horizon, which
+/// survives a reformat of the signature and reads the compiled metadata rather than the text.</para>
+///
+/// <para>If the source pin goes red, do not satisfy it by writing the number back. Either the horizon
+/// moved — in which case move <see cref="AnalysisRetentionDefaults.FindingsRetentionDays"/> and let both
+/// defaults follow — or the wiring was undone and belongs back.</para>
+/// </summary>
+public sealed class FindingsRetentionDefaultWiringPinTests
+{
+    /// <summary>
+    /// A numeric default on this parameter, in either file. The revert this pin exists to catch, expressed
+    /// as the shape it would take rather than as one exact string.
+    /// </summary>
+    private static readonly Regex NumericRetentionDefault = new(@"retentionDays\s*=\s*\d", RegexOptions.Compiled);
+
+    [Theory]
+    [InlineData("DarlingAnalysisService.cs", "CleanupAsync")]
+    [InlineData("PgFindingStore.cs", "CleanupOldFindingsAsync")]
+    public void TheCleanupDefaultNamesTheSharedHorizon(string file, string method)
+    {
+        /* Stripped so a doc comment quoting the old literal cannot satisfy or break either assertion. */
+        var code = CSharpSourceWalker.StripCommentsAndStrings(ReadAnalysisSource(file));
+
+        Assert.Contains(
+            $"{method}(int retentionDays = AnalysisRetentionDefaults.FindingsRetentionDays)",
+            code,
+            StringComparison.Ordinal);
+
+        Assert.DoesNotMatch(NumericRetentionDefault, code);
+    }
+
+    [Fact]
+    public void TheCompiledDefaultsAreTheSharedFindingsHorizon()
+    {
+        Assert.Equal(
+            AnalysisRetentionDefaults.FindingsRetentionDays,
+            CompiledRetentionDefault(typeof(DarlingAnalysisService), nameof(DarlingAnalysisService.CleanupAsync)));
+
+        Assert.Equal(
+            AnalysisRetentionDefaults.FindingsRetentionDays,
+            CompiledRetentionDefault(typeof(PgFindingStore), nameof(PgFindingStore.CleanupOldFindingsAsync)));
+    }
+
+    /// <summary>
+    /// The default baked into <c>PerformanceMonitor.Darling.Analysis.dll</c> for the method's single
+    /// <c>retentionDays</c> parameter — the value a caller that omits the argument actually gets.
+    /// </summary>
+    private static int CompiledRetentionDefault(Type type, string method)
+    {
+        var parameter = Assert.Single(type.GetMethod(method)!.GetParameters());
+
+        Assert.Equal("retentionDays", parameter.Name);
+        Assert.True(parameter.HasDefaultValue);
+
+        return Assert.IsType<int>(parameter.DefaultValue);
+    }
+
+    private static string ReadAnalysisSource(string file) =>
+        File.ReadAllText(Path.Combine(
+            RepoRoot(), "Darling", "PerformanceMonitor.Darling.Analysis", file));
+
+    private static string RepoRoot([CallerFilePath] string thisFile = "")
+    {
+        var dir = Path.GetDirectoryName(thisFile)!;
+        while (dir is not null
+               && !File.Exists(Path.Combine(dir, "PerformanceMonitor.sln"))
+               && !Directory.Exists(Path.Combine(dir, ".git")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        Assert.NotNull(dir);
+        return dir!;
+    }
+}

--- a/Darling/Darling.Tests/packages.lock.json
+++ b/Darling/Darling.Tests/packages.lock.json
@@ -681,6 +681,7 @@
           "ModelContextProtocol": "[2.2.0, )",
           "PerformanceMonitor.Analysis": "[1.0.0, )",
           "PerformanceMonitor.Collectors": "[1.0.0, )",
+          "PerformanceMonitor.Common": "[1.0.0, )",
           "PerformanceMonitor.Darling.Storage": "[1.0.0, )",
           "PerformanceMonitor.Notifications": "[1.0.0, )",
           "PerformanceMonitor.PlanAnalysis": "[1.0.0, )",

--- a/Darling/PerformanceMonitor.Darling.Analysis/DarlingAnalysisService.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/DarlingAnalysisService.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Npgsql;
 using PerformanceMonitor.Analysis;
+using PerformanceMonitor.Common;
 
 namespace PerformanceMonitor.Darling.Analysis;
 
@@ -517,8 +518,14 @@ public sealed class DarlingAnalysisService
 
     /// <summary>
     /// Cleans up old findings beyond the retention period.
+    ///
+    /// <para>The default names <see cref="AnalysisRetentionDefaults.FindingsRetentionDays"/> rather than
+    /// repeating its value. Nothing in the service calls this — it carries the twins' surface, and the
+    /// worker sweeps findings through <see cref="PgFindingStore.CleanupOldFindingsAsync"/> directly — so
+    /// for any future caller this default IS the horizon, with no call site above it to correct a stale
+    /// literal.</para>
     /// </summary>
-    public async Task CleanupAsync(int retentionDays = 30)
+    public async Task CleanupAsync(int retentionDays = AnalysisRetentionDefaults.FindingsRetentionDays)
     {
         await _findingStore.CleanupOldFindingsAsync(retentionDays);
     }

--- a/Darling/PerformanceMonitor.Darling.Analysis/PerformanceMonitor.Darling.Analysis.csproj
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PerformanceMonitor.Darling.Analysis.csproj
@@ -24,6 +24,12 @@
   <ItemGroup>
     <ProjectReference Include="..\..\PerformanceMonitor.Analysis\PerformanceMonitor.Analysis.csproj" />
     <ProjectReference Include="..\..\PerformanceMonitor.Collectors\PerformanceMonitor.Collectors.csproj" />
+    <!-- AnalysisRetentionDefaults: the findings-retention horizon the cleanup defaults below the
+         worker's call site are declared at. Referenced DIRECTLY rather than inherited through
+         PlanAnalysis, which is the only other path to Common from here — a PrivateAssets="all" added
+         to that reference would break this project's compile for a reason nobody would connect to a
+         retention constant. -->
+    <ProjectReference Include="..\..\PerformanceMonitor.Common\PerformanceMonitor.Common.csproj" />
     <!-- AlertContextSerializer: the finding store persists/reads remediation_action_json through the
          SAME serializer both apps use, so a Darling finding's action round-trips byte-identically. -->
     <ProjectReference Include="..\..\PerformanceMonitor.Notifications\PerformanceMonitor.Notifications.csproj" />

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgFindingStore.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgFindingStore.cs
@@ -15,6 +15,7 @@ using Npgsql;
 using NpgsqlTypes;
 using PerformanceMonitor.Analysis;
 using PerformanceMonitor.Collectors;
+using PerformanceMonitor.Common;
 using PerformanceMonitor.Notifications;
 
 namespace PerformanceMonitor.Darling.Analysis;
@@ -553,8 +554,12 @@ VALUES ($1, $2, $3, $4, $5, $6)";
     /// retention sweep — lifetimes with no per-pass budget and no wedged analysis to abandon — so
     /// its store calls take no pass token. Threading one here would mean inventing a caller that
     /// does not exist.</para>
+    ///
+    /// <para>The default names <see cref="AnalysisRetentionDefaults.FindingsRetentionDays"/> rather
+    /// than repeating its value, so the horizon this store falls back to cannot drift from the one the
+    /// worker's daily sweep passes in.</para>
     /// </summary>
-    public async Task CleanupOldFindingsAsync(int retentionDays = 30)
+    public async Task CleanupOldFindingsAsync(int retentionDays = AnalysisRetentionDefaults.FindingsRetentionDays)
     {
         try
         {

--- a/Darling/PerformanceMonitor.Darling.Viewer/packages.lock.json
+++ b/Darling/PerformanceMonitor.Darling.Viewer/packages.lock.json
@@ -410,6 +410,7 @@
           "ModelContextProtocol": "[2.2.0, )",
           "PerformanceMonitor.Analysis": "[1.0.0, )",
           "PerformanceMonitor.Collectors": "[1.0.0, )",
+          "PerformanceMonitor.Common": "[1.0.0, )",
           "PerformanceMonitor.Darling.Storage": "[1.0.0, )",
           "PerformanceMonitor.Notifications": "[1.0.0, )",
           "PerformanceMonitor.PlanAnalysis": "[1.0.0, )",


### PR DESCRIPTION
Darling's findings-retention horizon is named once rather than three times down one call chain.

#2988 wired the worker's call site to `DarlingRetention.DataRetentionBaseDays`, but the two defaults beneath it — `DarlingAnalysisService.CleanupAsync` and `PgFindingStore.CleanupOldFindingsAsync` — still carried `30` as a literal, so only the call site decided and the defaults could disagree with delivered behaviour indefinitely. Both now name `AnalysisRetentionDefaults.FindingsRetentionDays`. The value does not change.

`CleanupAsync` matters more than it looks: nothing in the service calls it — it exists to carry the twins' API surface, which `DarlingAnalysisPipelineTests` asserts — so its default is the whole of its behaviour for anyone who adds a caller, with no call site above it to correct a stale literal.

## Two constants, pinned equal

`AnalysisRetentionDefaults.FindingsRetentionDays` is the findings horizon; `DarlingRetention.DataRetentionBaseDays` stays the service's own base data-retention window. They are deliberately not merged, because the base has derived siblings: `CollectionLogRetentionDays = DataRetentionBaseDays * 2` and `CommandHistoryRetentionDays = DataRetentionBaseDays`. Deriving the base from a findings constant would mean moving the findings horizon silently moved `collection_log`'s 60-day window, whose whole purpose is that a run record outlives the metric rows it explains. `FindingsRetentionCrossSkuPinTests` asserts the two agree, so they cannot drift apart quietly.

`DarlingRetention.cs` is untouched.

## The direct Common reference

`PerformanceMonitor.Darling.Analysis` had no `ProjectReference` to `PerformanceMonitor.Common` and reached the assembly through exactly one transitive edge, `PerformanceMonitor.PlanAnalysis` → `Common`. Of the project's five direct references that is the only one leading to `Common` at all: `Analysis` and `Collectors` declare no project references, `Notifications` reaches only `Analysis`, and `Darling.Storage` reaches only `Collectors`. The reference is now stated directly, so a `PrivateAssets="all"` added to PlanAnalysis's `Common` reference cannot break this project's compile for a reason nobody would connect to a retention constant. `FindingsRetentionDays` is `internal`, which makes the assembly reference load-bearing rather than cosmetic.

The new edge is recorded in `Darling/Darling.Tests/packages.lock.json` and `Darling/PerformanceMonitor.Darling.Viewer/packages.lock.json`, one line each. `build.yml` restores both projects with `--locked-mode`, which fails `NU1004` on a lock file that predates a `ProjectReference`. Neither a local restore without that flag nor one against a warm `obj/` notices, so the check was reproduced locally against a cold `obj/` with the edge deleted as a negative control.

## The pin

`FindingsRetentionDefaultWiringPinTests` carries the claim in source text because nothing else can: naming a constant that reads 30 produces the same compiled default, so every behavioural assertion passes either way. A reflection pin beside it states the weaker independent claim that the default a caller actually receives is the shared horizon, read from compiled metadata rather than from the text.

Red-proved one mutation at a time, each restored and re-verified against the baseline source hashes:

- `PgFindingStore`'s default reverted to `= 30` → `TheCleanupDefaultNamesTheSharedHorizon(file: "PgFindingStore.cs")` fails. This is the wiring-reverted-constant-unchanged case, and it is the assertion that catches it.
- `DarlingAnalysisService`'s default reverted to `= 30` → the same theory's other case fails.
- The shared constant moved 30 → 45 with the wiring intact → the cross-SKU pin fails while both of mine stay green, the compiled default having followed the constant to 45.
- The constant at 45 with one default left behind at the literal → the reflection pin fails. No single-edit mutation can isolate it, so that one is compound by necessity.

An assembly hash is not used as evidence: a comment-only control edit moves `PerformanceMonitor.Darling.Analysis.dll`'s hash too, because a deterministic build embeds a hash of the source file. The behavioural instrument is the reflection pin's own result.

`DarlingAnalysisStoreTests.cs:404` keeps its explicit `retentionDays: 30`. It asserts that a 40-day-old finding is purged at a 30-day window, and the `-40` beside it is that literal's matched pair — reading the constant there would couple a fixture to a policy knob and could pass for the wrong reason if the horizon ever moved.
