### PR TITLE
Pin the compression policies to a phase grid clear of the refresh slots (#3035)

### DIFF
--- a/Darling/Darling.Tests/TimescaleSupportTests.cs
+++ b/Darling/Darling.Tests/TimescaleSupportTests.cs
@@ -2464,12 +2464,7 @@ LIMIT 1", connection))
            list is a defect only a live store can see, and it would silently read a phase out of a boolean.
            So the schema is asserted to be the LAST of exactly seven selected columns, which is the property
            the C# index depends on. */
-        var selected = read[(read.IndexOf("SELECT", StringComparison.Ordinal) + "SELECT".Length)
-                ..read.IndexOf("FROM timescaledb_information.jobs", StringComparison.Ordinal)]
-            .Split(',')
-            .Select(part => part.Trim().Replace("\r", string.Empty, StringComparison.Ordinal).Replace("\n", " ", StringComparison.Ordinal))
-            .Where(part => part.Length > 0)
-            .ToArray();
+        var selected = SelectedColumns(read);
 
         /* Control on the split itself: a CASE expression carries no top-level comma, so seven parts is the
            column count and not an artifact of splitting inside one. */
@@ -2482,6 +2477,24 @@ LIMIT 1", connection))
            purpose — that is #1778's reach. */
         Assert.Contains("j.hypertable_schema", read, StringComparison.Ordinal);
         Assert.DoesNotContain("hypertable_schema = ", read, StringComparison.Ordinal);
+
+        /* THE FALLBACK'S SHAPE PARITY. fixed_schedule and initial_start are younger columns than
+           schedule_interval, so a store that lacks them takes the narrow read rather than losing #1778's
+           cadence converge along with a phase it cannot use. One reader serves both statements, so the
+           narrow one's columns must be the wide one's FIRST FOUR, in the same order — a divergence there
+           reads a phase out of the wrong column and only a live old-runtime store could see it. Raised by
+           review. */
+        var narrowSelected = SelectedColumns(TimescaleSupport.CompressionCadenceOnlyStateSql);
+
+        Assert.Equal(4, narrowSelected.Length);
+        Assert.Equal(selected[..4], narrowSelected);
+        Assert.DoesNotContain("fixed_schedule", TimescaleSupport.CompressionCadenceOnlyStateSql, StringComparison.Ordinal);
+        Assert.DoesNotContain("initial_start", TimescaleSupport.CompressionCadenceOnlyStateSql, StringComparison.Ordinal);
+        Assert.DoesNotContain("hypertable_schema", TimescaleSupport.CompressionCadenceOnlyStateSql, StringComparison.Ordinal);
+
+        /* Same scope as the wide read, so falling back cannot quietly change WHICH jobs get converged. */
+        Assert.Contains("proc_name LIKE '%compression%'", TimescaleSupport.CompressionCadenceOnlyStateSql, StringComparison.Ordinal);
+        Assert.Contains("proc_name LIKE '%columnstore%'", TimescaleSupport.CompressionCadenceOnlyStateSql, StringComparison.Ordinal);
 
         var phased = TimescaleSupport.SetCompressionSchedulePhaseSql;
 
@@ -2875,6 +2888,19 @@ AND   (proc_name LIKE '%compression%' OR proc_name LIKE '%columnstore%')", conne
             });
         }
     }
+
+    /// <summary>The top-level items of a statement's SELECT list, trimmed and newline-flattened — used to
+    /// assert the ORDINAL contract the compression converge's reader depends on. Split on commas, which is
+    /// safe for these two statements specifically because neither carries a top-level comma inside an
+    /// expression; the caller asserts the resulting count, which is what would catch it if that ever stopped
+    /// being true.</summary>
+    private static string[] SelectedColumns(string sql)
+        => sql[(sql.IndexOf("SELECT", StringComparison.Ordinal) + "SELECT".Length)
+                ..sql.IndexOf("FROM timescaledb_information.jobs", StringComparison.Ordinal)]
+            .Split(',')
+            .Select(part => part.Trim().Replace("\r", string.Empty, StringComparison.Ordinal).Replace("\n", " ", StringComparison.Ordinal))
+            .Where(part => part.Length > 0)
+            .ToArray();
 
     /// <summary>A compression policy's schedule as the store reports it: cadence, whether that cadence is a
     /// FIXED schedule, and which minute of the hour it is anchored to (in UTC, for the same reason the shipped

--- a/Darling/Darling.Tests/TimescaleSupportTests.cs
+++ b/Darling/Darling.Tests/TimescaleSupportTests.cs
@@ -113,8 +113,15 @@ public sealed class TimescaleSupportTests
         Assert.Equal(
             "ALTER TABLE wait_stats SET (timescaledb.compress, timescaledb.compress_segmentby = 'server_id')",
             TimescaleSupport.EnableCompressionSql(byName["wait_stats"]));
+        /* #3035: initial_start is named too, which is what puts the job on a FIXED schedule. The minute
+           is interpolated from the grid rather than restated so this pin cannot disagree with it; the
+           grid itself is pinned literally, and wait_stats' own minute too, by the #3035 tests below —
+           so a moved grid is loud there rather than silently agreed with here. */
+        Assert.True(TimescaleSupport.TryCompressionPhaseMinutesFor("wait_stats", out var waitStatsPhase));
         Assert.Equal(
-            "SELECT add_compression_policy('wait_stats', compress_after => INTERVAL '1 days', schedule_interval => INTERVAL '1 hour', if_not_exists => true)",
+            "SELECT add_compression_policy('wait_stats', compress_after => INTERVAL '1 days', schedule_interval => INTERVAL '1 hour', if_not_exists => true, "
+            + "initial_start => date_trunc('hour', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' + INTERVAL '1 hour' + INTERVAL '"
+            + waitStatsPhase.ToString(CultureInfo.InvariantCulture) + " minutes')",
             TimescaleSupport.AddCompressionPolicySql(byName["wait_stats"]));
 
         /* 1 day matches the 1-day chunk interval so chunks become compressible quickly, keeping the
@@ -140,8 +147,11 @@ public sealed class TimescaleSupportTests
         Assert.Equal(
             "ALTER TABLE collection_log SET (timescaledb.compress, timescaledb.compress_segmentby = 'server_id')",
             TimescaleSupport.EnableCompressionSql(TimescaleSupport.CollectionLogTable));
+        Assert.True(TimescaleSupport.TryCompressionPhaseMinutesFor(TimescaleSupport.CollectionLogTable, out var logPhase));
         Assert.Equal(
-            "SELECT add_compression_policy('collection_log', compress_after => INTERVAL '1 days', schedule_interval => INTERVAL '1 hour', if_not_exists => true)",
+            "SELECT add_compression_policy('collection_log', compress_after => INTERVAL '1 days', schedule_interval => INTERVAL '1 hour', if_not_exists => true, "
+            + "initial_start => date_trunc('hour', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' + INTERVAL '1 hour' + INTERVAL '"
+            + logPhase.ToString(CultureInfo.InvariantCulture) + " minutes')",
             TimescaleSupport.AddCompressionPolicySql(TimescaleSupport.CollectionLogTable));
     }
 
@@ -481,7 +491,7 @@ WHERE hypertable_name = 'wait_stats'
     [Fact]
     public void CompressionScheduleConverge_ScopesToCompressionJobs_AndCastsJobIdToInteger()
     {
-        var probe = TimescaleSupport.StaleCompressionScheduleSql;
+        var probe = TimescaleSupport.CompressionPolicyStateSql;
 
         /* The same tolerant proc_name scoping the stuck-job reader uses — 'policy_compression' plus the 2.18+
            columnstore rebrand — and NOTHING else. */
@@ -489,9 +499,12 @@ WHERE hypertable_name = 'wait_stats'
         Assert.Contains("proc_name LIKE '%columnstore%'", probe, StringComparison.Ordinal);
         Assert.DoesNotContain("policy_retention", probe, StringComparison.Ordinal);
 
-        /* Compared as a typed INTERVAL by PostgreSQL, not as text in C#: '01:00:00' and '1 hour' are the same
-           interval and must not be seen as a difference to converge on every single start. */
-        Assert.Contains($"IS DISTINCT FROM INTERVAL '{TimescaleSupport.CompressScheduleInterval}'", probe, StringComparison.Ordinal);
+        /* Compared as SECONDS rather than as text: '01:00:00' and '1 hour' are the same interval and must
+           not be seen as a difference to converge on every single start. The comparison itself moved out
+           of the WHERE clause in #3035 — the wanted MINUTE is per hypertable, so a job stale only on its
+           phase would be filtered out before the caller ever saw it — which is why this pin is on the
+           emitted seconds and not on a predicate. */
+        Assert.Contains("EXTRACT(EPOCH FROM j.schedule_interval)::bigint", probe, StringComparison.Ordinal);
 
         /* #1586: alter_job takes job_id INTEGER and PostgreSQL will not down-cast a bigint bind during function
            resolution — an un-cast parameter fails 42883 at runtime while every string pin still passes. */
@@ -2248,4 +2261,581 @@ LIMIT 1", connection))
             $"DELETE FROM wait_stats WHERE server_id = {TestServerId}; DELETE FROM collection_log WHERE server_id = {TestServerId};", connection);
         await cleanup.ExecuteNonQueryAsync(ct);
     }
