### PR TITLE
Decide the live-cleanup ratchet on code, not on prose (#3014)

### DIFF
--- a/Darling/Darling.Tests/DarlingObservabilityTests.cs
+++ b/Darling/Darling.Tests/DarlingObservabilityTests.cs
@@ -636,6 +636,7 @@ public sealed class DarlingObservabilityTests
         /* try/finally around the repoint, so a failed assertion inside it cannot leave this shared-store
            row asserting Aurora for whatever runs next. The restore is the FINALLY, not a trailing
            statement: a trailing one is skipped by exactly the failure that makes it matter. */
+        var repointSucceeded = false;
         try
         {
             await DarlingObservability.UpsertServerAsync(postgres, repointed, null, TestContext.Current.CancellationToken);
@@ -648,14 +649,21 @@ public sealed class DarlingObservabilityTests
             /* And the edition it carries is 0 — the value that used to be indistinguishable from "never
                connected", which is the whole reason the kind column exists. */
             Assert.Equal(0, reader.GetInt32(1));
+
+            repointSucceeded = true;
         }
         finally
         {
             /* Put it back, so the rest of this test — and the next run of it — reads the SQL Server row it
-               was written against. Its own connection is not needed here the way LiveStoreCleanup gives
-               one: this restore goes through the pooled NpgsqlDataSource the upserts above use, not
-               through the possibly-broken body connection. */
-            await DarlingObservability.UpsertServerAsync(postgres, server, null, TestContext.Current.CancellationToken);
+               was written against. RunOwnedAsync rather than RunAsync (#1902): the restore goes through the
+               pooled NpgsqlDataSource the upserts above use, which UpsertServerAsync takes in place of a
+               connection, so this teardown was never exposed to the closed-body-connection half of the
+               defect. The masking half applies exactly as it does anywhere else — a throw from this finally
+               would replace the assertion that made it run — and that is the half this borrows. */
+            await LiveStoreCleanup.RunOwnedAsync(
+                repointSucceeded,
+                async () => await DarlingObservability.UpsertServerAsync(
+                    postgres, server, null, TestContext.Current.CancellationToken));
         }
 
         /* The second upsert must not throw and must refresh modified_date. */

--- a/Darling/Darling.Tests/LiveCleanupConversionRatchetTests.cs
+++ b/Darling/Darling.Tests/LiveCleanupConversionRatchetTests.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Xunit;
 
 namespace Darling.Tests;
@@ -38,9 +39,51 @@ namespace Darling.Tests;
 /// accepted: it is half the fix, it still throws from the finally, and an exemption shaped "this one is
 /// correct by hand" is one a later incorrect site inherits. The two live classes that had been doing exactly
 /// that were converted rather than exempted.</para>
+///
+/// <para><b>Every textual decision reads CODE, never prose (#3014).</b> Membership, compliance, the
+/// teardown-kind exclusion and the block match all run over
+/// <see cref="CSharpSourceWalker.StripCommentsAndStrings"/>'s output, so no comment and no string literal can
+/// decide any of them. Read over raw source all four were decidable by a sentence: a class joined the scan by
+/// NAMING the collection attribute in a doc comment, a teardown claimed compliance by naming
+/// <see cref="LiveStoreCleanup"/> in prose, a store teardown escaped as file teardown by mentioning
+/// <c>File.</c>, and a <c>}</c> written in prose ended the block early — the same blind spot the fixed line
+/// window had, arriving through the brace match instead of through the window.
+/// <see cref="CSharpSourceWalker.BraceBalanced"/> is only correct over stripped text, which is why the block
+/// match is that method rather than a second copy of it here.</para>
+///
+/// <para><b>There is no token exemption, because there is nothing left for one to exempt.</b> A pair of
+/// substrings — the <c>#1776 own-store</c> marker and the scratch-database helper's name — used to skip a
+/// whole file, and they existed to undo the prose-driven membership test above: the classes they silenced are
+/// the ones whose headers say, in words, that they are deliberately NOT in the collection. No class that
+/// APPLIES the attribute is own-store or scratch-database backed, so a membership test that reads code
+/// leaves those classes unscanned for the honest reason and needs nothing to exempt them. Nothing enforces
+/// that split and nothing needs to: a class that both joins the shared collection and mints its own store is
+/// simply scanned, and a teardown on resources the test already holds is what <c>RunOwnedAsync</c> is for —
+/// the same answer that converted the two by-hand classes instead of exempting them.</para>
 /// </summary>
 public sealed class LiveCleanupConversionRatchetTests
 {
+    /// <summary>The attribute that puts a class in the shared live collection, and so in this scan.</summary>
+    private const string LiveCollectionAttribute = "[Collection(\"live-postgres\")]";
+
+    /// <summary>
+    /// The part of <see cref="LiveCollectionAttribute"/> that survives stripping. The collection NAME is a
+    /// string literal, so stripped text carries the attribute with its name blanked to spaces, and only this
+    /// head can be matched there.
+    /// </summary>
+    private const string AttributeHead = "[Collection(";
+
+    /// <summary>
+    /// A <c>finally</c> that opens a block. Matched over stripped text, where prose cannot spell one, and
+    /// written to tolerate both <c>finally</c> alone above its brace and <c>finally {</c> on one line — the
+    /// fixed-shape match it replaces read only the first, so the second would have gone unscanned silently.
+    /// </summary>
+    private static readonly Regex FinallyBlock =
+        new(@"(?<![A-Za-z0-9_])finally\s*\{", RegexOptions.Compiled);
+
+    /// <summary>What one sweep found, and the population it actually examined to find it.</summary>
+    private readonly record struct Sweep(List<string> Offenders, int Files, int Blocks);
+
     [Fact]
     public void NoLiveTestCleansUpOnItsOwnBodysConnection()
     {
@@ -48,59 +91,220 @@ public sealed class LiveCleanupConversionRatchetTests
         Assert.True(directory is not null,
             "could not locate Darling/Darling.Tests by walking up from the test output directory.");
 
-        var offenders = Offenders(directory!);
+        var sweep = Scan(SourcesUnder(directory!));
 
-        Assert.True(offenders.Count == 0,
-            $"{offenders.Count} live-test teardown(s) do not go through LiveStoreCleanup (#1902). Wrap the "
-            + "finally body in LiveStoreCleanup.RunAsync(connectionString, bodySucceeded, ...) — or "
+        /* A membership test or a block match narrow enough to match NOTHING satisfies the offender assertion
+           below without reading a single teardown, and a green ratchet is indistinguishable from a compliant
+           tree. Both populations are asserted so that failure is loud rather than green. */
+        Assert.True(sweep.Files > 0,
+            $"no file under {directory} APPLIES {LiveCollectionAttribute} — the membership test matched "
+            + "nothing, so this ratchet examined no teardown at all.");
+        Assert.True(sweep.Blocks > 0,
+            $"no finally block was found in the {sweep.Files} file(s) that apply {LiveCollectionAttribute} — "
+            + "the block match found nothing, so the assertion below held over an empty set.");
+
+        Assert.True(sweep.Offenders.Count == 0,
+            $"{sweep.Offenders.Count} live-test teardown(s) do not go through LiveStoreCleanup (#1902). Wrap "
+            + "the finally body in LiveStoreCleanup.RunAsync(connectionString, bodySucceeded, ...) — or "
             + "RunOwnedAsync when the cleanup must use connections the test already holds — and set "
             + "bodySucceeded as the last statement of the try. Opening a connection by hand is not enough: it "
             + "leaves the throw-from-finally that replaces the body's exception."
-            + Environment.NewLine + string.Join(Environment.NewLine, offenders));
+            + Environment.NewLine + string.Join(Environment.NewLine, sweep.Offenders));
     }
 
     /// <summary>
-    /// Every <c>finally</c> in a shared-store live class whose body does not go through
-    /// <see cref="LiveStoreCleanup"/>, reported as <c>file:line</c>.
-    ///
-    /// <para>Own-store classes are exempt for the same reason #1776 exempts them: they mint and drop their own
-    /// database, so an abandoned teardown cannot reach anyone else. File and process teardown is excluded
-    /// because it is not store state and has nothing to do with a connection.</para>
-    ///
-    /// <para><b>The block is brace-matched, not a fixed line window.</b> Batches one and two scanned thirteen
-    /// lines after the <c>finally</c>, which a long explanatory comment pushes the actual statements past — so
-    /// the richest teardown in the suite (the retention test's, which carries a twelve-line comment) counted as
-    /// an offender while being fully converted. The same blind spot works the other way and matters more: an
-    /// genuinely unconverted teardown could hide behind a comment of its own. Matching braces reads the block
-    /// the compiler reads.</para>
+    /// A doc comment that NAMES an exemption the class does not claim does not silence the class. This is the
+    /// #3014 shape: the exemption was a whole-file substring match over raw source, so one occurrence
+    /// anywhere — including a sentence saying the class is NOT exempt — skipped every <c>finally</c> in the
+    /// file, and the ratchet reported zero offenders over a file it never read.
     /// </summary>
-    private static List<string> Offenders(string directory)
+    [Fact]
+    public void ProseNamingAnExemptionDoesNotSilenceTheFile()
+    {
+        var sweep = ScanOne(
+            "/// <summary>Not a ScratchPostgres class, and carrying no #1776 own-store marker.</summary>\n"
+            + LiveClass(UnconvertedTeardown));
+
+        Assert.Equal(1, sweep.Files);
+        Assert.Equal(1, sweep.Blocks);
+        Assert.Single(sweep.Offenders);
+    }
+
+    /// <summary>
+    /// A class that only NAMES the attribute is not in the collection and is not scanned. Own-store classes
+    /// record in their headers that they are "deliberately NOT" in it, and a raw substring match read that
+    /// sentence as membership — which is the whole reason the scan needed an exemption to undo it.
+    /// </summary>
+    [Fact]
+    public void AClassThatOnlyNamesTheAttributeIsNotScanned()
+    {
+        var sweep = ScanOne(OwnStoreClass(UnconvertedTeardown));
+
+        Assert.Equal(0, sweep.Files);
+        Assert.Equal(0, sweep.Blocks);
+        Assert.Empty(sweep.Offenders);
+    }
+
+    /// <summary>Naming <see cref="LiveStoreCleanup"/> in a comment does not convert a teardown.</summary>
+    [Fact]
+    public void ProseNamingLiveStoreCleanupDoesNotMakeATeardownCompliant()
+    {
+        var sweep = ScanOne(LiveClass(Lines(
+            "    [Fact]",
+            "    public void T()",
+            "    {",
+            "        try",
+            "        {",
+            "            Work();",
+            "        }",
+            "        finally",
+            "        {",
+            "            // Not through LiveStoreCleanup yet — this drops the rows the body wrote.",
+            "            Drop();",
+            "        }",
+            "    }")));
+
+        Assert.Equal(1, sweep.Blocks);
+        Assert.Single(sweep.Offenders);
+    }
+
+    /// <summary>
+    /// The file-and-process teardown exclusion cannot be claimed in a comment either. It exists because file
+    /// and process teardown is not store state and has nothing to do with a connection, and a store teardown
+    /// that merely MENTIONS a file or a kill is still a store teardown.
+    /// </summary>
+    [Fact]
+    public void ProseNamingFileTeardownDoesNotExcludeAStoreTeardown()
+    {
+        var sweep = ScanOne(LiveClass(Lines(
+            "    [Fact]",
+            "    public void T()",
+            "    {",
+            "        try",
+            "        {",
+            "            Work();",
+            "        }",
+            "        finally",
+            "        {",
+            "            /* No File.Delete here and nothing to Kill: this is store state. */",
+            "            Drop();",
+            "        }",
+            "    }")));
+
+        Assert.Equal(1, sweep.Blocks);
+        Assert.Single(sweep.Offenders);
+    }
+
+    /// <summary>
+    /// A closing brace written in prose does not end the block early. The fixed line window this scan
+    /// replaced had the same blind spot, and brace-matching RAW text reintroduces it in the false-positive
+    /// direction: the block ends at the first <c>}</c> the text contains, so a fully converted teardown whose
+    /// comment spells one is reported as unconverted.
+    /// </summary>
+    [Fact]
+    public void ABraceInProseDoesNotEndTheBlockEarly()
+    {
+        var sweep = ScanOne(LiveClass(Lines(
+            "    [Fact]",
+            "    public void T()",
+            "    {",
+            "        try",
+            "        {",
+            "            Work();",
+            "            ok = true;",
+            "        }",
+            "        finally",
+            "        {",
+            "            /* The old shape closed the teardown here: } */",
+            "            LiveStoreCleanup.RunAsync(ConnectionString, ok, Drop);",
+            "        }",
+            "    }")));
+
+        Assert.Equal(1, sweep.Blocks);
+        Assert.Empty(sweep.Offenders);
+    }
+
+    /// <summary>
+    /// A converted teardown is accepted through either entry point. The counterweight to the four pins above:
+    /// each of those asserts that something stops being exempt, and a scan made strict enough to satisfy all
+    /// four while rejecting real conversions would fail a green tree.
+    /// </summary>
+    [Theory]
+    [InlineData("LiveStoreCleanup.RunAsync(ConnectionString, ok, Drop);")]
+    [InlineData("await LiveStoreCleanup.RunOwnedAsync(ok, Drop);")]
+    public void AConvertedTeardownIsNotAnOffender(string teardown)
+    {
+        var sweep = ScanOne(LiveClass(Lines(
+            "    [Fact]",
+            "    public void T()",
+            "    {",
+            "        try",
+            "        {",
+            "            Work();",
+            "            ok = true;",
+            "        }",
+            "        finally",
+            "        {",
+            "            " + teardown,
+            "        }",
+            "    }")));
+
+        Assert.Equal(1, sweep.Files);
+        Assert.Equal(1, sweep.Blocks);
+        Assert.Empty(sweep.Offenders);
+    }
+
+    /// <summary>Every <c>*.cs</c> in the test project, as (file name, source) pairs.</summary>
+    private static IEnumerable<(string Name, string Source)> SourcesUnder(string directory) =>
+        Directory.EnumerateFiles(directory, "*.cs")
+            .OrderBy(p => p, StringComparer.Ordinal)
+            .Select(p => (Path.GetFileName(p), File.ReadAllText(p)));
+
+    /// <summary>
+    /// Every <c>finally</c> in a shared-store live class whose block does not go through
+    /// <see cref="LiveStoreCleanup"/>, reported as <c>file:line</c>, alongside the counts of files and blocks
+    /// the sweep examined.
+    ///
+    /// <para>Own-store classes are not scanned for the same reason #1776 does not serialize them: they mint
+    /// and drop their own database, so an abandoned teardown cannot reach anyone else. That is decided by
+    /// whether the class APPLIES the collection attribute, not by anything it says about itself. File and
+    /// process teardown is excluded because it is not store state and has nothing to do with a
+    /// connection.</para>
+    ///
+    /// <para>Every decision here reads the stripped text. The line numbers reported are the source's own:
+    /// stripping preserves newlines, so counting them in either text gives the same answer.</para>
+    /// </summary>
+    private static Sweep Scan(IEnumerable<(string Name, string Source)> sources)
     {
         var offenders = new List<string>();
+        var files = 0;
+        var blocks = 0;
 
-        foreach (var path in Directory.EnumerateFiles(directory, "*.cs").OrderBy(p => p, StringComparer.Ordinal))
+        foreach (var (name, source) in sources)
         {
-            var source = File.ReadAllText(path);
-            if (!source.Contains("[Collection(\"live-postgres\")]", StringComparison.Ordinal))
+            var code = CSharpSourceWalker.StripCommentsAndStrings(source);
+
+            /* Membership below reads the two texts at ONE offset, which only addresses the same character
+               while stripping is length-preserving. Checked here rather than assumed: the tree-wide
+               alignment pin in CSharpSourceWalkerTests covers the Viewer, Storage and Analysis projects,
+               not this one, and a guard reading the wrong offsets would report teardowns that are not
+               there. */
+            Assert.True(code.Length == source.Length,
+                $"{name}: stripping changed the text's length ({source.Length} -> {code.Length}), so the "
+                + "source and stripped offsets no longer address the same characters.");
+
+            if (!AppliesTheLiveCollectionAttribute(source, code))
             {
                 continue;
             }
 
-            if (source.Contains("#1776 own-store", StringComparison.Ordinal)
-                || source.Contains("ScratchPostgres", StringComparison.Ordinal))
-            {
-                continue;
-            }
+            files++;
 
-            var lines = source.Split('\n');
-            for (var i = 0; i < lines.Length; i++)
+            foreach (Match found in FinallyBlock.Matches(code))
             {
-                if (lines[i].Trim() != "finally" || i + 1 >= lines.Length || lines[i + 1].Trim() != "{")
-                {
-                    continue;
-                }
+                blocks++;
 
-                var block = BlockAt(lines, i + 1);
+                var block = CSharpSourceWalker.BraceBalanced(code, found.Index + found.Length - 1);
                 if (block.Contains("LiveStoreCleanup", StringComparison.Ordinal))
                 {
                     continue;
@@ -113,30 +317,84 @@ public sealed class LiveCleanupConversionRatchetTests
                     continue;
                 }
 
-                offenders.Add($"{Path.GetFileName(path)}:{i + 1}");
+                offenders.Add($"{name}:{code.AsSpan(0, found.Index).Count('\n') + 1}");
             }
         }
 
-        return offenders;
+        return new Sweep(offenders, files, blocks);
     }
 
-    /// <summary>The text of the brace-delimited block whose opening brace is on <paramref name="openLine"/>.</summary>
-    private static string BlockAt(string[] lines, int openLine)
+    /// <summary>
+    /// Is <see cref="LiveCollectionAttribute"/> APPLIED here, as opposed to merely named in prose?
+    ///
+    /// <para>Both texts are read at the SAME offset: the stripped text decides whether the occurrence is
+    /// code, and the source decides which collection it names, because the name is the one part of the
+    /// attribute that stripping blanks. The caller checks the length equality that lets one index address
+    /// both.</para>
+    ///
+    /// <para>Neither text alone is enough. The stripped text alone accepts any collection, of which this
+    /// project has four. The source alone accepts a doc comment, and that is not hypothetical: every class
+    /// that explains this rule quotes the attribute while explaining it, and ten files that only NAME it were
+    /// scanned as though they applied it — the collection's own definition and fixture, the sweep that
+    /// enforces it, and seven classes whose headers say they are deliberately NOT in it. #1862 met the same
+    /// wall in #1776's sweep and answered it by requiring the attribute to OPEN a line; asking the walk needs
+    /// no rule about where an attribute may sit.</para>
+    /// </summary>
+    private static bool AppliesTheLiveCollectionAttribute(string source, string code)
     {
-        var depth = 0;
-        for (var i = openLine; i < lines.Length; i++)
+        for (var i = code.IndexOf(AttributeHead, StringComparison.Ordinal);
+             i >= 0;
+             i = code.IndexOf(AttributeHead, i + 1, StringComparison.Ordinal))
         {
-            depth += lines[i].Count(c => c == '{') - lines[i].Count(c => c == '}');
-            if (depth == 0)
+            if (source.AsSpan(i).StartsWith(LiveCollectionAttribute, StringComparison.Ordinal))
             {
-                return string.Join("\n", lines.Skip(openLine).Take(i - openLine + 1));
+                return true;
             }
         }
 
-        /* Unbalanced braces mean the parse is wrong, and a parse that cannot find the end of a block must not
-           quietly report that block as clean. Returning the remainder makes it fail loudly instead. */
-        return string.Join("\n", lines.Skip(openLine));
+        return false;
     }
+
+    /// <summary>One fixture source, scanned as though it were the whole project.</summary>
+    private static Sweep ScanOne(string source) => Scan(new[] { ("Fixture.cs", source) });
+
+    /// <summary>
+    /// Joins fixture lines with <c>\n</c>, so what a fixture means never depends on this file's own line
+    /// endings.
+    /// </summary>
+    private static string Lines(params string[] lines) => string.Join("\n", lines);
+
+    /// <summary>A class that APPLIES the collection attribute, with <paramref name="body"/> as its member.</summary>
+    private static string LiveClass(string body) =>
+        Lines(LiveCollectionAttribute, "public sealed class Fixture", "{", body, "}", string.Empty);
+
+    /// <summary>
+    /// The same class with the attribute NAMED rather than applied — the shape every own-store class in this
+    /// project actually has.
+    /// </summary>
+    private static string OwnStoreClass(string body) =>
+        Lines(
+            "/* #1776 own-store: deliberately NOT " + LiveCollectionAttribute + ". It mints its own store. */",
+            "public sealed class Fixture",
+            "{",
+            body,
+            "}",
+            string.Empty);
+
+    /// <summary>A teardown that drops store state without going through <see cref="LiveStoreCleanup"/>.</summary>
+    private static readonly string UnconvertedTeardown = Lines(
+        "    [Fact]",
+        "    public void T()",
+        "    {",
+        "        try",
+        "        {",
+        "            Work();",
+        "        }",
+        "        finally",
+        "        {",
+        "            Drop();",
+        "        }",
+        "    }");
 
     /// <summary>
     /// Walks up from the test output directory to the repo root (the directory holding


### PR DESCRIPTION
`LiveCleanupConversionRatchetTests` made four textual decisions over raw source — which files it scans, whether a `finally` is exempt, whether a block is compliant, and where a block ends — so a comment or a string literal could decide any of them. All four now read `CSharpSourceWalker.StripCommentsAndStrings` output, and the block match is `CSharpSourceWalker.BraceBalanced` rather than a second brace counter of its own.

## What the issue reported, and what turned out to be wider

#3014 reported the exemption: `source.Contains("#1776 own-store") || source.Contains("ScratchPostgres")` skipped the whole file, so one occurrence anywhere — including a sentence saying a class is *not* exempt — silenced every `finally` in it. That is real, and reproduced: a planted class with an applied `[Collection("live-postgres")]`, a genuinely unconverted teardown, and a doc comment naming both tokens reports **zero offenders** on `dev`. Deleting only the doc-comment sentence from the same file turns it red at the teardown. The sentence was the whole difference.

The issue also recorded the state as latent — no file mis-exempted today — and that holds for the exemption. It does not hold for the sibling check one level down. `block.Contains("LiveStoreCleanup")` decided compliance over raw block text, and `DarlingObservabilityTests`' repoint restore contained the sentence *"Its own connection is not needed here the way LiveStoreCleanup gives one"* — a comment explaining why it did **not** need the helper, which is what marked the block compliant. That teardown still threw from its `finally`, which is the half of #1902 that replaces the body's in-flight exception. It goes through `RunOwnedAsync` now, matching `DarlingAlertingTests`' precedent for teardown that must use the data source the test already holds.

## Why the exemption is gone rather than narrowed

Membership was prose-driven in the same way, and that is what created the need for an exemption. `[Collection("live-postgres")]` is applied in **120** files; the raw substring matched **130**. The extra ten only *name* it — the collection's own definition and fixture, the sweep that enforces it, and seven classes whose headers say they are deliberately NOT in it. Every file the exemption silenced is in those ten, and **no file that applies the attribute matches either token**, so with membership decided on the applied attribute there is nothing left for a token exemption to exempt. A class that both joined the shared collection and minted its own store would simply be scanned, and a teardown on resources it already holds is what `RunOwnedAsync` is for.

Membership needs both texts at one offset: the stripped text says the occurrence is code, the source says which collection it names, because the name is the one part of the attribute that stripping blanks. The scan checks the length equality that makes one index address both, where it depends on it — the tree-wide alignment pin in `CSharpSourceWalkerTests` covers the Viewer, Storage and Analysis projects, not this one.

## Population

The narrowed scan reads **120 files** and **236 `finally` blocks**. Both agree with an independent count taken outside the code under test (`grep -lE '^[[:space:]]*\[Collection\("live-postgres"\)\]'` = 120; a bare-`finally`-line count over those files = 236). The `[Fact]` now asserts both are non-zero, because a membership test or a block match narrow enough to match nothing satisfies "no offenders" without reading a teardown.

## Pins

Six new fixture pins, each proved red by reverting exactly one half of the change:

| Half reverted | Pins that fail | Assertion |
| --- | --- | --- |
| membership → raw whole-file substring | `AClassThatOnlyNamesTheAttributeIsNotScanned`, `NoLiveTestCleansUpOnItsOwnBodysConnection` | `Assert.Equal` on the scanned-file count; tree offenders |
| stripping → raw source for the in-file reads | `ProseNamingLiveStoreCleanupDoesNotMakeATeardownCompliant`, `ProseNamingFileTeardownDoesNotExcludeAStoreTeardown`, `ABraceInProseDoesNotEndTheBlockEarly` | `Assert.Single` on an empty collection ×2; `Assert.Empty` on a non-empty one |
| token exemption restored | `ProseNamingAnExemptionDoesNotSilenceTheFile` | `Assert.Equal` on the offender count |

`AConvertedTeardownIsNotAnOffender` is the counterweight — `RunAsync` and `RunOwnedAsync` both stay accepted — so a scan made strict enough to satisfy the other five cannot pass by rejecting real conversions.

Verified against the tree as well as in fixtures: with the change in place, the planted prose-exempted offender is reported, a genuinely own-store class carrying the same unconverted teardown is not scanned, and a converted teardown passes. Each run rebuilt first — a restore that skipped the rebuild produced a green read against a mutated assembly once, which is what the rebuild-per-variant is for.

## Family census

The issue's "Not verified" asks whether the sibling textual ratchets share this shape. They do not; this is a one-file fix.

Population swept: **65** files in `Darling.Tests` and `Lite.Tests` that walk up to `PerformanceMonitor.sln` to read repo source, of which **30** enumerate more than one file and so can carry a per-file skip. Exactly **two** of those 30 make a skip decision from a substring of raw file text: this one, and `LivePostgresCollectionHygieneTests`. The second is already hardened — #1862 narrowed its attribute check to occurrences that OPEN a line after a prose mention exempted the store fixture, and its `#1776 own-store` marker is read from the 25 lines above a class declaration, not from the whole file. Its remaining whole-file substring is an *inclusion* test, whose failure direction is extra scanning.

Four more guards (`RollupCoverageRoutingTests`, `McpConfigReadAvoidsSecretColumnsTests`, `Lite.Tests/SettingsFileGuardTests`, `Lite.Tests/AuroraOnlySqlIsGatedTests`) are comment-aware already, each through its own hand-rolled stripper rather than the shared walker. That is the #2913 duplication shape, not this one, and it is left alone here.

## CHANGELOG

Not touched. Entry text for the coordinator:

- Fixed: the live-cleanup ratchet decided which files to scan, which teardowns were exempt, whether a teardown was converted, and where a teardown's block ended by matching substrings against raw source, so a doc comment could make any of those decisions; all four now read code with comments and string literals stripped, and one teardown the compliance hole had been hiding is converted ([#3014]).

## Closes

#3014. Closing keywords are a no-op on a `dev` merge, so this is stated rather than relied on.
