### PR TITLE
Run Darling's whole-tree guards where the area filters do not reach

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1013,6 +1013,16 @@ jobs:
       # Names the arm that decided, out loud, either way. A job reporting success having quietly run
       # nothing is indistinguishable from one that ran everything, and that indistinguishability is
       # the whole reason this job exists.
+      #
+      # An EMPTY outcome is its own arm rather than part of the else. A job's declared outputs do not
+      # reach a downstream consumer when the producing job's conclusion is failure, so a build job
+      # that fails - at Lite.Tests, before ever reaching the Darling step, or at the Darling step
+      # itself - can leave this reading empty no matter what that step actually did. Folding that
+      # into the else would print "the suite has already run on this commit" for a commit where it
+      # may not have run at all, which is the same dishonest-log failure this job exists to close.
+      # Skipping is still right there: a red build blocks the merge on its own, and re-running the
+      # suite on a commit nothing can merge buys no decision and would cost three minutes on every
+      # failing build. So the arm skips and says why, and which log holds the real answer.
       - name: Decide whether the whole-tree guards run here
         id: gate
         shell: bash
@@ -1031,9 +1041,12 @@ jobs:
           elif [ "${WORKFLOW:-}" = "true" ]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
             echo "::notice title=Whole-tree guards running::build.yml changed, so this job's own gate is exercised by the gate."
+          elif [ -z "${DARLING_TESTS:-}" ]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Whole-tree guards not decided here::The build job published no outcome for its 'Run Darling tests' step, which is what a failed build job leaves behind - so whether the suite ran on this commit is not knowable from here. Read it off the build job's own log; that job is not green, so nothing merges on this result."
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "::notice title=Whole-tree guards skipped::The build job's 'Run Darling tests' step reported '${DARLING_TESTS:-<no result>}', so the suite has already run on this commit."
+            echo "::notice title=Whole-tree guards skipped::The build job's 'Run Darling tests' step reported '${DARLING_TESTS}', so the suite has already run on this commit."
           fi
 
       - name: Setup .NET 10.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,14 @@ jobs:
   build:
     runs-on: windows-latest
 
+    # Whether THIS job ran Darling.Tests, taken from the step's own outcome rather than restated as
+    # a copy of the step's path gate. The darling-tree-guards job at the bottom of this file runs
+    # the suite when this reads `skipped`; a second list of paths there would be free to fall out
+    # of agreement with the list here, and area lists falling out of agreement with what a guard
+    # reads is the thing that job exists to stop.
+    outputs:
+      darling-tests: ${{ steps.darling-tests.outcome }}
+
     steps:
       - uses: actions/checkout@v7
 
@@ -328,6 +336,7 @@ jobs:
         run: dotnet run --project deprecated/Dashboard.Tests/Dashboard.Tests.csproj -c Release --no-build
 
       - name: Run Darling tests
+        id: darling-tests
         if: steps.filter.outputs.darling == 'true' || steps.filter.outputs.core == 'true' || steps.filter.outputs.root == 'true' || github.event_name == 'release'
         run: dotnet run --project Darling/Darling.Tests/Darling.Tests.csproj -c Release --no-build
 
@@ -945,3 +954,108 @@ jobs:
         uses: actions/attest-build-provenance@v4
         with:
           subject-path: releases/PerformanceMonitorDarling-linux-x64-*.tar.gz
