### PR TITLE
Fixes #3017 (items 1 and 2)

### DIFF
--- a/Darling/Darling.Tests/DarlingFleetReaderTests.cs
+++ b/Darling/Darling.Tests/DarlingFleetReaderTests.cs
@@ -7,6 +7,7 @@
  */
 
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json;
@@ -348,6 +349,232 @@ public sealed class DarlingMcpFleetToolsSurfaceTests
         Assert.All(toolMethods, m => Assert.True(m.IsStatic));
         Assert.All(toolMethods, m => Assert.Equal(typeof(Task<string>), m.ReturnType));
     }
+}
+
+/// <summary>
+/// #3017: the denominator beside <c>total_deadlocks</c>.
+///
+/// <para><b>The defect.</b> <see cref="DarlingFleetReader.FleetDeadlockSql"/> reads <c>v_deadlocks</c>, which
+/// is <c>SELECT * FROM deadlocks</c>, and <c>deadlocks</c> is written by exactly one collector — the SQL
+/// Server extended-event capture. A PostgreSQL target's deadlocks go to <c>pg_deadlocks</c>, nothing joins
+/// the two, and there is no <c>v_pg_deadlocks</c> at all. So on a PostgreSQL fleet <c>total_deadlocks</c> is
+/// permanently zero, for every server, whatever those clusters do and whatever grants the role holds — and
+/// zero is also exactly what a genuinely quiet SQL Server fleet reports. The reading that needs no action and
+/// the reading that does not cover the fleet were the same character, which is what made the bare number
+/// unusable.</para>
+///
+/// <para><b>Both directions, deliberately.</b> The failure mode of a coverage figure is over-exclusion: a
+/// denominator that quietly shrinks reads as a smaller fleet, which is a new wrong number rather than a fix.
+/// So every test asserting a band is EXCLUDED sits beside one asserting the degraded-but-reading bands are
+/// INCLUDED.</para>
+/// </summary>
+public sealed class DarlingFleetDeadlockCoverageTests
+{
+    /* Every band a collector that DID read can be in. Their rows are in the total, so all four count as
+       covered — including FAILING, which is loud on its own surfaces and does not need to be hidden inside a
+       coverage number to be seen. */
+    [Theory]
+    [InlineData(CollectorHealthClassifier.Healthy)]
+    [InlineData(CollectorHealthClassifier.Warning)]
+    [InlineData(CollectorHealthClassifier.Stale)]
+    [InlineData(CollectorHealthClassifier.Failing)]
+    public void ADeadlockReaderThatWorked_Counts_EvenDegraded(string band)
+        => Assert.Equal(
+            FleetDeadlockSource.Read,
+            DarlingFleetReader.ClassifyDeadlockSource(isPostgres: false, band));
+
+    /// <summary>
+    /// The excluded bands, each attributed to the cause that names its fix. STOPPED, NEVER_RUN and a null
+    /// band (the <c>deadlocks</c> collector left no row in the health window at all) are one bucket because
+    /// they take one action — look at the collector. NO_PERMISSIONS is its own, because a grant is the fix
+    /// and no amount of looking at the collector produces one.
+    /// </summary>
+    [Theory]
+    [InlineData(CollectorHealthClassifier.Stopped, FleetDeadlockSource.CollectorSilent)]
+    [InlineData(CollectorHealthClassifier.NeverRun, FleetDeadlockSource.CollectorSilent)]
+    [InlineData(null, FleetDeadlockSource.CollectorSilent)]
+    [InlineData(CollectorHealthClassifier.NoPermissions, FleetDeadlockSource.CollectorDenied)]
+    public void ADeadlockReaderThatReadNothing_DoesNotCount_AndNamesItsCause(
+        string? band, FleetDeadlockSource expected)
+        => Assert.Equal(expected, DarlingFleetReader.ClassifyDeadlockSource(isPostgres: false, band));
+
+    /// <summary>
+    /// The issue's own case: a PostgreSQL target is never covered, and its collector's band cannot change
+    /// that. <c>pg_deadlocks</c> can be perfectly HEALTHY on all fifty targets and this total still counts
+    /// none of it — the rows are in a different table. That is why PostgreSQL is asked before any band.
+    /// </summary>
+    [Theory]
+    [InlineData(CollectorHealthClassifier.Healthy)]
+    [InlineData(CollectorHealthClassifier.NoPermissions)]
+    [InlineData(CollectorHealthClassifier.Stopped)]
+    [InlineData(null)]
+    public void APostgresTarget_IsNeverCovered_WhateverItsCollectorSays(string? band)
+        => Assert.Equal(
+            FleetDeadlockSource.PostgresTarget,
+            DarlingFleetReader.ClassifyDeadlockSource(isPostgres: true, band));
+
+    /// <summary>
+    /// A card that sets nothing reads as UNCOVERED, and that is the load-bearing default. <c>DeadlockSource</c>
+    /// is derived rather than assigned precisely so a card built by a path nobody re-reads cannot sit at an
+    /// enum default meaning "read" and inflate the fleet's coverage — the silent-default shape this file's
+    /// own <c>AbandonedCount</c> comment already names as a defect class.
+    /// </summary>
+    [Fact]
+    public void ACardThatMakesNoClaim_IsUncovered_NotCovered()
+    {
+        var card = new FleetServerCard { ServerId = 1, DisplayName = "target-a", ServerName = "target-a" };
+
+        Assert.Equal(FleetDeadlockSource.CollectorSilent, card.DeadlockSource);
+        Assert.NotEqual(FleetDeadlockSource.Read, card.DeadlockSource);
+
+        var rollup = DarlingFleetReader.BuildRollup(
+            new[] { card }, Now, Now.AddHours(-1), Now);
+
+        Assert.Equal(0, rollup.DeadlockCoverage.ServersRead);
+        Assert.Equal(1, rollup.DeadlockCoverage.ServersTotal);
+    }
+
+    /// <summary>
+    /// The reduction, over one card of every kind: the coverage comes from the CARDS, the same way the totals
+    /// beside it do, so the denominator and the number it qualifies reconcile by construction rather than by
+    /// two queries agreeing.
+    /// </summary>
+    [Fact]
+    public void BuildRollup_ReducesCoverageFromTheCards_WithEveryCauseAttributed()
+    {
+        var rollup = DarlingFleetReader.BuildRollup(
+            new[]
+            {
+                Card(1, band: CollectorHealthClassifier.Healthy),
+                Card(2, band: CollectorHealthClassifier.Failing),
+                Card(3, isPostgres: true),
+                Card(4, isPostgres: true),
+                Card(5, band: CollectorHealthClassifier.Stopped),
+                Card(6, band: CollectorHealthClassifier.NoPermissions),
+                Card(7, band: null),
+            },
+            Now, Now.AddHours(-1), Now);
+
+        var coverage = rollup.DeadlockCoverage;
+
+        Assert.Equal(2, coverage.ServersRead);
+        Assert.Equal(7, coverage.ServersTotal);
+        Assert.Equal(2, coverage.PostgresServers);
+        Assert.Equal(2, coverage.ServersCollectorSilent);   // STOPPED + the null band
+        Assert.Equal(1, coverage.ServersCollectorDenied);
+
+        /* Every server is accounted for exactly once — an unattributed server would mean coverage that
+           reports a gap it cannot explain, which is the same shape as a total that reports no denominator. */
+        Assert.Equal(
+            coverage.ServersTotal,
+            coverage.ServersRead + coverage.PostgresServers
+                + coverage.ServersCollectorSilent + coverage.ServersCollectorDenied);
+
+        /* And it agrees with the field the fleet already reported. */
+        Assert.Equal(rollup.TotalServers, coverage.ServersTotal);
+    }
+
+    /// <summary>
+    /// The measured case, end to end: a PostgreSQL-only fleet reports <c>total_deadlocks: 0</c> with zero
+    /// coverage beside it, and the note sends the reader to the tool that can actually answer.
+    /// </summary>
+    [Fact]
+    public void APostgresOnlyFleet_ReportsZeroCoverage_AndNamesTheToolThatCanAnswer()
+    {
+        var rollup = DarlingFleetReader.BuildRollup(
+            new[] { Card(1, isPostgres: true), Card(2, isPostgres: true), Card(3, isPostgres: true) },
+            Now, Now.AddHours(-1), Now);
+
+        Assert.Equal(0, rollup.TotalDeadlocks);
+        Assert.Equal(0, rollup.DeadlockCoverage.ServersRead);
+        Assert.Equal(3, rollup.DeadlockCoverage.PostgresServers);
+
+        var note = rollup.DeadlockCoverage.Note;
+
+        Assert.Contains("read a deadlock source for 0 of 3", note, StringComparison.Ordinal);
+        Assert.Contains("get_pg_deadlocks", note, StringComparison.Ordinal);
+
+        /* The two causes that do not apply are absent, so a reader is not handed three actions when one is
+           called for. */
+        Assert.DoesNotContain("get_collection_health", note, StringComparison.Ordinal);
+        Assert.DoesNotContain("needs a grant", note, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// <b>The sentence this whole issue turns on.</b> The two windows genuinely diverge —
+    /// <c>total_deadlocks</c> is counted between the caller's bounds (one hour by default), while coverage is
+    /// banded over a FIXED trailing seven days of collection health — and that divergence is correct: whether
+    /// a reader works is a durable fact, and the banding thresholds are themselves defined in DAYS, so an
+    /// hour-wide health window could not produce a band at all.
+    ///
+    /// <para>But a note claiming both were "read in this window" would be the same defect one level up: a
+    /// surface asserting a scope it did not measure. So the note names each window against the figure it
+    /// belongs to, and says outright that coverage makes no claim about the caller's window.</para>
+    /// </summary>
+    [Fact]
+    public void TheNote_NamesEachWindow_AndClaimsNeitherForTheOther()
+    {
+        var note = DarlingFleetReader.BuildRollup(
+            new[] { Card(1, band: CollectorHealthClassifier.Healthy) },
+            Now, Now.AddHours(-1), Now).DeadlockCoverage.Note;
+
+        /* The coverage figure's own window, named as fixed and as seven days. */
+        Assert.Contains("fixed trailing seven days of collection health", note, StringComparison.Ordinal);
+
+        /* The total's window, named as the caller's bounds and as the ONLY thing bounded by them. */
+        Assert.Contains(
+            "total_deadlocks counts only between window_start and window_end", note, StringComparison.Ordinal);
+
+        /* And the disclaimer that keeps the first from being read as the second. */
+        Assert.Contains(
+            "makes no claim about what was read inside window_start..window_end", note, StringComparison.Ordinal);
+
+        /* The wording that would have been the defect: coverage described as something measured inside the
+           caller's window. */
+        Assert.DoesNotContain("read in this window", note, StringComparison.Ordinal);
+        Assert.DoesNotContain("in this window for", note, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The wire shape, on the same <see cref="DarlingFleetReader.JsonOptions"/> the web <c>/api/fleet</c> and
+    /// the <c>get_fleet_overview</c> MCP tool both serialize with: the coverage rides beside the total it
+    /// qualifies, and the per-card cause is a NAME rather than an ordinal a reordering would move.
+    /// </summary>
+    [Fact]
+    public void TheCoverageSerializes_BesideTheTotal_WithTheCauseAsAName()
+    {
+        var json = JsonSerializer.Serialize(
+            DarlingFleetReader.BuildRollup(
+                new[] { Card(1, isPostgres: true), Card(2, band: CollectorHealthClassifier.Healthy) },
+                Now, Now.AddHours(-1), Now),
+            DarlingFleetReader.JsonOptions);
+
+        foreach (var field in new[]
+        {
+            "\"total_deadlocks\"", "\"deadlock_coverage\"", "\"servers_read\"", "\"servers_total\"",
+            "\"postgres_servers\"", "\"servers_collector_silent\"", "\"servers_collector_denied\"",
+            "\"note\"", "\"deadlock_source\"", "\"deadlock_collector_band\"",
+        })
+        {
+            Assert.Contains(field, json, StringComparison.Ordinal);
+        }
+
+        JsonAssert.Contains("\"deadlock_source\": \"PostgresTarget\"", json);
+        JsonAssert.Contains("\"deadlock_source\": \"Read\"", json);
+        JsonAssert.Contains("\"servers_read\": 1", json);
+    }
+
+    private static readonly DateTime Now = new(2026, 9, 5, 12, 0, 0, DateTimeKind.Unspecified);
+
+    private static FleetServerCard Card(int id, bool isPostgres = false, string? band = null) =>
+        new()
+        {
+            ServerId = id,
+            DisplayName = "target-" + id.ToString(CultureInfo.InvariantCulture),
+            ServerName = "target-" + id.ToString(CultureInfo.InvariantCulture),
+            IsPostgres = isPostgres,
+            DeadlockCollectorBand = band,
+        };
 }
 
 /// <summary>

--- a/Darling/Darling.Tests/DarlingFleetReaderTests.cs
+++ b/Darling/Darling.Tests/DarlingFleetReaderTests.cs
@@ -416,8 +416,9 @@ public sealed class DarlingFleetDeadlockCoverageTests
     /// <summary>
     /// A card that sets nothing reads as UNCOVERED, and that is the load-bearing default. <c>DeadlockSource</c>
     /// is derived rather than assigned precisely so a card built by a path nobody re-reads cannot sit at an
-    /// enum default meaning "read" and inflate the fleet's coverage — the silent-default shape this file's
-    /// own <c>AbandonedCount</c> comment already names as a defect class.
+    /// enum default meaning "read" and inflate the fleet's coverage — the silent-default shape the READER's
+    /// own <c>AbandonedCount</c> comment (inside <c>FleetCollectionHealthSql</c>) already names as a defect
+    /// class: "it would COMPILE, because the default is silent".
     /// </summary>
     [Fact]
     public void ACardThatMakesNoClaim_IsUncovered_NotCovered()

--- a/Darling/Darling.Tests/NothingReadBandsTests.cs
+++ b/Darling/Darling.Tests/NothingReadBandsTests.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Linq;
+using System.Reflection;
 using PerformanceMonitor.Common;
 using Xunit;
 
@@ -61,22 +62,72 @@ public sealed class NothingReadBandsTests
     }
 
     /// <summary>
-    /// Set equality, so the two theories above cannot both keep passing while an EIGHTH band arrives with no
-    /// decision made about it. Every band constant on the classifier is accounted for by exactly one of the
-    /// two lists.
+    /// Set equality, so the two theories above cannot both keep passing while the set itself is widened or
+    /// narrowed without a decision reaching them.
     /// </summary>
     [Fact]
     public void TheSetIsExactly_TheThreeBandsThatReadNothing()
     {
         Assert.Equal(
-            new[]
-            {
-                CollectorHealthClassifier.NeverRun,
-                CollectorHealthClassifier.NoPermissions,
-                CollectorHealthClassifier.Stopped,
-            }.OrderBy(b => b, StringComparer.Ordinal).ToArray(),
+            ReadNothing.OrderBy(b => b, StringComparer.Ordinal).ToArray(),
             CollectorHealthClassifier.NothingReadBands.OrderBy(b => b, StringComparer.Ordinal).ToArray());
     }
+
+    /// <summary>
+    /// And the direction the set-equality test above cannot reach on its own: an EIGHTH band added to the
+    /// classifier and to NEITHER list.
+    ///
+    /// <para>A test that compared the set against a hand-written triple would keep passing through that
+    /// change, because nothing in it ever asks the classifier what bands EXIST — a decision would simply
+    /// never be made, and the new band would count as read by default. So the band constants are read off
+    /// the type and every one is required to sit in exactly one of the two lists.</para>
+    ///
+    /// <para>The band constants are told apart from the classifier's other <c>public const string</c>
+    /// members (<c>EmptyEnumerationMarker</c>, <c>HasUserDatabasesQualifier</c> — lower-case prose) by their
+    /// VALUE shape rather than by a name list, so a new band is picked up without this test being edited. A
+    /// non-band constant that happened to be upper-case would be swept in and demand a decision it does not
+    /// need, which is the safe direction: it fails loudly and gets one line of triage, where the miss it
+    /// replaces is silent and wrong.</para>
+    /// </summary>
+    [Fact]
+    public void EveryBandOnTheClassifier_HasADecision_InExactlyOneList()
+    {
+        var bands = typeof(CollectorHealthClassifier)
+            .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+            .Where(f => f is { IsLiteral: true, IsInitOnly: false } && f.FieldType == typeof(string))
+            .Select(f => (string)f.GetRawConstantValue()!)
+            .Where(v => v.Length > 0 && v.All(ch => char.IsAsciiLetterUpper(ch) || ch == '_'))
+            .ToList();
+
+        /* The precondition, named so a reflection change reports itself instead of turning this into a
+           vacuous pass over an empty sequence. */
+        Assert.Equal(7, bands.Count);
+
+        var decided = ReadNothing.Concat(DidRead).ToHashSet(StringComparer.Ordinal);
+
+        Assert.Equal(
+            bands.OrderBy(b => b, StringComparer.Ordinal).ToArray(),
+            decided.OrderBy(b => b, StringComparer.Ordinal).ToArray());
+
+        /* No band in both lists — a band that read nothing and also read is not a decision. */
+        Assert.Empty(ReadNothing.Intersect(DidRead, StringComparer.Ordinal));
+    }
+
+    /* The two decisions, as data, so both tests above read from the same lists the theories enumerate. */
+    private static readonly string[] ReadNothing =
+    [
+        CollectorHealthClassifier.NeverRun,
+        CollectorHealthClassifier.NoPermissions,
+        CollectorHealthClassifier.Stopped,
+    ];
+
+    private static readonly string[] DidRead =
+    [
+        CollectorHealthClassifier.Failing,
+        CollectorHealthClassifier.Stale,
+        CollectorHealthClassifier.Warning,
+        CollectorHealthClassifier.Healthy,
+    ];
 
     /// <summary>
     /// A null band answers FALSE, not TRUE. Absence of a band is not a claim that nothing was read, and a

--- a/Darling/Darling.Tests/NothingReadBandsTests.cs
+++ b/Darling/Darling.Tests/NothingReadBandsTests.cs
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Linq;
+using PerformanceMonitor.Common;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// The named set that says which bands mean NOTHING WAS READ (#3017), pinned in BOTH directions.
+///
+/// <para><b>Why both directions.</b> The failure mode of a coverage denominator is over-exclusion as much as
+/// under-exclusion: dropping FAILING, STALE or WARNING from what counts as read would shrink the denominator
+/// and report a smaller fleet than exists — a new wrong number in place of the old one, and one that looks
+/// more careful than the number it replaced. So the membership test sits beside a NON-membership test, and
+/// the two together are a set-equality assertion that a fourth band cannot slip past in either direction.</para>
+/// </summary>
+public sealed class NothingReadBandsTests
+{
+    /// <summary>
+    /// STOPPED and NO_PERMISSIONS are the two the field produces. NEVER_RUN is in the set on MEANING rather
+    /// than on reachability: it is <c>totalRuns == 0</c>, which a GROUP BY over a run log cannot currently
+    /// produce (no rows, no group), but that is a property of the QUERY and not of the band. A later outer
+    /// join against the collector catalog — the natural way to make a never-invoked collector visible at all
+    /// — makes it reachable, and a set that had left it out would then count the most completely unread
+    /// server of all as read. Relying on a row shape to keep a band unreachable is how the next query change
+    /// reintroduces the defect.
+    /// </summary>
+    [Theory]
+    [InlineData(CollectorHealthClassifier.NoPermissions)]
+    [InlineData(CollectorHealthClassifier.Stopped)]
+    [InlineData(CollectorHealthClassifier.NeverRun)]
+    public void ABandThatReadNothing_IsInTheSet(string band)
+    {
+        Assert.Contains(band, CollectorHealthClassifier.NothingReadBands);
+        Assert.True(CollectorHealthClassifier.ReadNothing(band));
+    }
+
+    /// <summary>
+    /// The other direction, and the one that keeps a denominator honest. A FAILING, STALE or WARNING
+    /// collector DID read on some cycles — its rows really are in whatever total is built from them — so
+    /// excluding it would understate coverage. Those states are not hidden by counting: they have their own
+    /// loud surfaces (the health grid's band, the fleet's failing-collector counts).
+    /// </summary>
+    [Theory]
+    [InlineData(CollectorHealthClassifier.Failing)]
+    [InlineData(CollectorHealthClassifier.Stale)]
+    [InlineData(CollectorHealthClassifier.Warning)]
+    [InlineData(CollectorHealthClassifier.Healthy)]
+    public void ABandThatDidRead_IsNotInTheSet(string band)
+    {
+        Assert.DoesNotContain(band, CollectorHealthClassifier.NothingReadBands);
+        Assert.False(CollectorHealthClassifier.ReadNothing(band));
+    }
+
+    /// <summary>
+    /// Set equality, so the two theories above cannot both keep passing while an EIGHTH band arrives with no
+    /// decision made about it. Every band constant on the classifier is accounted for by exactly one of the
+    /// two lists.
+    /// </summary>
+    [Fact]
+    public void TheSetIsExactly_TheThreeBandsThatReadNothing()
+    {
+        Assert.Equal(
+            new[]
+            {
+                CollectorHealthClassifier.NeverRun,
+                CollectorHealthClassifier.NoPermissions,
+                CollectorHealthClassifier.Stopped,
+            }.OrderBy(b => b, StringComparer.Ordinal).ToArray(),
+            CollectorHealthClassifier.NothingReadBands.OrderBy(b => b, StringComparer.Ordinal).ToArray());
+    }
+
+    /// <summary>
+    /// A null band answers FALSE, not TRUE. Absence of a band is not a claim that nothing was read, and a
+    /// caller holding no band at all has to decide that case for itself — <c>DarlingFleetReader</c>'s
+    /// deadlock coverage does, and treats it as uncovered, but it does so where a reader can see the
+    /// reasoning rather than having this predicate decide it silently.
+    /// </summary>
+    [Fact]
+    public void ANullOrUnknownBand_IsNotAClaimThatNothingWasRead()
+    {
+        Assert.False(CollectorHealthClassifier.ReadNothing(null));
+        Assert.False(CollectorHealthClassifier.ReadNothing("SOMETHING_A_LATER_BUILD_WROTE"));
+    }
+}

--- a/Darling/Darling.Tests/RdsCpuIngestorTests.cs
+++ b/Darling/Darling.Tests/RdsCpuIngestorTests.cs
@@ -41,19 +41,33 @@ public class RdsCpuIngestorTests
 
     /// <summary>Self-hosted PostgreSQL has no CPU route at all — a non-RDS host is this transport's ordinary
     /// answer, not an error, matching <see cref="RdsLogSource.ReadNewestAsync"/>'s identical null-return for
-    /// the same case.</summary>
+    /// the same case.
+    ///
+    /// <para><b>And the outcome says the source was NOT REACHED, not merely that it stored nothing</b>
+    /// (#3017). This is the case that made the defect reachable with no fleet and no permission claim:
+    /// <c>pg_cpu_utilization</c> dispatches unconditionally, so every cycle of every self-hosted PostgreSQL
+    /// target arrives here, and a bare zero let the runner stamp it "no new Performance Insights CPU samples
+    /// this cycle" — a claim about a window PI was never asked about. The <c>awsCalled</c> assertion is what
+    /// makes that concrete: nothing was queried, so nothing can be reported about it.</para></summary>
     [Fact]
-    public async Task ANonRdsHostReturnsZero()
+    public async Task ANonRdsHost_ReportsTheSourceUnreached_WithNoAwsCall()
     {
         var awsCalled = false;
         var ingestor = new RdsCpuIngestor(
             UnusedDataSource(),
             rdsClientFactory: _ => { awsCalled = true; return null!; });
 
-        var rows = await ingestor.IngestAsync(1, "srv", "db.internal.example.com");
+        var outcome = await ingestor.IngestAsync(1, "srv", "db.internal.example.com");
 
-        Assert.Equal(0, rows);
+        Assert.False(outcome.SourceReached);
+        Assert.Equal(0, outcome.Rows);
+        Assert.Equal(RdsIngestOutcome.NotReached, outcome);
         Assert.False(awsCalled, "a non-RDS host must never reach an AWS client factory");
+
+        /* The distinction, stated as the inequality the runner branches on: a read that found nothing is a
+           DIFFERENT value from a source that was never asked, so no rendering can conflate them again by
+           looking only at the count. */
+        Assert.NotEqual(RdsIngestOutcome.Read(0), outcome);
     }
 
     /// <summary>Reader and custom endpoints round-robin across replicas, so the instance behind one is not

--- a/Darling/Darling.Tests/RdsDeadlockIngestorTests.cs
+++ b/Darling/Darling.Tests/RdsDeadlockIngestorTests.cs
@@ -14,6 +14,7 @@ using Amazon.RDS;
 using Amazon.RDS.Model;
 using Npgsql;
 using PerformanceMonitor.Collectors;
+using PerformanceMonitor.Darling.Service;
 using PerformanceMonitor.Darling.Service.Targets;
 using Xunit;
 
@@ -243,10 +244,10 @@ public sealed class RdsDeadlockIngestorTests
         var (ingestor, client, _) = Build(store, new FakeRds { FirstBody = QuietText });
 
         var rows = await ingestor.IngestAsync(1, "target-a", Host);
-        Assert.Equal(0, rows);
+        Assert.Equal(RdsIngestOutcome.Read(0), rows);
 
         var more = await ingestor.IngestAsync(1, "target-a", Host);
-        Assert.Equal(0, more);
+        Assert.Equal(RdsIngestOutcome.Read(0), more);
 
         /* Advanced: the second read resumed from the first read's marker instead of asking for the tail
            again. */
@@ -287,14 +288,102 @@ public sealed class RdsDeadlockIngestorTests
     /// <summary>
     /// A non-RDS host is skipped without touching the store or the marker — that target reads its log
     /// through <c>pg_read_file</c>, and there is nothing here to report or to resume.
+    ///
+    /// <para><b>Skipped is reported as NOT REACHED, and that is a different value from an empty log</b>
+    /// (#3017). No log file was listed and none was downloaded (<c>client.Downloads</c> is empty), so
+    /// "no new deadlocks in the RDS log window" would be a claim about the contents of a log this cycle
+    /// never opened. The pairing with <see cref="AQuietCycleAdvancesTheMarker"/> is the point: that test
+    /// reaches the log and finds nothing, this one does not reach it, and the two now carry different
+    /// outcomes rather than the same zero.</para>
     /// </summary>
     [Fact]
-    public async Task ANonRdsHostIsSkipped()
+    public async Task ANonRdsHost_ReportsTheSourceUnreached_WithNoAwsCall()
     {
         await using var store = NpgsqlDataSource.Create(DeadStore);
         var (ingestor, client, _) = Build(store);
 
-        Assert.Equal(0, await ingestor.IngestAsync(1, "target-a", "db.internal.example.com"));
+        var outcome = await ingestor.IngestAsync(1, "target-a", "db.internal.example.com");
+
+        Assert.Equal(RdsIngestOutcome.NotReached, outcome);
+        Assert.False(outcome.SourceReached);
+        Assert.NotEqual(RdsIngestOutcome.Read(0), outcome);
         Assert.Empty(client.Downloads);
+    }
+
+    /// <summary>
+    /// The runner's rendering of both, side by side — the assertion that actually closes #3017, because the
+    /// two ingest outcomes above are only worth distinguishing if the note distinguishes them.
+    ///
+    /// <para>Pure: <see cref="DarlingCollectorRunner.RdsIngestNote"/> takes the outcome and the two
+    /// sentences, so no store, <c>ServerRuntime</c> or AWS client is needed to pin the three-way choice.</para>
+    /// </summary>
+    [Fact]
+    public void TheRunnerRendersADifferentNote_ForAnUnreachedLogThanForAnEmptyOne()
+    {
+        var notReached = DarlingCollectorRunner.RdsIngestNote(
+            RdsIngestOutcome.NotReached,
+            DarlingCollectorRunner.RdsDeadlockLogNotReachedNote,
+            DarlingCollectorRunner.RdsDeadlockLogEmptyNote);
+
+        var readNothing = DarlingCollectorRunner.RdsIngestNote(
+            RdsIngestOutcome.Read(0),
+            DarlingCollectorRunner.RdsDeadlockLogNotReachedNote,
+            DarlingCollectorRunner.RdsDeadlockLogEmptyNote);
+
+        var productive = DarlingCollectorRunner.RdsIngestNote(
+            RdsIngestOutcome.Read(3),
+            DarlingCollectorRunner.RdsDeadlockLogNotReachedNote,
+            DarlingCollectorRunner.RdsDeadlockLogEmptyNote);
+
+        Assert.Equal(DarlingCollectorRunner.RdsDeadlockLogNotReachedNote, notReached);
+        Assert.Equal(DarlingCollectorRunner.RdsDeadlockLogEmptyNote, readNothing);
+
+        /* The defect, stated directly: these two must never be the same sentence. */
+        Assert.NotEqual(readNothing, notReached);
+
+        /* A productive cycle still leaves no note — the rows are the statement. */
+        Assert.Null(productive);
+    }
+
+    /// <summary>
+    /// What the two sentences have to SAY, not merely that they differ. A pair of distinct strings that both
+    /// described the log's contents would satisfy the inequality above and still be the defect.
+    ///
+    /// <para>All three collectors' pairs are asserted here rather than one, because the three notes were
+    /// three independent copies of the same mistake and a fix that reached two of them would look
+    /// complete.</para>
+    /// </summary>
+    [Fact]
+    public void EveryNotReachedNote_SaysTheCycleDidNotLook_AndNamesWhy()
+    {
+        foreach (var note in new[]
+        {
+            DarlingCollectorRunner.RdsDeadlockLogNotReachedNote,
+            DarlingCollectorRunner.RdsPlanLogNotReachedNote,
+            DarlingCollectorRunner.PiCpuNotReachedNote,
+        })
+        {
+            /* #2633's own closing sentence, as an outcome rather than a rule: a cycle that could not look
+               must not claim it looked. An operator who learned the distinction from #2633's PERMISSIONS
+               rows meets the same words arriving through the one door that is not a failure. */
+            Assert.Contains("this cycle did not look", note, StringComparison.Ordinal);
+
+            /* And the cause, because "did not look" alone would send someone hunting for a collector to
+               restart. Nothing is wrong: this transport does not apply to this target. */
+            Assert.Contains("not an RDS or Aurora endpoint", note, StringComparison.Ordinal);
+        }
+
+        /* The empty notes are unchanged claims about a source that WAS read, and must stay that way -
+           those sentences are correct on their own path and are what the not-reached notes exist to stop
+           being borrowed. */
+        foreach (var note in new[]
+        {
+            DarlingCollectorRunner.RdsDeadlockLogEmptyNote,
+            DarlingCollectorRunner.RdsPlanLogEmptyNote,
+            DarlingCollectorRunner.PiCpuEmptyNote,
+        })
+        {
+            Assert.DoesNotContain("did not look", note, StringComparison.Ordinal);
+        }
     }
 }

--- a/Darling/Darling.Tests/RdsPlanIngestorTests.cs
+++ b/Darling/Darling.Tests/RdsPlanIngestorTests.cs
@@ -173,12 +173,37 @@ public sealed class RdsPlanIngestorTests
         await using var store = NpgsqlDataSource.Create(DeadStore);
         var (ingestor, client, _) = Build(store, new FakeRds { FirstBody = QuietText });
 
-        Assert.Equal(0, await ingestor.IngestAsync(1, "target-a", Host));
-        Assert.Equal(0, await ingestor.IngestAsync(1, "target-a", Host));
+        Assert.Equal(RdsIngestOutcome.Read(0), await ingestor.IngestAsync(1, "target-a", Host));
+        Assert.Equal(RdsIngestOutcome.Read(0), await ingestor.IngestAsync(1, "target-a", Host));
 
         Assert.Equal(2, client.Downloads.Count);
         Assert.Null(client.Downloads[0].Marker);
         Assert.Equal("MARKER-1", client.Downloads[1].Marker);
         Assert.Equal(0, client.Downloads[1].NumberOfLines);
+    }
+
+    /// <summary>
+    /// A non-RDS host reaches nothing, and the outcome says so rather than reporting an empty log (#3017).
+    /// That target reads its log through <c>pg_read_file</c> instead, so no log file was listed and none was
+    /// downloaded — "no new auto_explain plans in the RDS log window" would be a claim about a log this
+    /// cycle never opened.
+    ///
+    /// <para>Sits directly beside <see cref="AQuietCycleAdvancesTheMarker"/> on purpose: that one reaches
+    /// the log and finds nothing worth storing, this one never reaches it, and the pair is what makes the
+    /// over-exclusion direction visible too — a reached-but-empty cycle must NOT be reported as
+    /// unreached.</para>
+    /// </summary>
+    [Fact]
+    public async Task ANonRdsHost_ReportsTheSourceUnreached_WithNoAwsCall()
+    {
+        await using var store = NpgsqlDataSource.Create(DeadStore);
+        var (ingestor, client, _) = Build(store);
+
+        var outcome = await ingestor.IngestAsync(1, "target-a", "db.internal.example.com");
+
+        Assert.Equal(RdsIngestOutcome.NotReached, outcome);
+        Assert.False(outcome.SourceReached);
+        Assert.NotEqual(RdsIngestOutcome.Read(0), outcome);
+        Assert.Empty(client.Downloads);
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
@@ -601,7 +601,7 @@ public sealed class DarlingCollectorRunner
 
         var started = Stopwatch.GetTimestamp();
 
-        var rows = await _rdsPlans.IngestAsync(
+        var outcome = await _rdsPlans.IngestAsync(
             server.ServerId, server.StorageName, host, cancellationToken);
 
         var elapsedMs = (long)Stopwatch.GetElapsedTime(started).TotalMilliseconds;
@@ -609,8 +609,8 @@ public sealed class DarlingCollectorRunner
         /* Counted as STORAGE time rather than SQL time: no query ran against the monitored server, and
            filing an HTTPS round trip under sql_duration_ms would make one target's numbers mean something
            different from every other target's. */
-        return new CollectorRunResult(rows, 0, elapsedMs,
-            rows == 0 ? "no new auto_explain plans in the RDS log window" : null);
+        return new CollectorRunResult(outcome.Rows, 0, elapsedMs,
+            RdsIngestNote(outcome, RdsPlanLogNotReachedNote, RdsPlanLogEmptyNote));
     }
 
     /// <summary>
@@ -629,13 +629,13 @@ public sealed class DarlingCollectorRunner
 
         var started = Stopwatch.GetTimestamp();
 
-        var rows = await _rdsDeadlocks.IngestAsync(
+        var outcome = await _rdsDeadlocks.IngestAsync(
             server.ServerId, server.StorageName, host, cancellationToken);
 
         var elapsedMs = (long)Stopwatch.GetElapsedTime(started).TotalMilliseconds;
 
-        return new CollectorRunResult(rows, 0, elapsedMs,
-            rows == 0 ? "no new deadlocks in the RDS log window" : null);
+        return new CollectorRunResult(outcome.Rows, 0, elapsedMs,
+            RdsIngestNote(outcome, RdsDeadlockLogNotReachedNote, RdsDeadlockLogEmptyNote));
     }
 
     /// <summary>
@@ -655,7 +655,7 @@ public sealed class DarlingCollectorRunner
 
         var started = Stopwatch.GetTimestamp();
 
-        var rows = await _rdsCpu.IngestAsync(
+        var outcome = await _rdsCpu.IngestAsync(
             server.ServerId, server.StorageName, host, cancellationToken);
 
         var elapsedMs = (long)Stopwatch.GetElapsedTime(started).TotalMilliseconds;
@@ -663,9 +663,69 @@ public sealed class DarlingCollectorRunner
         /* Counted as STORAGE time rather than SQL time, matching the other two RDS-API ingestors: no query
            ran against the monitored server, and filing an HTTPS round trip under sql_duration_ms would make
            one target's numbers mean something different from every other target's. */
-        return new CollectorRunResult(rows, 0, elapsedMs,
-            rows == 0 ? "no new Performance Insights CPU samples this cycle" : null);
+        return new CollectorRunResult(outcome.Rows, 0, elapsedMs,
+            RdsIngestNote(outcome, PiCpuNotReachedNote, PiCpuEmptyNote));
     }
+
+    /* ── #3017: the notes an AWS-API ingest cycle leaves in collection_log ──────────────────────────────
+       Six constants, in pairs, because the two members of each pair are the whole point: one says the
+       source was read and held nothing, the other says the source was never asked. Before this there was
+       one sentence per collector and it was the first of the two, stamped on both outcomes — a claim about
+       the contents of a log nobody opened.
+
+       Named constants rather than inline strings so RdsIngestNote can be pinned without a store or an AWS
+       client, and so the pair for each collector can be asserted DIFFERENT — the failure mode of a fix like
+       this is the two arms converging back onto one sentence during a later edit, which no compiler
+       notices.
+
+       No host is interpolated into any of them. collection_log is read by operators and shipped in support
+       bundles, and the fact worth recording is the KIND of target, not its name. */
+
+    /// <summary>The plan log was read and no auto_explain block in it was new.</summary>
+    internal const string RdsPlanLogEmptyNote = "no new auto_explain plans in the RDS log window";
+
+    /// <summary>The plan log was never opened: this host is not an RDS or Aurora endpoint.</summary>
+    internal const string RdsPlanLogNotReachedNote =
+        "this target's host is not an RDS or Aurora endpoint, so no RDS log was requested and no plan "
+        + "capture was attempted - this cycle did not look";
+
+    /// <summary>The deadlock log was read and held no new deadlock.</summary>
+    internal const string RdsDeadlockLogEmptyNote = "no new deadlocks in the RDS log window";
+
+    /// <summary>The deadlock log was never opened: this host is not an RDS or Aurora endpoint.</summary>
+    internal const string RdsDeadlockLogNotReachedNote =
+        "this target's host is not an RDS or Aurora endpoint, so no RDS log was requested and no deadlock "
+        + "capture was attempted - this cycle did not look";
+
+    /// <summary>Performance Insights answered and had no new CPU sample.</summary>
+    internal const string PiCpuEmptyNote = "no new Performance Insights CPU samples this cycle";
+
+    /// <summary>Performance Insights was never queried: this host is not an RDS or Aurora endpoint.</summary>
+    internal const string PiCpuNotReachedNote =
+        "this target's host is not an RDS or Aurora endpoint, so Performance Insights was not queried and "
+        + "no instance CPU was attempted - this cycle did not look";
+
+    /// <summary>
+    /// The <c>collection_log</c> note for one AWS-API ingest cycle (#3017) — the three-way rendering the
+    /// bare row count could not express.
+    ///
+    /// <para><b>Not reached is asked FIRST and answers on its own.</b> A cycle that never made an AWS call
+    /// knows nothing about the source, so <paramref name="nothingNewNote"/> — which is a claim about what
+    /// the source held — must not be reachable from it. That ordering is the fix; the rest is unchanged
+    /// behaviour.</para>
+    ///
+    /// <para><b>A productive cycle still leaves no note</b>, exactly as before: the rows themselves are the
+    /// statement, and a note on every successful cycle would fill the column an operator scans for the
+    /// unusual.</para>
+    ///
+    /// <para>Pure and <c>internal static</c> so the three-way decision can be pinned directly, with no
+    /// store, no <c>ServerRuntime</c> and no AWS client — the shape #2633's own pins already use for this
+    /// family.</para>
+    /// </summary>
+    internal static string? RdsIngestNote(RdsIngestOutcome outcome, string notReachedNote, string nothingNewNote) =>
+        !outcome.SourceReached ? notReachedNote
+        : outcome.Rows == 0 ? nothingNewNote
+        : null;
 
     /// <summary>
     /// The per-database phase line for a database that FAULTED (#2896) — the case the #2855 split was added

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingFleetReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingFleetReader.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
@@ -205,7 +206,16 @@ FULL OUTER JOIN
 ) AS dmv ON xe.server_id = dmv.server_id";
 
     /// <summary>Deadlocks in the window per server — count and newest deadlock instant (for each card's
-    /// "last seen" detail). $1 window start, $2 window end (both naive UTC).</summary>
+    /// "last seen" detail). $1 window start, $2 window end (both naive UTC).
+    ///
+    /// <para><b>This view is the SQL Server extended-event capture and nothing else</b> (#3017).
+    /// <c>v_deadlocks</c> is <c>SELECT * FROM deadlocks</c>, and <c>deadlocks</c> is written by exactly one
+    /// collector — <c>DeadlocksCollector</c>, whose <c>TargetTable</c> it is. A PostgreSQL target's deadlocks
+    /// go to <c>pg_deadlocks</c> instead, there is no <c>v_pg_deadlocks</c>, and nothing joins the two, so
+    /// this count is structurally zero for a PostgreSQL server no matter how many deadlocks its clusters
+    /// have. Zero is also what a genuinely quiet SQL Server reports, which is why the total ships with
+    /// <see cref="FleetDeadlockCoverage"/> beside it: the reading that needs no action and the reading that
+    /// does not cover the fleet are otherwise the same character.</para></summary>
     public const string FleetDeadlockSql = @"
 SELECT server_id, COUNT(*) AS cnt, MAX(deadlock_time) AS last_seen
 FROM v_deadlocks
@@ -441,6 +451,7 @@ GROUP BY server_id, collector_name";
             DeadlockCount = deadlockCount,
             DeadlockLastSeen = deadlock.LastSeen,
             DeadlockSeverity = ServerHealthClassifier.DeadlockSeverity(deadlockCount),
+            DeadlockCollectorBand = collectors.DeadlockBand,
             TotalThreads = threads.TotalThreads,
             CurrentWorkers = threads.CurrentWorkers,
             AvailableThreads = availableThreads,
@@ -471,6 +482,10 @@ GROUP BY server_id, collector_name";
         var failures = 0;
         long totalBlocking = 0;
         long totalDeadlocks = 0;
+        var deadlockSourcesRead = 0;
+        var deadlockPostgresTargets = 0;
+        var deadlockCollectorsSilent = 0;
+        var deadlockCollectorsDenied = 0;
 
         foreach (var card in cards)
         {
@@ -485,6 +500,20 @@ GROUP BY server_id, collector_name";
             if (card.FailedCollectorCount > 0)
             {
                 failures++;
+            }
+
+            /* #3017's denominator, reduced from the CARDS for the same reason the totals above are: the
+               coverage figure and the total it qualifies then reconcile by construction rather than by two
+               queries agreeing. Only Read is counted as read — every other arm, INCLUDING an enum value a
+               later build adds and this switch has never heard of, lands in the silent bucket. A new source
+               kind that inflated the read count would restore exactly the defect this exists to fix, where
+               one that lands in an uncovered bucket merely attributes a real gap imprecisely. */
+            switch (card.DeadlockSource)
+            {
+                case FleetDeadlockSource.Read: deadlockSourcesRead++; break;
+                case FleetDeadlockSource.PostgresTarget: deadlockPostgresTargets++; break;
+                case FleetDeadlockSource.CollectorDenied: deadlockCollectorsDenied++; break;
+                default: deadlockCollectorsSilent++; break;
             }
 
             totalBlocking += card.BlockingCount;
@@ -524,6 +553,14 @@ GROUP BY server_id, collector_name";
             ServersWithCollectionFailures = failures,
             TotalBlockingEvents = totalBlocking,
             TotalDeadlocks = totalDeadlocks,
+            DeadlockCoverage = new FleetDeadlockCoverage
+            {
+                ServersRead = deadlockSourcesRead,
+                ServersTotal = cards.Count,
+                PostgresServers = deadlockPostgresTargets,
+                ServersCollectorSilent = deadlockCollectorsSilent,
+                ServersCollectorDenied = deadlockCollectorsDenied,
+            },
             WorstServers = worst,
             AdditionalProblemCount = Math.Max(0, problems.Count - worst.Count),
             Cards = cards,
@@ -622,6 +659,49 @@ GROUP BY server_id, collector_name";
     /// </summary>
     internal static (bool IsPostgres, bool IsAurora) ClassifyEngineKind(string? engineKind) =>
         (MonitoredEngineKind.IsPostgres(engineKind), MonitoredEngineKind.IsAurora(engineKind));
+
+    /// <summary>
+    /// Whether one server's deadlock count — and so the fleet total it sums into — actually read a deadlock
+    /// source, and when it did not, which of the three causes it was (#3017). The three take OPPOSITE
+    /// actions, which is why one uncovered tally would not have been enough: a different tool for a
+    /// PostgreSQL target, a collector to look at for one that is not being invoked, a grant for one that was
+    /// refused.
+    ///
+    /// <para><b>PostgreSQL is asked first and answers on its own.</b> It is not a degraded collector, it is
+    /// the wrong table: <see cref="FleetDeadlockSql"/> reads <c>v_deadlocks</c>, which holds only the SQL
+    /// Server extended-event capture, and no health band on any collector changes that. A PostgreSQL target
+    /// whose <c>pg_deadlocks</c> collector is perfectly healthy still contributes nothing here.</para>
+    ///
+    /// <para><b>A null band is uncovered, not covered.</b> Null means the <c>deadlocks</c> collector left no
+    /// row in the health window — nothing was read for this server, whatever else is true of it — and
+    /// defaulting an absent band to "read" is precisely how a coverage figure becomes another number nobody
+    /// can trust. It is folded in with STOPPED and NEVER_RUN because all three take the same action.</para>
+    ///
+    /// <para><b>FAILING, STALE and WARNING count as READ, deliberately.</b> Those collectors succeeded on
+    /// some cycles, so their rows really are in the total and a denominator excluding them would understate
+    /// the fleet — a new wrong number in place of the old one. They are not hidden by being counted here:
+    /// <see cref="FleetOverviewResult.ServersWithCollectionFailures"/> and each card's
+    /// <see cref="FleetServerCard.FailedCollectorCount"/> are where a degraded collector shows, and the
+    /// card's own <see cref="FleetServerCard.DeadlockCollectorBand"/> carries the band verbatim.</para>
+    /// </summary>
+    internal static FleetDeadlockSource ClassifyDeadlockSource(bool isPostgres, string? deadlockCollectorBand)
+    {
+        if (isPostgres)
+        {
+            return FleetDeadlockSource.PostgresTarget;
+        }
+
+        /* Tested ahead of the general set below rather than as part of it: NO_PERMISSIONS is IN
+           NothingReadBands, so asking the set first would swallow the one cause with a different fix. */
+        if (string.Equals(deadlockCollectorBand, CollectorHealthClassifier.NoPermissions, StringComparison.Ordinal))
+        {
+            return FleetDeadlockSource.CollectorDenied;
+        }
+
+        return deadlockCollectorBand is null || CollectorHealthClassifier.ReadNothing(deadlockCollectorBand)
+            ? FleetDeadlockSource.CollectorSilent
+            : FleetDeadlockSource.Read;
+    }
 
     /* ─────────────────────────── per-query readers ─────────────────────────── */
 
@@ -847,7 +927,15 @@ GROUP BY server_id, collector_name";
             var status = health.HealthStatus;
             counts[serverId] = new CollectorCounts(
                 existing.Healthy + (status == "HEALTHY" ? 1 : 0),
-                existing.Failing + (status == "FAILING" ? 1 : 0));
+                existing.Failing + (status == "FAILING" ? 1 : 0),
+                /* #3017: the ONE collector whose band the deadlock total's coverage turns on, kept
+                   alongside the Healthy/Failing tallies because it comes out of the same aggregate — no
+                   extra round trip, which is what keeps this reader's fan-out bounded. Named from the
+                   collector rather than as a literal so a rename cannot leave this silently matching
+                   nothing and reporting every server uncovered. */
+                string.Equals(health.CollectorName, DeadlocksCollector.Instance.Name, StringComparison.Ordinal)
+                    ? status
+                    : existing.DeadlockBand);
         }
 
         return counts;
