### PR TITLE
Escape the angle-bracket placeholders introduced into two XML doc comments

### DIFF
--- a/PerformanceMonitor.Collectors/PlanCorrectionCollector.cs
+++ b/PerformanceMonitor.Collectors/PlanCorrectionCollector.cs
@@ -148,7 +148,7 @@ public sealed class PlanCorrectionCollector : CollectorDefinitionBase<PlanCorrec
     ///
     /// <para>
     /// Correcting the record, because it was wrong once and cost a round trip: #2760 removed both hints
-    /// on the theory that ~4,237ms of avg CPU seen on <host>/<database> was compile cost. That
+    /// on the theory that ~4,237ms of avg CPU seen on &lt;host&gt;/&lt;database&gt; was compile cost. That
     /// attribution was never verified — it was inferred from a CPU-heavy/low-read/low-row telemetry
     /// signature. The cost was the LIVE Query Store catalog-view joins that #2764 then replaced with
     /// staged temps. Removing RECOMPILE never addressed it; staging did.

--- a/PerformanceMonitor.Collectors/QueryStoreOpenIntervalState.cs
+++ b/PerformanceMonitor.Collectors/QueryStoreOpenIntervalState.cs
@@ -65,7 +65,7 @@ public static class QueryStoreOpenIntervalState
     /// recorded rationale beats a knob nobody can reason about.
     ///
     /// <para>Moved from 15 to 30 (#2759) because the #2312 yardstick it was tuned against — multi-53 at
-    /// ~50 s/run — stopped holding. Measured live on <c><host></c> (2026-09-01, 3-hour
+    /// ~50 s/run — stopped holding. Measured live on <c>&lt;host&gt;</c> (2026-09-01, 3-hour
     /// window of <c>collection_log</c>): open-interval-inclusive runs cost 110–133 s each (2–2.5x the
     /// original yardstick), landing every 12–19 minutes — the 15-minute skip window was already firing as
     /// designed, spacing the expensive runs out, but each one had grown too large for that spacing to be


### PR DESCRIPTION
#3020 replaced a host name with the `<host>` placeholder in two `///` XML doc comments without escaping the angle brackets. Inside doc XML, `<host>` is an opening tag with no close — not literal text — so the parser sees an unclosed `host` element and the placeholder is silently swallowed.

Both now use the escaping convention already in this codebase: `&lt;host&gt;`, matching `PgSessionStatesCollector.cs`'s `&lt;insufficient privilege&gt;` and the `&gt;` escape already present a few lines above the first site.

| file | was | now |
|---|---|---|
| `QueryStoreOpenIntervalState.cs:68` | `<c><host></c>` | `<c>&lt;host&gt;</c>` |
| `PlanCorrectionCollector.cs:151` | `<host>/<database>` | `&lt;host&gt;/&lt;database&gt;` |

**The third site from #3020 is deliberately left unescaped.** `Lite.Tests/PlanCorrectionCollectorDefinitionTests.cs:190` sits inside a `/* ... */` block comment, not a `///` doc comment, so `<host>/<database>` there is literal text already and escaping it would render the entities visibly. Verified by reading the surrounding block rather than assuming the file's style is uniform.

## Why CI did not catch this, which is the part worth keeping

`GenerateDocumentationFile` is not enabled for these projects, so malformed doc XML is not a build error. #3020 went green on all seven checks — including a full 598s `build` that really did compile — with both sites broken. The failure is invisible today and shows up as broken IDE tooltips, or as a swallowed placeholder if doc generation is ever turned on.

So there is no guard for this class, and this PR does not add one. Adding `GenerateDocumentationFile` across these projects would surface every pre-existing doc-XML defect in the tree at once, which is a much larger change than the two lines here and should be its own decision rather than a side effect of fixing them.
