### PR TITLE
Screen rdsadmin out of PostgreSQL per-database enumeration

### DIFF
--- a/Darling/Darling.Tests/PostgresDatabaseListScreenLivePostgresTests.cs
+++ b/Darling/Darling.Tests/PostgresDatabaseListScreenLivePostgresTests.cs
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+using PerformanceMonitor.Darling.Service.Targets;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #2995 against a REAL catalog. The source pin in <c>TargetProviderTests</c> proves the screen is in the
+/// string; it cannot prove the row is gone, and "the string contains rdsadmin" is also true of a query
+/// that mentions it in a comment.
+///
+/// <para>So this creates a database actually named <c>rdsadmin</c>, runs the SHIPPED query — the one
+/// <c>BuildDatabaseListPlan</c> hands the runner, not a retyped copy — against <c>pg_database</c>, and
+/// asserts both halves of the fix in one read: <c>rdsadmin</c> is absent, and every other database on the
+/// cluster is still there. The second assertion is the one that matters. The failure mode this fix could
+/// introduce is over-exclusion, and the note it protects (#2623) is only worth protecting if a real
+/// database still reaches the fan-out to fail in.</para>
+///
+/// <para><b>Why a real database rather than a fixture.</b> The row has to exist in <c>pg_database</c> to be
+/// screened out of <c>pg_database</c>, and nothing but <c>CREATE DATABASE</c> puts it there. A
+/// <c>VALUES</c> substitution would mean rewriting the query, at which point the thing under test is the
+/// rewrite.</para>
+/// </summary>
+[Collection("live-postgres")]
+public sealed class PostgresDatabaseListScreenLivePostgresTests
+{
+    private static string? ConnectionString => Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+
+    /// <summary>
+    /// A stand-in for a customer database — the one that must survive the screen, because a fix that
+    /// silences rdsadmin by narrowing the fan-out to nothing would pass an rdsadmin-absent assertion.
+    /// </summary>
+    private const string CustomerDatabase = "darling_screen_appdb";
+
+    [Fact]
+    public async Task TheShippedEnumerationScreensRdsadminAndKeepsEveryOtherDatabase()
+    {
+        var cs = ConnectionString;
+        Assert.SkipWhen(
+            string.IsNullOrEmpty(cs),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the live database-list screen test.");
+
+        var ct = TestContext.Current.CancellationToken;
+
+        /* Create-if-absent, drop-only-if-created. Not defensive padding: if this suite is ever pointed at a
+           real managed cluster, rdsadmin is already there and is the platform's, so an unconditional
+           CREATE would fail the test on a duplicate and an unconditional DROP would be the single most
+           destructive thing in the repository. Owning only what we made keeps both outcomes impossible. */
+        var weCreatedRdsadmin = false;
+
+        try
+        {
+            weCreatedRdsadmin = await CreateIfAbsentAsync(
+                cs!, PostgresTargetProvider.ManagedMaintenanceDatabase, ct);
+            await CreateIfAbsentAsync(cs!, CustomerDatabase, ct);
+
+            var (enumerationConnectionString, query) =
+                PostgresTargetProvider.Instance.BuildDatabaseListPlan(cs!, excludedDatabases: null);
+
+            var enumerated = new List<string>();
+            await using (var connection = new NpgsqlConnection(enumerationConnectionString))
+            {
+                await connection.OpenAsync(ct);
+                await using var command = new NpgsqlCommand(query.Text, connection);
+                await using var reader = await command.ExecuteReaderAsync(ct);
+                while (await reader.ReadAsync(ct))
+                {
+                    enumerated.Add(reader.GetString(0));
+                }
+            }
+
+            /* The screen fired. */
+            Assert.DoesNotContain(PostgresTargetProvider.ManagedMaintenanceDatabase, enumerated);
+
+            /* And took nothing else with it. `postgres` is a genuine collection target on a managed
+               instance — pg_extension_availability returns rows in it — and is what a "screen the
+               system-looking databases" fix would quietly eat. */
+            Assert.Contains(CustomerDatabase, enumerated);
+            Assert.Contains("postgres", enumerated);
+
+            /* The two sibling screens still fire, so this change is additive rather than a rewrite of the
+               WHERE clause: template1 is connectable and excluded only by datistemplate, template0 only by
+               datallowconn. Both are permanent cluster fixtures, unlike anything a test creates.
+               Deliberately NOT an assertion on the total count — the own-store classes create and drop
+               scratch databases in parallel with this collection, so a count is a race, and a moving
+               cross-class flake is the exact failure LivePostgresCollectionHygieneTests exists to stop. */
+            Assert.DoesNotContain("template0", enumerated);
+            Assert.DoesNotContain("template1", enumerated);
+        }
+        finally
+        {
+            await DropAsync(cs!, CustomerDatabase);
+
+            if (weCreatedRdsadmin)
+            {
+                await DropAsync(cs!, PostgresTargetProvider.ManagedMaintenanceDatabase);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns true when this call created the database, false when it was already present. PostgreSQL has
+    /// no <c>CREATE DATABASE IF NOT EXISTS</c>, so the check and the create are separate statements.
+    /// </summary>
+    private static async Task<bool> CreateIfAbsentAsync(
+        string adminConnectionString, string databaseName, CancellationToken cancellationToken)
+    {
+        await using var admin = new NpgsqlConnection(adminConnectionString);
+        await admin.OpenAsync(cancellationToken);
+
+        await using (var exists = new NpgsqlCommand("SELECT 1 FROM pg_database WHERE datname = $1", admin))
+        {
+            exists.Parameters.AddWithValue(databaseName);
+            if (await exists.ExecuteScalarAsync(cancellationToken) is not null)
+            {
+                return false;
+            }
+        }
+
+        /* Both names are compile-time constants in this file, so quoting the identifier is sufficient —
+           no caller can reach this with an arbitrary string. */
+        await using var create = new NpgsqlCommand($"CREATE DATABASE \"{databaseName}\"", admin);
+        await create.ExecuteNonQueryAsync(cancellationToken);
+        return true;
+    }
+
+    /// <summary>
+    /// Best-effort teardown with <c>WITH (FORCE)</c>, matching <c>ScratchPostgres</c>: a throw from this
+    /// finally would replace the body's in-flight exception and hide the real failure (#1794).
+    /// </summary>
+    private static async Task DropAsync(string adminConnectionString, string databaseName)
+    {
+        try
+        {
+            await using var admin = new NpgsqlConnection(adminConnectionString);
+            await admin.OpenAsync();
+            await using var drop = new NpgsqlCommand(
+                $"DROP DATABASE IF EXISTS \"{databaseName}\" WITH (FORCE)", admin);
+            await drop.ExecuteNonQueryAsync();
+        }
+        catch
+        {
+            /* A leaked database on a throwaway CI cluster is harmless, and failing a passing test in its
+               cleanup would invert the signal. */
+        }
+    }
+}

--- a/Darling/Darling.Tests/PostgresDatabaseListScreenLivePostgresTests.cs
+++ b/Darling/Darling.Tests/PostgresDatabaseListScreenLivePostgresTests.cs
@@ -73,6 +73,7 @@ public sealed class PostgresDatabaseListScreenLivePostgresTests
            CREATE would fail the test on a duplicate and an unconditional DROP would be the single most
            destructive thing in the repository. Owning only what we made keeps both outcomes impossible. */
         var weCreatedRdsadmin = false;
+        var bodySucceeded = false;
 
         try
         {
@@ -111,15 +112,26 @@ public sealed class PostgresDatabaseListScreenLivePostgresTests
                cross-class flake is the exact failure LivePostgresCollectionHygieneTests exists to stop. */
             Assert.DoesNotContain("template0", enumerated);
             Assert.DoesNotContain("template1", enumerated);
+
+            bodySucceeded = true;
         }
         finally
         {
-            await DropAsync(cs!, CustomerDatabase);
-
-            if (weCreatedRdsadmin)
+            /* Through LiveStoreCleanup (#1902), on its own fresh connection. Hand-rolling this would earn
+               the #1902 ratchet's exact complaint — a throw from a finally replaces the body's in-flight
+               exception — and a bare catch-and-swallow would trade that for the opposite fault: a database
+               this test leaked would then go unreported even on a passing run, and the NEXT run would find
+               rdsadmin already present, not create it, and so never drop it either. RunAsync stays silent
+               only while the body's own failure is in flight. */
+            await LiveStoreCleanup.RunAsync(cs!, bodySucceeded, async (cleanup, cleanupCt) =>
             {
-                await DropAsync(cs!, ManagedMaintenanceDatabase);
-            }
+                await DropAsync(cleanup, CustomerDatabase, cleanupCt);
+
+                if (weCreatedRdsadmin)
+                {
+                    await DropAsync(cleanup, ManagedMaintenanceDatabase, cleanupCt);
+                }
+            });
         }
     }
 
@@ -150,23 +162,20 @@ public sealed class PostgresDatabaseListScreenLivePostgresTests
     }
 
     /// <summary>
-    /// Best-effort teardown with <c>WITH (FORCE)</c>, matching <c>ScratchPostgres</c>: a throw from this
-    /// finally would replace the body's in-flight exception and hide the real failure (#1794).
+    /// Drops on the cleanup connection the caller supplies, and does NOT swallow — the masking rule lives
+    /// in <see cref="LiveStoreCleanup.RunAsync"/>, which is the only place that knows whether the body
+    /// already failed. A <c>catch</c> here would apply it unconditionally and hide a real leak.
+    /// <para><c>WITH (FORCE)</c> so a pooled connection somewhere cannot wedge the drop, matching the
+    /// scratch-database helper's teardown. <c>IF EXISTS</c> because the create is conditional.</para>
+    /// <para>The helper is named in prose only, never as a bare identifier: the #1902 ratchet exempts any
+    /// file whose text contains that type's name, so mentioning it would have taken this class out of
+    /// scope of the very rule it now satisfies — passing for the wrong reason instead of complying.</para>
     /// </summary>
-    private static async Task DropAsync(string adminConnectionString, string databaseName)
+    private static async Task DropAsync(
+        NpgsqlConnection connection, string databaseName, CancellationToken cancellationToken)
     {
-        try
-        {
-            await using var admin = new NpgsqlConnection(adminConnectionString);
-            await admin.OpenAsync();
-            await using var drop = new NpgsqlCommand(
-                $"DROP DATABASE IF EXISTS \"{databaseName}\" WITH (FORCE)", admin);
-            await drop.ExecuteNonQueryAsync();
-        }
-        catch
-        {
-            /* A leaked database on a throwaway CI cluster is harmless, and failing a passing test in its
-               cleanup would invert the signal. */
-        }
+        await using var drop = new NpgsqlCommand(
+            $"DROP DATABASE IF EXISTS \"{databaseName}\" WITH (FORCE)", connection);
+        await drop.ExecuteNonQueryAsync(cancellationToken);
     }
 }

