### PR TITLE
Read the log prefix a managed PostgreSQL target renders, and test both parsers on one (#3030)

### DIFF
--- a/Darling/Darling.Tests/RdsDeadlockIngestorTests.cs
+++ b/Darling/Darling.Tests/RdsDeadlockIngestorTests.cs
@@ -66,6 +66,22 @@ public sealed class RdsDeadlockIngestorTests
     private static readonly string NonUtcDeadlockText =
         DeadlockText.Replace(" UTC ", " EST ", StringComparison.Ordinal);
 
+    /* The same report as a MANAGED target renders it, whose parameter group carries the system default
+       log_line_prefix = '%t:%r:%u@%d:[%p]:'. This suite is the managed transport's, so this is the shape
+       it is actually handed: %t renders no fractional seconds, and the prefix's own ':' sits where the
+       self-hosted default puts a space.
+
+       Identifiers synthesised, shape verbatim: %r renders host(port) and %u@%d the connected user and
+       database, so a real line carries a real user and database name there. 192.0.2.10 is RFC 5737
+       documentation space, which exists to be written down. */
+    private const string ManagedPrefix =
+        "2026-08-26 22:25:24 UTC:192.0.2.10(52345):app_user@app_db:[1549]:";
+
+    private const string SelfHostedPrefix = "2026-08-26 22:25:24.100 UTC [1549] ";
+
+    private static readonly string ManagedDeadlockText =
+        DeadlockText.Replace(SelfHostedPrefix, ManagedPrefix, StringComparison.Ordinal);
+
     /* A window with log traffic but no deadlock in it — the ordinary quiet cycle, and the positive control
        for the commit firing at all. */
     private const string QuietText =
@@ -385,5 +401,59 @@ public sealed class RdsDeadlockIngestorTests
         {
             Assert.DoesNotContain("did not look", note, StringComparison.Ordinal);
         }
+    }
+
+    /// <summary>
+    /// The managed fixture's precondition, the counterpart of
+    /// <see cref="TheFixtureReallyParsesToOneDeadlock"/>: the re-rendering really did replace the prefix
+    /// on every prefixed line, and the result really is one report.
+    /// </summary>
+    [Fact]
+    public void TheManagedFixtureCarriesTheManagedPrefix_AndParsesToTheSameReport()
+    {
+        Assert.DoesNotContain(SelfHostedPrefix, ManagedDeadlockText, StringComparison.Ordinal);
+        Assert.Contains(ManagedPrefix, ManagedDeadlockText, StringComparison.Ordinal);
+
+        var managed = Assert.Single(PgDeadlockLogParser.Extract(ManagedDeadlockText));
+        var selfHosted = Assert.Single(PgDeadlockLogParser.Extract(DeadlockText));
+
+        Assert.Equal(1549, managed.VictimPid);
+        Assert.Equal(2, managed.ParticipantCount);
+
+        /* One report, one identity, whichever prefix rendered it - the prefix is not part of the graph.
+           A target that moved between the two transports would otherwise store its history twice. */
+        Assert.Equal(selfHosted.DeadlockHash, managed.DeadlockHash);
+    }
+
+    /// <summary>
+    /// A managed window carrying a report reaches the WRITE, and this is the assertion the managed
+    /// transport was missing: every other test here drives it over text a self-hosted target renders, so
+    /// the suite proved the plumbing over a shape its own targets do not emit (#3030).
+    ///
+    /// <para>The store is the dead one, so reaching the write means throwing. An
+    /// <c>RdsIngestOutcome.Read(0)</c> here would be the quiet-cycle path in
+    /// <see cref="AQuietCycleAdvancesTheMarker"/> taken over a window that is not quiet: the note would
+    /// say the window held no deadlock, and the marker would advance and consume it, so the report is
+    /// never offered again.</para>
+    /// </summary>
+    [Fact]
+    public async Task AManagedPrefixWindowReachesTheWrite_RatherThanReportingAnEmptyLog()
+    {
+        await using var store = NpgsqlDataSource.Create(DeadStore);
+        var (ingestor, client, _) = Build(store, new FakeRds { FirstBody = ManagedDeadlockText });
+
+        var failure = await Assert.ThrowsAnyAsync<Exception>(
+            () => ingestor.IngestAsync(1, "target-a", Host));
+
+        /* The WRITE failed, not the read: RdsLogUnavailableException would mean the fetch produced no
+           chunk and nothing here would mean anything. */
+        Assert.IsNotType<RdsLogUnavailableException>(failure);
+        Assert.Single(client.Downloads);
+
+        /* And the window survives the failed write, exactly as the self-hosted one does. */
+        await Assert.ThrowsAnyAsync<Exception>(() => ingestor.IngestAsync(1, "target-a", Host));
+
+        Assert.Equal(2, client.Downloads.Count);
+        Assert.Null(client.Downloads[1].Marker);
     }
 }

--- a/Lite.Tests/PgDeadlockLogParserTests.cs
+++ b/Lite.Tests/PgDeadlockLogParserTests.cs
@@ -78,6 +78,153 @@ public sealed class PgDeadlockLogParserTests
         Assert.Single(PgDeadlockLogParser.Extract(noQueryId));
     }
 
