### PR TITLE
Fixes #3053

### DIFF
--- a/Darling/Darling.Tests/StoreLogSeverityLocaleTests.cs
+++ b/Darling/Darling.Tests/StoreLogSeverityLocaleTests.cs
@@ -23,13 +23,14 @@ namespace Darling.Tests;
 /// The seam between the managed store's <c>postgresql.conf</c> and the store-log parser's severity
 /// vocabulary (#3053).
 ///
-/// <para><b>What was wrong.</b> initdb takes <c>lc_messages</c> from the host OS, and PostgreSQL translates
-/// the SEVERITY LABEL along with the message body — a German host writes <c>FEHLER:</c> where an English one
-/// writes <c>ERROR:</c>. <see cref="StoreLogClassifier"/> anchors on that field, and its residue class is
-/// gated on <see cref="StoreLogClassifier.IsAtLeastWarning"/>: a token the gate does not recognise cannot
-/// reach <c>unclassified</c>-retained and falls to the <c>routine</c> arm, counted with its text dropped. So
-/// under a localised label the classifier's load-bearing property — a rule the table forgot costs a heading,
-/// never a row — inverted and cost the row.</para>
+/// <para><b>What was wrong.</b> PostgreSQL translates the SEVERITY LABEL along with the message body — a
+/// store running a German catalogue writes <c>FEHLER:</c> where an English one writes <c>ERROR:</c>.
+/// <see cref="StoreLogClassifier"/> anchors on that field, and its residue class is gated on
+/// <see cref="StoreLogClassifier.IsAtLeastWarning"/>: a token the gate does not recognise cannot reach
+/// <c>unclassified</c>-retained and falls to the <c>routine</c> arm, counted with its text dropped. So under
+/// a localised label the classifier's load-bearing property — a rule the table forgot costs a heading, never
+/// a row — inverted and cost the row. The managed bootstrap's <c>--locale=C</c> already kept a cluster it
+/// initialized off that path; nothing named the dependency, so nothing stopped the argument moving.</para>
 ///
 /// <para><b>Why the pins are shaped this way.</b> A test that merely asserted the parser knows four English
 /// tokens would pass on a German store, and a test that merely asserted the conf carries a line would pass

--- a/Darling/Darling.Tests/StoreLogSeverityLocaleTests.cs
+++ b/Darling/Darling.Tests/StoreLogSeverityLocaleTests.cs
@@ -165,27 +165,41 @@ public class StoreLogSeverityLocaleTests
 
     /// <summary>
     /// A conf block nobody appends is inert, and the failure is silent — the builder compiles, its own pin
-    /// passes, and no store ever gains the setting. So for EVERY <c>ConfMarkerV*</c> the class declares,
-    /// <c>EnsureConfAppended</c> has to test that marker. Derived from the declared constants rather than
-    /// listed, so the next versioned block is covered the moment its marker exists.
+    /// passes, and no store ever gains the setting. So every <c>ConfMarkerV*</c> the class declares has to be
+    /// written by some <c>Build*ConfAppend</c> factory, and that factory has to be called by
+    /// <c>EnsureConfAppended</c>.
+    ///
+    /// <para>Stated as reachability rather than as "the body names the marker", which is what this test
+    /// asserted first and which v8 correctly fails: v8 is the one block keyed on a hardware fingerprint
+    /// instead of on its own marker's absence, so its marker appears only inside its factory. Naming the
+    /// marker is one way to be reached, not the requirement.</para>
     /// </summary>
     [Fact]
-    public void EveryDeclaredConfMarkerIsCheckedByEnsureConfAppended()
+    public void EveryDeclaredConfMarkerIsWrittenByAFactoryEnsureConfAppendedCalls()
     {
-        var markers = typeof(DarlingManagedPostgres)
-            .GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
-            .Where(f => f.IsLiteral && f.FieldType == typeof(string) && f.Name.StartsWith("ConfMarker", StringComparison.Ordinal))
-            .Select(f => f.Name)
-            .OrderBy(n => n, StringComparer.Ordinal)
-            .ToArray();
-
-        Assert.NotEmpty(markers);
-
+        var markers = DeclaredConfMarkers();
+        var factories = ConfFactoryBlocks();
         var body = EnsureConfAppendedBody();
 
-        foreach (var marker in markers)
+        Assert.NotEmpty(markers);
+        Assert.NotEmpty(factories);
+
+        foreach (var (markerName, markerValue) in markers)
         {
-            Assert.Contains(marker, body, StringComparison.Ordinal);
+            var writers = factories
+                .Where(f => f.Block.Contains(markerValue, StringComparison.Ordinal))
+                .Select(f => f.Name)
+                .ToArray();
+
+            Assert.True(
+                writers.Length > 0,
+                $"{markerName} is declared but no Build*ConfAppend factory writes it, so no store's postgresql.conf "
+                + "can ever carry the block it guards.");
+
+            Assert.True(
+                writers.Any(w => body.Contains(w + "(", StringComparison.Ordinal)),
+                $"{markerName} is written only by {string.Join(", ", writers)}, and EnsureConfAppended calls none of "
+                + "them — the block compiles, its own pin passes, and no store ever gains the setting.");
         }
     }
 
@@ -226,13 +240,24 @@ public class StoreLogSeverityLocaleTests
             .ToArray();
     }
 
+    /// <summary>Every <c>ConfMarkerV*</c> constant the class declares, by name and value.</summary>
+    private static (string Name, string Value)[] DeclaredConfMarkers() =>
+        typeof(DarlingManagedPostgres)
+            .GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Where(f => f.IsLiteral
+                        && f.FieldType == typeof(string)
+                        && f.Name.StartsWith("ConfMarker", StringComparison.Ordinal))
+            .Select(f => (f.Name, Value: (string)f.GetRawConstantValue()!))
+            .OrderBy(m => m.Name, StringComparer.Ordinal)
+            .ToArray();
+
     /// <summary>