--- a/Darling/Darling.Tests/PostgresDatabaseListScreenLivePostgresTests.cs
+++ b/Darling/Darling.Tests/PostgresDatabaseListScreenLivePostgresTests.cs
@@ -44,6 +44,20 @@ public sealed class PostgresDatabaseListScreenLivePostgresTests
     /// </summary>
     private const string CustomerDatabase = "darling_screen_appdb";
 
+    /// <summary>
+    /// The name RDS actually uses, spelled out here rather than read from
+    /// <c>PostgresTargetProvider.ManagedMaintenanceDatabase</c> — deliberately, and it is the difference
+    /// between this test proving something and proving nothing.
+    ///
+    /// <para>Building the fixture from the constant makes the test self-consistent under a rename: misspell
+    /// the constant and this would create <c>rdsadmn</c>, screen <c>rdsadmn</c>, and pass green while the
+    /// real <c>rdsadmin</c> went on failing every cycle on every managed target. Verified by mutation — with
+    /// the fixture built from the constant, a one-character typo in it left this test passing and only the
+    /// source pin in <c>TargetProviderTests</c> caught it. Hardcoding the platform's name here means the two
+    /// assertions have to AGREE with reality rather than with each other.</para>
+    /// </summary>
+    private const string ManagedMaintenanceDatabase = "rdsadmin";
+
     [Fact]
     public async Task TheShippedEnumerationScreensRdsadminAndKeepsEveryOtherDatabase()
     {
@@ -62,8 +76,7 @@ public sealed class PostgresDatabaseListScreenLivePostgresTests
 
         try
         {
-            weCreatedRdsadmin = await CreateIfAbsentAsync(
-                cs!, PostgresTargetProvider.ManagedMaintenanceDatabase, ct);
+            weCreatedRdsadmin = await CreateIfAbsentAsync(cs!, ManagedMaintenanceDatabase, ct);
             await CreateIfAbsentAsync(cs!, CustomerDatabase, ct);
 
             var (enumerationConnectionString, query) =
@@ -82,7 +95,7 @@ public sealed class PostgresDatabaseListScreenLivePostgresTests
             }
 
             /* The screen fired. */
-            Assert.DoesNotContain(PostgresTargetProvider.ManagedMaintenanceDatabase, enumerated);
+            Assert.DoesNotContain(ManagedMaintenanceDatabase, enumerated);
 
             /* And took nothing else with it. `postgres` is a genuine collection target on a managed
                instance — pg_extension_availability returns rows in it — and is what a "screen the
@@ -105,7 +118,7 @@ public sealed class PostgresDatabaseListScreenLivePostgresTests
 
             if (weCreatedRdsadmin)
             {
-                await DropAsync(cs!, PostgresTargetProvider.ManagedMaintenanceDatabase);
+                await DropAsync(cs!, ManagedMaintenanceDatabase);
             }
         }
     }

--- a/Darling/Darling.Tests/TargetProviderTests.cs
+++ b/Darling/Darling.Tests/TargetProviderTests.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Data.SqlClient;
 using Npgsql;
 using PerformanceMonitor.Collectors;
@@ -229,6 +230,62 @@ public class TargetProviderTests
 
         Assert.Contains("datallowconn", query.Text, StringComparison.Ordinal);
         Assert.Contains("NOT datistemplate", query.Text, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// #2995: the third screen, and the one the other two cannot make. RDS leaves
+    /// <c>datallowconn = true</c> and <c>datistemplate = false</c> on <c>rdsadmin</c>, so it enumerates
+    /// looking exactly like a user database, and then <c>pg_hba.conf</c> rejects the connection for every
+    /// principal a customer can hold. Without this the five per-database collectors attempted it once per
+    /// database-cycle on every managed target and failed every time — fleet-measured at
+    /// <c>note_count == total_runs</c> on 250 of 250 collector-instances.
+    /// <para>Asserted against the constant rather than a retyped literal: a test that spells the name out
+    /// again passes when the constant is misspelled, which is the one mistake the screen can actually make.</para>
+    /// </summary>
+    [Fact]
+    public void PostgresDatabaseList_SkipsTheManagedMaintenanceDatabase()
+    {
+        var (_, query) = PostgresTargetProvider.Instance.BuildDatabaseListPlan("Host=aurora;Database=postgres", null);
+
+        Assert.Equal("rdsadmin", PostgresTargetProvider.ManagedMaintenanceDatabase);
+        Assert.Contains(
+            $"datname <> '{PostgresTargetProvider.ManagedMaintenanceDatabase}'", query.Text, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The other half of #2995, and the half worth more than the fix: the screen has to be EXACTLY one
+    /// name. #2623 built the survivors note to mean "this cycle's rows are partial — read this", and the
+    /// cheap ways to silence the rdsadmin noise all destroy it — suppressing the note, or dropping every
+    /// database that fails to connect, would take a genuinely-broken customer database with them and
+    /// leave the same silent partial collection #2623 was filed for.
+    /// <para>So: one hardcoded name in the query, and none of the databases that legitimately enumerate.
+    /// <c>postgres</c> in particular is a real collection target on RDS — <c>pg_extension_availability</c>
+    /// returns rows there — and is the obvious casualty of a "screen the system-looking ones" fix.</para>
+    /// </summary>
+    [Fact]
+    public void PostgresDatabaseList_ScreensExactlyOneNameAndNoLegitimateDatabase()
+    {
+        var (_, query) = PostgresTargetProvider.Instance.BuildDatabaseListPlan("Host=aurora;Database=postgres", null);
+
+        /* One quoted literal in the whole enumeration: the managed maintenance database and nothing else.
+           Counts quotes rather than listing names, so a name added here without field evidence fails this
+           even though nobody thought to assert against that particular name. */
+        Assert.Equal(2, query.Text.Count(c => c == '\''));
+
+        foreach (var legitimate in new[] { "postgres", "template1", "appdb" })
+        {
+            Assert.DoesNotContain($"'{legitimate}'", query.Text, StringComparison.Ordinal);
+        }
+
+        /* The note mechanism is untouched and must stay that way: a real customer database failing out of
+           the surviving set still composes the survivors-ONLY warning, with its own name in it. */
+        var note = EnumeratedCollectorDriver.BuildPartialFailureNote(
+            failed: 1, attempted: 3, failedDatabases: new[] { "appdb" }, firstError: "28000: connection refused");
+
+        Assert.NotNull(note);
+        Assert.Contains("1 of 3", note, StringComparison.Ordinal);
+        Assert.Contains("appdb", note, StringComparison.Ordinal);
+        Assert.Contains("survivors ONLY", note, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Service/Targets/PostgresTargetProvider.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Targets/PostgresTargetProvider.cs
@@ -131,11 +131,24 @@ public sealed class PostgresTargetProvider : ITargetProvider
     /// <summary>
     /// Enumerates from wherever the service is already connected — <c>pg_database</c> is a shared
     /// catalog, so unlike SQL Server there is no equivalent of hopping to <c>master</c> first.
-    /// <para>Both filters are load-bearing. <c>datistemplate</c> excludes <c>template0</c> and
-    /// <c>template1</c>; <c>template0</c> in particular is frozen and rejects connections outright, so
-    /// including it would guarantee one failed connection per collection cycle forever. <c>datallowconn</c>
-    /// excludes any database an administrator has deliberately closed — most often one mid-restore or
-    /// being retired, exactly the databases where an extra connection attempt is least welcome.</para>
+    /// <para>All three filters are load-bearing, and each screens a different kind of database that
+    /// cannot be collected from. <c>datistemplate</c> excludes <c>template0</c> and <c>template1</c>;
+    /// <c>template0</c> in particular is frozen and rejects connections outright, so including it would
+    /// guarantee one failed connection per collection cycle forever. <c>datallowconn</c> excludes any
+    /// database an administrator has deliberately closed — most often one mid-restore or being retired,
+    /// exactly the databases where an extra connection attempt is least welcome.</para>
+    /// <para><c>rdsadmin</c> is the managed-platform maintenance database, and it needs its own screen
+    /// because the other two cannot see it: RDS leaves <c>datallowconn = true</c> and
+    /// <c>datistemplate = false</c> on it, so it enumerates like a user database, and then
+    /// <c>pg_hba.conf</c> rejects the connection (SQLSTATE 28000) for every principal a customer can
+    /// hold. Excluded by name rather than behind a managed-mode gate, matching the SQL Server screen
+    /// (#1565), which lists the vendor management databases unconditionally on the same reasoning: the
+    /// names are vendor-controlled, so they cannot collide with real customer data, and no target flag
+    /// has to be threaded down here to be trusted. Self-hosted PostgreSQL has no such database, so the
+    /// filter removes nothing there.</para>
+    /// <para>A name literal, not a parameter, precisely because it is not operator input — the
+    /// <c>excludedDatabases</c> parameters carry configured names, and keeping this out of that set
+    /// leaves an empty exclusion list producing no parameters at all.</para>
     /// </summary>
     public (string ConnectionString, CollectorQuery Query) BuildDatabaseListPlan(
         string connectionString, IReadOnlyList<string>? excludedDatabases)
@@ -148,8 +161,19 @@ SELECT datname
 FROM pg_database
 WHERE datallowconn
 AND   NOT datistemplate
+AND   datname <> '{ManagedMaintenanceDatabase}'
 {exclusionClause}
 ORDER BY datname",
             exclusionParameters));
     }