+    /* The log prefix in front of every line, and the only thing the regimes below vary. The report body
+       is RealBlock's, so a regime that yields nothing yields nothing because of its prefix.
+
+       Two requirements of the shape are separable, and PostgreSQL's own default satisfies both while the
+       system default on a managed target satisfies neither:
+
+         FRACTION - %m renders fractional seconds on the stamp; %t does not.
+         BRACKET  - '%m [%p] ' puts a SPACE before the bracketed pid. '%t:%r:%u@%d:[%p]:' puts a COLON
+                    there, because ':' is that prefix's own delimiter and %r and %u@%d sit between the
+                    zone and the pid.
+
+       Identifiers in the managed prefixes are synthesised and the shape is not: %r renders host(port) and
+       %u@%d the connected user and database, so a real line carries a real user and database name in that
+       slot. 192.0.2.10 is RFC 5737 documentation space, which exists to be written down. */
+    private const string SelfHostedPrefix = "2026-08-26 22:25:24.100 UTC [1549] ";
+    private const string NoFractionAndSpacePrefix = "2026-08-26 22:25:24 UTC [1549] ";
+    private const string FractionAndColonPrefix = "2026-08-26 22:25:24.100 UTC:192.0.2.10(52345):app_user@app_db:[1549]:";
+    private const string NoFractionAndColonPrefix = "2026-08-26 22:25:24 UTC:192.0.2.10(52345):app_user@app_db:[1549]:";
+    private const string EmptyRemoteHostPrefix = "2026-08-26 22:25:24 UTC::@:[1549]:";
+
+    /// <summary>The captured report re-rendered under another <c>log_line_prefix</c>, prefix only.</summary>
+    private static string ReportUnder(string prefix) =>
+        RealBlock.Replace(SelfHostedPrefix, prefix, StringComparison.Ordinal);
+
+    private static int Occurrences(string text, string token)
+    {
+        var count = 0;
+
+        for (var i = text.IndexOf(token, StringComparison.Ordinal);
+             i >= 0;
+             i = text.IndexOf(token, i + token.Length, StringComparison.Ordinal))
+        {
+            count++;
+        }
+
+        return count;
+    }
+
+    /// <summary>
+    /// The re-rendering's own control, so no regime below can pass on the shape the rest of this suite is
+    /// already built from. Three of the report's lines carry a prefix - ERROR, DETAIL and HINT - and all
+    /// three must be re-rendered, while the tab-indented continuation lines carry none and must be left
+    /// alone. A rewrite that missed a line, or reached into the graph, would make the regimes measure
+    /// something other than the prefix.
+    /// </summary>
+    [Fact]
+    public void ReRenderingThePrefixReplacesEveryPrefixedLine_AndNothingElse()
+    {
+        Assert.Equal(3, Occurrences(RealBlock, SelfHostedPrefix));
+
+        var managed = ReportUnder(NoFractionAndColonPrefix);
+
+        Assert.Equal(3, Occurrences(managed, NoFractionAndColonPrefix));
+        Assert.DoesNotContain(SelfHostedPrefix, managed, StringComparison.Ordinal);
+        Assert.Equal(Occurrences(RealBlock, "\tProcess "), Occurrences(managed, "\tProcess "));
+    }
+
+    /// <summary>
+    /// <c>log_line_prefix = '%t:%r:%u@%d:[%p]:'</c>, the system default on a managed PostgreSQL parameter
+    /// group and therefore the shape the RDS log-API transport is handed on those targets (#3030). It
+    /// carries neither fractional seconds nor a space before the pid, so both requirements above fail on
+    /// the same line.
+    /// </summary>
+    [Fact]
+    public void ParsesTheManagedSystemDefaultPrefix()
+    {
+        var deadlock = Assert.Single(PgDeadlockLogParser.Extract(ReportUnder(NoFractionAndColonPrefix)));
+
+        /* Whole seconds, because %t renders no fraction. A millisecond component here would mean some
+           other stamp was read. */
+        Assert.Equal(new DateTime(2026, 8, 26, 22, 25, 24, DateTimeKind.Utc), deadlock.OccurredAtUtc);
+        Assert.Equal(1549, deadlock.VictimPid);
+        Assert.Equal(2, deadlock.ParticipantCount);
+        Assert.Equal("ShareLock", deadlock.LockModes);
+
+        /* The prefix is not part of the graph, so one report has one identity whichever prefix rendered
+           it, and the two transports' copies of it dedupe against each other. */
+        Assert.Equal(
+            Assert.Single(PgDeadlockLogParser.Extract(RealBlock)).DeadlockHash,
+            deadlock.DeadlockHash);
+    }
+
+    /// <summary>
+    /// The fraction on its own, under <c>'%t [%p] '</c>: a space precedes the pid and only the fractional
+    /// seconds are absent. This is the regime that isolates the stamp - a pattern requiring
+    /// <c>\.\d+</c> matches nothing here while still matching a colon-delimited prefix that has one.
+    /// </summary>
+    [Fact]
+    public void ParsesAStampWithNoFractionalSeconds()
+    {
+        var deadlock = Assert.Single(PgDeadlockLogParser.Extract(ReportUnder(NoFractionAndSpacePrefix)));
+
+        Assert.Equal(new DateTime(2026, 8, 26, 22, 25, 24, DateTimeKind.Utc), deadlock.OccurredAtUtc);
+        Assert.Equal(1549, deadlock.VictimPid);
+    }
+
+    /// <summary>
+    /// The delimiter on its own, under <c>'%m:%r:%u@%d:[%p]:'</c>: the stamp carries its fraction and only
+    /// the character before the bracket differs. This is the regime that isolates the delimiter - a
+    /// pattern requiring a space there matches nothing here while still matching a fraction-less prefix
+    /// that has one.
+    /// </summary>
+    [Fact]
+    public void ParsesAColonBeforeTheBracketedPid()
+    {
+        var deadlock = Assert.Single(PgDeadlockLogParser.Extract(ReportUnder(FractionAndColonPrefix)));
+
+        Assert.Equal(new DateTime(2026, 8, 26, 22, 25, 24, 100, DateTimeKind.Utc), deadlock.OccurredAtUtc);
+        Assert.Equal(1549, deadlock.VictimPid);
+    }
+
+    /// <summary>
+    /// The zone token ends at the prefix's OWN delimiter, asserted as the absence of a refusal rather than
+    /// as a count.
+    ///
+    /// <para>Under a colon-delimited prefix the run between the stamp and the pid holds the zone, the
+    /// remote host and port, and the user and database. A zone read across that whole run is
+    /// <c>UTC:192.0.2.10(52345):app_user@app_db</c>, which
+    /// <see cref="PgDeadlockLogParser.IsZeroOffsetLogZone"/> refuses - so the report is REFUSED rather
+    /// than missed, and on a fleet whose <c>log_timezone</c> really is UTC every window is abandoned with
+    /// a message naming a setting that is already correct. Missing the report and refusing it are two
+    /// different wrongs, they are one character apart in the pattern, and a count-only assertion cannot
+    /// tell them apart because both leave nothing stored.</para>
+    /// </summary>
+    [Fact]
+    public void ReadsTheZoneUpToThePrefixDelimiter_RatherThanRefusingTheWholeRun()
+    {
+        Assert.Null(Record.Exception(() => PgDeadlockLogParser.Extract(ReportUnder(NoFractionAndColonPrefix))));
+        Assert.Null(Record.Exception(() => PgDeadlockLogParser.Extract(ReportUnder(FractionAndColonPrefix))));
+        Assert.Null(Record.Exception(() => PgDeadlockLogParser.Extract(ReportUnder(EmptyRemoteHostPrefix))));
+    }
+
+    /// <summary>
+    /// <c>%r</c> renders EMPTY on a line with no client connection, and <c>%u@%d</c> with it, so the run
+    /// between the zone and the pid collapses to <c>::@:</c> - consecutive colons and an <c>@</c> are all
+    /// that is left of three escapes. Those lines share the window with the reports, so the pattern must
+    /// not require that run to be non-empty.
+    /// </summary>
+    [Fact]
+    public void ParsesTheManagedPrefixWhenTheRemoteHostRendersEmpty()
+    {
+        var deadlock = Assert.Single(PgDeadlockLogParser.Extract(ReportUnder(EmptyRemoteHostPrefix)));
+
+        Assert.Equal(new DateTime(2026, 8, 26, 22, 25, 24, DateTimeKind.Utc), deadlock.OccurredAtUtc);
+        Assert.Equal(1549, deadlock.VictimPid);
+    }
+
     /// <summary>
     /// A participant's statement is arbitrary user SQL and can span lines, each arriving tab-indented under
     /// the DETAIL block. Taking one line per participant would truncate every multi-line statement to its

