### PR TITLE
De-skew query_stats.creation_time before comparing it to the analysis window (Part of #2991)

### DIFF
--- a/Darling/Darling.Tests/CreationTimeClockFrameDisciplineTests.cs
+++ b/Darling/Darling.Tests/CreationTimeClockFrameDisciplineTests.cs
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #2991: no analysis SQL in either store may compare <c>query_stats.creation_time</c> against a window
+/// bound without first de-skewing it by the collected <c>server_properties.utc_offset_minutes</c>.
+///
+/// <para><c>creation_time</c> is the monitored server's LOCAL wall clock and the window bound is naive
+/// UTC, so the untranslated comparison asks a different question on every server. The behavioural pins
+/// (<c>ParameterSensitivityClockFrameLiveTests</c> and Lite's
+/// <c>ParameterSensitivityClockFrameTests</c>) prove the two DETECTORS and the two DRILL-DOWNS answer
+/// correctly; this scan exists for the two sites they cannot cheaply reach — the
+/// <c>psp_signature</c> CTE inside each SKU's regressed-queries read, which needs a whole Query Store
+/// fixture before it returns a row — and for every site added after this was written.</para>
+///
+/// <para><b>Why a scan and not more fixtures.</b> The six sites were byte-comparable across the two
+/// SKUs before this change, and the inventory that preceded it found NOTHING in either suite that
+/// compares Darling's analysis SQL against Lite's: no parity guard, no shared constant, not even a
+/// count. So the realistic regression is not someone breaking the arithmetic — it is someone porting a
+/// read to one store and not the other, or adding a seventh site that reads correctly and skews
+/// silently. That is a category, and the thing that catches a category is an invariant over the
+/// corpus rather than another example.</para>
+///
+/// <para>Both directions are pinned. <see cref="TheDiscriminator_FlagsABareComparison_AndPassesADeSkewedOne"/>
+/// runs the same two regexes over literals written for the purpose, because a scan whose discriminator
+/// has quietly stopped matching reports a clean bill of health, and that is worse than no scan.</para>
+/// </summary>
+public sealed class CreationTimeClockFrameDisciplineTests
+{
+    /// <summary>
+    /// A window comparison against a bare <c>creation_time</c> — the defect. Deliberately spelled
+    /// against the positional bind (<c>$2</c> / <c>$3</c>) rather than any identifier, because that is
+    /// what a window bound is in both dialects and it cannot be satisfied by renaming a column.
+    /// </summary>
+    private static readonly Regex BareComparison =
+        new(@"(?<![\w.])creation_time\s*(?:<=|<|>=|>|BETWEEN)\s*\$\d", RegexOptions.IgnoreCase);
+
+    /// <summary>
+    /// The de-skew, in either dialect: PostgreSQL <c>make_interval(mins =&gt; ...)</c> or DuckDB
+    /// <c>... * INTERVAL '1' MINUTE</c>. DuckDB has no <c>make_interval</c> and <c>AT TIME ZONE</c>
+    /// would drag in ICU, so the two spellings are a real and permanent divergence — matching both here
+    /// is what lets one guard cover both stores.
+    /// </summary>
+    private static readonly Regex DeSkew =
+        new(@"creation_time\s*-\s*(?:make_interval\s*\(\s*mins\s*=>\s*\w+\.offset_minutes\s*\)"
+            + @"|\w+\.offset_minutes\s*\*\s*INTERVAL\s*'1'\s*MINUTE)\s+AS\s+creation_time_utc",
+            RegexOptions.IgnoreCase);
+
+    /// <summary>
+    /// The de-skew sites, per file, as of #2991 — a floor AND a ceiling. Naming the count per file is
+    /// what makes a site silently dropped from one SKU fail here: a bare total would let a Darling site
+    /// move to Lite and still add up.
+    /// </summary>
+    private static readonly (string RelativePath, int Sites)[] ExpectedSites =
+    [
+        ("Darling/PerformanceMonitor.Darling.Analysis/PgFactCollector.QueryPerf.cs", 1),
+        ("Darling/PerformanceMonitor.Darling.Analysis/PgDrillDownCollector.Queries.cs", 2),
+        ("Lite/Analysis/DuckDbFactCollector.QueryPerf.cs", 1),
+        ("Lite/Analysis/DrillDownCollector.Queries.cs", 2),
+    ];
+
+    [Fact]
+    public void NoAnalysisSql_ComparesABareCreationTime_AgainstAWindowBound()
+    {
+        var offenders = new List<string>();
+        var scanned = 0;
+
+        foreach (var path in AnalysisSourceFiles())
+        {
+            scanned++;
+            var text = File.ReadAllText(path);
+
+            foreach (Match m in BareComparison.Matches(text))
+            {
+                offenders.Add($"{Path.GetFileName(path)}: {m.Value.Trim()}");
+            }
+        }
+
+        /* A floor, so a broken glob cannot report a clean bill of health. Measured at 40 files across
+           the two analysis projects when this was written; set well below that so ordinary growth never
+           trips it, but high enough that an empty enumeration fails instead of passing. */
+        Assert.True(scanned >= 20, $"scanned only {scanned} analysis source files — check the globs below");
+
+        Assert.True(
+            offenders.Count == 0,
+            "analysis SQL compares a bare creation_time against a window bound:"
+            + Environment.NewLine + string.Join(Environment.NewLine, offenders) + Environment.NewLine
+            + "creation_time is the monitored server's LOCAL wall clock and the bound is naive UTC. "
+            + "De-skew it by the collected server_properties.utc_offset_minutes first — Postgres "
+            + "make_interval(mins => svr.offset_minutes), DuckDB svr.offset_minutes * INTERVAL '1' "
+            + "MINUTE — and compare the resulting creation_time_utc.");
+    }
+
+    [Fact]
+    public void EveryKnownDeSkewSite_IsStillThere_InBothStores()
+    {
+        foreach (var (relativePath, expected) in ExpectedSites)
+        {
+            var path = RepoPath(relativePath);
+            Assert.True(File.Exists(path), $"{relativePath} is gone — update this guard deliberately");
+
+            var found = DeSkew.Matches(File.ReadAllText(path)).Count;
+
+            Assert.True(
+                found == expected,
+                $"{relativePath} carries {found} creation_time de-skew site(s), expected {expected}. "
+                + "A read was added, removed or ported: if it windows on creation_time it needs the "
+                + "de-skew, and if it does not, update this guard in the same commit. The two SKUs are "
+                + "ports of one another and nothing else in either suite compares their SQL, so a "
+                + "one-sided change is otherwise silent.");
+        }
+    }
+
+    /// <summary>
+    /// The discriminator, pinned in BOTH directions against literals written for the purpose. Each
+    /// hazard is a form that actually shipped in this repo; each benign form is one the corpus contains
+    /// and must not be dragged in with them.
+    /// </summary>
+    [Fact]
+    public void TheDiscriminator_FlagsABareComparison_AndPassesADeSkewedOne()
+    {
+        string[] hazards =
+        [
+            /* The two spellings that shipped, one per SKU's parameter layout. */
+            "AND   creation_time <= $2",
+            "    AND   creation_time <= $3",
+            /* Qualified, and the other operators. */
+            "AND creation_time >= $2",
+            "AND creation_time BETWEEN $2 AND $3",
+        ];
+
+        foreach (var sql in hazards)
+        {
+            Assert.True(BareComparison.IsMatch(sql), $"discriminator missed the hazard: {sql}");
+        }
+
+        string[] benign =
+        [
+            /* The fix, in each dialect. */
+            "AND   creation_time_utc <= $2",
+            "creation_time - make_interval(mins => svr.offset_minutes) AS creation_time_utc,",
+            "creation_time - svr.offset_minutes * INTERVAL '1' MINUTE AS creation_time_utc,",
+            /* A projection, and a comparison against another COLUMN rather than a window bound. */
+            "        creation_time,",
+            "MAX(creation_time) AS creation_time,",
+            "AND creation_time <= last_execution_time",
+            /* The suffix guard: a different column that merely ends in creation_time. */
+            "AND plan_creation_time <= $2",
+        ];
+
+        foreach (var sql in benign)
+        {
+            Assert.False(BareComparison.IsMatch(sql), $"discriminator dragged in a benign form: {sql}");
+        }
+
+        /* And the de-skew regex must actually recognise both dialects, or the site census above passes
+           by finding nothing rather than by the sites being present. */
+        Assert.True(DeSkew.IsMatch("creation_time - make_interval(mins => svr.offset_minutes) AS creation_time_utc,"));
+        Assert.True(DeSkew.IsMatch("creation_time - svr.offset_minutes * INTERVAL '1' MINUTE AS creation_time_utc,"));
+        Assert.False(DeSkew.IsMatch("        creation_time,"));
+    }
+
+    /* ── Source location. Resolved by walking up from this file, the way the sibling scans do. ── */
+
+    private static IEnumerable<string> AnalysisSourceFiles([CallerFilePath] string thisFile = "")
+    {
+        foreach (var root in new[]
+        {
+            RepoPath("Darling/PerformanceMonitor.Darling.Analysis", thisFile),
+            RepoPath("Lite/Analysis", thisFile),
+        })
+        {
+            foreach (var path in Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories))
+            {
+                if (path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                    || path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                yield return path;
+            }
+        }
+    }
+
+    private static string RepoPath(string relative, [CallerFilePath] string thisFile = "")
+    {
+        /* This file lives at <repo>/Darling/Darling.Tests/, so the repo root is two levels up. */
+        var repoRoot = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(thisFile)!, "..", ".."));
+        return Path.GetFullPath(Path.Combine(repoRoot, relative.Replace('/', Path.DirectorySeparatorChar)));
+    }
+}