+
+    /* ---------------- the compression PHASE grid (#3035) ---------------- */
+
+    /// <summary>
+    /// The grid's actual invariant: every minute a compression policy may start on is clear of the band
+    /// after each refresh slot, and none of them is inside the heaviest refresh's slot at all.
+    ///
+    /// <para><b>Not "different from the refresh minutes".</b> That weaker property is satisfied by :07, and
+    /// :07 sits squarely inside the 864 s the heaviest hourly refresh occupies from :00 — a compression tick
+    /// there is exactly the arrangement #3012's convoy formed on. What has to hold is a DISTANCE from each
+    /// refresh START, because the convoy needs compression's <c>AccessExclusiveLock</c> request to arrive
+    /// while a refresh already holds its shared lock.</para>
+    ///
+    /// <para>The whole minute list is pinned LITERALLY as well as checked against the rule that produced it.
+    /// A test that only re-derived the rule would agree with any derivation, including a wrong one; the
+    /// literal is what makes a moved grid loud.</para>
+    /// </summary>
+    [Fact]
+    public void CompressionPhaseGrid_ClearsEveryRefreshSlotsGuardBand_AndTheHeaviestRefreshsSlotWhole()
+    {
+        Assert.Equal(15, TimescaleSupport.RefreshPhaseStepMinutes);
+        Assert.Equal(7, TimescaleSupport.CompressionPhaseGuardMinutes);
+        Assert.Equal(TimescaleSupport.RefreshPhaseStepMinutes / 2, TimescaleSupport.CompressionPhaseGuardMinutes);
+
+        /* THE OPERATING ENVELOPE, as assertions rather than as prose. The whole grid rests on the
+           heaviest refresh finishing inside ONE slot; a downgrade whose condition is only written in a
+           comment reads as unconditional to whoever finds it next. Raising the recorded ceiling past the
+           slot width therefore has to FAIL here rather than be renumbered through, because past that
+           point the refresh runs into its neighbour and the grid needs redesigning. */
+        Assert.Equal(864, TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds);
+        Assert.Equal(140, TimescaleSupport.OtherHourlyRefreshObservedCeilingSeconds);
+        Assert.True(
+            TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds < TimescaleSupport.RefreshPhaseStepMinutes * 60,
+            $"the heaviest hourly refresh's recorded ceiling is {TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds}s "
+            + $"against a {TimescaleSupport.RefreshPhaseStepMinutes * 60}s slot — it no longer fits inside its own slot, so "
+            + "excluding one slot is no longer enough and the compression grid has to be re-derived");
+
+        /* And it is WHY the heaviest slot is excluded whole rather than guarded: the guard band is
+           shorter than the ceiling, so no minute of that slot could be recovered by widening it. */
+        Assert.True(
+            TimescaleSupport.CompressionPhaseGuardMinutes * 60 < TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds,
+            "the guard band now clears the heaviest refresh, so excluding its whole slot is over-conservative and the grid should be widened deliberately rather than left as-is");
+
+        /* The guard band itself is 3x the recorded ceiling for every OTHER hourly refresh, which is the
+           margin the light slots are held to. */
+        Assert.True(
+            TimescaleSupport.OtherHourlyRefreshObservedCeilingSeconds * 3 <= TimescaleSupport.CompressionPhaseGuardMinutes * 60,
+            $"the {TimescaleSupport.CompressionPhaseGuardMinutes}-minute guard band is no longer 3x the "
+            + $"{TimescaleSupport.OtherHourlyRefreshObservedCeilingSeconds}s recorded ceiling for a non-heaviest hourly refresh");
+
+        var refreshSlots = TimescaleSupport.HourlyRefreshPhaseOrder
+            .Select(TimescaleSupport.RefreshPhaseMinutesFor)
+            .Distinct()
+            .OrderBy(m => m)
+            .ToArray();
+        Assert.Equal(new[] { 0, 15, 30, 45 }, refreshSlots);
+
+        var heaviestSlot = TimescaleSupport.RefreshPhaseMinutesFor(TimescaleSupport.HeaviestHourlyRefreshView);
+
+        Assert.Equal(
+            new[] { 22, 23, 24, 25, 26, 27, 28, 29, 37, 38, 39, 40, 41, 42, 43, 44, 52, 53, 54, 55, 56, 57, 58, 59 },
+            TimescaleSupport.CompressionPhaseMinutes.ToArray());
+
+        foreach (var minute in TimescaleSupport.CompressionPhaseMinutes)
+        {
+            var slot = minute / TimescaleSupport.RefreshPhaseStepMinutes * TimescaleSupport.RefreshPhaseStepMinutes;
+
+            Assert.DoesNotContain(minute, refreshSlots);
+            Assert.NotEqual(heaviestSlot, slot);
+            Assert.True(
+                minute - slot >= TimescaleSupport.CompressionPhaseGuardMinutes,
+                $":{minute.ToString("00", CultureInfo.InvariantCulture)} is only {minute - slot} minute(s) past the "
+                + $":{slot.ToString("00", CultureInfo.InvariantCulture)} refresh start, inside the "
+                + $"{TimescaleSupport.CompressionPhaseGuardMinutes}-minute guard band");
+        }
+
+        /* THE CONTROL: both exclusions actually removed a population. Every assertion in the loop above
+           passes vacuously on an empty or already-clear list, so the excluded sets are named, shown
+           non-empty, shown disjoint from the grid, and shown to account for exactly the minutes missing
+           from it — which is the difference between "the filter matched what it was aimed at" and "the
+           filter produced output". */
+        var excludedByGuard = Enumerable.Range(0, 60)
+            .Where(m => m % TimescaleSupport.RefreshPhaseStepMinutes < TimescaleSupport.CompressionPhaseGuardMinutes)
+            .ToArray();
+        var excludedByHeaviestSlot = Enumerable.Range(heaviestSlot, TimescaleSupport.RefreshPhaseStepMinutes).ToArray();
+
+        Assert.Equal(28, excludedByGuard.Length);
+        Assert.Equal(15, excludedByHeaviestSlot.Length);
+        Assert.Contains(7, excludedByHeaviestSlot);
+        Assert.Empty(excludedByGuard.Intersect(TimescaleSupport.CompressionPhaseMinutes));
+        Assert.Empty(excludedByHeaviestSlot.Intersect(TimescaleSupport.CompressionPhaseMinutes));
+        Assert.Equal(
+            60 - excludedByGuard.Union(excludedByHeaviestSlot).Count(),
+            TimescaleSupport.CompressionPhaseMinutes.Count);
+    }
+
+    /// <summary>
+    /// Every hypertable this product owns gets a minute on the grid, and they stay SPREAD across it.
+    ///
+    /// <para><b>The spread is a property, not an accident of the modulo.</b> All the compression policies
+    /// could share one minute as far as locks go — they compress different hypertables and so never contend
+    /// with each other — but <see cref="TimescaleSupport.CompressAfterDays"/> and
+    /// <see cref="TimescaleSupport.ChunkIntervalDays"/> are both 1 and TimescaleDB aligns 1-day chunks to the
+    /// epoch, so every hypertable's newest closed chunk becomes eligible at the same UTC midnight. The number
+    /// of policies sharing a minute is therefore the number of hypertables rewritten SIMULTANEOUSLY once a
+    /// day, and collapsing the grid onto one minute would be this change introducing a burst rather than
+    /// removing one. Pinned as a per-minute ceiling so that collapse is red.</para>
+    ///
+    /// <para>One assignment is pinned literally, on the catalog's FIRST entry, so appending a collector
+    /// cannot move it and the pin does not have to be re-touched for unrelated work.</para>
+    /// </summary>
+    [Fact]
+    public void EveryHypertableWeOwn_GetsACompressionMinuteOnTheGrid_AndTheyStaySpread()
+    {
+        Assert.Equal(TimescaleSupport.HypertableCount, TimescaleSupport.CompressionPhaseOrder.Count);
+        Assert.Equal(CollectorCatalog.All.Count + 1, TimescaleSupport.CompressionPhaseOrder.Count);
+        Assert.Equal(TimescaleSupport.CollectionLogTable, TimescaleSupport.CompressionPhaseOrder[^1]);
+
+        var byMinute = new Dictionary<int, List<string>>();
+        foreach (var table in TimescaleSupport.CompressionPhaseOrder)
+        {
+            Assert.True(
+                TimescaleSupport.TryCompressionPhaseMinutesFor(table, out var minute),
+                $"{table} carries a compression policy but no phase, so its policy would be created finish-to-start and drift");
+            Assert.Contains(minute, TimescaleSupport.CompressionPhaseMinutes);
+
+            if (!byMinute.TryGetValue(minute, out var tables))
+            {
+                byMinute[minute] = tables = new List<string>();
+            }
+
+            tables.Add(table);
+        }
+
+        Assert.Equal(TimescaleSupport.CompressionPhaseMinutes.Count, byMinute.Count);
+
+        var ceiling = (TimescaleSupport.CompressionPhaseOrder.Count + TimescaleSupport.CompressionPhaseMinutes.Count - 1)
+            / TimescaleSupport.CompressionPhaseMinutes.Count;
+        Assert.Equal(3, ceiling);
+
+        var crowded = byMinute.Where(kv => kv.Value.Count > ceiling).ToArray();
+        Assert.True(crowded.Length == 0,
+            "compression policies are bunched onto one minute, which is one simultaneous chunk rewrite per hypertable once a day: "
+            + string.Join("; ", crowded.Select(kv => $":{kv.Key.ToString("00", CultureInfo.InvariantCulture)}={kv.Value.Count}")));
+
+        Assert.Equal("wait_stats", TimescaleSupport.CompressionPhaseOrder[0]);
+        Assert.True(TimescaleSupport.TryCompressionPhaseMinutesFor("wait_stats", out var waitStats));
+        Assert.Equal(22, waitStats);
+
+        /* A FOREIGN hypertable is left unphased rather than assigned a minute this code has no basis for
+           choosing — CompressionPhaseOrder is derived from the catalog, so an unrecognised name means "not
+           ours", never "forgotten". */
+        Assert.False(TimescaleSupport.TryCompressionPhaseMinutesFor("someone_elses_hypertable", out _));
+        Assert.False(TimescaleSupport.TryCompressionPhaseMinutesFor("", out _));
+
+        /* Bare or collect.-qualified resolve to the SAME minute: the product passes the bare TargetTable,
+           but the raw-name overload is reachable with a qualified one. */
+        Assert.True(TimescaleSupport.TryCompressionPhaseMinutesFor("collect.wait_stats", out var qualified));
+        Assert.Equal(waitStats, qualified);
+    }
+
+    /// <summary>
+    /// The converge statements: identity is the HYPERTABLE, the job id only ever reaches
+    /// <c>alter_job</c> as a bound <c>::integer</c>, and the phased form pins the schedule as well as the
+    /// minute.
+    ///
+    /// <para>#3012's evidence names TimescaleDB job ids. Those are assigned per deployment and would name
+    /// entirely different jobs on any other store, so a fix that encoded one would be correct on exactly one
+    /// box. Unlike a refresh job, a compression job reports its own hypertable directly, which is why this
+    /// read needs no catalog join to recover identity.</para>
+    /// </summary>
+    [Fact]
+    public void CompressionScheduleConverge_OwnsCadenceAndPhase_KeyedOnTheHypertable_NeverAJobId()
+    {
+        var read = TimescaleSupport.CompressionPolicyStateSql;
+
+        /* The same tolerant proc_name scoping the stuck-job reader uses, and NOTHING else: retuning a
+           retention job would re-cadence the armed/paused machinery #1680 depends on. */
+        Assert.Contains("proc_name LIKE '%compression%'", read, StringComparison.Ordinal);
+        Assert.Contains("proc_name LIKE '%columnstore%'", read, StringComparison.Ordinal);
+        Assert.DoesNotContain("policy_retention", read, StringComparison.Ordinal);
+        Assert.DoesNotContain("policy_refresh_continuous_aggregate", read, StringComparison.Ordinal);
+
+        Assert.Contains("j.hypertable_name", read, StringComparison.Ordinal);
+
+        /* Cadence as SECONDS so '01:00:00' and '1 hour' cannot read as a difference and re-alter the same
+           job on every start; phase as a minute already converted to UTC, because a bare EXTRACT would read
+           the SESSION time zone and skew the whole store on a quarter-hour zone. */
+        Assert.Contains("EXTRACT(EPOCH FROM j.schedule_interval)::bigint", read, StringComparison.Ordinal);
+        Assert.Contains("j.fixed_schedule", read, StringComparison.Ordinal);
+        Assert.Contains("EXTRACT(MINUTE FROM j.initial_start AT TIME ZONE 'UTC')::int", read, StringComparison.Ordinal);
+
+        /* The staleness test is deliberately NOT in the WHERE clause, and it cannot be: the wanted minute
+           is per hypertable, so no single SQL literal stands for it and a job stale only on its phase would
+           be filtered out before the caller ever saw it. */
+        Assert.DoesNotContain("IS DISTINCT FROM", read, StringComparison.Ordinal);
+
+        var phased = TimescaleSupport.SetCompressionSchedulePhaseSql;
+
+        Assert.Contains("$1::integer", phased, StringComparison.Ordinal);
+        Assert.Contains($"schedule_interval => INTERVAL '{TimescaleSupport.CompressScheduleInterval}'", phased, StringComparison.Ordinal);
+        Assert.Contains("fixed_schedule => true", phased, StringComparison.Ordinal);
+        Assert.Contains("($2::int * INTERVAL '1 minute')", phased, StringComparison.Ordinal);
+
+        /* UTC, not the session time zone — a bare date_trunc('hour', now()) lands off-grid on the half-hour
+           and quarter-hour zones. */
+        Assert.Contains("now() AT TIME ZONE 'UTC'", phased, StringComparison.Ordinal);
+        Assert.DoesNotContain("date_trunc('hour', now())", phased, StringComparison.Ordinal);
+
+        /* Every un-named alter_job parameter means "leave unchanged", so the converge cannot arm a paused
+           job. Load-bearing rather than defensive: the fixture idiom for a deterministic compression test
+           is a policy created and parked at scheduled = false in one transaction (#1888). */
+        Assert.DoesNotContain("scheduled =>", phased, StringComparison.Ordinal);
+        Assert.DoesNotContain("next_start =>", phased, StringComparison.Ordinal);
+
+        /* The FOREIGN-hypertable form is #1778's statement, unchanged: cadence only, so this code never
+           decides when a hypertable it does not own compresses. */
+        Assert.Equal(
+            "SELECT alter_job($1::integer, schedule_interval => INTERVAL '1 hour')",
+            TimescaleSupport.SetCompressionScheduleSql);
+        Assert.DoesNotContain("fixed_schedule", TimescaleSupport.SetCompressionScheduleSql, StringComparison.Ordinal);
+        Assert.DoesNotContain("initial_start", TimescaleSupport.SetCompressionScheduleSql, StringComparison.Ordinal);
+
+        Assert.Equal("1 hour", TimescaleSupport.CompressScheduleInterval);
+        Assert.Equal(TimeSpan.FromHours(1), TimescaleSupport.CompressScheduleSpan);
+    }
+
+    /// <summary>
+    /// The refresh grid is UNCHANGED by the compression grid, view by view — and the compression grid's one
+    /// input from it is pinned separately.
+    ///
+    /// <para><b>Why a compression change pins the refresh assignment.</b> #3024's own stagger pin asserts
+    /// only that each phase is one of the four slots, so a reordering that permutes which view gets which
+    /// minute passes it. The compression grid is built by excluding the slot
+    /// <see cref="TimescaleSupport.HeaviestHourlyRefreshView"/> occupies, so that permutation is exactly the
+    /// edit that could put a compression minute back inside 864 s of refresh while every other pin in the
+    /// tree stayed green. Both halves are asserted: the full assignment, and the heaviest view's slot.</para>
+    /// </summary>
+    [Fact]
+    public void TheRefreshGridIsUnchanged_AndTheCompressionGridsOneInputFromItIsPinned()
+    {
+        var expected = new (string View, int Minute)[]
+        {
+            (TimescaleSupport.QueryStatsHourlyView, 0),
+            (TimescaleSupport.ProcedureStatsHourlyView, 15),
+            (TimescaleSupport.QueryStoreStatsHourlyView, 30),
+            (TimescaleSupport.QueryStatsDbHourlyView, 45),
+            (TimescaleSupport.QueryStoreStatsIntervalHourlyView, 0),
+            (TimescaleSupport.QueryStoreStatsCorrectedHourlyView, 15),
+            (TimescaleSupport.PerfmonBaselineView, 30),
+            (TimescaleSupport.WaitStatsBaselineView, 45),
+            (TimescaleSupport.SessionStatsBaselineView, 0),
+            (TimescaleSupport.QueryStatsBaselineView, 15),
+            (TimescaleSupport.BlockedProcessBaselineView, 30),
+            (TimescaleSupport.DeadlockBaselineView, 45),
+            (TimescaleSupport.MemoryBaselineView, 0),
+        };
+
+        Assert.Equal(expected.Length, TimescaleSupport.HourlyRefreshPhaseOrder.Count);
+        for (var index = 0; index < expected.Length; index++)
+        {
+            Assert.Equal(expected[index].View, TimescaleSupport.HourlyRefreshPhaseOrder[index]);
+            Assert.Equal(expected[index].Minute, TimescaleSupport.RefreshPhaseMinutesFor(expected[index].View));
+        }
+
+        Assert.Equal(TimescaleSupport.QueryStoreStatsIntervalHourlyView, TimescaleSupport.HeaviestHourlyRefreshView);
+        Assert.Equal(0, TimescaleSupport.RefreshPhaseMinutesFor(TimescaleSupport.HeaviestHourlyRefreshView));
+
+        /* No compression minute shares a SLOT with the heaviest refresh — the property the permutation
+           above would break. */
+        var heaviestSlotIndex = TimescaleSupport.RefreshPhaseMinutesFor(TimescaleSupport.HeaviestHourlyRefreshView)
+            / TimescaleSupport.RefreshPhaseStepMinutes;
+        Assert.DoesNotContain(
+            heaviestSlotIndex,
+            TimescaleSupport.CompressionPhaseMinutes.Select(m => m / TimescaleSupport.RefreshPhaseStepMinutes).ToArray());
+
+        /* The daily refresh tier stays off the grid entirely, so nothing added here can drag one on. */
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => TimescaleSupport.RefreshPhaseMinutesFor(TimescaleSupport.QueryStatsDailyView));
+
+        /* And the refresh STATEMENTS are untouched: still the refresh phase, still no compression in them. */
+        var refreshSql = TimescaleSupport.AddHourlyRefreshPolicySql(TimescaleSupport.ProcedureStatsHourlyView);
+        Assert.Contains("INTERVAL '15 minutes'", refreshSql, StringComparison.Ordinal);
+        Assert.Contains("add_continuous_aggregate_policy", refreshSql, StringComparison.Ordinal);
+        Assert.DoesNotContain("compression", refreshSql, StringComparison.Ordinal);
+        Assert.DoesNotContain("columnstore", refreshSql, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Compression has no DAILY tier to exempt, which is the whole answer to the question #3024's daily
+    /// carve-out raises here.
+    ///
+    /// <para>#3024 left the daily refresh policies at a 3-day window on finish-to-start scheduling because a
+    /// daily job's window is 3 days of scan against an 86,400-second cadence rather than a 3,600-second one,
+    /// and it never appeared in the convoy. There is no counterpart on the compression side: ONE cadence
+    /// constant exists, every policy is created with it, and the converge moves every policy to it — so the
+    /// decision is not "which tier follows the convention", it is that there is only one tier. Pinned so a
+    /// second cadence cannot be introduced without landing here, which is where the exemption question would
+    /// then have to be answered.</para>
+    /// </summary>
+    [Fact]
+    public void CompressionHasNoDailyTier_OneCadenceAndOnePhaseGridForEveryHypertable()
+    {
+        const string Anchor = "+ INTERVAL '1 hour' + INTERVAL '";
+
+        var statements = TimescaleSupport.CompressionPhaseOrder
+            .Select(t => TimescaleSupport.AddCompressionPolicySql(t))
+            .ToArray();
+
+        Assert.Equal(TimescaleSupport.HypertableCount, statements.Length);
+
+        foreach (var sql in statements)
+        {
+            Assert.Contains($"compress_after => INTERVAL '{TimescaleSupport.CompressAfterDays} days'", sql, StringComparison.Ordinal);
+            Assert.Contains($"schedule_interval => INTERVAL '{TimescaleSupport.CompressScheduleInterval}'", sql, StringComparison.Ordinal);
+            Assert.Contains("if_not_exists => true", sql, StringComparison.Ordinal);
+            Assert.Contains("initial_start => date_trunc('hour', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' " + Anchor, sql, StringComparison.Ordinal);
+        }
+
+        /* THE CONTROL on the loop above: the statements really do differ in their minute, so those
+           Assert.Contains calls were matching a per-table value and not one constant substring that happens
+           to appear in all seventy strings. Recovered from the shipped text, then checked to cover the whole
+           grid and nothing outside it. */
+        var minutes = statements
+            .Select(sql =>
+            {
+                var at = sql.IndexOf(Anchor, StringComparison.Ordinal) + Anchor.Length;
+                var end = sql.IndexOf(' ', at);
+                Assert.True(end > at, $"could not recover a phase from the shipped statement: {sql}");
+                return int.Parse(sql[at..end], CultureInfo.InvariantCulture);
+            })
+            .ToArray();
+
+        Assert.Equal(TimescaleSupport.CompressionPhaseMinutes.Count, minutes.Distinct().Count());
+        Assert.Empty(minutes.Except(TimescaleSupport.CompressionPhaseMinutes));
+
+        /* A foreign hypertable gets the statement with NO initial_start — the one shape that stays
+           finish-to-start, and deliberately so. */
+        var foreignSql = TimescaleSupport.AddCompressionPolicySql("collect.someone_elses_hypertable");
+        Assert.DoesNotContain("initial_start", foreignSql, StringComparison.Ordinal);
+        Assert.Contains($"schedule_interval => INTERVAL '{TimescaleSupport.CompressScheduleInterval}'", foreignSql, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// THE PHASE PIN (#3035), live — the half that reaches already-deployed stores, and the only way to
+    /// settle whether <c>add_compression_policy</c> behaves like the refresh function it is being modelled
+    /// on.
+    ///
+    /// <para><b>The sibling question, answered by running it.</b>
+    /// <c>add_continuous_aggregate_policy(if_not_exists =&gt; true)</c> RAISES <c>22023</c> against a policy
+    /// whose window differs, which is what forced #3024's converge to run BEFORE its create.
+    /// <c>add_compression_policy</c> was assumed to do the opposite — key on the policy EXISTING and skip
+    /// quietly — and this test is what makes that an observation rather than an analogy. It matters twice
+    /// over: it is why the compression create can stay where it is, ahead of the converge, and it is why
+    /// the create path cannot move a deployed store at all.</para>
+    ///
+    /// <para><b>What it would mean for this test not to exist.</b> Every assertion the phase rests on is
+    /// invisible to a string pin, because a string pin never runs the statement: that a policy created with
+    /// <c>initial_start</c> comes back <c>fixed_schedule = true</c> (on which the converge's own no-op-ness
+    /// rests — a store whose jobs read <c>false</c> would be re-altered on every start forever), that
+    /// <c>alter_job</c> takes <c>schedule_interval</c>, <c>fixed_schedule</c> and <c>initial_start</c>
+    /// together on this runtime, and that the minute survives the round trip through
+    /// <c>timescaledb_information.jobs</c>.</para>
+    ///
+    /// <para><b>The #1581 interaction is checked too</b>, because a fixed schedule is the one thing that
+    /// could plausibly break the stuck-job self-heal: it re-arms a job with
+    /// <c>alter_job(next_start =&gt; now())</c>, which has to be accepted against a fixed-schedule job and
+    /// has to leave it on its slot afterwards. Under finish-to-start a re-arm re-phases the job
+    /// permanently, which is the drift this change removes.</para>
+    /// </summary>
+    [Fact]
+    public async Task EndToEnd_CompressionSchedule_PinsADriftingPolicyToItsPhase_AndLeavesForeignHypertablesUnphased_AgainstDevPostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string (with TimescaleDB installed) to run the live compression-phase converge test.");
+
+        var ct = TestContext.Current.CancellationToken;
+
+        using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(ct);
+        await PgMigrations.MigrateAsync(connection, ct);
+        Assert.True(await TimescaleSupport.TryEnableAsync(connection, null, ct),
+            "the dev fixture is expected to have TimescaleDB installed");
+        await TimescaleSupport.ConvertToHypertablesAsync(connection, null, ct);
+
+        /* A REAL collector hypertable, because the phase is scoped by membership of CompressionPhaseOrder
+           and a throwaway name would be skipped — which is a property worth having, and is asserted below
+           against a planted foreign hypertable. */
+        const string Owned = "wait_stats";
+        const string Foreign = "tick3035_foreign";
+        const string Phased = "tick3035_phased";
+        const int PlantedPhase = 37;
+
+        Assert.True(TimescaleSupport.TryCompressionPhaseMinutesFor(Owned, out var ownedPhase));
+        Assert.False(TimescaleSupport.TryCompressionPhaseMinutesFor(Foreign, out _));
+        var ownedPhaseText = ownedPhase.ToString("00", CultureInfo.InvariantCulture);
+
+        /* Idempotent, and needed before add_compression_policy will accept the table at all — the product
+           runs this on every start. */
+        await ExecAsync(connection, TimescaleSupport.EnableCompressionSql($"collect.{Owned}"), ct);
+
+        var bodySucceeded = false;
+        try
+        {
+            await DropTickTableAsync(connection, Foreign, ct);
+            await DropTickTableAsync(connection, Phased, ct);
+
+            /* ---- (1) A REAL hypertable's policy as an OLDER BUILD left it: no schedule_interval and no
+                    initial_start. Both halves MEASURED rather than assumed — the 12 hours is TimescaleDB's
+                    computed default, and the finish-to-start scheduling is the drift itself. ---- */
+            await ExecAsync(connection, $"SELECT remove_compression_policy('collect.{Owned}', if_exists => true)", ct);
+            await ExecAsync(connection,
+                $"SELECT add_compression_policy('collect.{Owned}', compress_after => INTERVAL '{TimescaleSupport.CompressAfterDays} days', if_not_exists => true)", ct);
+
+            var legacy = await CompressionPolicyStateAsync(connection, Owned, ct);
+            Assert.NotNull(legacy);
+            Assert.Equal(TimeSpan.FromHours(12), legacy!.ScheduleInterval);
+            Assert.False(legacy.FixedSchedule,
+                "a compression policy created without initial_start is expected to be finish-to-start on this runtime — that is the drift #3035 is about");
+            Assert.Null(legacy.PhaseMinutes);
+
+            /* ---- (2) THE SIBLING BEHAVIOUR, settled. The shipped create statement carries BOTH the tick
+                    and the phase, runs cleanly against the existing policy, and changes NOTHING. Contrast
+                    the refresh side, where the same call raises 22023 against a differing window. ---- */
+            await ExecAsync(connection, TimescaleSupport.AddCompressionPolicySql($"collect.{Owned}"), ct);
+
+            var afterCreate = await CompressionPolicyStateAsync(connection, Owned, ct);
+            Assert.Equal(TimeSpan.FromHours(12), afterCreate!.ScheduleInterval);
+            Assert.False(afterCreate.FixedSchedule);
+            Assert.Null(afterCreate.PhaseMinutes);
+
+            /* ---- (3) A FOREIGN hypertable on the same store, planted so the scope check at (5) is not
+                    satisfied vacuously by a store that has none. ---- */
+            await CreateTickTableAsync(connection, Foreign, ct);
+            await ExecAsync(connection,
+                $"SELECT add_compression_policy('collect.{Foreign}', compress_after => INTERVAL '{TimescaleSupport.CompressAfterDays} days', if_not_exists => true)", ct);
+            Assert.Equal(TimeSpan.FromHours(12), (await CompressionPolicyStateAsync(connection, Foreign, ct))!.ScheduleInterval);
+
+            /* ---- (4) THE ASSERTION THE WHOLE CHANGE COMES DOWN TO: the deployed store converges, on both
+                    properties, and the phase is the one the grid chose for THIS hypertable. ---- */
+            var convergeLog = new CapturingTestLogger();
+            var converged = await TimescaleSupport.ConvergeCompressionScheduleAsync(connection, convergeLog, ct);
+            Assert.True(converged >= 2,
+                $"expected both the owned and the planted foreign policy to be converged; {convergeLog.Joined}");
+
+            var moved = await CompressionPolicyStateAsync(connection, Owned, ct);
+            Assert.NotNull(moved);
+            Assert.Equal(TimescaleSupport.CompressScheduleSpan, moved!.ScheduleInterval);
+            Assert.True(moved.FixedSchedule,
+                $"the converge must pin the schedule, or the minute slides off by the run's own duration every cycle; {convergeLog.Joined}");
+            Assert.Equal(ownedPhase, moved.PhaseMinutes);
+
+            /* The rendered line names the hypertable, the cadence it left and the minute it is on now,
+               because that line IS the operator's evidence the store changed — and a structured-logging
+               placeholder/argument mismatch would render it wrong with no error anywhere. */
+            Assert.Contains(
+                $"retuned {Owned}'s compression policy from a 12:00:00 tick to 1 hour on a fixed :{ownedPhaseText} schedule",
+                convergeLog.Joined, StringComparison.Ordinal);
+
+            /* ---- (5) SCOPE: the foreign hypertable gets #1778's cadence and NOT a phase, deliberately.
+                    Checked AFTER a converge that demonstrably moved things, so "it was left alone" cannot
+                    be a sweep that looked at nothing. ---- */
+            var foreignAfter = await CompressionPolicyStateAsync(connection, Foreign, ct);
+            Assert.Equal(TimescaleSupport.CompressScheduleSpan, foreignAfter!.ScheduleInterval);
+            Assert.False(foreignAfter.FixedSchedule,
+                "a hypertable this product does not own must keep its own scheduling — the grid is derived from the collector catalog");
+            Assert.False(foreignAfter.HasInitialStart);
+
+            /* ---- (6) Idempotent: nothing left stale, so a settled store never churns alter_job. This is
+                    also what fails if a policy created with initial_start does not come back
+                    fixed_schedule = true. ---- */
+            Assert.Equal(0, await TimescaleSupport.ConvergeCompressionScheduleAsync(connection, null, ct));
+
+            /* ---- (7) The CREATE path on a hypertable with no policy yet: both halves from the start, which
+                    is the FRESH-store state — the mirror of the refresh converge, which sees an empty set on
+                    a fresh store because its aggregates do not exist yet. ---- */
+            await ExecAsync(connection, $"SELECT remove_compression_policy('collect.{Owned}', if_exists => true)", ct);
+            await ExecAsync(connection, TimescaleSupport.AddCompressionPolicySql(Owned), ct);
+
+            var fresh = await CompressionPolicyStateAsync(connection, Owned, ct);
+            Assert.NotNull(fresh);
+            Assert.Equal(TimescaleSupport.CompressScheduleSpan, fresh!.ScheduleInterval);
+            Assert.True(fresh.FixedSchedule,
+                "passing initial_start is expected to put the job on a fixed schedule; if it does not, the converge re-alters every compression policy on every start");
+            Assert.Equal(ownedPhase, fresh.PhaseMinutes);
+            Assert.Equal(0, await TimescaleSupport.ConvergeCompressionScheduleAsync(connection, null, ct));
+
+            /* ---- (8) THE #1581 INTERACTION. Planted on a throwaway so the fixture's own policies are not
+                    made to run mid-suite, and pinned with the SHIPPED alter statement so the statement
+                    itself is exercised independently of the converge's selection logic. ---- */
+            await CreateTickTableAsync(connection, Phased, ct);
+            await ExecAsync(connection,
+                $"SELECT add_compression_policy('collect.{Phased}', compress_after => INTERVAL '{TimescaleSupport.CompressAfterDays} days', if_not_exists => true)", ct);
+
+            int phasedJobId;
+            using (var probe = new NpgsqlCommand($@"
+SELECT job_id
+FROM timescaledb_information.jobs
+WHERE hypertable_schema = 'collect' AND hypertable_name = '{Phased}'
+AND   (proc_name LIKE '%compression%' OR proc_name LIKE '%columnstore%')", connection))
+            {
+                phasedJobId = Convert.ToInt32((await probe.ExecuteScalarAsync(ct))!, CultureInfo.InvariantCulture);
+            }
+
+            using (var pin = new NpgsqlCommand(TimescaleSupport.SetCompressionSchedulePhaseSql, connection))
+            {
+                pin.Parameters.AddWithValue(phasedJobId);
+                pin.Parameters.AddWithValue(PlantedPhase);
+                await pin.ExecuteNonQueryAsync(ct);
+            }
+
+            var pinned = await CompressionPolicyStateAsync(connection, Phased, ct);
+            Assert.NotNull(pinned);
+            Assert.Equal(TimescaleSupport.CompressScheduleSpan, pinned!.ScheduleInterval);
+            Assert.True(pinned.FixedSchedule);
+            Assert.Equal(PlantedPhase, pinned.PhaseMinutes);
+
+            using (var rearm = new NpgsqlCommand(TimescaleSupport.RearmJobSql, connection))
+            {
+                rearm.Parameters.AddWithValue(phasedJobId);
+                await rearm.ExecuteNonQueryAsync(ct);
+            }
+
+            var rearmed = await CompressionPolicyStateAsync(connection, Phased, ct);
+            Assert.NotNull(rearmed);
+            Assert.True(rearmed!.FixedSchedule,
+                "the #1581 self-heal must not knock a compression job off its fixed schedule, or one re-arm undoes the pinning for good");
+            Assert.Equal(PlantedPhase, rearmed.PhaseMinutes);
+
+            bodySucceeded = true;
+        }
+        finally
+        {
+            await LiveStoreCleanup.RunAsync(connectionString!, bodySucceeded, async (cleanup, cleanupCt) =>
+            {
+                await DropTickTableAsync(cleanup, Foreign, cleanupCt);
+                await DropTickTableAsync(cleanup, Phased, cleanupCt);
+            });
+        }
+    }
+
+    /// <summary>A compression policy's schedule as the store reports it: cadence, whether that cadence is a
+    /// FIXED schedule, and which minute of the hour it is anchored to (in UTC, for the same reason the shipped
+    /// read converts it there). <c>HasInitialStart</c> is carried separately so "no anchor at all" is
+    /// distinguishable from "anchored to minute zero".</summary>
+    private sealed record CompressionPolicyState(TimeSpan? ScheduleInterval, bool FixedSchedule, int? PhaseMinutes, bool HasInitialStart);
+
+    private static async Task<CompressionPolicyState?> CompressionPolicyStateAsync(
+        NpgsqlConnection connection, string table, System.Threading.CancellationToken ct)
+    {
+        using var command = new NpgsqlCommand($@"
+SELECT
+    j.schedule_interval,
+    j.fixed_schedule,
+    CASE
+        WHEN j.initial_start IS NULL THEN NULL
+        ELSE EXTRACT(MINUTE FROM j.initial_start AT TIME ZONE 'UTC')::int
+    END,
+    (j.initial_start IS NOT NULL)
+FROM timescaledb_information.jobs AS j
+WHERE j.hypertable_schema = 'collect' AND j.hypertable_name = '{table}'
+AND   (j.proc_name LIKE '%compression%' OR j.proc_name LIKE '%columnstore%')", connection);
+
+        await using var reader = await command.ExecuteReaderAsync(ct);
+        if (!await reader.ReadAsync(ct))
+        {
+            return null;
+        }
+
+        return new CompressionPolicyState(
+            reader.IsDBNull(0) ? null : reader.GetFieldValue<TimeSpan>(0),
+            !reader.IsDBNull(1) && reader.GetBoolean(1),
+            reader.IsDBNull(2) ? null : reader.GetInt32(2),
+            !reader.IsDBNull(3) && reader.GetBoolean(3));
+    }
+
 }

--- a/Darling/Darling.Tests/TimescaleSupportTests.cs
+++ b/Darling/Darling.Tests/TimescaleSupportTests.cs
@@ -2889,6 +2889,117 @@ AND   (proc_name LIKE '%compression%' OR proc_name LIKE '%columnstore%')", conne
         }
     }
 
+    /// <summary>
+    /// THE DEGRADATION DIRECTION (#3035), live: a probe failure costs the PHASE and nothing else.
+    ///
+    /// <para><b>Why this is the assertion that makes the widened read safe.</b>
+    /// <see cref="TimescaleSupport.CompressionPolicyStateSql"/> names <c>fixed_schedule</c> and
+    /// <c>initial_start</c>, which entered <c>timescaledb_information.jobs</c> later than
+    /// <c>schedule_interval</c> did. Nothing in this product declares a TimescaleDB floor or checks
+    /// <c>extversion</c>, and the file's own comments state a 2.x compatibility target, handle a store where
+    /// <c>force</c> does not exist, and name "a TimescaleDB too old to expose <c>initial_start</c>" as a
+    /// state that reaches the continuous-aggregate converge's catch. So on a store inside the stated range the
+    /// wide read can throw — and if that returned 0, the store would silently lose #1778's cadence converge
+    /// as well, which had worked there before this change ever existed. A total regression wearing a
+    /// partial's clothes.</para>
+    ///
+    /// <para><b>Proven by inducing the failure rather than by reading the catch.</b> The fixture is 2.28.1 and
+    /// has the columns, so the only way to exercise the fallback is to hand the converge a wide statement that
+    /// fails — which is what <see cref="TimescaleSupport.ConvergeCompressionScheduleAsync(NpgsqlConnection, Microsoft.Extensions.Logging.ILogger, string, System.Threading.CancellationToken)"/>
+    /// exists for. The fallback statement itself is NOT injectable, so this cannot pass against a statement
+    /// the product does not ship.</para>
+    ///
+    /// <para>The planted hypertable is FOREIGN on purpose: it is the population #1778 exists for, and it also
+    /// makes the "phase not applied" half of the assertion unambiguous — a foreign hypertable would be left
+    /// unphased on the happy path too, so the pin that separates the two is that the CADENCE moved.</para>
+    /// </summary>
+    [Fact]
+    public async Task EndToEnd_CompressionSchedule_AProbeFailureCostsThePhaseAndKeepsTheCadenceConverge_AgainstDevPostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string (with TimescaleDB installed) to run the live compression-converge degradation test.");
+
+        var ct = TestContext.Current.CancellationToken;
+
+        using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(ct);
+        await PgMigrations.MigrateAsync(connection, ct);
+        Assert.True(await TimescaleSupport.TryEnableAsync(connection, null, ct),
+            "the dev fixture is expected to have TimescaleDB installed");
+
+        const string Stale = "tick3035_degrade";
+
+        /* A wide read shaped exactly like the shipped one except for a column no job catalog has — so it
+           fails the same way a missing fixed_schedule/initial_start would, at the same point, and the SCOPE
+           it would have selected is identical. */
+        const string BrokenPhasedRead = @"
+SELECT
+    j.job_id,
+    j.hypertable_name,
+    j.schedule_interval::text,
+    EXTRACT(EPOCH FROM j.schedule_interval)::bigint AS schedule_interval_seconds,
+    j.fixed_schedule,
+    j.initial_start_column_that_does_not_exist,
+    j.hypertable_schema
+FROM timescaledb_information.jobs AS j
+WHERE (j.proc_name LIKE '%compression%' OR j.proc_name LIKE '%columnstore%')";
+
+        var bodySucceeded = false;
+        try
+        {
+            await DropTickTableAsync(connection, Stale, ct);
+            await CreateTickTableAsync(connection, Stale, ct);
+
+            /* A policy on the 12-hour default — the #1778 population, which must survive the degradation. */
+            await ExecAsync(connection,
+                $"SELECT add_compression_policy('collect.{Stale}', compress_after => INTERVAL '{TimescaleSupport.CompressAfterDays} days', if_not_exists => true)", ct);
+            Assert.Equal(TimeSpan.FromHours(12), (await CompressionPolicyStateAsync(connection, Stale, ct))!.ScheduleInterval);
+
+            /* CONTROL, first: the broken read really does fail, and fails on its own rather than because
+               the store is unreachable. Without this the test could "prove" the fallback while the wide read
+               was quietly succeeding. */
+            var broken = await Assert.ThrowsAsync<PostgresException>(
+                async () => await ExecAsync(connection, BrokenPhasedRead, ct));
+            Assert.Equal("42703", broken.SqlState);
+
+            /* And the shipped wide read does NOT fail on this runtime — so the fallback below is being
+               reached by the induced failure and not by an ambient one. */
+            await ExecAsync(connection, TimescaleSupport.CompressionPolicyStateSql, ct);
+
+            /* ---- THE ASSERTION: the phase is lost, the cadence converge is not. ---- */
+            var log = new CapturingTestLogger();
+            var converged = await TimescaleSupport.ConvergeCompressionScheduleAsync(connection, log, BrokenPhasedRead, ct);
+
+            Assert.True(converged >= 1,
+                $"a failed phase probe returned no conversions, so the store lost #1778's cadence converge along with the phase it could not have; {log.Joined}");
+
+            var after = await CompressionPolicyStateAsync(connection, Stale, ct);
+            Assert.NotNull(after);
+            Assert.Equal(TimescaleSupport.CompressScheduleSpan, after!.ScheduleInterval);
+
+            /* The phase half is genuinely absent, so this is a DEGRADATION and not a silent success. */
+            Assert.False(after.FixedSchedule);
+            Assert.False(after.HasInitialStart);
+
+            /* The operator is told which half was lost and which was kept — the line is the only signal a
+               store has silently dropped to cadence-only. */
+            Assert.Contains("retrying without it", log.Joined, StringComparison.Ordinal);
+            Assert.Contains("#1778", log.Joined, StringComparison.Ordinal);
+
+            /* Idempotent on the fallback path too: the cadence now matches, so a second degraded pass finds
+               nothing rather than re-altering the same job on every start. */
+            Assert.Equal(0, await TimescaleSupport.ConvergeCompressionScheduleAsync(connection, null, BrokenPhasedRead, ct));
+
+            bodySucceeded = true;
+        }
+        finally
+        {
+            await LiveStoreCleanup.RunAsync(connectionString!, bodySucceeded, async (cleanup, cleanupCt) =>
+                await DropTickTableAsync(cleanup, Stale, cleanupCt));
+        }
+    }
+
     /// <summary>The top-level items of a statement's SELECT list, trimmed and newline-flattened — used to
     /// assert the ORDINAL contract the compression converge's reader depends on. Split on commas, which is
     /// safe for these two statements specifically because neither carries a top-level comma inside an

--- a/Darling/Darling.Tests/TimescaleSupportTests.cs
+++ b/Darling/Darling.Tests/TimescaleSupportTests.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Npgsql;
@@ -2602,6 +2603,50 @@ LIMIT 1", connection))
         var foreignSql = TimescaleSupport.AddCompressionPolicySql("collect.someone_elses_hypertable");
         Assert.DoesNotContain("initial_start", foreignSql, StringComparison.Ordinal);
         Assert.Contains($"schedule_interval => INTERVAL '{TimescaleSupport.CompressScheduleInterval}'", foreignSql, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The converge really CALLS the phase-setting statement, read out of the IL — because the pure suite
+    /// cannot see it any other way.
+    ///
+    /// <para><b>This gap was found by a control, not reasoned about.</b> Mutating
+    /// <see cref="TimescaleSupport.ConvergeCompressionScheduleAsync"/> so an owned hypertable takes the
+    /// cadence-only branch — so the phase never reaches a deployed store at all — left the entire pure suite
+    /// GREEN. Every string pin above still passed, because a string pin asserts what a statement SAYS and
+    /// never that anything runs it, and that is the inert-fix-with-a-passing-suite shape rather than a milder
+    /// version of a red one. The live converge test catches it, but only in CI's PostgreSQL job; this catches
+    /// the wiring on every build.</para>
+    ///
+    /// <para>Scanned inside the compiler-generated state machine, because an async method's body lives there
+    /// after compilation and not in the source method. The cadence-only statement is the control: it has to
+    /// appear too, so a scan that resolved nothing cannot satisfy this by finding zero of everything — and
+    /// the state-machine name is asserted present first, for the same reason.</para>
+    /// </summary>
+    [Fact]
+    public void ConvergeCompressionSchedule_ActuallyCallsThePhaseStatement_NotOnlyTheCadenceOne()
+    {
+        const string Machine = "<ConvergeCompressionScheduleAsync>d__";
+        const string Phase = "get_SetCompressionSchedulePhaseSql";
+        const string Cadence = "get_SetCompressionScheduleSql";
+
+        var assemblyPath = typeof(TimescaleSupport).Assembly.Location;
+        Assert.True(File.Exists(assemblyPath), $"Storage assembly not found at '{assemblyPath}'.");
+
+        var byMachine = IlCallSiteScanner.CountCallsByStateMachine(
+            assemblyPath,
+            [Machine],
+            [Phase, Cadence]);
+
+        Assert.True(byMachine.ContainsKey(Machine),
+            $"no state machine whose name starts with {Machine} in {assemblyPath} — a renamed or inlined machine "
+            + "would report zero calls to everything and satisfy this pin for the wrong reason");
+
+        var counts = byMachine[Machine];
+
+        Assert.True(counts[Phase] >= 1,
+            "the converge never reads the phase-setting statement, so a deployed store's compression policies would keep drifting while every string pin stayed green");
+        Assert.True(counts[Cadence] >= 1,
+            "the converge never reads the cadence-only statement, so #1778's reach onto a foreign hypertable is gone");
     }
 
     /// <summary>

--- a/Darling/Darling.Tests/TimescaleSupportTests.cs
+++ b/Darling/Darling.Tests/TimescaleSupportTests.cs
@@ -2522,8 +2522,47 @@ LIMIT 1", connection))
         Assert.DoesNotContain("fixed_schedule", TimescaleSupport.SetCompressionScheduleSql, StringComparison.Ordinal);
         Assert.DoesNotContain("initial_start", TimescaleSupport.SetCompressionScheduleSql, StringComparison.Ordinal);
 
+        /* THE TWIN CROSS-CHECK, and it has to PARSE the literal rather than pin both sides to their own
+           constant. Two independent literal pins force the edit on whichever side the editor happens to be
+           looking at and force nothing on the other: change the interval to "30 minutes", update the string
+           pin because it went red, and CompressScheduleSpan keeps an hour with its own pin still green. The
+           consequence is not cosmetic — `desiredSeconds` in ConvergeCompressionScheduleAsync comes off the
+           SPAN while the policy is created with the STRING, so a divergence makes `cadenceStale` true forever
+           and the converge re-alters every compression policy on every service start. That is the exact
+           "same interval read as a difference" failure the read's own doc comment is careful about,
+           reintroduced through the twin. Same mechanism as
+           TimescaleContinuousAggregateTests.EveryRetentionIntervalLiteral_EqualsItsTimeSpanTwin. Raised by
+           review. */
         Assert.Equal("1 hour", TimescaleSupport.CompressScheduleInterval);
-        Assert.Equal(TimeSpan.FromHours(1), TimescaleSupport.CompressScheduleSpan);
+        Assert.Equal(ParsePostgresInterval(TimescaleSupport.CompressScheduleInterval), TimescaleSupport.CompressScheduleSpan);
+
+        /* Control on the parser, in the identical form: it must return the value under test for the shipped
+           literal AND reject a shape it cannot read, or a parser that answered TimeSpan.Zero to everything
+           would make the assertion above vacuous the moment the literal changed. */
+        Assert.Equal(TimeSpan.FromHours(1), ParsePostgresInterval("1 hour"));
+        Assert.Equal(TimeSpan.FromDays(3), ParsePostgresInterval("3 days"));
+        Assert.Equal(TimeSpan.Zero, ParsePostgresInterval("30 minutes"));
+    }
+
+    /// <summary>"1 hour" / "4 days" -> a <see cref="TimeSpan"/>, so a string literal and its
+    /// <see cref="TimeSpan"/> twin can be compared against ONE representation instead of two hand-maintained
+    /// ones. Unreadable shapes come back <see cref="TimeSpan.Zero"/> rather than throwing, which fails the
+    /// comparison loudly instead of passing it quietly — deliberately the same shape as
+    /// TimescaleContinuousAggregateTests' own parser, so the two do not disagree about what a literal
+    /// means.</summary>
+    private static TimeSpan ParsePostgresInterval(string interval)
+    {
+        var parts = interval.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length != 2 || !int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var count))
+        {
+            return TimeSpan.Zero;
+        }
+
+        return parts[1].StartsWith("day", StringComparison.OrdinalIgnoreCase)
+            ? TimeSpan.FromDays(count)
+            : parts[1].StartsWith("hour", StringComparison.OrdinalIgnoreCase)
+                ? TimeSpan.FromHours(count)
+                : TimeSpan.Zero;
     }
 
     /// <summary>