--- a/Lite.Tests/PgDeadlockLogParserTests.cs
+++ b/Lite.Tests/PgDeadlockLogParserTests.cs
@@ -225,6 +225,83 @@ public sealed class PgDeadlockLogParserTests
         Assert.Equal(1549, deadlock.VictimPid);
     }
 
+    /* A numeric-offset zone under a COLON-delimited prefix: the one combination where the zone's own
+       colons and the prefix's delimiter are the same character, and therefore the only combination where
+       reading the zone is ambiguous at all. A zone with no abbreviation renders as an offset, so this is
+       what a managed target with log_timezone set to such a zone emits.
+
+       The IPv6 %r is the case that decides it. 2001:db8::1 is RFC 3849 documentation space; its leading
+       hextet is all decimal digits, so an offset pattern that keeps its own colons cannot tell `:2001`
+       from another of its own groups, and IPv6's next colon then satisfies the delimiter with nothing
+       left to backtrack. Two digits is not the boundary either, which the second address is here to say:
+       0020 renders as `20`. */
+    private const string ZeroOffsetColonPrefix =
+        "2026-08-26 22:25:24 +00:00:192.0.2.10(52345):app_user@app_db:[1549]:";
+    private const string ZeroOffsetColonPrefixIpv6 =
+        "2026-08-26 22:25:24 +00:2001:db8::1(52345):app_user@app_db:[1549]:";
+    private const string ZeroOffsetColonPrefixIpv6ShortHextet =
+        "2026-08-26 22:25:24 +00:20:db8::1(52345):app_user@app_db:[1549]:";
+    private const string NonZeroOffsetColonPrefix =
+        "2026-08-26 22:25:24 -03:30:192.0.2.10(52345):app_user@app_db:[1549]:";
+
+    /// <summary>
+    /// A zone that IS zero offset, spelled numerically, under a colon-delimited prefix: parsed, not
+    /// refused, whatever the client address looks like.
+    ///
+    /// <para>Refusing here is the failure worth designing against, because it is a wrong ANSWER rather
+    /// than a missing one — the target's <c>log_timezone</c> is zero-offset, the stamps beside it really
+    /// are UTC, and a refusal abandons the whole read while telling the operator to set a setting that is
+    /// already right. On the consume-once transport that recurs every cycle for as long as the client
+    /// keeps connecting from that address.</para>
+    /// </summary>
+    [Theory]
+    [InlineData(nameof(ZeroOffsetColonPrefix))]
+    [InlineData(nameof(ZeroOffsetColonPrefixIpv6))]
+    [InlineData(nameof(ZeroOffsetColonPrefixIpv6ShortHextet))]
+    public void ANumericZeroOffsetZoneParsesUnderAColonDelimitedPrefix(string which)
+    {
+        var prefix = which switch
+        {
+            nameof(ZeroOffsetColonPrefix) => ZeroOffsetColonPrefix,
+            nameof(ZeroOffsetColonPrefixIpv6) => ZeroOffsetColonPrefixIpv6,
+            _ => ZeroOffsetColonPrefixIpv6ShortHextet,
+        };
+
+        var report = ReportUnder(prefix);
+
+        /* Named separately from the count, because the two failures are different: a refusal means the
+           zone was misread, and an empty list means the block was. */
+        Assert.Null(Record.Exception(() => PgDeadlockLogParser.Extract(report)));
+
+        var deadlock = Assert.Single(PgDeadlockLogParser.Extract(report));
+
+        Assert.Equal(new DateTime(2026, 8, 26, 22, 25, 24, DateTimeKind.Utc), deadlock.OccurredAtUtc);
+        Assert.Equal(1549, deadlock.VictimPid);
+    }
+
+    /// <summary>
+    /// And the same combination still REFUSES a zone that is not zero offset, so the tolerance above is
+    /// not a blanket acceptance of anything numeric. The token in the message is read up to the prefix's
+    /// delimiter — <c>-03</c> rather than <c>-03:30</c> — which is the accepted cost of the zone and the
+    /// delimiter sharing a character; the verdict is what has to be right, and the space-delimited
+    /// prefix (where nothing is ambiguous) still names the offset whole.
+    /// </summary>
+    [Fact]
+    public void ANumericNonZeroOffsetZoneStillRefusesUnderAColonDelimitedPrefix()
+    {
+        var ex = Assert.Throws<PgLogTimezoneUnsupportedException>(
+            () => PgDeadlockLogParser.Extract(ReportUnder(NonZeroOffsetColonPrefix)));
+
+        Assert.StartsWith("-03", ex.ObservedZone, StringComparison.Ordinal);
+        Assert.Contains("log_timezone", ex.Message, StringComparison.Ordinal);
+
+        /* The space-delimited prefix is where the offset is unambiguous, and there it stays whole. */
+        var whole = Assert.Throws<PgLogTimezoneUnsupportedException>(
+            () => PgDeadlockLogParser.Extract(WithLogZone("-03:30")));
+
+        Assert.Equal("-03:30", whole.ObservedZone);
+    }
+
     /// <summary>
     /// A participant's statement is arbitrary user SQL and can span lines, each arriving tab-indented under
     /// the DETAIL block. Taking one line per participant would truncate every multi-line statement to its