--- a/Darling/Darling.Tests/ParameterSensitivityClockFrameLiveTests.cs
+++ b/Darling/Darling.Tests/ParameterSensitivityClockFrameLiveTests.cs
@@ -1,0 +1,314 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+using PerformanceMonitor.Analysis;
+using PerformanceMonitor.Darling.Analysis;
+using PerformanceMonitor.Darling.Storage;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Live-Postgres pin for #2991, the Darling twin of Lite's
+/// <c>ParameterSensitivityClockFrameTests</c>: the PARAMETER_SENSITIVITY detector's
+/// compiled-before-the-window predicate must select the same plan population no matter what the
+/// monitored server's UTC offset is.
+///
+/// <para><c>query_stats.creation_time</c> is the monitored server's LOCAL wall clock —
+/// <c>QueryStatsCollector</c> ships the <c>sys.dm_exec_query_stats</c> value verbatim, and says so about
+/// this very column: "creation_time is in the monitored server's local time while collection times are
+/// UTC". The window bound it is compared against is naive UTC off <c>DateTime.UtcNow</c>. Comparing them
+/// untranslated is a different question on every server, and the answer is wrong in both directions.</para>
+///
+/// <para><b>What the predicate is for.</b> It means "this plan was compiled before the analysis window
+/// opened", which is what makes a wide min/max worker-time spread evidence of PARAMETER SENSITIVITY
+/// rather than an artefact of a plan too young to have seen varied parameters yet. Loosening it or
+/// removing it destroys the signal, so the fix is to make it mean what it says.</para>
+///
+/// <para><b>The invariance, not a timestamp.</b> This asserts a FRAME RELATIONSHIP: the same five-plan
+/// fixture, re-expressed in each server's local clock the way the collector would really have stored it,
+/// must yield the identical offender set. Pinning one expected <c>creation_time</c> instead would pass
+/// for the wrong reason the moment anything shifted. Membership is asserted alongside invariance on
+/// purpose — a constant empty result is also invariant, so invariance alone is not a test.</para>
+///
+/// <para><b>Both signs and zero.</b> UTC-4 is the live production fleet (every monitored SQL Server
+/// reports <c>utc_offset_minutes = -240</c>; the only target at <c>0</c> is a dev box), and it is the
+/// FALSE-POSITIVE direction: a plan compiled at UTC instant T is stored as T-4h, so the untranslated
+/// predicate admits T &lt;= W+4h and on the default four-hour window that is every plan compiled inside
+/// the window — precisely the population the predicate exists to exclude. A POSITIVE offset is the
+/// suppression direction: at UTC+10 it admits only plans compiled at least ten hours before the window,
+/// so the plans that legitimately predate it are discarded and the finding class is sharply thinned. A
+/// fixture at -240 alone would never see that half.</para>
+///
+/// <para><b>Watched RED before the fix</b> at 5 / 3 / 1 offenders for -240 / 0 / +600 against a true 3,
+/// on this exact fixture. Zero was the only offset that was ever right, which is why every store anyone
+/// develops against agreed with the bug.</para>
+///
+/// <para>Live rather than a string pin because the thing under test is the ENGINE's answer to signed
+/// <c>make_interval</c> arithmetic against a naive <c>timestamp</c> column, and the resolution of the
+/// collected offset through the real migrated schema. An <c>Assert.Contains</c> on query text cannot see
+/// either, and a retyped copy of the query would only prove the transcription.</para>
+/// </summary>
+[Collection("live-postgres")]
+public sealed class ParameterSensitivityClockFrameLiveTests
+{
+    /// <summary>Distinctive fake id — a real server_id is a storage-name hash, never this.</summary>
+    private const int TestServerId = -299101;
+    private const string TestServerName = "SynthSrv";
+    private const string Db = "SynthDb";
+
+    /* The three offsets the fix has to hold at. -240 is the live fleet and the false-positive
+       direction, +600 is the suppression direction, 0 is the dev box and the no-offset fallback. */
+    private const int EasternOffsetMinutes = -240;
+    private const int UtcOffsetMinutes = 0;
+    private const int FarEastOffsetMinutes = 600;
+
+    /* Minutes of the plan's compile instant relative to the window START, in UTC, and whether it
+       therefore belongs in the offender set. Two plans straddle the bound by a single minute in each
+       direction: that is what makes a wrong frame change the ANSWER rather than just the arithmetic. */
+    private static readonly (string Label, int MinutesFromWindowStart, bool Expected)[] Plans =
+    [
+        ("old_3d", -3 * 24 * 60, true),
+        ("pre_5h", -5 * 60,      true),
+        ("pre_1m", -1,           true),
+        ("in_1m",  1,            false),
+        ("in_3h",  3 * 60,       false),
+    ];
+
+    private static int ExpectedOffenders => Plans.Count(p => p.Expected);
+
+    private static DateTime TruncateToSeconds(DateTime t) =>
+        DateTime.SpecifyKind(new DateTime(t.Ticks - (t.Ticks % TimeSpan.TicksPerSecond)), DateTimeKind.Unspecified);
+
+    /// <summary>
+    /// Opens a session with the store's search_path SET explicitly rather than inherited — Npgsql pools
+    /// PHYSICAL sessions, so one opened before this store's first migration keeps the pre-ALTER default
+    /// for its whole life and the bare table names below resolve to nothing on a first run.
+    /// </summary>
+    private static async Task<NpgsqlConnection> OpenWithSearchPathAsync(string connectionString, CancellationToken ct)
+    {
+        var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(ct);
+        await using var setPath = new NpgsqlCommand("SET search_path = " + PgSchemaGenerator.SearchPath, connection);
+        await setPath.ExecuteNonQueryAsync(ct);
+        return connection;
+    }
+
+    [Fact]
+    public async Task TheCompiledBeforeTheWindowPredicate_SelectsTheSamePlans_AtEveryServerUtcOffset()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the live #2991 clock-frame test.");
+
+        var ct = TestContext.Current.CancellationToken;
+        var bodySucceeded = false;
+
+        await using (var connection = new NpgsqlConnection(connectionString))
+        {
+            await connection.OpenAsync(ct);
+            await PgMigrations.MigrateAsync(connection, ct);
+        }
+
+        await using (var connection = await OpenWithSearchPathAsync(connectionString!, ct))
+        {
+            await DeleteTestRowsAsync(connection, ct);
+        }
+
+        try
+        {
+            var windowEnd = TruncateToSeconds(DateTime.UtcNow);
+            var windowStart = windowEnd.AddHours(-4);
+            var context = new AnalysisContext
+            {
+                ServerId = TestServerId,
+                ServerName = TestServerName,
+                TimeRangeStart = windowStart,
+                TimeRangeEnd = windowEnd,
+            };
+
+            var observed = new Dictionary<string, double>(StringComparer.Ordinal);
+            var drilled = new Dictionary<string, double>(StringComparer.Ordinal);
+
+            /* Each case re-expresses the SAME five compile instants in a different server-local clock,
+               exactly as the collector would have stored them, and writes the matching collected
+               offset. The last case writes NO offset at all. */
+            foreach (var (name, offsetMinutes) in new (string, int?)[]
+            {
+                ("utc-4 (the live fleet)", EasternOffsetMinutes),
+                ("utc (the dev box)",      UtcOffsetMinutes),
+                ("utc+10 (suppression)",   FarEastOffsetMinutes),
+                ("no collected offset",    null),
+            })
+            {
+                await using (var connection = await OpenWithSearchPathAsync(connectionString!, ct))
+                {
+                    await DeleteTestRowsAsync(connection, ct);
+                    if (offsetMinutes.HasValue)
+                    {
+                        await SeedServerPropertiesAsync(connection, windowEnd, offsetMinutes.Value, ct);
+                    }
+                    await SeedPlansAsync(connection, windowStart, offsetMinutes ?? 0, ct);
+                }
+
+                await using var postgres = NpgsqlDataSource.Create(connectionString!);
+                var fact = await CollectParameterSensitivityFactAsync(postgres, context);
+
+                Assert.NotNull(fact);
+                observed[name] = fact!.Metadata["offender_count"];
+
+                /* The drill-down re-runs the detector's own signature to list the offenders, so it
+                   carries a SECOND copy of the same predicate. A fix applied only to the detector
+                   would leave the operator reading a list assembled in the wrong frame. */
+                drilled[name] = await CountParameterSensitiveDrillDownAsync(postgres, context);
+            }
+
+            /* The invariance. The offset is a property of the SERVER's clock, not of its workload, so it
+               must not be able to change which plans the detector counts. */
+            Assert.True(
+                observed.Values.Distinct().Count() == 1,
+                "the compiled-before-the-window predicate selected a DIFFERENT plan population per server "
+                + "UTC offset, so creation_time is still being compared across frames: "
+                + string.Join(", ", observed.Select(kv => $"{kv.Key} => {kv.Value}")));
+
+            /* And membership, because a constant empty answer would satisfy the invariance above while
+               having destroyed the signal. The two plans that straddle the window bound by one minute
+               are what make this assertion load-bearing. */
+            foreach (var (name, count) in observed)
+            {
+                Assert.True(
+                    count == ExpectedOffenders,
+                    $"at {name} the detector counted {count} offenders against the {ExpectedOffenders} plans "
+                    + "whose UTC compile instant really precedes the window. Admitting the in-window plans "
+                    + "is the UTC-4 failure (5 here); dropping the ones that just predate the window is the "
+                    + "UTC+10 failure (1 here).");
+            }
+
+            /* Same two assertions again for the drill-down's own copy of the predicate. */
+            Assert.True(
+                drilled.Values.Distinct().Count() == 1,
+                "the drill-down's copy of the compiled-before-the-window predicate selected a DIFFERENT "
+                + "plan population per server UTC offset: "
+                + string.Join(", ", drilled.Select(kv => $"{kv.Key} => {kv.Value}")));
+
+            foreach (var (name, count) in drilled)
+            {
+                Assert.True(
+                    count == ExpectedOffenders,
+                    $"at {name} the drill-down listed {count} offenders against the {ExpectedOffenders} "
+                    + "plans whose UTC compile instant really precedes the window.");
+            }
+
+            bodySucceeded = true;
+        }
+        finally
+        {
+            await LiveStoreCleanup.RunAsync(connectionString!, bodySucceeded, DeleteTestRowsAsync);
+        }
+    }
+
+    /// <summary>
+    /// Drives the drill-down's own copy of the detection through the real enrich seam. Severity is set
+    /// past the display gate, below which the expensive drill-downs are skipped wholesale and this
+    /// collector never runs at all.
+    /// </summary>
+    private static async Task<double> CountParameterSensitiveDrillDownAsync(
+        NpgsqlDataSource postgres, AnalysisContext context)
+    {
+        var finding = new AnalysisFinding
+        {
+            RootFactKey = "PARAMETER_SENSITIVITY",
+            StoryPath = "PARAMETER_SENSITIVITY",
+            Severity = 1.0,
+        };
+
+        await new PgDrillDownCollector(postgres).EnrichFindingsAsync([finding], context);
+
+        if (finding.DrillDown is null
+            || !finding.DrillDown.TryGetValue("parameter_sensitive_queries", out var raw))
+        {
+            return 0;
+        }
+
+        return System.Text.Json.JsonSerializer.SerializeToElement(raw).GetArrayLength();
+    }
+
+    private static async Task<Fact?> CollectParameterSensitivityFactAsync(NpgsqlDataSource postgres, AnalysisContext context)
+    {
+        var facts = await new PgFactCollector(postgres).CollectFactsAsync(context);
+        return facts.FirstOrDefault(f => f.Key == "PARAMETER_SENSITIVITY");
+    }
+
+    private static async Task SeedServerPropertiesAsync(
+        NpgsqlConnection connection, DateTime collectionTime, int offsetMinutes, CancellationToken ct)
+    {
+        await using var cmd = new NpgsqlCommand(@"
+INSERT INTO server_properties
+    (collection_id, collection_time, server_id, server_name, edition, product_version, product_level,
+     engine_edition, utc_offset_minutes)
+VALUES ($1, $2, $3, $4, 'Enterprise Edition', '16.0.4085.2', 'RTM', 3, $5)", connection);
+        cmd.Parameters.AddWithValue(-9_299_000L);
+        cmd.Parameters.AddWithValue(DateTime.SpecifyKind(collectionTime, DateTimeKind.Unspecified));
+        cmd.Parameters.AddWithValue(TestServerId);
+        cmd.Parameters.AddWithValue(TestServerName);
+        cmd.Parameters.AddWithValue(offsetMinutes);
+        await cmd.ExecuteNonQueryAsync(ct);
+    }
+
+    /// <summary>
+    /// Seeds the five plans. <paramref name="offsetMinutes"/> is applied to <c>creation_time</c> and
+    /// ONLY to creation_time: server-local is UTC plus the offset, which is what the DMV would have read
+    /// on a server at that offset. collection_time stays UTC because the collector stamps it from the
+    /// monitoring host's clock. Every row clears the detector's other floors with room to spare, so the
+    /// only thing that can move the offender count is the compile-time predicate.
+    /// </summary>
+    private static async Task SeedPlansAsync(
+        NpgsqlConnection connection, DateTime windowStart, int offsetMinutes, CancellationToken ct)
+    {
+        var id = -9_299_100L;
+
+        for (var i = 0; i < Plans.Length; i++)
+        {
+            var plan = Plans[i];
+            var compiledUtc = windowStart.AddMinutes(plan.MinutesFromWindowStart);
+
+            await using var cmd = new NpgsqlCommand(@"
+INSERT INTO query_stats
+    (collection_id, collection_time, server_id, server_name, database_name, query_hash, query_plan_hash,
+     creation_time, execution_count, min_worker_time, max_worker_time, min_grant_kb, max_grant_kb,
+     min_spills, max_spills, query_text, delta_execution_count)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 5000, 20000, 20000000, 1024, 1048576, 0, 50, $9, 500)", connection);
+            cmd.Parameters.AddWithValue(id--);
+            cmd.Parameters.AddWithValue(DateTime.SpecifyKind(windowStart.AddMinutes(30 + i), DateTimeKind.Unspecified));
+            cmd.Parameters.AddWithValue(TestServerId);
+            cmd.Parameters.AddWithValue(TestServerName);
+            cmd.Parameters.AddWithValue(Db);
+            cmd.Parameters.AddWithValue("0xQH_" + plan.Label);
+            cmd.Parameters.AddWithValue("0xPH_" + plan.Label);
+            cmd.Parameters.AddWithValue(DateTime.SpecifyKind(compiledUtc.AddMinutes(offsetMinutes), DateTimeKind.Unspecified));
+            cmd.Parameters.AddWithValue("SELECT * FROM dbo.Synth_" + plan.Label + " WHERE col = @p");
+            await cmd.ExecuteNonQueryAsync(ct);
+        }
+    }
+
+    private static async Task DeleteTestRowsAsync(NpgsqlConnection connection, CancellationToken ct)
+    {
+        foreach (var table in new[] { "query_stats", "server_properties" })
+        {
+            await using var cmd = new NpgsqlCommand($"DELETE FROM {table} WHERE server_id = $1", connection);
+            cmd.Parameters.AddWithValue(TestServerId);
+            await cmd.ExecuteNonQueryAsync(ct);
+        }
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgDrillDownCollector.Queries.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgDrillDownCollector.Queries.cs
@@ -195,14 +195,32 @@ LIMIT 5";
     }
 
     public const string ParameterSensitiveSql = @"
-WITH latest AS
+WITH svr AS
+(
+    -- Detector A's creation_time de-skew, same shape and same reason: creation_time is the monitored
+    -- server's local wall clock, the window bound is naive UTC, and 0 covers a server whose
+    -- server_properties has not been collected yet. The CTE returns exactly one row, so nothing is lost.
+    SELECT COALESCE
+    (
+        (
+            SELECT sp.utc_offset_minutes
+            FROM server_properties AS sp
+            WHERE sp.server_id = $1
+            AND   sp.utc_offset_minutes IS NOT NULL
+            ORDER BY sp.collection_time DESC
+            LIMIT 1
+        ),
+        0
+    ) AS offset_minutes
+),
+latest AS
 (
     SELECT
         database_name,
         query_hash,
         query_plan_hash,
         execution_count,
-        creation_time,
+        creation_time - make_interval(mins => svr.offset_minutes) AS creation_time_utc,
         min_worker_time,
         max_worker_time,
         min_grant_kb,
@@ -215,7 +233,7 @@ WITH latest AS
             PARTITION BY database_name, query_hash, query_plan_hash
             ORDER BY collection_time DESC
         ) AS rn
-    FROM v_query_stats
+    FROM v_query_stats, svr
     WHERE server_id = $1
     AND   collection_time >= $2
     AND   collection_time <= $3
@@ -237,7 +255,7 @@ WHERE rn = 1
 AND   min_worker_time >= 10000
 AND   max_worker_time >= 250000
 AND   execution_count >= 20
-AND   creation_time <= $2
+AND   creation_time_utc <= $2
 AND   max_worker_time::DOUBLE PRECISION / NULLIF(min_worker_time, 0) >= 10
 ORDER BY worker_ratio DESC
 LIMIT 5";
@@ -280,7 +298,25 @@ LIMIT 5";
     }
 
     public const string RegressedQueriesSql = @"
