### PR TITLE
Cross-check Lite's QUERY_HIGH_DOP against the server's current MAXDOP (Part of #2999)

### DIFF
--- a/Darling/Darling.Tests/QueryHighDopStaleMaxDopParityTests.cs
+++ b/Darling/Darling.Tests/QueryHighDopStaleMaxDopParityTests.cs
@@ -1,0 +1,580 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Cross-SKU parity guard for the QUERY_HIGH_DOP staleness cross-check: #2705's guard, written out twice
+/// across two stores and otherwise held equal by nothing. Built to the shape
+/// <c>ParameterSensitivityFiringSignatureParityTests</c> established in #2998, because this is the defect
+/// that guard exists to catch and did not cover.
+///
+/// <para><b>What the cross-check is.</b> <c>max_dop</c> on <c>v_query_stats</c> is
+/// <c>sys.dm_exec_query_stats</c>' LIFETIME max for the plan's time in cache, so a plan compiled before
+/// <c>max degree of parallelism</c> was lowered keeps reporting the old higher DOP until it is evicted or
+/// recompiled. A reading that EXCEEDS what the server's current MAXDOP can produce is impossible under
+/// today's configuration, so it provably predates the change that set it and must not be counted. Each
+/// store's fact collector therefore resolves the server's current MAXDOP in a <c>current_maxdop</c> CTE
+/// and cross-checks the per-query reading against it. One copy per SKU, two in total.</para>
+///
+/// <para><b>Why it matters more than a noisy finding.</b> Lowering MAXDOP is the ordinary remediation FOR
+/// this finding. Without the cross-check the finding keeps firing from plans cached before the change, so
+/// its own remediation does not make it stop, and the advice it drives is to do what has already been
+/// done.</para>
+///
+/// <para><b>The two carve-outs are load-bearing in the OTHER direction.</b> A <c>current_maxdop</c> of 0
+/// (unlimited) and an absent config row both make no configuration claim, so both must leave the count
+/// ALONE. Getting either backwards suppresses the finding entirely, which is worse than over-reporting
+/// because nothing then surfaces it — <see cref="EveryHighDopCount_CarriesTheStalenessCrossCheck"/> and
+/// <see cref="TheNullSafeJoin_IsPinnedInBothStores"/> are what hold that shape.</para>
+///
+/// <para><b>Scope: the predicate, not the text.</b> The two stores' SQL diverges legitimately and
+/// permanently — Darling reads <c>server_config</c> directly because its store has no <c>v_</c> views,
+/// where Lite must read <c>v_server_config</c> (its <c>v_</c> views union the live tables with archived
+/// Parquet, and <c>Lite.Tests.AnalysisDataSpanTests.AnalysisPipeline_NeverReadsAnArchivableTableRaw</c>
+/// positively REQUIRES that form under Lite's analysis tree). The config SOURCE is therefore declared per
+/// file and pinned per store, while the cross-check predicate itself is dialect-free and pinned
+/// identically.</para>
+///
+/// <para><b>Where the halves live.</b> This file does the cross-store work because <c>build.yml</c>'s
+/// <c>darling</c> path filter covers the whole Darling tree AND every Lite <c>.cs</c> file, so it runs on
+/// an edit to either analysis tree. Lite's twin,
+/// <c>Lite.Tests.QueryHighDopStaleMaxDopParityTests</c>, declares Lite's own half and meta-pins
+/// <see cref="LiteGuardCopies"/> and <see cref="CanonicalStaleMaxDopGuard"/> out of this file, so raising
+/// a number or retuning a literal in one guard without the other fails. Its filter, <c>lite</c>, covers
+/// Darling's test tree — exactly the edits that could weaken this file.</para>
+/// </summary>
+public sealed class QueryHighDopStaleMaxDopParityTests
+{
+    /// <summary>
+    /// The cross-check, normalized: runs of whitespace collapsed to single spaces. Every copy in either
+    /// store reduces to exactly this, which is the parity claim in one line. Lite's twin declares the
+    /// identical literal and its meta-pin compares the two, so the floor and the unlimited sentinel
+    /// cannot be retuned on one side alone.
+    ///
+    /// <para>Written as a concatenation of plain string segments, none containing a quote or a backslash,
+    /// because Lite's meta-pin reconstructs it by reading THIS FILE as source — no test project
+    /// references both SKUs' assemblies. That parser is self-validated against an in-memory copy of the
+    /// same literal on both sides, so a parser bug fails loudly instead of green-washing drift.</para>
+    /// </summary>
+    internal const string CanonicalStaleMaxDopGuard =
+        "COUNT(CASE WHEN v.max_dop > 8 " +
+        "AND (m.value_in_use IS NULL OR m.value_in_use = 0 OR v.max_dop <= m.value_in_use) " +
+        "THEN 1 END) AS high_dop_queries";
+
+    /// <summary>Copies of the cross-check in Darling's analysis tree.</summary>
+    internal const int DarlingGuardCopies = 1;
+
+    /// <summary>
+    /// Copies of the cross-check in LITE's analysis tree. Lite's twin declares the same number for its
+    /// own half and reads this constant back out of this file, so neither side can be raised alone.
+    /// </summary>
+    internal const int LiteGuardCopies = 1;
+
+    /// <summary>
+    /// The cross-check, per file, across BOTH stores — a floor and a ceiling — with the config source
+    /// each store legitimately reads. Naming the count per file is what makes a copy silently dropped
+    /// from one SKU fail: a bare total would let a Darling copy move to Lite and still add up.
+    /// </summary>
+    private static readonly (string RelativePath, int Copies, string ConfigSource)[] ExpectedCopies =
+    [
+        ("Darling/PerformanceMonitor.Darling.Analysis/PgFactCollector.QueryPerf.cs", 1, "server_config"),
+        ("Lite/Analysis/DuckDbFactCollector.QueryPerf.cs", 1, "v_server_config"),
+    ];
+
+    /// <summary>
+    /// Every read that COUNTS high-DOP queries at all, guarded or not. This is the census the cross-check
+    /// has to cover: the floor and its operator are captured so a retuned copy is still FOUND and then
+    /// reported as a wrong value rather than vanishing. Deliberately looser than
+    /// <see cref="StaleMaxDopGuard"/> — the whole point is that a count WITHOUT the cross-check still
+    /// lands here.
+    /// </summary>
+    private static readonly Regex HighDopCount = new(
+        @"COUNT\([ \t]*CASE[ \t]+WHEN[ \t]+(?:[A-Za-z_]\w*\.)?max_dop[ \t]*(?<floorOp>>=?)[ \t]*(?<floor>\d+)",
+        RegexOptions.IgnoreCase);
+
+    /// <summary>
+    /// The cross-check as a shape: every token pinned literally EXCEPT the DOP floor and the unlimited
+    /// sentinel, which are captured so a skewed copy is still found and reported as a wrong value.
+    /// Adjacency is pinned with <c>[ \t]</c> rather than <c>\s</c> so a blank line or a reordering cannot
+    /// slide past.
+    /// </summary>
+    private static readonly Regex StaleMaxDopGuard = new(
+        @"COUNT\([ \t]*CASE[ \t]+WHEN[ \t]+v\.max_dop[ \t]*(?<floorOp>>=?)[ \t]*(?<floor>\d+)[ \t]*\r?\n"
+        + @"[ \t]*AND[ \t]+\([ \t]*m\.value_in_use[ \t]+IS[ \t]+NULL[ \t]+OR[ \t]+"
+        + @"m\.value_in_use[ \t]*=[ \t]*(?<unlimited>\d+)[ \t]+OR[ \t]+"
+        + @"v\.max_dop[ \t]*<=[ \t]*m\.value_in_use[ \t]*\)[ \t]*\r?\n"
+        + @"[ \t]*THEN[ \t]+1[ \t]+END\)[ \t]+AS[ \t]+high_dop_queries",
+        RegexOptions.IgnoreCase);
+
+    /// <summary>
+    /// The CTE that resolves the server's CURRENT MAXDOP. The config source is captured because it is the
+    /// one part that legitimately differs by store; everything that decides WHICH row wins is pinned,
+    /// because a copy that reads the oldest capture, or an unrelated setting, would cross-check against a
+    /// number that means nothing.
+    /// </summary>
+    private static readonly Regex CurrentMaxDopCte = new(
+        @"WITH[ \t]+current_maxdop[ \t]+AS[ \t]*\r?\n"
+        + @"[ \t]*\([ \t]*\r?\n"
+        + @"[ \t]*SELECT[ \t]+value_in_use[ \t]*\r?\n"
+        + @"[ \t]*FROM[ \t]+(?<source>v_server_config|server_config)[ \t]*\r?\n"
+        + @"[ \t]*WHERE[ \t]+server_id[ \t]*=[ \t]*\$\d+[ \t]*\r?\n"
+        + @"[ \t]*AND[ \t]+configuration_name[ \t]*=[ \t]*'max degree of parallelism'[ \t]*\r?\n"
+        + @"[ \t]*ORDER[ \t]+BY[ \t]+capture_time[ \t]+DESC[ \t]*\r?\n"
+        + @"[ \t]*LIMIT[ \t]+1[ \t]*\r?\n"
+        + @"[ \t]*\)",
+        RegexOptions.IgnoreCase);
+
+    /// <summary>
+    /// The NULL-safe join. <c>LEFT JOIN ... ON true</c> against a one-row CTE is what makes an absent
+    /// config row arrive as NULL and take the leave-the-count-alone arm. An inner join instead would
+    /// return NO ROWS at all on a server with no collected config, so QUERY_HIGH_DOP — and every other
+    /// fact this read emits — would silently vanish rather than being over-reported.
+    /// </summary>
+    private static readonly Regex NullSafeJoin = new(
+        @"LEFT[ \t]+JOIN[ \t]+current_maxdop[ \t]+AS[ \t]+m[ \t]+ON[ \t]+true",
+        RegexOptions.IgnoreCase);
+
+    [Fact]
+    public void EveryCopyOfTheCrossCheck_IsAccountedFor_InBothStores()
+    {
+        foreach (var (relativePath, expected, _) in ExpectedCopies)
+        {
+            var path = RepoPath(relativePath);
+            Assert.True(File.Exists(path), $"{relativePath} is gone — update this guard deliberately");
+
+            var actual = StaleMaxDopGuard.Matches(ReadNormalizedSource(path)).Count;
+
+            Assert.True(
+                actual == expected,
+                $"{relativePath} carries {actual} copy/copies of the QUERY_HIGH_DOP staleness cross-check, "
+                + $"expected {expected}. #2705 landed on Darling only and #2999 is what that cost: the two "
+                + "SKUs are ports of one another, so a one-sided change is otherwise silent. If a read moved "
+                + "or was added, update this guard AND the other store in the same commit.");
+        }
+    }
+
+    /// <summary>
+    /// The assertion that fails if the cross-check is deleted while everything else stays. A high-DOP
+    /// COUNT with no staleness cross-check is exactly the #2999 defect, and it satisfies every count and
+    /// canonical assertion above by simply not being there to disagree with.
+    /// </summary>
+    [Fact]
+    public void EveryHighDopCount_CarriesTheStalenessCrossCheck()
+    {
+        var unguarded = new List<string>();
+
+        foreach (var (relativePath, _, _) in ExpectedCopies)
+        {
+            var source = ReadNormalizedSource(RepoPath(relativePath));
+            var counts = HighDopCount.Matches(source).Count;
+            var guarded = StaleMaxDopGuard.Matches(source).Count;
+
+            if (counts != guarded)
+            {
+                unguarded.Add($"{relativePath}: {counts} high-DOP count(s), {guarded} carrying the cross-check");
+            }
+        }
+
+        Assert.True(
+            unguarded.Count == 0,
+            "a QUERY_HIGH_DOP count exists that does NOT cross-check max_dop against the server's current "
+            + "MAXDOP:" + Environment.NewLine + string.Join(Environment.NewLine, unguarded) + Environment.NewLine
+            + "max_dop is dm_exec_query_stats' LIFETIME max, so a raw count fires from readings the current "
+            + "configuration makes impossible — and lowering MAXDOP is the remediation this very finding "
+            + "recommends, so the finding would outlive its own fix.");
+    }
+
+    [Fact]
+    public void NoUndeclaredAnalysisRead_CountsHighDopQueries()
+    {
+        var declared = ExpectedCopies
+            .Select(e => RepoPath(e.RelativePath))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var scanned = AnalysisSourceFiles().ToList();
+        var strays = new List<string>();
+
+        foreach (var path in scanned)
+        {
+            if (declared.Contains(path))
+            {
+                continue;
+            }
+
+            var count = HighDopCount.Matches(ReadNormalizedSource(path)).Count;
+            if (count > 0)
+            {
+                strays.Add($"{Path.GetFileName(path)}: {count} high-DOP count(s)");
+            }
+        }
+
+        /* A floor, so a broken glob cannot report a clean bill of health. 44 files across the two
+           analysis projects when this was written; set well below that so ordinary growth never trips it,
+           but high enough that an empty enumeration fails instead of passing. */
+        Assert.True(
+            scanned.Count >= 20,
+            $"scanned only {scanned.Count} analysis source files — check the globs below");
+
+        /* And every declared file must be one of the files scanned, or the census above and this sweep are
+           reading different trees — which is how the sweep comes to skip exactly the files that matter. */
+        var unreached = declared.Except(scanned, StringComparer.OrdinalIgnoreCase).ToList();
+        Assert.True(
+            unreached.Count == 0,
+            "the globs below do not reach every declared file:" + Environment.NewLine
+            + string.Join(Environment.NewLine, unreached));
+
+        Assert.True(
+            strays.Count == 0,
+            "an analysis read counts high-DOP queries in a file this guard does not declare:"
+            + Environment.NewLine + string.Join(Environment.NewLine, strays) + Environment.NewLine
+            + "Add it to ExpectedCopies — with the staleness cross-check, and with the mirror copy in the "
+            + "other store — in the same commit.");
+    }
+
+    [Fact]
+    public void EveryCopyOfTheCrossCheck_ReducesToTheCanonicalOne_InBothStores()
+    {
+        var perStore = new Dictionary<string, int>(StringComparer.Ordinal) { ["Darling"] = 0, ["Lite"] = 0 };
+        var skewed = new List<string>();
+
+        foreach (var (relativePath, _, _) in ExpectedCopies)
+        {
+            var store = relativePath.StartsWith("Lite/", StringComparison.Ordinal) ? "Lite" : "Darling";
+
+            foreach (Match m in StaleMaxDopGuard.Matches(ReadNormalizedSource(RepoPath(relativePath))))
+            {
+                perStore[store]++;
+
+                if (!string.Equals(Normalize(m.Value), CanonicalStaleMaxDopGuard, StringComparison.Ordinal))
+                {
+                    skewed.Add(
+                        $"{relativePath} @ char {m.Index}: floor={m.Groups["floorOp"].Value} "
+                        + $"{m.Groups["floor"].Value}, unlimited sentinel={m.Groups["unlimited"].Value}");
+                }
+            }
+        }
+
+        Assert.True(
+            skewed.Count == 0,
+            "QUERY_HIGH_DOP staleness cross-check copies disagree with the canonical one:"
+            + Environment.NewLine + string.Join(Environment.NewLine, skewed) + Environment.NewLine
+            + "canonical: " + CanonicalStaleMaxDopGuard + Environment.NewLine
+            + "Both stores must apply the SAME floor and the SAME unlimited sentinel, or one SKU reports a "
+            + "finding the other provably excludes. Retuning them means editing both copies and both "
+            + "guards' canonical literal in one commit.");
+
+        /* Both stores must actually have contributed. A store whose copy disappeared would otherwise pass
+           this test by having nothing left to disagree with. */
+        Assert.Equal(DarlingGuardCopies, perStore["Darling"]);
+        Assert.Equal(LiteGuardCopies, perStore["Lite"]);
+    }
+
+    /// <summary>
+    /// The <c>current_maxdop</c> CTE, per store, including which config source each legitimately reads.
+    /// Lite's <c>v_server_config</c> is not a style choice: its <c>v_</c> views union the live tables with
+    /// archived Parquet, and <c>AnalysisPipeline_NeverReadsAnArchivableTableRaw</c> fails on the bare name.
+    /// </summary>
+    [Fact]
+    public void TheCurrentMaxDopCte_ReadsTheRightConfigSource_InEachStore()
+    {
+        foreach (var (relativePath, _, expectedSource) in ExpectedCopies)
+        {
+            var source = ReadNormalizedSource(RepoPath(relativePath));
+
+            var m = CurrentMaxDopCte.Match(source);
+            Assert.True(
+                m.Success,
+                $"{relativePath} no longer resolves the server's current MAXDOP in a current_maxdop CTE "
+                + "that takes the NEWEST 'max degree of parallelism' capture. Without it the cross-check "
+                + "compares against nothing.");
+
+            Assert.True(
+                string.Equals(m.Groups["source"].Value, expectedSource, StringComparison.Ordinal),
+                $"{relativePath}'s current_maxdop CTE reads {m.Groups["source"].Value}, expected "
+                + $"{expectedSource}.");
+        }
+    }
+
+    /// <summary>
+    /// The NULL-safe join, in both stores. This is the carve-out that keeps an absent config row from
+    /// suppressing the finding — and, because the join feeds the whole read, from suppressing every other
+    /// fact it emits.
+    /// </summary>
+    [Fact]
+    public void TheNullSafeJoin_IsPinnedInBothStores()
+    {
+        foreach (var (relativePath, expected, _) in ExpectedCopies)
+        {
+            var actual = NullSafeJoin.Matches(ReadNormalizedSource(RepoPath(relativePath))).Count;
+
+            Assert.True(
+                actual == expected,
+                $"{relativePath} carries {actual} NULL-safe current_maxdop join(s), expected {expected}. "
+                + "LEFT JOIN ... ON true against the one-row CTE is what delivers NULL — and therefore the "
+                + "leave-the-count-alone arm — on a server with no collected config. An inner join would "
+                + "return no rows at all there, silently dropping every fact this read emits.");
+        }
+    }
+
+    /// <summary>
+    /// The discriminators, pinned in BOTH directions against literals written for the purpose. A scan
+    /// whose pattern has quietly stopped matching reports a clean bill of health, which is worse than no
+    /// scan — so every negative claim above is backed by a positive control through the identical regex.
+    /// </summary>
+    [Fact]
+    public void TheDiscriminators_MatchTheShippedForms_AndSkew_ButNotABareProjection()
+    {
+        /* The shipped layout, in both line endings: the committed blobs are pure LF while the working
+           tree is CRLF, so both have to reduce to one answer. */
+        string[] shipped =
+        [
+            "    COUNT(CASE WHEN v.max_dop > 8\r\n"
+            + "                AND (m.value_in_use IS NULL OR m.value_in_use = 0 OR v.max_dop <= m.value_in_use)\r\n"
+            + "               THEN 1 END) AS high_dop_queries,\r\n",
+
+            "    COUNT(CASE WHEN v.max_dop > 8\n"
+            + "                AND (m.value_in_use IS NULL OR m.value_in_use = 0 OR v.max_dop <= m.value_in_use)\n"
+            + "               THEN 1 END) AS high_dop_queries,\n",
+        ];
+
+        foreach (var sql in shipped)
+        {
+            var m = StaleMaxDopGuard.Match(sql);
+            Assert.True(m.Success, "the discriminator missed a shipped cross-check form");
+            Assert.Equal(CanonicalStaleMaxDopGuard, Normalize(m.Value));
+            Assert.True(HighDopCount.IsMatch(sql), "the census pattern missed a shipped high-DOP count");
+        }
+
+        /* THE DEFECT ITSELF — #2999's Lite read as it stood. It must land in the CENSUS and must NOT
+           match the guard, or EveryHighDopCount_CarriesTheStalenessCrossCheck cannot see it. */
+        const string unguarded = "    COUNT(CASE WHEN max_dop > 8 THEN 1 END) AS high_dop_queries,\r\n";
+        Assert.True(
+            HighDopCount.IsMatch(unguarded),
+            "the census pattern does not see an UNGUARDED high-DOP count — the #2999 defect would pass");
+        Assert.False(
+            StaleMaxDopGuard.IsMatch(unguarded),
+            "the guard pattern matched an unguarded high-DOP count");
+
+        /* SKEW — each must still MATCH, so it lands in the census and is reported as a wrong value, and
+           must NOT reduce to the canonical cross-check. */
+        (string Sql, string What)[] skews =
+        [
+            (shipped[0].Replace("max_dop > 8", "max_dop > 16", StringComparison.Ordinal), "DOP floor raised"),
+            (shipped[0].Replace("max_dop > 8", "max_dop >= 8", StringComparison.Ordinal), "DOP floor operator loosened"),
+            (shipped[0].Replace("value_in_use = 0", "value_in_use = 1", StringComparison.Ordinal), "unlimited sentinel changed"),
+        ];
+
+        foreach (var (sql, what) in skews)
+        {
+            var m = StaleMaxDopGuard.Match(sql);
+            Assert.True(
+                m.Success,
+                $"the discriminator stopped matching a skewed copy ({what}) — it would be reported as a "
+                + "missing copy rather than a skewed literal");
+            Assert.NotEqual(CanonicalStaleMaxDopGuard, Normalize(m.Value));
+        }
+
+        /* CARVE-OUTS DROPPED. Either one alone inverts the fix: without the NULL arm a server with no
+           collected config stops reporting, without the zero arm an unlimited server does. Both must
+           leave the census — the copy is no longer the cross-check — while still being counted as a
+           high-DOP read, so the pairing assertion is what reports them. */
+        (string Sql, string What)[] mutilated =
+        [
+            (shipped[0].Replace("m.value_in_use IS NULL OR ", "", StringComparison.Ordinal), "NULL carve-out dropped"),
+            (shipped[0].Replace("m.value_in_use = 0 OR ", "", StringComparison.Ordinal), "unlimited carve-out dropped"),
+            (shipped[0].Replace(" OR v.max_dop <= m.value_in_use", "", StringComparison.Ordinal), "ceiling test dropped"),
+        ];
+
+        foreach (var (sql, what) in mutilated)
+        {
+            Assert.False(
+                StaleMaxDopGuard.IsMatch(sql),
+                $"the guard pattern matched a cross-check with the {what}");
+            Assert.True(
+                HighDopCount.IsMatch(sql),
+                $"the census pattern lost sight of the read when the {what} — it would be reported as a "
+                + "deleted read rather than an unguarded one");
+        }
+
+        /* BARE PROJECTIONS — real lines from this corpus. max_dop is projected by both stores'
+           drill-downs and activity reads; a pattern keyed on the column rather than on the COUNT would
+           flag every one of them. */
+        string[] benign =
+        [
+            "       MAX(max_dop) AS max_dop,",
+            "    MAX(max_dop) AS max_dop",
+            "    MAX(dop) AS max_dop,",
+            "                max_dop = reader.IsDBNull(4) ? 0 : Convert.ToInt32(reader.GetValue(4)),",
+            "                        [\"max_dop\"] = maxDop",
+            /* And a genuinely unrelated COUNT(CASE WHEN ...) from the same read. */
+            "    COUNT(CASE WHEN v.delta_spills > 0 THEN 1 END) AS spilling_queries,",
+        ];
+
+        foreach (var sql in benign)
+        {
+            Assert.False(HighDopCount.IsMatch(sql), $"the census pattern dragged in a benign form: {sql}");
+            Assert.False(StaleMaxDopGuard.IsMatch(sql), $"the guard pattern dragged in a benign form: {sql}");
+        }
+
+        /* The CTE and join discriminators need their own positive control, for the same reason. */
+        const string shippedCte =
+            "WITH current_maxdop AS\r\n"
+            + "(\r\n"
+            + "    SELECT value_in_use\r\n"
+            + "    FROM v_server_config\r\n"
+            + "    WHERE server_id = $1\r\n"
+            + "    AND   configuration_name = 'max degree of parallelism'\r\n"
+            + "    ORDER BY capture_time DESC\r\n"
+            + "    LIMIT 1\r\n"
+            + ")\r\n";
+
+        var cte = CurrentMaxDopCte.Match(shippedCte);
+        Assert.True(cte.Success, "the CTE discriminator missed a shipped current_maxdop CTE");
+        Assert.Equal("v_server_config", cte.Groups["source"].Value);
+
+        Assert.False(
+            CurrentMaxDopCte.IsMatch(
+                shippedCte.Replace("capture_time DESC", "capture_time ASC", StringComparison.Ordinal)),
+            "the CTE discriminator accepted the OLDEST config capture");
+        Assert.False(
+            CurrentMaxDopCte.IsMatch(
+                shippedCte.Replace(
+                    "'max degree of parallelism'",
+                    "'cost threshold for parallelism'",
+                    StringComparison.Ordinal)),
+            "the CTE discriminator accepted an unrelated configuration setting");
+
+        Assert.Matches(NullSafeJoin, "LEFT JOIN current_maxdop AS m ON true\r\n");
+        Assert.False(
+            NullSafeJoin.IsMatch("INNER JOIN current_maxdop AS m ON true\r\n"),
+            "the join discriminator accepted an inner join");
+        Assert.False(
+            NullSafeJoin.IsMatch("JOIN current_maxdop AS m ON true\r\n"),
+            "the join discriminator accepted a bare (inner) join");
+    }
+
+    /// <summary>
+    /// Lite's twin must exist and pin the SAME canonical cross-check and the same Lite-side count.
+    /// Deleting or softening one guard while the other keeps claiming parity is the drift this pair
+    /// exists to prevent, and <c>build.yml</c>'s <c>lite</c> filter covers Darling's test tree, so the
+    /// mirror of this assertion runs on any edit to this file.
+    /// </summary>
+    [Fact]
+    public void LitesTwinGuard_PinsTheSameCanonicalCrossCheck_AndTheSameLiteSideCount()
+    {
+        const string twin = "Lite.Tests/QueryHighDopStaleMaxDopParityTests.cs";
+        var path = RepoPath(twin);
+        Assert.True(File.Exists(path), $"Lite's counterpart guard is missing: {twin}");
+
+        var source = ReadNormalizedSource(path);
+
+        Assert.Equal(CanonicalStaleMaxDopGuard, ParseCanonicalCrossCheck(source, twin));
+
+        var declared = Regex.Match(source, @"ExpectedGuardCopies\s*=\s*(?<n>\d+)\s*;");
+        Assert.True(declared.Success, $"{twin} no longer declares ExpectedGuardCopies.");
+        Assert.Equal(
+            LiteGuardCopies,
+            int.Parse(declared.Groups["n"].Value, System.Globalization.CultureInfo.InvariantCulture));
+    }
+
+    /// <summary>
+    /// The source parser must read THIS file's own constant back correctly, or it proves nothing about
+    /// Lite's. Lite's twin runs the same self-check against its own copy.
+    /// </summary>
+    [Fact]
+    public void TheCanonicalCrossCheckParser_RoundTripsThisGuardsOwnDeclaration()
+    {
+        var thisFile = ThisFilePath();
+
+        Assert.Equal(
+            CanonicalStaleMaxDopGuard,
+            ParseCanonicalCrossCheck(ReadNormalizedSource(thisFile), thisFile));
+    }
+
+    /// <summary>
+    /// Reconstructs a <c>CanonicalStaleMaxDopGuard</c> declaration from C# source, for the half of the
+    /// pair that cannot reference the other SKU's assembly.
+    /// </summary>
+    internal static string ParseCanonicalCrossCheck(string source, string label)
+    {
+        var start = source.IndexOf("CanonicalStaleMaxDopGuard =", StringComparison.Ordinal);
+        Assert.True(start >= 0, $"{label} no longer declares CanonicalStaleMaxDopGuard.");
+
+        var end = source.IndexOf(';', start);
+        Assert.True(end > start, $"{label}'s CanonicalStaleMaxDopGuard declaration is unterminated.");
+
+        var declaration = source[start..end];
+
+        /* The literal is deliberately escape-free on both sides, so the segment pattern below is exact
+           rather than approximate. A backslash appearing here means the declaration changed shape and the
+           parser is no longer reading what it thinks it is. */
+        Assert.DoesNotContain("\\", declaration, StringComparison.Ordinal);
+
+        var segments = Regex.Matches(declaration, "\"(?<s>[^\"]*)\"")
+            .Select(m => m.Groups["s"].Value)
+            .ToList();
+
+        Assert.True(segments.Count > 0, $"{label}'s CanonicalStaleMaxDopGuard parsed to nothing.");
+
+        return string.Concat(segments);
+    }
+
+    /// <summary>Collapses runs of whitespace to single spaces.</summary>
+    private static string Normalize(string block) => Regex.Replace(block, @"\s+", " ").Trim();
+
+    /// <summary>
+    /// Reads source with line endings collapsed to LF. <c>.gitattributes</c> checks the working tree out
+    /// CRLF while the committed blobs are LF, and the cross-check is the same either way, so normalizing
+    /// here keeps the regexes from having to care which one they are looking at.
+    /// </summary>
+    private static string ReadNormalizedSource(string path) =>
+        File.ReadAllText(path).Replace("\r\n", "\n", StringComparison.Ordinal);
+
+    /* -- Source location. Resolved by walking up from this file, the way the sibling scans do. -- */
+
+    private static string ThisFilePath([CallerFilePath] string thisFile = "") => thisFile;
+
+    private static IEnumerable<string> AnalysisSourceFiles([CallerFilePath] string thisFile = "")
+    {
+        foreach (var root in new[]
+        {
+            RepoPath("Darling/PerformanceMonitor.Darling.Analysis", thisFile),
+            RepoPath("Lite/Analysis", thisFile),
+        })
+        {
+            /* AllDirectories, not TopDirectoryOnly: Lite/Analysis has a Recommendations subdirectory, and
+               an unscanned subtree is exactly how a ported copy escapes a census. */
+            foreach (var path in Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories))
+            {
+                if (path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                    || path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                yield return path;
+            }
+        }
+    }
+
+    private static string RepoPath(string relative, [CallerFilePath] string thisFile = "")
+    {
+        /* This file lives at <repo>/Darling/Darling.Tests/, so the repo root is two levels up. */
+        var repoRoot = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(thisFile)!, "..", ".."));
+        return Path.GetFullPath(Path.Combine(repoRoot, relative.Replace('/', Path.DirectorySeparatorChar)));
+    }
+}

