### PR TITLE
Fixes #3048

### DIFF
--- a/Darling/Darling.Tests/PgPanelTabOwnershipTests.cs
+++ b/Darling/Darling.Tests/PgPanelTabOwnershipTests.cs
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// A PostgreSQL panel must be filled by the tab it renders on (#3048).
+///
+/// <para>The viewer loads a server tab's panels on demand: the inner-tab dispatcher in
+/// <c>ViewerServerTab.xaml.cs</c> maps each <c>Pg…InnerTabIndex</c> to one <c>LoadPg…Async</c>, and that
+/// loader — plus whatever it calls — assigns the panels. Nothing checks that the panels it assigns are the
+/// panels declared inside that tab, and #3048 was a grid that rendered on Vacuum while only the Activity
+/// tab's load path filled it. Visiting Vacuum without Activity left it empty, which is indistinguishable
+/// from a server that never deadlocked.</para>
+///
+/// <para><b>It is invisible without this test.</b> The XAML compiles, BAML is produced, the build is green
+/// and the panel appears; it is only ever empty at a moment nobody scripted. The comment above it named the
+/// right tab for two years and the layout did not match, so prose is demonstrably not the check.</para>
+///
+/// <para>Ownership resolves to the OUTERMOST named <c>TabItem</c>, because Activity holds a sub-tab control
+/// and a panel inside its Blocking sub-tab is still loaded by <c>LoadPgActivityAsync</c>.</para>
+/// </summary>
+public sealed class PgPanelTabOwnershipTests
+{
+    /// <summary>
+    /// Panels whose load path is not their own tab's, each with the issue that tracks it. Deliberately
+    /// carrying the pair rather than muting the whole tab: any OTHER panel on those tabs is still checked.
+    /// </summary>
+    private static readonly Dictionary<string, string> KnownOffTab = new(StringComparer.Ordinal)
+    {
+        ["PgWaitSamplingGrid"] = "#3050",
+        ["PgWaitSamplingNote"] = "#3050",
+        ["PgPredicateStatsGrid"] = "#3050",
+        ["PgPredicateStatsNote"] = "#3050",
+    };
+
+    private static readonly Regex ControlAssignment = new(
+        @"\b(?<name>Pg[A-Za-z]+(?:Grid|Note|Expander))\s*(?:\.\w+)?\s*=", RegexOptions.Compiled);
+
+    private static readonly Regex LoaderCall = new(
+        @"\b(?<name>LoadPg[A-Za-z]+Async)\b", RegexOptions.Compiled);
+
+    private static readonly Regex DispatcherArm = new(
+        @"case\s+Pg(?<tab>\w+)InnerTabIndex:\s*\r?\n\s*await\s+LoadPg(?<loader>\w+)Async\(\);",
+        RegexOptions.Compiled);
+
+    [Fact]
+    public void EveryPanelAPgTabLoadPathFills_IsDeclaredInsideThatTab()
+    {
+        var (tabOf, loadPaths) = Read();
+
+        /* Floors first. Every assertion below is over these two sets, so an empty one would make the whole
+           test pass by having nothing to disagree about — which is the failure this test is about. */
+        Assert.True(tabOf.Count >= 40, $"Only {tabOf.Count} named controls resolved to a Pg tab; the XAML walk is not finding the tree.");
+        Assert.True(loadPaths.Count >= 6, $"Only {loadPaths.Count} dispatcher arms found; the tab-to-loader map is not being read.");
+
+        var offenders = new List<string>();
+        var exemptionsSeen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var (tab, panels) in loadPaths.OrderBy(p => p.Key, StringComparer.Ordinal))
+        {
+            Assert.True(panels.Count > 0, $"{tab}'s load path assigns no panel at all, so nothing about it is verified.");
+
+            foreach (var panel in panels.OrderBy(p => p, StringComparer.Ordinal))
+            {
+                if (!tabOf.TryGetValue(panel, out var declaredIn))
+                {
+                    continue; /* not declared in this XAML at all — another file's control, not this rule's business */
+                }
+
+                if (declaredIn == tab)
+                {
+                    continue;
+                }
+
+                if (KnownOffTab.TryGetValue(panel, out var issue))
+                {
+                    exemptionsSeen.Add(panel);
+                    continue;
+                }
+
+                offenders.Add($"{panel} is filled by {tab}'s load path but is declared inside {declaredIn}");
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            "A PostgreSQL panel is filled by one tab's load path and rendered on another, so it is empty "
+            + "until the other tab is visited — and an empty panel reads as 'nothing to report' rather than "
+            + "'nothing loaded this'. Either move the declaration into the tab that loads it, or move the "
+            + "loader call into the tab that renders it, and say which evidence decided:\n  "
+            + string.Join("\n  ", offenders));
+
+        /* An exemption that has stopped being true is worse than no exemption: it documents debt that is
+           already paid and licenses the defect to come back at that name unnoticed. */
+        var stale = KnownOffTab.Keys.Where(k => !exemptionsSeen.Contains(k)).OrderBy(k => k, StringComparer.Ordinal).ToList();
+        Assert.True(stale.Count == 0,
+            "These panels are exempt but no longer off-tab, so the exemption is stale. Remove them from "
+            + $"KnownOffTab and close the issue they cite:\n  {string.Join("\n  ", stale)}");
+    }
+
+    [Fact]
+    public void TheDispatcher_NamesEachTabAndItsLoaderConsistently()
+    {
+        var shell = File.ReadAllText(Path.Combine(ViewerDirectory(), "ViewerServerTab.xaml.cs"));
+        var arms = DispatcherArm.Matches(shell);
+
+        Assert.True(arms.Count >= 6, $"Found {arms.Count} PostgreSQL dispatcher arms; the pattern no longer matches the switch.");
+
+        foreach (Match arm in arms)
+        {
+            var tab = arm.Groups["tab"].Value;
+            var loader = arm.Groups["loader"].Value;
+            Assert.True(tab == loader,
+                $"The dispatcher routes Pg{tab}InnerTabIndex to LoadPg{loader}Async. The rest of this file "
+                + "derives a tab's loader from its name, so a mismatch here would silently check the wrong "
+                + "tab's panels against the wrong load path.");
+        }
+    }
+
+    [Fact]
+    public void TheDetector_FindsAnOffTabPanelPlantedIntoTheRealTree()
+    {
+        /* Without this the rule above passes on any tree where the walk quietly returns nothing, and the
+           exemptions would be the only evidence it ever fires. Plant a panel that IS declared on one tab
+           and IS assigned by another tab's loader, and require it to be reported. */
+        var (tabOf, loadPaths) = Read();
+
+        var vacuumPanel = tabOf.First(kv => kv.Value == "PgVacuumTab" && !KnownOffTab.ContainsKey(kv.Key)).Key;
+        var activityPanels = new HashSet<string>(loadPaths["PgActivityTab"], StringComparer.Ordinal) { vacuumPanel };
+
+        var reported = activityPanels
+            .Where(p => tabOf.TryGetValue(p, out var t) && t != "PgActivityTab" && !KnownOffTab.ContainsKey(p))
+            .ToList();
+
+        Assert.Contains(vacuumPanel, reported);
+        Assert.Single(reported);
+    }
+
+    private static string ViewerDirectory()
+    {
+        var root = FindRepoRoot();
+        Assert.True(root is not null,
+            "Could not locate the repository root (walked up from the test binary looking for "
+            + "PerformanceMonitor.sln). This test reads the source tree, so it cannot run without it — fix "
+            + "the walk-up rather than skipping, or the rule stops being enforced without anyone noticing.");
+        return Path.Combine(root!, "Darling", "PerformanceMonitor.Darling.Viewer");
+    }
+
+    /// <summary>
+    /// (control -> outermost named Pg tab, tab -> every panel its load path assigns).
+    /// </summary>
+    private static (Dictionary<string, string> TabOf, Dictionary<string, HashSet<string>> LoadPaths) Read()
+    {
+        var dir = ViewerDirectory();
+        var x = XName.Get("Name", "http://schemas.microsoft.com/winfx/2006/xaml");
+
+        var doc = XDocument.Load(Path.Combine(dir, "ViewerServerTab.xaml"));
+        var tabOf = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var element in doc.Descendants())
+        {
+            var name = element.Attribute(x)?.Value;
+            if (name is null)
+            {
+                continue;
+            }
+
+            /* Outermost, not nearest: a panel in Activity's Blocking sub-tab is loaded by the Activity arm. */
+            var owner = element.Ancestors()
+                .Where(a => a.Name.LocalName == "TabItem" && a.Attribute(x)?.Value is not null)
+                .Select(a => a.Attribute(x)!.Value)
+                .LastOrDefault(t => t.StartsWith("Pg", StringComparison.Ordinal));
+
+            if (owner is not null)
+            {
+                tabOf[name] = owner;
+            }
+        }
+
+        var source = Strip(File.ReadAllText(Path.Combine(dir, "ViewerServerTab.Postgres.cs")));
+        var bodies = MethodBodies(source);
+
+        var loadPaths = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+        foreach (Match arm in DispatcherArm.Matches(File.ReadAllText(Path.Combine(dir, "ViewerServerTab.xaml.cs"))))
+        {
+            var tab = $"Pg{arm.Groups["tab"].Value}Tab";
+            var entry = $"LoadPg{arm.Groups["loader"].Value}Async";
+            loadPaths[tab] = Transitive(entry, bodies, new HashSet<string>(StringComparer.Ordinal));
+        }
+
+        return (tabOf, loadPaths);
+    }
+
+    private static HashSet<string> Transitive(string method, Dictionary<string, string> bodies, HashSet<string> seen)
+    {
+        var found = new HashSet<string>(StringComparer.Ordinal);
+        if (!seen.Add(method) || !bodies.TryGetValue(method, out var body))
+        {
+            return found;
+        }
+
+        foreach (Match m in ControlAssignment.Matches(body))
+        {
+            found.Add(m.Groups["name"].Value);
+        }
+
+        foreach (Match m in LoaderCall.Matches(body))
+        {
+            var callee = m.Groups["name"].Value;
+            if (callee != method)
+            {
+                found.UnionWith(Transitive(callee, bodies, seen));
+            }
+        }
+
+        return found;
+    }
+
+    /// <summary>Doc comments and line comments out, so prose naming a grid cannot read as an assignment.</summary>
+    private static string Strip(string source) =>
+        Regex.Replace(Regex.Replace(source, @"^[ \t]*///.*$", string.Empty, RegexOptions.Multiline),
+                      @"//.*$", string.Empty, RegexOptions.Multiline);
+
+    private static Dictionary<string, string> MethodBodies(string source)
+    {
+        var bodies = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (Match m in Regex.Matches(source, @"private\s+async\s+Task\s+(?<name>LoadPg[A-Za-z]+Async)\s*\("))
+        {
+            var depth = 0;
+            var started = false;
+            for (var i = m.Index; i < source.Length; i++)
+            {
+                if (source[i] == '{')
+                {
+                    depth++;
+                    started = true;
+                }
+                else if (source[i] == '}')
+                {
+                    depth--;
+                    if (started && depth == 0)
+                    {
+                        bodies[m.Groups["name"].Value] = source[m.Index..(i + 1)];
+                        break;
+                    }
+                }
+            }
+        }
+
+        return bodies;
+    }
+
+    /// <summary>Same walk-up idiom as <c>DocCommentHygieneTests.FindRepoRoot</c>.</summary>
+    private static string? FindRepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        for (var i = 0; i < 10 && dir is not null; i++)
+        {
+            if (File.Exists(Path.Combine(dir, "PerformanceMonitor.sln")))
+            {
+                return dir;
+            }
+
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        return null;
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Postgres.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Postgres.cs
@@ -564,8 +564,8 @@ public partial class ViewerServerTab
 
         PgDeadlocksNote.Text = PanelNote("pg_deadlocks", rows.Count,
             "No deadlock was reported in this window. That is the healthy answer, and it is also what an "
-            + "unreadable server log looks like — the plan-capture panel above reads the same file and says "
-            + "which it is.")
+            + "unreadable server log looks like — the Vacuum tab's plan-capture readiness panel reads the "
+            + "same file and says which it is.")
             + (rows.Count == 0
                 ? string.Empty
                 : "  Sightings counts how often the collector saw the SAME report while it stayed inside "

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Postgres.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Postgres.cs
@@ -537,14 +537,14 @@ public partial class ViewerServerTab
     }
 
     /// <summary>