-WITH psp_signature AS
+WITH svr AS
+(
+    -- Detector A's creation_time de-skew, same shape and same reason: creation_time is the monitored
+    -- server's local wall clock, the window bound is naive UTC, and 0 covers a server whose
+    -- server_properties has not been collected yet. The CTE returns exactly one row, so nothing is lost.
+    SELECT COALESCE
+    (
+        (
+            SELECT sp.utc_offset_minutes
+            FROM server_properties AS sp
+            WHERE sp.server_id = $1
+            AND   sp.utc_offset_minutes IS NOT NULL
+            ORDER BY sp.collection_time DESC
+            LIMIT 1
+        ),
+        0
+    ) AS offset_minutes
+),
+psp_signature AS
 (
     -- #2138 gap 3: the PARAMETER_SENSITIVITY detector's EXACT firing signature (same floors, same
     -- ratio, same analysis window) reduced to the (database, query_hash) set it would report. Using
@@ -297,7 +333,7 @@ WITH psp_signature AS
             query_hash,
             query_plan_hash,
             execution_count,
-            creation_time,
+            creation_time - make_interval(mins => svr.offset_minutes) AS creation_time_utc,
             min_worker_time,
             max_worker_time,
             ROW_NUMBER() OVER
@@ -305,7 +341,7 @@ WITH psp_signature AS
                 PARTITION BY database_name, query_hash, query_plan_hash
                 ORDER BY collection_time DESC
             ) AS rn
