### PR TITLE
Keep the identifier guard's comment to what maintaining it requires

### DIFF
--- a/Darling/Darling.Tests/FleetIdentifierScrubTests.cs
+++ b/Darling/Darling.Tests/FleetIdentifierScrubTests.cs
@@ -26,23 +26,26 @@ namespace Darling.Tests;
     TWO shapes are reachable that way -- a full hostname, and a short name plus its ordinal.
     Two more are NOT, and the sweeps below deliberately do not attempt them:
 
-      - A bare short name in prose: "measured on OMEGA". There is no shape to match, because
-        the token is just a word. Matching capitalised prose tokens instead ("on <ALLCAPS>")
-        returns 606 hits across 102 words on this tree, and they are all either an acronym
-        (SQL, DMV, CPU, RDS) or this codebase's own emphasis caps (EVERY, BOTH, ENTIRE, ONLY).
-        The allowlist would have to be the English language.
+      - A bare name in prose: "measured on OMEGA". There is no shape to match, because the
+        token is just a word. The nearest pattern available -- capitalised prose tokens --
+        cannot tell a name from an acronym or from this codebase's own emphasis caps, so its
+        allowlist would have to be the English language.
 
-      - A real value in an identity-bearing fixture field -- a display_name, a ServerName.
-        Also no shape: this tree assigns 251 distinct free-form descriptive names to those
-        properties (ServerName = "blocking-stats-read"), which is GOOD test naming and worth
-        keeping, and a short name hides among them indistinguishably from srv, host or shared.
+      - A name standing as the value of an identity-bearing fixture field. Also no shape: those
+        fields hold free-form descriptive strings by design, which is GOOD test naming and worth
+        keeping, and a name reads as one more of them.
 
