### PR TITLE
Refuse deadlock reports from a non-UTC PostgreSQL log (#2993)

### DIFF
--- a/Darling/Darling.Tests/CollectionLogDrainForensicsStoreTests.cs
+++ b/Darling/Darling.Tests/CollectionLogDrainForensicsStoreTests.cs
@@ -329,13 +329,14 @@ public class CollectionLogDrainForensicsStoreTests
            rationale is that a ratio needs a denominator from ordinary rows, not only from failures. */
         Assert.DoesNotContain("sweepPeerMaxMs: null", worker, StringComparison.Ordinal);
 
-        /* drain STAYS null on those arms: nothing was drained, so there is nothing to describe. */
-        Assert.Equal(7, Regex.Matches(worker, @"drain: null").Count);
+        /* drain STAYS null on those arms: nothing was drained, so there is nothing to describe.
+           8 since #2993 added a PERMISSIONS arm for a target whose log_timezone is not UTC. */
+        Assert.Equal(8, Regex.Matches(worker, @"drain: null").Count);
 
         /* And V110's fetch sums stay null on the same seven arms and for the same reason: no item completed,
            so no fetch was performed. Counted rather than merely present, so an arm that starts passing a
            real value - which would mean attributing another run's fetch to a failure row - is a red. */
-        Assert.Equal(7, Regex.Matches(worker, @"fetchPhases: null").Count);
+        Assert.Equal(8, Regex.Matches(worker, @"fetchPhases: null").Count);
     }
 
     /// <summary>

--- a/Darling/Darling.Tests/CollectionLogDrainForensicsStoreTests.cs
+++ b/Darling/Darling.Tests/CollectionLogDrainForensicsStoreTests.cs
@@ -329,11 +329,11 @@ public class CollectionLogDrainForensicsStoreTests
            rationale is that a ratio needs a denominator from ordinary rows, not only from failures. */
         Assert.DoesNotContain("sweepPeerMaxMs: null", worker, StringComparison.Ordinal);
 
-        /* drain STAYS null on those arms: nothing was drained, so there is nothing to describe.
-           8 since #2993 added a PERMISSIONS arm for a target whose log_timezone is not UTC. */
+        /* drain STAYS null on those arms: nothing was drained, so there is nothing to describe. The count
+           follows the arms - #2993's log_timezone PERMISSIONS arm was the eighth. */
         Assert.Equal(8, Regex.Matches(worker, @"drain: null").Count);
 
-        /* And V110's fetch sums stay null on the same seven arms and for the same reason: no item completed,
+        /* And V110's fetch sums stay null on those same arms and for the same reason: no item completed,
            so no fetch was performed. Counted rather than merely present, so an arm that starts passing a
            real value - which would mean attributing another run's fetch to a failure row - is a red. */
         Assert.Equal(8, Regex.Matches(worker, @"fetchPhases: null").Count);

