### PR TITLE
Record real elapsed time on the six classified fault arms, in the slot the time was spent

### DIFF
--- a/Darling/Darling.Tests/PostgresFaultOutcomeTests.cs
+++ b/Darling/Darling.Tests/PostgresFaultOutcomeTests.cs
@@ -524,11 +524,17 @@ public class PostgresFaultOutcomeTests
         /* Never queried the target - the RDS log API and Performance Insights are both HTTPS. */
         Assert.Equal(2, Regex.Matches(worker, @"""PERMISSIONS"", 0, 0, runClock\.ElapsedMilliseconds").Count);
 
-        /* And the file carries exactly ONE three-zero write: the log_timezone arm, whose two transports
-           disagree about which slot is correct, documented at the arm itself. Counted over the whole file
-           rather than asserted absent arm by arm, so an arm ADDED with three zeros reds HERE instead of
-           passing unnoticed until someone re-runs the census by hand. */
-        Assert.Equal(1, Regex.Matches(worker, @", 0, 0, 0,").Count);
+        /* And exactly ONE arm still writes three zeros: the log_timezone arm, whose two transports
+           disagree about which slot is correct, documented at the arm itself. Counted rather than asserted
+           absent arm by arm, so an arm ADDED with three zeros reds HERE instead of passing unnoticed until
+           someone re-runs the census by hand.
+
+           Anchored on the CALL's shape (the collector name, then a status literal or the computed `status`)
+           rather than on a bare ", 0, 0, 0," run. The bare form counts 1 today too, but it would also match
+           any unrelated four-argument call elsewhere in this 6,600-line file, and a pin that reds on a
+           change it does not guard is a pin someone eventually loosens. This form still catches a new arm
+           whether it passes a literal status or a computed one. */
+        Assert.Equal(1, Regex.Matches(worker, @"collectorName, (?:""[A-Z_]+""|status), 0, 0, 0,").Count);
         Assert.Equal(1, Regex.Matches(worker, @"""PERMISSIONS"", 0, 0, 0, ex\.Message").Count);
     }
 

--- a/Darling/Darling.Tests/PostgresFaultOutcomeTests.cs
+++ b/Darling/Darling.Tests/PostgresFaultOutcomeTests.cs
@@ -489,6 +489,49 @@ public class PostgresFaultOutcomeTests
             worker);
     }
 
