### PR TITLE
Recurse the live-cleanup ratchet, narrow its process-kill exclusion, and state the scratch-database exemption accurately (#3036)

### DIFF
--- a/Darling/Darling.Tests/LiveCleanupConversionRatchetTests.cs
+++ b/Darling/Darling.Tests/LiveCleanupConversionRatchetTests.cs
@@ -124,6 +124,22 @@ public sealed class LiveCleanupConversionRatchetTests
     /// tree changes verdict, which is precisely why it was cheap to narrow now instead of on the day it
     /// silenced something.</para>
     ///
+    /// <para><b><c>File.</c> and <c>Directory.</c> are deliberately NOT narrowed the same way.</b> They
+    /// carry the same over-breadth in principle — <c>tempFile.Delete()</c> contains <c>File.</c> — and
+    /// measured, neither is matched that way in this tree: over the same 237 blocks, the bare token and an
+    /// identifier-boundary form exclude the same set, and both of the blocks <c>File.</c> excludes are
+    /// genuine static <c>File.Delete</c> calls. What decides it is what the narrowed form would COST.
+    /// <c>.Kill(</c> still matches every idiomatic spelling of a process kill, because a kill is an
+    /// instance call however the variable is named; a boundary-anchored <c>File.</c> would match only the
+    /// STATIC helper, so file teardown written through a <c>FileInfo</c> or <c>DirectoryInfo</c> —
+    /// <c>root.Delete(recursive: true)</c>, the idiom in seven files here and in the planted-tree pin
+    /// below — becomes a reported offender. The report then asks its author to wrap the block in
+    /// <see cref="LiveStoreCleanup"/>, whose <c>RunAsync</c> OPENS A STORE CONNECTION, for teardown that
+    /// touches no store. An over-broad exclusion fails toward a silent miss, which is the wrong direction
+    /// for a guard; a narrow one here would fail toward a loud demand to do the wrong thing, which is
+    /// worse, and unlike the kill there is no narrow pattern covering every real spelling of file
+    /// teardown.</para>
+    ///
     /// <para>Read as a SET by the sweep and asserted as one by
     /// <see cref="EveryNonStoreTeardownTokenIsPinned"/>, so a token added here without a case arrives
     /// unexercised and fails rather than passing quietly.</para>

--- a/Darling/Darling.Tests/LiveCleanupConversionRatchetTests.cs
+++ b/Darling/Darling.Tests/LiveCleanupConversionRatchetTests.cs
@@ -309,16 +309,17 @@ public sealed class LiveCleanupConversionRatchetTests
     ///
     /// <para>The enumeration was <c>TopDirectoryOnly</c> while its sibling guard over this same project was
     /// <c>AllDirectories</c> with a written rationale for it. Latent, because the project is flat — which is
-    /// what makes it worth a pin rather than a flag flip: the vacuity floor added with #3032 fails when the
-    /// population reaches zero, and a population missing exactly one subdirectory is not zero. Nothing about
-    /// a green run distinguishes "no offenders" from "never looked there".</para>
+    /// what makes it worth a pin rather than a flag flip: the vacuity floor added with #3014's fix fails
+    /// when the population reaches zero, and a population missing exactly one subdirectory is not zero.
+    /// Nothing about a green run distinguishes "no offenders" from "never looked there".</para>
     ///
     /// <para>Every expectation is COUNTED from <see cref="PlantedTree"/> rather than written as a literal,
     /// so a case added to that table cannot pass against a stale number, and the offenders are compared as
-    /// a SET of relative paths — which is what makes this one pin fail three different ways: drop the
-    /// recursion and the nested file leaves the population and the offender set empties; drop the build-output
-    /// filter and two generated files join both; report the bare file name again and the paths stop
-    /// matching.</para>
+    /// a SET of relative paths rather than by count. Between them the three assertions separate three
+    /// regressions: losing the recursion or the build-output filter moves the FILE count, in opposite
+    /// directions; reading a nested file without reaching inside it moves the BLOCK count with the file
+    /// count intact; and reporting the bare file name again leaves both counts right and only the PATHS
+    /// wrong.</para>
     ///
     /// <para>The root is planted under a directory literally named <c>bin</c>, so the exclusion is proven to
     /// be judged relative to the scanned directory. Judged on the absolute path it would classify the whole
@@ -430,11 +431,21 @@ public sealed class LiveCleanupConversionRatchetTests
     /// over-broad exclusion fails toward a MISSED offender, so nothing would have said so. Both halves are
     /// asserted per token: without the excluded half, narrowing to the point of matching nothing would pass
     /// the near-miss half on its own.</para>
+    ///
+    /// <para>The fixtures are checked against the token BEFORE either sweep runs. A near miss that carries
+    /// no part of the token, or an excluded case that does not carry the token at all, is reported correctly
+    /// for reasons unrelated to the token — this test would then pass on any narrowing whatsoever, including
+    /// one that matched nothing, while reading as though it had exercised the token.</para>
     /// </summary>
     [Theory]
     [MemberData(nameof(NonStoreTeardownCases))]
-    public void ANonStoreTeardownIsExcludedAndItsNearMissIsNot(string token, string excluded, string nearMiss)
+    public void ANonStoreTeardownIsExcludedAndItsNearMissIsNot(
+        string token, string stem, string excluded, string nearMiss)
     {
+        Assert.Contains(token, excluded, StringComparison.Ordinal);
+        Assert.Contains(stem, nearMiss, StringComparison.Ordinal);
+        Assert.DoesNotContain(token, nearMiss, StringComparison.Ordinal);
+
         var excludedSweep = ScanOne(LiveClass(Teardown(excluded)));
 
         Assert.Equal(1, excludedSweep.Blocks);
@@ -447,9 +458,10 @@ public sealed class LiveCleanupConversionRatchetTests
 
         Assert.Equal(1, nearMissSweep.Blocks);
         Assert.True(nearMissSweep.Offenders.Count == 1,
-            $"'{nearMiss}' merely CONTAINS '{token}' and tears down store state, so it must be reported. "
-            + "It was not, which means the token is matching a substring rather than a call — an exclusion "
-            + "wide enough to silence an unconverted teardown, in the direction nothing complains about.");
+            $"'{nearMiss}' carries '{stem}' but not the call '{token}', and it tears down store state, so "
+            + "it must be reported. It was not, which means the token is matching a bare stem rather than a "
+            + "call — an exclusion wide enough to silence an unconverted teardown, in the direction nothing "
+            + "complains about.");
     }
 
     /// <summary>