--- a/Darling/Darling.Tests/TimescaleSupportTests.cs
+++ b/Darling/Darling.Tests/TimescaleSupportTests.cs
@@ -2606,16 +2606,20 @@ LIMIT 1", connection))
     }
 
     /// <summary>
-    /// The converge really CALLS the phase-setting statement, read out of the IL — because the pure suite
-    /// cannot see it any other way.
+    /// The converge really references the phase-setting statement, read out of the IL — because a string pin
+    /// asserts what a statement SAYS and never that anything runs it.
     ///
-    /// <para><b>This gap was found by a control, not reasoned about.</b> Mutating
-    /// <see cref="TimescaleSupport.ConvergeCompressionScheduleAsync"/> so an owned hypertable takes the
-    /// cadence-only branch — so the phase never reaches a deployed store at all — left the entire pure suite
-    /// GREEN. Every string pin above still passed, because a string pin asserts what a statement SAYS and
-    /// never that anything runs it, and that is the inert-fix-with-a-passing-suite shape rather than a milder
-    /// version of a red one. The live converge test catches it, but only in CI's PostgreSQL job; this catches
-    /// the wiring on every build.</para>
+    /// <para><b>What this catches, measured rather than assumed.</b> It goes red when the phased branch is
+    /// wired to the cadence-only statement — the phase computed, selected on, logged, and never written —
+    /// which is the shape where the whole feature is inert and every other pin in this file stays green.
+    /// That was proven by mutation.</para>
+    ///
+    /// <para><b>And what it does NOT catch, which matters more than what it does.</b> Making the branch
+    /// GUARD always false leaves this pin green: the call is still emitted into the unreachable branch, so
+    /// its presence in the IL says the statement is wired, not that the branch is taken. Reachability
+    /// through that guard is only covered by the live converge test, which runs in CI's PostgreSQL job
+    /// alone. Both of those were run; this comment records the boundary rather than implying there
+    /// isn't one.</para>
     ///
     /// <para>Scanned inside the compiler-generated state machine, because an async method's body lives there
     /// after compilation and not in the source method. The cadence-only statement is the control: it has to