+    /// <summary>
+    /// The CLASSIFIED fault arms record the run's real elapsed time too, in the slot the time was actually
+    /// spent - the sibling of <see cref="TheErrorArmsRecordRealElapsedTimeRatherThanLiteralZeros"/> one
+    /// classification down.
+    ///
+    /// <para>Pinned in the source for the same reason that one is: the value is written by
+    /// <c>LogCollectionAsync</c> inside a live sweep, so no pure test can observe it, and the defect is an
+    /// argument list rather than a logic error.</para>
+    ///
+    /// <para><b>Why the SLOT is counted and not merely the presence of a clock.</b> An arm whose statement
+    /// reached the target and was refused THERE owes its time to <c>sqlMs</c>; an arm that never queried the
+    /// target owes it to <c>storageMs</c>, which is what the three RDS-API ingestors already do so that one
+    /// target's <c>sql_duration_ms</c> cannot mean something different from every other target's. Both
+    /// spellings produce an honest <c>duration_ms</c>, because that column is <c>sqlMs + storageMs</c> - so a
+    /// test that only looked for a stopwatch would pass on an arm filing an HTTPS round trip as target time,
+    /// which is the one mistake here that is invisible in the very column this pin exists to protect.</para>
+    /// </summary>
+    [Fact]
+    public void TheClassifiedFaultArmsRecordElapsedTimeInTheSlotTheTimeWasSpent()
+    {
+        var worker = ReadSource(Path.Combine(
+            "Darling", "PerformanceMonitor.Darling.Service", "DarlingWorker.cs"));
+
+        /* Refused ON the target: the statement got there, so the wall clock is target-side. */
+        Assert.Equal(1, Regex.Matches(worker, @"""SESSION_MISSING"", 0, runClock\.ElapsedMilliseconds, 0").Count);
+        Assert.Equal(1, Regex.Matches(worker, @"""YIELDED"", 0, runClock\.ElapsedMilliseconds, 0").Count);
+        Assert.Equal(1, Regex.Matches(worker, @"""PERMISSIONS"", 0, runClock\.ElapsedMilliseconds, 0, message").Count);
+
+        /* The SQLSTATE arm passes a COMPUTED status rather than a literal, which is why it is invisible to a
+           census keyed on the status strings and earns its own pin here. */
+        Assert.Equal(1, Regex.Matches(worker, @"collectorName, status, 0, runClock\.ElapsedMilliseconds, 0").Count);
+
+        /* Never queried the target - the RDS log API and Performance Insights are both HTTPS. */
+        Assert.Equal(2, Regex.Matches(worker, @"""PERMISSIONS"", 0, 0, runClock\.ElapsedMilliseconds").Count);
+
+        /* And the file carries exactly ONE three-zero write: the log_timezone arm, whose two transports
+           disagree about which slot is correct, documented at the arm itself. Counted over the whole file
+           rather than asserted absent arm by arm, so an arm ADDED with three zeros reds HERE instead of
+           passing unnoticed until someone re-runs the census by hand. */
+        Assert.Equal(1, Regex.Matches(worker, @", 0, 0, 0,").Count);
+        Assert.Equal(1, Regex.Matches(worker, @"""PERMISSIONS"", 0, 0, 0, ex\.Message").Count);
+    }
+
     private static string ReadSource(string relativePath)
     {
         var dir = AppContext.BaseDirectory;

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -6075,7 +6075,16 @@ LIMIT 1";
            The fault arms have no split to report, because a fault by definition interrupted whichever
            phase was running, and what they recorded instead was three literal zeros. That made a
            300-second death indistinguishable from an instant one and sent two separate investigations
-           after a connection that dies at open. One honest total beats three precise zeros. */
+           after a connection that dies at open. One honest total beats three precise zeros.
+
+           WHICH SLOT each arm reads this into follows where the time was actually spent, not
+           convenience: an arm whose statement reached the target and was refused THERE passes it as
+           sqlMs, and an arm that never queried the target at all passes it as storageMs. The RDS/PI
+           authorization arms are the second kind, and take the accounting their own success paths
+           already use — see IngestRdsPlansAsync, IngestRdsDeadlocksAsync and IngestRdsCpuAsync, which
+           file an HTTPS round trip as storage time so that one target's sql_duration_ms cannot mean
+           something different from every other target's. duration_ms is sqlMs + storageMs either way,
+           so the wall clock is honest under both; only the decomposition differs. */
         var runClock = System.Diagnostics.Stopwatch.StartNew();
 
         try
@@ -6174,7 +6183,7 @@ LIMIT 1";
                 server.Config.DisplayName, collectorName, ex.Message);
 
             await DarlingObservability.LogCollectionAsync(
-                _postgres!, runtime, collectorName, "SESSION_MISSING", 0, 0, 0, ex.Message, fanout: null, phases: null, drain: null, fetchPhases: null, sweepPeerMaxMs: peerMaxAtDispatchMs, _logger, cancellationToken);
+                _postgres!, runtime, collectorName, "SESSION_MISSING", 0, runClock.ElapsedMilliseconds, 0, ex.Message, fanout: null, phases: null, drain: null, fetchPhases: null, sweepPeerMaxMs: peerMaxAtDispatchMs, _logger, cancellationToken);
             return 0;
         }
         catch (RdsLogUnavailableException ex) when (ex.IsAuthorizationFailure)
@@ -6192,7 +6201,7 @@ LIMIT 1";
                 server.Config.DisplayName, collectorName);
 
             await DarlingObservability.LogCollectionAsync(
-                _postgres!, runtime, collectorName, "PERMISSIONS", 0, 0, 0,
+                _postgres!, runtime, collectorName, "PERMISSIONS", 0, 0, runClock.ElapsedMilliseconds,
                 $"{ex.Message} — the MONITORING HOST's IAM role lacks a grant this source needs, which is "
                 + "not a database grant: plan capture on managed PostgreSQL reads the server log through "
                 + "the RDS API, so the role needs rds:DescribeDBLogFiles and rds:DownloadDBLogFilePortion "
@@ -6210,7 +6219,7 @@ LIMIT 1";
                 server.Config.DisplayName, collectorName);
 
             await DarlingObservability.LogCollectionAsync(
-                _postgres!, runtime, collectorName, "PERMISSIONS", 0, 0, 0,
+                _postgres!, runtime, collectorName, "PERMISSIONS", 0, 0, runClock.ElapsedMilliseconds,
                 $"{ex.Message} — the MONITORING HOST's IAM role lacks a grant this source needs, which is "
                 + "not a database grant: instance CPU on managed PostgreSQL reads AWS Performance Insights, "
                 + "so the role needs rds:DescribeDBInstances, rds:DescribeDBClusters and "
@@ -6237,7 +6246,17 @@ LIMIT 1";
                wrong zone reading as a target with no deadlocks.
 
                Both transports arrive here: the pg_read_file route throws out of the collector's ReadAsync,
-               the RDS log-API route out of the ingestor's Extract. */
+               the RDS log-API route out of the ingestor's Extract.
+
+               That shared arrival is also why this is the ONE fault arm that records zeros rather than
+               runClock's wall clock. The slot rule at the stopwatch's declaration keys on whether the
+               target was queried, and the two transports answer that oppositely: pg_read_file IS a target
+               query and belongs in sqlMs, while the RDS log API is an HTTPS round trip that belongs in
+               storageMs. The exception carries only ObservedZone, so this catch cannot tell which one it
+               is, and either slot would be wrong for half the fleet. A zero here understates a duration;
+               a guessed slot would misattribute one, and this store's readers decompose sql vs storage
+               per target. Threading the transport onto PgLogTimezoneUnsupportedException is what would
+               let this arm join the rule. */
             _logger.LogWarning("  [{Server}] {Collector} => PERMISSIONS: the server log is stamped '{Zone}', not UTC",
                 server.Config.DisplayName, collectorName, ex.ObservedZone);
 
@@ -6262,7 +6281,7 @@ LIMIT 1";
                 server.Config.DisplayName, collectorName);
 
             await DarlingObservability.LogCollectionAsync(
-                _postgres!, runtime, collectorName, "YIELDED", 0, 0, 0,
+                _postgres!, runtime, collectorName, "YIELDED", 0, runClock.ElapsedMilliseconds, 0,
                 $"Lock-timeout yield (SQL error #{ex.Number}): the 1-second LOCK_TIMEOUT guard fired rather than waiting in a blocking chain. One snapshot sweep skipped; evidence of lock contention on the monitored server, not a monitoring failure.",
                 fanout: null, phases: null, drain: null, fetchPhases: null, sweepPeerMaxMs: peerMaxAtDispatchMs, _logger, cancellationToken);
             return 0;
@@ -6287,7 +6306,7 @@ LIMIT 1";
                 server.Config.DisplayName, collectorName, ex.Number, message);
 
             await DarlingObservability.LogCollectionAsync(
-                _postgres!, runtime, collectorName, "PERMISSIONS", 0, 0, 0, message, fanout: null, phases: null, drain: null, fetchPhases: null, sweepPeerMaxMs: peerMaxAtDispatchMs, _logger, cancellationToken);
+                _postgres!, runtime, collectorName, "PERMISSIONS", 0, runClock.ElapsedMilliseconds, 0, message, fanout: null, phases: null, drain: null, fetchPhases: null, sweepPeerMaxMs: peerMaxAtDispatchMs, _logger, cancellationToken);
             return 0;
         }
         /* #2997: the database is read off the EXCEPTION first, falling back to the runtime's own. #2638
@@ -6328,7 +6347,7 @@ LIMIT 1";
             }
 
             await DarlingObservability.LogCollectionAsync(
-                _postgres!, runtime, collectorName, status, 0, 0, 0, explanation, fanout: null, phases: null, drain: null, fetchPhases: null, sweepPeerMaxMs: peerMaxAtDispatchMs, _logger, cancellationToken);
+                _postgres!, runtime, collectorName, status, 0, runClock.ElapsedMilliseconds, 0, explanation, fanout: null, phases: null, drain: null, fetchPhases: null, sweepPeerMaxMs: peerMaxAtDispatchMs, _logger, cancellationToken);
             return 0;
         }
         /* yieldsOnLockTimeout: false is deliberate, and matches the general catch below rather than the


### PR DESCRIPTION
Six of the seven early-return fault arms in `RunOneAsync` passed three literal zeros to `LogCollectionAsync`. `collection_log.duration_ms` is written as `sqlMs + storageMs`, so every classified failure stored a row claiming the run took no time at all. #3003 fixed the two ERROR arms; this is the same defect one classification down.

## The slot rule

The wall clock goes in the slot the time was actually spent, rather than uniformly into `sqlMs`.

An arm whose statement reached the target and was refused **there** passes it as `sqlMs`: `SESSION_MISSING`, the SQL Server permission-denied filter, the 1222 lock-timeout yield, and the PostgreSQL SQLSTATE arm. The last of those passes a computed `status` rather than a status literal, which is why it is invisible to a census keyed on the status strings.

The RDS log-API and Performance Insights authorization arms never queried the target, so they pass it as `storageMs`. That is not a new convention — it is the one their own success paths already use, in `IngestRdsPlansAsync`, `IngestRdsDeadlocksAsync` and `IngestRdsCpuAsync`, each carrying the same rationale: *"no query ran against the monitored server, and filing an HTTPS round trip under sql_duration_ms would make one target's numbers mean something different from every other target's."* Filing a denied AWS call as target time would contradict a decision this code has already made three times.

`duration_ms` is `sqlMs + storageMs` either way, so wall clock is honest under both spellings; only the decomposition differs. This is why the new pin counts the **slot** and not merely the presence of a stopwatch — an arm filing an HTTPS round trip as target time is the one mistake here that is invisible in the very column the change exists to fix.

## The arm that keeps its zeros

`PgLogTimezoneUnsupportedException` is unchanged, deliberately. Both transports reach that arm — the `pg_read_file` route throws out of the collector's `ReadAsync`, the RDS log-API route out of the ingestor's `Extract` — and they answer the slot question oppositely. The exception carries only `ObservedZone`, so the catch cannot tell which one it is, and either slot would be wrong for half the fleet. A zero understates a duration; a guessed slot misattributes one. Threading a transport discriminator onto the exception is what would let this arm join the rule, and is not done here.

## Read-surface effect, per consumer

Three consumers were named as at risk. The first is not a consumer of these rows at all.

**`collector_cost` — structurally unaffected.** It is not an aggregate over `collection_log`. It is fed by `CollectorCostAccumulator.Record`, called from exactly one site (`DarlingWorker.cs`, the success path, from `result.SqlMs` / `result.StorageMs`), and `DarlingCollectorCostReader` never reads `collection_log`. A classified-failure row has never reached the cost series at zero or at any other value, so no degraded server's cost total moves.

**Collection Health — the duration statistics move; the band cannot.** `CollectionHealthSql` computes

```sql
AVG(duration_ms) AS avg_duration_ms,
MAX(duration_ms) AS max_duration_ms,
PERCENTILE_DISC(0.95) WITHIN GROUP (ORDER BY duration_ms) AS p95_duration_ms,
```

over the whole 7-day window with **no status predicate**, while every other aggregate in the same statement is status-gated. So the zeros do not merely sit on their own rows — they deflate the mean of any collector with a mixed population. The HEALTHY/WARNING/FAILING verdict is a separate matter and is duration-free: `CollectorHealthClassifier.Classify` takes counts plus elapsed hours, and its thresholds are `WarningFailureRatePercent = 20.0` and `WarningAbandonRatePercent = 0.5` — percentages of runs, not milliseconds.

**Daily health band — cannot move.** `DailyHealthSignals` has eight fields, every one a `long` count or `bool HasData`. The thresholds are `HighCpuCriticalSamples = 6`, `HighCpuWarningSamples = 1`, `BlockingCriticalEvents = 11`, `BlockingWarningEvents = 1`, `AlertWarningCount = 1` — all sample or event counts. The band's entire `collection_log` contribution is `COUNT(*) AS runs` and `COUNT(*) FILTER (WHERE status = 'ERROR') AS errs`; `duration_ms` is never selected. `PERMISSIONS` / `YIELDED` / `SESSION_MISSING` rows reach only `runs`, which sets the collected flag.

The collection-failure self-alerts are **not** a consumer: the only duration the self-alert evaluator reads is `job.LastRunDurationMs`, a SQL Agent job's runtime, and nothing in it reads `collection_log.duration_ms`.

**`sweep_pressure` — a fourth consumer, and the only band that moves.** Its thresholds *are* duration-expressed: `AtRiskBusyPercent = 75.0`, `SaturatedBusyPercent = 100.0`, `BodyOverrunPercent = 100.0` against `SweepBudgetMs = 60_000.0`, fed by `AvgDurationMs` / `P95DurationMs` straight from that unfiltered aggregate. The mechanism is its own guard:

```csharp
if (frequencyMinutes <= 0 || (avgDurationMs <= 0 && p95DurationMs <= 0))
```

A collector denied on every run currently reports zero for both and is skipped by that `continue`, which excludes it from `busyMsPerMinute` **and** from `peakCycleMs` — so both the sustained verdict and the peak-cycle risk are affected. It now carries its real cost and is counted in both.

That is a behaviour change, and it is the right direction rather than an incidental one: `busy_ms_per_minute` is a capacity question about the sweep body, and a collector that spends a second yielding on a target lock every minute genuinely occupies a second of that body. Excluding it understates real occupancy. The movement is one-directional — only ever toward AT_RISK/SATURATED — and bounded per collector by `elapsed_ms / frequency_minutes`. On a measured dogfood target the baseline is 3,305 ms/min against a 45,000 ms AT_RISK boundary, so the arms in question move it by fractions of a percent; the 1-second lock-timeout guard is the largest single contributor at up to 1,000 ms/min on a 1-minute cadence.

The `YIELDED` arm is the clearest gain of the six on this surface, and no arm is made worse by it, which is why the change is applied to all six rather than to that one.

## Verification

Red-first through `redproof.sh`, one mutation at a time, each restored byte-identical against a SHA-256 of the baseline, with the baseline committed first. Four distinct assertions exercised:

- reverting the `YIELDED` arm to zeros — fails the YIELDED slot count
- reverting `SESSION_MISSING` to zeros — fails the SESSION_MISSING slot count
- moving both AWS arms into the `sqlMs` slot — fails only the storage-slot count, leaving the three-zero census intact, which is the proof that the pin catches a wrong slot and not just a missing clock
- regressing the general ERROR catch to zeros — fails the three-zero census here **and** #3003's own pin

The census assertion is anchored on the call's shape (`collectorName`, then a status literal or the computed `status`) rather than on a bare `, 0, 0, 0,` run. Both count 1 today, but the bare form would also match any unrelated four-argument call in this 6,600-line file, and a pin that reds on changes it does not guard is one somebody eventually loosens. The anchored form still catches a new arm passing three zeros under either status form, which is verified by the ERROR-regression mutation above.

A comment-only control stayed green. `PostgresFaultOutcomeTests` runs 38 tests, `Failed: 0`, `Not Run: 0`, none skipped.

`ThePeerMarkIsCapturedAtDispatchNotAtCompletion` needed no change. It counts `drain: null` (9), `fetchPhases: null` (9) and `peerMaxAtDispatchMs: null` (2) plus two peer-mark literals, and this diff touches none of them — all eight of its assertions were verified against the source directly, since that suite references the WPF Viewer and cannot compile into a runnable non-Windows host. The same was done for `DarlingLockTimeoutYieldTests` and `RdsLogUnavailableTests`, neither of which pins the argument list.

## What this closes

Nothing, by keyword or otherwise — closing keywords are a no-op on a merge to `dev`.

It does answer the open question in #3011's own Not-verified section, and answers it the other way: that issue records "the classified PERMISSIONS/YIELDED paths record real durations, but I checked those by reading rather than by measurement." They did not — they passed three literals, which is what this changes. #3011's stated subject, the general catch, is already fixed by #3003.

## Not verified

- No runtime observation of the new values. The write happens inside a live sweep, which is why the invariant is pinned in source; that no pure test can reach it is the same limitation #3003 documented.
- The PostgreSQL-side arms (RDS log API, Performance Insights, SQLSTATE) are not exercised against a live Aurora/RDS target here — the PostgreSQL dogfood store was not reachable from this session, so the AWS arms' real elapsed magnitudes are unmeasured and the storage-slot choice rests on the convention argument rather than on observed numbers.
- `sweep_pressure` movement is quantified from one dogfood target, not swept across the fleet. A server already near the 75% boundary is where this would matter, and no such server was identified.
- Lite's equivalent arms are structurally immune to this defect class, so there is no parity drift to port. `RemoteCollectorService.LogCollectionAsync` computes `durationMs` as `(int)(DateTime.UtcNow - startTime).TotalMilliseconds` independently of the `sqlMs` / `duckDbMs` parameters it also stores, so Lite's `duration_ms` was never derived from the split the way Darling's is, and its fault arms' zeros for the split columns never zeroed the total. Verified from source at `Lite/Services/RemoteCollectorService.cs:790-794`. #3011's Lite question is answered by that, not by this diff.

## CHANGELOG entry (not committed here — `CHANGELOG.md` is left alone so lanes do not serialize on it)

Under `[Unreleased]` → `### Fixed`:

```markdown
- Collector runs that end in a classified fault now record the run's real elapsed time in `collection_log` instead of three literal zeros, so a permission denial, a lock-timeout yield and a missing XE session are no longer stored as instantaneous. The wall clock is filed against the target for faults the target refused, and against the storage phase for the RDS log-API and Performance Insights denials, which never query the target. The one arm reached by both transports is unchanged, because its slot cannot be determined from the fault alone.
```
