### PR TITLE
Bound pg_index_bloat by bytes and classify the deadline it dies on

### DIFF
--- a/Darling/Darling.Tests/CollectionLogDrainForensicsStoreTests.cs
+++ b/Darling/Darling.Tests/CollectionLogDrainForensicsStoreTests.cs
@@ -329,13 +329,17 @@ public class CollectionLogDrainForensicsStoreTests
            rationale is that a ratio needs a denominator from ordinary rows, not only from failures. */
         Assert.DoesNotContain("sweepPeerMaxMs: null", worker, StringComparison.Ordinal);
 
-        /* drain STAYS null on those arms: nothing was drained, so there is nothing to describe. */
-        Assert.Equal(7, Regex.Matches(worker, @"drain: null").Count);
+        /* drain STAYS null on those arms: nothing was drained, so there is nothing to describe.
 
-        /* And V110's fetch sums stay null on the same seven arms and for the same reason: no item completed,
+           Eight since #2997 added the authored PostgreSQL command-timeout arm, which is an early-return
+           fault arm like the rest and drained nothing either. The count is what makes that visible: a new
+           arm has to come through this pin and state which of the two it is. */
+        Assert.Equal(8, Regex.Matches(worker, @"drain: null").Count);
+
+        /* And V110's fetch sums stay null on the same eight arms and for the same reason: no item completed,
            so no fetch was performed. Counted rather than merely present, so an arm that starts passing a
            real value - which would mean attributing another run's fetch to a failure row - is a red. */
-        Assert.Equal(7, Regex.Matches(worker, @"fetchPhases: null").Count);
+        Assert.Equal(8, Regex.Matches(worker, @"fetchPhases: null").Count);
     }
 
     /// <summary>

--- a/Darling/Darling.Tests/PostgresFaultOutcomeTests.cs
+++ b/Darling/Darling.Tests/PostgresFaultOutcomeTests.cs
@@ -267,6 +267,14 @@ public class PostgresFaultOutcomeTests
         Assert.Contains("CLIENT-SIDE", client, StringComparison.Ordinal);
         Assert.DoesNotContain("57014", client, StringComparison.Ordinal);
 
+        /* And it names no KNOB. This arm fires for every PostgreSQL collector classified as
+           CommandTimeout, but only two of them set CommandTimeoutSecondsOverride - the rest use
+           DarlingCollectorRunner.CommandTimeoutSeconds - so naming the override would be false for most
+           of the collectors that can reach here and would send an operator after a setting that
+           collector does not have. The measured elapsed time is what the deadline actually was. */
+        Assert.DoesNotContain("CommandTimeoutSecondsOverride", client, StringComparison.Ordinal);
+        Assert.DoesNotContain("CommandTimeoutSecondsOverride", server, StringComparison.Ordinal);
+
         Assert.Contains("CANCELLED BY THE SERVER", server, StringComparison.Ordinal);
         Assert.Contains("57014", server, StringComparison.Ordinal);
         Assert.Contains("statement_timeout", server, StringComparison.Ordinal);

--- a/Darling/Darling.Tests/PostgresFaultOutcomeTests.cs
+++ b/Darling/Darling.Tests/PostgresFaultOutcomeTests.cs
@@ -346,6 +346,105 @@ public class PostgresFaultOutcomeTests
             PostgresTargetProvider.Instance.Classify(dead, yieldsOnLockTimeout: false));
     }
 