@@ -865,7 +953,12 @@ GROUP BY server_id, collector_name";
     private readonly record struct ThreadsRow(int? TotalThreads, int? CurrentWorkers, int RunnableTasks, long WorkQueue);
     private readonly record struct BlockingRow(int XeCount, long XeMaxWait, int DmvCount, long DmvMaxWait);
     private readonly record struct DeadlockRow(int Count, DateTime? LastSeen);
-    private readonly record struct CollectorCounts(int Healthy, int Failing);
+    /// <param name="DeadlockBand">The <c>deadlocks</c> collector's own 7-day band for this server, or null
+    /// when that collector left no row in the health window at all (#3017). Null and
+    /// <see cref="CollectorHealthClassifier.NeverRun"/> mean the same thing to a reader and take the same
+    /// action, but they arrive differently: null is the absent GROUP, NEVER_RUN would be a present group with
+    /// no runs in it.</param>
+    private readonly record struct CollectorCounts(int Healthy, int Failing, string? DeadlockBand = null);
 }
 
 /// <summary>
@@ -981,6 +1074,26 @@ public sealed class FleetServerCard
     [JsonPropertyName("deadlock_last_seen")] public DateTime? DeadlockLastSeen { get; init; }
     [JsonPropertyName("deadlock_severity")] public HealthSeverity DeadlockSeverity { get; init; }
 
