### PR TITLE
Price the viewer's read deadline against the pool the seat has, and bound the two fleet-wide fan-outs to it (#3016)

### DIFF
--- a/Darling/Darling.Tests/ViewerCommandTimeoutTests.cs
+++ b/Darling/Darling.Tests/ViewerCommandTimeoutTests.cs
@@ -71,6 +71,17 @@ public sealed class ViewerCommandTimeoutTests
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     /// <summary>
+    /// The lane split a fan-out whose work is fleet-many routes through, so that the width it declares is a
+    /// concurrency it really has rather than a queue of reads that can only wait for a permit and fail
+    /// (#3016). Captures the local it is assigned to, because
+    /// <see cref="NoDeclaredFanOutWidth_OutrunsThePermitsOrTheMeasurement"/> has to tie a
+    /// <c>&lt;name&gt;.Count</c> width back to the split that bounded it.
+    /// </summary>
+    private static readonly Regex s_laneSplit = new(
+        @"(?:var|IReadOnlyList\s*<[^;={}]*>)\s+(?<name>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*ViewerReadFanOut\s*\.\s*Lanes\s*\(",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>
     /// A fire-and-forget call — <c>_ = SomethingAsync();</c>. Two of them in one member is a fan-out; ONE
     /// is this project's ordinary single-flight-guarded refresh and is not.
     ///
@@ -1162,7 +1173,11 @@ public sealed class ViewerCommandTimeoutTests
     public void TheFanOutDeadline_IsDerivedFromTheConcurrentBand_NotTheSoloOne()
     {
         var solo = ViewerCommandDeadlines.InteractiveReadSeconds;
-        var widest = ViewerCommandDeadlines.FanOutReadSeconds(ViewerSettings.ManagedMaxPoolSize);
+
+        /* The EXPLICIT pool, not the process-published one (#3016): this asserts the derivation, and a
+           derivation asserted against whatever another test class last published is asserting less. */
+        var widest = ViewerCommandDeadlines.FanOutReadSeconds(
+            ViewerCommandDeadlines.MeasuredFanOutWidth, ViewerSettings.ManagedMaxPoolSize);
 
         Assert.True(
             solo < 24,
@@ -1176,43 +1191,109 @@ public sealed class ViewerCommandTimeoutTests
             + "measured for ten concurrent 30-day reads on a store at production density. A ceiling under the "
             + "measurement it is supposed to bound fails every read in the widest fan-out on every attempt, "
             + "auto-refresh included — a deadline nothing can finish under is not a deadline");
+
+        /* The band has ONE measurement in it, at ten wide. A bring-your-own store with Npgsql's default
+           hundred-connection pool must not be handed ten times the allowance on the strength of that one
+           point — 700 s is not a deadline anybody has measured or would wait for. */
+        Assert.Equal(
+            widest,
+            ViewerCommandDeadlines.FanOutReadSeconds(
+                ViewerCommandDeadlines.MeasuredFanOutWidth, ViewerStorePool.NpgsqlDefaultMaxPoolSize));
+
+        Assert.True(
+            ViewerCommandDeadlines.MeasuredFanOutWidth <= ViewerSettings.ManagedMaxPoolSize,
+            $"the measured fan-out width {ViewerCommandDeadlines.MeasuredFanOutWidth} exceeds the managed pool "
+            + $"{ViewerSettings.ManagedMaxPoolSize}, so the shipped seat can no longer reach the width the "
+            + "per-lane allowance was divided out of — the allowance is then an extrapolation on the default "
+            + "install, not only on a BYO one");
     }
 
     /// <summary>
-    /// The fan-out ceiling can only ever grant MORE time than a solo read gets, and it stops growing where
-    /// the permits run out. The clamp is what lets the two unbounded per-server fan-outs
-    /// (<c>FinOpsTab.Loaders</c>'s inventory overlay, <c>MainWindow</c>'s overview cards) hand over a raw
-    /// fleet count instead of a hand-capped guess, so it is load-bearing rather than defensive.
+    /// The fan-out ceiling can only ever grant MORE time than a solo read gets, and it stops growing at the
+    /// smaller of two bounds: the permits this seat has, and the width the per-lane allowance was measured
+    /// at. Swept across POOL SIZES as well as widths (#3016) — the pool used to be a compile-time constant
+    /// and a sweep over widths alone could not tell a threaded pool size from a hardcoded one.
+    ///
+    /// <para>Three of the pool sizes carry a specific claim. At <c>ManagedMaxPoolSize</c> nothing about the
+    /// shipped seat may move. At <c>NpgsqlDefaultMaxPoolSize</c> — a bring-your-own string that names no
+    /// pool size — the answer must be the SAME as at ten, because the extra permits buy contention nobody
+    /// has priced. Below ten it must be strictly SMALLER, which is the half a hardcoded constant got wrong
+    /// in the expensive direction: a pool of three cannot produce ten-way contention, so a ten-lane
+    /// allowance there is 49 s of a stalled panel holding permits nothing else can have.</para>
     /// </summary>
     [Fact]
     public void TheFanOutDeadline_IsMonotonicAndClampedAtThePool()
     {
-        var pool = ViewerSettings.ManagedMaxPoolSize;
-        var previous = 0;
-
-        for (var width = -3; width <= pool * 4; width++)
+        var measured = ViewerCommandDeadlines.MeasuredFanOutWidth;
+        var pools = new[]
         {
-            var seconds = ViewerCommandDeadlines.FanOutReadSeconds(width);
+            1, 2, 3, ViewerSettings.ManagedMaxPoolSize, ViewerStorePool.NpgsqlDefaultMaxPoolSize, int.MaxValue,
+        };
 
-            Assert.True(
-                seconds >= ViewerCommandDeadlines.InteractiveReadSeconds,
-                $"width {width} yields {seconds}s, under the solo floor — a declared fan-out must never buy a "
-                + "read LESS time than the same read issued alone");
+        foreach (var pool in pools)
+        {
+            var bound = System.Math.Min(pool, measured);
+            var previous = 0;
 
-            Assert.True(seconds >= previous, $"width {width} yields {seconds}s, below width {width - 1}'s {previous}s");
+            for (var width = -3; width <= bound * 4; width++)
+            {
+                var seconds = ViewerCommandDeadlines.FanOutReadSeconds(width, pool);
 
-            previous = seconds;
+                Assert.True(
+                    seconds >= ViewerCommandDeadlines.InteractiveReadSeconds,
+                    $"pool {pool} width {width} yields {seconds}s, under the solo floor — a declared fan-out "
+                    + "must never buy a read LESS time than the same read issued alone");
+
+                Assert.True(
+                    seconds >= previous,
+                    $"pool {pool} width {width} yields {seconds}s, below width {width - 1}'s {previous}s");
+
+                Assert.True(
+                    seconds <= ViewerCommandDeadlines.FanOutLaneSeconds * measured,
+                    $"pool {pool} width {width} yields {seconds}s, above the {measured}-lane allowance the "
+                    + "concurrent band was measured at — every second past it is extrapolated from a single "
+                    + "data point");
+
+                previous = seconds;
+            }
+
+            Assert.Equal(
+                ViewerCommandDeadlines.FanOutReadSeconds(bound, pool),
+                ViewerCommandDeadlines.FanOutReadSeconds(bound * 4, pool));
         }
 
         Assert.Equal(
-            ViewerCommandDeadlines.FanOutReadSeconds(pool),
-            ViewerCommandDeadlines.FanOutReadSeconds(pool * 4));
+            ViewerCommandDeadlines.FanOutReadSeconds(measured, ViewerSettings.ManagedMaxPoolSize),
+            ViewerCommandDeadlines.FanOutReadSeconds(measured, ViewerStorePool.NpgsqlDefaultMaxPoolSize));
+
+        Assert.True(
+            ViewerCommandDeadlines.FanOutReadSeconds(measured, 3)
+            < ViewerCommandDeadlines.FanOutReadSeconds(measured, ViewerSettings.ManagedMaxPoolSize),
+            "a three-permit pool is priced the same as a ten-permit one, so the deadline is not reading the "
+            + "pool size at all — it is reading a constant that only describes the managed derivation");
+
+        /* The overload the 187 command sites actually reach must agree with the pure one at the pool this
+           process published; otherwise the derivation above is pinned on a path nothing calls. */
+        for (var width = -3; width <= measured * 4; width++)
+        {
+            Assert.Equal(
+                ViewerCommandDeadlines.FanOutReadSeconds(width, ViewerStorePool.MaxPoolSize),
+                ViewerCommandDeadlines.FanOutReadSeconds(width));
+        }
     }
 
     /// <summary>
     /// The ambient width itself: one when nobody declared a fan-out (so an unscoped read keeps exactly the
     /// solo ceiling), the declared value inside a scope, the enclosing value again after it, and the PRODUCT
     /// when scopes nest — because a read two scopes deep really does contend with both widths.
+    ///
+    /// <para>The clamp is asserted against <see cref="ViewerReadFanOut.MaxConcurrentReads"/> rather than
+    /// against <c>ViewerSettings.ManagedMaxPoolSize</c> (#3016). The two are the same number on the shipped
+    /// managed seat, so this reads as a rename here and is not one: the bound is now the smaller of the
+    /// permits this seat has and the width the allowance was measured at, and pinning the constant would
+    /// pass identically whether or not the pool is read at all. <see cref="ViewerReadFanOut.ConcurrentReadsFor"/>
+    /// is swept below at pool sizes this process is not configured for, which is where the difference
+    /// shows.</para>
     /// </summary>
     [Fact]
     public void TheFanOutWidth_DefaultsToOne_AndNestsByMultiplying()
@@ -1233,16 +1314,134 @@ public sealed class ViewerCommandTimeoutTests
 
         Assert.Equal(1, ViewerReadFanOut.CurrentWidth);
 