-    /// Deadlocks reported in the window (#2661), last on this tab because they are blocking at its limit: a
-    /// chain the server had to break by cancelling somebody.
+    /// Deadlocks reported in the window (#2661), last on the Activity tab's Blocking sub-tab because they
+    /// are blocking at its limit: a chain the server had to break by cancelling somebody.
     ///
     /// <para><b>An empty grid is the healthy answer AND the shape of a log that cannot be read or cannot be
     /// parsed</b>, which is why the note names the other checks rather than leaving them. Deadlock reports
     /// need nothing ENABLED on the target, unlike plan capture, but they are not unsuppressable. Two things
-    /// have to hold: the log must be readable, which the plan-capture panel above already reports on
-    /// because it reads the same file, AND it must carry DETAIL, which <c>log_error_verbosity = terse</c>
+    /// have to hold: the log must be readable, which the Vacuum tab's plan-capture readiness panel
+    /// reports on because it reads the same file, AND it must carry DETAIL, which <c>log_error_verbosity = terse</c>
     /// strips along with the whole graph. pg_stat_database's cumulative deadlock counter is the independent
     /// test: if that moved and this is empty, the log is the problem — unreadable or too terse — rather
     /// than the server (#3030).</para>

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.xaml
@@ -3781,6 +3781,8 @@
                                 <RowDefinition Height="Auto"/>
                                 <RowDefinition Height="*"/>
                                 <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
                             </Grid.RowDefinitions>
                             <TextBlock Grid.Row="0" x:Name="PgBlockingNote" FontSize="12" Margin="0,0,0,6" TextWrapping="Wrap"
                                        Foreground="{DynamicResource ForegroundMutedBrush}"/>