+    /// <summary>This server's <c>deadlocks</c> collector band over the trailing seven days of collection
+    /// health (#3017) — the fact that explains a <see cref="DeadlockCount"/> of zero. Null when that
+    /// collector left no row in the health window, which is itself the answer rather than the absence of
+    /// one: nothing was read for this server. A PostgreSQL target has no <c>deadlocks</c> collector at all,
+    /// so it is null there too and <see cref="DeadlockSource"/> answers on the engine instead.</summary>
+    [JsonPropertyName("deadlock_collector_band")] public string? DeadlockCollectorBand { get; init; }
+
+    /// <summary>Whether <see cref="DeadlockCount"/> read a deadlock source for this server, and when it did
+    /// not, which cause (#3017) — see <see cref="DarlingFleetReader.ClassifyDeadlockSource"/> for what each
+    /// value means and what it asks an operator to do.
+    ///
+    /// <para>DERIVED rather than assigned, for the reason <see cref="EngineDescription"/> is: every card is
+    /// built by an object initializer, and a settable field would sit at its enum default on any card whose
+    /// builder did not think of it — including one added later on a path nobody re-reads. Derived, the
+    /// unset case is <see cref="FleetDeadlockSource.CollectorSilent"/>, which is the honest reading of a
+    /// card carrying no band and the only default that cannot inflate the fleet's coverage.</para></summary>
+    [JsonPropertyName("deadlock_source")]
+    public FleetDeadlockSource DeadlockSource =>
+        DarlingFleetReader.ClassifyDeadlockSource(IsPostgres, DeadlockCollectorBand);
+
     [JsonPropertyName("total_threads")] public int? TotalThreads { get; init; }
     [JsonPropertyName("current_workers")] public int? CurrentWorkers { get; init; }
     [JsonPropertyName("available_threads")] public int? AvailableThreads { get; init; }