+    /// <summary>
+    /// The fault's database is read off the EXCEPTION, not off the runtime, at both PostgreSQL fault arms.
+    ///
+    /// <para><b>The defect this pins.</b> <c>ServerRuntime.ConnectedDatabase</c> is <c>init</c>-only and
+    /// stamped once during the initial connect-and-probe, from whatever database the probe landed on. A
+    /// <c>RunsPerDatabase</c> collector never uses that connection — the per-database loop opens one per
+    /// database — and when every database fails it rethrows the first failure BARE. So a handler reading
+    /// the runtime's field names a database that had nothing to do with the fault, confidently. Seven
+    /// collectors fan out that way, <c>pg_index_bloat</c> among them, which makes it the wrong database
+    /// for the exact collector and target #2997 is about, and for #2638's
+    /// "run CREATE EXTENSION in database X" sentence on every permission-degraded target.</para>
+    ///
+    /// <para>A wiring invariant, pinned in source: the value is assembled inside a live sweep from a
+    /// rethrow three call frames up, so no pure test reaches it, and the defect is which expression a
+    /// call site passes rather than any logic. Both arms must go through the helper — an arm that reverts
+    /// to <c>runtime.ConnectedDatabase</c> compiles, runs, and lies.</para>
+    /// </summary>
+    [Fact]
+    public void BothPostgresFaultArmsTakeTheDatabaseFromTheException()
+    {
+        var worker = ReadSource(Path.Combine(
+            "Darling", "PerformanceMonitor.Darling.Service", "DarlingWorker.cs"));
+
+        /* Exactly two fault arms name a database, and both read it through the helper. */
+        Assert.Equal(2, Regex.Matches(
+            worker, @"CollectorFaultDatabase\.For\(ex, runtime\.ConnectedDatabase\)").Count);
+
+        /* And neither passes the runtime's field straight into a fault message. These are the two
+           expressions the arms used before, and they are what a revert would restore. */
+        Assert.DoesNotContain(
+            "PostgresFaultOutcome(ex, collectorName, runtime.ConnectedDatabase)", worker, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "collectorName, runtime.ConnectedDatabase, elapsedMs", worker, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The per-database loop is what puts the name there, on both of its failure arms — the budget-expiry
+    /// one and the generic one. A stamp on only one of them would leave whichever arm lost the race
+    /// falling back silently.
+    /// </summary>
+    [Fact]
+    public void ThePerDatabaseLoopStampsTheDatabaseOnItsFailures()
+    {
+        var runner = ReadSource(Path.Combine(
+            "Darling", "PerformanceMonitor.Darling.Service", "DarlingCollectorRunner.cs"));
+
+        Assert.Equal(2, Regex.Matches(
+            runner, @"CollectorFaultDatabase\.Stamp\((?:budgetFailure|ex), databaseName\);").Count);
+
+        /* Stamped BEFORE firstFailure is captured, or the exception that actually gets rethrown is the
+           one that missed the stamp. */
+        Assert.Equal(2, Regex.Matches(
+            runner,
+            @"CollectorFaultDatabase\.Stamp\((?:budgetFailure|ex), databaseName\);[\s\S]{0,600}?firstFailure \?\?=").Count);
+    }
+
+    /// <summary>
+    /// Reading is total, because most collectors never fan out and must behave exactly as they did: an
+    /// unstamped exception, a non-string payload, or a blank name all fall back to the caller's value.
+    /// </summary>
+    [Fact]
+    public void TheFaultDatabaseReadFallsBackRatherThanInventingAName()
+    {
+        Assert.Equal("probe-db", CollectorFaultDatabase.For(new InvalidOperationException(), "probe-db"));
+        Assert.Null(CollectorFaultDatabase.For(new InvalidOperationException(), null));
+
+        var stamped = new InvalidOperationException();
+        CollectorFaultDatabase.Stamp(stamped, "appdb");
+        Assert.Equal("appdb", CollectorFaultDatabase.For(stamped, "probe-db"));
+
+        /* A blank name is not a name; stamping one must not shadow the fallback. */
+        var blank = new InvalidOperationException();
+        CollectorFaultDatabase.Stamp(blank, "   ");
+        Assert.Equal("probe-db", CollectorFaultDatabase.For(blank, "probe-db"));
+
+        var wrongType = new InvalidOperationException();
+        wrongType.Data[CollectorFaultDatabase.DataKey] = 42;
+        Assert.Equal("probe-db", CollectorFaultDatabase.For(wrongType, "probe-db"));
+    }
+
+    /// <summary>
+    /// The stamp rides on <see cref="Exception.Data"/> and therefore cannot change what the classifier
+    /// sees. That is the whole reason it is not a wrapper exception: every arm of
+    /// <c>PostgresTargetProvider.Classify</c> keys on the exception's TYPE, so wrapping the failure would
+    /// silently re-route the fault to a different handler in order to improve a sentence.
+    /// </summary>
+    [Fact]
+    public void StampingDoesNotChangeHowTheFaultClassifies()
+    {
+        var timeout = new NpgsqlException("Exception while reading from stream", new TimeoutException());
+        var before = PostgresTargetProvider.Instance.Classify(timeout, yieldsOnLockTimeout: false);
+
+        CollectorFaultDatabase.Stamp(timeout, "appdb");
+
+        Assert.Equal(before, PostgresTargetProvider.Instance.Classify(timeout, yieldsOnLockTimeout: false));
+        Assert.Equal(CollectorTargetFault.CommandTimeout, before);
+        Assert.IsType<NpgsqlException>(timeout);
+    }
+
     private static string ReadSource(string relativePath)
     {
         var dir = AppContext.BaseDirectory;

--- a/Darling/Darling.Tests/PostgresFaultOutcomeTests.cs
+++ b/Darling/Darling.Tests/PostgresFaultOutcomeTests.cs
@@ -7,6 +7,8 @@
  */
 
 using System;
+using System.IO;
+using System.Text.RegularExpressions;
 using Npgsql;
 using PerformanceMonitor.Collectors;
 using PerformanceMonitor.Darling.Service;
@@ -205,5 +207,146 @@ public class PostgresFaultOutcomeTests
         var status = DarlingWorker.PostgresFaultOutcome(Pg(sqlState), PlainCollector).Status;
 
         Assert.Contains(status, new[] { "SUCCESS", "PERMISSIONS", "ERROR", "SESSION_MISSING", "YIELDED" });
+    }
+
+    /// <summary>
+    /// The gap #2997 is about, stated as an assertion: a client-side command deadline is NOT a
+    /// <see cref="PostgresException"/>, so no amount of widening the SQLSTATE map above could ever
+    /// classify it.
+    ///
+    /// <para>Npgsql raises an <c>NpgsqlException</c> wrapping a <c>TimeoutException</c> and carrying no
+    /// SQLSTATE at all — the transport's "Exception while reading from stream". The provider already
+    /// classifies that shape correctly; what could not reach it was <see cref="DarlingWorker"/>'s
+    /// PostgreSQL arm, whose parameter type excludes it. Eleven consecutive <c>pg_index_bloat</c>
+    /// failures were logged as raw transport text for exactly this reason, and two separate
+    /// investigations read them as a connection dying at open.</para>
+    /// </summary>
+    [Fact]
+    public void AClientSideDeadlineIsNotAPostgresException_SoTheSqlStateMapCannotReachIt()
+    {
+        var timeout = new NpgsqlException("Exception while reading from stream", new TimeoutException());
+
+        Assert.IsNotType<PostgresException>(timeout);
+        Assert.Equal(
+            CollectorTargetFault.CommandTimeout,
+            PostgresTargetProvider.Instance.Classify(timeout, yieldsOnLockTimeout: false));
+    }
+
+    /// <summary>
+    /// The authored sentence carries the four things the raw seven words did not: which collector, which
+    /// database, how long it actually ran, and that nothing was collected.
+    /// </summary>
+    [Fact]
+    public void TheTimeoutExplanationNamesTheCollectorTheDatabaseAndTheMeasuredElapsedTime()
+    {
+        var explanation = DarlingWorker.PostgresTimeoutExplanation(
+            "pg_index_bloat", "appdb", elapsedMs: 300_142, serverCancelled: false);
+
+        Assert.Contains("pg_index_bloat", explanation, StringComparison.Ordinal);
+        Assert.Contains("appdb", explanation, StringComparison.Ordinal);
+        Assert.Contains("300,142 ms", explanation, StringComparison.Ordinal);
+
+        /* The house rule on honest empties: a run that read nothing must never be mistakable for a run
+           that found nothing. */
+        Assert.Contains("Nothing was collected this cycle", explanation, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Two deadlines both classify as <see cref="CollectorTargetFault.CommandTimeout"/> and they are
+    /// fixed in different places — SQLSTATE 57014 is the TARGET's <c>statement_timeout</c>, the other is
+    /// ours. A single sentence covering both would send an operator to the wrong knob half the time.
+    /// </summary>
+    [Fact]
+    public void TheTimeoutExplanationDistinguishesTheServersDeadlineFromOurs()
+    {
+        var client = DarlingWorker.PostgresTimeoutExplanation(
+            "pg_index_bloat", "appdb", elapsedMs: 300_000, serverCancelled: false);
+        var server = DarlingWorker.PostgresTimeoutExplanation(
+            "pg_index_bloat", "appdb", elapsedMs: 300_000, serverCancelled: true);
+
+        Assert.Contains("CLIENT-SIDE", client, StringComparison.Ordinal);
+        Assert.DoesNotContain("57014", client, StringComparison.Ordinal);
+
+        Assert.Contains("CANCELLED BY THE SERVER", server, StringComparison.Ordinal);
+        Assert.Contains("57014", server, StringComparison.Ordinal);
+        Assert.Contains("statement_timeout", server, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// An unknown connected database degrades to a phrase rather than inventing a name — the same rule
+    /// <see cref="DarlingWorker.PostgresFaultOutcome"/>'s ObjectMissing arm follows via WhereToCreateIt.
+    /// </summary>
+    [Fact]
+    public void TheTimeoutExplanationDegradesWhenTheDatabaseIsUnknown()
+    {
+        var explanation = DarlingWorker.PostgresTimeoutExplanation(
+            "pg_index_bloat", connectedDatabase: null, elapsedMs: 1, serverCancelled: false);
+
+        Assert.Contains("the connected database", explanation, StringComparison.Ordinal);
+        Assert.DoesNotContain("''", explanation, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The ERROR arms record the run's REAL elapsed time, not the literal zeros they used to store
+    /// (#2997 item 3).
+    ///
+    /// <para>A wiring invariant, so it is pinned in the source the way this suite already pins the
+    /// #1648 middleware order and the #1706 upgrade catch order: the value is written by
+    /// <c>LogCollectionAsync</c> inside a live sweep, so no pure test can observe it, and the defect is
+    /// an argument list rather than a logic error. Three literal zeros made a 300-second death and an
+    /// instantly-refused connection store byte-identical rows — and <c>duration_ms</c> is
+    /// <c>sqlMs + storageMs</c>, so it destroyed the one number that separates them.</para>
+    /// </summary>
+    [Fact]
+    public void TheErrorArmsRecordRealElapsedTimeRatherThanLiteralZeros()
+    {
+        var worker = ReadSource(Path.Combine(
+            "Darling", "PerformanceMonitor.Darling.Service", "DarlingWorker.cs"));
+
+        /* The stopwatch the fault arms read. */
+        Assert.Contains("var runClock = System.Diagnostics.Stopwatch.StartNew();", worker, StringComparison.Ordinal);
+
+        /* No ERROR row may be written with the old three-zero argument list. This is the assertion that
+           fails if the fix is reverted: the arms once read `"ERROR", 0, 0, 0`. */
+        Assert.DoesNotContain("collectorName, \"ERROR\", 0, 0, 0", worker, StringComparison.Ordinal);
+
+        /* Both ERROR writes — the authored timeout arm and the general catch — now pass a measured
+           figure in the sqlMs slot that feeds duration_ms. */
+        Assert.Equal(2, Regex.Matches(
+            worker,
+            @"collectorName, ""ERROR"", 0, (?:elapsedMs|runClock\.ElapsedMilliseconds), 0").Count);
+    }
+
+    /// <summary>
+    /// The timeout arm must NOT force a reconnect. The provider classifies a deadline as
+    /// <see cref="CollectorTargetFault.CommandTimeout"/> rather than
+    /// <see cref="CollectorTargetFault.ConnectionFatal"/> specifically so a slow statement cannot turn a
+    /// tuning problem into a reconnect storm, and an arm that nulled the runtime would undo that while
+    /// also taking the reprobe away from the faults that genuinely need it.
+    /// </summary>
+    [Fact]
+    public void TheTimeoutArmDoesNotStealTheReprobeFromConnectionFatal()
+    {
+        var timeout = new NpgsqlException("Exception while reading from stream", new TimeoutException());
+        var dead = new NpgsqlException("connection was closed");
+
+        Assert.Equal(
+            CollectorTargetFault.CommandTimeout,
+            PostgresTargetProvider.Instance.Classify(timeout, yieldsOnLockTimeout: false));
+        Assert.Equal(
+            CollectorTargetFault.ConnectionFatal,
+            PostgresTargetProvider.Instance.Classify(dead, yieldsOnLockTimeout: false));
+    }
+
+    private static string ReadSource(string relativePath)
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null && !File.Exists(Path.Combine(dir, relativePath)))
+        {
+            dir = Directory.GetParent(dir)?.FullName;
+        }
+
+        Assert.NotNull(dir);
+        return File.ReadAllText(Path.Combine(dir!, relativePath));
     }
 }

--- a/Darling/Darling.Tests/PostgresFaultOutcomeTests.cs
+++ b/Darling/Darling.Tests/PostgresFaultOutcomeTests.cs
@@ -445,6 +445,50 @@ public class PostgresFaultOutcomeTests
         Assert.IsType<NpgsqlException>(timeout);
     }
 
+    /// <summary>
+    /// The authored Npgsql narrative is only reachable for a fault that actually came from Npgsql.
+    ///
+    /// <para><c>Classify</c>'s first branch answers <see cref="CollectorTargetFault.CommandTimeout"/> for
+    /// ANY <see cref="TimeoutException"/>, and <c>EnumeratedCollectorDriver.ItemBudgetException</c> throws
+    /// a BARE one for the in-process per-item wall-clock budget — a cut this service makes on itself,
+    /// which never reached the database and involves no Npgsql read. So classification alone is not
+    /// enough to earn the sentence, and the arm carries an <c>ex is NpgsqlException</c> term.</para>
+    ///
+    /// <para>Both real deadlines keep it: <see cref="PostgresException"/> derives from
+    /// <see cref="NpgsqlException"/>, so SQLSTATE 57014 still qualifies. Verified against the shipped
+    /// Npgsql, not assumed — the whole point of the term is a type relationship.</para>
+    ///
+    /// <para>Latent today, because no PostgreSQL collector declares a <c>PerItemWallClockBudget</c>. That
+    /// is precisely the sort of "true when it was written" a message should not depend on.</para>
+    /// </summary>
+    [Fact]
+    public void OnlyAnNpgsqlFaultCanEarnTheAuthoredTimeoutNarrative()
+    {
+        /* The two real deadlines: both are NpgsqlException, so both still reach the arm. */
+        var clientSide = new NpgsqlException("Exception while reading from stream", new TimeoutException());
+        var serverSide = new PostgresException("cancelling statement", "ERROR", "ERROR", "57014");
+
+        Assert.IsAssignableFrom<NpgsqlException>(clientSide);
+        Assert.IsAssignableFrom<NpgsqlException>(serverSide);
+
+        /* The in-process budget's exception classifies identically and must NOT reach it. */
+        var budgetExpiry = new TimeoutException("collector budget expired");
+
+        Assert.Equal(
+            CollectorTargetFault.CommandTimeout,
+            PostgresTargetProvider.Instance.Classify(budgetExpiry, yieldsOnLockTimeout: false));
+        Assert.IsNotAssignableFrom<NpgsqlException>(budgetExpiry);
+
+        /* And the arm's filter carries the term that tells them apart. Pinned in source because an
+           exception filter cannot be invoked directly. */
+        var worker = ReadSource(Path.Combine(
+            "Darling", "PerformanceMonitor.Darling.Service", "DarlingWorker.cs"));
+
+        Assert.Matches(
+            new Regex(@"&& ex is NpgsqlException\s*\r?\n\s*&& PostgresTargetProvider\.Instance\.Classify\("),
+            worker);
+    }
+
     private static string ReadSource(string relativePath)
     {
         var dir = AppContext.BaseDirectory;

--- a/Darling/Darling.Tests/StartupFailureTriageTests.cs
+++ b/Darling/Darling.Tests/StartupFailureTriageTests.cs
@@ -577,9 +577,16 @@ public class StartupFailureTriageTests
             }
         }
 
-        /* And exactly three triaged sites, so a fourth cannot be added without coming through here. */
+        /* And exactly three triaged sites, so a fourth cannot be added without coming through here.
+
+           The stopwatch count is spelled with the RetryBudget suffix all three share rather than as a
+           bare Stopwatch.StartNew(): every retry budget here is a stopwatch, but not every stopwatch is
+           a retry budget. The bare form made this pin fail for ANY unrelated timing added anywhere in
+           DarlingWorker - #2997 added a per-run clock to the collector fault arms, hundreds of lines and
+           one concern away - which tells nobody whether a fourth retry site appeared. Suffixed, the pin
+           measures the thing its own sentence claims. */
         Assert.Equal(3, CountOf(source, "StartupFailureTriage.IsRetryable(ex)"));
-        Assert.Equal(3, CountOf(source, "System.Diagnostics.Stopwatch.StartNew();"));
+        Assert.Equal(3, CountOf(source, "RetryBudget = System.Diagnostics.Stopwatch.StartNew();"));
     }
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Service/CollectorFaultDatabase.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/CollectorFaultDatabase.cs
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+
+namespace PerformanceMonitor.Darling.Service;
+
+/// <summary>
+/// Carries the database a per-database collection fault happened in, ON the exception, so a fault handler
+/// upstream can name it (#2997).
+///
+/// <para><b>Why this is needed at all.</b> A <c>RunsPerDatabase</c> collector does not use the runtime's
+/// own connection: the per-database loop opens one connection per database. When EVERY database fails the
+/// loop rethrows only the first failure, bare, and the handler's only other source of a database name is
+/// <c>ServerRuntime.ConnectedDatabase</c> - an <c>init</c>-only field stamped once during the initial
+/// connect-and-probe, from whatever database the probe landed on. For a per-database collector that is
+/// simply a different database from the one that failed, so a message built on it names the wrong one with
+/// full confidence. Seven collectors declare <c>RunsPerDatabase =&gt; true</c>, <c>pg_index_bloat</c>
+/// among them.</para>
+///
+/// <para><b>Why <see cref="Exception.Data"/> and not a wrapper exception.</b> Fault classification keys on
+/// the exception's TYPE and SQLSTATE - <c>PostgresTargetProvider.Classify</c> asks whether it is a
+/// <c>PostgresException</c>, an <c>NpgsqlException</c>, or wraps a <c>TimeoutException</c>. Wrapping the
+/// failure would change the type every one of those checks sees and silently re-route the fault, which is
+/// a far larger change than adding a name to a message. <c>Data</c> rides along and alters nothing.</para>
+///
+/// <para>Reading is total: an unstamped exception, or one whose payload is not a string, falls back to
+/// whatever the caller had before. So a non-per-database collector behaves exactly as it always did.</para>
+/// </summary>
+internal static class CollectorFaultDatabase
+{
+    /// <summary>The <see cref="Exception.Data"/> key. Named, so a test asserts the same identity the
+    /// producer uses rather than retyping the string and proving only its own transcription.</summary>
+    internal const string DataKey = "PerformanceMonitor.FaultedDatabase";
+
+    /// <summary>
+    /// Records <paramref name="databaseName"/> on <paramref name="exception"/>. Best-effort: an exception
+    /// type can override <see cref="Exception.Data"/> to be read-only or fixed-size, and losing a name from
+    /// a diagnostic message must never turn into a second fault on the failure path.
+    /// </summary>
+    internal static void Stamp(Exception? exception, string? databaseName)
+    {
+        if (exception is null || string.IsNullOrWhiteSpace(databaseName))
+        {
+            return;
+        }
+
+        try
+        {
+            exception.Data[DataKey] = databaseName;
+        }
+        catch
+        {
+            /* Intentionally empty - see the summary. A read-only or fixed-size Data bag costs the message
+               its database name and nothing else; throwing here would replace a classified fault with an
+               unclassified one, which is the opposite of what this exists to do. */
+        }
+    }
+
+    /// <summary>
+    /// The stamped database, or <paramref name="fallback"/> when the exception carries none - which is the
+    /// normal case for every collector that does not fan out per database.
+    /// </summary>
+    internal static string? For(Exception? exception, string? fallback)
+    {
+        try
+        {
+            if (exception?.Data[DataKey] is string stamped && !string.IsNullOrWhiteSpace(stamped))
+            {
+                return stamped;
+            }
+        }
+        catch
+        {
+            /* Same reasoning as Stamp: fall back rather than fault while reporting a fault. */
+        }
+
+        return fallback;
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
@@ -1422,6 +1422,7 @@ public sealed class DarlingCollectorRunner
                         definition.PerItemWallClockBudget!.Value);
                     failed++;
                     failedDatabases.Add(databaseName);
+                    CollectorFaultDatabase.Stamp(budgetFailure, databaseName);
                     firstFailure ??= budgetFailure;
 
                     /* Same #2111 stamp the generic arm makes, and it MATTERS more here: this is what turns
@@ -1452,6 +1453,13 @@ public sealed class DarlingCollectorRunner
                        routine one-database miss. */
                     failed++;
                     failedDatabases.Add(databaseName);
+                    /* #2997: which database this was, carried ON the exception. When every database fails
+                       the loop rethrows firstFailure bare, and the fault handlers upstream have only
+                       ServerRuntime.ConnectedDatabase to fall back on - an init-only field stamped once at
+                       the initial probe, which for a RunsPerDatabase collector is not the database that
+                       failed. The stamp travels with the exception through the rethrow, so a message can
+                       name the database it means. */
+                    CollectorFaultDatabase.Stamp(ex, databaseName);
                     firstFailure ??= ex;
 
                     /* #2111: the yield-to-live stamp + adaptive-shrink count for the Azure SQL DB

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -6298,6 +6298,13 @@ LIMIT 1";
                 _postgres!, runtime, collectorName, status, 0, 0, 0, explanation, fanout: null, phases: null, drain: null, fetchPhases: null, sweepPeerMaxMs: peerMaxAtDispatchMs, _logger, cancellationToken);
             return 0;
         }
+        /* yieldsOnLockTimeout: false is deliberate, and matches the general catch below rather than the
+           PostgresException arm above. That flag only ever decides the 55P03 branch inside Classify, so it
+           cannot change a CommandTimeout answer - passing the collector's real value here would read as
+           though the yield question were relevant to this filter, and it is not. Both of the plain-Exception
+           filters in this method ask a single narrow question of the classifier and pass false for the same
+           reason; the SQLSTATE arm passes the real value because it dispatches on the whole fault map,
+           55P03 included. */
         catch (Exception ex) when (
             server.Runtime?.Target.Engine == CollectorTargetEngine.PostgreSql
             && PostgresTargetProvider.Instance.Classify(ex, yieldsOnLockTimeout: false)

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -5900,10 +5900,61 @@ LIMIT 1";
                 + "rather than waiting in a blocking chain. One sweep skipped; evidence of lock contention "
                 + "on the monitored server, not a monitoring failure."),
 
-            /* Everything else — including a command timeout and a fatal connection error — belongs to the
-               general handler, which logs ERROR and (for ConnectionFatal) forces the reprobe. */
+            /* Everything else belongs to the general handler, which logs ERROR and (for
+               ConnectionFatal) forces the reprobe. A command timeout no longer arrives here as raw
+               transport text — see PostgresTimeoutExplanation and the arm that calls it — but it
+               still lands on ERROR, because a deadline that collected nothing IS a collection
+               failure and must stay inside the error counts that feed collector health. */
             _ => ("ERROR", ex.Message),
         };
+    }
+
+    /// <summary>
+    /// The sentence a PostgreSQL command timeout gets instead of the transport's seven words (#2997).
+    ///
+    /// <para><b>Why this is not folded into <see cref="PostgresFaultOutcome"/>.</b> That method takes a
+    /// <see cref="PostgresException"/>, and a client-side deadline never produces one: Npgsql surfaces it
+    /// as an <c>NpgsqlException</c> wrapping a <c>TimeoutException</c>, with no SQLSTATE to switch on. So
+    /// the classification it needed could not be reached through a SQLSTATE map however wide that map
+    /// grew — the gap was the parameter type, not the code list.</para>
+    ///
+    /// <para><b>The status stays ERROR.</b> The store has five and none of them means "ran out of time";
+    /// PERMISSIONS is the non-fatal-degradation bucket and would wrongly exclude this from the error
+    /// counts, the health band and the collection-failure self-alerts, which is precisely where a
+    /// collector that has never once succeeded belongs. What changes is that the row is now readable:
+    /// the message names the collector, the database, the mechanism and the measured elapsed time, and
+    /// the caller records that elapsed figure instead of a literal zero.</para>
+    ///
+    /// <para><paramref name="serverCancelled"/> splits the two deadlines that both classify as
+    /// <see cref="CollectorTargetFault.CommandTimeout"/>, because the remedy differs and the raw text
+    /// cannot tell them apart: SQLSTATE 57014 is the SERVER cancelling the statement (a
+    /// <c>statement_timeout</c> on the target, which an operator changes on the target), while the
+    /// client-side deadline is ours and is changed here.</para>
+    /// </summary>
+    internal static string PostgresTimeoutExplanation(
+        string collectorName, string? connectedDatabase, long elapsedMs, bool serverCancelled)
+    {
+        var where = string.IsNullOrWhiteSpace(connectedDatabase)
+            ? "the connected database"
+            : $"database '{connectedDatabase}'";
+
+        /* Invariant culture on the grouping separator: this string is read by operators and compared
+           across rows, and a machine-dependent thousands separator makes two identical durations look
+           like different ones. */
+        var elapsed = elapsedMs.ToString("N0", CultureInfo.InvariantCulture);
+
+        return serverCancelled
+            ? $"{collectorName} on {where} was CANCELLED BY THE SERVER after {elapsed} ms (SQLSTATE "
+              + "57014) — the target's own statement_timeout expired, so the deadline that fired is on "
+              + "the monitored server, not here. Nothing was collected this cycle: this is NOT 'there "
+              + "was nothing to collect'."
+            : $"{collectorName} on {where} hit its CLIENT-SIDE command deadline after {elapsed} ms — "
+              + "the collector's CommandTimeoutSecondsOverride expired and Npgsql cancelled the read "
+              + "mid-stream, which is why the transport reports 'Exception while reading from stream' "
+              + "with no SQLSTATE. The statement was still running when it was cut off, so the work "
+              + "asked for does not fit the deadline; raising the deadline is the wrong half of that "
+              + "and shrinking the work is the right one. Nothing was collected this cycle: this is "
+              + "NOT 'there was nothing to collect'.";
     }
 
     /// <summary>
@@ -6007,6 +6058,18 @@ LIMIT 1";
                 server.Config.DisplayName, collectorName);
             return 0;
         }