@@ -666,25 +678,32 @@ public sealed class LiveCleanupConversionRatchetTests
     ];
 
     /// <summary>
-    /// Per token: the call it exists to exclude, and a near miss that merely contains it and must still be
-    /// reported. Read as the coverage set by <see cref="EveryNonStoreTeardownTokenIsPinned"/>, so this table
-    /// and <see cref="NonStoreTeardownTokens"/> cannot drift apart.
+    /// Per token: the bare STEM a looser spelling of it would have matched, the call it exists to exclude,
+    /// and a near miss that carries the stem without the call and must still be reported. Read as the
+    /// coverage set by <see cref="EveryNonStoreTeardownTokenIsPinned"/>, so this table and
+    /// <see cref="NonStoreTeardownTokens"/> cannot drift apart.
+    ///
+    /// <para>The stem is what makes a near miss NEAR. A string that carries no part of the token is a plain
+    /// unconverted teardown, correctly reported for reasons that have nothing to do with the token, and it
+    /// would say nothing about the narrowing while looking as though it did — so
+    /// <see cref="ANonStoreTeardownIsExcludedAndItsNearMissIsNot"/> asserts the relationship rather than
+    /// describing it.</para>
     /// </summary>
-    private static readonly (string Token, string Excluded, string NearMiss)[] NonStoreTeardownPins =
+    private static readonly (string Token, string Stem, string Excluded, string NearMiss)[] NonStoreTeardownPins =
     [
-        ("File.", "File.Delete(configPath);", "var configFile = Drop();"),
-        ("Directory.", "Directory.Delete(spillDirectory, recursive: true);", "var directoryUsed = Drop();"),
-        (".Kill(", "process.Kill(entireProcessTree: true);", "var wasKilled = Drop();"),
+        ("File.", "File", "File.Delete(configPath);", "var configFile = Drop();"),
+        ("Directory.", "Directory", "Directory.Delete(spill, recursive: true);", "var spillDirectory = Drop();"),
+        (".Kill(", "Kill", "process.Kill(entireProcessTree: true);", "var wasKilled = Drop();"),
     ];
 
     /// <summary>The same table as xUnit data, so the theory and the coverage pin read one source.</summary>