@@ -1062,6 +1175,11 @@ public sealed class FleetOverviewResult
     [JsonPropertyName("servers_with_collection_failures")] public int ServersWithCollectionFailures { get; init; }
     [JsonPropertyName("total_blocking_events")] public long TotalBlockingEvents { get; init; }
     [JsonPropertyName("total_deadlocks")] public long TotalDeadlocks { get; init; }
+
+    /// <summary>How much of the fleet <see cref="TotalDeadlocks"/> actually read a deadlock source for, with
+    /// the causes named (#3017). Never null — a total with no denominator beside it is the defect.</summary>
+    [JsonPropertyName("deadlock_coverage")] public FleetDeadlockCoverage DeadlockCoverage { get; init; } = new();
+
     [JsonPropertyName("additional_problem_count")] public int AdditionalProblemCount { get; init; }
     [JsonPropertyName("worst_servers")] public IReadOnlyList<FleetRankedServer> WorstServers { get; init; } = Array.Empty<FleetRankedServer>();
     [JsonPropertyName("cards")] public IReadOnlyList<FleetServerCard> Cards { get; init; } = Array.Empty<FleetServerCard>();
@@ -1070,4 +1188,152 @@ public sealed class FleetOverviewResult
     /// parent, ordering, and colour, so the fleet page can group cards under a nested tag tree even when a parent
     /// tag has no directly-assigned servers. Empty when no tags are defined. Assignment/editing stays desktop-only.</summary>
     [JsonPropertyName("tags")] public IReadOnlyList<FleetTagNode> Tags { get; init; } = Array.Empty<FleetTagNode>();
