### PR TITLE
Census viewer fan-outs by shape rather than by their join (#3019)

### DIFF
--- a/Darling/Darling.Tests/ViewerCommandTimeoutTests.cs
+++ b/Darling/Darling.Tests/ViewerCommandTimeoutTests.cs
@@ -70,6 +70,54 @@ public sealed class ViewerCommandTimeoutTests
         @"ViewerReadFanOut\s*\.\s*Of\s*\(",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
+    /// <summary>
+    /// A fire-and-forget call — <c>_ = SomethingAsync();</c>. Two of them in one member is a fan-out; ONE
+    /// is this project's ordinary single-flight-guarded refresh and is not.
+    ///
+    /// <para>Deliberately WIDER than the identical-looking expression in
+    /// <c>ViewerFleetTimerGuardTests</c> and <c>ViewerFleetTimerFanOutPositionTests</c>, which use
+    /// <c>(\w+)</c>: those two ask a question about named calls inside ONE known tick, so a name they
+    /// cannot spell is a name they do not need. This is a project-wide census, and a census blind to
+    /// <c>_ = Controller.ReadAsync();</c> would report a clean sweep over a shape it never looked at —
+    /// which is the #3019 failure one level down.</para>
+    /// </summary>
+    private static readonly Regex s_fireAndForget = new(
+        @"(^|[^A-Za-z0-9_])_\s*=\s*[A-Za-z_][A-Za-z0-9_\.]*\s*\(",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// A task STARTED into a local without being awaited there — <c>var t = SomethingAsync();</c>. Two of
+    /// these with no <c>await</c> between them is the same fan-out as <c>Task.WhenAll(t1, t2)</c>, written
+    /// with the awaits one per line instead of joined.
+    /// </summary>
+    private static readonly Regex s_deferredRead = new(
+        @"(^|[^A-Za-z0-9_])(?:var|Task(?:\s*<[^;={}]*>)?)\s+[A-Za-z_][A-Za-z0-9_]*\s*=\s*[A-Za-z_][A-Za-z0-9_\.]*Async\s*\(",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>An <c>await</c> as a keyword, not as part of a longer identifier.</summary>
+    private static readonly Regex s_await = new(
+        @"(^|[^A-Za-z0-9_])await[^A-Za-z0-9_]",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// A member declaration with a body — accessibility, optional modifiers, return type, name, parameter
+    /// list, open brace. The unit fan-outs are paired within: see
+    /// <see cref="EveryViewerFanOut_DeclaresItsWidth"/> for why the enclosing BLOCK is the wrong unit.
+    /// </summary>
+    private static readonly Regex s_memberSignature = new(
+        @"(?:private|public|protected|internal)(?:\s+(?:static|async|override|virtual|sealed|new|partial|unsafe|extern))*"
+        + @"\s+[A-Za-z_][A-Za-z0-9_<>,\.\[\]\?\s]*?\s(?<name>[A-Za-z_][A-Za-z0-9_]*)\s*\([^;{}]*\)\s*\{",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// The concurrency primitives this project does not use and whose fan-outs
+    /// <see cref="EveryViewerFanOut_DeclaresItsWidth"/> therefore does not model. Pinned as ABSENT rather
+    /// than handled — see <see cref="NoUnmodelledConcurrencyPrimitive_ReachesTheViewer"/>.
+    /// </summary>
+    private static readonly Regex s_unmodelledConcurrency = new(
+        @"Task\s*\.\s*WhenAny\s*\(|Task\s*\.\s*Factory\s*\.|Parallel\s*\.\s*(?:For|Invoke)|\.\s*ContinueWith\s*\(",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
     [Fact]
     public void EveryViewerCommand_SetsAnExplicitDeadline()
     {
@@ -360,30 +408,62 @@ public sealed class ViewerCommandTimeoutTests
     }
 
     /// <summary>
-    /// Every joined fan-out in this project declares how wide it is, so the reads inside it are bounded by
+    /// Every fan-out in this project declares how wide it is, so the reads inside it are bounded by
     /// <see cref="ViewerCommandDeadlines.FanOutReadSeconds"/> rather than by a solo read's ceiling (#3004).
     ///
-    /// <para><b>Paired POSITIONALLY, not by enclosing block.</b> The obvious rule — the declaration must sit
-    /// in the same block as the <c>Task.WhenAll</c> — is wrong on this codebase's real shape:
-    /// <c>CorrelatedTimelineLanesControl</c> declares its width in the outer <c>try</c> and awaits the join
-    /// inside a nested one, so a single-level backward walk finds the inner brace and reports the widest
-    /// fan-out in the project as an offender. Requiring instead that the k-th join in a file be preceded by
-    /// at least k declarations is immune to nesting, still order-sensitive, and still fails if any one
-    /// declaration is deleted — which is the property being bought.</para>
+    /// <para><b>A fan-out is N reads in flight together, not a syntax</b>, and this project spells that
+    /// three ways. #3007 censused only the first, and #3019 is the hole that left: iterating
+    /// <c>Task.WhenAll</c> matches gives a fan-out that never joins ZERO iterations, so that shape could
+    /// not be reported however wrong it was — while being the very shape whose discovery took #3007's
+    /// census from one site to seventeen.
+    /// <list type="number">
+    /// <item><b>Joined</b> — <c>await Task.WhenAll(...)</c>. One occurrence makes the member a fan-out.</item>
+    /// <item><b>Fire-and-forget</b> — two or more <c>_ = SomethingAsync();</c>. One is this project's
+    /// ordinary single-flight-guarded refresh (27 such sites, none of them fan-outs); two is a fan-out,
+    /// because a discarded task has nobody to await it and is therefore still running when the next
+    /// starts. That is also why an <c>await</c> between two discards does NOT separate them, and why this
+    /// shape — unlike the deferred one below — takes no account of intervening awaits.</item>
+    /// <item><b>Deferred</b> — two or more <c>var t = SomethingAsync();</c> starts with no <c>await</c>
+    /// between them. Semantically the joined form with the awaits written one per line, and the spelling
+    /// <c>ViewerServerTab.Blocking</c>, <c>.Charts</c> and <c>.RunningJobs</c> use; each of those three
+    /// carries a doc comment stating in as many words that the reads run concurrently.</item>
+    /// </list></para>
     ///
-    /// <para><b>What this does NOT cover, stated because the gap is real.</b> A fan-out does not need a
-    /// <c>Task.WhenAll</c>: <c>MainWindow.OnRefreshTimerTick</c> fires five or six store reads unawaited and
-    /// joins none of them, and the connect path fires three. Nothing lexical distinguishes those from the
-    /// twenty other unawaited single reads in this project, which are single-flight-guarded and not
-    /// fan-outs at all, so a scan for that shape would be mostly false positives. Both real sites declare
-    /// their width by hand and carry a comment saying so; this test is the guard for the joined shape
-    /// ONLY.</para>
+    /// <para><b>Paired by MEMBER BODY — not positionally, and not by enclosing block.</b> Both obvious
+    /// rules are wrong on this codebase's real shapes, in opposite directions. Same-BLOCK pairing breaks on
+    /// <c>CorrelatedTimelineLanesControl</c>, which declares its width in an outer <c>try</c> and awaits
+    /// the join inside a nested one, so a single-level backward walk finds the inner brace and reports the
+    /// widest fan-out in the project as an offender. Per-FILE positional counting — "the k-th join is
+    /// preceded by at least k declarations", which is what this pin used to do — breaks the other way: it
+    /// lets declarations LAUNDER across unrelated members of one file. <c>MainWindow.xaml.cs</c> carries
+    /// three declarations against one join, so under the old rule the declaration that actually pairs with
+    /// that join could be deleted and the two unrelated unjoined ones covered for it. A member body is
+    /// immune to the nesting (the outer and nested <c>try</c> are the same member) and to the laundering (a
+    /// declaration in one method cannot satisfy a fan-out in another).</para>
+    ///
+    /// <para><b>What this does NOT cover, stated because each gap is real.</b>
+    /// <list type="bullet">
+    /// <item>The declared WIDTH is not checked, only that a width is declared. <c>Of(n)</c>'s own summary
+    /// makes the value the call site's responsibility.</item>
+    /// <item>Mutually exclusive branches count as one fan-out: the three <c>switch</c> cases of
+    /// <c>LoadBlockingAsync</c> never run together, and two discards in an <c>if</c>/<c>else</c> would
+    /// count as a pair. This over-reports rather than under-reports.</item>
+    /// <item>Within ONE member, several independent fan-outs share the credit of a single declaration —
+    /// the positional residual, narrowed from per-file to per-member but not eliminated.</item>
+    /// <item>Reads reached through a helper the member CALLS rather than fires are the helper's fan-out,
+    /// not the caller's.</item>
+    /// <item>Concurrency primitives this project does not use, pinned absent by
+    /// <see cref="NoUnmodelledConcurrencyPrimitive_ReachesTheViewer"/> so that adding one goes red here
+    /// rather than quietly widening this gap.</item>
+    /// </list></para>
     /// </summary>
     [Fact]
     public void EveryViewerFanOut_DeclaresItsWidth()
     {
         var offenders = new List<string>();
-        var joins = 0;
+        var fanOuts = 0;
+        var members = 0;
+        var unattributed = new List<string>();
 
         foreach (var path in ViewerSources())
         {
@@ -391,34 +471,240 @@ public sealed class ViewerCommandTimeoutTests
 
             /* Stripped, for the same reason the command scans are: this file's own prose names
                Task.WhenAll and ViewerReadFanOut.Of repeatedly, and a scan reading raw text would pair a
-               join against an explanation of a declaration. */
+               join against an explanation of a declaration. BraceBalanced below is only correct over
+               stripped text, which is that method's own stated contract. */
             var code = CSharpSourceWalker.StripCommentsAndStrings(text);
 
+            var bodies = MemberBodies(code);
+            members += bodies.Count;
+
+            var joins = s_joinedFanOut.Matches(code).Select(m => m.Index).ToArray();
+            var discards = s_fireAndForget.Matches(code).Select(m => m.Index).ToArray();
+            var deferred = s_deferredRead.Matches(code).Select(m => (m.Index, End: m.Index + m.Length)).ToArray();
             var declarations = s_fanOutDeclaration.Matches(code).Select(m => m.Index).ToArray();
-            var seen = 0;
 
-            foreach (Match join in s_joinedFanOut.Matches(code))
+            /* A marker inside no recognised member means the member walk missed a declaration shape, and a
+               fan-out the walk cannot see is exactly the silence this pin exists to break. Reported rather
+               than skipped. */
+            foreach (var index in joins.Concat(discards).Concat(deferred.Select(d => d.Index)))
             {
-                joins++;
-                seen++;
-
-                if (declarations.Count(index => index < join.Index) < seen)
+                if (Owner(bodies, index) is null)
                 {
-                    var line = text.Take(join.Index).Count(c => c == '\n') + 1;
-                    offenders.Add($"{Path.GetFileName(path)}:{line}");
+                    unattributed.Add($"{Path.GetFileName(path)}:{Line(text, index)}");
+                }
+            }
+
+            foreach (var body in bodies)
+            {
+                bool Mine(int index) => Owner(bodies, index) is { } owner && owner.Start == body.Start;
+
+                var myJoins = joins.Where(Mine).ToArray();
+                var myDiscards = discards.Where(Mine).ToArray();
+                var myDeferred = deferred.Where(d => Mine(d.Index)).ToArray();
+
+                var markers = new List<int>();
+
+                if (myJoins.Length > 0)
+                {
+                    markers.Add(myJoins[0]);
+                }
+
+                if (myDiscards.Length >= 2)
+                {
+                    markers.Add(myDiscards[0]);
+                }
+
+                if (ConcurrentRun(code, myDeferred) >= 2)
+                {
+                    markers.Add(myDeferred[0].Index);
+                }
+
+                if (markers.Count == 0)
+                {
+                    continue;
+                }
+
+                fanOuts++;
+                var first = markers.Min();
+
+                if (!declarations.Any(d => Mine(d) && d < first))
+                {
+                    offenders.Add($"{Path.GetFileName(path)}:{Line(text, first)} ({body.Name})");
                 }
             }
         }
 
-        Assert.True(joins >= 10, $"the fan-out scan matched only {joins} joins — the sweep is not reading the project");
+        /* Three floors, because each one fails differently. The member floor catches a member regex that
+           stopped matching (every fan-out then sits in no member and the sweep asserts over nothing); the
+           fan-out floor catches the sweep reading an empty or wrong directory; the attribution floor
+           catches a member walk that reads the project but drops the members the fan-outs are in. 21
+           fan-outs across 1,231 member bodies in 191 files when this landed. */
+        Assert.True(members >= 900, $"the member walk found only {members} member bodies — it is not reading the project");
+
+        Assert.True(fanOuts >= 15, $"the fan-out census matched only {fanOuts} fan-out(s) — the sweep is not reading the project");
+
+        Assert.True(
+            unattributed.Count == 0,
+            $"{unattributed.Count} fan-out marker(s) sit inside no recognised member body, so nothing required "
+            + "them to declare a width. The member signature pattern has stopped matching a declaration shape "
+            + "this project uses: " + string.Join(", ", unattributed));
 
         Assert.True(
             offenders.Count == 0,
-            $"{offenders.Count} joined fan-out(s) run their reads concurrently without declaring a width, so each "
+            $"{offenders.Count} fan-out(s) run their reads concurrently without declaring a width, so each "
             + "read is bounded by a ceiling derived from a read measured ALONE — which the ten-wide case sits "
             + "entirely above. Declare the width with ViewerReadFanOut.Of(n) before the first read: "
             + string.Join(", ", offenders));
     }
+
+    /// <summary>
+    /// The concurrency primitives <see cref="EveryViewerFanOut_DeclaresItsWidth"/> does not model are
+    /// pinned ABSENT, which is what lets that pin claim "every" rather than "every one of three spellings".
+    ///
+    /// <para>This is the ratchet #3019 was really about. A census names the shapes it knows; the failure is
+    /// not that the list is short but that a shape added later joins it silently and the guard stays green
+    /// while covering less. Asserting the unmodelled primitives are unused converts that silence into a red
+    /// build for whoever introduces one, and their options are then to model it above or to declare the
+    /// width by hand — either way it is a decision someone makes rather than one nobody sees.</para>
+    /// </summary>
+    [Fact]
+    public void NoUnmodelledConcurrencyPrimitive_ReachesTheViewer()
+    {
+        var offenders = new List<string>();
+
+        foreach (var path in ViewerSources())
+        {
+            var text = File.ReadAllText(path);
+            var code = CSharpSourceWalker.StripCommentsAndStrings(text);
+
+            foreach (Match hit in s_unmodelledConcurrency.Matches(code))
+            {
+                offenders.Add($"{Path.GetFileName(path)}:{Line(text, hit.Index)} ({hit.Value.Trim()})");
+            }
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            $"{offenders.Count} site(s) use a concurrency primitive the fan-out census does not model, so a "
+            + "fan-out spelled that way would never be asked to declare a width. Either teach "
+            + "EveryViewerFanOut_DeclaresItsWidth the shape, or declare the width at the site and narrow this "
+            + "pin deliberately: " + string.Join(", ", offenders));
+    }
+
+    /// <summary>
+    /// The census classifier, on the shapes that decide whether it is honest. A false negative here is
+    /// #3019 again; a false positive fails a green build on correct code.
+    ///
+    /// <para>The two that matter most are the last two. <b>Sequential start-await-start-await is NOT a
+    /// fan-out</b> — nothing is in flight together — and a deferred rule that ignored the intervening
+    /// <c>await</c> would report every such method. <b>Two discards separated by an await ARE</b> a
+    /// fan-out, because discarding a task means nothing waits for it; the asymmetry between those two
+    /// cases is the whole reason the deferred shape counts awaits and the discard shape does not.</para>
+    /// </summary>
+    [Theory]
+    /* One discard: the project's single-flight refresh, 27 of them, not a fan-out. */
+    [InlineData("_ = RefreshServerStatusAsync();\n", false)]
+    /* Two: MainWindow.LoadServersAsync's connect pair. */
+    [InlineData("_ = RefreshServerStatusAsync();\n_ = RefreshStoreSizeAsync();\n", true)]
+    /* Dotted receiver — the shape the sibling pins' (\w+) form cannot see. */
+    [InlineData("_ = Controller.LoadAsync();\n_ = Controller.SaveAsync();\n", true)]
+    /* A join alone is a fan-out; one occurrence is enough. */
+    [InlineData("await Task.WhenAll(a, b);\n", true)]
+    /* Deferred pair, then awaited — ViewerServerTab.Charts.LoadTempDbAsync. */
+    [InlineData("var trendTask = _dataService.GetTempDbTrendAsync(id);\nvar fileIoTask = _dataService.GetTempDbFileIoTrendAsync(id);\nvar trend = await trendTask;\n", true)]
+    /* One deferred start is not a fan-out. */
+    [InlineData("var only = _dataService.GetTempDbTrendAsync(id);\nvar rows = await only;\n", false)]
+    /* Sequential: each awaited before the next starts, so nothing overlaps. */
+    [InlineData("var a = _dataService.GetXAsync(id);\nvar ra = await a;\nvar b = _dataService.GetYAsync(id);\nvar rb = await b;\n", false)]
+    /* Discards are NOT separated by an await — the discarded task is still running. */
+    [InlineData("_ = RefreshServerStatusAsync();\nawait RefreshVisibleAsync();\n_ = PollAlertsAsync();\n", true)]
+    /* Prose cannot make a fan-out. */
+    [InlineData("/* two reads: _ = OneAsync(); _ = TwoAsync(); */\n", false)]
+    public void TheFanOutCensus_RecognisesEachShape_AndOnlyThose(string body, bool expectedFanOut)
+    {
+        var code = CSharpSourceWalker.StripCommentsAndStrings("private async Task Fixture()\n{\n" + body + "}\n");
+        var bodies = MemberBodies(code);
+
+        Assert.True(bodies.Count == 1, $"the fixture parsed to {bodies.Count} member bodies, not 1");
+
+        var joins = s_joinedFanOut.Matches(code).Select(m => m.Index).ToArray();
+        var discards = s_fireAndForget.Matches(code).Select(m => m.Index).ToArray();
+        var deferred = s_deferredRead.Matches(code).Select(m => (m.Index, End: m.Index + m.Length)).ToArray();
+
+        var isFanOut = joins.Length > 0 || discards.Length >= 2 || ConcurrentRun(code, deferred) >= 2;
+
+        Assert.Equal(expectedFanOut, isFanOut);
+    }
+
+    /// <summary>
+    /// The longest run of deferred reads with no <c>await</c> between consecutive members of the run — the
+    /// number actually in flight together. Two starts either side of an <c>await</c> are sequential and
+    /// must not count; see <see cref="TheFanOutCensus_RecognisesEachShape_AndOnlyThose"/>.
+    /// </summary>
+    private static int ConcurrentRun(string code, (int Index, int End)[] deferred)
+    {
+        var best = 0;
+        var run = 0;
+        var previousEnd = -1;
+
+        foreach (var (index, end) in deferred)
+        {
+            run = previousEnd >= 0 && !s_await.IsMatch(code[previousEnd..index]) ? run + 1 : 1;
+            best = System.Math.Max(best, run);
+            previousEnd = end;
+        }
+
+        return best;
+    }
+
+    /// <summary>
+    /// Every member body in <paramref name="code"/>, which must be
+    /// <see cref="CSharpSourceWalker.StripCommentsAndStrings"/>'s output — a brace in prose or in a literal
+    /// is exactly what would unbalance the walk.
+    /// </summary>
+    private static List<(int Start, int End, string Name)> MemberBodies(string code)
+    {
+        var bodies = new List<(int Start, int End, string Name)>();
+
+        foreach (Match signature in s_memberSignature.Matches(code))
+        {
+            /* The signature match ends ON the body brace, so search from there rather than from the
+               parameter list: a parameter default can carry a brace. */
+            var open = code.IndexOf('{', signature.Index + signature.Length - 1);
+
+            if (open < 0)
+            {
+                continue;
+            }
+
+            bodies.Add((open, open + CSharpSourceWalker.BraceBalanced(code, open).Length, signature.Groups["name"].Value));
+        }
+
+        return bodies;
+    }
+
+    /// <summary>
+    /// The OUTERMOST member body containing <paramref name="index"/>, or null. Outermost so that a read
+    /// inside a lambda or a local function is attributed to the method that fans it out, which is where the
+    /// width has to be declared.
+    /// </summary>
+    private static (int Start, int End, string Name)? Owner(List<(int Start, int End, string Name)> bodies, int index)
+    {
+        (int Start, int End, string Name)? owner = null;
+
+        foreach (var body in bodies)
+        {
+            if (index > body.Start && index < body.End && (owner is null || body.Start < owner.Value.Start))
+            {
+                owner = body;
+            }
+        }
+
+        return owner;
+    }
+
+    /// <summary>The 1-based line of <paramref name="index"/> in <paramref name="text"/>.</summary>
+    private static int Line(string text, int index) => text.Take(index).Count(c => c == '\n') + 1;
 
     /// <summary>
     /// A declared width must not outlive the reads it describes. A method-scoped <c>using var</c> runs to
@@ -435,6 +721,14 @@ public sealed class ViewerCommandTimeoutTests
     /// level: <c>MainWindow</c>'s fleet-totals read sits inside a <c>try</c> block, so a same-depth rule
     /// would miss a real one. Both shapes are live in this project, and each rules out one of the two
     /// obvious implementations.</para>
+    ///
+    /// <para><b>Joined fan-outs only, unlike
+    /// <see cref="EveryViewerFanOut_DeclaresItsWidth"/>.</b> "Outlives its join" needs a join to be
+    /// measured against, and the unjoined shapes have none — <c>MainWindow.OnRefreshTimerTick</c>
+    /// deliberately holds its scope to the end of the tick, because the visible-tab load below really does
+    /// contend with the reads still in flight. So the release discipline is not merely unchecked for those
+    /// shapes, it is a different question there with a different answer, and widening this scan to reach
+    /// them would report that deliberate choice as a defect (#3019).</para>
     /// </summary>
     [Fact]
     public void NoFanOutScope_OutlivesItsJoin()

--- a/Darling/Darling.Tests/ViewerCommandTimeoutTests.cs
+++ b/Darling/Darling.Tests/ViewerCommandTimeoutTests.cs
@@ -483,6 +483,20 @@ public sealed class ViewerCommandTimeoutTests
     /// immune to the nesting (the outer and nested <c>try</c> are the same member) and to the laundering (a
     /// declaration in one method cannot satisfy a fan-out in another).</para>
     ///
+    /// <para><b>The markers are censused TREE-WIDE and attributed afterwards, which is the whole reason
+    /// <c>unattributed</c> can mean anything.</b> Each pattern is matched against the file, not inside each
+    /// member body, and a marker whose <see cref="Owner"/> is null is REPORTED rather than skipped. Scoped
+    /// the other way round — search within each braced body — a marker in a shape the walk cannot see would
+    /// simply never be looked at, and <c>unattributed</c> would sit at zero VACUOUSLY while covering less.
+    /// That distinction is not academic here: an expression-bodied member
+    /// (<c>Task Both() =&gt; Task.WhenAll(a, b);</c>) is a legal join with no braced body at all, and this
+    /// project has 378 expression-bodied members against 1,234 braced ones. None holds a join today, and
+    /// the point is that the census does not depend on that staying true — the first one to appear is a red
+    /// build naming its line, not a silent zero. Pinned by
+    /// <see cref="TheCensus_ReportsAJoinInAMemberWithNoBracedBody"/>, and the same property for an
+    /// unrecognised BRACED shape (a property accessor) is why the assertion names the signature pattern in
+    /// its message rather than the offending member.</para>
+    ///
     /// <para><b>What this does NOT cover, stated because each gap is real.</b>
     /// <list type="bullet">
     /// <item>The declared WIDTH is not checked, only that a width is declared. <c>Of(n)</c>'s own summary
@@ -727,6 +741,36 @@ public sealed class ViewerCommandTimeoutTests
         Assert.True(deferred.Length == 2, $"{deferred.Length} deferred read(s) parsed out of the fixture, not 2");
         Assert.All(deferred, d => Assert.NotNull(Owner(bodies, d.Index)));
         Assert.True(ConcurrentRun(code, deferred) >= 2, "the generic method's deferred pair did not read as a fan-out");
+    }
+
+    /// <summary>
+    /// A join in a member with NO braced body is reported, not dropped. An expression-bodied member is a
+    /// legal fan-out site and the member walk cannot represent it, so the only thing standing between it
+    /// and a silent miss is that the census runs tree-wide and attributes afterwards.
+    ///
+    /// <para>This asserts the REPORTING path, not coverage: the join is matched, it has no owner, and the
+    /// sweep therefore lists it as unattributed. That is the honest outcome for a shape the walk cannot
+    /// pair a declaration against — a loud red naming the line, rather than a vacuous zero.</para>
+    /// </summary>
+    [Fact]
+    public void TheCensus_ReportsAJoinInAMemberWithNoBracedBody()
+    {
+        var code = CSharpSourceWalker.StripCommentsAndStrings(
+            "private Task RefreshBothAsync() => Task.WhenAll(LoadOneAsync(), LoadTwoAsync());\n");
+
+        var joins = s_joinedFanOut.Matches(code).Select(m => m.Index).ToArray();
+        var bodies = MemberBodies(code);
+
+        /* Censused: the pattern runs over the file, so the join is seen even though nothing can own it. */
+        Assert.True(joins.Length == 1, $"the census matched {joins.Length} join(s) in an expression-bodied member, not 1");
+
+        Assert.True(
+            bodies.Count == 0,
+            $"an expression-bodied member parsed to {bodies.Count} braced body(ies); if the walk starts "
+            + "representing them, pair the join against it here instead of asserting it is reported");
+
+        /* And unowned, so EveryViewerFanOut_DeclaresItsWidth adds it to `unattributed` and fails loudly. */
+        Assert.Null(Owner(bodies, joins[0]));
     }
 
     /// <summary>

--- a/Darling/Darling.Tests/ViewerCommandTimeoutTests.cs
+++ b/Darling/Darling.Tests/ViewerCommandTimeoutTests.cs
@@ -540,7 +540,7 @@ public sealed class ViewerCommandTimeoutTests
 
             var joins = s_joinedFanOut.Matches(code).Select(m => m.Index).ToArray();
             var discards = s_fireAndForget.Matches(code).Select(m => m.Index).ToArray();
-            var deferred = s_deferredRead.Matches(code).Select(m => (m.Index, End: m.Index + m.Length)).ToArray();
+            var deferred = DeferredReads(code);
             var declarations = s_fanOutDeclaration.Matches(code).Select(m => m.Index).ToArray();
 
             /* A marker inside no recognised member means the member walk missed a declaration shape, and a
@@ -694,7 +694,7 @@ public sealed class ViewerCommandTimeoutTests
 
         var joins = s_joinedFanOut.Matches(code).Select(m => m.Index).ToArray();
         var discards = s_fireAndForget.Matches(code).Select(m => m.Index).ToArray();
-        var deferred = s_deferredRead.Matches(code).Select(m => (m.Index, End: m.Index + m.Length)).ToArray();
+        var deferred = DeferredReads(code);
 
         var isFanOut = joins.Length > 0 || discards.Length >= 2 || ConcurrentRun(code, deferred) >= 2;
 
@@ -736,11 +736,80 @@ public sealed class ViewerCommandTimeoutTests
         Assert.Equal(expectedName, bodies[0].Name);
 
         /* And the fan-out inside it is attributed to that member rather than landing nowhere. */
-        var deferred = s_deferredRead.Matches(code).Select(m => (m.Index, End: m.Index + m.Length)).ToArray();
+        var deferred = DeferredReads(code);
 
         Assert.True(deferred.Length == 2, $"{deferred.Length} deferred read(s) parsed out of the fixture, not 2");
         Assert.All(deferred, d => Assert.NotNull(Owner(bodies, d.Index)));
         Assert.True(ConcurrentRun(code, deferred) >= 2, "the generic method's deferred pair did not read as a fan-out");
+    }
+
+    /// <summary>
+    /// An <c>await</c> inside the FIRST call's own argument list does not sequence the pair. The two tasks
+    /// are still started back to back, so this is a fan-out.
+    ///
+    /// <para>Deliberately separate from
+    /// <see cref="TheDeferredRun_IsBrokenByAnAwaitBetweenTheTwoStatements"/>: measuring the window from the
+    /// wrong end satisfies one of the two and breaks the other, so a single assertion would call a half-fix
+    /// proven. That is the lesson the <c>where T : class, new()</c> fixture taught on this same file.</para>
+    /// </summary>
+    [Fact]
+    public void TheDeferredRun_IgnoresAnAwaitInsideTheFirstCallsOwnArguments()
+    {
+        var code = CSharpSourceWalker.StripCommentsAndStrings(
+            "var firstTask = _dataService.GetOneAsync(await ResolveIdAsync());\n"
+            + "var secondTask = _dataService.GetTwoAsync(id);\n");
+
+        var deferred = DeferredReads(code);
+
+        Assert.True(deferred.Length == 2, $"{deferred.Length} deferred read(s) parsed, not 2");
+
+        Assert.True(
+            ConcurrentRun(code, deferred) >= 2,
+            "an await inside the first call's own arguments broke the run, so a real fan-out reads as "
+            + "sequential — the window is being measured from the match end instead of the statement end");
+    }
+
+    /// <summary>
+    /// An <c>await</c> genuinely BETWEEN the two statements does sequence them: the first task is finished
+    /// before the second starts, so nothing is in flight together and this is not a fan-out.
+    /// </summary>
+    [Fact]
+    public void TheDeferredRun_IsBrokenByAnAwaitBetweenTheTwoStatements()
+    {
+        var code = CSharpSourceWalker.StripCommentsAndStrings(
+            "var firstTask = _dataService.GetOneAsync(id);\n"
+            + "var first = await firstTask;\n"
+            + "var secondTask = _dataService.GetTwoAsync(id);\n"
+            + "var second = await secondTask;\n");
+
+        var deferred = DeferredReads(code);
+
+        Assert.True(deferred.Length == 2, $"{deferred.Length} deferred read(s) parsed, not 2");
+
+        Assert.True(
+            ConcurrentRun(code, deferred) < 2,
+            "start-await-start-await read as a fan-out; the window has been widened past the intervening "
+            + "await and the shape is now over-reported");
+    }
+
+    /// <summary>
+    /// A deferred read nested inside an earlier statement — a task started in a lambda handed to another
+    /// started task — does not index the window backwards. No site in this project is written that way; the
+    /// naive form throws rather than mis-reporting, so it is pinned rather than left to appear.
+    /// </summary>
+    [Fact]
+    public void TheDeferredRun_SurvivesAStartNestedInsideAnEarlierStatement()
+    {
+        var code = CSharpSourceWalker.StripCommentsAndStrings(
+            "var outerTask = _dataService.RunAsync(() => { var innerTask = _dataService.GetOneAsync(id); return innerTask; });\n");
+
+        var deferred = DeferredReads(code);
+
+        Assert.True(deferred.Length == 2, $"{deferred.Length} deferred read(s) parsed, not 2");
+        Assert.True(deferred[0].End > deferred[1].Index, "the fixture no longer nests, so it pins nothing");
+
+        /* The assertion is that this returns at all. */
+        Assert.True(ConcurrentRun(code, deferred) >= 1);
     }
 
     /// <summary>
@@ -827,9 +896,17 @@ public sealed class ViewerCommandTimeoutTests
     }
 
     /// <summary>
-    /// The longest run of deferred reads with no <c>await</c> between consecutive members of the run — the
-    /// number actually in flight together. Two starts either side of an <c>await</c> are sequential and
-    /// must not count; see <see cref="TheFanOutCensus_RecognisesEachShape_AndOnlyThose"/>.
+    /// The longest run of deferred reads with no <c>await</c> between consecutive STATEMENTS of the run —
+    /// the number actually in flight together. Two starts either side of an <c>await</c> are sequential and
+    /// must not count; see <see cref="TheDeferredRun_IsBrokenByAnAwaitBetweenTheTwoStatements"/>.
+    ///
+    /// <para><b>The window starts at the end of the previous STATEMENT, not at the end of its regex
+    /// match.</b> <see cref="s_deferredRead"/> ends on the call's opening paren, so a window measured from
+    /// there spans the rest of that call's own argument list — and an <c>await</c> in those arguments
+    /// (<c>var t1 = FooAsync(await Bar());</c>) would break the run and silently drop a real fan-out. That
+    /// is #3019's own failure inside the detector for it, and it applied to all 63 deferred sites in the
+    /// project rather than to an edge case. <see cref="DeferredReads"/> therefore carries the statement end.
+    /// Found in review.</para>
     /// </summary>
     private static int ConcurrentRun(string code, (int Index, int End)[] deferred)
     {
@@ -839,12 +916,47 @@ public sealed class ViewerCommandTimeoutTests
 
         foreach (var (index, end) in deferred)
         {
-            run = previousEnd >= 0 && !s_await.IsMatch(code[previousEnd..index]) ? run + 1 : 1;
+            if (previousEnd < 0)
+            {
+                run = 1;
+            }
+            else
+            {
+                /* previousEnd can sit PAST the next start, when that start is nested inside the previous
+                   statement — a task started inside a lambda handed to another. There is no "between" to
+                   scan and both are in flight, so the run continues rather than indexing backwards, which
+                   would throw. */
+                var between = previousEnd <= index ? code[previousEnd..index] : string.Empty;
+
+                run = s_await.IsMatch(between) ? 1 : run + 1;
+            }
+
             best = System.Math.Max(best, run);
-            previousEnd = end;
+
+            /* Monotonic, so a nested statement's earlier end cannot rewind the enclosing one's. */
+            previousEnd = System.Math.Max(previousEnd, end);
         }
 
         return best;
+    }
+
+    /// <summary>
+    /// Every deferred read in <paramref name="code"/>, each carrying the end of the STATEMENT it starts
+    /// rather than the end of its match. Shared by the sweep and its fixtures deliberately: a fixture
+    /// computing the window differently from the sweep would pin a property the sweep does not have.
+    /// </summary>
+    private static (int Index, int End)[] DeferredReads(string code)
+    {
+        return s_deferredRead.Matches(code)
+            .Select(match =>
+            {
+                /* The match ends ON the opening paren, which is what EndOfParenthesisedStatement wants;
+                   it counts parens, so a lambda argument cannot terminate the statement early. */
+                var end = EndOfParenthesisedStatement(code, match.Index + match.Length - 1);
+
+                return (match.Index, End: end < 0 ? match.Index + match.Length : end);
+            })
+            .ToArray();
     }
 
     /// <summary>

--- a/Darling/Darling.Tests/ViewerCommandTimeoutTests.cs
+++ b/Darling/Darling.Tests/ViewerCommandTimeoutTests.cs
@@ -104,9 +104,17 @@ public sealed class ViewerCommandTimeoutTests
     /// A task STARTED into a local without being awaited there — <c>var t = SomethingAsync();</c>. Two of
     /// these with no <c>await</c> between them is the same fan-out as <c>Task.WhenAll(t1, t2)</c>, written
     /// with the awaits one per line instead of joined.
+    ///
+    /// <para><b>A bare <c>_</c> is excluded from the name, so this shape and
+    /// <see cref="s_fireAndForget"/> stay disjoint.</b> <c>var _ = SomeAsync();</c> would otherwise satisfy
+    /// both — <c>_</c> is a legal name here, and the discard scan matches the same characters — and one
+    /// physical call would be counted into two different fan-out tallies, pairing against an unrelated
+    /// deferred start on one side and an unrelated discard on the other. It belongs to the DISCARD shape:
+    /// nothing holds the task, which is what a discard is. No site in this project spells it that way
+    /// today. Pinned by <see cref="TheDiscardAndDeferredShapes_StayDisjoint"/>. Found in review.</para>
     /// </summary>
     private static readonly Regex s_deferredRead = new(
-        @"(^|[^A-Za-z0-9_])(?:var|Task(?:\s*<[^;={}]*>)?)\s+[A-Za-z_][A-Za-z0-9_]*\s*=\s*[A-Za-z_][A-Za-z0-9_\.]*Async\s*\(",
+        @"(^|[^A-Za-z0-9_])(?:var|Task(?:\s*<[^;={}]*>)?)\s+(?!_\s*=)[A-Za-z_][A-Za-z0-9_]*\s*=\s*[A-Za-z_][A-Za-z0-9_\.]*Async\s*\(",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     /// <summary>An <c>await</c> as a keyword, not as part of a longer identifier.</summary>
@@ -116,12 +124,31 @@ public sealed class ViewerCommandTimeoutTests
 
     /// <summary>
     /// A member declaration with a body — accessibility, optional modifiers, return type, name, parameter
-    /// list, open brace. The unit fan-outs are paired within: see
+    /// list, an optional generic constraint clause, open brace. The unit fan-outs are paired within: see
     /// <see cref="EveryViewerFanOut_DeclaresItsWidth"/> for why the enclosing BLOCK is the wrong unit.
+    ///
+    /// <para><b>A generic method needs BOTH halves, and the constraint clause is only the visible one.</b>
+    /// Its type parameters sit between the NAME and the parameter list, and its constraints sit between the
+    /// parameter list and the BODY, so a tail of <c>\)\s*\{</c> against a bare name drops the member
+    /// entirely. Three are shaped that way today — <c>ViewerSettingsFile.Load&lt;T&gt;</c> and
+    /// <c>Save&lt;T&gt;</c>, and <c>SettingsWindow.TryReadSectionAsync&lt;T&gt;</c>. None holds a fan-out
+    /// marker, so the walk stayed green while seeing less than it claimed; the first one to grow a marker
+    /// would have tripped the unattributed assertion rather than being reported as an offender, which is a
+    /// confusing red rather than the useful one.</para>
+    ///
+    /// <para><b>The type-parameter group excludes <c>=</c> and newlines, which is load-bearing.</b> Allowing
+    /// them let it run from a field's declared type through <c>= new Dictionary&lt;...&gt;(comparer)</c> to
+    /// the collection initializer's brace, reading <c>CollectorSchedulePresets.Presets</c> — a field — as a
+    /// method whose body is the initializer. A phantom body is worse than a missing one here: <see
+    /// cref="Owner"/> takes the OUTERMOST match, so one could swallow a real member's markers and attribute
+    /// them to something that can never declare a width. Measured while widening this pattern, not
+    /// hypothesised. Pinned by <see cref="TheMemberWalk_SeesAGenericMethodWithAConstraintClause"/>.
+    /// Found in review.</para>
     /// </summary>
     private static readonly Regex s_memberSignature = new(
         @"(?:private|public|protected|internal)(?:\s+(?:static|async|override|virtual|sealed|new|partial|unsafe|extern))*"
-        + @"\s+[A-Za-z_][A-Za-z0-9_<>,\.\[\]\?\s]*?\s(?<name>[A-Za-z_][A-Za-z0-9_]*)\s*\([^;{}]*\)\s*\{",
+        + @"\s+[A-Za-z_][A-Za-z0-9_<>,\.\[\]\?\s]*?\s(?<name>[A-Za-z_][A-Za-z0-9_]*)"
+        + @"\s*(?:<[^;{}()=\n]*>)?\s*\([^;{}]*\)\s*(?:where\s[^{};]*)?\{",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     /// <summary>
@@ -557,7 +584,7 @@ public sealed class ViewerCommandTimeoutTests
            stopped matching (every fan-out then sits in no member and the sweep asserts over nothing); the
            fan-out floor catches the sweep reading an empty or wrong directory; the attribution floor
            catches a member walk that reads the project but drops the members the fan-outs are in. 21
-           fan-outs across 1,231 member bodies in 191 files when this landed. */
+           fan-outs across 1,234 member bodies in 191 files when this landed. */
         Assert.True(members >= 900, $"the member walk found only {members} member bodies — it is not reading the project");
 
         Assert.True(fanOuts >= 15, $"the fan-out census matched only {fanOuts} fan-out(s) — the sweep is not reading the project");
@@ -658,6 +685,101 @@ public sealed class ViewerCommandTimeoutTests
         var isFanOut = joins.Length > 0 || discards.Length >= 2 || ConcurrentRun(code, deferred) >= 2;
 
         Assert.Equal(expectedFanOut, isFanOut);
+    }
+
+    /// <summary>
+    /// The member walk sees a generic method: type parameters after the name, constraints before the body.
+    /// A member the walk cannot see cannot be required to declare a width, which is #3019's failure
+    /// reproduced inside the fix for it.
+    ///
+    /// <para><b>The constraint is spelled WITHOUT parentheses on purpose.</b> <c>where T : class, new()</c>
+    /// contains a <c>)</c>, and the parameter-list group is greedy, so it absorbs the whole clause and the
+    /// fixture then matches even with constraint support removed — it passes for the wrong reason. The real
+    /// <c>SettingsWindow.TryReadSectionAsync&lt;T&gt;</c> is <c>where T : class</c>, paren-free, which is
+    /// the shape that actually needs the clause admitted. The <c>new()</c> spelling is pinned separately
+    /// below so both live layouts are covered. Found by a mutation that stayed green.</para>
+    /// </summary>
+    [Theory]
+    /* Paren-free constraint — SettingsWindow.TryReadSectionAsync<T>. Sensitive to the constraint clause. */
+    [InlineData("private static async Task<T?> TryReadSectionAsync<T>(Func<Task<T?>> read) where T : class\n", "TryReadSectionAsync")]
+    /* Constraint on its own line, with new() — ViewerSettingsFile.Load<T> and Save<T>. */
+    [InlineData("internal static SettingsObjectRead<T> Load<T>(string filePath, JsonSerializerOptions options)\n    where T : class, new()\n", "Load")]
+    /* No constraint, type parameters only. */
+    [InlineData("private static Task<T> PassThroughAsync<T>(Task<T> inner)\n", "PassThroughAsync")]
+    public void TheMemberWalk_SeesAGenericMethod(string signature, string expectedName)
+    {
+        var code = CSharpSourceWalker.StripCommentsAndStrings(
+            signature
+            + "{\n"
+            + "    var firstTask = _dataService.GetOneAsync();\n"
+            + "    var secondTask = _dataService.GetTwoAsync();\n"
+            + "    return await firstTask ?? await secondTask;\n"
+            + "}\n");
+
+        var bodies = MemberBodies(code);
+
+        Assert.True(bodies.Count == 1, $"the generic signature parsed to {bodies.Count} member bodies, not 1");
+        Assert.Equal(expectedName, bodies[0].Name);
+
+        /* And the fan-out inside it is attributed to that member rather than landing nowhere. */
+        var deferred = s_deferredRead.Matches(code).Select(m => (m.Index, End: m.Index + m.Length)).ToArray();
+
+        Assert.True(deferred.Length == 2, $"{deferred.Length} deferred read(s) parsed out of the fixture, not 2");
+        Assert.All(deferred, d => Assert.NotNull(Owner(bodies, d.Index)));
+        Assert.True(ConcurrentRun(code, deferred) >= 2, "the generic method's deferred pair did not read as a fan-out");
+    }
+
+    /// <summary>
+    /// A FIELD whose initializer is a collection initializer is not a member body. The type-parameter group
+    /// excludes <c>=</c> and newlines to keep it that way: allowing them ran the pattern from the field's
+    /// declared type, through <c>= new Dictionary&lt;...&gt;(comparer)</c>, to the initializer's brace.
+    ///
+    /// <para>A phantom body is worse than a missing one. <see cref="Owner"/> takes the OUTERMOST match, so
+    /// one spanning an initializer could swallow a real member's markers and attribute them to something
+    /// that can never declare a width — a fan-out reported at a line where no edit makes the build pass.
+    /// This is <c>CollectorSchedulePresets.Presets</c>'s real shape.</para>
+    /// </summary>
+    [Fact]
+    public void TheMemberWalk_DoesNotReadAFieldInitializerAsAMember()
+    {
+        var code = CSharpSourceWalker.StripCommentsAndStrings(
+            "public static readonly IReadOnlyDictionary<string, IReadOnlyDictionary<string, int>> Presets =\n"
+            + "    new Dictionary<string, IReadOnlyDictionary<string, int>>(StringComparer.OrdinalIgnoreCase)\n"
+            + "    {\n"
+            + "        [\"Aggressive\"] = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)\n"
+            + "        {\n"
+            + "            [\"wait_stats\"] = 1,\n"
+            + "        },\n"
+            + "    };\n");
+
+        var bodies = MemberBodies(code);
+
+        Assert.True(
+            bodies.Count == 0,
+            "a field's collection initializer parsed as "
+            + $"{bodies.Count} member body(ies) ({string.Join(", ", bodies.Select(b => b.Name))}); Owner takes the "
+            + "outermost body, so a phantom one here would claim a real member's fan-out markers");
+    }
+
+    /// <summary>
+    /// The discard and deferred shapes never both claim one call. <c>var _ = SomeAsync();</c> is a DISCARD —
+    /// nothing holds the task — and counting it twice would let one physical call inflate two separate
+    /// fan-out tallies.
+    /// </summary>
+    [Fact]
+    public void TheDiscardAndDeferredShapes_StayDisjoint()
+    {
+        var code = CSharpSourceWalker.StripCommentsAndStrings("var _ = RefreshServerStatusAsync();\n");
+
+        Assert.True(s_fireAndForget.Matches(code).Count == 1, "the discard shape did not claim `var _ = SomeAsync();`");
+        Assert.True(s_deferredRead.Matches(code).Count == 0, "the deferred shape also claimed `var _ = SomeAsync();`, so one call is double-booked");
+
+        /* The ordinary deferred spelling still reads as deferred and NOT as a discard, so the exclusion
+           above narrowed the right one. */
+        var named = CSharpSourceWalker.StripCommentsAndStrings("var statusTask = RefreshServerStatusAsync();\n");
+
+        Assert.True(s_deferredRead.Matches(named).Count == 1, "the deferred shape stopped matching a named task start");
+        Assert.True(s_fireAndForget.Matches(named).Count == 0, "the discard shape claimed a named task start");
     }
 
     /// <summary>

--- a/Darling/Darling.Tests/ViewerCommandTimeoutTests.cs
+++ b/Darling/Darling.Tests/ViewerCommandTimeoutTests.cs
@@ -80,6 +80,21 @@ public sealed class ViewerCommandTimeoutTests
     /// cannot spell is a name they do not need. This is a project-wide census, and a census blind to
     /// <c>_ = Controller.ReadAsync();</c> would report a clean sweep over a shape it never looked at —
     /// which is the #3019 failure one level down.</para>
+    ///
+    /// <para><b>Unconstrained about the callee, unlike <see cref="s_deferredRead"/>, and that asymmetry is
+    /// a deliberate trade in BOTH directions.</b> Requiring an <c>Async</c> suffix here is not available:
+    /// three of this project's fifteen discarded call names are genuinely async without it —
+    /// <c>OpenPlanTab</c> (<c>private async Task</c>), <c>OnHeatmapDrillDown</c> and
+    /// <c>PlanViewerController.LoadPlanIntoSubTab</c> — so the suffix rule would reintroduce exactly the
+    /// silent gap #3019 is about. The cost paid instead is a false-positive path: <c>_ =</c> compiles for
+    /// any non-void call, so two discarded SYNCHRONOUS helpers in one member read as a two-wide fan-out and
+    /// would be asked for a width they do not need. Nothing in this project does that today (every
+    /// <c>_ = X(...)</c> site is a Task-returning call), the direction is a loud failure rather than a
+    /// silent one, and the shape is pinned in
+    /// <see cref="TheFanOutCensus_RecognisesEachShape_AndOnlyThose"/> so it reads as a known cost rather
+    /// than a surprise. The deferred rule can afford the suffix because its shape —
+    /// <c>var t = Call();</c> with no <c>await</c> — is otherwise indistinguishable from ordinary local
+    /// assignment, which is most lines in the project.</para>
     /// </summary>
     private static readonly Regex s_fireAndForget = new(
         @"(^|[^A-Za-z0-9_])_\s*=\s*[A-Za-z_][A-Za-z0-9_\.]*\s*\(",
@@ -452,6 +467,10 @@ public sealed class ViewerCommandTimeoutTests
     /// the positional residual, narrowed from per-file to per-member but not eliminated.</item>
     /// <item>Reads reached through a helper the member CALLS rather than fires are the helper's fan-out,
     /// not the caller's.</item>
+    /// <item>The deferred run is broken by any <c>await</c> between two starts, including one nested inside
+    /// a lambda rather than sequencing the starts at member level. That direction UNDER-reports — the same
+    /// direction as #3019 itself — and is left because the joined and fire-and-forget rules overlap it and
+    /// no member in this project is written that way; a depth-aware run would be the fix if one appears.</item>
     /// <item>Concurrency primitives this project does not use, pinned absent by
     /// <see cref="NoUnmodelledConcurrencyPrimitive_ReachesTheViewer"/> so that adding one goes red here
     /// rather than quietly widening this gap.</item>
@@ -620,6 +639,11 @@ public sealed class ViewerCommandTimeoutTests
     [InlineData("_ = RefreshServerStatusAsync();\nawait RefreshVisibleAsync();\n_ = PollAlertsAsync();\n", true)]
     /* Prose cannot make a fan-out. */
     [InlineData("/* two reads: _ = OneAsync(); _ = TwoAsync(); */\n", false)]
+    /* Two SYNCHRONOUS discards read as a fan-out — the accepted cost of not constraining the callee, and
+       the reason that trade is argued on s_fireAndForget rather than left to be rediscovered. Expected
+       true: this is the classifier's behaviour, not a defect to be fixed by narrowing the shape. Found in
+       review. */
+    [InlineData("_ = TryParseFirst(out var first);\n_ = TryParseSecond(out var second);\n", true)]
     public void TheFanOutCensus_RecognisesEachShape_AndOnlyThose(string body, bool expectedFanOut)
     {
         var code = CSharpSourceWalker.StripCommentsAndStrings("private async Task Fixture()\n{\n" + body + "}\n");

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
@@ -1898,6 +1898,9 @@ public partial class MainWindow : Window
            _minimizeToTray live). Minimize-to-tray is viewer-local (the reloaded file); the alerts-master +
            "Tray notification cooldown" the window just wrote to the STORE are re-read from there. */
         _minimizeToTray = reloaded.MinimizeToTray;
+        /* The toast-settings read and the display-mode tab reload below are both fired unawaited, so they
+           are in flight together whenever the mode changed. */
+        using var readFanOut = ViewerReadFanOut.Of(2);
         _ = RefreshAlertToastSettingsFromStoreAsync();
         /* Re-apply the fleet refresh interval to the live shell timers so a change takes effect immediately
            (the connection timeout is a connect-time setting and applies on the next viewer launch). */

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Blocking.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Blocking.cs
@@ -134,6 +134,9 @@ public partial class ViewerServerTab
         switch (BlockingSubTabs.SelectedIndex)
         {
             case BlockingTrendsSubTabIndex:
+            {
+                using var readFanOut = ViewerReadFanOut.Of(3);
+
                 var lockWaitTask = _dataService.GetLockWaitTrendAsync(_server.ServerId, startUtc, endUtc);
                 var blockingTask = _dataService.GetBlockingTrendAsync(_server.ServerId, startUtc, endUtc, databaseNames: SelectedDatabaseFilter);
                 var deadlockTask = _dataService.GetDeadlockTrendAsync(_server.ServerId, startUtc, endUtc);
@@ -144,7 +147,11 @@ public partial class ViewerServerTab
                 RenderBlockingTrendChart(blocking);
                 RenderDeadlockTrendChart(deadlocks);
                 break;
+            }
             case BlockingStatsSubTabIndex:
+            {
+                using var readFanOut = ViewerReadFanOut.Of(3);
+
                 /* Blocking SEVERITY: the duration aggregate reconciles with the count trend (same XE→DMV
                    source selection); the deadlock COUNT is the cheap sibling of the Trends tab's deadlock
                    trend, summed here for the summary strip. The deadlock SEVERITY aggregate (victim_count +
@@ -162,7 +169,11 @@ public partial class ViewerServerTab
                 RenderDeadlockTotalWaitChart(deadlockSeverity);
                 UpdateBlockingStatsSummary(durationStats, deadlockCounts, deadlockSeverity);
                 break;
+            }
             case BlockingCurrentWaitsSubTabIndex:
+            {
+                using var readFanOut = ViewerReadFanOut.Of(2);
+
                 var durationTask = _dataService.GetWaitingTaskTrendAsync(_server.ServerId, startUtc, endUtc);
                 var blockedTask = _dataService.GetBlockedSessionTrendAsync(_server.ServerId, startUtc, endUtc, databaseNames: SelectedDatabaseFilter);
                 var duration = await durationTask;
@@ -170,6 +181,7 @@ public partial class ViewerServerTab
                 RenderCurrentWaitsDurationChart(duration);
                 RenderCurrentWaitsBlockedChart(blocked);
                 break;
+            }
             case BlockedProcessReportsSubTabIndex:
                 await LoadBlockedProcessReportsAsync(startUtc, endUtc);
                 break;

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Charts.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Charts.cs
@@ -119,6 +119,7 @@ public partial class ViewerServerTab : IDisposable
         var (startUtc, endUtc) = GetWindowUtc();
 
         /* Both reads run concurrently — NpgsqlDataSource pools a connection for each. */
+        using var readFanOut = ViewerReadFanOut.Of(2);
         var trendTask = _dataService.GetTempDbTrendAsync(_server.ServerId, startUtc);
         var fileIoTask = _dataService.GetTempDbFileIoTrendAsync(_server.ServerId, startUtc);
         var trend = await trendTask;

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.RunningJobs.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.RunningJobs.cs
@@ -30,6 +30,7 @@ public partial class ViewerServerTab
     /// </summary>
     private async Task LoadRunningJobsAsync()
     {
+        using var readFanOut = ViewerReadFanOut.Of(2);
         var jobsTask = _dataService.GetRunningJobsAsync(_server.ServerId);
         var statusTask = _dataService.GetLatestRunningJobsCollectorStatusAsync(_server.ServerId);
         var jobs = await jobsTask;


### PR DESCRIPTION
Closes #3019. Closing keywords are a no-op on a `dev` merge, so this is stated rather than relied on.

## The defect

`EveryViewerFanOut_DeclaresItsWidth` iterated `Task.WhenAll` matches and added offenders only inside that loop. A fan-out that never joins therefore contributed zero iterations and could not be reported however wrong it was — while being the very shape whose discovery took #3007's census from one site to seventeen. The guard's claim was "every joined fan-out", and its name said otherwise.

## What changed

A fan-out is N reads in flight together, not a syntax. This project spells that three ways, and the census now recognises all three:

- **Joined** — `await Task.WhenAll(...)`. One occurrence makes the member a fan-out.
- **Fire-and-forget** — two or more `_ = SomethingAsync();`. One is the project's ordinary single-flight-guarded refresh (27 such sites, none of them fan-outs); two is a fan-out, because a discarded task has nobody to await it and is still running when the next starts. That is also why an `await` between two discards does not separate them.
- **Deferred** — two or more `var t = SomethingAsync();` starts with no `await` between them. Semantically the joined form with the awaits written one per line.

Each is paired against a declaration in the same **member body**, which replaces the per-file positional count. That count let declarations launder across unrelated members: `MainWindow.xaml.cs` carries several declarations against one join, so the declaration that actually paired with that join could be deleted while two unrelated unjoined ones covered for it. Member-body pairing is also immune to the nesting that defeats same-block pairing — `CorrelatedTimelineLanesControl` declares its width in an outer `try` and awaits the join in a nested one, and both are the same member.

`NoUnmodelledConcurrencyPrimitive_ReachesTheViewer` pins `Task.WhenAny`, `Parallel.For`/`Invoke`, `Task.Factory` and `ContinueWith` absent from the project. That is what lets the census claim "every" rather than "every one of three spellings": a fan-out spelled with one of those goes red here rather than quietly widening the gap.

## The widened census reports four undeclared fan-outs

These are live, not latent. Three spell the fan-out as deferred task starts and **each already carried a doc comment stating the reads run concurrently**; the fourth fires two unawaited reads.

| Member | Shape | Reads |
| --- | --- | --- |
| `ViewerServerTab.Blocking.LoadBlockingAsync` | deferred, three `switch` cases | 3 / 3 / 2 |
| `ViewerServerTab.Charts.LoadTempDbAsync` | deferred | 2 |
| `ViewerServerTab.RunningJobs.LoadRunningJobsAsync` | deferred | 2 |
| `MainWindow.SettingsButton_Click` | fire-and-forget | 2 |

Each now declares its width. The blocking cases take braces so each declares its own — the branches are mutually exclusive, and one method-level declaration would over-declare for the two branches that read solo, which `Of()`'s own summary calls the one way to misuse it. **The braces are required, not stylistic:** a `using var` directly in an unbraced `switch` section is CS8647, and the unbraced cases had also been sharing one declaration space. Behaviour is unchanged.

The failure direction was safe throughout: an undeclared fan-out clamps to `Math.Clamp(..., 1, ...)`, the solo floor, which is what these reads already got. So nothing regressed — the reads were priced against a ceiling derived from a read measured alone while running three-wide.

## What the census does NOT cover

Stated in the guard's own summary as well, because each gap is real:

- The declared **width** is not checked, only that a width is declared.
- Mutually exclusive branches count as one fan-out, so the rule over-reports rather than under-reports.
- Within one member, several independent fan-outs share the credit of a single declaration — the positional residual, narrowed from per-file to per-member but not eliminated. Measured, not assumed: deleting two of `LoadBlockingAsync`'s three declarations leaves this pin green, which is why all three are declared by hand rather than left to the guard to demand.
- Reads reached through a helper the member *calls* rather than *fires* are the helper's fan-out, not the caller's.
- The deferred run is broken by any `await` between two starts, including one nested inside a lambda rather than sequencing the starts at member level. That direction **under**-reports — the same direction as the defect itself — and is left because the joined and fire-and-forget rules overlap it and no member is written that way today.
- The deferred rule keys on the `Async` suffix. Verified to hold for all 55 `Task`-returning `ViewerDataService` members, so it is a convention the rule leans on rather than an assumption about one file.

`NoFanOutScope_OutlivesItsJoin` remains join-only and now says so. "Outlives its join" needs a join to measure against, and `MainWindow.OnRefreshTimerTick` deliberately holds its scope to the end of the tick because the visible-tab load below really does contend with reads still in flight — so widening that scan would report a deliberate choice as a defect.

## The fire-and-forget shape is unconstrained about its callee, on purpose

Raised in review. The discard scan matches `_ = <anything>(...)` while the deferred scan requires an `Async` suffix. Requiring the suffix on discards is not available: `OpenPlanTab` (`private async Task`), `OnHeatmapDrillDown` and `PlanViewerController.LoadPlanIntoSubTab` are genuinely async without it, so the suffix rule would blind the census to three of the project's fifteen discarded call names — the same silent gap this PR exists to close.

The cost paid instead is a false-positive path: `_ =` compiles for any non-void call, so two discarded *synchronous* helpers in one member read as a two-wide fan-out. Nothing in the Viewer does that today (every `_ = X(...)` site is Task-returning). The shape is now a fixture asserting the classifier's actual behaviour, so it reads as a known cost rather than a surprise, and the trade is argued on the regex itself.

## The member walk was missing generic methods, and the two read shapes overlapped

Both raised in review, both fixed rather than documented, because both are the defect this PR exists to close reproduced one level up — a census that cannot see part of what it sweeps, staying green because that part happens to be empty.

**Generic methods.** The walk required a bare name before the parameter list and only whitespace before the body. A generic method satisfies neither: type parameters sit after the name, constraints sit before the body. Three members were dropped entirely — `ViewerSettingsFile.Load<T>` and `Save<T>`, `SettingsWindow.TryReadSectionAsync<T>`. The two halves are interdependent, measured on the project: admitting the constraint clause alone gains nothing, type parameters alone gain one, both together gain three. Member bodies go 1,231 → 1,234; the fan-out census is unchanged at 21.

The type-parameter group excludes `=` and newlines deliberately. Allowing them ran the pattern from a field's declared type, through `= new Dictionary<...>(comparer)`, to the collection initializer's brace — reading `CollectorSchedulePresets.Presets`, a field, as a method whose body is the initializer. A phantom body is worse than a missing one: `Owner` takes the outermost match, so one could swallow a real member's markers and report a fan-out at a line where no edit makes the build pass. Pinned.

**Overlapping shapes.** `var _ = SomeAsync();` satisfied both the discard and deferred patterns, so one physical call could be counted into two fan-out tallies. A bare `_` is now excluded from the deferred name, leaving the call to the discard shape — which is what it is, since nothing holds the task.

One of these pins first passed for the wrong reason and a mutation caught it: the generic fixture was spelled `where T : class, new()`, whose `)` the greedy parameter-list group absorbs, so it matched even with constraint support removed. The real member is paren-free `where T : class`. The fixture now uses that shape, and the `new()` layout is pinned separately.

## Why `unattributed: 0` is coverage rather than silence

The markers are matched against the file and attributed afterwards, not searched for inside each braced body. A marker nothing owns is therefore **reported**, not skipped. Scoped the other way round, a marker in a shape the walk cannot represent would never be looked at and the count would sit at zero *vacuously* while covering less.

That decides the expression-bodied join — `Task Both() => Task.WhenAll(a, b);` is a legal fan-out with no braced body at all, and this project has **378 expression-bodied members against 1,234 braced ones**, so the shape is ordinary rather than exotic. None holds a join today, and the census does not depend on that staying true: planting one produces a red build naming its line. Pinned by `TheCensus_ReportsAJoinInAMemberWithNoBracedBody`, which asserts the reporting path — the join is matched, nothing owns it, so the sweep lists it.

The load-bearing part is demonstrated rather than argued: planting an expression-bodied join *and* neutering the unattributed reporting leaves the suite **green** with an undeclared fan-out in the tree, which is exactly the vacuous zero. With reporting intact the same plant is red.

## The deferred window was measured from the wrong end

`s_deferredRead` ends on the call's opening paren, so the window `ConcurrentRun` scanned for an intervening `await` began *inside* the first call and covered the rest of its own argument list. An `await` in those arguments — `var t1 = FooAsync(await Bar());` — broke the run and dropped a real fan-out silently. That is this pin's own failure class inside the detector built for it, and the window was wrong at **all 63** deferred sites in the project rather than at an edge case. No site currently puts an `await` in its arguments, so the census is unchanged at 21 fan-outs and 0 offenders under either window.

`DeferredReads` now carries the end of the **statement**, via the paren-balanced `EndOfParenthesisedStatement` this file already used for the join scan, so a lambda argument cannot terminate it early. The sweep and its fixtures share that helper deliberately: a fixture computing the window differently from the sweep would pin a property the sweep does not have.

Measuring from the statement end introduces an ordering hazard the match end did not have. A deferred read nested inside an earlier statement — a task started in a lambda handed to another started task — puts the previous end *past* the next start, and the naive slice throws rather than mis-reporting. The window is clamped and the previous end kept monotonic.

Three pins rather than one, because measuring from the wrong end satisfies half the property, and the two halves must fail separately.

## Verification

Red-first, one mutation at a time, each restored byte-identical via `redproof.sh` with a content witness:

| Mutation | Expected | Result |
| --- | --- | --- |
| Undeclared **deferred-pair** fan-out planted in a fresh member — the shape the old guard could never see | red | red |
| Undeclared **discard-pair** fan-out planted in a fresh member | red | red |
| Delete the declaration that pairs with `MainWindow`'s only join | red | red |
| Delete one of the new blocking-case declarations | red | red |
| Plant `Task.WhenAny(` | red, via the primitive pin | red |
| Comment-only: fan-out shapes written as prose | green | green |
| Revert both halves of the member-signature widening | red | red (all 3 generic fixtures) |
| Revert only the constraint-clause half | red | red (only the paren-free fixture) |
| Re-admit `=` into the type-parameter group | red | red (field-initializer pin) |
| Drop the bare-`_` exclusion | red | red (disjointness pin) |
| Plant an expression-bodied join | red | red (unattributed, names the line) |
| Plant it **and** neuter unattributed reporting | green (the hazard) | green — the vacuous zero, demonstrated |
| Flip the expression-bodied pin's assertion | red | red |
| Revert the deferred window to the match end | red | red — *only* the own-arguments half |
| Stop honouring the intervening `await` | red | red — *only* the between-statements half |
| Drop the nesting clamp | red | red — only the nested pin |

The third mutation is the positional-residual evidence: run under the **old** k-th-join rule it reports green (two declarations precede the only join, and the rule required one), and under the new rule it is red.

The Windows-only suite cannot run on macOS, so the **real** `ViewerCommandTimeoutTests.cs` was compiled into a throwaway `net10.0` xunit v3 host with `<AssemblyName>Darling.Tests</AssemblyName>`, staged outside the tree, `<Compile Include>`-ing the real repo paths alongside the real `ViewerCommandDeadlines.cs` and `ViewerReadFanOut.cs`. Counts moved 32 → 42 across the change, so the assembly was not stale. `ViewerFleetTimerFanOutPositionTests`, `ViewerFleetTimerGuardTests`, `CommandDeadlineScannerAdoptionTests` and `FleetIdentifierScrubTests` were run against the same tree (52 total) because all four read files this diff touches. CI is the arbiter for the rest.

## CHANGELOG entry (not committed — for the coordinator to place)

```markdown
- Viewer fan-out width declarations are now censused by shape rather than by their `Task.WhenAll`, so a fan-out that fires its reads unawaited is covered; four such fan-outs were declaring no width and were reading against a solo-read ceiling ([#3019]).
```

```markdown
[#3019]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/3019
```