-    public static TheoryData<string, string, string> NonStoreTeardownCases()
+    public static TheoryData<string, string, string, string> NonStoreTeardownCases()
     {
-        var cases = new TheoryData<string, string, string>();
+        var cases = new TheoryData<string, string, string, string>();
 
         foreach (var pin in NonStoreTeardownPins)
         {
-            cases.Add(pin.Token, pin.Excluded, pin.NearMiss);
+            cases.Add(pin.Token, pin.Stem, pin.Excluded, pin.NearMiss);
         }
 
         return cases;

--- a/Darling/Darling.Tests/LiveCleanupConversionRatchetTests.cs
+++ b/Darling/Darling.Tests/LiveCleanupConversionRatchetTests.cs
@@ -60,6 +60,34 @@ namespace Darling.Tests;
 /// that split and nothing needs to: a class that both joins the shared collection and mints its own store is
 /// simply scanned, and a teardown on resources the test already holds is what <c>RunOwnedAsync</c> is for —
 /// the same answer that converted the two by-hand classes instead of exempting them.</para>
+///
+/// <para><b>Why the scratch-database classes are out of scope, as facts about the code (#3036).</b> #3014
+/// justified the exemption it inherited by saying the exempt files stand up their own throwaway CLUSTER.
+/// That is true of the two <c>#1776 own-store</c> classes that bootstrap the bundled runtime, and false of
+/// <see cref="ScratchPostgres"/>, whose own summary says it mints a database on the SHARED
+/// <c>DARLING_TEST_PG</c> server. Three separate facts put those classes out of this scan's reach, and "it
+/// has its own cluster" is not one of them. MEMBERSHIP: not one of the ten classes backed by the scratch
+/// helper APPLIES the attribute, so the code-reading test above leaves them unscanned without an exemption
+/// existing at all. SHAPE: not one <c>finally</c> in any of them tears down store state — all four delete a
+/// temp config file, which is the file-teardown exclusion's own case — so there is nothing here for
+/// <see cref="LiveStoreCleanup"/> to wrap. EQUIVALENCE: the scratch drop already holds both properties
+/// #1902 is about, and could not be given them by conversion in any case, being an <c>await using</c>
+/// rather than a <c>try</c>/<c>finally</c>. It runs on an admin connection it opens itself and could not
+/// run on the body's if it tried, because <c>DROP DATABASE</c> cannot be issued from inside the database it
+/// drops; and it cannot throw out of its teardown at all, so it can never replace the body's in-flight
+/// exception.</para>
+///
+/// <para><b>An abandoned scratch-database drop is tolerable because of what the code does, not because of
+/// the word "throwaway".</b> The database is named from a fresh <c>Guid</c>, so a leaked one collides with
+/// nothing a later run creates; the drop is <c>WITH (FORCE)</c> against a <c>Pooling=false</c> connection
+/// string, so no lingering connection can wedge it; the one live class that reads <c>pg_database</c>
+/// deliberately asserts no total count, BECAUSE these databases come and go, so a leak is invisible to the
+/// only test that could have noticed it; and the shared server is itself a cluster the workflow
+/// <c>initdb</c>s in the runner's temp directory and stops again around this suite, so a leak cannot
+/// outlive the job. What one costs is disk on a cluster that is about to be deleted. This ratchet exists to
+/// stop state being stranded for someone ELSE, and a scratch database strands none — but that is a fact
+/// about scratch DATABASES and not a licence for the classes that use them: one which joins the shared
+/// collection is scanned like anything else, pinned below in both directions.</para>
 /// </summary>
 public sealed class LiveCleanupConversionRatchetTests
 {
@@ -80,6 +108,27 @@ public sealed class LiveCleanupConversionRatchetTests
     /// </summary>
     private static readonly Regex FinallyBlock =
         new(@"(?<![A-Za-z0-9_])finally\s*\{", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Teardown that is not store state, and so has nothing to do with a connection and nothing for
+    /// <see cref="LiveStoreCleanup"/> to do: deleting a file or a directory, and killing a process the test
+    /// started.
+    ///
+    /// <para><b>Every token is the shape of a CALL, which <c>Kill</c> alone was not (#3036).</b> As a bare
+    /// substring it also matched <c>Killed</c> and <c>Killer</c>, so a teardown holding nothing more than a
+    /// <c>wasKilled</c> local excluded itself from the sweep. That direction matters: these are EXCLUSIONS,
+    /// so an over-broad one fails toward a MISSED offender, which is the half of a guard whose mistakes are
+    /// silent. Measured before narrowing rather than after: the bare token excluded 0 of the 237
+    /// <c>finally</c> blocks in the 120 files that apply the attribute, and the project's only real
+    /// <c>process.Kill(</c> sites sit in classes that are not in the collection at all — so no block in the
+    /// tree changes verdict, which is precisely why it was cheap to narrow now instead of on the day it
+    /// silenced something.</para>
+    ///
+    /// <para>Read as a SET by the sweep and asserted as one by
+    /// <see cref="EveryNonStoreTeardownTokenIsPinned"/>, so a token added here without a case arrives
+    /// unexercised and fails rather than passing quietly.</para>
+    /// </summary>
+    private static readonly string[] NonStoreTeardownTokens = ["File.", "Directory.", ".Kill("];
 
     /// <summary>What one sweep found, and the population it actually examined to find it.</summary>
     private readonly record struct Sweep(List<string> Offenders, int Files, int Blocks);
@@ -254,20 +303,226 @@ public sealed class LiveCleanupConversionRatchetTests
         Assert.Empty(sweep.Offenders);
     }
 
-    /// <summary>Every <c>*.cs</c> in the test project, as (file name, source) pairs.</summary>
+    /// <summary>
+    /// The first test file placed in a SUBDIRECTORY is scanned, and build output under the same root is
+    /// not (#3036).
+    ///
+    /// <para>The enumeration was <c>TopDirectoryOnly</c> while its sibling guard over this same project was
+    /// <c>AllDirectories</c> with a written rationale for it. Latent, because the project is flat — which is
+    /// what makes it worth a pin rather than a flag flip: the vacuity floor added with #3032 fails when the
+    /// population reaches zero, and a population missing exactly one subdirectory is not zero. Nothing about
+    /// a green run distinguishes "no offenders" from "never looked there".</para>
+    ///
+    /// <para>Every expectation is COUNTED from <see cref="PlantedTree"/> rather than written as a literal,
+    /// so a case added to that table cannot pass against a stale number, and the offenders are compared as
+    /// a SET of relative paths — which is what makes this one pin fail three different ways: drop the
+    /// recursion and the nested file leaves the population and the offender set empties; drop the build-output
+    /// filter and two generated files join both; report the bare file name again and the paths stop
+    /// matching.</para>
+    ///
+    /// <para>The root is planted under a directory literally named <c>bin</c>, so the exclusion is proven to
+    /// be judged relative to the scanned directory. Judged on the absolute path it would classify the whole
+    /// tree as build output and this sweep would report no offenders having read nothing at all, which is
+    /// the shape of every failure this file is about.</para>
+    /// </summary>
+    [Fact]
+    public void ANestedTestFileIsScannedAndBuildOutputIsNot()
+    {
+        var temporary = Directory.CreateTempSubdirectory("darling-live-cleanup-ratchet-");
+        try
+        {
+            var root = Path.Combine(temporary.FullName, "bin", "project");
+
+            foreach (var planted in PlantedTree())
+            {
+                var path = Path.Combine(
+                    root, planted.RelativePath.Replace('/', Path.DirectorySeparatorChar));
+                Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+                File.WriteAllText(path, planted.Source);
+            }
+
+            var sweep = Scan(SourcesUnder(root));
+
+            var expectedFiles = PlantedTree().Count(planted => planted.Scanned);
+            var expectedBlocks = PlantedTree().Where(planted => planted.Scanned).Sum(planted => planted.Blocks);
+
+            Assert.True(sweep.Files == expectedFiles,
+                $"the sweep read {sweep.Files} of the {expectedFiles} planted source file(s). Too few means "
+                + "a subdirectory never reached the population — the whole defect — and too many means "
+                + "build output is being read as source.");
+
+            Assert.True(sweep.Blocks == expectedBlocks,
+                $"the sweep found {sweep.Blocks} finally block(s) where the planted files hold "
+                + $"{expectedBlocks}. The file count can be right while the blocks inside a nested file go "
+                + "unread, and this assertion is the one that separates them.");
+
+            var expected = PlantedTree()
+                .Where(planted => planted.Scanned && planted.Offends)
+                .Select(planted => planted.RelativePath)
+                .Order(StringComparer.Ordinal)
+                .ToArray();
+
+            /* Offenders are reported as path:line; the path is what this pin is about. */
+            var reported = sweep.Offenders
+                .Select(offender => offender[..offender.LastIndexOf(':')])
+                .Order(StringComparer.Ordinal)
+                .ToArray();
+
+            Assert.True(reported.SequenceEqual(expected, StringComparer.Ordinal),
+                "the offenders reported are not the ones planted. Expected ["
+                + string.Join(", ", expected) + "], got [" + string.Join(", ", reported)
+                + "]. A missing nested path means the recursion is not reaching it; a bin or obj path means "
+                + "the build-output filter has come detached from the enumeration; a bare file name means a "
+                + "nested offender no longer says where it is.");
+        }
+        finally
+        {
+            temporary.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// A class that mints its own scratch database is scanned anyway once it JOINS the shared collection
+    /// (#3036) — the direction the answer about scratch databases does not exempt.
+    ///
+    /// <para>No class in the project is in both states today, and that is the point: the reason the scratch
+    /// classes go unscanned is that they do not apply the attribute, not that minting a database is a
+    /// property that exempts anything. Add the attribute to one of them, or write a new class in both
+    /// states, and its teardown is read like any other — this is what stops "it has its own database" from
+    /// becoming the by-hand exemption <see cref="LiveStoreCleanup"/>'s two converted classes were denied.</para>
+    /// </summary>
+    [Fact]
+    public void MintingAScratchDatabaseDoesNotExemptAClassInTheSharedCollection()
+    {
+        var sweep = ScanOne(LiveClass(ScratchDatabaseTeardown("Drop();")));
+
+        Assert.Equal(1, sweep.Files);
+        Assert.Equal(1, sweep.Blocks);
+        Assert.Single(sweep.Offenders);
+    }
+
+    /// <summary>
+    /// The counterweight, and the other half of #3036's answer: a genuinely own-store scratch-database
+    /// class is not read at all, so its file teardown needs no conversion and its absence from the offender
+    /// list is not a near miss.
+    ///
+    /// <para>Shaped like the real ones — the <c>#1776 own-store</c> header that NAMES the attribute rather
+    /// than applying it, a scratch database minted in the body, and a <c>finally</c> that deletes a temp
+    /// config file. <c>Files</c> and <c>Blocks</c> are asserted at zero rather than only the offender list
+    /// being empty, because those two claims differ: an empty offender list is also what a scan that read
+    /// the file and wrongly excluded the block would produce.</para>
+    /// </summary>
+    [Fact]
+    public void AnOwnStoreScratchDatabaseClassIsNotReadAtAll()
+    {
+        var sweep = ScanOne(OwnStoreClass(ScratchDatabaseTeardown("File.Delete(configPath);")));
+
+        Assert.Equal(0, sweep.Files);
+        Assert.Equal(0, sweep.Blocks);
+        Assert.Empty(sweep.Offenders);
+    }
+
+    /// <summary>
+    /// Each non-store teardown token excludes the CALL it is for and leaves its near miss alone (#3036).
+    ///
+    /// <para>The near miss is the assertion that has teeth. <c>Kill</c> as a bare substring matched
+    /// <c>Killed</c>, so a <c>wasKilled</c> local in an otherwise unconverted teardown silenced it — and an
+    /// over-broad exclusion fails toward a MISSED offender, so nothing would have said so. Both halves are
+    /// asserted per token: without the excluded half, narrowing to the point of matching nothing would pass
+    /// the near-miss half on its own.</para>
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(NonStoreTeardownCases))]
+    public void ANonStoreTeardownIsExcludedAndItsNearMissIsNot(string token, string excluded, string nearMiss)
+    {
+        var excludedSweep = ScanOne(LiveClass(Teardown(excluded)));
+
+        Assert.Equal(1, excludedSweep.Blocks);
+        Assert.True(excludedSweep.Offenders.Count == 0,
+            $"'{excluded}' is the teardown '{token}' exists to exclude, and it was reported as an offender "
+            + "instead. Narrowing the token past the call it is for turns every real file, directory or "
+            + "process teardown in a live class into a false failure.");
+
+        var nearMissSweep = ScanOne(LiveClass(Teardown(nearMiss)));
+
+        Assert.Equal(1, nearMissSweep.Blocks);
+        Assert.True(nearMissSweep.Offenders.Count == 1,
+            $"'{nearMiss}' merely CONTAINS '{token}' and tears down store state, so it must be reported. "
+            + "It was not, which means the token is matching a substring rather than a call — an exclusion "
+            + "wide enough to silence an unconverted teardown, in the direction nothing complains about.");
+    }
+
+    /// <summary>
+    /// The tokens the sweep excludes on and the tokens pinned above are the same set.
+    ///
+    /// <para>A per-token pin list cannot see the set GROW: add a fourth exclusion to
+    /// <see cref="NonStoreTeardownTokens"/> and every case above still passes, having never exercised it.
+    /// Asserting the two as sets is what makes the new token's arrival the failure.</para>
+    /// </summary>
+    [Fact]
+    public void EveryNonStoreTeardownTokenIsPinned()
+    {
+        var scanned = NonStoreTeardownTokens.Order(StringComparer.Ordinal).ToArray();
+        var pinned = NonStoreTeardownPins.Select(pin => pin.Token).Order(StringComparer.Ordinal).ToArray();
+
+        Assert.True(scanned.SequenceEqual(pinned, StringComparer.Ordinal),
+            "the tokens the sweep excludes on and the tokens pinned by the theory above have drifted. "
+            + "Sweep: [" + string.Join(", ", scanned) + "]; pinned: [" + string.Join(", ", pinned)
+            + "]. Every one of these is an EXCLUSION, so an unexercised one fails toward a missed offender "
+            + "and nothing else in this file would report it.");
+    }
+
+    /// <summary>
+    /// Every <c>*.cs</c> SOURCE file in the test project, as (path relative to
+    /// <paramref name="directory"/>, source) pairs.
+    ///
+    /// <para><b>Recursive, for the reason the sibling guard already wrote down (#3036).</b>
+    /// <c>LivePostgresCollectionHygieneTests</c> enumerates this same project with
+    /// <see cref="SearchOption.AllDirectories"/> and says why: the project is flat today, so
+    /// <c>TopDirectoryOnly</c> is equivalent — and it also means the first test file someone puts in a
+    /// subfolder leaves this population silently, which is indistinguishable from a compliant tree and is
+    /// the failure mode the ratchet exists to prevent. The vacuity floor in the rule above catches the
+    /// population going to ZERO, not one subdirectory's worth of it never arriving.</para>
+    ///
+    /// <para><b>Build output is not source, and excluding it is load-bearing rather than defensive here.</b>
+    /// <c>Darling.Tests.csproj</c> copies three product <c>.cs</c> files into the output directory as
+    /// fixtures, so a BUILT tree really does hold <c>.cs</c> under <c>bin</c> — recursing without this would
+    /// read product source, generated <c>.AssemblyInfo.cs</c> and <c>.g.cs</c> as though they were tests.
+    /// The rule is <c>DocCommentHygieneTests</c>': whole path SEGMENTS, both separator characters, judged
+    /// RELATIVE to the scanned directory. A substring test eats <c>Objects</c> and <c>mybin</c>; an
+    /// absolute-path test excludes the entire tree whenever the checkout itself sits under a directory
+    /// called <c>bin</c>, and this sweep then reports no offenders having read nothing; and the host's
+    /// separator alone hands a Windows run and a macOS run different populations.</para>
+    ///
+    /// <para>The name reported is that relative path with <c>/</c> separators rather than the bare file
+    /// name, so a nested offender says where it is and says the same thing on either platform.</para>
+    /// </summary>
     private static IEnumerable<(string Name, string Source)> SourcesUnder(string directory) =>
-        Directory.EnumerateFiles(directory, "*.cs")
-            .OrderBy(p => p, StringComparer.Ordinal)
-            .Select(p => (Path.GetFileName(p), File.ReadAllText(p)));
+        Directory.EnumerateFiles(directory, "*.cs", SearchOption.AllDirectories)
+            .Select(path => (Name: Path.GetRelativePath(directory, path).Replace('\\', '/'), Path: path))
+            .Where(found => !IsBuildOutput(found.Name))
+            .OrderBy(found => found.Name, StringComparer.Ordinal)
+            .Select(found => (found.Name, File.ReadAllText(found.Path)));
+
+    /// <summary>
+    /// True when any whole SEGMENT of <paramref name="relativePath"/> is <c>bin</c> or <c>obj</c>, reading
+    /// both separator characters whatever the host's is. The path is already relative to the scanned
+    /// directory, which is what keeps a <c>bin</c> ABOVE that directory from excluding the whole tree.
+    /// </summary>
+    private static bool IsBuildOutput(string relativePath) =>
+        relativePath.Split('/', '\\')
+            .Any(segment => string.Equals(segment, "bin", StringComparison.OrdinalIgnoreCase)
+                            || string.Equals(segment, "obj", StringComparison.OrdinalIgnoreCase));
 
     /// <summary>
     /// Every <c>finally</c> in a shared-store live class whose block does not go through
     /// <see cref="LiveStoreCleanup"/>, reported as <c>file:line</c>, alongside the counts of files and blocks
     /// the sweep examined.
     ///
-    /// <para>Own-store classes are not scanned for the same reason #1776 does not serialize them: they mint
-    /// and drop their own database, so an abandoned teardown cannot reach anyone else. That is decided by
-    /// whether the class APPLIES the collection attribute, not by anything it says about itself. File and
+    /// <para>Own-store classes are not scanned for the same reason #1776 does not serialize them, which
+    /// this class's summary states as properties of their teardown rather than as a claim about what they
+    /// mint: an abandoned one of theirs strands nothing another test can read. That is decided by whether
+    /// the class APPLIES the collection attribute, not by anything it says about itself. File, directory and
     /// process teardown is excluded because it is not store state and has nothing to do with a
     /// connection.</para>
     ///
@@ -310,9 +565,7 @@ public sealed class LiveCleanupConversionRatchetTests
                     continue;
                 }
 
-                if (block.Contains("File.", StringComparison.Ordinal)
-                    || block.Contains("Directory.", StringComparison.Ordinal)
-                    || block.Contains("Kill", StringComparison.Ordinal))
+                if (NonStoreTeardownTokens.Any(t => block.Contains(t, StringComparison.Ordinal)))
                 {
                     continue;
                 }
@@ -382,7 +635,63 @@ public sealed class LiveCleanupConversionRatchetTests
             string.Empty);
 
     /// <summary>A teardown that drops store state without going through <see cref="LiveStoreCleanup"/>.</summary>