@@ -2623,7 +2627,7 @@ LIMIT 1", connection))
     /// the state-machine name is asserted present first, for the same reason.</para>
     /// </summary>
     [Fact]
-    public void ConvergeCompressionSchedule_ActuallyCallsThePhaseStatement_NotOnlyTheCadenceOne()
+    public void ConvergeCompressionSchedule_ReferencesThePhaseStatement_NotOnlyTheCadenceOne()
     {
         const string Machine = "<ConvergeCompressionScheduleAsync>d__";
         const string Phase = "get_SetCompressionSchedulePhaseSql";

--- a/Darling/Darling.Tests/TimescaleSupportTests.cs
+++ b/Darling/Darling.Tests/TimescaleSupportTests.cs
@@ -2459,6 +2459,30 @@ LIMIT 1", connection))
            be filtered out before the caller ever saw it. */
         Assert.DoesNotContain("IS DISTINCT FROM", read, StringComparison.Ordinal);
 
+        /* THE ORDINAL CONTRACT. The reader positions its columns by index, and hypertable_schema was
+           APPENDED rather than inserted precisely so no existing index moved — an ordinal shift in a column
+           list is a defect only a live store can see, and it would silently read a phase out of a boolean.
+           So the schema is asserted to be the LAST of exactly seven selected columns, which is the property
+           the C# index depends on. */
+        var selected = read[(read.IndexOf("SELECT", StringComparison.Ordinal) + "SELECT".Length)
+                ..read.IndexOf("FROM timescaledb_information.jobs", StringComparison.Ordinal)]
+            .Split(',')
+            .Select(part => part.Trim().Replace("\r", string.Empty, StringComparison.Ordinal).Replace("\n", " ", StringComparison.Ordinal))
+            .Where(part => part.Length > 0)
+            .ToArray();
+
+        /* Control on the split itself: a CASE expression carries no top-level comma, so seven parts is the
+           column count and not an artifact of splitting inside one. */
+        Assert.Equal(7, selected.Length);
+        Assert.StartsWith("j.job_id", selected[0], StringComparison.Ordinal);
+        Assert.Equal("j.hypertable_schema", selected[6]);
+
+        /* And the phase is gated on it: CompressionPhaseOrder holds BARE names, so a foreign hypertable
+           called like one of ours must not inherit its minute. The cadence converge stays unscoped on
+           purpose — that is #1778's reach. */
+        Assert.Contains("j.hypertable_schema", read, StringComparison.Ordinal);
+        Assert.DoesNotContain("hypertable_schema = ", read, StringComparison.Ordinal);
+
         var phased = TimescaleSupport.SetCompressionSchedulePhaseSql;
 
         Assert.Contains("$1::integer", phased, StringComparison.Ordinal);

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -3305,6 +3305,16 @@ WHERE (j.proc_name LIKE '%compression%' OR j.proc_name LIKE '%columnstore%')";
     /// name of a feature it cannot use. Falling back keeps the old behaviour exactly: cadence converged, phase
     /// skipped. Raised by review.</para>
     ///
+    /// <para><b>The version range this is for is the one this file already states, not one assumed from the
+    /// bundled runtime.</b> Nothing in the product declares a TimescaleDB floor and nothing checks
+    /// <c>extversion</c>: <see cref="EnableCompressionSql"/> says the pre-2.18 compression vocabulary is
+    /// "preferred here for compatibility across 2.x", the forced-refresh path already handles a store where
+    /// <c>force</c> does not exist (2.18+), and the continuous-aggregate converge's own catch already names "a
+    /// TimescaleDB too old to expose <c>initial_start</c>" as a state that reaches it. Fixed-schedule
+    /// background jobs — and therefore these two columns — are a later 2.x addition than
+    /// <c>schedule_interval</c>, so inside a stated 2.x compatibility target they cannot be assumed present.
+    /// That is the whole argument for degrading rather than for a floor pin.</para>
+    ///
     /// <para>The first four columns are byte-identical to the wide read's, in the same order, because the
     /// caller reads both with one set of ordinals — the phase columns are what it stops reading, not a
     /// different shape it starts reading.</para>
@@ -3399,8 +3409,29 @@ WHERE (j.proc_name LIKE '%compression%' OR j.proc_name LIKE '%columnstore%')";
     /// least-privilege bring-your-own store's login does not own the job) leaves that one hypertable on its old
     /// schedule and the rest still converge. Returns how many it moved.</para>
     /// </summary>
-    public static async Task<int> ConvergeCompressionScheduleAsync(
+    public static Task<int> ConvergeCompressionScheduleAsync(
         NpgsqlConnection connection, ILogger? logger, CancellationToken cancellationToken = default)
+        => ConvergeCompressionScheduleAsync(connection, logger, CompressionPolicyStateSql, cancellationToken);
+
+    /// <summary>
+    /// The seam that lets the FALLBACK DIRECTION be tested: <paramref name="phasedStateSql"/> is the wide read
+    /// the public entry point supplies, and a test supplies a deliberately-failing one instead.
+    ///
+    /// <para><b>Why a seam rather than prose.</b> The property that has to hold is not "the phase applies" but
+    /// "a probe failure costs the phase and NOTHING ELSE" — an old store must keep the
+    /// <see cref="CompressScheduleInterval"/> cadence converge it already had from #1778. Returning 0 there
+    /// would be a total regression wearing a partial's clothes, which is the failure shape this whole area
+    /// keeps producing: silent and partial, never loud. Against a runtime that HAS the phase columns there is
+    /// no other way to make the wide read fail, so without this the direction could only be reasoned about,
+    /// and that is exactly what a reviewer had to do.</para>
+    ///
+    /// <para>The FALLBACK statement is deliberately NOT injectable — <see cref="CompressionCadenceOnlyStateSql"/>
+    /// is always the one used, so a test cannot accidentally prove the degradation against a statement the
+    /// product does not ship. And the wide statement being injectable costs nothing: the public path's own
+    /// live assertions land real phases, which a wrong wide read could not do.</para>
+    /// </summary>
+    internal static async Task<int> ConvergeCompressionScheduleAsync(
+        NpgsqlConnection connection, ILogger? logger, string phasedStateSql, CancellationToken cancellationToken)
     {
         if (connection is null)
         {
@@ -3460,7 +3491,7 @@ WHERE (j.proc_name LIKE '%compression%' OR j.proc_name LIKE '%columnstore%')";
 
         try
         {
-            await ReadStateAsync(CompressionPolicyStateSql, withPhase: true);
+            await ReadStateAsync(phasedStateSql, withPhase: true);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -93,6 +93,12 @@ public static class TimescaleSupport
     /// </summary>
     public const string CompressScheduleInterval = "1 hour";
 
+    /// <summary><see cref="TimeSpan"/> twin of <see cref="CompressScheduleInterval"/>, for callers comparing a
+    /// job's cadence numerically instead of by text — <c>01:00:00</c> and <c>1 hour</c> are the same interval
+    /// and must never read as a difference (that would re-alter the same job on every service start). Pinned
+    /// equal to the string by TimescaleSupportTests.</summary>
+    public static readonly TimeSpan CompressScheduleSpan = TimeSpan.FromHours(1);
+
     /// <summary>
     /// Hypertable chunk width in days. TimescaleDB's 7-day default is far too coarse for
     /// 1-minute-cadence monitoring data: a chunk stays open (and uncompressible) for its whole
@@ -276,6 +282,12 @@ public static class TimescaleSupport
     /// initial_start TIMESTAMPTZ, timezone TEXT, compress_created_before INTERVAL)</c>, and the extension's own
     /// SQL notes it is "not strict because we need to set different default values for schedule_interval" —
     /// i.e. the default is computed in C, so omitting the argument is not the same as passing what we want.</para>
+    ///
+    /// <para>That verified signature is also where <c>initial_start</c> comes from: the statement names
+    /// it, which puts the job on this hypertable's slot on the <see cref="CompressionPhaseMinutes"/> grid
+    /// and on a FIXED schedule (#3035). The <c>-1</c> skip above applies to that too — it keys on the policy
+    /// EXISTING, not on its parameters matching — so the phase reaches a deployed store through the converge
+    /// and through nothing else.</para>
     /// </summary>
     public static string AddCompressionPolicySql(ICollectorSchemaInfo schema)
     {
@@ -287,10 +299,25 @@ public static class TimescaleSupport
         return AddCompressionPolicySql(schema.TargetTable);
     }
 
-    /// <summary>The raw-name compression-policy overload — the collection_log path (see
-    /// <see cref="CreateHypertableSql(string, string)"/>).</summary>
+    /// <summary>
+    /// The raw-name compression-policy overload — the collection_log path (see
+    /// <see cref="CreateHypertableSql(string, string)"/>), and the one that carries the phase.
+    ///
+    /// <para><b><c>initial_start</c> is named for every hypertable this product owns, and that is what puts
+    /// the job on a FIXED schedule (#3035).</b> Without it TimescaleDB computes each next start from the
+    /// previous FINISH, so a compression policy drifts through the hour by its own runtime every cycle and
+    /// crosses each fixed refresh slot in turn, spending hours to days inside one before drifting out. A
+    /// table outside <see cref="CompressionPhaseOrder"/> gets the statement without it: this code has no
+    /// business deciding when a foreign hypertable compresses.</para>
+    /// </summary>
     public static string AddCompressionPolicySql(string table)
-        => $"SELECT add_compression_policy('{table}', compress_after => INTERVAL '{CompressAfterDays} days', schedule_interval => INTERVAL '{CompressScheduleInterval}', if_not_exists => true)";
+    {
+        var initialStart = TryCompressionPhaseMinutesFor(table, out var phase)
+            ? $", initial_start => date_trunc('hour', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' + INTERVAL '1 hour' + INTERVAL '{phase.ToString(CultureInfo.InvariantCulture)} minutes'"
+            : string.Empty;
+
+        return $"SELECT add_compression_policy('{table}', compress_after => INTERVAL '{CompressAfterDays} days', schedule_interval => INTERVAL '{CompressScheduleInterval}', if_not_exists => true{initialStart})";
+    }
 
     /* ─────────────────────────── continuous aggregates (query acceleration) ─────────────────────────── */
 
@@ -1673,6 +1700,183 @@ WITH NO DATA";
             "not an hourly continuous aggregate — register it in TimescaleSupport.HourlyRefreshPhaseOrder before giving it an hourly refresh policy");
     }
 
+    /* ─────────────────────── the compression phase grid (#3035) ─────────────────────── */
+
+    /// <summary>
+    /// The hourly refresh the compression grid is placed AGAINST, named because its slot is the one no other
+    /// background work may be scheduled inside.
+    ///
+    /// <para>On the narrowed <see cref="HourlyRefreshStartOffset"/> window it is still by far the largest job
+    /// on the grid — see <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/> for the number the grid is
+    /// sized against and for the operating envelope that number defines. Every other hourly refresh is an
+    /// order of magnitude smaller (<see cref="OtherHourlyRefreshObservedCeilingSeconds"/>), and that asymmetry
+    /// is what the grid below is shaped by: one slot treated as FULL, the rest as occupied only at their
+    /// start.</para>
+    /// </summary>
+    public const string HeaviestHourlyRefreshView = QueryStoreStatsIntervalHourlyView;
+
+    /// <summary>
+    /// The longest run recorded for <see cref="HeaviestHourlyRefreshView"/> under the narrowed
+    /// <see cref="HourlyRefreshStartOffset"/> window, and the number the compression grid is sized against.
+    ///
+    /// <para><b>The measured range, so a later reader can tell whether they are still inside it.</b> Before
+    /// the narrowing this job ran 3,301-6,330 s against a 1-hour cadence. Under the 1-day window the highest
+    /// figure recorded is the 864 s here; the drift chart's most recent readings for the same job are
+    /// <b>194 s, 225 s and 335 s</b>, climbing with volume rather than settling. The grid is sized against the
+    /// 864 s ceiling and not against the 194 s low, because a slot chosen against the low would be correct
+    /// only at the load it was chosen at.</para>
+    ///
+    /// <para><b>THE OPERATING ENVELOPE, stated because it is a condition and not a property.</b> #3012's
+    /// convoy needed a refresh and a compression policy to want the same relation at the same time. Two things
+    /// make that residual small right now, and BOTH are load-dependent. The refresh window
+    /// (<c>[now - 1 day, now - 1 hour]</c>) and the chunks a compression policy finds eligible
+    /// (<c>range_end &lt;= now - 1 day</c> on <see cref="CompressAfterDays"/>) are disjoint at any single
+    /// instant — but the two <c>now</c>s are not the same instant. A refresh that started D seconds ago is
+    /// still holding its lock while a compression job evaluates eligibility against a <c>now</c> that has moved
+    /// D forward, so the set of chunks that are inside the running refresh's window AND already eligible for
+    /// the compression starting now is exactly <b>D wide</b>. The overlap therefore grows with D, and so does
+    /// the plain window in which a compression tick can queue an <c>AccessExclusiveLock</c> behind a refresh's
+    /// <c>AccessShareLock</c> on the same hypertable — the mechanism #3012 measured, which never needed chunk
+    /// overlap at all.</para>
+    ///
+    /// <para><b>So: the small-residual reading holds while this job completes well inside its slot, and what
+    /// invalidates it is this number approaching <see cref="RefreshPhaseStepMinutes"/> x 60.</b> At 864 s
+    /// against a 900-second slot the margin is already only 36 seconds, which is why the heaviest slot is
+    /// excluded WHOLE rather than guarded, and why a value at or past the slot width is asserted as a failure
+    /// rather than accommodated: past that point the refresh runs into its neighbour and the grid needs
+    /// redesigning, not renumbering.</para>
+    /// </summary>
+    public const int HeaviestHourlyRefreshObservedCeilingSeconds = 864;
+
+    /// <summary>
+    /// The longest run recorded for any hourly refresh OTHER than
+    /// <see cref="HeaviestHourlyRefreshView"/> — the number <see cref="CompressionPhaseGuardMinutes"/> is
+    /// derived from. The first full staggered cycle came back 26 s / 2 s / 864 s / 140 s, so this is the 140.
+    /// </summary>
+    public const int OtherHourlyRefreshObservedCeilingSeconds = 140;
+
+    /// <summary>
+    /// How long after a refresh slot starts a compression policy may be scheduled — half a
+    /// <see cref="RefreshPhaseStepMinutes"/> slot.
+    ///
+    /// <para><b>The guard is one-sided, and that asymmetry is the mechanism rather than a simplification.</b>
+    /// #3012's convoy needs compression's <c>AccessExclusiveLock</c> request to ARRIVE while a refresh already
+    /// holds <c>AccessShareLock</c> on the same hypertable: a QUEUED exclusive blocks every subsequent shared
+    /// request, so collector writes pile up behind a lock nobody holds. The reverse order does not compose
+    /// that way — a compression run already holding its lock blocks collectors for its own duration whether or
+    /// not a refresh starts, which is the ordinary cost of compressing and not something a schedule can move.
+    /// So compression is kept clear of the minutes AFTER a refresh start and needs no clearance before the
+    /// next one.</para>
+    ///
+    /// <para>Half a slot is 7 minutes here, which is exactly 3x
+    /// <see cref="OtherHourlyRefreshObservedCeilingSeconds"/> — the longest run recorded for any hourly
+    /// refresh other than the heaviest — and it can never exceed the gap it sits in, because it is
+    /// derived from the slot width rather than chosen against it. That 3x is the margin the envelope on
+    /// <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/> is stated in terms of: the light
+    /// refreshes would have to climb past 420 s, three times their recorded ceiling, before a
+    /// compression tick could land inside one.</para>
+    /// </summary>
+    public const int CompressionPhaseGuardMinutes = RefreshPhaseStepMinutes / 2;
+
+    /// <summary>
+    /// Every minute of the hour a compression policy may start on: the second half of each refresh slot,
+    /// with the heaviest refresh's slot excluded entirely.
+    ///
+    /// <para><b>Why a spread rather than one shared minute.</b> All the compression policies would happily
+    /// share a minute as far as LOCKS go — they compress different hypertables, so they do not contend with
+    /// each other at all — but they would then do their real work simultaneously. <see cref="CompressAfterDays"/>
+    /// and <see cref="ChunkIntervalDays"/> are both 1 and TimescaleDB aligns 1-day chunks to the epoch, so
+    /// every hypertable's newest closed chunk becomes eligible at the same UTC midnight. Drifting policies
+    /// discover that eligibility at whatever minute they have drifted to, which spreads the daily rewrite
+    /// across the hour; collapsing them onto one minute would concentrate it into one. That is a burst this
+    /// change would be INTRODUCING, not removing, so the grid keeps the spread and takes only the drift away.</para>
+    ///
+    /// <para><b>Why the heaviest slot is excluded whole rather than guarded.</b>
+    /// <see cref="HeaviestHourlyRefreshView"/> occupies 14.4 of the 15 minutes in its slot, so there is no
+    /// minute of that slot a <see cref="CompressionPhaseGuardMinutes"/> band could recover. Excluding it is
+    /// also what keeps the remaining minutes far from the only refresh that can reach forward: the nearest is
+    /// a full slot past the heaviest one, and the furthest is 59 minutes past it.</para>
+    ///
+    /// <para>Derived from the refresh grid, so a change to <see cref="RefreshPhaseStepMinutes"/> or to where
+    /// the heaviest refresh sits moves these minutes with it rather than leaving behind a literal that used to
+    /// be clear. Declared HERE, after <see cref="HourlyRefreshPhaseOrder"/>, because a static field
+    /// initializer runs in declaration order and this one reads that list through
+    /// <see cref="RefreshPhaseMinutesFor"/>.</para>
+    /// </summary>
+    public static readonly IReadOnlyList<int> CompressionPhaseMinutes = BuildCompressionPhaseMinutes();
+
+    private static int[] BuildCompressionPhaseMinutes()
+    {
+        var heaviestSlot = RefreshPhaseMinutesFor(HeaviestHourlyRefreshView);
+        var minutes = new List<int>(60);
+
+        for (var minute = 0; minute < 60; minute++)
+        {
+            var slot = minute / RefreshPhaseStepMinutes * RefreshPhaseStepMinutes;
+            if (slot == heaviestSlot || minute - slot < CompressionPhaseGuardMinutes)
+            {
+                continue;
+            }
+
+            minutes.Add(minute);
+        }
+
+        return minutes.ToArray();
+    }
+
+    /// <summary>
+    /// The hypertables that carry a compression policy, in phase order — the collector catalog, then
+    /// <c>collection_log</c>, which is a hypertable OUTSIDE that catalog (the same <c>+ 1</c>
+    /// <see cref="HypertableCount"/> accounts for).
+    ///
+    /// <para><b>Keyed on the HYPERTABLE, never on a job id.</b> TimescaleDB assigns job ids per deployment, so
+    /// an encoded id would name a different job on every other store. A compression job reports its own
+    /// hypertable directly in <c>timescaledb_information.jobs</c>, which is why the converge needs no catalog
+    /// join to recover identity the way the refresh converge does — and why the id only ever reaches
+    /// <c>alter_job</c> as a bound parameter.</para>
+    ///
+    /// <para>Derived from <see cref="HypertableTables"/> rather than hand-listed, so a new collector is
+    /// registered by adding it to the catalog and there is no second list to forget. That is why an
+    /// unrecognised name is a FOREIGN hypertable — a bring-your-own store's own table, or a fixture table —
+    /// rather than an omission, and is left unphased instead of throwing the way an unregistered hourly view
+    /// does.</para>
+    /// </summary>
+    public static readonly IReadOnlyList<string> CompressionPhaseOrder =
+        HypertableTables.Select(t => t.TargetTable).Append(CollectionLogTable).ToArray();
+
+    /// <summary>
+    /// Which minute of the hour <paramref name="table"/>'s compression policy starts on; <c>false</c> when
+    /// this product does not own the hypertable, in which case its schedule is none of this code's business
+    /// beyond the <see cref="CompressScheduleInterval"/> tick #1778 already converges.
+    ///
+    /// <para>Accepts a bare or <c>collect.</c>-qualified name: the product always passes the bare
+    /// <c>TargetTable</c>, but the raw-name overload of <see cref="AddCompressionPolicySql(string)"/> is
+    /// reachable with a qualified one.</para>
+    /// </summary>
+    public static bool TryCompressionPhaseMinutesFor(string table, out int minutes)
+    {
+        minutes = 0;
+
+        if (string.IsNullOrEmpty(table))
+        {
+            return false;
+        }
+
+        var dot = table.LastIndexOf('.');
+        var bare = dot >= 0 ? table[(dot + 1)..] : table;
+
+        for (var index = 0; index < CompressionPhaseOrder.Count; index++)
+        {
+            if (string.Equals(CompressionPhaseOrder[index], bare, StringComparison.Ordinal))
+            {
+                minutes = CompressionPhaseMinutes[index % CompressionPhaseMinutes.Count];
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /// <summary>
     /// An HOURLY continuous aggregate's refresh policy: <see cref="HourlyRefreshStartOffset"/> of window, an
     /// <see cref="HourlyRefreshScheduleInterval"/> cadence, and this view's own slot on the phase grid.
@@ -3035,26 +3239,42 @@ AND   j.hypertable_name = '{relation}'";
     }
 
     /// <summary>
-    /// Every COMPRESSION-policy job whose <c>schedule_interval</c> is not
-    /// <see cref="CompressScheduleInterval"/> — the stores that need converging (#1778). The comparison is
-    /// done by PostgreSQL against a typed <c>INTERVAL</c> literal rather than by string in C#, so
-    /// <c>01:00:00</c> and <c>1 hour</c> compare equal instead of drifting on formatting.
+    /// Every COMPRESSION-policy job's schedule, with the three things a converged policy is made of: the
+    /// cadence it wakes on, whether that cadence is a FIXED schedule, and which minute of the hour it starts
+    /// on.
+    ///
+    /// <para><b>Unfiltered, with staleness decided in C# (#3035).</b> The #1778 form carried
+    /// <c>schedule_interval IS DISTINCT FROM INTERVAL '1 hour'</c> in the WHERE clause, and that cannot
+    /// express the phase test: the wanted minute is PER HYPERTABLE, so no single SQL literal stands for it and
+    /// a job stale only on its phase would be filtered out before the caller ever saw it. The cadence is
+    /// therefore emitted as SECONDS as well as text, which is what the typed-INTERVAL comparison used to
+    /// provide — <c>01:00:00</c> and <c>1 hour</c> cannot read as a difference and re-alter the same job on
+    /// every start — and the text form stays because the line an operator reads names the cadence the policy
+    /// LEFT.</para>
     ///
     /// <para>Scoped to compression jobs the SAME tolerant way <see cref="ReadStuckCompressionJobsAsync"/> is
     /// (<c>policy_compression</c> plus the 2.18+ <c>columnstore</c> rebrand). Retention, continuous-aggregate
     /// refresh, reorder and every other job type are deliberately untouched: their cadences are separate
     /// decisions, and the retention jobs in particular carry an armed/paused state (#1680) this must never
     /// disturb.</para>
+    ///
+    /// <para>The phase comes back as a minute-of-hour already converted to UTC. A bare
+    /// <c>EXTRACT(MINUTE FROM initial_start)</c> would read the SESSION time zone, which on any of the
+    /// half-hour and quarter-hour zones is a store-wide silent skew rather than a local oddity.</para>
     /// </summary>
-    public static string StaleCompressionScheduleSql =>
-        $@"
+    public const string CompressionPolicyStateSql = @"
 SELECT
     j.job_id,
     j.hypertable_name,
-    j.schedule_interval::text
+    j.schedule_interval::text,
+    EXTRACT(EPOCH FROM j.schedule_interval)::bigint AS schedule_interval_seconds,
+    j.fixed_schedule,
+    CASE
+        WHEN j.initial_start IS NULL THEN NULL
+        ELSE EXTRACT(MINUTE FROM j.initial_start AT TIME ZONE 'UTC')::int
+    END AS phase_minutes
 FROM timescaledb_information.jobs AS j
-WHERE (j.proc_name LIKE '%compression%' OR j.proc_name LIKE '%columnstore%')
-AND   j.schedule_interval IS DISTINCT FROM INTERVAL '{CompressScheduleInterval}'";
+WHERE (j.proc_name LIKE '%compression%' OR j.proc_name LIKE '%columnstore%')";
 
     /// <summary>
     /// Retunes one existing compression policy to <see cref="CompressScheduleInterval"/>. The job id is BOUND
@@ -3067,24 +3287,75 @@ AND   j.schedule_interval IS DISTINCT FROM INTERVAL '{CompressScheduleInterval}'
     /// considers eligible. Measured on 2.28.1: the change also re-anchors <c>next_start</c> immediately
     /// (a job sitting at last-finish + 12h moved to last-finish + 1h), so a converged store starts honoring the
     /// new cadence on the next tick rather than after one final half-day wait.</para>
+    ///
+    /// <para>This is the FOREIGN-hypertable form. A hypertable this product owns takes
+    /// <see cref="SetCompressionSchedulePhaseSql"/> instead, which also pins the schedule; leaving a foreign
+    /// hypertable's <c>fixed_schedule</c> alone keeps #1778's reach exactly as wide as it was without this
+    /// code choosing a minute for a table it knows nothing about.</para>
     /// </summary>
     public static string SetCompressionScheduleSql =>
         $"SELECT alter_job($1::integer, schedule_interval => INTERVAL '{CompressScheduleInterval}')";
 
     /// <summary>
-    /// Retunes EXISTING compression policies to <see cref="CompressScheduleInterval"/> (#1778) — the half of
-    /// the tick fix that reaches stores which already have policies.
+    /// Moves one existing compression policy onto <see cref="CompressScheduleInterval"/> AND onto its slot on
+    /// the compression phase grid. <c>$1</c> the job id (<c>::integer</c>, the #1586 trap), <c>$2</c> the
+    /// minute of the hour.
     ///
-    /// <para>Without this the change would only ever help fresh installs: <see cref="AddCompressionPolicySql"/>
-    /// carries the interval, but <c>if_not_exists => true</c> makes it a documented no-op against an existing
-    /// policy (measured: returns -1, NOTICE, parameters untouched), so every store that ever ran an older build
-    /// — the field store in #1778 among them — would keep waking twice a day forever. Idempotent by
-    /// construction: it selects only the jobs that DIFFER, so the first start after deploy converges the store
-    /// and every start after that finds nothing and logs nothing.</para>
+    /// <para><b>Naming <c>initial_start</c> is the half that makes the minute durable</b>, not decoration:
+    /// TimescaleDB computes the next start from the previous FINISH when <c>initial_start</c> is absent, which
+    /// is why a compression policy set to a minute by hand slides off it by its own runtime every cycle. The
+    /// anchor is the NEXT whole hour plus the phase — deliberately in the future, because a fixed schedule
+    /// needs a non-null <c>initial_start</c> and anchoring forward never depends on how a past anchor is
+    /// handled — and computed in UTC rather than with a bare <c>date_trunc('hour', now())</c>, which truncates
+    /// in the SESSION time zone. Both for the same reasons
+    /// <see cref="AddContinuousAggregatePolicySql"/> computes it that way.</para>
+    ///
+    /// <para><c>scheduled</c> is deliberately not named, so this cannot arm a paused job. That is
+    /// load-bearing here rather than defensive: the fixture idiom for a deterministic compression test is a
+    /// policy created and parked at <c>scheduled = false</c> in one transaction (#1888), and a converge that
+    /// re-armed it would make those tests race the scheduler again.</para>
+    /// </summary>
+    public static string SetCompressionSchedulePhaseSql =>
+        $@"SELECT alter_job(
+    $1::integer,
+    schedule_interval => INTERVAL '{CompressScheduleInterval}',
+    fixed_schedule => true,
+    initial_start => date_trunc('hour', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' + INTERVAL '1 hour' + ($2::int * INTERVAL '1 minute'))";
+
+    /// <summary>
+    /// Converges EXISTING compression policies onto <see cref="CompressScheduleInterval"/> (#1778) and onto
+    /// the <see cref="CompressionPhaseMinutes"/> grid on a fixed schedule (#3035) — one function owning both
+    /// properties, because they are set by the same <c>alter_job</c> and a second sweep would fight this one
+    /// for the same rows.
+    ///
+    /// <para><b>Why converging is the only path that reaches a deployed store, and why the reason is not the
+    /// one the refresh side has.</b> <see cref="AddCompressionPolicySql"/> carries both the interval and the
+    /// phase, but <c>if_not_exists =&gt; true</c> makes it a documented no-op against a policy the store
+    /// already has (measured: returns -1, NOTICE, parameters untouched) — it keys on the policy EXISTING, not
+    /// on its parameters matching. So the create path reaches fresh installs only. That is a quiet skip rather
+    /// than the <c>22023</c> raise <c>add_continuous_aggregate_policy</c> answers a differing window with,
+    /// which is why the compression create can keep running BEFORE this converge while the refresh create has
+    /// to run after its own.</para>
+    ///
+    /// <para><b>Behaviour on each of the three store states.</b> A FRESH store has already had its policies
+    /// created by <see cref="ApplyCompressionPolicyAsync"/> and
+    /// <see cref="EnsureCollectionLogHypertableAsync"/> moments earlier, WITH <c>initial_start</c>, so this
+    /// reads them back matching and returns 0 — the mirror image of the refresh converge, which sees an empty
+    /// set on a fresh store because its aggregates do not exist yet. A store carrying OLD values gets both
+    /// properties on the first start after deploy. A store an operator already patched BY HAND to a minute is
+    /// re-phased anyway, and that is deliberate: a hand-set minute on a finish-to-start job is not a stagger
+    /// with a slow leak, it is one with a countdown, and the production store settled the argument by reading
+    /// <c>fixed_schedule = f</c> on every compression job it had.</para>
+    ///
+    /// <para><b>Idempotent by construction</b>: only jobs that DIFFER on cadence or on phase are altered, so
+    /// the first start after deploy converges the store and every start after that finds nothing and logs
+    /// nothing. FOREIGN hypertables — a bring-your-own store's own tables, fixture tables — keep #1778's
+    /// cadence converge and are left off the grid, because <see cref="CompressionPhaseOrder"/> is derived from
+    /// the collector catalog and an unrecognised name means "not ours" rather than "forgotten".</para>
     ///
     /// <para>Failure-isolated PER JOB, the #1775 shape: one <c>alter_job</c> that fails (most often because a
     /// least-privilege bring-your-own store's login does not own the job) leaves that one hypertable on its old
-    /// cadence and the rest still converge. Returns how many it retuned.</para>
+    /// schedule and the rest still converge. Returns how many it moved.</para>
     /// </summary>
     public static async Task<int> ConvergeCompressionScheduleAsync(
         NpgsqlConnection connection, ILogger? logger, CancellationToken cancellationToken = default)
@@ -3094,45 +3365,86 @@ AND   j.schedule_interval IS DISTINCT FROM INTERVAL '{CompressScheduleInterval}'
             throw new ArgumentNullException(nameof(connection));
         }
 
-        var stale = new List<(int JobId, string? Hypertable, string? Interval)>();
+        var desiredSeconds = (long)CompressScheduleSpan.TotalSeconds;
+
+        var stale = new List<(int JobId, string? Hypertable, string? Interval, bool WasFixed, int? WasPhase, int? Phase)>();
         try
         {
-            using var probe = new NpgsqlCommand(StaleCompressionScheduleSql, connection) { CommandTimeout = SetupTimeoutSeconds };
+            using var probe = new NpgsqlCommand(CompressionPolicyStateSql, connection) { CommandTimeout = SetupTimeoutSeconds };
             await using var reader = await probe.ExecuteReaderAsync(cancellationToken);
             while (await reader.ReadAsync(cancellationToken))
             {
+                var hypertable = reader.IsDBNull(1) ? null : reader.GetString(1);
+                var intervalText = reader.IsDBNull(2) ? null : reader.GetString(2);
+                var seconds = reader.IsDBNull(3) ? (long?)null : reader.GetInt64(3);
+                var fixedSchedule = !reader.IsDBNull(4) && reader.GetBoolean(4);
+                var wasPhase = reader.IsDBNull(5) ? (int?)null : reader.GetInt32(5);
+
+                int? phase = hypertable is not null && TryCompressionPhaseMinutesFor(hypertable, out var slot)
+                    ? slot
+                    : null;
+
+                /* A NULL cadence is the widest wakeup there is, so it counts as stale rather than as
+                   "nothing to compare". */
+                var cadenceStale = seconds != desiredSeconds;
+                var phaseStale = phase is int wanted && (!fixedSchedule || wasPhase != wanted);
+
+                if (!cadenceStale && !phaseStale)
+                {
+                    continue;
+                }
+
                 stale.Add((
                     Convert.ToInt32(reader.GetValue(0), CultureInfo.InvariantCulture),
-                    reader.IsDBNull(1) ? null : reader.GetString(1),
-                    reader.IsDBNull(2) ? null : reader.GetString(2)));
+                    hypertable,
+                    intervalText,
+                    fixedSchedule,
+                    wasPhase,
+                    phase));
             }
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            /* A plain-PostgreSQL store (the views do not exist) or a store hiccup. The caller already gates on
-               the extension; nothing to converge either way. */
+            /* A plain-PostgreSQL store (the views do not exist), a TimescaleDB too old to expose
+               initial_start, or a store hiccup. The caller already gates on the extension; nothing to
+               converge either way. */
             logger?.LogDebug("Compression-schedule converge: could not read policy jobs: {Message}", ex.Message);
             return 0;
         }
 
         var converged = 0;
-        foreach (var (jobId, hypertable, interval) in stale)
+        foreach (var (jobId, hypertable, interval, wasFixed, wasPhase, phase) in stale)
         {
             try
             {
-                using var alter = new NpgsqlCommand(SetCompressionScheduleSql, connection) { CommandTimeout = SetupTimeoutSeconds };
-                alter.Parameters.AddWithValue(jobId);
-                await alter.ExecuteNonQueryAsync(cancellationToken);
-                converged++;
+                if (phase is int slot)
+                {
+                    using var alter = new NpgsqlCommand(SetCompressionSchedulePhaseSql, connection) { CommandTimeout = SetupTimeoutSeconds };
+                    alter.Parameters.AddWithValue(jobId);
+                    alter.Parameters.AddWithValue(slot);
+                    await alter.ExecuteNonQueryAsync(cancellationToken);
+                    converged++;
 
-                logger?.LogInformation(
-                    "TimescaleDB: retuned {Hypertable}'s compression policy from a {Was} tick to {Now} — that is the longest an already-eligible chunk can now sit uncompressed.",
-                    hypertable, interval, CompressScheduleInterval);
+                    logger?.LogInformation(
+                        "TimescaleDB: retuned {Hypertable}'s compression policy from a {Was} tick to {Now} on a fixed :{Phase} schedule (was fixed_schedule={WasFixed}, phase {WasPhase}) — an unpinned policy computes its next start from its last FINISH, so it drifts by its own runtime every cycle and laps the hour through every refresh slot in turn (#3035).",
+                        hypertable, interval, CompressScheduleInterval, slot.ToString("00", CultureInfo.InvariantCulture), wasFixed, wasPhase);
+                }
+                else
+                {
+                    using var alter = new NpgsqlCommand(SetCompressionScheduleSql, connection) { CommandTimeout = SetupTimeoutSeconds };
+                    alter.Parameters.AddWithValue(jobId);
+                    await alter.ExecuteNonQueryAsync(cancellationToken);
+                    converged++;
+
+                    logger?.LogInformation(
+                        "TimescaleDB: retuned {Hypertable}'s compression policy from a {Was} tick to {Now} — that is the longest an already-eligible chunk can now sit uncompressed.",
+                        hypertable, interval, CompressScheduleInterval);
+                }
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 logger?.LogWarning(
-                    "Could not retune {Hypertable}'s compression policy (job {JobId}) to a {Interval} tick — it keeps its {Was} cadence, so its newest closed chunk stays uncompressed longer (often a permission issue: the store login must own the job): {Message}",
+                    "Could not converge {Hypertable}'s compression policy (job {JobId}) onto a {Interval} tick — it keeps its {Was} cadence and its old schedule, so its newest closed chunk stays uncompressed longer and its tick keeps drifting through the refresh slots (often a permission issue: the store login must own the job): {Message}",
                     hypertable, jobId, CompressScheduleInterval, interval, ex.Message);
             }
         }
@@ -3140,7 +3452,7 @@ AND   j.schedule_interval IS DISTINCT FROM INTERVAL '{CompressScheduleInterval}'
         if (converged > 0)
         {
             logger?.LogInformation(
-                "TimescaleDB: {Converged}/{Total} compression policies retuned to a {Interval} tick (#1778 — TimescaleDB's own default for 1-day chunks is 12 hours).",
+                "TimescaleDB: {Converged}/{Total} compression policies converged onto a {Interval} tick and, where the hypertable is ours, onto the compression phase grid (#1778 — TimescaleDB's own default for 1-day chunks is 12 hours; #3035 — an unpinned policy drifts finish-to-start).",
                 converged, stale.Count, CompressScheduleInterval);
         }
 

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -309,6 +309,17 @@ public static class TimescaleSupport
     /// crosses each fixed refresh slot in turn, spending hours to days inside one before drifting out. A
     /// table outside <see cref="CompressionPhaseOrder"/> gets the statement without it: this code has no
     /// business deciding when a foreign hypertable compresses.</para>
+    ///
+    /// <para><b>This resolves a bare name where the converge additionally checks the schema, and the
+    /// asymmetry is a caller invariant rather than an oversight.</b> A statement takes a table name and has
+    /// no schema to check — <c>add_compression_policy</c> resolves it through the session's search path, the
+    /// same way every other bare name in this file does. So the safety rests on WHO calls it, and both
+    /// callers pass names this product owns: <see cref="ApplyCompressionPolicyAsync"/> walks
+    /// <see cref="HypertableTables"/> and <see cref="EnsureCollectionLogHypertableAsync"/> passes
+    /// <see cref="CollectionLogTable"/>. The converge has a schema available because it reads one back from
+    /// the job catalog, where the rows are whatever the store contains rather than whatever this product
+    /// created, so it checks. A future caller handing this overload a foreign or qualified name would break
+    /// that invariant and get a phase it should not have. Raised by review.</para>
     /// </summary>
     public static string AddCompressionPolicySql(string table)
     {
@@ -3500,8 +3511,11 @@ WHERE (j.proc_name LIKE '%compression%' OR j.proc_name LIKE '%columnstore%')";
                giving up: a store old enough to lack them was converged fine by #1778 before the phase was
                added to this read, and returning 0 here would silently take that away as well. See
                CompressionCadenceOnlyStateSql. */
+            /* The catch is deliberately broad — the file's existing tolerant style — so this line must not
+               assert a cause it has not established. It states what was observed and what it costs, and
+               offers the two candidate reasons as candidates. Raised by review. */
             logger?.LogInformation(
-                "TimescaleDB: could not read compression-policy schedules with their phase ({Message}) — retrying without it. A store whose job catalog predates fixed_schedule/initial_start still gets the {Interval} tick (#1778); its compression policies keep TimescaleDB's finish-to-start scheduling and will drift through the refresh slots (#3035).",
+                "TimescaleDB: could not read compression-policy schedules with their phase ({Message}) — retrying without it, so the {Interval} tick (#1778) still converges and only the phase is skipped. The reason is not established here: a job catalog predating fixed_schedule/initial_start fails this way on every start, while a transient store error fails this way once and the next start pins the phases. Either way these policies keep TimescaleDB's finish-to-start scheduling until a phased read succeeds, so they drift through the refresh slots (#3035).",
                 ex.Message, CompressScheduleInterval);
 
             try

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -3258,6 +3258,13 @@ AND   j.hypertable_name = '{relation}'";
     /// decisions, and the retention jobs in particular carry an armed/paused state (#1680) this must never
     /// disturb.</para>
     ///
+    /// <para><b>Two of these columns are younger than the rest of the read, which is why
+    /// <see cref="CompressionCadenceOnlyStateSql"/> exists.</b> <c>fixed_schedule</c> and
+    /// <c>initial_start</c> entered <c>timescaledb_information.jobs</c> later than <c>schedule_interval</c>
+    /// did, so on a store old enough to lack them this statement throws — and #1778's cadence converge, which
+    /// only ever needed the older columns, would be lost with it. The caller retries with the narrow read
+    /// instead of returning zero.</para>
+    ///
     /// <para>The phase comes back as a minute-of-hour already converted to UTC. A bare
     /// <c>EXTRACT(MINUTE FROM initial_start)</c> would read the SESSION time zone, which on any of the
     /// half-hour and quarter-hour zones is a store-wide silent skew rather than a local oddity.</para>
@@ -3282,6 +3289,32 @@ SELECT
         ELSE EXTRACT(MINUTE FROM j.initial_start AT TIME ZONE 'UTC')::int
     END AS phase_minutes,
     j.hypertable_schema
+FROM timescaledb_information.jobs AS j
+WHERE (j.proc_name LIKE '%compression%' OR j.proc_name LIKE '%columnstore%')";
+
+    /// <summary>
+    /// The same read as <see cref="CompressionPolicyStateSql"/> minus the two columns the PHASE needs — the
+    /// fallback for a store whose <c>timescaledb_information.jobs</c> does not have them.
+    ///
+    /// <para><b>This exists because widening a read can turn a partial capability into a total outage, and
+    /// that direction is worse than the one it was widening for.</b> <c>schedule_interval</c> has been in that
+    /// view far longer than <c>fixed_schedule</c> and <c>initial_start</c> have. #1778's cadence converge only
+    /// ever needed the former, so a store old enough to lack the latter two used to be converged fine — and
+    /// once the phase columns were added to the one read this function makes, that store's probe would throw,
+    /// be caught, return 0, and lose the cadence converge it already had. A silent TOTAL regression in the
+    /// name of a feature it cannot use. Falling back keeps the old behaviour exactly: cadence converged, phase
+    /// skipped. Raised by review.</para>
+    ///
+    /// <para>The first four columns are byte-identical to the wide read's, in the same order, because the
+    /// caller reads both with one set of ordinals — the phase columns are what it stops reading, not a
+    /// different shape it starts reading.</para>
+    /// </summary>
+    public const string CompressionCadenceOnlyStateSql = @"
+SELECT
+    j.job_id,
+    j.hypertable_name,
+    j.schedule_interval::text,
+    EXTRACT(EPOCH FROM j.schedule_interval)::bigint AS schedule_interval_seconds
 FROM timescaledb_information.jobs AS j
 WHERE (j.proc_name LIKE '%compression%' OR j.proc_name LIKE '%columnstore%')";
 
@@ -3377,21 +3410,28 @@ WHERE (j.proc_name LIKE '%compression%' OR j.proc_name LIKE '%columnstore%')";
         var desiredSeconds = (long)CompressScheduleSpan.TotalSeconds;
 
         var stale = new List<(int JobId, string? Hypertable, string? Interval, bool WasFixed, int? WasPhase, int? Phase)>();
-        try
+
+        /* One reader for both statements: the narrow one is the wide one's first four columns in the same
+           order, so withPhase decides which ordinals are READ rather than selecting a different shape. */
+        async Task ReadStateAsync(string sql, bool withPhase)
         {
-            using var probe = new NpgsqlCommand(CompressionPolicyStateSql, connection) { CommandTimeout = SetupTimeoutSeconds };
+            stale.Clear();
+
+            using var probe = new NpgsqlCommand(sql, connection) { CommandTimeout = SetupTimeoutSeconds };
             await using var reader = await probe.ExecuteReaderAsync(cancellationToken);
             while (await reader.ReadAsync(cancellationToken))
             {
                 var hypertable = reader.IsDBNull(1) ? null : reader.GetString(1);
                 var intervalText = reader.IsDBNull(2) ? null : reader.GetString(2);
                 var seconds = reader.IsDBNull(3) ? (long?)null : reader.GetInt64(3);
-                var fixedSchedule = !reader.IsDBNull(4) && reader.GetBoolean(4);
-                var wasPhase = reader.IsDBNull(5) ? (int?)null : reader.GetInt32(5);
+
+                var fixedSchedule = withPhase && !reader.IsDBNull(4) && reader.GetBoolean(4);
+                var wasPhase = withPhase && !reader.IsDBNull(5) ? reader.GetInt32(5) : (int?)null;
 
                 /* Schema-exact, because CompressionPhaseOrder holds BARE names: a foreign hypertable
                    named like one of ours must not inherit its minute. */
-                var ours = !reader.IsDBNull(6)
+                var ours = withPhase
+                    && !reader.IsDBNull(6)
                     && string.Equals(reader.GetString(6), PgSchemaGenerator.CollectSchema, StringComparison.Ordinal);
 
                 int? phase = ours && hypertable is not null && TryCompressionPhaseMinutesFor(hypertable, out var slot)
@@ -3417,13 +3457,33 @@ WHERE (j.proc_name LIKE '%compression%' OR j.proc_name LIKE '%columnstore%')";
                     phase));
             }
         }
+
+        try
+        {
+            await ReadStateAsync(CompressionPolicyStateSql, withPhase: true);
+        }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            /* A plain-PostgreSQL store (the views do not exist), a TimescaleDB too old to expose
-               initial_start, or a store hiccup. The caller already gates on the extension; nothing to
-               converge either way. */
-            logger?.LogDebug("Compression-schedule converge: could not read policy jobs: {Message}", ex.Message);
-            return 0;
+            /* The wide read names fixed_schedule and initial_start, which entered
+               timescaledb_information.jobs later than schedule_interval did. Retry WITHOUT them rather than
+               giving up: a store old enough to lack them was converged fine by #1778 before the phase was
+               added to this read, and returning 0 here would silently take that away as well. See
+               CompressionCadenceOnlyStateSql. */
+            logger?.LogInformation(
+                "TimescaleDB: could not read compression-policy schedules with their phase ({Message}) — retrying without it. A store whose job catalog predates fixed_schedule/initial_start still gets the {Interval} tick (#1778); its compression policies keep TimescaleDB's finish-to-start scheduling and will drift through the refresh slots (#3035).",
+                ex.Message, CompressScheduleInterval);
+
+            try
+            {
+                await ReadStateAsync(CompressionCadenceOnlyStateSql, withPhase: false);
+            }
+            catch (Exception narrow) when (narrow is not OperationCanceledException)
+            {
+                /* A plain-PostgreSQL store (the views do not exist) or a store hiccup. The caller already
+                   gates on the extension; nothing to converge either way. */
+                logger?.LogDebug("Compression-schedule converge: could not read policy jobs: {Message}", narrow.Message);
+                return 0;
+            }
         }
 
         var converged = 0;

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -95,8 +95,14 @@ public static class TimescaleSupport
 
     /// <summary><see cref="TimeSpan"/> twin of <see cref="CompressScheduleInterval"/>, for callers comparing a
     /// job's cadence numerically instead of by text — <c>01:00:00</c> and <c>1 hour</c> are the same interval
-    /// and must never read as a difference (that would re-alter the same job on every service start). Pinned
-    /// equal to the string by TimescaleSupportTests.</summary>
+    /// and must never read as a difference (that would re-alter the same job on every service start).
+    ///
+    /// <para>Cross-checked against <see cref="CompressScheduleInterval"/> by PARSING that literal, not by
+    /// pinning each side to its own constant: two independent pins force the edit on whichever side the
+    /// editor is looking at and force nothing on the other, and a divergence here is not cosmetic —
+    /// <see cref="ConvergeCompressionScheduleAsync(NpgsqlConnection, ILogger, CancellationToken)"/> takes its
+    /// target seconds from THIS while the policy is created with the STRING, so the two disagreeing makes
+    /// every job read stale forever. Raised by review.</para></summary>
     public static readonly TimeSpan CompressScheduleSpan = TimeSpan.FromHours(1);
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -3261,6 +3261,14 @@ AND   j.hypertable_name = '{relation}'";
     /// <para>The phase comes back as a minute-of-hour already converted to UTC. A bare
     /// <c>EXTRACT(MINUTE FROM initial_start)</c> would read the SESSION time zone, which on any of the
     /// half-hour and quarter-hour zones is a store-wide silent skew rather than a local oddity.</para>
+    ///
+    /// <para><b><c>hypertable_schema</c> is selected because a bare name is not an identity.</b>
+    /// <see cref="CompressionPhaseOrder"/> holds bare table names, so a bring-your-own store carrying its own
+    /// <c>wait_stats</c> hypertable in another schema would otherwise match one of ours and be given a minute
+    /// this code has no basis for choosing. The cadence converge stays deliberately unscoped — that is
+    /// #1778's reach and narrowing it would be a behaviour change — so the schema gates the PHASE only.
+    /// Appended rather than inserted, so every ordinal the reader already uses keeps its position: an ordinal
+    /// shift in a column list is a defect nothing but a live store can see.</para>
     /// </summary>
     public const string CompressionPolicyStateSql = @"
 SELECT
@@ -3272,7 +3280,8 @@ SELECT
     CASE
         WHEN j.initial_start IS NULL THEN NULL
         ELSE EXTRACT(MINUTE FROM j.initial_start AT TIME ZONE 'UTC')::int
-    END AS phase_minutes
+    END AS phase_minutes,
+    j.hypertable_schema
 FROM timescaledb_information.jobs AS j
 WHERE (j.proc_name LIKE '%compression%' OR j.proc_name LIKE '%columnstore%')";
 
@@ -3380,7 +3389,12 @@ WHERE (j.proc_name LIKE '%compression%' OR j.proc_name LIKE '%columnstore%')";
                 var fixedSchedule = !reader.IsDBNull(4) && reader.GetBoolean(4);
                 var wasPhase = reader.IsDBNull(5) ? (int?)null : reader.GetInt32(5);
 
-                int? phase = hypertable is not null && TryCompressionPhaseMinutesFor(hypertable, out var slot)
+                /* Schema-exact, because CompressionPhaseOrder holds BARE names: a foreign hypertable
+                   named like one of ours must not inherit its minute. */
+                var ours = !reader.IsDBNull(6)
+                    && string.Equals(reader.GetString(6), PgSchemaGenerator.CollectSchema, StringComparison.Ordinal);
+
+                int? phase = ours && hypertable is not null && TryCompressionPhaseMinutesFor(hypertable, out var slot)
                     ? slot
                     : null;
 


### PR DESCRIPTION
Finishes #3012's deconfliction by taking the drift out of the other half of the pairing. Closes #3035 (closing keywords are a no-op on a `dev` merge, so this needs closing by hand).

## What was wrong

`add_compression_policy` was called with a `schedule_interval` but no `initial_start`, so every compression job kept TimescaleDB's finish-to-start scheduling: the next start is computed from the previous **finish**, so the job slides forward by its own runtime every cycle and laps the hour. #3024 pinned all thirteen hourly refresh policies to a fixed 15-minute grid and deliberately left compression out, which left one family fixed and the other one wandering across it — each compression job crossing each refresh slot in turn and spending hours to days inside one before drifting out.

## The severity is smaller than #3035 was filed on, and it is conditional

**The filing's "convoy at alignment" model does not hold at the current operating point, and this PR is not making that claim.** A live collision was watched today and was harmless for a structural reason: with the refresh window narrowed to 1 day, the window a refresh re-materializes (`[now - 1 day, now - 1 hour]`) and the chunks a compression policy finds eligible (`range_end <= now - 1 day`) barely intersect. Alignment on the clock no longer means contention for the same data.

**It is still a real residual, in two ways, and both scale with how long the heavy refresh runs.**

The first is the boundary chunk. The two `now`s above are not the same instant: a refresh that started D seconds ago still holds its lock while a compression job evaluates eligibility against a `now` that has moved D forward, so the set of chunks inside the running refresh's window **and** already eligible for the compression starting now is exactly D wide. At D = 194 s that is a sliver; at D = 864 s it is four and a half times the sliver.

The second is the one #3012 actually measured, and it never needed chunk overlap at all: the running refresh holds `AccessShareLock` on the hypertable, a compression tick queues an `AccessExclusiveLock` request behind it, and a **queued** exclusive blocks every subsequent shared request — so collector writes pile up behind a lock nobody holds. The width of that exposure is the refresh's runtime, whatever chunks either one touches.

**The operating envelope, stated rather than left implicit.** The small-residual reading holds while the heaviest hourly refresh completes well inside its slot. The numbers it was taken over: **3,301-6,330 s before #3024's narrowing; 864 s the highest figure recorded under the 1-day window; 194 s, 225 s and 335 s the most recent readings, climbing with volume rather than settling.** What invalidates it is that runtime approaching the slot width — 900 s — at which point the refresh runs into its neighbour and the grid needs redesigning rather than renumbering. That is why the grid is sized against the **864 s ceiling and not the 194 s low**, and why the envelope is an assertion (`HeaviestHourlyRefreshObservedCeilingSeconds < RefreshPhaseStepMinutes * 60`) and not a sentence in a comment: a downgrade whose condition is only written in prose reads as unconditional to whoever finds it next.

## Where compression sits, and why it is a grid rather than a slot

The refresh family occupies `:00`, `:15`, `:30`, `:45`. Compression takes **the second half of each of those slots, with the heaviest refresh's slot excluded whole** — 24 minutes: `:22`-`:29`, `:37`-`:44`, `:52`-`:59`.

- **The guard band is one-sided, 7 minutes, and that asymmetry is the mechanism.** The convoy needs compression's exclusive request to *arrive* while a refresh holds its shared lock, so what matters is distance **after** a refresh start. The reverse order does not compose the same way: a compression run already holding its lock blocks collectors for its own duration whether or not a refresh starts, which is the ordinary cost of compressing and not something a schedule can move. 7 minutes is half a slot by construction and exactly 3x the 140 s ceiling recorded for every hourly refresh other than the heaviest.
- **The heaviest refresh's slot is excluded entirely rather than guarded**, because at 864 s it occupies 14.4 of its 15 minutes and no guard band could recover a minute of it. That also puts every compression minute at least a full slot downstream of the only refresh that can reach forward — the nearest is 22 minutes past it, the furthest 59.
- **Does it survive the refresh running long?** Partly, and stated as a bound rather than as reassurance. The heaviest refresh would have to run past **1,320 s** (22 minutes: 3.9x its current 335 s, 1.5x its 864 s ceiling) to reach the earliest compression minute, and past 3,540 s to reach the latest. The light slots' occupants would have to run past **420 s**, three times their recorded ceiling. What it does **not** survive is the heaviest refresh exceeding its own 900-second slot; that case is asserted as a failure instead of accommodated.
- **A single shared minute was the hand patch's precedent and is rejected on measurement, not taste.** `CompressAfterDays` and `ChunkIntervalDays` are both 1 and TimescaleDB aligns 1-day chunks to the epoch, so every hypertable's newest closed chunk becomes eligible at the same UTC midnight. Drifting policies discover that eligibility at whatever minute they have drifted to, which spreads the daily rewrite across the hour; one shared minute would concentrate **70 simultaneous chunk rewrites** once a day, and `timescaledb.max_background_workers` is sized at `HypertableCount + 2` so they would genuinely all run at once. That is a burst this change would be introducing rather than removing. The grid holds it to 2-3 per minute and is pinned to a per-minute ceiling so a future collapse onto one minute is red.

## The daily tier

**There is no daily compression tier to include or exempt**, which is the whole answer. #3024 left the daily *refresh* policies at a 3-day window on finish-to-start scheduling because a daily job's window is 3 days of scan against an 86,400-second cadence rather than a 3,600-second one, and it never appeared in the convoy. Compression has one cadence constant, every policy is created with it, and the converge moves every policy to it. So the decision is not which tier follows the convention — it is that there is only one tier, and that is pinned, so a second cadence cannot be introduced without landing on the test where the exemption question would then have to be answered.

## The compression API does **not** behave like the refresh one, and it is measured, not assumed

#3024 found that `add_continuous_aggregate_policy(if_not_exists => true)` returns `-1` only when the window *matches*, and **raises `22023`** against a policy whose window differs — which is what forced its converge to run *before* its create. `add_compression_policy` keys on the policy **existing**, not on its parameters matching: the shipped statement, carrying both the tick and the phase, runs cleanly against an existing policy and changes nothing (`-1`, a `NOTICE`). Asserted by the live test rather than inherited by analogy, and it matters twice: it is why the compression create can stay where it is *ahead* of the converge, and it is why the create path cannot move a deployed store at all.

## Behaviour on all three store states

- **Fresh** — `ApplyCompressionPolicyAsync` and `EnsureCollectionLogHypertableAsync` create the policies with `initial_start` moments earlier, so the converge reads them back matching and returns 0. This is the mirror image of the refresh converge, which sees an *empty set* on a fresh store because its aggregates do not exist yet.
- **Old values** — both properties are applied on the first start after deploy, and the create that already ran was the documented no-op.
- **Already hand-patched to a minute** — re-phased anyway, deliberately. A hand-set minute on a finish-to-start job is not a stagger with a slow leak, it is one with a countdown; the production store settled that argument by reading `fixed_schedule = f` on every compression job it had.

Idempotent by construction: only jobs that differ on **cadence or phase** are altered. That is why the staleness test moved out of the WHERE clause — the wanted minute is per hypertable, so no single SQL literal stands for it and a job stale only on its phase would be filtered out before the caller ever saw it. The cadence is compared as **seconds** instead, so `01:00:00` and `1 hour` cannot read as a difference, which is the property the typed-`INTERVAL` predicate used to provide.

`ConvergeCompressionScheduleAsync` owns both properties rather than gaining a sibling sweep, since they are set by the same `alter_job` and two sweeps would fight for the same rows.

## Identity, and foreign hypertables

Keyed on the **hypertable**, never a job id — job ids are per-deployment, so an encoded one would be correct on exactly one store. Unlike a refresh job, a compression job reports its own hypertable directly in `timescaledb_information.jobs`, so this needs no catalog join to recover identity, and the id only ever reaches `alter_job` as a bound `$1::integer` (the #1586 down-cast trap). `CompressionPhaseOrder` is derived from the collector catalog plus `collection_log`, so an unrecognised name means **not ours** rather than *forgotten*: a foreign hypertable keeps #1778's cadence converge and is left unphased, with `fixed_schedule` and `initial_start` untouched. That list holds **bare** table names, so the phase decision is additionally gated on `hypertable_schema = collect` — a bring-your-own store carrying its own `wait_stats` hypertable in another schema would otherwise have matched one of ours and been given a minute this code has no basis for choosing. The cadence converge stays deliberately unscoped, because that is #1778's reach and narrowing it would be a behaviour change. `hypertable_schema` is **appended** to the state read rather than inserted, so no ordinal the reader already uses moves; an ordinal shift in a column list is a defect only a live store can see, so that contract is pinned as a column count and position. ## The widened read degrades instead of giving up, and the direction is pinned

`fixed_schedule` and `initial_start` entered `timescaledb_information.jobs` later than `schedule_interval` did. Naming them in the one read this function makes meant a store old enough to lack them threw, was caught, **returned 0 — and lost #1778's cadence converge**, which only ever needed the older column. That is not "the new pinning does not apply"; it is the pre-existing behaviour stopping quietly. A total regression wearing a partial's clothes. Raised by review.

**The version range this matters over is the one the repo already states, not one assumed from the bundled runtime.** Nothing in the product declares a TimescaleDB floor and nothing checks `extversion` — the docs say only that TimescaleDB is "optional and auto-adopted", and the bundled runtime's 2.28.1 pin governs the *managed* store, not the bring-your-own stores `tools/provision-roles.sql` exists for. Three places in this same file already work below that: `EnableCompressionSql` prefers the pre-2.18 compression vocabulary *"for compatibility across 2.x"*, the forced-refresh path handles a store where `force` does not exist (2.18+), and the continuous-aggregate converge's own catch already names *"a TimescaleDB too old to expose `initial_start`"* as a state that reaches it. Fixed-schedule background jobs — and therefore these two columns — are a later 2.x addition than `schedule_interval`, so inside a stated 2.x target they cannot be assumed present. **So this is the degrade case, not the floor-pin case.**

The converge retries with `CompressionCadenceOnlyStateSql`. One reader serves both statements, so the narrow one's columns are the wide one's **first four, in the same order**, pinned as a parity assertion — a divergence would read a phase out of the wrong column and only a live old-runtime store could see it.

**And the direction is asserted rather than reasoned about**, which is the part whose absence made a reviewer do the reasoning. The fixture is 2.28.1 and has the columns, so the only way to reach the fallback is to hand the converge a wide read that fails; an `internal` overload takes the wide statement for exactly that, and the **fallback statement is deliberately not injectable**, so the test cannot pass against a statement the product does not ship. The live test plants a 12-hour policy on a foreign hypertable — the #1778 population — controls that the broken read really fails (`42703`) *and* that the shipped wide read does **not** fail on this runtime, then asserts the cadence moved to 1 hour while `fixed_schedule` and `initial_start` stayed absent. Degradation, not silent success. It also asserts the fallback path is idempotent, and that the log line names both halves, since that line is the only signal a store has dropped to cadence-only.

`scheduled` is never named on either `alter_job`, so neither can arm a paused job — load-bearing rather than defensive, because the fixture idiom for a deterministic compression test is a policy created and parked at `scheduled = false` in one transaction.

## Later review observations, all acted on

**The cadence twin was two independent literals with a pin each.** `CompressScheduleInterval` (`"1 hour"`) and `CompressScheduleSpan` (`TimeSpan.FromHours(1)`) were pinned separately, which forces the edit on whichever side the editor is looking at and forces nothing on the other: change the interval, update the string pin because it went red, and the span keeps its old value with its own pin still green. The consequence is not cosmetic — `desiredSeconds` comes off the **span** while the policy is created with the **string**, so a divergence makes `cadenceStale` true forever and the converge re-alters every compression policy on every service start. That is the exact "same interval read as a difference" failure the state read's own doc comment is careful about, reintroduced through the twin. The span's independent literal pin is **gone**, replaced by a parse of the string, with the parser carrying its own control including a shape it must reject. Mutating the span now reddens **exactly one** assertion — the cross-check — which is the isolation the previous pair could not provide.

**The fallback's log line was asserting a cause it had not established.** The catch is deliberately broad — the file's existing tolerant style — so a transient failure on a modern store would have been reported as "a store whose job catalog predates `fixed_schedule`/`initial_start`". It now states what was observed and what it costs, and offers both reasons as candidates: an old catalog fails that read on every start, a transient error fails it once and the next start pins the phases. Same defect shape this PR's own envelope section exists to avoid — a conclusion without the condition that makes it true.

**The create path resolves a bare table name where the converge also checks the schema**, so in principle a same-named foreign hypertable outside `collect` would be phased by the create and not by the converge. That asymmetry is a caller invariant rather than an oversight, and it is now written where it lives: a statement takes a table name and has no schema to check, while the converge reads one back from a job catalog whose rows are whatever the store contains rather than whatever this product created. Both callers pass names this product owns — `ApplyCompressionPolicyAsync` walks `HypertableTables`, `EnsureCollectionLogHypertableAsync` passes `CollectionLogTable` — and a future caller handing that overload a foreign or qualified name would break it.

## Verification

No schema change and no version bump — idempotent runtime setup in the worker's TimescaleDB block, and no call-site reordering was needed.

The Windows suites cannot run on macOS, so the **actual** test file was compiled into a `net10.0` xunit shim against the real built assemblies and run there, with the shim's output directory placed inside the worktree so the repo-root walk-up the tree-wide guards depend on resolves: **121 tests, 0 failed, 14 skipped (the live ones), 0 not run**, re-run against the final commit so the whole matrix rests on one baseline. That run includes #3024's own refresh pins, the `HypertableCount`-versus-CI-workflow sizing pin, and the two whole-tree guards. The generated SQL and the grid were also dumped back out of the built assembly rather than read from source. `Lite.Tests` builds clean, and nothing in it reads `TimescaleSupport` or `Darling.Storage` — checked with a positive control on the identical grep, which found the 2 files that do reference `DarlingWorker.cs`.

Proven red **twelve** ways, one mutation at a time, each restored via `git stash` of the mutation only against a committed baseline and re-asserted by content:

| mutation | red | notes |
|---|---|---|
| create statement never emits `initial_start` | the exact-SQL pin + the one-tier pin, 2 fails | the grid pins stay green |
| every hypertable gets the FIRST grid minute | the spread pin + the one-tier pin's distinct-minutes control, 2 fails | the grid literal stays green |
| grid stops excluding the heaviest refresh's slot | the grid pin + **the refresh-grid-unchanged pin**, 3 fails | different assertion in each |
| guard band shrunk to 1 minute | the grid pin (guard equality) + the spread pin, 2 fails | |
| phased `alter_job` drops `fixed_schedule => true` | the converge-shape pin, **1 fail** | single-test |
| recorded ceiling raised to 920 s | the grid pin's **envelope inequality**, 1 fail | the stated bound, machine-checked |
| hourly list reordered so the heaviest view leaves `:00` | the refresh-grid pin + the grid pin + the spread pin + **#3024's own contention guard**, 4 fails | |
| phased branch wired to the cadence-only statement | the IL wiring pin, **1 fail** | the inert-fix shape |
| `CompressScheduleSpan` diverged from the interval string | the **twin cross-check**, 1 fail | isolation the old literal pair lacked |
| two of the wide read's first four columns swapped | the **fallback shape-parity** pin, 1 fail | one reader serves both statements |
| `hypertable_schema` moved into the middle of the SELECT list | the converge-shape pin's **ordinal contract**, 1 fail | an ordinal shift is otherwise live-only |
| a planted second `<summary>` in a new doc block | the whole-tree doc-hygiene guard, 1 fail | **the control that proves the tree-wide guard scans these files at all** |
| making the phased branch's **guard** always false | **nothing** — green | see below |
| comment-only | — | all 121 green |

**One control came back green, and it changed the change.** Mutating the converge so an owned hypertable takes the cadence-only branch — the phase computed, selected on, logged, and never written — left the entire pure suite green, because a string pin asserts what a statement *says* and never that anything runs it. That is the inert-fix-with-a-passing-suite shape, so an IL pin was added that reads the compiler-generated state machine and asserts the phase statement is referenced there, with the cadence-only statement as the control. It catches the wrong-statement wiring. It does **not** catch an always-false branch *guard*: the call is still emitted into the unreachable branch. That boundary is written into the test's own doc comment rather than left to be rediscovered, and reachability through the guard is covered by the live converge test alone.

The live tests settle what no string pin can reach: that `add_compression_policy` skips quietly where its refresh sibling raises; that a policy created with `initial_start` comes back `fixed_schedule = true` (on which the converge's no-op-ness rests — a store reading `false` would be re-altered on every start forever); that `alter_job` takes `schedule_interval`, `fixed_schedule` and `initial_start` together on this runtime; that the minute survives the round trip; that a foreign hypertable is left unphased, checked *after* a converge that demonstrably moved things; and that the #1581 stuck-job self-heal's `alter_job(next_start => now())` is accepted against a fixed-schedule compression job and leaves it on its slot — the one interaction a fixed schedule could plausibly break.

**All checks went green twice below this head — at `2b860128e` and again at `a3630f5a8`** — `build` in **503 s**, inside its real 470-720 s range rather than the sub-60 s shape a `build` takes when the path filters leave it nothing to do, and `Darling whole-tree guards` at 24 s appearing only after `build` finished, as it must. Both suites named by count rather than inferred from a green rollup: **`Darling.Tests` Total 7,655 / Failed 0 / Not Run 0** and **`Lite.Tests` Total 3,347 / Failed 0 / Skipped 0 / Not Run 0**. `a3630f5a8` repeated that green in full: `build` **528 s**, `Darling whole-tree guards` 14 s, all ten check-runs. This head adds the twin cross-check above — a test change plus one doc paragraph, no executable logic — and is running its own cycle.

**Both live tests have since run green in CI's `Darling PostgreSQL tests` job** — full suite, **Total 7,655, Failed 0, Skipped 6, Not Run 0**, and the six named skips are the SQL-Server and gated-upgrade ones, so neither of these executed as a skip. The suite count rose by exactly one when the degradation test was added, which is the second way of saying the same thing. There is no local TimescaleDB store here, so **neither was proven red-first** — that needs the store, and it is the one gap the local mutation matrix cannot close.

## Not verified

- **Neither live test was proven red-first.** They have both run green in CI, which settles that the assertions hold — but no PostgreSQL container runtime is available locally, so nothing demonstrated that they *fail* when the behaviour they pin is removed. A green live test that could not go red is the one shape the local matrix cannot rule out here.
- **The `-1` skip was measured against a policy differing on `schedule_interval`, not on `initial_start`.** The existing doc comment's `NOTICE: columnstore policy already exists ... skipping` implies the check is on existence, and the live test asserts the shipped statement changes nothing against an existing policy — but only CI settles it.
- **The chunk-set disjointness argument rests on `compress_after` selecting chunks by `range_end` (the documented `show_chunks(older_than => ...)` semantics), which I did not verify against the runtime.** If it selects by `range_start` instead, the overlap is wider than described — which would raise the residual, not lower it.
- **The IO argument for spreading is reasoned from chunk-boundary alignment and the worker sizing, not measured.** I did not observe a 70-way simultaneous compression, and could not: producing one would mean changing the live store. The direction is what the spread is chosen on.
- **No production figure here was re-measured by me.** The 864 s, the 3,301-6,330 s, the 140 s and the 194/225/335 s readings are relayed from #3012's comment trail, #3024's shipped doc comments and the drift chart. A same-day reading had described 864 s as the *pre-treatment* cost, which would have contradicted #3024's doc comments; that was resolved against the heavy job's own incident records and 864 s **is** the post-narrowing ceiling, so #3024's comments are right and the grid is sized against the correct figure.
- **The schema gate's behaviour is unpinned.** Its column is asserted present and its ordinal position is asserted, so removing the column or shifting the list is red — but deleting the `hypertable_schema = collect` comparison itself is not caught by any test. Proving it would mean creating a second schema with a colliding hypertable name on the live fixture, which I judged disproportionate to a failure mode whose consequence is a foreign job acquiring a fixed schedule on a clear minute.
- **The fallback path is now exercised, but by an INDUCED failure rather than by a genuinely old runtime.** The live test hands the converge a wide read naming a column no job catalog has, which fails at the same point and with the same scope a missing `fixed_schedule`/`initial_start` would — but a real pre-fixed-schedule TimescaleDB is still untested, and the fixture is 2.28.1. Neither live test has been proven red-first, because that needs the store; CI is the arbiter.
- **A TimescaleDB too old to expose `initial_start`** is untested: the converge read fails, is caught, logged at Debug and returns 0 — the same handling the cadence-only converge already had, but nothing exercises it.
- **Retention policies are out of scope.** An armed retention job takes `AccessExclusiveLock` for `drop_chunks` and is not on any grid. That was not in #3035 and is not addressed.
- **Whether re-phasing on the next service restart lands the live store's compression jobs on the minutes an operator hand-set** — it will not necessarily; code wins by design. Every grid minute is at least 7 minutes clear of a refresh start either way.
- **The 24-minute grid is a derived configuration, not a measured optimum.** The 15-minute refresh step and the 864 s / 140 s figures are what it is derived from; nothing was measured *on* it.

## CHANGELOG entry

**Not committed here, deliberately.** Every lane appends to the same `## [Unreleased]` -> `### Fixed` block, which made it the queue's serialization point while several lanes are open, so the entry is handed over as text instead of committed. That is a routing decision about concurrent lanes, not an omission.

```markdown
- **Compression policies are pinned to a phase grid clear of the refresh slots instead of drifting through them** ([#3035]) - `add_compression_policy` was called with a `schedule_interval` but no `initial_start`, so every compression job kept TimescaleDB's finish-to-start scheduling: the next start comes off the previous **finish**, so the job slides forward by its own runtime every cycle and laps the hour. [#3012] pinned all thirteen hourly refreshes to a fixed 15-minute grid and deliberately left compression out, leaving one family fixed and the other wandering across it - each compression job crossing each refresh slot in turn and sitting inside one for hours to days before drifting out. **The severity is smaller than a convoy and it is conditional, which is stated rather than left implicit**: with the refresh window narrowed to 1 day, the window a refresh re-materializes and the chunks a compression policy finds eligible barely intersect, so alignment on the clock no longer means contention for the same data. What remains scales with how long the heavy refresh runs - the two `now`s are not the same instant, so the chunks inside a running refresh's window AND already eligible for the compression starting now are exactly as wide as the refresh's elapsed time, and the [#3012] lock queue (a running refresh holds `AccessShareLock`, a compression tick queues an `AccessExclusiveLock` behind it, and a **queued** exclusive blocks every subsequent shared request) never needed chunk overlap at all. **The envelope is named and asserted, not described**: the reading holds while the heaviest hourly refresh finishes well inside its slot, measured over **3,301-6,330 s before the narrowing, 864 s the highest figure under the 1-day window, and 194/225/335 s most recently, climbing with volume**; a runtime reaching the 900-second slot width invalidates it, and `HeaviestHourlyRefreshObservedCeilingSeconds < RefreshPhaseStepMinutes * 60` fails the build rather than being renumbered through. Compression takes **the second half of each refresh slot with the heaviest refresh's slot excluded whole** - 24 minutes, `:22`-`:29` / `:37`-`:44` / `:52`-`:59`. The guard band is **one-sided and 7 minutes**, and that asymmetry is the mechanism: the convoy needs compression's exclusive request to ARRIVE while a refresh holds its shared lock, whereas a compression run already holding its lock blocks collectors for its own duration whether or not a refresh starts - the ordinary cost of compressing, not something a schedule can move. 7 minutes is half a slot by construction and exactly 3x the 140 s ceiling recorded for every hourly refresh other than the heaviest; the heaviest slot is excluded entirely because at 864 s it fills 14.4 of its 15 minutes and no guard could recover a minute of it. **The policies SPREAD across those 24 minutes rather than sharing one, and that is measurement rather than taste**: `CompressAfterDays` and `ChunkIntervalDays` are both 1 and TimescaleDB aligns 1-day chunks to the epoch, so every hypertable's newest closed chunk becomes eligible at the same UTC midnight - drifting policies discover that at whatever minute they drifted to, which spreads the daily rewrite across the hour, while one shared minute would concentrate **70 simultaneous chunk rewrites** once a day with `timescaledb.max_background_workers` sized at `HypertableCount + 2` so they would all genuinely run at once. That is a burst this change would be introducing rather than removing, so the grid is held to 2-3 policies per minute and pinned to a per-minute ceiling. **`add_compression_policy` does NOT behave like the refresh function this was modelled on, and that was measured rather than assumed**: `add_continuous_aggregate_policy` returns -1 only when the window MATCHES and raises **22023** against a differing one, which is what forced [#3012]'s converge ahead of its create - whereas `add_compression_policy` keys on the policy EXISTING, so the shipped statement carrying both tick and phase runs cleanly against an existing policy and changes nothing. That is why the compression create can stay ahead of the converge, and why the create path cannot move a deployed store at all. `ConvergeCompressionScheduleAsync` therefore owns the phase as well as [#1778]'s cadence - one function, because both are set by the same `alter_job` and two sweeps would fight for the same rows - and the staleness test moved OUT of the WHERE clause because the wanted minute is per hypertable, so no SQL literal stands for it and a job stale only on its phase would be filtered out before the caller saw it; the cadence is compared as SECONDS instead so `01:00:00` and `1 hour` cannot read as a difference. Behaviour by store state: a **fresh** store had its policies created with `initial_start` moments earlier so the converge reads them back matching and returns 0 (the mirror of the refresh converge, which sees an EMPTY SET on a fresh store); a store on **old** values gets both properties on the first start after deploy; a store **hand-patched** to a minute is re-phased anyway, because a hand-set minute on a finish-to-start job is a stagger with a countdown rather than a slow leak - the production store settled it by reading `fixed_schedule = f` on every compression job it had. Keyed on the **hypertable**, never a job id (ids are per-deployment), and unlike a refresh job a compression job reports its own hypertable directly so no catalog join is needed; the id reaches `alter_job` only as a bound `$1::integer` [#1586]. `CompressionPhaseOrder` is derived from the collector catalog plus `collection_log`, so an unrecognised name means NOT OURS rather than forgotten: a foreign hypertable keeps [#1778]'s cadence converge with its `fixed_schedule` and `initial_start` untouched. That list holds BARE names, so the phase is additionally gated on `hypertable_schema = collect` - a bring-your-own store's own `wait_stats` hypertable in another schema would otherwise have inherited one of our minutes - while the cadence converge stays unscoped because that is [#1778]'s reach; `hypertable_schema` is APPENDED to the state read so no ordinal the reader uses moves, and that contract is pinned as a column count and position because an ordinal shift is a defect only a live store can see. `scheduled` is named on neither statement, so neither can arm a paused job. **The widened read FALLS BACK rather than giving up**: `fixed_schedule` and `initial_start` entered `timescaledb_information.jobs` later than `schedule_interval` did, so naming them in the one read this function makes meant a store old enough to lack them threw, was caught, returned 0 - and lost [#1778]'s cadence converge, which only ever needed the older column, a silent TOTAL regression in the name of a feature that store cannot use. The converge retries with a cadence-only read, and one reader serves both statements so the narrow one's columns are the wide one's FIRST FOUR in the same order - pinned as a parity assertion, because a divergence would read a phase out of the wrong column and only a live old-runtime store could see it. **Compression has no DAILY tier to exempt** - one cadence constant, every policy created with it, every policy converged to it - which is the whole answer to the question [#3012]'s daily refresh carve-out raises here, and it is pinned so a second cadence cannot appear without landing on that test. Proven red twelve ways, one mutation at a time, restored via `git stash` of the mutation only against a committed baseline: the create statement, the grid, the guard band, the spread, the phased `alter_job`, the envelope inequality and a reorder of the hourly list each redden a DIFFERENT assertion, the reorder also reddens [#3012]'s own contention guard, and a planted second `<summary>` is the control proving the whole-tree doc guard reaches these files. **One control came back green and changed the change**: sending an owned hypertable down the cadence-only branch left the entire pure suite green, because a string pin asserts what a statement SAYS and never that anything runs it - so an IL pin now reads the compiler-generated state machine and asserts the phase statement is referenced there, with the cadence-only statement as its control. It catches a wrong-statement wiring; it does NOT catch an always-false branch GUARD, since the call is still emitted into the unreachable branch, and that boundary is written into the test rather than left to be rediscovered. No schema change and no version bump.
```

Needs `[#3035]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/3035` in the link-ref block.

## Gate

Likely dual-gate — it changes background-job scheduling on every store. Not merging, not force-pushing.