-        /* A count from a runtime collection, which is what the two per-server fan-outs pass. */
-        using (ViewerReadFanOut.Of(ViewerSettings.ManagedMaxPoolSize * 7))
+        /* A count from a runtime collection — what the two per-server fan-outs pass through Lanes. */
+        using (ViewerReadFanOut.Of(ViewerReadFanOut.MaxConcurrentReads * 7))
         {
-            Assert.Equal(ViewerSettings.ManagedMaxPoolSize, ViewerReadFanOut.CurrentWidth);
+            Assert.Equal(ViewerReadFanOut.MaxConcurrentReads, ViewerReadFanOut.CurrentWidth);
         }
 
         using (ViewerReadFanOut.Of(0))
         {
             Assert.Equal(1, ViewerReadFanOut.CurrentWidth);
         }
+
+        /* The bound the clamp above uses, at pool sizes no test can publish without racing another class:
+           BELOW the measured width the pool wins, AT or ABOVE it the measurement does, and a nonsense pool
+           still leaves one lane rather than zero. */
+        Assert.Equal(
+            ViewerReadFanOut.ConcurrentReadsFor(ViewerStorePool.MaxPoolSize),
+            ViewerReadFanOut.MaxConcurrentReads);
+
+        Assert.Equal(1, ViewerReadFanOut.ConcurrentReadsFor(1));
+        Assert.Equal(3, ViewerReadFanOut.ConcurrentReadsFor(3));
+
+        Assert.Equal(
+            ViewerCommandDeadlines.MeasuredFanOutWidth,
+            ViewerReadFanOut.ConcurrentReadsFor(ViewerSettings.ManagedMaxPoolSize));
+
+        Assert.Equal(
+            ViewerCommandDeadlines.MeasuredFanOutWidth,
+            ViewerReadFanOut.ConcurrentReadsFor(ViewerStorePool.NpgsqlDefaultMaxPoolSize));
+
+        Assert.Equal(
+            ViewerCommandDeadlines.MeasuredFanOutWidth,
+            ViewerReadFanOut.ConcurrentReadsFor(int.MaxValue));
+
+        Assert.Equal(1, ViewerReadFanOut.ConcurrentReadsFor(0));
+        Assert.Equal(1, ViewerReadFanOut.ConcurrentReadsFor(-7));
+    }
+
+    /// <summary>
+    /// The effective pool size is read off the CONNECTION STRING, which is the fact both the deadline and
+    /// the concurrency bound were missing (#3016). <c>ManagedMaxPoolSize</c> is applied to exactly one of
+    /// the two strings the viewer can be handed — the managed derivation — and a bring-your-own
+    /// <c>postgres.connectionString</c> is used verbatim.
+    ///
+    /// <para><b>The hundred is Npgsql's, measured off its own builder at the pinned version rather than
+    /// quoted from its documentation</b>, and asserted here so a version bump that moves the default fails
+    /// a build instead of silently changing what a BYO store is assumed to have. The fallbacks go to the
+    /// managed constant rather than to the hundred: a string this cannot read is a string
+    /// <c>NpgsqlDataSource.Create</c> will reject, and the operator needs that error rather than a second
+    /// one invented by a timeout calculation.</para>
+    /// </summary>
+    [Fact]
+    public void TheEffectivePoolSize_ReadsTheStringNotTheManagedConstant()
+    {
+        Assert.Equal(
+            ViewerStorePool.NpgsqlDefaultMaxPoolSize,
+            ViewerStorePool.MaxPoolSizeOf("Host=127.0.0.1;Port=5432;Database=darling;Username=admin"));
+
+        Assert.Equal(
+            7,
+            ViewerStorePool.MaxPoolSizeOf("Host=127.0.0.1;Database=darling;MaxPoolSize=7"));
+
+        Assert.Equal(
+            7,
+            ViewerStorePool.MaxPoolSizeOf("Host=127.0.0.1;Database=darling;Maximum Pool Size=7"));
+
+        Assert.Equal(
+            ViewerSettings.ManagedMaxPoolSize,
+            ViewerStorePool.MaxPoolSizeOf(
+                $"Host=127.0.0.1;Database=darling;MaxPoolSize={ViewerSettings.ManagedMaxPoolSize}"));
+
+        Assert.Equal(ViewerSettings.ManagedMaxPoolSize, ViewerStorePool.MaxPoolSizeOf(null));
+        Assert.Equal(ViewerSettings.ManagedMaxPoolSize, ViewerStorePool.MaxPoolSizeOf(""));
+        Assert.Equal(ViewerSettings.ManagedMaxPoolSize, ViewerStorePool.MaxPoolSizeOf("   "));
+        Assert.Equal(
+            ViewerSettings.ManagedMaxPoolSize,
+            ViewerStorePool.MaxPoolSizeOf("this is not a connection string at all"));
+
+        Assert.True(
+            ViewerStorePool.NpgsqlDefaultMaxPoolSize > ViewerSettings.ManagedMaxPoolSize,
+            $"Npgsql's default pool ({ViewerStorePool.NpgsqlDefaultMaxPoolSize}) is no longer larger than the "
+            + $"managed seat's ({ViewerSettings.ManagedMaxPoolSize}), so the BYO half of #3016 — a fan-out "
+            + "handed more permits than the deadline was sized for — no longer describes anything, and this "
+            + "family's reasoning needs re-reading rather than this number nudging");
+    }
+
+    /// <summary>
+    /// The pool size has to be PUBLISHED for either consumer to see it, and the publish is a wiring fact no
+    /// behavioural assertion in this class can reach: the value is process-wide, xunit runs test classes in
+    /// parallel, and this project has ninety other <c>new ViewerDataService(...)</c> sites in its live-store
+    /// suites — a test that published a value and asserted it back would be asserting against whichever
+    /// class wrote last. Parsed from source for the same reason <c>HostHeaderGuardTests</c> parses the
+    /// Kestrel hosts: the defect being guarded is an OMISSION, and a logic test passes on the broken build.
+    ///
+    /// <para>Pinned on the EFFECTIVE string, not the parameter. The connect-timeout preference rewrites the
+    /// string before the data source is built, and publishing the pre-rewrite text would read a different
+    /// string than Npgsql enforces — same class of mistake as the constant this replaces, one step
+    /// downstream.</para>
+    /// </summary>
+    [Fact]
+    public void TheDataService_PublishesTheEffectivePoolSizeItBuildsThePoolOn()
+    {
+        var path = Path.Combine(
+            RepoRoot(), "Darling", "PerformanceMonitor.Darling.Viewer", "ViewerDataService.cs");
+
+        Assert.True(File.Exists(path), $"the data service source is not where this pin looks: {path}");
+
+        var code = CSharpSourceWalker.StripCommentsAndStrings(File.ReadAllText(path));
+
+        var publish = code.IndexOf("ViewerStorePool.Publish(effectiveConnectionString)", System.StringComparison.Ordinal);
+        var create = code.IndexOf("NpgsqlDataSource.Create(effectiveConnectionString)", System.StringComparison.Ordinal);
+
+        Assert.True(
+            create >= 0,
+            "ViewerDataService no longer builds its data source from a local named effectiveConnectionString, so "
+            + "this pin is reading a shape the file has stopped using — re-anchor it on whatever the constructor "
+            + "now hands to NpgsqlDataSource.Create, do not delete it");
+
+        Assert.True(
+            publish >= 0,
+            "ViewerDataService does not publish its pool size to ViewerStorePool, so ViewerCommandDeadlines and "
+            + "ViewerReadFanOut are both back on the managed constant — which is only the pool size on a managed "
+            + "install (#3016). Call ViewerStorePool.Publish(effectiveConnectionString) in the constructor");
+
+        Assert.True(
+            publish < create,
+            "the pool size is published AFTER the data source is created. Nothing reads it in between today, so "
+            + "this is an ordering pin rather than a live defect — but a read issued during construction would "
+            + "see the previous seat's pool, and the two lines are one statement apart");
     }
 
     /// <summary>
@@ -1295,6 +1494,224 @@ public sealed class ViewerCommandTimeoutTests
             + "issued ALONE; a site spelled this way is not bounded by any fan-out it is called inside. Use "
             + "ViewerCommandDeadlines.CurrentInteractiveReadSeconds: "
             + string.Join(", ", offenders));