+}
+
+/// <summary>
+/// Whether one server's deadlock count read a deadlock source at all, and when it did not, which cause
+/// (#3017). Serialized as its STRING name (the fleet DTOs' <c>JsonStringEnumConverter</c>), so a consumer
+/// switches on a word rather than on an ordinal that a reordering would move underneath it.
+///
+/// <para>The three uncovered arms exist as three rather than as one flag because they take OPPOSITE actions,
+/// which is the whole reason a bare tally would not have been enough.</para>
+/// </summary>
+public enum FleetDeadlockSource
+{
+    /// <summary>The <c>deadlocks</c> collector read this server over the health window, so this server's
+    /// deadlocks — however many that is, including none — are in the total. Its band may still be FAILING,
+    /// STALE or WARNING: those collectors succeeded on some cycles, and their rows are in the total.</summary>
+    Read,
+
+    /// <summary>A PostgreSQL target, whose deadlocks the total cannot count at all: they are stored in
+    /// <c>pg_deadlocks</c>, which nothing joins into <c>v_deadlocks</c>. Nothing about this server's health
+    /// changes it and no grant addresses it — <c>get_pg_deadlocks</c> is the read that answers.</summary>
+    PostgresTarget,
+
+    /// <summary>The <c>deadlocks</c> collector is not being invoked — STOPPED, NEVER_RUN, or no row in the
+    /// health window at all. Silence, not failure: a collector still running and erroring every cycle bands
+    /// FAILING and counts as <see cref="Read"/>. Check the collector (<c>get_collection_health</c>).</summary>
+    CollectorSilent,
+
+    /// <summary>Every one of the <c>deadlocks</c> collector's attempts was refused for permissions
+    /// (NO_PERMISSIONS). The one cause a grant fixes, which is why it is not folded in with
+    /// <see cref="CollectorSilent"/> despite both meaning nothing was read.</summary>
+    CollectorDenied,
+}
+
+/// <summary>
+/// The denominator beside <see cref="FleetOverviewResult.TotalDeadlocks"/> (#3017): how many of the fleet's
+/// servers that total actually read a deadlock source for, and for the rest, which of the three causes it
+/// was.
+///
+/// <para><b>Why a total needs one at all.</b> <c>v_deadlocks</c> is the SQL Server extended-event capture and
+/// only that, so <c>total_deadlocks</c> is structurally zero for a PostgreSQL server — permanently, whatever
+/// its clusters do and whatever grants the monitoring role holds. Zero is also exactly what a genuinely quiet
+/// SQL Server fleet reports. The reading that needs no action and the reading that does not cover the fleet
+/// are the same character, and that is what makes the bare number unusable.</para>
+///
+/// <para><b>The convention this follows.</b> <c>get_pg_blocking</c> already reports <c>captures_total</c>
+/// beside <c>captures_with_blocking</c> and a sentence saying what an empty answer does and does not mean,
+/// because the denominator is the honest part of a sampled signal; <c>target_has_user_databases</c> (#1852)
+/// already states a fact about the TARGET beside a persistently empty result rather than banding it, so
+/// "nothing to collect" stops looking like "collecting nothing". This is the same move on a fleet total: a
+/// count, a denominator, named causes, and a note — and deliberately not a new band, for #1852's reason. A
+/// quiet SQL Server fleet with full coverage is healthy and must keep reading that way.</para>
+/// </summary>
+public sealed class FleetDeadlockCoverage
+{
+    /// <summary>Servers the total read a deadlock source for — the numerator of the coverage this object
+    /// reports, and NOT a count of servers that had deadlocks (that is
+    /// <see cref="FleetOverviewResult.TotalDeadlocks"/>'s job).</summary>
+    [JsonPropertyName("servers_read")] public int ServersRead { get; init; }
+
+    /// <summary>Enabled servers in the fleet — the same population as
+    /// <see cref="FleetOverviewResult.TotalServers"/>, repeated here so the denominator travels with its
+    /// numerator and a consumer reading only this object is never one field short of the ratio.</summary>
+    [JsonPropertyName("servers_total")] public int ServersTotal { get; init; }
+
+    /// <summary>Uncovered because the target is PostgreSQL — <c>get_pg_deadlocks</c> is the read that
+    /// answers for these.</summary>
+    [JsonPropertyName("postgres_servers")] public int PostgresServers { get; init; }
+
+    /// <summary>Uncovered because the <c>deadlocks</c> collector is not being invoked (STOPPED, NEVER_RUN,
+    /// or no row in the health window) — check the collector.</summary>
+    [JsonPropertyName("servers_collector_silent")] public int ServersCollectorSilent { get; init; }
+
+    /// <summary>Uncovered because every one of the <c>deadlocks</c> collector's attempts was refused for
+    /// permissions — these need a grant.</summary>
+    [JsonPropertyName("servers_collector_denied")] public int ServersCollectorDenied { get; init; }
+
+    /// <summary>
+    /// The sentence that keeps the two figures from being read as one measurement.
+    ///
+    /// <para><b>The windows genuinely diverge and this is the whole point of the field.</b>
+    /// <see cref="FleetOverviewResult.TotalDeadlocks"/> is counted between the caller's
+    /// <c>window_start</c> and <c>window_end</c> (one hour by default); coverage is banded over the FIXED
+    /// trailing seven days of collection health. That divergence is correct — whether a reader works is a
+    /// durable fact, and the banding thresholds are themselves defined in DAYS, so an hour-wide health
+    /// window could not produce a band at all — but a note claiming both were "read in this window" would be
+    /// the same defect one level up: a surface asserting a scope it did not measure. So the sentence names
+    /// each window against the figure it belongs to, and says outright that coverage makes no claim about
+    /// the caller's window.</para>
+    /// </summary>
+    public const string WindowNote =
+        "Coverage bands each server's deadlock reader over the fixed trailing seven days of collection "
+        + "health - whether the reader works at all, which is a durable fact - while total_deadlocks counts "
+        + "only between window_start and window_end. The two windows differ deliberately, and this coverage "
+        + "figure therefore makes no claim about what was read inside window_start..window_end.";
+
+    /// <summary>What to do about the PostgreSQL arm, appended after its count.</summary>
+    public const string PostgresCause =
+        "are PostgreSQL targets, whose deadlocks this total cannot count at all - they are stored separately "
+        + "and served by get_pg_deadlocks.";
+
+    /// <summary>What to do about the silent arm, appended after its count.</summary>
+    public const string CollectorSilentCause =
+        "have no current deadlock collection - the collector has stopped being invoked, or has never run; "
+        + "check it with get_collection_health.";
+
+    /// <summary>What to do about the denied arm, appended after its count.</summary>
+    public const string CollectorDeniedCause =
+        "had every deadlock-collector attempt refused for permissions - those need a grant.";
+
+    /// <summary>
+    /// The coverage in a sentence, with <see cref="WindowNote"/> and only the causes that actually apply.
+    ///
+    /// <para>DERIVED rather than assigned, for the reason <see cref="FleetServerCard.DeadlockSource"/> is:
+    /// a settable note is a note that can be omitted, or can drift from the counts it describes. Computed,
+    /// the numbers and the sentence cannot disagree.</para>
+    /// </summary>
+    [JsonPropertyName("note")]
+    public string Note
+    {
+        get
+        {
+            var note = new StringBuilder();
+
+            note.Append("total_deadlocks read a deadlock source for ")
+                .Append(ServersRead)
+                .Append(" of ")
+                .Append(ServersTotal)
+                .Append(" enabled servers. ")
+                .Append(WindowNote);
+
+            if (PostgresServers > 0)
+            {
+                note.Append(' ').Append(PostgresServers).Append(' ').Append(PostgresCause);
+            }
+
+            if (ServersCollectorSilent > 0)
+            {
+                note.Append(' ').Append(ServersCollectorSilent).Append(' ').Append(CollectorSilentCause);
+            }
+
+            if (ServersCollectorDenied > 0)
+            {
+                note.Append(' ').Append(ServersCollectorDenied).Append(' ').Append(CollectorDeniedCause);
+            }
+
+            return note.ToString();
+        }
+    }
 }