+
+        /* #2997: wall clock for the whole run, read ONLY by the fault arms below. The success path
+           keeps reporting the runner's own measured sql/storage split and never consults this — a
+           wall clock that included dispatch overhead would quietly widen three published numbers
+           (collection_log.duration_ms, sql_duration_ms and the collector_cost series) to satisfy a
+           log line.
+
+           The fault arms have no split to report, because a fault by definition interrupted whichever
+           phase was running, and what they recorded instead was three literal zeros. That made a
+           300-second death indistinguishable from an instant one and sent two separate investigations
+           after a connection that dies at open. One honest total beats three precise zeros. */
+        var runClock = System.Diagnostics.Stopwatch.StartNew();
 
         try
         {
@@ -6228,6 +6291,41 @@ LIMIT 1";
                 _postgres!, runtime, collectorName, status, 0, 0, 0, explanation, fanout: null, phases: null, drain: null, fetchPhases: null, sweepPeerMaxMs: peerMaxAtDispatchMs, _logger, cancellationToken);
             return 0;
         }
+        catch (Exception ex) when (
+            server.Runtime?.Target.Engine == CollectorTargetEngine.PostgreSql
+            && PostgresTargetProvider.Instance.Classify(ex, yieldsOnLockTimeout: false)
+               == CollectorTargetFault.CommandTimeout)
+        {
+            /* #2997: a PostgreSQL deadline, authored rather than left as transport text.
+               pg_index_bloat died here eleven consecutive times reporting only "Exception while
+               reading from stream" — seven words, no collector, no database, no duration — which is
+               indistinguishable from a dropped socket and was read as one twice.
+
+               Deliberately AFTER the PostgresException arm above and not merged into it: this arm has
+               to catch a plain Exception, because a client-side deadline arrives as an
+               NpgsqlException wrapping a TimeoutException and never as a PostgresException at all.
+               SQLSTATE 57014 (the server cancelling) does reach the arm above first, where
+               PostgresFaultOutcome maps it to ERROR and so declines it — which is what lets both
+               deadlines land here and be told apart by type rather than by two separate arms.
+
+               NO reprobe, and that is the same care the general catch takes: the provider classifies
+               this CommandTimeout rather than ConnectionFatal precisely so a slow statement cannot
+               force a reconnect and turn a tuning problem into a reconnect storm. ConnectionFatal is
+               left to the general catch below, which is where the reprobe lives; classifying it here
+               would take the reprobe away and re-create the bug that arm exists to fix. */
+            var elapsedMs = runClock.ElapsedMilliseconds;
+            var serverCancelled = ex is PostgresException { SqlState: "57014" };
+            var explanation = PostgresTimeoutExplanation(
+                collectorName, runtime.ConnectedDatabase, elapsedMs, serverCancelled);
+
+            _logger.LogError("  [{Server}] {Collector} => ERROR (timeout): {Message}",
+                server.Config.DisplayName, collectorName, explanation);
+
+            await DarlingObservability.LogCollectionAsync(
+                _postgres!, runtime, collectorName, "ERROR", 0, elapsedMs, 0, explanation,
+                fanout: null, phases: null, drain: null, fetchPhases: null, sweepPeerMaxMs: peerMaxAtDispatchMs, _logger, cancellationToken);
+            return 0;
+        }
         catch (Exception ex)
         {
             _logger.LogError("  [{Server}] {Collector} => ERROR: {Message}",
@@ -6262,8 +6360,14 @@ LIMIT 1";
                recorded the fault to the app log, so no signal is lost. */
             try
             {
+                /* #2997 item 3: the run's real elapsed time, not the literal zero this arm used to
+                   store. duration_ms is sqlMs + storageMs, so three zeros made every failure look
+                   instantaneous — a 300-second timeout and a refused connection stored the identical
+                   row, and the number that separates them is the only one an operator needs first.
+                   Read from the stopwatch rather than from the exception, because most faults carry
+                   no duration at all. */
                 await DarlingObservability.LogCollectionAsync(
-                    _postgres!, runtime, collectorName, "ERROR", 0, 0, 0, ex.Message, fanout: null, phases: null, drain: null, fetchPhases: null, sweepPeerMaxMs: peerMaxAtDispatchMs, _logger, cancellationToken);
+                    _postgres!, runtime, collectorName, "ERROR", 0, runClock.ElapsedMilliseconds, 0, ex.Message, fanout: null, phases: null, drain: null, fetchPhases: null, sweepPeerMaxMs: peerMaxAtDispatchMs, _logger, cancellationToken);
             }
             catch
             {

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -6340,6 +6340,21 @@ LIMIT 1";
            55P03 included. */
         catch (Exception ex) when (
             server.Runtime?.Target.Engine == CollectorTargetEngine.PostgreSql
+            /* The arm may only claim what the filter guarantees. Classify's first branch answers
+               CommandTimeout for ANY TimeoutException, and EnumeratedCollectorDriver.ItemBudgetException
+               throws a BARE one for the in-process per-item wall-clock budget - a monitoring-side cut
+               that never reached the database and has nothing to do with Npgsql. Without this term the
+               authored sentence below would tell an operator that Npgsql cancelled a read mid-stream
+               about a budget this service abandoned on its own. Latent today, because no PostgreSQL
+               collector declares PerItemWallClockBudget, which is exactly the kind of "true when written"
+               that stops being true without anyone revisiting the sentence.
+
+               NpgsqlException covers BOTH real deadlines and only those: PostgresException derives from
+               it (verified against Npgsql 10.0.3), so SQLSTATE 57014 still lands here, while the bare
+               TimeoutException falls through to the general catch - which classifies it CommandTimeout
+               too, so it still forces no reprobe, and now reports the budget's own message and the real
+               elapsed time rather than a borrowed narrative. */
+            && ex is NpgsqlException
             && PostgresTargetProvider.Instance.Classify(ex, yieldsOnLockTimeout: false)
                == CollectorTargetFault.CommandTimeout)
         {

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -5948,13 +5948,20 @@ LIMIT 1";
               + "57014) — the target's own statement_timeout expired, so the deadline that fired is on "
               + "the monitored server, not here. Nothing was collected this cycle: this is NOT 'there "
               + "was nothing to collect'."
+            /* "its command timeout", never the name of a knob. This arm fires for EVERY PostgreSQL
+               collector classified as CommandTimeout, and only two of them set
+               CommandTimeoutSecondsOverride at all - the rest fall back to
+               DarlingCollectorRunner.CommandTimeoutSeconds. Naming the override would therefore be
+               false for most collectors that can reach here, and would send an operator looking for a
+               setting that collector does not have. The MEASURED elapsed time above says what the
+               deadline actually was, which is the more useful number anyway: it is what applied,
+               rather than what was configured somewhere. */
             : $"{collectorName} on {where} hit its CLIENT-SIDE command deadline after {elapsed} ms — "
-              + "the collector's CommandTimeoutSecondsOverride expired and Npgsql cancelled the read "
-              + "mid-stream, which is why the transport reports 'Exception while reading from stream' "
-              + "with no SQLSTATE. The statement was still running when it was cut off, so the work "
-              + "asked for does not fit the deadline; raising the deadline is the wrong half of that "
-              + "and shrinking the work is the right one. Nothing was collected this cycle: this is "
-              + "NOT 'there was nothing to collect'.";
+              + "its command timeout expired and Npgsql cancelled the read mid-stream, which is why the "
+              + "transport reports 'Exception while reading from stream' with no SQLSTATE. The statement "
+              + "was still running when it was cut off, so the work asked for does not fit the deadline; "
+              + "raising the deadline is the wrong half of that and shrinking the work is the right one. "
+              + "Nothing was collected this cycle: this is NOT 'there was nothing to collect'.";
     }
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -6290,8 +6290,14 @@ LIMIT 1";
                 _postgres!, runtime, collectorName, "PERMISSIONS", 0, 0, 0, message, fanout: null, phases: null, drain: null, fetchPhases: null, sweepPeerMaxMs: peerMaxAtDispatchMs, _logger, cancellationToken);
             return 0;
         }