@@ -3832,6 +3834,34 @@
                                     </DataGrid.Columns>
                                 </DataGrid>
                             </Expander>
+                            <!-- #2661 deadlocks, last on the Blocking sub-tab because a deadlock is blocking at its
+                                 limit: a chain the server had to break by cancelling somebody. Below the chains grid and
+                                 the cycles expander because blocking is the far more common finding and this grid is
+                                 usually empty.
+
+                                 Bounded at 220 like the cycles grid beside it, and for the same reason: it shares an Auto
+                                 row and must not take height from the chains it is a consequence of.
+
+                                 LoadPgActivityAsync is the only caller of LoadPgDeadlocksAsync, so this panel is filled
+                                 by the load that fills the panels above it. -->
+                            <TextBlock Grid.Row="3" x:Name="PgDeadlocksNote" FontSize="12" Margin="0,10,0,6" TextWrapping="Wrap"
+                                       Foreground="{DynamicResource ForegroundMutedBrush}"/>
+                            <DataGrid Grid.Row="4" x:Name="PgDeadlocksGrid" Style="{StaticResource DarkGrid}" MaxHeight="220"
+                                      HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" CanUserSortColumns="True">
+                                <DataGrid.Columns>
+                                    <DataGridTextColumn Header="When" Binding="{Binding OccurredAtUtc, StringFormat=yyyy-MM-dd HH:mm:ss}" Width="150"/>
+                                    <!-- The session the server cancelled. It is the end whose application saw an error,
+                                         which is usually the only end anybody noticed. -->
+                                    <DataGridTextColumn Header="Victim PID" Binding="{Binding VictimPid}" Width="90"/>
+                                    <DataGridTextColumn Header="Sessions" Binding="{Binding ParticipantCount}" Width="80"/>
+                                    <DataGridTextColumn Header="Lock Modes" Binding="{Binding LockModes}" Width="150"/>
+                                    <DataGridTextColumn Header="Resources" Binding="{Binding Resources}" Width="220"/>
+                                    <DataGridTextColumn Header="Victim Statement" Binding="{Binding VictimStatement}" Width="*"/>
+                                    <!-- Re-reads of the SAME report, not repeats: the collector re-reads an overlapping
+                                         log tail on purpose, and a genuinely repeated deadlock is its own row. -->
+                                    <DataGridTextColumn Header="Sightings" Binding="{Binding TimesSeen}" Width="80"/>
+                                </DataGrid.Columns>
+                            </DataGrid>
                         </Grid>
                     </TabItem>
                     <!-- #2544 locks. A SIBLING of Blocking rather than part of it, because they answer