-    /// Every conf block the product appends, concatenated — discovered by reflection over the
-    /// <c>Build*ConfAppend</c> factories rather than listed, so a locale pinned from a future block is still
-    /// found and a block that stops existing is not silently skipped. The arguments are placeholders: these
-    /// factories are pure, and nothing read out of the text here depends on a size or a port.
+    /// Every conf block the product can append, with the factory that produced it — discovered by reflection
+    /// over the <c>Build*ConfAppend</c> methods rather than listed, so a setting pinned from a future block is
+    /// still found and a block that stops existing is not silently skipped. The arguments are placeholders:
+    /// these factories are pure, and nothing read out of the text here depends on a size or a port.
     /// </summary>
-    private static string ManagedConfBlocks()
+    private static (string Name, string Block)[] ConfFactoryBlocks()
     {
         var factories = typeof(DarlingManagedPostgres)
             .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
@@ -242,17 +267,25 @@ public class StoreLogSeverityLocaleTests
             .OrderBy(m => m.Name, StringComparer.Ordinal)
             .ToArray();
 
-        Assert.NotEmpty(factories);
-
-        var blocks = new List<string>(factories.Length);
+        var blocks = new List<(string Name, string Block)>(factories.Length);
 
         foreach (var factory in factories)
         {
             var arguments = factory.GetParameters().Select(p => Placeholder(factory, p)).ToArray();
-            blocks.Add((string)factory.Invoke(null, arguments)!);
+            blocks.Add((factory.Name, (string)factory.Invoke(null, arguments)!));
         }
 
-        return string.Concat(blocks);
+        return blocks.ToArray();
+    }
+
+    /// <summary>Every conf block concatenated, in factory-name order — the text the locale scan reads.</summary>
+    private static string ManagedConfBlocks()
+    {
+        var factories = ConfFactoryBlocks();
+
+        Assert.NotEmpty(factories);
+
+        return string.Concat(factories.Select(f => f.Block));
     }
 
     /// <summary>A stand-in value for a conf factory's parameter, or a failure naming the signature this scan