+        /* #2997: the database is read off the EXCEPTION first, falling back to the runtime's own. #2638
+           added the database name to the ObjectMissing sentence precisely so an operator would not go
+           looking in the wrong one - and for a RunsPerDatabase collector the runtime's field is the wrong
+           one, because it holds whatever database the initial probe landed on rather than the database
+           this fault came from. See CollectorFaultDatabase. */
         catch (PostgresException ex) when (
-            PostgresFaultOutcome(ex, collectorName, runtime.ConnectedDatabase) is { Status: not "ERROR" } outcome)
+            PostgresFaultOutcome(ex, collectorName, CollectorFaultDatabase.For(ex, runtime.ConnectedDatabase))
+                is { Status: not "ERROR" } outcome)
         {
             /* PostgreSQL faults classified by SQLSTATE through the same ITargetProvider.Classify the
                engine seam already exposes, so the runner and the provider cannot disagree about what an
@@ -6357,7 +6363,13 @@ LIMIT 1";
             var elapsedMs = runClock.ElapsedMilliseconds;
             var serverCancelled = ex is PostgresException { SqlState: "57014" };
             var explanation = PostgresTimeoutExplanation(
-                collectorName, runtime.ConnectedDatabase, elapsedMs, serverCancelled);
+                collectorName,
+                /* Off the exception, not the runtime: pg_index_bloat fans out per database and opens its
+                   own connection for each, so the runtime's initial-probe database is not the one that
+                   ran out of time. Naming the wrong database confidently is worse than naming none. */
+                CollectorFaultDatabase.For(ex, runtime.ConnectedDatabase),
+                elapsedMs,
+                serverCancelled);
 
             _logger.LogError("  [{Server}] {Collector} => ERROR (timeout): {Message}",
                 server.Config.DisplayName, collectorName, explanation);

--- a/Lite.Tests/PgIndexBloatCollectorDefinitionTests.cs
+++ b/Lite.Tests/PgIndexBloatCollectorDefinitionTests.cs
@@ -225,10 +225,24 @@ public class PgIndexBloatCollectorDefinitionTests
             new Regex(@"sum\(k\.index_bytes\)\s*FILTER\s*\(WHERE\s+k\.index_bytes\s*<\s*\d+\)"), Sql());
 
     /// <summary>