@@ -4017,8 +4047,6 @@
                                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="*"/>
 </Grid.RowDefinitions>
                 <TextBlock Grid.Row="0" x:Name="PgVacuumNote" FontSize="12" Margin="0,0,0,8" TextWrapping="Wrap"
                            Foreground="{DynamicResource ForegroundMutedBrush}"/>
@@ -4188,27 +4216,6 @@
                     </DataGrid.Columns>
                 </DataGrid>
 
-                <!-- #2661 deadlocks, last on Activity because they are blocking at its limit: a chain the
-                     server had to break by cancelling somebody. Below the blocking panels because blocking
-                     is the far more common finding, and a deadlock grid is usually empty. -->
-                <TextBlock Grid.Row="16" x:Name="PgDeadlocksNote" FontSize="12" Margin="0,10,0,6" TextWrapping="Wrap"
-                           Foreground="{DynamicResource ForegroundMutedBrush}"/>
-                <DataGrid Grid.Row="17" x:Name="PgDeadlocksGrid" Style="{StaticResource DarkGrid}"
-                          HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" CanUserSortColumns="True">
-                    <DataGrid.Columns>
-                        <DataGridTextColumn Header="When" Binding="{Binding OccurredAtUtc, StringFormat=yyyy-MM-dd HH:mm:ss}" Width="150"/>
-                        <!-- The session the server cancelled. It is the end whose application saw an error,
-                             which is usually the only end anybody noticed. -->
-                        <DataGridTextColumn Header="Victim PID" Binding="{Binding VictimPid}" Width="90"/>
-                        <DataGridTextColumn Header="Sessions" Binding="{Binding ParticipantCount}" Width="80"/>
-                        <DataGridTextColumn Header="Lock Modes" Binding="{Binding LockModes}" Width="150"/>
-                        <DataGridTextColumn Header="Resources" Binding="{Binding Resources}" Width="220"/>
-                        <DataGridTextColumn Header="Victim Statement" Binding="{Binding VictimStatement}" Width="*"/>
-                        <!-- Re-reads of the SAME report, not repeats: the collector re-reads an overlapping
-                             log tail on purpose, and a genuinely repeated deadlock is its own row. -->
-                        <DataGridTextColumn Header="Sightings" Binding="{Binding TimesSeen}" Width="80"/>
-                    </DataGrid.Columns>
-                </DataGrid>
             </Grid>
         </TabItem>
 