--- a/Lite.Tests/QueryHighDopStaleMaxDopParityTests.cs
+++ b/Lite.Tests/QueryHighDopStaleMaxDopParityTests.cs
@@ -1,0 +1,559 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Lite.Tests;
+
+/// <summary>
+/// Lite's half of the cross-SKU parity guard for the QUERY_HIGH_DOP staleness cross-check. The exact
+/// counterpart of <c>Darling.Tests.QueryHighDopStaleMaxDopParityTests</c>, deliberately built to the
+/// same shape — and to the shape <c>ParameterSensitivityFiringSignatureParityTests</c> established in
+/// #2998 — so the two apps are guarded the same way rather than one being guarded and the other trusted.
+///
+/// <para><b>The cross-check.</b> <c>max_dop</c> on <c>v_query_stats</c> is
+/// <c>sys.dm_exec_query_stats</c>' LIFETIME max for the plan's time in cache, so a plan compiled before
+/// <c>max degree of parallelism</c> was lowered keeps reporting the old higher DOP until it is evicted or
+/// recompiled. A reading that EXCEEDS what the server's current MAXDOP can produce is impossible under
+/// today's configuration, so it provably predates the change that set it and must not be counted. Lite
+/// writes the cross-check once, in <c>DuckDbFactCollector</c>'s query-stats read, and Darling writes the
+/// same one against its own store.</para>
+///
+/// <para><b>Why this pair exists at all.</b> #2705 fixed Darling and closed without a record that a twin
+/// existed; #2999 is what that cost — Lite kept raising the finding at full confidence from readings
+/// Darling provably excludes, and lowering MAXDOP is the ordinary remediation FOR this finding, so it
+/// survived its own fix. #2998's guard is deliberately scoped to the PARAMETER_SENSITIVITY firing
+/// signature and does not reach this predicate; this pair is its sibling for that reason.</para>
+///
+/// <para><b>The carve-outs cut the other way.</b> A <c>current_maxdop</c> of 0 (unlimited) and an absent
+/// config row both make no configuration claim, so both must leave the count ALONE. Getting either
+/// backwards suppresses the finding entirely, which is worse than over-reporting because nothing then
+/// surfaces it — hence <see cref="EveryHighDopCount_CarriesTheStalenessCrossCheck"/> and
+/// <see cref="TheNullSafeJoin_IsPinned"/>.</para>
+///
+/// <para><b>Why the pair, and not one scan.</b> Darling's twin does the cross-STORE comparison, because
+/// <c>build.yml</c>'s <c>darling</c> path filter covers every Lite <c>.cs</c> file as well as the whole
+/// Darling tree, so it runs on an edit to either analysis tree. This file owns Lite's own census and
+/// meta-pins Darling's declared numbers, and the <c>lite</c> filter covers Darling's test tree — so an
+/// edit that weakens Darling's guard runs this one. Raising a count or retuning a literal in one guard
+/// without the other fails:
+/// <see cref="DarlingsTwinGuard_PinsTheSameCanonicalCrossCheck_SoNeitherSideCanFallBehind"/> reads
+/// Darling's guard as source and compares the two declarations.</para>
+///
+/// <para><b>Read from source, not from a constant.</b> Lite's analysis SQL is inline
+/// <c>cmd.CommandText</c> where Darling's is a named constant. The asymmetry does not matter here,
+/// because no test project references both SKUs' assemblies — whichever suite hosts a cross-SKU claim has
+/// to read at least one side out of the checked-out tree anyway (that is what <see cref="ParitySource"/>
+/// exists for).</para>
+/// </summary>
+public sealed class QueryHighDopStaleMaxDopParityTests
+{
+    /// <summary>
+    /// The cross-check, normalized: runs of whitespace collapsed to single spaces. Byte-identical to the
+    /// literal Darling's twin declares, and the meta-pin below compares the two.
+    /// </summary>
+    internal const string CanonicalStaleMaxDopGuard =
+        "COUNT(CASE WHEN v.max_dop > 8 " +
+        "AND (m.value_in_use IS NULL OR m.value_in_use = 0 OR v.max_dop <= m.value_in_use) " +
+        "THEN 1 END) AS high_dop_queries";
+
+    /// <summary>
+    /// Copies of the cross-check in Lite's analysis tree. Darling's twin declares this same number as its
+    /// <c>LiteGuardCopies</c> and the meta-pin below reads it back, so neither side can be raised alone.
+    /// </summary>
+    internal const int ExpectedGuardCopies = 1;
+
+    /// <summary>
+    /// The config source Lite's read must use. Not a style choice: Lite's <c>v_</c> views union the live
+    /// tables with archived Parquet, and
+    /// <see cref="AnalysisDataSpanTests.AnalysisPipeline_NeverReadsAnArchivableTableRaw"/> positively
+    /// REQUIRES that form under <c>Lite/Analysis</c> — a bare <c>server_config</c> fails it, and would
+    /// also cross-check against whatever survived the last 512 MB reset.
+    /// </summary>
+    private const string LiteConfigSource = "v_server_config";
+
+    /// <summary>Darling's guard, read as source because no test project references both SKUs.</summary>
+    private const string DarlingGuard = "Darling/Darling.Tests/QueryHighDopStaleMaxDopParityTests.cs";
+
+    /// <summary>This file, read as source so the meta-pin's parser can be self-validated.</summary>
+    private const string ThisGuard = "Lite.Tests/QueryHighDopStaleMaxDopParityTests.cs";
+
+    /// <summary>
+    /// The cross-check, per Lite file — a floor and a ceiling. Written out rather than globbed so that
+    /// deleting a read, or moving one to a new file, fails here and has to be re-declared instead of
+    /// quietly reducing this guard's coverage to whatever is left.
+    /// </summary>
+    private static readonly (string RelativePath, int Copies)[] ExpectedCopies =
+    [
+        ("Lite/Analysis/DuckDbFactCollector.QueryPerf.cs", 1),
+    ];
+
+    /// <summary>
+    /// Every read that COUNTS high-DOP queries at all, guarded or not — the census the cross-check has to
+    /// cover. Deliberately looser than <see cref="StaleMaxDopGuard"/>: the whole point is that a count
+    /// WITHOUT the cross-check still lands here.
+    /// </summary>
+    private static readonly Regex HighDopCount = new(
+        @"COUNT\([ \t]*CASE[ \t]+WHEN[ \t]+(?:[A-Za-z_]\w*\.)?max_dop[ \t]*(?<floorOp>>=?)[ \t]*(?<floor>\d+)",
+        RegexOptions.IgnoreCase);
+
+    /// <summary>
+    /// The cross-check as a shape: every token pinned literally EXCEPT the DOP floor and the unlimited
+    /// sentinel, which are captured so a skewed copy is still found and reported as a wrong value rather
+    /// than vanishing from the census. Adjacency is pinned with <c>[ \t]</c> rather than <c>\s</c> so a
+    /// blank line or a reordering cannot slide past.
+    /// </summary>
+    private static readonly Regex StaleMaxDopGuard = new(
+        @"COUNT\([ \t]*CASE[ \t]+WHEN[ \t]+v\.max_dop[ \t]*(?<floorOp>>=?)[ \t]*(?<floor>\d+)[ \t]*\r?\n"
+        + @"[ \t]*AND[ \t]+\([ \t]*m\.value_in_use[ \t]+IS[ \t]+NULL[ \t]+OR[ \t]+"
+        + @"m\.value_in_use[ \t]*=[ \t]*(?<unlimited>\d+)[ \t]+OR[ \t]+"
+        + @"v\.max_dop[ \t]*<=[ \t]*m\.value_in_use[ \t]*\)[ \t]*\r?\n"
+        + @"[ \t]*THEN[ \t]+1[ \t]+END\)[ \t]+AS[ \t]+high_dop_queries",
+        RegexOptions.IgnoreCase);
+
+    /// <summary>
+    /// The CTE that resolves the server's CURRENT MAXDOP. The config source is captured so it can be
+    /// pinned to Lite's <c>v_</c> form; everything that decides WHICH row wins is pinned, because a copy
+    /// that reads the oldest capture, or an unrelated setting, would cross-check against a number that
+    /// means nothing.
+    /// </summary>
+    private static readonly Regex CurrentMaxDopCte = new(
+        @"WITH[ \t]+current_maxdop[ \t]+AS[ \t]*\r?\n"
+        + @"[ \t]*\([ \t]*\r?\n"
+        + @"[ \t]*SELECT[ \t]+value_in_use[ \t]*\r?\n"
+        + @"[ \t]*FROM[ \t]+(?<source>v_server_config|server_config)[ \t]*\r?\n"
+        + @"[ \t]*WHERE[ \t]+server_id[ \t]*=[ \t]*\$\d+[ \t]*\r?\n"
+        + @"[ \t]*AND[ \t]+configuration_name[ \t]*=[ \t]*'max degree of parallelism'[ \t]*\r?\n"
+        + @"[ \t]*ORDER[ \t]+BY[ \t]+capture_time[ \t]+DESC[ \t]*\r?\n"
+        + @"[ \t]*LIMIT[ \t]+1[ \t]*\r?\n"
+        + @"[ \t]*\)",
+        RegexOptions.IgnoreCase);
+
+    /// <summary>
+    /// The NULL-safe join. <c>LEFT JOIN ... ON true</c> against a one-row CTE is what makes an absent
+    /// config row arrive as NULL and take the leave-the-count-alone arm. An inner join would return NO
+    /// ROWS on a server with no collected config, so QUERY_HIGH_DOP — and QUERY_SPILLS with it — would
+    /// silently vanish rather than being over-reported.
+    /// </summary>
+    private static readonly Regex NullSafeJoin = new(
+        @"LEFT[ \t]+JOIN[ \t]+current_maxdop[ \t]+AS[ \t]+m[ \t]+ON[ \t]+true",
+        RegexOptions.IgnoreCase);
+
+    [Fact]
+    public void EveryCopyOfTheCrossCheck_IsAccountedFor_InLitesAnalysisSql()
+    {
+        var total = 0;
+
+        foreach (var (relativePath, expected) in ExpectedCopies)
+        {
+            var actual = StaleMaxDopGuard.Matches(ReadNormalized(relativePath)).Count;
+            total += actual;
+
+            Assert.True(
+                actual == expected,
+                $"{relativePath} carries {actual} copy/copies of the QUERY_HIGH_DOP staleness cross-check, "
+                + $"expected {expected}. #2705 landed on Darling only and #2999 is what that cost: if a read "
+                + "moved or was added, update this guard AND Darling's in the same commit.");
+        }
+
+        Assert.Equal(ExpectedGuardCopies, total);
+    }
+
+    /// <summary>
+    /// The assertion that fails if the cross-check is deleted while everything else stays. A high-DOP
+    /// COUNT with no staleness cross-check is exactly the #2999 defect, and it satisfies every count and
+    /// canonical assertion above by simply not being there to disagree with.
+    /// </summary>
+    [Fact]
+    public void EveryHighDopCount_CarriesTheStalenessCrossCheck()
+    {
+        var unguarded = new List<string>();
+
+        foreach (var (relativePath, _) in ExpectedCopies)
+        {
+            var source = ReadNormalized(relativePath);
+            var counts = HighDopCount.Matches(source).Count;
+            var guarded = StaleMaxDopGuard.Matches(source).Count;
+
+            if (counts != guarded)
+            {
+                unguarded.Add($"{relativePath}: {counts} high-DOP count(s), {guarded} carrying the cross-check");
+            }
+        }
+
+        Assert.True(
+            unguarded.Count == 0,
+            "a QUERY_HIGH_DOP count exists that does NOT cross-check max_dop against the server's current "
+            + "MAXDOP:" + Environment.NewLine + string.Join(Environment.NewLine, unguarded) + Environment.NewLine
+            + "max_dop is dm_exec_query_stats' LIFETIME max, so a raw count fires from readings the current "
+            + "configuration makes impossible — and lowering MAXDOP is the remediation this very finding "
+            + "recommends, so the finding would outlive its own fix. That was #2999.");
+    }
+
+    [Fact]
+    public void NoUndeclaredLiteAnalysisRead_CountsHighDopQueries()
+    {
+        var declared = ExpectedCopies
+            .Select(e => RepoPath(e.RelativePath))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var files = LiteAnalysisSourceFiles();
+
+        /* A floor, so a broken enumeration cannot report a clean bill of health. 24 files under
+           Lite/Analysis when this was written; set well below that so ordinary growth never trips it, but
+           high enough that an empty enumeration fails instead of passing. */
+        Assert.True(files.Length >= 12, $"enumerated only {files.Length} files under Lite/Analysis");
+
+        /* And the declared files must be part of what was enumerated, or the two halves of this guard are
+           looking at different trees. */
+        Assert.Equal(ExpectedCopies.Length, declared.Intersect(files, StringComparer.OrdinalIgnoreCase).Count());
+
+        var strays = new List<string>();
+
+        foreach (var path in files)
+        {
+            if (declared.Contains(path))
+            {
+                continue;
+            }
+
+            var count = HighDopCount.Matches(
+                File.ReadAllText(path).Replace("\r\n", "\n", StringComparison.Ordinal)).Count;
+
+            if (count > 0)
+            {
+                strays.Add($"{Path.GetFileName(path)}: {count} high-DOP count(s)");
+            }
+        }
+
+        Assert.True(
+            strays.Count == 0,
+            "a Lite analysis read counts high-DOP queries in a file this guard does not declare:"
+            + Environment.NewLine + string.Join(Environment.NewLine, strays) + Environment.NewLine
+            + "Add it to ExpectedCopies — with the staleness cross-check, and with the mirror copy in "
+            + "Darling's store — in the same commit.");
+    }
+
+    [Fact]
+    public void EveryCopyOfTheCrossCheck_ReducesToTheCanonicalOne()
+    {
+        var skewed = new List<string>();
+        var seen = 0;
+
+        foreach (var (relativePath, _) in ExpectedCopies)
+        {
+            foreach (Match m in StaleMaxDopGuard.Matches(ReadNormalized(relativePath)))
+            {
+                seen++;
+
+                if (!string.Equals(Normalize(m.Value), CanonicalStaleMaxDopGuard, StringComparison.Ordinal))
+                {
+                    skewed.Add(
+                        $"{relativePath} @ char {m.Index}: floor={m.Groups["floorOp"].Value} "
+                        + $"{m.Groups["floor"].Value}, unlimited sentinel={m.Groups["unlimited"].Value}");
+                }
+            }
+        }
+
+        Assert.True(
+            skewed.Count == 0,
+            "QUERY_HIGH_DOP staleness cross-check copies disagree with the canonical one:"
+            + Environment.NewLine + string.Join(Environment.NewLine, skewed) + Environment.NewLine
+            + "canonical: " + CanonicalStaleMaxDopGuard + Environment.NewLine
+            + "Lite AND Darling must apply the SAME floor and the SAME unlimited sentinel, or one SKU "
+            + "reports a finding the other provably excludes.");
+
+        /* The census must have had something to look at: nothing found would otherwise pass this test by
+           having nothing left to disagree with. */
+        Assert.Equal(ExpectedGuardCopies, seen);
+    }
+
+    /// <summary>
+    /// The <c>current_maxdop</c> CTE, and the <c>v_</c> config source it must read. Both halves matter:
+    /// without the CTE the cross-check compares against nothing, and with the bare table name it compares
+    /// against whatever survived the last 512 MB archive reset.
+    /// </summary>
+    [Fact]
+    public void TheCurrentMaxDopCte_ReadsTheArchiveView_NotServerConfigRaw()
+    {
+        foreach (var (relativePath, _) in ExpectedCopies)
+        {
+            var source = ReadNormalized(relativePath);
+
+            var m = CurrentMaxDopCte.Match(source);
+            Assert.True(
+                m.Success,
+                $"{relativePath} no longer resolves the server's current MAXDOP in a current_maxdop CTE "
+                + "that takes the NEWEST 'max degree of parallelism' capture.");
+
+            Assert.Equal(LiteConfigSource, m.Groups["source"].Value);
+
+            Assert.False(
+                Regex.IsMatch(source, @"\bFROM\s+server_config\b"),
+                $"{relativePath} reads server_config raw — AnalysisPipeline_NeverReadsAnArchivableTableRaw "
+                + "fails on that, and the read would lose everything archived to Parquet.");
+        }
+    }
+
+    /// <summary>
+    /// The NULL-safe join. This is the carve-out that keeps an absent config row from suppressing the
+    /// finding — and, because the join feeds the whole read, from suppressing every other fact it emits.
+    /// </summary>
+    [Fact]
+    public void TheNullSafeJoin_IsPinned()
+    {
+        foreach (var (relativePath, expected) in ExpectedCopies)
+        {
+            var actual = NullSafeJoin.Matches(ReadNormalized(relativePath)).Count;
+
+            Assert.True(
+                actual == expected,
+                $"{relativePath} carries {actual} NULL-safe current_maxdop join(s), expected {expected}. "
+                + "LEFT JOIN ... ON true against the one-row CTE is what delivers NULL — and therefore the "
+                + "leave-the-count-alone arm — on a server with no collected config. An inner join would "
+                + "return no rows at all there, silently dropping every fact this read emits.");
+        }
+    }
+
+    /// <summary>
+    /// The discriminators, pinned in BOTH directions against literals written for the purpose, and kept
+    /// in this suite as well as Darling's so that each half can fail on its own rather than inheriting
+    /// the other's confidence.
+    /// </summary>
+    [Fact]
+    public void TheDiscriminators_MatchTheShippedForms_AndSkew_ButNotABareProjection()
+    {
+        /* The shipped layout, in both line endings: the committed blobs are pure LF while the working
+           tree is CRLF, so both have to reduce to one answer. */
+        string[] shipped =
+        [
+            "    COUNT(CASE WHEN v.max_dop > 8\r\n"
+            + "                AND (m.value_in_use IS NULL OR m.value_in_use = 0 OR v.max_dop <= m.value_in_use)\r\n"
+            + "               THEN 1 END) AS high_dop_queries,\r\n",
+
+            "    COUNT(CASE WHEN v.max_dop > 8\n"
+            + "                AND (m.value_in_use IS NULL OR m.value_in_use = 0 OR v.max_dop <= m.value_in_use)\n"
+            + "               THEN 1 END) AS high_dop_queries,\n",
+        ];
+
+        foreach (var sql in shipped)
+        {
+            var m = StaleMaxDopGuard.Match(sql);
+            Assert.True(m.Success, "the discriminator missed a shipped cross-check form");
+            Assert.Equal(CanonicalStaleMaxDopGuard, Normalize(m.Value));
+            Assert.True(HighDopCount.IsMatch(sql), "the census pattern missed a shipped high-DOP count");
+        }
+
+        /* THE DEFECT ITSELF — #2999's Lite read as it stood. It must land in the CENSUS and must NOT
+           match the guard, or EveryHighDopCount_CarriesTheStalenessCrossCheck cannot see it. */
+        const string unguarded = "    COUNT(CASE WHEN max_dop > 8 THEN 1 END) AS high_dop_queries,\r\n";
+        Assert.True(
+            HighDopCount.IsMatch(unguarded),
+            "the census pattern does not see an UNGUARDED high-DOP count — the #2999 defect would pass");
+        Assert.False(
+            StaleMaxDopGuard.IsMatch(unguarded),
+            "the guard pattern matched an unguarded high-DOP count");
+
+        /* SKEW — each must still MATCH, so it lands in the census and is reported as a wrong value, and
+           must NOT reduce to the canonical cross-check. */
+        (string Sql, string What)[] skews =
+        [
+            (shipped[0].Replace("max_dop > 8", "max_dop > 16", StringComparison.Ordinal), "DOP floor raised"),
+            (shipped[0].Replace("max_dop > 8", "max_dop >= 8", StringComparison.Ordinal), "DOP floor operator loosened"),
+            (shipped[0].Replace("value_in_use = 0", "value_in_use = 1", StringComparison.Ordinal), "unlimited sentinel changed"),
+        ];
+
+        foreach (var (sql, what) in skews)
+        {
+            var m = StaleMaxDopGuard.Match(sql);
+            Assert.True(
+                m.Success,
+                $"the discriminator stopped matching a skewed copy ({what}) — it would be reported as a "
+                + "missing copy rather than a skewed literal");
+            Assert.NotEqual(CanonicalStaleMaxDopGuard, Normalize(m.Value));
+        }
+
+        /* CARVE-OUTS DROPPED. Either one alone inverts the fix: without the NULL arm a server with no
+           collected config stops reporting, without the zero arm an unlimited server does. */
+        (string Sql, string What)[] mutilated =
+        [
+            (shipped[0].Replace("m.value_in_use IS NULL OR ", "", StringComparison.Ordinal), "NULL carve-out dropped"),
+            (shipped[0].Replace("m.value_in_use = 0 OR ", "", StringComparison.Ordinal), "unlimited carve-out dropped"),
+            (shipped[0].Replace(" OR v.max_dop <= m.value_in_use", "", StringComparison.Ordinal), "ceiling test dropped"),
+        ];
+
+        foreach (var (sql, what) in mutilated)
+        {
+            Assert.False(
+                StaleMaxDopGuard.IsMatch(sql),
+                $"the guard pattern matched a cross-check with the {what}");
+            Assert.True(
+                HighDopCount.IsMatch(sql),
+                $"the census pattern lost sight of the read when the {what} — it would be reported as a "
+                + "deleted read rather than an unguarded one");
+        }
+
+        /* BARE PROJECTIONS — real lines from this corpus. max_dop is projected by Lite's drill-down and
+           activity reads; a pattern keyed on the column rather than on the COUNT would flag every one. */
+        string[] benign =
+        [
+            "       MAX(max_dop) AS max_dop,",
+            "    MAX(max_dop) AS max_dop",
+            "    MAX(dop) AS max_dop,",
+            "                max_dop = reader.IsDBNull(4) ? 0 : Convert.ToInt32(reader.GetValue(4)),",
+            "                        [\"max_dop\"] = maxDop",
+            /* And a genuinely unrelated COUNT(CASE WHEN ...) from the same read. */
+            "    COUNT(CASE WHEN v.delta_spills > 0 THEN 1 END) AS spilling_queries,",
+        ];
+
+        foreach (var sql in benign)
+        {
+            Assert.False(HighDopCount.IsMatch(sql), $"the census pattern dragged in a benign form: {sql}");
+            Assert.False(StaleMaxDopGuard.IsMatch(sql), $"the guard pattern dragged in a benign form: {sql}");
+        }
+
+        /* The CTE and join discriminators need their own positive control, for the same reason. */
+        const string shippedCte =
+            "WITH current_maxdop AS\r\n"
+            + "(\r\n"
+            + "    SELECT value_in_use\r\n"
+            + "    FROM v_server_config\r\n"
+            + "    WHERE server_id = $1\r\n"
+            + "    AND   configuration_name = 'max degree of parallelism'\r\n"
+            + "    ORDER BY capture_time DESC\r\n"
+            + "    LIMIT 1\r\n"
+            + ")\r\n";
+
+        var cte = CurrentMaxDopCte.Match(shippedCte);
+        Assert.True(cte.Success, "the CTE discriminator missed a shipped current_maxdop CTE");
+        Assert.Equal(LiteConfigSource, cte.Groups["source"].Value);
+
+        Assert.False(
+            CurrentMaxDopCte.IsMatch(
+                shippedCte.Replace("capture_time DESC", "capture_time ASC", StringComparison.Ordinal)),
+            "the CTE discriminator accepted the OLDEST config capture");
+        Assert.False(
+            CurrentMaxDopCte.IsMatch(
+                shippedCte.Replace(
+                    "'max degree of parallelism'",
+                    "'cost threshold for parallelism'",
+                    StringComparison.Ordinal)),
+            "the CTE discriminator accepted an unrelated configuration setting");
+
+        /* And the raw-table check must actually fire on the bare name, or the v_ assertion above is
+           decoration. */
+        Assert.True(
+            Regex.IsMatch("    FROM server_config\r\n", @"\bFROM\s+server_config\b"),
+            "the raw-table pattern does not see a bare server_config read");
+        Assert.False(
+            Regex.IsMatch("    FROM v_server_config\r\n", @"\bFROM\s+server_config\b"),
+            "the raw-table pattern flagged the v_ form");
+
+        Assert.Matches(NullSafeJoin, "LEFT JOIN current_maxdop AS m ON true\r\n");
+        Assert.False(
+            NullSafeJoin.IsMatch("INNER JOIN current_maxdop AS m ON true\r\n"),
+            "the join discriminator accepted an inner join");
+        Assert.False(
+            NullSafeJoin.IsMatch("JOIN current_maxdop AS m ON true\r\n"),
+            "the join discriminator accepted a bare (inner) join");
+    }
+
+    /// <summary>
+    /// Darling's twin must exist, pin the SAME canonical cross-check, and declare the same Lite-side
+    /// count this file declares for itself. Retuning a literal or moving a copy on one side of the SKU
+    /// boundary without the other is what this fails on — and because the guards, not just the SQL, are
+    /// compared, deleting or softening one while the other keeps claiming parity fails too.
+    /// </summary>
+    [Fact]
+    public void DarlingsTwinGuard_PinsTheSameCanonicalCrossCheck_SoNeitherSideCanFallBehind()
+    {
+        /* Self-validate the parser against THIS file first: a parser that reads nothing would otherwise
+           "agree" with Darling by returning the same nothing from both sides. */
+        Assert.Equal(CanonicalStaleMaxDopGuard, ParseCanonicalCrossCheck(ReadNormalized(ThisGuard), ThisGuard));
+
+        var darling = ReadNormalized(DarlingGuard);
+
+        Assert.Equal(CanonicalStaleMaxDopGuard, ParseCanonicalCrossCheck(darling, DarlingGuard));
+
+        var liteSide = Regex.Match(darling, @"LiteGuardCopies\s*=\s*(?<n>\d+)\s*;");
+        Assert.True(liteSide.Success, $"{DarlingGuard} no longer declares LiteGuardCopies.");
+        Assert.Equal(
+            ExpectedGuardCopies,
+            int.Parse(liteSide.Groups["n"].Value, System.Globalization.CultureInfo.InvariantCulture));
+
+        /* And it must still declare its own side, and still enumerate its files rather than globbing, for
+           the same reason this one does. */
+        Assert.Matches(@"DarlingGuardCopies\s*=\s*\d+\s*;", darling);
+        Assert.Contains("ExpectedCopies", darling, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Reconstructs a <c>CanonicalStaleMaxDopGuard</c> declaration from C# source, for the half of the
+    /// pair that cannot reference the other SKU's assembly.
+    /// </summary>
+    private static string ParseCanonicalCrossCheck(string source, string label)
+    {
+        var start = source.IndexOf("CanonicalStaleMaxDopGuard =", StringComparison.Ordinal);
+        Assert.True(start >= 0, $"{label} no longer declares CanonicalStaleMaxDopGuard.");
+
+        var end = source.IndexOf(';', start);
+        Assert.True(end > start, $"{label}'s CanonicalStaleMaxDopGuard declaration is unterminated.");
+
+        var declaration = source[start..end];
+
+        /* The literal is deliberately escape-free on both sides, so the segment pattern below is exact
+           rather than approximate. A backslash appearing here means the declaration changed shape and the
+           parser is no longer reading what it thinks it is. */
+        Assert.DoesNotContain("\\", declaration, StringComparison.Ordinal);
+
+        var segments = Regex.Matches(declaration, "\"(?<s>[^\"]*)\"")
+            .Select(m => m.Groups["s"].Value)
+            .ToList();
+
+        Assert.True(segments.Count > 0, $"{label}'s CanonicalStaleMaxDopGuard parsed to nothing.");
+
+        return string.Concat(segments);
+    }
+
+    /// <summary>Collapses runs of whitespace to single spaces.</summary>
+    private static string Normalize(string block) => Regex.Replace(block, @"\s+", " ").Trim();
+
+    /// <summary>
+    /// Reads a repo-relative source file with line endings collapsed to LF. <c>.gitattributes</c> checks
+    /// the working tree out CRLF while the committed blobs are LF, and the cross-check is the same either
+    /// way, so normalizing here keeps the regexes from having to care which one they are looking at.
+    /// </summary>
+    private static string ReadNormalized(string relativePath) =>
+        ParitySource.ReadFile(relativePath).Replace("\r\n", "\n", StringComparison.Ordinal);
+
+    /// <summary>Resolves a repo-relative path the same way <see cref="ParitySource.ReadFile"/> does.</summary>
+    private static string RepoPath(string relativePath) =>
+        Path.Combine(ParitySource.RepoRoot(), relativePath.Replace('/', Path.DirectorySeparatorChar));
+
+    /// <summary>
+    /// Every <c>.cs</c> file under Lite's analysis tree, RECURSIVELY.
+    /// <see cref="ParitySource.EnumerateCsFiles"/> is top-directory-only, which would leave
+    /// <c>Lite/Analysis/Recommendations</c> unscanned — and an unscanned subtree is exactly how a copy of
+    /// a read added elsewhere escapes the census above.
+    /// </summary>
+    private static string[] LiteAnalysisSourceFiles()
+    {
+        var root = RepoPath("Lite/Analysis");
+
+        return Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories)
+            .Where(p =>
+                !p.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                && !p.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .ToArray();
+    }
+}

--- a/Lite.Tests/QueryHighDopStaleMaxDopTests.cs
+++ b/Lite.Tests/QueryHighDopStaleMaxDopTests.cs
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using DuckDB.NET.Data;
+using PerformanceMonitor.Analysis;
+using PerformanceMonitorLite.Analysis;
+using PerformanceMonitorLite.Database;
+using PerformanceMonitorLite.Tests;
+using Xunit;
+
+namespace Lite.Tests;
+
+/// <summary>
+/// Real-DuckDB pin for #2999, the Lite twin of Darling's <c>QueryHighDopStaleMaxDopLiveTests</c>:
+/// QUERY_HIGH_DOP must not fire from a <c>max_dop</c> reading the server's current configuration makes
+/// impossible.
+///
+/// <para><c>v_query_stats.max_dop</c> is <c>sys.dm_exec_query_stats</c>' lifetime max for the plan's time
+/// in cache — the same semantics <c>get_top_queries_by_cpu</c>'s <c>parallel_only</c> description has
+/// always warned about. A plan compiled before <c>max degree of parallelism</c> was lowered keeps
+/// reporting its old, higher DOP until it is evicted or recompiled, so on a server now configured to
+/// MAXDOP 1 a cached max_dop of 16 is not a current problem; it is a high-water mark that predates the
+/// configuration change.</para>
+///
+/// <para><b>Why it is worse than a noisy finding.</b> Lowering MAXDOP is the ordinary remediation FOR
+/// this finding. Uncrossed, the finding keeps firing from plans cached before the change, and the advice
+/// it drives is to do what has already been done — a finding whose own remediation does not make it
+/// stop.</para>
+///
+/// <para><b>The carve-outs are asserted, not assumed.</b> A current MAXDOP of 0 (unlimited) and an
+/// absent <c>v_server_config</c> row both make no configuration claim, so both must leave the count
+/// ALONE. Getting either backwards would silently stop Lite raising the finding at all, which is worse
+/// than the over-reporting it replaces — so the two must-still-fire cases carry equal weight here with
+/// the must-not-fire one, and the boundary case (current MAXDOP exactly equal to the reading) pins that
+/// the test is <c>&lt;=</c> and not <c>&lt;</c>.</para>
+///
+/// <para><b>Real DuckDB rather than a string pin.</b> The thing under test is the ENGINE's answer: that
+/// <c>LEFT JOIN current_maxdop AS m ON true</c> against an EMPTY one-row CTE really does deliver NULL to
+/// the count's NULL arm rather than eliminating the row, and that the newest <c>capture_time</c> is the
+/// one that wins. A text assertion cannot see either.
+/// <c>Lite.Tests.QueryHighDopStaleMaxDopParityTests</c> holds the text half, across both SKUs.</para>
+/// </summary>
+public sealed class QueryHighDopStaleMaxDopTests : IClassFixture<SharedDuckDbFixture>, IDisposable
+{
+    private const int ServerId = 29990;
+    private const string ServerName = "SynthDopSrv";
+    private const string Db = "SynthDopDb";
+
+    /* The plan's lifetime high-water mark. Every case seeds this one reading and varies only what the
+       server's CURRENT configuration says, so nothing but the cross-check can move the answer. */
+    private const long CachedMaxDop = 16;
+
+    private static readonly DateTime WindowEnd = DateTime.SpecifyKind(
+        new DateTime(DateTime.UtcNow.Ticks - (DateTime.UtcNow.Ticks % TimeSpan.TicksPerSecond)),
+        DateTimeKind.Unspecified);
+
+    private static readonly DateTime WindowStart = WindowEnd.AddHours(-4);
+
+    private readonly DuckDbInitializer _duckDb;
+    private DuckDBConnection? _seedConn;
+    private long _nextId = 1;
+
+    public QueryHighDopStaleMaxDopTests(SharedDuckDbFixture fixture)
+    {
+        fixture.ResetData();
+        _duckDb = fixture.DuckDb;
+    }
+
+    public void Dispose() => _seedConn?.Dispose();
+
+    private static AnalysisContext Context() => new()
+    {
+        ServerId = ServerId,
+        ServerName = ServerName,
+        TimeRangeStart = WindowStart,
+        TimeRangeEnd = WindowEnd,
+    };
+
+    [Fact]
+    public async Task QueryHighDop_DoesNotFire_WhenMaxDopExceedsCurrentServerConfig()
+    {
+        /* -- RED without the cross-check: the plan's lifetime max_dop of 16 predates the server being
+              reconfigured to MAXDOP 1, which makes DOP > 1 impossible right now. -- */
+        await ClearAsync();
+        await SeedHighDopQueryStatsAsync();
+        await SeedServerConfigMaxDopAsync(valueInUse: 1, capturedMinutesBeforeWindowEnd: 5);
+
+        var facts = await new DuckDbFactCollector(_duckDb).CollectFactsAsync(Context());
+
+        Assert.DoesNotContain(facts, f => f.Key == "QUERY_HIGH_DOP");
+
+        /* And the read's OTHER facts survive: the cross-check must narrow one count, not eliminate the
+           row. QUERY_SPILLS comes out of the same SELECT. */
+        var spills = Assert.Single(facts, f => f.Key == "QUERY_SPILLS");
+        Assert.Equal(500.0, spills.Value);
+    }
+
+    [Fact]
+    public async Task QueryHighDop_StillFires_WhenCurrentMaxDopIsUnlimited()
+    {
+        /* MAXDOP 0 makes no reading impossible, so the finding fires exactly as it did before the
+           cross-check existed. Reading this as "0 is lower than 16, therefore stale" is the inversion
+           that would silently retire the finding on every default-configured server in the fleet. */
+        await ClearAsync();
+        await SeedHighDopQueryStatsAsync();
+        await SeedServerConfigMaxDopAsync(valueInUse: 0, capturedMinutesBeforeWindowEnd: 5);
+
+        var facts = await new DuckDbFactCollector(_duckDb).CollectFactsAsync(Context());
+
+        var fact = Assert.Single(facts, f => f.Key == "QUERY_HIGH_DOP");
+        Assert.Equal(1.0, fact.Metadata["high_dop_query_count"]);
+    }
+
+    [Fact]
+    public async Task QueryHighDop_StillFires_WhenNoServerConfigHasBeenCollected()
+    {
+        /* No v_server_config row at all — the state every server passes through before its first config
+           capture. An unknown current MAXDOP corroborates nothing, so the count is unchanged rather than
+           manufacturing confidence either way: the same "omit rather than invent" rule the CPU-
+           attribution ratio already follows. This is also the case that fails if the NULL-safe LEFT JOIN
+           is ever narrowed to an inner one. */
+        await ClearAsync();
+        await SeedHighDopQueryStatsAsync();
+
+        var facts = await new DuckDbFactCollector(_duckDb).CollectFactsAsync(Context());
+
+        var fact = Assert.Single(facts, f => f.Key == "QUERY_HIGH_DOP");
+        Assert.Equal(1.0, fact.Metadata["high_dop_query_count"]);
+    }
+
+    [Fact]
+    public async Task QueryHighDop_StillFires_WhenCurrentMaxDopExactlyPermitsTheReading()
+    {
+        /* The boundary. A cached DOP of 16 on a server configured to MAXDOP 16 is perfectly possible
+           today, so it is evidence and not staleness. This is what makes the predicate <= rather than <,
+           and an off-by-one here would drop every query running at exactly the configured limit — which
+           is most of them on a server that has been tuned. */
+        await ClearAsync();
+        await SeedHighDopQueryStatsAsync();
+        await SeedServerConfigMaxDopAsync(valueInUse: CachedMaxDop, capturedMinutesBeforeWindowEnd: 5);
+
+        var facts = await new DuckDbFactCollector(_duckDb).CollectFactsAsync(Context());
+
+        var fact = Assert.Single(facts, f => f.Key == "QUERY_HIGH_DOP");
+        Assert.Equal(1.0, fact.Metadata["high_dop_query_count"]);
+    }
+
+    [Fact]
+    public async Task TheCrossCheck_ReadsTheNewestConfigCapture_NotTheOldest()
+    {
+        /* server_config accumulates a row per capture, so "the server's current MAXDOP" is the LATEST
+           one. Seeded out of order on purpose: the stale MAXDOP 1 capture is written second and dated
+           first, so a read that took whatever the engine handed back, or the oldest row, would suppress
+           a finding that is genuinely current. */
+        await ClearAsync();
+        await SeedHighDopQueryStatsAsync();
+        await SeedServerConfigMaxDopAsync(valueInUse: CachedMaxDop, capturedMinutesBeforeWindowEnd: 5);
+        await SeedServerConfigMaxDopAsync(valueInUse: 1, capturedMinutesBeforeWindowEnd: 200);
+
+        var facts = await new DuckDbFactCollector(_duckDb).CollectFactsAsync(Context());
+
+        var fact = Assert.Single(facts, f => f.Key == "QUERY_HIGH_DOP");
+        Assert.Equal(1.0, fact.Metadata["high_dop_query_count"]);
+    }
+
+    [Fact]
+    public async Task TheCrossCheck_NarrowsOnlyTheImpossibleRows()
+    {
+        /* Several plans against one configuration, because a fixture of one row per case can never show
+           that the cross-check is row-wise rather than a switch on the whole read. At MAXDOP 12: 10 and
+           12 are possible and counted, 16 and 32 are not, and 4 never cleared the DOP > 8 floor. */
+        await ClearAsync();
+        await SeedServerConfigMaxDopAsync(valueInUse: 12, capturedMinutesBeforeWindowEnd: 5);
+
+        foreach (var maxDop in new long[] { 4, 10, 12, 16, 32 })
+        {
+            await SeedHighDopQueryStatsAsync(maxDop: maxDop, spills: 0);
+        }
+
+        var facts = await new DuckDbFactCollector(_duckDb).CollectFactsAsync(Context());
+
+        var fact = Assert.Single(facts, f => f.Key == "QUERY_HIGH_DOP");
+        Assert.Equal(2.0, fact.Metadata["high_dop_query_count"]);
+
+        /* The windowed totals must still cover EVERY row, including the two the count excluded: the
+           cross-check narrows one aggregate, it does not filter the read. */
+        Assert.Equal(50.0, fact.Metadata["total_executions"]);
+    }
+
+    private async Task<DuckDBConnection> SeedConnectionAsync()
+    {
+        if (_seedConn is null)
+        {
+            _seedConn = _duckDb.CreateConnection();
+            await _seedConn.OpenAsync();
+        }
+        return _seedConn;
+    }
+
+    private async Task ClearAsync()
+    {
+        using var readLock = _duckDb.AcquireReadLock();
+        var connection = await SeedConnectionAsync();
+        foreach (var table in new[] { "query_stats", "server_config" })
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = $"DELETE FROM {table} WHERE server_id = $1";
+            cmd.Parameters.Add(new DuckDBParameter { Value = ServerId });
+            await cmd.ExecuteNonQueryAsync();
+        }
+    }
+
+    /// <summary>
+    /// Seeds one cached plan inside the window. Every value other than <c>max_dop</c> is held constant
+    /// across the cases so the cross-check is the only thing that can move the answer.
+    /// </summary>
+    private async Task SeedHighDopQueryStatsAsync(long maxDop = CachedMaxDop, long spills = 500)
+    {
+        using var readLock = _duckDb.AcquireReadLock();
+        var connection = await SeedConnectionAsync();
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = @"
+INSERT INTO query_stats
+    (collection_id, collection_time, server_id, server_name, database_name, query_hash, query_plan_hash,
+     max_dop, min_dop, delta_execution_count, delta_worker_time, delta_elapsed_time, delta_spills,
+     query_text)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 1, 10, 100000, 200000, $9, $10)";
+        var id = _nextId++;
+        cmd.Parameters.Add(new DuckDBParameter { Value = id });
+        cmd.Parameters.Add(new DuckDBParameter { Value = WindowEnd.AddMinutes(-30) });
+        cmd.Parameters.Add(new DuckDBParameter { Value = ServerId });
+        cmd.Parameters.Add(new DuckDBParameter { Value = ServerName });
+        cmd.Parameters.Add(new DuckDBParameter { Value = Db });
+        cmd.Parameters.Add(new DuckDBParameter { Value = $"0xDOPHASH{id:D4}" });
+        cmd.Parameters.Add(new DuckDBParameter { Value = $"0xDOPPLAN{id:D4}" });
+        cmd.Parameters.Add(new DuckDBParameter { Value = maxDop });
+        cmd.Parameters.Add(new DuckDBParameter { Value = spills });
+        cmd.Parameters.Add(new DuckDBParameter { Value = "SELECT * FROM dbo.SynthDopTable" });
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private async Task SeedServerConfigMaxDopAsync(long valueInUse, int capturedMinutesBeforeWindowEnd)
+    {
+        using var readLock = _duckDb.AcquireReadLock();
+        var connection = await SeedConnectionAsync();
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = @"
+INSERT INTO server_config
+    (config_id, capture_time, server_id, server_name, configuration_name,
+     value_configured, value_in_use, is_dynamic, is_advanced)
+VALUES ($1, $2, $3, $4, 'max degree of parallelism', $5, $6, true, false)";
+        cmd.Parameters.Add(new DuckDBParameter { Value = _nextId++ });
+        cmd.Parameters.Add(new DuckDBParameter { Value = WindowEnd.AddMinutes(-capturedMinutesBeforeWindowEnd) });
+        cmd.Parameters.Add(new DuckDBParameter { Value = ServerId });
+        cmd.Parameters.Add(new DuckDBParameter { Value = ServerName });
+        cmd.Parameters.Add(new DuckDBParameter { Value = valueInUse });
+        cmd.Parameters.Add(new DuckDBParameter { Value = valueInUse });
+        await cmd.ExecuteNonQueryAsync();
+    }
+}

--- a/Lite/Analysis/DuckDbFactCollector.QueryPerf.cs
+++ b/Lite/Analysis/DuckDbFactCollector.QueryPerf.cs
@@ -25,18 +25,45 @@ public partial class DuckDbFactCollector
             await connection.OpenAsync(context.CancellationToken);
 
             using var cmd = connection.CreateCommand();
+            /* #2705/#2999: max_dop on v_query_stats is sys.dm_exec_query_stats' lifetime-max for the
+               plan's time in cache (QueryStatExtremes.cs's doctrine — same semantics as
+               max/min_cpu_ms), so a plan compiled before 'max degree of parallelism' was lowered
+               keeps reporting the old higher DOP until it is evicted or recompiled.
+               get_top_queries_by_cpu's parallel_only description carries this caveat for a human
+               reader; current_maxdop applies the same provable-tell reasoning QueryStatExtremes uses
+               for CPU/elapsed: a max_dop reading that EXCEEDS what the server's current maxdop
+               setting can produce right now is impossible under today's configuration, so it provably
+               predates whatever change set that configuration and must not be counted. Lowering
+               MAXDOP is the ordinary remediation for this very finding, so without the cross-check
+               the finding survives its own fix. A current_maxdop of 0 (unlimited) or unknown (no
+               v_server_config row yet) makes no configuration impossible, so the count is unchanged
+               in both of those cases.
+               LEFT JOIN ... ON true rather than a correlated subquery: the CTE is at most one row, so
+               the join stays one-to-one and the config read is evaluated once, not per query row. */
             cmd.CommandText = @"
+WITH current_maxdop AS
+(
+    SELECT value_in_use
+    FROM v_server_config
+    WHERE server_id = $1
+    AND   configuration_name = 'max degree of parallelism'
+    ORDER BY capture_time DESC
+    LIMIT 1
+)
 SELECT
-    SUM(delta_spills) AS total_spills,
-    COUNT(CASE WHEN max_dop > 8 THEN 1 END) AS high_dop_queries,
-    COUNT(CASE WHEN delta_spills > 0 THEN 1 END) AS spilling_queries,
-    SUM(delta_execution_count) AS total_executions,
-    SUM(delta_worker_time) AS total_cpu_time_us
-FROM v_query_stats
-WHERE server_id = $1
-AND   collection_time >= $2
-AND   collection_time <= $3
-AND   delta_execution_count > 0";
+    SUM(v.delta_spills) AS total_spills,
+    COUNT(CASE WHEN v.max_dop > 8
+                AND (m.value_in_use IS NULL OR m.value_in_use = 0 OR v.max_dop <= m.value_in_use)
+               THEN 1 END) AS high_dop_queries,
+    COUNT(CASE WHEN v.delta_spills > 0 THEN 1 END) AS spilling_queries,
+    SUM(v.delta_execution_count) AS total_executions,
+    SUM(v.delta_worker_time) AS total_cpu_time_us
+FROM v_query_stats AS v
+LEFT JOIN current_maxdop AS m ON true
+WHERE v.server_id = $1
+AND   v.collection_time >= $2
+AND   v.collection_time <= $3
+AND   v.delta_execution_count > 0";
 
             cmd.Parameters.Add(new DuckDBParameter { Value = context.ServerId });
             cmd.Parameters.Add(new DuckDBParameter { Value = context.TimeRangeStart });


### PR DESCRIPTION
Part of #2999.

`Lite/Analysis/DuckDbFactCollector.QueryPerf.cs`'s `CollectQueryStatsFactsAsync` counted `max_dop > 8` raw. `max_dop` on `v_query_stats` is `sys.dm_exec_query_stats`' lifetime max for the plan's time in cache, so a plan compiled before `max degree of parallelism` was lowered keeps reporting the old higher DOP until it is evicted or recompiled — and lowering MAXDOP is the ordinary remediation for QUERY_HIGH_DOP, so the finding survived its own fix. Darling has cross-checked this since #2705; Lite had no equivalent.

The read now resolves the newest `max degree of parallelism` capture in a `current_maxdop` CTE and excludes readings that exceed it. The two carve-outs are the same ones Darling makes, and they cut the other way: a `current_maxdop` of `0` (unlimited) and an absent config row both make no configuration claim, so both leave the count alone. `LEFT JOIN current_maxdop AS m ON true` against the one-row CTE is what delivers NULL to that arm rather than eliminating the row — an inner join there would drop QUERY_SPILLS along with QUERY_HIGH_DOP on any server with no collected config. The CTE reads `v_server_config`, not the bare table, because Lite's `v_` views union the live tables with archived Parquet and `AnalysisDataSpanTests.AnalysisPipeline_NeverReadsAnArchivableTableRaw` requires that form.

`QueryHighDopStaleMaxDopParityTests`, added to both `Darling.Tests` and `Lite.Tests`, is a sibling of #2998's `ParameterSensitivityFiringSignatureParityTests` rather than a widening of it: that guard's class name, docs and failure messages are all scoped to the PARAMETER_SENSITIVITY firing signature, and this predicate has a different shape and a different per-file census. It keeps two patterns — `HighDopCount`, which matches any read that counts high-DOP queries at all, and `StaleMaxDopGuard`, which matches only the cross-checked form — so `EveryHighDopCount_CarriesTheStalenessCrossCheck` fails on a count that exists without the cross-check, which is the one failure mode every other assertion passes over by having nothing left to disagree with. `TheCurrentMaxDopCte_ReadsTheRightConfigSource_InEachStore` pins the config source per store (`server_config` for Darling, `v_server_config` for Lite) since that is the one part that legitimately differs, and `TheNullSafeJoin_IsPinned` pins the join. The pair carries #2998's bidirectional meta-pin: Darling declares `DarlingGuardCopies` and `LiteGuardCopies`, Lite declares `ExpectedGuardCopies` and reads Darling's back out of source, each side self-validates its `CanonicalStaleMaxDopGuard` parser against its own file first, and `Lite/Analysis` is enumerated recursively rather than through `ParitySource.EnumerateCsFiles`, which is `TopDirectoryOnly` and would leave `Recommendations/` unscanned.

`Lite.Tests/QueryHighDopStaleMaxDopTests` is Lite's twin of `Darling.Tests/QueryHighDopStaleMaxDopLiveTests`. Lite's store is embedded, so the twin runs in the ordinary `build` job against a real DuckDB with the real schema where Darling's needs `DARLING_TEST_PG`; it covers the must-not-fire case, both must-still-fire carve-outs, the `<=` boundary where the current MAXDOP exactly permits the reading, newest-capture-wins, and a five-plan fixture that shows the cross-check is row-wise and leaves the windowed totals covering every row.

One thing found while checking that both halves of the pair actually run, worth recording for whoever next touches those docs: `build.yml`'s `darling` filter reaches `Lite/**/*.cs` but **not** `Lite.Tests/**/*.cs`, while `lite` reaches `Darling/Darling.Tests/**`. So a Lite-guard-only edit runs Lite's half and not Darling's. Both halves' cross-SKU claims survive that — Lite's half is the one that reads Darling's guard as source, and a Darling-side edit fires both filters — but #2998's inherited phrasing that the `darling` filter covers "every Lite `.cs` file" is true of `Lite/` and false of `Lite.Tests/`, and this pair's docs repeat it. Not corrected here, to keep this diff to the defect.

No project file, lock file or package reference changed.