--- a/Darling/PerformanceMonitor.Darling.Service/Targets/RdsCpuIngestor.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Targets/RdsCpuIngestor.cs
@@ -69,11 +69,15 @@ public sealed class RdsCpuIngestor
         _logger = logger;
     }
 
-    /// <param name="host">The target's connection host. A non-RDS host is skipped silently — self-hosted
-    /// PostgreSQL has no CPU route at all (see <see cref="PgCpuUtilizationCollector"/>'s doc comment), so
-    /// there is nowhere else for it to fall back to.</param>
-    /// <returns>Rows stored, or zero when this target is not RDS/Aurora or PI had nothing new.</returns>
-    public async Task<int> IngestAsync(
+    /// <param name="host">The target's connection host. A non-RDS host means Performance Insights was never
+    /// queried — self-hosted PostgreSQL has no CPU route at all (see
+    /// <see cref="PgCpuUtilizationCollector"/>'s doc comment), so there is nowhere else for it to fall back
+    /// to — and the outcome says so rather than reporting an empty sample window (#3017).</param>
+    /// <returns>Rows stored and whether Performance Insights was reached at all. This ingestor is the one
+    /// that meets the not-reached case routinely: <c>pg_cpu_utilization</c>'s dispatch is UNCONDITIONAL, with
+    /// no <c>pg_read_file</c>-shaped fallback for a self-hosted target, so every cycle of every self-hosted
+    /// PostgreSQL target lands here and no-ops.</returns>
+    public async Task<RdsIngestOutcome> IngestAsync(
         int serverId,
         string storageName,
         string host,
@@ -83,7 +87,11 @@ public sealed class RdsCpuIngestor
 
         if (endpoint is null)
         {
-            return 0;
+            /* #3017: NOT_REACHED, not zero rows. No AWS call has been made at this point — nothing is known
+               about this instance's CPU, which is a different fact from PI answering with no samples, and
+               the runner's note now says which one it was. This branch is reached on every cycle of every
+               self-hosted PostgreSQL target, because the dispatch above it is unconditional. */
+            return RdsIngestOutcome.NotReached;
         }
 
         var parsed = endpoint.Value;
@@ -164,10 +172,14 @@ public sealed class RdsCpuIngestor
 
         if (dataPoints.Count == 0)
         {
-            return 0;
+            /* READ, and it held nothing new. PI answered — the caller's "no new Performance Insights CPU
+               samples this cycle" is a true statement here, which is exactly why the not-reached branch
+               above must not share it. */
+            return RdsIngestOutcome.Read(0);
         }
 
-        return await WriteAsync(serverId, storageName, dataPoints, cancellationToken);
+        return RdsIngestOutcome.Read(
+            await WriteAsync(serverId, storageName, dataPoints, cancellationToken));
     }
 
     /// <summary>Identical resolution to <see cref="RdsLogSource"/>'s own — kept as a separate copy rather

--- a/Darling/PerformanceMonitor.Darling.Service/Targets/RdsDeadlockIngestor.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Targets/RdsDeadlockIngestor.cs
@@ -48,15 +48,18 @@ public sealed class RdsDeadlockIngestor
         _logger = logger;
     }
 
-    /// <param name="host">The target's connection host. A non-RDS host is skipped silently — that target
-    /// uses the <c>pg_read_file</c> route instead, and there is nothing to report.</param>
-    /// <returns>Rows stored, or zero when this target is not RDS or had nothing new.</returns>
+    /// <param name="host">The target's connection host. A non-RDS host means this transport does not apply
+    /// to that target — it uses the <c>pg_read_file</c> route instead — and the outcome says so rather than
+    /// reporting an empty log (#3017).</param>
+    /// <returns>Rows stored and whether the log was reached at all. Reaching it and finding nothing is a
+    /// real statement about the log; not reaching it is not, and
+    /// <see cref="RdsIngestOutcome.SourceReached"/> is what keeps the runner from making one.</returns>
     /// <exception cref="PgLogTimezoneUnsupportedException">The log is stamped in a non-UTC zone, so its
     /// timestamps are local and nothing in it can be stored (#2993). Propagated for the same reason
     /// <see cref="RdsLogUnavailableException"/> is: the runner classifies it and names the setting, where
     /// swallowing it would return zero rows and be recorded as a log that was read and held no
     /// deadlocks.</exception>
-    public async Task<int> IngestAsync(
+    public async Task<RdsIngestOutcome> IngestAsync(
         int serverId,
         string storageName,
         string host,
@@ -84,7 +87,12 @@ public sealed class RdsDeadlockIngestor
 
         if (chunk is null)
         {
-            return 0;
+            /* #3017: NOT_REACHED, not zero rows. ReadNewestAsync answers null for exactly one reason — the
+               host is not an RDS or Aurora endpoint, so RdsEndpoint.TryParse declined and no AWS call was
+               made. Every other outcome either throws or hands back a chunk. Returning a bare 0 here made
+               this indistinguishable from a log that was opened and held nothing, and the runner stamped the
+               cycle with a sentence claiming the second. */
+            return RdsIngestOutcome.NotReached;
         }
 
         var written = await StoreAsync(serverId, storageName, chunk.Value.Text, cancellationToken);
@@ -99,7 +107,7 @@ public sealed class RdsDeadlockIngestor
            every deadlock in it was gone with no error naming the loss. */
         _logs.CommitResume(chunk.Value.Resume);
 
-        return written;
+        return RdsIngestOutcome.Read(written);
     }
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Service/Targets/RdsIngestOutcome.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Targets/RdsIngestOutcome.cs
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+namespace PerformanceMonitor.Darling.Service.Targets;
+
+/// <summary>
+/// What one AWS-API ingest cycle actually did: how many rows it stored, and whether it reached the source at
+/// all (#3017).
+///
+/// <para><b>The two are one value without this type, and that is the defect.</b> The three ingestors
+/// (<see cref="RdsPlanIngestor"/>, <see cref="RdsDeadlockIngestor"/>, <see cref="RdsCpuIngestor"/>) returned a
+/// bare <c>int</c>, and <c>DarlingCollectorRunner</c> stamped a zero with a positive claim about the source's
+/// contents — "no new deadlocks in the RDS log window", "no new Performance Insights CPU samples this cycle".
+/// A zero, though, spans two states the runner could not tell apart: the AWS API answered and the log
+/// genuinely held nothing new, or <see cref="RdsEndpoint.TryParse"/> returned null for the host, NO AWS CALL
+/// WAS MADE AT ALL, and the ingestor returned 0. The second one renders a sentence about the contents of a log
+/// nobody opened.</para>
+///
+/// <para><b>Why this rather than a second out-parameter or a sentinel row count.</b> A caller cannot take the
+/// count and drop the signal: <see cref="Rows"/> is only reachable through a value that also carries
+/// <see cref="SourceReached"/>. A negative-row sentinel would have been the same collapse with extra steps —
+/// every arithmetic consumer of the count would have to know the convention, and one that did not would file
+/// a phantom -1 into <c>collection_log</c>.</para>
+///
+/// <para><b>This is not the #2633 case and does not overlap it.</b> #2633 stopped a DENIAL arriving as a
+/// zero-row success, by rethrowing: a refusal now reaches the runner as an exception and is classified
+/// PERMISSIONS. What is left is the one door that is not a failure at all — a target this transport simply
+/// does not apply to, answering honestly and quietly. #2633's own closing sentence is the rule both halves
+/// serve: a cycle that could not look must not claim it looked.</para>
+/// </summary>
+/// <param name="Rows">Rows stored. Always 0 when <paramref name="SourceReached"/> is false.</param>
+/// <param name="SourceReached">True when this cycle actually asked AWS for the source — so a
+/// <paramref name="Rows"/> of 0 is a real statement about what the source held. False when the target's host
+/// is not an RDS or Aurora endpoint, so no AWS call was made and nothing at all is known about the
+/// source.</param>
+public readonly record struct RdsIngestOutcome(int Rows, bool SourceReached)
+{
+    /// <summary>
+    /// The source was never asked — this target's host is not an RDS or Aurora endpoint, so this transport
+    /// does not apply to it. Zero rows, and zero rows carrying no claim about the source.
+    /// </summary>
+    public static RdsIngestOutcome NotReached => new(0, false);
+
+    /// <summary>
+    /// The source was read and held <paramref name="rows"/> rows worth storing — including zero, which here
+    /// is a genuine all-clear bounded by the read's own window rather than an absence of information.
+    /// </summary>
+    public static RdsIngestOutcome Read(int rows) => new(rows, true);
+}

--- a/Darling/PerformanceMonitor.Darling.Service/Targets/RdsPlanIngestor.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Targets/RdsPlanIngestor.cs
@@ -50,10 +50,13 @@ public sealed class RdsPlanIngestor
         _logger = logger;
     }
 