-        FROM v_query_stats
+        FROM v_query_stats, svr
         WHERE server_id = $1
         AND   collection_time >= $3
         AND   collection_time <= $4
@@ -315,7 +351,7 @@ WITH psp_signature AS
     AND   min_worker_time >= 10000
     AND   max_worker_time >= 250000
     AND   execution_count >= 20
-    AND   creation_time <= $3
+    AND   creation_time_utc <= $3
     AND   max_worker_time::DOUBLE PRECISION / NULLIF(min_worker_time, 0) >= 10
 ),
 deduped AS

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgFactCollector.QueryPerf.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgFactCollector.QueryPerf.cs
@@ -121,14 +121,39 @@ AND   v.delta_execution_count > 0";
     }
 
     public const string ParameterSensitivitySql = @"
-WITH latest AS
+WITH svr AS
+(
+    -- creation_time is the MONITORED SERVER's local wall clock -- QueryStatsCollector ships the
+    -- dm_exec_query_stats value verbatim -- while the window bound is naive UTC off DateTime.UtcNow.
+    -- De-skewing the column by the collected offset is what lets the compiled-before-the-window test
+    -- compare a single frame. Untranslated, a negative offset admits exactly the in-window plans this
+    -- predicate exists to exclude, and a positive one discards plans that legitimately predate the
+    -- window; either way a wide min/max worker-time spread stops being evidence of parameter
+    -- sensitivity and becomes an artefact of plan age. COALESCE to 0 because server_properties is an
+    -- on-load collector, so an absent offset is the state every server passes through on its first
+    -- cycle -- refusing the read there would pre-empt the two answers that outrank any window. The
+    -- CTE returns exactly one row, so no plan is lost to it.
+    SELECT COALESCE
+    (
+        (
+            SELECT sp.utc_offset_minutes
+            FROM server_properties AS sp
+            WHERE sp.server_id = $1
+            AND   sp.utc_offset_minutes IS NOT NULL
+            ORDER BY sp.collection_time DESC
+            LIMIT 1
+        ),
+        0
+    ) AS offset_minutes
+),
+latest AS
 (
     SELECT
         query_hash,
         query_plan_hash,
         database_name,
         execution_count,
-        creation_time,
+        creation_time - make_interval(mins => svr.offset_minutes) AS creation_time_utc,
         min_worker_time,
         max_worker_time,
         min_grant_kb,
@@ -140,7 +165,7 @@ WITH latest AS
             PARTITION BY database_name, query_hash, query_plan_hash
             ORDER BY collection_time DESC
         ) AS rn