+
+  # Darling.Tests is not only Darling's test suite: some of its guards take the WHOLE REPOSITORY as
+  # input rather than the Darling tree.
+  # MigrationUpgradeLadderLiveTests.TheMostRecentRelease_HasALadderFixture derives the ladder
+  # fixture it requires from CHANGELOG.md's newest released heading, so a release cut committed as a
+  # CHANGELOG-only change is precisely the input it exists to fail on; FleetIdentifierScrubTests
+  # enumerates every tracked file carrying one of nine extensions, `.md` among them.
+  #
+  # The build job's `darling`, `core` and `root` filters describe Darling PRODUCT code, which is
+  # what they are for: they decide what to compile and publish. They are not a description of what
+  # those guards read, so the two sets differ, and a change confined to markdown or to `.github/`
+  # leaves all three false and the suite unrun. Measured over the last 100 pull requests: 92 lit
+  # one of the three, 8 lit none, and 7 of those 8 changed markdown.
+  #
+  # So the gate here is the COMPLEMENT of the build job's, read off that job's own step outcome
+  # rather than written out again as a second set of paths. A second set is what would drift: an
+  # enumerated area list stops covering the next tree added, which #2114, #2830 and #2839 each hit
+  # in turn. `steps.darling-tests.outcome` is `skipped` exactly when the build job did not run the
+  # suite, so there is no pair of lists to keep in agreement.
+  #
+  # Being the complement, it never double-runs the suite - 92 of those 100 PRs report here without
+  # spinning up .NET at all - and it needs no upkeep as the area filters change. It ALSO runs
+  # whenever this workflow changes, so a change to the gate is exercised by the gate, the same
+  # self-validation darling-pg takes.
+  #
+  # No PostgreSQL here, deliberately. The whole-tree guards need none, and standing up a throwaway
+  # TimescaleDB cluster would make a documentation change depend on the flakiest part of CI
+  # (#1862's compression flake failed twice in two unrecognizably different ways). Runs on every
+  # non-cancelled event and always reports a result, so it can be a required check.
+  darling-tree-guards:
+    name: Darling whole-tree guards
+    needs: build
+    if: ${{ !cancelled() }}
+    runs-on: windows-latest
+    # Measured on a warm NuGet cache: ~40s of .NET setup, ~10s restore, ~95s to build
+    # Darling.Tests, ~35s for the suite. 20 minutes is ~6x that, past which something is hung and a
+    # shared-pool Windows runner is being held for nothing.
+    timeout-minutes: 20
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+
+      # Feeds the self-validation arm below only. Skipped on release for the same reason the other
+      # jobs skip it there: a release has no diff to classify.
+      - name: Detect changed paths
+        id: filter
+        if: github.event_name != 'release'
+        uses: dorny/paths-filter@v4
+        with:
+          base: ${{ github.event_name == 'push' && github.event.before || '' }}
+          filters: |
+            workflow:
+              - '.github/workflows/build.yml'
+
+      # Names the arm that decided, out loud, either way. A job reporting success having quietly run
+      # nothing is indistinguishable from one that ran everything, and that indistinguishability is
+      # the whole reason this job exists.
+      - name: Decide whether the whole-tree guards run here
+        id: gate
+        shell: bash
+        env:
+          DARLING_TESTS: ${{ needs.build.outputs.darling-tests }}
+          WORKFLOW: ${{ steps.filter.outputs.workflow }}
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Whole-tree guards skipped::Release event - the build job compiles and runs every suite unconditionally."
+          elif [ "${DARLING_TESTS:-}" = "skipped" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Whole-tree guards running::The build job's path filters left Darling.Tests unrun, so the guards that read the whole repository run here."
+          elif [ "${WORKFLOW:-}" = "true" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Whole-tree guards running::build.yml changed, so this job's own gate is exercised by the gate."
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Whole-tree guards skipped::The build job's 'Run Darling tests' step reported '${DARLING_TESTS:-<no result>}', so the suite has already run on this commit."
+          fi
+
+      - name: Setup .NET 10.0
+        if: steps.gate.outputs.run == 'true'
+        uses: actions/setup-dotnet@v6
+        with:
+          global-json-file: global.json
+          cache: true
+          cache-dependency-path: '**/packages.lock.json'
+
+      - name: Restore Darling.Tests
+        if: steps.gate.outputs.run == 'true'
+        run: dotnet restore Darling/Darling.Tests/Darling.Tests.csproj --locked-mode
+
+      - name: Build Darling.Tests
+        if: steps.gate.outputs.run == 'true'
+        run: dotnet build Darling/Darling.Tests/Darling.Tests.csproj -c Release --no-restore
+
+      # The FULL suite, not a class filter naming the whole-tree guards. Such a filter would be one
+      # more enumeration: a guard added tomorrow would not be in it, and this job would report green
+      # having skipped exactly the test it was added for. DARLING_TEST_PG and DARLING_TEST_SQL stay
+      # unset, so the gated-live classes skip here just as they do in the build job.
+      - name: Run the whole-tree guards
+        if: steps.gate.outputs.run == 'true'
+        run: dotnet run --project Darling/Darling.Tests/Darling.Tests.csproj -c Release --no-build

--- a/Lite.Tests/CrossAppGuardCiGateTests.cs
+++ b/Lite.Tests/CrossAppGuardCiGateTests.cs
@@ -93,6 +93,53 @@ public class CrossAppGuardCiGateTests
             string.Join("\n  ", failures));
     }
 
