### PR TITLE
Use the placeholder convention for the host named in AlertEngine's poison-wait comment

### DIFF
--- a/PerformanceMonitor.Alerting/AlertEngine.cs
+++ b/PerformanceMonitor.Alerting/AlertEngine.cs
@@ -120,7 +120,7 @@ public sealed class AlertEngine
     /* The collection_time of the wait_stats row(s) last actually fired on. Read adapters answer
        "what's the newest poison-wait row within the last 10 minutes", which is independent of
        whether it is NEW since the previous ask — at fleet load the collector's delivered cadence
-       can lag the alert cooldown (PerformanceMonitor's own dogfooding on prod-pos-use2-monitor-01
+       can lag the alert cooldown (PerformanceMonitor's own dogfooding on <monitor-host>
        caught byte-identical duplicate alerts ~5-7 minutes apart), so the cooldown elapsing is not
        proof a fresh observation exists. Poison wait is deliberately NOT level-triggered like CPU
        (which resamples live every sweep): a delta is one collector cycle's computation, and


### PR DESCRIPTION
Brings one comment in `AlertEngine` into line with the placeholder convention the rest of the repo uses for targets.

The comment above `_lastPoisonWaitCollectionTime` explains why poison-wait re-fire gates on a newer `collection_time` as well as on the cooldown: at fleet load the collector's delivered cadence can lag the cooldown, so the cooldown elapsing is not proof a fresh observation exists. It cited the instance the duplicate alerts were observed on by name. Every comparable observation comment refers to targets through a placeholder, so this one now reads `<monitor-host>`.

The reasoning the comment records is unchanged — including the part worth keeping, that poison wait is deliberately not level-triggered like CPU, because a delta is one collector cycle's computation and reading it twice is the same event surfacing twice rather than two observations of a standing condition.

Comment-only: one line, no behaviour change, CRLF preserved (`--numstat` reports 1/1, not a whole-file rewrite).

## CHANGELOG entry text

Nothing. A comment aligning with a naming convention is not a user-visible change and does not earn a line.