-    /// The running total is a running total — ordered largest-first and framed from the start of the
-    /// partition. An unframed window sum would return the WHOLE total on every row, so no row would ever
-    /// be under budget and nothing would be measured; a differently-ordered one would spend the budget
-    /// on small indexes and pass over the big ones, inverting the argument the ORDER BY exists to make.
+    /// The running total is a running total — ordered largest-first and framed by ROWS from the start of
+    /// the partition.
+    ///
+    /// <para><b>ROWS, not the default frame.</b> A window with an ORDER BY and no explicit frame gets
+    /// <c>RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW</c>, which is also a running total but groups
+    /// PEERS: every row tying on the whole ORDER BY sees the tie's ENTIRE total, the first member
+    /// included. A tied pair is then all-or-nothing against the budget — measured with a spare index'
+    /// worth of headroom, or skipped together even though one of them would have fitted. ROWS charges
+    /// each row for itself, which is what spending a budget largest-first means.
+    ///
+    /// Ties are reachable, not theoretical: <c>index_name</c> is the tiebreaker and is unique per SCHEMA
+    /// rather than per database, so two schemas can hold equally-sized indexes of the same name. Measured
+    /// on PostgreSQL 17.11 with exactly that pair at 1,138,688 bytes each — ROWS gives 1,138,688 then
+    /// 2,277,376, while the default RANGE frame gives 2,277,376 on BOTH rows.</para>
+    ///
+    /// <para>Dropping the ORDER BY instead would make the sum the whole total on every row, so no row
+    /// would ever be under budget and nothing would be measured; reversing it would spend the budget on
+    /// small indexes and pass over the big ones, inverting the argument the ordering exists to make.</para>
     /// </summary>
     [Fact]
     public void TheByteBudget_AccumulatesLargestFirst()

--- a/Lite.Tests/PgIndexBloatCollectorDefinitionTests.cs
+++ b/Lite.Tests/PgIndexBloatCollectorDefinitionTests.cs
@@ -7,6 +7,7 @@
  */
 
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Lite.Tests.Helpers;
@@ -183,5 +184,90 @@ public class PgIndexBloatCollectorDefinitionTests
     {
         Assert.NotNull(PgIndexBloatCollector.Instance.CommandTimeoutSecondsOverride);
         Assert.True(PgIndexBloatCollector.Instance.CommandTimeoutSecondsOverride >= 120);
+    }
+
+    /// <summary>
+    /// The cycle budget bounds BYTES, not just index count (#2997).
+    ///
+    /// <para><b>This is the assertion that would have caught eleven consecutive failures.</b> The count
+    /// budget from #2617 and the 300-second override from #2618 were both in place and both pinned, and
+    /// the collector still died every single run with <c>rows = 0</c> — because 200 sub-ceiling indexes
+    /// on a real Aurora target admit 286 GB, and <c>pgstatindex</c> reads every page of every one of
+    /// them. A count bounds pages only where count correlates with bytes, and the one target that had
+    /// the extension installed was the counterexample.</para>
+    ///
+    /// <para>The gate has to sit on the LATERAL. Labelling rows over the budget while still passing
+    /// every one of them to the function is precisely the shape that shipped: correct
+    /// <c>skipped_reason</c> text on a statement that reads the whole instance anyway.</para>
+    /// </summary>
+    [Fact]
+    public void TheCycleBudget_BoundsBytes_NotJustIndexCount()
+    {
+        var sql = Sql();
+
+        Assert.Contains("measured_bytes_through_here", sql, StringComparison.Ordinal);
+        Assert.Matches(
+            new Regex(@"LEFT JOIN LATERAL[\s\S]*?measured_bytes_through_here\s*<=\s*\d+"), sql);
+    }
+
+    /// <summary>
+    /// Only the indexes that will actually be READ may spend the budget.
+    ///
+    /// <para>An over-ceiling index is never handed to <c>pgstatindex</c>, so it costs no pages. Charging
+    /// it to the byte budget anyway would spend the allowance on work nobody does — and not marginally:
+    /// on the target this bounds, the three over-ceiling indexes total 71 GB against a 20 GB budget, so
+    /// the unfiltered running total would exhaust the budget before the first measurable index and the
+    /// collector would return zero measurements for a second, entirely new reason.</para>
+    /// </summary>
+    [Fact]
+    public void TheByteBudget_ChargesOnlyTheIndexesItWillActuallyRead()
+        => Assert.Matches(
+            new Regex(@"sum\(k\.index_bytes\)\s*FILTER\s*\(WHERE\s+k\.index_bytes\s*<\s*\d+\)"), Sql());
+
+    /// <summary>
+    /// The running total is a running total — ordered largest-first and framed from the start of the
+    /// partition. An unframed window sum would return the WHOLE total on every row, so no row would ever
+    /// be under budget and nothing would be measured; a differently-ordered one would spend the budget
+    /// on small indexes and pass over the big ones, inverting the argument the ORDER BY exists to make.
+    /// </summary>
+    [Fact]
+    public void TheByteBudget_AccumulatesLargestFirst()
+        => Assert.Matches(
+            new Regex(@"OVER \(ORDER BY k\.index_bytes DESC, k\.index_name\s+"
+                      + @"ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\)"), Sql());
+
+    /// <summary>
+    /// Over-budget-by-bytes indexes are RETURNED with a reason, on the same argument as the count budget
+    /// and the size ceiling: an index missing from the result reads as one that does not exist.
+    /// </summary>
+    [Fact]
+    public void OverByteBudgetIndexesAreReturnedWithAReason()
+        => Assert.Matches(
+            new Regex(@"WHEN k\.measured_bytes_through_here\s*>\s*\d+[\s\S]*?"
+                      + @"not measured this cycle \(work budget\)"), Sql());
+
+    /// <summary>
+    /// The SQL literals agree with the constants a reader will find in C#. Two representations of one
+    /// number is the existing shape here (<c>CeilingLiteral</c> beside
+    /// <see cref="PgIndexBloatCollector.MeasureCeilingBytes"/>), and it had no pin — so this reads the
+    /// literal out of the gate it actually governs rather than merely looking for the digits somewhere
+    /// in the query, which a stale second copy would also satisfy.
+    /// </summary>
+    [Fact]
+    public void TheBudgetLiterals_AgreeWithTheirConstants()
+    {
+        var sql = Sql();
+
+        var byteGate = Regex.Match(sql, @"measured_bytes_through_here\s*<=\s*(\d+)");
+        Assert.True(byteGate.Success, "the cycle byte budget no longer gates the LATERAL");
+        Assert.Equal(
+            PgIndexBloatCollector.CycleMeasureBudgetBytes,
+            long.Parse(byteGate.Groups[1].Value, CultureInfo.InvariantCulture));
+
+        var ceilingFilter = Regex.Match(sql, @"FILTER \(WHERE k\.index_bytes < (\d+)\)");
+        Assert.True(ceilingFilter.Success, "the byte budget no longer filters on the per-index ceiling");
+        Assert.Equal(
+            PgIndexBloatCollector.MeasureCeilingBytes,
+            long.Parse(ceilingFilter.Groups[1].Value, CultureInfo.InvariantCulture));
     }
 }

--- a/Lite.Tests/PgIndexBloatCollectorDefinitionTests.cs
+++ b/Lite.Tests/PgIndexBloatCollectorDefinitionTests.cs
@@ -270,4 +270,29 @@ public class PgIndexBloatCollectorDefinitionTests
             PgIndexBloatCollector.MeasureCeilingBytes,
             long.Parse(ceilingFilter.Groups[1].Value, CultureInfo.InvariantCulture));
     }
+
+    /// <summary>
+    /// The cycle byte budget may never sit BELOW the per-index ceiling.
+    ///
+    /// <para>The two bounds are independent in what they measure — one index versus the whole statement —
+    /// and their doc comments each argue their number on its own terms, which makes it look as though any
+    /// pair of values would do. It would not. A cycle budget under the ceiling opens a band between the
+    /// two in which an index can never be measured at all: it is under the ceiling, so it is a legitimate
+    /// candidate and earns no "too large" reason, yet it alone exceeds the entire cycle, so it is over
+    /// budget on its own first row on every run forever. It would carry
+    /// <c>not measured this cycle (work budget)</c> in perpetuity — a reason whose whole claim is that the
+    /// index is DEFERRED, attached to one that is permanently skipped. That is the exact confusion between
+    /// "unmeasured" and "healthy" that <c>skipped_reason</c> exists to prevent, reintroduced one level up.</para>
+    ///
+    /// <para>Pinned as an inequality rather than as equality: raising the cycle budget above the ceiling is
+    /// a legitimate tuning move once a SUCCESS row supplies a real duration, and this must not stand in the
+    /// way of it. Only the floor is load-bearing.</para>
+    /// </summary>
+    [Fact]
+    public void TheCycleBudget_IsNeverBelowThePerIndexCeiling()
+        => Assert.True(
+            PgIndexBloatCollector.CycleMeasureBudgetBytes >= PgIndexBloatCollector.MeasureCeilingBytes,
+            $"the cycle budget ({PgIndexBloatCollector.CycleMeasureBudgetBytes}) is below the per-index "
+            + $"ceiling ({PgIndexBloatCollector.MeasureCeilingBytes}), so any index between the two can "
+            + "never be measured while still being reported as merely deferred");
 }

--- a/PerformanceMonitor.Collectors/PgIndexBloatCollector.cs
+++ b/PerformanceMonitor.Collectors/PgIndexBloatCollector.cs
@@ -62,6 +62,26 @@ public sealed class PgIndexBloatCollector : PostgresCollectorDefinitionBase<PgIn
     /// </summary>
     public const long MeasureCeilingBytes = 20L * 1024 * 1024 * 1024;
 
