### PR TITLE
Name the branch an absent AWS response collection came from (#2996)

### DIFF
--- a/Darling/Darling.Tests/RdsCpuIngestorTests.cs
+++ b/Darling/Darling.Tests/RdsCpuIngestorTests.cs
@@ -7,9 +7,11 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Amazon.RDS;
+using Amazon.RDS.Model;
 using Npgsql;
 using PerformanceMonitor.Darling.Service.Targets;
 using Xunit;
@@ -69,5 +71,81 @@ public class RdsCpuIngestorTests
             () => ingestor.IngestAsync(1, "srv", host));
 
         Assert.Contains("does not resolve to a stable instance", ex.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Its copy of <see cref="RdsLogSource"/>'s writer/instance resolution carries the same three named
+    /// branches, and reaches the runner with the branch in the message rather than the SDK's
+    /// <c>Value cannot be null. (Parameter 'source')</c> (#2996). Wrapped in
+    /// <see cref="PiMetricsUnavailableException"/> because <c>IngestAsync</c>'s tolerant catch owns
+    /// everything from the first AWS call onwards — which is exactly why the inner message has to be the
+    /// classified one: it is what the runner stores.
+    /// </summary>
+    [Theory]
+    [InlineData(true, false, false, "DescribeDBClusters returned no cluster")]
+    [InlineData(false, true, false, "reports no writer among its members")]
+    [InlineData(false, false, true, "DescribeDBInstances returned no instance")]
+    public async Task EachAbsentResolutionCollectionNamesItsOwnBranch(
+        bool omitClusters, bool omitMembers, bool omitInstances, string expected)
+    {
+        var ingestor = new RdsCpuIngestor(
+            UnusedDataSource(),
+            rdsClientFactory: _ => new FakeRds
+            {
+                OmitClusters = omitClusters,
+                OmitClusterMembers = omitMembers,
+                OmitInstances = omitInstances,
+            });
+
+        var ex = await Assert.ThrowsAsync<PiMetricsUnavailableException>(
+            () => ingestor.IngestAsync(1, "srv", "shared.cluster-abc123.us-east-1.rds.amazonaws.com"));
+
+        Assert.Contains(expected, ex.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("Value cannot be null", ex.Message, StringComparison.Ordinal);
+        Assert.False(ex.IsAuthorizationFailure);
+    }
+
+    /* Only the RDS half is faked: every case above throws inside ResolveWriterAsync or
+       ResolveDbiResourceIdAsync, both of which run before the watermark read, so no PI client and no store
+       connection are ever reached. The PI leg (an omitted MetricList, which means "no sample in this
+       window" and is coalesced to empty rather than raised) needs a real store for the watermark read and
+       is not covered here — the same gap this file's class comment already records for the write path. */
+    private sealed class FakeRds : AmazonRDSClient
+    {
+        public FakeRds() : base(new Amazon.Runtime.BasicAWSCredentials("a", "b"),
+            Amazon.RegionEndpoint.USEast1) { }
+
+        public bool OmitClusters { get; init; }
+        public bool OmitClusterMembers { get; init; }
+        public bool OmitInstances { get; init; }
+
+        public override Task<DescribeDBClustersResponse> DescribeDBClustersAsync(
+            DescribeDBClustersRequest request, CancellationToken cancellationToken = default)
+            => Task.FromResult(new DescribeDBClustersResponse
+            {
+                DBClusters = OmitClusters
+                    ? null
+                    : new List<DBCluster>
+                    {
+                        new()
+                        {
+                            DBClusterMembers = OmitClusterMembers
+                                ? null
+                                : new List<DBClusterMember>
+                                {
+                                    new() { DBInstanceIdentifier = "writer-1", IsClusterWriter = true },
+                                },
+                        },
+                    },
+            });
+
+        public override Task<DescribeDBInstancesResponse> DescribeDBInstancesAsync(
+            DescribeDBInstancesRequest request, CancellationToken cancellationToken = default)
+            => Task.FromResult(new DescribeDBInstancesResponse
+            {
+                DBInstances = OmitInstances
+                    ? null
+                    : new List<DBInstance> { new() { DbiResourceId = "db-EXAMPLE" } },
+            });
     }
 }

--- a/Darling/Darling.Tests/RdsLogSourceTests.cs
+++ b/Darling/Darling.Tests/RdsLogSourceTests.cs
@@ -44,11 +44,11 @@ public class RdsLogSourceTests
            production fleet past a green suite (#2996). */
         public bool OmitClusters { get; init; }
         public bool OmitClusterMembers { get; init; }
-        public bool OmitLogFiles { get; init; }
 
-        /// <summary>An empty-but-present list, which is the same FACT as an absent one and has to reach the
-        /// same named branch — pre-#2996 the two diverged, one crashing and one answering silently.</summary>
-        public bool EmptyLogFiles { get; init; }
+        /// <summary>Which of the three "nothing here to open" shapes the log-file list comes back in.
+        /// Absent, empty and present-but-unnamed are one fact and have to reach one named branch; they used
+        /// to diverge, the first crashing and the other two answering silently (#2996).</summary>
+        public string? LogFileShape { get; init; }
 
         public override Task<DescribeDBClustersResponse> DescribeDBClustersAsync(
             DescribeDBClustersRequest request, CancellationToken cancellationToken = default)
@@ -75,15 +75,17 @@ public class RdsLogSourceTests
             DescribeDBLogFilesRequest request, CancellationToken cancellationToken = default)
             => Task.FromResult(new DescribeDBLogFilesResponse
             {
-                DescribeDBLogFiles = OmitLogFiles
-                    ? null
-                    : EmptyLogFiles
-                        ? new List<DescribeDBLogFilesDetails>()
-                        : new List<DescribeDBLogFilesDetails>
-                        {
-                            new() { LogFileName = "error/postgresql.log.2026-08-09-01", LastWritten = 1000 },
-                            new() { LogFileName = LogName, LastWritten = 9999 },
-                        },
+                DescribeDBLogFiles = LogFileShape switch
+                {
+                    "absent" => null,
+                    "empty" => new List<DescribeDBLogFilesDetails>(),
+                    "unnamed" => new List<DescribeDBLogFilesDetails> { new() { LastWritten = 9999 } },
+                    _ => new List<DescribeDBLogFilesDetails>
+                    {
+                        new() { LogFileName = "error/postgresql.log.2026-08-09-01", LastWritten = 1000 },
+                        new() { LogFileName = LogName, LastWritten = 9999 },
+                    },
+                },
             });
 
         public override Task<DownloadDBLogFilePortionResponse> DownloadDBLogFilePortionAsync(
@@ -197,17 +199,20 @@ public class RdsLogSourceTests
     }
 
     /// <summary>
-    /// An instance that lists no PostgreSQL log file is NAMED, whether the SDK omitted the collection or
-    /// handed back an empty one. Both mean no log was opened, and neither may reach the runner as
-    /// <c>Value cannot be null. (Parameter 'source')</c> — the whole message the null form produced on a
-    /// live fleet, which names no call, no branch and no instance (#2996).
+    /// An instance with no openable PostgreSQL log file is NAMED, in all three shapes the answer arrives
+    /// in: the SDK omitted the collection, it came back empty, or its newest entry carries no filename.
+    /// All three mean no log was opened, and none may reach the runner as <c>Value cannot be null.
+    /// (Parameter 'source')</c> — the whole message the absent form produced on a live fleet, which names
+    /// no call, no branch and no instance (#2996) — nor as a silent empty read, which the runner stamps
+    /// with a sentence about a log's contents.
     /// </summary>
     [Theory]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    public async Task AnInstanceListingNoPostgresLogFileIsNamed(bool omit, bool empty)
+    [InlineData("absent")]
+    [InlineData("empty")]
+    [InlineData("unnamed")]
+    public async Task AnInstanceListingNoPostgresLogFileIsNamed(string shape)
     {
-        var (source, client) = Build(new FakeRds { OmitLogFiles = omit, EmptyLogFiles = empty });
+        var (source, client) = Build(new FakeRds { LogFileShape = shape });
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
             () => source.ReadNewestAsync("solo.abc123.us-east-1.rds.amazonaws.com"));

--- a/Darling/Darling.Tests/RdsLogSourceTests.cs
+++ b/Darling/Darling.Tests/RdsLogSourceTests.cs
@@ -38,16 +38,18 @@ public class RdsLogSourceTests
         public string LogName { get; init; } = "error/postgresql.log.2026-08-25-18";
         public string? NextMarker { get; set; } = "MARKER-1";
 
-        /* The three shapes a real answer takes that the populated fixtures above cannot produce. The AWS SDK
-           leaves a response collection NULL rather than empty when the service omits it, so every fixture
-           that sets its lists exercises only the populated half — which is why a null-source crash reached a
-           production fleet past a green suite (#2996). */
+        /* The answers the populated fixtures above cannot produce. The AWS SDK leaves a response collection
+           NULL rather than empty when the service omits it, so a fixture that sets all its lists exercises
+           only the populated half — which is why a null-source crash reached a production fleet past a
+           green suite (#2996). */
         public bool OmitClusters { get; init; }
         public bool OmitClusterMembers { get; init; }
 
-        /// <summary>Which of the three "nothing here to open" shapes the log-file list comes back in.
-        /// Absent, empty and present-but-unnamed are one fact and have to reach one named branch; they used
-        /// to diverge, the first crashing and the other two answering silently (#2996).</summary>
+        /// <summary>Which shape the log-file list comes back in. <c>absent</c>, <c>empty</c> and
+        /// <c>unnamed</c> are one fact — nothing here to open — and have to reach one named branch; they
+        /// used to diverge, the first crashing and the other two answering silently (#2996).
+        /// <c>unnamed-newest</c> is the opposite case and the positive control: a nameless entry sitting
+        /// beside real logs, which must still be read.</summary>
         public string? LogFileShape { get; init; }
 
         public override Task<DescribeDBClustersResponse> DescribeDBClustersAsync(
@@ -284,7 +286,7 @@ public class RdsLogSourceTests
     }
 
     /// <summary>
-    /// The SDK contract the three guards above exist for, pinned rather than remembered: a response
+    /// The SDK contract the guards above exist for, pinned rather than remembered: a response
     /// collection is <c>null</c> when the service omits it, and LINQ over one names only <c>source</c>.
     /// An SDK upgrade that went back to empty collections would make the guards look like dead defence;
     /// this says they are not.

--- a/Darling/Darling.Tests/RdsLogSourceTests.cs
+++ b/Darling/Darling.Tests/RdsLogSourceTests.cs
@@ -8,10 +8,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Amazon.RDS;
 using Amazon.RDS.Model;
+using Npgsql;
 using PerformanceMonitor.Collectors;
 
 using PerformanceMonitor.Darling.Service.Targets;
@@ -36,32 +38,52 @@ public class RdsLogSourceTests
         public string LogName { get; init; } = "error/postgresql.log.2026-08-25-18";
         public string? NextMarker { get; set; } = "MARKER-1";
 
+        /* The three shapes a real answer takes that the populated fixtures above cannot produce. The AWS SDK
+           leaves a response collection NULL rather than empty when the service omits it, so every fixture
+           that sets its lists exercises only the populated half — which is why a null-source crash reached a
+           production fleet past a green suite (#2996). */
+        public bool OmitClusters { get; init; }
+        public bool OmitClusterMembers { get; init; }
+        public bool OmitLogFiles { get; init; }
+
+        /// <summary>An empty-but-present list, which is the same FACT as an absent one and has to reach the
+        /// same named branch — pre-#2996 the two diverged, one crashing and one answering silently.</summary>
+        public bool EmptyLogFiles { get; init; }
+
         public override Task<DescribeDBClustersResponse> DescribeDBClustersAsync(
             DescribeDBClustersRequest request, CancellationToken cancellationToken = default)
             => Task.FromResult(new DescribeDBClustersResponse
             {
-                DBClusters = new List<DBCluster>
-                {
-                    new()
+                DBClusters = OmitClusters
+                    ? null
+                    : new List<DBCluster>
                     {
-                        DBClusterMembers = new List<DBClusterMember>
+                        new()
                         {
-                            new() { DBInstanceIdentifier = "reader-1", IsClusterWriter = false },
-                            new() { DBInstanceIdentifier = WriterId ?? "writer-1", IsClusterWriter = true },
+                            DBClusterMembers = OmitClusterMembers
+                                ? null
+                                : new List<DBClusterMember>
+                                {
+                                    new() { DBInstanceIdentifier = "reader-1", IsClusterWriter = false },
+                                    new() { DBInstanceIdentifier = WriterId ?? "writer-1", IsClusterWriter = true },
+                                },
                         },
                     },
-                },
             });
 
         public override Task<DescribeDBLogFilesResponse> DescribeDBLogFilesAsync(
             DescribeDBLogFilesRequest request, CancellationToken cancellationToken = default)
             => Task.FromResult(new DescribeDBLogFilesResponse
             {
-                DescribeDBLogFiles = new List<DescribeDBLogFilesDetails>
-                {
-                    new() { LogFileName = "error/postgresql.log.2026-08-09-01", LastWritten = 1000 },
-                    new() { LogFileName = LogName, LastWritten = 9999 },
-                },
+                DescribeDBLogFiles = OmitLogFiles
+                    ? null
+                    : EmptyLogFiles
+                        ? new List<DescribeDBLogFilesDetails>()
+                        : new List<DescribeDBLogFilesDetails>
+                        {
+                            new() { LogFileName = "error/postgresql.log.2026-08-09-01", LastWritten = 1000 },
+                            new() { LogFileName = LogName, LastWritten = 9999 },
+                        },
             });
 
         public override Task<DownloadDBLogFilePortionResponse> DownloadDBLogFilePortionAsync(
@@ -172,6 +194,133 @@ public class RdsLogSourceTests
 
         Assert.Null(await source.ReadNewestAsync("db.internal.example.com"));
         Assert.Empty(client.Downloads);
+    }
+
+    /// <summary>
+    /// An instance that lists no PostgreSQL log file is NAMED, whether the SDK omitted the collection or
+    /// handed back an empty one. Both mean no log was opened, and neither may reach the runner as
+    /// <c>Value cannot be null. (Parameter 'source')</c> — the whole message the null form produced on a
+    /// live fleet, which names no call, no branch and no instance (#2996).
+    /// </summary>
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public async Task AnInstanceListingNoPostgresLogFileIsNamed(bool omit, bool empty)
+    {
+        var (source, client) = Build(new FakeRds { OmitLogFiles = omit, EmptyLogFiles = empty });
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => source.ReadNewestAsync("solo.abc123.us-east-1.rds.amazonaws.com"));
+
+        Assert.Contains("listed no PostgreSQL server log file", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("solo", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("NO LOG WAS OPENED", ex.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("Value cannot be null", ex.Message, StringComparison.Ordinal);
+
+        /* And nothing was downloaded — the branch is decided before a byte is asked for. */
+        Assert.Empty(client.Downloads);
+    }
+
+    /// <summary>
+    /// A cluster the API returns nothing for gets the "was not found" answer that was already written for
+    /// it. It was unreachable: the SDK's absent collection made LINQ raise first, so a target pointed at a
+    /// cluster that does not exist reported the same seven words as a failover.
+    /// </summary>
+    [Fact]
+    public async Task AnAbsentClusterListNamesTheMissingCluster()
+    {
+        var (source, _) = Build(new FakeRds { OmitClusters = true });
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => source.ReadNewestAsync("shared.cluster-abc123.us-east-1.rds.amazonaws.com"));
+
+        Assert.Contains("was not found", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("DescribeDBClusters returned no cluster", ex.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("Value cannot be null", ex.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A cluster with no member list is the FAILOVER answer, and it says so — the distinction the
+    /// "was not found" message above must not absorb, because one is worth retrying and the other is a
+    /// target to repoint.
+    /// </summary>
+    [Fact]
+    public async Task AClusterWithNoMemberListReportsTheFailoverState()
+    {
+        var (source, _) = Build(new FakeRds { OmitClusterMembers = true });
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => source.ReadNewestAsync("shared.cluster-abc123.us-east-1.rds.amazonaws.com"));
+
+        Assert.Contains("reports no writer", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("during a failover", ex.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("Value cannot be null", ex.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The SDK contract the three guards above exist for, pinned rather than remembered: a response
+    /// collection is <c>null</c> when the service omits it, and LINQ over one names only <c>source</c>.
+    /// An SDK upgrade that went back to empty collections would make the guards look like dead defence;
+    /// this says they are not.
+    /// </summary>
+    [Fact]
+    public void AnOmittedResponseCollectionIsNullAndLinqOverItNamesOnlySource()
+    {
+        Assert.Null(new DescribeDBLogFilesResponse().DescribeDBLogFiles);
+        Assert.Null(new DescribeDBClustersResponse().DBClusters);
+        Assert.Null(new DBCluster().DBClusterMembers);
+        Assert.Null(new DescribeDBInstancesResponse().DBInstances);
+
+        var ex = Assert.Throws<ArgumentNullException>(
+            () => new DescribeDBLogFilesResponse().DescribeDBLogFiles.FirstOrDefault());
+
+        Assert.Equal("source", ex.ParamName);
+        Assert.Equal("Value cannot be null. (Parameter 'source')", ex.Message);
+    }
+}
+
+/// <summary>
+/// What the deadlock ingestor hands the runner for each of <see cref="RdsLogSource"/>'s named branches —
+/// the layer that decides what <c>collection_log</c> says (#2996).
+///
+/// <para>The classification matters as much as the message. <c>IsAuthorizationFailure</c> false is what
+/// keeps a transient log-file absence out of the PERMISSIONS bucket, whose text tells an operator to go
+/// add an IAM grant; and the message is what the runner stores, so it is the difference between a row that
+/// names the instance and the branch and a row reading only <c>Value cannot be null. (Parameter
+/// 'source')</c>.</para>
+/// </summary>
+public class RdsDeadlockBranchClassificationTests
+{
+    private sealed class FakeRds : AmazonRDSClient
+    {
+        public FakeRds() : base(new Amazon.Runtime.BasicAWSCredentials("a", "b"),
+            Amazon.RegionEndpoint.USEast1) { }
+
+        public override Task<DescribeDBLogFilesResponse> DescribeDBLogFilesAsync(
+            DescribeDBLogFilesRequest request, CancellationToken cancellationToken = default)
+            => Task.FromResult(new DescribeDBLogFilesResponse());
+    }
+
+    /* Never opened: IngestAsync reads the log before it touches the store, and this branch throws there.
+       NpgsqlDataSource.Create does not connect eagerly, the same stand-in RdsCpuIngestorTests uses. */
+    private static NpgsqlDataSource UnusedDataSource()
+        => NpgsqlDataSource.Create("Host=localhost;Port=1;Database=unused");
+
+    [Fact]
+    public async Task AnAbsentLogFileListReachesTheRunnerNamedAndNotAsAPermissionsSkip()
+    {
+        var ingestor = new RdsDeadlockIngestor(
+            UnusedDataSource(), new RdsLogSource(_ => new FakeRds()));
+
+        var ex = await Assert.ThrowsAsync<RdsLogUnavailableException>(
+            () => ingestor.IngestAsync(1, "srv", "solo.abc123.us-east-1.rds.amazonaws.com"));
+
+        Assert.Contains("listed no PostgreSQL server log file", ex.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("Value cannot be null", ex.Message, StringComparison.Ordinal);
+
+        /* Not an authorization refusal, so the runner does not append the "the role needs
+           rds:DescribeDBLogFiles" sentence to a fault no grant fixes. */
+        Assert.False(ex.IsAuthorizationFailure);
     }
 }
 

--- a/Darling/Darling.Tests/RdsLogSourceTests.cs
+++ b/Darling/Darling.Tests/RdsLogSourceTests.cs
@@ -80,6 +80,11 @@ public class RdsLogSourceTests
                     "absent" => null,
                     "empty" => new List<DescribeDBLogFilesDetails>(),
                     "unnamed" => new List<DescribeDBLogFilesDetails> { new() { LastWritten = 9999 } },
+                    "unnamed-newest" => new List<DescribeDBLogFilesDetails>
+                    {
+                        new() { LogFileName = LogName, LastWritten = 1000 },
+                        new() { LastWritten = 9999 },
+                    },
                     _ => new List<DescribeDBLogFilesDetails>
                     {
                         new() { LogFileName = "error/postgresql.log.2026-08-09-01", LastWritten = 1000 },
@@ -224,6 +229,22 @@ public class RdsLogSourceTests
 
         /* And nothing was downloaded — the branch is decided before a byte is asked for. */
         Assert.Empty(client.Downloads);
+    }
+
+    /// <summary>
+    /// The positive control for the test above, and the reason the read looks for the newest NAMED file
+    /// rather than the newest one: a nameless entry alongside real ones is not "nothing to open", so it
+    /// falls through to the newest file that can be named instead of refusing a log that is right there.
+    /// Without this the three refusals above would pass just as well over a read that refused everything.
+    /// </summary>
+    [Fact]
+    public async Task ANamelessNewestEntryFallsThroughToTheNewestNamedFile()
+    {
+        var (source, client) = Build(new FakeRds { LogFileShape = "unnamed-newest" });
+
+        await source.ReadNewestAsync("solo.abc123.us-east-1.rds.amazonaws.com");
+
+        Assert.Equal("error/postgresql.log.2026-08-25-18", client.Downloads[0].LogFileName);
     }
 
     /// <summary>

--- a/Darling/Darling.Tests/RdsLogSourceTests.cs
+++ b/Darling/Darling.Tests/RdsLogSourceTests.cs
@@ -229,6 +229,12 @@ public class RdsLogSourceTests
         Assert.Contains("NO LOG WAS OPENED", ex.Message, StringComparison.Ordinal);
         Assert.DoesNotContain("Value cannot be null", ex.Message, StringComparison.Ordinal);
 
+        /* The text and the band have to agree. This lands as ERROR through the runner's generic arm, so
+           the message has to say that rather than imply the softer treatment an IAM denial gets — a
+           sentence promising one classification while the row carries another is the contradiction
+           CollectorRuntimePrecondition's own doc comment exists to record. */
+        Assert.Contains("records as a collection ERROR", ex.Message, StringComparison.Ordinal);
+
         /* And nothing was downloaded — the branch is decided before a byte is asked for. */
         Assert.Empty(client.Downloads);
     }
@@ -344,6 +350,7 @@ public class RdsDeadlockBranchClassificationTests
             () => ingestor.IngestAsync(1, "srv", "solo.abc123.us-east-1.rds.amazonaws.com"));
 
         Assert.Contains("listed no PostgreSQL server log file", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("records as a collection ERROR", ex.Message, StringComparison.Ordinal);
         Assert.DoesNotContain("Value cannot be null", ex.Message, StringComparison.Ordinal);
 
         /* Not an authorization refusal, so the runner does not append the "the role needs

--- a/Darling/PerformanceMonitor.Darling.Service/Targets/RdsCpuIngestor.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Targets/RdsCpuIngestor.cs
@@ -132,8 +132,15 @@ public sealed class RdsCpuIngestor
                 },
                 cancellationToken);
 
-            dataPoints = response.MetricList
-                .SelectMany(m => m.DataPoints)
+            /* Absent and empty mean the same thing coming out of PI — no sample in this window — and the
+               caller already names that outcome ("no new Performance Insights CPU samples this cycle"), so
+               an empty sequence is the honest reading of a null here. It is NOT the honest reading of an
+               absent RDS log-file list, where "no file" means nothing was opened at all; see
+               RdsLogSource.NewestLogFileAsync for why that branch raises instead. Both collections are null
+               rather than empty when the service omits them, and LINQ over either raises
+               ArgumentNullException whose whole message is "Value cannot be null. (Parameter 'source')". */
+            dataPoints = (response.MetricList ?? [])
+                .SelectMany(m => m.DataPoints ?? [])
                 /* PI returns a data point with a null Value for a period it has no sample for — nothing to
                    store, and Value.HasValue is required below so the row is never null-cast. */
                 .Where(p => p.Timestamp.HasValue && p.Value.HasValue
@@ -166,20 +173,24 @@ public sealed class RdsCpuIngestor
     /// <summary>Identical resolution to <see cref="RdsLogSource"/>'s own — kept as a separate copy rather
     /// than shared, matching this codebase's existing precedent of each RDS-API ingestor owning its own
     /// AWS calls end to end (see <see cref="RdsDeadlockIngestor"/>'s doc comment on why it holds its own
-    /// <see cref="RdsLogSource"/> rather than sharing one).</summary>
+    /// <see cref="RdsLogSource"/> rather than sharing one). That includes the null tests: a response
+    /// collection the service omitted arrives as null, and LINQ over one raises an ArgumentNullException
+    /// naming only "source", so each null goes into the message describing its own branch.</summary>
     private static async Task<string> ResolveWriterAsync(
         IAmazonRDS client, string clusterId, CancellationToken cancellationToken)
     {
         var clusters = await client.DescribeDBClustersAsync(
             new DescribeDBClustersRequest { DBClusterIdentifier = clusterId }, cancellationToken);
 
-        var cluster = clusters.DBClusters.FirstOrDefault()
-            ?? throw new InvalidOperationException($"Aurora cluster '{clusterId}' was not found.");
-
-        var writer = cluster.DBClusterMembers.FirstOrDefault(m => m.IsClusterWriter == true)
+        var cluster = clusters.DBClusters?.FirstOrDefault()
             ?? throw new InvalidOperationException(
-                $"Aurora cluster '{clusterId}' reports no writer. That is a real state during a failover, "
-                + "so this is worth retrying rather than treating as a configuration error.");
+                $"Aurora cluster '{clusterId}' was not found: DescribeDBClusters returned no cluster for it.");
+
+        var writer = cluster.DBClusterMembers?.FirstOrDefault(m => m.IsClusterWriter == true)
+            ?? throw new InvalidOperationException(
+                $"Aurora cluster '{clusterId}' reports no writer among its members. That is a real state "
+                + "during a failover, so this is worth retrying rather than treating as a configuration "
+                + "error.");
 
         return writer.DBInstanceIdentifier;
     }
@@ -195,8 +206,10 @@ public sealed class RdsCpuIngestor
         var instances = await client.DescribeDBInstancesAsync(
             new DescribeDBInstancesRequest { DBInstanceIdentifier = instanceId }, cancellationToken);
 
-        var instance = instances.DBInstances.FirstOrDefault()
-            ?? throw new InvalidOperationException($"RDS/Aurora instance '{instanceId}' was not found.");
+        var instance = instances.DBInstances?.FirstOrDefault()
+            ?? throw new InvalidOperationException(
+                $"RDS/Aurora instance '{instanceId}' was not found: DescribeDBInstances returned no "
+                + "instance for it.");
 
         return instance.DbiResourceId
             ?? throw new InvalidOperationException($"RDS/Aurora instance '{instanceId}' reports no DbiResourceId.");

--- a/Darling/PerformanceMonitor.Darling.Service/Targets/RdsLogSource.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Targets/RdsLogSource.cs
@@ -131,19 +131,31 @@ public sealed class RdsLogSource
             return new LogChunk(response.LogFileData ?? string.Empty, response.AdditionalDataPending == true);
     }
 
+    /* An AWS SDK response collection is NULL when the service omitted it, not an empty list, so the two
+       null tests below are the ordinary path rather than defence: DescribeDBClusters answers with no
+       DBClusters element when it matched nothing, and DBClusterMembers is absent on a cluster reporting no
+       members. LINQ over either raises ArgumentNullException, whose entire message is "Value cannot be
+       null. (Parameter 'source')" — seven words naming neither the call nor the branch, and it lands in
+       collection_log as a raw ERROR.
+
+       Each null is therefore routed into the message that already says what THAT branch means, rather than
+       coalesced to an empty sequence: "this cluster does not exist" is a target pointed somewhere wrong and
+       "this cluster has no writer" is a failover in progress, and the two have opposite responses. */
     private static async Task<string> ResolveWriterAsync(
         IAmazonRDS client, string clusterId, CancellationToken cancellationToken)
     {
         var clusters = await client.DescribeDBClustersAsync(
             new DescribeDBClustersRequest { DBClusterIdentifier = clusterId }, cancellationToken);
 
-        var cluster = clusters.DBClusters.FirstOrDefault()
-            ?? throw new InvalidOperationException($"Aurora cluster '{clusterId}' was not found.");
-
-        var writer = cluster.DBClusterMembers.FirstOrDefault(m => m.IsClusterWriter == true)
+        var cluster = clusters.DBClusters?.FirstOrDefault()
             ?? throw new InvalidOperationException(
-                $"Aurora cluster '{clusterId}' reports no writer. That is a real state during a failover, "
-                + "so this is worth retrying rather than treating as a configuration error.");
+                $"Aurora cluster '{clusterId}' was not found: DescribeDBClusters returned no cluster for it.");
+
+        var writer = cluster.DBClusterMembers?.FirstOrDefault(m => m.IsClusterWriter == true)
+            ?? throw new InvalidOperationException(
+                $"Aurora cluster '{clusterId}' reports no writer among its members. That is a real state "
+                + "during a failover, so this is worth retrying rather than treating as a configuration "
+                + "error.");
 
         return writer.DBInstanceIdentifier;
     }
@@ -152,6 +164,14 @@ public sealed class RdsLogSource
     /// The newest PostgreSQL log file. Filtered by name because an instance's log list also carries
     /// upgrade and other logs, and sorted by last-written rather than by name — the filename embeds a
     /// timestamp, but sorting text would order 2026-08-9 after 2026-08-10.
+    ///
+    /// <para><b>An instance that lists no PostgreSQL log file raises rather than answering "nothing".</b>
+    /// A caller can act on two outcomes — the log was opened and held nothing new, or no log was opened —
+    /// and only the first licenses the "no new … in the RDS log window" note the runner stamps on a
+    /// zero-row cycle, which is a claim about the log's CONTENTS. Answering an absent file list with a
+    /// silent empty read is the #2633 confusion arriving by a second route. A stopped instance, one still
+    /// being created, and one whose logs have just rotated all answer this way, so the message says it is
+    /// worth retrying rather than sending anyone to look for a grant.</para>
     /// </summary>
     private static async Task<string?> NewestLogFileAsync(
         IAmazonRDS client, string instanceId, CancellationToken cancellationToken)
@@ -163,6 +183,20 @@ public sealed class RdsLogSource
                 FilenameContains = "postgresql",
             },
             cancellationToken);
+
+        /* Absent and empty are the same fact here, and both have to be caught BEFORE the LINQ: the SDK
+           omits the collection entirely on an answer that carried no file, so ordering a null throws
+           ArgumentNullException and buries this branch behind "Value cannot be null. (Parameter
+           'source')". */
+        if (files.DescribeDBLogFiles is not { Count: > 0 })
+        {
+            throw new InvalidOperationException(
+                $"RDS listed no PostgreSQL server log file for instance '{instanceId}': DescribeDBLogFiles "
+                + "filtered on 'postgresql' returned nothing. NO LOG WAS OPENED this cycle, so this is not "
+                + "an empty log — whatever this window held is unread. An instance that is stopped, still "
+                + "being created, or has just rotated its logs answers this way, so it is worth retrying "
+                + "rather than treating as a configuration error.");
+        }
 
         return files.DescribeDBLogFiles
             .OrderByDescending(f => f.LastWritten)

--- a/Darling/PerformanceMonitor.Darling.Service/Targets/RdsLogSource.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Targets/RdsLogSource.cs
@@ -165,8 +165,11 @@ public sealed class RdsLogSource
     /// was opened — and only the first licenses the "no new … in the RDS log window" note the runner stamps
     /// on a zero-row cycle, which is a claim about the log's CONTENTS. Answering with a silent empty read
     /// is the #2633 confusion arriving by a second route. A stopped instance, one still being created, and
-    /// one whose logs have just rotated all answer this way, so the message says it is worth retrying
-    /// rather than sending anyone to look for a grant.</para>
+    /// one whose logs have just rotated all answer this way and clear on the first cycle that finds a
+    /// log, and the message says so rather than sending anyone to look for a grant. It stays a loud
+    /// ERROR either way — the store's rule for an unclassified failure, and the band a target nobody
+    /// can read should carry, because the alternative on this fleet is the quiet blindness #2994 is
+    /// about.</para>
     ///
     /// <para>Total, therefore, rather than nullable: an empty list, an omitted one, and a newest entry
     /// carrying no filename are one fact — there is nothing here to open — and a null return would have the
@@ -195,8 +198,10 @@ public sealed class RdsLogSource
             ?? throw new InvalidOperationException(
                 $"RDS listed no PostgreSQL server log file for instance '{instanceId}': DescribeDBLogFiles "
                 + "filtered on 'postgresql' returned nothing it could name. NO LOG WAS OPENED this cycle, "
-                + "so this is not an empty log — whatever this window held is unread. An instance that is "
-                + "stopped, still being created, or has just rotated its logs answers this way, so it is "
-                + "worth retrying rather than treating as a configuration error.");
+                + "so this is not an empty log — whatever this window held is unread. This records as a "
+                + "collection ERROR and not as a permissions skip, because no grant fixes it: an instance "
+                + "that is stopped, still being created, or has just rotated its logs answers this way and "
+                + "clears itself on the first cycle that finds a log, while one that keeps answering this "
+                + "way is a target nobody can read and wants a decision rather than silence.");
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Service/Targets/RdsLogSource.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Targets/RdsLogSource.cs
@@ -183,17 +183,15 @@ public sealed class RdsLogSource
             },
             cancellationToken);
 
-        /* The null test comes BEFORE the LINQ because it has to: the SDK omits the collection entirely on
-           an answer that carried no file, so ordering a null raises ArgumentNullException and buries this
-           branch behind "Value cannot be null. (Parameter 'source')". */
-        var newest = files.DescribeDBLogFiles is null
-            ? null
-            : files.DescribeDBLogFiles
-                .OrderByDescending(f => f.LastWritten)
-                .Select(f => f.LogFileName)
-                .FirstOrDefault(name => !string.IsNullOrEmpty(name));
-
-        return newest
+        /* The null-conditional is load bearing, as in ResolveWriterAsync above: the SDK omits the
+           collection entirely on an answer that carried no file, so ordering a null raises
+           ArgumentNullException and buries this branch behind "Value cannot be null. (Parameter
+           'source')". It short-circuits the whole chain, so absent and empty both arrive as null and reach
+           the one message below. */
+        return files.DescribeDBLogFiles?
+            .OrderByDescending(f => f.LastWritten)
+            .Select(f => f.LogFileName)
+            .FirstOrDefault(name => !string.IsNullOrEmpty(name))
             ?? throw new InvalidOperationException(
                 $"RDS listed no PostgreSQL server log file for instance '{instanceId}': DescribeDBLogFiles "
                 + "filtered on 'postgresql' returned nothing it could name. NO LOG WAS OPENED this cycle, "

--- a/Darling/PerformanceMonitor.Darling.Service/Targets/RdsLogSource.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Targets/RdsLogSource.cs
@@ -98,11 +98,6 @@ public sealed class RdsLogSource
 
         var newest = await NewestLogFileAsync(client, instanceId, cancellationToken);
 
-        if (newest is null)
-        {
-            return new LogChunk(string.Empty, false);
-        }
-
         var key = instanceId + "|" + newest;
         _markers.TryGetValue(key, out var marker);
 
@@ -165,15 +160,19 @@ public sealed class RdsLogSource
     /// upgrade and other logs, and sorted by last-written rather than by name — the filename embeds a
     /// timestamp, but sorting text would order 2026-08-9 after 2026-08-10.
     ///
-    /// <para><b>An instance that lists no PostgreSQL log file raises rather than answering "nothing".</b>
-    /// A caller can act on two outcomes — the log was opened and held nothing new, or no log was opened —
-    /// and only the first licenses the "no new … in the RDS log window" note the runner stamps on a
-    /// zero-row cycle, which is a claim about the log's CONTENTS. Answering an absent file list with a
-    /// silent empty read is the #2633 confusion arriving by a second route. A stopped instance, one still
-    /// being created, and one whose logs have just rotated all answer this way, so the message says it is
-    /// worth retrying rather than sending anyone to look for a grant.</para>
+    /// <para><b>An instance with no openable PostgreSQL log file raises rather than answering
+    /// "nothing".</b> A caller can act on two outcomes — the log was opened and held nothing new, or no log
+    /// was opened — and only the first licenses the "no new … in the RDS log window" note the runner stamps
+    /// on a zero-row cycle, which is a claim about the log's CONTENTS. Answering with a silent empty read
+    /// is the #2633 confusion arriving by a second route. A stopped instance, one still being created, and
+    /// one whose logs have just rotated all answer this way, so the message says it is worth retrying
+    /// rather than sending anyone to look for a grant.</para>
+    ///
+    /// <para>Total, therefore, rather than nullable: an empty list, an omitted one, and a newest entry
+    /// carrying no filename are one fact — there is nothing here to open — and a null return would have the
+    /// caller decide that again, which is where the silent empty read came from.</para>
     /// </summary>
-    private static async Task<string?> NewestLogFileAsync(
+    private static async Task<string> NewestLogFileAsync(
         IAmazonRDS client, string instanceId, CancellationToken cancellationToken)
     {
         var files = await client.DescribeDBLogFilesAsync(
@@ -184,23 +183,22 @@ public sealed class RdsLogSource
             },
             cancellationToken);
 
-        /* Absent and empty are the same fact here, and both have to be caught BEFORE the LINQ: the SDK
-           omits the collection entirely on an answer that carried no file, so ordering a null throws
-           ArgumentNullException and buries this branch behind "Value cannot be null. (Parameter
-           'source')". */
-        if (files.DescribeDBLogFiles is not { Count: > 0 })
-        {
-            throw new InvalidOperationException(
-                $"RDS listed no PostgreSQL server log file for instance '{instanceId}': DescribeDBLogFiles "
-                + "filtered on 'postgresql' returned nothing. NO LOG WAS OPENED this cycle, so this is not "
-                + "an empty log — whatever this window held is unread. An instance that is stopped, still "
-                + "being created, or has just rotated its logs answers this way, so it is worth retrying "
-                + "rather than treating as a configuration error.");
-        }
+        /* The null test comes BEFORE the LINQ because it has to: the SDK omits the collection entirely on
+           an answer that carried no file, so ordering a null raises ArgumentNullException and buries this
+           branch behind "Value cannot be null. (Parameter 'source')". */
+        var newest = files.DescribeDBLogFiles is null
+            ? null
+            : files.DescribeDBLogFiles
+                .OrderByDescending(f => f.LastWritten)
+                .Select(f => f.LogFileName)
+                .FirstOrDefault(name => !string.IsNullOrEmpty(name));
 
-        return files.DescribeDBLogFiles
-            .OrderByDescending(f => f.LastWritten)
-            .Select(f => f.LogFileName)
-            .FirstOrDefault();
+        return newest
+            ?? throw new InvalidOperationException(
+                $"RDS listed no PostgreSQL server log file for instance '{instanceId}': DescribeDBLogFiles "
+                + "filtered on 'postgresql' returned nothing it could name. NO LOG WAS OPENED this cycle, "
+                + "so this is not an empty log — whatever this window held is unread. An instance that is "
+                + "stopped, still being created, or has just rotated its logs answers this way, so it is "
+                + "worth retrying rather than treating as a configuration error.");
     }
 }


### PR DESCRIPTION
Part of #2996.

## What produced the null

An AWS SDK response collection is **null when the service omitted it**, not an empty list. **Seven** sites applied a LINQ operator directly to one, and every one of them raises `ArgumentNullException` whose entire message is `Value cannot be null. (Parameter 'source')` — the seven words #2996 reports, stored raw in `collection_log` as an `ERROR`.

Measured against the pinned packages (AWSSDK.RDS 4.0.104.4, AWSSDK.PI 4.0.100.11) rather than assumed: `DescribeDBLogFilesResponse.DescribeDBLogFiles`, `DescribeDBClustersResponse.DBClusters`, `DBCluster.DBClusterMembers`, `DescribeDBInstancesResponse.DBInstances`, `GetResourceMetricsResponse.MetricList` and `MetricKeyDataPoints.DataPoints` all default to `null`, and a LINQ operator applied to each one produces that message byte for byte. `RdsLogSourceTests.AnOmittedResponseCollectionIsNullAndLinqOverItNamesOnlySource` pins that contract so an SDK upgrade back to empty collections does not leave the guards looking like dead defence.

An eighth site is in the same category but does **not** produce those seven words, and the claim is narrowed rather than rounded up: `m.DataPoints` sits inside a `SelectMany` selector, so a null there is `foreach`-ed rather than passed as `source` and raises `NullReferenceException: Object reference not set to an instance of an object.` — measured, same probe. It is guarded with the rest.

Completeness is bounded by census rather than by grep: exactly **four** files in the repository reference the SDK and two of them are tests, so both non-test files were read end to end. A line-scoped `grep` for the pattern finds only 5 of the 8 sites — two are split across lines and one is the nested selector — which is why the file census carries the argument. The negative sweep after the fix is empty apart from the deliberate throw inside the contract pin, and the same regex fires on all five it can see in the pre-fix blobs, so that empty is real.

**Two of the three branches in `RdsLogSource` already had a message written for the empty case and could not reach it** — the `ArgumentNullException` fires before the `??`. So a target pointed at a cluster that does not exist, a cluster mid-failover, and an instance listing no log file all reported the same seven words as each other, and the sentences that distinguish them were unreachable code.

## What each branch says now

Each null routes into the message describing its own branch, rather than being coalesced to an empty sequence:

- **`DBClusters` absent** — `Aurora cluster '…' was not found: DescribeDBClusters returned no cluster for it.` A target to repoint.
- **`DBClusterMembers` absent** — `… reports no writer among its members. That is a real state during a failover, so this is worth retrying rather than treating as a configuration error.` The opposite response to the one above, which is why they must not share a message.
- **No openable log file** — `RDS listed no PostgreSQL server log file for instance '…': DescribeDBLogFiles filtered on 'postgresql' returned nothing it could name. NO LOG WAS OPENED this cycle, so this is not an empty log — whatever this window held is unread. This records as a collection ERROR and not as a permissions skip, because no grant fixes it: an instance that is stopped, still being created, or has just rotated its logs answers this way and clears itself on the first cycle that finds a log, while one that keeps answering this way is a target nobody can read and wants a decision rather than silence.` This one **raises where it used to answer silently**: a zero-row cycle gets stamped `no new … in the RDS log window`, and that note is a claim about the contents of a log this branch never opened.

  Three shapes are one fact — an omitted collection, an empty list, and a list whose newest entry carries no filename — and before this they diverged three ways: the first crashed, the other two answered quietly. `NewestLogFileAsync` is now total (returns `string`, not `string?`) and raises once for all three, which also retires the caller's own null branch instead of leaving the same decision to be made in two places. It looks for the newest **named** file rather than the newest one, so a nameless entry sitting beside real logs falls through to a log that can be opened rather than refusing one that is right there — `ANamelessNewestEntryFallsThroughToTheNewestNamedFile` is the positive control for that, without which the three refusals would pass just as well over a read that refused everything.

`RdsDeadlockBranchClassificationTests` asserts the classification as well as the text: `RdsLogUnavailableException.IsAuthorizationFailure` is `false`, so the runner does not append its "the role needs `rds:DescribeDBLogFiles`" sentence to a fault no grant fixes.

**Performance Insights is the deliberate exception.** An omitted `MetricList` means no sample in this window, which the caller already names (`no new Performance Insights CPU samples this cycle`), so an empty sequence is the honest reading there — and the comment says why that differs from the log-file list, where "no file" means nothing was opened at all.

## The band this branch lands on, and why the message now names it

`ERROR`, through the runner's generic arm, which bands the collector FAILING. That is deliberate and it is the store's own rule — `RdsLogUnavailableException`'s doc comment: only an authorization refusal degrades to PERMISSIONS, and "a throttle, a failover, an endpoint that stopped resolving" stays loud, because a permanent-sounding status on a transient fault is how an outage reads as a configuration choice. No grant fixes an absent log file, so PERMISSIONS would send an operator to look for one that cannot be issued; and a target nobody can read is the exact condition #2994 exists because the surface kept quiet about.

What was wrong was the sentence, not the band. It told the reader a stopped or freshly-created instance was "worth retrying rather than treating as a configuration error" while the row it lands on says FAILING — a message claiming one treatment over a row carrying another, which is the contradiction `CollectorRuntimePrecondition`'s own doc comment was written to record. The message now names the ERROR, says what clears it (the first cycle that finds a log), and says what a target that keeps answering this way needs. Both tests assert the classification sentence is present, so the text and the band cannot drift apart again.

A softer sixth status for "the capture source is absent" is a real option — `SESSION_MISSING` is the existing precedent and is deliberately excluded from `last_error` — but adding one touches the self-alert evaluator, the health bands, both stores and the MCP/viewer surfaces, which is #2994's rollup half rather than this branch's guard.

## Why `RdsCpuIngestor` is in this diff

Its writer/instance resolution is a deliberate copy of `RdsLogSource`'s, and between that and its PI read it carried five of the eight sites — the identical seven-word message on `pg_cpu_utilization`. Fixing one copy and leaving the other is the same defect shipped twice.

## The `last_error` single-slot overwrite is NOT fixed here

Stated rather than skipped. `last_error` is `MAX(CASE WHEN error_rank = 1 AND status IN ('ERROR', 'PERMISSIONS') THEN error_message END)` in three places — `DarlingDataReader`, `ViewerDataService.CollectionHealth`, `LocalDataService.CollectionHealth` — one slot for a *standing* condition and a *transient* fault, so the newer one always wins. Splitting it (a standing-denial value beside `last_error`) means those three reads, their DTOs and projections, the fleet-overview variant, both stores' parity and the pinned SQL text in `DarlingEmptyEnumerationNoteTests` / `EmptyEnumerationNoteTests`. That is #2994's rollup half, whose own chosen fix is a distinct skip counter or a `NO_PERMISSIONS` band over exactly these surfaces; doing a slice of it here would conflict with it. #2996's observable half — a seven-word message naming no call, no branch and no instance — is fully fixed in this PR, not deferred.

## One finding for #2994

`no new deadlocks in the RDS log window` is emitted only by `DarlingCollectorRunner.IngestRdsDeadlocksAsync`, i.e. only on the RDS-API route. #2994 reports that note on ~1,590 of ~2,000 `pg_deadlocks` runs *and* `permission denied for function pg_read_file` as `last_error` on 48 of 50 targets. Those cannot both describe current behaviour: if the note fires, the collector is on the RDS route and never calls `pg_read_file`. The 42501 is a retained slot value from before the route split, which makes it a second instance of #2994's own thesis rather than evidence of a live denial — worth re-deriving from per-status histograms before the grants half is worked.

## Verification

Windows-only suite, so `Darling.Tests`' `RdsLogSourceTests`, `RdsCpuIngestorTests`, `RdsLogUnavailableTests` and `RdsEndpointTests` were compiled **as shipped** into a throwaway `net10.0` xunit v3 host (`AssemblyName` `Darling.Tests`, staged outside the tree): **53 tests, 0 failed, 0 not run**, and every new method confirmed executed by name.

Red proven one mutation at a time, anchor count 1 and source hash recorded per mutation, each restored:

| mutation | red |
|---|---|
| `RdsLogSource` log-file-list `?.` → `.` | `AnInstanceListingNoPostgresLogFileIsNamed(absent)` (`ArgumentNullException`) + `AnAbsentLogFileListReachesTheRunnerNamedAndNotAsAPermissionsSkip` |
| `RdsLogSource` classified throw → `string.Concat` | all three `AnInstanceListingNoPostgresLogFileIsNamed` rows, *no exception thrown* + the ingestor test |
| `RdsLogSource` newest-**named** predicate dropped | `ANamelessNewestEntryFallsThroughToTheNewestNamedFile` |
| `RdsLogSource` `DBClusters?.` → `.` | `AnAbsentClusterListNamesTheMissingCluster` |
| `RdsLogSource` `DBClusterMembers?.` → `.` | `AClusterWithNoMemberListReportsTheFailoverState` |
| `RdsCpuIngestor` `DBClusters?.` → `.` | `EachAbsentResolutionCollectionNamesItsOwnBranch` row 1 |
| `RdsCpuIngestor` `DBClusterMembers?.` → `.` | row 2 |
| `RdsCpuIngestor` `DBInstances?.` → `.` | row 3 |

Every null-shaped red carries `Value cannot be null. (Parameter 'source')` in its failure output — the fixtures reproduce the reported fault, they do not merely assert around it. Each mutation was applied alone, at anchor count 1, with the source hash recorded before and after and re-verified on restore; one multi-line anchor initially matched nothing against the CRLF working tree and one earlier attempt failed to compile, so the runner now aborts a mutation whose build fails rather than reading a stale binary as green.

## Not verified

- **Which of the three branches fired on the two affected targets.** The AWS CLI is unavailable in this session and the pgmon store's `collection_log` could not be read, so the `collection_time` / `error_message` rows #2996 asks for are unread. From the code alone, `DescribeDBClusters` and `DescribeDBLogFiles` demonstrably succeed on the ordinary path for those targets (they reach a zero-row cycle and stamp the RDS-log-window note), so the one-off is an absent `DBClusterMembers` — a failover — or an absent `DescribeDBLogFiles`. Both are named branches now, and both were the same seven words before.
- **The PI leg** (`MetricList` / `DataPoints` coalesced to empty). It sits past the watermark read, so it needs a real store; no ingestor in this family covers its post-store path today.
- `PgDeadlockLogParser` is untouched, so nothing here overlaps #2993.