-    /// <param name="host">The target's connection host. A non-RDS host is skipped silently — that target
-    /// uses the <c>pg_read_file</c> route instead, and there is nothing to report.</param>
-    /// <returns>Rows stored, or zero when this target is not RDS or had nothing new.</returns>
-    public async Task<int> IngestAsync(
+    /// <param name="host">The target's connection host. A non-RDS host means this transport does not apply
+    /// to that target — it uses the <c>pg_read_file</c> route instead — and the outcome says so rather than
+    /// reporting an empty log (#3017).</param>
+    /// <returns>Rows stored and whether the log was reached at all. Reaching it and finding nothing is a
+    /// real statement about the log; not reaching it is not, and
+    /// <see cref="RdsIngestOutcome.SourceReached"/> is what keeps the runner from making one.</returns>
+    public async Task<RdsIngestOutcome> IngestAsync(
         int serverId,
         string storageName,
         string host,
@@ -88,7 +91,10 @@ public sealed class RdsPlanIngestor
 
         if (chunk is null)
         {
-            return 0;
+            /* #3017: NOT_REACHED, not zero rows — the same distinction, and the same single cause, as
+               RdsDeadlockIngestor. ReadNewestAsync answers null only when RdsEndpoint.TryParse declined the
+               host, which means no AWS call was made and nothing is known about the log. */
+            return RdsIngestOutcome.NotReached;
         }
 
         var written = await StoreAsync(serverId, storageName, chunk.Value.Text, cancellationToken);
@@ -102,7 +108,7 @@ public sealed class RdsPlanIngestor
            the store already has. The loss it replaces was unbounded and silent. */
         _logs.CommitResume(chunk.Value.Resume);
 
-        return written;
+        return RdsIngestOutcome.Read(written);
     }
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Service/wwwroot/css/app.css
+++ b/Darling/PerformanceMonitor.Darling.Service/wwwroot/css/app.css
@@ -343,6 +343,11 @@ a:hover { text-decoration: underline; }
 }
 .rollup .tile .num { font-size: 1.5rem; font-weight: 700; line-height: 1.1; font-variant-numeric: tabular-nums; }
 .rollup .tile .lbl { font-size: 0.72rem; color: var(--muted); letter-spacing: 0.3px; }
+/* #3017: the deadlock total's coverage denominator, under its label. Smaller than .lbl so it reads as a
+   qualifier on the number rather than as a second label, and styled on its OWN state rather than inheriting
+   the tile's severity — full coverage under a red count is good news about a bad number. */
+.rollup .tile .sub { font-size: 0.68rem; color: var(--muted); letter-spacing: 0.2px; margin-top: 0.15rem; }
+.rollup .tile .sub.partial { color: var(--warn); }
 .rollup .tile.healthy .num { color: var(--ok); }
 .rollup .tile.warning .num { color: var(--warn); }
 .rollup .tile.critical .num { color: var(--err); }

--- a/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/pages/fleet.js
+++ b/Darling/PerformanceMonitor.Darling.Service/wwwroot/js/pages/fleet.js
@@ -448,12 +448,53 @@ function groupControl() {
   return el("label", { class: "group-control" }, [cb, el("span", { text: "Group by tag" })]);
 }
 