--- a/Lite.Tests/PgPlanCaptureCollectorDefinitionTests.cs
+++ b/Lite.Tests/PgPlanCaptureCollectorDefinitionTests.cs
@@ -222,6 +222,40 @@ public class PgPlanLogParserTests
         Assert.DoesNotContain(plans, p => p.TopNodeType is null);
     }
 
+    /// <summary>
+    /// The prefix a MANAGED target renders. <c>auto_explain</c>'s query id needs <c>%Q</c> in
+    /// <c>log_line_prefix</c>, and adding it to the system default on a managed parameter group gives
+    /// <c>'%t:%r:%u@%d:[%p]:%Q '</c> - which puts a COLON after the bracketed pid where PostgreSQL's own
+    /// default puts a space (#3030).
+    ///
+    /// <para>Mixed on purpose: the first block is re-rendered under the managed prefix and the second
+    /// keeps the self-hosted one, so the count is the assertion and neither shape can pass on the
+    /// other's behalf.</para>
+    ///
+    /// <para>Identifiers synthesised, shape verbatim: %r renders host(port) and %u@%d the connected user
+    /// and database, so a real line carries a real user and database name there. 192.0.2.10 is RFC 5737
+    /// documentation space, which exists to be written down.</para>
+    /// </summary>
+    [Fact]
+    public void ExtractReadsAManagedPrefixAlongsideASelfHostedOne()
+    {
+        var mixed = RawLog.Replace(
+            "2026-08-25 14:50:05.299 UTC [58] ",
+            "2026-08-25 14:50:05 UTC:192.0.2.10(52345):app_user@app_db:[58]:",
+            StringComparison.Ordinal);
+
+        /* The re-rendering fired, so this is not a second run over RawLog. */
+        Assert.DoesNotContain("UTC [58] ", mixed, StringComparison.Ordinal);
+        Assert.Contains(":[58]:", mixed, StringComparison.Ordinal);
+
+        var plans = PgPlanLogParser.Extract(mixed);
+
+        Assert.Equal(2, plans.Count);
+        Assert.Equal(-3560200806914842915, plans[0].QueryId);
+        Assert.Equal(0.006, plans[0].DurationMs, 3);
+        Assert.Equal(510393640047350727, plans[1].QueryId);
+    }
+
     [Fact]
     public void ExtractRedactsEveryPlanItReturns()
     {

--- a/PerformanceMonitor.Collectors/PgDeadlockLogParser.cs
+++ b/PerformanceMonitor.Collectors/PgDeadlockLogParser.cs
@@ -58,29 +58,35 @@ public static class PgDeadlockLogParser
         string? VictimStatement,
         string GraphText);
 