--- a/Darling/Darling.Tests/PgDeadlockLogTimezoneTests.cs
+++ b/Darling/Darling.Tests/PgDeadlockLogTimezoneTests.cs
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System.IO;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #2993, Darling half: a log stamped in a non-UTC zone records as <c>PERMISSIONS</c>, not <c>ERROR</c>
+/// and not a successful empty read.
+///
+/// <para>The refusal itself and every zone decision are pinned in Lite.Tests
+/// (<c>PgDeadlockLogParserTests</c>) against the shared parser both transports use. What is only pinnable
+/// here is the CLASSIFICATION, which is try/catch glue around a live collection sweep — the same shape and
+/// the same reason as <see cref="DarlingLockTimeoutYieldTests"/>: source-level, because there is no way to
+/// reach the arm without a monitored PostgreSQL target.</para>
+///
+/// <para>The status is the load-bearing part. <c>ERROR</c> would be a monitoring fault, which this is not,
+/// and collection health would carry it forever for as long as the parameter group says what it says;
+/// <c>PERMISSIONS</c> is the store's non-fatal degradation bucket, and
+/// <c>CollectorRuntimePrecondition</c>'s arm for it already tells a reader the condition can be satisfied
+/// on the monitored server and is re-derived every cycle. Both are true here.</para>
+/// </summary>
+public sealed class PgDeadlockLogTimezoneTests
+{
+    [Fact]
+    public void Worker_Records_A_NonUtc_Log_As_Permissions_Not_Error()
+    {
+        var source = ReadRepoFile(Path.Combine("Darling", "PerformanceMonitor.Darling.Service", "DarlingWorker.cs"));
+
+        var armIndex = source.IndexOf("catch (PgLogTimezoneUnsupportedException ex)", System.StringComparison.Ordinal);
+        Assert.True(armIndex >= 0, "The #2993 classification arm is gone — a non-UTC log would fall to the general handler and record ERROR every cycle.");
+
+        /* Bounded to the arm's own body. An unscoped Contains would pass on any of the other PERMISSIONS
+           arms in this file and prove nothing about this one. */
+        var body = source[armIndex..];
+        var close = body.IndexOf("\n            return 0;", System.StringComparison.Ordinal);
+        body = close > 0 ? body[..close] : body;
+
+        Assert.Contains("\"PERMISSIONS\"", body, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("\"ERROR\"", body, System.StringComparison.Ordinal);
+
+        /* The message is the exception's own, which is where log_timezone is named. Re-authoring it in the
+           arm would be a second copy of prose whose whole value is naming one setting correctly. */
+        Assert.Contains("ex.Message", body, System.StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The <c>pg_read_file</c> route's own half: the query has to RETURN the prefix zone, or the parser has
+    /// nothing to check and the refusal is unreachable on the transport that has a database connection.
+    /// The zone was matched and discarded here before #2993.
+    /// </summary>
+    [Fact]
+    public void The_Collector_Query_Returns_The_Prefix_Zone()
+    {
+        var source = ReadRepoFile(Path.Combine("PerformanceMonitor.Collectors", "PgDeadlocksCollector.cs"));
+
+        Assert.Contains("AS log_zone_text", source, System.StringComparison.Ordinal);
+
+        /* [^ \n]+ rather than \w+: a numeric-offset zone matched no block at all under \w+, so the
+           server reported no deadlocks instead of reporting a zone this cannot store. */
+        Assert.Contains("([^ \\n]+) \\[(\\d+)\\]", source, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("\\w+ \\[(\\d+)\\]", source, System.StringComparison.Ordinal);
+    }
+
+    /* Locate the repo from this file — the DarlingLockTimeoutYieldTests idiom; no build-output copying. */
+    private static string ReadRepoFile(string relative, [CallerFilePath] string thisFile = "")
+    {
+        var dir = Path.GetDirectoryName(thisFile)!;
+        while (dir is not null && !File.Exists(Path.Combine(dir, relative)))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        Assert.NotNull(dir);
+        return File.ReadAllText(Path.Combine(dir!, relative));
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -6149,6 +6149,33 @@ LIMIT 1";
                 fanout: null, phases: null, drain: null, fetchPhases: null, sweepPeerMaxMs: peerMaxAtDispatchMs, _logger, cancellationToken);
             return 0;
         }
+        catch (PgLogTimezoneUnsupportedException ex)
+        {
+            /* #2993: this target's log_timezone is not UTC, so the deadlock reports in its server log are
+               stamped in local time and occurred_at cannot be filled from them.
+
+               PERMISSIONS for the same reason the PostgresException FeatureDisabled arm below is: none of
+               the store's five statuses means "this target is configured in a way this source cannot be
+               read under", so the non-fatal degradation bucket carries it and the MESSAGE is where the
+               truth goes. It also earns that bucket on the merits — the cause is a setting on the
+               monitored server, an operator can clear it, and CollectorRuntimePrecondition's PERMISSIONS
+               arm already frames the condition as satisfiable and re-derives it on every read.
+
+               Not ERROR: nothing is broken on the monitoring side, and a parameter group does not change
+               because we shouted about it once a minute. Not a SUCCESS row with zero rows, which is what
+               dropping the unusable blocks quietly would have produced — a target whose log is in the
+               wrong zone reading as a target with no deadlocks.
+
+               Both transports arrive here: the pg_read_file route throws out of the collector's ReadAsync,
+               the RDS log-API route out of the ingestor's Extract. */
+            _logger.LogWarning("  [{Server}] {Collector} => PERMISSIONS: the server log is stamped '{Zone}', not UTC",
+                server.Config.DisplayName, collectorName, ex.ObservedZone);
+
+            await DarlingObservability.LogCollectionAsync(
+                _postgres!, runtime, collectorName, "PERMISSIONS", 0, 0, 0, ex.Message,
+                fanout: null, phases: null, drain: null, fetchPhases: null, sweepPeerMaxMs: peerMaxAtDispatchMs, _logger, cancellationToken);
+            return 0;
+        }
         catch (SqlException ex) when (ex.Number == 1222 && CollectorCatalog.YieldsOnLockTimeout(collectorName))
         {
             /* The 1-second LOCK_TIMEOUT guard doing its job (#1805): the snapshot sweep stepped aside

--- a/Darling/PerformanceMonitor.Darling.Service/Targets/RdsDeadlockIngestor.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Targets/RdsDeadlockIngestor.cs
@@ -51,6 +51,11 @@ public sealed class RdsDeadlockIngestor
     /// <param name="host">The target's connection host. A non-RDS host is skipped silently — that target
     /// uses the <c>pg_read_file</c> route instead, and there is nothing to report.</param>
     /// <returns>Rows stored, or zero when this target is not RDS or had nothing new.</returns>
+    /// <exception cref="PgLogTimezoneUnsupportedException">The log is stamped in a non-UTC zone, so its
+    /// timestamps are local and nothing in it can be stored (#2993). Propagated for the same reason
+    /// <see cref="RdsLogUnavailableException"/> is: the runner classifies it and names the setting, where
+    /// swallowing it would return zero rows and be recorded as a log that was read and held no
+    /// deadlocks.</exception>
     public async Task<int> IngestAsync(
         int serverId,
         string storageName,
@@ -82,6 +87,9 @@ public sealed class RdsDeadlockIngestor
             return 0;
         }
 
+        /* Not inside the tolerant catch above, which covers the AWS FETCH. A parse refusal is a statement
+           about the target's configuration rather than about reaching it, and it has to reach the runner
+           to be classified. */
         var deadlocks = PgDeadlockLogParser.Extract(chunk.Value.Text);
 
         if (deadlocks.Count == 0)

--- a/Lite.Tests/PgDeadlockLogParserTests.cs
+++ b/Lite.Tests/PgDeadlockLogParserTests.cs
@@ -357,8 +357,10 @@ public sealed class PgDeadlockLogParserTests
     /// the accepted trade and this pins it as a DECISION rather than leaving it an accident - storing the
     /// UTC half would leave a partial history from a target just declared unreadable, with nothing in the
     /// data marking what is missing, and a reader could not then tell a quiet server from a
-    /// half-collected one. The straddle only arises while a <c>log_timezone</c> change crosses the tail,
-    /// and the transports read the newest file only, so a rotation clears it.</para>
+    /// half-collected one. The straddle only arises while a <c>log_timezone</c> change crosses the read.
+    /// What it costs differs by transport, which <see cref="PgDeadlockLogParser.Extract"/>'s remarks
+    /// state: the <c>pg_read_file</c> route re-reads an overlapping tail, while the RDS log-API route is
+    /// consume-once and loses the readable siblings for the life of its resume marker.</para>
     /// </summary>
     [Fact]
     public void AStraddledWindowRefusesTheWholeRead_NotJustTheOffendingBlock()

--- a/Lite.Tests/PgDeadlockLogParserTests.cs
+++ b/Lite.Tests/PgDeadlockLogParserTests.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Lite.Tests.Helpers;
 using PerformanceMonitor.Collectors;
 using Xunit;
@@ -26,6 +28,17 @@ public sealed class PgDeadlockLogParserTests
         + "\tProcess 1556: \n"
         + "\tBEGIN; UPDATE dl SET v=v+1 WHERE id=2; SELECT pg_sleep(2); UPDATE dl SET v=v+1 WHERE id=1; COMMIT;\n"
         + "2026-08-26 22:25:24.100 UTC [1549] 322048460535975151HINT:  See server log for query details.\n";
+
+    /// <summary>
+    /// The captured report with its prefix zone SUBSTITUTED, and the zone is the only thing changed.
+    ///
+    /// <para>Synthesised on purpose, and it is what makes the #2993 assertions mean anything: every target
+    /// on the fleet runs <c>log_timezone = UTC</c>, so a fixture carrying the captured zone passes
+    /// identically whether the check exists or not. A prefix the fleet does not produce is the only
+    /// evidence available for the path that matters.</para>
+    /// </summary>
+    private static string WithLogZone(string zone) =>
+        RealBlock.Replace(" UTC [", $" {zone} [", StringComparison.Ordinal);
 
     [Fact]
     public void ParsesARealReport_WholeGraphAndBothStatements()
@@ -187,6 +200,153 @@ public sealed class PgDeadlockLogParserTests
             MakeContext());
 
         Assert.Equal(PgDeadlocksCollector.Instance.PayloadColumns.Count, writer.Values.Count);
+    }
+
+    /// <summary>
+    /// #2993: a log stamped in a non-UTC zone is REFUSED, naming the setting.
+    ///
+    /// <para>Before this, the prefix zone was captured by the pattern and read by nothing, and the stamp
+    /// went through <c>TryParse</c> with <c>AssumeUniversal</c> — so this exact fixture parsed, cleanly,
+    /// into a deadlock at 22:25:24 UTC that actually happened at 03:25:24 the next day. Nothing errored,
+    /// nothing was empty, and the row was five hours wrong in a trend bucket. That is why the refusal is
+    /// the assertion here: there is no output to check, because the whole point is that no output is
+    /// produced.</para>
+    /// </summary>
+    [Fact]
+    public void RefusesAReportWhoseLogPrefixIsNotUtc_NamingTheSetting()
+    {
+        var ex = Assert.Throws<PgLogTimezoneUnsupportedException>(
+            () => PgDeadlockLogParser.Extract(WithLogZone("EST")));
+
+        Assert.Equal("EST", ex.ObservedZone);
+        Assert.Contains("log_timezone", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("EST", ex.Message, StringComparison.Ordinal);
+
+        /* The sentence that stops the row being read as an empty log. A refusal whose message does not say
+           so is the same silent nothing one layer over. */
+        Assert.Contains("NOT 'no deadlocks were detected'", ex.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A zone with no abbreviation renders as a NUMERIC offset, and that shape has to be refused too.
+    ///
+    /// <para>It is the case that would have escaped the check by never reaching it: the pattern matched the
+    /// zone as <c>\w+</c>, which matches neither the sign nor the colon, so a <c>+07</c> prefix matched no
+    /// block at all and the collector reported a server with no deadlocks. Silent in a different direction
+    /// from the shifted stamp, and the same category — so it is refused rather than skipped, which is what
+    /// this asserts: an exception, not an empty list.</para>
+    /// </summary>
+    [Theory]
+    [InlineData("+07")]
+    [InlineData("-03:30")]
+    [InlineData("+0530")]
+    public void RefusesANumericNonZeroOffsetPrefix_RatherThanMatchingNothing(string zone)
+    {
+        var ex = Assert.Throws<PgLogTimezoneUnsupportedException>(
+            () => PgDeadlockLogParser.Extract(WithLogZone(zone)));
+
+        Assert.Equal(zone, ex.ObservedZone);
+    }
+
+    /// <summary>
+    /// Every spelling of zero offset still parses, through the whole pattern rather than the predicate
+    /// alone. A check that refused a UTC server would be worse than no check: it would take deadlock
+    /// capture away from the entire fleet.
+    /// </summary>
+    [Theory]
+    [InlineData("UTC")]
+    [InlineData("GMT")]
+    [InlineData("UCT")]
+    [InlineData("+00")]
+    [InlineData("-00")]
+    [InlineData("+00:00")]
+    [InlineData("-0000")]
+    public void AZeroOffsetPrefixStillParses(string zone)
+    {
+        var deadlock = Assert.Single(PgDeadlockLogParser.Extract(WithLogZone(zone)));
+
+        Assert.Equal(new DateTime(2026, 8, 26, 22, 25, 24, 100, DateTimeKind.Utc), deadlock.OccurredAtUtc);
+        Assert.Equal(1549, deadlock.VictimPid);
+    }
+
+    /// <summary>
+    /// The predicate on its own, because the allowlist is the load-bearing part and an over-long one is
+    /// the same silent-wrong defect as no check at all, arriving one entry at a time. <c>BST</c> and
+    /// <c>CST</c> are here to be REFUSED: they are the ambiguity that makes conversion impossible —
+    /// <c>CST</c> is three zones — and refusing them is the whole trade this fix makes.
+    /// </summary>
+    [Theory]
+    [InlineData("UTC", true)]
+    [InlineData("utc", true)]
+    [InlineData("GMT", true)]
+    [InlineData("UCT", true)]
+    [InlineData("+00", true)]
+    [InlineData("-00:00", true)]
+    [InlineData("EST", false)]
+    [InlineData("CST", false)]
+    [InlineData("BST", false)]
+    [InlineData("IST", false)]
+    [InlineData("AEST", false)]
+    [InlineData("+01", false)]
+    [InlineData("+0030", false)]
+    [InlineData("-05:30", false)]
+    [InlineData("+", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void IsZeroOffsetLogZone_AnswersDetectionRatherThanConversion(string? zone, bool expected)
+        => Assert.Equal(expected, PgDeadlockLogParser.IsZeroOffsetLogZone(zone));
+
+    /// <summary>
+    /// The WIRING, not the pattern: the collector's four result columns reach the parser in the right
+    /// order, driven through the real <c>ReadAsync</c>.
+    ///
+    /// <para>An <c>Assert.Contains</c> on the query text cannot see this. The zone arrived as a new column
+    /// in the middle of the list, so a mis-ordinal would hand the parser the zone where it expects the
+    /// victim pid — which parses as nothing, returns null, and drops every deadlock silently. This is the
+    /// one seam where that is possible.</para>
+    /// </summary>
+    [Fact]
+    public async Task TheCollectorHandsTheParserItsFourColumnsInOrder()
+    {
+        var reader = new FakeCollectorDataReader(
+            new object[]
+            {
+                "2026-08-26 22:25:24.100",
+                "UTC",
+                "1549",
+                "Process 1549 waits for ShareLock on transaction 809; blocked by process 1556.\n"
+                + "\tProcess 1556 waits for ShareLock on transaction 808; blocked by process 1549.\n",
+            });
+
+        var rows = await PgDeadlocksCollector.Instance.ReadAsync(reader, MakeContext(), CancellationToken.None);
+
+        var row = Assert.Single(rows);
+        Assert.Equal(1549, row.VictimPid);
+        Assert.Equal(2, row.ParticipantCount);
+        Assert.Equal(new DateTime(2026, 8, 26, 22, 25, 24, 100, DateTimeKind.Utc), row.OccurredAtUtc);
+    }
+
+    /// <summary>
+    /// And the same seam refuses: the zone column is READ rather than carried past, so a non-UTC target
+    /// gets a classified refusal out of the collector instead of rows stamped in local time.
+    /// </summary>
+    [Fact]
+    public async Task TheCollectorRefusesWhenItsZoneColumnIsNotUtc()
+    {
+        var reader = new FakeCollectorDataReader(
+            new object[]
+            {
+                "2026-08-26 22:25:24.100",
+                "EST",
+                "1549",
+                "Process 1549 waits for ShareLock on transaction 809; blocked by process 1556.\n"
+                + "\tProcess 1556 waits for ShareLock on transaction 808; blocked by process 1549.\n",
+            });
+
+        var ex = await Assert.ThrowsAsync<PgLogTimezoneUnsupportedException>(
+            async () => await PgDeadlocksCollector.Instance.ReadAsync(reader, MakeContext(), CancellationToken.None));
+
+        Assert.Equal("EST", ex.ObservedZone);
     }
 
     private static CollectorContext MakeContext() => new()

--- a/Lite.Tests/PgDeadlockLogParserTests.cs
+++ b/Lite.Tests/PgDeadlockLogParserTests.cs
@@ -349,6 +349,40 @@ public sealed class PgDeadlockLogParserTests
         Assert.Equal("EST", ex.ObservedZone);
     }
 
+    /// <summary>
+    /// A window holding a non-UTC block and a readable UTC one refuses the WHOLE read, siblings included.
+    ///
+    /// <para>Raised in review on the PR rather than predicted: the throw is per block and unwinds
+    /// <c>Extract</c>'s loop, so a straddled window loses deadlocks that were perfectly storable. It is
+    /// the accepted trade and this pins it as a DECISION rather than leaving it an accident - storing the
+    /// UTC half would leave a partial history from a target just declared unreadable, with nothing in the
+    /// data marking what is missing, and a reader could not then tell a quiet server from a
+    /// half-collected one. The straddle only arises while a <c>log_timezone</c> change crosses the tail,
+    /// and the transports read the newest file only, so a rotation clears it.</para>
+    /// </summary>
+    [Fact]
+    public void AStraddledWindowRefusesTheWholeRead_NotJustTheOffendingBlock()
+    {
+        /* Ordered so the readable block comes FIRST: if the loop returned what it had instead of
+           unwinding, this would come back with one deadlock and no exception. */
+        var straddled = WithLogZone("UTC")
+            + RealBlock.Replace(" UTC [", " EST [", StringComparison.Ordinal)
+                       .Replace("1549", "1827", StringComparison.Ordinal)
+                       .Replace("1556", "1830", StringComparison.Ordinal);
+
+        Assert.Equal(2, s_blockCount.Matches(straddled).Count);
+
+        var ex = Assert.Throws<PgLogTimezoneUnsupportedException>(
+            () => PgDeadlockLogParser.Extract(straddled));
+
+        Assert.Equal("EST", ex.ObservedZone);
+    }
+
+    /* The fixture's own positive control: without it a straddled slab that had somehow stopped holding
+       two recognisable blocks would satisfy the refusal above for the wrong reason. */
+    private static readonly System.Text.RegularExpressions.Regex s_blockCount =
+        new(@"ERROR:  deadlock detected");
+
     private static CollectorContext MakeContext() => new()
     {
         ServerId = 42,

--- a/PerformanceMonitor.Collectors/PgDeadlockLogParser.cs
+++ b/PerformanceMonitor.Collectors/PgDeadlockLogParser.cs
@@ -56,9 +56,19 @@ public static class PgDeadlockLogParser
        The DETAIL block is the first line plus every TAB-INDENTED line after it. It ends at the next line
        carrying a log prefix, which is what (?:\t[^\n]*\n)* expresses: a statement inside the block can
        itself contain newlines, and each continuation arrives tab-indented, so a line-count rule or a
-       blank-line rule would truncate multi-line SQL silently. */
+       blank-line rule would truncate multi-line SQL silently.
+
+       The zone is captured and READ (#2993). PostgreSQL renders %m in log_timezone and prints that zone's
+       abbreviation beside the stamp, so this token is the setting's own rendered value for THIS line, and
+       it is what decides whether the naive timestamp next to it is already UTC. See IsZeroOffsetLogZone
+       for why that question is answerable from an abbreviation when "which zone is this" is not.
+
+       [^ \n]+ for it rather than \w+: a zone with no abbreviation renders as a numeric offset (+07,
+       -03:30) and \w+ matches neither the sign nor the colon, so the whole block failed to match and the
+       server reported no deadlocks at all — the same silent nothing the [^\n]* trap above avoids, and the
+       one shape that would have slipped past the zone check by never reaching it. */
     private static readonly Regex s_deadlockBlock = new(
-        @"^(\d{4}-\d\d-\d\d \d\d:\d\d:\d\d\.\d+) (?<zone>\w+) \[(?<pid>\d+)\][^\n]*ERROR:  deadlock detected\s*\n"
+        @"^(\d{4}-\d\d-\d\d \d\d:\d\d:\d\d\.\d+) (?<zone>[^ \n]+) \[(?<pid>\d+)\][^\n]*ERROR:  deadlock detected\s*\n"
         + @"[^\n]*DETAIL:  (?<detail>(?:[^\n]*\n)(?:\t[^\n]*\n)*)",
         RegexOptions.Compiled | RegexOptions.Multiline);
 
@@ -68,6 +78,12 @@ public static class PgDeadlockLogParser
        enumeration would silently drop the shapes it did not anticipate. */
     private static readonly Regex s_edge = new(
         @"Process (?<waiter>\d+) waits for (?<mode>[A-Za-z ]+) on (?<resource>[^;]+); blocked by process (?<blocker>\d+)\.",
+        RegexOptions.Compiled);
+
+    /* A numeric log-prefix offset that is zero: +00, -00, +00:00, -0000. Anchored, so a non-zero offset
+       sharing a prefix with a zero one (+0030) cannot match part of itself and pass. */
+    private static readonly Regex s_zeroOffset = new(
+        @"^[+-]0+(?::0+)*$",
         RegexOptions.Compiled);
 
     /* `Process 1549: ` then the statement, which runs to the next such header or the end of the block. */
@@ -82,6 +98,9 @@ public static class PgDeadlockLogParser
     /// <see cref="PgPlanLogParser"/>: both transports read a bounded window, so a report cut in half at the
     /// edge is an ordinary consequence of not reading the whole file rather than a fault worth surfacing
     /// every cycle. It will be read whole on the next pass, because the window overlaps.</para>
+    ///
+    /// <para>The one exception is a log stamped in a non-UTC zone, which throws
+    /// <see cref="PgLogTimezoneUnsupportedException"/> instead: see <see cref="FromBlock"/>.</para>
     /// </summary>
     public static List<ParsedDeadlock> Extract(string? logBody)
     {
@@ -96,6 +115,7 @@ public static class PgDeadlockLogParser
         {
             var parsed = FromBlock(
                 match.Groups[1].Value,
+                match.Groups["zone"].Value,
                 match.Groups["pid"].Value,
                 match.Groups["detail"].Value);
 
@@ -109,14 +129,31 @@ public static class PgDeadlockLogParser
     }
 
     /// <summary>
-    /// One report, from its timestamp, victim pid and DETAIL block. Null when the block carries no wait
-    /// edge, which is the one thing that makes it a deadlock report rather than some other DETAIL.
+    /// One report, from its log-prefix timestamp and zone, its victim pid and its DETAIL block. Null when
+    /// the block carries no wait edge, which is the one thing that makes it a deadlock report rather than
+    /// some other DETAIL.
     /// </summary>
-    public static ParsedDeadlock? FromBlock(string timestampText, string victimPidText, string? detail)
+    /// <param name="zoneText">The zone token from the log prefix, which is <c>log_timezone</c> as the
+    /// server rendered it for this line. Required, and required to mean an offset of zero.</param>
+    /// <exception cref="PgLogTimezoneUnsupportedException">The prefix zone is not a zero-offset one, so the
+    /// timestamp beside it is local rather than UTC and the report cannot be stored (#2993).</exception>
+    public static ParsedDeadlock? FromBlock(string timestampText, string zoneText, string victimPidText, string? detail)
     {
         if (string.IsNullOrWhiteSpace(detail))
         {
             return null;
+        }
+
+        /* THROWN rather than skipped, and it is the only thing in this parser that is not tolerant.
+           Everything else a block can be wrong about is read again on the next overlapping pass, so
+           skipping it costs nothing. This one neither clears itself nor announces itself: the timestamp
+           below parses PERFECTLY under a non-UTC prefix, AssumeUniversal takes it for UTC, and the row
+           lands in the wrong hour with nothing anywhere disagreeing. Returning null instead would store no
+           deadlocks and read as a server that has none, which is the same silent-wrong one layer up. A
+           refusal the runner can classify is the only outcome that names the setting. */
+        if (!IsZeroOffsetLogZone(zoneText))
+        {
+            throw new PgLogTimezoneUnsupportedException(zoneText);
         }
 
         if (!DateTime.TryParse(
@@ -178,6 +215,53 @@ public static class PgDeadlockLogParser
             Resources: resources.Count > 0 ? string.Join(", ", resources) : null,
             VictimStatement: victimStatement,
             GraphText: graph);
+    }
+
+    /// <summary>
+    /// Whether a log-prefix zone token means an offset of exactly zero, so the naive timestamp printed
+    /// beside it is already UTC and needs no conversion.
+    ///
+    /// <para><b>Detection, never conversion.</b> An abbreviation cannot be converted from — <c>CST</c> is
+    /// US Central, China Standard and Cuba Standard — and that is the good reason the captured zone was
+    /// never wired up. But "is this offset zero" is a far weaker question than "which zone is this", and
+    /// the token answers it exactly: three abbreviations are zero by definition, a numeric offset says so
+    /// arithmetically, and everything else either has an offset or is ambiguous about having one, which for
+    /// this purpose is the same answer.</para>
+    ///
+    /// <para><b>Per LINE rather than per server, which is why <c>log_timezone</c> is not read from the
+    /// target.</b> <c>current_setting('log_timezone')</c> describes the collector's connection now; this
+    /// token was written by the server into the line being parsed, under whatever the setting was then, so
+    /// it is the better witness of the two for the row it is attached to. On <c>Europe/London</c> they
+    /// disagree for half the year — winter lines are stamped <c>GMT</c> and really are UTC, and a GUC read
+    /// would refuse them — and on the managed transport there is no connection to ask at all, because that
+    /// route receives log TEXT and runs no SQL.</para>
+    /// </summary>
+    public static bool IsZeroOffsetLogZone(string? zone)
+    {
+        if (string.IsNullOrWhiteSpace(zone))
+        {
+            /* Nothing said the timestamp was UTC. Unreachable through Extract, whose pattern requires
+               the token, and reachable through the collector, which reads the zone from a result column
+               that can come back NULL. */
+            return false;
+        }
+
+        var token = zone.Trim();
+
+        /* UT is deliberately absent: it is not a zone PostgreSQL renders, and an over-long allowlist is
+           the same silent-wrong defect as no check at all, arriving one entry at a time. */
+        if (string.Equals(token, "UTC", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(token, "GMT", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(token, "UCT", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        /* A zone with no abbreviation renders as a numeric offset, and a numerically zero one is UTC by
+           another spelling. Matched as a SHAPE rather than enumerated, because the rendering carries only
+           as much precision as the offset needs (+00, +00:00, -0000) and an allowlist that missed a form
+           would refuse a server that is perfectly UTC. */
+        return s_zeroOffset.IsMatch(token);
     }
 
     /// <summary>

--- a/PerformanceMonitor.Collectors/PgDeadlockLogParser.cs
+++ b/PerformanceMonitor.Collectors/PgDeadlockLogParser.cs
@@ -101,6 +101,16 @@ public static class PgDeadlockLogParser
     ///
     /// <para>The one exception is a log stamped in a non-UTC zone, which throws
     /// <see cref="PgLogTimezoneUnsupportedException"/> instead: see <see cref="FromBlock"/>.</para>
+    ///
+    /// <para><b>That throw abandons the WHOLE read, siblings included, and that is the accepted trade
+    /// rather than an oversight.</b> One log has one <c>log_timezone</c> at any instant, so a window
+    /// holding both a non-UTC and a UTC stamp only happens while a change to that setting straddles the
+    /// tail. Storing the UTC half and refusing the rest would leave a partial history from a target we
+    /// have just declared unreadable, with nothing in the data marking what is missing — the reader could
+    /// not then tell a quiet server from a half-collected one. A whole-read refusal says one thing, and
+    /// the runner's row says it. The straddle is bounded by the log itself: both transports read the
+    /// NEWEST file only, so a rotation clears it, and until then every cycle records the refusal with the
+    /// setting named rather than going quiet.</para>
     /// </summary>
     public static List<ParsedDeadlock> Extract(string? logBody)
     {
@@ -150,7 +160,11 @@ public static class PgDeadlockLogParser
            below parses PERFECTLY under a non-UTC prefix, AssumeUniversal takes it for UTC, and the row
            lands in the wrong hour with nothing anywhere disagreeing. Returning null instead would store no
            deadlocks and read as a server that has none, which is the same silent-wrong one layer up. A
-           refusal the runner can classify is the only outcome that names the setting. */
+           refusal the runner can classify is the only outcome that names the setting.
+
+           Per BLOCK, so it abandons the whole read from inside Extract's loop and the collector's row
+           loop alike. See Extract's remarks for why losing the readable siblings is preferred to storing
+           a partial history nothing marks as partial. */
         if (!IsZeroOffsetLogZone(zoneText))
         {
             throw new PgLogTimezoneUnsupportedException(zoneText);

--- a/PerformanceMonitor.Collectors/PgDeadlockLogParser.cs
+++ b/PerformanceMonitor.Collectors/PgDeadlockLogParser.cs
@@ -102,15 +102,21 @@ public static class PgDeadlockLogParser
     /// <para>The one exception is a log stamped in a non-UTC zone, which throws
     /// <see cref="PgLogTimezoneUnsupportedException"/> instead: see <see cref="FromBlock"/>.</para>
     ///
-    /// <para><b>That throw abandons the WHOLE read, siblings included, and that is the accepted trade
-    /// rather than an oversight.</b> One log has one <c>log_timezone</c> at any instant, so a window
-    /// holding both a non-UTC and a UTC stamp only happens while a change to that setting straddles the
-    /// tail. Storing the UTC half and refusing the rest would leave a partial history from a target we
-    /// have just declared unreadable, with nothing in the data marking what is missing — the reader could
-    /// not then tell a quiet server from a half-collected one. A whole-read refusal says one thing, and
-    /// the runner's row says it. The straddle is bounded by the log itself: both transports read the
-    /// NEWEST file only, so a rotation clears it, and until then every cycle records the refusal with the
-    /// setting named rather than going quiet.</para>
+    /// <para><b>That throw abandons the WHOLE read, siblings included.</b> One log has one
+    /// <c>log_timezone</c> at any instant, so a window holding both a non-UTC and a UTC stamp only
+    /// happens while a change to that setting straddles the read. Storing the UTC half and refusing the
+    /// rest would leave a partial history from a target we have just declared unreadable, with nothing in
+    /// the data marking what is missing — the reader could not then tell a quiet server from a
+    /// half-collected one. A whole-read refusal says one thing, and the runner's row says it.</para>
+    ///
+    /// <para><b>What that costs is NOT the same on the two transports, and the difference is the read, not
+    /// this method.</b> <see cref="PgDeadlocksCollector"/> re-reads an overlapping byte-window tail every
+    /// cycle, so a straddled window there loses nothing permanently — the same text arrives again next
+    /// cycle, and once the non-UTC lines age out of the window the readable siblings store. The RDS
+    /// log-API route is CONSUME-ONCE: <c>RdsLogSource.ReadNewestAsync</c> advances and persists its resume
+    /// marker as a side effect of the fetch, before this parser is reached, so text abandoned here is not
+    /// re-fetched for the life of that marker and the readable siblings in it are lost. Do not describe
+    /// this refusal as bounded without saying which transport is meant.</para>
     /// </summary>
     public static List<ParsedDeadlock> Extract(string? logBody)
     {
@@ -164,7 +170,8 @@ public static class PgDeadlockLogParser
 
            Per BLOCK, so it abandons the whole read from inside Extract's loop and the collector's row
            loop alike. See Extract's remarks for why losing the readable siblings is preferred to storing
-           a partial history nothing marks as partial. */
+           a partial history nothing marks as partial — and for why that trade is cheap on the
+           re-reading transport and NOT cheap on the consume-once one. */
         if (!IsZeroOffsetLogZone(zoneText))
         {
             throw new PgLogTimezoneUnsupportedException(zoneText);

--- a/PerformanceMonitor.Collectors/PgDeadlocksCollector.cs
+++ b/PerformanceMonitor.Collectors/PgDeadlocksCollector.cs
@@ -70,8 +70,14 @@ public sealed class PgDeadlocksCollector : PostgresCollectorDefinitionBase<PgDea
          participant's statement is arbitrary user SQL that can contain newlines, each arriving
          tab-indented. A blank-line or line-count rule truncates multi-line SQL silently.
 
+         ([^ \n]+) for the prefix's ZONE, returned as its own column (#2993). It was matched and discarded
+         here, and the parser could then only assume the stamp beside it was UTC. [^ \n]+ rather than \w+
+         because a zone with no abbreviation renders as a numeric offset (+07) that \w+ cannot match, so
+         the block matched nothing and the server reported no deadlocks.
+
        The 'n' flag makes ^ match at line starts. Parsing of the block itself is C#, in
-       PgDeadlockLogParser, so the RDS transport — which receives log TEXT and runs no SQL — shares it. */
+       PgDeadlockLogParser, so the RDS transport — which receives log TEXT and runs no SQL — shares it, and
+       both routes get the same zone refusal from the same code. */
     private const string QueryText = @"
 WITH newest AS (
     SELECT name, size
@@ -88,12 +94,13 @@ tail AS (
 )
 SELECT
     m[1]    AS occurred_at_text,
-    m[2]    AS victim_pid_text,
-    m[3]    AS detail_body
+    m[2]    AS log_zone_text,
+    m[3]    AS victim_pid_text,
+    m[4]    AS detail_body
 FROM tail,
      regexp_matches(
          tail.body,
-         '^(\d{4}-\d\d-\d\d \d\d:\d\d:\d\d\.\d+) \w+ \[(\d+)\][^\n]*ERROR:  deadlock detected\s*\n[^\n]*DETAIL:  ((?:[^\n]*\n)(?:\t[^\n]*\n)*)',
+         '^(\d{4}-\d\d-\d\d \d\d:\d\d:\d\d\.\d+) ([^ \n]+) \[(\d+)\][^\n]*ERROR:  deadlock detected\s*\n[^\n]*DETAIL:  ((?:[^\n]*\n)(?:\t[^\n]*\n)*)',
          'gn') AS m
 LIMIT 500";
 
@@ -138,10 +145,15 @@ LIMIT 500";
 
         while (await reader.ReadAsync(cancellationToken))
         {
+            /* Ordinals track the query's four columns: stamp, zone, victim pid, DETAIL. The zone is
+               ordinal 1 and reaching the parser is what makes the stamp's meaning checked rather than
+               assumed; a non-zero-offset one throws out of here, and the worker records the refusal
+               against log_timezone instead of storing a shifted occurred_at. */
             var parsed = PgDeadlockLogParser.FromBlock(
                 reader.IsDBNull(0) ? string.Empty : reader.GetString(0),
                 reader.IsDBNull(1) ? string.Empty : reader.GetString(1),
-                reader.IsDBNull(2) ? null : reader.GetString(2));
+                reader.IsDBNull(2) ? string.Empty : reader.GetString(2),
+                reader.IsDBNull(3) ? null : reader.GetString(3));
 
             /* A block that will not parse is skipped rather than reported. The window is bounded, so a
                report cut in half at its edge is ordinary and is read whole on the next overlapping pass. */

--- a/PerformanceMonitor.Collectors/PgDeadlocksCollector.cs
+++ b/PerformanceMonitor.Collectors/PgDeadlocksCollector.cs
@@ -148,7 +148,10 @@ LIMIT 500";
             /* Ordinals track the query's four columns: stamp, zone, victim pid, DETAIL. The zone is
                ordinal 1 and reaching the parser is what makes the stamp's meaning checked rather than
                assumed; a non-zero-offset one throws out of here, and the worker records the refusal
-               against log_timezone instead of storing a shifted occurred_at. */
+               against log_timezone instead of storing a shifted occurred_at. The throw abandons rows
+               already read in this batch, which is the trade PgDeadlockLogParser.Extract's remarks argue
+               for: a partial history from a target declared unreadable is worse for the reader than a
+               refusal that says one thing. */
             var parsed = PgDeadlockLogParser.FromBlock(
                 reader.IsDBNull(0) ? string.Empty : reader.GetString(0),
                 reader.IsDBNull(1) ? string.Empty : reader.GetString(1),

--- a/PerformanceMonitor.Collectors/PgLogTimezoneUnsupportedException.cs
+++ b/PerformanceMonitor.Collectors/PgLogTimezoneUnsupportedException.cs
@@ -23,8 +23,9 @@ namespace PerformanceMonitor.Collectors;
 /// </para>
 ///
 /// <para><b>And why it is not simply skipped.</b> The parser tolerates everything else a block can be wrong
-/// about, because both transports read an OVERLAPPING window and a report cut at its edge is whole on the
-/// next pass. This is different in both directions: it does not clear itself, and the block PARSES — the
+/// about, because the <c>pg_read_file</c> transport re-reads an overlapping window and a report cut at its
+/// edge is whole on the next pass. This is different in both directions: it does not clear itself, and the
+/// block PARSES — the
 /// timestamp is well formed, the graph is intact, and the only thing wrong with the row is the moment it
 /// claims. Stored, it puts every deadlock in the wrong trend bucket and misaligns it against every
 /// UTC-keyed collection beside it, with nothing erroring anywhere. Dropped silently, it reads as a server

--- a/PerformanceMonitor.Collectors/PgLogTimezoneUnsupportedException.cs
+++ b/PerformanceMonitor.Collectors/PgLogTimezoneUnsupportedException.cs
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+
+namespace PerformanceMonitor.Collectors;
+
+/// <summary>
+/// The PostgreSQL server log is timestamped in a zone that is not UTC, so the deadlock reports in it cannot
+/// be stored (#2993).
+///
+/// <para><b>Why this refuses rather than converting.</b> The log prefix carries the zone as an
+/// ABBREVIATION, and abbreviations are ambiguous: <c>CST</c> is US Central, China Standard and Cuba
+/// Standard — three offsets and two hemispheres of daylight saving. There is no correct conversion to make
+/// from one, which is presumably why <see cref="PgDeadlockLogParser"/> captured the zone and never read
+/// it. What the token DOES answer exactly is whether the offset is zero, and that is the only question
+/// asked of it here: <c>occurred_at</c> is a naive UTC column, as every other collection on the server is.
+/// </para>
+///
+/// <para><b>And why it is not simply skipped.</b> The parser tolerates everything else a block can be wrong
+/// about, because both transports read an OVERLAPPING window and a report cut at its edge is whole on the
+/// next pass. This is different in both directions: it does not clear itself, and the block PARSES — the
+/// timestamp is well formed, the graph is intact, and the only thing wrong with the row is the moment it
+/// claims. Stored, it puts every deadlock in the wrong trend bucket and misaligns it against every
+/// UTC-keyed collection beside it, with nothing erroring anywhere. Dropped silently, it reads as a server
+/// with no deadlocks. Thrown, the runner records the store's non-fatal degradation status with a message
+/// naming <c>log_timezone</c> — a setting an operator can change, and on a managed fleet a parameter-group
+/// change.</para>
+/// </summary>
+public sealed class PgLogTimezoneUnsupportedException : Exception
+{
+    /// <summary>
+    /// The setting to change, named in one place so the message and any caller inspecting this cannot
+    /// disagree about which GUC is at fault.
+    /// </summary>
+    public const string SettingName = "log_timezone";
+
+    public PgLogTimezoneUnsupportedException(string? observedZone)
+        : base(BuildMessage(observedZone))
+        => ObservedZone = observedZone;
+
+    /// <summary>
+    /// The zone token the log prefix actually carried, kept alongside the message so a caller can log or
+    /// group on it without parsing prose back out.
+    /// </summary>
+    public string? ObservedZone { get; }
+
+    private static string BuildMessage(string? observedZone)
+    {
+        var zone = string.IsNullOrWhiteSpace(observedZone) ? "(none)" : observedZone.Trim();
+
+        return $"The PostgreSQL server log on this target is timestamped '{zone}', which is not a "
+            + $"zero-offset zone: {SettingName} is not UTC, so every timestamp in its deadlock reports is "
+            + "local time. Nothing was stored this cycle, and this is NOT 'no deadlocks were detected'. "
+            + "The reports are refused rather than shifted because a log-prefix zone is an ABBREVIATION "
+            + "and abbreviations are ambiguous — CST alone is three different zones — so there is no "
+            + "conversion to apply that would not be a guess, and a guess here produces plausible rows "
+            + $"stamped at the wrong moment. Set {SettingName} = 'UTC' on the target (on managed "
+            + "PostgreSQL that is a parameter-group change, and it takes effect on reload rather than "
+            + "needing a restart); the next collection cycle stores normally.";
+    }
+}


### PR DESCRIPTION
Part of #2993.

`PgDeadlockLogParser` captured the log prefix's timezone in a named group and read it nowhere, then put the naive timestamp through `DateTime.TryParse` with `AdjustToUniversal | AssumeUniversal`. On a target whose `log_timezone` is not UTC, every `occurred_at` was shifted by the zone offset with nothing erroring: trend buckets in the wrong hour, deadlock detail misaligned against every other UTC-keyed collection, plausible rows at the wrong moment. Measured against the parser with the check removed, an `EST`-stamped 22:25:24 line comes back as 22:25:24 `Kind=Utc` — five hours early — and `IST` and `+07` are wrong in the other direction by the same mechanism.

## What this does

**Option 3 from the issue, not option 2, and not from a `log_timezone` read.** The abbreviation is unusable for conversion — `CST` is three different zones, which is the good reason the capture was never wired up — but it answers "is this offset zero" exactly, and that is the only question `occurred_at` needs answered. PostgreSQL renders `%m` in `log_timezone` and prints that zone's abbreviation beside the stamp, so the captured token *is* the GUC as the server rendered it for the line being parsed. That makes it a better witness than `current_setting('log_timezone')` on two counts: it describes the line rather than the collector's connection at some later moment, and it needs no round trip, so it works identically on the RDS log-API transport, which receives log text and runs no SQL. On `Europe/London` the two even disagree for half the year — winter lines are stamped `GMT` and really are UTC, and a GUC read would refuse them.

A non-zero-offset prefix throws `PgLogTimezoneUnsupportedException`, which `DarlingWorker` records as **`PERMISSIONS`** with a message naming `log_timezone`, quoting the observed zone, saying the remedy, and saying outright that this is not "no deadlocks were detected". `PERMISSIONS` rather than `ERROR` for the reason the `FeatureDisabled` arm beside it gives: none of the store's five statuses means "this target is configured in a way this source cannot be read under", the cause is a setting an operator can change (a parameter-group change on a managed fleet, effective on reload), and `CollectorRuntimePrecondition`'s `PERMISSIONS` arm already frames the condition as satisfiable and re-derives it every read. Both transports land on the one arm — the `pg_read_file` route throws out of `ReadAsync`, the RDS route out of the ingestor's `Extract`.

Refusing rather than skipping is the point. This is the only intolerant thing in a deliberately tolerant parser: everything else a block can be wrong about is read whole on the next overlapping pass, while this neither clears itself nor announces itself. Returning null would have stored no deadlocks and read as a server that has none — the same silent-wrong one layer up.

### Why the allowlist is not just `UTC`

`GMT` and the numeric zero forms are in it deliberately, and the issue's own independent re-verification is what makes that concrete: across 16 sampled targets `log_timezone = UTC` comes from `source = configuration file` with `default_value = GMT` and `is_default = false`. So PostgreSQL's own compiled default here is `GMT` — a target that lost the configuration-file setting would render `GMT`, which is zero-offset and genuinely UTC. An allowlist of `UTC` alone would have refused it and taken deadlock capture away from a server that was never wrong. `UT` is deliberately absent for the mirror-image reason: it is not a zone PostgreSQL renders, and an over-long allowlist is the same silent-wrong defect as no check at all, arriving one entry at a time.

## The dead capture is now load-bearing

The `zone` group is read, and reading it is what the refusal is built on, so it can no longer be a thing someone "just uses" for a conversion.

## The zone token widens, in both patterns

`\w+` to `[^ \n]+`, in the C# pattern and in the collector's server-side `regexp_matches`. A zone with no abbreviation renders as a numeric offset (`+07`, `-03:30`), and `\w+` matches neither the sign nor the colon — so the whole block matched nothing and the server reported no deadlocks at all. Same category as the shifted stamp, silent in the other direction, and the one shape that would have escaped the new check by never reaching it. The collector's query now returns the zone as its own column (`log_zone_text`), which is what gives the SQL route anything to check.

Both are matched with a bracket-expression form the query already relies on in production (`[^\n]*`), rather than a new escape construct, since neither the .NET nor the PostgreSQL pattern can be run against a live server from here.

## Verification

Every new test was proved red first, one mutation at a time, against the real committed source:

| mutation | assertion that goes red |
|---|---|
| refusal removed from `FromBlock` | `RefusesAReportWhoseLogPrefixIsNotUtc_NamingTheSetting` — `Assert.Throws() Failure: No exception was thrown` (5 tests) |
| zone class narrowed back to `\w+` | `RefusesANumericNonZeroOffsetPrefix_RatherThanMatchingNothing(zone: "+07")` — no exception thrown; the probe prints `+07 -> 0 deadlocks` (7 tests) |
| reader ordinals left unshifted | `TheCollectorHandsTheParserItsFourColumnsInOrder` — `Assert.Single() Failure: The collection was empty` (1 test) |
| arm status changed to `ERROR` | `Worker_Records_A_NonUtc_Log_As_Permissions_Not_Error` (1 test) |
| collector query reverted | `The_Collector_Query_Returns_The_Prefix_Zone` (1 test) |

The non-UTC fixture is the captured report with only its prefix zone substituted. It is what makes any of this meaningful: the whole fleet is uniformly UTC, so a fixture carrying the captured zone passes identically whether the check exists or not.

`TheCollectorHandsTheParserItsFourColumnsInOrder` drives the real `ReadAsync` through a four-column fake reader, because the zone arrived as a new column in the middle of the list and a mis-ordinal would hand the parser the zone where it expects the victim pid — which parses as nothing, returns null, and drops every deadlock silently. An `Assert.Contains` on the query text cannot see that.

`Darling.Tests` and `Lite.Tests` are `net10.0-windows` and cannot run on macOS, so the real test files were compiled into throwaway `net10.0` xunit v3 hosts staged outside the repo: `Lite.Tests` 38 tests / 0 failed / 0 not run, `Darling.Tests` 2 / 0 / 0.

## The straddled window, raised in review

The throw is per block and unwinds `Extract`'s loop, so a window holding a non-UTC block **and** a readable UTC one abandons both. That is the trade rather than an oversight, and it is now documented at the throw and pinned by `AStraddledWindowRefusesTheWholeRead_NotJustTheOffendingBlock`, whose fixture puts the readable block FIRST so a catch-and-continue would return one deadlock and no exception (proved: it goes red on exactly that mutation).

Storing the UTC half would leave a partial history from a target just declared unreadable, with nothing in the data marking what is missing — a reader could not then tell a quiet server from a half-collected one, which is the failure this whole change exists to stop. One log has one `log_timezone` at any instant, so the mixed window only arises while a change to that setting straddles the read.

**What that costs is not the same on the two transports, and an earlier revision of this description and of the source claimed otherwise.** Review caught it and the claim is corrected in `eee73527a`. `PgDeadlocksCollector` re-reads an overlapping byte-window tail every cycle, so a straddled window there loses nothing permanently. The RDS log-API route is **consume-once**: `RdsLogSource.ReadNewestAsync` sets `_markers[key] = response.Marker` as a side effect of the fetch, before the parser is reached, so text the refusal abandons is not re-fetched for the life of that marker and the readable siblings in it are lost. **That loss is real and is not fixed here** — see Not covered.

## Not covered

The server-side `regexp_matches` change is unexercised here — no PostgreSQL target is reachable from this environment, and `Darling PostgreSQL tests` runs against a store rather than a monitored target. Its bracket-expression form is the one the query already uses, and the C# pattern it mirrors is tested directly.

`pg_deadlocks` log reads are denied fleet-wide on the managed path (filed separately), so both halves of this are unexercised in production today.

**The consume-once loss on the RDS transport is not fixed here, and it needs a decision that touches another lane.** The marker advance lives in `RdsLogSource.ReadNewestAsync`, which is #3002's active file, so the symmetric fix — do not persist the marker until the chunk's rows are written — is not mine to make unilaterally. The alternative is asymmetric and entirely in these files: give the consume-once route a non-throwing entry point that stores what parsed and reports the refusal, justified by the two routes' different read semantics rather than by preference. Both are real; the choice is a coordination call, and the mechanism is verified either way. It is latent today because the grant is denied fleet-wide, and it becomes live the moment that is restored.

This PR does not attempt an ARE-level validation of the server-side pattern against a live PostgreSQL from a development machine: there is no local PostgreSQL here, and the one read-only probe available (the monitoring store over SSM) was not reachable in this environment. The bracket-expression form is the one the shipped query already relies on in production, and the .NET pattern it mirrors is tested directly.

`PgPlanLogParser`, the sibling that shares the RDS transport, parses no timestamp out of the log prefix and stores none, so it does not carry this defect.