+
+    /// <summary>
+    /// The managed-platform maintenance database screened out of per-database fan-out.
+    /// <para>Named rather than inlined so the exclusion is assertable by identity: a test that retypes
+    /// the string proves the transcription, not the screen. Deliberately one name and not a list — the
+    /// field evidence (#2995) is that the failure is always exactly this database, and the other
+    /// providers' equivalents (<c>cloudsqladmin</c>, <c>azure_maintenance</c>) have never been measured
+    /// on a monitored target, so adding them would be excluding databases nobody has seen.</para>
+    /// </summary>
+    internal const string ManagedMaintenanceDatabase = "rdsadmin";
 }

--- a/docs/postgres-first-target-runbook.md
+++ b/docs/postgres-first-target-runbook.md
@@ -474,7 +474,7 @@ re-probes the target — which is how a promoted reader stops being gated as a s
 | Autovacuum health reports everything fine on a cluster you know is behind | you are reading a **reader**. It reports all zeros, not an error. Measured: writer 13,654,458 dead tuples, reader 0, same cluster and tables |
 | Added a target to darling.json and nothing happened | the store was already seeded; use `add_servers` (step 2) |
 | `pg_wait_stats` and `pg_top_queries` empty, everything else fine | not Aurora. Core PostgreSQL has no cumulative wait counters at all |