+    }
+
+    /// <summary>
+    /// The two live members read the PUBLISHED pool, not the managed constant — the substitution no
+    /// behavioural assertion in this suite can see (#3016).
+    ///
+    /// <para>The managed seat publishes ten and <c>ManagedMaxPoolSize</c> is ten, so swapping one for the
+    /// other in <c>FanOutReadSeconds(int)</c> or <c>MaxConcurrentReads</c> changes no value this process
+    /// can produce: every arithmetic pin in this class would stay green over code that had stopped reading
+    /// the pool at all. The alternative — publishing a different pool and asserting it back — would put a
+    /// process-wide value under a class that xunit runs in parallel with ninety live-store
+    /// <c>new ViewerDataService(...)</c> sites, each of which publishes its own. So the wiring is read from
+    /// source, and the ONE legitimate mention of the constant is named exactly: the
+    /// <see cref="ViewerCommandDeadlines.MeasuredFanOutWidth"/> initializer, which is what deliberately
+    /// ties the measured width to the managed pool until a sweep unties them.</para>
+    /// </summary>
+    [Fact]
+    public void TheDeadlineFamily_ReadsThePublishedPool_NotTheManagedConstant()
+    {
+        var viewer = Path.Combine(RepoRoot(), "Darling", "PerformanceMonitor.Darling.Viewer");
+
+        var deadlines = CSharpSourceWalker.StripCommentsAndStrings(
+            File.ReadAllText(Path.Combine(viewer, "ViewerCommandDeadlines.cs")));
+
+        var fanOut = CSharpSourceWalker.StripCommentsAndStrings(
+            File.ReadAllText(Path.Combine(viewer, "ViewerReadFanOut.cs")));
+
+        Assert.Contains("ViewerStorePool.MaxPoolSize", deadlines, System.StringComparison.Ordinal);
+        Assert.Contains("ViewerStorePool.MaxPoolSize", fanOut, System.StringComparison.Ordinal);
+
+        Assert.Contains(
+            "MeasuredFanOutWidth = ViewerSettings.ManagedMaxPoolSize",
+            deadlines,
+            System.StringComparison.Ordinal);
+
+        var inDeadlines = deadlines.Split("ManagedMaxPoolSize").Length - 1;
+
+        Assert.True(
+            inDeadlines == 1,
+            $"ViewerCommandDeadlines mentions ManagedMaxPoolSize {inDeadlines} time(s) in code. Exactly one is "
+            + "correct — the MeasuredFanOutWidth initializer. A second is a pool size being read from the "
+            + "constant again, which is only the pool size on a managed install (#3016)");
+
+        var inFanOut = fanOut.Split("ManagedMaxPoolSize").Length - 1;
+
+        Assert.True(
+            inFanOut == 0,
+            $"ViewerReadFanOut mentions ManagedMaxPoolSize {inFanOut} time(s) in code. Its bound is the smaller "
+            + "of the published pool and ViewerCommandDeadlines.MeasuredFanOutWidth; the constant reaches it "
+            + "only through that name");
+    }
+
+    /// <summary>
+    /// The lane split every fleet-wide fan-out goes through: a partition of the input — every item once,
+    /// in order — into no more lanes than the seat has permits (#3016).
+    ///
+    /// <para><b>Contiguity is asserted, not incidental.</b> Both callers concatenate the lanes' results in
+    /// lane order and rely on that reproducing the input order: <c>MainWindow</c>'s overview re-sorts
+    /// afterwards, but the FinOps inventory overlay mutates the rows it was handed and hands the SAME list
+    /// to its filter manager, so a split that reordered anything would reorder the grid. A stride split
+    /// would satisfy every other assertion here and break that one, which is why it is spelled out.</para>
+    /// </summary>
+    [Fact]
+    public void TheLaneSplit_PartitionsInOrder_AndNeverExceedsThePermits()
+    {
+        var cap = ViewerReadFanOut.MaxConcurrentReads;
+
+        Assert.True(cap >= 1, $"the concurrency bound is {cap}; a fan-out cannot have fewer than one lane");
+        Assert.Empty(ViewerReadFanOut.Lanes(System.Array.Empty<int>()));
+
+        for (var count = 1; count <= cap * 4 + 3; count++)
+        {
+            var items = Enumerable.Range(0, count).ToArray();
+            var lanes = ViewerReadFanOut.Lanes(items);
+
+            Assert.True(
+                lanes.Count <= cap,
+                $"{count} items split into {lanes.Count} lanes, above the {cap} the pool can serve — the reads "
+                + "past the permits are not contenders, they are queued and failing");
+
+            Assert.Equal(System.Math.Min(count, cap), lanes.Count);
+
+            /* A partition: every item exactly once, and in input order when the lanes are concatenated. */
+            Assert.Equal(items, lanes.SelectMany(lane => lane).ToArray());
+
+            var shortest = lanes.Min(lane => lane.Count);
+            var longest = lanes.Max(lane => lane.Count);
+
+            Assert.True(
+                longest - shortest <= 1,
+                $"{count} items split into lanes of {shortest}..{longest} — an unbalanced split makes the whole "
+                + "fan-out as slow as its longest lane for no reason");
+        }
+    }
+
+    /// <summary>
+    /// No fan-out declares a width above what the seat can actually run concurrently (#3016). Two shapes,
+    /// and the pin has to reach both: a LITERAL width is checked against
+    /// <see cref="ViewerCommandDeadlines.MeasuredFanOutWidth"/>, and a RUNTIME width is required to be the
+    /// lane count of a <c>ViewerReadFanOut.Lanes</c> split in the same member.
+    ///
+    /// <para><b>The runtime half is the one that matters and the reason this is not a value assertion.</b>
+    /// The two per-server fan-outs used to pass their raw fleet count, on the stated reasoning that the
+    /// clamp inside <c>ViewerReadFanOut</c> made a hand-capped guess unnecessary. The clamp did bound the
+    /// DEADLINE, and nothing bounded the READS — so a fleet of forty-two started forty-two of them against
+    /// ten permits and thirty-two failed on <c>ConnectionTimeoutSeconds</c> without reaching a deadline at
+    /// all. A clamp cannot fix that from inside; only the site can, by not starting them. Re-spell either
+    /// site as <c>Of(servers.Count)</c> and this goes red.</para>
+    ///
+    /// <para>Both populations carry a floor, because a scan that matched neither shape would otherwise
+    /// report a clean sweep over nothing — this project has twenty-one literal declarations and two runtime
+    /// ones.</para>
+    /// </summary>
+    [Fact]
+    public void NoDeclaredFanOutWidth_OutrunsThePermitsOrTheMeasurement()
+    {
+        var offenders = new List<string>();
+        var literals = 0;
+        var derived = 0;
+
+        foreach (var path in ViewerSources())
+        {
+            var text = File.ReadAllText(path);
+            var code = CSharpSourceWalker.StripCommentsAndStrings(text);
+            var bodies = MemberBodies(code);
+
+            var splits = s_laneSplit.Matches(code)
+                .Select(m => (m.Index, Name: m.Groups["name"].Value))
+                .ToArray();
+
+            foreach (Match declaration in s_fanOutDeclaration.Matches(code))
+            {
+                var openParen = declaration.Index + declaration.Length - 1;
+                var argument = ParenthesisedArgument(code, openParen);
+                var where = $"{Path.GetFileName(path)}:{Line(text, declaration.Index)}";
+
+                if (argument is null)
+                {
+                    offenders.Add($"{where} (unbalanced parentheses)");
+                    continue;
+                }
+
+                var trimmed = argument.Trim();
+
+                if (int.TryParse(trimmed, System.Globalization.NumberStyles.Integer,
+                        System.Globalization.CultureInfo.InvariantCulture, out var width))
+                {
+                    literals++;
+
+                    if (width < 1 || width > ViewerCommandDeadlines.MeasuredFanOutWidth)
+                    {
+                        offenders.Add($"{where} (literal width {width})");
+                    }
+
+                    continue;
+                }
+
+                derived++;
+
+                var owner = Owner(bodies, declaration.Index);
+                var fromSplit = splits.Any(split =>
+                    trimmed == split.Name + ".Count"
+                    && split.Index < declaration.Index
+                    && owner is { } body
+                    && Owner(bodies, split.Index) is { } splitOwner
+                    && splitOwner.Start == body.Start);
+
+                if (!fromSplit)
+                {
+                    offenders.Add($"{where} (runtime width `{trimmed}` is not a Lanes split's lane count)");
+                }
+            }
+        }
+
+        Assert.True(
+            literals >= 15,
+            $"only {literals} literal fan-out width(s) were read — the argument scan is not seeing the project, "
+            + "so its clean result is about nothing");
+
+        Assert.True(
+            derived >= 2,
+            $"only {derived} runtime fan-out width(s) were read. The two per-server fan-outs are the whole "
+            + "reason this pin exists; a scan that no longer sees them cannot report on them");
+
+        Assert.True(
+            offenders.Count == 0,
+            $"{offenders.Count} fan-out(s) declare a width the seat cannot run concurrently. A literal must sit "
+            + $"within 1..{ViewerCommandDeadlines.MeasuredFanOutWidth}; a runtime count must be the lane count of "
+            + "a ViewerReadFanOut.Lanes split in the same member, so the reads started never exceed the permits: "
+            + string.Join(", ", offenders));
+    }
+
+    /// <summary>
+    /// The text between the <c>(</c> at <paramref name="openParen"/> and its match, or null when the
+    /// parentheses do not balance. Counts depth so a nested call in the argument cannot end it early.
+    /// </summary>
+    private static string? ParenthesisedArgument(string code, int openParen)
+    {
+        var depth = 0;
+
+        for (var i = openParen; i < code.Length; i++)
+        {
+            if (code[i] == '(')
+            {
+                depth++;
+            }
+            else if (code[i] == ')')
+            {
+                depth--;
+
+                if (depth == 0)
+                {
+                    return code[(openParen + 1)..i];
+                }
+            }
+        }
+
+        return null;
     }
 
     private static IEnumerable<string> ViewerSources()

--- a/Darling/Darling.Tests/ViewerCommandTimeoutTests.cs
+++ b/Darling/Darling.Tests/ViewerCommandTimeoutTests.cs
@@ -1391,6 +1391,23 @@ public sealed class ViewerCommandTimeoutTests
             ViewerSettings.ManagedMaxPoolSize,
             ViewerStorePool.MaxPoolSizeOf("this is not a connection string at all"));
 
