### PR TITLE
Fixes #3029

### DIFF
--- a/Darling/Darling.Tests/DarlingFleetReaderTests.cs
+++ b/Darling/Darling.Tests/DarlingFleetReaderTests.cs
@@ -381,7 +381,7 @@ public sealed class DarlingFleetDeadlockCoverageTests
     public void ADeadlockReaderThatWorked_Counts_EvenDegraded(string band)
         => Assert.Equal(
             FleetDeadlockSource.Read,
-            DarlingFleetReader.ClassifyDeadlockSource(isPostgres: false, band));
+            FleetDeadlockCoverage.ClassifyDeadlockSource(isPostgres: false, band));
 
     /// <summary>
     /// The excluded bands, each attributed to the cause that names its fix. STOPPED, NEVER_RUN and a null
@@ -396,7 +396,7 @@ public sealed class DarlingFleetDeadlockCoverageTests
     [InlineData(CollectorHealthClassifier.NoPermissions, FleetDeadlockSource.CollectorDenied)]
     public void ADeadlockReaderThatReadNothing_DoesNotCount_AndNamesItsCause(
         string? band, FleetDeadlockSource expected)
-        => Assert.Equal(expected, DarlingFleetReader.ClassifyDeadlockSource(isPostgres: false, band));
+        => Assert.Equal(expected, FleetDeadlockCoverage.ClassifyDeadlockSource(isPostgres: false, band));
 
     /// <summary>
     /// The issue's own case: a PostgreSQL target is never covered, and its collector's band cannot change
@@ -411,7 +411,7 @@ public sealed class DarlingFleetDeadlockCoverageTests
     public void APostgresTarget_IsNeverCovered_WhateverItsCollectorSays(string? band)
         => Assert.Equal(
             FleetDeadlockSource.PostgresTarget,
-            DarlingFleetReader.ClassifyDeadlockSource(isPostgres: true, band));
+            FleetDeadlockCoverage.ClassifyDeadlockSource(isPostgres: true, band));
 
     /// <summary>
     /// A card that sets nothing reads as UNCOVERED, and that is the load-bearing default. <c>DeadlockSource</c>

--- a/Darling/Darling.Tests/ViewerFleetRollupTests.cs
+++ b/Darling/Darling.Tests/ViewerFleetRollupTests.cs
@@ -8,6 +8,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Npgsql;
@@ -622,5 +624,487 @@ public sealed class ViewerFleetRollupLivePostgresTests
                 $"DELETE FROM {table} WHERE server_id IN ({XeServerId}, {DmvServerId});", connection);
             await cleanup.ExecuteNonQueryAsync(ct);
         }