+    /// <summary>
+    /// How many bytes of index ONE CYCLE will measure in total, largest first. Independent of
+    /// <see cref="MeasureCeilingBytes"/> on purpose: that one bounds a single index, this one bounds
+    /// the statement, and #2617 shipped the first believing it covered the second.
+    ///
+    /// <para><b>Why 20 GB and not more.</b> The only hard datum is a negative one: 286 GB of
+    /// sub-ceiling index did NOT finish inside the 300-second deadline on a live Aurora target, so
+    /// effective throughput there is below 0.95 GB/s and the true figure is unknown - a cut-off run
+    /// gives a lower bound on its own duration and nothing else. The <c>:61</c> "a few seconds of
+    /// I/O" figure beside the per-index ceiling is an estimate that was never measured, and the
+    /// live failure bounds it well away from that. So this is set an order of magnitude below the
+    /// number that failed rather than derived from a throughput nobody has.</para>
+    ///
+    /// <para><b>What would justify raising it.</b> A SUCCESS row's own
+    /// <c>collection_log.sql_duration_ms</c>. That number did not exist when this was chosen - the
+    /// ERROR arm recorded a literal zero for every one of the eleven failures - and recording it
+    /// (#2997) is what turns the next raise into a measurement instead of another guess.</para>
+    /// </summary>
+    public const long CycleMeasureBudgetBytes = 20L * 1024 * 1024 * 1024;
+
     /// <param name="AvgLeafDensity">The server's own figure, 0–100. NOT a bloat percentage — a healthy
     /// index sits near 90, so subtracting from 100 invents roughly 10 points of bloat that is not there.</param>
     /// <param name="LeafFragmentation">Share of leaf pages out of physical order. Zero on a freshly built