-    FROM v_query_stats
+    FROM v_query_stats, svr
     WHERE server_id = $1
     AND   collection_time >= $2
     AND   collection_time <= $3
@@ -157,7 +182,7 @@ WHERE rn = 1
 AND   min_worker_time >= 10000
 AND   max_worker_time >= 250000
 AND   execution_count >= 20
-AND   creation_time <= $2
+AND   creation_time_utc <= $2
 AND   max_worker_time::DOUBLE PRECISION / NULLIF(min_worker_time, 0) >= 10
 ORDER BY worker_ratio DESC
 LIMIT 20";

--- a/Lite.Tests/ParameterSensitivityClockFrameTests.cs
+++ b/Lite.Tests/ParameterSensitivityClockFrameTests.cs
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using DuckDB.NET.Data;
+using PerformanceMonitor.Analysis;
+using PerformanceMonitorLite.Analysis;
+using PerformanceMonitorLite.Database;
+using PerformanceMonitorLite.Tests;
+using Xunit;
+
+namespace Lite.Tests;
+
+/// <summary>
+/// Real-DuckDB pin for #2991, the Lite twin of Darling's
+/// <c>ParameterSensitivityClockFrameLiveTests</c>: the PARAMETER_SENSITIVITY detector's
+/// compiled-before-the-window predicate must select the same plan population no matter what the
+/// monitored server's UTC offset is.
+///
+/// <para><c>query_stats.creation_time</c> is the monitored server's LOCAL wall clock —
+/// <c>QueryStatsCollector</c> ships the <c>sys.dm_exec_query_stats</c> value verbatim, and says so about
+/// this very column: "creation_time is in the monitored server's local time while collection times are
+/// UTC". The window bound it is compared against is naive UTC off <c>DateTime.UtcNow</c>. Comparing them
+/// untranslated is a different question on every server, and the answer is wrong in both directions.</para>
+///
+/// <para><b>What the predicate is for.</b> It means "this plan was compiled before the analysis window
+/// opened", which is what makes a wide min/max worker-time spread evidence of PARAMETER SENSITIVITY
+/// rather than an artefact of a plan too young to have seen varied parameters yet. Loosening it or
+/// removing it destroys the signal, so the fix is to make it mean what it says.</para>
+///
+/// <para><b>The invariance, not a timestamp.</b> This asserts a FRAME RELATIONSHIP: the same five-plan
+/// fixture, re-expressed in each server's local clock the way the collector would really have stored it,
+/// must yield the identical offender set. Pinning one expected <c>creation_time</c> instead would pass
+/// for the wrong reason the moment anything shifted. Membership is asserted alongside invariance on
+/// purpose — a constant empty result is also invariant, so invariance alone is not a test.</para>
+///
+/// <para><b>Both signs and zero.</b> UTC-4 is the live production fleet and the FALSE-POSITIVE
+/// direction: a plan compiled at UTC instant T is stored as T-4h, so the untranslated predicate admits
+/// T &lt;= W+4h and on the default four-hour window that is every plan compiled inside the window —
+/// precisely the population the predicate exists to exclude. A POSITIVE offset is the suppression
+/// direction: at UTC+10 it admits only plans compiled at least ten hours before the window, so the plans
+/// that legitimately predate it are discarded and the finding class is sharply thinned. A fixture at
+/// -240 alone would never see that half.</para>
+///
+/// <para><b>Watched RED before the fix</b> at 5 / 3 / 1 offenders for -240 / 0 / +600 against a true 3,
+/// on this exact fixture. Zero was the only offset that was ever right, which is why every store anyone
+/// develops against agreed with the bug.</para>
+///
+/// <para>Real DuckDB rather than a string pin for two reasons this dialect makes specific. Lite's copy
+/// of the query is an inline <c>CommandText</c>, so there is no constant for a text assertion to name;
+/// and the thing under test is the ENGINE's answer to <c>&lt;signed int&gt; * INTERVAL '1' MINUTE</c>
+/// against a naive <c>TIMESTAMP</c>. DuckDB has no <c>make_interval(mins =&gt; ...)</c>, so this dialect
+/// cannot share Darling's spelling, and <c>AT TIME ZONE</c> would drag in ICU — the multiplication form
+/// is the one already used against the sibling column in this same table
+/// (<c>LocalDataService.QueryStats</c>), and it needs no extension.</para>
+/// </summary>
+public sealed class ParameterSensitivityClockFrameTests : IClassFixture<SharedDuckDbFixture>, IDisposable
+{
+    private const int ServerId = 29910;
+    private const string ServerName = "SynthSrv";
+    private const string Db = "SynthDb";
+
+    /* The three offsets the fix has to hold at. -240 is the live fleet and the false-positive
+       direction, +600 is the suppression direction, 0 is the dev box and the no-offset fallback. */
+    private const int EasternOffsetMinutes = -240;
+    private const int UtcOffsetMinutes = 0;
+    private const int FarEastOffsetMinutes = 600;
+
+    /* Minutes of the plan's compile instant relative to the window START, in UTC, and whether it
+       therefore belongs in the offender set. Two plans straddle the bound by a single minute in each
+       direction: that is what makes a wrong frame change the ANSWER rather than just the arithmetic. */
+    private static readonly (string Label, int MinutesFromWindowStart, bool Expected)[] Plans =
+    [
+        ("old_3d", -3 * 24 * 60, true),
+        ("pre_5h", -5 * 60,      true),
+        ("pre_1m", -1,           true),
+        ("in_1m",  1,            false),
+        ("in_3h",  3 * 60,       false),
+    ];
+
+    private static int ExpectedOffenders => Plans.Count(p => p.Expected);
+
+    private static readonly DateTime WindowEnd =
+        DateTime.SpecifyKind(new DateTime(DateTime.UtcNow.Ticks - (DateTime.UtcNow.Ticks % TimeSpan.TicksPerSecond)), DateTimeKind.Unspecified);
+    private static readonly DateTime WindowStart = WindowEnd.AddHours(-4);
+
+    private readonly DuckDbInitializer _duckDb;
+    private DuckDBConnection? _seedConn;
+    private long _nextId = 1;
+
+    public ParameterSensitivityClockFrameTests(SharedDuckDbFixture fixture)
+    {
+        fixture.ResetData();
+        _duckDb = fixture.DuckDb;
+    }
+
+    public void Dispose() => _seedConn?.Dispose();
+
+    private static AnalysisContext Context() => new()
+    {
+        ServerId = ServerId,
+        ServerName = ServerName,
+        TimeRangeStart = WindowStart,
+        TimeRangeEnd = WindowEnd,
+    };
+
+    [Fact]
+    public async Task TheCompiledBeforeTheWindowPredicate_SelectsTheSamePlans_AtEveryServerUtcOffset()
+    {
+        var observed = new Dictionary<string, double>(StringComparer.Ordinal);
+        var drilled = new Dictionary<string, double>(StringComparer.Ordinal);
+
+        /* Each case re-expresses the SAME five compile instants in a different server-local clock,
+           exactly as the collector would have stored them, and writes the matching collected offset.
+           The last case writes NO offset at all. */
+        foreach (var (name, offsetMinutes) in new (string, int?)[]
+        {
+            ("utc-4 (the live fleet)", EasternOffsetMinutes),
+            ("utc (the dev box)",      UtcOffsetMinutes),
+            ("utc+10 (suppression)",   FarEastOffsetMinutes),
+            ("no collected offset",    null),
+        })
+        {
+            await ClearAsync();
+            if (offsetMinutes.HasValue)
+            {
+                await SeedServerPropertiesAsync(offsetMinutes.Value);
+            }
+            await SeedPlansAsync(offsetMinutes ?? 0);
+
+            var facts = await new DuckDbFactCollector(_duckDb).CollectFactsAsync(Context());
+            var fact = facts.FirstOrDefault(f => f.Key == "PARAMETER_SENSITIVITY");
+
+            Assert.NotNull(fact);
+            observed[name] = fact!.Metadata["offender_count"];
+
+            /* The drill-down re-runs the detector's own signature to list the offenders, so it carries
+               a SECOND copy of the same predicate. A fix applied only to the detector would leave the
+               operator reading a list assembled in the wrong frame. */
+            drilled[name] = await CountParameterSensitiveDrillDownAsync();
+        }
+
+        /* The invariance. The offset is a property of the SERVER's clock, not of its workload, so it
+           must not be able to change which plans the detector counts. */
+        Assert.True(
+            observed.Values.Distinct().Count() == 1,
+            "the compiled-before-the-window predicate selected a DIFFERENT plan population per server "
+            + "UTC offset, so creation_time is still being compared across frames: "
+            + string.Join(", ", observed.Select(kv => $"{kv.Key} => {kv.Value}")));
+
+        /* And membership, because a constant empty answer would satisfy the invariance above while
+           having destroyed the signal. The two plans that straddle the window bound by one minute are
+           what make this assertion load-bearing. */
+        foreach (var (name, count) in observed)
+        {
+            Assert.True(
+                count == ExpectedOffenders,
+                $"at {name} the detector counted {count} offenders against the {ExpectedOffenders} plans "
+                + "whose UTC compile instant really precedes the window. Admitting the in-window plans "
+                + "is the UTC-4 failure (5 here); dropping the ones that just predate the window is the "
+                + "UTC+10 failure (1 here).");
+        }
+
+        /* Same two assertions again for the drill-down's own copy of the predicate. */
+        Assert.True(
+            drilled.Values.Distinct().Count() == 1,
+            "the drill-down's copy of the compiled-before-the-window predicate selected a DIFFERENT "
+            + "plan population per server UTC offset: "
+            + string.Join(", ", drilled.Select(kv => $"{kv.Key} => {kv.Value}")));
+
+        foreach (var (name, count) in drilled)
+        {
+            Assert.True(
+                count == ExpectedOffenders,
+                $"at {name} the drill-down listed {count} offenders against the {ExpectedOffenders} "
+                + "plans whose UTC compile instant really precedes the window.");
+        }
+    }
+
+    /// <summary>
+    /// Drives the drill-down's own copy of the detection through the real enrich seam. Severity is set
+    /// past the display gate, below which the expensive drill-downs are skipped wholesale and this
+    /// collector never runs at all.
+    /// </summary>
+    private async Task<double> CountParameterSensitiveDrillDownAsync()
+    {
+        var finding = new AnalysisFinding
+        {
+            RootFactKey = "PARAMETER_SENSITIVITY",
+            StoryPath = "PARAMETER_SENSITIVITY",
+            Severity = 1.0,
+        };
+
+        await new DrillDownCollector(_duckDb).EnrichFindingsAsync([finding], Context());
+
+        if (finding.DrillDown is null
+            || !finding.DrillDown.TryGetValue("parameter_sensitive_queries", out var raw))
+        {
+            return 0;
+        }
+
+        return System.Text.Json.JsonSerializer.SerializeToElement(raw).GetArrayLength();
+    }
+
+    private async Task<DuckDBConnection> SeedConnectionAsync()
+    {
+        if (_seedConn is null)
+        {
+            _seedConn = _duckDb.CreateConnection();
+            await _seedConn.OpenAsync();
+        }
+        return _seedConn;
+    }
+
+    private async Task ClearAsync()
+    {
+        using var readLock = _duckDb.AcquireReadLock();
+        var connection = await SeedConnectionAsync();
+        foreach (var table in new[] { "query_stats", "server_properties" })
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = $"DELETE FROM {table} WHERE server_id = $1";
+            cmd.Parameters.Add(new DuckDBParameter { Value = ServerId });
+            await cmd.ExecuteNonQueryAsync();
+        }
+    }
+
+    private async Task SeedServerPropertiesAsync(int offsetMinutes)
+    {
+        using var readLock = _duckDb.AcquireReadLock();
+        var connection = await SeedConnectionAsync();
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = @"
+INSERT INTO server_properties
+    (collection_id, collection_time, server_id, server_name, edition, product_version, product_level,
+     engine_edition, utc_offset_minutes)
+VALUES ($1, $2, $3, $4, 'Enterprise Edition', '16.0.4085.2', 'RTM', 3, $5)";
+        cmd.Parameters.Add(new DuckDBParameter { Value = _nextId++ });
+        cmd.Parameters.Add(new DuckDBParameter { Value = WindowEnd });
+        cmd.Parameters.Add(new DuckDBParameter { Value = ServerId });
+        cmd.Parameters.Add(new DuckDBParameter { Value = ServerName });
+        cmd.Parameters.Add(new DuckDBParameter { Value = offsetMinutes });
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    /// <summary>
+    /// Seeds the five plans. <paramref name="offsetMinutes"/> is applied to <c>creation_time</c> and
+    /// ONLY to creation_time: server-local is UTC plus the offset, which is what the DMV would have read
+    /// on a server at that offset. collection_time stays UTC because the collector stamps it from the
+    /// monitoring host's clock. Every row clears the detector's other floors with room to spare, so the
+    /// only thing that can move the offender count is the compile-time predicate.
+    /// </summary>
+    private async Task SeedPlansAsync(int offsetMinutes)
+    {
+        using var readLock = _duckDb.AcquireReadLock();
+        var connection = await SeedConnectionAsync();
+
+        for (var i = 0; i < Plans.Length; i++)
+        {
+            var plan = Plans[i];
+            var compiledUtc = WindowStart.AddMinutes(plan.MinutesFromWindowStart);
+
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = @"
+INSERT INTO query_stats
+    (collection_id, collection_time, server_id, server_name, database_name, query_hash, query_plan_hash,
+     creation_time, execution_count, min_worker_time, max_worker_time, min_grant_kb, max_grant_kb,
+     min_spills, max_spills, query_text, delta_execution_count)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 5000, 20000, 20000000, 1024, 1048576, 0, 50, $9, 500)";
+            cmd.Parameters.Add(new DuckDBParameter { Value = _nextId++ });
+            cmd.Parameters.Add(new DuckDBParameter { Value = WindowStart.AddMinutes(30 + i) });
+            cmd.Parameters.Add(new DuckDBParameter { Value = ServerId });
+            cmd.Parameters.Add(new DuckDBParameter { Value = ServerName });
+            cmd.Parameters.Add(new DuckDBParameter { Value = Db });
+            cmd.Parameters.Add(new DuckDBParameter { Value = "0xQH_" + plan.Label });
+            cmd.Parameters.Add(new DuckDBParameter { Value = "0xPH_" + plan.Label });
+            cmd.Parameters.Add(new DuckDBParameter { Value = compiledUtc.AddMinutes(offsetMinutes) });
+            cmd.Parameters.Add(new DuckDBParameter { Value = "SELECT * FROM dbo.Synth_" + plan.Label });
+            await cmd.ExecuteNonQueryAsync();
+        }
+    }
+}