### PR DESCRIPTION
Fixes #3048.

**It was the grid, not the comment.** `PgDeadlocksNote` and `PgDeadlocksGrid` were declared inside `<TabItem x:Name="PgVacuumTab">` and are now last in the Activity tab's Blocking sub-tab, below `PgBlockingChainsGrid` and `PgBlockingCyclesExpander`, where the comment said they belonged.

## What decided it

Five signals name Activity; one positional phrase was consistent with Vacuum.

- **The load path, which is behaviour rather than prose.** `LoadPgVacuumAsync` populates every other panel on that tab — session states, xmin horizon, autovacuum, wraparound, plan-capture readiness — and never assigned either deadlock control. `LoadPgDeadlocksAsync` assigns exactly those two, and its **only** caller anywhere is `LoadPgActivityAsync`.
- **`ViewerDataService.Postgres.cs`'s doc comment** on `GetPgDeadlocksAsync` opens *"Activity tab - PostgreSQL deadlocks reported in the window (#2661)"* — an independent statement in a different file naming the tab explicitly.
- **The XAML comment** named Activity and positioned it below the blocking panels.
- **Subject matter.** Vacuum is transaction age, bloat and wraparound headroom. A deadlock is a blocking chain the server broke.
- **The tab's own layout convention.** Every other note/grid pair on Vacuum is separated by a spacer row (2/3, 5/6, 8/9, 11/12, 14/15); the deadlock pair sat at 16/17 with no spacer, which is the shape of an append into the wrong container.

**The contrary evidence, and why it lost.** `LoadPgDeadlocksAsync`'s doc said log readability is reported by *"the plan-capture panel above"* — true only in the Vacuum layout, where the readiness panel sat at rows 14/15 directly above. That is a **positional** reference, not a claim about tab membership, and the kind of phrase written to match whatever happens to be adjacent. It is rewritten here to name the readiness panel and its tab, because the move invalidates it.

## This was a live defect, not a cosmetic one

The panel rendered on Vacuum and was filled only once Activity had been visited. Opening a PostgreSQL server and going straight to Vacuum showed an empty grid and a blank note whether or not the target had deadlocked — the #3030 failure shape from a different direction, where an empty grid means "nothing loaded this" and reads as "this server does not deadlock".

## The move

