### PR TITLE
Narrow the hourly refresh window and phase the refresh family across the hour (#3012)

### DIFF
--- a/Darling/Darling.Tests/QueryStoreBackfillTests.cs
+++ b/Darling/Darling.Tests/QueryStoreBackfillTests.cs
@@ -66,16 +66,43 @@ public sealed class QueryStoreBackfillTests
         Assert.Equal((from, to), QueryStoreBackfillState.MergeHole("garbage", from, to));
     }
 
+    /// <summary>
+    /// The backfill horizon is the SMALLER of two conditions that both have to hold, and #3012 is what made
+    /// them differ.
+    ///
+    /// <para>A slice lands rows at a BACKDATED <c>collection_time</c>, so two things must be true at the depth
+    /// it lands: raw retention must not immediately drop them, and the hourly aggregates must still
+    /// re-materialize the buckets it touched. The rollups are materialized-only — the watermark is a hard
+    /// partition, not a fallback — so a bucket the refresh window no longer covers keeps whatever it was
+    /// materialized with, and the backfilled rows become invisible to every window that routes at hourly grain
+    /// while still being visible at raw grain. A split between two tiers, not a delay.</para>
+    ///
+    /// <para><b>Why the old single-term form was not merely simpler.</b> It read
+    /// <c>Horizon == RetentionTierRouter.RawMaxAge</c>, and that was indistinguishable from correct only
+    /// because the hourly refresh window was ALSO 3 days: the retention term was standing in for the refresh
+    /// term. That is the coupling #3012 is about — the refresh window having to cover a depth retention chose,
+    /// so every retention increase silently bought more refresh cost. With the window now chosen against its
+    /// own cadence the two terms separate, and the refresh one is the binding one.</para>
+    ///
+    /// <para>The concrete value is pinned as well as the relationship, because the relationship alone would
+    /// hold under either treatment: 23 hours is the hourly window minus one refresh interval. Reverting the
+    /// window to 3 days makes it 71 hours; dropping the refresh term makes it 3 days. Both are red here.</para>
+    /// </summary>
     [Fact]
-    public void Horizon_IsDerivedFromTheRawTier_NotHandMaintained()
+    public void Horizon_IsTheSmallerOfTheRefreshWindowAndTheRawTier_NotEitherAlone()
     {
-        /* The backfill refuses to dig below the raw tier's read horizon: inside it, every CAGG's
-           3-day start_offset re-materializes backdated buckets and the 4-day raw retention cannot
-           immediately drop them; below it, neither holds (the issue's own staging boundary).
-           Derived so a retention change moves this automatically — the #1937 rule. */
-        Assert.Equal(RetentionTierRouter.RawMaxAge, QueryStoreBackfill.Horizon);
+        var refreshReach = TimescaleSupport.HourlyRefreshStartSpan - TimescaleSupport.HourlyRefreshScheduleSpan;
+
+        Assert.Equal(TimeSpan.FromHours(23), QueryStoreBackfill.Horizon);
+
+        Assert.True(QueryStoreBackfill.Horizon <= refreshReach,
+            "a slice below the depth the next hourly refresh still reaches lands rows no rollup will ever materialize");
+        Assert.True(QueryStoreBackfill.Horizon <= RetentionTierRouter.RawMaxAge,
+            "a slice below the raw read horizon lands rows the next purge immediately drops");
         Assert.True(QueryStoreBackfill.Horizon < TimescaleSupport.RawRetentionSpan,
             "the backfill horizon must sit strictly inside raw retention, or a slice could land rows the next purge immediately drops");
+        Assert.True(QueryStoreBackfill.Horizon < TimescaleSupport.HourlyRefreshStartSpan,
+            "the horizon must sit strictly inside the refresh window: the window slides forward by one schedule interval between runs, so its own boundary is already outside it by the time the policy next fires");
     }
 
     [Fact]