--- a/Lite/Analysis/DrillDownCollector.Queries.cs
+++ b/Lite/Analysis/DrillDownCollector.Queries.cs
@@ -199,14 +199,32 @@ LIMIT 5";
 
         using var cmd = connection.CreateCommand();
         cmd.CommandText = @"
-WITH latest AS
+WITH svr AS
+(
+    -- Detector A's creation_time de-skew, same shape and same reason: creation_time is the monitored
+    -- server's local wall clock, the window bound is naive UTC, and 0 covers a server whose
+    -- server_properties has not been collected yet. The CTE returns exactly one row, so nothing is lost.
+    SELECT COALESCE
+    (
+        (
+            SELECT utc_offset_minutes
+            FROM v_server_properties
+            WHERE server_id = $1
+            AND   utc_offset_minutes IS NOT NULL
+            ORDER BY collection_time DESC
+            LIMIT 1
+        ),
+        0
+    ) AS offset_minutes
+),
+latest AS
 (
     SELECT
         database_name,
         query_hash,
         query_plan_hash,
         execution_count,
-        creation_time,
+        creation_time - svr.offset_minutes * INTERVAL '1' MINUTE AS creation_time_utc,
         min_worker_time,
         max_worker_time,
         min_grant_kb,
@@ -219,7 +237,7 @@ WITH latest AS
             PARTITION BY database_name, query_hash, query_plan_hash
             ORDER BY collection_time DESC
         ) AS rn