-| Only some databases in `pg_autovacuum_stats` | by design: `datallowconn` and non-template only, minus your `excludedDatabases` |
+| Only some databases in `pg_autovacuum_stats` | by design: `datallowconn` and non-template only, minus `rdsadmin` on a managed instance (it rejects every customer principal) and your `excludedDatabases` |
 | Store stopped compressing after adding targets | background workers (step 4). Silent — check the postmaster log for "out of background workers" |
 
 ## 11. Removing a target


### PR DESCRIPTION
Part of #2995

`rdsadmin` is now screened out of PostgreSQL per-database enumeration, in the enumeration itself.

## Why the other two filters miss it

`PostgresTargetProvider.BuildDatabaseListPlan` already screened the databases a fan-out cannot connect to, and its doc comment already stated the exact rationale this needs — `template0` is excluded because "including it would guarantee one failed connection per collection cycle forever." `rdsadmin` is that same sentence, and neither existing filter can see it: RDS leaves `datallowconn = true` and `datistemplate = false` on it, so it enumerates looking exactly like a user database, and only then does `pg_hba.conf` reject the connection with SQLSTATE 28000. So it needs its own screen, sitting beside the two it belongs with.

## Where, and the precedent it matches

The enumeration, not the collectors and not a managed-mode gate. There is exactly one PostgreSQL per-database enumeration in the product — `BuildDatabaseListPlan`, reached from `DarlingCollectorRunner.GetPostgresDatabaseListAsync` — and all five per-database collectors fan out from it, so one screen fixes all five. Lite has no PostgreSQL per-database path, so there is no second implementation to keep in step.