--- a/Darling/Darling.Tests/StoreLogSeverityLocaleTests.cs
+++ b/Darling/Darling.Tests/StoreLogSeverityLocaleTests.cs
@@ -1,0 +1,335 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using PerformanceMonitor.Darling.Service;
+using PerformanceMonitor.Darling.Storage;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// The seam between the managed store's <c>postgresql.conf</c> and the store-log parser's severity
+/// vocabulary (#3053).
+///
+/// <para><b>What was wrong.</b> initdb takes <c>lc_messages</c> from the host OS, and PostgreSQL translates
+/// the SEVERITY LABEL along with the message body — a German host writes <c>FEHLER:</c> where an English one
+/// writes <c>ERROR:</c>. <see cref="StoreLogClassifier"/> anchors on that field, and its residue class is
+/// gated on <see cref="StoreLogClassifier.IsAtLeastWarning"/>: a token the gate does not recognise cannot
+/// reach <c>unclassified</c>-retained and falls to the <c>routine</c> arm, counted with its text dropped. So
+/// under a localised label the classifier's load-bearing property — a rule the table forgot costs a heading,
+/// never a row — inverted and cost the row.</para>
+///
+/// <para><b>Why the pins are shaped this way.</b> A test that merely asserted the parser knows four English
+/// tokens would pass on a German store, and a test that merely asserted the conf carries a line would pass
+/// with the parser rewritten underneath it. These assert the RELATION: every token the parser accepts must be
+/// one <c>error_severity()</c> can write under the locale the managed conf actually pins. Both sides are
+/// derived — the accepted set by walking <see cref="StoreLogClassifier"/>'s own source, the pinned locale by
+/// scanning every conf block the product appends, the guaranteed vocabulary by reading
+/// <see cref="StoreLogClassifier.PrimarySeverities"/> — so neither side can change without this being
+/// consulted, which a hand-written list of either could not manage.</para>
+///
+/// <para><b>Scope, stated rather than implied.</b> These are SOURCE and PURE-FUNCTION pins. No cluster is
+/// started, so what is verified is that the product writes the pin and that the parser's vocabulary is
+/// inside what the pin guarantees — not that a live server honoured it. And the pin reaches the MANAGED
+/// store only: a bring-your-own store, and every monitored PostgreSQL target, keeps whatever
+/// <c>lc_messages</c> its owner gave it.</para>
+/// </summary>
+public class StoreLogSeverityLocaleTests
+{
+    /// <summary>
+    /// The locales under which PostgreSQL emits its message catalogue UNTRANSLATED, so
+    /// <c>error_severity()</c> writes the English token names <see cref="StoreLogClassifier"/> matches.
+    /// <c>C</c> and its <c>POSIX</c> alias are the only two that are guaranteed present with no locale
+    /// installed on the host, which is why the conf pins one of them rather than <c>en_US.UTF-8</c>.
+    /// </summary>
+    private static readonly string[] UntranslatedLocales = ["C", "POSIX"];
+
+    /// <summary>
+    /// THE pin. Every severity token <see cref="StoreLogClassifier.IsAtLeastWarning"/> accepts has to be one
+    /// <c>error_severity()</c> can write under the locale the managed <c>postgresql.conf</c> pins — which
+    /// ties the parser's English assumption to the configuration that makes it true. Deleting the
+    /// <c>lc_messages</c> pin from the conf turns this red instead of silently breaking the parser on a
+    /// non-English host.
+    ///
+    /// <para>Three independent failures, so a regression says which half moved: no pin in the conf, a pin to
+    /// a locale that translates, or a token the guaranteed vocabulary does not contain.</para>
+    /// </summary>
+    [Fact]
+    public void EverySeverityTheParserAcceptsIsOneTheManagedConfGuarantees()
+    {
+        /* Side one: what the conf actually pins, read out of the blocks the product appends. */
+        var found = PinnedMessageLocale(ManagedConfBlocks());
+
+        Assert.True(
+            found is not null,
+            "No managed postgresql.conf block pins lc_messages. Without it initdb takes the locale from the host OS and "
+            + "PostgreSQL translates the severity label, so StoreLogClassifier.IsAtLeastWarning stops recognising the "
+            + "token that decides whether an entry keeps its text.");
+
+        var pinned = found!;
+
+        Assert.True(
+            UntranslatedLocales.Contains(pinned, StringComparer.Ordinal),
+            $"The managed conf pins lc_messages = '{pinned}', which is not a locale that leaves PostgreSQL's message "
+            + $"catalogue untranslated ({string.Join(" or ", UntranslatedLocales)}). Under a translated catalogue "
+            + "error_severity() writes localised labels and the severity tokens below are unreachable.");
+
+        /* Side two: what the parser accepts, derived from its own source rather than restated here. */
+        var accepted = AcceptedSeverities();
+        var guaranteed = StoreLogClassifier.PrimarySeverities;
+
+        var unguaranteed = accepted.Where(s => !guaranteed.Contains(s, StringComparer.Ordinal))
+            .OrderBy(s => s, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.True(
+            unguaranteed.Length == 0,
+            $"IsAtLeastWarning accepts {string.Join(", ", unguaranteed.Select(s => $"'{s}'"))}, which error_severity() "
+            + $"cannot write under lc_messages = '{pinned}'. StoreLogClassifier.PrimarySeverities is what that locale "
+            + "guarantees; a token outside it can never match, so the class it was meant to reach is dead code.");
+    }
+
+    /// <summary>
+    /// The parse behind the pin above, checked against the compiled method so a broken anchor fails loudly
+    /// instead of vacuously. Over-reading shows up as a parsed token the method rejects; under-reading shows
+    /// up as a guaranteed token the method accepts but the parse never saw. Without this a regex that stopped
+    /// matching would make the pin pass on an empty set — a pass for the wrong reason, which is worth less
+    /// than a failure.
+    /// </summary>
+    [Fact]
+    public void TheAcceptedSeverityParseAgreesWithTheCompiledGate()
+    {
+        var accepted = AcceptedSeverities();
+
+        Assert.NotEmpty(accepted);
+
+        foreach (var severity in accepted)
+        {
+            Assert.True(
+                StoreLogClassifier.IsAtLeastWarning(severity),
+                $"The source walk read '{severity}' out of IsAtLeastWarning's expression, but the compiled method "
+                + "rejects it — the parse is reading something other than the gate's severity literals.");
+        }
+
+        foreach (var severity in StoreLogClassifier.PrimarySeverities)
+        {
+            if (accepted.Contains(severity, StringComparer.Ordinal))
+            {
+                continue;
+            }
+
+            Assert.False(
+                StoreLogClassifier.IsAtLeastWarning(severity),
+                $"The compiled method accepts '{severity}' but the source walk did not find it — the parse is missing "
+                + "literals, so the pin above is checking an incomplete set.");
+        }
+    }
+
+    /// <summary>
+    /// The v10 block itself: the marker, the pin, and nothing else. It rides after the v8 hardware check, whose
+    /// staleness test keys on the LAST fingerprint line in the text read before any of these appends, so a
+    /// fingerprint or a sizing line here would be both invisible to that check and able to override it.
+    /// </summary>
+    [Fact]
+    public void MessageLocaleConfAppend_PinsV10Marker_AndCarriesNothingButTheLocale()
+    {
+        var block = DarlingManagedPostgres.BuildMessageLocaleConfAppend();
+
+        Assert.Contains(DarlingManagedPostgres.ConfMarkerV10, block, StringComparison.Ordinal);
+        Assert.Contains("lc_messages = 'C'", block, StringComparison.Ordinal);
+
+        Assert.DoesNotContain(DarlingManagedPostgres.ConfHardwareFingerprintPrefix, block, StringComparison.Ordinal);
+        Assert.DoesNotContain("shared_buffers", block, StringComparison.Ordinal);
+        Assert.DoesNotContain("maintenance_work_mem", block, StringComparison.Ordinal);
+        Assert.DoesNotContain("max_worker_processes", block, StringComparison.Ordinal);
+
+        /* lc_messages ALONE. lc_monetary/lc_numeric/lc_time govern how the server renders values the product
+           reads as typed parameters rather than as text, so pinning them would be a behaviour change with no
+           defect behind it. */
+        Assert.DoesNotContain("lc_monetary", block, StringComparison.Ordinal);
+        Assert.DoesNotContain("lc_numeric", block, StringComparison.Ordinal);
+        Assert.DoesNotContain("lc_time", block, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A conf block nobody appends is inert, and the failure is silent — the builder compiles, its own pin
+    /// passes, and no store ever gains the setting. So for EVERY <c>ConfMarkerV*</c> the class declares,
+    /// <c>EnsureConfAppended</c> has to test that marker. Derived from the declared constants rather than
+    /// listed, so the next versioned block is covered the moment its marker exists.
+    /// </summary>
+    [Fact]
+    public void EveryDeclaredConfMarkerIsCheckedByEnsureConfAppended()
+    {
+        var markers = typeof(DarlingManagedPostgres)
+            .GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Where(f => f.IsLiteral && f.FieldType == typeof(string) && f.Name.StartsWith("ConfMarker", StringComparison.Ordinal))
+            .Select(f => f.Name)
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.NotEmpty(markers);
+
+        var body = EnsureConfAppendedBody();
+
+        foreach (var marker in markers)
+        {
+            Assert.Contains(marker, body, StringComparison.Ordinal);
+        }
+    }
+
+    // ── Deriving each side ────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The severity literals in <see cref="StoreLogClassifier.IsAtLeastWarning"/>'s expression, read from the
+    /// file. The gate is a pattern (<c>severity is "WARNING" or ...</c>), which reflection cannot see into,
+    /// so the source is the only place the accepted set exists as data. Walked with
+    /// <see cref="CSharpSourceWalker"/> so the anchor cannot land in a comment and a comment inside the span
+    /// cannot contribute a token.
+    /// </summary>
+    private static string[] AcceptedSeverities()
+    {
+        var source = File.ReadAllText(ClassifierSourcePath());
+        var code = CSharpSourceWalker.StripCommentsAndStrings(source);
+
+        const string Anchor = "bool IsAtLeastWarning(";
+        var declaration = code.IndexOf(Anchor, StringComparison.Ordinal);
+
+        Assert.True(
+            declaration >= 0,
+            $"'{Anchor}' was not found in the code of {ClassifierSourcePath()} — the gate was renamed or reshaped and "
+            + "this walk is no longer reading it.");
+
+        Assert.True(
+            code.IndexOf(Anchor, declaration + Anchor.Length, StringComparison.Ordinal) < 0,
+            $"'{Anchor}' appears more than once, so this walk would silently read only the first. Point it at the "
+            + "declaration that decides retention.");
+
+        var end = code.IndexOf(';', declaration);
+
+        Assert.True(end > declaration, "IsAtLeastWarning's expression has no terminating ';' in the code stream.");
+
+        return CSharpSourceWalker.StringLiteralBodies(source)
+            .Where(l => l.Start > declaration && l.Start < end)
+            .Select(l => l.Text)
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Every conf block the product appends, concatenated — discovered by reflection over the
+    /// <c>Build*ConfAppend</c> factories rather than listed, so a locale pinned from a future block is still
+    /// found and a block that stops existing is not silently skipped. The arguments are placeholders: these
+    /// factories are pure, and nothing read out of the text here depends on a size or a port.
+    /// </summary>
+    private static string ManagedConfBlocks()
+    {
+        var factories = typeof(DarlingManagedPostgres)
+            .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Where(m => m.Name.StartsWith("Build", StringComparison.Ordinal)
+                        && m.Name.EndsWith("ConfAppend", StringComparison.Ordinal)
+                        && m.ReturnType == typeof(string))
+            .OrderBy(m => m.Name, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.NotEmpty(factories);
+
+        var blocks = new List<string>(factories.Length);
+
+        foreach (var factory in factories)
+        {
+            var arguments = factory.GetParameters().Select(p => Placeholder(factory, p)).ToArray();
+            blocks.Add((string)factory.Invoke(null, arguments)!);
+        }
+
+        return string.Concat(blocks);
+    }
+
+    /// <summary>A stand-in value for a conf factory's parameter, or a failure naming the signature this scan
+    /// cannot fill — never a skip, which would drop the block from the scan without saying so.</summary>
+    private static object Placeholder(MethodInfo factory, ParameterInfo parameter)
+    {
+        if (parameter.ParameterType == typeof(int))
+        {
+            return 32;
+        }
+
+        if (parameter.ParameterType == typeof(long))
+        {
+            return 16L * 1024 * 1024 * 1024;
+        }
+
+        Assert.Fail(
+            $"{factory.Name} takes a {parameter.ParameterType.Name} parameter '{parameter.Name}' this scan cannot "
+            + "supply, so its block would go unscanned. Extend the placeholders rather than excluding the block.");
+
+        return null!;
+    }
+
+    /// <summary>The value of the LAST <c>lc_messages</c> assignment in <paramref name="conf"/>, or null when
+    /// there is none. Last, not first: postgresql.conf takes the last occurrence of a setting, which is the
+    /// whole mechanism the versioned blocks override each other through.</summary>
+    private static string? PinnedMessageLocale(string conf)
+    {
+        var matches = Regex.Matches(
+            conf,
+            @"^[ \t]*lc_messages[ \t]*=[ \t]*'(?<locale>[^']*)'",
+            RegexOptions.Multiline | RegexOptions.CultureInvariant);
+
+        return matches.Count == 0 ? null : matches[^1].Groups["locale"].Value;
+    }
+
+    /// <summary>The brace-balanced body of <c>EnsureConfAppended</c>, comments and literals blanked so a
+    /// marker named only in a comment cannot satisfy the wiring pin.</summary>
+    private static string EnsureConfAppendedBody()
+    {
+        var source = File.ReadAllText(ManagedPostgresSourcePath());
+        var code = CSharpSourceWalker.StripCommentsAndStrings(source);
+
+        const string Anchor = "void EnsureConfAppended(";
+        var declaration = code.IndexOf(Anchor, StringComparison.Ordinal);
+
+        Assert.True(
+            declaration >= 0,
+            $"'{Anchor}' was not found in the code of {ManagedPostgresSourcePath()} — the append path was renamed and "
+            + "this pin is no longer reading it.");
+
+        var open = code.IndexOf('{', declaration);
+
+        Assert.True(open > declaration, "EnsureConfAppended has no body in the code stream.");
+
+        return CSharpSourceWalker.BraceBalanced(code, open);
+    }
+
+    private static string ClassifierSourcePath() =>
+        Path.Combine(RepoRoot(), "Darling", "PerformanceMonitor.Darling.Storage", "StoreLogClassifier.cs");
+
+    private static string ManagedPostgresSourcePath() =>
+        Path.Combine(RepoRoot(), "Darling", "PerformanceMonitor.Darling.Service", "DarlingManagedPostgres.cs");
+
+    private static string RepoRoot([CallerFilePath] string thisFile = "")
+    {
+        var dir = Path.GetDirectoryName(thisFile)!;
+
+        while (dir is not null
+               && !File.Exists(Path.Combine(dir, "PerformanceMonitor.sln"))
+               && !Directory.Exists(Path.Combine(dir, ".git")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        Assert.NotNull(dir);
+
+        return dir!;
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingManagedPostgres.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingManagedPostgres.cs
@@ -221,6 +221,38 @@ public sealed class DarlingManagedPostgres
     public const string ConfMarkerV9 = "# Managed by PerformanceMonitor Darling (v9 session time zone) -- do not remove this block";
 
     /// <summary>
+    /// Marker for the v10 message-locale block (#3053): pin <c>lc_messages</c> so the server writes its own
+    /// messages — <b>and its severity labels</b> — untranslated. A TENTH independently versioned block, for
+    /// the same reason v9 is separate from v3: an existing cluster gains it by the marker being absent on its
+    /// next service-owned start, which is what carries the pin to the stores already in the field.
+    ///
+    /// <para><b>The severity label is the part that bites.</b> initdb takes <c>lc_messages</c> from the host
+    /// OS, and PostgreSQL translates the label as well as the body — a German host writes <c>FEHLER:</c>
+    /// where an English one writes <c>ERROR:</c>. <see cref="StoreLogClassifier"/> anchors on that field and
+    /// its residue class is gated on <see cref="StoreLogClassifier.IsAtLeastWarning"/>, so a token it does
+    /// not recognise cannot reach <c>unclassified</c>-retained and lands in <c>routine</c>, counted with its
+    /// text dropped. The design's property is that a rule the table forgot costs a heading and never a row;
+    /// under a translated label it costs the row. The store is product-managed, so making the English
+    /// assumption true belongs here rather than in each parser.</para>
+    ///
+    /// <para><c>C</c> rather than <c>en_US.UTF-8</c>: <c>C</c> is guaranteed present with no locale
+    /// installed on the host, and it is the locale under which PostgreSQL emits its untranslated message
+    /// catalogue. Nothing in this product renders PostgreSQL message text to an end user in their own
+    /// language — it goes to parsers and to English-throughout operator diagnostics — so the pin costs
+    /// nothing it does not buy back. It is <c>lc_messages</c> ALONE: <c>lc_monetary</c>, <c>lc_numeric</c>
+    /// and <c>lc_time</c> govern how the server renders values the product reads as typed parameters, not as
+    /// text, and would be a behaviour change with no defect behind it.</para>
+    ///
+    /// <para><c>lc_messages</c> is a SIGHUP-context setting and this append runs before pg_ctl start, so it
+    /// takes effect on the very start that writes it — the v9 story. The one exception is the adopted-listener
+    /// path in <see cref="EnsureRunningAsync"/>: when a postmaster is already running this service neither
+    /// stops nor signals it, so the pin waits for the next service-owned start. Nothing here reloads, and the
+    /// class's only <c>pg_ctl reload</c> is gated on pg_hba.conf changing, so it cannot be relied on to
+    /// carry this.</para>
+    /// </summary>
+    public const string ConfMarkerV10 = "# Managed by PerformanceMonitor Darling (v10 message locale) -- do not remove this block";
+
+    /// <summary>
     /// Prefix of the v8 fingerprint line — the record of what the sizing beneath it was derived FROM,
     /// which is the whole mechanism: a marker can only say "a block exists", a fingerprint says "a block
     /// exists FOR THIS MACHINE". Compared by <see cref="ConfHasCurrentHardwareFingerprint"/> against the
@@ -796,6 +828,24 @@ public sealed class DarlingManagedPostgres
         return builder.ToString();
     }
 
+    /* ===================== v10 message locale ===================== */
+
+    /// <summary>
+    /// The v10 block: pin the cluster's <c>lc_messages</c> to <c>C</c> so the server writes its messages, and
+    /// the severity label that <see cref="StoreLogClassifier"/> anchors on, untranslated. See
+    /// <see cref="ConfMarkerV10"/> for why, why <c>C</c> and not a named English locale, and what this
+    /// deliberately does not pin. Carries no fingerprint line, so the v8 staleness check's invariant about
+    /// what it reads is untouched.
+    /// </summary>
+    public static string BuildMessageLocaleConfAppend()
+    {
+        var builder = new StringBuilder();
+        builder.Append('\n');
+        builder.Append(ConfMarkerV10).Append('\n');
+        builder.Append("lc_messages = 'C'\n");
+        return builder.ToString();
+    }
+
     /// <summary>
     /// The derived managed-mode connection string: <c>127.0.0.1</c> + port + darling/darling + the
     /// generated password, carrying the collect/config <see cref="SearchPath"/> so every pooled connection
@@ -1363,13 +1413,26 @@ public sealed class DarlingManagedPostgres
 
         /* Checked independently of v1-v8, and placed AFTER v8 on purpose: v8 keys on the last fingerprint
            line in the text it read at the top of this method, so a block appended before it must not carry
-           one. This block carries only `timezone`, but sitting last means the ordering cannot be broken by
-           editing it. Effective on this start (SIGHUP-context, appended before pg_ctl start). */
+           one. Every block from here down carries no sizing and no fingerprint, which is what keeps that
+           check reading what it thinks it reads. Effective on this start (SIGHUP-context, appended before
+           pg_ctl start). */
         if (!conf.Contains(ConfMarkerV9, StringComparison.Ordinal))
         {
             File.AppendAllText(confPath, BuildTimeZoneConfAppend());
             _logger.LogInformation(
                 "Appended v9 session time zone to postgresql.conf (timezone = 'UTC'): the store's timestamp columns hold naive UTC, so a host-derived session zone would shift any comparison against now() and render timestamptz output on a different clock than the collected data.");
+        }
+
+        /* Checked independently of v1-v9: an existing cluster heals by GAINING the message-locale block
+           (#3053). initdb takes lc_messages from the host OS and PostgreSQL translates the SEVERITY LABEL as
+           well as the body, so a non-English host writes a token StoreLogClassifier does not recognise —
+           which then cannot reach its unclassified-retained residue class and is counted as routine with its
+           text dropped. SIGHUP-context and appended before pg_ctl start, so effective on this very start. */
+        if (!conf.Contains(ConfMarkerV10, StringComparison.Ordinal))
+        {
+            File.AppendAllText(confPath, BuildMessageLocaleConfAppend());
+            _logger.LogInformation(
+                "Appended v10 message locale to postgresql.conf (lc_messages = 'C'): PostgreSQL translates its severity labels under the host locale, and the store's own log parser matches them as English tokens.");
         }
     }
 

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingManagedPostgres.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingManagedPostgres.cs
@@ -226,14 +226,31 @@ public sealed class DarlingManagedPostgres
     /// the same reason v9 is separate from v3: an existing cluster gains it by the marker being absent on its
     /// next service-owned start, which is what carries the pin to the stores already in the field.
     ///
-    /// <para><b>The severity label is the part that bites.</b> initdb takes <c>lc_messages</c> from the host
-    /// OS, and PostgreSQL translates the label as well as the body — a German host writes <c>FEHLER:</c>
-    /// where an English one writes <c>ERROR:</c>. <see cref="StoreLogClassifier"/> anchors on that field and
-    /// its residue class is gated on <see cref="StoreLogClassifier.IsAtLeastWarning"/>, so a token it does
-    /// not recognise cannot reach <c>unclassified</c>-retained and lands in <c>routine</c>, counted with its
-    /// text dropped. The design's property is that a rule the table forgot costs a heading and never a row;
-    /// under a translated label it costs the row. The store is product-managed, so making the English
-    /// assumption true belongs here rather than in each parser.</para>
+    /// <para><b>The severity label is the part that bites.</b> PostgreSQL translates the label as well as the
+    /// body — a store running a German catalogue writes <c>FEHLER:</c> where an English one writes
+    /// <c>ERROR:</c>. <see cref="StoreLogClassifier"/> anchors on that field and its residue class is gated on
+    /// <see cref="StoreLogClassifier.IsAtLeastWarning"/>, so a token it does not recognise cannot reach
+    /// <c>unclassified</c>-retained and lands in <c>routine</c>, counted with its text dropped. The design's
+    /// property is that a rule the table forgot costs a heading and never a row; under a translated label it
+    /// costs the row.</para>
+    ///
+    /// <para><b>What this block adds over the initdb line, stated precisely, because it is less than it
+    /// looks.</b> <see cref="InitializeClusterAsync"/> already passes <c>--locale=C</c>, and initdb templates
+    /// the resolved <c>lc_*</c> values into the conf it generates — so a cluster this build initialized was
+    /// never running a translated catalogue, and the plain default-initdb exposure does not apply to it. This
+    /// block buys three things that argument does not. It makes the parser's dependency EXPLICIT and testable,
+    /// so changing <c>--locale</c> for the collation reason it exists for cannot silently re-localise messages
+    /// as a side effect. It reaches data directories this build's initdb did not create — built before that
+    /// argument landed, restored, adopted, or hand-initialized — which is the population the marker-absent
+    /// heal exists for. And it wins over the generated line by last-occurrence, so an edited value is
+    /// corrected rather than inherited.</para>
+    ///
+    /// <para><b>What it does not reach.</b> <c>postgresql.auto.conf</c> is read after <c>postgresql.conf</c>,
+    /// so an <c>ALTER SYSTEM SET lc_messages</c> still wins; this is diagnostic fidelity, not a security
+    /// boundary, so it is not forced through the <c>-o</c> runtime override the way <c>listen_addresses</c>
+    /// is. And it reaches MANAGED stores only, while the classifier does not: <c>StoreLogSweep</c> runs on
+    /// every store shape, so a bring-your-own store's log is classified under whatever locale its owner gave
+    /// it.</para>
     ///
     /// <para><c>C</c> rather than <c>en_US.UTF-8</c>: <c>C</c> is guaranteed present with no locale
     /// installed on the host, and it is the locale under which PostgreSQL emits its untranslated message
@@ -1423,11 +1440,13 @@ public sealed class DarlingManagedPostgres
                 "Appended v9 session time zone to postgresql.conf (timezone = 'UTC'): the store's timestamp columns hold naive UTC, so a host-derived session zone would shift any comparison against now() and render timestamptz output on a different clock than the collected data.");
         }
 
-        /* Checked independently of v1-v9: an existing cluster heals by GAINING the message-locale block
-           (#3053). initdb takes lc_messages from the host OS and PostgreSQL translates the SEVERITY LABEL as
-           well as the body, so a non-English host writes a token StoreLogClassifier does not recognise —
-           which then cannot reach its unclassified-retained residue class and is counted as routine with its
-           text dropped. SIGHUP-context and appended before pg_ctl start, so effective on this very start. */
+        /* Checked independently of v1-v9: a data directory this build's initdb did not create heals by
+           GAINING the message-locale block (#3053). PostgreSQL translates the SEVERITY LABEL as well as the
+           body, so a translated catalogue writes a token StoreLogClassifier does not recognise — which then
+           cannot reach its unclassified-retained residue class and is counted as routine with its text
+           dropped. The initdb call already passes --locale=C, so this states the parser's dependency rather
+           than repairing a fresh install; see ConfMarkerV10 for what that distinction does and does not buy.
+           SIGHUP-context and appended before pg_ctl start, so effective on this very start. */
         if (!conf.Contains(ConfMarkerV10, StringComparison.Ordinal))
         {
             File.AppendAllText(confPath, BuildMessageLocaleConfAppend());

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingManagedPostgres.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingManagedPostgres.cs
@@ -1451,7 +1451,7 @@ public sealed class DarlingManagedPostgres
         {
             File.AppendAllText(confPath, BuildMessageLocaleConfAppend());
             _logger.LogInformation(
-                "Appended v10 message locale to postgresql.conf (lc_messages = 'C'): PostgreSQL translates its severity labels under the host locale, and the store's own log parser matches them as English tokens.");
+                "Appended v10 message locale to postgresql.conf (lc_messages = 'C'): PostgreSQL translates its severity labels under lc_messages, and the store's own log parser matches them as English tokens.");
         }
     }
 


### PR DESCRIPTION
Fixes #3053.

## The defect

PostgreSQL translates its own messages under `lc_messages` — **including the severity label**. A store running a German catalogue writes `FEHLER:` where an English one writes `ERROR:`.

`StoreLogClassifier` (V111, #3021) anchors on that field and gates its residue class on

```csharp
public static bool IsAtLeastWarning(string? severity) =>
    severity is "WARNING" or "ERROR" or "FATAL" or "PANIC";
```

so an unrecognised token cannot satisfy `IsAtLeastWarning`, cannot reach `unclassified`-retained, and falls to the `routine` arm — counted with its text dropped. The design's load-bearing property is that a rule the table forgot costs a heading and never a row; under a translated label it costs the row.

## The change

A v10 marker-guarded `postgresql.conf` block carrying `lc_messages = 'C'`, through the mechanism `DarlingManagedPostgres` already owns: a separate versioned marker rather than an edit of v9, because a marker-present-but-different block is never rewritten in place, so an existing store would never gain the setting from an in-place edit. Appended after v9 so the v8 fingerprint check still reads what it thinks it reads. No `ALTER SYSTEM`.

`C` rather than `en_US.UTF-8` because `C` is guaranteed present without a locale being installed on the host.

## What this adds over the initdb argument — less than the issue assumed

The issue (and this PR's first draft) said initdb takes `lc_messages` from the host OS. That is initdb's default, but **this product already overrides it**: `InitializeClusterAsync` passes `--locale=C` (landed 2026-08-08, #2128), and initdb templates the resolved `lc_*` values into the conf it generates. So a cluster any current build initialized was never running a translated catalogue, and the fresh-install exposure the issue describes does not exist.

Three things the block buys that the argument does not:

- The parser's dependency becomes **explicit and testable**. `--locale=C` is there for collation and ctype determinism; moving it for that reason would silently re-localise messages. The pin and its test decouple the two.
- It reaches **data directories this build's initdb did not create** — built before #2128, restored, adopted, or hand-initialized. That is the population the marker-absent heal exists for.
- It **wins by last-occurrence** over the generated line, so an edited value is corrected rather than inherited.

Both the marker's doc comment and the heal comment now say this rather than claiming the stronger version.

## The three things asked to be established rather than assumed

**1. Reload or restart — neither; it rides the start.** `EnsureConfAppended` is called from `EnsureRunningAsync` **before** the `IsRunningAsync` / `StartServerAsync` decision, and it neither reloads nor restarts. On the normal path (nothing listening) the append lands and this process then does the `pg_ctl start`, so the pin is in force from that very start — the v6 log-rotation and v9 timezone story, not the `shared_buffers` one. `lc_messages` being `SIGHUP`-changeable means a reload *would* suffice, but nothing in the class delivers one for it: the only `pg_ctl reload` is inside `ReconcileNetworkAsync` and is gated on `pg_hba.conf` actually changing, which `NeedsPgHbaReconcile` returns false for on a never-exposed loopback store. The one case where an operator waits is the **adopted-listener** path — a surviving postmaster from a crash, or one an operator started, which the code explicitly uses and never stops or signals. There the pin waits for the next service-owned start.

**2. Nothing wants localised messages — confirmed by looking, not by agreeing.** The tree has **zero** `.resx`, `.xlf` or `.po` files and zero occurrences of `NeutralResourcesLanguage`, `SatelliteResourceLanguages`, `CurrentUICulture` or `ResourceManager` — there is no localisation infrastructure to serve. Every `CultureInfo.CurrentCulture` use is number/date **rendering** (`ToString("N0", …)`, a decimal-separator-derived CSV delimiter); not one routes message text through a culture. PostgreSQL message text goes to parsers and to operator diagnostics that are English throughout. So `C` costs nothing here, and that is now recorded rather than implied.

**3. Nothing locale-adjacent was already set, so `lc_messages` got its own block.** `lc_monetary`, `lc_numeric`, `lc_time`, `lc_collate`, `lc_ctype`, `client_encoding`, `DateStyle` and `IntervalStyle` appear **zero** times anywhere in the tree. The nearest neighbour in kind is v9's `timezone = 'UTC'` — also a host-OS-derived, SIGHUP-context setting pinned so a parsing assumption holds — so v10 sits directly after it and the two read together. It is `lc_messages` **alone**: the other `lc_*` categories govern how the server renders values this product reads as typed parameters rather than as text, so pinning them would be a behaviour change with no defect behind it. A pin asserts that.

## Verification

`StoreLogSeverityLocaleTests`, four tests. The one that matters asserts the **relation**, not either side: every severity token `IsAtLeastWarning` accepts must be one `error_severity()` can write under the locale the managed conf actually pins.

Both sides are derived, so neither can move without this being consulted:

- the **accepted set** by walking `StoreLogClassifier`'s own source with `CSharpSourceWalker` (the gate is a pattern, which reflection cannot see into) — comment-proof and literal-aware;
- the **pinned locale** by reflecting over every `Build*ConfAppend` factory and scanning the concatenated text for the last `lc_messages` assignment, so a locale pinned from a future block is still found;
- the **guaranteed vocabulary** from `StoreLogClassifier.PrimarySeverities`, which is already declared as "what `error_severity()` can write at the head of a NEW entry".

Two supporting pins. `TheAcceptedSeverityParseAgreesWithTheCompiledGate` checks the source walk against the compiled method in both directions, so a broken anchor fails loudly instead of making the main pin pass on an empty set. `EveryDeclaredConfMarkerIsWrittenByAFactoryEnsureConfAppendedCalls` catches the silent "builder added, never wired" failure for every declared marker, not just this one — stated as *reachability* rather than as "the body names the marker", because v8 correctly fails that stronger form: it is the one block keyed on a hardware fingerprint instead of its own marker's absence, so its marker appears only inside its factory.

### Red-proofed five ways, each on a different named assertion

Run against a copy at the committed SHA, restored between variants. Every variant produced test output, so every one compiled.

| Variant | Failing assertion |
|---|---|
| Remove `lc_messages` from the builder | `No managed postgresql.conf block pins lc_messages…` (and the block pin's `Assert.Contains`) |
| Add a fifth token `"FEHLER"` to `IsAtLeastWarning` | `IsAtLeastWarning accepts 'FEHLER', which error_severity() cannot write under lc_messages = 'C'…` |
| Pin `de_DE.UTF-8` instead of `C` | `…is not a locale that leaves PostgreSQL's message catalogue untranslated (C or POSIX)…` |
| Remove the v10 wiring from `EnsureConfAppended`, leaving the builder | `ConfMarkerV10 is written only by BuildMessageLocaleConfAppend, and EnsureConfAppended calls none of them…` |
| Move `"PANIC"` behind a `const` so the source walk under-reads | `The compiled method accepts 'PANIC' but the source walk did not find it…` |

The existing `DarlingManagedPostgresTests` conf-append suite was run alongside and is unaffected, `TimeZoneConfAppend_PinsV9Marker_AndCarriesNothingButTheZone` included.

### Not verified

- **No live managed store is startable from the development host, so the conf-append behaviour is source-pinned only.** That the append runs before `pg_ctl start`, that the adopted-listener path defers the pin, and that a real postmaster reads `lc_messages = 'C'` and writes `ERROR:` are all read off the source and off PostgreSQL's documented `SIGHUP` context — none of them was exercised against a running server here.
- The three `DarlingManagedPostgresTests` failures observed locally are Windows path-separator expectations (`D:\darling\…`) failing on a macOS runner, not regressions. `Darling.Tests` cannot execute on macOS, so the real test files were compiled into a throwaway net10.0 xunit v3 host to run them; CI is the arbiter.

## Sites now resting on this guarantee — enumerated, not converted

Enumerating was in scope; converting was not. The pin reaches the **managed store's own log** only.

**Reached by the pin** — `StoreLogClassifier` (`PerformanceMonitor.Darling.Storage`): `PrimarySeverities`, `ContinuationFields`, the four per-rule severity arrays, the case-sensitive `Array.IndexOf(rule.Severities, severity)` in `Match`, `IsAtLeastWarning`, the `FindField` label scans, and `ContinuesAnUpperCaseToken`'s upper-case-ASCII assumption — plus ~25 English message-body literals across the rule table (`"deadlock detected"`, `"canceling statement due to statement timeout"`, `"page verification failed"`, `"database system was not properly shut down"`, and so on).

**Not reached, and this is the larger exposure** — four PostgreSQL **target**-side parsers read the log of a customer-owned instance whose `lc_messages` this product neither sets nor reads:

- `PerformanceMonitor.Collectors/PgDeadlockLogParser.cs` — `ERROR:  deadlock detected`, `DETAIL:  `, and the `Process N waits for … blocked by process N.` errdetail; the mode group is `[A-Za-z ]+`, so it is doubly broken under a translated catalogue.
- `PerformanceMonitor.Collectors/PgDeadlocksCollector.cs` — the same assumption again, independently, pushed server-side into the collector's `regexp_matches`.
- `PerformanceMonitor.Collectors/PgPlanLogParser.cs` — `LOG:  duration: … ms  plan:`. `auto_explain`'s message is LOG-level with SQLSTATE `00000`, so there is no error code to fall back to even under `csvlog`; `lc_messages` is the only lever.
- `PerformanceMonitor.Collectors/PgPlanCaptureCollector.cs` — the server-side copy of that one.

Both collectors are `AppliesTo(target) => true`, and zero rows is the documented healthy resting state for `pg_deadlocks`, so a locale-blinded reader is indistinguishable from a quiet one. Worth knowing: `PgServerConfigCollector` already selects all of `pg_settings` with no `WHERE`, so **every monitored target's `lc_messages` is already in the store and simply never read** — which makes a `lc_messages` facet on `pg_plan_capture_readiness` (which already reports `log_line_prefix`, `log_format` and `log_min_duration` as satisfiable preconditions) the cheap way to turn this from a silent zero into a named precondition. Not done here.

One more the pin does not cover: `StoreLogSweep` runs on **every store shape**, not just managed ones — its own comment contemplates a bring-your-own store's owner withholding the `pg_read_binary_file` grant — so a BYO store's log is classified under whatever locale its owner gave it. Stated in the marker's doc comment.

Cleared as non-hits, so nobody re-walks them: `PostgresTargetProvider.Classify` and every other `PostgresException` handler are SQLSTATE-keyed; `pg_stat_activity.state` and `version()` are not gettext-translated; the `shared_preload_libraries` / `log_line_prefix` matches are config text; and every other `"ERROR"`/`"WARNING"` literal in the tree is the product's own status vocabulary.

## CHANGELOG entry text (not applied — one `[Unreleased]` block, several lanes)

```
- Managed store: pin `lc_messages = 'C'` in `postgresql.conf` (v10 marker-guarded block) so PostgreSQL writes its severity labels untranslated. Under a localised catalogue `error_severity()` writes a token the store-log classifier does not recognise, which cannot reach the retained `unclassified` residue class and was counted as `routine` with its text dropped. Data directories not created by the current `initdb --locale=C` call gain the pin on their next service-owned start.
```