--- a/Darling/Darling.Tests/QueryStoreBackfillTests.cs
+++ b/Darling/Darling.Tests/QueryStoreBackfillTests.cs
@@ -93,16 +93,43 @@ public sealed class QueryStoreBackfillTests
     {
         var refreshReach = TimescaleSupport.HourlyRefreshStartSpan - TimescaleSupport.HourlyRefreshScheduleSpan;
 
-        Assert.Equal(TimeSpan.FromHours(23), QueryStoreBackfill.Horizon);
+        Assert.Equal(TimeSpan.FromHours(23), QueryStoreBackfill.RollupStoreHorizon);
 
-        Assert.True(QueryStoreBackfill.Horizon <= refreshReach,
+        Assert.True(QueryStoreBackfill.RollupStoreHorizon <= refreshReach,
             "a slice below the depth the next hourly refresh still reaches lands rows no rollup will ever materialize");
-        Assert.True(QueryStoreBackfill.Horizon <= RetentionTierRouter.RawMaxAge,
+        Assert.True(QueryStoreBackfill.RollupStoreHorizon <= RetentionTierRouter.RawMaxAge,
             "a slice below the raw read horizon lands rows the next purge immediately drops");
-        Assert.True(QueryStoreBackfill.Horizon < TimescaleSupport.RawRetentionSpan,
+        Assert.True(QueryStoreBackfill.RollupStoreHorizon < TimescaleSupport.RawRetentionSpan,
             "the backfill horizon must sit strictly inside raw retention, or a slice could land rows the next purge immediately drops");
-        Assert.True(QueryStoreBackfill.Horizon < TimescaleSupport.HourlyRefreshStartSpan,
+        Assert.True(QueryStoreBackfill.RollupStoreHorizon < TimescaleSupport.HourlyRefreshStartSpan,
             "the horizon must sit strictly inside the refresh window: the window slides forward by one schedule interval between runs, so its own boundary is already outside it by the time the policy next fires");
+    }
+
+    /// <summary>
+    /// The refresh term applies only where there are rollups to fall out of.
+    ///
+    /// <para>TimescaleDB is optional and auto-detected, and plain PostgreSQL is a supported configuration
+    /// rather than a degraded one. On such a store every read goes to raw, so a backdated row cannot be
+    /// stranded outside a refresh window — and narrowing the horizon for that term anyway would have cost that
+    /// deployment mode two days of catch-up reach in exchange for nothing. #3012's change narrowed
+    /// unconditionally at first; this is the pin for the correction.</para>
+    ///
+    /// <para>Asserted as an INEQUALITY between the two horizons, not just as two values: the defect shape is
+    /// the plain store silently inheriting the rollup store's narrower reach, and that reads as equal
+    /// horizons. So a future change that collapses them back is red here even if both numbers move.</para>
+    /// </summary>
+    [Fact]
+    public void PlainPostgresHorizon_KeepsTheFullRawDepth_BecauseThereAreNoRollupsToFallOutOf()
+    {
+        Assert.Equal(RetentionTierRouter.RawMaxAge, QueryStoreBackfill.PlainStoreHorizon);
+        Assert.Equal(TimeSpan.FromDays(3), QueryStoreBackfill.PlainStoreHorizon);
+
+        Assert.True(QueryStoreBackfill.PlainStoreHorizon > QueryStoreBackfill.RollupStoreHorizon,
+            "a plain-PostgreSQL store must not inherit the rollup store's narrower reach — it has no rollups, so the refresh term does not apply to it");
+
+        /* The selector is what the slice path actually calls, so it is pinned rather than only the pair. */
+        Assert.Equal(QueryStoreBackfill.RollupStoreHorizon, QueryStoreBackfill.HorizonFor(hasContinuousAggregates: true));
+        Assert.Equal(QueryStoreBackfill.PlainStoreHorizon, QueryStoreBackfill.HorizonFor(hasContinuousAggregates: false));
     }
 
     [Fact]

--- a/Darling/Darling.Tests/TimescaleContinuousAggregateTests.cs
+++ b/Darling/Darling.Tests/TimescaleContinuousAggregateTests.cs
@@ -7,8 +7,10 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Text.RegularExpressions;
 using PerformanceMonitor.Analysis.Baselines;
 using PerformanceMonitor.Darling.Storage;
 using Xunit;
@@ -202,8 +204,8 @@ public sealed class TimescaleContinuousAggregateTests
                 StringComparison.Ordinal);
         }
 
-        /* The lock adjacency the convoy actually formed on: the hourly policies over the query_store_stats
-           family must not be coincident with each other. */
+        /* The lock adjacency the convoy actually formed on, named explicitly because it is the group the
+           production measurements were taken against. Generalized below; kept here as the measured case. */
         var family = new[]
         {
             TimescaleSupport.QueryStoreStatsHourlyView,
@@ -219,6 +221,77 @@ public sealed class TimescaleContinuousAggregateTests
         var anchored = TimescaleSupport.AddHourlyRefreshPolicySql(TimescaleSupport.QueryStatsHourlyView);
         Assert.Contains("now() AT TIME ZONE 'UTC'", anchored, StringComparison.Ordinal);
         Assert.DoesNotContain("date_trunc('hour', now())", anchored, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The grid's actual invariant, over EVERY contended relation rather than the one family the incident
+    /// evidence named.
+    ///
+    /// <para><b>Why the family-only check was not enough.</b> <c>collect.query_stats</c> — the other dominant
+    /// table — feeds THREE hourly policies: the query-grain rollup, the per-database rollup, and the
+    /// query_stats baseline. Their phases land on distinct minutes today, but only because of where they
+    /// happen to sit in <see cref="TimescaleSupport.HourlyRefreshPhaseOrder"/>. Phases collide whenever two
+    /// positions differ by a multiple of <see cref="TimescaleSupport.RefreshPhaseSlots"/>, so inserting one
+    /// aggregate ahead of the per-database rollup would silently put two <c>query_stats</c> refreshes back on
+    /// the same minute — the exact lock-queue adjacency this change exists to remove — and the family-only
+    /// assertion would have stayed green. Raised by review rather than found here.</para>
+    ///
+    /// <para><b>Contended relation, not source table.</b> Two hourly refreshes contend when one SELECTs from
+    /// what the other WRITES, so the group key is a view's immediate <c>FROM collect.&lt;x&gt;</c> — and a view
+    /// that is itself a source joins the group of its own consumers, because refreshing it writes the
+    /// materialization hypertable they read. That is why the corrected Query Store rollup and the interval
+    /// layer it reads are checked against each other and not merely against raw.</para>
+    ///
+    /// <para><b>Derived from the shipped CREATE text</b>, via
+    /// <see cref="TimescaleSupport.HourlyRefreshDefinitions"/>, so a new aggregate is covered the moment it is
+    /// registered. The extraction is asserted non-empty per view first: a regex that matched nothing would
+    /// group every view under "no source" and report a clean sweep for having checked nothing, which is the
+    /// failure mode a guard proving an absence has to rule out before its result means anything.</para>
+    /// </summary>
+    [Fact]
+    public void HourlyRefreshPhases_AreDistinctForEveryRelationTwoPoliciesContendFor()
+    {
+        var definitions = TimescaleSupport.HourlyRefreshDefinitions;
+        Assert.Equal(TimescaleSupport.HourlyRefreshPhaseOrder.Count, definitions.Count);
+
+        /* view -> the relation its own CREATE selects FROM. */
+        var sourceOf = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var (createSql, view) in definitions)
+        {
+            var match = Regex.Match(createSql, @"FROM\s+collect\.(\w+)", RegexOptions.IgnoreCase);
+            Assert.True(match.Success,
+                $"could not recover a source relation from {view}'s CREATE — the guard would group every view under one bucket and report a clean sweep having checked nothing");
+            sourceOf[view] = match.Groups[1].Value;
+        }
+
+        /* Positive control on the extraction itself, in the identical form: the two relations whose
+           multi-consumer shape this test exists for must both come back with the consumers we know they have.
+           A control that only proved "some regex matched something" would not exercise the case at issue. */
+        Assert.Equal(3, sourceOf.Count(kv => string.Equals(kv.Value, "query_stats", StringComparison.Ordinal)));
+        Assert.Equal(2, sourceOf.Count(kv => string.Equals(kv.Value, "query_store_stats", StringComparison.Ordinal)));
+
+        var views = new HashSet<string>(definitions.Select(a => a.View), StringComparer.Ordinal);
+
+        foreach (var relation in sourceOf.Values.Distinct(StringComparer.Ordinal))
+        {
+            /* Everything that reads the relation, plus the relation itself when it is an hourly view —
+               refreshing it WRITES what its consumers read. */
+            var contenders = sourceOf.Where(kv => string.Equals(kv.Value, relation, StringComparison.Ordinal))
+                .Select(kv => kv.Key)
+                .ToList();
+
+            if (views.Contains(relation))
+            {
+                contenders.Add(relation);
+            }
+
+            var phases = contenders.Select(TimescaleSupport.RefreshPhaseMinutesFor).ToArray();
+
+            Assert.True(
+                phases.Length == phases.Distinct().Count(),
+                $"two hourly refresh policies contending for collect.{relation} start on the same minute: "
+                + string.Join(", ", contenders.Zip(phases, (v, m) => $"{v}=:{m.ToString("00", CultureInfo.InvariantCulture)}")));
+        }
     }
 
     /// <summary>

--- a/Darling/Darling.Tests/TimescaleContinuousAggregateTests.cs
+++ b/Darling/Darling.Tests/TimescaleContinuousAggregateTests.cs
@@ -116,13 +116,149 @@ public sealed class TimescaleContinuousAggregateTests
     [Fact]
     public void ContinuousAggregatePolicy_IsTheConservativeHourlyShape_Idempotent()
     {
-        var sql = TimescaleSupport.AddContinuousAggregatePolicySql(TimescaleSupport.QueryStatsHourlyView);
+        var sql = TimescaleSupport.AddHourlyRefreshPolicySql(TimescaleSupport.QueryStatsHourlyView);
 
         Assert.Contains("add_continuous_aggregate_policy('collect.query_stats_hourly'", sql, StringComparison.Ordinal);
-        Assert.Contains("start_offset => INTERVAL '3 days'", sql, StringComparison.Ordinal);
         Assert.Contains("end_offset => INTERVAL '1 hour'", sql, StringComparison.Ordinal);
         Assert.Contains("schedule_interval => INTERVAL '1 hour'", sql, StringComparison.Ordinal);
         Assert.Contains("if_not_exists => true", sql, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// TREATMENT ONE of #3012, pinned ALONE so that reverting it is red here even if the stagger survives.
+    ///
+    /// <para>An hourly refresh's cost is set by the window it re-scans, and a 3-day window against a 4-day raw
+    /// retention re-materialized roughly three quarters of the hypertable every hour. Measured on the
+    /// production store: the heaviest hourly refresh ran 3,301-6,330 s against its own 1-hour cadence — 118-175%
+    /// of it, so each run started into the tail of the last — while rows arriving per hour FELL ~3x. On the
+    /// narrowed window the same refresh runs 864 s, 24% of cadence, which is what makes the overlap
+    /// structurally impossible rather than merely absent.</para>
+    ///
+    /// <para>Asserted for EVERY hourly view rather than the heavy one alone: the defect was a shared default,
+    /// so a fix that reached only the aggregate named in the incident would leave twelve behind.</para>
+    /// </summary>
+    [Fact]
+    public void HourlyRefreshWindow_IsOneDay_NotTheRawRetentionHorizon()
+    {
+        Assert.Equal("1 day", TimescaleSupport.HourlyRefreshStartOffset);
+        Assert.Equal(TimeSpan.FromDays(1), TimescaleSupport.HourlyRefreshStartSpan);
+        Assert.Equal("1 hour", TimescaleSupport.HourlyRefreshScheduleInterval);
+        Assert.Equal(TimeSpan.FromHours(1), TimescaleSupport.HourlyRefreshScheduleSpan);
+
+        foreach (var view in TimescaleSupport.HourlyRefreshPhaseOrder)
+        {
+            var sql = TimescaleSupport.AddHourlyRefreshPolicySql(view);
+
+            Assert.Contains("start_offset => INTERVAL '1 day'", sql, StringComparison.Ordinal);
+            Assert.DoesNotContain("start_offset => INTERVAL '3 days'", sql, StringComparison.Ordinal);
+        }
+
+        /* The window is now chosen against its own cadence, and raw retention only has to clear it — the
+           opposite of the dependency that made the refresh expensive, where the window had to cover a depth
+           retention chose. Both directions asserted so neither can be narrowed into the other. */
+        Assert.True(TimescaleSupport.HourlyRefreshStartSpan < TimescaleSupport.RawRetentionSpan,
+            "raw retention must outlive the hourly refresh window, or a drop outruns the aggregate meant to preserve it");
+        Assert.True(TimescaleSupport.HourlyRefreshScheduleSpan < TimescaleSupport.HourlyRefreshStartSpan,
+            "a refresh window narrower than its own cadence would leave buckets no run ever covers");
+    }
+
+    /// <summary>
+    /// TREATMENT TWO of #3012, pinned ALONE so that reverting it is red here even if the narrowing survives.
+    ///
+    /// <para>The heaviest hourly refresh is still ~33x its lightest sibling on the narrowed window, so 864 s
+    /// has to be invisible to everything else rather than merely short. Two things do that, and the second is
+    /// the less obvious one:</para>
+    ///
+    /// <para><b>Distinct minutes of the hour.</b> A refresh holds <c>AccessShareLock</c> on what it reads; a
+    /// compression policy on that same hypertable queues an <c>AccessExclusiveLock</c> request behind it; and a
+    /// QUEUED exclusive request blocks every subsequent shared request, so collector store-writes convoy behind
+    /// a lock nobody holds. Policies that share a hypertable therefore have to start at different times, which
+    /// is why the <c>query_store_stats</c> family's slots are asserted DISTINCT rather than merely present.</para>
+    ///
+    /// <para><b>A fixed schedule.</b> Naming <c>initial_start</c> is what switches TimescaleDB from
+    /// finish-to-start to start-to-start scheduling. Under finish-to-start, one bad hour phase-locks a family
+    /// permanently — the incident's three jobs, on unrelated schedules with very different workloads, finished
+    /// within 119 seconds of each other and then re-started together every hour after that. The offsets without
+    /// the fixed schedule would drift back into coincidence the first time a run overran.</para>
+    /// </summary>
+    [Fact]
+    public void HourlyRefreshPolicies_AreStaggeredAcrossTheHour_OnAFixedSchedule()
+    {
+        Assert.Equal(15, TimescaleSupport.RefreshPhaseStepMinutes);
+        Assert.Equal(4, TimescaleSupport.RefreshPhaseSlots);
+
+        /* Thirteen hourly refreshes: the six named rollups plus the seven baseline aggregates. */
+        Assert.Equal(13, TimescaleSupport.HourlyRefreshPhaseOrder.Count);
+
+        foreach (var view in TimescaleSupport.HourlyRefreshPhaseOrder)
+        {
+            var phase = TimescaleSupport.RefreshPhaseMinutesFor(view);
+            Assert.Contains(phase, new[] { 0, 15, 30, 45 });
+
+            var sql = TimescaleSupport.AddHourlyRefreshPolicySql(view);
+            Assert.Contains(
+                $"initial_start => date_trunc('hour', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' + INTERVAL '1 hour' + INTERVAL '{phase.ToString(CultureInfo.InvariantCulture)} minutes'",
+                sql,
+                StringComparison.Ordinal);
+        }
+
+        /* The lock adjacency the convoy actually formed on: the hourly policies over the query_store_stats
+           family must not be coincident with each other. */
+        var family = new[]
+        {
+            TimescaleSupport.QueryStoreStatsHourlyView,
+            TimescaleSupport.QueryStoreStatsIntervalHourlyView,
+            TimescaleSupport.QueryStoreStatsCorrectedHourlyView,
+        };
+
+        var slots = family.Select(TimescaleSupport.RefreshPhaseMinutesFor).ToArray();
+        Assert.Equal(slots.Length, slots.Distinct().Count());
+
+        /* UTC, not the session time zone: a bare date_trunc('hour', now()) lands off-grid on the half-hour and
+           quarter-hour zones, which is a store-wide silent skew rather than a local oddity. */
+        var anchored = TimescaleSupport.AddHourlyRefreshPolicySql(TimescaleSupport.QueryStatsHourlyView);
+        Assert.Contains("now() AT TIME ZONE 'UTC'", anchored, StringComparison.Ordinal);
+        Assert.DoesNotContain("date_trunc('hour', now())", anchored, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The phase grid is keyed on the VIEW, and nothing shipped carries a job id.
+    ///
+    /// <para>#3012's evidence names job ids in the 1050s. Those exist only on the store it was measured
+    /// against and would name entirely different jobs anywhere else, so a fix that encoded one would be
+    /// correct on exactly one deployment. The converge path recovers the view name with a join rather than
+    /// reading an id, because a refresh job's own <c>hypertable_name</c> is the aggregate's per-deployment
+    /// materialization hypertable.</para>
+    /// </summary>
+    [Fact]
+    public void RefreshPolicyIdentity_IsTheView_NeverAJobId()
+    {
+        var read = TimescaleSupport.ContinuousAggregateRefreshStateSql;
+
+        Assert.Contains("j.proc_name = 'policy_refresh_continuous_aggregate'", read, StringComparison.Ordinal);
+        Assert.Contains("ca.view_name", read, StringComparison.Ordinal);
+        Assert.Contains("ca.materialization_hypertable_name = j.hypertable_name", read, StringComparison.Ordinal);
+        Assert.Contains("ca.view_schema = 'collect'", read, StringComparison.Ordinal);
+
+        /* Compared as SECONDS, so '1 day' / '1 day 00:00:00' / '24:00:00' cannot read as a difference and
+           re-alter the same job on every start; and the phase read in UTC for the same reason the write is. */
+        Assert.Contains("EXTRACT(EPOCH FROM (j.config->>'start_offset')::interval)::bigint", read, StringComparison.Ordinal);
+        Assert.Contains("EXTRACT(MINUTE FROM j.initial_start AT TIME ZONE 'UTC')::int", read, StringComparison.Ordinal);
+
+        var write = TimescaleSupport.SetContinuousAggregateRefreshSql;
+
+        /* The job id reaches alter_job ONLY as a bound parameter, cast ::integer (the #1586 trap). */
+        Assert.Contains("j.job_id = $1::integer", write, StringComparison.Ordinal);
+        Assert.Contains("jsonb_set(j.config, '{start_offset}', to_jsonb($2::text))", write, StringComparison.Ordinal);
+        Assert.Contains("fixed_schedule => true", write, StringComparison.Ordinal);
+        Assert.Contains("initial_start =>", write, StringComparison.Ordinal);
+
+        /* Every un-named alter_job parameter means "leave unchanged", so the converge cannot arm a paused job
+           or retune a cadence. Naming `scheduled` here would weaken #1680's never-expose-an-armed-window
+           discipline through a path that has nothing to do with retention. */
+        Assert.DoesNotContain("scheduled =>", write, StringComparison.Ordinal);
+        Assert.DoesNotContain("schedule_interval =>", write, StringComparison.Ordinal);
+        Assert.DoesNotContain("next_start =>", write, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -204,16 +340,52 @@ public sealed class TimescaleContinuousAggregateTests
         Assert.Contains("WITH NO DATA", sql, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// The DAILY tier keeps its 3-day window and stays OFF the phase grid — the regression #3012 invites is a
+    /// tidy-up that makes every refresh window "consistent".
+    ///
+    /// <para>Narrowing this would trade nothing for a correctness risk. A daily job's 3-day window is 3 days
+    /// of scan against an 86,400-second cadence rather than a 3,600-second one, so it was never near its own
+    /// schedule interval and never appeared in the convoy; and the 3 days are the buffer
+    /// <see cref="TimescaleSupport.HourlyRetentionInterval"/> leans on, so the hourly rollups' drop at 90 days
+    /// can never outrun the daily aggregate meant to preserve that history.</para>
+    ///
+    /// <para><see cref="TimescaleSupport.RefreshPhaseMinutesFor"/> is asserted to THROW for every daily view,
+    /// which is what stops one being dragged onto the grid by a caller that only knows it has a view name.</para>
+    /// </summary>
     [Fact]
     public void DailyPolicy_UsesOneDayEndOffsetAndSchedule_KeepsThreeDayStart()
     {
-        var sql = TimescaleSupport.AddContinuousAggregatePolicySql(TimescaleSupport.QueryStatsDailyView, "1 day", "1 day");
+        Assert.Equal("3 days", TimescaleSupport.DailyRefreshStartOffset);
+        Assert.Equal(TimeSpan.FromDays(3), TimescaleSupport.DailyRefreshStartSpan);
 
-        Assert.Contains("add_continuous_aggregate_policy('collect.query_stats_daily'", sql, StringComparison.Ordinal);
-        Assert.Contains("start_offset => INTERVAL '3 days'", sql, StringComparison.Ordinal);
-        Assert.Contains("end_offset => INTERVAL '1 day'", sql, StringComparison.Ordinal);
-        Assert.Contains("schedule_interval => INTERVAL '1 day'", sql, StringComparison.Ordinal);
-        Assert.Contains("if_not_exists => true", sql, StringComparison.Ordinal);
+        foreach (var view in new[]
+        {
+            TimescaleSupport.QueryStatsDailyView,
+            TimescaleSupport.ProcedureStatsDailyView,
+            TimescaleSupport.QueryStoreStatsDailyView,
+            TimescaleSupport.QueryStoreStatsCorrectedDailyView,
+            TimescaleSupport.QueryStatsDbDailyView,
+            TimescaleSupport.QueryStoreStatsIntervalDailyView,
+            TimescaleSupport.QueryStoreStatsDayGrainDailyView,
+        })
+        {
+            var sql = TimescaleSupport.AddDailyRefreshPolicySql(view);
+
+            Assert.Contains($"add_continuous_aggregate_policy('collect.{view}'", sql, StringComparison.Ordinal);
+            Assert.Contains("start_offset => INTERVAL '3 days'", sql, StringComparison.Ordinal);
+            Assert.Contains("end_offset => INTERVAL '1 day'", sql, StringComparison.Ordinal);
+            Assert.Contains("schedule_interval => INTERVAL '1 day'", sql, StringComparison.Ordinal);
+            Assert.Contains("if_not_exists => true", sql, StringComparison.Ordinal);
+
+            /* No initial_start: the daily tier keeps TimescaleDB's finish-to-start scheduling, untouched. */
+            Assert.DoesNotContain("initial_start", sql, StringComparison.Ordinal);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => TimescaleSupport.RefreshPhaseMinutesFor(view));
+        }
+
+        Assert.True(TimescaleSupport.DailyRefreshStartSpan < TimescaleSupport.HourlyRetentionSpan,
+            "the hourly rollups' retention must outlive the daily refresh window, or a drop outruns the daily aggregate");
     }
 
     [Fact]
@@ -229,9 +401,11 @@ public sealed class TimescaleContinuousAggregateTests
     [Fact]
     public void RetentionTiers_RawFourDays_HourlyNinetyDays_StayPastTheNextRefreshWindow()
     {
-        /* The buffers the whole tiering rests on: raw's 4d stays past the hourly CAGG's 3d refresh start; the
-           hourly CAGGs' 90d stays past the daily CAGG's 3d refresh start. Either dropping below 3 days would let a
-           drop outrun the aggregate meant to preserve that history.
+        /* The buffers the whole tiering rests on: raw's 4d stays past the hourly CAGG's refresh start; the
+           hourly CAGGs' 90d stays past the daily CAGG's refresh start. Either horizon dropping below the
+           refresh window beneath it would let a drop outrun the aggregate meant to preserve that history —
+           asserted against the refresh constants themselves in HourlyRefreshWindow_IsOneDay_... and
+           DailyPolicy_UsesOneDayEndOffsetAndSchedule_..., so the pair cannot drift.
 
            The hourly number is 90 rather than 21 since #1937, and the reason is a READ one rather than a refresh
            one: the viewer offers month-plus windows, and at 21 days a 30-day view could not render at hourly

--- a/Darling/Darling.Tests/TimescaleContinuousAggregateTests.cs
+++ b/Darling/Darling.Tests/TimescaleContinuousAggregateTests.cs
@@ -237,6 +237,11 @@ public sealed class TimescaleContinuousAggregateTests
 
         Assert.Contains("j.proc_name = 'policy_refresh_continuous_aggregate'", read, StringComparison.Ordinal);
         Assert.Contains("ca.view_name", read, StringComparison.Ordinal);
+        /* BOTH identities, because timescaledb_information.jobs resolves a continuous-aggregate job back to
+           its USER VIEW rather than reporting the materialization hypertable the bgw_job row actually carries.
+           The materialization-only form read back nothing at all against a live store, so matching only the
+           name the catalog columns imply is the shape that already failed once. */
+        Assert.Contains("ca.view_name = j.hypertable_name", read, StringComparison.Ordinal);
         Assert.Contains("ca.materialization_hypertable_name = j.hypertable_name", read, StringComparison.Ordinal);
         Assert.Contains("ca.view_schema = 'collect'", read, StringComparison.Ordinal);
 

--- a/Darling/Darling.Tests/TimescaleSupportTests.cs
+++ b/Darling/Darling.Tests/TimescaleSupportTests.cs
@@ -1042,6 +1042,193 @@ AND   (proc_name LIKE '%compression%' OR proc_name LIKE '%columnstore%')", conne
         }
     }
 
+    /// <summary>
+    /// THE REFRESH-WINDOW PIN (#3012), live — the half that reaches already-deployed stores, which is the
+    /// only population the incident was reported from.
+    ///
+    /// <para><b>What it would mean for this test not to exist.</b>
+    /// <c>add_continuous_aggregate_policy(if_not_exists =&gt; true)</c> returns -1 against a policy the store
+    /// already has and changes nothing about it, so a store still on the 3-day window keeps re-materializing
+    /// three days every hour and the fix is INERT while the whole suite stays green. That failure direction is
+    /// worse than a red one, not milder: an inert fix with a passing suite is a fix nobody looks at again.
+    /// String-shape assertions on the SQL cannot see it, because they never run the statement.</para>
+    ///
+    /// <para><b>The four assumptions only a live store can settle</b>, all named as unverified when the change
+    /// was written: that <c>alter_job</c> takes <c>fixed_schedule</c> and <c>initial_start</c> together on this
+    /// runtime; that <c>jsonb_set</c> produces a <c>start_offset</c> TimescaleDB then honours; that the
+    /// <c>jobs</c> → <c>continuous_aggregates</c> join on materialization-hypertable schema/name recovers
+    /// <c>view_name</c> for a refresh policy; and that a policy CREATED with <c>initial_start</c> comes back
+    /// <c>fixed_schedule = true</c> — on which the converge's own no-op-ness rests, because a fresh store whose
+    /// jobs read <c>false</c> would be re-altered on every start forever.</para>
+    ///
+    /// <para><b>The fixed schedule is not a refinement.</b> Measured on the production store roughly two hours
+    /// after the offsets were applied by hand: every job read <c>fixed_schedule = f</c> and only one of six
+    /// hourly refreshes was still on the minute it was set to. TimescaleDB computes the next start from the
+    /// previous FINISH when <c>initial_start</c> is absent, so a hand-applied stagger decays back into
+    /// coincidence within hours — correct at apply time and gone by the afternoon. A stagger that drifts is not
+    /// a stagger, which is why <c>fixed_schedule</c> is asserted here rather than only the minute.</para>
+    /// </summary>
+    [Fact]
+    public async Task EndToEnd_HourlyRefreshWindow_ConvergesAThreeDayFinishToStartPolicy_AndLeavesTheDailyTierAlone_AgainstDevPostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string (with TimescaleDB installed) to run the live refresh-window converge test.");
+
+        var ct = TestContext.Current.CancellationToken;
+
+        using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(ct);
+        await PgMigrations.MigrateAsync(connection, ct);
+        Assert.True(await TimescaleSupport.TryEnableAsync(connection, null, ct),
+            "the dev fixture is expected to have TimescaleDB installed");
+        await TimescaleSupport.ConvertToHypertablesAsync(connection, null, ct);
+
+        /* Two REAL views, because the converge is scoped by membership of HourlyRefreshPhaseOrder and a
+           throwaway name would be skipped — which is a property worth having, and is asserted at the end. */
+        const string Hourly = TimescaleSupport.QueryStatsHourlyView;
+        const string Daily = TimescaleSupport.QueryStatsDailyView;
+
+        /* This test MUTATES the shared fixture's shape (creating the hourly/daily CAGGs changes compose's tier
+           routing), so it restores it: snapshot what already exists and drop only what it creates. */
+        var preexistingCaggs = await ExistingCaggsAsync(connection, ct);
+
+        var bodySucceeded = false;
+        try
+        {
+            var createLog = new CapturingTestLogger();
+            await TimescaleSupport.EnsureContinuousAggregatesAsync(connection, createLog, ct);
+
+            /* ---- (1) A policy as an OLDER BUILD left it: 3-day window, no initial_start. ---- */
+            await ExecAsync(connection, $"SELECT remove_continuous_aggregate_policy('collect.{Hourly}', if_exists => true)", ct);
+            await ExecAsync(connection,
+                $"SELECT add_continuous_aggregate_policy('collect.{Hourly}', start_offset => INTERVAL '3 days', end_offset => INTERVAL '1 hour', schedule_interval => INTERVAL '1 hour', if_not_exists => true)", ct);
+
+            var legacy = await RefreshPolicyStateAsync(connection, Hourly, ct);
+            Assert.NotNull(legacy);
+            Assert.Equal(TimeSpan.FromDays(3).TotalSeconds, legacy!.StartOffsetSeconds);
+
+            /* MEASURED, not assumed: omitting initial_start is what leaves a job on finish-to-start
+               scheduling, which is the mechanism by which the production store's hand-set offsets drifted. */
+            Assert.False(legacy.FixedSchedule,
+                "a policy created without initial_start is expected to be finish-to-start on this runtime");
+
+            /* ---- (2) The CREATE statement ALONE cannot fix it — if_not_exists skips outright. ---- */
+            await ExecAsync(connection, TimescaleSupport.AddHourlyRefreshPolicySql(Hourly), ct);
+            var afterCreate = await RefreshPolicyStateAsync(connection, Hourly, ct);
+            Assert.Equal(TimeSpan.FromDays(3).TotalSeconds, afterCreate!.StartOffsetSeconds);
+            Assert.False(afterCreate.FixedSchedule);
+
+            /* ---- (3) THE ASSERTION THE WHOLE CHANGE COMES DOWN TO: the deployed store converges. ---- */
+            var convergeLog = new CapturingTestLogger();
+            var converged = await TimescaleSupport.ConvergeContinuousAggregateRefreshAsync(connection, convergeLog, ct);
+            Assert.True(converged >= 1,
+                $"expected the 3-day finish-to-start policy on {Hourly} to be moved; {convergeLog.Joined}");
+
+            var moved = await RefreshPolicyStateAsync(connection, Hourly, ct);
+            Assert.NotNull(moved);
+            Assert.Equal(TimescaleSupport.HourlyRefreshStartSpan.TotalSeconds, moved!.StartOffsetSeconds);
+            Assert.True(moved.FixedSchedule,
+                $"the converge must pin the schedule, or the phase drifts back to coincidence within hours; {convergeLog.Joined}");
+            Assert.Equal(TimescaleSupport.RefreshPhaseMinutesFor(Hourly), moved.PhaseMinutes);
+
+            /* end_offset must survive untouched — the converge writes start_offset with jsonb_set against the
+               job's OWN config, so losing a sibling key here would mean it replaced the config wholesale. */
+            Assert.Equal(TimeSpan.FromHours(1), moved.EndOffset);
+
+            /* The rendered line names the view and the window it is on now, because that line IS the
+               operator's evidence the store changed. A structured-logging placeholder/argument mismatch would
+               render it wrong with no error anywhere — the one defect asserting on the return value cannot see. */
+            Assert.Contains($"moved {Hourly}'s refresh policy to a {TimescaleSupport.HourlyRefreshStartOffset} window",
+                convergeLog.Joined, StringComparison.Ordinal);
+
+            /* ---- (4) Idempotent: a converged store finds nothing, so this never churns alter_job. ---- */
+            Assert.Equal(0, await TimescaleSupport.ConvergeContinuousAggregateRefreshAsync(connection, null, ct));
+
+            /* ---- (5) The CREATE path on a store with no policy yet: both halves from the start. ---- */
+            await ExecAsync(connection, $"SELECT remove_continuous_aggregate_policy('collect.{Hourly}', if_exists => true)", ct);
+            await ExecAsync(connection, TimescaleSupport.AddHourlyRefreshPolicySql(Hourly), ct);
+
+            var fresh = await RefreshPolicyStateAsync(connection, Hourly, ct);
+            Assert.NotNull(fresh);
+            Assert.Equal(TimescaleSupport.HourlyRefreshStartSpan.TotalSeconds, fresh!.StartOffsetSeconds);
+            Assert.True(fresh.FixedSchedule,
+                "passing initial_start is expected to put the job on a fixed schedule; if it does not, the converge re-alters every hourly policy on every start");
+            Assert.Equal(TimescaleSupport.RefreshPhaseMinutesFor(Hourly), fresh.PhaseMinutes);
+
+            /* And therefore the converge is a no-op against a FRESH store too, not only a settled one. */
+            Assert.Equal(0, await TimescaleSupport.ConvergeContinuousAggregateRefreshAsync(connection, null, ct));
+
+            /* ---- (6) SCOPE: the DAILY tier keeps its 3-day window and its finish-to-start schedule. ---- */
+            var daily = await RefreshPolicyStateAsync(connection, Daily, ct);
+            Assert.NotNull(daily);
+            Assert.Equal(TimeSpan.FromDays(3).TotalSeconds, daily!.StartOffsetSeconds);
+            Assert.False(daily.FixedSchedule, "the daily tier is deliberately left on finish-to-start scheduling");
+
+            /* Deliberately AFTER a converge has run and reported 0: "the daily policy is still on 3 days" is
+               trivially true if the converge never looked at anything, so the check has to follow a pass that
+               did look at the hourly policies and chose not to touch this one. */
+            await ExecAsync(connection,
+                $@"SELECT alter_job(j.job_id, config => jsonb_set(j.config, '{{start_offset}}', to_jsonb('3 days'::text)))
+FROM timescaledb_information.jobs AS j
+JOIN timescaledb_information.continuous_aggregates AS ca
+  ON  ca.materialization_hypertable_schema = j.hypertable_schema
+  AND ca.materialization_hypertable_name = j.hypertable_name
+WHERE j.proc_name = 'policy_refresh_continuous_aggregate'
+AND   ca.view_schema = 'collect'
+AND   ca.view_name = '{Daily}'", ct);
+
+            Assert.Equal(TimeSpan.FromDays(3).TotalSeconds,
+                (await RefreshPolicyStateAsync(connection, Daily, ct))!.StartOffsetSeconds);
+
+            bodySucceeded = true;
+        }
+        finally
+        {
+            await LiveStoreCleanup.RunAsync(connectionString!, bodySucceeded, async (cleanup, cleanupCt) =>
+                await new LiveCleanupBatch(cleanup).DropContinuousAggregatesAsync(
+                    (await ExistingCaggsAsync(cleanup, cleanupCt)).Except(preexistingCaggs, StringComparer.Ordinal), cleanupCt));
+        }
+    }
+
+    /// <summary>One continuous aggregate's live refresh-policy state, read the same way
+    /// <see cref="TimescaleSupport.ContinuousAggregateRefreshStateSql"/> reads it — by VIEW NAME, recovered
+    /// through the materialization-hypertable join, never by job id.</summary>
+    private sealed record RefreshPolicyState(double StartOffsetSeconds, bool FixedSchedule, int? PhaseMinutes, TimeSpan? EndOffset);
+
+    private static async Task<RefreshPolicyState?> RefreshPolicyStateAsync(
+        NpgsqlConnection connection, string view, System.Threading.CancellationToken ct)
+    {
+        using var command = new NpgsqlCommand($@"
+SELECT
+    EXTRACT(EPOCH FROM (j.config->>'start_offset')::interval)::double precision,
+    j.fixed_schedule,
+    CASE
+        WHEN j.initial_start IS NULL THEN NULL
+        ELSE EXTRACT(MINUTE FROM j.initial_start AT TIME ZONE 'UTC')::int
+    END,
+    (j.config->>'end_offset')::interval
+FROM timescaledb_information.jobs AS j
+JOIN timescaledb_information.continuous_aggregates AS ca
+  ON  ca.materialization_hypertable_schema = j.hypertable_schema
+  AND ca.materialization_hypertable_name = j.hypertable_name
+WHERE j.proc_name = 'policy_refresh_continuous_aggregate'
+AND   ca.view_schema = 'collect'
+AND   ca.view_name = '{view}'", connection);
+
+        using var reader = await command.ExecuteReaderAsync(ct);
+        if (!await reader.ReadAsync(ct))
+        {
+            return null;
+        }
+
+        return new RefreshPolicyState(
+            reader.GetDouble(0),
+            !reader.IsDBNull(1) && reader.GetBoolean(1),
+            reader.IsDBNull(2) ? null : reader.GetInt32(2),
+            reader.IsDBNull(3) ? null : reader.GetFieldValue<TimeSpan>(3));
+    }
+
     /* ---- #1778 live-test helpers: throwaway hypertables shaped like a collector table ---- */
 
     private static async Task ExecAsync(NpgsqlConnection connection, string sql, System.Threading.CancellationToken ct)

--- a/Darling/Darling.Tests/TimescaleSupportTests.cs
+++ b/Darling/Darling.Tests/TimescaleSupportTests.cs
@@ -1104,6 +1104,14 @@ AND   (proc_name LIKE '%compression%' OR proc_name LIKE '%columnstore%')", conne
             await ExecAsync(connection,
                 $"SELECT add_continuous_aggregate_policy('collect.{Hourly}', start_offset => INTERVAL '3 days', end_offset => INTERVAL '1 hour', schedule_interval => INTERVAL '1 hour', if_not_exists => true)", ct);
 
+            /* Counted a SECOND way, on nothing but proc_name, before the view-keyed read is trusted. The
+               view-keyed read and the shipped converge share a join, so a wrong join makes both of them find
+               nothing and a bare Assert.NotNull below would report "no policy" for a store that has one. That
+               is not hypothetical: the materialization-hypertable-only join shipped first and did exactly
+               this, and this counter is what tells the two apart. */
+            Assert.True(await RefreshPolicyCountAsync(connection, ct) > 0,
+                "no continuous-aggregate refresh job exists at all — the fixture did not build the aggregates");
+
             var legacy = await RefreshPolicyStateAsync(connection, Hourly, ct);
             Assert.NotNull(legacy);
             Assert.Equal(TimeSpan.FromDays(3).TotalSeconds, legacy!.StartOffsetSeconds);
@@ -1172,8 +1180,8 @@ AND   (proc_name LIKE '%compression%' OR proc_name LIKE '%columnstore%')", conne
                 $@"SELECT alter_job(j.job_id, config => jsonb_set(j.config, '{{start_offset}}', to_jsonb('3 days'::text)))
 FROM timescaledb_information.jobs AS j
 JOIN timescaledb_information.continuous_aggregates AS ca
-  ON  ca.materialization_hypertable_schema = j.hypertable_schema
-  AND ca.materialization_hypertable_name = j.hypertable_name
+  ON  (ca.view_schema = j.hypertable_schema AND ca.view_name = j.hypertable_name)
+  OR  (ca.materialization_hypertable_schema = j.hypertable_schema AND ca.materialization_hypertable_name = j.hypertable_name)
 WHERE j.proc_name = 'policy_refresh_continuous_aggregate'
 AND   ca.view_schema = 'collect'
 AND   ca.view_name = '{Daily}'", ct);
@@ -1196,6 +1204,16 @@ AND   ca.view_name = '{Daily}'", ct);
     /// through the materialization-hypertable join, never by job id.</summary>
     private sealed record RefreshPolicyState(double StartOffsetSeconds, bool FixedSchedule, int? PhaseMinutes, TimeSpan? EndOffset);
 
+    /// <summary>How many continuous-aggregate refresh jobs the store has, keyed on nothing but
+    /// <c>proc_name</c> — deliberately sharing no join with the read under test, so "the policy is missing"
+    /// and "the read cannot find the policy" are distinguishable.</summary>
+    private static async Task<long> RefreshPolicyCountAsync(NpgsqlConnection connection, System.Threading.CancellationToken ct)
+    {
+        using var command = new NpgsqlCommand(
+            "SELECT COUNT(*) FROM timescaledb_information.jobs WHERE proc_name = 'policy_refresh_continuous_aggregate'", connection);
+        return (long)(await command.ExecuteScalarAsync(ct))!;
+    }
+
     private static async Task<RefreshPolicyState?> RefreshPolicyStateAsync(
         NpgsqlConnection connection, string view, System.Threading.CancellationToken ct)
     {
@@ -1210,8 +1228,8 @@ SELECT
     (j.config->>'end_offset')::interval
 FROM timescaledb_information.jobs AS j
 JOIN timescaledb_information.continuous_aggregates AS ca
-  ON  ca.materialization_hypertable_schema = j.hypertable_schema
-  AND ca.materialization_hypertable_name = j.hypertable_name
+  ON  (ca.view_schema = j.hypertable_schema AND ca.view_name = j.hypertable_name)
+  OR  (ca.materialization_hypertable_schema = j.hypertable_schema AND ca.materialization_hypertable_name = j.hypertable_name)
 WHERE j.proc_name = 'policy_refresh_continuous_aggregate'
 AND   ca.view_schema = 'collect'
 AND   ca.view_name = '{view}'", connection);

--- a/Darling/Darling.Tests/TimescaleSupportTests.cs
+++ b/Darling/Darling.Tests/TimescaleSupportTests.cs
@@ -1053,13 +1053,23 @@ AND   (proc_name LIKE '%compression%' OR proc_name LIKE '%columnstore%')", conne
     /// worse than a red one, not milder: an inert fix with a passing suite is a fix nobody looks at again.
     /// String-shape assertions on the SQL cannot see it, because they never run the statement.</para>
     ///
-    /// <para><b>The four assumptions only a live store can settle</b>, all named as unverified when the change
-    /// was written: that <c>alter_job</c> takes <c>fixed_schedule</c> and <c>initial_start</c> together on this
-    /// runtime; that <c>jsonb_set</c> produces a <c>start_offset</c> TimescaleDB then honours; that the
-    /// <c>jobs</c> → <c>continuous_aggregates</c> join on materialization-hypertable schema/name recovers
-    /// <c>view_name</c> for a refresh policy; and that a policy CREATED with <c>initial_start</c> comes back
-    /// <c>fixed_schedule = true</c> — on which the converge's own no-op-ness rests, because a fresh store whose
-    /// jobs read <c>false</c> would be re-altered on every start forever.</para>
+    /// <para><b>It found two defects on its first two runs, which is the argument for its existence.</b> The
+    /// join was written on <c>materialization_hypertable_schema/name</c>, because that is the id the
+    /// underlying <c>bgw_job</c> row carries — and <c>timescaledb_information.jobs</c> resolves a
+    /// continuous-aggregate job back to its USER VIEW, so the read found nothing at all and the converge would
+    /// have reported a tidy zero on every store. Then, with the join fixed:
+    /// <c>add_continuous_aggregate_policy(if_not_exists =&gt; true)</c> does NOT skip an existing policy
+    /// quietly the way its compression and retention siblings do — against a differing window it raises
+    /// <c>22023</c>, which makes the converge/ensure ORDER a correctness requirement rather than a
+    /// preference. Neither is visible to a string assertion on the SQL, because a string assertion never runs
+    /// the statement.</para>
+    ///
+    /// <para><b>The remaining assumptions this settles</b>, all named as unverified when the change was
+    /// written: that <c>alter_job</c> takes <c>fixed_schedule</c> and <c>initial_start</c> together on this
+    /// runtime; that <c>jsonb_set</c> produces a <c>start_offset</c> TimescaleDB then honours; and that a
+    /// policy CREATED with <c>initial_start</c> comes back <c>fixed_schedule = true</c> — on which the
+    /// converge's own no-op-ness rests, because a fresh store whose jobs read <c>false</c> would be re-altered
+    /// on every start forever.</para>
     ///
     /// <para><b>The fixed schedule is not a refinement.</b> Measured on the production store roughly two hours
     /// after the offsets were applied by hand: every job read <c>fixed_schedule = f</c> and only one of six
@@ -1096,8 +1106,12 @@ AND   (proc_name LIKE '%compression%' OR proc_name LIKE '%columnstore%')", conne
         var bodySucceeded = false;
         try
         {
+            /* The settled baseline: everything created with the shipped values, so every policy matches and
+               the count is what a healthy store reports. Held so step (4) can show the ensure UNDER-reporting
+               by exactly one when a single policy is left stale. */
             var createLog = new CapturingTestLogger();
-            await TimescaleSupport.EnsureContinuousAggregatesAsync(connection, createLog, ct);
+            var readyAll = await TimescaleSupport.EnsureContinuousAggregatesAsync(connection, createLog, ct);
+            Assert.True(readyAll > 0, $"the fixture did not build the aggregates; {createLog.Joined}");
 
             /* ---- (1) A policy as an OLDER BUILD left it: 3-day window, no initial_start. ---- */
             await ExecAsync(connection, $"SELECT remove_continuous_aggregate_policy('collect.{Hourly}', if_exists => true)", ct);
@@ -1121,13 +1135,28 @@ AND   (proc_name LIKE '%compression%' OR proc_name LIKE '%columnstore%')", conne
             Assert.False(legacy.FixedSchedule,
                 "a policy created without initial_start is expected to be finish-to-start on this runtime");
 
-            /* ---- (2) The CREATE statement ALONE cannot fix it — if_not_exists skips outright. ---- */
-            await ExecAsync(connection, TimescaleSupport.AddHourlyRefreshPolicySql(Hourly), ct);
+            /* ---- (2) The CREATE statement alone cannot fix it, and NOT for the reason the sibling
+                    converges taught. add_compression_policy and add_retention_policy skip an existing policy
+                    quietly and return -1. add_continuous_aggregate_policy does that only when the window
+                    MATCHES: against one whose window DIFFERS it RAISES. So the create path is not merely
+                    unable to move a deployed store, it cannot even run before the converge has. ---- */
+            var overlap = await Assert.ThrowsAsync<PostgresException>(
+                async () => await ExecAsync(connection, TimescaleSupport.AddHourlyRefreshPolicySql(Hourly), ct));
+            Assert.Equal("22023", overlap.SqlState);
+
             var afterCreate = await RefreshPolicyStateAsync(connection, Hourly, ct);
             Assert.Equal(TimeSpan.FromDays(3).TotalSeconds, afterCreate!.StartOffsetSeconds);
             Assert.False(afterCreate.FixedSchedule);
 
-            /* ---- (3) THE ASSERTION THE WHOLE CHANGE COMES DOWN TO: the deployed store converges. ---- */
+            /* ---- (3) THE ORDERING CONTRACT, functionally. Run in the wrong order the ensure meets that
+                    raise, swallows it in its per-aggregate catch, and comes back one short — reporting the
+                    aggregate as unready when only its refresh window was stale. Pinned as a COUNT rather than
+                    a log substring so it fails on the behaviour and not on the wording. ---- */
+            var wrongOrderLog = new CapturingTestLogger();
+            Assert.Equal(readyAll - 1, await TimescaleSupport.EnsureContinuousAggregatesAsync(connection, wrongOrderLog, ct));
+            Assert.Contains(Hourly, wrongOrderLog.Joined, StringComparison.Ordinal);
+
+            /* ---- (4) THE ASSERTION THE WHOLE CHANGE COMES DOWN TO: the deployed store converges. ---- */
             var convergeLog = new CapturingTestLogger();
             var converged = await TimescaleSupport.ConvergeContinuousAggregateRefreshAsync(connection, convergeLog, ct);
             Assert.True(converged >= 1,
@@ -1150,10 +1179,16 @@ AND   (proc_name LIKE '%compression%' OR proc_name LIKE '%columnstore%')", conne
             Assert.Contains($"moved {Hourly}'s refresh policy to a {TimescaleSupport.HourlyRefreshStartOffset} window",
                 convergeLog.Joined, StringComparison.Ordinal);
 
-            /* ---- (4) Idempotent: a converged store finds nothing, so this never churns alter_job. ---- */
+            /* ---- (5) And NOW the ensure is whole again — the shipped order, on the store state that
+                    exposed the requirement. This is the assertion that would go red if the two calls in
+                    DarlingWorker were ever swapped back. ---- */
+            var rightOrderLog = new CapturingTestLogger();
+            Assert.Equal(readyAll, await TimescaleSupport.EnsureContinuousAggregatesAsync(connection, rightOrderLog, ct));
+
+            /* ---- (6) Idempotent: a converged store finds nothing, so this never churns alter_job. ---- */
             Assert.Equal(0, await TimescaleSupport.ConvergeContinuousAggregateRefreshAsync(connection, null, ct));
 
-            /* ---- (5) The CREATE path on a store with no policy yet: both halves from the start. ---- */
+            /* ---- (7) The CREATE path on a store with no policy yet: both halves from the start. ---- */
             await ExecAsync(connection, $"SELECT remove_continuous_aggregate_policy('collect.{Hourly}', if_exists => true)", ct);
             await ExecAsync(connection, TimescaleSupport.AddHourlyRefreshPolicySql(Hourly), ct);
 
@@ -1167,7 +1202,7 @@ AND   (proc_name LIKE '%compression%' OR proc_name LIKE '%columnstore%')", conne
             /* And therefore the converge is a no-op against a FRESH store too, not only a settled one. */
             Assert.Equal(0, await TimescaleSupport.ConvergeContinuousAggregateRefreshAsync(connection, null, ct));
 
-            /* ---- (6) SCOPE: the DAILY tier keeps its 3-day window and its finish-to-start schedule. ---- */
+            /* ---- (8) SCOPE: the DAILY tier keeps its 3-day window and its finish-to-start schedule. ---- */
             var daily = await RefreshPolicyStateAsync(connection, Daily, ct);
             Assert.NotNull(daily);
             Assert.Equal(TimeSpan.FromDays(3).TotalSeconds, daily!.StartOffsetSeconds);

--- a/Darling/PerformanceMonitor.Darling.Service/Compose/ComposeSourceRouter.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Compose/ComposeSourceRouter.cs
@@ -133,7 +133,7 @@ public static class ComposeCaggCatalog
 /// ago") must reach the tier that still retains it or the query returns empty rows.
 ///
 /// <para>Route thresholds sit a margin BELOW each retention horizon (raw kept 4d → route ≤3d; hourly kept 90d →
-/// route ≤89d), so a drop lagging the boundary (1-day chunk granularity + the 3-day CAGG refresh) can never leave
+/// route ≤89d), so a drop lagging the boundary (1-day chunk granularity + the CAGG refresh interval) can never leave
 /// the chosen tier missing the oldest chunk. The margin is pinned as a test invariant against the retention
 /// constants. A whole window routes to the single tier its OLDEST point needs — uniform coarsening, no cross-tier
 /// union (a future optimization); real-time aggregation on the CAGG stitches the still-filling recent edge.</para>

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -1232,16 +1232,19 @@ public sealed class DarlingWorker : BackgroundService
                 // Reshape: drop stale old-shape QS / procedure_stats CAGGs FIRST so the ensure below rebuilds them
                 // in the composer-dimension shape (no-op once reshaped, and on a fresh store nothing matches).
                 await TimescaleSupport.DropStaleContinuousAggregatesAsync(timescaleConnection, _logger, stoppingToken);
-                await TimescaleSupport.EnsureContinuousAggregatesAsync(timescaleConnection, _logger, stoppingToken);
-
-                /* #3012: same if_not_exists no-op as the compression tick above, on the refresh policies. The
-                   CREATE carries the narrowed 1-day window and the 15-minute phase grid, but a store that ever
-                   ran an older build keeps re-materializing three days every hour — cost set by the window, so
-                   it grows with the hypertable and eventually outruns its own cadence, at which point a queued
-                   compression exclusive lock convoys every collector store-write behind it. Only selects
-                   policies that DIFFER, and only hourly ones, so the daily tier keeps its 3-day window and a
-                   settled store is a no-op. */
+                /* #3012: the refresh-window converge, and it runs BEFORE the ensure rather than after it —
+                   which is a measured ordering requirement, not a preference. add_continuous_aggregate_policy
+                   does NOT behave like its compression and retention siblings: against a policy whose window
+                   DIFFERS, if_not_exists => true does not return -1, it raises 22023 "refresh interval
+                   overlaps with an existing continuous aggregate policy". So on any store that ever ran an
+                   older build, the ensure below would fail per-aggregate on all thirteen hourly views and
+                   under-report how many are ready, while the policies stayed on the 3-day window. Converging
+                   first leaves the ensure looking at policies that already match, which is the quiet -1 it
+                   was written for. Only hourly policies, only ones that DIFFER, so the daily tier keeps its
+                   3-day window and a settled store is a no-op. */
                 await TimescaleSupport.ConvergeContinuousAggregateRefreshAsync(timescaleConnection, _logger, stoppingToken);
+
+                await TimescaleSupport.EnsureContinuousAggregatesAsync(timescaleConnection, _logger, stoppingToken);
 
                 // AFTER the CAGGs exist: the tiered retention (raw 4d, hourly HISTORY CAGGs 90d per #1937, daily
                 // history kept indefinitely; the interval-dedup and baseline tiers carry their own, #1958).

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -1535,8 +1535,13 @@ public sealed class DarlingWorker : BackgroundService
            Fills the two windows the live path discards by design — the 60-minute first-contact tail and
            clamp-bounded outage holes — newest-first, byte-budgeted, strictly BELOW the live path's floor, and
            never past the raw tier's horizon. Plan capture reads the same live provider the runner does. */
+        /* The extension flag reaches the backfill because its HORIZON depends on it (#3012): on a plain
+           PostgreSQL store there are no hourly rollups for a backdated row to fall out of, so the refresh
+           term does not apply and that deployment mode keeps the full raw-tier depth. Passed as a provider
+           rather than a value so it cannot capture a stale reading. */
         var queryStoreBackfill = new QueryStoreBackfill(postgres, runner, deltas, _logger, () => config.CapturePlans,
-            () => StoreConfigProvider.ClampTextBudgetMb(config.QueryStoreTextBudgetMb));
+            () => StoreConfigProvider.ClampTextBudgetMb(config.QueryStoreTextBudgetMb),
+            () => _timescaleAvailable);
         var backfillLoop = RunQueryStoreBackfillLoopAsync(queryStoreBackfill, servers, () => config.QueryStoreBackfillEnabled, stoppingToken);
 
         /* The fleet concurrency gate (#1553 D2): at most N=4 per-server collection bodies open a SQL connection

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -1233,13 +1233,23 @@ public sealed class DarlingWorker : BackgroundService
                 // in the composer-dimension shape (no-op once reshaped, and on a fresh store nothing matches).
                 await TimescaleSupport.DropStaleContinuousAggregatesAsync(timescaleConnection, _logger, stoppingToken);
                 await TimescaleSupport.EnsureContinuousAggregatesAsync(timescaleConnection, _logger, stoppingToken);
+
+                /* #3012: same if_not_exists no-op as the compression tick above, on the refresh policies. The
+                   CREATE carries the narrowed 1-day window and the 15-minute phase grid, but a store that ever
+                   ran an older build keeps re-materializing three days every hour — cost set by the window, so
+                   it grows with the hypertable and eventually outruns its own cadence, at which point a queued
+                   compression exclusive lock convoys every collector store-write behind it. Only selects
+                   policies that DIFFER, and only hourly ones, so the daily tier keeps its 3-day window and a
+                   settled store is a no-op. */
+                await TimescaleSupport.ConvergeContinuousAggregateRefreshAsync(timescaleConnection, _logger, stoppingToken);
+
                 // AFTER the CAGGs exist: the tiered retention (raw 4d, hourly HISTORY CAGGs 90d per #1937, daily
                 // history kept indefinitely; the interval-dedup and baseline tiers carry their own, #1958).
                 await TimescaleSupport.EnsureRetentionPoliciesAsync(timescaleConnection, _logger, stoppingToken);
 
                 /* #1757: the baseline aggregates ship WITH NO DATA and their refresh policy only ever covers
-                   the trailing 3 days, so without this they would answer a 30-day question with 3 days of
-                   supply. DELIBERATELY LAUNCHED, NOT AWAITED: it is a bulk materialization whose cost scales
+                   the trailing TimescaleSupport.HourlyRefreshStartOffset, so without this they would answer a
+                   30-day question with a day of supply. DELIBERATELY LAUNCHED, NOT AWAITED: it is a bulk materialization whose cost scales
                    with however much history the store already had, and every step below this block — the
                    composer tuning, the delta re-seed, the collection loop itself — is sequenced after it.
                    Awaiting it here would take a restarted service dark for as long as the backfill runs,
@@ -2148,7 +2158,8 @@ public sealed class DarlingWorker : BackgroundService
     /// <summary>
     /// Materializes the baseline aggregates over the history the store already had (#1757), concurrently with
     /// the collection sweep rather than ahead of it. On a fresh store the coverage gate makes this a no-op; on
-    /// an upgraded store it is the one-time pass that turns a 3-day supply into the full baseline window.
+    /// an upgraded store it is the one-time pass that turns a refresh-window-deep supply into the full
+    /// baseline window.
     ///
     /// <para>Takes its OWN connection rather than borrowing the startup one: the caller's connection is scoped
     /// to the TimescaleDB setup block and is disposed the moment that block exits, which is long before this

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -1248,9 +1248,9 @@ public sealed class DarlingWorker : BackgroundService
                 await TimescaleSupport.EnsureRetentionPoliciesAsync(timescaleConnection, _logger, stoppingToken);
 
                 /* #1757: the baseline aggregates ship WITH NO DATA and their refresh policy only ever covers
-                   the trailing TimescaleSupport.HourlyRefreshStartOffset, so without this they would answer a
-                   30-day question with a day of supply. DELIBERATELY LAUNCHED, NOT AWAITED: it is a bulk materialization whose cost scales
-                   with however much history the store already had, and every step below this block — the
+                   the trailing 1-day refresh window, so without this they would answer a 30-day question with
+                   a day of supply. DELIBERATELY LAUNCHED, NOT AWAITED: it is a bulk materialization whose
+                   cost scales with however much history the store already had, and every step below — the
                    composer tuning, the delta re-seed, the collection loop itself — is sequenced after it.
                    Awaiting it here would take a restarted service dark for as long as the backfill runs,
                    which is exactly when an operator is most likely to be restarting it. Coverage-gated, so it

--- a/Darling/PerformanceMonitor.Darling.Service/QueryStoreBackfill.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/QueryStoreBackfill.cs
@@ -97,8 +97,10 @@ public sealed class QueryStoreBackfill
     /// the refresh term, which is exactly the coupling that made the refresh expensive. The hourly window is
     /// now chosen against its own cadence (<see cref="TimescaleSupport.HourlyRefreshStartOffset"/>), so the
     /// two terms differ and the smaller one is the real horizon. The cost is stated rather than hidden: this
-    /// horizon narrows from 3 days to 23 hours, so post-outage catch-up and first-contact tail recovery reach
-    /// less far back per store. Digging deeper than the refresh window is a separate stage that would have to
+    /// horizon narrows from three days to one day minus a refresh interval, so post-outage catch-up and
+    /// first-contact tail recovery reach less far back per store. The figure itself stays in the constants
+    /// this derives from — <c>QueryStoreBackfillTests</c> pins it — rather than being restated here where it
+    /// would go stale. Digging deeper than the refresh window is a separate stage that would have to
     /// refresh the buckets it wrote — which is a decision about running
     /// <c>refresh_continuous_aggregate</c> off the backfill loop, not a constant.</para>
     /// </summary>

--- a/Darling/PerformanceMonitor.Darling.Service/QueryStoreBackfill.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/QueryStoreBackfill.cs
@@ -49,12 +49,12 @@ namespace PerformanceMonitor.Darling.Service;
 /// <para><b>The horizon.</b> Slices carry a BACKDATED collection_time (the slice ceiling), so the
 /// rows land in time buckets adjacent to their own activity — readers window on collection_time,
 /// hourly CAGGs bucket on it, and retention drops on it. That is exactly why this stage refuses to
-/// dig below <see cref="Horizon"/> (derived from the raw tier, not hand-maintained — the #1937
-/// rule): inside it, every CAGG's 3-day <c>start_offset</c> re-materializes the touched buckets on
-/// its next scheduled run and the 4-day raw retention cannot immediately drop what was just
-/// shipped; below it, neither holds, and that deeper stage is a separate decision (#2022's own
-/// staging note). Re-shipped interval rows are already deduped by every reader (#1907/#1841), so a
-/// boundary overlap is waste at worst, never a double-count.</para>
+/// dig below <see cref="Horizon"/> (derived from the refresh window and the raw tier, not
+/// hand-maintained — the #1937 rule): inside it, the hourly CAGGs' refresh window re-materializes
+/// the touched buckets on their next scheduled run AND raw retention cannot immediately drop what
+/// was just shipped; below it, at least one of those stops holding, and that deeper stage is a
+/// separate decision (#2022's own staging note). Re-shipped interval rows are already deduped by
+/// every reader (#1907/#1841), so a boundary overlap is waste at worst, never a double-count.</para>
 ///
 /// <para><b>Pacing.</b> One slice per server per tick on the worker's OWN loop (the command-loop
 /// precedent), each slice bounded by the same per-database byte budget as the live path, on its own
@@ -71,11 +71,41 @@ public sealed class QueryStoreBackfill
     public const string StateCollectorName = QueryStoreBackfillState.StateCollectorName;
 
     /// <summary>
-    /// How far below now a backfill slice may reach — the raw tier's read horizon
-    /// (<see cref="RetentionTierRouter.RawMaxAge"/>, raw retention minus the route margin), derived
-    /// so it can never drift from the retention/CAGG numbers it exists to respect.
+    /// How deep the hourly refresh policy can still reach on its NEXT run — its start offset minus one
+    /// schedule interval, because the window slides forward by exactly that much between runs. A row landed at
+    /// the start-offset boundary itself is already outside the window by the time the policy next fires.
     /// </summary>
-    public static readonly TimeSpan Horizon = RetentionTierRouter.RawMaxAge;
+    private static readonly TimeSpan RefreshReachableDepth =
+        TimescaleSupport.HourlyRefreshStartSpan - TimescaleSupport.HourlyRefreshScheduleSpan;
+
+    /// <summary>
+    /// How far below now a backfill slice may reach — the SMALLER of the two conditions that both have to
+    /// hold, derived from each rather than hand-maintained.
+    ///
+    /// <para><b>Both, not either.</b> A slice lands rows at a BACKDATED <c>collection_time</c>, so for the
+    /// slice to be worth shipping two things must be true of the depth it lands at: raw retention must not
+    /// immediately drop it (<see cref="RetentionTierRouter.RawMaxAge"/>, raw retention minus the route
+    /// margin), and the hourly continuous aggregates must still re-materialize the buckets it touched
+    /// (<see cref="RefreshReachableDepth"/>). The rollups are materialized-only — the watermark is a hard
+    /// partition, not a fallback — so a bucket the refresh window no longer covers keeps whatever it was
+    /// materialized with, and the backfilled rows are invisible to every window that routes at hourly grain
+    /// while still being visible at raw grain. That is a silent split between two tiers, not a delay.</para>
+    ///
+    /// <para><b>Why this is a <c>min</c> now and was a single term before (#3012).</b> The two conditions
+    /// happened to coincide: the hourly refresh window was 3 days and <c>RawMaxAge</c> is 3 days, so taking
+    /// only the retention term looked complete. It was not — it was the retention term acting as a PROXY for
+    /// the refresh term, which is exactly the coupling that made the refresh expensive. The hourly window is
+    /// now chosen against its own cadence (<see cref="TimescaleSupport.HourlyRefreshStartOffset"/>), so the
+    /// two terms differ and the smaller one is the real horizon. The cost is stated rather than hidden: this
+    /// horizon narrows from 3 days to 23 hours, so post-outage catch-up and first-contact tail recovery reach
+    /// less far back per store. Digging deeper than the refresh window is a separate stage that would have to
+    /// refresh the buckets it wrote — which is a decision about running
+    /// <c>refresh_continuous_aggregate</c> off the backfill loop, not a constant.</para>
+    /// </summary>
+    public static readonly TimeSpan Horizon =
+        RetentionTierRouter.RawMaxAge <= RefreshReachableDepth
+            ? RetentionTierRouter.RawMaxAge
+            : RefreshReachableDepth;
 
     /// <summary>Candidate databases come from rows this window fresh — a database that stopped
     /// shipping Query Store rows entirely ages out of the backfill scan with them.</summary>

--- a/Darling/PerformanceMonitor.Darling.Service/QueryStoreBackfill.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/QueryStoreBackfill.cs
@@ -49,7 +49,7 @@ namespace PerformanceMonitor.Darling.Service;
 /// <para><b>The horizon.</b> Slices carry a BACKDATED collection_time (the slice ceiling), so the
 /// rows land in time buckets adjacent to their own activity — readers window on collection_time,
 /// hourly CAGGs bucket on it, and retention drops on it. That is exactly why this stage refuses to
-/// dig below <see cref="Horizon"/> (derived from the refresh window and the raw tier, not
+/// dig below <see cref="HorizonFor"/> (derived from the refresh window and the raw tier, not
 /// hand-maintained — the #1937 rule): inside it, the hourly CAGGs' refresh window re-materializes
 /// the touched buckets on their next scheduled run AND raw retention cannot immediately drop what
 /// was just shipped; below it, at least one of those stops holding, and that deeper stage is a
@@ -79,8 +79,25 @@ public sealed class QueryStoreBackfill
         TimescaleSupport.HourlyRefreshStartSpan - TimescaleSupport.HourlyRefreshScheduleSpan;
 
     /// <summary>
-    /// How far below now a backfill slice may reach — the SMALLER of the two conditions that both have to
-    /// hold, derived from each rather than hand-maintained.
+    /// How far below now a backfill slice may reach on a store WITHOUT continuous aggregates: the raw read
+    /// horizon alone.
+    ///
+    /// <para>TimescaleDB is optional and auto-detected, and plain PostgreSQL is a supported configuration
+    /// rather than a degraded one. On such a store there are no hourly rollups for a backdated row to fall
+    /// out of — every read goes to raw — so the refresh term below does not apply, and narrowing for it would
+    /// cost that deployment mode two days of catch-up reach in exchange for nothing. Raised by review; the
+    /// first version of #3012's change narrowed unconditionally.</para>
+    ///
+    /// <para>A store that LATER gains the extension is not left with a split: the aggregates are born
+    /// <c>WITH NO DATA</c> and <see cref="RetentionTierRouter"/> routes any window below a rollup's measured
+    /// floor to raw, so rows shipped while the store was plain are served from raw exactly as they were
+    /// before.</para>
+    /// </summary>
+    public static readonly TimeSpan PlainStoreHorizon = RetentionTierRouter.RawMaxAge;
+
+    /// <summary>
+    /// How far below now a backfill slice may reach on a store WITH continuous aggregates — the SMALLER of
+    /// the two conditions that both have to hold, derived from each rather than hand-maintained.
     ///
     /// <para><b>Both, not either.</b> A slice lands rows at a BACKDATED <c>collection_time</c>, so for the
     /// slice to be worth shipping two things must be true of the depth it lands at: raw retention must not
@@ -104,10 +121,18 @@ public sealed class QueryStoreBackfill
     /// refresh the buckets it wrote — which is a decision about running
     /// <c>refresh_continuous_aggregate</c> off the backfill loop, not a constant.</para>
     /// </summary>
-    public static readonly TimeSpan Horizon =
+    public static readonly TimeSpan RollupStoreHorizon =
         RetentionTierRouter.RawMaxAge <= RefreshReachableDepth
             ? RetentionTierRouter.RawMaxAge
             : RefreshReachableDepth;
+
+    /// <summary>
+    /// The horizon for THIS store. <paramref name="hasContinuousAggregates"/> is the TimescaleDB-extension
+    /// flag, which is the right question rather than a proxy for it: the hourly rollups are created by
+    /// <c>EnsureContinuousAggregatesAsync</c> under exactly that gate, so they exist if and only if it does.
+    /// </summary>
+    public static TimeSpan HorizonFor(bool hasContinuousAggregates)
+        => hasContinuousAggregates ? RollupStoreHorizon : PlainStoreHorizon;
 
     /// <summary>Candidate databases come from rows this window fresh — a database that stopped
     /// shipping Query Store rows entirely ages out of the backfill scan with them.</summary>
@@ -118,6 +143,12 @@ public sealed class QueryStoreBackfill
     private readonly CollectorDeltaCalculator _deltas;
     private readonly ILogger? _logger;
     private readonly Func<bool> _capturePlans;
+
+    /* Whether this store has TimescaleDB continuous aggregates, read LIVE rather than captured: the worker
+       sets its flag during startup detection and this class is constructed after that, but reading it through
+       a provider keeps the two from depending on construction order. Defaults to true for hosts that do not
+       say — the conservative direction, since the narrower horizon cannot produce a tier split. */
+    private readonly Func<bool> _hasContinuousAggregates;
 
     /* #2164: the per-database text budget override in MB, read live like _capturePlans. Backfill slices
        carry the SAME nvarchar(max) query-text/plan-XML payload over the same link as a live tick, so the
@@ -131,7 +162,8 @@ public sealed class QueryStoreBackfill
         CollectorDeltaCalculator deltas,
         ILogger? logger,
         Func<bool>? capturePlans = null,
-        Func<int>? textBudgetMb = null)
+        Func<int>? textBudgetMb = null,
+        Func<bool>? hasContinuousAggregates = null)
     {
         _postgres = postgres ?? throw new ArgumentNullException(nameof(postgres));
         _runner = runner ?? throw new ArgumentNullException(nameof(runner));
@@ -140,6 +172,7 @@ public sealed class QueryStoreBackfill
         _capturePlans = capturePlans ?? (() => true);
         /* Null provider = keep the collector's compile-time budget (tests and any non-Darling host). */
         _textBudgetMb = textBudgetMb ?? (() => 0);
+        _hasContinuousAggregates = hasContinuousAggregates ?? (() => true);
     }
 
     /// <summary>
@@ -180,7 +213,7 @@ public sealed class QueryStoreBackfill
         var databases = await GetCandidateDatabasesAsync(server.ServerId, cancellationToken);
 
         var nowUtc = DateTime.UtcNow;
-        var floorLimit = nowUtc - Horizon;
+        var floorLimit = nowUtc - HorizonFor(_hasContinuousAggregates());
 
         foreach (var databaseName in databases)
         {

--- a/Darling/PerformanceMonitor.Darling.Storage/RetentionTierRouter.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/RetentionTierRouter.cs
@@ -159,8 +159,10 @@ public static class RetentionTierRouter
     /// slip through, both known and both accepted:</para>
     ///
     /// <para><i>A mid-window HOLE is invisible.</i> Coverage is one number — the oldest materialized bucket —
-    /// so it cannot see a gap ABOVE itself. A service down longer than the refresh policy's 3-day
-    /// <c>start_offset</c> resumes at now-3d and never backfills the skipped interval, while
+    /// so it cannot see a gap ABOVE itself. A service down longer than the refresh policy's
+    /// <c>start_offset</c> (<see cref="TimescaleSupport.HourlyRefreshStartOffset"/> since #3012 narrowed it,
+    /// so this exposure is WIDER than it was) resumes at now minus that offset and never backfills the
+    /// skipped interval, while
     /// <c>min(bucket)</c> goes on reporting the original deep floor. The window then routes to the tier and is
     /// served as complete with the gap silently inside it.</para>
     ///

--- a/Darling/PerformanceMonitor.Darling.Storage/RollupBackfill.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/RollupBackfill.cs
@@ -245,7 +245,7 @@ SELECT
     ///
     /// <para>The estimate is CALIBRATED from what the rollup has already materialized (bytes per bucket, scaled
     /// by the buckets to add) whenever there is a sample — which on the stores this exists for there always is,
-    /// since their refresh policies have been materializing a trailing 3-day window all along. With no sample at
+    /// since their refresh policies have been materializing a trailing start-offset window all along. With no sample at
     /// all it falls back to a fraction of raw's own bytes over the same span and says so, so an operator can
     /// tell a measured number from a bounding one.</para>
     /// </summary>
@@ -416,7 +416,8 @@ SELECT
     /// <summary>
     /// TimescaleDB serializes refreshes of the same aggregate and raises <see cref="ConcurrentRefreshSqlState"/>
     /// (<c>55P03 lock_not_available</c>) rather than waiting. This verb runs while the SERVICE IS UP, so the
-    /// aggregate's own refresh policy — which fires roughly hourly over a trailing 3-day window — will
+    /// aggregate's own refresh policy — which fires roughly hourly over a trailing
+    /// <see cref="TimescaleSupport.HourlyRefreshStartOffset"/> window — will
     /// eventually land on top of a slice. Caught live on the gated PostgreSQL 18.4 / TimescaleDB 2.28.1 leg:
     /// <c>EnsureContinuousAggregatesAsync</c> attaches the policy, the policy runs immediately, and the very
     /// next slice failed.

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -1902,12 +1902,19 @@ WITH NO DATA";
     /// made of: the window it re-materializes, whether it is on a fixed schedule, and which minute of the hour
     /// it starts on.
     ///
-    /// <para><b>Keyed on the VIEW, which takes a join to get.</b> A refresh job's own
-    /// <c>hypertable_name</c> is the aggregate's MATERIALIZATION hypertable
-    /// (<c>_materialized_hypertable_N</c>), a per-deployment name that says nothing about which rollup it
-    /// belongs to — so this joins <c>continuous_aggregates</c> to recover <c>view_name</c>, and the caller
-    /// decides what each view should look like from <see cref="HourlyRefreshPhaseOrder"/>. Nothing here or in
-    /// the caller reads a job id for anything except passing it back to <c>alter_job</c>.</para>
+    /// <para><b>Keyed on the VIEW, and the join matches EITHER identity on purpose.</b> The caller decides
+    /// what each view should look like from <see cref="HourlyRefreshPhaseOrder"/>, so this has to hand it a
+    /// <c>view_name</c>; nothing here or in the caller reads a job id for anything except passing it back to
+    /// <c>alter_job</c>. What the join cannot assume is WHICH name a refresh job reports. The underlying
+    /// <c>bgw_job</c> row carries the aggregate's MATERIALIZATION hypertable id, so the obvious form joins on
+    /// <c>materialization_hypertable_schema/name</c> — and that form is measured to find NOTHING, because
+    /// <c>timescaledb_information.jobs</c> already resolves a continuous-aggregate job back to its USER VIEW
+    /// and reports <c>collect</c> / <c>&lt;view&gt;</c>. Matching either identity is therefore not
+    /// belt-and-braces for its own sake: it is one measured behaviour plus the one the catalog columns imply,
+    /// and it cannot double-count, because a user view lives in <c>collect</c> while a materialization
+    /// hypertable lives in <c>_timescaledb_internal</c> — disjoint, so at most one row can match per job.
+    /// This was a real defect caught by the live test rather than a hypothetical: the materialization-only
+    /// form shipped first and read back nothing at all.</para>
     ///
     /// <para>Emitted as NUMBERS, not text: <c>start_offset</c> comes back as seconds so a C# comparison cannot
     /// be fooled by <c>1 day</c> / <c>1 day 00:00:00</c> / <c>24:00:00</c> all meaning the same interval, and
@@ -1928,8 +1935,8 @@ SELECT
     END AS phase_minutes
 FROM timescaledb_information.jobs AS j
 JOIN timescaledb_information.continuous_aggregates AS ca
-  ON  ca.materialization_hypertable_schema = j.hypertable_schema
-  AND ca.materialization_hypertable_name = j.hypertable_name
+  ON  (ca.view_schema = j.hypertable_schema AND ca.view_name = j.hypertable_name)
+  OR  (ca.materialization_hypertable_schema = j.hypertable_schema AND ca.materialization_hypertable_name = j.hypertable_name)
 WHERE j.proc_name = 'policy_refresh_continuous_aggregate'
 AND   ca.view_schema = 'collect'";
 

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -902,8 +902,6 @@ $do$";
         _ => throw new ArgumentOutOfRangeException(nameof(view), view, "not a baseline aggregate"),
     };
 
-    /// <summary>The seven baseline-tier aggregates in creation order (nine until #2007 retired the unread CPU/IO pair). Named ONCE so the ensure sweep, the
-    /// retention list and the tests read one list rather than three hand-kept copies.</summary>
     /// <summary>
     /// The non-baseline HOURLY continuous aggregates, in CREATION order, paired with their CREATE SQL.
     ///
@@ -929,6 +927,8 @@ $do$";
         (CreateQueryStoreStatsCorrectedHourlySql, QueryStoreStatsCorrectedHourlyView),
     };
 
+    /// <summary>The seven baseline-tier aggregates in creation order (nine until #2007 retired the unread CPU/IO pair). Named ONCE so the ensure sweep, the
+    /// retention list and the tests read one list rather than three hand-kept copies.</summary>
     public static readonly (string CreateSql, string View)[] BaselineAggregates =
     {
         (CreatePerfmonBaselineSql,        PerfmonBaselineView),

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -1629,16 +1629,18 @@ WITH NO DATA";
     /// </summary>
     public static int RefreshPhaseMinutesFor(string view)
     {
-        var index = HourlyRefreshPhaseOrder.ToList().IndexOf(view);
-        if (index < 0)
+        for (var index = 0; index < HourlyRefreshPhaseOrder.Count; index++)
         {
-            throw new ArgumentOutOfRangeException(
-                nameof(view),
-                view,
-                "not an hourly continuous aggregate — register it in TimescaleSupport.HourlyRefreshPhaseOrder before giving it an hourly refresh policy");
+            if (string.Equals(HourlyRefreshPhaseOrder[index], view, StringComparison.Ordinal))
+            {
+                return index % RefreshPhaseSlots * RefreshPhaseStepMinutes;
+            }
         }
 
-        return index % RefreshPhaseSlots * RefreshPhaseStepMinutes;
+        throw new ArgumentOutOfRangeException(
+            nameof(view),
+            view,
+            "not an hourly continuous aggregate — register it in TimescaleSupport.HourlyRefreshPhaseOrder before giving it an hourly refresh policy");
     }
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -463,9 +463,9 @@ WITH NO DATA";
 
     /// <summary>
     /// One-time backfill of the baseline aggregates (#1757). WITHOUT THIS THE WHOLE CHANGE IS A REGRESSION:
-    /// the aggregates are created WITH NO DATA and their refresh policy has a 3-day start_offset, so left
-    /// alone they would hold roughly three days for a thirty-day question -- less than the four-day raw
-    /// horizon the change exists to escape. The provider is repointed at them, so an un-backfilled deploy
+    /// the aggregates are created WITH NO DATA and their refresh policy only re-materializes
+    /// <see cref="HourlyRefreshStartOffset"/>, so left alone they would hold roughly one day for a
+    /// thirty-day question -- far less than the four-day raw horizon the change exists to escape. The provider is repointed at them, so an un-backfilled deploy
     /// loses every baseline rather than improving it.
     ///
     /// <para>COVERAGE-GATED and self-healing, the shape the reshape sweep already uses: it compares the
@@ -1301,7 +1301,8 @@ WITH NO DATA";
     /// reduction is the collection multiplicity, NOT the dimensional collapse the composer-grain rollups get.
     /// It is therefore the one rollup here whose retention is deliberately SHORT
     /// (<see cref="IntervalRetentionInterval"/>): nothing reads it, so it only has to outlive raw for the
-    /// arming gate and outlive its consumers' 3-day refresh window.</para>
+    /// arming gate and outlive its consumers' refresh windows (<see cref="HourlyRefreshStartOffset"/> for
+    /// the corrected hourly, <see cref="DailyRefreshStartOffset"/> for the corrected daily).</para>
     /// </summary>
     public const string CreateQueryStoreStatsIntervalHourlySql = @"CREATE MATERIALIZED VIEW IF NOT EXISTS collect.query_store_stats_interval_hourly
 WITH (timescaledb.continuous) AS
@@ -1494,15 +1495,213 @@ GROUP BY server_id, server_name, database_name, module_name, query_hash, time_bu
 WITH NO DATA";
 
     /// <summary>
-    /// The refresh policy for a continuous aggregate: materialize <c>[now - 3 days, now - endOffset]</c> every
-    /// <c>scheduleInterval</c>. <c>start_offset 3 days</c> gives margin past the ~2-day compression/hot window
-    /// (covers same-day-arriving corrections) and is the buffer the retention tiers lean on — a tier's drop must
-    /// never outrun the next tier's 3-day refresh start. <c>endOffset</c> leaves the still-filling current bucket
-    /// unmaterialized (no repeated rework); <c>scheduleInterval</c> matches the bucket. Defaults are the hourly
-    /// shape; the daily CAGGs pass <c>"1 day"</c>/<c>"1 day"</c>. <c>if_not_exists</c> so a restart re-converges.
+    /// The HOURLY refresh window: each hourly continuous aggregate re-materializes <c>[now - 1 day,
+    /// now - 1 hour]</c> on every run.
+    ///
+    /// <para><b>1 day rather than 3 (#3012).</b> A refresh's cost is set by the WINDOW it re-scans, not by the
+    /// rows that arrived in it — so a 3-day window against <see cref="RawRetentionInterval"/>'s 4 days
+    /// re-materialized roughly three quarters of the whole hypertable every hour, and that cost grew with the
+    /// hypertable rather than with ingest. Measured on the production store: the heaviest hourly refresh
+    /// (<see cref="QueryStoreStatsIntervalHourlyView"/>) ran 3,301-6,330 s against a 1-hour cadence —
+    /// <b>118-175% of its own schedule interval</b> — while rows arriving per hour FELL ~3x over the same
+    /// period. Narrowed to 1 day the same refresh runs <b>864 s, 24% of cadence</b>. The direction of that
+    /// measurement is the whole argument: duration tracking window size while ingest moves the other way is
+    /// what rules out "more rows to materialize" and rules in "too much window".</para>
+    ///
+    /// <para><b>Why a job that outran its cadence could not recover.</b> A refresh holds
+    /// <c>AccessShareLock</c> on the hypertable it reads; the compression policy on that same hypertable
+    /// queues an <c>AccessExclusiveLock</c> request behind it; and a queued exclusive request blocks every
+    /// SUBSEQUENT shared request — so collector store-writes and readers piled up behind a lock that was
+    /// merely QUEUED, not held, even though their own locks are mutually compatible. At >100% of cadence the
+    /// next run started into the tail of the previous one, and the convoy sustained itself. Below cadence it
+    /// cannot form, which is why this number and <see cref="RefreshPhaseStepMinutes"/> are complements rather
+    /// than alternatives: narrowing is what makes the heavy refresh finish, phasing is what keeps its
+    /// remaining 864 s out of everyone else's way.</para>
+    ///
+    /// <para><b>What still has to fit inside it, now stated as a relationship rather than left to a
+    /// constant.</b> Two things need the window to reach back far enough. Live collectors only ever append
+    /// current-time rows, so for them one refresh interval would do and a day is generous. The one writer of
+    /// BACKDATED rows is <c>QueryStoreBackfill</c>, and its reach is now DERIVED from this span (minus one
+    /// <see cref="HourlyRefreshScheduleInterval"/>, because the window slides forward between runs) instead of
+    /// from the raw retention horizon. That inversion is the actual fix: before it, the refresh window had to
+    /// cover a depth that retention chose, so every retention increase silently bought more refresh cost;
+    /// after it, the refresh window is chosen against its own cadence and the backdating depth follows.</para>
     /// </summary>
-    public static string AddContinuousAggregatePolicySql(string view, string endOffset = "1 hour", string scheduleInterval = "1 hour")
-        => $"SELECT add_continuous_aggregate_policy('collect.{view}', start_offset => INTERVAL '3 days', end_offset => INTERVAL '{endOffset}', schedule_interval => INTERVAL '{scheduleInterval}', if_not_exists => true)";
+    public const string HourlyRefreshStartOffset = "1 day";
+
+    /// <summary><see cref="TimeSpan"/> twin of <see cref="HourlyRefreshStartOffset"/> for callers doing
+    /// arithmetic against it — <c>QueryStoreBackfill.Horizon</c> is derived from this, so the backdating depth
+    /// cannot be left behind when the window moves. Pinned equal to the string by
+    /// TimescaleContinuousAggregateTests.</summary>
+    public static readonly TimeSpan HourlyRefreshStartSpan = TimeSpan.FromDays(1);
+
+    /// <summary>The hourly refresh cadence, and also the hourly <c>end_offset</c> — the still-filling current
+    /// bucket is left unmaterialized so no run reworks it.</summary>
+    public const string HourlyRefreshScheduleInterval = "1 hour";
+
+    /// <summary><see cref="TimeSpan"/> twin of <see cref="HourlyRefreshScheduleInterval"/>. The refresh window
+    /// slides forward by exactly this much between runs, which is why anything relying on "the next run will
+    /// re-materialize what I just wrote" has to subtract it from
+    /// <see cref="HourlyRefreshStartSpan"/> rather than using the span itself.</summary>
+    public static readonly TimeSpan HourlyRefreshScheduleSpan = TimeSpan.FromHours(1);
+
+    /// <summary>
+    /// The DAILY refresh window, deliberately still 3 days.
+    ///
+    /// <para>The daily tier is NOT the tier #3012 was about and must not be "made consistent" with the hourly
+    /// one. Its jobs run once a day, so a 3-day window is 3 days of scan against an 86,400-second cadence
+    /// rather than against 3,600 — it was never near its own schedule interval, and it never appeared in the
+    /// convoy. What it buys is the buffer <see cref="HourlyRetentionInterval"/> leans on: the hourly rollups
+    /// are dropped at 90 days, and the daily refresh reaching 3 days back is what guarantees a drop can never
+    /// outrun the aggregate meant to preserve that history. Narrowing this would trade nothing for a
+    /// correctness risk.</para>
+    /// </summary>
+    public const string DailyRefreshStartOffset = "3 days";
+
+    /// <summary><see cref="TimeSpan"/> twin of <see cref="DailyRefreshStartOffset"/>, pinned equal to the
+    /// string and pinned STRICTLY BELOW <see cref="HourlyRetentionSpan"/> by
+    /// TimescaleContinuousAggregateTests.</summary>
+    public static readonly TimeSpan DailyRefreshStartSpan = TimeSpan.FromDays(3);
+
+    /// <summary>The daily refresh cadence, and also the daily <c>end_offset</c>.</summary>
+    public const string DailyRefreshScheduleInterval = "1 day";
+
+    /// <summary>
+    /// Minutes between adjacent slots on the hourly refresh grid (#3012): the hourly refresh policies are
+    /// phased across the hour instead of all starting together.
+    ///
+    /// <para><b>Phasing alone is not the fix and neither is narrowing alone.</b>
+    /// <see cref="HourlyRefreshStartOffset"/> is what brought the heavy refresh from 6,330 s to 864 s; this is
+    /// what keeps those 864 s from being visible to anything else, because the refresh that is running is not
+    /// the one a compression policy or a sibling refresh is about to want. The heaviest hourly refresh is
+    /// still ~33x its lightest sibling on the narrowed window, so the two treatments address different halves
+    /// and dropping either one reopens the door.</para>
+    ///
+    /// <para><b>15 minutes over four slots is the configuration that was measured</b>, not a round number: the
+    /// production store's <c>query_store_stats</c> job family was moved to :00/:15/:30/:45 and the first full
+    /// staggered cycle came back 26 s / 2 s / 864 s / 140 s with zero ungranted locks on every sample since.
+    /// Spreading all thirteen hourly policies across thirteen distinct minutes would contend less still, and
+    /// is the obvious next refinement — but it is not what the numbers above were taken on.</para>
+    /// </summary>
+    public const int RefreshPhaseStepMinutes = 15;
+
+    /// <summary>Slots on the hourly refresh grid — 60 minutes divided by
+    /// <see cref="RefreshPhaseStepMinutes"/>. Pinned as that quotient rather than restated, so the two cannot
+    /// disagree.</summary>
+    public const int RefreshPhaseSlots = 60 / RefreshPhaseStepMinutes;
+
+    /// <summary>
+    /// The hourly refresh policies in phase order — the ONLY thing that decides which slot a policy gets, and
+    /// it is keyed on the VIEW name.
+    ///
+    /// <para><b>Never on a job id.</b> TimescaleDB job ids are assigned per deployment: the ids that appear in
+    /// #3012's evidence exist only on the store it was measured against, and would name entirely different
+    /// jobs anywhere else. Keying the grid on view identity is what makes the same configuration reproducible
+    /// on a store that has never seen those ids.</para>
+    ///
+    /// <para>Order matters and is asserted, because what the grid has to guarantee is that the policies
+    /// sharing a hypertable land on DIFFERENT slots — that is the lock-queue adjacency the convoy formed on.
+    /// The baseline aggregates are appended from <see cref="BaselineAggregates"/> rather than restated, so
+    /// this list and that one cannot drift apart.</para>
+    /// </summary>
+    public static readonly IReadOnlyList<string> HourlyRefreshPhaseOrder =
+        new[]
+        {
+            QueryStatsHourlyView,
+            ProcedureStatsHourlyView,
+            QueryStoreStatsHourlyView,
+            QueryStatsDbHourlyView,
+            QueryStoreStatsIntervalHourlyView,
+            QueryStoreStatsCorrectedHourlyView,
+        }
+        .Concat(BaselineAggregates.Select(a => a.View))
+        .ToArray();
+
+    /// <summary>
+    /// Which minute of the hour <paramref name="view"/>'s hourly refresh policy starts on.
+    ///
+    /// <para>Throws for a view that is not on <see cref="HourlyRefreshPhaseOrder"/> — including every DAILY
+    /// view, which must not be dragged onto the grid. That is deliberately loud rather than defaulted: a new
+    /// hourly aggregate that silently got slot 0 would be coincident with three others, which is the exact
+    /// state #3012 was about. <see cref="EnsureContinuousAggregatesAsync"/> builds each policy statement
+    /// inside its own per-aggregate try, so an unregistered view costs that one aggregate and names itself in
+    /// the warning instead of taking the sweep down.</para>
+    /// </summary>
+    public static int RefreshPhaseMinutesFor(string view)
+    {
+        var index = HourlyRefreshPhaseOrder.ToList().IndexOf(view);
+        if (index < 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(view),
+                view,
+                "not an hourly continuous aggregate — register it in TimescaleSupport.HourlyRefreshPhaseOrder before giving it an hourly refresh policy");
+        }
+
+        return index % RefreshPhaseSlots * RefreshPhaseStepMinutes;
+    }
+
+    /// <summary>
+    /// An HOURLY continuous aggregate's refresh policy: <see cref="HourlyRefreshStartOffset"/> of window, an
+    /// <see cref="HourlyRefreshScheduleInterval"/> cadence, and this view's own slot on the phase grid.
+    /// </summary>
+    public static string AddHourlyRefreshPolicySql(string view)
+        => AddContinuousAggregatePolicySql(
+            view,
+            HourlyRefreshStartOffset,
+            HourlyRefreshScheduleInterval,
+            HourlyRefreshScheduleInterval,
+            RefreshPhaseMinutesFor(view));
+
+    /// <summary>
+    /// A DAILY continuous aggregate's refresh policy: <see cref="DailyRefreshStartOffset"/> of window on a
+    /// daily cadence, and NO <c>initial_start</c> — the daily tier keeps TimescaleDB's finish-to-start
+    /// scheduling, exactly as it did before #3012, because it was never near its own cadence and never
+    /// appeared in the convoy.
+    /// </summary>
+    public static string AddDailyRefreshPolicySql(string view)
+        => AddContinuousAggregatePolicySql(
+            view,
+            DailyRefreshStartOffset,
+            DailyRefreshScheduleInterval,
+            DailyRefreshScheduleInterval,
+            phaseMinutes: null);
+
+    /// <summary>
+    /// The refresh policy for a continuous aggregate: materialize
+    /// <c>[now - startOffset, now - endOffset]</c> every <c>scheduleInterval</c>. <c>endOffset</c> leaves the
+    /// still-filling current bucket unmaterialized (no repeated rework); <c>scheduleInterval</c> matches the
+    /// bucket. <c>if_not_exists</c> so a restart re-converges. Prefer
+    /// <see cref="AddHourlyRefreshPolicySql"/> / <see cref="AddDailyRefreshPolicySql"/>, which carry the
+    /// per-tier decisions; this overload exists so those two share one statement shape.
+    ///
+    /// <para><b><paramref name="phaseMinutes"/> does two things, and the second one is the less obvious
+    /// half.</b> It puts the job on a known minute of the hour, which is the stagger. It also switches the job
+    /// to a FIXED schedule: TimescaleDB computes the next start from the previous FINISH when
+    /// <c>initial_start</c> is absent, and from the previous START when it is present. Finish-to-start is what
+    /// let one convoy phase-lock a whole family permanently — three jobs with unrelated schedules and very
+    /// different workloads finished within 119 seconds of each other, and then re-started together every hour
+    /// after that. A fixed schedule cannot inherit a phase from a bad hour.</para>
+    ///
+    /// <para>The anchor is the NEXT whole hour plus the phase, deliberately in the future: a fixed schedule
+    /// needs a non-null <c>initial_start</c>, and anchoring forward means the statement never depends on
+    /// TimescaleDB's handling of a past anchor. It is computed in UTC (<c>now() AT TIME ZONE 'UTC'</c>, then
+    /// back to <c>timestamptz</c>) rather than with a bare <c>date_trunc('hour', now())</c>, which truncates
+    /// in the SESSION time zone and would land off-grid on any of the half-hour and quarter-hour zones.</para>
+    /// </summary>
+    public static string AddContinuousAggregatePolicySql(
+        string view,
+        string startOffset,
+        string endOffset,
+        string scheduleInterval,
+        int? phaseMinutes)
+    {
+        var initialStart = phaseMinutes is int phase
+            ? $", initial_start => date_trunc('hour', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' + INTERVAL '1 hour' + INTERVAL '{phase.ToString(CultureInfo.InvariantCulture)} minutes'"
+            : string.Empty;
+
+        return $"SELECT add_continuous_aggregate_policy('collect.{view}', start_offset => INTERVAL '{startOffset}', end_offset => INTERVAL '{endOffset}', schedule_interval => INTERVAL '{scheduleInterval}', if_not_exists => true{initialStart})";
+    }
 
     /// <summary>
     /// The composer-dimension reshape: the QS hourly CAGG regrouped query_id/plan_id → module_name/query_hash
@@ -1588,8 +1787,9 @@ WITH NO DATA";
     ///
     /// <para>Does NOT backfill history, and on a store that already holds history that leaves a real gap rather
     /// than a merely un-accelerated one (#1759): the aggregates are born WITH NO DATA and each refresh policy
-    /// starts 3 days back, so the materialized span begins at roughly creation-minus-3-days and never reaches
-    /// further back on its own. Reads stay CORRECT because <see cref="RetentionTierRouter"/> routes windows
+    /// only reaches its own start offset back (<see cref="HourlyRefreshStartOffset"/> hourly,
+    /// <see cref="DailyRefreshStartOffset"/> daily), so the materialized span begins at roughly creation minus
+    /// that offset and never reaches further back on its own. Reads stay CORRECT because <see cref="RetentionTierRouter"/> routes windows
     /// below a rollup's measured floor to raw; the materialization itself is an operator op
     /// (<c>--backfill-rollups</c>), which is where the disk cost is preflighted rather than incurred at
     /// startup.</para>
@@ -1606,32 +1806,33 @@ WITH NO DATA";
         // sweep. Daily policies use the 1-day end-offset/schedule; the hourly ones take the helper's defaults.
         var aggregates = new[]
         {
-            (CreateSql: CreateQueryStatsHourlySql,      View: QueryStatsHourlyView,      PolicySql: AddContinuousAggregatePolicySql(QueryStatsHourlyView)),
-            (CreateSql: CreateProcedureStatsHourlySql,  View: ProcedureStatsHourlyView,  PolicySql: AddContinuousAggregatePolicySql(ProcedureStatsHourlyView)),
-            (CreateSql: CreateQueryStoreStatsHourlySql, View: QueryStoreStatsHourlyView, PolicySql: AddContinuousAggregatePolicySql(QueryStoreStatsHourlyView)),
-            (CreateSql: CreateQueryStatsDbHourlySql,    View: QueryStatsDbHourlyView,    PolicySql: AddContinuousAggregatePolicySql(QueryStatsDbHourlyView)),
+            (CreateSql: CreateQueryStatsHourlySql,      View: QueryStatsHourlyView,      Hourly: true),
+            (CreateSql: CreateProcedureStatsHourlySql,  View: ProcedureStatsHourlyView,  Hourly: true),
+            (CreateSql: CreateQueryStoreStatsHourlySql, View: QueryStoreStatsHourlyView, Hourly: true),
+            (CreateSql: CreateQueryStatsDbHourlySql,    View: QueryStatsDbHourlyView,    Hourly: true),
             /* The corrected Query Store rollups (#1849). L1 is raw-sourced and MUST precede both corrected
                views, which are hierarchical from it — the same ordering requirement the daily tier has. Both
                corrected views read L1 (the daily is its SIBLING, not the hourly's child: an identity-width
                hierarchical CAGG is a leaf — see CreateQueryStoreStatsCorrectedDailySql). */
-            (CreateSql: CreateQueryStoreStatsIntervalHourlySql,  View: QueryStoreStatsIntervalHourlyView,  PolicySql: AddContinuousAggregatePolicySql(QueryStoreStatsIntervalHourlyView)),
-            (CreateSql: CreateQueryStoreStatsCorrectedHourlySql, View: QueryStoreStatsCorrectedHourlyView, PolicySql: AddContinuousAggregatePolicySql(QueryStoreStatsCorrectedHourlyView)),
-            (CreateSql: CreateQueryStatsDailySql,       View: QueryStatsDailyView,       PolicySql: AddContinuousAggregatePolicySql(QueryStatsDailyView, "1 day", "1 day")),
-            (CreateSql: CreateProcedureStatsDailySql,   View: ProcedureStatsDailyView,   PolicySql: AddContinuousAggregatePolicySql(ProcedureStatsDailyView, "1 day", "1 day")),
-            (CreateSql: CreateQueryStoreStatsDailySql,  View: QueryStoreStatsDailyView,  PolicySql: AddContinuousAggregatePolicySql(QueryStoreStatsDailyView, "1 day", "1 day")),
-            (CreateSql: CreateQueryStoreStatsCorrectedDailySql, View: QueryStoreStatsCorrectedDailyView, PolicySql: AddContinuousAggregatePolicySql(QueryStoreStatsCorrectedDailyView, "1 day", "1 day")),
-            (CreateSql: CreateQueryStatsDbDailySql,     View: QueryStatsDbDailyView,     PolicySql: AddContinuousAggregatePolicySql(QueryStatsDbDailyView, "1 day", "1 day")),
+            (CreateSql: CreateQueryStoreStatsIntervalHourlySql,  View: QueryStoreStatsIntervalHourlyView,  Hourly: true),
+            (CreateSql: CreateQueryStoreStatsCorrectedHourlySql, View: QueryStoreStatsCorrectedHourlyView, Hourly: true),
+            (CreateSql: CreateQueryStatsDailySql,       View: QueryStatsDailyView,       Hourly: false),
+            (CreateSql: CreateProcedureStatsDailySql,   View: ProcedureStatsDailyView,   Hourly: false),
+            (CreateSql: CreateQueryStoreStatsDailySql,  View: QueryStoreStatsDailyView,  Hourly: false),
+            (CreateSql: CreateQueryStoreStatsCorrectedDailySql, View: QueryStoreStatsCorrectedDailyView, Hourly: false),
+            (CreateSql: CreateQueryStatsDbDailySql,     View: QueryStatsDbDailyView,     Hourly: false),
             /* The DAY-grain corrected daily (#1869), THREE levels deep: L1 (above) -> L2 interval_daily ->
                daygrain_daily. Both must follow L1 and L2 must precede its own child, which this ordered sweep
                gives — the same requirement the daily tier has, one level longer. */
-            (CreateSql: CreateQueryStoreStatsIntervalDailySql, View: QueryStoreStatsIntervalDailyView, PolicySql: AddContinuousAggregatePolicySql(QueryStoreStatsIntervalDailyView, "1 day", "1 day")),
-            (CreateSql: CreateQueryStoreStatsDayGrainDailySql, View: QueryStoreStatsDayGrainDailyView, PolicySql: AddContinuousAggregatePolicySql(QueryStoreStatsDayGrainDailyView, "1 day", "1 day")),
+            (CreateSql: CreateQueryStoreStatsIntervalDailySql, View: QueryStoreStatsIntervalDailyView, Hourly: false),
+            (CreateSql: CreateQueryStoreStatsDayGrainDailySql, View: QueryStoreStatsDayGrainDailyView, Hourly: false),
         }
-        /* The seven baseline-tier aggregates (#1757; nine until #2007) take the helper's hourly defaults: they are sourced from
+        /* The seven baseline-tier aggregates (#1757; nine until #2007) ride the HOURLY tier: they are sourced from
            raw like the hourly tier, not hierarchically from another CAGG, so they carry no ordering
            requirement against the daily tier. Appended from the single BaselineAggregates list so this sweep
-           and the retention list cannot drift apart. */
-        .Concat(BaselineAggregates.Select(a => (CreateSql: a.CreateSql, View: a.View, PolicySql: AddContinuousAggregatePolicySql(a.View))))
+           and the retention list cannot drift apart. HourlyRefreshPhaseOrder appends them from the same list,
+           so every view here has a slot on the phase grid. */
+        .Concat(BaselineAggregates.Select(a => (CreateSql: a.CreateSql, View: a.View, Hourly: true)))
         .ToArray();
 
         /* A store that ran WITHOUT TimescaleDB and has now gained it is carrying the plain fallback views
@@ -1655,7 +1856,7 @@ WITH NO DATA";
         }
 
         var ready = 0;
-        foreach (var (createSql, view, policySql) in aggregates)
+        foreach (var (createSql, view, hourly) in aggregates)
         {
             try
             {
@@ -1663,6 +1864,11 @@ WITH NO DATA";
                 {
                     await create.ExecuteNonQueryAsync(cancellationToken);
                 }
+
+                /* Built HERE, not in the array above, so RefreshPhaseMinutesFor's throw for an hourly view
+                   missing from HourlyRefreshPhaseOrder costs that one aggregate and names it in the warning
+                   below, instead of taking the whole sweep down before the first CREATE runs. */
+                var policySql = hourly ? AddHourlyRefreshPolicySql(view) : AddDailyRefreshPolicySql(view);
 
                 using (var policy = new NpgsqlCommand(policySql, connection) { CommandTimeout = SetupTimeoutSeconds })
                 {
@@ -1689,8 +1895,179 @@ WITH NO DATA";
         return ready;
     }
 
-    /// <summary>Raw-tier retention horizon: keep per-sweep raw ~4 days — one day past the hourly CAGG's own 3-day
-    /// refresh window, so the raw drop never outruns the aggregate that preserves it.</summary>
+    /// <summary>
+    /// Every continuous-aggregate REFRESH job in <c>collect</c>, with the three things #3012's treatment is
+    /// made of: the window it re-materializes, whether it is on a fixed schedule, and which minute of the hour
+    /// it starts on.
+    ///
+    /// <para><b>Keyed on the VIEW, which takes a join to get.</b> A refresh job's own
+    /// <c>hypertable_name</c> is the aggregate's MATERIALIZATION hypertable
+    /// (<c>_materialized_hypertable_N</c>), a per-deployment name that says nothing about which rollup it
+    /// belongs to — so this joins <c>continuous_aggregates</c> to recover <c>view_name</c>, and the caller
+    /// decides what each view should look like from <see cref="HourlyRefreshPhaseOrder"/>. Nothing here or in
+    /// the caller reads a job id for anything except passing it back to <c>alter_job</c>.</para>
+    ///
+    /// <para>Emitted as NUMBERS, not text: <c>start_offset</c> comes back as seconds so a C# comparison cannot
+    /// be fooled by <c>1 day</c> / <c>1 day 00:00:00</c> / <c>24:00:00</c> all meaning the same interval, and
+    /// the phase comes back as a minute-of-hour already converted to UTC (a bare
+    /// <c>EXTRACT(MINUTE FROM initial_start)</c> would read the SESSION time zone). A policy created with a
+    /// NULL <c>start_offset</c> — refresh from the beginning of time — yields NULL here and is treated as
+    /// stale, which is correct: it is the widest window there is.</para>
+    /// </summary>
+    public const string ContinuousAggregateRefreshStateSql = @"
+SELECT
+    j.job_id,
+    ca.view_name,
+    EXTRACT(EPOCH FROM (j.config->>'start_offset')::interval)::bigint AS start_offset_seconds,
+    j.fixed_schedule,
+    CASE
+        WHEN j.initial_start IS NULL THEN NULL
+        ELSE EXTRACT(MINUTE FROM j.initial_start AT TIME ZONE 'UTC')::int
+    END AS phase_minutes
+FROM timescaledb_information.jobs AS j
+JOIN timescaledb_information.continuous_aggregates AS ca
+  ON  ca.materialization_hypertable_schema = j.hypertable_schema
+  AND ca.materialization_hypertable_name = j.hypertable_name
+WHERE j.proc_name = 'policy_refresh_continuous_aggregate'
+AND   ca.view_schema = 'collect'";
+
+    /// <summary>
+    /// Moves one EXISTING hourly refresh policy onto the shipped window and phase. <c>$1</c> the job id
+    /// (<c>::integer</c> — <c>alter_job</c> takes <c>job_id INTEGER</c> and PostgreSQL does not down-cast
+    /// bigint during function resolution, the #1586 trap), <c>$2</c> the <c>start_offset</c> text, <c>$3</c>
+    /// the minute of the hour.
+    ///
+    /// <para><b>Why this has to exist at all.</b>
+    /// <c>add_continuous_aggregate_policy(if_not_exists =&gt; true)</c> returns -1 for a policy the store
+    /// already has and changes NOTHING about it — the same documented behaviour
+    /// <see cref="ConvergeRetentionHorizonSql"/> and <see cref="ConvergeCompressionScheduleAsync"/> exist for.
+    /// Without this, #3012's fix would reach fresh installs only, and every store that ever ran an older build
+    /// would keep re-materializing three days every hour forever, with nothing failing until its hypertable
+    /// grew into the same convoy.</para>
+    ///
+    /// <para><c>config</c> is updated with <c>jsonb_set</c> against the job's OWN config so the other keys
+    /// (<c>end_offset</c>, <c>mat_hypertable_id</c>) are preserved untouched, which is why this is a
+    /// <c>SELECT ... FROM timescaledb_information.jobs</c> rather than a bare function call. <c>scheduled</c>
+    /// is deliberately not named: every un-named <c>alter_job</c> parameter means "leave unchanged", so this
+    /// cannot arm a paused job.</para>
+    /// </summary>
+    public const string SetContinuousAggregateRefreshSql = @"
+SELECT alter_job(
+    j.job_id,
+    config => jsonb_set(j.config, '{start_offset}', to_jsonb($2::text)),
+    fixed_schedule => true,
+    initial_start => date_trunc('hour', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' + INTERVAL '1 hour' + ($3::int * INTERVAL '1 minute'))
+FROM timescaledb_information.jobs AS j
+WHERE j.job_id = $1::integer";
+
+    /// <summary>
+    /// Converges EXISTING hourly continuous-aggregate refresh policies onto both halves of #3012's treatment —
+    /// the narrowed <see cref="HourlyRefreshStartOffset"/> window and the
+    /// <see cref="RefreshPhaseStepMinutes"/> phase grid — for stores that already have policies.
+    ///
+    /// <para><b>Behaviour on each of the three store states, because that is the whole contract.</b> A FRESH
+    /// store had its policies created by <see cref="EnsureContinuousAggregatesAsync"/> moments earlier with
+    /// these exact values, so nothing here matches and nothing is touched. A store still carrying the OLD
+    /// values gets both halves applied on the first start after deploy. A store an operator already patched BY
+    /// HAND to the right window is matched on the window and left alone on it — it is only re-phased if its
+    /// job is not on a fixed schedule or not on this grid, which is the one case where code deliberately wins
+    /// over a live hand-applied value: a hand-set <c>next_start</c> without a fixed schedule drifts back to
+    /// finish-to-start scheduling and re-phases itself the first time a run overruns.</para>
+    ///
+    /// <para><b>DAILY refresh policies are skipped, by membership rather than by name-matching.</b> A view
+    /// that is not on <see cref="HourlyRefreshPhaseOrder"/> is passed over untouched, so the daily tier keeps
+    /// <see cref="DailyRefreshStartOffset"/> and its finish-to-start scheduling. This is the guard against the
+    /// obvious future regression — a "make every refresh window consistent" edit — arriving through the
+    /// converge path instead of through the create path.</para>
+    ///
+    /// <para>Failure-isolated PER JOB, the #1775 shape: one <c>alter_job</c> that fails (most often because a
+    /// least-privilege bring-your-own store's login does not own the job) leaves that one policy on its old
+    /// window and the rest still converge. Returns how many it moved.</para>
+    /// </summary>
+    public static async Task<int> ConvergeContinuousAggregateRefreshAsync(
+        NpgsqlConnection connection, ILogger? logger, CancellationToken cancellationToken = default)
+    {
+        if (connection is null)
+        {
+            throw new ArgumentNullException(nameof(connection));
+        }
+
+        var hourly = new HashSet<string>(HourlyRefreshPhaseOrder, StringComparer.Ordinal);
+        var desiredSeconds = (long)HourlyRefreshStartSpan.TotalSeconds;
+
+        var stale = new List<(int JobId, string View, long? WasSeconds, bool WasFixed, int? WasPhase)>();
+        try
+        {
+            using var probe = new NpgsqlCommand(ContinuousAggregateRefreshStateSql, connection) { CommandTimeout = SetupTimeoutSeconds };
+            await using var reader = await probe.ExecuteReaderAsync(cancellationToken);
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                var view = reader.GetString(1);
+                if (!hourly.Contains(view))
+                {
+                    continue;
+                }
+
+                var seconds = reader.IsDBNull(2) ? (long?)null : reader.GetInt64(2);
+                var fixedSchedule = !reader.IsDBNull(3) && reader.GetBoolean(3);
+                var phase = reader.IsDBNull(4) ? (int?)null : reader.GetInt32(4);
+
+                if (seconds == desiredSeconds && fixedSchedule && phase == RefreshPhaseMinutesFor(view))
+                {
+                    continue;
+                }
+
+                stale.Add((Convert.ToInt32(reader.GetValue(0), CultureInfo.InvariantCulture), view, seconds, fixedSchedule, phase));
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            /* A plain-PostgreSQL store (the views do not exist) or a TimescaleDB too old to expose
+               initial_start. The caller already gates on the extension; nothing to converge either way. */
+            logger?.LogDebug("Continuous-aggregate refresh converge: could not read policy jobs: {Message}", ex.Message);
+            return 0;
+        }
+
+        var converged = 0;
+        foreach (var (jobId, view, wasSeconds, wasFixed, wasPhase) in stale)
+        {
+            var phase = RefreshPhaseMinutesFor(view);
+            try
+            {
+                using var alter = new NpgsqlCommand(SetContinuousAggregateRefreshSql, connection) { CommandTimeout = SetupTimeoutSeconds };
+                alter.Parameters.AddWithValue(jobId);
+                alter.Parameters.AddWithValue(HourlyRefreshStartOffset);
+                alter.Parameters.AddWithValue(phase);
+                await alter.ExecuteNonQueryAsync(cancellationToken);
+                converged++;
+
+                logger?.LogInformation(
+                    "TimescaleDB: moved {View}'s refresh policy to a {Now} window on a fixed :{Phase} schedule (was {WasSeconds}s of window, fixed_schedule={WasFixed}, phase {WasPhase}) — a refresh window wider than its own cadence is what turns a shared lock into a convoy (#3012).",
+                    view, HourlyRefreshStartOffset, phase.ToString("00", CultureInfo.InvariantCulture), wasSeconds, wasFixed, wasPhase);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                logger?.LogWarning(
+                    "Could not move {View}'s refresh policy (job {JobId}) to a {Interval} window on a fixed :{Phase} schedule — it keeps re-materializing its old window every run (often a permission issue: the store login must own the job): {Message}",
+                    view, jobId, HourlyRefreshStartOffset, phase.ToString("00", CultureInfo.InvariantCulture), ex.Message);
+            }
+        }
+
+        if (converged > 0)
+        {
+            logger?.LogInformation(
+                "TimescaleDB: {Converged}/{Total} hourly refresh policies moved onto the {Interval} window and the {Step}-minute phase grid (#3012).",
+                converged, stale.Count, HourlyRefreshStartOffset, RefreshPhaseStepMinutes);
+        }
+
+        return converged;
+    }
+
+    /// <summary>Raw-tier retention horizon: keep per-sweep raw ~4 days — comfortably past the hourly CAGG's own
+    /// <see cref="HourlyRefreshStartOffset"/> refresh window, so the raw drop never outruns the aggregate that
+    /// preserves it. The margin is three days since #3012 narrowed that window; it was one day before, and the
+    /// dependency now runs the other way — the refresh window is chosen against its own cadence and this
+    /// horizon only has to clear it.</summary>
     public const string RawRetentionInterval = "4 days";
 
     /// <summary>Hourly-CAGG-tier retention horizon: keep the hourly rollups 90 days — well past the daily CAGG's
@@ -1722,7 +2099,8 @@ WITH NO DATA";
     /// by taste. It must EXCEED <see cref="RawRetentionInterval"/> (4 days) with margin, because the raw purge
     /// is gated on this view covering raw's oldest row — equal horizons would race, with raw's newest-dropped
     /// chunk and L1's oldest-kept bucket at the same age. And it only has to exceed it: nothing READS this
-    /// view, and its consumers (the two corrected rollups) refresh over a 3-day window.</para>
+    /// view, and its consumers refresh over at most <see cref="DailyRefreshStartOffset"/> (the corrected
+    /// daily; the corrected hourly reaches only <see cref="HourlyRefreshStartOffset"/> back).</para>
     ///
     /// <para><b>MEASURED, because #1849 raises capacity as a real input and #1581 says settle it before
     /// shipping.</b> On a seeded 600-query store at the default 5-minute <c>query_store</c> cadence
@@ -2157,8 +2535,9 @@ AND   j.hypertable_name = '{relation}'";
     /// logs names all of them, because an operator cross-checking it against
     /// <c>timescaledb_information.jobs</c> meets every one (#1958).
     /// Ordering safety is by HORIZON, not run order — each tier's drop stays comfortably past the next
-    /// tier's 3-day refresh start_offset (4d raw vs 3d hourly refresh; 90d hourly vs 3d daily refresh), so a drop
-    /// never removes history the next tier has not yet materialized. Idempotent (<c>if_not_exists</c>) and
+    /// tier's refresh start_offset (4d raw vs the hourly refresh's <see cref="HourlyRefreshStartOffset"/>;
+    /// 90d hourly vs the daily refresh's <see cref="DailyRefreshStartOffset"/>), so a drop never removes
+    /// history the next tier has not yet materialized. Idempotent (<c>if_not_exists</c>) and
     /// failure-isolated per policy. MUST run AFTER <see cref="EnsureContinuousAggregatesAsync"/> so the hourly
     /// CAGGs the hourly policies target already exist. Returns the number of policies in place.
     ///
@@ -2449,8 +2828,9 @@ AND   j.hypertable_name = '{relation}'";
     /// pre-existing history serves ONLY what was materialized. Real-time aggregation cannot rescue it —
     /// the watermark is a hard partition (materialized below <c>UNION ALL</c> raw at-or-above), so raw
     /// older than the watermark is excluded by construction, not merely un-accelerated. Every rollup's
-    /// refresh policy starts 3 days back, so on a store that existed before its rollups the materialized
-    /// span begins at roughly creation-minus-3-days and NEVER reaches further back on its own.</para>
+    /// refresh policy only reaches its own start offset back, so on a store that existed before its rollups
+    /// the materialized span begins at roughly creation minus that offset and NEVER reaches further back on
+    /// its own.</para>
     ///
     /// <para><b><c>to_regclass</c>-safe by construction, not by guard.</b> A relation named in a statement
     /// is resolved at PARSE time, so no in-statement <c>to_regclass</c> test can keep <c>min(bucket)</c>

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -1787,6 +1787,15 @@ WITH NO DATA";
     /// statement. Failure-isolated per aggregate: one failure warns and the composer keeps querying raw.
     /// Idempotent (IF NOT EXISTS on both), so it re-converges every restart. Returns the number ready.
     ///
+    /// <para><b>MUST run AFTER <see cref="ConvergeContinuousAggregateRefreshAsync"/> (#3012).</b> The policy
+    /// half is idempotent only against a policy whose window MATCHES: <c>if_not_exists =&gt; true</c> returns
+    /// -1 for an identical policy, but against one whose window differs it raises <c>22023 refresh interval
+    /// overlaps with an existing continuous aggregate policy</c>. That is measured, and it is unlike
+    /// <c>add_compression_policy</c> and <c>add_retention_policy</c>, which both skip quietly. Run BEFORE the
+    /// converge, this sweep would raise on every hourly view of every already-deployed store, swallow it in
+    /// the per-aggregate catch, and report a count that reads as "the aggregates are broken" when only their
+    /// refresh windows are stale.</para>
+    ///
     /// <para>Does NOT backfill history, and on a store that already holds history that leaves a real gap rather
     /// than a merely un-accelerated one (#1759): the aggregates are born WITH NO DATA and each refresh policy
     /// only reaches its own start offset back (<see cref="HourlyRefreshStartOffset"/> hourly,
@@ -1946,13 +1955,17 @@ AND   ca.view_schema = 'collect'";
     /// bigint during function resolution, the #1586 trap), <c>$2</c> the <c>start_offset</c> text, <c>$3</c>
     /// the minute of the hour.
     ///
-    /// <para><b>Why this has to exist at all.</b>
-    /// <c>add_continuous_aggregate_policy(if_not_exists =&gt; true)</c> returns -1 for a policy the store
-    /// already has and changes NOTHING about it — the same documented behaviour
-    /// <see cref="ConvergeRetentionHorizonSql"/> and <see cref="ConvergeCompressionScheduleAsync"/> exist for.
-    /// Without this, #3012's fix would reach fresh installs only, and every store that ever ran an older build
-    /// would keep re-materializing three days every hour forever, with nothing failing until its hypertable
-    /// grew into the same convoy.</para>
+    /// <para><b>Why this has to exist, and why it is worse than the sibling cases.</b>
+    /// <see cref="ConvergeRetentionHorizonSql"/> and <see cref="ConvergeCompressionScheduleAsync"/> exist
+    /// because their <c>add_*</c> function returns -1 for a policy the store already has and changes nothing.
+    /// <c>add_continuous_aggregate_policy</c> does that only when the window MATCHES. Against a policy whose
+    /// window DIFFERS it raises <c>22023 refresh interval overlaps with an existing continuous aggregate
+    /// policy</c> — measured on a live store, and it is why
+    /// <see cref="EnsureContinuousAggregatesAsync"/> must run AFTER this rather than before. So without this
+    /// the narrowing would not merely fail to reach an upgraded store: the create path would raise on all
+    /// thirteen hourly views every start, be swallowed by that sweep's per-aggregate isolation, and leave the
+    /// policies re-materializing three days an hour forever, with nothing failing until the hypertable grew
+    /// into the same convoy.</para>
     ///
     /// <para><c>config</c> is updated with <c>jsonb_set</c> against the job's OWN config so the other keys
     /// (<c>end_offset</c>, <c>mat_hypertable_id</c>) are preserved untouched, which is why this is a
@@ -1975,13 +1988,16 @@ WHERE j.job_id = $1::integer";
     /// <see cref="RefreshPhaseStepMinutes"/> phase grid — for stores that already have policies.
     ///
     /// <para><b>Behaviour on each of the three store states, because that is the whole contract.</b> A FRESH
-    /// store had its policies created by <see cref="EnsureContinuousAggregatesAsync"/> moments earlier with
-    /// these exact values, so nothing here matches and nothing is touched. A store still carrying the OLD
-    /// values gets both halves applied on the first start after deploy. A store an operator already patched BY
-    /// HAND to the right window is matched on the window and left alone on it — it is only re-phased if its
-    /// job is not on a fixed schedule or not on this grid, which is the one case where code deliberately wins
-    /// over a live hand-applied value: a hand-set <c>next_start</c> without a fixed schedule drifts back to
-    /// finish-to-start scheduling and re-phases itself the first time a run overruns.</para>
+    /// store has no refresh jobs yet — its aggregates are created moments LATER — so this reads an empty set
+    /// and returns 0. A store still carrying the OLD values gets both halves applied on the first start after
+    /// deploy, and the create that follows then finds policies which match. A store an operator already
+    /// patched BY HAND to the right window is matched on the window and left alone on it — it is only
+    /// re-phased if its job is not on a fixed schedule or not on this grid, which is the one case where code
+    /// deliberately wins over a live hand-applied value, and production settled that argument: measured about
+    /// two hours after the offsets were applied by hand, every job read <c>fixed_schedule = false</c> and only
+    /// one of six hourly refreshes was still on the minute it had been set to. Without a fixed schedule the
+    /// next start comes off the previous FINISH, so a hand-applied stagger decays back into coincidence within
+    /// hours.</para>
     ///
     /// <para><b>DAILY refresh policies are skipped, by membership rather than by name-matching.</b> A view
     /// that is not on <see cref="HourlyRefreshPhaseOrder"/> is passed over untouched, so the daily tier keeps

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -904,6 +904,31 @@ $do$";
 
     /// <summary>The seven baseline-tier aggregates in creation order (nine until #2007 retired the unread CPU/IO pair). Named ONCE so the ensure sweep, the
     /// retention list and the tests read one list rather than three hand-kept copies.</summary>
+    /// <summary>
+    /// The non-baseline HOURLY continuous aggregates, in CREATION order, paired with their CREATE SQL.
+    ///
+    /// <para>Order is load-bearing twice over. <see cref="EnsureContinuousAggregatesAsync"/> builds them in
+    /// this sequence because <see cref="CreateQueryStoreStatsCorrectedHourlySql"/> is hierarchical from
+    /// <see cref="CreateQueryStoreStatsIntervalHourlySql"/> and a hierarchical aggregate cannot precede its
+    /// source. And <see cref="HourlyRefreshPhaseOrder"/> derives each view's slot on the phase grid from its
+    /// position here, so a reordering moves phases — which is why the collision guard checks the RESULT rather
+    /// than trusting the list.</para>
+    ///
+    /// <para>Hoisted out of the ensure sweep (#3012) so that sweep, the phase order and the collision guard
+    /// all read ONE list. Restating it in the guard would let the guard pass while the sweep drifted.</para>
+    /// </summary>
+    public static readonly (string CreateSql, string View)[] HourlyAggregates =
+    {
+        (CreateQueryStatsHourlySql,      QueryStatsHourlyView),
+        (CreateProcedureStatsHourlySql,  ProcedureStatsHourlyView),
+        (CreateQueryStoreStatsHourlySql, QueryStoreStatsHourlyView),
+        (CreateQueryStatsDbHourlySql,    QueryStatsDbHourlyView),
+        /* The corrected Query Store rollups (#1849): L1 is raw-sourced and MUST precede the corrected view,
+           which is hierarchical from it. */
+        (CreateQueryStoreStatsIntervalHourlySql,  QueryStoreStatsIntervalHourlyView),
+        (CreateQueryStoreStatsCorrectedHourlySql, QueryStoreStatsCorrectedHourlyView),
+    };
+
     public static readonly (string CreateSql, string View)[] BaselineAggregates =
     {
         (CreatePerfmonBaselineSql,        PerfmonBaselineView),
@@ -1605,17 +1630,22 @@ WITH NO DATA";
     /// this list and that one cannot drift apart.</para>
     /// </summary>
     public static readonly IReadOnlyList<string> HourlyRefreshPhaseOrder =
-        new[]
-        {
-            QueryStatsHourlyView,
-            ProcedureStatsHourlyView,
-            QueryStoreStatsHourlyView,
-            QueryStatsDbHourlyView,
-            QueryStoreStatsIntervalHourlyView,
-            QueryStoreStatsCorrectedHourlyView,
-        }
-        .Concat(BaselineAggregates.Select(a => a.View))
-        .ToArray();
+        HourlyAggregates.Concat(BaselineAggregates).Select(a => a.View).ToArray();
+
+    /// <summary>
+    /// Every hourly continuous aggregate paired with the CREATE that defines it —
+    /// <see cref="HourlyAggregates"/> then <see cref="BaselineAggregates"/>, in the same order
+    /// <see cref="HourlyRefreshPhaseOrder"/> derives from.
+    ///
+    /// <para>Exists so the phase grid's real invariant can be checked against the SHIPPED DEFINITIONS rather
+    /// than a second hand-written map. What the grid has to guarantee is that policies CONTENDING FOR THE SAME
+    /// RELATION start at different minutes — that is the lock adjacency the convoy formed on — and a view's
+    /// contended relation is whatever its own CREATE selects <c>FROM</c>. Recovering it from this text means a
+    /// new aggregate is covered the moment it is registered, and a map that drifted from the definitions
+    /// cannot report a false all-clear.</para>
+    /// </summary>
+    public static readonly IReadOnlyList<(string CreateSql, string View)> HourlyRefreshDefinitions =
+        HourlyAggregates.Concat(BaselineAggregates).ToArray();
 
     /// <summary>
     /// Which minute of the hour <paramref name="view"/>'s hourly refresh policy starts on.
@@ -1815,18 +1845,16 @@ WITH NO DATA";
         // Hourly CAGGs FIRST (the two delta tables + query_store_stats), THEN the daily tier — the daily CAGGs are
         // hierarchical (sourced from the hourly CAGGs), so the hourly ones must be created earlier in this ordered
         // sweep. Daily policies use the 1-day end-offset/schedule; the hourly ones take the helper's defaults.
-        var aggregates = new[]
+        /* The hourly tier comes from HourlyAggregates rather than being restated here (#3012): the phase grid
+           and its collision guard derive from that same list, and a second copy could drift from it. The
+           corrected Query Store rollups' ordering requirement lives with the list — L1 is raw-sourced and must
+           precede the corrected view, which is hierarchical from it. (The corrected DAILY is L1's SIBLING, not
+           the hourly's child: an identity-width hierarchical CAGG is a leaf — see
+           CreateQueryStoreStatsCorrectedDailySql.) */
+        var aggregates = HourlyAggregates
+            .Select(a => (CreateSql: a.CreateSql, View: a.View, Hourly: true))
+            .Concat(new[]
         {
-            (CreateSql: CreateQueryStatsHourlySql,      View: QueryStatsHourlyView,      Hourly: true),
-            (CreateSql: CreateProcedureStatsHourlySql,  View: ProcedureStatsHourlyView,  Hourly: true),
-            (CreateSql: CreateQueryStoreStatsHourlySql, View: QueryStoreStatsHourlyView, Hourly: true),
-            (CreateSql: CreateQueryStatsDbHourlySql,    View: QueryStatsDbHourlyView,    Hourly: true),
-            /* The corrected Query Store rollups (#1849). L1 is raw-sourced and MUST precede both corrected
-               views, which are hierarchical from it — the same ordering requirement the daily tier has. Both
-               corrected views read L1 (the daily is its SIBLING, not the hourly's child: an identity-width
-               hierarchical CAGG is a leaf — see CreateQueryStoreStatsCorrectedDailySql). */
-            (CreateSql: CreateQueryStoreStatsIntervalHourlySql,  View: QueryStoreStatsIntervalHourlyView,  Hourly: true),
-            (CreateSql: CreateQueryStoreStatsCorrectedHourlySql, View: QueryStoreStatsCorrectedHourlyView, Hourly: true),
             (CreateSql: CreateQueryStatsDailySql,       View: QueryStatsDailyView,       Hourly: false),
             (CreateSql: CreateProcedureStatsDailySql,   View: ProcedureStatsDailyView,   Hourly: false),
             (CreateSql: CreateQueryStoreStatsDailySql,  View: QueryStoreStatsDailyView,  Hourly: false),
@@ -1837,7 +1865,7 @@ WITH NO DATA";
                gives — the same requirement the daily tier has, one level longer. */
             (CreateSql: CreateQueryStoreStatsIntervalDailySql, View: QueryStoreStatsIntervalDailyView, Hourly: false),
             (CreateSql: CreateQueryStoreStatsDayGrainDailySql, View: QueryStoreStatsDayGrainDailyView, Hourly: false),
-        }
+        })
         /* The seven baseline-tier aggregates (#1757; nine until #2007) ride the HOURLY tier: they are sourced from
            raw like the hourly tier, not hierarchically from another CAGG, so they carry no ordering
            requirement against the daily tier. Appended from the single BaselineAggregates list so this sweep


### PR DESCRIPTION
Makes #3012's two operator treatments durable in code, and inverts the dependency that made the first one necessary. Fixes #3012 (closing keywords are a no-op on a `dev` merge, so this needs closing by hand).

## What was wrong

Every hourly continuous-aggregate refresh carried `start_offset => INTERVAL '3 days'` against a hypertable with 4-day raw retention, so each run re-materialized roughly three quarters of the table. A refresh's cost is set by the window it re-scans, not by the rows that arrived in it, so the cost tracked retained volume rather than arrival rate — measured on the production store, refresh duration rose ~8x while rows arriving per hour *fell* ~3x, which is what falsifies "more rows to materialize" and leaves "too much window".

The heaviest hourly refresh reached 3,301–6,330 s against its own 1-hour cadence — 118–175% of it — at which point each run started into the tail of the last. That is when the lock queue turns it into a convoy: the running refresh holds `AccessShareLock`, the compression policy on the same hypertable queues an `AccessExclusiveLock` request behind it, and a *queued* exclusive request blocks every subsequent shared request, so collector store-writes pile up behind a lock nobody holds. 40 of 40 collector write errors in the reported window fell inside a running refresh or compression window.

## What this changes

`TimescaleSupport.HourlyRefreshStartOffset` is `1 day`, applied to all thirteen hourly refresh policies (the six named rollups plus the seven baseline aggregates). On the narrowed window the heavy refresh runs 864 s, 24% of cadence, so it can no longer outrun its own schedule.

`TimescaleSupport.RefreshPhaseStepMinutes` puts those thirteen on a 15-minute grid keyed on `HourlyRefreshPhaseOrder` — the view name, never a job id, because TimescaleDB job ids are per-deployment. Naming `initial_start` also switches each job to a **fixed schedule**, which is the less obvious half: without it TimescaleDB computes the next start from the previous *finish*, so one convoy phase-locks a family permanently — the incident's three jobs, on unrelated schedules with very different workloads, finished within 119 seconds of each other and re-started together every hour after that.

The two are complements, not alternatives. The heavy refresh is still ~33x its lightest sibling on the narrowed window, so narrowing is what makes it finish and phasing is what keeps its remaining 864 s out of everything else's way. They are pinned separately for that reason, and each pin is red on its own mutation with the other green — and reverting *both* at once reddens three disjoint tests rather than one, so neither pin is wearing two hats.

What the grid has to guarantee is that policies **contending for the same relation** start on different minutes, and that is now asserted for every such group rather than for the one family the incident evidence named. `collect.query_stats` feeds three hourly policies; their minutes are distinct today only because of where they sit in the order, and phases collide whenever two positions differ by a multiple of the slot count. The guard derives each view's contended relation from the shipped `CREATE` text via `HourlyRefreshDefinitions`, counts a view that is itself a source into its consumers' group (refreshing it *writes* what they *read*), and asserts its extraction found a source per view before concluding anything. Raised by review, not found here.

`ConvergeContinuousAggregateRefreshAsync` reaches stores that already have policies, and it runs **before** `EnsureContinuousAggregatesAsync` rather than after — which is a measured ordering requirement, not a preference.

`add_continuous_aggregate_policy` does not behave like `add_compression_policy` or `add_retention_policy`. Those return `-1` and change nothing against a policy the store already has. This one does that only when the window *matches*; against a policy whose window **differs** it raises `22023 refresh interval overlaps with an existing continuous aggregate policy`. So the create sweep running first would raise on all thirteen hourly views of every already-deployed store, swallow each one in its per-aggregate catch, and report the aggregates as unready while the windows stayed at three days. That premise was stated the other way in the first revision of this description and in several doc comments; the live test disproved it and both are corrected. Converging first leaves the create looking at policies that already match, which is the quiet `-1` it was written for.

The converge selects only jobs that differ, compares `start_offset` as **seconds** so `1 day` / `24:00:00` cannot read as a difference and re-alter the same job every start, reads the phase in UTC, and names no `scheduled` argument so it cannot arm a paused job. Behaviour by store state: a **fresh** store has no refresh jobs yet (its aggregates are created moments later), so the converge reads an empty set and returns 0; a store on the **old** values gets both halves on the first start after deploy and the create that follows then finds policies which match; a store already **hand-patched** to the right window is left alone on the window and re-phased only if its job is not on a fixed schedule or not on this grid.

That last case is no longer a judgement call. The live store was probed roughly two hours after the offsets were applied by hand: every job read `fixed_schedule = false`, and only one of six hourly refreshes was still on the minute it had been set to. A follow-up read put a number on the rate — the heavy refresh's next start was exactly its previous *finish* plus one hour, so it drifts by its own runtime every cycle and laps the hour in days. A hand-applied stagger is not a stagger with a slow leak; it is a stagger with a countdown, and pinning the schedule is what stops it.

Daily refreshes are untouched — `DailyRefreshStartOffset` is still `3 days`, still finish-to-start, and `RefreshPhaseMinutesFor` throws for a daily view so one cannot be dragged onto the grid. That is deliberate and pinned: a daily job's 3-day window is 3 days of scan against an 86,400-second cadence rather than a 3,600-second one, it was never near its own schedule interval, and the 3 days are the buffer `HourlyRetentionInterval`'s 90-day drop leans on. The obvious future regression here is a tidy-up that makes every refresh window "consistent".

## The relationship, not just the constant

`QueryStoreBackfill.Horizon` was `RetentionTierRouter.RawMaxAge` alone, and that read as correct only because the hourly refresh window was *also* 3 days: the retention term was standing in for the refresh term. That is the coupling — the refresh window had to cover a backdating depth that retention chose, so every retention increase silently bought more refresh cost.

The horizon is now the smaller of the two conditions that both have to hold at the depth a backdated slice lands: raw retention must not immediately drop the rows, **and** the hourly aggregates must still re-materialize the buckets it touched. The rollups are materialized-only — the watermark is a hard partition, not a fallback — so a bucket outside the refresh window keeps whatever it was materialized with, and backfilled rows become invisible to every window that routes at hourly grain while still being visible at raw grain. That is a split between two tiers, not a delay.

The refresh term is now the binding one **where rollups exist**, and the cost is stated rather than hidden: `RollupStoreHorizon` is **23 hours** (the window minus one refresh interval, because the window slides forward by exactly that much between runs), so post-outage catch-up and first-contact tail recovery reach less far back on a TimescaleDB store.

`PlainStoreHorizon` stays at the full **3 days**. TimescaleDB is optional and auto-detected and `QueryStoreBackfill` is constructed unconditionally, so the first revision of this change narrowed plain-PostgreSQL stores too — where there are no hourly rollups for a backdated row to fall out of, every read goes to raw, and the refresh term buys nothing. Raised by review. `HorizonFor(bool hasContinuousAggregates)` is what the slice path calls and `DarlingWorker` threads the extension flag in as a provider so it cannot capture a pre-detection reading. A store that gains the extension later is not left with a split either: the aggregates are born `WITH NO DATA` and `RetentionTierRouter` already routes any window below a rollup's measured floor to raw.

Digging deeper on a rollup store would mean running `refresh_continuous_aggregate` off the backfill loop, which is a decision about putting the convoying operation on an unphased path — not a constant, and not in this change.

## Deliberately not here

A per-job `lock_timeout` wrapper. It cannot be a role-level setting: every TimescaleDB background job runs as the same role as the collectors, so a role-level `lock_timeout` would cap collector sessions too. That analysis is on #3012 and the wrapper is a separate decision.

`max_concurrent_sweeps` needed no change — `DarlingConfig`, `StoreConfigProvider` and `ViewerDataService.ServiceConfig` all default to 4, neither sample config carries the key, and the store seed writes the code default. The settled value already had a correct durable home.

## Verification

No schema change and no version bump — this is all idempotent runtime setup in the worker's TimescaleDB block.

The Windows suites cannot run on macOS, so the two pure-unit test files were compiled into a `net10.0` console harness against the real built assemblies and run there: 45/45. That harness compiles two files rather than the suite, which is why a repo-wide hygiene guard and a Lite-side source scan both went red in CI on things it could not see; both of those guards have since been replicated locally over the whole tree with planted positive controls. The generated SQL and `Horizon` were also dumped back out of the built assembly rather than read from source. **Both CI suites are green at the head SHA and both are named rather than inferred from a green `build`**: `Lite.Tests Total: 3323, Failed: 0, Skipped: 0, Not Run: 0` and `Darling.Tests Total: 7596, Failed: 0`. The live converge test is absent from the `Darling PostgreSQL tests` job's six-test SKIP list, so it executed against a real TimescaleDB store; that grep was run with a positive control on the identical invocation, because a failed fetch and a clean result look the same.

Proven red nine ways, one mutation at a time, each restored byte-identically against a source hash with the tree committed first:

| mutation | red | green (independence) |
|---|---|---|
| `HourlyRefreshStartOffset` → `3 days` | narrowing pin, 1 fail | stagger pin |
| `HourlyRefreshStartSpan` → `FromDays(3)` | narrowing pin + horizon pin, 2 fails | stagger pin |
| `AddHourlyRefreshPolicySql` passes `phaseMinutes: null` | stagger pin, 1 fail | narrowing pin |
| **both of the above at once** | narrowing + stagger + horizon, **3 disjoint fails** | — |
| `RefreshPhaseMinutesFor` returns one slot for everything | stagger pin + contention pin, 2 fails | narrowing pin |
| **`HourlyAggregates` reordered so two `query_stats` consumers land on `:00`** | **contention pin, 1 fail** | **the family-only assertion, which is the point** |
| `DailyRefreshStartOffset` → `1 day` | daily pin, 1 fail | both treatment pins |
| `AddDailyRefreshPolicySql` passes a phase | daily pin, 1 fail | both treatment pins |
| `RollupStoreHorizon` back to `RawMaxAge` alone | both horizon pins, 2 fails | both treatment pins |
| `PlainStoreHorizon` collapsed onto `RollupStoreHorizon` | plain-store pin, 1 fail | the `min`-relationship pin |
| `HorizonFor` ignores its argument | plain-store pin, 1 fail | the `min`-relationship pin |
| `fixed_schedule => true` dropped from the converge | converge pin, 1 fail | both treatment pins |
| comment-only control | — | all 45 |

The reorder row is a control as well as a red-first proof: it is exactly the case the family-only assertion would have missed, and it stays green there while the generalized guard fails naming `collect.query_stats` and both minutes.

**What was unverified is now measured, and two of the four assumptions were wrong.** There is no local TimescaleDB rig here, so the live test was the only way to settle them, and it settled them by failing twice. The catalog join was wrong (`timescaledb_information.jobs` reports the *user view*, not the materialization hypertable, so the read matched nothing and the converge would have reported a tidy zero everywhere). The `if_not_exists` premise was wrong (`22023` on a differing window, not a quiet `-1`), which is what moved the converge ahead of the create. The other two hold: `alter_job` takes `fixed_schedule` and `initial_start` together on this runtime, and a policy created with `initial_start` does come back `fixed_schedule = true` — asserted, because the converge's no-op-ness rests on it.

**Still not verified.** The plain-PostgreSQL horizon branch is pinned by unit assertion but not exercised live — the fixture has TimescaleDB, so nothing runs the `hasContinuousAggregates: false` path against a store. A store on a TimescaleDB too old to expose `initial_start` is untested: the converge read fails, which is caught, logged at Debug and returns 0 — the same handling the compression converge has, but nothing exercises it. The 15-minute/4-slot grid over thirteen policies is the measured configuration rather than the best one; spreading over thirteen distinct minutes would contend less but is not what the 26 s / 2 s / 864 s / 140 s figures were taken on. The daily tier keeps finish-to-start scheduling, so the drift argument technically applies to it too — it just has 24x the cadence headroom. And **compression policies are not pinned**: they have no `initial_start`, so they still drift, and a compression tick wandering into a refresh window is how the convoy heads. A 14:52 collision was watched for and did not fire, but only because that compression run had nothing eligible (0 s) and that refresh run happened to take 194 s instead of its 864 s — two favourable coincidences, not a demonstration of safety. That is a required follow-up, not something this change addresses. None of the production figures quoted here were re-measured by me; they are relayed from #3012's own comments and from the monitoring session's probes.

Also not verified: whether re-phasing on the next service restart lands the live store's jobs on the same slots they were hand-set to. It will not necessarily — code wins by design — but every slot is 15 minutes from its neighbours either way, and at 24% of cadence the heavy refresh fits in any of them.

## CHANGELOG entry

```markdown
- **The hourly continuous-aggregate refreshes re-materialize a day instead of three, and start on distinct minutes of the hour** ([#3012]) - each hourly refresh carried `start_offset => INTERVAL '3 days'` against a hypertable with 4-day raw retention, so every run re-scanned roughly three quarters of the table. A refresh's cost is set by the WINDOW, not by the rows that arrived in it, which is why the measurement points the way it does: duration rose **~8x** while rows arriving per hour **fell ~3x** (999,101 down to 359,605) and run counts moved +23%. The heaviest hourly refresh reached **3,301-6,330 s against its own 1-hour cadence - 118-175% of it**, at which point each run started into the tail of the last, and the lock queue did the rest: the running refresh holds `AccessShareLock`, the compression policy on the same hypertable queues an `AccessExclusiveLock` request behind it, and a **queued** exclusive blocks every subsequent shared request, so collector store-writes convoyed behind a lock nobody held - **40 of 40** collector write errors in a 7-day window fell inside a running refresh or compression window, at worst three servers' collectors failing **11 ms apart**. On the narrowed window the same refresh runs **864 s, 24% of cadence**, so the overlap is structurally impossible rather than currently absent; ungranted locks 0 on every sample since, service-log errors 61/hr -> 3/hr, relaunch-skips 87/hr -> 7/hr. **Both treatments ship, because they address different halves**: the heavy refresh is still ~33x its lightest sibling on the 1-day window, so narrowing is what makes it finish and the 15-minute phase grid is what keeps its 864 s invisible to everything else - and naming `initial_start` also switches each job to a FIXED schedule, without which TimescaleDB computes the next start from the previous FINISH and one convoy phase-locks a family permanently (the incident's three jobs, on unrelated schedules with very different workloads, finished within 119 seconds of each other and re-started together every hour after). The grid is keyed on the VIEW NAME via `HourlyRefreshPhaseOrder`, never on a job id - job ids are per-deployment. **Its invariant is asserted over every relation two policies contend for**, not just the family the incident evidence named: `collect.query_stats` feeds three hourly policies whose minutes are distinct only incidentally, and phases collide whenever two positions differ by a multiple of the slot count, so the guard derives each view's contended relation from the shipped CREATE text and counts a view that is itself a source into its consumers' group - refreshing it WRITES what they READ. **The hand-applied stagger was measured decaying**: two hours after it was applied, every job read `fixed_schedule = f` and only one of six hourly refreshes was still on its slot, and the heavy refresh's next start was exactly its previous FINISH plus an hour - so it drifts by its own runtime every cycle and laps the hour in days. That is why `initial_start` is not decoration. **Existing stores are converged, and the converge runs BEFORE the create rather than after - a measured ordering requirement.** `add_continuous_aggregate_policy` does not behave like the `add_compression_policy` / `add_retention_policy` no-ops [#1778] and [#1937] were built on: it returns -1 only when the window MATCHES, and against a differing window it raises **22023 refresh interval overlaps with an existing continuous aggregate policy**. So the create sweep running first would raise on all thirteen hourly views of every already-deployed store, swallow each in its per-aggregate catch, and report the aggregates as unready while the windows stayed at three days. Converging first leaves the create looking at policies that already match. The converge selects only jobs that DIFFER, compares `start_offset` as SECONDS so `1 day` and `24:00:00` cannot read as a difference and re-alter the same job every start, and names no `scheduled` argument so it cannot arm a paused job. It keys on the VIEW, recovered by matching a job against EITHER its user view or its materialization hypertable - because `timescaledb_information.jobs` resolves a continuous-aggregate job back to its user view, so the materialization-only form that shipped first read back nothing at all and would have reported a tidy zero on every store. Both of those were caught by a live-store test, not by review or by reading. **The DAILY tier is deliberately untouched** at 3 days and finish-to-start, and `RefreshPhaseMinutesFor` throws for a daily view so one cannot be dragged onto the grid: a daily job's 3-day window is 3 days of scan against an 86,400-second cadence rather than a 3,600-second one, it never appeared in the convoy, and those 3 days are the buffer the hourly rollups' 90-day drop leans on - the regression this invites is a tidy-up that makes every window "consistent". **The `start_offset`-versus-retention coupling is fixed, not just the constant**: `QueryStoreBackfill.Horizon` was `RetentionTierRouter.RawMaxAge` alone, which read as correct only because the refresh window was ALSO 3 days - the retention term standing in for the refresh term, so every retention increase silently bought more refresh cost. It is now the smaller of the two conditions that both have to hold where a backdated slice lands: raw retention must not immediately drop the rows AND the hourly aggregates must still re-materialize the buckets touched. The rollups are materialized-only, so a bucket outside the refresh window keeps what it was materialized with and backfilled rows go invisible at hourly grain while staying visible at raw - a split between tiers, not a delay. The cost is stated rather than hidden: the horizon narrows from 3 days to **23 hours** (the window minus one refresh interval, because the window slides forward by that much between runs). A per-job `lock_timeout` wrapper was considered and left out: every TimescaleDB background job runs as the same role as the collectors, so a role-level `lock_timeout` would cap collector sessions too, and a per-job wrapper is a separate decision. `max_concurrent_sweeps` needed no change - all three code defaults already read 4. Proven red eleven ways, one mutation at a time, restored byte-identically against a source hash with the tree committed first: the narrowing and the stagger are each red on their own mutation while the other stays green, reverting BOTH reddens three disjoint tests rather than one (so neither pin wears two hats), and reordering the hourly list so two `query_stats` consumers share a minute reddens the contention guard while the family-only assertion stays green - which makes that mutation a control for the new check as well as a proof of it. Plus a comment-only control. Compression policies are deliberately NOT pinned here and still drift; that is a required follow-up. No schema change and no version bump.
```

Needs `[#3012]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/3012` in the link-ref block.

## Gate

Likely dual-gate — it changes a budget/timeout-adjacent configuration family. Not merging.