-    /* The report as PostgreSQL writes it, under either family of log_line_prefix this parser meets.
+    /* The report as PostgreSQL writes it, under either family of log_line_prefix this parser meets. The
+       two families are ALTERNATIVES rather than one relaxed pattern, and that is the load-bearing part.
 
-       PostgreSQL's own default is '%m [%p] ', rendering `2026-08-26 22:25:24.100 UTC [1549] `. The system
-       default on a managed parameter group is '%t:%r:%u@%d:[%p]:', rendering
-       `2026-08-26 22:25:24 UTC:<host>(<port>):<user>@<db>:[1549]:`. Two things differ between them and
-       both are load bearing:
+       PostgreSQL's own default is '%m [%p] ', rendering `2026-08-26 22:25:24.100 UTC [1549] `: the zone
+       runs to a SPACE, and a space is the one character it cannot contain, so [^ \n]+ reads it whole
+       whatever it is. The system default on a managed parameter group is '%t:%r:%u@%d:[%p]:', rendering
+       `2026-08-26 22:25:24 UTC:<host>(<port>):<user>@<db>:[1549]:`: the zone runs to a COLON, %r and
+       %u@%d follow it, and %r renders EMPTY on a line with no client connection, so that run can collapse
+       to consecutive colons. [^\n]*? is lazy, so the pid is the FIRST bracketed run of digits after the
+       delimiter - an %r rendering an IPv6 address brings its own brackets, and an all-digit pid is what
+       tells them apart.
 
-       The FRACTION is optional, because %m renders fractional seconds and %t does not.
+       ONE pattern spanning both, with the delimiter as [ :] and the zone as an abbreviation-or-offset
+       alternation, is WRONG, and the way it is wrong is a wrong answer rather than no answer. A numeric
+       offset carries colons of its own (-03:30), so a zone allowed to keep them cannot tell its own colon
+       from the prefix's: on `+00:2001:db8::1(...)` — a zero-offset zone and an IPv6 %r — the offset loop
+       eats `:2001` as another of its groups, IPv6's own colon then satisfies the delimiter, nothing
+       backtracks, and the zone reads `+00:2001`. IsZeroOffsetLogZone refuses that, so a target that IS
+       UTC has every window abandoned with a message naming a setting already correct. Bounding the
+       offset's groups to two digits only moves the boundary: `+00:20:db8::1(...)` breaks it again.
 
-       The character before the bracketed pid is a space OR a colon, and whatever sits between it and the
-       bracket is prefix rather than report: %r and %u@%d land there, and %r renders EMPTY on a line with
-       no client connection, so that run can collapse to consecutive colons. Lazy, so the pid is the FIRST
-       bracketed run of digits on the line - an %r rendering an IPv6 address brings its own brackets.
+       Splitting by delimiter removes the ambiguity instead of narrowing it, because the colon family's
+       zone then excludes ':' outright. The trade is that a numeric offset under a colon-delimited prefix
+       is read up to its first colon, so a non-zero one is refused as `-03` rather than `-03:30`. The
+       VERDICT is unchanged in every case; only the token in the message is shorter, and only on a prefix
+       family that no measured target combines with a numeric zone. Reading a UTC server as non-UTC is the
+       failure worth designing against; a terser refusal message is not.
 
-       The ZONE is bounded by the prefix's OWN delimiter, and that boundary is the difference between
-       missing a report and REFUSING one. A zone allowed to run to the last delimiter before the bracket
-       reads `UTC:<host>(<port>):<user>@<db>`, which IsZeroOffsetLogZone refuses - so a fleet whose
-       log_timezone really is UTC has every window abandoned, with a message naming a setting that is
-       already correct. Two alternatives, because a zone renders as either an abbreviation or a numeric
-       offset and only the numeric one contains a colon of its own: [+-]\d+(?::\d+)* keeps -03:30 whole so
-       a refusal names the zone it read, and [^ :\n]+ takes an abbreviation up to the delimiter. Not \w+
-       for the second - \w matches neither a sign nor a colon, and a prefix the pattern cannot match
-       produces no block at all, which reads as a server with no deadlocks.
+       The FRACTION is optional in both, because %m renders fractional seconds and %t does not.
 
        %Q puts the query id immediately before the severity with NO separator — measured output reads
        `[1549] 322048460535975151ERROR:  deadlock detected` — so this must not require whitespace there.
@@ -94,12 +100,19 @@ public static class PgDeadlockLogParser
        The zone is captured and READ (#2993). PostgreSQL renders the stamp in log_timezone and prints that
        zone's abbreviation beside it, so this token is the setting's own rendered value for THIS line, and
        it is what decides whether the naive timestamp next to it is already UTC. See IsZeroOffsetLogZone
-       for why that question is answerable from an abbreviation when "which zone is this" is not.
+       for why that question is answerable from an abbreviation when "which zone is this" is not. Both
+       families name the group `zone` and the group `pid`, which .NET allows across alternatives and which
+       keeps the reads below indifferent to which family matched.
+
+       Not \w+ for either zone: \w matches neither a sign nor a colon, and a prefix the pattern cannot
+       match produces no block at all, which reads as a server with no deadlocks.
 
        PgDeadlocksCollector holds this pattern's counterpart for the pg_read_file route, as SQL and
-       narrower: that one requires the fraction and the space, which PostgreSQL's own default renders. */
+       narrower: that one carries the space family only, which PostgreSQL's own default renders. */
     private static readonly Regex s_deadlockBlock = new(
-        @"^(\d{4}-\d\d-\d\d \d\d:\d\d:\d\d(?:\.\d+)?) (?<zone>[+-]\d+(?::\d+)*|[^ :\n]+)[ :][^\n]*?\[(?<pid>\d+)\][^\n]*ERROR:  deadlock detected\s*\n"
+        @"^(\d{4}-\d\d-\d\d \d\d:\d\d:\d\d(?:\.\d+)?) "
+        + @"(?:(?<zone>[^ \n]+) \[(?<pid>\d+)\]|(?<zone>[^ :\n]+):[^\n]*?\[(?<pid>\d+)\])"
+        + @"[^\n]*ERROR:  deadlock detected\s*\n"
         + @"[^\n]*DETAIL:  (?<detail>(?:[^\n]*\n)(?:\t[^\n]*\n)*)",
         RegexOptions.Compiled | RegexOptions.Multiline);
 