+/*
+ * #3017: the deadlock total's denominator, as a VISIBLE sub-line rather than a tooltip.
+ *
+ * total_deadlocks comes out of v_deadlocks, which is the SQL Server extended-event capture and nothing else,
+ * so it is structurally zero on a PostgreSQL fleet — permanently, whatever those clusters do. Zero is also
+ * exactly what a genuinely quiet SQL Server fleet reports, and the tile could not tell an operator which one
+ * they were looking at. The API answers that (deadlock_coverage), and this renders it.
+ *
+ * ALWAYS shown when the API reports coverage, including at full coverage, for two reasons. A line that
+ * appeared only on partial coverage would make its ABSENCE the load-bearing signal, which an operator has to
+ * already know the rule to read — and worse, it would leave "zero, whole fleet measured" and "zero, from a
+ * build that reports no coverage at all" looking identical, which is the same defect one step out. Present
+ * unconditionally, absence means exactly one thing: this response made no coverage claim.
+ *
+ * Returns null (no sub-line) for a response with no coverage object or an empty fleet — nothing to qualify.
+ */
+function deadlockCoverageSub(coverage) {
+  if (!coverage || typeof coverage.servers_total !== "number" || coverage.servers_total <= 0) return null;
+
+  const total = coverage.servers_total;
+  const read = typeof coverage.servers_read === "number" ? coverage.servers_read : 0;
+  const noun = total === 1 ? "server" : "servers";
+
+  return read >= total
+    ? { text: "read all " + fmtInt(total) + " " + noun, partial: false }
+    : { text: "read " + fmtInt(read) + " of " + fmtInt(total) + " " + noun, partial: true };
+}
+
 function rollup(d) {
-  const tile = (num, lbl, cls) =>
-    el("div", { class: "tile " + (cls || "") }, [
+  const tile = (num, lbl, cls, sub, title) =>
+    el("div", { class: "tile " + (cls || ""), title: title || null }, [
       el("div", { class: "num", text: fmtInt(num) }),
       el("div", { class: "lbl", text: lbl }),
+      /* The sub-line's colour tracks COVERAGE, not the tile's number severity: "read all 12 servers" under a
+         red count is good news about a bad number and must not be painted as part of the alarm. */
+      sub ? el("div", { class: sub.partial ? "sub partial" : "sub", text: sub.text }) : null,
     ]);
+
+  const coverage = d.deadlock_coverage;
+  const deadlockSub = deadlockCoverageSub(coverage);
+
+  /* A partly-covered fleet reporting zero deadlocks is not an all-clear, so it stops rendering as one. It is
+     not a confirmed incident either — warning is the "interrogate this number" class without claiming a
+     deadlock happened. A real deadlock keeps critical whatever the coverage: a measured incident outranks an
+     incomplete denominator, and the sub-line under it already says the count may be short. */
+  const deadlockClass = d.total_deadlocks > 0 ? "critical" : deadlockSub && deadlockSub.partial ? "warning" : "";
+
   /* Two fixed groups (server-band counts | event counts) split by a divider; a non-zero blocking / deadlock
      total takes a severity color. */
   return el("div", { class: "rollup" }, [
@@ -467,7 +508,16 @@ function rollup(d) {
     el("div", { class: "rollup-divider" }),
     el("div", { class: "rollup-group" }, [
       tile(d.total_blocking_events, "Blocking (recent)", d.total_blocking_events > 0 ? "warning" : ""),
-      tile(d.total_deadlocks, "Deadlocks (recent)", d.total_deadlocks > 0 ? "critical" : ""),
+      /* The API's own note rides along as the tile's title — the causes and the two windows, in the words the
+         service already renders for get_fleet_overview, so the hover is DETAIL on a signal that is already
+         visible rather than the only place the signal exists. */
+      tile(
+        d.total_deadlocks,
+        "Deadlocks (recent)",
+        deadlockClass,
+        deadlockSub,
+        coverage ? coverage.note : null,
+      ),
     ]),
   ]);
 }

--- a/PerformanceMonitor.Common/ServerHealthBands.cs
+++ b/PerformanceMonitor.Common/ServerHealthBands.cs
@@ -567,6 +567,43 @@ namespace PerformanceMonitor.Common
         public const string Warning = "WARNING";
         public const string Healthy = "HEALTHY";
 
+        /// <summary>
+        /// The bands in which the collector read NOTHING over the whole window — so a surface reporting a
+        /// total assembled from that collector's rows covers none of the window for a server sitting in one
+        /// of them. Named as a set rather than compared band-by-band at each call site so a band added later
+        /// gets one decision here instead of N independent omissions, each of which fails silently by
+        /// counting an unread server as read.
+        ///
+        /// <para><b>NO_PERMISSIONS and STOPPED are the two the field produces.</b> NO_PERMISSIONS is every
+        /// attempt refused. STOPPED is this classifier's own "attempted nothing at all — no success, no
+        /// error, nothing" past the FAILING cutoff, which an extended outage or a stalled loop reaches while
+        /// the server is still enabled.</para>
+        ///
+        /// <para><b>NEVER_RUN is in the set on MEANING, not on reachability.</b> It is <c>totalRuns == 0</c>,
+        /// which a <c>GROUP BY</c> over a run log cannot currently produce — no rows, no group — so today a
+        /// caller aggregating that way never sees it. That is a property of the QUERY, not of the band: a
+        /// later outer join against the collector catalog or the server registry (the natural way to make a
+        /// never-invoked collector visible at all) makes it reachable, and leaving it out would then count
+        /// the most completely unread server of all as covered. It cannot mean anything but "nothing was
+        /// read", so it belongs here whether or not a caller can reach it.</para>
+        ///
+        /// <para><b>FAILING, STALE and WARNING are deliberately NOT in the set.</b> Those collectors did
+        /// read on some cycles and their rows ARE in the total; excluding them would shrink the denominator
+        /// and read as a smaller fleet, which is a new wrong number in place of the old one rather than a
+        /// fix. HEALTHY is obviously not in it.</para>
+        /// </summary>
+        public static readonly IReadOnlySet<string> NothingReadBands =
+            new HashSet<string>(StringComparer.Ordinal) { NeverRun, NoPermissions, Stopped };
+
+        /// <summary>
+        /// True when <paramref name="band"/> is one of <see cref="NothingReadBands"/> — the collector read
+        /// nothing in the window, so nothing of its is in any total built from its rows. A null or unknown
+        /// band answers FALSE: absence of a band is not a claim that nothing was read, and a caller with no
+        /// band at all has to decide that case for itself rather than have this predicate decide it silently.
+        /// </summary>
+        public static bool ReadNothing(string? band) =>
+            band is not null && NothingReadBands.Contains(band);
+
         /// <summary>A collector with runs whose error rate exceeds this percent bands WARNING (when not STALE/FAILING).</summary>
         public const double WarningFailureRatePercent = 20.0;
 


### PR DESCRIPTION
Fixes items 1 and 2 of #3017. **Item 3 is deliberately left open** — do not close #3017 on this PR.

Both halves are the same shape: a surface reporting a measurement it did not take.

## 1. `get_fleet_overview`'s `total_deadlocks` now says how much of the fleet it covers

`FleetDeadlockSql` reads `v_deadlocks`, which is `SELECT * FROM deadlocks`, and `deadlocks` is written by exactly one collector — the SQL Server extended-event capture. A PostgreSQL target's deadlocks go to `pg_deadlocks`, there is no `v_pg_deadlocks`, and nothing joins the two, so on a PostgreSQL fleet this total is permanently zero for every server, whatever those clusters do and whatever grants the role holds. Zero is also exactly what a genuinely quiet SQL Server fleet reports, so the reading that needs no action and the reading that does not cover the fleet had the same character.

`FleetOverviewResult` now carries `deadlock_coverage` beside the total: how many servers the total read a deadlock source for, out of how many, with the three uncovered causes counted separately because they take opposite actions — `get_pg_deadlocks` for a PostgreSQL target, a collector to look at for one that is not being invoked, a grant for one that was refused. Each card carries `deadlock_collector_band` (the fact that explains its own zero) and a derived `deadlock_source`, and the rollup reduces from the cards, so the denominator and the total it qualifies reconcile by construction rather than by two queries agreeing.

**Coverage excludes `NO_PERMISSIONS`, `STOPPED` and `NEVER_RUN`**, via a named `CollectorHealthClassifier.NothingReadBands` set rather than a comparison at the call site, so a band added later gets one decision instead of N silent omissions. `NEVER_RUN` is in the set on meaning, not on reachability: it is `totalRuns == 0`, which a `GROUP BY` over a run log cannot produce today, but that is a property of the query and not of the band — an outer join added later to make a never-invoked collector visible would make it reachable, and a set that had left it out would then count the most completely unread server of all as read.

**`FAILING`, `STALE` and `WARNING` count as read.** Those collectors succeeded on some cycles and their rows really are in the total; excluding them would report a smaller fleet than exists, which is a new wrong number in place of the old one. They are not hidden by being counted — `servers_with_collection_failures` and each card's `failed_collector_count` are where a degraded collector shows.

**The note names each window against the figure it belongs to.** The total is counted between the caller's `window_start` and `window_end` (one hour by default); coverage is banded over the fixed trailing seven days of collection health. That divergence is correct — whether a reader works is a durable fact, and the banding thresholds are themselves defined in days, so an hour-wide health window could not produce a band at all — but a sentence claiming both were read in this window would be the same defect one level up. The note therefore says outright that coverage makes no claim about what was read inside `window_start..window_end`.

The denominator follows the convention already in the tree twice: `get_pg_blocking` reports `captures_total` beside `captures_with_blocking` with a sentence saying what an empty answer does and does not mean, and `target_has_user_databases` (#1852) states a fact about the target beside a persistently empty result rather than banding it. Deliberately not a new band, for #1852's reason: a quiet SQL Server fleet with full coverage is healthy and keeps reading that way.

## 1b. And the same total on the web fleet page, which is the surface an operator actually looks at

`wwwroot/js/pages/fleet.js` rendered `total_deadlocks` as a bare tile. Rendering only — no server-side change; `deadlock_coverage` already ships on the same `/api/fleet` body.

The figure is a **visible sub-line** under the tile's label, not a tooltip: an operator who does not already suspect a problem never hovers. It renders whenever the response carries coverage, **including at full coverage** — a line that appeared only on a partial read would make its absence the load-bearing signal, and would leave "zero, whole fleet measured" indistinguishable from "zero, from a build that reports no coverage at all", which is the same defect one step out. Absent coverage on the payload means exactly one thing: this response made no coverage claim. The API's own note rides along as the tile's `title`, so hovering adds detail to a signal that is already on screen rather than being the only place it exists.

The severity class moved too. A partly-covered fleet reporting zero deadlocks was rendering as the unstyled all-clear; it now takes `warning` — "interrogate this number", without claiming a deadlock happened. A real deadlock keeps `critical` whatever the coverage: a measured incident outranks an incomplete denominator, and the sub-line under it already says the count may be short. The sub-line's own colour tracks coverage rather than the tile's severity, because "read all 12 servers" under a red count is good news about a bad number.


## 2. The RDS/PI ingest note no longer describes a log the cycle never opened

`RdsPlanIngestor`, `RdsDeadlockIngestor` and `RdsCpuIngestor` returned a bare `int`, so two states collapsed into one value: the AWS API answered and the source genuinely held nothing new, or `RdsEndpoint.TryParse` returned null for the host, **no AWS call was made at all**, and the ingestor returned 0. `DarlingCollectorRunner` stamped both with a positive claim about the source's contents.

All three now return `RdsIngestOutcome(int Rows, bool SourceReached)`, so a caller cannot take the count and drop the signal, and the runner renders a different note for each outcome through one pure `RdsIngestNote`. The not-reached notes name the cause and end on #2633's own closing sentence — *this cycle did not look* — so an operator who learned the distinction from #2633's `PERMISSIONS` rows meets the same words arriving through the one door that is not a failure. The read-and-empty notes are unchanged; those sentences are correct on their own path, and stopping them being borrowed is the whole point.

`pg_cpu_utilization` meets this on every cycle of every self-hosted PostgreSQL target: its dispatch is unconditional, because there is no `pg_read_file`-shaped fallback for instance CPU, so `RdsCpuIngestor` is always called and always no-ops on a non-RDS host. For the two log readers the not-reached branch is reachable by construction — the dispatch gate is `IsAurora || IsAwsRds`, and `IsAurora` is probed from the database while `IsAwsRds` is derived from the endpoint, so an Aurora cluster reached through a hostname `RdsEndpoint` does not parse routes there — but that configuration is not asserted as observed on any fleet.

Not #3008 (marker advanced inside the fetch, merged) or #3009 (report cut at a chunk boundary, open): both are `RdsLogSource` read-correctness defects, where this is the runner mislabelling an outcome `RdsLogSource` reported correctly.

## Review findings

**The web dashboard tile** — already fixed here, in `7d934a5f6`. The review ran against the previous head, before that commit existed; section 1b above is that finding.

**`ViewerDataService.Fleet.cs`'s `FleetTotalsSql` has the same defect** — correct, and not fixed here. Its `SELECT COUNT(*) FROM v_deadlocks` is a third independent computation of the same total, rendered in the WPF Viewer's Overview as a bare `Deadlocks: {0}`. Measured cost before deciding, because it is not the rendering-only change the web tile was: `PerformanceMonitor.Darling.Viewer` does **not** reference `PerformanceMonitor.Darling.Service`, so `FleetDeadlockSource`, `FleetDeadlockCoverage` and `ClassifyDeadlockSource` would have to move into `PerformanceMonitor.Common` — a public type crossing assemblies. On top of that, the Viewer's Overview read selects no `engine_kind` at all and `ServerSummaryItem` carries no PostgreSQL flag, so the read and the DTO both have to grow one, and the summary path currently keeps only a FAILING *count* rather than the `deadlocks` collector's band. With the XAML and `ViewerFleetRollupTests` that is roughly five more files including a cross-assembly type move, against a diff already at ~1000 lines. Left for a routing decision rather than folded in unannounced — flagged to the coordinator with this costing, not filed as a fire-and-forget follow-up.


## Verification

Baseline committed first, then one mutation at a time through `redproof.sh`: each restored via a stash of the mutation only, the fix re-asserted by content after restore, and the repo-wide stash list proven unchanged. Fourteen kill-mutations, each caught:

- the set with `STOPPED` removed (the exact shape of an earlier attempt), with `NEVER_RUN` removed, and — the other direction — with `FAILING` added, which is what a quietly shrinking denominator looks like
- the PostgreSQL arm disabled; a null band treated as covered; the rollup reporting every server as read
- the window note's "makes no claim" clause deleted, and the note rewritten to claim coverage was read in the caller's window
- the not-reached arm dropped from the note rendering (the original defect); each of the three ingestors reporting an unreached source as read-but-empty; #2633's closing sentence stripped from a not-reached note; and a log that *was* read reported as unreached

A comment-only control stayed green, so neither an assembly rebuild nor a source edit is being treated as evidence of behaviour.

**The client half has no test harness in this repo** — no `package.json`, no eslint config, no JS suite, and nothing in CI that executes `wwwroot/js`. Saying so rather than implying coverage that does not exist. It was verified by hand in a browser against the real, unmodified `wwwroot`, served statically with `window.fetch` stubbed so `/api/fleet` returned four payloads: full coverage, a PostgreSQL fleet at zero coverage, real deadlocks with partial coverage, and a payload carrying no coverage object at all. Six observables were recorded per run — whether the sub-line exists and has non-zero height (i.e. is visible without hovering), its text, its `partial` class, its computed colour, the tile's class, and whether the title is the API note.

Baseline: all six hold. Then four independent reverts, each breaking a **different** observable set, with the tree committed first and each file restored by targeted checkout plus a content re-assertion:

- drop the sub-line node only — the four sub-line observables break; the tile class and title still hold
- revert the severity class only — **only** the tile class breaks; the sub-line still reads "read 0 of 12 servers" in warn colour
- break the coverage computation only (always report full coverage) — the text becomes "read all 12 servers", the `partial` class goes, the colour drops to muted and the class to unstyled, while the sub-line's existence and the title are untouched
- delete the stylesheet rule only — **only** the computed colour breaks, from warn to muted

No two variants fail the same set, and two of them fail exactly one observable each, so no single check is standing in for the others. Measured separately: at a 375px viewport the rollup's horizontal overflow is byte-identical with and without the coverage sub-line (`scrollWidth` 474 in both), so the pre-existing non-responsive sidebar is not made worse by this.

The Windows-only `Darling.Tests` suite cannot run on macOS, so the real test files were compiled into a throwaway `net10.0` xunit v3 console host named `Darling.Tests` (the product projects carry `InternalsVisibleTo`) staged outside the tree, `Compile Include`-ing the repo paths with the solution symlinked in so the source pins' upward walk resolves: 95 tests, 0 failed, 0 not run, 2 skipped (both the `DARLING_TEST_PG`-gated live round-trips). Seventeen of those are new. CI is the arbiter for the rest of the suite.

## CHANGELOG

Not edited here, per the multi-lane routing. Entry text for `[Unreleased]` → `### Fixed`, with the link-ref definition it needs:

- **`get_fleet_overview`'s `total_deadlocks` now reports how much of the fleet it covers** ([#3027]) — `v_deadlocks` is the SQL Server extended-event capture and nothing else, so on a PostgreSQL fleet the total was permanently zero for every server whatever those clusters did, and zero is also what a quiet SQL Server fleet reports. A `deadlock_coverage` object now sits beside the total — servers read out of servers total, with PostgreSQL targets, silent collectors and permission-denied collectors counted apart because they take opposite actions — plus a per-card `deadlock_collector_band` and `deadlock_source`. Coverage excludes `NO_PERMISSIONS`, `STOPPED` and `NEVER_RUN` through a named set on the shared classifier and counts `FAILING`/`STALE`/`WARNING` as read, since those collectors' rows are genuinely in the total. Its note names each of the two windows against the figure it belongs to and states that coverage makes no claim about the caller's window. The web fleet page's Deadlocks tile carries the figure as a visible sub-line rather than a tooltip, and a partly-covered fleet reporting zero deadlocks stops rendering as an all-clear.
- **The RDS/Performance Insights ingest note no longer describes a source the cycle never opened** ([#3027]) — the three AWS-API ingestors returned a bare row count, so a cycle where `RdsEndpoint.TryParse` declined the host and no AWS call was made at all was indistinguishable from one that read the source and found nothing, and the runner stamped both with a claim about the source's contents. They now return an outcome carrying rows and whether the source was reached, and the runner renders a distinct note that names the cause and ends on #2633's own closing sentence. `pg_cpu_utilization` met this on every cycle of every self-hosted PostgreSQL target, its dispatch being unconditional.


```
[#3027]: https://github.com/erikdarlingdata/PerformanceMonitor/pull/3027
```