-    FROM v_query_stats
+    FROM v_query_stats, svr
     WHERE server_id = $1
     AND   collection_time >= $2
     AND   collection_time <= $3
@@ -241,7 +259,7 @@ WHERE rn = 1
 AND   min_worker_time >= 10000
 AND   max_worker_time >= 250000
 AND   execution_count >= 20
-AND   creation_time <= $2
+AND   creation_time_utc <= $2
 AND   max_worker_time::DOUBLE PRECISION / NULLIF(min_worker_time, 0) >= 10
 ORDER BY worker_ratio DESC
 LIMIT 5";
@@ -287,7 +305,25 @@ LIMIT 5";
 
         using var cmd = connection.CreateCommand();
         cmd.CommandText = @"
-WITH psp_signature AS
+WITH svr AS
+(
+    -- Detector A's creation_time de-skew, same shape and same reason: creation_time is the monitored
+    -- server's local wall clock, the window bound is naive UTC, and 0 covers a server whose
+    -- server_properties has not been collected yet. The CTE returns exactly one row, so nothing is lost.
+    SELECT COALESCE
+    (
+        (
+            SELECT utc_offset_minutes
+            FROM v_server_properties
+            WHERE server_id = $1
+            AND   utc_offset_minutes IS NOT NULL
+            ORDER BY collection_time DESC
+            LIMIT 1
+        ),
+        0
+    ) AS offset_minutes
+),
+psp_signature AS
 (
     -- #2138 gap 3: the PARAMETER_SENSITIVITY detector's EXACT firing signature (same floors, same
     -- ratio, same analysis window) reduced to the (database, query_hash) set it would report. Using
@@ -304,7 +340,7 @@ WITH psp_signature AS
             query_hash,
             query_plan_hash,
             execution_count,
-            creation_time,
+            creation_time - svr.offset_minutes * INTERVAL '1' MINUTE AS creation_time_utc,
             min_worker_time,
             max_worker_time,
             ROW_NUMBER() OVER
@@ -312,7 +348,7 @@ WITH psp_signature AS
                 PARTITION BY database_name, query_hash, query_plan_hash
                 ORDER BY collection_time DESC
             ) AS rn
-        FROM v_query_stats
+        FROM v_query_stats, svr
         WHERE server_id = $1
         AND   collection_time >= $3
         AND   collection_time <= $4
@@ -322,7 +358,7 @@ WITH psp_signature AS
     AND   min_worker_time >= 10000
     AND   max_worker_time >= 250000
     AND   execution_count >= 20
-    AND   creation_time <= $3
+    AND   creation_time_utc <= $3
     AND   max_worker_time::DOUBLE PRECISION / NULLIF(min_worker_time, 0) >= 10
 ),
 deduped AS

--- a/Lite/Analysis/DuckDbFactCollector.QueryPerf.cs
+++ b/Lite/Analysis/DuckDbFactCollector.QueryPerf.cs
@@ -111,14 +111,39 @@ AND   delta_execution_count > 0";
 
             using var cmd = connection.CreateCommand();
             cmd.CommandText = @"
-WITH latest AS
+WITH svr AS
+(
+    -- creation_time is the MONITORED SERVER's local wall clock -- QueryStatsCollector ships the
+    -- dm_exec_query_stats value verbatim -- while the window bound is naive UTC off DateTime.UtcNow.
+    -- De-skewing the column by the collected offset is what lets the compiled-before-the-window test
+    -- compare a single frame. Untranslated, a negative offset admits exactly the in-window plans this
+    -- predicate exists to exclude, and a positive one discards plans that legitimately predate the
+    -- window; either way a wide min/max worker-time spread stops being evidence of parameter
+    -- sensitivity and becomes an artefact of plan age. COALESCE to 0 because server_properties is an
+    -- on-load collector, so an absent offset is the state every server passes through on its first
+    -- cycle -- refusing the read there would pre-empt the two answers that outrank any window. The
+    -- CTE returns exactly one row, so no plan is lost to it.
+    SELECT COALESCE
+    (
+        (
+            SELECT utc_offset_minutes
+            FROM v_server_properties
+            WHERE server_id = $1
+            AND   utc_offset_minutes IS NOT NULL
+            ORDER BY collection_time DESC
+            LIMIT 1
+        ),
+        0
+    ) AS offset_minutes
+),
+latest AS
 (
     SELECT
         query_hash,
         query_plan_hash,
         database_name,
         execution_count,
-        creation_time,
+        creation_time - svr.offset_minutes * INTERVAL '1' MINUTE AS creation_time_utc,
         min_worker_time,
         max_worker_time,
         min_grant_kb,
@@ -130,7 +155,7 @@ WITH latest AS
             PARTITION BY database_name, query_hash, query_plan_hash
             ORDER BY collection_time DESC
         ) AS rn