--- a/PerformanceMonitor.Collectors/PgDeadlockLogParser.cs
+++ b/PerformanceMonitor.Collectors/PgDeadlockLogParser.cs
@@ -47,7 +47,29 @@ public static class PgDeadlockLogParser
         string? VictimStatement,
         string GraphText);
 
-    /* The report as PostgreSQL writes it. Two traps are encoded here rather than discovered later:
+    /* The report as PostgreSQL writes it, under either family of log_line_prefix this parser meets.
+
+       PostgreSQL's own default is '%m [%p] ', rendering `2026-08-26 22:25:24.100 UTC [1549] `. The system
+       default on a managed parameter group is '%t:%r:%u@%d:[%p]:', rendering
+       `2026-08-26 22:25:24 UTC:<host>(<port>):<user>@<db>:[1549]:`. Two things differ between them and
+       both are load bearing:
+
+       The FRACTION is optional, because %m renders fractional seconds and %t does not.
+
+       The character before the bracketed pid is a space OR a colon, and whatever sits between it and the
+       bracket is prefix rather than report: %r and %u@%d land there, and %r renders EMPTY on a line with
+       no client connection, so that run can collapse to consecutive colons. Lazy, so the pid is the FIRST
+       bracketed run of digits on the line - an %r rendering an IPv6 address brings its own brackets.
+
+       The ZONE is bounded by the prefix's OWN delimiter, and that boundary is the difference between
+       missing a report and REFUSING one. A zone allowed to run to the last delimiter before the bracket
+       reads `UTC:<host>(<port>):<user>@<db>`, which IsZeroOffsetLogZone refuses - so a fleet whose
+       log_timezone really is UTC has every window abandoned, with a message naming a setting that is
+       already correct. Two alternatives, because a zone renders as either an abbreviation or a numeric
+       offset and only the numeric one contains a colon of its own: [+-]\d+(?::\d+)* keeps -03:30 whole so
+       a refusal names the zone it read, and [^ :\n]+ takes an abbreviation up to the delimiter. Not \w+
+       for the second - \w matches neither a sign nor a colon, and a prefix the pattern cannot match
+       produces no block at all, which reads as a server with no deadlocks.
 
        %Q puts the query id immediately before the severity with NO separator — measured output reads
        `[1549] 322048460535975151ERROR:  deadlock detected` — so this must not require whitespace there.
@@ -58,17 +80,15 @@ public static class PgDeadlockLogParser
        itself contain newlines, and each continuation arrives tab-indented, so a line-count rule or a
        blank-line rule would truncate multi-line SQL silently.
 
-       The zone is captured and READ (#2993). PostgreSQL renders %m in log_timezone and prints that zone's
-       abbreviation beside the stamp, so this token is the setting's own rendered value for THIS line, and
+       The zone is captured and READ (#2993). PostgreSQL renders the stamp in log_timezone and prints that
+       zone's abbreviation beside it, so this token is the setting's own rendered value for THIS line, and
        it is what decides whether the naive timestamp next to it is already UTC. See IsZeroOffsetLogZone
        for why that question is answerable from an abbreviation when "which zone is this" is not.
 
-       [^ \n]+ for it rather than \w+: a zone with no abbreviation renders as a numeric offset (+07,
-       -03:30) and \w+ matches neither the sign nor the colon, so the whole block failed to match and the
-       server reported no deadlocks at all — the same silent nothing the [^\n]* trap above avoids, and the
-       one shape that would have slipped past the zone check by never reaching it. */
+       PgDeadlocksCollector holds this pattern's counterpart for the pg_read_file route, as SQL and
+       narrower: that one requires the fraction and the space, which PostgreSQL's own default renders. */
     private static readonly Regex s_deadlockBlock = new(
-        @"^(\d{4}-\d\d-\d\d \d\d:\d\d:\d\d\.\d+) (?<zone>[^ \n]+) \[(?<pid>\d+)\][^\n]*ERROR:  deadlock detected\s*\n"
+        @"^(\d{4}-\d\d-\d\d \d\d:\d\d:\d\d(?:\.\d+)?) (?<zone>[+-]\d+(?::\d+)*|[^ :\n]+)[ :][^\n]*?\[(?<pid>\d+)\][^\n]*ERROR:  deadlock detected\s*\n"
         + @"[^\n]*DETAIL:  (?<detail>(?:[^\n]*\n)(?:\t[^\n]*\n)*)",
         RegexOptions.Compiled | RegexOptions.Multiline);
 

