### PR TITLE
Derive the viewer's interactive read deadline from its fan-out width

### DIFF
--- a/Darling/Darling.Tests/ViewerCommandTimeoutTests.cs
+++ b/Darling/Darling.Tests/ViewerCommandTimeoutTests.cs
@@ -421,6 +421,138 @@ public sealed class ViewerCommandTimeoutTests
     }
 
     /// <summary>
+    /// A declared width must not outlive the reads it describes. A method-scoped <c>using var</c> runs to
+    /// the closing brace, so a store read AFTER the join inherits a contention count that is over by the
+    /// whole fan-out — and a nested fan-out below it multiplies against that stale count and lands on the
+    /// pool ceiling. <c>ViewerReadFanOut.Scope.Release()</c> ends it at the join; this asserts it is called
+    /// wherever the method goes on to await anything.
+    ///
+    /// <para><b>The join is matched as a STATEMENT, not a line</b>, which is what makes the scan sound. The
+    /// two per-server fan-outs pass <c>Task.WhenAll(servers.Select(async item =&gt; ...))</c>, whose lambda
+    /// body contains the very <c>await</c> that IS the fan-out — searching from the line would report both
+    /// as offenders. Searching from the end of the parenthesised statement puts those awaits inside the
+    /// join rather than after it. Conversely the search cannot be depth-restricted to the join's own brace
+    /// level: <c>MainWindow</c>'s fleet-totals read sits inside a <c>try</c> block, so a same-depth rule
+    /// would miss a real one. Both shapes are live in this project, and each rules out one of the two
+    /// obvious implementations.</para>
+    /// </summary>
+    [Fact]
+    public void NoFanOutScope_OutlivesItsJoin()
+    {
+        var offenders = new List<string>();
+        var checked_ = 0;
+
+        foreach (var path in ViewerSources())
+        {
+            var text = File.ReadAllText(path);
+            var code = CSharpSourceWalker.StripCommentsAndStrings(text);
+
+            /* Only joins that a declaration precedes are in scope for this rule; a file with no fan-out
+               declaration at all is EveryViewerFanOut_DeclaresItsWidth's business, not this test's. */
+            var firstDeclaration = code.IndexOf("ViewerReadFanOut", System.StringComparison.Ordinal);
+
+            foreach (Match join in s_joinedFanOut.Matches(code))
+            {
+                if (firstDeclaration < 0 || firstDeclaration > join.Index)
+                {
+                    continue;
+                }
+
+                var afterJoin = EndOfParenthesisedStatement(code, join.Index + join.Length - 1);
+                if (afterJoin < 0)
+                {
+                    continue;
+                }
+
+                var methodEnd = EndOfEnclosingBlock(code, afterJoin);
+                var window = code[afterJoin..methodEnd];
+                var nextAwait = Regex.Match(window, @"(^|[^A-Za-z0-9_])await[^A-Za-z0-9_]");
+
+                if (!nextAwait.Success)
+                {
+                    continue;
+                }
+
+                checked_++;
+
+                var released = window[..nextAwait.Index].Contains(".Release()", System.StringComparison.Ordinal);
+                if (!released)
+                {
+                    var line = text.Take(afterJoin).Count(c => c == '\n') + 1;
+                    offenders.Add($"{Path.GetFileName(path)}:{line}");
+                }
+            }
+        }
+
+        Assert.True(checked_ >= 3, $"only {checked_} join(s) were followed by a further await — the scan is not reading the project");
+
+        Assert.True(
+            offenders.Count == 0,
+            $"{offenders.Count} fan-out scope(s) stay open past their join while the method reads the store again, "
+            + "so those later reads are priced against contention that has already finished (and a nested fan-out "
+            + "multiplies against it onto the pool ceiling). Call readFanOut.Release() right after the join: "
+            + string.Join(", ", offenders));
+    }
+
+    /// <summary>
+    /// The index just past the <c>;</c> that closes the statement whose opening <c>(</c> is at
+    /// <paramref name="openParen"/>, or -1. Counts parens so a nested lambda cannot end it early.
+    /// </summary>
+    private static int EndOfParenthesisedStatement(string code, int openParen)
+    {
+        var depth = 0;
+
+        for (var i = openParen; i < code.Length; i++)
+        {
+            if (code[i] == '(')
+            {
+                depth++;
+            }
+            else if (code[i] == ')')
+            {
+                depth--;
+
+                if (depth == 0)
+                {
+                    var semi = code.IndexOf(';', i);
+                    return semi < 0 ? -1 : semi + 1;
+                }
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// The index of the <c>}</c> that closes the block containing <paramref name="from"/> — the method
+    /// body, for a statement at method level. Terminates on the first unmatched close rather than clamping
+    /// at zero, which is the walker bug that made two scanners miss real sites during #2888.
+    /// </summary>
+    private static int EndOfEnclosingBlock(string code, int from)
+    {
+        var depth = 0;
+
+        for (var i = from; i < code.Length; i++)
+        {
+            if (code[i] == '{')
+            {
+                depth++;
+            }
+            else if (code[i] == '}')
+            {
+                if (depth == 0)
+                {
+                    return i;
+                }
+
+                depth--;
+            }
+        }
+
+        return code.Length;
+    }
+
+    /// <summary>
     /// The two ceilings answer different questions, and this is the pin that says so in the only terms
     /// available without a store: where each one sits relative to the CONCURRENT band #2901 measured
     /// (24.4-64.1 s per read for ten concurrent 30-day reads, against 3.01 s for the same read alone).

--- a/Darling/Darling.Tests/ViewerCommandTimeoutTests.cs
+++ b/Darling/Darling.Tests/ViewerCommandTimeoutTests.cs
@@ -57,6 +57,19 @@ public sealed class ViewerCommandTimeoutTests
         @"\.CreateCommand\s*[,)]",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
+    /// <summary>
+    /// A joined fan-out — the shape whose reads run concurrently and therefore cannot be bounded by a
+    /// deadline derived from one read in isolation (#3004).
+    /// </summary>
+    private static readonly Regex s_joinedFanOut = new(
+        @"Task\s*\.\s*WhenAll\s*\(",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>The declaration that tells those reads how many of them there are.</summary>
+    private static readonly Regex s_fanOutDeclaration = new(
+        @"ViewerReadFanOut\s*\.\s*Of\s*\(",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
     [Fact]
     public void EveryViewerCommand_SetsAnExplicitDeadline()
     {
@@ -344,6 +357,216 @@ public sealed class ViewerCommandTimeoutTests
         var code = CSharpSourceWalker.StripCommentsAndStrings(source);
 
         Assert.Equal(expectedSite, s_commandCtor.IsMatch(code));
+    }
+
+    /// <summary>
+    /// Every joined fan-out in this project declares how wide it is, so the reads inside it are bounded by
+    /// <see cref="ViewerCommandDeadlines.FanOutReadSeconds"/> rather than by a solo read's ceiling (#3004).
+    ///
+    /// <para><b>Paired POSITIONALLY, not by enclosing block.</b> The obvious rule — the declaration must sit
+    /// in the same block as the <c>Task.WhenAll</c> — is wrong on this codebase's real shape:
+    /// <c>CorrelatedTimelineLanesControl</c> declares its width in the outer <c>try</c> and awaits the join
+    /// inside a nested one, so a single-level backward walk finds the inner brace and reports the widest
+    /// fan-out in the project as an offender. Requiring instead that the k-th join in a file be preceded by
+    /// at least k declarations is immune to nesting, still order-sensitive, and still fails if any one
+    /// declaration is deleted — which is the property being bought.</para>
+    ///
+    /// <para><b>What this does NOT cover, stated because the gap is real.</b> A fan-out does not need a
+    /// <c>Task.WhenAll</c>: <c>MainWindow.OnRefreshTimerTick</c> fires five or six store reads unawaited and
+    /// joins none of them, and the connect path fires three. Nothing lexical distinguishes those from the
+    /// twenty other unawaited single reads in this project, which are single-flight-guarded and not
+    /// fan-outs at all, so a scan for that shape would be mostly false positives. Both real sites declare
+    /// their width by hand and carry a comment saying so; this test is the guard for the joined shape
+    /// ONLY.</para>
+    /// </summary>
+    [Fact]
+    public void EveryViewerFanOut_DeclaresItsWidth()
+    {
+        var offenders = new List<string>();
+        var joins = 0;
+
+        foreach (var path in ViewerSources())
+        {
+            var text = File.ReadAllText(path);
+
+            /* Stripped, for the same reason the command scans are: this file's own prose names
+               Task.WhenAll and ViewerReadFanOut.Of repeatedly, and a scan reading raw text would pair a
+               join against an explanation of a declaration. */
+            var code = CSharpSourceWalker.StripCommentsAndStrings(text);
+
+            var declarations = s_fanOutDeclaration.Matches(code).Select(m => m.Index).ToArray();
+            var seen = 0;
+
+            foreach (Match join in s_joinedFanOut.Matches(code))
+            {
+                joins++;
+                seen++;
+
+                if (declarations.Count(index => index < join.Index) < seen)
+                {
+                    var line = text.Take(join.Index).Count(c => c == '\n') + 1;
+                    offenders.Add($"{Path.GetFileName(path)}:{line}");
+                }
+            }
+        }
+
+        Assert.True(joins >= 10, $"the fan-out scan matched only {joins} joins — the sweep is not reading the project");
+
+        Assert.True(
+            offenders.Count == 0,
+            $"{offenders.Count} joined fan-out(s) run their reads concurrently without declaring a width, so each "
+            + "read is bounded by a ceiling derived from a read measured ALONE — which the ten-wide case sits "
+            + "entirely above. Declare the width with ViewerReadFanOut.Of(n) before the first read: "
+            + string.Join(", ", offenders));
+    }
+
+    /// <summary>
+    /// The two ceilings answer different questions, and this is the pin that says so in the only terms
+    /// available without a store: where each one sits relative to the CONCURRENT band #2901 measured
+    /// (24.4-64.1 s per read for ten concurrent 30-day reads, against 3.01 s for the same read alone).
+    ///
+    /// <para>Deliberately NOT a timing test. The failure it guards needs a Windows host and a store dense
+    /// enough to reach the band; a test that measured anything here would pass on a fast machine and prove
+    /// nothing. What it asserts instead is arithmetic on shipped constants, which holds identically
+    /// everywhere.</para>
+    /// </summary>
+    [Fact]
+    public void TheFanOutDeadline_IsDerivedFromTheConcurrentBand_NotTheSoloOne()
+    {
+        var solo = ViewerCommandDeadlines.InteractiveReadSeconds;
+        var widest = ViewerCommandDeadlines.FanOutReadSeconds(ViewerSettings.ManagedMaxPoolSize);
+
+        Assert.True(
+            solo < 24,
+            $"the solo read deadline {solo}s has risen into the concurrent band (24.4-64.1 s). Either it is no "
+            + "longer derived from the 3.01 s solo measurement, or the two regimes have been collapsed back "
+            + "into one constant — which is the defect #3004 exists to undo, in the other direction");
+
+        Assert.True(
+            widest > 64,
+            $"the fan-out deadline at the pool ceiling is {widest}s, which does not cover the 64.1 s worst read "
+            + "measured for ten concurrent 30-day reads on a store at production density. A ceiling under the "
+            + "measurement it is supposed to bound fails every read in the widest fan-out on every attempt, "
+            + "auto-refresh included — a deadline nothing can finish under is not a deadline");
+    }
+
+    /// <summary>
+    /// The fan-out ceiling can only ever grant MORE time than a solo read gets, and it stops growing where
+    /// the permits run out. The clamp is what lets the two unbounded per-server fan-outs
+    /// (<c>FinOpsTab.Loaders</c>'s inventory overlay, <c>MainWindow</c>'s overview cards) hand over a raw
+    /// fleet count instead of a hand-capped guess, so it is load-bearing rather than defensive.
+    /// </summary>
+    [Fact]
+    public void TheFanOutDeadline_IsMonotonicAndClampedAtThePool()
+    {
+        var pool = ViewerSettings.ManagedMaxPoolSize;
+        var previous = 0;
+
+        for (var width = -3; width <= pool * 4; width++)
+        {
+            var seconds = ViewerCommandDeadlines.FanOutReadSeconds(width);
+
+            Assert.True(
+                seconds >= ViewerCommandDeadlines.InteractiveReadSeconds,
+                $"width {width} yields {seconds}s, under the solo floor — a declared fan-out must never buy a "
+                + "read LESS time than the same read issued alone");
+
+            Assert.True(seconds >= previous, $"width {width} yields {seconds}s, below width {width - 1}'s {previous}s");
+
+            previous = seconds;
+        }
+
+        Assert.Equal(
+            ViewerCommandDeadlines.FanOutReadSeconds(pool),
+            ViewerCommandDeadlines.FanOutReadSeconds(pool * 4));
+    }
+
+    /// <summary>
+    /// The ambient width itself: one when nobody declared a fan-out (so an unscoped read keeps exactly the
+    /// solo ceiling), the declared value inside a scope, the enclosing value again after it, and the PRODUCT
+    /// when scopes nest — because a read two scopes deep really does contend with both widths.
+    /// </summary>
+    [Fact]
+    public void TheFanOutWidth_DefaultsToOne_AndNestsByMultiplying()
+    {
+        Assert.Equal(1, ViewerReadFanOut.CurrentWidth);
+
+        using (ViewerReadFanOut.Of(3))
+        {
+            Assert.Equal(3, ViewerReadFanOut.CurrentWidth);
+
+            using (ViewerReadFanOut.Of(2))
+            {
+                Assert.Equal(6, ViewerReadFanOut.CurrentWidth);
+            }
+
+            Assert.Equal(3, ViewerReadFanOut.CurrentWidth);
+        }
+
+        Assert.Equal(1, ViewerReadFanOut.CurrentWidth);
+
+        /* A count from a runtime collection, which is what the two per-server fan-outs pass. */
+        using (ViewerReadFanOut.Of(ViewerSettings.ManagedMaxPoolSize * 7))
+        {
+            Assert.Equal(ViewerSettings.ManagedMaxPoolSize, ViewerReadFanOut.CurrentWidth);
+        }
+
+        using (ViewerReadFanOut.Of(0))
+        {
+            Assert.Equal(1, ViewerReadFanOut.CurrentWidth);
+        }
+    }
+
+    /// <summary>
+    /// No command site stamps the solo constant directly. The sites take
+    /// <see cref="ViewerCommandDeadlines.CurrentInteractiveReadSeconds"/> uniformly — including the reads no
+    /// fan-out currently reaches, where the two are the same number — so that a future <c>Task.WhenAll</c>
+    /// over any of them is bounded the day it is written rather than silently inheriting a solo ceiling.
+    /// That uniformity is the whole reason the previous test's arithmetic reaches the reads at all, so it
+    /// needs a pin of its own; without it a single new site spelled the old way is invisible.
+    /// </summary>
+    [Fact]
+    public void NoViewerCommand_StampsTheSoloDeadlineDirectly()
+    {
+        var offenders = new List<string>();
+        var stamps = 0;
+
+        foreach (var path in ViewerSources())
+        {
+            var text = File.ReadAllText(path);
+            var code = CSharpSourceWalker.StripCommentsAndStrings(text);
+
+            stamps += code.Split("CurrentInteractiveReadSeconds").Length - 1;
+
+            var at = 0;
+            while (true)
+            {
+                /* The solo name is a PREFIX of nothing, but it is a SUFFIX of the fan-out-aware one, so a
+                   plain search for it matches every correct site too. Anchored on the assignment to make the
+                   two distinguishable. */
+                var index = code.IndexOf(
+                    "CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds",
+                    at,
+                    System.StringComparison.Ordinal);
+
+                if (index < 0)
+                {
+                    break;
+                }
+
+                offenders.Add($"{Path.GetFileName(path)}:{text.Take(index).Count(c => c == '\n') + 1}");
+                at = index + 1;
+            }
+        }
+
+        Assert.True(stamps >= 150, $"only {stamps} site(s) stamp the fan-out-aware deadline — the sweep is not reading the project");
+
+        Assert.True(
+            offenders.Count == 0,
+            $"{offenders.Count} command site(s) stamp InteractiveReadSeconds directly. That constant bounds a read "
+            + "issued ALONE; a site spelled this way is not bounded by any fan-out it is called inside. Use "
+            + "ViewerCommandDeadlines.CurrentInteractiveReadSeconds: "
+            + string.Join(", ", offenders));
     }
 
     private static IEnumerable<string> ViewerSources()

--- a/Darling/PerformanceMonitor.Darling.Viewer/CorrelatedTimelineLanesControl.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/CorrelatedTimelineLanesControl.xaml.cs
@@ -143,9 +143,14 @@ public partial class CorrelatedTimelineLanesControl : UserControl
     }
 
     /// <summary>
-    /// Refreshes all lane data for the given time range. The viewer's Overview always passes a fixed
-    /// 24-hour window (hoursBack = 24, fromDate/toDate null); the fromDate/toDate branch is kept for a
-    /// future custom-range picker. Reads run against explicit naive-UTC windows derived here.
+    /// Refreshes all lane data for the given time range. The Overview passes the toolbar's window —
+    /// hours-back for a preset, or the custom From/To when one is picked
+    /// (<c>ViewerServerTab.LoadOverviewChartsAsync</c>), so the widest range the picker offers reaches these
+    /// reads. Reads run against explicit naive-UTC windows derived here.
+    ///
+    /// <para>Ten reads go out at once against a ten-permit pool, which is why the fan-out width is declared
+    /// below: at a 30-day range these were measured at 24.4-64.1 s EACH, and a deadline derived from one read
+    /// in isolation is not a bound on that (#3004).</para>
     /// </summary>
     public async Task RefreshAsync(int hoursBack, DateTime? fromDate, DateTime? toDate)
     {
@@ -163,6 +168,11 @@ public partial class CorrelatedTimelineLanesControl : UserControl
             /* Reads run concurrently — NpgsqlDataSource pools a connection for each; genuinely async so
                no Task.Run wrap (matches the W1a/W1c viewer ports). CPU reuses W1a's raw-sample read;
                blocking/deadlock/file-IO reuse W1c's trend reads; total-wait + memory are new (W1d). */
+            /* Ten reads, one pool of ten permits: each one contends with the other nine, so each one
+               needs the deadline a ten-wide batch was measured to cost rather than a solo read's.
+               Declared here, before the first task, so every one of the ten inherits it. */
+            using var readFanOut = ViewerReadFanOut.Of(10);
+
             var cpuTask = _dataService.GetCpuUtilizationAsync(_serverId, startUtc);
             var waitTask = _dataService.GetTotalWaitTrendAsync(_serverId, startUtc, endUtc);
             var blockingTask = _dataService.GetBlockingTrendAsync(_serverId, startUtc, endUtc);

--- a/Darling/PerformanceMonitor.Darling.Viewer/FinOpsTab.Loaders.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/FinOpsTab.Loaders.cs
@@ -467,6 +467,8 @@ public partial class FinOpsTab
 
     private async Task LoadFinOpsOptimizationAsync()
     {
+        using var readFanOut = ViewerReadFanOut.Of(5);
+
         await Task.WhenAll(
             LoadFinOpsIdleDatabasesAsync(),
             LoadFinOpsTempdbSummaryAsync(),
@@ -562,6 +564,10 @@ public partial class FinOpsTab
         /* Overlay each server's collected metrics + compute the health score (mirrors Lite's
            LoadServerInventoryAsync minus the live query). memScore/storScore use Lite's inventory-path
            defaults (buffer-pool ratio / file-level free space aren't in the inventory read). */
+        /* Width is the inventory size, passed raw: the clamp to the pool ceiling belongs to
+           ViewerReadFanOut, and a hand-capped guess here would be the copied-number mistake again. */
+        using var readFanOut = ViewerReadFanOut.Of(servers.Count);
+
         await Task.WhenAll(servers.Select(async item =>
         {
             var (avgCpu, storageGb, idleDbs, status) = await _dataService.GetServerMetricsAsync(item.ServerId);

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.ServerManagement.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.ServerManagement.cs
@@ -96,10 +96,11 @@ public partial class MainWindow
     /// <para><b>Single-flight</b>, because both fleet timers fire this unawaited on an interval an operator can
     /// dial down to 10s (<see cref="ViewerAppSettings.NocRefreshIntervalSeconds"/>) and nothing else bounds it.
     /// One pass is TWO store reads — the freshness query plus <see cref="UpdateCollectorHealthTextAsync"/>'s own
-    /// — each capped at <see cref="ViewerCommandDeadlines.InteractiveReadSeconds"/> (15), so an unguarded pass
-    /// could hold a permit for 30s against a pool of ten (<c>MaxPoolSize = 10</c> on the managed-derived string
-    /// in <c>ViewerSettings</c>) while the next tick started another. The deadline #2901 added caps how long one
-    /// stacked read holds a permit; it cannot stop the stacking, which is what this does.</para>
+    /// — each capped at <see cref="ViewerCommandDeadlines.CurrentInteractiveReadSeconds"/>, which is the solo
+    /// 15 s when this is called on its own and the wider figure when a caller has declared a fan-out around it
+    /// (both fleet-timer callers do). So an unguarded pass could hold a permit for twice that against a pool of
+    /// <see cref="ViewerSettings.ManagedMaxPoolSize"/> while the next tick started another. A deadline caps how
+    /// long one stacked read holds a permit; it cannot stop the stacking, which is what this does.</para>
     ///
     /// <para><paramref name="replayIfBusy"/> is why this is not <c>_alertPollInFlight</c>'s plain drop. A
     /// PERIODIC caller drops, because the next tick IS its retry and replaying one would delete the interval's
@@ -231,7 +232,7 @@ public partial class MainWindow
     /// <para><b>The scope is captured before the read and verified after it</b> (#2924). One field carries
     /// every scope's answer, so an answer read for a scope that has since left the screen must be dropped
     /// rather than painted: the operator can change tab during the read, which is one store read bounded at
-    /// <see cref="ViewerCommandDeadlines.InteractiveReadSeconds"/> by #2901.</para>
+    /// <see cref="ViewerCommandDeadlines.CurrentInteractiveReadSeconds"/>.</para>
     ///
     /// <para><b>A drop is right here, where <see cref="RefreshServerStatusAsync"/> needs a replay</b>, and
     /// the difference is whether anything else is going to ask. The event that invalidates the scope IS a

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
@@ -564,9 +564,21 @@ public partial class MainWindow : Window
            UpdateCollectorHealthTextAsync's collector-health read) and PollAlertsAsync is another (history,
            then UpdateServerSilencedAsync's mute rules), so this fan-out is FIVE store reads before
            RefreshVisibleAsync starts — six on the fleets that ship with the AG tab hidden, which is most of
-           them. Each is capped at ViewerCommandDeadlines.InteractiveReadSeconds (15) by #2901, against a
-           ten-connection pool, on an interval an operator can set to 10s — so the deadline bounds how long
-           one of them holds a permit and the guards are what stop ticks from stacking. */
+           them. They run TOGETHER, so each one's deadline has to cover contending with the other five for
+           the ten-connection pool rather than a solo read's — hence the declared width, on an interval an
+           operator can set to 10s. The deadline bounds how long one of them holds a permit and the guards are
+           what stop ticks from stacking.
+
+           This is a fan-out without a Task.WhenAll: nothing joins these, they are simply all in flight at
+           once. ViewerCommandTimeoutTests can only scan the WhenAll shape, so this site and the connect-path
+           pair below are the two the width is declared on by hand.
+
+           The scope deliberately runs to the end of the tick rather than closing after the three starts: the
+           visible-tab load below begins while these are still in flight, so it really is contending with
+           them, and a tab load that declares its own fan-out nests to the pool ceiling — which is the width
+           the concurrent measurement actually covers. */
+        using var readFanOut = ViewerReadFanOut.Of(6);
+
         _ = RefreshServerStatusAsync();
         _ = RefreshStoreSizeAsync();
 
@@ -1027,7 +1039,12 @@ public partial class MainWindow : Window
                answer: this path runs on connect and after every add/edit/remove, and a freshness dictionary
                fetched before a server was registered has no entry for it — the row it paints after the fleet
                rebuild reads as never-collected. Dropping that would leave a just-added server's dot wrong for
-               a whole interval. The store-size read takes no scope, so it drops like any other caller. */
+               a whole interval. The store-size read takes no scope, so it drops like any other caller.
+
+               Three reads in flight together — the freshness pair plus the store size — so the width is
+               declared for the same reason the fleet timer's is. */
+            using var readFanOut = ViewerReadFanOut.Of(3);
+
             _ = RefreshServerStatusAsync(replayIfBusy: true);
             _ = RefreshStoreSizeAsync();
         }
@@ -1407,6 +1424,9 @@ public partial class MainWindow : Window
 
         var service = _dataService;
         var nowUtc = DateTime.UtcNow;
+        /* Width is the fleet size, passed raw — see the inventory overlay in FinOpsTab.Loaders. */
+        using var readFanOut = ViewerReadFanOut.Of(list.Count);
+
         var summaries = await Task.WhenAll(list.Select(async server =>
         {
             try

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
@@ -1443,6 +1443,9 @@ public partial class MainWindow : Window
             }
         }));
 
+        /* The per-server reads are done; the fleet-totals read below does not contend with them. */
+        readFanOut.Release();
+
         var built = summaries.OfType<ServerSummaryItem>().ToList();
         StampTagPills(built);
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerCommandDeadlines.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerCommandDeadlines.cs
@@ -74,7 +74,7 @@ public static class ViewerCommandDeadlines
     /// <c>ConnectionTimeoutSeconds</c> (default 5) for a slot and then throws a CONNECT error, which
     /// misattributes a slow store to the network. Fifteen seconds is half the inherited 30 s, which
     /// halves that worst-case hold.</para>
-
+    ///
     /// <para><b>This value bounds a read issued ALONE, and only that</b> (#3004). The permit argument
     /// above says a concurrent fan-out is the state worth protecting the pool from; it does not say a
     /// solo read's ceiling can bound one. On the same rig, ten concurrent 30-day reads measured

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerCommandDeadlines.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerCommandDeadlines.cs
@@ -6,6 +6,8 @@
  * Licensed under the MIT License. See LICENSE file in the project root for full license information.
  */
 
+using System;
+
 namespace PerformanceMonitor.Darling.Viewer;
 
 /// <summary>
@@ -67,14 +69,22 @@ public static class ViewerCommandDeadlines
     /// <c>SemaphoreSlim</c>, no <c>WaitAsync</c>, and no request timeout, because the viewer is a WPF
     /// <c>WinExe</c> and hosts no web endpoint — so this deadline IS the budget, the same finding
     /// #2882 and #2888 both made, and the same reason both erred short. What it competes for is the
-    /// ten-connection pool: <c>CorrelatedTimelineLanesControl</c> awaits one <c>Task.WhenAll</c> over
-    /// exactly ten reads, so a single panel can hold every permit, and while they are held the sidebar
-    /// freshness dots, the alert poll and every other panel get nothing — read eleven waits
+    /// ten-connection pool (<see cref="ViewerSettings.ManagedMaxPoolSize"/>), and while permits are held
+    /// the sidebar freshness dots, the alert poll and every other panel get nothing — read eleven waits
     /// <c>ConnectionTimeoutSeconds</c> (default 5) for a slot and then throws a CONNECT error, which
-    /// misattributes a slow store to the network. Halving the inherited 30 s halves that worst-case
-    /// hold. Ten concurrent 30-day reads on the rig above measured 24.4-64.1 s, six of them past the
-    /// silent default they used to inherit; cutting each at 15 s returns permits sooner, which is the
-    /// outcome to want in that state.</para>
+    /// misattributes a slow store to the network. Fifteen seconds is half the inherited 30 s, which
+    /// halves that worst-case hold.</para>
+
+    /// <para><b>This value bounds a read issued ALONE, and only that</b> (#3004). The permit argument
+    /// above says a concurrent fan-out is the state worth protecting the pool from; it does not say a
+    /// solo read's ceiling can bound one. On the same rig, ten concurrent 30-day reads measured
+    /// 24.4-64.1 s EACH against 3.01 s solo — ten-way contention costs 8-21x, and running the ten
+    /// together cost 64.1 s of wall clock against 30.1 s of serial work, so concurrency is net negative
+    /// on this store rather than merely crowded. Fifteen seconds is below the whole of that band, so it
+    /// is not a ceiling a ten-wide batch can finish under and applying it to one would fail every read in
+    /// it on every attempt, auto-refresh included. A read that is part of a fan-out therefore takes
+    /// <see cref="FanOutReadSeconds"/>, derived from that concurrent measurement, and the two are the
+    /// same number for any width the pool can serve without contention worth pricing.</para>
     ///
     /// <para>The asymmetry, worked out for this surface rather than assumed: too short and one panel
     /// shows an error the user can retry — and the auto-refresh timer retries it within 30 s anyway,
@@ -82,6 +92,72 @@ public static class ViewerCommandDeadlines
     /// the failure mode that cannot be diagnosed from the UI. Erring short is right here.</para>
     /// </summary>
     public const int InteractiveReadSeconds = 15;
+
+    /// <summary>
+    /// The per-lane contention allowance a concurrent read is granted on top of
+    /// <see cref="InteractiveReadSeconds"/>, and the only number here derived from a CONCURRENT
+    /// measurement rather than a solo one.
+    ///
+    /// <para>The derivation is one division. #2901's rig — a store stood up by the product's own
+    /// <c>PgMigrations.MigrateAsync</c> at V109 with TimescaleDB, seeded to exact production per-server
+    /// density across the collector's full 30-day retention horizon — measured ten concurrent 30-day
+    /// reads at 24.4-64.1 s each. The worst read in that batch is what a deadline has to cover, and the
+    /// width that produced it is ten: 64.1 / 10 = 6.41 s of allowance per lane, rounded UP to 7 so the
+    /// rounding falls on the side that does not fail a legitimate panel. At the full pool width that is
+    /// 70 s, about 9% over the worst read actually measured there.</para>
+    ///
+    /// <para><b>Why per-lane and not one wider constant.</b> A single number big enough for the ten-wide
+    /// case would hand 70 s to a read with no contention at all, which is the same error as handing 15 s
+    /// to a read with nine siblings — the wrong population, in the other direction. Scaling by the width
+    /// the caller declares is what keeps a solo read on its own measured floor.</para>
+    ///
+    /// <para><b>Nothing enclosing this is smaller.</b> The per-tab auto-refresh timer floors at 30 s and
+    /// the fleet timer at 10 s, but neither bounds a read: the fan-out those timers fire is single-flight
+    /// (<c>_isRefreshing</c> in <see cref="CorrelatedTimelineLanesControl"/>, and #2907 for the unawaited
+    /// pair), so a read outliving its own tick is not joined by the next one. A cadence shorter than the
+    /// deadline would matter only if a slow read could be re-entered, and it cannot.</para>
+    /// </summary>
+    public const int FanOutLaneSeconds = 7;
+
+    /// <summary>
+    /// The deadline for a read issued as one of <paramref name="concurrentReads"/> reads running
+    /// together — the ceiling that has to cover contention with its siblings rather than a solo read's.
+    ///
+    /// <para>Clamped at <see cref="ViewerSettings.ManagedMaxPoolSize"/> because contention stops growing
+    /// where the permits run out: an eleventh concurrent read against a ten-connection pool is not an
+    /// eleventh contender, it is a read waiting on <c>ConnectionTimeoutSeconds</c> for a slot. That is
+    /// what lets the two unbounded per-server fan-outs declare their raw fleet count and still get a
+    /// bounded answer.</para>
+    ///
+    /// <para>Floored at <see cref="InteractiveReadSeconds"/> so this can only ever grant a read MORE time
+    /// than a solo read gets, never less. A width the pool serves without contention worth pricing lands
+    /// on the floor and is indistinguishable from an unscoped read, which is the correct outcome: two
+    /// concurrent reads are not the state the concurrent measurement describes.</para>
+    /// </summary>
+    public static int FanOutReadSeconds(int concurrentReads)
+    {
+        var lanes = Math.Clamp(concurrentReads, 1, ViewerSettings.ManagedMaxPoolSize);
+
+        return Math.Max(InteractiveReadSeconds, FanOutLaneSeconds * lanes);
+    }
+
+    /// <summary>
+    /// What all 187 interactive command sites stamp: <see cref="FanOutReadSeconds"/> for the width the
+    /// enclosing fan-out site declared through <see cref="ViewerReadFanOut"/>, or
+    /// <see cref="InteractiveReadSeconds"/> when nothing declared one.
+    ///
+    /// <para>Read at command construction, which is what makes it correct: the width is already in the
+    /// task's execution context by then, and the value is frozen onto that one command rather than shared
+    /// with any other read in flight.</para>
+    ///
+    /// <para>The sites take this instead of <see cref="InteractiveReadSeconds"/> uniformly, including the
+    /// reads no fan-out currently reaches. A read outside a scope gets the same number either way, so
+    /// there is no behavioural difference to weigh — what uniformity buys is that a future
+    /// <c>Task.WhenAll</c> over any of them is bounded the day it is written instead of silently
+    /// inheriting a solo read's ceiling, which is the trap this whole constant family exists to close.
+    /// <c>ViewerCommandTimeoutTests</c> holds that uniformity as a pin.</para>
+    /// </summary>
+    public static int CurrentInteractiveReadSeconds => FanOutReadSeconds(ViewerReadFanOut.CurrentWidth);
 
     /// <summary>
     /// The store&lt;-&gt;service command plane — the three commands in

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.AlertHistory.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.AlertHistory.cs
@@ -135,7 +135,7 @@ LIMIT $2";
         var rows = new List<ViewerAlertRow>();
 
         await using var command = _dataSource.CreateCommand(serverId.HasValue ? AlertHistorySql : AlertHistoryAllServersSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<DateTime>
         {
             TypedValue = DateTime.SpecifyKind(sinceUtc, DateTimeKind.Unspecified),
@@ -233,7 +233,7 @@ AND    dismissed = FALSE";
         }
 
         await using var command = _dataSource.CreateCommand(DismissAlertsSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter { Value = times });
         command.Parameters.Add(new NpgsqlParameter { Value = ids });
         command.Parameters.Add(new NpgsqlParameter { Value = metrics });
@@ -251,7 +251,7 @@ AND    dismissed = FALSE";
     {
         await using var command = _dataSource.CreateCommand(
             serverId.HasValue ? DismissAllAlertsForServerSql : DismissAllAlertsSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<DateTime>
         {
             TypedValue = DateTime.SpecifyKind(sinceUtc, DateTimeKind.Unspecified),

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.AlertSettings.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.AlertSettings.cs
@@ -150,7 +150,7 @@ ON CONFLICT (id) DO UPDATE SET
     public async Task<AlertSettingsRow?> GetAlertSettingsAsync(CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(AlertSettingsSelectSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         return await reader.ReadAsync(cancellationToken) ? ReadAlertSettingsRow(reader) : null;
     }
@@ -162,7 +162,7 @@ ON CONFLICT (id) DO UPDATE SET
         ArgumentNullException.ThrowIfNull(row);
 
         await using var command = _dataSource.CreateCommand(AlertSettingsUpsertSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         BindAlertSettings(command, row);
         await ExecuteWriteAsync(command, cancellationToken);
     }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.AvailabilityGroups.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.AvailabilityGroups.cs
@@ -113,7 +113,7 @@ ORDER BY d.server_name, d.ag_name, d.database_name, d.replica_server_name";
     {
         var rows = new List<AgTopologyReplicaRow>();
         await using var command = _dataSource.CreateCommand(AgReplicaStatesSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
         {
@@ -143,7 +143,7 @@ ORDER BY d.server_name, d.ag_name, d.database_name, d.replica_server_name";
     {
         var rows = new List<AgTopologyDatabaseRow>();
         await using var command = _dataSource.CreateCommand(AgDatabaseReplicaStatesSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
         {

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Blocking.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Blocking.cs
@@ -243,7 +243,7 @@ public sealed partial class ViewerDataService
         var rows = new List<ViewerBlockedProcessRow>();
 
         await using var command = _dataSource.CreateCommand(BlockedProcessReportsSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddBlockingParameters(command, serverId, startUtc, endUtc);
         command.Parameters.Add(DatabaseFilterParameter(databaseNames));
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
@@ -304,7 +304,7 @@ public sealed partial class ViewerDataService
         var rows = new List<ViewerBlockedProcessRow>();
 
         await using var command = _dataSource.CreateCommand(DmvBlockingSnapshotsSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddBlockingParameters(command, serverId, startUtc, endUtc);
         command.Parameters.Add(DatabaseFilterParameter(databaseNames));
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
@@ -360,7 +360,7 @@ public sealed partial class ViewerDataService
         await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken);
         await using (var command = connection.CreateCommand())
         {
-            command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+            command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
             command.CommandText = BlockingPairRowsSql;
             AddBlockingParameters(command, serverId, startUtc, endUtc);
             await using var reader = await command.ExecuteReaderAsync(cancellationToken);
@@ -380,7 +380,7 @@ public sealed partial class ViewerDataService
             () =>
             {
                 var command = connection.CreateCommand();
-                command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+                command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
                 return command;
             },
             rows, serverId, startUtc, endUtc, cancellationToken);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.BlockingSlicers.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.BlockingSlicers.cs
@@ -74,7 +74,7 @@ public sealed partial class ViewerDataService
         var items = new List<TimeSliceBucket>();
 
         await using var command = _dataSource.CreateCommand(BlockingSlicerSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddBlockingParameters(command, serverId, startUtc, endUtc);
         command.Parameters.Add(DatabaseFilterParameter(databaseNames));
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
@@ -118,7 +118,7 @@ public sealed partial class ViewerDataService
         var items = new List<TimeSliceBucket>();
 
         await using var command = _dataSource.CreateCommand(DeadlockSlicerSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddBlockingParameters(command, serverId, startUtc, endUtc);
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.BlockingStats.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.BlockingStats.cs
@@ -85,7 +85,7 @@ public sealed partial class ViewerDataService
         var items = new List<BlockingDurationStatsPoint>();
 
         await using var command = _dataSource.CreateCommand(BlockingDurationStatsSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime>
         {
@@ -149,7 +149,7 @@ public sealed partial class ViewerDataService
         var graphs = new List<(DateTime? DeadlockTime, string? Xml)>();
 
         await using var command = _dataSource.CreateCommand(DeadlockSeverityGraphsSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddBlockingParameters(command, serverId, startUtc, endUtc);
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.BlockingTrends.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.BlockingTrends.cs
@@ -196,7 +196,7 @@ public sealed partial class ViewerDataService
         var items = new List<BlockingTrendPoint>();
 
         await using var command = _dataSource.CreateCommand(sql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime>
         {
@@ -226,7 +226,7 @@ public sealed partial class ViewerDataService
         var items = new List<LockWaitTrendPoint>();
 
         await using var command = _dataSource.CreateCommand(LockWaitTrendSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime>
         {
@@ -255,7 +255,7 @@ public sealed partial class ViewerDataService
         var items = new List<WaitingTaskTrendPoint>();
 
         await using var command = _dataSource.CreateCommand(WaitingTaskTrendSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime>
         {
@@ -284,7 +284,7 @@ public sealed partial class ViewerDataService
         var items = new List<BlockedSessionTrendPoint>();
 
         await using var command = _dataSource.CreateCommand(BlockedSessionTrendSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime>
         {

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.CollectionHealth.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.CollectionHealth.cs
@@ -193,7 +193,7 @@ public sealed partial class ViewerDataService
     public async Task<int> GetPermissionDeniedCollectorCountAsync(int serverId, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(PermissionDeniedCollectorCountSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = DateTime.SpecifyKind(DateTime.UtcNow.AddDays(-7), DateTimeKind.Unspecified) });
 
@@ -333,7 +333,7 @@ public sealed partial class ViewerDataService
         var items = new List<CollectorHealthRow>();
 
         await using var command = _dataSource.CreateCommand(CollectionHealthSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime>
         {
@@ -361,7 +361,7 @@ public sealed partial class ViewerDataService
         var items = new List<CollectorHealthRow>();
 
         await using var command = _dataSource.CreateCommand(FleetCollectionHealthSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<DateTime>
         {
             TypedValue = DateTime.SpecifyKind(DateTime.UtcNow.AddDays(-7), DateTimeKind.Unspecified),
@@ -413,7 +413,7 @@ public sealed partial class ViewerDataService
     public async Task<List<CollectionLogRow>> GetRecentCollectionLogAsync(int serverId, DateTime startUtc, DateTime endUtc, int maxRows = 500, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(RecentCollectionLogSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime>
         {
@@ -436,7 +436,7 @@ public sealed partial class ViewerDataService
     public async Task<List<CollectionLogRow>> GetCollectionLogByCollectorAsync(int serverId, string collectorName, int hoursBack = 168, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(CollectionLogByCollectorSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = collectorName });
         command.Parameters.Add(new NpgsqlParameter<DateTime>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.CollectorSchedules.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.CollectorSchedules.cs
@@ -85,7 +85,7 @@ ON CONFLICT (server_id, collector_name) WHERE server_id IS NOT NULL DO UPDATE SE
         var rows = new List<CollectorScheduleRow>();
 
         await using var command = _dataSource.CreateCommand(CollectorSchedulesSelectSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
         {
@@ -126,7 +126,7 @@ ON CONFLICT (server_id, collector_name) WHERE server_id IS NOT NULL DO UPDATE SE
     public async Task<int> ResetAllServerSchedulesAsync(CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(CollectorScheduleDeleteAllServerScopesSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         return await ExecuteWriteAsync(command, cancellationToken);
     }
 
@@ -143,7 +143,7 @@ ON CONFLICT (server_id, collector_name) WHERE server_id IS NOT NULL DO UPDATE SE
             await using (var delete = new NpgsqlCommand(
                 serverId is null ? CollectorScheduleDeleteFleetScopeSql : CollectorScheduleDeleteServerScopeSql, connection, transaction))
             {
-                delete.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+                delete.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
                 if (serverId is int sid)
                 {
                     delete.Parameters.Add(new NpgsqlParameter<int> { TypedValue = sid });
@@ -156,7 +156,7 @@ ON CONFLICT (server_id, collector_name) WHERE server_id IS NOT NULL DO UPDATE SE
             {
                 await using var upsert = new NpgsqlCommand(
                     serverId is null ? CollectorScheduleFleetUpsertSql : CollectorScheduleServerUpsertSql, connection, transaction);
-                upsert.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+                upsert.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
                 if (serverId is int sid)
                 {
                     upsert.Parameters.Add(new NpgsqlParameter<int> { TypedValue = sid });                    // $1 (server scope)

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Config.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Config.cs
@@ -87,7 +87,7 @@ public sealed partial class ViewerDataService
         var items = new List<ServerConfigRow>();
 
         await using var command = _dataSource.CreateCommand(ServerConfigSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
@@ -111,7 +111,7 @@ public sealed partial class ViewerDataService
         var items = new List<DatabaseConfigRow>();
 
         await using var command = _dataSource.CreateCommand(DatabaseConfigSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(DatabaseFilterParameter(databaseNames));
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
@@ -162,7 +162,7 @@ public sealed partial class ViewerDataService
         var items = new List<DatabaseScopedConfigRow>();
 
         await using var command = _dataSource.CreateCommand(DatabaseScopedConfigSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(DatabaseFilterParameter(databaseNames));
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
@@ -187,7 +187,7 @@ public sealed partial class ViewerDataService
         var items = new List<QueryStoreHealthRow>();
 
         await using var command = _dataSource.CreateCommand(QueryStoreHealthSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(DatabaseFilterParameter(databaseNames));
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
@@ -217,7 +217,7 @@ public sealed partial class ViewerDataService
         var items = new List<TraceFlagRow>();
 
         await using var command = _dataSource.CreateCommand(TraceFlagsSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ConfigChanges.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ConfigChanges.cs
@@ -171,7 +171,7 @@ public sealed partial class ViewerDataService
     {
         var rows = new List<ConfigChangeDiff.ServerConfigSnapshot>();
         await using var command = _dataSource.CreateCommand(ServerConfigChangesSnapshotsSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddServerIdAndWindowEnd(command, serverId, endUtc);
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
@@ -193,7 +193,7 @@ public sealed partial class ViewerDataService
     {
         var rows = new List<ConfigChangeDiff.DatabaseConfigSnapshot>();
         await using var command = _dataSource.CreateCommand(DatabaseConfigChangesSnapshotsSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddServerIdAndWindowEnd(command, serverId, endUtc);
         command.Parameters.Add(DatabaseFilterParameter(databaseNames));
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
@@ -220,7 +220,7 @@ public sealed partial class ViewerDataService
     {
         var rows = new List<ConfigChangeDiff.TraceFlagSnapshot>();
         await using var command = _dataSource.CreateCommand(TraceFlagChangesSnapshotsSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddServerIdAndWindowEnd(command, serverId, endUtc);
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Cpu.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Cpu.cs
@@ -87,7 +87,7 @@ public sealed partial class ViewerDataService
         var samples = new List<CpuUtilizationSample>();
 
         await using var command = _dataSource.CreateCommand(CpuUtilizationSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime>
         {

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.CpuScheduler.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.CpuScheduler.cs
@@ -136,7 +136,7 @@ public sealed partial class ViewerDataService
         var result = new List<CpuSchedulerTrendPoint>();
 
         await using var command = _dataSource.CreateCommand(CpuSchedulerTrendSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddWindowParameters(command, serverId, startUtc, endUtc);
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
@@ -156,7 +156,7 @@ public sealed partial class ViewerDataService
         int serverId, DateTime startUtc, DateTime endUtc, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(CpuSchedulerSnapshotSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddWindowParameters(command, serverId, startUtc, endUtc);
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         if (!await reader.ReadAsync(cancellationToken))

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.DailySummary.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.DailySummary.cs
@@ -58,7 +58,7 @@ public sealed partial class ViewerDataService
             coverage.For(TimescaleSupport.QueryStatsHourlyView, TimescaleSupport.QueryStatsDailyView));
 
         await using var command = _dataSource.CreateCommand(DailySummaryRangeSqlFor(tier));
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = DateTime.SpecifyKind(fromDate.Date, DateTimeKind.Unspecified) });
         command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = DateTime.SpecifyKind(toDate.Date, DateTimeKind.Unspecified) });

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.DatabaseStates.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.DatabaseStates.cs
@@ -104,19 +104,19 @@ DO UPDATE SET expected_state = EXCLUDED.expected_state, is_user_override = false
         if (!IsReadOnly)
         {
             await using var seed = _dataSource.CreateCommand(DatabaseStateSeedSql);
-            seed.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+            seed.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
             seed.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
             await seed.ExecuteNonQueryAsync(cancellationToken);
 
             await using var heal = _dataSource.CreateCommand(DatabaseStateHealToOnlineSql);
-            heal.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+            heal.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
             heal.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
             await heal.ExecuteNonQueryAsync(cancellationToken);
         }
 
         var rows = new List<DatabaseStateExpectedRow>();
         await using var command = _dataSource.CreateCommand(DatabaseStateExpectationsSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
@@ -138,7 +138,7 @@ DO UPDATE SET expected_state = EXCLUDED.expected_state, is_user_override = false
     public async Task SetDatabaseStateExpectedAsync(int serverId, string databaseName, string expectedState, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(DatabaseStateSetExpectedSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = databaseName });
         command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = expectedState });
@@ -149,7 +149,7 @@ DO UPDATE SET expected_state = EXCLUDED.expected_state, is_user_override = false
     public async Task ResetDatabaseStateExpectedToCurrentAsync(int serverId, string databaseName, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(DatabaseStateResetToCurrentSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = databaseName });
         await ExecuteWriteAsync(command, cancellationToken);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Deadlock.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Deadlock.cs
@@ -117,7 +117,7 @@ public sealed partial class ViewerDataService
         var rows = new List<ViewerDeadlockRow>();
 
         await using var command = _dataSource.CreateCommand(RecentDeadlocksSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddBlockingParameters(command, serverId, startUtc, endUtc);
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ExcludedDatabases.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ExcludedDatabases.cs
@@ -62,7 +62,7 @@ public sealed partial class ViewerDataService
         var names = new List<string>();
 
         await using var command = _dataSource.CreateCommand(CollectedDatabaseNamesSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
@@ -85,7 +85,7 @@ public sealed partial class ViewerDataService
         }
 
         await using var command = _dataSource.CreateCommand(ServerIdByNameSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = serverName });
         var result = await command.ExecuteScalarAsync(cancellationToken);
         return result is null or DBNull ? null : Convert.ToInt32(result, System.Globalization.CultureInfo.InvariantCulture);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FileIo.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FileIo.cs
@@ -151,7 +151,7 @@ public sealed partial class ViewerDataService
         var items = new List<FileIoLatencyPoint>();
 
         await using var command = _dataSource.CreateCommand(FileIoLatencyTrendSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime>
         {
@@ -187,7 +187,7 @@ public sealed partial class ViewerDataService
         var items = new List<FileIoThroughputPoint>();
 
         await using var command = _dataSource.CreateCommand(FileIoThroughputTrendSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime>
         {

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.IndexAnalysis.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.IndexAnalysis.cs
@@ -333,7 +333,7 @@ LIMIT 1";
         var inputs = new List<IndexCleanupIndexInput>();
 
         await using var command = _dataSource.CreateCommand(IndexObjectStatsLatestSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
 
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
@@ -353,7 +353,7 @@ LIMIT 1";
         DateTime? startTime = null;
 
         await using var command = _dataSource.CreateCommand(ServerCompressionInfoSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
 
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.Inventory.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.Inventory.cs
@@ -125,7 +125,7 @@ LEFT JOIN grants g ON true";
         var idleCutoff = DateTime.UtcNow.AddDays(-7);
 
         await using var command = _dataSource.CreateCommand(ServerMetricsSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = DateTime.SpecifyKind(cpuCutoff, DateTimeKind.Unspecified) });
         command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = DateTime.SpecifyKind(idleCutoff, DateTimeKind.Unspecified) });
@@ -218,7 +218,7 @@ ORDER BY s.is_enabled DESC, server_name";
     public async Task<List<ServerPropertyRow>> GetServerInventoryAsync(CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(ServerInventorySql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
 
         var items = new List<ServerPropertyRow>();
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.Locking.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.Locking.cs
@@ -113,7 +113,7 @@ LIMIT $3";
         await using var command = databaseName == null
             ? _dataSource.CreateCommand(IndexLockingAllSql)
             : _dataSource.CreateCommand(IndexLockingByDbSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
 
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         if (databaseName != null)
@@ -175,7 +175,7 @@ ORDER BY ios.database_name";
     public async Task<List<string>> GetIndexLockingDatabasesAsync(int serverId, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(IndexLockingDatabasesSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
 
         var items = new List<string>();

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.Pvs.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.Pvs.cs
@@ -85,7 +85,7 @@ ORDER BY p.database_name, p.collection_time";
         int serverId, DateTime sinceUtc, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(PvsTrendSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = DateTime.SpecifyKind(sinceUtc, DateTimeKind.Unspecified) });
 
@@ -106,7 +106,7 @@ ORDER BY p.database_name, p.collection_time";
     public async Task<List<PvsStatsRow>> GetPvsStatsLatestAsync(int serverId, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(PvsStatsLatestSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
 
         var items = new List<PvsStatsRow>();

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.Recommendations.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.Recommendations.cs
@@ -137,7 +137,7 @@ HAVING COUNT(*) >= 24";
     public async Task<EditionFacts?> GetEditionFactsAsync(int serverId, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(RecommendationsEditionFactsSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
 
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
@@ -544,7 +544,7 @@ HAVING COUNT(*) >= 24";
         try
         {
             await using var command = _dataSource.CreateCommand(RecommendationsMaintenanceWindowSql);
-            command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+            command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
             command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
             command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = memoryCutoff });
 
@@ -588,7 +588,7 @@ HAVING COUNT(*) >= 24";
                 try
                 {
                     await using var cpuCommand = _dataSource.CreateCommand(RecommendationsCpuP95Sql);
-                    cpuCommand.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+                    cpuCommand.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
                     cpuCommand.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
                     cpuCommand.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = memoryCutoff });
 
@@ -671,7 +671,7 @@ HAVING COUNT(*) >= 24";
 
             await using (var command = _dataSource.CreateCommand(RecommendationsStorageTierSql))
             {
-                command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+                command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
                 command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
                 command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = memoryCutoff });
 
@@ -719,7 +719,7 @@ HAVING COUNT(*) >= 24";
         try
         {
             await using var command = _dataSource.CreateCommand(RecommendationsReservedCapacitySql);
-            command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+            command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
             command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
             command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = memoryCutoff });
 
@@ -760,7 +760,7 @@ HAVING COUNT(*) >= 24";
     private async Task<(int P95Mb, long SampleCount)> ReadMemoryP95Async(int serverId, DateTime cutoff, CancellationToken cancellationToken)
     {
         await using var command = _dataSource.CreateCommand(RecommendationsMemoryP95Sql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = cutoff });
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.Storage.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.Storage.cs
@@ -59,7 +59,7 @@ ORDER BY total_size_mb DESC, database_name, file_type_desc, file_name";
     public async Task<List<DatabaseSizeRow>> GetDatabaseSizeLatestAsync(int serverId, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(DatabaseSizeLatestSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
 
         var items = new List<DatabaseSizeRow>();
@@ -104,7 +104,7 @@ LIMIT $2";
     public async Task<List<DatabaseSizeSummaryRow>> GetDatabaseSizeSummaryAsync(int serverId, int topN = 10, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(DatabaseSizeSummarySql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = topN });
 
@@ -165,7 +165,7 @@ ORDER BY ds.total_size_mb DESC";
         var cutoff = DateTime.UtcNow.AddDays(-daysBack);
 
         await using var command = _dataSource.CreateCommand(IdleDatabasesSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = DateTime.SpecifyKind(cutoff, DateTimeKind.Unspecified) });
 
@@ -231,7 +231,7 @@ FROM latest l CROSS JOIN peak p";
         var cutoff = DateTime.UtcNow.AddHours(-24);
 
         await using var command = _dataSource.CreateCommand(TempdbSummarySql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = DateTime.SpecifyKind(cutoff, DateTimeKind.Unspecified) });
 
@@ -324,7 +324,7 @@ ORDER BY growth_30d_mb DESC";
         var cutoff30d = now.AddDays(-30);
 
         await using var command = _dataSource.CreateCommand(StorageGrowthSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = DateTime.SpecifyKind(cutoff7d, DateTimeKind.Unspecified) });
         command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = DateTime.SpecifyKind(cutoff30d, DateTimeKind.Unspecified) });
@@ -437,7 +437,7 @@ ORDER BY ios.schema_name, ios.table_name, the_day";
 
         await using (var command = _dataSource.CreateCommand(ObjectGrowthSummarySql))
         {
-            command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+            command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
             command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
             command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = databaseName });
             command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = windowStart });
@@ -467,7 +467,7 @@ ORDER BY ios.schema_name, ios.table_name, the_day";
 
         await using (var command = _dataSource.CreateCommand(ObjectGrowthSeriesSql))
         {
-            command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+            command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
             command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
             command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = databaseName });
             command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = windowStart });
@@ -523,7 +523,7 @@ ORDER BY index_id";
     public async Task<List<IndexUsageRow>> GetObjectIndexDetailAsync(int serverId, string databaseName, string schemaName, string tableName, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(ObjectIndexDetailSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = databaseName });
         command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = schemaName });

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.Utilization.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.Utilization.cs
@@ -102,7 +102,7 @@ LEFT JOIN grants g ON true";
         var cutoff = DateTime.UtcNow.AddHours(-24);
 
         await using var command = _dataSource.CreateCommand(UtilizationEfficiencySql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = DateTime.SpecifyKind(cutoff, DateTimeKind.Unspecified) });
 
@@ -211,7 +211,7 @@ ORDER BY c.day";
         var cutoff = DateTime.UtcNow.AddDays(-7);
 
         await using var command = _dataSource.CreateCommand(ProvisioningTrendSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = DateTime.SpecifyKind(cutoff, DateTimeKind.Unspecified) });
 
@@ -272,7 +272,7 @@ ORDER BY CAST(collection_time AS DATE)";
         var cutoff = DateTime.UtcNow.AddHours(-hoursBack);
 
         await using var command = _dataSource.CreateCommand(MemoryGrantEfficiencySql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = DateTime.SpecifyKind(cutoff, DateTimeKind.Unspecified) });
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.Workload.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.FinOps.Workload.cs
@@ -207,7 +207,7 @@ ORDER BY c.cpu_time_ms DESC";
             coverage.For(TimescaleSupport.QueryStatsDbHourlyView, TimescaleSupport.QueryStatsDbDailyView));
 
         await using var command = _dataSource.CreateCommand(DatabaseResourceUsageSqlFor(tier));
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = DateTime.SpecifyKind(cutoff, DateTimeKind.Unspecified) });
 
@@ -272,7 +272,7 @@ ORDER BY max_connections DESC";
         var cutoff = DateTime.UtcNow.AddHours(-24);
 
         await using var command = _dataSource.CreateCommand(ApplicationConnectionsSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = DateTime.SpecifyKind(cutoff, DateTimeKind.Unspecified) });
 
@@ -367,7 +367,7 @@ LIMIT $3";
             coverage.For(TimescaleSupport.QueryStatsHourlyView, TimescaleSupport.QueryStatsDailyView));
 
         await using var command = _dataSource.CreateCommand(TopResourceConsumersByTotalSqlFor(tier));
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = DateTime.SpecifyKind(cutoff, DateTimeKind.Unspecified) });
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = topN });
@@ -434,7 +434,7 @@ LIMIT $3";
             coverage.For(TimescaleSupport.QueryStatsHourlyView, TimescaleSupport.QueryStatsDailyView));
 
         await using var command = _dataSource.CreateCommand(TopResourceConsumersByAvgSqlFor(tier));
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = DateTime.SpecifyKind(cutoff, DateTimeKind.Unspecified) });
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = topN });
@@ -525,7 +525,7 @@ ORDER BY bc.total_wait_time_ms DESC";
         var cutoff = DateTime.UtcNow.AddHours(-hoursBack);
 
         await using var command = _dataSource.CreateCommand(WaitCategorySummarySql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = DateTime.SpecifyKind(cutoff, DateTimeKind.Unspecified) });
 
@@ -582,7 +582,7 @@ LIMIT $3";
         var (cutoff, _) = RetentionTierRouter.ClampToTextHorizon(now, now.AddHours(-hoursBack));
 
         await using var command = _dataSource.CreateCommand(ExpensiveQueriesSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = DateTime.SpecifyKind(cutoff, DateTimeKind.Unspecified) });
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = topN });
@@ -668,7 +668,7 @@ ORDER BY SUM(delta_worker_time) DESC";
         var cutoff = DateTime.UtcNow.AddHours(-hoursBack);
 
         await using var command = _dataSource.CreateCommand(HighImpactQueriesSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = DateTime.SpecifyKind(cutoff, DateTimeKind.Unspecified) });
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Findings.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Findings.cs
@@ -95,7 +95,7 @@ WHERE server_id = $1";
         try
         {
             await using var command = _dataSource.CreateCommand(GetAnalysisStateSql);
-            command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+            command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
             command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
 
             await using var reader = await command.ExecuteReaderAsync();

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Fleet.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Fleet.cs
@@ -102,7 +102,7 @@ SELECT
     public async Task<FleetTotals> GetFleetTotalsAsync(DateTime startUtc, DateTime endUtc, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(FleetTotalsSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<DateTime>
         {
             TypedValue = DateTime.SpecifyKind(startUtc, DateTimeKind.Unspecified),

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ItemHistory.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ItemHistory.cs
@@ -114,7 +114,7 @@ public sealed partial class ViewerDataService
         var rows = new List<ViewerQueryStatsHistoryRow>();
 
         await using var command = _dataSource.CreateCommand(QueryStatsHistorySql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddItemWindowParameters(command, serverId, databaseName, queryHash, startUtc, endUtc);
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
@@ -238,7 +238,7 @@ public sealed partial class ViewerDataService
         var rows = new List<ViewerProcedureStatsHistoryRow>();
 
         await using var command = _dataSource.CreateCommand(ProcStatsHistorySql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = databaseName ?? "" });
         command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = schemaName ?? "" });
@@ -377,7 +377,7 @@ public sealed partial class ViewerDataService
         var rows = new List<ViewerQueryStoreHistoryRow>();
 
         await using var command = _dataSource.CreateCommand(QueryStoreHistorySql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = databaseName ?? "" });
         command.Parameters.Add(new NpgsqlParameter<long> { TypedValue = queryId });

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ItemTimeline.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ItemTimeline.cs
@@ -57,7 +57,7 @@ public sealed partial class ViewerDataService
         CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(QueryStatsItemTimelineSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddItemWindowParameters(command, serverId, databaseName, queryHash, startUtc, endUtc);
         return await ReadItemTimelineAsync(command, cancellationToken);
     }
@@ -86,7 +86,7 @@ public sealed partial class ViewerDataService
         CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(ProcStatsItemTimelineSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = databaseName ?? "" });
         command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = schemaName ?? "" });
@@ -188,7 +188,7 @@ public sealed partial class ViewerDataService
         CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(QueryStoreItemTimelineSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = databaseName ?? "" });
         command.Parameters.Add(new NpgsqlParameter<long> { TypedValue = queryId });

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.JobHistory.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.JobHistory.cs
@@ -179,7 +179,7 @@ LIMIT {limitParam}";
         var rows = new List<ViewerJobHistoryRow>();
 
         await using var command = _dataSource.CreateCommand(sql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = DateTime.SpecifyKind(sinceUtc, DateTimeKind.Unspecified) });
         if (serverId.HasValue)
         {
@@ -265,7 +265,7 @@ ORDER BY server_name";
         var rows = new List<ViewerAgentStatusRow>();
 
         await using var command = _dataSource.CreateCommand(sql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         if (serverId.HasValue)
         {
             command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId.Value });

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.LatchSpinlock.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.LatchSpinlock.cs
@@ -193,7 +193,7 @@ public sealed partial class ViewerDataService
         var result = new List<LatchStatsTrendPoint>();
 
         await using var command = _dataSource.CreateCommand(LatchTrendSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddWindowParameters(command, serverId, startUtc, endUtc);
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
@@ -214,7 +214,7 @@ public sealed partial class ViewerDataService
         var result = new List<LatchStatsSnapshotRow>();
 
         await using var command = _dataSource.CreateCommand(LatchSnapshotSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddWindowParameters(command, serverId, startUtc, endUtc);
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
@@ -238,7 +238,7 @@ public sealed partial class ViewerDataService
         var result = new List<SpinlockStatsTrendPoint>();
 
         await using var command = _dataSource.CreateCommand(SpinlockTrendSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddWindowParameters(command, serverId, startUtc, endUtc);
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
@@ -259,7 +259,7 @@ public sealed partial class ViewerDataService
         var result = new List<SpinlockStatsSnapshotRow>();
 
         await using var command = _dataSource.CreateCommand(SpinlockSnapshotSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddWindowParameters(command, serverId, startUtc, endUtc);
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.LongQueries.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.LongQueries.cs
@@ -105,7 +105,7 @@ public sealed partial class ViewerDataService
         var rows = new List<ViewerLongQueryRow>();
 
         await using var command = _dataSource.CreateCommand(LongQueryCompletionsSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddWindowParameters(command, serverId, startUtc, endUtc);
         command.Parameters.Add(DatabaseFilterParameter(databaseNames));
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Memory.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Memory.cs
@@ -230,7 +230,7 @@ public sealed partial class ViewerDataService
         int serverId, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(LatestMemoryStatsSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
 
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
@@ -261,7 +261,7 @@ public sealed partial class ViewerDataService
         var items = new List<MemoryGrantTrendPoint>();
 
         await using var command = _dataSource.CreateCommand(MemoryGrantTrendSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime>
         {
@@ -291,7 +291,7 @@ public sealed partial class ViewerDataService
         var items = new List<string>();
 
         await using var command = _dataSource.CreateCommand(DistinctMemoryClerkTypesSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime>
         {
@@ -323,7 +323,7 @@ public sealed partial class ViewerDataService
         }
 
         await using var command = _dataSource.CreateCommand(MemoryClerkTrendsSql(clerkTypes.Count));
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime>
         {
@@ -364,7 +364,7 @@ public sealed partial class ViewerDataService
         var items = new List<MemoryGrantChartPoint>();
 
         await using var command = _dataSource.CreateCommand(MemoryGrantChartDataSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime>
         {
@@ -403,7 +403,7 @@ public sealed partial class ViewerDataService
         var items = new List<MemoryPressureEventRow>();
 
         await using var command = _dataSource.CreateCommand(MemoryPressureEventsSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime>
         {

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.MonitoredServers.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.MonitoredServers.cs
@@ -219,7 +219,7 @@ ORDER BY COALESCE(s.display_name, c.name)";
         var servers = new List<DarlingServer>();
 
         await using var command = _dataSource.CreateCommand(ManagedServersSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
         {
@@ -250,7 +250,7 @@ ORDER BY COALESCE(s.display_name, c.name)";
         try
         {
             await using var command = _dataSource.CreateCommand(ConfigSeededSql);
-            command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+            command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
             var result = await command.ExecuteScalarAsync(cancellationToken);
             return result is true;
         }
@@ -277,7 +277,7 @@ ORDER BY COALESCE(s.display_name, c.name)";
         var servers = new List<MonitoredServerRow>();
 
         await using var command = _dataSource.CreateCommand(MonitoredServersSelectSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
         {
@@ -296,14 +296,14 @@ ORDER BY COALESCE(s.display_name, c.name)";
         if (IsReadOnly)
         {
             await using var noSecretCommand = _dataSource.CreateCommand(MonitoredServerByIdNoSecretSql);
-            noSecretCommand.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+            noSecretCommand.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
             noSecretCommand.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
             await using var noSecretReader = await noSecretCommand.ExecuteReaderAsync(cancellationToken);
             return await noSecretReader.ReadAsync(cancellationToken) ? ReadMonitoredServerRowNoSecret(noSecretReader) : null;
         }
 
         await using var command = _dataSource.CreateCommand(MonitoredServerByIdSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         return await reader.ReadAsync(cancellationToken) ? ReadMonitoredServerRow(reader) : null;
@@ -320,7 +320,7 @@ ORDER BY COALESCE(s.display_name, c.name)";
         string host, string? database, bool readOnlyIntent, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(MonitoredServerByAddressSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = host });
         command.Parameters.Add(new NpgsqlParameter { Value = (object?)database ?? DBNull.Value });
         command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = readOnlyIntent });
@@ -332,7 +332,7 @@ ORDER BY COALESCE(s.display_name, c.name)";
     public async Task<long> GetMonitoredServerCountAsync(CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(MonitoredServersCountSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         var result = await command.ExecuteScalarAsync(cancellationToken);
         return result is null or DBNull ? 0 : Convert.ToInt64(result, System.Globalization.CultureInfo.InvariantCulture);
     }
@@ -347,7 +347,7 @@ ORDER BY COALESCE(s.display_name, c.name)";
         ArgumentNullException.ThrowIfNull(row);
 
         await using var command = _dataSource.CreateCommand(MonitoredServerUpsertSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         BindMonitoredServer(command, row);
         await ExecuteWriteAsync(command, cancellationToken);
     }
@@ -362,7 +362,7 @@ ORDER BY COALESCE(s.display_name, c.name)";
         ArgumentNullException.ThrowIfNull(row);
 
         await using var command = _dataSource.CreateCommand(MonitoredServerInsertIfAbsentSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         BindMonitoredServer(command, row);
         return await ExecuteWriteAsync(command, cancellationToken) > 0;
     }
@@ -371,7 +371,7 @@ ORDER BY COALESCE(s.display_name, c.name)";
     public async Task DeleteMonitoredServerAsync(int serverId, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(MonitoredServerDeleteSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         await ExecuteWriteAsync(command, cancellationToken);
     }
@@ -380,7 +380,7 @@ ORDER BY COALESCE(s.display_name, c.name)";
     public async Task SetMonitoredServerEnabledAsync(int serverId, bool enabled, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(MonitoredServerSetEnabledSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = enabled });
         await ExecuteWriteAsync(command, cancellationToken);
@@ -390,7 +390,7 @@ ORDER BY COALESCE(s.display_name, c.name)";
     public async Task SetMonitoredServerExcludedDatabasesAsync(int serverId, IEnumerable<string> excludedDatabases, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(MonitoredServerSetExcludedDatabasesSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         AddTextArray(command, excludedDatabases);
         await ExecuteWriteAsync(command, cancellationToken);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.MuteRules.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.MuteRules.cs
@@ -121,7 +121,7 @@ WHERE id = $1";
         var rules = new List<MuteRule>();
 
         await using var command = _dataSource.CreateCommand(MuteRulesSelectSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
         {
@@ -153,7 +153,7 @@ WHERE id = $1";
         }
 
         await using var command = _dataSource.CreateCommand(MuteRuleInsertSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = rule.Id });
         command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = rule.Enabled });
         command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = Naive(rule.CreatedAtUtc) });
@@ -178,7 +178,7 @@ WHERE id = $1";
         }
 
         await using var command = _dataSource.CreateCommand(MuteRuleUpdateSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = rule.Id });
         command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = rule.Enabled });
         AddNullableTimestamp(command, rule.ExpiresAtUtc);
@@ -197,7 +197,7 @@ WHERE id = $1";
     public async Task SetMuteRuleEnabledAsync(string ruleId, bool enabled, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(MuteRuleSetEnabledSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = ruleId });
         command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = enabled });
         await ExecuteWriteAsync(command, cancellationToken);
@@ -216,7 +216,7 @@ WHERE id = $1";
     private async Task DeleteMuteRuleRawAsync(string ruleId, CancellationToken cancellationToken)
     {
         await using var command = _dataSource.CreateCommand(MuteRuleDeleteSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = ruleId });
         await ExecuteWriteAsync(command, cancellationToken);
     }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Notification.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Notification.cs
@@ -102,13 +102,13 @@ ON CONFLICT (id) DO UPDATE SET
         if (IsReadOnly)
         {
             await using var noSecretCommand = _dataSource.CreateCommand(NotificationSelectNoSecretSql);
-            noSecretCommand.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+            noSecretCommand.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
             await using var noSecretReader = await noSecretCommand.ExecuteReaderAsync(cancellationToken);
             return await noSecretReader.ReadAsync(cancellationToken) ? ReadNotificationRowNoSecret(noSecretReader) : null;
         }
 
         await using var command = _dataSource.CreateCommand(NotificationSelectSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         return await reader.ReadAsync(cancellationToken) ? ReadNotificationRow(reader) : null;
     }
@@ -120,7 +120,7 @@ ON CONFLICT (id) DO UPDATE SET
         ArgumentNullException.ThrowIfNull(row);
 
         await using var command = _dataSource.CreateCommand(NotificationUpsertSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = row.SmtpHost });            // $1
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = row.SmtpPort });               // $2
         command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = row.SmtpUseSsl });            // $3

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Overview.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Overview.cs
@@ -184,7 +184,7 @@ WHERE server_id = $1";
            number alongside (Lite's headline). */
         await using (var command = _dataSource.CreateCommand(ServerSummaryCpuSql))
         {
-            command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+            command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
             command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
             await using var reader = await command.ExecuteReaderAsync(cancellationToken);
             if (await reader.ReadAsync(cancellationToken))
@@ -197,7 +197,7 @@ WHERE server_id = $1";
         /* Latest total server memory + buffer pool. */
         await using (var command = _dataSource.CreateCommand(ServerSummaryMemorySql))
         {
-            command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+            command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
             command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
             await using var reader = await command.ExecuteReaderAsync(cancellationToken);
             if (await reader.ReadAsync(cancellationToken))
@@ -210,7 +210,7 @@ WHERE server_id = $1";
         /* Latest resource-semaphore pressure (grant waiters / timeouts / forced grants + granted MB). */
         await using (var command = _dataSource.CreateCommand(ServerSummaryMemoryPressureSql))
         {
-            command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+            command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
             command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
             await using var reader = await command.ExecuteReaderAsync(cancellationToken);
             if (await reader.ReadAsync(cancellationToken))
@@ -225,7 +225,7 @@ WHERE server_id = $1";
         /* Latest worker-thread pressure (max / in-use / runnable-waiting / work-queue). Absent on Azure. */
         await using (var command = _dataSource.CreateCommand(ServerSummaryThreadsSql))
         {
-            command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+            command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
             command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
             await using var reader = await command.ExecuteReaderAsync(cancellationToken);
             if (await reader.ReadAsync(cancellationToken))
@@ -240,7 +240,7 @@ WHERE server_id = $1";
         /* Blocking count + worst wait in the last hour (XE preferred, DMV fallback — same source for both). */
         await using (var command = _dataSource.CreateCommand(ServerSummaryBlockingSql))
         {
-            command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+            command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
             command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
             command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = windowStart });
             await using var reader = await command.ExecuteReaderAsync(cancellationToken);
@@ -279,7 +279,7 @@ WHERE server_id = $1";
         /* Deadlock count in the last hour + the newest deadlock ever (for "Last: N ago"). */
         await using (var command = _dataSource.CreateCommand(ServerSummaryDeadlockSql))
         {
-            command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+            command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
             command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
             command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = windowStart });
             await using var reader = await command.ExecuteReaderAsync(cancellationToken);
@@ -293,7 +293,7 @@ WHERE server_id = $1";
         /* Newest collection time across all collectors — drives the freshness status. */
         await using (var command = _dataSource.CreateCommand(ServerSummaryLastCollectionSql))
         {
-            command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+            command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
             command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
             var result = await command.ExecuteScalarAsync(cancellationToken);
             if (result is not null && result != DBNull.Value)

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.OverviewLanes.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.OverviewLanes.cs
@@ -101,7 +101,7 @@ public sealed partial class ViewerDataService
         var items = new List<WaitStatsTrendPoint>();
 
         await using var command = _dataSource.CreateCommand(TotalWaitTrendSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime>
         {
@@ -134,7 +134,7 @@ public sealed partial class ViewerDataService
         var items = new List<MemoryTrendPoint>();
 
         await using var command = _dataSource.CreateCommand(MemoryTrendSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime>
         {

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Perfmon.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Perfmon.cs
@@ -90,7 +90,7 @@ public sealed partial class ViewerDataService
         var items = new List<string>();
 
         await using var command = _dataSource.CreateCommand(DistinctPerfmonCountersSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime>
         {
@@ -123,7 +123,7 @@ public sealed partial class ViewerDataService
         }
 
         await using var command = _dataSource.CreateCommand(PerfmonTrendsSql(counterNames.Count));
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime>
         {

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.PlanCache.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.PlanCache.cs
@@ -159,7 +159,7 @@ public sealed partial class ViewerDataService
         var result = new List<PlanCacheTrendPoint>();
 
         await using var command = _dataSource.CreateCommand(PlanCacheTrendSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddWindowParameters(command, serverId, startUtc, endUtc);
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
@@ -180,7 +180,7 @@ public sealed partial class ViewerDataService
         var result = new List<PlanCacheSnapshotRow>();
 
         await using var command = _dataSource.CreateCommand(PlanCacheSnapshotSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddWindowParameters(command, serverId, startUtc, endUtc);
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
@@ -208,7 +208,7 @@ public sealed partial class ViewerDataService
         int serverId, DateTime startUtc, DateTime endUtc, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(PlanCacheSummarySql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddWindowParameters(command, serverId, startUtc, endUtc);
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         if (!await reader.ReadAsync(cancellationToken))

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.PlanCorrection.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.PlanCorrection.cs
@@ -99,7 +99,7 @@ public sealed partial class ViewerDataService
         var rows = new List<PlanCorrectionRow>();
 
         await using var command = _dataSource.CreateCommand(PlanCorrectionsSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddWindowParameters(command, serverId, startUtc, endUtc);
         command.Parameters.Add(DatabaseFilterParameter(databaseNames));
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
@@ -147,7 +147,7 @@ public sealed partial class ViewerDataService
         var rows = new List<AutomaticTuningRow>();
 
         await using var command = _dataSource.CreateCommand(AutomaticTuningSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(DatabaseFilterParameter(databaseNames));
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Plans.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Plans.cs
@@ -63,7 +63,7 @@ public sealed partial class ViewerDataService
         }
 
         await using var command = _dataSource.CreateCommand(QueryStatsPlanXmlSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = databaseName ?? "" });
         command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = queryHash });
@@ -95,7 +95,7 @@ public sealed partial class ViewerDataService
         int serverId, string databaseName, long queryId, long planId, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(QueryStorePlanTextSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = databaseName ?? "" });
         command.Parameters.Add(new NpgsqlParameter<long> { TypedValue = queryId });
@@ -148,7 +148,7 @@ public sealed partial class ViewerDataService
         }
 
         await using var command = _dataSource.CreateCommand(ProcedureStatsPlanXmlSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = databaseName ?? "" });
         command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = schemaName ?? "" });

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Postgres.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Postgres.cs
@@ -102,7 +102,7 @@ public sealed partial class ViewerDataService
         }
 
         await using var command = _dataSource.CreateCommand(PostgresCollectorHealthSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         /* Kind-Unspecified at the bind, per the store's naive-UTC discipline: a Kind=Utc DateTime makes
            Npgsql infer timestamptz, and PostgreSQL then zone-shifts these naive columns to compare them, so

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ProcedureStats.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ProcedureStats.cs
@@ -142,7 +142,7 @@ public sealed partial class ViewerDataService
         var rows = new List<ViewerProcedureStatsRow>();
 
         await using var command = _dataSource.CreateCommand(TopProceduresSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddServerWindowParameters(command, serverId, startUtc, endUtc);
         command.Parameters.Add(new Npgsql.NpgsqlParameter<int> { TypedValue = top });
         command.Parameters.Add(DatabaseFilterParameter(databaseNames));
@@ -299,7 +299,7 @@ public sealed partial class ViewerDataService
         var items = new List<ProcedureStatsComparisonItem>();
 
         await using var command = _dataSource.CreateCommand(ProcedureStatsComparisonSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddComparisonParameters(command, serverId, currentStart, currentEnd, baselineStart, baselineEnd);
         command.Parameters.Add(DatabaseFilterParameter(databaseNames));
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryHeatmap.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryHeatmap.cs
@@ -162,7 +162,7 @@ public sealed partial class ViewerDataService
         var rawCells = new List<HeatmapCell>();
 
         await using var command = _dataSource.CreateCommand(BuildQueryHeatmapSql(metric));
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddServerWindowParameters(command, serverId, startUtc, endUtc);
         command.Parameters.Add(DatabaseFilterParameter(databaseNames));
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QuerySnapshots.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QuerySnapshots.cs
@@ -169,7 +169,7 @@ public sealed partial class ViewerDataService
         int serverId, DateTime startUtc, DateTime endUtc, IReadOnlyList<string>? databaseNames = null, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(LatestQuerySnapshotsSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddServerWindowParameters(command, serverId, startUtc, endUtc);
         command.Parameters.Add(DatabaseFilterParameter(databaseNames));
         return await ReadQuerySnapshotsAsync(command, cancellationToken);
@@ -199,7 +199,7 @@ public sealed partial class ViewerDataService
         int serverId, string waitType, DateTime startUtc, DateTime endUtc, IReadOnlyList<string>? databaseNames = null, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(QuerySnapshotsByWaitTypeSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddServerWindowParameters(command, serverId, startUtc, endUtc);
         command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = waitType });
         command.Parameters.Add(DatabaseFilterParameter(databaseNames));
@@ -215,7 +215,7 @@ public sealed partial class ViewerDataService
         int serverId, IReadOnlyList<string>? databaseNames = null, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(LatestQuerySnapshotBatchSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(DatabaseFilterParameter(databaseNames));
         var rows = await ReadQuerySnapshotsAsync(command, cancellationToken);
@@ -305,7 +305,7 @@ public sealed partial class ViewerDataService
         var items = new List<TimeSliceBucket>();
 
         await using var command = _dataSource.CreateCommand(ActiveQuerySlicerSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddServerWindowParameters(command, serverId, startUtc, endUtc);
         command.Parameters.Add(DatabaseFilterParameter(databaseNames));
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStats.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStats.cs
@@ -318,7 +318,7 @@ public sealed partial class ViewerDataService
         var rows = new List<ViewerQueryStatsRow>();
 
         await using var command = _dataSource.CreateCommand(TopQueriesSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddServerWindowParameters(command, serverId, startUtc, endUtc);
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = top });
         command.Parameters.Add(DatabaseFilterParameter(databaseNames));
@@ -479,7 +479,7 @@ public sealed partial class ViewerDataService
         var items = new List<QueryStatsComparisonItem>();
 
         await using var command = _dataSource.CreateCommand(QueryStatsComparisonSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddComparisonParameters(command, serverId, currentStart, currentEnd, baselineStart, baselineEnd);
         command.Parameters.Add(DatabaseFilterParameter(databaseNames));
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
@@ -546,7 +546,7 @@ public sealed partial class ViewerDataService
         var items = new List<TimeSliceBucket>();
 
         await using var command = _dataSource.CreateCommand(sql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddServerWindowParameters(command, serverId, startUtc, endUtc);
         command.Parameters.Add(DatabaseFilterParameter(databaseNames));
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStore.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStore.cs
@@ -319,7 +319,7 @@ public sealed partial class ViewerDataService
         var rows = new List<ViewerQueryStoreRow>();
 
         await using var command = _dataSource.CreateCommand(QueryStoreTopSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddServerWindowParameters(command, serverId, startUtc, endUtc);
         command.Parameters.Add(new Npgsql.NpgsqlParameter<int> { TypedValue = top });
         command.Parameters.Add(DatabaseFilterParameter(databaseNames));
@@ -548,7 +548,7 @@ public sealed partial class ViewerDataService
         var items = new List<QueryStatsComparisonItem>();
 
         await using var command = _dataSource.CreateCommand(QueryStoreComparisonSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddComparisonParameters(command, serverId, currentStart, currentEnd, baselineStart, baselineEnd);
         command.Parameters.Add(DatabaseFilterParameter(databaseNames));
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStoreRegressions.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryStoreRegressions.cs
@@ -226,7 +226,7 @@ public sealed partial class ViewerDataService
         var rows = new List<ViewerQueryStoreRegressionRow>();
 
         await using var command = _dataSource.CreateCommand(QueryStoreRegressionsSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddServerWindowParameters(command, serverId, startUtc, endUtc);
         command.Parameters.Add(DatabaseFilterParameter(databaseNames));
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryTrends.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.QueryTrends.cs
@@ -262,7 +262,7 @@ public sealed partial class ViewerDataService
         var items = new List<QueryTrendPoint>();
 
         await using var command = _dataSource.CreateCommand(QueryStoreDurationTrendRollupSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddServerWindowParameters(command, serverId, startUtc, endUtc);
         command.Parameters.Add(new Npgsql.NpgsqlParameter<DateTime>
         {
@@ -294,7 +294,7 @@ public sealed partial class ViewerDataService
         var items = new List<QueryTrendPoint>();
 
         await using var command = _dataSource.CreateCommand(sql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddServerWindowParameters(command, serverId, startUtc, endUtc);
         command.Parameters.Add(DatabaseFilterParameter(databaseNames));
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
@@ -318,7 +318,7 @@ public sealed partial class ViewerDataService
         var items = new List<QueryTrendPoint>();
 
         await using var command = _dataSource.CreateCommand(ExecutionCountTrendSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddServerWindowParameters(command, serverId, startUtc, endUtc);
         command.Parameters.Add(DatabaseFilterParameter(databaseNames));
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.RunningJobs.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.RunningJobs.cs
@@ -72,7 +72,7 @@ public sealed partial class ViewerDataService
         var items = new List<RunningJobRow>();
 
         await using var command = _dataSource.CreateCommand(RunningJobsSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
@@ -103,7 +103,7 @@ public sealed partial class ViewerDataService
     public async Task<string?> GetLatestRunningJobsCollectorStatusAsync(int serverId, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(RunningJobsCollectorStatusSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         var result = await command.ExecuteScalarAsync(cancellationToken);
         return result as string;

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ServerStatus.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ServerStatus.cs
@@ -49,7 +49,7 @@ GROUP BY server_id";
         var result = new Dictionary<int, DateTime>();
 
         await using var command = _dataSource.CreateCommand(ServerFreshnessSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
         {
@@ -66,7 +66,7 @@ GROUP BY server_id";
     public async Task<long?> GetStoreSizeBytesAsync(CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(StoreSizeSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         var result = await command.ExecuteScalarAsync(cancellationToken);
         return result is null || result == DBNull.Value ? null : Convert.ToInt64(result);
     }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ServerTags.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ServerTags.cs
@@ -104,7 +104,7 @@ public sealed partial class ViewerDataService
     {
         var tags = new List<DarlingTag>();
         await using var command = _dataSource.CreateCommand(ServerTagsSelectSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
         {
@@ -124,7 +124,7 @@ public sealed partial class ViewerDataService
     {
         var assignments = new List<DarlingTagAssignment>();
         await using var command = _dataSource.CreateCommand(ServerTagMapSelectSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
         {
@@ -140,7 +140,7 @@ public sealed partial class ViewerDataService
         int id;
         await using (var command = _dataSource.CreateCommand(ServerTagInsertSql))
         {
-            command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+            command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
             command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = name });
             command.Parameters.Add(parentId is int parent
                 ? new NpgsqlParameter<int> { TypedValue = parent }
@@ -167,7 +167,7 @@ public sealed partial class ViewerDataService
     public async Task RenameServerTagAsync(int tagId, string name, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(ServerTagRenameSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = tagId });
         command.Parameters.Add(new NpgsqlParameter<string> { TypedValue = name });
         await ExecuteWriteAsync(command, cancellationToken);
@@ -179,7 +179,7 @@ public sealed partial class ViewerDataService
     public async Task SetServerTagColorAsync(int tagId, string? colour, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(ServerTagSetColourSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = tagId });
         command.Parameters.Add(colour is null
             ? new NpgsqlParameter { Value = System.DBNull.Value }
@@ -192,7 +192,7 @@ public sealed partial class ViewerDataService
     public async Task ReparentServerTagAsync(int tagId, int? newParentId, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(ServerTagReparentSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = tagId });
         command.Parameters.Add(newParentId is int parent
             ? new NpgsqlParameter<int> { TypedValue = parent }
@@ -204,7 +204,7 @@ public sealed partial class ViewerDataService
     public async Task<bool> ServerTagHasChildrenAsync(int tagId, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(ServerTagHasChildrenSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = tagId });
         return (bool)(await command.ExecuteScalarAsync(cancellationToken))!;
     }
@@ -213,7 +213,7 @@ public sealed partial class ViewerDataService
     public async Task DeleteServerTagAsync(int tagId, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(ServerTagDeleteSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = tagId });
         await ExecuteWriteAsync(command, cancellationToken);
     }
@@ -222,7 +222,7 @@ public sealed partial class ViewerDataService
     public async Task AssignServerTagAsync(IReadOnlyList<int> serverIds, int tagId, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(ServerTagAssignSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int[]> { TypedValue = System.Linq.Enumerable.ToArray(serverIds) });
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = tagId });
         await ExecuteWriteAsync(command, cancellationToken);
@@ -232,7 +232,7 @@ public sealed partial class ViewerDataService
     public async Task UnassignServerTagAsync(IReadOnlyList<int> serverIds, int tagId, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(ServerTagUnassignSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int[]> { TypedValue = System.Linq.Enumerable.ToArray(serverIds) });
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = tagId });
         await ExecuteWriteAsync(command, cancellationToken);
@@ -242,7 +242,7 @@ public sealed partial class ViewerDataService
     public async Task ClearServerTagsAsync(int serverId, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(ServerTagClearForServerSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         await ExecuteWriteAsync(command, cancellationToken);
     }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ServiceConfig.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.ServiceConfig.cs
@@ -54,7 +54,7 @@ WHERE id = 1";
     public async Task<ServiceConfigRow?> GetServiceConfigAsync(CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(ServiceConfigSelectSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         if (!await reader.ReadAsync(cancellationToken))
         {
@@ -99,7 +99,7 @@ WHERE id = 1";
         bool capturePlans, bool mcpEnabled, int mcpPort, bool webEnabled, int webPort, bool queryStoreBackfillEnabled, int queryStoreTextBudgetMb, int maxConcurrentSweeps, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(ServiceConfigUpdateFlagsSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = capturePlans });
         command.Parameters.Add(new NpgsqlParameter<bool> { TypedValue = mcpEnabled });
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = mcpPort });
@@ -127,7 +127,7 @@ WHERE id = 1";
     public async Task SignalConfigReloadAsync(CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(ConfigReloadSignalSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         await ExecuteWriteAsync(command, cancellationToken);
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.SessionStats.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.SessionStats.cs
@@ -84,7 +84,7 @@ public sealed partial class ViewerDataService
         var result = new List<SessionStatsPoint>();
 
         await using var command = _dataSource.CreateCommand(SessionStatsSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddWindowParameters(command, serverId, startUtc, endUtc);
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.SystemEvents.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.SystemEvents.cs
@@ -321,7 +321,7 @@ public sealed partial class ViewerDataService
         var map = new Dictionary<int, string>();
 
         await using var command = _dataSource.CreateCommand(DatabaseNameMapSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
@@ -350,7 +350,7 @@ public sealed partial class ViewerDataService
         var xmls = new List<string>();
 
         await using var command = _dataSource.CreateCommand(SystemHealthEventsByTypeSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         AddSystemEventParameters(command, serverId, startUtc, endUtc, eventType);
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
@@ -653,7 +653,7 @@ public sealed partial class ViewerDataService
         var rows = new List<DefaultTraceEventRow>();
 
         await using var command = _dataSource.CreateCommand(DefaultTraceEventsByWindowSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = DateTime.SpecifyKind(startUtc, DateTimeKind.Unspecified) });
         command.Parameters.Add(new NpgsqlParameter<DateTime> { TypedValue = DateTime.SpecifyKind(endUtc, DateTimeKind.Unspecified) });

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.TempDb.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.TempDb.cs
@@ -104,7 +104,7 @@ public sealed partial class ViewerDataService
         var samples = new List<TempDbSample>();
 
         await using var command = _dataSource.CreateCommand(TempDbTrendSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime>
         {
@@ -138,7 +138,7 @@ public sealed partial class ViewerDataService
         var samples = new List<TempDbFileIoSample>();
 
         await using var command = _dataSource.CreateCommand(TempDbFileIoTrendSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime>
         {

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Waits.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Waits.cs
@@ -104,7 +104,7 @@ public sealed partial class ViewerDataService
         var items = new List<string>();
 
         await using var command = _dataSource.CreateCommand(DistinctWaitTypesSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime>
         {
@@ -137,7 +137,7 @@ public sealed partial class ViewerDataService
         }
 
         await using var command = _dataSource.CreateCommand(WaitTrendsSql(waitTypes.Count));
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         command.Parameters.Add(new NpgsqlParameter<DateTime>
         {

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.cs
@@ -1546,7 +1546,7 @@ SELECT
         var servers = new List<DarlingServer>();
 
         await using var command = _dataSource.CreateCommand(ServersSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
         while (await reader.ReadAsync(cancellationToken))
         {
@@ -1602,7 +1602,7 @@ LIMIT 1";
     public async Task<int?> GetServerUtcOffsetMinutesAsync(int serverId, CancellationToken cancellationToken = default)
     {
         await using var command = _dataSource.CreateCommand(ServerUtcOffsetSql);
-        command.CommandTimeout = ViewerCommandDeadlines.InteractiveReadSeconds;
+        command.CommandTimeout = ViewerCommandDeadlines.CurrentInteractiveReadSeconds;
         command.Parameters.Add(new NpgsqlParameter<int> { TypedValue = serverId });
         var result = await command.ExecuteScalarAsync(cancellationToken);
         return result is null or DBNull

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerReadFanOut.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerReadFanOut.cs
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Threading;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// How many of this project's store reads are in flight together, declared by the site that fans them out
+/// and read by <see cref="ViewerCommandDeadlines.CurrentInteractiveReadSeconds"/> when it stamps a
+/// command's deadline (#3004).
+///
+/// <para><b>Why a deadline needs to know this.</b> #2901 gave every interactive read one ceiling and
+/// derived it from the heaviest shipped read measured ALONE — 3.01 s cold for <c>TopQueriesSql</c> over a
+/// 30-day custom range at production per-server density. Fifteen sites in this project do not issue reads
+/// alone: they await one <c>Task.WhenAll</c> over between two and (unbounded) fleet-many of them. The same
+/// rig measured TEN concurrent 30-day reads at 24.4-64.1 s EACH, so ten-way contention on this store costs
+/// 8-21x, and a ceiling derived from one read in isolation is not a bound on ten reads at all — it is a
+/// bound on a different population that happens to share a code path. The widest fan-out,
+/// <see cref="CorrelatedTimelineLanesControl"/>'s ten, sat entirely above it.</para>
+///
+/// <para><b>Why the width travels with the call rather than the signature.</b> The deadline is stamped at
+/// each of this project's 187 interactive command sites, by design: #2901 chose per-site over a wrapper so
+/// the regime is visible where the command is built. A width parameter would have to be threaded through
+/// every method between the panel and the command to reach those sites, and it is not a property of any of
+/// them — it is a property of the CALL. <see cref="AsyncLocal{T}"/> is captured into each task's execution
+/// context at the moment the fan-out site creates it, so all ten tasks read the width that site declared
+/// even though the declaring frame has long since left the scope by the time they finish. Nothing here is
+/// mutable shared state: a write branches the context rather than reaching sibling reads.</para>
+///
+/// <para><b>Nesting multiplies, it does not take the larger.</b> A read two scopes deep contends with the
+/// product of both widths, so that is what it is told. The product is clamped at
+/// <see cref="ViewerSettings.ManagedMaxPoolSize"/> going in, because a pool of ten cannot serve an
+/// eleventh read concurrently however many were asked for — which is also what makes the two unbounded
+/// per-server fan-outs (<c>FinOpsTab.Loaders.cs</c>'s inventory overlay and <c>MainWindow</c>'s overview
+/// cards) safe to declare with their raw fleet count rather than a hand-capped guess.</para>
+///
+/// <para><b>What this does NOT do.</b> It does not throttle anything. The reads still all start at once and
+/// still all take a permit; this only stops the deadline cutting reads that the store was always going to
+/// take that long to serve. Bounding the fan-out itself is the better fix and is tracked on #3004 — it
+/// needs a concurrency sweep (per-read duration at width 1, 2, 4, 6, 8, 10) that does not exist yet,
+/// because the two data points available extrapolate to a cap of about two, and serializing every panel in
+/// the viewer on a two-point extrapolation is not a trade to make blind.</para>
+/// </summary>
+public static class ViewerReadFanOut
+{
+    /// <summary>
+    /// The declared width for the current execution context. Zero — the default for a context no scope
+    /// has touched — means "nobody declared a fan-out", which <see cref="CurrentWidth"/> reports as one.
+    /// </summary>
+    private static readonly AsyncLocal<int> s_width = new();
+
+    /// <summary>
+    /// How many concurrent reads the read being constructed right now is one of. One when no enclosing
+    /// site declared otherwise, which is the honest answer for a read issued on its own and the reason an
+    /// unscoped read keeps exactly #2901's single-read ceiling rather than inheriting a fan-out's.
+    /// </summary>
+    public static int CurrentWidth
+    {
+        get
+        {
+            var declared = s_width.Value;
+
+            return declared < 1 ? 1 : declared;
+        }
+    }
+
+    /// <summary>
+    /// Declares that the store reads created inside the returned scope run concurrently with each other,
+    /// so each one's deadline has to cover contention with the other
+    /// <paramref name="concurrentReads"/> - 1 of them.
+    ///
+    /// <para>Pass the ACTUAL width, including a runtime count for a fan-out whose width is the fleet size;
+    /// the clamp to <see cref="ViewerSettings.ManagedMaxPoolSize"/> is this type's job, not the call
+    /// site's. Declaring a width the site does not really have is the one way to misuse this — it buys a
+    /// longer deadline for a read that has no contention to justify it.</para>
+    /// </summary>
+    public static Scope Of(int concurrentReads) => new(concurrentReads);
+
+    /// <summary>
+    /// The lifetime of a declared width. A struct because a fan-out site is on the refresh path and this
+    /// should not allocate; <c>using var</c> disposes it the same either way.
+    /// </summary>
+    public readonly struct Scope : IDisposable
+    {
+        private readonly int _restore;
+
+        internal Scope(int concurrentReads)
+        {
+            _restore = s_width.Value;
+
+            /* Both factors are clamped into 1..pool BEFORE the multiply, so the product cannot overflow
+               and cannot be dragged below 1 by a caller passing 0 or a negative count. */
+            var declared = Math.Clamp(concurrentReads, 1, ViewerSettings.ManagedMaxPoolSize);
+            var enclosing = Math.Clamp(_restore, 1, ViewerSettings.ManagedMaxPoolSize);
+
+            s_width.Value = Math.Clamp(declared * enclosing, 1, ViewerSettings.ManagedMaxPoolSize);
+        }
+
+        /// <summary>
+        /// Restores the enclosing width on THIS context. Reads already in flight branched their context
+        /// when they were created, so they keep the width they were given — which is the point: the
+        /// declaring frame returns from <c>Task.WhenAll</c> long before the store does.
+        /// </summary>
+        public void Dispose() => s_width.Value = _restore;
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerReadFanOut.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerReadFanOut.cs
@@ -104,10 +104,24 @@ public static class ViewerReadFanOut
         }
 
         /// <summary>
+        /// Ends the declared width EARLY — call it as soon as the reads it describes have been joined, so
+        /// that anything the method does afterwards is not priced as contending with reads that have
+        /// already finished. Without it a method-scoped <c>using var</c> runs to the closing brace, and a
+        /// store read after the join inherits a contention count that is over by the whole fan-out; a
+        /// nested fan-out below it then multiplies against that stale count and lands on the pool ceiling.
+        ///
+        /// <para>Idempotent, and safe to pair with <c>using</c>: both this and <see cref="Dispose"/> write
+        /// the same saved value, so the second write is a no-op and an exception between them still
+        /// restores. That is why this is a plain method on a <c>readonly struct</c> rather than a flag —
+        /// there is no state to keep, only a value to put back.</para>
+        /// </summary>
+        public void Release() => s_width.Value = _restore;
+
+        /// <summary>
         /// Restores the enclosing width on THIS context. Reads already in flight branched their context
         /// when they were created, so they keep the width they were given — which is the point: the
         /// declaring frame returns from <c>Task.WhenAll</c> long before the store does.
         /// </summary>
-        public void Dispose() => s_width.Value = _restore;
+        public void Dispose() => Release();
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.CollectionHealth.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.CollectionHealth.cs
@@ -61,6 +61,7 @@ public partial class ViewerServerTab
            settable window EXACTLY — a preset or a custom From/To — via GetWindowUtc(), matching the Wait
            Stats / Blocking tabs (the old GetWindowHoursBack() rounded a custom range to a now-relative span). */
         var (startUtc, endUtc) = GetWindowUtc();
+        using var readFanOut = ViewerReadFanOut.Of(2);
         var healthTask = _dataService.GetCollectionHealthAsync(_server.ServerId);
         var logTask = _dataService.GetRecentCollectionLogAsync(_server.ServerId, startUtc, endUtc);
         await Task.WhenAll(healthTask, logTask);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.ConfigChanges.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.ConfigChanges.cs
@@ -29,6 +29,8 @@ public partial class ViewerServerTab : UserControl
     {
         var (startUtc, endUtc) = GetWindowUtc();
 
+        using var readFanOut = ViewerReadFanOut.Of(3);
+
         var serverTask = _dataService.GetServerConfigChangesAsync(_server.ServerId, startUtc, endUtc);
         var databaseTask = _dataService.GetDatabaseConfigChangesAsync(_server.ServerId, startUtc, endUtc, databaseNames: SelectedDatabaseFilter);
         var traceFlagTask = _dataService.GetTraceFlagChangesAsync(_server.ServerId, startUtc, endUtc);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.CpuScheduler.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.CpuScheduler.cs
@@ -48,6 +48,8 @@ public partial class ViewerServerTab
     {
         var (startUtc, endUtc) = GetWindowUtc();
 
+        using var readFanOut = ViewerReadFanOut.Of(2);
+
         var trendTask = _dataService.GetCpuSchedulerTrendAsync(_server.ServerId, startUtc, endUtc);
         var snapshotTask = _dataService.GetCpuSchedulerSnapshotAsync(_server.ServerId, startUtc, endUtc);
         await Task.WhenAll(trendTask, snapshotTask);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Filters.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Filters.cs
@@ -111,6 +111,8 @@ public partial class ViewerServerTab : UserControl
     /// </summary>
     private async Task LoadConfigurationAsync()
     {
+        using var readFanOut = ViewerReadFanOut.Of(6);
+
         var serverConfigTask = _dataService.GetLatestServerConfigAsync(_server.ServerId);
         var databaseConfigTask = _dataService.GetLatestDatabaseConfigAsync(_server.ServerId, databaseNames: SelectedDatabaseFilter);
         var databaseScopedConfigTask = _dataService.GetLatestDatabaseScopedConfigAsync(_server.ServerId, databaseNames: SelectedDatabaseFilter);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.LatchSpinlock.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.LatchSpinlock.cs
@@ -60,6 +60,8 @@ public partial class ViewerServerTab
     {
         var (startUtc, endUtc) = GetWindowUtc();
 
+        using var readFanOut = ViewerReadFanOut.Of(4);
+
         var latchTrendTask = _dataService.GetLatchStatsTrendAsync(_server.ServerId, startUtc, endUtc);
         var latchSnapshotTask = _dataService.GetLatchStatsSnapshotAsync(_server.ServerId, startUtc, endUtc);
         var spinlockTrendTask = _dataService.GetSpinlockStatsTrendAsync(_server.ServerId, startUtc, endUtc);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Memory.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Memory.cs
@@ -94,6 +94,8 @@ public partial class ViewerServerTab
     {
         var (startUtc, endUtc) = GetWindowUtc();
 
+        using var readFanOut = ViewerReadFanOut.Of(6);
+
         var latestTask = _dataService.GetLatestMemoryStatsAsync(_server.ServerId);
         var trendTask = _dataService.GetMemoryTrendAsync(_server.ServerId, startUtc, endUtc);
         var grantTrendTask = _dataService.GetMemoryGrantTrendAsync(_server.ServerId, startUtc, endUtc);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Memory.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Memory.cs
@@ -105,6 +105,11 @@ public partial class ViewerServerTab
 
         await Task.WhenAll(latestTask, trendTask, grantTrendTask, clerkTypesTask, grantChartTask, pressureTask);
 
+        /* The six are done, and this method reads the store twice more below — the clerk chart and the
+           whole Plan Cache sub-tab, which declares its own fan-out. Release here or those inherit this
+           width and the nested one multiplies against a contention count that no longer exists. */
+        readFanOut.Release();
+
         RenderMemorySummary(latestTask.Result);
         RenderMemoryChart(trendTask.Result, grantTrendTask.Result, startUtc, endUtc);
         RenderMemoryGrantCharts(grantChartTask.Result, startUtc, endUtc);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.PlanCache.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.PlanCache.cs
@@ -48,6 +48,8 @@ public partial class ViewerServerTab
     {
         var (startUtc, endUtc) = GetWindowUtc();
 
+        using var readFanOut = ViewerReadFanOut.Of(2);
+
         var trendTask = _dataService.GetPlanCacheTrendAsync(_server.ServerId, startUtc, endUtc);
         /* The summary strip's totals come from a dedicated uncapped aggregate (not a capped grid),
            so "Total Plans" is exact (Dashboard parity). */

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Postgres.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Postgres.cs
@@ -280,6 +280,8 @@ public partial class ViewerServerTab
     {
         var (startUtc, endUtc) = GetWindowUtc();
 
+        using var readFanOut = ViewerReadFanOut.Of(5);
+
         var countsTask = _dataService.GetPgBlockingCaptureCountsAsync(_server.ServerId, startUtc, endUtc);
         var chainsTask = _dataService.GetPgBlockingChainsAsync(_server.ServerId, startUtc, endUtc, PgGridRowLimit);
         var cyclesTask = _dataService.GetPgBlockingCyclesAsync(_server.ServerId, startUtc, endUtc, PgGridRowLimit);
@@ -577,6 +579,8 @@ public partial class ViewerServerTab
     {
         var (startUtc, endUtc) = GetWindowUtc();
 
+        using var readFanOut = ViewerReadFanOut.Of(5);
+
         var sessionsTask = _dataService.GetPgSessionStatesAsync(_server.ServerId, startUtc, endUtc, PgGridRowLimit);
         var xminTask = _dataService.GetPgXminHorizonAsync(_server.ServerId, startUtc, endUtc);
         var autovacuumTask = _dataService.GetPgAutovacuumAsync(_server.ServerId, startUtc, endUtc, PgGridRowLimit);
@@ -836,6 +840,8 @@ public partial class ViewerServerTab
     private async Task LoadPgStorageAsync()
     {
         var (startUtc, endUtc) = GetWindowUtc();
+
+        using var readFanOut = ViewerReadFanOut.Of(2);
 
         var bloatTask = _dataService.GetPgTableBloatAsync(_server.ServerId, startUtc, endUtc, PgGridRowLimit);
         var indexTask = _dataService.GetPgIndexUsageAsync(_server.ServerId, startUtc, endUtc, PgGridRowLimit);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Postgres.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Postgres.cs
@@ -298,6 +298,10 @@ public partial class ViewerServerTab
 
         await Task.WhenAll(countsTask, chainsTask, cyclesTask, statementsTask, databasesTask);
 
+        /* Released here rather than at the closing brace: the six sub-tab loads at the end of this method
+           run after these five have finished, so they do not contend with them. */
+        readFanOut.Release();
+
         var counts = countsTask.Result;
         var chains = chainsTask.Result;
         var cycles = cyclesTask.Result;
@@ -847,6 +851,9 @@ public partial class ViewerServerTab
         var indexTask = _dataService.GetPgIndexUsageAsync(_server.ServerId, startUtc, endUtc, PgGridRowLimit);
 
         await Task.WhenAll(bloatTask, indexTask);
+
+        /* Released here — the two sub-tab loads at the end of this method do not contend with these two. */
+        readFanOut.Release();
 
         var bloat = bloatTask.Result;
         var indexes = indexTask.Result;

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.QueryTrends.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.QueryTrends.cs
@@ -66,6 +66,8 @@ public partial class ViewerServerTab
     /// (NpgsqlDataSource pools a connection each), then each result renders into its chart.</summary>
     private async Task LoadPerformanceTrendsAsync(DateTime startUtc, DateTime endUtc)
     {
+        using var readFanOut = ViewerReadFanOut.Of(4);
+
         var queryDurationTask = _dataService.GetQueryDurationTrendAsync(_server.ServerId, startUtc, endUtc, databaseNames: SelectedDatabaseFilter);
         var procDurationTask = _dataService.GetProcedureDurationTrendAsync(_server.ServerId, startUtc, endUtc, databaseNames: SelectedDatabaseFilter);
         var queryStoreDurationTask = _dataService.GetQueryStoreDurationTrendAsync(_server.ServerId, startUtc, endUtc, databaseNames: SelectedDatabaseFilter);

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerSettings.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerSettings.cs
@@ -138,6 +138,16 @@ public sealed class ViewerSettings
     private const string ViewerCredentialFileName = "pg-viewer-credential.dpapi";
     private const string ManagedSearchPath = "collect,config,public";
 
+    /// <summary>
+    /// The viewer seat's connection-pool ceiling (#1566), named rather than left a literal in the
+    /// builder below because it is not only a resource bound: it is the DIVISOR in the interactive read
+    /// deadline (<see cref="ViewerCommandDeadlines.FanOutReadSeconds"/>, #3004). A read issued as one of
+    /// many concurrent reads can only contend with as many siblings as there are permits, so the pool
+    /// size is what caps the contention a deadline has to cover. Referenced rather than copied so the
+    /// two cannot drift apart, which is the mistake the deadline it feeds was itself fixing.
+    /// </summary>
+    public const int ManagedMaxPoolSize = 10;
+
     /* #2197: the same sliver rule again, for the files that answer "has a bootstrap already been TRIED
        against this store?" — the store's own credential (written immediately before initdb), the mcp role
        credential, and pg_ctl's server log. Pinned against the service's constants by ViewerDataServiceTests. */
@@ -351,7 +361,7 @@ public sealed class ViewerSettings
                #1559, but this string was built independently and rode Npgsql's default of 100). Every
                pooled connection is a live postgres.exe on Windows; a read-only UI seat polling on 30/60s
                timers needs a handful, not a hundred. */
-            MaxPoolSize = 10,
+            MaxPoolSize = ManagedMaxPoolSize,
         };
         return builder.ConnectionString;
     }


### PR DESCRIPTION
Fixes #3004.

`ViewerCommandDeadlines.InteractiveReadSeconds = 15` bounds a read issued **alone** and was derived from a solo measurement (3.01 s). Seventeen sites in this project issue their reads **concurrently**, and the ten-wide case was measured at **24.4–64.1 s per read** against a ten-permit pool. A ceiling taken from the solo figure is not a bound on that population: the widest fan-out sits entirely above 15 s, and its auto-refresh timer re-issues the same batch.

## Which shape, and why

Of the three shapes #3004 names, this is **the concurrency-aware deadline** — the deadline's job is to bound one read, and ten reads competing for ten permits is a different question.

**Capping the fan-out is probably the better long-term fix and this is not it.** The concurrent measurement says concurrency is *net negative* on this store: ten reads at 3.01 s each is 30.1 s of serial work and running them together cost 64.1 s of wall clock. So a cap would likely make the panel **faster** as well as making a 15 s per-read deadline honest. What is missing is the cap itself. The only two data points available — 3.01 s at width 1, 24.4–64.1 s at width 10 — extrapolate to a per-read worst of roughly `3.01 + 6.79(C−1)`, which stays under 15 s only to about **C = 2**. Serializing every panel in the viewer five-deep on a two-point extrapolation is not a trade to make from a machine that cannot run the app.

The asymmetry decided it. Scaling the deadline **cannot make anything slower** — it only stops the deadline cutting reads the store was always going to take that long to serve. Capping concurrency changes how every panel behaves, and if the model is wrong there is no signal here that would say so. The measurement that should decide the cap — per-read duration at width 1, 2, 4, 6, 8, 10 — is named on #3004.

## The derivation

`FanOutLaneSeconds = 7`, and it is one division: the worst read in the ten-wide batch is 64.1 s, the width that produced it is ten, so the per-lane allowance is 64.1 / 10 = 6.41 s, rounded **up** so the rounding falls on the side that does not fail a legitimate panel.

```
FanOutReadSeconds(w) = max(InteractiveReadSeconds, FanOutLaneSeconds * clamp(w, 1, ManagedMaxPoolSize))
```

- **Floored** at the solo value, so a declared fan-out can only ever grant a read *more* time than the same read alone. Widths 1 and 2 land on the floor and are indistinguishable from an unscoped read, which is correct — two concurrent reads are not the state the measurement describes.
- **Clamped** at the pool size, because contention stops growing where the permits run out: an eleventh concurrent read against a ten-connection pool is not an eleventh contender, it is a read waiting on `ConnectionTimeoutSeconds` for a slot. That clamp is what lets the two unbounded per-server fan-outs hand over a raw fleet count instead of a hand-capped guess.
- At the pool ceiling that is **70 s**, about 9% over the worst read measured there.

Nothing enclosing it is smaller: the per-tab timer floors at 30 s and the fleet timer at 10 s, but the fan-outs those fire are single-flight, so a read outliving its own tick is not joined by the next one.

The width reaches the 187 command sites through `ViewerReadFanOut`, an `AsyncLocal` scope declared by the site that fans out. A parameter would have to be threaded through every method between the panel and the command, and the width is not a property of any of them — it is a property of the call. The sites stamp `CurrentInteractiveReadSeconds` **uniformly**, including reads no fan-out currently reaches, where the two are the same number: what uniformity buys is that a future `Task.WhenAll` over any of them is bounded the day it is written.

`ViewerSettings.ManagedMaxPoolSize` is named so the deadline pins against the pool **relationally** rather than copying the number — which is the mistake it is undoing.

## The shape is general — 17 sites, and two of them are not `Task.WhenAll`

Every one of these inherited the solo constant. All 17 now declare a width.

| site | width |
|---|---|
| `CorrelatedTimelineLanesControl.xaml.cs` | 10 |
| `MainWindow.OnRefreshTimerTick` | 6 — **unawaited, unjoined** |
| `ViewerServerTab.Filters.cs`, `.Memory.cs` | 6 |
| `ViewerServerTab.Postgres.cs` (x2), `FinOpsTab.Loaders.cs` | 5 |
| `ViewerServerTab.LatchSpinlock.cs`, `.QueryTrends.cs` | 4 |
| `ViewerServerTab.ConfigChanges.cs` | 3 |
| `MainWindow` connect path | 3 — **unawaited, unjoined** |
| `ViewerServerTab.PlanCache.cs`, `.Postgres.cs`, `.CpuScheduler.cs`, `.CollectionHealth.cs` | 2 |
| `FinOpsTab.Loaders.cs` inventory overlay | one per server in the inventory |
| `MainWindow` overview cards | one per server in the fleet |

Two findings worth stating separately:

**A fan-out does not need a `Task.WhenAll`.** `OnRefreshTimerTick` fires five or six store reads unawaited and joins none of them; the connect path fires three. A `Task.WhenAll` census — which is what I started with — misses both. Nothing lexical separates them from this project's twenty other unawaited single reads, which are single-flight-guarded and not fan-outs at all, so the pin covers the joined shape only and both unjoined sites declare their width by hand with a comment saying so. The gap is named in the test's own doc comment rather than left implied.

**The last two are unbounded** (`Task.WhenAll(servers.Select(...))`), so their width is the fleet size. For those the *binding* constraint is not the command deadline but `ConnectionTimeoutSeconds` (default 5 s) — reads past the tenth wait for a permit and then throw a **connect** error, the misattribution `ViewerCommandDeadlines`' own doc comment describes. That is a distinct defect which predates #2901; it is recorded on #3004 and not touched here.

## Also corrected

`CorrelatedTimelineLanesControl.RefreshAsync`'s doc comment claimed the Overview "always passes a fixed 24-hour window" and that the `fromDate`/`toDate` branch was "kept for a future custom-range picker". `ViewerServerTab.LoadOverviewChartsAsync` passes `GetOverviewCustomRange()` straight through, so the widest range the picker offers reaches these ten reads — which is what makes the 30-day figure the relevant one rather than hypothetical.

Two doc comments in `MainWindow.ServerManagement.cs` stated a flat "(15)" for reads that both fleet-timer callers now scope; they name the fan-out-aware value instead.

## The pin

Five assertions in `ViewerCommandTimeoutTests`, all on shipped constants and source shape, **none on timing**. The failure needs a Windows host and a store dense enough to reach the concurrent band, so a test that measured anything here would pass on a fast machine and prove nothing.

`EveryViewerFanOut_DeclaresItsWidth` pairs declarations to joins **positionally**, not by enclosing block: the widest fan-out declares its width in an outer `try` and awaits the join in a nested one, so a same-block rule reports the very site this PR exists for as an offender. Requiring the k-th join in a file to be preceded by at least k declarations is immune to nesting and still fails if any one declaration is deleted.

### Proven red, one mutation at a time

Each row is a single mutation with the anchor count asserted at 1 and the **source** sha256 recorded before and after; the suite was rebuilt and re-run per row and the file restored and hash-verified after.

| mutation | assertion that failed |
|---|---|
| remove the widest fan-out's declared width | `EveryViewerFanOut_DeclaresItsWidth` |
| per-lane allowance 7 → 1 (i.e. 15 s everywhere — the regression itself) | `TheFanOutDeadline_IsDerivedFromTheConcurrentBand_NotTheSoloOne` |
| `FanOutReadSeconds` collapsed to return the solo constant | `TheFanOutDeadline_IsDerivedFromTheConcurrentBand_NotTheSoloOne` |
| one command site stamps `InteractiveReadSeconds` directly | `NoViewerCommand_StampsTheSoloDeadlineDirectly` |
| drop the pool clamp | `TheFanOutDeadline_IsMonotonicAndClampedAtThePool` |
| nested scopes take the larger width instead of the product | `TheFanOutWidth_DefaultsToOne_AndNestsByMultiplying` |
| remove one `Release()` call | `NoFanOutScope_OutlivesItsJoin` |
| re-split the doc-comment run | `EveryDocRunClosesTheSummariesItOpens` (the shipped defect, reproduced byte-for-byte — the mutated file hashes to the pre-fix source) |
| **control:** comment-only, naming `Task.WhenAll` and `ViewerReadFanOut.Of(` in prose | none — all 72 pass |

The control is the reason the scans strip comments first, and the reason a moved source or assembly hash is not on its own evidence of anything.

**A methodology note that cost two full matrix runs and is worth recording.** The first two runs reported the four constant- and method-reading mutations as *green*. They were not green — the throwaway host was executing a stale copy of the Viewer assembly, and MSBuild did not re-copy the `HintPath` reference even after `bin/` and `obj/` were wiped (measured: host copy and fresh build differed by content hash). Only the two source-scanning mutations went red, which is exactly the pattern that looks like "those assertions are weak" rather than "the harness is lying". The harness now copies the assembly explicitly and **asserts the runtime copy is byte-identical to the build output** before running anything.

## Two defects found after the first push

**A split doc-comment run** (caught by CI). The separator line before the new `<para>` on `InteractiveReadSeconds` lost its `///`, which broke the comment into two runs: the first opened a `<summary>` it never closed, the second closed one it never opened. `DocCommentHygieneTests.EveryDocRunClosesTheSummariesItOpens` is what failed — one test out of 7,507, with `Lite.Tests` fully green.

Worth stating precisely, because the review bot named a different mechanism: it predicted **CS1587** and read my "0 warnings from the Viewer" claim as contradicted. The claim was accurate — CS1587 does not fire without a documentation file, and the Viewer build reported zero warnings both before and after the fix. The defect was real and the clean build simply was not evidence about it. My local host had not compiled `DocCommentHygieneTests`, so nothing here could see it; it does now, which is why the local count went 31 → 72.

**A fan-out scope outliving its join** (caught by review). A method-scoped `using var` runs to the closing brace, so a store read *after* the join inherited a contention count over by the whole fan-out — and a nested fan-out below it multiplied against that stale count onto the pool ceiling. `LoadMemoryAsync`'s six, then `LoadPlanCacheAsync`'s two, gave those two reads 70 s where two genuinely concurrent reads should get the 15 s floor.

Review found one instance. **There are four**: also both PostgreSQL sub-tab loads and the fleet overview cards. `Scope.Release()` ends the width at the join — idempotent, writing the same saved value `Dispose` does, so it pairs with `using` and an exception between them still restores, which is why it is a plain method on a `readonly struct` rather than a flag. Nothing about this can shorten a deadline; the floor invariant holds either way. What it restores is the claim that a declared width tracks concurrency actually in flight.

`NoFanOutScope_OutlivesItsJoin` pins the category. Two details are load-bearing and each rules out one of the two obvious implementations: the join is matched as a parenthesised **statement** rather than a line, because the two per-server fan-outs pass a lambda to `Task.WhenAll` whose body holds the very `await` that *is* the fan-out; and the search is **not** restricted to the join's own brace depth, because the fleet-totals read sits inside a `try`. Both shapes are live in this project.

## Verification

- `PerformanceMonitor.Darling.Viewer` and `Darling.Tests` both build on macOS with `-p:EnableWindowsTargeting=true`: 0 errors, and 0 warnings from the Viewer.
- `dotnet restore --locked-mode` passes on both touched projects with `obj/` cleared first, so it is a real check rather than a warm cache. No lock file changed.
- The Windows-only suite was executed by compiling the **real** `ViewerCommandTimeoutTests.cs`, `CSharpSourceWalker.cs` and `CommandDeadlineScanner.cs` into a throwaway `net10.0` xunit v3 console host staged outside the repo tree: **72 tests, 0 failed, 0 not run** — `ViewerCommandTimeoutTests` (26 before, 32 now) plus the real `DocCommentHygieneTests`, added to the host after it was the suite that caught the doc-run defect.
- Merged `origin/dev` and re-verified after.

## Not verified

- **No runtime behaviour of any kind.** The Viewer is `net10.0-windows` and cannot run here, so nothing in this PR has been observed against a real store or a real seat. The panel was not watched recovering.
- **The regression was not reproduced.** It needs a Windows host and a store dense enough to reach the concurrent band. The fix is argued from #2901's own measurements and from source, not from a repro.
- **70 s has not been measured as sufficient.** It is 9% over the worst read in a ten-wide batch on #2901's rig, which is a local rig at production *density* — not a production store. If the real ceiling is worse than 64.1 s, this is still short, and the concurrency sweep on #3004 is what would say so.
- **The pool clamp is the MANAGED pool, and a bring-your-own store's is not clamped at all.** `ViewerSettings.Parse` imposes `MaxPoolSize` only on the managed derivation; a BYO store connects on the operator's own `postgres.connectionString` verbatim, so its pool is whatever they set and Npgsql's own default is 100. On such a store a fleet-wide per-server fan-out really does face fleet-many-way contention while this deadline covers only ten-way, so it is still short there. Strictly better than the solo constant it replaces in every case, but not complete: reading the live pool size means threading runtime settings into a static constant family, so it is recorded on #3004 rather than guessed at.
- **The `AsyncLocal` flow is reasoned, not observed.** Execution context is captured when the fan-out site creates each task, so the reads see the declared width and the declaring frame's disposal cannot reach them. That is how `AsyncLocal` is specified; it was not watched happening in the app.
- The two unjoined fan-outs are correct by inspection and by hand-placed declaration. No scan enforces them.
- CI is the arbiter for the xUnit pin itself; the host above is not `Darling.Tests` as CI builds it.