+    /// <summary>
+    /// The suite that reads the whole tree has to run on the whole tree.
+    ///
+    /// <para><see cref="EveryCrossAppSourceRead_IsReachableByTheFilterThatGatesItsSuite"/> above covers reads
+    /// of a NAMED path, which is what a cross-app guard does — there is a path, so a filter can name it. Some
+    /// guards in <c>Darling.Tests</c> take the repository ITSELF as input instead: <c>FleetIdentifierScrubTests</c>
+    /// enumerates every tracked file carrying one of nine extensions, and <c>MigrationUpgradeLadderLiveTests</c>
+    /// derives the fixture it requires from <c>CHANGELOG.md</c>. Those have no path to add, and
+    /// <c>darling</c> / <c>core</c> / <c>root</c> describe Darling product code rather than the tree.</para>
+    ///
+    /// <para>So <c>build.yml</c> answers it from the other side: the <c>build</c> job publishes whether it ran
+    /// the suite, and a second job runs the suite when that reads <c>skipped</c>. Three pieces of wiring carry
+    /// that, and losing any one of them leaves a job reporting success having run nothing — the step must
+    /// carry the id, the job must publish its outcome, and the consuming job must actually invoke the suite.
+    /// Pinned here rather than in <c>Darling.Tests</c> because the failure being pinned is a suite that does
+    /// not run: a pin inside it would be gated by the thing it is checking.</para>
+    /// </summary>
+    [Fact]
+    public void TheDarlingSuite_RunsWhereTheAreaFiltersDoNotReach()
+    {
+        var yaml = ReadBuildYaml(RepoRoot());
+
+        var step = yaml.IndexOf("- name: Run Darling tests", StringComparison.Ordinal);
+        Assert.True(step > 0, "the step that runs Darling.Tests was renamed — re-point this assertion before editing it");
+        Assert.Contains(
+            "id: darling-tests",
+            yaml[step..Math.Min(step + 200, yaml.Length)],
+            StringComparison.Ordinal);
+
+        Assert.Contains("darling-tests: ${{ steps.darling-tests.outcome }}", yaml, StringComparison.Ordinal);
+
+        var consumer = yaml.IndexOf("needs.build.outputs.darling-tests", StringComparison.Ordinal);
+        Assert.True(
+            consumer > 0,
+            "nothing reads the build job's Darling.Tests outcome, so the suite runs only where the area "
+          + "filters reach and a markdown-only or .github-only change runs none of it");
+
+        /* From the consumer onward, so this cannot be satisfied by the darling-pg job's invocation earlier
+           in the file — the job that reads the outcome is the one that has to run the suite. */
+        var consumingJob = yaml[consumer..];
+        Assert.Contains("= \"skipped\"", consumingJob, StringComparison.Ordinal);
+        Assert.Contains(
+            "dotnet run --project Darling/Darling.Tests/Darling.Tests.csproj",
+            consumingJob,
+            StringComparison.Ordinal);
+    }
+
     private static void Check(
         string repo,
         string yaml,


### PR DESCRIPTION
## What changed

`Darling.Tests` is not only Darling's test suite. Some of its guards take the **repository itself** as input rather than the Darling tree, and `build.yml` gated all of them on filters that describe Darling product code.

**Two instances, both derived from the guards' own source.** `MigrationUpgradeLadderLiveTests.TheMostRecentRelease_HasALadderFixture` derives the ladder fixture it requires from `CHANGELOG.md`'s newest released heading — its own doc comment says "The release cut moves the heading, and this fails until the fixture beside it exists" — so a release cut committed as a CHANGELOG-only change is precisely the input it exists to fail on, and it is the input no check would run it against. `FleetIdentifierScrubTests` enumerates every tracked file carrying one of nine extensions, `.md` among them, so markdown is in its own declared scope.

**The filters are not wrong; they answer a different question.** `darling`, `core` and `root` decide what to compile and publish, which is what they are for. They are not a description of what a whole-tree guard reads, so the two sets differ. Measured against the last 100 pull requests, replaying each one's file list through this workflow's actual filter patterns: **92 lit one of the three and 8 lit none** — 7 of the 8 changed markdown, the eighth changed `.github/`.

**So the new job's gate is the complement of the build job's, read off that job's own step rather than restated.** The `build` job now publishes `steps.darling-tests.outcome` as an output; `darling-tree-guards` runs the suite when it reads `skipped`. Nothing is enumerated, so nothing can go stale: an enumerated area list stops covering the next tree added, which is the shape #2114, #2830 and #2839 each hit in turn, and a second copy of the gate would drift from the first the same way. It also runs whenever this workflow changes, so a change to the gate is exercised by the gate — the same self-validation `darling-pg` takes.

## The cost, and the two shapes I did not take

The complement gate never double-runs the suite: 92 of those 100 PRs land on the already-ran side and report here without spinning up .NET at all. On the other 8 it costs one Windows runner for about three minutes, priced off run `33969850863`'s real step times — 35s of .NET setup, 9s restore, 93s to build `Darling.Tests`, 32s for the suite.

**Not `'**/*.md'` on the `darling` filter.** It would retire the `#1712` docs fast path for the only change class it serves (the fast path engages only when no area is lit, and running the guards needs the restore the fast path skips), and it would make `darling` mean "Darling code, or any markdown anywhere" for the four steps that consume it — including two publishes. Same runner cost, worse signal.

**Not `'**/*.md'` on a new job's own filter.** 52 of the last 100 PRs touch markdown and 45 of those already run the suite in `build`, so a markdown filter would double-run it on 45% of PRs — about 2.4 hours of extra Windows runner per 100 PRs on the pool this workflow's own concurrency comment identifies as the thing that serializes everyone's CI.

**No PostgreSQL in the new job, deliberately.** The whole-tree guards need none, and standing up a throwaway TimescaleDB cluster would make a documentation change depend on the flakiest part of CI — `#1862`'s compression flake failed twice on CI in two unrecognizably different ways and could not be reproduced locally at all.

## Deliberately unchanged

- **The `lite` / `Lite.Tests` filter asymmetry.** `darling` reaches `Lite/**/*.cs` but not `Lite.Tests/**`, while `lite` reaches `Darling/Darling.Tests/**`. Untouched: it is a separate question about cross-app reads, `EveryCrossAppSourceRead_IsReachableByTheFilterThatGatesItsSuite` already governs it, and nothing here depends on it.
- **The docs fast path.** A markdown-only PR still fast-paths `build` in ~30s; the guards run in a job of their own.
- **Workflow triggers.** No `on:` block is touched in any workflow, so nothing that can register twice registers differently.
- **`CHANGELOG.md`.** Entry text is below rather than committed.

The required-check count goes from six to seven.

## Verified

- **The pin is red six ways, five of them on distinct assertions**, executed by compiling the actual `CrossAppGuardCiGateTests.cs` — unmodified, so the assertions are the real ones — into a `net10.0` console harness with xunit.v3 3.2.2, the version this repo pins. `build.yml` as it stands on `dev` fails on the missing step id; removing only the id fails the same way; removing only the `outputs:` block fails on the published outcome; deleting the consuming job fails on "nothing reads the build job's Darling.Tests outcome"; pointing the consuming job at a different suite fails on the `dotnet run` assertion; and changing the gate to key on `success` instead of `skipped` fails on that comparison. Green with the change in place.
- **The two pre-existing facts in that file still pass** — 3 of 3 in the class, `Failed: 0`, `Not Run: 0`.
- **`FleetIdentifierScrubTests` passes on this tree and is not vacuous here**: run through the same harness it reports `Failed: 0`, and planting a non-allowlisted slug with a padded ordinal into a markdown file under `docs/` turns **both** of its facts red, naming the file and line; removing it returns both to green. So the guard does reach markdown, which is what makes the gate matter.
- **The workflow parses**, and `jobs` resolves to `build`, `darling-pg`, `darling-linux`, `darling-tree-guards` with the new job's `needs`, `if`, `runs-on`, `timeout-minutes` and `permissions` as written, and `id: darling-tests` landing on the `Run Darling tests` step and no other.
- **The three existing assertions that read this file by offset still find the build job's step first.** `ViewerSidebarDotRendersTheCardStatusTests.TheGuard_RunsOnEveryTreeItScans` and `CrossAppGuardCiGateTests.Check` both locate `- name: Run Darling tests` by `IndexOf` and read forward a bounded window; the new job is appended after the build job and its step is named `Run the whole-tree guards`, so neither can latch onto it. `CiClusterWorkerSizingTests` parses only `Add-Content ... -Value "setting = value"` lines, and the diff adds none.
- **Line endings and BOM**: `build.yml` and `CrossAppGuardCiGateTests.cs` are both CRLF with no BOM on `dev` and stay that way in the working tree; both blobs are LF after staging, 0 CRLF, which is what `* text=auto eol=crlf` should produce.
- **The mutation loop restored by content, not by `git checkout`**, with the fixed file's md5 re-asserted after every one of the six cases; the working tree matched the commit afterwards.

## Review findings

**Taken, in `3529495`.** The `else` arm printed "the suite has already run on this commit" for an EMPTY `needs.build.outputs.darling-tests` as well as for `success` / `failure`. A job's declared outputs do not reach a downstream consumer when the producing job's conclusion is `failure`, so a `build` that fails — at `Lite.Tests`, before reaching the Darling step, or at the Darling step itself — can leave that read empty whatever the step actually did, and the notice would then assert something it cannot know. That is the dishonest-log failure this job exists to close, arriving in the job's own log. The empty outcome now has its own arm: still skip, because a red `build` blocks the merge on its own and re-running the suite on a commit nothing can merge buys no decision while costing three minutes on every failing build — but it says the status is not knowable from here and names the log that holds it.

**Declined, in the second pass: passing `github.event_name` through `env:` for consistency.** The `env:` indirection in this step carries the two *filter-derived* values, and that is the pattern the workflow already uses — `ALL_COUNT`, `DOCS_COUNT` and `AREAS` in the docs fast path, `DARLING_TESTS` and `WORKFLOW` here. `github.event_name` is interpolated directly into bash in every gate-decision step in this file: lines 255 and 261 in the fast-path classifier, 690 in the Darling PG gate, 865 in the Linux gate, and 1035 here. So this step already matches the house pattern on both halves; routing `event_name` through `env:` would make it the only one that does.

**Raised as a checklist item, not a code change: the required-status-checks list.** See "Action needed outside this diff" above — it is real, it is confirmed against the API, and it cannot be expressed in this diff.

Fixing the wording also retires the suggestion to confirm the propagation behaviour with a deliberately broken `build`: both branches are now correct under either behaviour, so the question stops being load-bearing.

All four arms exercised directly, by extracting the gate script from the parsed workflow and running it under each input: `release` → skip; `skipped` → run; `workflow` filter true → run; empty → the new not-knowable arm; `success` and `failure` → skip with the outcome named. `bash -n` clean on the extracted script.

## After, observed on `3529495`

`Darling whole-tree guards` **ran and did the work**: 2m39s wall, of which .NET setup 29s, restore 8s, `Build Darling.Tests` 77s, and `Run the whole-tree guards` 30s reporting `Darling.Tests  Total: 7546, Errors: 0, Failed: 0, Skipped: 313, Not Run: 0`. A no-op report on this job costs ~15s, so the duration alone separates the two, and the test count settles it.

Which arm fired is in the log, and it is the one predicted: `DARLING_TESTS: success`, `WORKFLOW: true`, `##[notice]build.yml changed, so this job's own gate is exercised by the gate.` The complement arm could not fire here — `build` ran the suite on this PR because `build.yml` is in the `root` filter — which is the limit recorded below.

`needs: build` sequenced as intended: `build` completed 14:41:22, this job started 14:41:30.

Incidental confirmation of `if: ${{ !cancelled() }}`: on the superseded first run this job reported `cancelled` with `started_at == completed_at`, so it did not take a runner for a run that no longer mattered.

## Action needed outside this diff

`dev`'s branch protection currently requires exactly two contexts — `build` and `Darling PostgreSQL tests`. `Darling whole-tree guards` therefore **reports** a result but does not yet **block** a merge, and neither do `Darling Linux build`, `check-branches` or `verify`. That is a repo Settings change, not something a workflow file can express (there is no `.github/settings.yml` or rulesets-as-code here), so it will not happen as a side effect of merging this:

```
gh api -X PATCH repos/erikdarlingdata/PerformanceMonitor/branches/dev/protection/required_status_checks \
  -f 'contexts[]=build' -f 'contexts[]=Darling PostgreSQL tests' -f 'contexts[]=Darling whole-tree guards'
```

Worth noting alongside it: on a markdown-only change both currently-required contexts go green having executed nothing, so until this job is added the required set is satisfied by two vacuous passes.

## Before, measured

Markdown-only PRs on this workflow today, by duration and by step conclusion rather than by the check mark:

| check | #2984 (`CHANGELOG.md` only, `4344fcf`) | #2980 (`CHANGELOG.md` only, `fa7fd5f`) | a Darling code PR (run `33969850863`) |
| --- | --- | --- | --- |
| `build` | 31s | 20s | 545s |
| `Darling PostgreSQL tests` | 14s | 21s | 262s |
| `Darling Linux build` | 8s | 11s | 108s |

On #2984's `build` job, all 35 build / test / publish steps report `skipped`; four steps ran — job setup, checkout, `Detect changed paths`, and `Classify change for the docs fast path`. `Run Darling tests` is one of the 35. That `skipped` is the exact value the new gate keys on, so the arm is reading a value whose real-world setting on a markdown-only diff is measured rather than assumed.

## Not verified

- **The complement arm did not fire pre-merge, and no design could have made it.** Confirmed rather than predicted: this run logged `DARLING_TESTS: success`. A PR that introduces this job necessarily changes `build.yml`, which is in the `root` filter, so `build` runs `Darling.Tests` on the very commit that adds the job and publishes `success`, never `skipped`. What is observed instead is the job's mechanics end to end via the self-validation arm, plus the arm's input in two measured halves: `build` publishes that step's outcome (seen here as `success`), and #2984's run shows the same step's conclusion is `skipped` on a markdown-only diff. One observation short of end-to-end, and I am not going to call it end-to-end.
- The Windows suites cannot run on macOS. The harness compiles the real test files, so the assertions and the regexes are the real ones, but xunit's own discovery and the rest of both suites are CI's word.
- `needs: build` adds the new job's own startup to the workflow's wall clock on the 92% of PRs where it reports without working. This run measured the pre-gate steps at 9s (job setup 1s, checkout 7s, filter 0s, gate 1s), so ~10s plus queue time — but a run where the gate says skip has not been observed, because this PR's gate says run.
- ~~Whether GitHub's expression parser accepts a hyphenated job-output name.~~ Settled by the run: `needs.build.outputs.darling-tests` resolved to `success` in the job's `env:` block.

## CHANGELOG entry, not committed — for the coordinator to place

```markdown
- Darling's whole-tree guards now run on changes the product-area path filters do not reach. `Darling.Tests` takes the repository itself as input in places — the ladder-fixture guard derives what it expects from `CHANGELOG.md`, and the identifier sweep enumerates every tracked file carrying one of nine extensions — so gating the suite on `darling` / `core` / `root` left it unrun on markdown-only and `.github`-only changes. A new `Darling whole-tree guards` job runs the suite when the `build` job's filters did not, keyed on that job's own step outcome rather than on a second list of paths.
```