--- a/PerformanceMonitor.Collectors/PgPlanLogParser.cs
+++ b/PerformanceMonitor.Collectors/PgPlanLogParser.cs
@@ -51,9 +51,17 @@ public static class PgPlanLogParser
 
     /* The log line prefix carries the query id via %Q, which is the ONLY place auto_explain exposes it -
        the plan JSON has no identifier of its own even with compute_query_id on. The JSON block follows,
-       tab-indented, which is what makes it recognisable as a unit rather than needing a brace counter. */
+       tab-indented, which is what makes it recognisable as a unit rather than needing a brace counter.
+
+       A space OR a colon after the bracketed pid, because the character there belongs to log_line_prefix
+       and not to auto_explain. PostgreSQL's own default spells '%m [%p] ' and puts a space; the system
+       default on a managed parameter group spells '%t:%r:%u@%d:[%p]:' and puts its own ':' there, so
+       adding the %Q this parser requires gives '%t:%r:%u@%d:[%p]:%Q ' and the line reads `]:<id> LOG:`.
+
+       PgPlanCaptureCollector holds this pattern's counterpart for the pg_read_file route, as SQL and
+       narrower: that one requires the space, which PostgreSQL's own default renders. */
     private static readonly Regex s_planBlock = new(
-        @"\[\d+\] (-?\d+) LOG:  duration: ([0-9.]+) ms  plan:\s*\n((?:\t[^\n]*\n)+)",
+        @"\[\d+\][ :](-?\d+) LOG:  duration: ([0-9.]+) ms  plan:\s*\n((?:\t[^\n]*\n)+)",
         RegexOptions.Compiled);
 
     /* Condition fields, where a bare number is a VALUE rather than part of a name. Enumerated rather than


### PR DESCRIPTION
`PgDeadlockLogParser.s_deadlockBlock` requires two things a managed PostgreSQL target's log never renders, and so it matches no line of one. `Extract` returns nothing, `RdsDeadlockIngestor` stores nothing, and the cycle records the source as reached with zero rows — while advancing and persisting its resume marker, so the window is consumed and the text is not offered again. Fixes #3030.

`log_line_prefix = '%m [%p] '`, PostgreSQL's own default, renders `2026-08-26 22:25:24.100 UTC [1549] `. The system default on a managed parameter group is `'%t:%r:%u@%d:[%p]:'`, rendering `2026-08-26 22:25:24 UTC:<host>(<port>):<user>@<db>:[1549]:`. Two things differ, and each is independently fatal — restoring only the fraction, or only the space, still yields nothing:

- `%t` renders no fractional seconds where `\.\d+` was mandatory. The fraction is optional now.
- The prefix's own `:` sits where the pattern spelled a space, with `%r` and `%u@%d` between the zone and the pid, and `%r` renders empty on a line with no client connection.

## The two prefix families are alternatives, not one relaxed pattern

The obvious single pattern — `[ :]` for the delimiter and an abbreviation-or-numeric-offset alternation for the zone — is **wrong in the worst available direction: a wrong answer rather than a missing one.** A numeric offset carries colons of its own, so under a colon-delimited prefix the zone cannot tell its own colon from the prefix's. On `+00:2001:db8::1(...)` — a zero-offset zone and an IPv6 `%r` — the offset loop takes `:2001` as another of its groups, IPv6's next colon satisfies the delimiter, nothing backtracks, and the zone reads `+00:2001`. `IsZeroOffsetLogZone` refuses that, so a target whose `log_timezone` **is** zero-offset has every window abandoned with a message naming a setting that is already correct — every cycle, for as long as a client keeps connecting from that address. Bounding the offset's inner groups to two digits only moves the boundary: `+00:20:db8::1(...)` breaks it again, because `0020` renders as `20`.

Splitting by delimiter removes the ambiguity instead of narrowing it. The space family is character-for-character what it was, so every existing zone shape captures identically; the colon family excludes `:` from the zone outright. Both name the same two groups, which .NET allows across alternatives.

The trade is that a numeric offset under a colon-delimited prefix is read up to the delimiter, so a non-zero one refuses as `-03` rather than `-03:30`. **The verdict is unchanged in every case** — measured across 22 renderings — and only the token in the message is shorter, on a prefix family no measured target combines with a numeric zone. Reading a UTC server as non-UTC is the failure worth designing against; a terser refusal message is not.

## The plan parser

`PgPlanLogParser.s_planBlock` has the same delimiter requirement after the pid, and takes a space or a colon there now. That route is inert on a managed target with the system default prefix regardless, because `auto_explain`'s query id only reaches the log through `%Q` and the system default has none — but appending the `%Q` this parser already requires gives `'%t:%r:%u@%d:[%p]:%Q '`, and the line then reads `]:<id> LOG:`, which is what the change accepts.

## The fixtures are the other half of the fix

Swept over 2,688 tracked files with the self-hosted prefix as a firing positive control and the managed prefix cross-controlled against it: 27 log-prefix lines across five files, **every one self-hosted, none managed anywhere in the tree**. `RdsDeadlockIngestorTests` is the managed transport's own suite, and its `DeadlockText` is captured self-hosted output — so the transport was proven over text no managed target emits, and a regex-only fix would leave the same class of defect undetectable.

That suite now carries a managed-prefix report driven through the real ingestor. The parser suites carry the four prefix regimes as separate tests — both requirements present, each one absent alone, and neither present — plus the combination that decides the zone question and previously had no coverage at all: a numeric zero-offset zone under a colon-delimited prefix, with an IPv4 `%r`, an IPv6 `%r` whose leading hextet is four digits, and one whose leading hextet is two.

Identifiers in the new fixtures are synthesised. `192.0.2.10` is RFC 5737 documentation space and `2001:db8::1` is RFC 3849.

## Verification

Compiled the real Windows-only test files into `net10.0` xunit v3 hosts on macOS. **Lite 63/63 and Darling 109/109 pass, 0 failed, 0 skipped, 0 not run.** The Darling host covers all six `Darling.Tests` files that reference either parser or either collector, plus `DocCommentHygieneTests` and `FleetIdentifierScrubTests`; both guards were shown to reach the changed files by planting a violation in one of them and watching each name the file and line.

Six mutations, each against a committed baseline, rebuilt every cycle, restored by content-verified single-path checkout. Each half reverted **separately** reddens a **different** named assertion and leaves the other half's green:

| mutation | red | still green |
|---|---|---|
| fractional seconds mandatory again | `ParsesAStampWithNoFractionalSeconds` — `Assert.Single` empty | `ParsesAColonBeforeTheBracketedPid` |
| colon family removed | `ParsesAColonBeforeTheBracketedPid` — `Assert.Single` empty | `ParsesAStampWithNoFractionalSeconds` |
| families collapsed to one relaxed pattern | both IPv6 cases of `ANumericZeroOffsetZoneParsesUnderAColonDelimitedPrefix` — `Assert.Null`, i.e. a refusal, not a miss | the IPv4 case, and both regime tests |
| plan delimiter reverted | `ExtractReadsAManagedPrefixAlongsideASelfHostedOne` (2 → 1) | every deadlock test |
| `ReportUnder` made an identity | the re-rendering control at `Expected 3, Actual 0`, **and** five regime tests on their timestamp assertions | — |
| `ManagedDeadlockText` collapsed to `DeadlockText` | the managed fixture's control on `Assert.DoesNotContain` | — |

The third row is the one that matters most: with the single relaxed pattern the IPv4 fixture passes and only the IPv6 ones fail, which is exactly why an IPv4-only fixture set could not have caught it.

The self-hosted format still parses, by count and not by assertion: the 45 pre-existing tests across `PgDeadlockLogParserTests` and `PgPlanLogParserTests` are unchanged and green, `+00:00`, `-00`, `-0000`, `GMT` and `UCT` prefixes still parse, and `EST`, `+07`, `-03:30` and `+0530` still refuse **with the observed zone reported verbatim** under the space-delimited family. A 22-case adversarial probe against the built assembly — patterns dumped back out of `PerformanceMonitor.Collectors.dll` by reflection — covers both families, both isolating regimes, IPv6 and empty `%r`, a bracketed app name before the pid, CRLF bodies, a mixed slab (2 reports, no duplicates), and every zone spelling. All 22 verdicts correct.

## Scope boundary

The SQL counterparts of both patterns — `PgDeadlocksCollector` and `PgPlanCaptureCollector`, which serve the `pg_read_file` route — carry the space family only. Both parsers now say so in place of assuming parity. They are left narrow deliberately: that route only runs against self-hosted targets, the verification rig's own prefix is `%m [%p] %Q `, widening them needs any new groups spelled non-capturing so `m[1]`…`m[4]` do not shift, and there is no PostgreSQL here to exercise ARE against.

## CHANGELOG entry

Not committed, per the routing rule. For the `[Unreleased]` → `### Fixed` block:

```markdown
- **Deadlock capture read nothing at all from a managed PostgreSQL target's log, and reported the window as read and empty** ([#3030]) - `PgDeadlockLogParser.s_deadlockBlock` required fractional seconds (`\.\d+`, which only `%m` renders) and a space before the bracketed pid. The system default `log_line_prefix` on a managed parameter group is `'%t:%r:%u@%d:[%p]:'`, which renders neither, so the pattern matched no line of such a log; `Extract` returned nothing, `RdsDeadlockIngestor` stored nothing, and the cycle recorded the source as reached with zero rows while advancing its resume marker, consuming the window permanently. **Both halves are independently fatal** - restoring only the fraction, or only the space, still yields zero. The two prefix families are now ALTERNATIVES rather than one relaxed pattern, and that distinction is load-bearing: a numeric zone offset carries colons of its own, so a single pattern using `[ :]` as the delimiter cannot tell the zone's colon from the prefix's, and on `+00:2001:db8::1(...)` - a zero-offset zone and an IPv6 `%r` - the offset loop eats `:2001`, IPv6's own colon satisfies the delimiter, nothing backtracks, and the zone reads `+00:2001`. `IsZeroOffsetLogZone` refuses that, so a target that IS zero-offset would have every window abandoned with a message naming a setting already correct; bounding the offset's groups to two digits only moves the boundary, since `0020` renders as `20`. The space family is character-for-character what it was, so every existing zone shape captures identically; the colon family excludes `:` from the zone, at the cost of reading a numeric offset up to the delimiter there (`-03` rather than `-03:30`) with the verdict unchanged in all 22 measured renderings. `PgPlanLogParser.s_planBlock` had the same delimiter requirement after the pid and takes either character now too. **Every log fixture in the tree carried the self-hosted prefix and none carried the managed one** (27 lines across five files, swept over 2,688 tracked files with a firing positive control), including `RdsDeadlockIngestorTests`' - the managed transport's own suite, proving its plumbing over text no managed target emits. That suite now carries a managed-prefix report driven through the real ingestor, and the parser suites carry the four prefix regimes plus the numeric-zone-under-a-colon-prefix combination that had no coverage, so each half reverted alone reddens a different assertion.
```

And the link reference:

```markdown
[#3030]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/3030
```