@@ -140,7 +160,21 @@ WITH candidates AS (
 ranked AS (
     SELECT
         k.*,
-        row_number() OVER (ORDER BY k.index_bytes DESC, k.index_name) AS size_rank
+        row_number() OVER (ORDER BY k.index_bytes DESC, k.index_name) AS size_rank,
+        /* The running total of what will actually be READ, so the cycle can stop at a byte figure
+           rather than a row count. FILTERed to sub-ceiling indexes because an over-ceiling one is
+           never handed to pgstatindex and therefore costs no pages; charging it to the budget would
+           spend the whole allowance on indexes nobody reads. On the target this bounds, the three
+           over-ceiling indexes total 71 GB - more than the budget by themselves.
+
+           coalesce because a FILTERed window sum is NULL until its frame contains a matching row,
+           and the over-ceiling indexes sort FIRST under size DESC. NULL <= budget is NULL rather
+           than false, so the raw form would leave the gate neither open nor closed. */
+        coalesce(
+            sum(k.index_bytes) FILTER (WHERE k.index_bytes < " + CeilingLiteral + @")
+                OVER (ORDER BY k.index_bytes DESC, k.index_name
+                      ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW),
+            0)::bigint                      AS measured_bytes_through_here
     FROM candidates AS k
 )
 SELECT
@@ -160,6 +194,13 @@ SELECT
         WHEN k.index_bytes >= " + CeilingLiteral + @"
             THEN 'index is larger than the measurement ceiling; pgstatindex reads every page, so it is '
                  || 'recorded but not measured'
+        /* The BYTE budget is reported ahead of the count one because it is the bound that actually
+           binds on a large-index target, and an index past both is past this one first. */
+        WHEN k.measured_bytes_through_here > " + CycleByteBudgetLiteral + @"
+            THEN 'not measured this cycle (work budget): pgstatindex reads every page, so a run '
+                 || 'stops once it has measured ' || pg_catalog.pg_size_pretty(" + CycleByteBudgetLiteral + @"::bigint)
+                 || ' of index, largest first. This one is recorded at its size so it is never '
+                 || 'mistaken for healthy.'
         WHEN k.size_rank > " + BudgetLiteral + @"
             THEN 'not measured this cycle (work budget): pgstatindex reads every page, so only the '
                  || 'largest ' || " + BudgetLiteral + @" || ' indexes are measured per run. This one is '
@@ -169,23 +210,44 @@ FROM ranked AS k
 LEFT JOIN LATERAL public.pgstatindex(k.index_oid::regclass) AS s
   ON  k.index_bytes < " + CeilingLiteral + @"
   AND k.size_rank  <= " + BudgetLiteral + @"
+  /* The gate that bounds the statement's real cost. Without this term the two above label rows
+     correctly while still reading every one of them - which is exactly how a 200-index budget
+     came to read 286 GB. */
+  AND k.measured_bytes_through_here <= " + CycleByteBudgetLiteral + @"
 ORDER BY k.index_bytes DESC";
 
     private const string CeilingLiteral = "21474836480";
 
-    /* How many indexes one cycle will actually MEASURE, largest first. 200 rather than a byte budget
-       because the cost is per PAGE and the sizes are wildly uneven: a byte cap would measure three
-       large indexes on one server and four hundred small ones on another, and neither operator could
-       predict what they were getting. A count is legible, and the ORDER BY means the 200 measured are
-       always the ones where bloat is worth reclaiming. */
+    /* How many indexes one cycle will actually MEASURE, largest first: 200 indexes OR
+       CycleMeasureBudgetBytes, whichever comes first.
+
+       A count is the legible half and is kept for that reason - an operator can predict "the 200
+       biggest" in a way they cannot predict a byte figure. But legibility is not a bound: the cost
+       is per PAGE, and a count bounds pages only where count correlates with bytes. On the first
+       production target it did not, and the byte term below is what makes the pair a budget rather
+       than a label. */
     private const string BudgetLiteral = "200";
 
+    /* Kept in the C# type system as well as in the SQL literal so a reader has one authoritative
+       figure and CycleByteBudgetIsThePinnedConstant can pin that the two agree. */
+    private const string CycleByteBudgetLiteral = "21474836480";
+
     /// <summary>
-    /// Five minutes, because even 200 indexes of pages is real work and a slow single index should
-    /// yield a CLASSIFIED timeout rather than a dropped connection. #2617 surfaced as
-    /// <c>Exception while reading from stream</c> - an unclassified Npgsql failure - precisely because
-    /// there was no budget and no override; index_object_stats took the same override for the same
-    /// reason (#1135).
+    /// Five minutes, because even a bounded cycle of pages is real work and a slow single index
+    /// should yield a CLASSIFIED timeout rather than a dropped connection. index_object_stats takes
+    /// the same override for the same reason (#1135).
+    ///
+    /// <para>This is a BACKSTOP, not the bound. The deadline cannot make an over-large statement
+    /// finish - it only decides how long the sweep waits before giving up, and for eleven
+    /// consecutive runs the answer was "the whole five minutes, then nothing". What bounds the work
+    /// is <see cref="CycleMeasureBudgetBytes"/>; a run that needs this deadline has already been
+    /// mis-budgeted.</para>
+    ///
+    /// <para>Npgsql's CommandTimeout is a socket READ timeout that every backend message restarts,
+    /// so it bounds backend SILENCE rather than total elapsed time. <c>pgstatindex</c> sends nothing
+    /// while it scans, so it gets no reprieve from that and the deadline does fire - which is why
+    /// the failures arrive as <c>Exception while reading from stream</c>, the transport's own words
+    /// for a read that ran out of time.</para>
     /// </summary>
     public override int? CommandTimeoutSecondsOverride => 300;
 

--- a/PerformanceMonitor.Collectors/PgIndexBloatCollector.cs
+++ b/PerformanceMonitor.Collectors/PgIndexBloatCollector.cs
@@ -70,8 +70,8 @@ public sealed class PgIndexBloatCollector : PostgresCollectorDefinitionBase<PgIn
     /// <para><b>Why 20 GB and not more.</b> The only hard datum is a negative one: 286 GB of
     /// sub-ceiling index did NOT finish inside the 300-second deadline on a live Aurora target, so
     /// effective throughput there is below 0.95 GB/s and the true figure is unknown - a cut-off run
-    /// gives a lower bound on its own duration and nothing else. The <c>:61</c> "a few seconds of
-    /// I/O" figure beside the per-index ceiling is an estimate that was never measured, and the
+    /// gives a lower bound on its own duration and nothing else. The "a few seconds of I/O" figure in
+    /// <see cref="MeasureCeilingBytes"/>' own summary is an estimate that was never measured, and the
     /// live failure bounds it well away from that. So this is set an order of magnitude below the
     /// number that failed rather than derived from a throughput nobody has.</para>
     ///

--- a/PerformanceMonitor.Collectors/PgIndexBloatCollector.cs
+++ b/PerformanceMonitor.Collectors/PgIndexBloatCollector.cs
@@ -156,7 +156,14 @@ WITH candidates AS (
 
    Ranked by size and measured largest-first, because bloat that matters is concentrated in big
    indexes - a small index at 40% density is worth kilobytes. Everything past the budget is still
-   RETURNED, with a reason, so the read never mistakes unmeasured for healthy. */
+   RETURNED, with a reason, so the read never mistakes unmeasured for healthy.
+
+   TWO budgets now, and the BYTE one is what actually bounds the work (#2997). A count bounds pages
+   only where count correlates with bytes; on the first production target it did not, and the 200
+   largest sub-ceiling indexes admitted 286 GB in this one statement - so every run for the
+   collector's whole life died on the 300-second deadline having measured nothing, exactly as
+   described above but one dimension up. The count survives because it is legible, not because it
+   bounds anything: see CycleMeasureBudgetBytes for which of the two is load-bearing. */
 ranked AS (
     SELECT
         k.*,

--- a/PerformanceMonitor.Collectors/PgIndexBloatCollector.cs
+++ b/PerformanceMonitor.Collectors/PgIndexBloatCollector.cs
@@ -79,6 +79,23 @@ public sealed class PgIndexBloatCollector : PostgresCollectorDefinitionBase<PgIn
     /// <c>collection_log.sql_duration_ms</c>. That number did not exist when this was chosen - the
     /// ERROR arm recorded a literal zero for every one of the eleven failures - and recording it
     /// (#2997) is what turns the next raise into a measurement instead of another guess.</para>
+    ///
+    /// <para><b>It must never drop BELOW <see cref="MeasureCeilingBytes"/>, and that it currently
+    /// equals it is a floor rather than a coincidence.</b> The two bounds are independent in what they
+    /// measure - one index versus the statement - but a cycle budget under the per-index ceiling opens a
+    /// band between them in which an index can never be measured at all: it is under the ceiling, so it
+    /// is a legitimate candidate and gets no "too large" reason, yet it alone exceeds the whole cycle,
+    /// so it is over budget on its own first row every single run. It would be labelled
+    /// <c>not measured this cycle</c> forever, which is precisely the "deferred" reading that this
+    /// collector refuses to let stand for "never". Equal is the tightest value with no such band, and
+    /// <c>TheCycleBudget_IsNeverBelowThePerIndexCeiling</c> pins it.</para>
+    ///
+    /// <para><b>Accepted consequence.</b> At equality a single index just under the ceiling consumes
+    /// almost the whole cycle - on the target this was built for the largest sub-ceiling index is
+    /// 19.68 GB, so that run measures essentially that one index. That is the right answer for a
+    /// largest-first budget (it is the most reclaimable index on the instance) and every other index
+    /// still returns a row carrying its size and its reason, but it does mean coverage of the tail
+    /// depends on the measured set rotating, which it does not yet.</para>
     /// </summary>
     public const long CycleMeasureBudgetBytes = 20L * 1024 * 1024 * 1024;
 

--- a/PerformanceMonitor.Collectors/PgIndexBloatCollector.cs
+++ b/PerformanceMonitor.Collectors/PgIndexBloatCollector.cs
@@ -229,7 +229,7 @@ ORDER BY k.index_bytes DESC";
     private const string BudgetLiteral = "200";
 
     /* Kept in the C# type system as well as in the SQL literal so a reader has one authoritative
-       figure and CycleByteBudgetIsThePinnedConstant can pin that the two agree. */
+       figure and TheBudgetLiterals_AgreeWithTheirConstants can pin that the two agree. */
     private const string CycleByteBudgetLiteral = "21474836480";
 
     /// <summary>


### PR DESCRIPTION
`pg_index_bloat` has produced zero rows fleet-wide since it shipped. On the one target with `pgstatindex` installed, all eleven runs are `status=ERROR`, `rows=0`, `Exception while reading from stream` — including every run after #2618's command-timeout override landed. This bounds the work by bytes, gives the deadline a readable classification, and stops the ERROR arms from recording a literal zero where the duration goes.

Part of #2997.

## The 300-second reading, and what the store can and cannot confirm

The issue's evidence points at a timeout at the 300-second override rather than a network fault, and source agrees: `CommandTimeoutSecondsOverride => 300` is present, wired (`DarlingCollectorRunner.cs:1012` honours it on the per-database path), and pinned. Npgsql's CommandTimeout is a socket read timeout that every backend message restarts, so it bounds backend *silence* — and `pgstatindex` is silent for the whole scan, so it gets no reprieve.

**The failure durations cannot be read from the store rows, and that is the third defect rather than a gap in the investigation.** `RunOneAsync`'s general catch called `LogCollectionAsync(..., "ERROR", 0, 0, 0, ...)`, and `duration_ms` is written as `sqlMs + storageMs`. So all eleven rows carry `duration_ms = 0`, `sql_duration_ms = 0`, `rows_collected = 0`: the measurement that would distinguish a 300-second death from an instantly-refused connection was destroyed at write time. The only surviving evidence for the duration is the indirect one the issue already reports — the 316-second sweep freeze, measured from *other* collectors' gaps. That is consistent with a single database hitting the deadline, and after this change the same run records its own elapsed time directly.

One amplification worth stating: because `RunsPerDatabase` is true and the per-database loop counts a failure and continues, a target where several databases have the extension pays the deadline **per database**, and only rethrows once all of them have failed. The 316-second observation implies one attempted database on that target; it is not the ceiling.

## What changed

**1. The budget bounds bytes, not just a count.** 200 indexes is a count-based budget on a per-page cost. It bounds pages only where count correlates with bytes, and the one target with the extension is the counterexample: 200 sub-ceiling indexes admit 286 GB in a single `LEFT JOIN LATERAL`. The count budget stays for the legibility argument at `:176` — an operator can predict "the 200 biggest" — and a cumulative sub-ceiling byte budget now sits beside it, gated on the LATERAL rather than on `skipped_reason` alone. Gating only the label is the shape that shipped: correct text on a statement that reads everything anyway.

Charging **only sub-ceiling** indexes to the running total is load-bearing, not tidiness. An over-ceiling index is never handed to `pgstatindex`, so it costs no pages; on that target the three over-ceiling indexes total 71 GB against a 20 GB budget, so an unfiltered running total would exhaust the allowance before the first measurable index and return zero measurements for a second, entirely new reason.

The 20 GB figure is deliberately conservative and the doc comment says why: the only hard datum is negative — 286 GB did *not* finish in 300 s, so effective throughput is below 0.95 GB/s and the true value is unknown, because a cut-off run bounds only its own duration. The `:61` "a few seconds of I/O" estimate was never measured and the live failure bounds it well away from that. What would justify raising it is a SUCCESS row's own `sql_duration_ms` — which did not exist before item 3 below, and now does.

**2. The deadline is classified.** #2618 wanted "a classified timeout rather than a dropped connection" and could not get one: `PostgresFaultOutcome` takes a `PostgresException`, and a client-side deadline is an `NpgsqlException` wrapping a `TimeoutException` with no SQLSTATE. The gap was the **parameter type**, so no amount of widening the SQLSTATE map could ever have reached it. A dedicated arm now catches it and composes an authored sentence naming the collector, the database, the mechanism, and the measured elapsed time, and it distinguishes the two deadlines that both classify as `CommandTimeout` — SQLSTATE 57014 is the target's own `statement_timeout` and is fixed there; the client-side one is ours.

Two deliberate narrowings against the issue's suggested shape:

- **The status stays `ERROR`.** The store has five statuses and none means "ran out of time". `PERMISSIONS` is the non-fatal-degradation bucket and would exclude this from the error counts, the health band and the collection-failure self-alerts — which is exactly where a collector that has never once succeeded belongs. What changes is that the row is readable, not which bucket it lands in.
- **`ConnectionFatal` is left with the general catch**, which is where the reprobe lives. Classifying it in the new arm would have taken `server.Runtime = null` away from it and re-created the bug that arm exists to fix. The provider already classifies a deadline as `CommandTimeout` rather than `ConnectionFatal` so a slow statement cannot force a reconnect storm, and the new arm preserves that by not reprobing.

**3. Both ERROR arms record real elapsed time.** A stopwatch read only by the fault arms; the success path keeps reporting the runner's own measured sql/storage split, because a wall clock including dispatch overhead would quietly widen three published numbers to satisfy a log line.

**4. The message names the database that actually faulted.** Found in review, and it is the sharpest defect on the branch. `ServerRuntime.ConnectedDatabase` is `init`-only and stamped once during the initial connect-and-probe, from whatever database the probe landed on. A `RunsPerDatabase` collector never uses that connection — the per-database loop opens one per database — and when every database fails it rethrows the first failure *bare*. So both PostgreSQL fault arms named a database that had nothing to do with the fault, with full confidence. Seven collectors fan out that way, `pg_index_bloat` among them, which made it wrong for exactly the collector and target this PR is about.

**Both arms are fixed, not just the new one.** The `ObjectMissing` arm has had the same defect since #2638 — the arm whose entire purpose is stopping an operator from checking the wrong database, telling them to `CREATE EXTENSION` in the probe's database on every permission-degraded target. Repairing the new arm and filing that one would have been shipping half a fix for a single defect.

The name rides on `Exception.Data` rather than a wrapper exception because every arm of `PostgresTargetProvider.Classify` keys on the exception's **type**: wrapping would change the type all of those checks see and silently re-route the fault to a different handler in order to improve a sentence. `StampingDoesNotChangeHowTheFaultClassifies` pins that. Reading is total, so the collectors that do not fan out behave exactly as before.

**5. Only an Npgsql fault earns the Npgsql narrative.** Also from review. `Classify`'s first branch answers `CommandTimeout` for *any* `TimeoutException`, and `EnumeratedCollectorDriver.ItemBudgetException` throws a bare one for the in-process per-item wall-clock budget — a cut the service makes on itself, which never reached the database and involves no Npgsql read. The arm would have told an operator that Npgsql cancelled a read mid-stream about a budget we abandoned ourselves. Latent, because no PostgreSQL collector declares `PerItemWallClockBudget` — but this branch already stamps that same `budgetFailure` with its database name, so the two mechanisms are one edit from meeting.

The filter now carries `ex is NpgsqlException`. Verified against the shipped assembly rather than assumed: Npgsql 10.0.3 gives `PostgresException : NpgsqlException = True`, so SQLSTATE 57014 still qualifies, while the bare `TimeoutException` does not and falls to the general catch — which classifies it `CommandTimeout` too, so it still forces no reprobe, and now reports the budget's own message with a real duration.

## Out of scope, and why

**The sweep freeze is not addressed directly, deliberately.** 300 s of a 60,000 ms sweep budget blocking every 1-minute collector is real, and the mechanism that would fix it structurally is detaching the collector the way #2717 does for `plan_correction`. That is an independent architectural change with its own gate and its own risk, and it would be riding a fix whose entire purpose is that the run no longer takes 300 seconds. If the byte budget works there is nothing left to detach around; if it does not, the freeze is the symptom that says so, and detaching would have hidden it. Worth revisiting only if a bounded run still shows up in the sweep.

**Largest-first is deterministic, so the measured set never rotates.** That is pre-existing from #2617, but the byte budget makes it sharper: on a target with 286 GB of sub-ceiling index, a 20 GB cycle measures roughly the same top handful every day and the tail is never measured at all — honestly labelled, but never measured. Not fixed here because rotation is a third design axis the issue does not raise and it would need its own state.

## Two shared source pins move, and one of them collides with another lane

The new catch arm is another early-return fault arm, so it passes `drain: null` and `fetchPhases: null` for exactly the reason the other seven do — nothing was drained, no item completed. `CollectionLogDrainForensicsStoreTests.ThePeerMarkIsCapturedAtDispatchNotAtCompletion` counts both, and the count is the point of that pin ("counted rather than merely present"), so it is bumped 7 to 8 rather than loosened. The test's other assertions all still pass unchanged, including `DoesNotContain("sweepPeerMaxMs: null")` — the new arm carries the body's mark like every other arm.

**This collision has since landed and been resolved at nine.** `fix/2993` merged as #3001, and the merge conflicted on exactly this literal: both lanes added one early-return fault arm and each had independently moved the pin from 7 to 8. Both arms belong in the count, so the merged file holds nine and the pin now says nine (`028337e`). The conflict is the pin doing its job: neither lane could see the other, and without a counted assertion the number would simply have been wrong in whichever merged second. Nothing here touched their branch.

`StartupFailureTriageTests.TheThreeSitesHaveDistinctBudgetVariables` is a different case and was **narrowed rather than bumped**. It asserted `Equal(3, CountOf(source, "System.Diagnostics.Stopwatch.StartNew();"))` as a proxy for "exactly three triaged retry sites". Every retry budget in that file is a stopwatch, but not every stopwatch is a retry budget, so a per-run clock added to the collector fault arms — hundreds of lines and one concern away from startup triage — turned that pin red about something it has no opinion on. Bumping it to 4 would have pinned "there are exactly four stopwatches in DarlingWorker.cs", which is a meaningless coupling that the next unrelated timing breaks again. It now counts `"RetryBudget = System.Diagnostics.Stopwatch.StartNew();"`, the suffix all three sites share, which is what its own sentence already claimed to measure and still forces a fourth retry site through it.

## Review dispositions

Two findings on the first pass, both fixed in `bbb2453` and both replied to in-thread and resolved:

- **The timeout message named a knob most collectors do not have.** A real defect, not a wording preference: the arm's filter is engine-plus-classification, so it fires for every Postgres collector that times out, and only `pg_index_bloat` and `pg_buffer_usage` set `CommandTimeoutSecondsOverride` — the rest fall back to `DarlingCollectorRunner.CommandTimeoutSeconds`. It now says "its command timeout" and a pin asserts the override's name appears in neither branch of the explanation. Reinstating the old wording turns `TheTimeoutExplanationDistinguishesTheServersDeadlineFromOurs` red; verified.
- **A comment named a test that was never written** (`CycleByteBudgetIsThePinnedConstant`, a draft name). Corrected to `TheBudgetLiterals_AgreeWithTheirConstants`. Not treated as a nit: a comment pointing at a pin is worth writing only if the pin is findable, and a wrong name reads as authoritative.

Third pass asked whether `CycleMeasureBudgetBytes` and `MeasureCeilingBytes` both being 20 GB was deliberate, given each doc comment argues its number independently. Asking it produced something better than a confirmation, in `1249648`: **the equality is a floor, for a reason neither comment gave.** A cycle budget *below* the per-index ceiling opens a band in which an index can never be measured at all — under the ceiling so it earns no "too large" reason, yet alone exceeding the whole cycle so it is over budget on its own first row every run, carrying `not measured this cycle (work budget)` in perpetuity. That is a reason whose entire claim is that the index is *deferred*, attached to one that is permanently skipped: the unmeasured-versus-healthy confusion `skipped_reason` exists to prevent, one level up. Now pinned by `TheCycleBudget_IsNeverBelowThePerIndexCeiling` as an **inequality**, since raising the budget above the ceiling is legitimate tuning once a SUCCESS row supplies a duration; only the floor is load-bearing. Dropping the constant to 10 GB turns it red with the reason in the failure message.

The same review named a real coverage consequence, now recorded on the constant as accepted: at equality a single index just under the ceiling consumes almost the whole cycle, and on this target the largest sub-ceiling index is 19.68 GB, so that run measures essentially one index rather than the ~14 the average implies. Correct for a largest-first budget, and it sharpens the rotation limitation named above.

Later passes raised the `ROWS` versus default `RANGE` frame, which caught a false statement in one of my own test doc comments and then a second, opposite false statement in the first correction. The comment had claimed an unframed window sum returns the whole total on every row; that holds only without an `ORDER BY`, since with one the default frame is `RANGE`, a running total that groups peers. My first fix then asserted a tie would admit *more* bytes. Measuring settled it, in `4ed8278`: on PostgreSQL 17.11 with a real tie — two schemas holding an index of the same name and the same 1,138,688 bytes, which is reachable because `index_name` is unique per schema rather than per database — `ROWS` gives 1,138,688 then 2,277,376 while the default `RANGE` gives 2,277,376 on **both** rows. So `RANGE` charges the tie's entire total to its first member and the pair goes all-or-nothing against the budget, skipped together where one would have fitted. It under-admits. The explicit `ROWS` frame was already correct and is pinned by `TheByteBudget_AccumulatesLargestFirst`; only the explanation was wrong, twice, and the measured numbers are in it now rather than a direction I reasoned to.

Second pass found nothing to block on and one non-blocking nit: the new filter hardcodes `yieldsOnLockTimeout: false` while the `PostgresException` arm above passes the collector's real value. Kept `false`, and said why in the code (`4fcd14d`) rather than only in a thread. The flag only decides the `55P03` branch inside `Classify`, so it cannot change a `CommandTimeout` answer; passing the real value would imply the yield question bears on this filter. Both plain-`Exception` filters in that method pass `false` for that reason — the pre-existing general catch included — and it is the SQLSTATE arm that is the exception, because it dispatches on the whole fault map.

## Verification

Everything below ran on macOS; the Windows-only suites cannot execute here, so the real test files were compiled into throwaway `net10.0` xunit v3 console hosts staged outside the repo with the required `<AssemblyName>` and `<Compile Include>` pointing at the real repo paths.

- `Lite.Tests` host, focused: **16 tests, 0 failed** (11 pre-existing + 5 new).
- `Darling.Tests` host, expanded to every one of the 25 test files that source-scan `DarlingWorker.cs` plus their helpers: **432 tests, 0 failed, 9 skipped**. The only failures were 7 in `DarlingServiceInstallLocationTests`, which asserts Windows path semantics (`Expected "C:/Users"` / `Actual "C:\\/Users"`) and passes on the Windows runner — a macOS artifact, and CI confirms it.
- `CollectionLogDrainForensicsStoreTests` and `DarlingEmptyEnumerationNoteTests` reference the WPF Viewer, so they cannot compile into a `net10.0` host that actually runs on macOS. Its eight assertions were instead evaluated directly against the real `DarlingWorker.cs` — the same file it reads through `ReadSource` — and all eight pass, including the two counts at 8. CI is the arbiter for the test itself.

Red proven per mutation, one at a time, each with the anchor count and the source hash, judged by which assertion failed:

| Mutation | Result |
|---|---|
| Drop the byte term from the LATERAL `ON` | `TheCycleBudget_BoundsBytes_NotJustIndexCount`, `TheBudgetLiterals_AgreeWithTheirConstants` |
| Drop `FILTER (WHERE index_bytes < ceiling)` | `TheByteBudget_ChargesOnlyTheIndexesItWillActuallyRead`, `TheBudgetLiterals_AgreeWithTheirConstants` |
| Restore `"ERROR", 0, 0, 0` on the general arm | `TheErrorArmsRecordRealElapsedTimeRatherThanLiteralZeros` |
| Zero the timeout arm's elapsed | `TheErrorArmsRecordRealElapsedTimeRatherThanLiteralZeros` |
| Collapse the authored explanation | `TheTimeoutExplanationNamesTheCollectorTheDatabaseAndTheMeasuredElapsedTime`, `TheTimeoutExplanationDistinguishesTheServersDeadlineFromOurs` |
| **Comment-only control** | **0 failed** — source hash and assembly hash both moved, which is why neither is behaviour evidence |

The assertion that fails if the byte budget is reverted is `TheCycleBudget_BoundsBytes_NotJustIndexCount`, which requires the byte term inside the LATERAL `ON` and not merely the column's presence.

**Live SQL, both majors the fleet runs.** The shipped string was dumped from `BuildQuery(ctx).Text` — never a retyped copy — and run verbatim against real PostgreSQL 17.11 and 16.15 in containers with `pgstattuple` installed, against btree, GIN, BRIN and hash indexes. Identical results on both: three btree indexes measured, the non-btree ones never reaching the function, `avg_leaf_density` ~90 on freshly built indexes as the type header claims. This matters because CI never parses a collector query — the `Darling PostgreSQL tests` job exercises the store, not a target — so `sum(...) FILTER (...) OVER (...)` had no other route to being proven to parse.

The budget was then forced to bind, by substitution into that same shipped string, with a scenario built to discriminate the `FILTER` rather than merely exercise it: with the ceiling lowered so the largest index is over it, the two smaller indexes are both measured, which is only possible if the over-ceiling one was not charged. The negative control — the identical probe with the `FILTER` removed and nothing else changed — produces the predicted wrong answer, skipping both and measuring nothing.

## CI, and one failure that is not this branch

First run on `4bbddf6`: `Lite.Tests` **3,271 tests, 0 failed, 0 skipped** and `Dashboard.Tests` **782, 0 failed** both green. `Darling.Tests` failed on the two source pins above, now fixed; `Darling PostgreSQL tests` went green at 236s on `bbb2453` once they were, which is the same suite plus a live store.

**The new tests are confirmed to have executed, by count rather than by name.** The last green `dev` run (`33956294976`) reports `Lite.Tests` **3,266** and `Darling.Tests` **7,490**; this branch reports **3,271** and **7,496** — exactly +5 and +6, which is exactly what was added, with `Skipped: 0` on Lite and no new entry in Darling's skip list. A name grep is not available here: under Microsoft.Testing.Platform the runner prints no per-test `Passed` lines, so the delta plus the skip counts is the evidence.

The live-store job additionally failed `QueryStoreCorrectedRollupLiveTests.RetentionSweep_TreatsAFailedProbeAsUnknown_NeverAsACoverageRegression` with `InvalidOperationException: Connection is not open` from `IsArmedAsync`. **That is not this branch:** nothing here touches the Query Store rollup or its retention sweep, the failure is a dropped store connection rather than an assertion, and the same test does not fail in the Windows `build` job, where it is skipped for want of a live store. Treated as a flake pending the re-run on this head; if it reproduces it belongs to whoever owns that sweep, not to this change.

## Not verified

The pgmon store could not be read this session (no pgmon MCP in this session's tool set, and AWS CLI calls were blocked in this environment), so the eleven rows are taken from the issue rather than re-read, and the `duration_ms = 0` claim is established from source rather than from the rows. Nothing here has run against the affected target; the observation that decides is its next scheduled attempt.


## When the fix can first be observed

The affected target's next run tonight executes the **currently-deployed build, not this branch**. The deciding observation is the first daily run after the next nightly reaches the box. Tonight's expected failure is not evidence that this fix did not work.