+        /* Two unparseable shapes, because Npgsql raises two different exception types for them and a
+           narrower catch would let one escape a constructor whose call site does not catch — the fallback
+           would then REPLACE the connect-time error it exists to defer to. Measured at 10.0.3: a bad value
+           for a recognised keyword is ArgumentException; this one is KeyNotFoundException, which does not
+           derive from it. Found in review on #3034. */
+        Assert.Equal(
+            ViewerSettings.ManagedMaxPoolSize,
+            ViewerStorePool.MaxPoolSizeOf("Host=127.0.0.1;Database=darling;MaxPoolSize=not-a-number"));
+
+        Assert.Equal(ViewerSettings.ManagedMaxPoolSize, ViewerStorePool.MaxPoolSizeOf("====="));
+
+        /* A pool size of zero PARSES — Npgsql validates it at connect, not at the builder — so the floor
+           below one is what keeps a zero out of the lane arithmetic rather than the catch above. */
+        Assert.Equal(
+            ViewerSettings.ManagedMaxPoolSize,
+            ViewerStorePool.MaxPoolSizeOf("Host=127.0.0.1;Database=darling;MaxPoolSize=0"));
+
         Assert.True(
             ViewerStorePool.NpgsqlDefaultMaxPoolSize > ViewerSettings.ManagedMaxPoolSize,
             $"Npgsql's default pool ({ViewerStorePool.NpgsqlDefaultMaxPoolSize}) is no longer larger than the "

--- a/Darling/PerformanceMonitor.Darling.Viewer/FinOpsTab.Loaders.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/FinOpsTab.Loaders.cs
@@ -571,6 +571,10 @@ public partial class FinOpsTab
         var lanes = ViewerReadFanOut.Lanes(servers);
         using var readFanOut = ViewerReadFanOut.Of(lanes.Count);
 
+        /* A lane is walked sequentially, so a read that throws abandons the rest of ITS lane while the
+           other lanes finish. That is the same visible outcome as attempting every row: this loader is
+           all-or-nothing either way — RunFinOpsLoad catches the join's exception and never reaches
+           UpdateData, so a partial overlay is never rendered. */
         await Task.WhenAll(lanes.Select(async lane =>
         {
             foreach (var item in lane)

--- a/Darling/PerformanceMonitor.Darling.Viewer/FinOpsTab.Loaders.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/FinOpsTab.Loaders.cs
@@ -564,22 +564,28 @@ public partial class FinOpsTab
         /* Overlay each server's collected metrics + compute the health score (mirrors Lite's
            LoadServerInventoryAsync minus the live query). memScore/storScore use Lite's inventory-path
            defaults (buffer-pool ratio / file-level free space aren't in the inventory read). */
-        /* Width is the inventory size, passed raw: the clamp to the pool ceiling belongs to
-           ViewerReadFanOut, and a hand-capped guess here would be the copied-number mistake again. */
-        using var readFanOut = ViewerReadFanOut.Of(servers.Count);
+        /* #3016: the inventory size is not a contention count once it passes the pool — the reads past the
+           permits are queued in Npgsql and fail there on ConnectionTimeoutSeconds without ever reaching a
+           command deadline. Split into pool-many lanes and declare the lane count, so the width declared is
+           the concurrency this really has. */
+        var lanes = ViewerReadFanOut.Lanes(servers);
+        using var readFanOut = ViewerReadFanOut.Of(lanes.Count);
 
-        await Task.WhenAll(servers.Select(async item =>
+        await Task.WhenAll(lanes.Select(async lane =>
         {
-            var (avgCpu, storageGb, idleDbs, status) = await _dataService.GetServerMetricsAsync(item.ServerId);
-            if (avgCpu.HasValue) item.AvgCpuPct = avgCpu;
-            if (storageGb.HasValue) item.StorageTotalGb = storageGb;
-            if (idleDbs.HasValue) item.IdleDbCount = idleDbs;
-            if (status != null) item.ProvisioningStatus = status;
+            foreach (var item in lane)
+            {
+                var (avgCpu, storageGb, idleDbs, status) = await _dataService.GetServerMetricsAsync(item.ServerId);
+                if (avgCpu.HasValue) item.AvgCpuPct = avgCpu;
+                if (storageGb.HasValue) item.StorageTotalGb = storageGb;
+                if (idleDbs.HasValue) item.IdleDbCount = idleDbs;
+                if (status != null) item.ProvisioningStatus = status;
 
-            var cpuScore = FinOpsHealthCalculator.CpuScore(item.AvgCpuPct ?? 0m);
-            var memScore = 80;
-            var storScore = FinOpsHealthCalculator.StorageScore(50);
-            item.HealthScore = FinOpsHealthCalculator.Overall(cpuScore, memScore, storScore);
+                var cpuScore = FinOpsHealthCalculator.CpuScore(item.AvgCpuPct ?? 0m);
+                var memScore = 80;
+                var storScore = FinOpsHealthCalculator.StorageScore(50);
+                item.HealthScore = FinOpsHealthCalculator.Overall(cpuScore, memScore, storScore);
+            }
         }));
 
         _finopsServerInventoryFilterMgr!.UpdateData(servers);

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.ServerManagement.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.ServerManagement.cs
@@ -98,9 +98,10 @@ public partial class MainWindow
     /// One pass is TWO store reads — the freshness query plus <see cref="UpdateCollectorHealthTextAsync"/>'s own
     /// — each capped at <see cref="ViewerCommandDeadlines.CurrentInteractiveReadSeconds"/>, which is the solo
     /// 15 s when this is called on its own and the wider figure when a caller has declared a fan-out around it
-    /// (both fleet-timer callers do). So an unguarded pass could hold a permit for twice that against a pool of
-    /// <see cref="ViewerSettings.ManagedMaxPoolSize"/> while the next tick started another. A deadline caps how
-    /// long one stacked read holds a permit; it cannot stop the stacking, which is what this does.</para>
+    /// (both fleet-timer callers do). So an unguarded pass could hold a permit for twice that against the store
+    /// connection pool (<see cref="ViewerStorePool.MaxPoolSize"/> — ten on a managed seat, the operator's value
+    /// on a bring-your-own one) while the next tick started another. A deadline caps how long one stacked read
+    /// holds a permit; it cannot stop the stacking, which is what this does.</para>
     ///
     /// <para><paramref name="replayIfBusy"/> is why this is not <c>_alertPollInFlight</c>'s plain drop. A
     /// PERIODIC caller drops, because the next tick IS its retry and replaying one would delete the interval's

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
@@ -1424,29 +1424,41 @@ public partial class MainWindow : Window
 
         var service = _dataService;
         var nowUtc = DateTime.UtcNow;
-        /* Width is the fleet size, passed raw — see the inventory overlay in FinOpsTab.Loaders. */
-        using var readFanOut = ViewerReadFanOut.Of(list.Count);
+        /* #3016: pool-many lanes, not fleet-many reads — see the inventory overlay in FinOpsTab.Loaders.
+           A fleet wider than the pool used to render SHORT here rather than slowly: the per-server catch
+           below turned each pool-exhaustion failure into an absent card, so the panel a fleet is watched
+           from silently dropped every server past the permits whenever the store was slow enough for the
+           first ten to hold their slots for ConnectionTimeoutSeconds. Lanes are contiguous, so
+           concatenating them in lane order restores the fleet order this used to read in. */
+        var lanes = ViewerReadFanOut.Lanes(list);
+        using var readFanOut = ViewerReadFanOut.Of(lanes.Count);
 
-        var summaries = await Task.WhenAll(list.Select(async server =>
+        var perLane = await Task.WhenAll(lanes.Select(async lane =>
         {
-            try
+            var found = new List<ServerSummaryItem>(lane.Count);
+
+            foreach (var server in lane)
             {
-                var summary = await service.GetServerSummaryAsync(server.ServerId, server.DisplayName);
-                summary.ServerName = server.ServerName;
-                summary.ApplyFreshness(nowUtc);
-                return summary;
+                try
+                {
+                    var summary = await service.GetServerSummaryAsync(server.ServerId, server.DisplayName);
+                    summary.ServerName = server.ServerName;
+                    summary.ApplyFreshness(nowUtc);
+                    found.Add(summary);
+                }
+                catch
+                {
+                    /* A per-server read failure shouldn't blank the whole grid (Lite logs + continues). */
+                }
             }
-            catch
-            {
-                /* A per-server read failure shouldn't blank the whole grid (Lite logs + continues). */
-                return null;
-            }
+
+            return found;
         }));
 
         /* The per-server reads are done; the fleet-totals read below does not contend with them. */
         readFanOut.Release();
 
-        var built = summaries.OfType<ServerSummaryItem>().ToList();
+        var built = perLane.SelectMany(lane => lane).ToList();
         StampTagPills(built);
 
         var cards = ServerOverviewSort.Order(

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerCommandDeadlines.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerCommandDeadlines.cs
@@ -68,12 +68,20 @@ public static class ViewerCommandDeadlines
     /// argument rather than a budget one. Nothing encloses these reads — no <c>CancelAfter</c>, no
     /// <c>SemaphoreSlim</c>, no <c>WaitAsync</c>, and no request timeout, because the viewer is a WPF
     /// <c>WinExe</c> and hosts no web endpoint — so this deadline IS the budget, the same finding
-    /// #2882 and #2888 both made, and the same reason both erred short. What it competes for is the
-    /// ten-connection pool (<see cref="ViewerSettings.ManagedMaxPoolSize"/>), and while permits are held
-    /// the sidebar freshness dots, the alert poll and every other panel get nothing — read eleven waits
-    /// <c>ConnectionTimeoutSeconds</c> (default 5) for a slot and then throws a CONNECT error, which
-    /// misattributes a slow store to the network. Fifteen seconds is half the inherited 30 s, which
-    /// halves that worst-case hold.</para>
+    /// #2882 and #2888 both made, and the same reason both erred short. What it competes for is the store
+    /// connection pool (<see cref="ViewerStorePool.MaxPoolSize"/> — ten on a managed seat, the operator's
+    /// value on a bring-your-own one), and while permits are held the sidebar freshness dots, the alert
+    /// poll and every other panel get nothing. Fifteen seconds is half the inherited 30 s, which halves
+    /// that worst-case hold.</para>
+    ///
+    /// <para><b>A read that cannot get a permit never reaches this deadline, so it is not the thing that
+    /// bounds one</b> (#3016). It waits <c>ConnectionTimeoutSeconds</c> (default 5) for a slot and then
+    /// fails with Npgsql's own pool-exhaustion message, which names the exhausted pool and both knobs and
+    /// does NOT read as a network fault — measured against Npgsql 10.0.3, correcting the earlier claim
+    /// here that it misattributed a slow store to the network. What it does misattribute is nothing: on
+    /// the fleet overview those failures are caught per server and the card is simply absent, so a fleet
+    /// wider than the pool rendered short with no error at all. Both per-server fan-outs are bounded at
+    /// the permit count since #3016, so the state is no longer reachable from a shipped panel.</para>
     ///
     /// <para><b>This value bounds a read issued ALONE, and only that</b> (#3004). The permit argument
     /// above says a concurrent fan-out is the state worth protecting the pool from; it does not say a
@@ -120,23 +128,56 @@ public static class ViewerCommandDeadlines
     public const int FanOutLaneSeconds = 7;
 
     /// <summary>
+    /// The width <see cref="FanOutLaneSeconds"/> was measured at, and so the widest fan-out this family
+    /// can price from data rather than from extrapolation.
+    ///
+    /// <para>It equals <see cref="ViewerSettings.ManagedMaxPoolSize"/> because ten permits are what
+    /// BOUNDED #2901's rig — ten concurrent reads was the widest batch that store would serve at once —
+    /// not because a resource ceiling and a measurement width are the same kind of fact. They are two
+    /// facts that share a number today, named apart so a sweep at a different width can move one without
+    /// dragging the other (#3016). The sweep #3004 asked for (per-read duration at width 1, 2, 4, 6, 8,
+    /// 10) is what would let this exceed ten; until it exists, this is the honest edge of the
+    /// data.</para>
+    /// </summary>
+    public const int MeasuredFanOutWidth = ViewerSettings.ManagedMaxPoolSize;
+
+    /// <summary>
     /// The deadline for a read issued as one of <paramref name="concurrentReads"/> reads running
     /// together — the ceiling that has to cover contention with its siblings rather than a solo read's.
     ///
-    /// <para>Clamped at <see cref="ViewerSettings.ManagedMaxPoolSize"/> because contention stops growing
-    /// where the permits run out: an eleventh concurrent read against a ten-connection pool is not an
-    /// eleventh contender, it is a read waiting on <c>ConnectionTimeoutSeconds</c> for a slot. That is
-    /// what lets the two unbounded per-server fan-outs declare their raw fleet count and still get a
-    /// bounded answer.</para>
+    /// <para>Priced against the pool this seat actually has
+    /// (<see cref="ViewerStorePool.MaxPoolSize"/>) rather than the managed constant it used to read
+    /// (#3016). The constant is applied only to the managed derivation, so on a bring-your-own store it
+    /// was not the pool size but a guess about it.</para>
     ///
     /// <para>Floored at <see cref="InteractiveReadSeconds"/> so this can only ever grant a read MORE time
     /// than a solo read gets, never less. A width the pool serves without contention worth pricing lands
     /// on the floor and is indistinguishable from an unscoped read, which is the correct outcome: two
     /// concurrent reads are not the state the concurrent measurement describes.</para>
     /// </summary>
-    public static int FanOutReadSeconds(int concurrentReads)
+    public static int FanOutReadSeconds(int concurrentReads) =>
+        FanOutReadSeconds(concurrentReads, ViewerStorePool.MaxPoolSize);
+
+    /// <summary>
+    /// The same ceiling against an EXPLICIT pool size — the pure form, so the derivation can be pinned at
+    /// pool sizes this machine is not configured for rather than only at whatever the process published.
+    ///
+    /// <para><b>Two ceilings on the lane count, and the smaller wins, because they answer different
+    /// questions.</b> PERMITS (<paramref name="maxPoolSize"/>): contention stops growing where the slots
+    /// run out — an eleventh concurrent read against a ten-connection pool is not an eleventh contender,
+    /// it is a read waiting on <c>ConnectionTimeoutSeconds</c> for a slot, and a deadline cannot help it.
+    /// MEASUREMENT (<see cref="MeasuredFanOutWidth"/>): <see cref="FanOutLaneSeconds"/> is one division of
+    /// one measured batch, taken at ten wide, so a wider pool multiplies an allowance nothing has measured
+    /// — 100 permits would read as 700 s, a number no panel and no user has any relationship with. Holding
+    /// the lane count to the measured width keeps every value this returns inside the band it was derived
+    /// from, and <c>ViewerReadFanOut</c> holds the CONCURRENCY to the same bound so the two agree
+    /// (#3016).</para>
+    /// </summary>
+    public static int FanOutReadSeconds(int concurrentReads, int maxPoolSize)
     {
-        var lanes = Math.Clamp(concurrentReads, 1, ViewerSettings.ManagedMaxPoolSize);
+        var permits = Math.Max(1, maxPoolSize);
+        var priced = Math.Min(permits, MeasuredFanOutWidth);
+        var lanes = Math.Clamp(concurrentReads, 1, priced);
 
         return Math.Max(InteractiveReadSeconds, FanOutLaneSeconds * lanes);
     }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerCommandDeadlines.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerCommandDeadlines.cs
@@ -36,9 +36,10 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// <para><b>Why none of these is <c>StorageCommandDeadlines.McpReadSeconds</c>.</b> That constant is
 /// 30 s for the MCP read surface and its derivation does not transfer. The MCP's worst verified read
 /// was 685 ms and its permit is an unbounded pool; the viewer's worst measured read is 3.0 s — 4.4x
-/// slower — yet its permit is ten times scarcer (<c>MaxPoolSize = 10</c>, set on the managed-derived
-/// string in <c>ViewerSettings</c>), and a single control fans out to exactly ten concurrent reads and
-/// so can hold every one of them. Slower reads against a scarcer permit land BELOW 30 s, not at it.
+/// slower — yet its permit is far scarcer (<see cref="ViewerStorePool.MaxPoolSize"/>, ten on the
+/// managed derivation and the operator's value on a bring-your-own store), and a single control fans
+/// out to exactly ten concurrent reads and so can hold every one of a managed seat's permits. Slower
+/// reads against a scarcer permit land BELOW 30 s, not at it.
 /// (This paragraph also read "and an unguarded fleet-timer read can re-fire every 10 s" when it landed,
 /// which was true and is no longer: the fan-out those timers fire unawaited is single-flight since
 /// #2907, so a slow read is no longer joined by the next tick's. The panel fan-out above it is the

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerCommandDeadlines.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerCommandDeadlines.cs
@@ -80,8 +80,14 @@ public static class ViewerCommandDeadlines
     /// does NOT read as a network fault — measured against Npgsql 10.0.3, correcting the earlier claim
     /// here that it misattributed a slow store to the network. What it does misattribute is nothing: on
     /// the fleet overview those failures are caught per server and the card is simply absent, so a fleet
-    /// wider than the pool rendered short with no error at all. Both per-server fan-outs are bounded at
-    /// the permit count since #3016, so the state is no longer reachable from a shipped panel.</para>
+    /// wider than the pool rendered short with no error at all.</para>
+    ///
+    /// <para>The two fleet-wide fan-outs cannot reach that state since #3016 — they run pool-many lanes
+    /// rather than fleet-many reads. The literal-width sites can still reach it, but only on a
+    /// bring-your-own store the operator configured with FEWER permits than
+    /// <see cref="MeasuredFanOutWidth"/>: their widths are two to ten, which a managed seat serves without
+    /// a queue. <c>ViewerCommandTimeoutTests</c> holds every literal width at or under that bound, so the
+    /// residual cannot widen without someone deciding to widen it.</para>
     ///
     /// <para><b>This value bounds a read issued ALONE, and only that</b> (#3004). The permit argument
     /// above says a concurrent fan-out is the state worth protecting the pool from; it does not say a

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.cs
@@ -386,6 +386,14 @@ public sealed partial class ViewerDataService : IAsyncDisposable
         var effectiveConnectionString = connectionTimeoutSeconds is int seconds
             ? ApplyConnectionTimeout(connectionString, seconds)
             : connectionString;
+
+        /* #3016: the read-deadline family and the fan-out bound both need the pool size this seat really
+           gets, and the managed constant is only one of the two strings the viewer can be handed. Published
+           from the EFFECTIVE string, here, because this is the line that decides how many permits exist —
+           a call site could be added later that forgets, and there is nowhere else the two can be kept
+           from disagreeing. */
+        ViewerStorePool.Publish(effectiveConnectionString);
+
         _dataSource = NpgsqlDataSource.Create(effectiveConnectionString);
         StoreIsOnThisMachine = StoreHostIsLoopback(connectionString);
     }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerReadFanOut.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerReadFanOut.cs
@@ -7,6 +7,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 
 namespace PerformanceMonitor.Darling.Viewer;
@@ -36,17 +37,19 @@ namespace PerformanceMonitor.Darling.Viewer;
 ///
 /// <para><b>Nesting multiplies, it does not take the larger.</b> A read two scopes deep contends with the
 /// product of both widths, so that is what it is told. The product is clamped at
-/// <see cref="ViewerSettings.ManagedMaxPoolSize"/> going in, because a pool of ten cannot serve an
-/// eleventh read concurrently however many were asked for — which is also what makes the two unbounded
-/// per-server fan-outs (<c>FinOpsTab.Loaders.cs</c>'s inventory overlay and <c>MainWindow</c>'s overview
-/// cards) safe to declare with their raw fleet count rather than a hand-capped guess.</para>
+/// <see cref="MaxConcurrentReads"/> going in, because a pool cannot serve one more read concurrently than
+/// it has permits however many were asked for.</para>
 ///
-/// <para><b>What this does NOT do.</b> It does not throttle anything. The reads still all start at once and
-/// still all take a permit; this only stops the deadline cutting reads that the store was always going to
-/// take that long to serve. Bounding the fan-out itself is the better fix and is tracked on #3004 — it
-/// needs a concurrency sweep (per-read duration at width 1, 2, 4, 6, 8, 10) that does not exist yet,
-/// because the two data points available extrapolate to a cap of about two, and serializing every panel in
-/// the viewer on a two-point extrapolation is not a trade to make blind.</para>
+/// <para><b>What this does NOT do, and the one thing it now does</b> (#3016). It is still not a throttle:
+/// the reads inside a declared scope all start at once and all take a permit, and the width only stops the
+/// deadline cutting reads the store was always going to take that long to serve. What changed is that the
+/// two per-server fan-outs no longer hand over a raw fleet count — a count above
+/// <see cref="MaxConcurrentReads"/> was never a contention count, it was that many contenders plus a queue
+/// of reads that could only wait <c>ConnectionTimeoutSeconds</c> for a permit and fail. They split their
+/// work into <see cref="Lanes{T}"/> instead, so the width they declare is the concurrency they really
+/// have. A cap at the OPTIMUM concurrency — the two-point extrapolation #3004 declined to serialize every
+/// panel on — is still not attempted and still needs that sweep; this caps at the permit count, which is a
+/// resource fact rather than a performance one.</para>
 /// </summary>
 public static class ViewerReadFanOut
 {
@@ -55,6 +58,79 @@ public static class ViewerReadFanOut
     /// has touched — means "nobody declared a fan-out", which <see cref="CurrentWidth"/> reports as one.
     /// </summary>
     private static readonly AsyncLocal<int> s_width = new();
+
+    /// <summary>
+    /// The most reads this project will run against the store at once: the smaller of the permits this
+    /// seat actually has (<see cref="ViewerStorePool.MaxPoolSize"/>) and the width the per-lane contention
+    /// allowance was measured at (<see cref="ViewerCommandDeadlines.MeasuredFanOutWidth"/>).
+    ///
+    /// <para><b>Both bounds are load-bearing and neither implies the other</b> (#3016). Past the PERMITS a
+    /// read is not a contender at all — it is queued in Npgsql waiting <c>ConnectionTimeoutSeconds</c> for
+    /// a slot, and it fails there without ever reaching a command deadline. Past the MEASURED WIDTH the
+    /// deadline it would be handed is an extrapolation of a single ten-wide batch, which at Npgsql's
+    /// default hundred-connection pool would price a read at 700 s. On the shipped managed seat the two
+    /// are the same ten, so this changes nothing there; it is a bring-your-own store, where the operator
+    /// owns the pool size, that the old single constant described wrongly in both
+    /// directions.</para>
+    /// </summary>
+    public static int MaxConcurrentReads => ConcurrentReadsFor(ViewerStorePool.MaxPoolSize);
+
+    /// <summary>
+    /// <see cref="MaxConcurrentReads"/> against an EXPLICIT pool size — the pure form, so the bound can be
+    /// pinned at pool sizes this process is not configured for.
+    /// </summary>
+    public static int ConcurrentReadsFor(int maxPoolSize) =>
+        Math.Clamp(maxPoolSize, 1, ViewerCommandDeadlines.MeasuredFanOutWidth);
+
+    /// <summary>
+    /// Splits <paramref name="items"/> into at most <see cref="MaxConcurrentReads"/> lanes, so a caller
+    /// with fleet-many reads to issue can run one task per lane and walk its own lane sequentially — a
+    /// fan-out whose width is bounded by the pool instead of by the fleet (#3016).
+    ///
+    /// <para>Lanes are CONTIGUOUS and balanced to within one item. Contiguous because concatenating the
+    /// lanes' results in lane order then reproduces the input order, which is what lets a caller drop the
+    /// per-item ordering it had before; balanced because a lane holding two items while another holds
+    /// eight would make the fan-out as slow as the long lane for no reason.</para>
+    ///
+    /// <para>Returns no lanes for an empty input, so a caller's <c>Task.WhenAll</c> over the lanes is a
+    /// no-op rather than a lane that reads nothing. An empty result also means
+    /// <see cref="Of(int)"/> is handed zero, which reports a width of one — the honest answer for a
+    /// fan-out with no reads in it.</para>
+    /// </summary>
+    public static IReadOnlyList<IReadOnlyList<T>> Lanes<T>(IReadOnlyList<T> items)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+
+        var count = items.Count;
+        if (count == 0)
+        {
+            return Array.Empty<IReadOnlyList<T>>();
+        }
+
+        var laneCount = Math.Min(count, MaxConcurrentReads);
+        var lanes = new List<IReadOnlyList<T>>(laneCount);
+
+        /* Balanced contiguous split: the first (count % laneCount) lanes take one extra item, so no lane
+           is ever more than one item longer than another and every item lands in exactly one lane. */
+        var quotient = count / laneCount;
+        var remainder = count % laneCount;
+        var next = 0;
+
+        for (var lane = 0; lane < laneCount; lane++)
+        {
+            var size = quotient + (lane < remainder ? 1 : 0);
+            var slice = new List<T>(size);
+
+            for (var i = 0; i < size; i++)
+            {
+                slice.Add(items[next++]);
+            }
+
+            lanes.Add(slice);
+        }
+
+        return lanes;
+    }
 
     /// <summary>
     /// How many concurrent reads the read being constructed right now is one of. One when no enclosing
@@ -76,10 +152,12 @@ public static class ViewerReadFanOut
     /// so each one's deadline has to cover contention with the other
     /// <paramref name="concurrentReads"/> - 1 of them.
     ///
-    /// <para>Pass the ACTUAL width, including a runtime count for a fan-out whose width is the fleet size;
-    /// the clamp to <see cref="ViewerSettings.ManagedMaxPoolSize"/> is this type's job, not the call
-    /// site's. Declaring a width the site does not really have is the one way to misuse this — it buys a
-    /// longer deadline for a read that has no contention to justify it.</para>
+    /// <para>Pass the ACTUAL width; the clamp to <see cref="MaxConcurrentReads"/> is this type's job, not
+    /// the call site's. Declaring a width the site does not really have is the one way to misuse this — it
+    /// buys a longer deadline for a read that has no contention to justify it, and a raw fleet count is
+    /// that misuse rather than a safe over-declaration, because the reads past the permits are not
+    /// contending, they are queued and failing (#3016). A fan-out whose work is fleet-many splits through
+    /// <see cref="Lanes{T}"/> first and declares the lane count.</para>
     /// </summary>
     public static Scope Of(int concurrentReads) => new(concurrentReads);
 
@@ -95,12 +173,14 @@ public static class ViewerReadFanOut
         {
             _restore = s_width.Value;
 
-            /* Both factors are clamped into 1..pool BEFORE the multiply, so the product cannot overflow
-               and cannot be dragged below 1 by a caller passing 0 or a negative count. */
-            var declared = Math.Clamp(concurrentReads, 1, ViewerSettings.ManagedMaxPoolSize);
-            var enclosing = Math.Clamp(_restore, 1, ViewerSettings.ManagedMaxPoolSize);
+            /* Both factors are clamped into 1..cap BEFORE the multiply, so the product cannot overflow
+               and cannot be dragged below 1 by a caller passing 0 or a negative count. The cap is read
+               once so a re-publish between the two reads cannot produce a product above either value. */
+            var cap = MaxConcurrentReads;
+            var declared = Math.Clamp(concurrentReads, 1, cap);
+            var enclosing = Math.Clamp(_restore, 1, cap);
 
-            s_width.Value = Math.Clamp(declared * enclosing, 1, ViewerSettings.ManagedMaxPoolSize);
+            s_width.Value = Math.Clamp(declared * enclosing, 1, cap);
         }
 
         /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerStorePool.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerStorePool.cs
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Threading;
+using Npgsql;
+
+namespace PerformanceMonitor.Darling.Viewer;
+
+/// <summary>
+/// How many pooled store connections this viewer seat actually has, as a RUNTIME fact rather than a
+/// compile-time one (#3016).
+///
+/// <para><b>Why this exists at all.</b> The read-deadline family prices contention against the number of
+/// permits a fan-out can hold (<see cref="ViewerCommandDeadlines.FanOutReadSeconds(int)"/>) and the fan-out
+/// census bounds a declared width by it (<see cref="ViewerReadFanOut.MaxConcurrentReads"/>). Both read
+/// <see cref="ViewerSettings.ManagedMaxPoolSize"/> when #3007 landed, and that constant is applied to ONE of
+/// the two connection strings the viewer can be handed: the managed derivation sets
+/// <c>MaxPoolSize = 10</c> (<c>ViewerSettings.DeriveManagedConnectionString</c>), while a bring-your-own
+/// <c>postgres.connectionString</c> is used verbatim and its pool is whatever the operator wrote — Npgsql's
+/// own default being <see cref="NpgsqlDefaultMaxPoolSize"/>. So on a BYO store the constant was not the pool
+/// size, it was a guess about it, and the deadline sized for ten lanes was handed to a fan-out that could
+/// hold a hundred permits.</para>
+///
+/// <para><b>Process-wide, because the pool is.</b> A viewer seat opens exactly one
+/// <c>NpgsqlDataSource</c> (<c>MainWindow.OnLoaded</c> constructs the single
+/// <see cref="ViewerDataService"/>), so one published value describes every read in the process. The
+/// publish happens in <see cref="ViewerDataService"/>'s constructor rather than at the call site, so the
+/// thing that CREATES the pool is the thing that reports its size and a second construction cannot leave
+/// the two disagreeing.</para>
+///
+/// <para><b>Both consumers take a minimum against a measured width, which is what makes this safe to
+/// publish repeatedly.</b> A larger pool than the managed ten cannot raise either consumer past ten (the
+/// concurrent band was only ever measured at ten wide), so a re-publish can only matter when the operator
+/// configured a pool SMALLER than ten — the case the constant got wrong in the expensive direction. Reads
+/// and writes go through <see cref="Volatile"/> because the fleet timer's fan-out and the UI thread both
+/// read it.</para>
+///
+/// <para><b>What it does not model.</b> <c>Pooling=false</c> on a BYO string removes the permit ceiling
+/// entirely; this reports Npgsql's nominal maximum for that string and the concurrency bound then comes
+/// from <see cref="ViewerReadFanOut.MaxConcurrentReads"/> alone, which is the correct answer either way
+/// because that bound is the smaller of the two.</para>
+/// </summary>
+public static class ViewerStorePool
+{
+    /// <summary>
+    /// Npgsql's own <c>Max Pool Size</c> default — what a bring-your-own connection string that names no
+    /// pool size actually gets. Measured off <c>NpgsqlConnectionStringBuilder</c> at the pinned Npgsql
+    /// version rather than quoted from its documentation, and pinned by
+    /// <c>ViewerCommandTimeoutTests.TheEffectivePoolSize_ReadsTheStringNotTheManagedConstant</c> so a
+    /// version bump that moves it fails a build instead of silently re-guessing.
+    /// </summary>
+    public const int NpgsqlDefaultMaxPoolSize = 100;
+
+    /// <summary>
+    /// The managed seat's ceiling, which is also what an unpublished process reports: a code path that
+    /// never published leaves the deadline family exactly where #3007 left it rather than inventing a
+    /// wider pool it cannot prove exists.
+    /// </summary>
+    private static int s_maxPoolSize = ViewerSettings.ManagedMaxPoolSize;
+
+    /// <summary>The effective pool size for this seat's store connection.</summary>
+    public static int MaxPoolSize => Volatile.Read(ref s_maxPoolSize);
+
+    /// <summary>
+    /// Records the pool size the given connection string will actually get. Called from
+    /// <see cref="ViewerDataService"/>'s constructor with the string the data source is built on — the
+    /// EFFECTIVE string, after the connect-timeout preference is applied, so the value published and the
+    /// value Npgsql enforces come from the same text.
+    /// </summary>
+    internal static void Publish(string? connectionString) =>
+        Volatile.Write(ref s_maxPoolSize, MaxPoolSizeOf(connectionString));
+
+    /// <summary>
+    /// The pool size a connection string resolves to: the configured value when it names one, Npgsql's
+    /// <see cref="NpgsqlDefaultMaxPoolSize"/> when it does not, and
+    /// <see cref="ViewerSettings.ManagedMaxPoolSize"/> when there is no usable string to read.
+    ///
+    /// <para><b>Npgsql's builder, not the base <c>DbConnectionStringBuilder</c></b> — the opposite choice
+    /// from <c>ViewerDataService.StoreHostIsLoopback</c>, and for the opposite reason. That one needs to
+    /// know whether a key was PRESENT, so it cannot use a builder that answers with defaults. This one
+    /// needs the EFFECTIVE value, which is exactly what a defaulting builder returns, and it also gets the
+    /// keyword aliases (<c>Maximum Pool Size</c>) and the range validation for free.</para>
+    ///
+    /// <para>An unusable string falls back rather than throwing: this feeds a deadline computation, and a
+    /// string Npgsql cannot parse fails at <c>NpgsqlDataSource.Create</c> with a message about the string —
+    /// which is the error the operator needs, not a second one from a timeout calculation.</para>
+    /// </summary>
+    public static int MaxPoolSizeOf(string? connectionString)
+    {
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            return ViewerSettings.ManagedMaxPoolSize;
+        }
+
+        try
+        {
+            var configured = new NpgsqlConnectionStringBuilder(connectionString).MaxPoolSize;
+
+            return configured < 1 ? ViewerSettings.ManagedMaxPoolSize : configured;
+        }
+        catch (ArgumentException)
+        {
+            return ViewerSettings.ManagedMaxPoolSize;
+        }
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerStorePool.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerStorePool.cs
@@ -89,7 +89,15 @@ public static class ViewerStorePool
     ///
     /// <para>An unusable string falls back rather than throwing: this feeds a deadline computation, and a
     /// string Npgsql cannot parse fails at <c>NpgsqlDataSource.Create</c> with a message about the string —
-    /// which is the error the operator needs, not a second one from a timeout calculation.</para>
+    /// which is the error the operator needs, not a second one from a timeout calculation. This runs one
+    /// statement ahead of that <c>Create</c>, inside a constructor whose call site does not catch, so the
+    /// fallback has to be unconditional or it would replace that error rather than defer to it.</para>
+    ///
+    /// <para><b>Caught broadly, matching the three other sites that wrap this constructor</b>
+    /// (<c>ViewerConfigDiagnostics</c>, <c>ViewerCertificateAnchor</c>, <c>StoreConnectionSelfTest</c>),
+    /// whose own comments say why: Npgsql's parse failures are not one exception type. Measured at 10.0.3 —
+    /// a bad value for a recognised keyword raises <c>ArgumentException</c>, but <c>"====="</c> raises
+    /// <c>KeyNotFoundException</c>, which does not derive from it. Both are pinned.</para>
     /// </summary>
     public static int MaxPoolSizeOf(string? connectionString)
     {
@@ -104,7 +112,7 @@ public static class ViewerStorePool
 
             return configured < 1 ? ViewerSettings.ManagedMaxPoolSize : configured;
         }
-        catch (ArgumentException)
+        catch (Exception)
         {
             return ViewerSettings.ManagedMaxPoolSize;
         }


### PR DESCRIPTION
Closes #3016 (a `dev` merge does not fire closing keywords, so this is a statement, not an instruction).

## What was wrong

`ViewerCommandDeadlines.FanOutReadSeconds` and `ViewerReadFanOut.Scope` both clamped at `ViewerSettings.ManagedMaxPoolSize`, and that constant is applied to exactly one of the two connection strings the viewer can be handed. The managed derivation sets `MaxPoolSize = 10`; a bring-your-own `postgres.connectionString` is used verbatim, so its pool is whatever the operator wrote. Measured off `NpgsqlConnectionStringBuilder` at the pinned Npgsql 10.0.3: a string that names no pool size resolves to **100**. On that store the clamp was not the permit count, it was a guess about it — and the guess was wrong in both directions, since an operator who set the pool *below* ten was also being priced for ten-way contention they cannot have.

Past the permits nothing was bounded at all. Both fleet-wide fan-outs declared their raw fleet count and started that many reads, so on a fleet larger than the pool the reads past the tenth queued in Npgsql, waited `ConnectionTimeoutSeconds` (default 5) for a slot, and failed there without ever reaching a command deadline.

## One premise in #3016 is wrong, measured

#3016 and `ViewerCommandDeadlines.cs`'s own prose both said that failure "misattributes a slow store to the network". Against Npgsql 10.0.3 — `postgres:18`, `MaxPoolSize=2;Timeout=5`, four concurrent `pg_sleep(20)` reads — the two starved reads threw `Npgsql.NpgsqlException` after 5.0 s with `The connection pool has been exhausted, either raise 'Max Pool Size' (currently 2) or 'Timeout' (currently 5 seconds) in your connection string.` (inner `System.TimeoutException`). That message names the exhausted pool and both knobs and does not mention the network. `RunFinOpsLoad` surfaces `ex.Message` verbatim, so on the inventory overlay the operator was already being told the truth.

What the fleet overview did instead is worse than a wrong message. `LoadOverviewAsync` caught per-server failures and returned null, and `OfType<ServerSummaryItem>()` dropped the nulls — so **the default-visible panel a fleet is watched from rendered short, with no error at all**, whenever the store was slow enough for the first ten reads to hold their permits for five seconds. The stale claim is corrected in the doc comment that carried it.

## The choice on #3016's item 2

#3016 offered "bound the two fan-outs" or "give the permit wait its own error naming permit exhaustion", and called the second cheaper. **Bounded**, because the second option's premise does not survive the measurement above: Npgsql already names it, so that work would be a re-wording, and it would not restore a single missing card on the panel where the failure is silent.

Bounding also removes the need to extrapolate. `FanOutLaneSeconds = 7` is one division of one measured batch taken at ten wide; letting a width above ten reach the multiply would price a hundred-permit pool at 700 s, a number nothing has measured and nobody would wait for. Holding the concurrency to the measured width keeps every value the family returns inside the band it came from.

## What changed

`ViewerStorePool` publishes the effective pool size, parsed from the string the data source is actually built on. Published from `ViewerDataService`'s constructor rather than the call site: that is the line that decides how many permits exist. `MaxPoolSizeOf` falls back to the managed constant on a string it cannot read, because an unparseable string fails at `NpgsqlDataSource.Create` with a message about the string and the operator needs that one, not a second one invented by a timeout calculation.

`FanOutReadSeconds` gains a pure `(concurrentReads, maxPoolSize)` overload and clamps the lane count at the smaller of the permits and the new `MeasuredFanOutWidth`. `MeasuredFanOutWidth` is defined as `ViewerSettings.ManagedMaxPoolSize` and says why they share a number without being the same fact: ten permits are what *bounded* #2901's rig, and a sweep at another width should be able to move one without dragging the other.

`ViewerReadFanOut` gains `MaxConcurrentReads` / `ConcurrentReadsFor` on the same two bounds, and `Lanes<T>` — a balanced, contiguous partition into at most pool-many lanes. The two fleet-wide fan-outs split through it and declare the lane count, so the width they declare is the concurrency they have. Contiguity is load-bearing: `MainWindow` concatenates the lanes in order to restore the fleet order it used to read in, and the FinOps overlay hands the same list it mutated to its filter manager.

On the shipped managed seat the pool is ten and `MeasuredFanOutWidth` is ten, so no deadline and no concurrency changes there — what changes is that the overview's reads past the permits now wait for a slot in-process and render, instead of failing in five seconds and vanishing.

## #3023's pins: what moved, and how each stayed load-bearing

- **`TheFanOutDeadline_IsDerivedFromTheConcurrentBand_NotTheSoloOne`** called `FanOutReadSeconds(ManagedMaxPoolSize)` — the single-argument form, so it asserted against whatever pool the process had published. It now asserts the pure overload at an explicit `ManagedMaxPoolSize`, keeps both original assertions unchanged (`solo < 24`, `widest > 64`), and adds two: the same width against `NpgsqlDefaultMaxPoolSize` must return the same seconds, and `MeasuredFanOutWidth` must not exceed the managed pool (or the default install can no longer reach the width the allowance was divided out of).
- **`TheFanOutDeadline_IsMonotonicAndClampedAtThePool`** swept widths against one hardcoded pool. It now sweeps widths **across pool sizes** `{1, 2, 3, 10, 100, int.MaxValue}`, keeping the floor and monotonicity assertions per pool, and adds: no value may exceed the `MeasuredFanOutWidth`-lane allowance; a three-permit pool must price strictly below a ten-permit one; and the single-argument overload the 187 command sites reach must agree with the pure one at the published pool, so the derivation is pinned on the path something calls.
- **`TheFanOutWidth_DefaultsToOne_AndNestsByMultiplying`** clamped against `ViewerSettings.ManagedMaxPoolSize`. It now clamps against `ViewerReadFanOut.MaxConcurrentReads`. That reads like a rename and is not one — the constant would pass identically whether the pool is read at all — so it also sweeps `ConcurrentReadsFor` at 1, 3, the managed pool, Npgsql's default, `int.MaxValue`, 0 and −7. The nesting, `Of(0)` and `Of(pool * 7)` cases are unchanged.
- **`EveryViewerFanOut_DeclaresItsWidth`** and **`NoFanOutScope_OutlivesItsJoin`** are untouched, and their coverage is unchanged by measurement rather than by inspection: **21 fan-outs before and after**, and **4 joins followed by a further await before and after** (both probed by raising the floors and reading the reported counts). Both fleet-wide sites still hold a method-level `Task.WhenAll` with a preceding `Of(...)`, and `MainWindow` still calls `Release()` between its join and the fleet-totals read, so neither site fell out of either census.
- Nothing else in the file moved. The three band pins for the interactive, command-plane and connect-gate constants, the scanner-blind-spot theories, the member walk and the deferred-run pins are byte-for-byte as #3023 left them.

Five pins are new: the effective-pool parse (including Npgsql's 100, so a version bump that moves it fails a build), the `ViewerDataService` publish wiring, the lane-split partition properties, a declared-width census, and a source pin that the two live members read the published pool rather than the constant. That last one exists because the substitution is invisible behaviourally — the managed seat publishes ten and the constant is ten, so swapping them changes no value this process can produce.

## Review finding, taken

The review bot flagged `MaxPoolSizeOf`'s `catch (ArgumentException)` as narrower than the `catch (Exception)` this codebase already uses at the three other sites that wrap `new NpgsqlConnectionStringBuilder(...)` — `ViewerConfigDiagnostics.cs:106`, `ViewerCertificateAnchor.cs:100`, `StoreConnectionSelfTest.cs:97` — whose own comments say why. Correct, and its concrete hypothesis was not: measured at 10.0.3, a bad value for a *recognised* keyword (`MaxPoolSize=abc`, `Port=abc`, `SslMode=Nonsense`, an unknown keyword) does raise `ArgumentException`. **The real counterexample is `"====="`, which raises `KeyNotFoundException`** out of `NpgsqlConnectionStringBuilder.Remove` → `GeneratedActions`, and does not derive from `ArgumentException`.

That matters exactly as the bot said it would: `Publish` runs one statement ahead of `NpgsqlDataSource.Create`, inside a constructor whose call site (`MainWindow.xaml.cs:362`) does not catch, so the escaping exception would have *replaced* the connect-time error the fallback exists to defer to. Widened to `catch (Exception)`, and both exception shapes are now pinned rather than only the one a narrow catch happens to cover. Reverting to `catch (ArgumentException)` reddens the pin with that `KeyNotFoundException` — the twelfth variant below.

A third case came out of the same probe and is pinned too: `MaxPoolSize=0` **parses** (Npgsql validates the pool size at connect, not at the builder), so it is the `< 1` floor rather than the catch that keeps a zero out of the lane arithmetic. Removing that floor reddens with `Expected: 10 / Actual: 0` — the thirteenth variant.

The bot's second pass raised one non-blocking observation, taken: a lane is walked sequentially, so a read that throws abandons the rest of *its* lane while the other lanes finish. The FinOps overlay's visible outcome is unchanged either way — `RunFinOpsLoad` catches the join's exception and never reaches `UpdateData`, so a partial overlay is never rendered — and that is now written at the site rather than left to be re-derived.

A third pass flagged that the class summary still described the viewer's permit as a flat `MaxPoolSize = 10` while comparing against `StorageCommandDeadlines.McpReadSeconds`, contradicting the paragraph below it that this change corrected. Taken — that sentence now names `ViewerStorePool.MaxPoolSize` and the managed/BYO split, and the "ten concurrent reads can hold every one of them" claim is scoped to a managed seat, which is where it is true. The derivation itself (685 ms unbounded against 3.0 s scarce, landing below 30 s) is unchanged.

A fourth pass found nothing in the diff and flagged one pre-existing doc reference outside it — `MainWindow.ServerManagement.cs:102`'s single-flight rationale still described the permit contest as being "against a pool of `ViewerSettings.ManagedMaxPoolSize`". Taken, and the whole class is closed rather than iterated: a census of every remaining `ManagedMaxPoolSize` reference in product code leaves exactly three, all deliberate — the `MeasuredFanOutWidth` tie, `ViewerStorePool`'s statement of what the deadline family used to read, and the documented fallback value, which really is that constant.

## Verification

Full `Darling.Tests` suite, run on macOS by building the real project and repointing its `runtimeconfig.json` from `Microsoft.WindowsDesktop.App` to `Microsoft.NETCore.App`. Against base `ba78352340`: **7612 total / 181 failed**; on this branch: **7617 total / 181 failed** — the +5 is exactly the five new tests, and the failing test-name sets are **identical** in both directions (`comm` empty both ways over two non-empty 181-line files). All 181 are pre-existing macOS artifacts. `ViewerCommandTimeoutTests` alone: 52 → 57, all green.

The behaviour change was also demonstrated functionally, end to end through the real product types against `postgres:18` with `MaxPoolSize=2;Timeout=5` and an eight-item "fleet" of 3-second reads. `new ViewerDataService(cs)` published a pool of 2, giving `MaxConcurrentReads = 2`. The old shape — fleet-many reads, per-server catch, nulls dropped — returned **4 of 8 cards after 6.1 s**, the other four swallowed with `The connection pool has been exhausted, either raise 'Max Pool Size' (currently 2) or 'Timeout' (currently 5 seconds) in your connection string`. The lane shape returned **8 of 8 after 12.1 s**, in fleet order. That is the trade this makes: a complete panel that takes longer, instead of a fast one missing half the fleet with no error.

Red-proved thirteen ways, each variant reverting one separable piece and failing a different named assertion:

| Reverted | Red assertion |
| --- | --- |
| the `min(permits, MeasuredFanOutWidth)` in the deadline | `pool 100 width 11 yields 77s, above the 10-lane allowance...` |
| the deadline's use of `maxPoolSize` | the clamp equality `FanOutReadSeconds(bound, pool) == FanOutReadSeconds(bound * 4, pool)` |
| the single-argument overload's `ViewerStorePool.MaxPoolSize` | `Assert.Contains("ViewerStorePool.MaxPoolSize", deadlines)` |
| `Of(lanes.Count)` back to `Of(list.Count)` | `MainWindow.xaml.cs:1434 (runtime width list.Count is not a Lanes split's lane count)` |
| contiguous lanes, made a stride split | the partition-order `Assert.Equal(items, lanes.SelectMany(...))` |
| the `ViewerStorePool.Publish` call | `ViewerDataService does not publish its pool size to ViewerStorePool...` |
| `MaxPoolSizeOf`'s string parse | `Expected: 100 / Actual: 10` |
| `ConcurrentReadsFor`'s clamp | `ConcurrentReadsFor(3)`: `Expected: 1 / Actual: 10` |
| `permits` floored at the managed constant | `ViewerCommandDeadlines mentions ManagedMaxPoolSize 2 time(s) in code` |
| a literal width raised to 11 | `CorrelatedTimelineLanesControl.xaml.cs:174 (literal width 11)` |
| a literal width replaced by `System.Math.Min(6, 7)` | `runtime width System.Math.Min(6, 7) is not a Lanes split's lane count` (the paren-matching extractor) |
| the widened `catch (Exception)`, narrowed back | `System.Collections.Generic.KeyNotFoundException` escapes `MaxPoolSizeOf` |
| the `< 1` pool-size floor | `Expected: 10 / Actual: 0` |

Each mutation was applied to a committed baseline, run, then restored by stashing only the mutation and dropping the stash, with a clean `git status` re-asserted before the next one.

## The concurrency sweep was not run

#3004's sweep — per-read duration at width 1, 2, 4, 6, 8, 10 — still does not exist, and this branch does not substitute reasoning for it. `FanOutLaneSeconds` is unchanged at 7. There is no TimescaleDB store at production density available here, and standing one up would produce a fresh rig whose absolute numbers are not comparable to #2901's. The fix is deliberately structured so the sweep is not a prerequisite: the lane count is held to the width the existing measurement covers, so no value the family returns is extrapolated. The sweep is what would let `MeasuredFanOutWidth` exceed ten, and the doc comment on it says so.

## Residual, stated rather than filed

The literal-width fan-outs (widths two to ten, twenty-one sites) are not lane-split. A managed seat serves all of them without a queue. On a bring-your-own store an operator configured with **fewer than ten** permits, a ten-wide site can still start reads that only wait for a slot and fail — the same shape as arm 1, at a bounded site, needing a configuration nobody is known to run. Its deadline is now correct there (a three-permit pool prices three lanes), and the new declared-width census holds every literal at or under `MeasuredFanOutWidth`, so it cannot widen silently.

`Lite.Tests` could not be run here: unlike `Darling.Tests` it fails xunit *discovery* on macOS with `Could not load file or assembly 'WindowsBase'`, before any test executes. Instead, a controlled scan of all 304 `Lite.Tests` source files (3.74 MB, positive control fired on a known split-`Path.Combine` read of `SettingsWindow.xaml.cs`) found **no reference to any of the seven files this branch touches** — the only `MainWindow.xaml.cs` read there is `Lite/MainWindow.xaml.cs`. CI's `build` is the arbiter.

## CHANGELOG entry (not committed, per the lane routing)

```markdown
- **The viewer's read deadline is priced against the pool the seat actually has, and the two fleet-wide fan-outs no longer start more reads than it has permits** ([#3016]) - `FanOutReadSeconds` and `ViewerReadFanOut` both clamped at `ViewerSettings.ManagedMaxPoolSize`, which is applied only to the managed derivation; a bring-your-own `postgres.connectionString` is used verbatim and resolves to Npgsql's default of **100** (measured off `NpgsqlConnectionStringBuilder` at 10.0.3). New `ViewerStorePool` publishes the effective size from the string the data source is built on, and both consumers take the smaller of it and the new `MeasuredFanOutWidth` - the ten wide the concurrent band was actually measured at, so a hundred-permit pool is not priced at 700 s on a single data point. Past the permits nothing was bounded at all: the fleet overview and the FinOps inventory overlay declared their raw fleet count, so on a fleet larger than the pool the reads past the tenth waited `ConnectionTimeoutSeconds` for a slot and failed with Npgsql's pool-exhaustion error without reaching a command deadline. **On the overview those failures were caught per server and dropped, so the default-visible fleet panel rendered SHORT with no error at all.** Both now split through `ViewerReadFanOut.Lanes` into at most pool-many contiguous lanes and declare the lane count, so the declared width is the concurrency they have. #3016's claim that the starved read "misattributes a slow store to the network" is corrected in the doc comment that carried it: measured against Npgsql 10.0.3, the message names the exhausted pool and both knobs.
```

Link ref: `[#3016]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/3016`