-    private static readonly string UnconvertedTeardown = Lines(
+    private static readonly string UnconvertedTeardown = Teardown("Drop();");
+
+    /// <summary>The same teardown, converted — the compliant half of every planted tree above.</summary>
+    private static readonly string ConvertedTeardown =
+        Teardown("LiveStoreCleanup.RunAsync(ConnectionString, ok, Drop);");
+
+    /// <summary>
+    /// One planted source file: where it goes under the scanned root, what it holds, how many
+    /// <c>finally</c> blocks it holds, whether the sweep is meant to READ it, and whether its teardown is
+    /// an offender. The last two are separate on purpose: the build-output entries carry a non-compliant
+    /// teardown deliberately, so if the filter ever comes detached from the enumeration they turn up.
+    /// </summary>
+    private readonly record struct Planted(
+        string RelativePath, string Source, int Blocks, bool Scanned, bool Offends);
+
+    /// <summary>
+    /// The tree <see cref="ANestedTestFileIsScannedAndBuildOutputIsNot"/> plants, and the only place its
+    /// expectations are written down. A method rather than a field so it cannot depend on where the fixture
+    /// strings it composes are declared.
+    /// </summary>
+    private static Planted[] PlantedTree() =>
+    [
+        new("TopLevel.cs", LiveClass(ConvertedTeardown), 1, Scanned: true, Offends: false),
+        new("Nested/Deeper/NestedOffender.cs", LiveClass(UnconvertedTeardown), 1, Scanned: true, Offends: true),
+        /* Named LIKE build output and not build output — the half a substring filter gets wrong. */
+        new("Objects/NamedLikeOutput.cs", LiveClass(ConvertedTeardown), 1, Scanned: true, Offends: false),
+        new("bin/Debug/net10.0/Copied.cs", LiveClass(UnconvertedTeardown), 1, Scanned: false, Offends: true),
+        new("obj/Debug/net10.0/Generated.g.cs", LiveClass(UnconvertedTeardown), 1, Scanned: false, Offends: true),
+    ];
+
+    /// <summary>
+    /// Per token: the call it exists to exclude, and a near miss that merely contains it and must still be
+    /// reported. Read as the coverage set by <see cref="EveryNonStoreTeardownTokenIsPinned"/>, so this table
+    /// and <see cref="NonStoreTeardownTokens"/> cannot drift apart.
+    /// </summary>
+    private static readonly (string Token, string Excluded, string NearMiss)[] NonStoreTeardownPins =
+    [
+        ("File.", "File.Delete(configPath);", "var configFile = Drop();"),
+        ("Directory.", "Directory.Delete(spillDirectory, recursive: true);", "var directoryUsed = Drop();"),
+        (".Kill(", "process.Kill(entireProcessTree: true);", "var wasKilled = Drop();"),
+    ];
+
+    /// <summary>The same table as xUnit data, so the theory and the coverage pin read one source.</summary>
+    public static TheoryData<string, string, string> NonStoreTeardownCases()
+    {
+        var cases = new TheoryData<string, string, string>();
+
+        foreach (var pin in NonStoreTeardownPins)
+        {
+            cases.Add(pin.Token, pin.Excluded, pin.NearMiss);
+        }
+
+        return cases;
+    }
+
+    /// <summary>A test whose <c>finally</c> body is <paramref name="statement"/> and nothing else.</summary>
+    private static string Teardown(string statement) => Lines(
         "    [Fact]",
         "    public void T()",
         "    {",
@@ -392,7 +701,31 @@ public sealed class LiveCleanupConversionRatchetTests
         "        }",
         "        finally",
         "        {",
-        "            Drop();",
+        "            " + statement,
+        "        }",
+        "    }");
+
+    /// <summary>
+    /// The shape the scratch-database classes actually have: a database minted for this test alone, and a
+    /// <c>try</c>/<c>finally</c> inside it.
+    ///
+    /// <para>The helper's factory call is deliberately NOT spelled here.
+    /// <c>LivePostgresCollectionHygieneTests</c> keys its own membership rule on that exact string, so a
+    /// fixture containing it would enrol THIS class in that guard's population as a shared-store
+    /// toucher — a fixture changing what a different guard thinks of the file that holds it.</para>
+    /// </summary>
+    private static string ScratchDatabaseTeardown(string statement) => Lines(
+        "    [Fact]",
+        "    public async Task T()",
+        "    {",
+        "        await using var scratch = await MintAScratchDatabaseAsync(ct);",
+        "        try",
+        "        {",
+        "            Work(scratch.ConnectionString);",
+        "        }",
+        "        finally",
+        "        {",
+        "            " + statement,
         "        }",
         "    }");
 

--- a/Darling/Darling.Tests/PostgresDatabaseListScreenLivePostgresTests.cs
+++ b/Darling/Darling.Tests/PostgresDatabaseListScreenLivePostgresTests.cs
@@ -165,11 +165,8 @@ public sealed class PostgresDatabaseListScreenLivePostgresTests
     /// Drops on the cleanup connection the caller supplies, and does NOT swallow — the masking rule lives
     /// in <see cref="LiveStoreCleanup.RunAsync"/>, which is the only place that knows whether the body
     /// already failed. A <c>catch</c> here would apply it unconditionally and hide a real leak.
-    /// <para><c>WITH (FORCE)</c> so a pooled connection somewhere cannot wedge the drop, matching the
-    /// scratch-database helper's teardown. <c>IF EXISTS</c> because the create is conditional.</para>
-    /// <para>The helper is named in prose only, never as a bare identifier: the #1902 ratchet exempts any
-    /// file whose text contains that type's name, so mentioning it would have taken this class out of
-    /// scope of the very rule it now satisfies — passing for the wrong reason instead of complying.</para>
+    /// <para><c>WITH (FORCE)</c> so a pooled connection somewhere cannot wedge the drop, matching
+    /// <see cref="ScratchPostgres"/>'s teardown. <c>IF EXISTS</c> because the create is conditional.</para>
     /// </summary>
     private static async Task DropAsync(
         NpgsqlConnection connection, string databaseName, CancellationToken cancellationToken)


### PR DESCRIPTION
Closes #3036, all three items. A closing keyword is a no-op on a `dev` merge, so this is a statement rather than an instruction.

## Item 1 — the exemption is right; its stated reason was not

#3014 justified the exemption by saying the exempt files stand up their own throwaway cluster. True of the two `#1776 own-store` classes that bootstrap the bundled runtime, false of `ScratchPostgres`, which mints a database on the shared `DARLING_TEST_PG` server. Measured, the issue's account of the consequence is also off: it is **four `finally` blocks across two classes**, not four classes — `QueryStoreSliceRepairLiveTests` (1) and `RollupBackfillLiveTests` (3) — and **all four are `File.Delete(configPath)`**. No `finally` in any scratch-database class tears down store state.

**Answer: harmless. The exemption stands and the rationale is replaced.** Three facts put those classes out of the scan's reach, and "own cluster" is not one of them.

- **Membership.** None of the ten classes backed by the helper APPLIES `[Collection("live-postgres")]`, so #3032's code-reading membership test already leaves them unscanned with no exemption existing to be justified.
- **Shape.** All four blocks are file teardown, which is the `File.` exclusion's own case. There is nothing here for `LiveStoreCleanup` to wrap.
- **Equivalence.** `ScratchPostgres.DisposeAsync` already holds both properties #1902 is about, and could not be given them by conversion in any case, being an `await using` rather than a `try`/`finally`. It runs on an admin connection it opens itself and could not run on the body's if it tried — `DROP DATABASE` cannot be issued from inside the database it drops — and it cannot throw out of its teardown at all, so it can never replace the body's in-flight exception.

An abandoned drop is tolerable because of what the code does, not because of the word "throwaway": a fresh `Guid` name, so a leak collides with nothing a later run creates; `WITH (FORCE)` over a `Pooling=false` string, so no lingering connection wedges it; `PostgresDatabaseListScreenLivePostgresTests`, the one live class that reads `pg_database`, deliberately asserts no total count BECAUSE these databases come and go, so a leak is invisible to the only test that could have noticed it; and the shared server is a cluster `build.yml` `initdb`s into the runner's temp directory and stops again around this suite, so a leak cannot outlive the job. What one costs is disk on a cluster that is about to be deleted.

Pinned in both directions rather than left as prose. `AnOwnStoreScratchDatabaseClassIsNotReadAtAll` asserts `Files` and `Blocks` at zero, not merely an empty offender list — an empty list is equally what reading the file and wrongly excluding its block produces. `MintingAScratchDatabaseDoesNotExemptAClassInTheSharedCollection` is the other half: join the shared collection and the teardown is read, whatever the class mints.

## Item 2 — recursion, pinned rather than flag-flipped

`SourcesUnder` enumerates with `AllDirectories`, minus build output, and reports offenders by path relative to the project with `/` separators so a nested one says where it is. Excluding build output is load-bearing rather than defensive: `Darling.Tests.csproj` copies three product `.cs` files into the output as fixtures, so a built tree really does hold `.cs` under `bin`. The rule is `DocCommentHygieneTests`' — whole path segments, both separator characters, judged relative to the scanned directory.

The floor #3032 added catches the population reaching zero, not one subdirectory's worth of it never arriving, so this needs a pin. `ANestedTestFileIsScannedAndBuildOutputIsNot` plants a tree — a top-level compliant class, a nested non-compliant one, an `Objects/` directory named like build output, and `bin`/`obj` copies carrying non-compliant teardowns deliberately — under a root inside a directory literally named `bin`, so relativising the path is proven too. Every expectation is counted from the `PlantedTree` table, and offenders are compared as a set of relative paths, which is what lets one pin fail three ways.

## Item 3 — measured first, then narrowed

`Kill` excluded **0 of the 237 `finally` blocks in the 120 files that apply the attribute**, and the project's only real `process.Kill(` sites (`DarlingDeployRollbackRetentionTests`, `DarlingDeployStaleFileTests`) are in classes that are not in the collection at all. So the bare token is not merely over-broad, it is dead over the scanned population — which is exactly what makes narrowing it to `.Kill(` free: no block in the tree changes verdict. It is not academic, though. In a planted control a nested unconverted teardown holding nothing but a `wasKilled` local was silenced by it, and an over-broad exclusion fails toward a MISSED offender, so nothing would have said so.

The three exclusions become `NonStoreTeardownTokens`, read as a set by the sweep. **`File.` and `Directory.` are deliberately left as they are, and the reason is written into the code.** They carry the same over-breadth in principle (`tempFile.Delete()` contains `File.`) and measured, neither is matched that way in this tree: the bare token and an identifier-boundary form exclude the same 2 blocks, both genuine static `File.Delete` calls, so the narrowing would newly report nothing. The cost is what decides it. `.Kill(` still matches every idiomatic spelling of a process kill, because a kill is an instance call however the variable is named; a boundary-anchored `File.` matches only the STATIC helper, so file teardown through a `FileInfo` or `DirectoryInfo` — `root.Delete(recursive: true)`, the idiom in seven files here and in this PR's own planted-tree pin — becomes a reported offender, and the offender message asks its author to wrap it in `LiveStoreCleanup`, whose `RunAsync` opens a store connection, for teardown that touches no store. An over-broad exclusion fails toward a silent miss, which is the wrong direction for a guard; a narrow one here fails toward a loud demand to do the wrong thing, which is worse. Raised by review on this PR and declined on that measurement, not waved off. `ANonStoreTeardownIsExcludedAndItsNearMissIsNot` asserts both halves per token — the call is excluded, the near miss is still reported — and `EveryNonStoreTeardownTokenIsPinned` asserts the sweep's set equals the pinned set, so a fourth token cannot arrive unexercised.

Each pin also carries the bare **stem** a looser spelling would have matched, and the theory asserts the fixture relationship before either sweep runs: the excluded case contains the token, the near miss contains the stem and NOT the token. That closes a review finding on this PR that was right — the near-miss strings did not in fact carry their tokens, and the directory case carried no capital `Directory` at all, so it was a plain unconverted teardown reported for reasons unrelated to the token. A pin like that passes under any narrowing whatsoever, including one that matches nothing, while reading as though it had exercised the token. The relationship is asserted now rather than described in a failure message.

## Also in the diff

`PostgresDatabaseListScreenLivePostgresTests.DropAsync`'s doc recorded a constraint on how the scratch-database helper may be MENTIONED in that file, on the grounds that the #1902 sweep exempts any file containing the type's name. Nothing constrains it: membership is the applied attribute, and the sibling guard keys on the factory call rather than the type name. The stale paragraph goes and the surviving sentence names the type it compares against. It is the only instance in the tree — swept for `ratchet exempts any` and `named in prose only`, with a positive control on the same invocation.

## Verification

Compiled the real `LiveCleanupConversionRatchetTests.cs`, `CSharpSourceWalker.cs` and `DocCommentHygieneTests.cs` into a throwaway `net10.0` xunit v3 host outside the tree, with the repo symlinked in so the walk-up resolves. 55 tests, `Failed: 0`, `Not Run: 0`; 8 → 15 in the ratchet class. `Lite.Tests/CrossAppGuardCiGateTests` compiled and run the same way, 3 tests green.

The count delta on Windows is exact: the gated-live job reports `Total: 7647, Failed: 0, Skipped: 6, Not Run: 0` on the base commit and `Total: 7654, Failed: 0, Skipped: 6, Not Run: 0` here — **+7**, the seven added tests, so they ran rather than merely compiled. That run is on a BUILT tree, which is where `bin` and `obj` exist and the build-output filter is actually load-bearing.

Fourteen mutation cycles, each rebuilt, restored from a byte snapshot rather than `git checkout`, and re-asserted by content afterwards. Two were superseded by sharper variants that isolate one property each; the twelve that landed:

| mutation | fails |
| --- | --- |
| `AllDirectories` → `TopDirectoryOnly` | file count, `read 1 of the 3 planted` |
| build-output filter detached | file count, `read 5 of the 3 planted` |
| bare file name in the projection only | offender set, `Expected [Nested/Deeper/NestedOffender.cs], got [NestedOffender.cs]` |
| whole-segment `obj` → substring | file count, `read 2 of the 3` (the `Objects/` half) |
| `.Kill(` → `Kill` | token-set pin **and** the `.Kill(` near-miss half |
| `.Kill(` removed | token-set pin **and** the `.Kill(` excluded half |
| scratch-database whole-file exemption reintroduced | `MintingAScratchDatabase…` only; the own-store pin stays green |
| vacuity floor pushed past the population | the whole-tree rule, reporting `files=120 blocks=237 offenders=0` |
| second `<summary>` stacked in the file | `DocCommentHygieneTests`, proving it reads this file |
| `Directory.` near miss reverted to one carrying no stem | `Assert.Contains(stem, nearMiss)` — the review finding, now caught |
| an excluded fixture stripped of its own token | `Assert.Contains(token, excluded)` |
| a near miss given the whole token | `Assert.DoesNotContain(token, nearMiss)` |

The population probe is the control that the whole-tree run is not vacuous: 120 files and 237 blocks through the guard's own code path, matching an independent count taken outside it.

## CHANGELOG entry

For the `[Unreleased]` -> `### Fixed` block. **Deliberately not committed in this PR.** With several lanes open at once every one of them appends to the same `[Unreleased]` -> `### Fixed` block, which made it the queue's serialization point; the entry text is handed over here instead and applied once. That is a change in routing, not a skipped step — flagged by review on this PR, and answered rather than overlooked.

```
- **The live-cleanup ratchet read only the top directory, excluded on a substring where it meant a call, and justified its exemption with a reason that was false** ([#3036]) - `LiveCleanupConversionRatchetTests` enumerated `Darling.Tests` with `TopDirectoryOnly` while `LivePostgresCollectionHygieneTests`, over the same project, uses `AllDirectories` and carries a written rationale for it: the first test file placed in a subfolder would otherwise leave the population silently, which is indistinguishable from a compliant tree. Latent - the project is flat, 443 `.cs` files, none nested - and the vacuity floor added with [#3014]'s fix catches the population reaching ZERO rather than one subdirectory's worth of it never arriving, so this lands with a pin rather than a flag flip: a planted tree whose nested non-compliant teardown must be FOUND, whose `bin`/`obj` copies (carrying non-compliant teardowns deliberately) must not be read, and whose expectations are counted from the fixture table rather than written as literals. Excluding build output is load-bearing, not defensive - `Darling.Tests.csproj` copies three product `.cs` files into the output as fixtures - and the rule is `DocCommentHygieneTests`': whole path segments, both separator characters, judged relative to the scanned directory. Offenders now report a project-relative path, so a nested one says where it is. **The exemption's stated reason was false and is replaced.** [#3014] described the exempt classes as standing up their own throwaway cluster from the bundled runtime; that is true of the two [#1776] own-store classes with `finally` blocks (8 and 13 of them) and false of the scratch-database helper, which mints a database on the SHARED server. Three facts put those classes out of scope instead: not one of the ten classes backed by the helper APPLIES the collection attribute, so the code-reading membership test already leaves them unscanned; not one `finally` in any of them tears down store state (all four delete a temp config file, the file-teardown exclusion's own case); and the scratch drop already holds both properties [#1902] is about, and could not be given them by conversion in any case, being an `await using` rather than a `try`/`finally` - it runs on an admin connection it opens itself and could not run on the body's if it tried, since `DROP DATABASE` cannot be issued from inside the database it drops, and it cannot throw out of its teardown at all. An abandoned drop is tolerable because of the code, not the word "throwaway": a fresh `Guid` name, `WITH (FORCE)` over a `Pooling=false` string, the one live class that reads `pg_database` deliberately asserting no total count BECAUSE these databases come and go, and a shared server that is itself a cluster `build.yml` `initdb`s into the runner's temp directory and stops again around the suite. Both directions are pinned: an own-store scratch class is not read at all (`Files` and `Blocks` asserted at zero, since an empty offender list is equally what reading the file and wrongly excluding its block produces), and one that JOINS the collection is scanned whatever it mints. **The process-kill exclusion is narrowed to `.Kill(`** - as a bare substring `Kill` also matched `Killed` and `Killer`, so a teardown holding nothing but a `wasKilled` local silenced itself, and an over-broad EXCLUSION fails toward a MISSED offender, the half of a guard whose mistakes are silent. Measured before narrowing rather than after: it excluded **0 of the 237 `finally` blocks in the 120 files that apply the attribute**, and the project's only real `process.Kill(` sites are in classes that are not in the collection at all, so no block in the tree changes verdict. The three exclusions are a set now, with each token's call and its near miss pinned, and the sweep's set asserted equal to the pinned set so a fourth cannot arrive unexercised. Test-suite only - no shipped code changed.
```

New link-reference definitions this entry needs (`[#1776]` and `[#1902]` are already defined):

```
[#3014]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/3014
[#3036]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/3036
```