Excluded by **name**, unconditionally, rather than behind an `IsAwsRds` gate. That matches the SQL Server screen (#1565), which lists the vendor management databases (`rdsadmin`, `gcloud_cloudsqladmin`) with no platform check at all, on stated reasoning that applies here unchanged: the names are vendor-controlled, so they cannot collide with real customer data. To be precise about where that precedent lives, since it is not where the analogy would suggest: it is the `db_check` cursor in `PerformanceMonitor.Collectors/QueryStoreCollector.cs`, **not** `SqlServerTargetProvider.BuildDatabaseListPlan`, which screens only `database_id > 0` and has no name list at all.

That asymmetry is not an oversight on the SQL Server side, and it is worth stating because it is the first thing someone will check for a matching bug. `SqlServerTargetProvider.BuildDatabaseListPlan` has exactly one caller — `GetAzureDatabaseListAsync` — so the provider-level enumeration there serves the Azure SQL DB master hop, and Azure has no `rdsadmin`. The RDS SQL Server per-database collectors do not use it; they override `BuildEnumerationQuery` and carry both the #1565 name screen and a `HAS_DBACCESS` screen of their own. So there is no SQL Server counterpart to this defect to fix. It is also the cheaper shape — `BuildDatabaseListPlan` takes a connection string and an exclusion list, not a `CollectorTargetInfo`, so a managed-mode gate would mean widening `ITargetProvider`, both implementations and every call site for zero behavioural difference. Self-hosted PostgreSQL has no such database, so the filter removes nothing there.

One screen, and it covers more than the five collectors the issue measured. Seven PostgreSQL collectors declare `RunsPerDatabase => true` — the five named in #2995 plus `pg_index_bloat` and `pg_predicate_stats`, both of which fan out the same way and neither of which was in the measured set. A per-collector fix would have repaired five and left at least two doing it forever. I have not established why those two were absent from the field numbers (a gate, a cadence, or an enrolment difference — not visible from here), but the enumeration is upstream of all seven either way, and of any added later.

The screen is scoped to the connection-opening fan-out and deliberately does not touch the server-scoped reads. `pg_wraparound_stats` reads the shared `pg_database` catalog with no per-database connection and still includes `rdsadmin`, which is correct: the cluster-wide stop limit derives from the oldest `datfrozenxid` anywhere in the cluster, so dropping that row would understate real risk. Two queries, two right answers — the contrast is already documented on `PgWraparoundStatsCollectorDefinitionTests.ReadsTheSharedCatalogAndIncludesTemplates`, and its wording holds unchanged.

A literal rather than a parameter, because it is not operator input: the `@excl_db_N` parameters carry configured names, and keeping this out of that set is what leaves an empty exclusion list still producing no parameters and no `NOT IN`.

## Not over-excluding, which is the half that matters

The cheap ways to silence this noise all destroy what #2623 built. Suppressing the survivors note, or dropping any database that fails to connect, would take a genuinely-broken customer database with them and restore exactly the silent partial collection #2623 was filed for. So the screen is one name, and three assertions hold it to that:

- `PostgresDatabaseList_ScreensExactlyOneNameAndNoLegitimateDatabase` counts the quote characters in the enumeration and requires **exactly two**. It counts rather than listing names, so a second name added later without field evidence fails it even though nobody thought to assert against that particular name.
- The same test asserts `postgres`, `template1` and `appdb` are not screened. `postgres` is the one that matters — it is a genuine collection target on a managed instance, `pg_extension_availability` returns rows in it, and it is what a "screen the system-looking databases" fix quietly eats.
- It then composes a survivors note for a failed `appdb` and asserts it still reads `1 of 3`, still names `appdb`, and still says `survivors ONLY`. The note path is untouched by this change and the screen is strictly upstream of it — this pins that the two stay independent.

`cloudsqladmin` and `azure_maintenance` are deliberately **not** included. The field evidence is that the failure is always exactly `rdsadmin`; neither of the others has ever been measured on a monitored target, so adding them would be excluding databases nobody has seen.

## The operator-facing answer

`docs/postgres-first-target-runbook.md` has a troubleshooting entry for "only some databases in `pg_autovacuum_stats`" whose answer lists the enumeration's screens exhaustively — so it is the line someone reads to find out why a database is missing from their per-database data. It now names the third screen alongside the other two.

## The one-time note, declined

#2995 offers an optional trace — one note on the first cycle after the change, recording that `rdsadmin` was excluded as a managed-platform database. Not implemented, deliberately. "First cycle" is per-server persistent state, so it needs its own watermark that advances on every observation rather than only when something fires, and it needs it in **both** stores or Lite reads a permanently-empty value. That is a schema rung and a two-store contract to record a decision that the code comment, this description and the changelog entry already record, in places a reader will actually look. The screen's own doc comment carries the reasoning at the point of the code.

## Verification

A new live test, `PostgresDatabaseListScreenLivePostgresTests`, creates a database actually named `rdsadmin`, runs the **shipped** query — the one `BuildDatabaseListPlan` hands the runner, not a retyped copy — against the real `pg_database`, and asserts `rdsadmin` is gone while `postgres` and a customer stand-in are still there. A source pin cannot prove a row is absent, and "the string contains rdsadmin" is equally true of a query that only mentions it in a comment.

It creates the database only if absent and drops it only if it created it. That is not padding: pointed at a real managed cluster, `rdsadmin` is already there and is the platform's, so an unconditional `CREATE` would fail on a duplicate and an unconditional `DROP` would be the most destructive statement in the repository.

Run against PostgreSQL 17.11, red-first per mutation, one at a time:

| mutation | result |
|---|---|
| screen line deleted (the plain revert) | **3 fail** — both source pins, and the live test reporting the real catalog as `["darling_screen_appdb", "postgres", "rdsadmin"]` with `rdsadmin` found |
| constant `rdsadmin` → `rdsadmn` | **2 fail** — the name pin, and the live test |
| `postgres` added to the screen (over-exclusion) | **2 fail** — quote count 4 ≠ 2, and the live test losing `postgres` |
| `BuildPartialFailureNote` forced to return null (silence the note instead) | **1 fail** — the note assertion |

The second row is a fix to the test itself, found by mutation. The live fixture originally built its `rdsadmin` database *from the provider's constant*, which made it self-consistent under a rename — it created `rdsadmn`, screened `rdsadmn`, agreed with itself, and passed green while the real `rdsadmin` went on failing every cycle. Only the source pin caught it. The fixture now spells the platform's name out, so the two assertions have to agree with reality rather than with each other, and the typo fails both.

Its teardown goes through `LiveStoreCleanup.RunAsync` on a fresh connection, with `bodySucceeded` as the last statement of the try. Worth calling out because the #1902 ratchet was not catching the first version of it: that rule exempts any file whose text contains the scratch-helper's type name, and a doc comment here mentioned it, so the class sat outside the rule while doing exactly what the rule forbids — a bare `catch` around drops on hand-opened connections. The mention is now prose, which puts the class in scope, and the teardown complies rather than being exempt. The distinction is not academic: swallowing unconditionally would hide a leaked `rdsadmin`, and a leaked `rdsadmin` makes the next run find it already present, not create it, and so never drop it — while still passing. Verified both ways against 17.11 — both databases are gone after a passing run and after a deliberately failing one.

Windows-only suites cannot execute on macOS, so these ran by compiling the actual test files into a throwaway `net10.0` xunit v3 host with `<AssemblyName>Darling.Tests</AssemblyName>` (required — `ManagedMaintenanceDatabase` is `internal` and reachable only through the service project's `InternalsVisibleTo`). 30 tests, 0 failed, 0 skipped with a live Postgres attached. `Darling.Tests` and the service project also both build clean under `-p:EnableWindowsTargeting=true`, 0 errors.

No `.csproj`, `packages.lock.json`, `Directory.Packages.props` or `global.json` is touched, so locked-mode restore is unaffected.