-    Hashing a denylist of the real names rescues neither case. A three-letter name has 17,576
-    candidates, so a hash committed here is recoverable by brute force in microseconds --
-    publishing the hash publishes the name -- and moving the salt to a CI secret would make the
-    guard silently no-op on every fork and outside contribution, which is exactly the "green for
-    the wrong reason" failure the scanned-count assert exists to catch. So those two categories
-    stay a review matter, and what is left below is a tripwire rather than a proof.
+    Hashing a denylist rescues neither case. A hostname slug is a short token drawn from a small
+    alphabet, so its whole keyspace enumerates in microseconds: a hash committed to a public repo
+    publishes what it stands for. Moving the salt to a CI secret trades that for a guard that
+    silently no-ops on every fork and outside contribution, which is exactly the "green for the
+    wrong reason" failure the scanned-count assert exists to catch. So those two categories stay a
+    review matter, and what is left below is a tripwire rather than a proof.
+
+    Deliberately not written down here: any inventory of how much ordinary prose the unreachable
+    shapes would match, and any distinguishing property of the names this guard exists to keep out.
+    Neither is needed to maintain the guard, both are useful only to someone working out where it
+    does not look, and this file is public. Resist the urge to helpfully re-add them.
 */
 public sealed class FleetIdentifierScrubTests
 {
@@ -80,8 +83,8 @@ public sealed class FleetIdentifierScrubTests
     /*
         A server gets named by its short name and ordinal too -- omega-01, not
         prod-sql-use1-omega-01 -- and InstanceName cannot see that form: it requires the
-        service prefix and both middle segments. Both real identifiers that survived #2490
-        and #2900 to be caught by hand in #2903 were exactly this shape.
+        service prefix and both middle segments. #2490 and #2900 swept the full-hostname shape
+        only, #2903 closed this one by hand, and the sweep below is what makes it automatic.
 
         The ZERO PADDING is what makes the shape checkable at all. Prose writes a measurement
         as top-25, sev-10, pre-18, phase-2, and never pads one to two digits; a fleet pads
@@ -90,9 +93,16 @@ public sealed class FleetIdentifierScrubTests
         and demanding a purely alphabetic word drops the escape-sequence and version debris
         with it (n2026-08 out of a literal "\n2026-08", krb5-2, w1f-2).
 
-        Accepted blind spot: this reaches -00 through -09 only, so a name whose first published
-        box is -10 or higher slips past. A fleet's first box is -01, and every real identifier
-        this guard has had to catch so far has been -01.
+        The ceiling follows from that padding, as a property of the shape rather than a bet on
+        how a fleet numbers its boxes: padding is only observable below ten. A two-digit ordinal
+        needs none, so it is shape-identical to the two-digit measurements prose already writes,
+        and widening the ordinal does not extend the discriminator -- it spends it. Re-measured
+        on this tree: allowing any two-digit ordinal doubles the false-positive vocabulary, 11
+        words to 28 and 103 occurrences to 204, and every word it adds is a measurement or a
+        version number rather than a name. So this reaches -00 through -09 by construction; a
+        short name first published above that is out of reach, and stays a review matter like
+        the two shapes at the top of the file. Widen the shape only against a measurement that
+        says the trade has changed, and prefer tightening it over lengthening either allowlist.
     */
     private static readonly Regex ShortNameOrdinal = new(
         @"\b(?<slug>[a-z]{3,})-0[0-9]\b",

--- a/Darling/Darling.Tests/FleetIdentifierScrubTests.cs
+++ b/Darling/Darling.Tests/FleetIdentifierScrubTests.cs
@@ -45,7 +45,7 @@ namespace Darling.Tests;
     Deliberately not written down here: any inventory of how much ordinary prose the unreachable
     shapes would match, and any distinguishing property of the names this guard exists to keep out.
     Neither is needed to maintain the guard, both are useful only to someone working out where it
-    does not look, and this file is public. Resist the urge to helpfully re-add them.
+    does not look, and this file is public. Their absence is load-bearing, not an oversight.
 */
 public sealed class FleetIdentifierScrubTests
 {


### PR DESCRIPTION
## What changed

`FleetIdentifierScrubTests` is comment-only in this diff. Neither regex, neither allowlist, and neither `scanned > 200` floor moves.

**The two out-of-reach shapes keep their reasoning and lose their inventory.** The comment explained why a bare name in prose, and a name standing as the value of an identity-bearing fixture field, have no shape to match — then measured both: how many capitalised prose tokens the nearest alternative pattern matches, how many free-form values those fixture fields hold, and which properties they are. The reasoning is what a maintainer needs. The counts and the property names are useful only to someone working out where the guard does not look, which a public repo has no reason to publish. The argument against committing a hashed denylist is kept for the same reason and rewritten the same way: it is now made from the general shape of a hostname slug rather than from a specific length, which the argument never needed in order to work.

**The ordinal ceiling is restated as a property of the pattern.** It previously read as an inference from which boxes have needed renaming so far, which invites treating the ceiling as a fact about how fleets are numbered rather than a fact about the regex. It is a fact about the regex: zero padding is the discriminator, and padding is only observable below ten.

## The measurement behind leaving `ShortNameOrdinal` alone

I measured the widening to any two-digit ordinal rather than assuming it was cheap, using the file's own `TrackedSourceFiles()` selection and its own two allowlists, over 2445 files:

| ordinal shape | non-synthetic vocabulary | of which would fail today |
| --- | --- | --- |
| `-0[0-9]` (current) | 11 words, 103 occurrences | 0 words, 0 occurrences |
| any two digits | 28 words, 204 occurrences | 17 words, 101 occurrences |

The current figure reproduces the 11 (103) already written in the comment, exactly, so that number has not rotted.

The 17 words a widening admits: top (31 occurrences), utf (21), pre (15), upgrade (7), postgresql (6), fillfactor (3), sev (3), hour (2), memory (2), post (2), trailing (2), utc (2), and batch, max, old, retained, sub (1 each). Every one is a prose measurement or a version number — top-25, sev-10, pre-18, postgresql-17, fillfactor-70 — rather than a role, a product, an environment or a test state, so none of them belongs on `OrdinalRoleWords`, whose contract is exactly that. Nor would allowlisting them be a fixed cost: with the ordinal unbounded the same measurement returns 120 words and 1035 occurrences, so documentation measurement is an open, growing vocabulary, not a list of 17.

The structural half matters more than the count. Zero padding only exists below ten. `-01` is padded and therefore distinguishable from the `-1` that prose writes, while `-15` needs no padding at all and is shape-identical to top-15. Widening the ordinal does not extend the discriminator, it spends it. So the pattern is left alone, and the comment now says why, together with the condition under which widening would be right: a measurement showing the trade has changed, and tightening the shape preferred over lengthening either allowlist.

## Verified

- Both facts pass with **2445 files scanned** (the floor is 200), executed from the edited file.
- Positive-controlled after the edit, not just before: planting a non-allowlisted slug with a padded ordinal into a scanned file turns both sweeps red — the full-hostname sweep on the hostname form, the short-name sweep on the bare form — and removing it returns both to green. The guard still fires.
- The reverse control too: the same slug with a two-digit ordinal is not matched, which is the ceiling this comment now describes, demonstrated rather than asserted.
- Working tree byte-identical to the commit afterwards, checked by content rather than by diffstat.
- No BOM introduced and CRLF preserved; the file is CRLF on `dev` and stays CRLF.

## Not verified

- The Windows `Darling.Tests` suite cannot run on macOS. The two facts were executed by compiling the actual test file, unmodified, into a `net10.0` console harness with an xunit shim — so the regexes, the allowlists and the file selection are the real ones — but xunit's own discovery, and the rest of the suite, are CI's word rather than mine.
- The "114 words (985 occurrences)" baseline already in the comment is left exactly as it was measured when it was written. Today's comparable unbounded-ordinal figure is larger because the tree has grown; I did not restate a historical measurement I did not take.
- Whether a comment-only change to a test file is enough to light the Darling test job in CI is CI's answer, not one I could take locally.

## CHANGELOG entry, not committed — for the coordinator to place

Under `[Unreleased]` -> `### Changed`:

- Kept `FleetIdentifierScrubTests`' commentary to what maintaining the guard requires, and restated its ordinal ceiling as a property of the shape being matched rather than an inference from past renames. Measured rather than assumed: widening the ordinal to any two digits would double the false-positive vocabulary, 11 words to 28 and 103 occurrences to 204, with every added word a documentation measurement or a version number, so both patterns and both allowlists are unchanged.