-    FROM v_query_stats
+    FROM v_query_stats, svr
     WHERE server_id = $1
     AND   collection_time >= $2
     AND   collection_time <= $3
@@ -147,7 +172,7 @@ WHERE rn = 1
 AND   min_worker_time >= 10000
 AND   max_worker_time >= 250000
 AND   execution_count >= 20
-AND   creation_time <= $2
+AND   creation_time_utc <= $2
 AND   max_worker_time::DOUBLE PRECISION / NULLIF(min_worker_time, 0) >= 10
 ORDER BY worker_ratio DESC
 LIMIT 20";


### PR DESCRIPTION
Part of #2991.

`query_stats.creation_time` is the monitored server's local wall clock — `QueryStatsCollector` ships the `sys.dm_exec_query_stats` value verbatim, and says so about this very column. The bound it was compared against is naive UTC off `DateTime.UtcNow`. Six analysis reads across the two stores compared them untranslated, so the `PARAMETER_SENSITIVITY` detector's compiled-before-the-window guard asked a different question on every server that is not UTC.

## The direction, re-derived

`utc_offset_minutes` is `DATEDIFF(MINUTE, GETUTCDATE(), GETDATE())`, i.e. `local - utc`, so a plan compiled at UTC instant `T` is stored as `creation_time = T + offset`. The old predicate `creation_time <= W` therefore admitted `T <= W - offset`, where the correct bound is `T <= W`.

Measured against real PostgreSQL 17 and real DuckDB 1.5.5, on a five-plan fixture straddling the window bound, default four-hour window:

| server offset | old predicate selects | correct |
|---|---|---|
| UTC-12 | all 5 | 3 |
| UTC-4 (the production fleet) | all 5 | 3 |
| UTC (a dev box) | 3 | 3 |
| UTC+10 | 1 | 3 |
| UTC+14 | 1 | 3 |

So a **negative** offset is the false-positive direction: it admits every plan compiled *inside* the window, which is exactly the population the predicate exists to exclude, and a young plan's partial-life min/max worker-time spread is then scored as full-life variance. A **positive** offset is the suppression direction. One correction to the issue's wording: at a positive offset the finding class is sharply *thinned*, not silenced — a plan cached longer than the offset still qualifies, which is why `old_3d` survives at UTC+10 above. Zero was the only offset that was ever right, which is why every store anyone develops or tests against agreed with the bug.

## The fix

Each site resolves the collected `server_properties.utc_offset_minutes` in a single-row `COALESCE` CTE and compares a de-skewed `creation_time_utc`. Subtracting the offset is the direction already established at the three existing de-skew sites (`ViewerDataService.SystemEvents`, `ViewerDataService.JobHistory`, and `PgFindingStore`'s `- context.ServerUtcOffset`).

No parameter was added: `server_id` is already `$1`, so the ordinals and the C# bind order are unchanged.

The two dialects diverge, and have to. PostgreSQL gets `make_interval(mins => svr.offset_minutes)`; DuckDB has no `make_interval`, and `AT TIME ZONE` would pull in ICU, so Lite multiplies `INTERVAL '1' MINUTE` — the form it already uses against `last_execution_time` in this same table. Each expression was verified independently against its own engine rather than assumed portable.

`server_properties` is an on-load collector, so "no offset yet" is the state every server passes through on its first cycle. Both dialects fall back to `0` and the read proceeds, rather than refusing and pre-empting the answers that outrank any window. A pre-migration snapshot whose `utc_offset_minutes` is NULL behaves identically to an absent row, and a NULL `creation_time` is still excluded exactly as before — `NULL - interval` is still NULL.

`compile_age_seconds` would have been a frame-free alternative, and `QueryStatsCollector` computes it for exactly this reason, but it is deliberately not stored (`PayloadColumns` is unchanged; it exists only to inform the delta), so it is not reachable from either store.

`AnalysisContext.ServerUtcOffset` is deliberately untouched. It is `TimeSpan.Zero` in both live SKUs, the only non-zero assignments are in the retired Dashboard, and its documented meaning is the inverse — a server-local window converted back to UTC for persistence. Setting it here would silently move the window `PgFindingStore` persists, which is a different change.

## What pins it now

Two behavioural twins, one per store, plus a source-level guard.

`ParameterSensitivityClockFrameLiveTests` (live Postgres) and `ParameterSensitivityClockFrameTests` (real DuckDB) assert an **invariance** rather than a timestamp: the same five compile instants, re-expressed in each server's local clock the way the collector would really have stored them, must yield the identical offender set. Membership is asserted alongside invariance on purpose — a constant empty result is also invariant, so invariance alone is not a test. Three offsets plus the no-offset fallback: UTC-4, UTC, UTC+10. Each covers the detector *and* the drill-down, which carries its own copy of the same predicate.

`CreationTimeClockFrameDisciplineTests` scans both analysis trees for a bare `creation_time` compared against a window bound and censuses the de-skew sites per file. It exists because the inventory found **nothing** in either suite that compares Darling's analysis SQL against Lite's — no parity guard, no shared constant, not even a count — so the realistic regression is a read ported to one store and not the other. It also reaches the two `psp_signature` sites, which need a whole Query Store fixture before they return a row. Its discriminator is pinned in both directions.

No existing test asserted the buggy behaviour. Every seeded `creation_time` in the suite is `TestPeriodStart.AddDays(-3)` with no collected offset, so those fixtures are offset-tolerant with a three-day margin and pass unchanged.

## Verified

Eight one-at-a-time mutations, each anchor-count-asserted and hashed before and after, each watched red and restored:

| mutation | assertion that moved |
|---|---|
| drop the de-skew, Darling detector | detector invariance + site census 0/1 |
| flip the sign, Darling detector | detector invariance + site census |
| drop the de-skew, Darling drill-down | drill-down invariance + site census 1/2 |
| drop the de-skew, Darling `psp_signature` | site census 1/2 only |
| drop the de-skew, Lite detector | Lite detector invariance + site census |
| flip the sign, Lite detector | Lite detector invariance + site census |
| drop the de-skew, Lite drill-down | Lite drill-down invariance + site census |
| drop the de-skew, Lite `psp_signature` | site census 1/2 only |

The two `psp_signature` rows are the honest gap: only the source guard sees them, which is why it is here.

The three shipped Darling SQL constants were also executed against a real migrated store schema rather than a retyped copy, and the DuckDB expression against DuckDB 1.5.5 in-process.

**Not measured:** whether stored `analysis_findings` counts actually look inflated on the fleet. That needs a store query, and it is the comparison that would confirm the over-reporting empirically.