+    }
+}
+
+/// <summary>
+/// The denominator beside the Overview's deadlock total (#3029). <c>FleetTotalsSql</c>'s
+/// <c>SELECT COUNT(*) FROM v_deadlocks</c> reads the SQL Server extended-event capture and nothing else —
+/// a PostgreSQL target's deadlocks go to <c>pg_deadlocks</c>, which nothing joins in — so on a PostgreSQL
+/// fleet that total is structurally zero forever. Zero is also exactly what a genuinely quiet SQL Server
+/// fleet reports, so the reading that needs no action and the reading that does not cover the fleet had the
+/// same character, and the tile could not tell an operator which one they were looking at.
+///
+/// <para><b>Both directions, deliberately.</b> The failure mode of a coverage figure is over-exclusion: a
+/// denominator that quietly shrinks reads as a smaller fleet, which is a new wrong number rather than a fix.
+/// So every test asserting a band is EXCLUDED sits beside one asserting the degraded-but-reading bands are
+/// INCLUDED.</para>
+///
+/// <para>The classification itself is <see cref="FleetDeadlockCoverage.ClassifyDeadlockSource"/> in
+/// PerformanceMonitor.Common, shared with the service's fleet reader, so these assertions and
+/// <c>DarlingFleetDeadlockCoverageTests</c> are pinning ONE decision from two surfaces rather than two
+/// look-alikes.</para>
+/// </summary>
+public sealed class ViewerFleetDeadlockCoverageTests
+{
+    private static readonly FleetTotals NoTotals = new();
+
+    private static ServerSummaryItem Card(int id, bool isPostgres = false, string? band = null) =>
+        new()
+        {
+            ServerId = id,
+            DisplayName = "target-" + id.ToString(CultureInfo.InvariantCulture),
+            IsOnline = true,
+            IsPostgres = isPostgres,
+            DeadlockCollectorBand = band,
+        };
+
+    // ── The card's own reading of whether its deadlock count read anything ──────────────────────────
+
+    /* Every band a collector that DID read can be in. Their rows are in the total, so all four count as
+       covered — including FAILING, which is loud on its own surfaces (the card's Collectors row, the
+       roll-up's collection-failures line) and does not need to be hidden inside a coverage number to be
+       seen. */
+    [Theory]
+    [InlineData(CollectorHealthClassifier.Healthy)]
+    [InlineData(CollectorHealthClassifier.Warning)]
+    [InlineData(CollectorHealthClassifier.Stale)]
+    [InlineData(CollectorHealthClassifier.Failing)]
+    public void ADeadlockReaderThatWorked_Counts_EvenDegraded(string band)
+        => Assert.Equal(FleetDeadlockSource.Read, Card(1, band: band).DeadlockSource);
+
+    /// <summary>
+    /// The excluded bands, each attributed to the cause that names its fix. STOPPED, NEVER_RUN and a null
+    /// band (the <c>deadlocks</c> collector left no row in the health window at all) are one bucket because
+    /// they take one action — look at the collector. NO_PERMISSIONS is its own, because a grant is the fix
+    /// and no amount of looking at the collector produces one.
+    /// </summary>
+    [Theory]
+    [InlineData(CollectorHealthClassifier.Stopped, FleetDeadlockSource.CollectorSilent)]
+    [InlineData(CollectorHealthClassifier.NeverRun, FleetDeadlockSource.CollectorSilent)]
+    [InlineData(null, FleetDeadlockSource.CollectorSilent)]
+    [InlineData(CollectorHealthClassifier.NoPermissions, FleetDeadlockSource.CollectorDenied)]
+    public void ADeadlockReaderThatReadNothing_DoesNotCount_AndNamesItsCause(string? band, FleetDeadlockSource expected)
+        => Assert.Equal(expected, Card(1, band: band).DeadlockSource);
+
+    /// <summary>
+    /// The issue's own case: a PostgreSQL target is never covered, and its collector's band cannot change
+    /// that. <c>pg_deadlocks</c> can be perfectly HEALTHY on all fifty targets and this total still counts
+    /// none of it — the rows are in a different table. That is why PostgreSQL is asked before any band.
+    /// </summary>
+    [Theory]
+    [InlineData(CollectorHealthClassifier.Healthy)]
+    [InlineData(CollectorHealthClassifier.NoPermissions)]
+    [InlineData(CollectorHealthClassifier.Stopped)]
+    [InlineData(null)]
+    public void APostgresTarget_IsNeverCovered_WhateverItsCollectorSays(string? band)
+        => Assert.Equal(FleetDeadlockSource.PostgresTarget, Card(1, isPostgres: true, band: band).DeadlockSource);
+
+    /// <summary>
+    /// A card that sets nothing reads as UNCOVERED, and that is the load-bearing default.
+    /// <see cref="ServerSummaryItem.DeadlockSource"/> is derived rather than assigned precisely so a card
+    /// built by a path nobody re-reads cannot sit at an enum default meaning "read" and inflate the fleet's
+    /// coverage — a defect that would COMPILE, because the default is silent.
+    /// </summary>
+    [Fact]
+    public void ACardThatMakesNoClaim_IsUncovered_NotCovered()
+    {
+        var card = new ServerSummaryItem { ServerId = 1, DisplayName = "target-a" };
+
+        Assert.Equal(FleetDeadlockSource.CollectorSilent, card.DeadlockSource);
+        Assert.NotEqual(FleetDeadlockSource.Read, card.DeadlockSource);
+
+        var rollup = FleetRollup.Build(new[] { card }, NoTotals);
+
+        Assert.Equal(0, rollup.DeadlockCoverage.ServersRead);
+        Assert.Equal(1, rollup.DeadlockCoverage.ServersTotal);
+    }
+
+    // ── The reduction ──────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Over one card of every kind: the coverage comes from the same cards every other count in the roll-up
+    /// comes from, so the denominator and the number it qualifies reconcile by construction rather than by
+    /// two reads agreeing.
+    /// </summary>
+    [Fact]
+    public void Build_ReducesCoverageFromTheCards_WithEveryCauseAttributed()
+    {
+        var rollup = FleetRollup.Build(
+            new[]
+            {
+                Card(1, band: CollectorHealthClassifier.Healthy),
+                Card(2, band: CollectorHealthClassifier.Failing),
+                Card(3, isPostgres: true),
+                Card(4, isPostgres: true),
+                Card(5, band: CollectorHealthClassifier.Stopped),
+                Card(6, band: CollectorHealthClassifier.NoPermissions),
+                Card(7, band: null),
+            },
+            NoTotals);
+
+        var coverage = rollup.DeadlockCoverage;
+
+        Assert.Equal(2, coverage.ServersRead);
+        Assert.Equal(7, coverage.ServersTotal);
+        Assert.Equal(2, coverage.PostgresServers);
+        Assert.Equal(2, coverage.ServersCollectorSilent);   // STOPPED + the null band
+        Assert.Equal(1, coverage.ServersCollectorDenied);
+
+        /* With every registered server loaded, the four causes account for the fleet exactly once — an
+           unattributed server would mean coverage reporting a gap it cannot explain, which is the same
+           shape as a total reporting no denominator. */
+        Assert.Equal(
+            coverage.ServersTotal,
+            coverage.ServersRead + coverage.PostgresServers
+                + coverage.ServersCollectorSilent + coverage.ServersCollectorDenied);
+
+        /* And it agrees with the count the panel already shows beside it. */
+        Assert.Equal(rollup.TotalServers, coverage.ServersTotal);
+        Assert.Equal(0, rollup.UnknownCount);
+    }
+
+    /// <summary>
+    /// <b>The denominator is the REGISTERED fleet, not whatever loaded this cycle.</b> The deadlock total is
+    /// a cross-server COUNT over the whole store, so the population it covers is every registered server;
+    /// a denominator that shrank to the loaded subset would report a smaller fleet than exists — the
+    /// "quietly shrinking denominator" failure this figure exists to prevent, arriving through the #2753
+    /// transient-read-failure path instead of through a band.
+    ///
+    /// <para>The shortfall is <see cref="FleetRollup.UnknownCount"/>, so the arithmetic still closes: read
+    /// plus the three causes plus the unreported equals the registered fleet.</para>
+    /// </summary>
+    [Fact]
+    public void Build_CoverageDenominator_IsTheRegisteredFleet_AndTheShortfallIsTheUnreportedCount()
+    {
+        var loaded = new[]
+        {
+            Card(1, band: CollectorHealthClassifier.Healthy),
+            Card(2, isPostgres: true),
+        };
+
+        var rollup = FleetRollup.Build(loaded, NoTotals, totalServerCount: 5);
+        var coverage = rollup.DeadlockCoverage;
+
+        Assert.Equal(5, coverage.ServersTotal);
+        Assert.NotEqual(loaded.Length, coverage.ServersTotal);
+        Assert.Equal(1, coverage.ServersRead);
+        Assert.Equal(1, coverage.PostgresServers);
+        Assert.Equal(3, rollup.UnknownCount);
+
+        /* The three unreported servers are attributed to NO cause — none was measured for them. */
+        Assert.Equal(0, coverage.ServersCollectorSilent);
+        Assert.Equal(0, coverage.ServersCollectorDenied);
+
+        Assert.Equal(
+            coverage.ServersTotal,
+            coverage.ServersRead + coverage.PostgresServers + coverage.ServersCollectorSilent
+                + coverage.ServersCollectorDenied + rollup.UnknownCount);
+    }
+
+    /// <summary>
+    /// An empty fleet with servers registered still reports a denominator: nothing loaded, so nothing was
+    /// read, and "read 0 of 5" is the honest reading. <see cref="FleetRollup.Build"/> returns early on an
+    /// empty summary list, and a coverage object left at its default on that path would report the fleet as
+    /// having no denominator at all.
+    /// </summary>
+    [Fact]
+    public void Build_WithNoSummariesLoaded_StillReportsTheRegisteredDenominator()
+    {
+        var rollup = FleetRollup.Build(Array.Empty<ServerSummaryItem>(), NoTotals, totalServerCount: 5);
+
+        Assert.Equal(5, rollup.DeadlockCoverage.ServersTotal);
+        Assert.Equal(0, rollup.DeadlockCoverage.ServersRead);
+        Assert.True(rollup.HasDeadlockCoverage);
+        Assert.True(rollup.DeadlockCoverageIsPartial);
+        Assert.Equal("Deadlock coverage: read 0 of 5 servers", rollup.DeadlockCoverageText);
+    }
+
+    /// <summary>
+    /// A fleet with nothing registered has nothing for a coverage figure to qualify, so the line goes —
+    /// the ONE case it is hidden, and the whole roll-up panel is collapsed there anyway. It is never hidden
+    /// as a way of not saying that coverage is complete.
+    /// </summary>
+    [Fact]
+    public void Build_WithNoFleetAtAll_HasNothingToQualify()
+    {
+        var rollup = FleetRollup.Build(Array.Empty<ServerSummaryItem>(), NoTotals);
+
+        Assert.Equal(0, rollup.TotalServers);
+        Assert.False(rollup.HasDeadlockCoverage);
+        Assert.False(FleetRollup.Empty.HasDeadlockCoverage);
+    }
+
+    /// <summary>
+    /// <b>Only <see cref="FleetDeadlockSource.Read"/> counts as read, and the enum cannot grow unnoticed.</b>
+    /// Reflected off the type rather than listed by hand: a pin that enumerates the kinds by hand cannot see
+    /// the set grow, and a source kind added later that landed in the read bucket by default would restore
+    /// exactly the defect this figure exists to fix. If this count moves, whoever moved it decides here.
+    /// </summary>
+    [Fact]
+    public void EverySourceKind_IsProducible_AndOnlyReadCountsAsRead()
+    {
+        var kinds = Enum.GetValues<FleetDeadlockSource>();
+        Assert.Equal(4, kinds.Length);
+
+        /* Every kind is reachable through the shared classifier — a kind nothing can produce is a bucket
+           nothing can land in, which is a decision table with a hole in it rather than a spare arm. */
+        var producible = new[]
+        {
+            (IsPostgres: false, Band: (string?)CollectorHealthClassifier.Healthy),
+            (IsPostgres: true, Band: (string?)null),
+            (IsPostgres: false, Band: (string?)CollectorHealthClassifier.Stopped),
+            (IsPostgres: false, Band: (string?)CollectorHealthClassifier.NoPermissions),
+        }
+            .Select(c => FleetDeadlockCoverage.ClassifyDeadlockSource(c.IsPostgres, c.Band))
+            .ToHashSet();
+
+        Assert.Equal(kinds.Length, producible.Count);
+        Assert.All(kinds, k => Assert.Contains(k, producible));
+
+        /* And the reducer counts exactly one of them as read: one card of each kind, ServersRead == 1. */
+        var coverage = FleetRollup.ReduceDeadlockCoverage(
+            new[]
+            {
+                Card(1, band: CollectorHealthClassifier.Healthy),
+                Card(2, isPostgres: true),
+                Card(3, band: CollectorHealthClassifier.Stopped),
+                Card(4, band: CollectorHealthClassifier.NoPermissions),
+            },
+            registeredTotal: 4);
+
+        Assert.Equal(1, coverage.ServersRead);
+    }
+
+    // ── What the panel actually renders ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// <b>The line reads at FULL coverage too.</b> One that appeared only on a partial read would make its
+    /// ABSENCE the load-bearing signal — which a reader has to already know the rule to interpret — and it
+    /// would leave "zero, whole fleet measured" indistinguishable from "zero, from a build that reports no
+    /// coverage at all", the same defect one step out. The web fleet page's tile made the same call for the
+    /// same reason; this is that decision matched rather than a second convention.
+    /// </summary>
+    [Fact]
+    public void TheCoverageLine_ReadsAtFullCoverage_AndIsNotPaintedAsAProblem()
+    {
+        var rollup = FleetRollup.Build(
+            new[]
+            {
+                Card(1, band: CollectorHealthClassifier.Healthy),
+                Card(2, band: CollectorHealthClassifier.Failing),
+            },
+            new FleetTotals { TotalDeadlocks = 0 });
+
+        Assert.True(rollup.HasDeadlockCoverage);
+        Assert.False(rollup.DeadlockCoverageIsPartial);
+        Assert.Equal("Deadlock coverage: read all 2 servers", rollup.DeadlockCoverageText);
+    }
+
+    /// <summary>
+    /// A large deadlock count with complete coverage still reads as complete: the line's own state tracks
+    /// COVERAGE, not the count's severity. "read all 2 servers" beside a bad number is good news about a
+    /// bad number and must not be painted as part of the alarm.
+    /// </summary>
+    [Fact]
+    public void TheCoverageLine_TracksCoverage_NotTheDeadlockCount()
+    {
+        var rollup = FleetRollup.Build(
+            new[] { Card(1, band: CollectorHealthClassifier.Healthy), Card(2, band: CollectorHealthClassifier.Healthy) },
+            new FleetTotals { TotalDeadlocks = 900 });
+
+        Assert.False(rollup.DeadlockCoverageIsPartial);
+        Assert.Equal("Deadlock coverage: read all 2 servers", rollup.DeadlockCoverageText);
+    }
+
+    /// <summary>The issue's measured case: a PostgreSQL-only fleet reporting zero, now saying so.</summary>
+    [Fact]
+    public void APostgresOnlyFleet_ReportsZeroCoverage_AndNamesWhereThoseDeadlocksAre()
+    {
+        var rollup = FleetRollup.Build(
+            new[] { Card(1, isPostgres: true), Card(2, isPostgres: true), Card(3, isPostgres: true) },
+            new FleetTotals { TotalDeadlocks = 0 });
+
+        Assert.Equal(0, rollup.TotalDeadlocks);
+        Assert.Equal(0, rollup.DeadlockCoverage.ServersRead);
+        Assert.Equal(3, rollup.DeadlockCoverage.PostgresServers);
+        Assert.True(rollup.DeadlockCoverageIsPartial);
+        Assert.Equal("Deadlock coverage: read 0 of 3 servers", rollup.DeadlockCoverageText);
+        Assert.Contains(FleetRollup.DeadlockPostgresCause, rollup.DeadlockCoverageTooltip, StringComparison.Ordinal);
+    }
+
+    /// <summary>A one-server fleet says "server", not "servers" — both ways round.</summary>
+    [Fact]
+    public void TheCoverageLine_AgreesWithItselfOnNumber()
+    {
+        Assert.Equal(
+            "Deadlock coverage: read all 1 server",
+            FleetRollup.Build(new[] { Card(1, band: CollectorHealthClassifier.Healthy) }, NoTotals).DeadlockCoverageText);
+
+        Assert.Equal(
+            "Deadlock coverage: read 0 of 1 server",
+            FleetRollup.Build(new[] { Card(1, isPostgres: true) }, NoTotals).DeadlockCoverageText);
+    }
+
+    /// <summary>
+    /// <b>The sentence this whole issue turns on.</b> The two windows genuinely diverge — the deadlock total
+    /// is counted over the last hour, while coverage is banded over a FIXED trailing seven days of
+    /// collection health — and that divergence is correct: whether a reader works is a durable fact, and the
+    /// banding thresholds are themselves defined in DAYS, so an hour-wide health window could not produce a
+    /// band at all.
+    ///
+    /// <para>But a note claiming both were read in the same window would be the same defect one level up: a
+    /// surface asserting a scope it did not measure. So the tooltip names each window against the figure it
+    /// belongs to, and says outright that coverage makes no claim about the hour the total covers.</para>
+    /// </summary>
+    [Fact]
+    public void TheTooltip_NamesEachWindow_AndClaimsNeitherForTheOther()
+    {
+        var tooltip = FleetRollup.Build(
+            new[] { Card(1, band: CollectorHealthClassifier.Healthy) }, NoTotals).DeadlockCoverageTooltip;
+
+        /* The coverage figure's own window, named as fixed and as seven days. */
+        Assert.Contains("fixed trailing seven days of collection health", tooltip, StringComparison.Ordinal);
+
+        /* The total's window, named as the only thing bounded by it. */
+        Assert.Contains("deadlock total counts only the last hour", tooltip, StringComparison.Ordinal);
+
+        /* And the disclaimer that keeps the first from being read as the second. */
+        Assert.Contains("makes no claim about what was read in the last hour", tooltip, StringComparison.Ordinal);
+
+        /* What the total is assembled from — the fact that makes a PostgreSQL zero structural. */
+        Assert.Contains("SQL Server extended-event capture and nothing else", tooltip, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Only the causes that actually apply, so a reader is not handed four actions when one is called for.
+    /// </summary>
+    [Fact]
+    public void TheTooltip_CarriesOnlyTheCausesThatApply()
+    {
+        var tooltip = FleetRollup.Build(
+            new[] { Card(1, isPostgres: true), Card(2, band: CollectorHealthClassifier.Healthy) },
+            NoTotals).DeadlockCoverageTooltip;
+
+        Assert.Contains("1 " + FleetRollup.DeadlockPostgresCause, tooltip, StringComparison.Ordinal);
+        Assert.DoesNotContain(FleetRollup.DeadlockCollectorSilentCause, tooltip, StringComparison.Ordinal);
+        Assert.DoesNotContain(FleetRollup.DeadlockCollectorDeniedCause, tooltip, StringComparison.Ordinal);
+        Assert.DoesNotContain(FleetRollup.DeadlockUnreportedCause, tooltip, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The arm the service's fleet reader has no equivalent of. A registered server with no summary this
+    /// cycle is uncovered — nothing was read FOR it — but it must NOT be attributed to the silent-collector
+    /// cause: that one sends the reader to a collector, and this one is the viewer's own read having failed,
+    /// which is a different thing to go and look at. Naming it as "the collector has stopped being invoked"
+    /// would be a confidently wrong instruction, which is worse than the bare number was.
+    /// </summary>
+    [Fact]
+    public void TheTooltip_NamesAnUnreportedServer_WithoutBlamingItsCollector()
+    {
+        var rollup = FleetRollup.Build(
+            new[] { Card(1, band: CollectorHealthClassifier.Healthy) }, NoTotals, totalServerCount: 3);
+
+        var tooltip = rollup.DeadlockCoverageTooltip;
+
+        Assert.Equal(2, rollup.UnknownCount);
+        Assert.Contains("2 " + FleetRollup.DeadlockUnreportedCause, tooltip, StringComparison.Ordinal);
+        Assert.DoesNotContain(FleetRollup.DeadlockCollectorSilentCause, tooltip, StringComparison.Ordinal);
+        Assert.Equal(0, rollup.DeadlockCoverage.ServersCollectorSilent);
+
+        /* And the gap keeps the line it already had, rather than only living inside a tooltip. */
+        Assert.Equal("2 servers didn't report this cycle", rollup.UnknownStatusText);
+    }
+
+    // ── The two seams a pure reduction cannot reach ────────────────────────────────────────────────
+
+    /// <summary>
+    /// The Overview's roll-up row renders the coverage BESIDE the total it qualifies, not somewhere else in
+    /// the panel and not only as a hover. Scoped to the fleet-totals <c>WrapPanel</c> itself rather than to
+    /// the whole file, so a binding that existed anywhere in <c>MainWindow.xaml</c> could not satisfy it.
+    /// </summary>
+    [Fact]
+    public void TheOverviewRow_RendersTheCoverageBesideTheDeadlockTotal()
+    {
+        var xaml = ReadRepoFile("Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml");
+
+        var start = xaml.IndexOf("Text=\"Last hour:\"", StringComparison.Ordinal);
+        Assert.True(start > 0, "the fleet-totals row's own label was not found");
+        var end = xaml.IndexOf("</WrapPanel>", start, StringComparison.Ordinal);
+        Assert.True(end > start, "the fleet-totals row did not close");
+
+        var row = xaml[start..end];
+
+        /* The total is still there, and the coverage is in the same row. */
+        Assert.Contains("{Binding TotalDeadlocks, StringFormat='Deadlocks: {0}'}", row, StringComparison.Ordinal);
+        Assert.Contains("{Binding DeadlockCoverageText}", row, StringComparison.Ordinal);
+
+        /* Visible without hovering: the text is bound to Text, and the detail hangs off BOTH the count and
+           the coverage line so either gesture reaches it. */
+        Assert.Contains("Text=\"{Binding DeadlockCoverageText}\"", row, StringComparison.Ordinal);
+        Assert.Equal(2, CountOccurrences(row, "ToolTip=\"{Binding DeadlockCoverageTooltip}\""));
+
+        /* And its colour tracks coverage rather than being a fixed brush. */
+        Assert.Contains("{Binding DeadlockCoverageIsPartial}", row, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The per-server summary read retains the <c>deadlocks</c> collector's own band out of the collection-
+    /// health rows it already enumerates, matched from the collector's OWN name rather than a spelled
+    /// literal — a rename against a literal leaves the match silently finding nothing, which reports every
+    /// server uncovered and looks exactly like a PostgreSQL fleet.
+    ///
+    /// <para>Neither collector TALLY can stand in for the band, which is why it has to be carried at all:
+    /// STOPPED, NEVER_RUN and NO_PERMISSIONS are none of them FAILING, so a server reading nothing at all
+    /// shows up in both counts as a zero.</para>
+    /// </summary>
+    [Fact]
+    public void TheSummaryRead_RetainsTheDeadlockCollectorsBand_MatchedFromItsOwnName()
+    {
+        var source = ReadRepoFile("Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Overview.cs");
+
+        /* Anchored on the DECLARATION, which is itself the shape being pinned: the helper hands the band
+           back beside the tallies rather than returning a pair the caller has to re-read the store for. */
+        var start = source.IndexOf(
+            "private async Task<(int Healthy, int Failing, string? DeadlockBand)> GetCollectorHealthCountsAsync",
+            StringComparison.Ordinal);
+        Assert.True(start > 0, "the collector-health helper does not hand back the deadlock band");
+        var end = source.IndexOf("private static int? MinutesAgo", start, StringComparison.Ordinal);
+        Assert.True(end > start, "the collector-health helper's body did not end where expected");
+
+        var body = source[start..end];
+
+        Assert.Contains("DeadlocksCollector.Instance.Name", body, StringComparison.Ordinal);
+
+        /* The literal is the shape a careless match takes, and it is what the collector name is TODAY —
+           so this is a real trap rather than a hypothetical one. */
+        Assert.DoesNotContain("\"deadlocks\"", body, StringComparison.Ordinal);
+        Assert.Equal("deadlocks", DeadlocksCollector.Instance.Name);
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+        return count;
+    }
+
+    private static string ReadRepoFile(string relative) =>
+        File.ReadAllText(Path.Combine(RepoRoot(), relative));
+
+    private static string RepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "PerformanceMonitor.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName ?? throw new InvalidOperationException("PerformanceMonitor.sln not found above the test output directory.");
     }
 }

--- a/Darling/Darling.Tests/ViewerFleetRollupTests.cs
+++ b/Darling/Darling.Tests/ViewerFleetRollupTests.cs
@@ -986,10 +986,50 @@ public sealed class ViewerFleetDeadlockCoverageTests
             new[] { Card(1, isPostgres: true), Card(2, band: CollectorHealthClassifier.Healthy) },
             NoTotals).DeadlockCoverageTooltip;
 
-        Assert.Contains("1 " + FleetRollup.DeadlockPostgresCause, tooltip, StringComparison.Ordinal);
+        Assert.Contains("1 server: " + FleetRollup.DeadlockPostgresCause, tooltip, StringComparison.Ordinal);
         Assert.DoesNotContain(FleetRollup.DeadlockCollectorSilentCause, tooltip, StringComparison.Ordinal);
         Assert.DoesNotContain(FleetRollup.DeadlockCollectorDeniedCause, tooltip, StringComparison.Ordinal);
         Assert.DoesNotContain(FleetRollup.DeadlockUnreportedCause, tooltip, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Each cause carries the noun its own count needs, both ways round. An "N are PostgreSQL targets"
+    /// shape prints "1 are PostgreSQL targets" the moment a fleet has exactly one of something, which is
+    /// the common case for the denied and silent arms — so the causes are verb-free noun phrases and the
+    /// count is turned into words in ONE place rather than once per arm.
+    /// </summary>
+    [Fact]
+    public void TheTooltip_AgreesWithItselfOnNumber_ForEveryCause()
+    {
+        var singular = FleetRollup.Build(
+            new[]
+            {
+                Card(1, isPostgres: true),
+                Card(2, band: CollectorHealthClassifier.Stopped),
+                Card(3, band: CollectorHealthClassifier.NoPermissions),
+            },
+            NoTotals, totalServerCount: 4).DeadlockCoverageTooltip;
+
+        Assert.Contains("1 server: " + FleetRollup.DeadlockPostgresCause, singular, StringComparison.Ordinal);
+        Assert.Contains("1 server: " + FleetRollup.DeadlockCollectorSilentCause, singular, StringComparison.Ordinal);
+        Assert.Contains("1 server: " + FleetRollup.DeadlockCollectorDeniedCause, singular, StringComparison.Ordinal);
+        Assert.Contains("1 server: " + FleetRollup.DeadlockUnreportedCause, singular, StringComparison.Ordinal);
+        Assert.DoesNotContain("1 servers", singular, StringComparison.Ordinal);
+
+        var plural = FleetRollup.Build(
+            new[]
+            {
+                Card(1, isPostgres: true), Card(2, isPostgres: true),
+                Card(3, band: CollectorHealthClassifier.Stopped), Card(4, band: CollectorHealthClassifier.NeverRun),
+                Card(5, band: CollectorHealthClassifier.NoPermissions), Card(6, band: CollectorHealthClassifier.NoPermissions),
+            },
+            NoTotals, totalServerCount: 8).DeadlockCoverageTooltip;
+
+        Assert.Contains("2 servers: " + FleetRollup.DeadlockPostgresCause, plural, StringComparison.Ordinal);
+        Assert.Contains("2 servers: " + FleetRollup.DeadlockCollectorSilentCause, plural, StringComparison.Ordinal);
+        Assert.Contains("2 servers: " + FleetRollup.DeadlockCollectorDeniedCause, plural, StringComparison.Ordinal);
+        Assert.Contains("2 servers: " + FleetRollup.DeadlockUnreportedCause, plural, StringComparison.Ordinal);
+        Assert.DoesNotContain("2 server:", plural, StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -1008,7 +1048,7 @@ public sealed class ViewerFleetDeadlockCoverageTests
         var tooltip = rollup.DeadlockCoverageTooltip;
 
         Assert.Equal(2, rollup.UnknownCount);
-        Assert.Contains("2 " + FleetRollup.DeadlockUnreportedCause, tooltip, StringComparison.Ordinal);
+        Assert.Contains("2 servers: " + FleetRollup.DeadlockUnreportedCause, tooltip, StringComparison.Ordinal);
         Assert.DoesNotContain(FleetRollup.DeadlockCollectorSilentCause, tooltip, StringComparison.Ordinal);
         Assert.Equal(0, rollup.DeadlockCoverage.ServersCollectorSilent);
 

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingFleetReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingFleetReader.cs
@@ -660,49 +660,6 @@ GROUP BY server_id, collector_name";
     internal static (bool IsPostgres, bool IsAurora) ClassifyEngineKind(string? engineKind) =>
         (MonitoredEngineKind.IsPostgres(engineKind), MonitoredEngineKind.IsAurora(engineKind));
 
-    /// <summary>
-    /// Whether one server's deadlock count — and so the fleet total it sums into — actually read a deadlock
-    /// source, and when it did not, which of the three causes it was (#3017). The three take OPPOSITE
-    /// actions, which is why one uncovered tally would not have been enough: a different tool for a
-    /// PostgreSQL target, a collector to look at for one that is not being invoked, a grant for one that was
-    /// refused.
-    ///
-    /// <para><b>PostgreSQL is asked first and answers on its own.</b> It is not a degraded collector, it is
-    /// the wrong table: <see cref="FleetDeadlockSql"/> reads <c>v_deadlocks</c>, which holds only the SQL
-    /// Server extended-event capture, and no health band on any collector changes that. A PostgreSQL target
-    /// whose <c>pg_deadlocks</c> collector is perfectly healthy still contributes nothing here.</para>
-    ///
-    /// <para><b>A null band is uncovered, not covered.</b> Null means the <c>deadlocks</c> collector left no
-    /// row in the health window — nothing was read for this server, whatever else is true of it — and
-    /// defaulting an absent band to "read" is precisely how a coverage figure becomes another number nobody
-    /// can trust. It is folded in with STOPPED and NEVER_RUN because all three take the same action.</para>
-    ///
-    /// <para><b>FAILING, STALE and WARNING count as READ, deliberately.</b> Those collectors succeeded on
-    /// some cycles, so their rows really are in the total and a denominator excluding them would understate
-    /// the fleet — a new wrong number in place of the old one. They are not hidden by being counted here:
-    /// <see cref="FleetOverviewResult.ServersWithCollectionFailures"/> and each card's
-    /// <see cref="FleetServerCard.FailedCollectorCount"/> are where a degraded collector shows, and the
-    /// card's own <see cref="FleetServerCard.DeadlockCollectorBand"/> carries the band verbatim.</para>
-    /// </summary>
-    internal static FleetDeadlockSource ClassifyDeadlockSource(bool isPostgres, string? deadlockCollectorBand)
-    {
-        if (isPostgres)
-        {
-            return FleetDeadlockSource.PostgresTarget;
-        }
-
-        /* Tested ahead of the general set below rather than as part of it: NO_PERMISSIONS is IN
-           NothingReadBands, so asking the set first would swallow the one cause with a different fix. */
-        if (string.Equals(deadlockCollectorBand, CollectorHealthClassifier.NoPermissions, StringComparison.Ordinal))
-        {
-            return FleetDeadlockSource.CollectorDenied;
-        }
-
-        return deadlockCollectorBand is null || CollectorHealthClassifier.ReadNothing(deadlockCollectorBand)
-            ? FleetDeadlockSource.CollectorSilent
-            : FleetDeadlockSource.Read;
-    }
-
     /* ─────────────────────────── per-query readers ─────────────────────────── */
 
     private static async Task<List<FleetServerRow>> ReadServersAsync(NpgsqlDataSource postgres, CancellationToken cancellationToken)
@@ -1082,7 +1039,7 @@ public sealed class FleetServerCard
     [JsonPropertyName("deadlock_collector_band")] public string? DeadlockCollectorBand { get; init; }
 
     /// <summary>Whether <see cref="DeadlockCount"/> read a deadlock source for this server, and when it did
-    /// not, which cause (#3017) — see <see cref="DarlingFleetReader.ClassifyDeadlockSource"/> for what each
+    /// not, which cause (#3017) — see <see cref="FleetDeadlockCoverage.ClassifyDeadlockSource"/> for what each
     /// value means and what it asks an operator to do.
     ///
     /// <para>DERIVED rather than assigned, for the reason <see cref="EngineDescription"/> is: every card is
@@ -1092,7 +1049,7 @@ public sealed class FleetServerCard
     /// card carrying no band and the only default that cannot inflate the fleet's coverage.</para></summary>
     [JsonPropertyName("deadlock_source")]
     public FleetDeadlockSource DeadlockSource =>
-        DarlingFleetReader.ClassifyDeadlockSource(IsPostgres, DeadlockCollectorBand);
+        FleetDeadlockCoverage.ClassifyDeadlockSource(IsPostgres, DeadlockCollectorBand);
 
     [JsonPropertyName("total_threads")] public int? TotalThreads { get; init; }
     [JsonPropertyName("current_workers")] public int? CurrentWorkers { get; init; }
@@ -1188,152 +1145,4 @@ public sealed class FleetOverviewResult
     /// parent, ordering, and colour, so the fleet page can group cards under a nested tag tree even when a parent
     /// tag has no directly-assigned servers. Empty when no tags are defined. Assignment/editing stays desktop-only.</summary>
     [JsonPropertyName("tags")] public IReadOnlyList<FleetTagNode> Tags { get; init; } = Array.Empty<FleetTagNode>();
-}
-
-/// <summary>
-/// Whether one server's deadlock count read a deadlock source at all, and when it did not, which cause
-/// (#3017). Serialized as its STRING name (the fleet DTOs' <c>JsonStringEnumConverter</c>), so a consumer
-/// switches on a word rather than on an ordinal that a reordering would move underneath it.
-///
-/// <para>The three uncovered arms exist as three rather than as one flag because they take OPPOSITE actions,
-/// which is the whole reason a bare tally would not have been enough.</para>
-/// </summary>
-public enum FleetDeadlockSource
-{
-    /// <summary>The <c>deadlocks</c> collector read this server over the health window, so this server's
-    /// deadlocks — however many that is, including none — are in the total. Its band may still be FAILING,
-    /// STALE or WARNING: those collectors succeeded on some cycles, and their rows are in the total.</summary>
-    Read,
-
-    /// <summary>A PostgreSQL target, whose deadlocks the total cannot count at all: they are stored in
-    /// <c>pg_deadlocks</c>, which nothing joins into <c>v_deadlocks</c>. Nothing about this server's health
-    /// changes it and no grant addresses it — <c>get_pg_deadlocks</c> is the read that answers.</summary>
-    PostgresTarget,
-
-    /// <summary>The <c>deadlocks</c> collector is not being invoked — STOPPED, NEVER_RUN, or no row in the
-    /// health window at all. Silence, not failure: a collector still running and erroring every cycle bands
-    /// FAILING and counts as <see cref="Read"/>. Check the collector (<c>get_collection_health</c>).</summary>
-    CollectorSilent,
-
-    /// <summary>Every one of the <c>deadlocks</c> collector's attempts was refused for permissions
-    /// (NO_PERMISSIONS). The one cause a grant fixes, which is why it is not folded in with
-    /// <see cref="CollectorSilent"/> despite both meaning nothing was read.</summary>
-    CollectorDenied,
-}
-
-/// <summary>
-/// The denominator beside <see cref="FleetOverviewResult.TotalDeadlocks"/> (#3017): how many of the fleet's
-/// servers that total actually read a deadlock source for, and for the rest, which of the three causes it
-/// was.
-///
-/// <para><b>Why a total needs one at all.</b> <c>v_deadlocks</c> is the SQL Server extended-event capture and
-/// only that, so <c>total_deadlocks</c> is structurally zero for a PostgreSQL server — permanently, whatever
-/// its clusters do and whatever grants the monitoring role holds. Zero is also exactly what a genuinely quiet
-/// SQL Server fleet reports. The reading that needs no action and the reading that does not cover the fleet
-/// are the same character, and that is what makes the bare number unusable.</para>
-///
-/// <para><b>The convention this follows.</b> <c>get_pg_blocking</c> already reports <c>captures_total</c>
-/// beside <c>captures_with_blocking</c> and a sentence saying what an empty answer does and does not mean,
-/// because the denominator is the honest part of a sampled signal; <c>target_has_user_databases</c> (#1852)
-/// already states a fact about the TARGET beside a persistently empty result rather than banding it, so
-/// "nothing to collect" stops looking like "collecting nothing". This is the same move on a fleet total: a
-/// count, a denominator, named causes, and a note — and deliberately not a new band, for #1852's reason. A
-/// quiet SQL Server fleet with full coverage is healthy and must keep reading that way.</para>
-/// </summary>
-public sealed class FleetDeadlockCoverage
-{
-    /// <summary>Servers the total read a deadlock source for — the numerator of the coverage this object
-    /// reports, and NOT a count of servers that had deadlocks (that is
-    /// <see cref="FleetOverviewResult.TotalDeadlocks"/>'s job).</summary>
-    [JsonPropertyName("servers_read")] public int ServersRead { get; init; }
-
-    /// <summary>Enabled servers in the fleet — the same population as
-    /// <see cref="FleetOverviewResult.TotalServers"/>, repeated here so the denominator travels with its
-    /// numerator and a consumer reading only this object is never one field short of the ratio.</summary>
-    [JsonPropertyName("servers_total")] public int ServersTotal { get; init; }
-
-    /// <summary>Uncovered because the target is PostgreSQL — <c>get_pg_deadlocks</c> is the read that
-    /// answers for these.</summary>
-    [JsonPropertyName("postgres_servers")] public int PostgresServers { get; init; }
-
-    /// <summary>Uncovered because the <c>deadlocks</c> collector is not being invoked (STOPPED, NEVER_RUN,
-    /// or no row in the health window) — check the collector.</summary>
-    [JsonPropertyName("servers_collector_silent")] public int ServersCollectorSilent { get; init; }
-
-    /// <summary>Uncovered because every one of the <c>deadlocks</c> collector's attempts was refused for
-    /// permissions — these need a grant.</summary>
-    [JsonPropertyName("servers_collector_denied")] public int ServersCollectorDenied { get; init; }
-
-    /// <summary>
-    /// The sentence that keeps the two figures from being read as one measurement.
-    ///
-    /// <para><b>The windows genuinely diverge and this is the whole point of the field.</b>
-    /// <see cref="FleetOverviewResult.TotalDeadlocks"/> is counted between the caller's
-    /// <c>window_start</c> and <c>window_end</c> (one hour by default); coverage is banded over the FIXED
-    /// trailing seven days of collection health. That divergence is correct — whether a reader works is a
-    /// durable fact, and the banding thresholds are themselves defined in DAYS, so an hour-wide health
-    /// window could not produce a band at all — but a note claiming both were "read in this window" would be
-    /// the same defect one level up: a surface asserting a scope it did not measure. So the sentence names
-    /// each window against the figure it belongs to, and says outright that coverage makes no claim about
-    /// the caller's window.</para>
-    /// </summary>
-    public const string WindowNote =
-        "Coverage bands each server's deadlock reader over the fixed trailing seven days of collection "
-        + "health - whether the reader works at all, which is a durable fact - while total_deadlocks counts "
-        + "only between window_start and window_end. The two windows differ deliberately, and this coverage "
-        + "figure therefore makes no claim about what was read inside window_start..window_end.";
-
-    /// <summary>What to do about the PostgreSQL arm, appended after its count.</summary>
-    public const string PostgresCause =
-        "are PostgreSQL targets, whose deadlocks this total cannot count at all - they are stored separately "
-        + "and served by get_pg_deadlocks.";
-
-    /// <summary>What to do about the silent arm, appended after its count.</summary>
-    public const string CollectorSilentCause =
-        "have no current deadlock collection - the collector has stopped being invoked, or has never run; "
-        + "check it with get_collection_health.";
-
-    /// <summary>What to do about the denied arm, appended after its count.</summary>
-    public const string CollectorDeniedCause =
-        "had every deadlock-collector attempt refused for permissions - those need a grant.";
-
-    /// <summary>
-    /// The coverage in a sentence, with <see cref="WindowNote"/> and only the causes that actually apply.
-    ///
-    /// <para>DERIVED rather than assigned, for the reason <see cref="FleetServerCard.DeadlockSource"/> is:
-    /// a settable note is a note that can be omitted, or can drift from the counts it describes. Computed,
-    /// the numbers and the sentence cannot disagree.</para>
-    /// </summary>
-    [JsonPropertyName("note")]
-    public string Note
-    {
-        get
-        {
-            var note = new StringBuilder();
-
-            note.Append("total_deadlocks read a deadlock source for ")
-                .Append(ServersRead)
-                .Append(" of ")
-                .Append(ServersTotal)
-                .Append(" enabled servers. ")
-                .Append(WindowNote);
-
-            if (PostgresServers > 0)
-            {
-                note.Append(' ').Append(PostgresServers).Append(' ').Append(PostgresCause);
-            }
-
-            if (ServersCollectorSilent > 0)
-            {
-                note.Append(' ').Append(ServersCollectorSilent).Append(' ').Append(CollectorSilentCause);
-            }
-
-            if (ServersCollectorDenied > 0)
-            {
-                note.Append(' ').Append(ServersCollectorDenied).Append(' ').Append(CollectorDeniedCause);
-            }
-
-            return note.ToString();
-        }
-    }
 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml
@@ -866,14 +866,40 @@
 
                                 <!-- (2) Fleet totals: the cross-server aggregate over the last hour (the
                                      same window the per-server cards use, so these reconcile with the card
-                                     counts). -->
+                                     counts), plus the denominator the deadlock total is only readable
+                                     against (#3029 - see DeadlockCoverageText). -->
                                 <WrapPanel Margin="0,0,0,12">
                                     <TextBlock Text="Last hour:" FontSize="11" FontWeight="SemiBold"
                                                Foreground="{DynamicResource ForegroundMutedBrush}" Margin="0,0,10,0" VerticalAlignment="Center"/>
                                     <TextBlock FontSize="11" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,16,0" VerticalAlignment="Center"
                                                Text="{Binding TotalBlockingEvents, StringFormat='Blocking events: {0}'}"/>
                                     <TextBlock FontSize="11" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,16,0" VerticalAlignment="Center"
-                                               Text="{Binding TotalDeadlocks, StringFormat='Deadlocks: {0}'}"/>
+                                               Text="{Binding TotalDeadlocks, StringFormat='Deadlocks: {0}'}"
+                                               ToolTip="{Binding DeadlockCoverageTooltip}"/>
+                                    <!-- #3029: how much of the fleet the deadlock total beside it actually
+                                         read. v_deadlocks is the SQL Server extended-event capture and
+                                         nothing else, so on a PostgreSQL fleet that total is structurally
+                                         zero forever - and zero is also what a genuinely quiet SQL Server
+                                         fleet reports, which is what made the bare number unreadable.
+                                         Shown whenever there is a fleet, INCLUDING at full coverage: a line
+                                         that appeared only when short would make its absence the signal.
+                                         Its colour tracks COVERAGE, not the count's severity - "read all 12
+                                         servers" beside a large count is good news about a bad number. -->
+                                    <TextBlock FontSize="11" Margin="0,0,16,0" VerticalAlignment="Center"
+                                               Text="{Binding DeadlockCoverageText}"
+                                               ToolTip="{Binding DeadlockCoverageTooltip}"
+                                               Visibility="{Binding HasDeadlockCoverage, Converter={StaticResource BoolToVisibility}}">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Foreground" Value="{DynamicResource ForegroundMutedBrush}"/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding DeadlockCoverageIsPartial}" Value="True">
+                                                        <Setter Property="Foreground" Value="{DynamicResource WarningBrush}"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
                                     <TextBlock FontSize="11" Foreground="{DynamicResource ForegroundBrush}" Margin="0,0,16,0" VerticalAlignment="Center"
                                                Text="{Binding CollectionFailuresText, StringFormat='Collection failures: {0}'}"/>
                                 </WrapPanel>

--- a/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/MainWindow.xaml.cs
@@ -1443,6 +1443,12 @@ public partial class MainWindow : Window
                 {
                     var summary = await service.GetServerSummaryAsync(server.ServerId, server.DisplayName);
                     summary.ServerName = server.ServerName;
+                    /* #3029: the engine discriminator comes from the REGISTRY row, which already carries it
+                       (servers.engine_kind, via ManagedServersSql / ServersSql) — the per-server summary
+                       reads have no engine column and need none. It is what tells the fleet deadlock total's
+                       coverage apart from a quiet SQL Server fleet: v_deadlocks holds the SQL Server
+                       extended-event capture and nothing else. */
+                    summary.IsPostgres = server.IsPostgres;
                     summary.ApplyFreshness(nowUtc);
                     found.Add(summary);
                 }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Fleet.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Fleet.cs
@@ -329,19 +329,23 @@ public sealed class FleetRollup
         + "therefore makes no claim about what was read in the last hour.";
 
     /// <summary>What to do about the PostgreSQL arm, appended after its count. Names no tab, because a
-    /// PostgreSQL target's deadlock grid is reached through that server's own tab rather than from here.</summary>
+    /// PostgreSQL target's deadlock grid is reached through that server's own tab rather than from here.
+    ///
+    /// <para>Every cause here is a VERB-FREE noun phrase, so one form reads correctly after both "1 server:"
+    /// and "4 servers:" — an "N are ..." shape needs a second string the moment N is one, and the surface
+    /// that forgets it prints "1 are PostgreSQL targets".</para></summary>
     public const string DeadlockPostgresCause =
-        "are PostgreSQL targets, whose deadlocks this total cannot count at all - they are collected "
-        + "separately and show on that target's own server tab.";
+        "PostgreSQL targets, whose deadlocks this total cannot count at all - collected separately, and "
+        + "shown on that target's own server tab.";
 
     /// <summary>What to do about the silent arm, appended after its count.</summary>
     public const string DeadlockCollectorSilentCause =
-        "have no current deadlock collection - the collector has stopped being invoked, or has never run; "
-        + "that server's Collection Health tab shows which.";
+        "no current deadlock collection - the collector has stopped being invoked, or has never run; the "
+        + "server's Collection Health tab shows which.";
 
     /// <summary>What to do about the denied arm, appended after its count.</summary>
     public const string DeadlockCollectorDeniedCause =
-        "had every deadlock-collector attempt refused for permissions - those need a grant.";
+        "every deadlock-collector attempt refused for permissions - needs a grant.";
 
     /// <summary>
     /// The arm the service's fleet reader has no equivalent of: a registered server whose per-server
@@ -352,8 +356,8 @@ public sealed class FleetRollup
     /// the viewer's own read having failed, which is a different thing to go and look at.
     /// </summary>
     public const string DeadlockUnreportedCause =
-        "did not report a summary this cycle, so whether their deadlock collection works could not be "
-        + "classified either way.";
+        "no summary this cycle, so whether the deadlock collection works could not be classified either "
+        + "way.";
 
     /// <summary>Whether there is a fleet for the coverage figure to qualify. False only on an empty fleet,
     /// where the whole roll-up panel is collapsed anyway — never as a way of hiding a complete reading.</summary>
@@ -410,29 +414,32 @@ public sealed class FleetRollup
                 .Append(' ')
                 .Append(DeadlockCoverageWindowNote);
 
-            if (DeadlockCoverage.PostgresServers > 0)
-            {
-                note.Append(' ').Append(DeadlockCoverage.PostgresServers).Append(' ').Append(DeadlockPostgresCause);
-            }
-
-            if (DeadlockCoverage.ServersCollectorSilent > 0)
-            {
-                note.Append(' ').Append(DeadlockCoverage.ServersCollectorSilent).Append(' ').Append(DeadlockCollectorSilentCause);
-            }
-
-            if (DeadlockCoverage.ServersCollectorDenied > 0)
-            {
-                note.Append(' ').Append(DeadlockCoverage.ServersCollectorDenied).Append(' ').Append(DeadlockCollectorDeniedCause);
-            }
+            Cause(note, DeadlockCoverage.PostgresServers, DeadlockPostgresCause);
+            Cause(note, DeadlockCoverage.ServersCollectorSilent, DeadlockCollectorSilentCause);
+            Cause(note, DeadlockCoverage.ServersCollectorDenied, DeadlockCollectorDeniedCause);
 
             /* The viewer-only arm, last because it is about this cycle's read rather than about a target. */
-            if (UnknownCount > 0)
-            {
-                note.Append(' ').Append(UnknownCount).Append(' ').Append(DeadlockUnreportedCause);
-            }
+            Cause(note, UnknownCount, DeadlockUnreportedCause);
 
             return note.ToString();
         }
+    }
+
+    /// <summary>
+    /// One cause, appended only when it applies, as "N server(s): what it is" — so a reader is not handed
+    /// four actions when one is called for.
+    ///
+    /// <para>The ONE place a count becomes words here, which is what keeps the four arms from disagreeing
+    /// about the noun. Nothing in the cause strings inflects, so this needs no second form for N = 1.</para>
+    /// </summary>
+    private static void Cause(StringBuilder note, int count, string cause)
+    {
+        if (count <= 0)
+        {
+            return;
+        }
+
+        note.Append(' ').Append(count).Append(count == 1 ? " server: " : " servers: ").Append(cause);
     }
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Fleet.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Fleet.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Media;
@@ -229,6 +230,21 @@ public sealed class FleetRollup
     /// <summary>Fleet-wide deadlocks this window (from the cross-server SQL total).</summary>
     public long TotalDeadlocks { get; init; }
 
+    /// <summary>
+    /// How much of the fleet <see cref="TotalDeadlocks"/> actually read a deadlock source for, with the
+    /// causes named (#3029) — the shared <see cref="FleetDeadlockCoverage"/>, so this panel and the
+    /// service's <c>get_fleet_overview</c> report the same denominator against the same total rather than
+    /// two surfaces each having an opinion.
+    ///
+    /// <para><see cref="FleetDeadlockCoverage.ServersTotal"/> is <see cref="TotalServers"/>, the REGISTERED
+    /// fleet — the same population the SQL total counts over, which is every server in the store and not
+    /// just the ones whose card loaded this cycle. So its four causes need not add up to it: the shortfall
+    /// is <see cref="UnknownCount"/>, the servers this cycle has no summary to classify, and that gap has
+    /// its own line already (<see cref="UnknownStatusText"/>) rather than being attributed to a cause it
+    /// was not measured to have.</para>
+    /// </summary>
+    public FleetDeadlockCoverage DeadlockCoverage { get; init; } = new();
+
     /// <summary>The worst-first problem servers (band != Healthy), capped at the requested depth.</summary>
     public IReadOnlyList<FleetRankedServer> WorstServers { get; init; } = Array.Empty<FleetRankedServer>();
 
@@ -284,6 +300,141 @@ public sealed class FleetRollup
         ? "1 server"
         : $"{ServersWithCollectionFailures} servers";
 
+    /* ─────────────────────── the deadlock total's coverage (#3029) ─────────────────────── */
+
+    /// <summary>
+    /// What <see cref="TotalDeadlocks"/> is assembled from, and so why it needs a denominator at all. The
+    /// leading sentence of <see cref="DeadlockCoverageTooltip"/>.
+    /// </summary>
+    public const string DeadlockSourceNote =
+        "Deadlocks come from the SQL Server extended-event capture and nothing else, so a server this "
+        + "total does not cover contributes nothing to it whatever that server's deadlocks do.";
+
+    /// <summary>
+    /// The sentence that keeps the two figures from being read as one measurement — the desktop wording of
+    /// the same disclaimer the service's <see cref="FleetDeadlockCoverage.WindowNote"/> carries for an API
+    /// reader.
+    ///
+    /// <para><b>The two windows genuinely diverge and that is the point of saying so.</b>
+    /// <see cref="TotalDeadlocks"/> is counted over the last hour, the same window the cards use; coverage
+    /// is banded over the FIXED trailing seven days of collection health, because whether a reader works is
+    /// a durable fact and the banding thresholds are themselves defined in DAYS — an hour-wide health
+    /// window could not produce a band at all. A note claiming both were read in the same window would be
+    /// this issue's own defect one level up: a surface asserting a scope it did not measure.</para>
+    /// </summary>
+    public const string DeadlockCoverageWindowNote =
+        "Coverage bands each server's deadlock reader over the fixed trailing seven days of collection "
+        + "health - whether the reader works at all, which is a durable fact - while the deadlock total "
+        + "counts only the last hour. The two windows differ deliberately, and this coverage figure "
+        + "therefore makes no claim about what was read in the last hour.";
+
+    /// <summary>What to do about the PostgreSQL arm, appended after its count. Names no tab, because a
+    /// PostgreSQL target's deadlock grid is reached through that server's own tab rather than from here.</summary>
+    public const string DeadlockPostgresCause =
+        "are PostgreSQL targets, whose deadlocks this total cannot count at all - they are collected "
+        + "separately and show on that target's own server tab.";
+
+    /// <summary>What to do about the silent arm, appended after its count.</summary>
+    public const string DeadlockCollectorSilentCause =
+        "have no current deadlock collection - the collector has stopped being invoked, or has never run; "
+        + "that server's Collection Health tab shows which.";
+
+    /// <summary>What to do about the denied arm, appended after its count.</summary>
+    public const string DeadlockCollectorDeniedCause =
+        "had every deadlock-collector attempt refused for permissions - those need a grant.";
+
+    /// <summary>
+    /// The arm the service's fleet reader has no equivalent of: a registered server whose per-server
+    /// summary read did not complete this cycle (<see cref="UnknownCount"/>). It is uncovered for the same
+    /// reason a null band is — nothing was read FOR IT, so counting it as read is how a coverage figure
+    /// becomes another number nobody can trust — but it is deliberately NOT folded into
+    /// <see cref="DeadlockCollectorSilentCause"/>: that one sends the reader to a collector, and this one is
+    /// the viewer's own read having failed, which is a different thing to go and look at.
+    /// </summary>
+    public const string DeadlockUnreportedCause =
+        "did not report a summary this cycle, so whether their deadlock collection works could not be "
+        + "classified either way.";
+
+    /// <summary>Whether there is a fleet for the coverage figure to qualify. False only on an empty fleet,
+    /// where the whole roll-up panel is collapsed anyway — never as a way of hiding a complete reading.</summary>
+    public bool HasDeadlockCoverage => DeadlockCoverage.ServersTotal > 0;
+
+    /// <summary>
+    /// True when <see cref="TotalDeadlocks"/> did not read every registered server — the flag the coverage
+    /// line's colour tracks. It tracks COVERAGE rather than the deadlock count's own severity: "read all 12
+    /// servers" beside a large count is good news about a bad number and must not be painted as part of the
+    /// alarm.
+    /// </summary>
+    public bool DeadlockCoverageIsPartial => DeadlockCoverage.ServersRead < DeadlockCoverage.ServersTotal;
+
+    /// <summary>
+    /// The coverage beside the deadlock total, in the "Label: value" shape the rest of that row already
+    /// uses. Rendered whenever there is a fleet, INCLUDING at full coverage.
+    ///
+    /// <para><b>Always, rather than only when short.</b> A line that appeared only on partial coverage would
+    /// make its ABSENCE the load-bearing signal, which a reader has to already know the rule to read, and it
+    /// would leave "zero, whole fleet measured" looking identical to "zero, from a build that reports no
+    /// coverage at all" — the same defect one step out. Present unconditionally, it says which one this is.
+    /// The web fleet page's tile made the same call for the same reason.</para>
+    ///
+    /// <para>It carries its own subject rather than reading as a bare "read 0 of 12 servers": the row it
+    /// sits in is a <see cref="System.Windows.Controls.WrapPanel"/> of independently-labelled phrases, so an
+    /// unlabelled one could wrap onto the next line under a different figure and read as qualifying that.</para>
+    /// </summary>
+    public string DeadlockCoverageText
+    {
+        get
+        {
+            var total = DeadlockCoverage.ServersTotal;
+            var noun = total == 1 ? "server" : "servers";
+
+            return DeadlockCoverage.ServersRead >= total
+                ? $"Deadlock coverage: read all {total} {noun}"
+                : $"Deadlock coverage: read {DeadlockCoverage.ServersRead} of {total} {noun}";
+        }
+    }
+
+    /// <summary>
+    /// The hover detail behind <see cref="DeadlockCoverageText"/>: what the total is built from, only the
+    /// causes that actually apply, and the two windows named against the figures they belong to.
+    ///
+    /// <para>DERIVED rather than assigned, for the reason
+    /// <see cref="ServerSummaryItem.DeadlockSource"/> is: a settable string is one that can be omitted, or
+    /// can drift from the counts it describes. Computed, the numbers and the sentence cannot disagree.</para>
+    /// </summary>
+    public string DeadlockCoverageTooltip
+    {
+        get
+        {
+            var note = new StringBuilder(DeadlockSourceNote)
+                .Append(' ')
+                .Append(DeadlockCoverageWindowNote);
+
+            if (DeadlockCoverage.PostgresServers > 0)
+            {
+                note.Append(' ').Append(DeadlockCoverage.PostgresServers).Append(' ').Append(DeadlockPostgresCause);
+            }
+
+            if (DeadlockCoverage.ServersCollectorSilent > 0)
+            {
+                note.Append(' ').Append(DeadlockCoverage.ServersCollectorSilent).Append(' ').Append(DeadlockCollectorSilentCause);
+            }
+
+            if (DeadlockCoverage.ServersCollectorDenied > 0)
+            {
+                note.Append(' ').Append(DeadlockCoverage.ServersCollectorDenied).Append(' ').Append(DeadlockCollectorDeniedCause);
+            }
+
+            /* The viewer-only arm, last because it is about this cycle's read rather than about a target. */
+            if (UnknownCount > 0)
+            {
+                note.Append(' ').Append(UnknownCount).Append(' ').Append(DeadlockUnreportedCause);
+            }
+
+            return note.ToString();
+        }
+    }
+
     /// <summary>
     /// Rolls the per-server Overview cards up into the fleet view-model. The band counts,
     /// servers-with-failures, and worst-first ranking reduce the <paramref name="summaries"/> using #1426's
@@ -304,6 +455,11 @@ public sealed class FleetRollup
         var registeredTotal = totalServerCount ?? summaries.Count;
         var unknown = Math.Max(0, registeredTotal - summaries.Count);
 
+        /* Reduced ONCE, above the early return, so the two exits cannot disagree about whether the deadlock
+           total carries a denominator — a coverage object left at its default on one path would report every
+           server uncovered on an empty fleet and nothing at all on a populated one. */
+        var deadlockCoverage = ReduceDeadlockCoverage(summaries, registeredTotal);
+
         if (summaries.Count == 0)
         {
             return new FleetRollup
@@ -312,6 +468,7 @@ public sealed class FleetRollup
                 UnknownCount = unknown,
                 TotalBlockingEvents = totals.TotalBlockingEvents,
                 TotalDeadlocks = totals.TotalDeadlocks,
+                DeadlockCoverage = deadlockCoverage,
             };
         }
 
@@ -371,8 +528,60 @@ public sealed class FleetRollup
             ServersWithCollectionFailures = failures,
             TotalBlockingEvents = totals.TotalBlockingEvents,
             TotalDeadlocks = totals.TotalDeadlocks,
+            DeadlockCoverage = deadlockCoverage,
             WorstServers = worst,
             AdditionalProblemCount = Math.Max(0, problems.Count - worst.Count),
+        };
+    }
+
+    /// <summary>
+    /// How much of the fleet <see cref="TotalDeadlocks"/> read a deadlock source for, reduced from the SAME
+    /// cards every other count here comes from, so the coverage and the total it qualifies reconcile by
+    /// construction rather than by two reads agreeing (#3029).
+    ///
+    /// <para><paramref name="registeredTotal"/> is the denominator, not <paramref name="summaries"/>' own
+    /// count. The SQL total is a cross-server COUNT over the whole store, so the population it covers is the
+    /// registered fleet; a denominator that shrank to whatever loaded this cycle would report a smaller
+    /// fleet than exists, which is a new wrong number in place of the old one rather than a fix.</para>
+    ///
+    /// <para><b>Only <see cref="FleetDeadlockSource.Read"/> counts as read</b> — every other arm, INCLUDING
+    /// an enum value a later build adds and this switch has never heard of, lands in the silent bucket. A
+    /// new source kind that inflated the read count would restore exactly the defect this exists to fix,
+    /// where one that lands in an uncovered bucket merely attributes a real gap imprecisely.</para>
+    ///
+    /// <para>The four causes therefore need not sum to <paramref name="registeredTotal"/>: a registered
+    /// server with no summary this cycle is classified by none of them, and that shortfall is
+    /// <see cref="UnknownCount"/> — stated in its own words by <see cref="UnknownStatusText"/> and by
+    /// <see cref="DeadlockUnreportedCause"/>, rather than attributed to a cause it was not measured to
+    /// have.</para>
+    /// </summary>
+    public static FleetDeadlockCoverage ReduceDeadlockCoverage(IReadOnlyList<ServerSummaryItem> summaries, int registeredTotal)
+    {
+        ArgumentNullException.ThrowIfNull(summaries);
+
+        var read = 0;
+        var postgres = 0;
+        var silent = 0;
+        var denied = 0;
+
+        foreach (var s in summaries)
+        {
+            switch (s.DeadlockSource)
+            {
+                case FleetDeadlockSource.Read: read++; break;
+                case FleetDeadlockSource.PostgresTarget: postgres++; break;
+                case FleetDeadlockSource.CollectorDenied: denied++; break;
+                default: silent++; break;
+            }
+        }
+
+        return new FleetDeadlockCoverage
+        {
+            ServersRead = read,
+            ServersTotal = registeredTotal,
+            PostgresServers = postgres,
+            ServersCollectorSilent = silent,
+            ServersCollectorDenied = denied,
         };
     }
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Overview.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Overview.cs
@@ -13,6 +13,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Media;
 using Npgsql;
+using PerformanceMonitor.Collectors;
 using PerformanceMonitor.Common;
 
 namespace PerformanceMonitor.Darling.Viewer;
@@ -305,7 +306,7 @@ WHERE server_id = $1";
         /* Collectors row — REUSE the viewer's own 7-day per-collector health banding (the same STALE /
            FAILING / NEVER_RUN / HEALTHY logic the Collection Health tab renders), mirroring the Dashboard's
            SUM(CASE health_status = 'HEALTHY' / 'FAILING') over report.collection_health. */
-        var (healthyCollectors, failingCollectors) = await GetCollectorHealthCountsAsync(serverId, cancellationToken);
+        var (healthyCollectors, failingCollectors, deadlockBand) = await GetCollectorHealthCountsAsync(serverId, cancellationToken);
 
         return new ServerSummaryItem
         {
@@ -330,6 +331,7 @@ WHERE server_id = $1";
             RequestsWaitingForThreads = requestsWaitingForThreads,
             HealthyCollectorCount = healthyCollectors,
             FailedCollectorCount = failingCollectors,
+            DeadlockCollectorBand = deadlockBand,
             LastCollectionTime = lastCollection,
         };
     }
@@ -341,13 +343,26 @@ WHERE server_id = $1";
     /// <c>report.collection_health</c>) — HEALTHY and FAILING are the two bands the card surfaces; the
     /// STALE / WARNING / NO_PERMISSIONS / NEVER_RUN rows count as neither (a failing collector is one the
     /// banding calls FAILING: no success in over 24h).
+    ///
+    /// <para>The <c>deadlocks</c> collector's own band comes back BESIDE the tallies rather than as a second
+    /// read, because it is in the rows already enumerated here and the Overview fans this call out once per
+    /// server (#3029). It is the one collector whose band the fleet deadlock total's coverage turns on, and
+    /// neither tally can stand in for it: STOPPED, NEVER_RUN and NO_PERMISSIONS all count as neither HEALTHY
+    /// nor FAILING, so a server reading nothing at all shows up in both counts as a zero.</para>
+    ///
+    /// <para>Null when the collector left no row in the window. Matched from
+    /// <see cref="DeadlocksCollector"/>'s own name rather than a literal, so a rename cannot leave this
+    /// silently matching nothing and reporting every server uncovered.</para>
     /// </summary>
-    private async Task<(int Healthy, int Failing)> GetCollectorHealthCountsAsync(int serverId, CancellationToken cancellationToken)
+    private async Task<(int Healthy, int Failing, string? DeadlockBand)> GetCollectorHealthCountsAsync(int serverId, CancellationToken cancellationToken)
     {
         var rows = await GetCollectionHealthAsync(serverId, cancellationToken);
         var healthy = rows.Count(r => r.HealthStatus == "HEALTHY");
         var failing = rows.Count(r => r.HealthStatus == "FAILING");
-        return (healthy, failing);
+        var deadlockBand = rows
+            .FirstOrDefault(r => string.Equals(r.CollectorName, DeadlocksCollector.Instance.Name, StringComparison.Ordinal))
+            ?.HealthStatus;
+        return (healthy, failing, deadlockBand);
     }
 
     /// <summary>Whole minutes elapsed from a stored naive-UTC instant to now (UTC), floored at 0, or null
@@ -457,6 +472,45 @@ public sealed class ServerSummaryItem
 
     /// <summary>Minutes since the most recent deadlock ever — the "Last: N ago" deadlock detail.</summary>
     public int? LastDeadlockMinutesAgo { get; set; }
+
+    /// <summary>
+    /// Whether the store says this target is PostgreSQL — stamped by the Overview loader from the registry
+    /// row (<c>DarlingServer.IsPostgres</c>), the way <see cref="ServerName"/> is, because the per-server
+    /// summary reads carry no engine column of their own.
+    ///
+    /// <para>It is here for <see cref="DeadlockSource"/>: <see cref="DeadlockCount"/> comes out of
+    /// <c>v_deadlocks</c>, which holds the SQL Server extended-event capture and nothing else, so a
+    /// PostgreSQL target's zero is structural rather than quiet. Absence is not evidence for either engine,
+    /// so the default false keeps the SQL Server reading for a row no connect has stamped — the same
+    /// posture <c>DarlingServer.IsPostgres</c> takes.</para>
+    /// </summary>
+    public bool IsPostgres { get; set; }
+
+    /// <summary>
+    /// The <c>deadlocks</c> collector's own 7-day band for this server, or null when that collector left no
+    /// row in the health window at all (#3029). Retained from the same
+    /// <see cref="ViewerDataService.GetCollectionHealthAsync"/> read the
+    /// <see cref="HealthyCollectorCount"/> / <see cref="FailedCollectorCount"/> tallies come out of, so it
+    /// costs no extra round trip.
+    ///
+    /// <para>The counts alone could not answer this. A FAILING tally says how many collectors are failing,
+    /// not WHICH — and the one collector <see cref="DeadlockCount"/> depends on can be STOPPED, NEVER_RUN or
+    /// permission-denied while that tally reads zero, because none of those three bands is FAILING.</para>
+    /// </summary>
+    public string? DeadlockCollectorBand { get; set; }
+
+    /// <summary>
+    /// Whether <see cref="DeadlockCount"/> read a deadlock source for this server at all, and when it did
+    /// not, which cause (#3029) — the shared <see cref="FleetDeadlockCoverage.ClassifyDeadlockSource"/>, so
+    /// this card and the service's fleet card cannot disagree about what covers a total.
+    ///
+    /// <para>DERIVED rather than assigned, so a card built by a path that does not set the two inputs reads
+    /// as UNCOVERED rather than sitting at an enum default meaning "read" and inflating the fleet's
+    /// coverage. The unset case is <see cref="FleetDeadlockSource.CollectorSilent"/>, which is the honest
+    /// reading of a card that makes no claim.</para>
+    /// </summary>
+    public FleetDeadlockSource DeadlockSource =>
+        FleetDeadlockCoverage.ClassifyDeadlockSource(IsPostgres, DeadlockCollectorBand);
 
     /// <summary>Worker-thread ceiling (max_workers_count). NULL = no scheduler snapshot (e.g. Azure SQL DB).</summary>
     public int? TotalThreads { get; set; }

--- a/PerformanceMonitor.Common/FleetDeadlockCoverage.cs
+++ b/PerformanceMonitor.Common/FleetDeadlockCoverage.cs
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Text;
+using System.Text.Json.Serialization;
+
+namespace PerformanceMonitor.Common;
+
+
+/// <summary>
+/// Whether one server's deadlock count read a deadlock source at all, and when it did not, which cause
+/// (#3017). Serialized as its STRING name (the fleet DTOs' <c>JsonStringEnumConverter</c>), so a consumer
+/// switches on a word rather than on an ordinal that a reordering would move underneath it.
+///
+/// <para>The three uncovered arms exist as three rather than as one flag because they take OPPOSITE actions,
+/// which is the whole reason a bare tally would not have been enough.</para>
+/// </summary>
+public enum FleetDeadlockSource
+{
+    /// <summary>The <c>deadlocks</c> collector read this server over the health window, so this server's
+    /// deadlocks — however many that is, including none — are in the total. Its band may still be FAILING,
+    /// STALE or WARNING: those collectors succeeded on some cycles, and their rows are in the total.</summary>
+    Read,
+
+    /// <summary>A PostgreSQL target, whose deadlocks the total cannot count at all: they are stored in
+    /// <c>pg_deadlocks</c>, which nothing joins into <c>v_deadlocks</c>. Nothing about this server's health
+    /// changes it and no grant addresses it — <c>get_pg_deadlocks</c> is the read that answers.</summary>
+    PostgresTarget,
+
+    /// <summary>The <c>deadlocks</c> collector is not being invoked — STOPPED, NEVER_RUN, or no row in the
+    /// health window at all. Silence, not failure: a collector still running and erroring every cycle bands
+    /// FAILING and counts as <see cref="Read"/>. Check the collector (<c>get_collection_health</c>).</summary>
+    CollectorSilent,
+
+    /// <summary>Every one of the <c>deadlocks</c> collector's attempts was refused for permissions
+    /// (NO_PERMISSIONS). The one cause a grant fixes, which is why it is not folded in with
+    /// <see cref="CollectorSilent"/> despite both meaning nothing was read.</summary>
+    CollectorDenied,
+}
+
+/// <summary>
+/// The denominator beside <c>total_deadlocks</c> (#3017): how many of the fleet's
+/// servers that total actually read a deadlock source for, and for the rest, which of the three causes it
+/// was.
+///
+/// <para><b>Why a total needs one at all.</b> <c>v_deadlocks</c> is the SQL Server extended-event capture and
+/// only that, so <c>total_deadlocks</c> is structurally zero for a PostgreSQL server — permanently, whatever
+/// its clusters do and whatever grants the monitoring role holds. Zero is also exactly what a genuinely quiet
+/// SQL Server fleet reports. The reading that needs no action and the reading that does not cover the fleet
+/// are the same character, and that is what makes the bare number unusable.</para>
+///
+/// <para><b>The convention this follows.</b> <c>get_pg_blocking</c> already reports <c>captures_total</c>
+/// beside <c>captures_with_blocking</c> and a sentence saying what an empty answer does and does not mean,
+/// because the denominator is the honest part of a sampled signal; <c>target_has_user_databases</c> (#1852)
+/// already states a fact about the TARGET beside a persistently empty result rather than banding it, so
+/// "nothing to collect" stops looking like "collecting nothing". This is the same move on a fleet total: a
+/// count, a denominator, named causes, and a note — and deliberately not a new band, for #1852's reason. A
+/// quiet SQL Server fleet with full coverage is healthy and must keep reading that way.</para>
+///
+/// <para><b>Why this sits in Common rather than beside either reader.</b> TWO surfaces compute this same
+/// fleet total from the same <c>v_deadlocks</c>, out of two assemblies that do not reference each other —
+/// the service's <c>get_fleet_overview</c> / <c>/api/fleet</c> reader and the WPF viewer's Overview
+/// roll-up (#3029). The buckets, the enum they reduce from and
+/// <see cref="ClassifyDeadlockSource"/> therefore live once, here: a cause added to
+/// <see cref="FleetDeadlockSource"/> gets ONE decision instead of one per surface, and the surface that
+/// was not updated would have mis-bucketed silently. What each surface keeps for itself is the PROSE: the
+/// <see cref="Note"/> below names JSON fields and MCP tools because its reader is an API consumer, and a
+/// desktop tile naming <c>window_start</c> would be describing a payload nobody there can see.</para>
+/// </summary>
+public sealed class FleetDeadlockCoverage
+{
+    /// <summary>Servers the total read a deadlock source for — the numerator of the coverage this object
+    /// reports, and NOT a count of servers that had deadlocks (that is
+    /// <c>total_deadlocks</c>'s job).</summary>
+    [JsonPropertyName("servers_read")] public int ServersRead { get; init; }
+
+    /// <summary>Enabled servers in the fleet — the same population as
+    /// <c>total_servers</c>, repeated here so the denominator travels with its
+    /// numerator and a consumer reading only this object is never one field short of the ratio.</summary>
+    [JsonPropertyName("servers_total")] public int ServersTotal { get; init; }
+
+    /// <summary>Uncovered because the target is PostgreSQL — <c>get_pg_deadlocks</c> is the read that
+    /// answers for these.</summary>
+    [JsonPropertyName("postgres_servers")] public int PostgresServers { get; init; }
+
+    /// <summary>Uncovered because the <c>deadlocks</c> collector is not being invoked (STOPPED, NEVER_RUN,
+    /// or no row in the health window) — check the collector.</summary>
+    [JsonPropertyName("servers_collector_silent")] public int ServersCollectorSilent { get; init; }
+
+    /// <summary>Uncovered because every one of the <c>deadlocks</c> collector's attempts was refused for
+    /// permissions — these need a grant.</summary>
+    [JsonPropertyName("servers_collector_denied")] public int ServersCollectorDenied { get; init; }
+
+    /// <summary>
+    /// The sentence that keeps the two figures from being read as one measurement.
+    ///
+    /// <para><b>The windows genuinely diverge and this is the whole point of the field.</b>
+    /// <c>total_deadlocks</c> is counted between the caller's
+    /// <c>window_start</c> and <c>window_end</c> (one hour by default); coverage is banded over the FIXED
+    /// trailing seven days of collection health. That divergence is correct — whether a reader works is a
+    /// durable fact, and the banding thresholds are themselves defined in DAYS, so an hour-wide health
+    /// window could not produce a band at all — but a note claiming both were "read in this window" would be
+    /// the same defect one level up: a surface asserting a scope it did not measure. So the sentence names
+    /// each window against the figure it belongs to, and says outright that coverage makes no claim about
+    /// the caller's window.</para>
+    /// </summary>
+    public const string WindowNote =
+        "Coverage bands each server's deadlock reader over the fixed trailing seven days of collection "
+        + "health - whether the reader works at all, which is a durable fact - while total_deadlocks counts "
+        + "only between window_start and window_end. The two windows differ deliberately, and this coverage "
+        + "figure therefore makes no claim about what was read inside window_start..window_end.";
+
+    /// <summary>What to do about the PostgreSQL arm, appended after its count.</summary>
+    public const string PostgresCause =
+        "are PostgreSQL targets, whose deadlocks this total cannot count at all - they are stored separately "
+        + "and served by get_pg_deadlocks.";
+
+    /// <summary>What to do about the silent arm, appended after its count.</summary>
+    public const string CollectorSilentCause =
+        "have no current deadlock collection - the collector has stopped being invoked, or has never run; "
+        + "check it with get_collection_health.";
+
+    /// <summary>What to do about the denied arm, appended after its count.</summary>
+    public const string CollectorDeniedCause =
+        "had every deadlock-collector attempt refused for permissions - those need a grant.";
+
+    /// <summary>
+    /// The coverage in a sentence, with <see cref="WindowNote"/> and only the causes that actually apply.
+    ///
+    /// <para>DERIVED rather than assigned, for the reason each surface's own per-server <c>deadlock_source</c> is:
+    /// a settable note is a note that can be omitted, or can drift from the counts it describes. Computed,
+    /// the numbers and the sentence cannot disagree.</para>
+    /// </summary>
+    [JsonPropertyName("note")]
+    public string Note
+    {
+        get
+        {
+            var note = new StringBuilder();
+
+            note.Append("total_deadlocks read a deadlock source for ")
+                .Append(ServersRead)
+                .Append(" of ")
+                .Append(ServersTotal)
+                .Append(" enabled servers. ")
+                .Append(WindowNote);
+
+            if (PostgresServers > 0)
+            {
+                note.Append(' ').Append(PostgresServers).Append(' ').Append(PostgresCause);
+            }
+
+            if (ServersCollectorSilent > 0)
+            {
+                note.Append(' ').Append(ServersCollectorSilent).Append(' ').Append(CollectorSilentCause);
+            }
+
+            if (ServersCollectorDenied > 0)
+            {
+                note.Append(' ').Append(ServersCollectorDenied).Append(' ').Append(CollectorDeniedCause);
+            }
+
+            return note.ToString();
+        }
+    }
+
+    /// <summary>
+    /// Whether one server's deadlock count — and so the fleet total it sums into — actually read a deadlock
+    /// source, and when it did not, which of the three causes it was (#3017). The three take OPPOSITE
+    /// actions, which is why one uncovered tally would not have been enough: a different tool for a
+    /// PostgreSQL target, a collector to look at for one that is not being invoked, a grant for one that was
+    /// refused.
+    ///
+    /// <para><b>PostgreSQL is asked first and answers on its own.</b> It is not a degraded collector, it is
+    /// the wrong table: every fleet deadlock total reads <c>v_deadlocks</c>, which holds only the SQL
+    /// Server extended-event capture, and no health band on any collector changes that. A PostgreSQL target
+    /// whose <c>pg_deadlocks</c> collector is perfectly healthy still contributes nothing here.</para>
+    ///
+    /// <para><b>A null band is uncovered, not covered.</b> Null means the <c>deadlocks</c> collector left no
+    /// row in the health window — nothing was read for this server, whatever else is true of it — and
+    /// defaulting an absent band to "read" is precisely how a coverage figure becomes another number nobody
+    /// can trust. It is folded in with STOPPED and NEVER_RUN because all three take the same action.</para>
+    ///
+    /// <para><b>FAILING, STALE and WARNING count as READ, deliberately.</b> Those collectors succeeded on
+    /// some cycles, so their rows really are in the total and a denominator excluding them would understate
+    /// the fleet — a new wrong number in place of the old one. They are not hidden by being counted here:
+    /// <c>servers_with_collection_failures</c> and each card's
+    /// <c>failed_collector_count</c> are where a degraded collector shows, and the
+    /// card's own <c>deadlock_collector_band</c> carries the band verbatim.</para>
+    /// </summary>
+    public static FleetDeadlockSource ClassifyDeadlockSource(bool isPostgres, string? deadlockCollectorBand)
+    {
+        if (isPostgres)
+        {
+            return FleetDeadlockSource.PostgresTarget;
+        }
+
+        /* Tested ahead of the general set below rather than as part of it: NO_PERMISSIONS is IN
+           NothingReadBands, so asking the set first would swallow the one cause with a different fix. */
+        if (string.Equals(deadlockCollectorBand, CollectorHealthClassifier.NoPermissions, StringComparison.Ordinal))
+        {
+            return FleetDeadlockSource.CollectorDenied;
+        }
+
+        return deadlockCollectorBand is null || CollectorHealthClassifier.ReadNothing(deadlockCollectorBand)
+            ? FleetDeadlockSource.CollectorSilent
+            : FleetDeadlockSource.Read;
+    }
+}

--- a/PerformanceMonitor.Common/FleetDeadlockCoverage.cs
+++ b/PerformanceMonitor.Common/FleetDeadlockCoverage.cs
@@ -12,7 +12,6 @@ using System.Text.Json.Serialization;
 
 namespace PerformanceMonitor.Common;
 
-
 /// <summary>
 /// Whether one server's deadlock count read a deadlock source at all, and when it did not, which cause
 /// (#3017). Serialized as its STRING name (the fleet DTOs' <c>JsonStringEnumConverter</c>), so a consumer


### PR DESCRIPTION
Fixes #3029.

The WPF Overview's `Deadlocks: N` is the third independent computation of the same fleet total. `ViewerDataService.Fleet.cs`'s `FleetTotalsSql` runs its own `SELECT COUNT(*) FROM v_deadlocks`, and `v_deadlocks` is the SQL Server extended-event capture and nothing else — a PostgreSQL target's deadlocks go to `pg_deadlocks`, which nothing joins in. So on a PostgreSQL fleet that number is structurally zero forever, whatever those clusters do and whatever grants the role holds. Zero is also exactly what a genuinely quiet SQL Server fleet reports, so the reading that needs no action and the reading that does not cover the fleet had the same character.

## The shared types moved into Common, and the service's wire shape did not change

`PerformanceMonitor.Darling.Viewer` does not reference `PerformanceMonitor.Darling.Service`, so `FleetDeadlockSource`, `FleetDeadlockCoverage` and `ClassifyDeadlockSource` were unreachable from it. They now live in `PerformanceMonitor.Common/FleetDeadlockCoverage.cs` — its own new file, not appended to `ServerHealthBands.cs`, because a fleet-coverage DTO is not a health band. `ClassifyDeadlockSource` is a static on `FleetDeadlockCoverage` rather than on a separate classifier class, so a cause added to the enum cannot be added without seeing the buckets it has to land in.

**The viewer takes the full coverage object, not a narrower signal.** A viewer-only carrier with its own five counts would have been a second counting shape for one measurement — the defect this issue is about, one level up. Sharing the carrier means the enum, the classifier and the buckets travel together, so a fifth cause gets one decision instead of one per surface. What each surface keeps for itself is the PROSE: the shared `Note` names JSON fields and MCP tool names because its reader is an API consumer, and a desktop tooltip citing `window_start` would be describing a payload nobody there can see.

The service keeps the type verbatim — same properties, same `JsonPropertyName` attributes, same `Note`, same `WindowNote`/cause constants. Only the doc-comment `see cref`s pointing at service types were rewritten to `c` tags, since Common cannot reference them.

## The card's two new inputs are both free

- **The engine flag costs no SQL.** The issue's costing said the Overview read selects no `engine_kind` and that both the read and the DTO have to grow one. The DTO does; the read does not. `LoadOverviewAsync` iterates `DarlingServer`, which already carries `IsPostgres` from `servers.engine_kind` through both registry reads, and already stamps `summary.ServerName` from it — so `summary.IsPostgres` is one more stamp on a line that already exists. No summary query changed.
- **The band comes out of a read already being made.** `GetCollectorHealthCountsAsync` enumerates the 7-day collection-health rows to count HEALTHY and FAILING; it now also picks the `deadlocks` collector's own band out of the same rows, matched from `DeadlocksCollector.Instance.Name` rather than a literal. Neither tally could stand in for it: STOPPED, NEVER_RUN and NO_PERMISSIONS are none of them FAILING, so a server reading nothing at all shows up in both counts as a zero.

`ServerSummaryItem.DeadlockSource` is derived, not assigned, for the same reason the service card's is: a card built by a path nobody re-reads then reads as UNCOVERED rather than sitting at an enum default meaning "read".

## The denominator is the registered fleet, and the fifth gap keeps its own words

The deadlock total is a cross-server COUNT over the whole store, so the population it covers is every registered server — not whichever cards loaded this cycle. `ServersTotal` is therefore `TotalServers`, and the four causes need not sum to it.

That shortfall is real and the service has no equivalent of it: `DarlingFleetReader` builds a card for every enabled server in one query, where the viewer's `summaries` silently drops any server whose per-server read failed this cycle (#2753). Such a server is uncovered for the same reason a null band is — nothing was read for it — but it is deliberately **not** folded into the silent-collector cause. That cause sends the reader to a collector; this one is the viewer's own read having failed, which is a different thing to go and look at. Naming it "the collector has stopped being invoked" would be a confidently wrong instruction, which is worse than the bare number was. It is `UnknownCount`, which already has its own line in the panel, and it is named in the tooltip.

## What the row renders, and the complete-coverage decision

A second `TextBlock` beside the deadlock total in the fleet-totals row, reading `Deadlock coverage: read all 12 servers` or `Deadlock coverage: read 0 of 12 servers`. The inner phrasing is #3027's web sub-line verbatim; the label is added because that row is a `WrapPanel` of independently-labelled phrases, so an unlabelled one could wrap onto the next line under a different figure and read as qualifying that.

**Shown whenever there is a fleet, including at full coverage — matching what #3027 chose for the web tile, and for its reason.** A line that appeared only on a partial read would make its ABSENCE the load-bearing signal, which a reader has to already know the rule to interpret, and it would leave "zero, whole fleet measured" indistinguishable from "zero, from a build that reports no coverage at all". The one case it is hidden is a fleet with nothing registered, where the whole roll-up panel is collapsed anyway.

Each cause in the tooltip is a verb-free noun phrase and the count becomes words in ONE place (`Cause`), so `1 server: every deadlock-collector attempt refused for permissions` reads correctly without a second string per arm — an `N are PostgreSQL targets` shape prints `1 are PostgreSQL targets` the moment a fleet has exactly one of something, which for the denied and silent arms is the common case. The shared `Note` the service serializes has that shape and is left alone: changing it would change the wire output, which is the one thing this diff is claiming it does not do.

Its colour tracks COVERAGE rather than the count's severity — muted at full, `WarningBrush` at partial — because "read all 12 servers" beside a large count is good news about a bad number. The count itself is deliberately **not** recoloured: nothing in that row carries severity today, not even `Collection failures`, so giving one of the three a severity brush would be a new inconsistency rather than a fix. Deliberately not a new band either, for #1852's reason: a quiet SQL Server fleet with full coverage is healthy and must keep reading that way. The tooltip hangs off both the count and the coverage line, so either hover reaches the detail.

## Verification

`Darling.Tests` and `Lite.Tests` cannot run on macOS, so the real test files were compiled into throwaway `net10.0` xunit v3 console hosts named `Darling.Tests`, staged outside the tree, `Compile Include`-ing the repo paths with the solution symlinked in so the source pins' upward walk resolves.

- **Viewer suite: 62 total, 28 new, 0 failed** on the coverage class; the 1 failure is `RankedServer_LabelAndBrush_MatchTheBand`, which constructs a WPF `SolidColorBrush` and cannot run against reference assemblies. Controlled: the same harness fails it identically on `origin/dev`'s own copy of the file. Same for `ViewerSidebarDotRendersTheCardStatusTests.EveryStateTheCardPaints_HasADotColourToMatch`, controlled against a separately-built `origin/dev` harness.
- **Service pins: 60 total, 0 failed, 2 skipped** (both `DARLING_TEST_PG`-gated). `TheCoverageSerializes_BesideTheTotal_WithTheCauseAsAName`, `TheNote_NamesEachWindow_AndClaimsNeitherForTheOther` and `NothingReadBandsTests.EveryBandOnTheClassifier_HasADecision_InExactlyOneList` were each confirmed executed by name, not inferred from a suite total.
- **Whole-tree guards: 225 total, 0 failed** beyond the controlled WPF one — including `DocCommentHygieneTests`, `XamlStaticResourceHygieneTests`, `RollupCoverageRoutingTests`, `FleetIdentifierScrubTests`, `ViewerCommandTimeoutTests`, `ViewerFleetTimerGuardTests`, `CSharpSourceWalkerTests`, `PayloadDimensionTests` and `CommandDeadlineScannerAdoptionTests`, all of which enumerate source and would see a new file in Common.
- **`Lite.Tests` compiles clean** against the changed Common. It cannot execute here — `Microsoft.WindowsDesktop.App` is not installed for `osx-arm64`, and the launcher says so rather than failing a test.

**The wire shape is proven byte-identical, not asserted.** A probe serializes the same rollup through `DarlingFleetReader.JsonOptions` on this branch and on `origin/dev`: md5 `c6cfb86cfd50ca3e418016d592fdaf7a` on both. With a content mutation to one of the moved constants it moves to `b53c7f7e…` and returns on restore, so the probe is live rather than a stale binary.

**The XAML is proven compiled, not merely present.** `MainWindow.baml` in the build output carries `DeadlockCoverageText`, `DeadlockCoverageTooltip` and `DeadlockCoverageIsPartial`, so the markup compiler accepted the new element, its `Style` and its `DataTrigger`.

Baseline committed first, then one mutation at a time through `redproof.sh` — each restored via a stash of the mutation only, the fix re-asserted by content after restore, and the repo-wide stash list proven unchanged. The harness reference to the viewer is a built DLL, so a rebuild target was added and then proven non-vacuous by mutating viewer source and watching the harness go red. **Nineteen kill-mutations, each caught, plus a comment-only control that stayed green:**

- the PostgreSQL arm counted as read; the denied arm folded into the silent one; the denominator shrunk to the loaded subset; the coverage dropped from `Build`'s early-return path
- always-partial; the line blanked at full coverage; the line hidden unless partial (each of the last three the "absence carries meaning" defect from a different direction)
- the window disclaimer deleted, and separately the source note dropped — same test, **different** assertions (`makes no claim about what was read in the last hour` vs `SQL Server extended-event capture and nothing else`)
- the unreported shortfall blamed on the silent collector
- a null band defaulted to read; the PostgreSQL arm disabled — both in Common, and **both proven to redden the service suite as well as the viewer's, from one mutation**, which is the whole claim of the move
- the XAML line removed, and separately its `DataTrigger` removed — same test, different assertions (`DeadlockCoverageText` vs `DeadlockCoverageIsPartial`)
- the collector matched by the literal `"deadlocks"`, and separately the band dropped from the tuple — same test, different assertions. A further mutation adds the literal *alongside* the collector-name match, so the `DoesNotContain` arm is proven live rather than shadowed by the `Contains` arm that fired first
- the singular arm dropped from `Cause`, so every count reads `N servers:` — caught on `1 server: PostgreSQL targets…`
- a fifth member added to `FleetDeadlockSource`, which the reflection pin catches by count — the service suite does **not** catch this, so that pin is the only thing standing between a new cause and a silent mis-bucket

## Merged `origin/dev` in

`dev` moved to `82782e9d4` (#3038 and #3041) while this was in flight, so it is merged in as an ordinary merge commit. No file overlap, and the diff against the new base is still exactly these eight files. #3038 touched `fleet.js`, so I checked specifically whether it reworded the web sub-line this PR matches: `deadlockCoverageSub` is byte-identical to #3027's, so the "verbatim" claim above still holds. Neither commit touches `Mcp/`, `PerformanceMonitor.Common/` or `PerformanceMonitor.Collectors/`, so the byte-identical-JSON comparison above is still measured against an unchanged base. Every suite, the probe and the BAML check were re-run on the merged tree.

## Not verified

- **No live store.** Nothing was run against a real Darling store, so the `deadlocks`-collector band actually arriving from `v_collection_log` for a real server is reasoned from `FleetCollectionHealthSql`'s shape and the service's identical match, not observed. The two `DARLING_TEST_PG`-gated round-trips in the touched files skipped.
- **Nothing was rendered.** The panel was never displayed. Wrap behaviour at a narrow window, the two brushes against the dark theme, and the tooltip's length on screen are all unobserved; only that the bindings compiled into BAML and that the strings are what the pins say.
- **A PostgreSQL-only fleet was never loaded in the viewer.** The measured case is asserted over constructed cards, not observed end to end.
- **`Lite.Tests` did not execute.** Compilation only.
- **The two WPF-brush tests did not execute anywhere**, here or on `origin/dev` — they are controlled as pre-existing, not passed.