`Grid.Row` 16 → 3 and 17 → 4. `PgVacuumTab`'s `RowDefinitions` 18 → 16; the Blocking sub-tab's 3 → 5. The grid gains `MaxHeight="220"`, matching `PgBlockingCyclesGrid` beside it and for the same reason: it shares an `Auto` row and must not take height from the chains it is a consequence of. On Vacuum it had a star row, so there was no prior appearance to preserve — the height had to be chosen either way.

## The guard, and the two instances it found

`PgPanelTabOwnershipTests` asserts the invariant across every PostgreSQL tab: **a panel a tab's load path assigns must be declared inside that tab.** It derives the tab-to-loader map from the dispatcher's own `case Pg…InnerTabIndex: await LoadPg…Async();` arms, follows each loader's calls transitively, and resolves ownership to the **outermost** named `TabItem` so a panel inside Activity's Blocking sub-tab still belongs to Activity.

Running it turned up **two more pairs with the identical shape**, filed as #3050:

| pair | declared on | filled by | that loader's only caller |
|---|---|---|---|
| `PgWaitSamplingGrid` / `Note` | `PgWaitsTab` | `LoadPgWaitSamplingAsync` | `LoadPgActivityAsync` |
| `PgPredicateStatsGrid` / `Note` | `PgStorageTab` | `LoadPgPredicateStatsAsync` | `LoadPgActivityAsync` |

They are **exempt by name with the issue cited**, not by muting their tabs — every other panel on Waits and Storage is still checked. And a **stale exemption fails**: if a pair stops being off-tab, the test demands the exemption be removed, so the table cannot outlive the debt it documents. Fixing #3050 is not a decision this PR makes, because unlike #3048 neither pair has evidence naming an intended tab, and the two may well go opposite ways.

## Verification

`Darling.Tests` targets Windows and cannot execute on macOS, so the real test files were compiled into a throwaway `net10.0` xunit v3 host named `Darling.Tests`, staged outside the tree with `PerformanceMonitor.sln` symlinked in so the source pins' walk-up resolves.

- **Viewer builds** with `-p:EnableWindowsTargeting=true`, 0 errors — and the XAML compiled: `ViewerServerTab.baml` carries the pair in the intended order, `PgBlockingNote` → `PgBlockingChainsGrid` → `PgBlockingCyclesExpander` → `PgDeadlocksNote` → `PgDeadlocksGrid`, before the Locks and Query Shapes panels.
- **48 cases, 47 pass** across `XamlStaticResourceHygieneTests`, `ViewerFleetTimerGuardTests`, `DocCommentHygieneTests` and the new pin. The one failure, `SourceFilesDoesNotReadBuildOutputUnderTheRoot`, **fails identically on a pristine `origin/dev` worktree through the same harness** (44/45 there) — a harness-layout artifact, controlled rather than passed.
- **A file-wide row-bounds check** over the XAML: after the move, exactly one grid assigns a `Grid.Row` at or beyond its own `RowDefinition` count, and it is the pre-existing Query Shapes one filed as #3049. Both edited grids are consistent.
- **Six red-proof variants, all red, across three distinct assertions**, run against a copied sandbox with the worktree `git status --porcelain` clean afterwards. Reverting the XAML to `origin/dev` reports both controls by name and both tabs. Removing an exemption while its pair is still off-tab reports it. Adding an exemption for an on-tab panel trips the stale check. Breaking dispatcher name parity, the `x:Name` walk, and the dispatcher pattern each fail their own assertion or floor.
- A seventh variant **came back green and was discarded rather than counted**: its mutation script threw before applying, so nothing was tested. A variant that never ran is indistinguishable from one that passed unless the harness insists on a test summary, which this one does.

**Not verified:** nothing was rendered. The panel appearing in the Blocking sub-tab, the 220-pixel cap against real content, and wrap behaviour are all unobserved — only that the bindings compiled into BAML and the layout is internally consistent.

## Deliberately not done

`FleetRollup.DeadlockPostgresCause` still says "shown on that target's own server tab" rather than naming it. Now that the tab is settled it *could* name it; that is a string change on a different surface with its own review surface, and #3048 flagged it as optional.

## CHANGELOG entry text

**Fixed** — The PostgreSQL deadlock panel rendered on the server tab's Vacuum tab while only the Activity tab's load path filled it, so it was empty until Activity had been visited — indistinguishable from a server with no deadlocks. It now sits below the blocking panels on the Activity tab, where its own comment and the data service's doc comment both said it belonged, and a new guard asserts that every PostgreSQL panel is declared inside the tab whose load path fills it.
