### PR TITLE
Fixes #3062

### DIFF
--- a/Darling/Darling.Tests/PgRegistryPanelPlacementTests.cs
+++ b/Darling/Darling.Tests/PgRegistryPanelPlacementTests.cs
@@ -540,7 +540,10 @@ public sealed class PgRegistryPanelPlacementTests
             /* The entry's literals, in source order: id, header, then the collector array, then the note.
                Taken as the CONTIGUOUS run of collector-shaped literals after the header, which is what the
                array is — a note that happened to be exactly a collector name could not join it, because the
-               note comes after the array and the run has already ended. */
+               note comes after the array and the run has already ended.
+
+               entry.Index is an offset into the WALKED text and l.Start into the ORIGINAL; comparing them is
+               sound because StripCommentsAndStrings is character-aligned with its input. */
             var literals = registryLiterals
                 .Where(l => l.Start > entry.Index)
                 .Select(l => l.Text)
@@ -654,9 +657,17 @@ public sealed class PgRegistryPanelPlacementTests
     }
 
     /// <summary>
-    /// Each <c>LoadPg…Async</c>'s body as a half-open range over the WALKED code. Braces inside a literal or
-    /// a comment cannot unbalance the count there, which is the whole reason the walk is used rather than a
-    /// comment-stripping regex of this file's own (#3052).
+    /// Each <c>LoadPg…Async</c>'s body as a half-open range over the WALKED code.
+    ///
+    /// <para><b>The brace count is only sound because the input is walked, and that is measured rather than
+    /// assumed.</b> Run over raw source the count would depend on every brace in the file appearing in a
+    /// balanced pair, and an escaped <c>{{</c> in an interpolated string is the case that breaks it —
+    /// silently, by handing the rules a truncated body with nothing asserting on it.
+    /// <see cref="CSharpSourceWalker.StripCommentsAndStrings"/> removes the hazard at the source rather than
+    /// leaving it as a standing assumption: probed against it, a brace inside a plain, verbatim, raw or char
+    /// literal, inside a comment, and an escaped <c>{{</c> or <c>}}</c> in an interpolated string — including
+    /// an unpaired <c>{{</c> — all come back blanked, while an interpolation HOLE keeps its own balanced
+    /// pair. So the only braces the loop can see are code braces.</para>
     /// </summary>
     private static Dictionary<string, (int Start, int End)> MethodRanges(string code)
     {

--- a/Darling/Darling.Tests/PgRegistryPanelPlacementTests.cs
+++ b/Darling/Darling.Tests/PgRegistryPanelPlacementTests.cs
@@ -200,17 +200,6 @@ public sealed class PgRegistryPanelPlacementTests
     {
         var chain = Read();
 
-        Assert.True(chain.Registry.Count == 7,
-            $"Parsed {chain.Registry.Count} entries out of ViewerPostgresTabs.All; the registry has seven "
-            + "tabs and this file's parse no longer matches its shape.");
-        Assert.True(chain.Collectors.Count >= 25,
-            $"Parsed only {chain.Collectors.Count} collectors out of the registry, which is fewer than the "
-            + "PostgreSQL surface ships. The parse is losing entries and every rule here is running on the "
-            + "remainder.");
-        Assert.True(chain.NamedBy.Count >= 15,
-            $"Only {chain.NamedBy.Count} loader methods name a collector at all; ViewerServerTab.Postgres.cs "
-            + "is not being read the way this file assumes.");
-
         /* Resolved means it reached a PANEL, not merely a method: a collector named inside a method that
            assigns no control would otherwise leave both rules with nothing to compare while this list
            stayed empty — the same invisible skip, one step further along. */
@@ -590,6 +579,24 @@ public sealed class PgRegistryPanelPlacementTests
                 .Where(n => !string.Equals(n, method, StringComparison.Ordinal))
                 .ToHashSet(StringComparer.Ordinal);
         }
+
+        /* The POPULATION floors, here in the shared read rather than in each rule, because every rule
+           divides by this chain and a rule's own floor cannot save it: "compared >= Collectors.Count * 2"
+           is 0 >= 0 on an empty registry, and "one dispatcher arm per registry entry" is 0 == 0. A parse
+           that finds nothing has to fail here, once, loudly — that is the whole failure mode this file
+           exists to prevent, one level up. */
+        Assert.True(registry.Count == 7,
+            $"Parsed {registry.Count} entries out of ViewerPostgresTabs.All; the registry has seven tabs and "
+            + "this file's parse no longer matches its shape, so every rule here would run on the remainder.");
+
+        var declared = registry.SelectMany(t => t.Collectors).Distinct(StringComparer.Ordinal).Count();
+        Assert.True(declared >= 25,
+            $"Parsed only {declared} collectors out of the registry, which is fewer than the PostgreSQL "
+            + "surface ships. The collector arrays are not being read.");
+
+        Assert.True(namedBy.Count >= 15,
+            $"Only {namedBy.Count} loader methods name a collector at all; ViewerServerTab.Postgres.cs is "
+            + "not being read the way this file assumes.");
 
         var loadPathOf = new Dictionary<string, IReadOnlySet<string>>(StringComparer.Ordinal);
         foreach (Match arm in DispatcherArm.Matches(shell))

--- a/Darling/Darling.Tests/PgRegistryPanelPlacementTests.cs
+++ b/Darling/Darling.Tests/PgRegistryPanelPlacementTests.cs
@@ -274,6 +274,13 @@ public sealed class PgRegistryPanelPlacementTests
         foreach (var tab in chain.Registry)
         {
             Assert.StartsWith("Pg", chain.XamlTabAt[tab.InnerTabIndex], StringComparison.Ordinal);
+
+            /* And it is the tab the registry MEANT. The index-to-TabItem step is the one place a silent
+               off-by-one could put a whole entry's collectors against the wrong tab, and the header is the
+               registry's own second description of the same tab. Read off the parsed DOM here, where
+               ViewerPostgresTabsTests reads it off the line shape — two different readings agreeing is the
+               point. */
+            Assert.Equal(tab.Header, chain.XamlHeaderAt[tab.InnerTabIndex]);
         }
 
         Assert.Equal(chain.Registry.Count, chain.Registry.Select(t => t.XamlTabName).Distinct(StringComparer.Ordinal).Count());
@@ -325,6 +332,7 @@ public sealed class PgRegistryPanelPlacementTests
     private sealed record PlacementChain(
         IReadOnlyList<RegistryTab> Registry,
         IReadOnlyDictionary<int, string> XamlTabAt,
+        IReadOnlyDictionary<int, string> XamlHeaderAt,
         IReadOnlyDictionary<string, string> TabOf,
         IReadOnlyDictionary<string, IReadOnlySet<string>> NamedBy,
         IReadOnlyDictionary<string, IReadOnlySet<string>> PanelsOf,
@@ -337,6 +345,16 @@ public sealed class PgRegistryPanelPlacementTests
 
         public IReadOnlyList<string> Collectors { get; } =
             Registry.SelectMany(t => t.Collectors).Distinct(StringComparer.Ordinal).ToList();
+    }
+
+    /// <summary>
+    /// A tab named the way the registry names it — <c>PgStorageTab (the 'storage' entry, "Storage")</c> — so
+    /// an offender line reads in the vocabulary of the file that has to be edited to resolve it.
+    /// </summary>
+    private static string Vocabulary(PlacementChain chain, string xamlTabName)
+    {
+        var tab = chain.Registry.FirstOrDefault(t => string.Equals(t.XamlTabName, xamlTabName, StringComparison.Ordinal));
+        return tab is null ? xamlTabName : $"{xamlTabName} (the '{tab.Id}' entry, \"{tab.Header}\")";
     }
 
     /// <summary>Every loader method that names <paramref name="collector"/>.</summary>
@@ -382,8 +400,8 @@ public sealed class PgRegistryPanelPlacementTests
 
                 if (!string.Equals(declaredIn, registryTab, StringComparison.Ordinal))
                 {
-                    offenders.Add($"{collector} is registered on {registryTab} but its panel {panel} is "
-                                  + $"declared inside {declaredIn} (resolved through "
+                    offenders.Add($"{collector} is registered on {Vocabulary(chain, registryTab)} but its "
+                                  + $"panel {panel} is declared inside {declaredIn} (resolved through "
                                   + $"{string.Join(", ", Methods(chain, collector))})");
                 }
             }
@@ -422,7 +440,8 @@ public sealed class PgRegistryPanelPlacementTests
                 continue;
             }
 
-            offenders.Add($"{collector} is registered on {registryTab} but its panels are filled by "
+            offenders.Add($"{collector} is registered on {Vocabulary(chain, registryTab)} but its panels are "
+                          + "filled by "
                           + (fillers.Count == 0
                               ? "no tab's load path at all"
                               : $"{string.Join(" and ", fillers)}")
@@ -441,10 +460,12 @@ public sealed class PgRegistryPanelPlacementTests
            Header="Blocking" - the SQL Server tab and the PostgreSQL sub-tab - so indexing on the header
            picks whichever comes first. */
         var innerTabs = doc.Descendants().Single(e => e.Attribute(x)?.Value == "InnerTabs");
-        var xamlTabAt = innerTabs.Elements()
+        var tops = innerTabs.Elements()
             .Where(e => e.Name.LocalName == "TabItem")
-            .Select((e, i) => (Index: i, Name: e.Attribute(x)?.Value ?? string.Empty))
-            .ToDictionary(p => p.Index, p => p.Name);
+            .Select((e, i) => (Index: i, Name: e.Attribute(x)?.Value ?? string.Empty, Header: e.Attribute("Header")?.Value ?? string.Empty))
+            .ToList();
+        var xamlTabAt = tops.ToDictionary(p => p.Index, p => p.Name);
+        var xamlHeaderAt = tops.ToDictionary(p => p.Index, p => p.Header);
 
         var tabOf = new Dictionary<string, string>(StringComparer.Ordinal);
         foreach (var element in doc.Descendants())
@@ -527,7 +548,7 @@ public sealed class PgRegistryPanelPlacementTests
             loadPathOf[tab] = Transitive(arm.Groups["loader"].Value, bodies, new HashSet<string>(StringComparer.Ordinal));
         }
 
-        return new PlacementChain(registry, xamlTabAt, tabOf, namedBy, panelsOf, loadPathOf);
+        return new PlacementChain(registry, xamlTabAt, xamlHeaderAt, tabOf, namedBy, panelsOf, loadPathOf);
     }
 
     /// <summary>Every <c>LoadPg…Async</c> reachable from <paramref name="method"/>, itself included.</summary>

--- a/Darling/Darling.Tests/PgRegistryPanelPlacementTests.cs
+++ b/Darling/Darling.Tests/PgRegistryPanelPlacementTests.cs
@@ -129,6 +129,14 @@ public sealed class PgRegistryPanelPlacementTests
     private static readonly Regex CollectorName = new(@"^pg_[a-z_]+$", RegexOptions.Compiled);
 
     /// <summary>
+    /// A loader declaration. A field rather than an inline literal so <see cref="Read"/> can count the
+    /// declarations WITHOUT going through the brace scan — a scan that lost a method would otherwise be
+    /// counted by the same code that lost it.
+    /// </summary>
+    private static readonly Regex MethodDeclaration = new(
+        @"private\s+async\s+Task\s+(?<name>LoadPg[A-Za-z]+Async)\s*\(", RegexOptions.Compiled);
+
+    /// <summary>
     /// The comparison this issue is about: a collector's panels are declared inside the tab the REGISTRY
     /// places it on. #3048 in one assertion — the deadlock note and grid sat in <c>PgVacuumTab</c> while the
     /// Activity entry had named <c>pg_deadlocks</c> all along.
@@ -336,6 +344,70 @@ public sealed class PgRegistryPanelPlacementTests
 
         /* Whether the SHIPPED placement is clean is the two rules above, not this one. Asserting it here as
            well would make one misplaced panel red three tests and cost a reader the attribution. */
+    }
+
+    /// <summary>
+    /// The control for the step everything else here stands on: <see cref="MethodRanges"/> counts braces, so
+    /// a brace inside a string or char literal decides whether a loader's body is read whole. Arranged rather
+    /// than measured on the shipped tree, because the shipped tree happens to balance its literal braces
+    /// today — and "safe today because they happen to balance" is precisely the standing assumption this
+    /// file exists to refuse.
+    ///
+    /// <para>Both directions are asserted, so the walk is shown to be what saves it rather than asserted to
+    /// be. A <c>}</c> in a literal ends the raw count early and TRUNCATES the body, which silently drops the
+    /// control assignments after it. A <c>{</c> in a char literal never lets the count return to zero: at
+    /// the end of a file the method is dropped outright, which is what this fixture shows, and mid-file it
+    /// OVER-EXTENDS into the methods below and attributes their panels to this one's collectors. Neither
+    /// shows up as an error anywhere downstream — a truncated body just yields fewer panels, and fewer
+    /// panels is a quieter rule, not a failing one.</para>
+    /// </summary>
+    [Fact]
+    public void TheMethodWalk_ReadsABodyWhoseLiteralsHoldUnbalancedBraces_AndTheRawCountDoesNot()
+    {
+        /* A closing brace inside a literal: the raw count reaches zero at it and stops. */
+        const string truncates = """
+            private async Task LoadPgProbeAsync()
+            {
+                PgProbeNote.Text = "no autovacuum has run } yet";
+                PgProbeGrid.ItemsSource = rows;
+            }
+            """;
+
+        var walked = MethodRanges(CSharpSourceWalker.StripCommentsAndStrings(truncates));
+        var raw = MethodRanges(truncates);
+
+        var walkedBody = truncates[walked["LoadPgProbeAsync"].Start..walked["LoadPgProbeAsync"].End];
+        Assert.Contains("PgProbeNote", walkedBody, StringComparison.Ordinal);
+        Assert.Contains("PgProbeGrid", walkedBody, StringComparison.Ordinal);
+        Assert.Equal(2, ControlAssignment.Matches(walkedBody).Count);
+
+        var rawBody = truncates[raw["LoadPgProbeAsync"].Start..raw["LoadPgProbeAsync"].End];
+        Assert.Contains("PgProbeNote", rawBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("PgProbeGrid", rawBody, StringComparison.Ordinal);
+        Assert.Equal(1, ControlAssignment.Matches(rawBody).Count);
+
+        /* And the guard in Read() is what turns that truncation into a red rather than a quieter rule. */
+        var w = walked["LoadPgProbeAsync"];
+        var r = raw["LoadPgProbeAsync"];
+        Assert.True(BodyIsWellFormed(CSharpSourceWalker.StripCommentsAndStrings(truncates), w.Start, w.End));
+        Assert.False(BodyIsWellFormed(CSharpSourceWalker.StripCommentsAndStrings(truncates), r.Start, r.End));
+
+        /* An OPENING brace in a char literal is the other direction: the raw count never returns to zero.
+           This fixture ends with the method, so there is no later brace to stop on and the method is
+           dropped entirely — the declaration-count assertion in Read() is what names that. In a real file
+           the scan instead runs into the methods below and over-extends, which the well-formedness
+           assertion names. */
+        const string drops = """
+            private async Task LoadPgProbeAsync()
+            {
+                var opener = '{';
+                PgProbeGrid.ItemsSource = rows;
+            }
+            """;
+
+        Assert.True(MethodRanges(CSharpSourceWalker.StripCommentsAndStrings(drops)).ContainsKey("LoadPgProbeAsync"));
+        Assert.Empty(MethodRanges(drops));
+        Assert.Equal(1, MethodDeclaration.Matches(drops).Count);
     }
 
     // ── The chain ────────────────────────────────────────────────────────────────────────────────
@@ -555,6 +627,37 @@ public sealed class PgRegistryPanelPlacementTests
         var loaderCode = CSharpSourceWalker.StripCommentsAndStrings(loaderSource);
         var ranges = MethodRanges(loaderCode);
 
+        /* The brace count is only sound over WALKED text, and "it is safe because the braces happen to
+           balance today" is the exact shape of assumption this file exists to refuse. So every range is
+           re-checked against the walked source INDEPENDENTLY of what the scan was handed.
+
+           Both failure directions are silent without this, and they are different failures. A '}' inside a
+           literal ends the count early and TRUNCATES the body, which yields fewer control assignments — so
+           the placement rules would cover less than they claim while staying green. A '{' inside a literal
+           never lets the count return to zero, so the scan runs on and OVER-EXTENDS into the methods below,
+           attributing their panels to this one's collectors; at end of file it finds no closing brace at
+           all and the method is dropped instead. The well-formedness assertion names the first two at the
+           method, and the declaration count names the drop, rather than either leaking into a downstream
+           total that nobody reads. */
+        var declarations = MethodDeclaration.Matches(loaderCode).Count;
+        Assert.True(ranges.Count == declarations,
+            $"{declarations} LoadPg…Async declarations are in ViewerServerTab.Postgres.cs but the brace scan "
+            + $"resolved {ranges.Count} bodies. A body whose braces never balance is DROPPED, so every "
+            + "collector it names would resolve to no panel at all. The scan reads walked source, where a "
+            + "brace inside a literal cannot count — so this is the walk failing, not the source.");
+
+        var malformed = ranges
+            .Where(r => !BodyIsWellFormed(loaderCode, r.Value.Start, r.Value.End))
+            .Select(r => $"{r.Key} (offsets {r.Value.Start}..{r.Value.End})")
+            .OrderBy(r => r, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.True(malformed.Count == 0,
+            "These loader bodies do not balance their own braces in the walked source, so the scan ended "
+            + "somewhere other than the method's closing brace — the body is TRUNCATED or runs past the "
+            + "method. A truncated body assigns fewer panels, and both placement rules then check less than "
+            + "they claim while reporting a clean run:\n  " + string.Join("\n  ", malformed));
+
         var namedBy = new Dictionary<string, IReadOnlySet<string>>(StringComparer.Ordinal);
         var panelsOf = new Dictionary<string, IReadOnlySet<string>>(StringComparer.Ordinal);
         var callees = new Dictionary<string, IReadOnlySet<string>>(StringComparer.Ordinal);
@@ -679,7 +782,7 @@ public sealed class PgRegistryPanelPlacementTests
     private static Dictionary<string, (int Start, int End)> MethodRanges(string code)
     {
         var ranges = new Dictionary<string, (int Start, int End)>(StringComparer.Ordinal);
-        foreach (Match m in Regex.Matches(code, @"private\s+async\s+Task\s+(?<name>LoadPg[A-Za-z]+Async)\s*\("))
+        foreach (Match m in MethodDeclaration.Matches(code))
         {
             var depth = 0;
             var started = false;
@@ -703,6 +806,48 @@ public sealed class PgRegistryPanelPlacementTests
         }
 
         return ranges;
+    }
+
+    /// <summary>
+    /// Whether <c>code[start..end]</c> is one whole method body: it opens a brace, never closes more than
+    /// it opened, ends exactly on the brace that returns it to zero, and that brace is the last character.
+    /// Checked over the walked text, so a brace inside a literal is not a brace here.
+    /// </summary>
+    private static bool BodyIsWellFormed(string code, int start, int end)
+    {
+        if (end <= start || end > code.Length || code[end - 1] != '}')
+        {
+            return false;
+        }
+
+        var depth = 0;
+        var opened = false;
+
+        for (var i = start; i < end; i++)
+        {
+            if (code[i] == '{')
+            {
+                depth++;
+                opened = true;
+            }
+            else if (code[i] == '}')
+            {
+                depth--;
+                if (depth < 0)
+                {
+                    return false;
+                }
+
+                /* Returning to zero anywhere but the last character means the scan kept going past the
+                   method it was reading, which is the over-extension half of the same defect. */
+                if (depth == 0 && i != end - 1)
+                {
+                    return false;
+                }
+            }
+        }
+
+        return opened && depth == 0;
     }
 
     /// <summary>Same <c>[CallerFilePath]</c> resolver <c>ViewerPostgresTabsTests</c> uses — no walk-up, so it

--- a/Darling/Darling.Tests/PgRegistryPanelPlacementTests.cs
+++ b/Darling/Darling.Tests/PgRegistryPanelPlacementTests.cs
@@ -36,7 +36,17 @@ namespace Darling.Tests;
 /// question this screen answers — and the registry is the only artifact that records it in those terms,
 /// beside the prose explaining why those panels sit together. The XAML and the load path are both
 /// implementations of that decision, so "they disagree" is not the finding; "neither of them is what was
-/// declared" is.</para>
+/// declared" is. #3048 is what that costs: it was resolved through five circumstantial signals — the load
+/// path, a doc comment in another file, subject matter, a spacer-row convention, a XAML comment — which
+/// reached the right answer the long way while the authoritative source sat unread.</para>
+///
+/// <para><b>The class nothing else can see, measured rather than argued.</b>
+/// <c>PgPanelTabOwnershipTests</c> reds on all three of those historical defects, because in each of them
+/// the two implementations disagreed with EACH OTHER. Move the deadlock pair onto Vacuum in the XAML AND
+/// move the <c>LoadPgDeadlocksAsync</c> call into the Vacuum load path, and it goes green: the two agree,
+/// and they are both wrong. That mutation reds only the two rules here, naming <c>pg_deadlocks</c>, the tab
+/// the registry gives it and the tab it moved to. A panel can be consistently in the wrong place, and
+/// consistency is exactly what the other pin measures.</para>
 ///
 /// <para><b>Collector to panel, and why not by name.</b> Each panel block is loaded by a
 /// <c>LoadPg…Async</c> method that names its own collector — <c>PgCollectorIsGatedOff("pg_deadlocks")</c> to

--- a/Darling/Darling.Tests/PgRegistryPanelPlacementTests.cs
+++ b/Darling/Darling.Tests/PgRegistryPanelPlacementTests.cs
@@ -71,6 +71,15 @@ namespace Darling.Tests;
 /// EMPTY rather than carrying an exemption list — and it names whatever it could not resolve instead of
 /// passing on the ones it could.</para>
 ///
+/// <para><b>Read through the shared walk, not a comment regex of its own.</b> Both source files are put
+/// through <see cref="CSharpSourceWalker"/> (#3052): the registry's reasoning lives in block comments
+/// BETWEEN its constructor arguments and several of them name collectors, and the loaders' comments name
+/// grids, so prose would otherwise read as an argument or an assignment. The walk also makes the brace
+/// count that finds a method body immune to a brace inside a literal. Where a collector NAME is needed the
+/// call is matched in the walked code and the literal read out of the original text at the same offset,
+/// because the walk blanks literal text — the idiom <c>CommentFilterAdoptionTests</c> uses, sound because
+/// the two are character-aligned.</para>
+///
 /// <para><b>Ownership resolves to the OUTERMOST named <c>TabItem</c></b>, because Activity holds a sub-tab
 /// control and a panel in its Blocking sub-tab still belongs to Activity. Read by parsing the XAML rather
 /// than by line range or by the position of a <c>Header</c>: there are two <c>Header="Blocking"</c>
@@ -84,9 +93,13 @@ namespace Darling.Tests;
 /// </summary>
 public sealed class PgRegistryPanelPlacementTests
 {
-    /// <summary>The two forms a loader uses to name the collector whose rows its panels render.</summary>
-    private static readonly Regex CollectorNamed = new(
-        @"(?:PgCollectorIsGatedOff|PanelNote)\(\s*""(?<collector>pg_[a-z_]+)""", RegexOptions.Compiled);
+    /// <summary>
+    /// The two forms a loader uses to name the collector whose rows its panels render. Matched over the
+    /// WALKED code; the name itself is then read out of the original text at the same offset, because the
+    /// walk blanks literal text.
+    /// </summary>
+    private static readonly Regex CollectorNamingCall = new(
+        @"\b(?:PgCollectorIsGatedOff|PanelNote)\(", RegexOptions.Compiled);
 
     /// <summary>A control this method assigns. Same shape as <c>PgPanelTabOwnershipTests</c>' detector.</summary>
     private static readonly Regex ControlAssignment = new(
@@ -103,13 +116,17 @@ public sealed class PgRegistryPanelPlacementTests
         @"internal const int (?<constant>Pg\w+InnerTabIndex)\s*=\s*(?<index>\d+);", RegexOptions.Compiled);
 
     /// <summary>
-    /// One registry entry, read out of <c>ViewerPostgresTabs.cs</c>: the index constant it occupies, its id,
-    /// and the collectors it claims. Parsed rather than referenced so the whole rule runs against source
-    /// files; the compiled registry's own shape is already pinned by <c>ViewerPostgresTabsTests</c>.
+    /// Where a registry entry starts, and which index constant it occupies. The entry's id, header and
+    /// collector list are string LITERALS and are read positionally from that offset — a single regex over
+    /// the whole entry would have to span the block comments the registry carries between its arguments.
+    /// Parsed rather than referenced so the whole rule runs against source files; the compiled registry's
+    /// own shape is already pinned by <c>ViewerPostgresTabsTests</c>.
     /// </summary>
-    private static readonly Regex RegistryEntry = new(
-        @"new ViewerPostgresTab\(\s*ViewerServerTab\.(?<constant>Pg\w+InnerTabIndex),\s*""(?<id>\w+)"",\s*""(?<header>[^""]+)"",\s*new\[\]\s*\{(?<collectors>[^}]*)\}",
-        RegexOptions.Compiled);
+    private static readonly Regex RegistryEntryHead = new(
+        @"new ViewerPostgresTab\(\s*ViewerServerTab\.(?<constant>Pg\w+InnerTabIndex),", RegexOptions.Compiled);
+
+    /// <summary>A collector name, to tell the registry's collector array from the note that follows it.</summary>
+    private static readonly Regex CollectorName = new(@"^pg_[a-z_]+$", RegexOptions.Compiled);
 
     /// <summary>
     /// The comparison this issue is about: a collector's panels are declared inside the tab the REGISTRY
@@ -258,15 +275,22 @@ public sealed class PgRegistryPanelPlacementTests
     public void TheRegistryParse_AgreesWithASecondReadingOfTheSameFile()
     {
         var chain = Read();
-        var source = Strip(ViewerFile("ViewerPostgresTabs.cs"));
-        var initialiser = source[source.IndexOf("All = new[]", StringComparison.Ordinal)..];
+        var source = ViewerFile("ViewerPostgresTabs.cs");
 
+        /* Two readings of one file that share no code with the parse above: how many entries the CODE
+           constructs, and which collector-shaped LITERALS it holds. A structural parse that quietly lost an
+           entry would take both rules with it and still report green. */
         Assert.Equal(
-            Regex.Matches(initialiser, @"new ViewerPostgresTab\(").Count,
+            Regex.Matches(CSharpSourceWalker.StripCommentsAndStrings(source), @"new ViewerPostgresTab\(").Count,
             chain.Registry.Count);
 
         Assert.Equal(
-            Regex.Matches(initialiser, @"""pg_[a-z_]+""").Select(m => m.Value.Trim('"')).Order(StringComparer.Ordinal).ToList(),
+            CSharpSourceWalker.StringLiteralBodies(source)
+                .Select(l => l.Text)
+                .Where(t => CollectorName.IsMatch(t))
+                .Distinct(StringComparer.Ordinal)
+                .Order(StringComparer.Ordinal)
+                .ToList(),
             chain.Collectors.Order(StringComparer.Ordinal).ToList());
 
         /* Every entry lands on a NAMED PostgreSQL TabItem. A registry index that resolved to an unnamed
@@ -492,8 +516,13 @@ public sealed class PgRegistryPanelPlacementTests
         var indices = IndexConstant.Matches(shell)
             .ToDictionary(m => m.Groups["constant"].Value, m => int.Parse(m.Groups["index"].Value), StringComparer.Ordinal);
 
+        var registrySource = ViewerFile("ViewerPostgresTabs.cs");
+        var registryCode = CSharpSourceWalker.StripCommentsAndStrings(registrySource);
+        var registryLiterals = CSharpSourceWalker.StringLiteralBodies(registrySource).OrderBy(l => l.Start).ToList();
+        var heads = RegistryEntryHead.Matches(registryCode).ToList();
+
         var registry = new List<RegistryTab>();
-        foreach (Match entry in RegistryEntry.Matches(Strip(ViewerFile("ViewerPostgresTabs.cs"))))
+        foreach (var entry in heads)
         {
             var constant = entry.Groups["constant"].Value;
             Assert.True(indices.ContainsKey(constant),
@@ -508,30 +537,55 @@ public sealed class PgRegistryPanelPlacementTests
                 $"The TabItem at index {index} ({constant}) carries no x:Name, so no panel can be resolved "
                 + "to it and every collector on that registry entry would go unchecked.");
 
+            /* The entry's literals, in source order: id, header, then the collector array, then the note.
+               Taken as the CONTIGUOUS run of collector-shaped literals after the header, which is what the
+               array is — a note that happened to be exactly a collector name could not join it, because the
+               note comes after the array and the run has already ended. */
+            var literals = registryLiterals
+                .Where(l => l.Start > entry.Index)
+                .Select(l => l.Text)
+                .ToList();
+
+            Assert.True(literals.Count >= 3,
+                $"The registry entry at {constant} is followed by {literals.Count} string literal(s); its "
+                + "id, header and collector array cannot be read, so this file would check nothing about it.");
+
             registry.Add(new RegistryTab(
                 constant,
-                entry.Groups["id"].Value,
-                entry.Groups["header"].Value,
+                literals[0],
+                literals[1],
                 index,
                 xamlTabAt[index],
-                Regex.Matches(entry.Groups["collectors"].Value, @"""(?<name>pg_[a-z_]+)""")
-                    .Select(m => m.Groups["name"].Value)
-                    .ToList()));
+                literals.Skip(2).TakeWhile(l => CollectorName.IsMatch(l)).ToList()));
         }
 
-        var bodies = MethodBodies(Strip(ViewerFile("ViewerServerTab.Postgres.cs")));
+        var loaderSource = ViewerFile("ViewerServerTab.Postgres.cs");
+        var loaderCode = CSharpSourceWalker.StripCommentsAndStrings(loaderSource);
+        var ranges = MethodRanges(loaderCode);
 
         var namedBy = new Dictionary<string, IReadOnlySet<string>>(StringComparer.Ordinal);
         var panelsOf = new Dictionary<string, IReadOnlySet<string>>(StringComparer.Ordinal);
-        foreach (var (method, body) in bodies)
+        var callees = new Dictionary<string, IReadOnlySet<string>>(StringComparer.Ordinal);
+        foreach (var (method, (start, end)) in ranges)
         {
-            var named = CollectorNamed.Matches(body).Select(m => m.Groups["collector"].Value).ToHashSet(StringComparer.Ordinal);
+            var body = loaderCode[start..end];
+
+            var named = CollectorNamingCall.Matches(body)
+                .Select(m => LiteralAt(loaderSource, start + m.Index + m.Length))
+                .Where(n => n is not null && CollectorName.IsMatch(n))
+                .Select(n => n!)
+                .ToHashSet(StringComparer.Ordinal);
+
             if (named.Count > 0)
             {
                 namedBy[method] = named;
             }
 
             panelsOf[method] = ControlAssignment.Matches(body).Select(m => m.Groups["name"].Value).ToHashSet(StringComparer.Ordinal);
+            callees[method] = LoaderCall.Matches(body)
+                .Select(m => m.Groups["name"].Value)
+                .Where(n => !string.Equals(n, method, StringComparison.Ordinal))
+                .ToHashSet(StringComparer.Ordinal);
         }
 
         var loadPathOf = new Dictionary<string, IReadOnlySet<string>>(StringComparer.Ordinal);
@@ -545,74 +599,92 @@ public sealed class PgRegistryPanelPlacementTests
                 continue; /* a SQL Server arm — this file only speaks for the PostgreSQL run */
             }
 
-            loadPathOf[tab] = Transitive(arm.Groups["loader"].Value, bodies, new HashSet<string>(StringComparer.Ordinal));
+            loadPathOf[tab] = Transitive(arm.Groups["loader"].Value, callees, new HashSet<string>(StringComparer.Ordinal));
         }
 
         return new PlacementChain(registry, xamlTabAt, xamlHeaderAt, tabOf, namedBy, panelsOf, loadPathOf);
     }
 
     /// <summary>Every <c>LoadPg…Async</c> reachable from <paramref name="method"/>, itself included.</summary>
-    private static IReadOnlySet<string> Transitive(string method, Dictionary<string, string> bodies, HashSet<string> seen)
+    private static IReadOnlySet<string> Transitive(string method, IReadOnlyDictionary<string, IReadOnlySet<string>> callees, HashSet<string> seen)
     {
         var found = new HashSet<string>(StringComparer.Ordinal);
-        if (!seen.Add(method) || !bodies.TryGetValue(method, out var body))
+        if (!seen.Add(method) || !callees.TryGetValue(method, out var direct))
         {
             return found;
         }
 
         found.Add(method);
 
-        foreach (Match m in LoaderCall.Matches(body))
+        foreach (var callee in direct)
         {
-            var callee = m.Groups["name"].Value;
-            if (callee != method)
-            {
-                found.UnionWith(Transitive(callee, bodies, seen));
-            }
+            found.UnionWith(Transitive(callee, callees, seen));
         }
 
         return found;
     }
 
     /// <summary>
-    /// Comments out — doc, line and block — so prose naming a collector or a grid cannot read as a call or an
-    /// assignment. The registry's own reasoning is block comments INSIDE the initialiser and several of them
-    /// name collectors.
+    /// The plain <c>"…"</c> literal opening an argument list at <paramref name="at"/>, read out of the
+    /// ORIGINAL source at an offset matched in the walked text — the idiom
+    /// <c>CommentFilterAdoptionTests.PrefixFilterSites</c> uses, sound because
+    /// <see cref="CSharpSourceWalker.StripCommentsAndStrings"/> is character-aligned with its input.
+    ///
+    /// <para>Only a plain literal is recognised: a collector named through a <c>const</c>, a verbatim
+    /// literal or an interpolation would read as null. There is no such call site today — all 27 registry
+    /// collectors are named with a plain literal — and that is a stated bound on this reader rather than a
+    /// claim about C#. <see cref="EveryRegistryCollector_ResolvesToAPanel_OrIsNamedAsUnresolved"/> is what
+    /// goes red if it stops holding, naming the collector it could no longer read.</para>
     /// </summary>
-    private static string Strip(string source)
+    private static string? LiteralAt(string source, int at)
     {
-        source = Regex.Replace(source, @"^[ \t]*///.*$", string.Empty, RegexOptions.Multiline);
-        source = Regex.Replace(source, @"/\*.*?\*/", string.Empty, RegexOptions.Singleline);
-        return Regex.Replace(source, @"//.*$", string.Empty, RegexOptions.Multiline);
+        var i = at;
+        while (i < source.Length && char.IsWhiteSpace(source[i]))
+        {
+            i++;
+        }
+
+        if (i >= source.Length || source[i] != '"')
+        {
+            return null;
+        }
+
+        var close = source.IndexOf('"', i + 1);
+        return close < 0 ? null : source[(i + 1)..close];
     }
 
-    private static Dictionary<string, string> MethodBodies(string source)
+    /// <summary>
+    /// Each <c>LoadPg…Async</c>'s body as a half-open range over the WALKED code. Braces inside a literal or
+    /// a comment cannot unbalance the count there, which is the whole reason the walk is used rather than a
+    /// comment-stripping regex of this file's own (#3052).
+    /// </summary>
+    private static Dictionary<string, (int Start, int End)> MethodRanges(string code)
     {
-        var bodies = new Dictionary<string, string>(StringComparer.Ordinal);
-        foreach (Match m in Regex.Matches(source, @"private\s+async\s+Task\s+(?<name>LoadPg[A-Za-z]+Async)\s*\("))
+        var ranges = new Dictionary<string, (int Start, int End)>(StringComparer.Ordinal);
+        foreach (Match m in Regex.Matches(code, @"private\s+async\s+Task\s+(?<name>LoadPg[A-Za-z]+Async)\s*\("))
         {
             var depth = 0;
             var started = false;
-            for (var i = m.Index; i < source.Length; i++)
+            for (var i = m.Index; i < code.Length; i++)
             {
-                if (source[i] == '{')
+                if (code[i] == '{')
                 {
                     depth++;
                     started = true;
                 }
-                else if (source[i] == '}')
+                else if (code[i] == '}')
                 {
                     depth--;
                     if (started && depth == 0)
                     {
-                        bodies[m.Groups["name"].Value] = source[m.Index..(i + 1)];
+                        ranges[m.Groups["name"].Value] = (m.Index, i + 1);
                         break;
                     }
                 }
             }
         }
 
-        return bodies;
+        return ranges;
     }
 
     /// <summary>Same <c>[CallerFilePath]</c> resolver <c>ViewerPostgresTabsTests</c> uses — no walk-up, so it

--- a/Darling/Darling.Tests/PgRegistryPanelPlacementTests.cs
+++ b/Darling/Darling.Tests/PgRegistryPanelPlacementTests.cs
@@ -384,7 +384,7 @@ public sealed class PgRegistryPanelPlacementTests
         var rawBody = truncates[raw["LoadPgProbeAsync"].Start..raw["LoadPgProbeAsync"].End];
         Assert.Contains("PgProbeNote", rawBody, StringComparison.Ordinal);
         Assert.DoesNotContain("PgProbeGrid", rawBody, StringComparison.Ordinal);
-        Assert.Equal(1, ControlAssignment.Matches(rawBody).Count);
+        Assert.Single(ControlAssignment.Matches(rawBody));
 
         /* And the guard in Read() is what turns that truncation into a red rather than a quieter rule. */
         var w = walked["LoadPgProbeAsync"];
@@ -407,7 +407,7 @@ public sealed class PgRegistryPanelPlacementTests
 
         Assert.True(MethodRanges(CSharpSourceWalker.StripCommentsAndStrings(drops)).ContainsKey("LoadPgProbeAsync"));
         Assert.Empty(MethodRanges(drops));
-        Assert.Equal(1, MethodDeclaration.Matches(drops).Count);
+        Assert.Single(MethodDeclaration.Matches(drops));
     }
 
     // ── The chain ────────────────────────────────────────────────────────────────────────────────

--- a/Darling/Darling.Tests/PgRegistryPanelPlacementTests.cs
+++ b/Darling/Darling.Tests/PgRegistryPanelPlacementTests.cs
@@ -1,0 +1,597 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// <c>ViewerPostgresTabs.All</c> is the DECLARED intent for where a PostgreSQL panel lives — its
+/// <c>Collectors</c> parameter is documented "every collector whose stored rows this tab renders" — and this
+/// file is the comparison that was missing: the registry against the XAML that renders the panels, and the
+/// registry against the load path that fills them (#3062).
+///
+/// <para><b>Three artifacts describe one fact, and only one pairing was pinned.</b>
+/// <c>ViewerPostgresTabsTests</c> holds the registry to the catalog and to the XAML's tab STRIP — indices,
+/// headers, order — but never to the panels inside a tab. <c>PgPanelTabOwnershipTests</c> holds the load path
+/// to the XAML. Nothing consulted the registry about a panel, so when the load path and the XAML disagreed
+/// there was no third opinion to say which of them was wrong, and three placement defects landed:
+/// #3048 (the deadlock pair declared inside <c>PgVacuumTab</c> while the registry's Activity entry named
+/// <c>pg_deadlocks</c>) and both of #3050's pairs (<c>pg_wait_sampling</c> registered on Waits and
+/// <c>pg_predicate_stats</c> on Storage, both filled only from the Activity load path).</para>
+///
+/// <para><b>Why the registry is the side that decides.</b> A panel's home is a product decision — which
+/// question this screen answers — and the registry is the only artifact that records it in those terms,
+/// beside the prose explaining why those panels sit together. The XAML and the load path are both
+/// implementations of that decision, so "they disagree" is not the finding; "neither of them is what was
+/// declared" is.</para>
+///
+/// <para><b>Collector to panel, and why not by name.</b> Each panel block is loaded by a
+/// <c>LoadPg…Async</c> method that names its own collector — <c>PgCollectorIsGatedOff("pg_deadlocks")</c> to
+/// skip a permanent gap, and <c>PanelNote("pg_deadlocks", …)</c> to print the reason for one — so the method
+/// body is the link from a collector name to the controls that render its rows. Resolving by NAME instead
+/// was measured and rejected: 8 of the 27 registry collectors have no control named after them at all, and
+/// four notes are named for the tab or the subject rather than the collector (<c>PgWaitsNote</c> for
+/// <c>pg_wait_stats</c>, <c>PgIoNote</c> for <c>pg_io_stats</c>, <c>PgReplicationNote</c> for
+/// <c>pg_replication_slots</c>, <c>PgDatabasesNote</c> for <c>pg_database_stats</c>).</para>
+///
+/// <para><b>Both naming forms are read, because one of them covers only 21 of 27.</b>
+/// <c>PgCollectorIsGatedOff</c> is called by 21 collectors' loaders; the other six —
+/// <c>pg_autovacuum_stats</c>, <c>pg_database_stats</c>, <c>pg_io_stats</c>, <c>pg_replication_slots</c>,
+/// <c>pg_wraparound_stats</c>, <c>pg_xmin_horizon</c> — issue their read unconditionally and name themselves
+/// only through <c>PanelNote</c>. Reading just the gate call would have covered 21 and skipped six SILENTLY,
+/// which is worse than it sounds: the skipped six include the entire Vacuum causal chain and both halves of
+/// Replication. <c>PanelNote</c> is not a fallback but the better link of the two — every panel has one by
+/// construction (<c>ViewerPostgresTabsTests.EveryPostgresPanel_ExplainsItsOwnEmptyState</c> already refuses
+/// a panel without one), and its first argument is keyed on the same collector name the capability sentence
+/// takes. Together they resolve 27 of 27, so
+/// <see cref="EveryRegistryCollector_ResolvesToAPanel_OrIsNamedAsUnresolved"/> asserts the unresolved set is
+/// EMPTY rather than carrying an exemption list — and it names whatever it could not resolve instead of
+/// passing on the ones it could.</para>
+///
+/// <para><b>Ownership resolves to the OUTERMOST named <c>TabItem</c></b>, because Activity holds a sub-tab
+/// control and a panel in its Blocking sub-tab still belongs to Activity. Read by parsing the XAML rather
+/// than by line range or by the position of a <c>Header</c>: there are two <c>Header="Blocking"</c>
+/// TabItems in the file, one SQL Server and one PostgreSQL.</para>
+///
+/// <para><b>Out of scope, deliberately.</b> This asserts WHICH tab, never in what order. The registry
+/// documents its collector list as panel order and the Storage entry orders <c>pg_index_bloat</c> before
+/// <c>pg_column_stats</c> while the XAML renders them the other way round; that is pre-existing, untested in
+/// either direction, and widening this rule to order is a separate decision. Nothing here reads
+/// <c>Grid.Row</c> either — <c>XamlGridRowRangeTests</c> owns the row rules.</para>
+/// </summary>
+public sealed class PgRegistryPanelPlacementTests
+{
+    /// <summary>The two forms a loader uses to name the collector whose rows its panels render.</summary>
+    private static readonly Regex CollectorNamed = new(
+        @"(?:PgCollectorIsGatedOff|PanelNote)\(\s*""(?<collector>pg_[a-z_]+)""", RegexOptions.Compiled);
+
+    /// <summary>A control this method assigns. Same shape as <c>PgPanelTabOwnershipTests</c>' detector.</summary>
+    private static readonly Regex ControlAssignment = new(
+        @"\b(?<name>Pg[A-Za-z]+(?:Grid|Note|Expander))\s*(?:\.\w+)?\s*=(?!=)", RegexOptions.Compiled);
+
+    private static readonly Regex LoaderCall = new(
+        @"\b(?<name>LoadPg[A-Za-z]+Async)\b", RegexOptions.Compiled);
+
+    private static readonly Regex DispatcherArm = new(
+        @"case\s+(?<constant>Pg\w+InnerTabIndex):\s*\r?\n\s*await\s+(?<loader>LoadPg\w+Async)\(\);",
+        RegexOptions.Compiled);
+
+    private static readonly Regex IndexConstant = new(
+        @"internal const int (?<constant>Pg\w+InnerTabIndex)\s*=\s*(?<index>\d+);", RegexOptions.Compiled);
+
+    /// <summary>
+    /// One registry entry, read out of <c>ViewerPostgresTabs.cs</c>: the index constant it occupies, its id,
+    /// and the collectors it claims. Parsed rather than referenced so the whole rule runs against source
+    /// files; the compiled registry's own shape is already pinned by <c>ViewerPostgresTabsTests</c>.
+    /// </summary>
+    private static readonly Regex RegistryEntry = new(
+        @"new ViewerPostgresTab\(\s*ViewerServerTab\.(?<constant>Pg\w+InnerTabIndex),\s*""(?<id>\w+)"",\s*""(?<header>[^""]+)"",\s*new\[\]\s*\{(?<collectors>[^}]*)\}",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// The comparison this issue is about: a collector's panels are declared inside the tab the REGISTRY
+    /// places it on. #3048 in one assertion — the deadlock note and grid sat in <c>PgVacuumTab</c> while the
+    /// Activity entry had named <c>pg_deadlocks</c> all along.
+    /// </summary>
+    [Fact]
+    public void EveryRegistryCollectorsPanels_AreDeclaredInsideTheTabTheRegistryPlacesItOn()
+    {
+        var chain = Read();
+        var (offenders, compared) = DeclarationOffenders(chain, chain.PlacedOn);
+
+        /* Floors first, because every assertion below is over a set this walk produced: an empty one would
+           make the rule pass by having nothing to disagree about, which is the failure this file exists to
+           prevent. Derived rather than a round number - each panel block is a note and a grid, so two
+           panels per registry collector is the shape, not a guess. */
+        Assert.True(compared >= chain.Collectors.Count * 2,
+            $"Only {compared} collector/panel pairs were compared for {chain.Collectors.Count} registry "
+            + "collectors. Every panel block is a note plus a grid, so the walk is finding less than the "
+            + "shipped tree holds and the rule below is checking almost nothing.");
+
+        Assert.True(offenders.Count == 0,
+            "A PostgreSQL panel renders on a tab other than the one ViewerPostgresTabs.All places its "
+            + "collector on. The registry is the DECLARED intent — its Collectors list is documented as "
+            + "'every collector whose stored rows this tab renders' — so either move the declaration into "
+            + "the tab the registry names, or change the registry and say why that tab is now the right "
+            + "home:\n  " + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
+    /// The other half: a collector's panels are filled by the load path of the tab the REGISTRY places it
+    /// on. Both of #3050's pairs in one assertion — <c>pg_wait_sampling</c> and <c>pg_predicate_stats</c>
+    /// rendered on Waits and Storage exactly as registered, and were populated only once Activity had been
+    /// visited.
+    ///
+    /// <para>Distinct from <c>PgPanelTabOwnershipTests</c>, which compares the load path against the XAML.
+    /// That pin can only report that two artifacts disagree; this one reports which of them left the
+    /// declared intent, which is the question a fix has to answer.</para>
+    /// </summary>
+    [Fact]
+    public void EveryRegistryCollector_IsFilledByTheLoadPathOfTheTabTheRegistryPlacesItOn()
+    {
+        var chain = Read();
+
+        Assert.True(chain.LoadPathOf.Count == chain.Registry.Count,
+            $"{chain.LoadPathOf.Count} PostgreSQL dispatcher arms resolved to a tab for "
+            + $"{chain.Registry.Count} registry entries; the tab-to-loader map is not being read, so this "
+            + "rule would pass with nothing to check.");
+
+        var offenders = LoadPathOffenders(chain, chain.PlacedOn);
+
+        Assert.True(offenders.Count == 0,
+            "A PostgreSQL panel is filled by the load path of a tab other than the one "
+            + "ViewerPostgresTabs.All places its collector on, so it is blank until that other tab is "
+            + "visited — and a blank panel reads as 'nothing to report' rather than 'nothing loaded this'. "
+            + "Move the loader call onto the tab the registry names:\n  " + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
+    /// Which collectors the chain could not resolve to a panel at all, named rather than skipped.
+    ///
+    /// <para>This is the assertion that keeps the two rules above honest. Reading only
+    /// <c>PgCollectorIsGatedOff</c> resolves 21 of the 27 registry collectors and skips six INVISIBLY, so a
+    /// green run would have meant "21 are placed correctly and six were never asked" while reading like full
+    /// coverage. Reading <c>PanelNote</c> as well resolves all 27, so the expected unresolved set is empty —
+    /// and if a 28th collector arrives that neither form names, this names it instead of quietly dropping
+    /// it.</para>
+    /// </summary>
+    [Fact]
+    public void EveryRegistryCollector_ResolvesToAPanel_OrIsNamedAsUnresolved()
+    {
+        var chain = Read();
+
+        Assert.True(chain.Registry.Count == 7,
+            $"Parsed {chain.Registry.Count} entries out of ViewerPostgresTabs.All; the registry has seven "
+            + "tabs and this file's parse no longer matches its shape.");
+        Assert.True(chain.Collectors.Count >= 25,
+            $"Parsed only {chain.Collectors.Count} collectors out of the registry, which is fewer than the "
+            + "PostgreSQL surface ships. The parse is losing entries and every rule here is running on the "
+            + "remainder.");
+        Assert.True(chain.NamedBy.Count >= 15,
+            $"Only {chain.NamedBy.Count} loader methods name a collector at all; ViewerServerTab.Postgres.cs "
+            + "is not being read the way this file assumes.");
+
+        /* Resolved means it reached a PANEL, not merely a method: a collector named inside a method that
+           assigns no control would otherwise leave both rules with nothing to compare while this list
+           stayed empty — the same invisible skip, one step further along. */
+        var unresolved = chain.Collectors
+            .Where(c => Panels(chain, c).Count == 0)
+            .Select(c => Methods(chain, c).Count == 0
+                ? $"{c} — no loader method names it"
+                : $"{c} — named by {string.Join(", ", Methods(chain, c))}, which assigns no panel")
+            .OrderBy(c => c, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.True(unresolved.Count == 0,
+            "These registry collectors reach no panel, so nothing here can say which controls render them "
+            + "and their placement is NOT checked by either rule in this file. A collector's loader names it "
+            + "through PgCollectorIsGatedOff or PanelNote and assigns the controls beside it; if one "
+            + "genuinely cannot, the honest fix is a stated exemption in this message rather than a silent "
+            + "skip:\n  " + string.Join("\n  ", unresolved));
+    }
+
+    /// <summary>
+    /// A loader method may not name collectors that the registry places on two different tabs, because the
+    /// panels it assigns can only be declared inside one of them. The attribution above is per METHOD — a
+    /// method's collectors share its panels — so this is what keeps that coarseness sound: without it, adding
+    /// a second tab's <c>PanelNote</c> into an existing loader would make both rules report a confusing
+    /// mismatch on panels that never moved.
+    /// </summary>
+    [Fact]
+    public void NoLoaderMethod_NamesCollectorsFromTwoDifferentRegistryTabs()
+    {
+        var chain = Read();
+
+        var offenders = new List<string>();
+        foreach (var (method, named) in chain.NamedBy.OrderBy(p => p.Key, StringComparer.Ordinal))
+        {
+            var tabs = named
+                .Where(chain.PlacedOn.ContainsKey)
+                .Select(c => chain.PlacedOn[c])
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(t => t, StringComparer.Ordinal)
+                .ToList();
+
+            if (tabs.Count > 1)
+            {
+                offenders.Add($"{method} names collectors registered on {string.Join(" and ", tabs)} "
+                              + $"({string.Join(", ", named.OrderBy(n => n, StringComparer.Ordinal))})");
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            "A loader method names collectors that the registry places on different tabs. Its panels are "
+            + "attributed to every collector it names, so which panel belongs to which collector is no "
+            + "longer derivable and the two rules in this file would blame the wrong one. Split the method, "
+            + "one tab's panels each:\n  " + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
+    /// The registry parse, read a second and dumber way out of the same file. Without this, a parse that
+    /// silently lost an entry would take both rules with it and still report green — the exact shape of
+    /// failure the floors above exist for, one level further in.
+    /// </summary>
+    [Fact]
+    public void TheRegistryParse_AgreesWithASecondReadingOfTheSameFile()
+    {
+        var chain = Read();
+        var source = Strip(ViewerFile("ViewerPostgresTabs.cs"));
+        var initialiser = source[source.IndexOf("All = new[]", StringComparison.Ordinal)..];
+
+        Assert.Equal(
+            Regex.Matches(initialiser, @"new ViewerPostgresTab\(").Count,
+            chain.Registry.Count);
+
+        Assert.Equal(
+            Regex.Matches(initialiser, @"""pg_[a-z_]+""").Select(m => m.Value.Trim('"')).Order(StringComparer.Ordinal).ToList(),
+            chain.Collectors.Order(StringComparer.Ordinal).ToList());
+
+        /* Every entry lands on a NAMED PostgreSQL TabItem. A registry index that resolved to an unnamed
+           SQL Server tab would make both rules skip that entry rather than fail it. */
+        foreach (var tab in chain.Registry)
+        {
+            Assert.StartsWith("Pg", chain.XamlTabAt[tab.InnerTabIndex], StringComparison.Ordinal);
+        }
+
+        Assert.Equal(chain.Registry.Count, chain.Registry.Select(t => t.XamlTabName).Distinct(StringComparer.Ordinal).Count());
+    }
+
+    /// <summary>
+    /// Both detectors fire on a placement planted into the REAL tree, in the shape each historical defect
+    /// had. Without this the rules above would pass on any tree where a walk quietly returned nothing, and
+    /// an empty offender list would be the only evidence they ever ran.
+    /// </summary>
+    [Fact]
+    public void TheDetectors_ReportAPlantedMisplacementInTheRealTree()
+    {
+        var chain = Read();
+
+        /* #3048's shape: the registry says one tab, the XAML declares the panels in another. Move a
+           resolved collector's registry placement onto a different tab and require it to be named. */
+        var moved = chain.Collectors.First(c => Methods(chain, c).Count > 0);
+        var elsewhere = chain.Registry.Select(t => t.XamlTabName).First(t => !string.Equals(t, chain.PlacedOn[moved], StringComparison.Ordinal));
+
+        var planted = new Dictionary<string, string>(chain.PlacedOn, StringComparer.Ordinal) { [moved] = elsewhere };
+
+        /* Measured as the DIFFERENCE against the shipped placement rather than as the whole list, so this
+           self-test keeps saying something on a tree that already has a real offender: on a clean tree the
+           shipped lists are empty and the two are the same claim, and on a broken one this still isolates
+           what the plant added instead of drowning in what was already wrong. */
+        var declaration = DeclarationOffenders(chain, planted).Offenders
+            .Except(DeclarationOffenders(chain, chain.PlacedOn).Offenders, StringComparer.Ordinal)
+            .ToList();
+        Assert.NotEmpty(declaration);
+        Assert.All(declaration, o => Assert.Contains(moved, o, StringComparison.Ordinal));
+
+        /* #3050's shape: the registry and the XAML agree, and some other tab's load path is what fills the
+           panels. Same planted placement reaches it, because the load path still runs from the real tab. */
+        var loadPath = LoadPathOffenders(chain, planted)
+            .Except(LoadPathOffenders(chain, chain.PlacedOn), StringComparer.Ordinal)
+            .ToList();
+        Assert.NotEmpty(loadPath);
+        Assert.All(loadPath, o => Assert.Contains(moved, o, StringComparison.Ordinal));
+
+        /* Whether the SHIPPED placement is clean is the two rules above, not this one. Asserting it here as
+           well would make one misplaced panel red three tests and cost a reader the attribution. */
+    }
+
+    // ── The chain ────────────────────────────────────────────────────────────────────────────────
+
+    private sealed record RegistryTab(string Constant, string Id, string Header, int InnerTabIndex, string XamlTabName, IReadOnlyList<string> Collectors);
+
+    private sealed record PlacementChain(
+        IReadOnlyList<RegistryTab> Registry,
+        IReadOnlyDictionary<int, string> XamlTabAt,
+        IReadOnlyDictionary<string, string> TabOf,
+        IReadOnlyDictionary<string, IReadOnlySet<string>> NamedBy,
+        IReadOnlyDictionary<string, IReadOnlySet<string>> PanelsOf,
+        IReadOnlyDictionary<string, IReadOnlySet<string>> LoadPathOf)
+    {
+        /// <summary>Collector -> the XAML TabItem the registry places it on.</summary>
+        public IReadOnlyDictionary<string, string> PlacedOn { get; } =
+            Registry.SelectMany(t => t.Collectors.Select(c => (c, t.XamlTabName)))
+                    .ToDictionary(p => p.c, p => p.XamlTabName, StringComparer.Ordinal);
+
+        public IReadOnlyList<string> Collectors { get; } =
+            Registry.SelectMany(t => t.Collectors).Distinct(StringComparer.Ordinal).ToList();
+    }
+
+    /// <summary>Every loader method that names <paramref name="collector"/>.</summary>
+    private static List<string> Methods(PlacementChain chain, string collector) =>
+        chain.NamedBy.Where(p => p.Value.Contains(collector))
+             .Select(p => p.Key)
+             .OrderBy(m => m, StringComparer.Ordinal)
+             .ToList();
+
+    /// <summary>Every panel assigned by a method that names <paramref name="collector"/>.</summary>
+    private static List<string> Panels(PlacementChain chain, string collector) =>
+        Methods(chain, collector)
+            .SelectMany(m => chain.PanelsOf[m])
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(p => p, StringComparer.Ordinal)
+            .ToList();
+
+    /// <summary>
+    /// Registry against the XAML, plus how many collector/panel pairs it actually compared — the number the
+    /// floor is taken over, so a walk that found nothing cannot report a clean run.
+    /// </summary>
+    private static (List<string> Offenders, int Compared) DeclarationOffenders(
+        PlacementChain chain, IReadOnlyDictionary<string, string> placement)
+    {
+        var offenders = new List<string>();
+        var compared = 0;
+
+        foreach (var collector in chain.Collectors.OrderBy(c => c, StringComparer.Ordinal))
+        {
+            if (!placement.TryGetValue(collector, out var registryTab))
+            {
+                continue;
+            }
+
+            foreach (var panel in Panels(chain, collector))
+            {
+                if (!chain.TabOf.TryGetValue(panel, out var declaredIn))
+                {
+                    continue; /* not declared in this XAML at all — another file's control, not this rule's business */
+                }
+
+                compared++;
+
+                if (!string.Equals(declaredIn, registryTab, StringComparison.Ordinal))
+                {
+                    offenders.Add($"{collector} is registered on {registryTab} but its panel {panel} is "
+                                  + $"declared inside {declaredIn} (resolved through "
+                                  + $"{string.Join(", ", Methods(chain, collector))})");
+                }
+            }
+        }
+
+        return (offenders, compared);
+    }
+
+    /// <summary>Registry against the load path: which tabs' load paths reach the methods naming a collector.</summary>
+    private static List<string> LoadPathOffenders(
+        PlacementChain chain, IReadOnlyDictionary<string, string> placement)
+    {
+        var offenders = new List<string>();
+
+        foreach (var collector in chain.Collectors.OrderBy(c => c, StringComparer.Ordinal))
+        {
+            if (!placement.TryGetValue(collector, out var registryTab))
+            {
+                continue;
+            }
+
+            var methods = Methods(chain, collector);
+            if (methods.Count == 0)
+            {
+                continue; /* reported by EveryRegistryCollector_ResolvesToAPanel_OrIsNamedAsUnresolved */
+            }
+
+            var fillers = chain.LoadPathOf
+                .Where(p => methods.Any(m => p.Value.Contains(m)))
+                .Select(p => p.Key)
+                .OrderBy(t => t, StringComparer.Ordinal)
+                .ToList();
+
+            if (fillers.Count == 1 && string.Equals(fillers[0], registryTab, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            offenders.Add($"{collector} is registered on {registryTab} but its panels are filled by "
+                          + (fillers.Count == 0
+                              ? "no tab's load path at all"
+                              : $"{string.Join(" and ", fillers)}")
+                          + $" (resolved through {string.Join(", ", methods)})");
+        }
+
+        return offenders;
+    }
+
+    private static PlacementChain Read()
+    {
+        var x = XName.Get("Name", "http://schemas.microsoft.com/winfx/2006/xaml");
+        var doc = XDocument.Load(ViewerPath("ViewerServerTab.xaml"));
+
+        /* Parsed, never line ranges and never the position of a Header: two TabItems in this file read
+           Header="Blocking" - the SQL Server tab and the PostgreSQL sub-tab - so indexing on the header
+           picks whichever comes first. */
+        var innerTabs = doc.Descendants().Single(e => e.Attribute(x)?.Value == "InnerTabs");
+        var xamlTabAt = innerTabs.Elements()
+            .Where(e => e.Name.LocalName == "TabItem")
+            .Select((e, i) => (Index: i, Name: e.Attribute(x)?.Value ?? string.Empty))
+            .ToDictionary(p => p.Index, p => p.Name);
+
+        var tabOf = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var element in doc.Descendants())
+        {
+            var name = element.Attribute(x)?.Value;
+            if (name is null)
+            {
+                continue;
+            }
+
+            /* Outermost, not nearest: a panel in Activity's Blocking sub-tab belongs to Activity. */
+            var owner = element.Ancestors()
+                .Where(a => a.Name.LocalName == "TabItem" && a.Attribute(x)?.Value is not null)
+                .Select(a => a.Attribute(x)!.Value)
+                .LastOrDefault(t => t.StartsWith("Pg", StringComparison.Ordinal));
+
+            if (owner is not null)
+            {
+                tabOf[name] = owner;
+            }
+        }
+
+        var shell = ViewerFile("ViewerServerTab.xaml.cs");
+        var indices = IndexConstant.Matches(shell)
+            .ToDictionary(m => m.Groups["constant"].Value, m => int.Parse(m.Groups["index"].Value), StringComparer.Ordinal);
+
+        var registry = new List<RegistryTab>();
+        foreach (Match entry in RegistryEntry.Matches(Strip(ViewerFile("ViewerPostgresTabs.cs"))))
+        {
+            var constant = entry.Groups["constant"].Value;
+            Assert.True(indices.ContainsKey(constant),
+                $"The registry occupies {constant}, which ViewerServerTab.xaml.cs does not declare — the "
+                + "index constants and the registry have drifted apart and nothing here can resolve a tab.");
+
+            var index = indices[constant];
+            Assert.True(xamlTabAt.ContainsKey(index),
+                $"{constant} is {index}, past the last of the {xamlTabAt.Count} TabItems ViewerServerTab.xaml "
+                + "declares inside InnerTabs, so the registry entry occupying it resolves to no tab at all.");
+            Assert.False(string.IsNullOrEmpty(xamlTabAt[index]),
+                $"The TabItem at index {index} ({constant}) carries no x:Name, so no panel can be resolved "
+                + "to it and every collector on that registry entry would go unchecked.");
+
+            registry.Add(new RegistryTab(
+                constant,
+                entry.Groups["id"].Value,
+                entry.Groups["header"].Value,
+                index,
+                xamlTabAt[index],
+                Regex.Matches(entry.Groups["collectors"].Value, @"""(?<name>pg_[a-z_]+)""")
+                    .Select(m => m.Groups["name"].Value)
+                    .ToList()));
+        }
+
+        var bodies = MethodBodies(Strip(ViewerFile("ViewerServerTab.Postgres.cs")));
+
+        var namedBy = new Dictionary<string, IReadOnlySet<string>>(StringComparer.Ordinal);
+        var panelsOf = new Dictionary<string, IReadOnlySet<string>>(StringComparer.Ordinal);
+        foreach (var (method, body) in bodies)
+        {
+            var named = CollectorNamed.Matches(body).Select(m => m.Groups["collector"].Value).ToHashSet(StringComparer.Ordinal);
+            if (named.Count > 0)
+            {
+                namedBy[method] = named;
+            }
+
+            panelsOf[method] = ControlAssignment.Matches(body).Select(m => m.Groups["name"].Value).ToHashSet(StringComparer.Ordinal);
+        }
+
+        var loadPathOf = new Dictionary<string, IReadOnlySet<string>>(StringComparer.Ordinal);
+        foreach (Match arm in DispatcherArm.Matches(shell))
+        {
+            var constant = arm.Groups["constant"].Value;
+            if (!indices.TryGetValue(constant, out var index)
+                || !xamlTabAt.TryGetValue(index, out var tab)
+                || !tab.StartsWith("Pg", StringComparison.Ordinal))
+            {
+                continue; /* a SQL Server arm — this file only speaks for the PostgreSQL run */
+            }
+
+            loadPathOf[tab] = Transitive(arm.Groups["loader"].Value, bodies, new HashSet<string>(StringComparer.Ordinal));
+        }
+
+        return new PlacementChain(registry, xamlTabAt, tabOf, namedBy, panelsOf, loadPathOf);
+    }
+
+    /// <summary>Every <c>LoadPg…Async</c> reachable from <paramref name="method"/>, itself included.</summary>
+    private static IReadOnlySet<string> Transitive(string method, Dictionary<string, string> bodies, HashSet<string> seen)
+    {
+        var found = new HashSet<string>(StringComparer.Ordinal);
+        if (!seen.Add(method) || !bodies.TryGetValue(method, out var body))
+        {
+            return found;
+        }
+
+        found.Add(method);
+
+        foreach (Match m in LoaderCall.Matches(body))
+        {
+            var callee = m.Groups["name"].Value;
+            if (callee != method)
+            {
+                found.UnionWith(Transitive(callee, bodies, seen));
+            }
+        }
+
+        return found;
+    }
+
+    /// <summary>
+    /// Comments out — doc, line and block — so prose naming a collector or a grid cannot read as a call or an
+    /// assignment. The registry's own reasoning is block comments INSIDE the initialiser and several of them
+    /// name collectors.
+    /// </summary>
+    private static string Strip(string source)
+    {
+        source = Regex.Replace(source, @"^[ \t]*///.*$", string.Empty, RegexOptions.Multiline);
+        source = Regex.Replace(source, @"/\*.*?\*/", string.Empty, RegexOptions.Singleline);
+        return Regex.Replace(source, @"//.*$", string.Empty, RegexOptions.Multiline);
+    }
+
+    private static Dictionary<string, string> MethodBodies(string source)
+    {
+        var bodies = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (Match m in Regex.Matches(source, @"private\s+async\s+Task\s+(?<name>LoadPg[A-Za-z]+Async)\s*\("))
+        {
+            var depth = 0;
+            var started = false;
+            for (var i = m.Index; i < source.Length; i++)
+            {
+                if (source[i] == '{')
+                {
+                    depth++;
+                    started = true;
+                }
+                else if (source[i] == '}')
+                {
+                    depth--;
+                    if (started && depth == 0)
+                    {
+                        bodies[m.Groups["name"].Value] = source[m.Index..(i + 1)];
+                        break;
+                    }
+                }
+            }
+        }
+
+        return bodies;
+    }
+
+    /// <summary>Same <c>[CallerFilePath]</c> resolver <c>ViewerPostgresTabsTests</c> uses — no walk-up, so it
+    /// cannot resolve to the wrong tree or fail to resolve at all.</summary>
+    private static string ViewerFile(string fileName, [CallerFilePath] string thisFile = "") =>
+        File.ReadAllText(ViewerPath(fileName, thisFile));
+
+    private static string ViewerPath(string fileName, [CallerFilePath] string thisFile = "") =>
+        Path.Combine(
+            Path.GetDirectoryName(Path.GetDirectoryName(thisFile)!)!,
+            "PerformanceMonitor.Darling.Viewer",
+            fileName);
+}


### PR DESCRIPTION
Fixes #3062.

## The comparison that was missing

Three artifacts describe where a PostgreSQL panel lives: `ViewerPostgresTabs.All` (declared intent, whose `Collectors` parameter is documented "every collector whose stored rows this tab renders"), `ViewerServerTab.xaml` (where it renders) and the loader call graph (which tab's load path fills it). `ViewerPostgresTabsTests` held the registry to the catalog and to the tab STRIP — indices, headers, contiguity — but never to the panels inside a tab. `PgPanelTabOwnershipTests` (#3051) held the load path to the XAML. Nothing consulted the registry about a panel, so when the load path and the XAML disagreed there was no third opinion to say which of them had left the declared intent — and #3048 was resolved through five circumstantial signals for exactly that reason.

`PgRegistryPanelPlacementTests` is that comparison, in both directions: a collector's panels must be declared inside the tab the registry places it on, AND filled by that tab's load path.

## The chain, and the six-collector shortfall

`registry collector -> the loader method naming it -> the panels that method assigns -> the outermost named TabItem those panels sit in`, compared against the registry's own tab.

The shortfall the issue carries is real and is resolved by a second link rather than an exemption list. `PgCollectorIsGatedOff("pg_deadlocks")` names 21 of the 27 registry collectors; the other six — `pg_autovacuum_stats`, `pg_database_stats`, `pg_io_stats`, `pg_replication_slots`, `pg_wraparound_stats`, `pg_xmin_horizon` — issue their read unconditionally and name themselves only through `PanelNote("pg_xmin_horizon", …)`. Both forms are read, and together they resolve **27 of 27**, so the unresolved set is asserted EMPTY rather than carried as a stated list.

`PanelNote` is not a fallback but the better link of the two: every panel has one by construction, `ViewerPostgresTabsTests.EveryPostgresPanel_ExplainsItsOwnEmptyState` already refuses a panel without one, and its first argument is keyed on the same collector name the capability sentence takes. Reading only the gate call would have covered 21 and skipped six **silently** — and those six are the entire Vacuum causal chain plus both halves of Replication.

Resolving a collector's panels by NAME instead was measured and rejected: 8 of the 27 have no control named after them (`pg_extension_availability`, `pg_cpu_utilization`, `pg_statement_stats`, `pg_autovacuum_stats`, `pg_wraparound_stats`, `pg_plan_capture_readiness`, `pg_table_bloat_stats`, `pg_index_usage_stats`), and four notes are named for the tab or the subject rather than the collector (`PgWaitsNote`, `PgIoNote`, `PgReplicationNote`, `PgDatabasesNote`).

## Floors, so a walk that finds nothing cannot report a clean run

The POPULATION floors live in the shared read, not in each rule, because a rule's own floor cannot save it: the declaration rule floors its pair count at two per registry collector, and that is `0 >= 0` on a chain that parsed no entries. Measured — with the registry constants imported rather than qualified so the entry-head parse matches nothing, that rule was **green** while the other five red on their own floors. Now all six inherit: exactly 7 registry entries, >= 25 collectors, >= 15 loader methods naming one.

On top of that:

- collector/panel pairs compared >= 2 per registry collector (every panel block is a note plus a grid; 116 pairs compared on this tree), and 7 dispatcher arms resolving to a tab
- every registry index resolves to a TabItem that exists and carries an `x:Name` starting `Pg`, whose `Header` is the registry's own — a registry entry that resolved to an unnamed SQL Server tab would make both rules SKIP it rather than fail it
- the registry parse is cross-checked against a second reading of the same file that shares no code with it: how many entries the CODE constructs, and which collector-shaped LITERALS it holds
- a collector that resolves to a method which assigns no panel is reported as unresolved, not as checked

`NoLoaderMethod_NamesCollectorsFromTwoDifferentRegistryTabs` keeps the per-method attribution sound: a method's panels are attributed to every collector it names, so a method naming two tabs' collectors makes "which panel belongs to which" underivable, and the message says to split it rather than leaving the two rules to blame the wrong one.

## How the source is read

Ownership is resolved by parsing the XAML with `System.Xml.Linq` and walking to the **outermost** named `TabItem` — Activity holds a sub-tab control, so a panel in its Blocking sub-tab still belongs to Activity. Not line ranges and not `Header="Blocking"`, of which the file has two: the SQL Server tab and the PostgreSQL sub-tab.

Both `.cs` files go through `CSharpSourceWalker` (#3052) rather than a comment-stripping regex of this file's own — the registry's reasoning lives in block comments BETWEEN its constructor arguments and several of them name collectors, and the loaders' comments name grids. The walk also makes the brace count that finds a method body immune to a brace inside a literal; probed against the real walker, a brace inside a plain, verbatim, raw or char literal, inside a comment, and an escaped `{{` or `}}` in an interpolated string — including an unpaired `{{` — all come back blanked, while an interpolation hole keeps its own balanced pair.

Because the walk blanks literal TEXT, a registry entry's id, header and collector array are read positionally from `StringLiteralBodies`, and a collector name is read out of the original source at the offset the call matched in the walked text — the idiom `CommentFilterAdoptionTests.PrefixFilterSites` uses, sound because the two are character-aligned. Only a plain `"…"` literal is recognised; that is stated as a bound on the reader, and the unresolved-set assertion is what reds if it stops holding.

### The brace scan is asserted, not trusted

Adopting the walker for the brace scan would otherwise be an unverified refactor of the step every rule here stands on. **Measured: reverting the scan to raw source on today's tree is GREEN**, because every brace inside a `LoadPg*Async` body happens to appear in a balanced pair. "Safe today because they balance" is the standing assumption this file exists to refuse, so it is now asserted in two places.

The shared read re-checks every resolved range against the WALKED source, independently of what the scan was handed, and names the method. Three distinct failure shapes, all otherwise silent:

- a `}` inside a literal ends the count early and **truncates** the body, which assigns fewer panels and makes both placement rules quieter rather than red
- a `{` inside a literal runs the scan into the methods below and **over-extends**, attributing their panels to this method's collectors
- the same `{` at end of file finds no closing brace and the method is **dropped**, so every collector it names resolves to nothing

Well-formedness (brace-balanced, ending exactly on its own closing brace) names the first two; a declaration-count assertion names the drop.

`TheMethodWalk_ReadsABodyWhoseLiteralsHoldUnbalancedBraces_AndTheRawCountDoesNot` is the control, on an arranged body rather than the shipped tree precisely because the shipped tree balances today. It asserts both directions, so the walk is shown to be what saves it rather than asserted to be.

## Verification

`Darling.Tests` cannot run on macOS, so the real test files were compiled into a throwaway net10.0 xunit v3 host and run there. Executing pins went from **14 to 21** (7 new facts), `Failed: 0`, `Skipped: 0`, `Not Run: 0` on a clean tree.

Thirteen mutations against copies of the tree. The nine that must red each fail a different named assertion; two are green-by-design controls proving the walk is load-bearing:

| Mutation | Red assertion | What it names |
|---|---|---|
| #3048: deadlock pair back inside `PgVacuumTab` | `EveryRegistryCollectorsPanels_AreDeclaredInsideTheTabTheRegistryPlacesItOn` | `pg_deadlocks` registered on `PgActivityTab`, panels declared inside `PgVacuumTab` |
| #3050 pair 1: `LoadPgWaitSamplingAsync` called from the Activity load path | `EveryRegistryCollector_IsFilledByTheLoadPathOfTheTabTheRegistryPlacesItOn` | `pg_wait_sampling` registered on `PgWaitsTab`, filled by `PgActivityTab` |
| #3050 pair 2: `LoadPgPredicateStatsAsync` called from the Activity load path | same | `pg_predicate_stats` registered on `PgStorageTab`, filled by `PgActivityTab` |
| `pg_io_stats` stops being named by its loader | `EveryRegistryCollector_ResolvesToAPanel_OrIsNamedAsUnresolved` | `pg_io_stats — no loader method names it` |
| the I/O controls renamed off the `Pg` prefix | same | `pg_io_stats — named by LoadPgIoAsync, which assigns no panel` |
| a Storage collector's `PanelNote` added to `LoadPgActivityAsync` | `NoLoaderMethod_NamesCollectorsFromTwoDifferentRegistryTabs` | `LoadPgActivityAsync names collectors registered on PgActivityTab and PgStorageTab` |
| `PgWaitsInnerTabIndex` renumbered to 26 | the index resolution in the shared read | past the last of the 26 TabItems, so the entry resolves to no tab |
| the deadlock pair moved onto Vacuum in **both** the XAML **and** the load path | both registry rules | `pg_deadlocks` registered on `PgActivityTab`, declared inside and filled by `PgVacuumTab` |
| the registry constants imported rather than qualified, so the entry-head parse matches nothing | the population floor in the shared read | `Parsed 0 entries out of ViewerPostgresTabs.All` — all six rules, where the declaration rule alone had been green |
| an unbalanced `}` in a loader literal **plus** the raw brace scan | the body well-formedness check in the shared read | the body is TRUNCATED, named at the method — not a downstream count |
| an unbalanced `{` in a loader literal **plus** the raw brace scan | same | the scan OVER-EXTENDS past the method |
| the same unbalanced `}` with the walk **kept** | *(green — the walk is what saves it)* | new pin green; only the sibling's own floor trips |
| the raw brace scan alone, today's tree | *(green — the review thread's "safe today only because")* | nothing reds, which is why the assertion above exists |

In every one of the nine, `XamlGridRowRangeTests` stays green — nothing here reads `Grid.Row`. All three historical defects are caught, each naming the right collector and the right two tabs. The two `pg_io_stats` variants are the shortfall made visible: **only** the new pin reds on them — the existing guards are blind to a collector nothing resolves.

### The class only this comparison can see

Worth stating plainly rather than implying more than the diff earns: `PgPanelTabOwnershipTests` reds on all three historical defects too, because in each of them the XAML and the load path disagreed with EACH OTHER. What it cannot do is say which of them left the declared intent.

The eighth mutation is the decisive one. Move the deadlock pair onto Vacuum in the XAML **and** move the `LoadPgDeadlocksAsync` call into the Vacuum load path: `PgPanelTabOwnershipTests` goes fully **green**, because the two implementations now agree — and they are both wrong. Only the two rules here red, naming `pg_deadlocks`, the tab the registry gives it and the tab it moved to. A panel can be consistently in the wrong place, and consistency is exactly what the existing pin measures.

## Not verified

Nothing renders on macOS: no WPF window was opened, no panel was drawn, and no tab was clicked. Every claim here is about source and markup as parsed. `Darling.Tests` itself runs only on the Windows CI job.

## Out of scope, deliberately

- **Panel ORDER.** The registry documents its collector list as panel order and the Storage entry orders `pg_index_bloat` before `pg_column_stats` while the XAML renders column stats above index bloat (`Grid.Row` 5/6 vs 7/8). Pre-existing, untested in either direction, and this rule asserts WHICH tab only. Widening it to order is a separate decision.
- **"Two controls must not share a grid cell."** Not added — the shipped XAML has 31 deliberate visibility-toggled overlays, so it would need a 31-entry exemption table. `XamlGridRowRangeTests` (#3056) covers the exemption-free range rule.
- The #3049 grid-row collision is invisible to this pin and stays `XamlGridRowRangeTests`' to catch.
- **`PgPanelTabOwnershipTests` has both of the defects this PR just fixed in its sibling** — its `Strip` is a regex that misses `/* … */` blocks entirely, and its `MethodBodies` counts braces on that raw output. Under the unbalanced-`}` mutation it does fail, but only because the truncation happened to zero out a whole tab and trip its own floor; a truncation removing some of a method's assignments rather than all of them would pass. Filed separately rather than widened into this PR.

## CHANGELOG

Not edited here — every lane appends to the same `[Unreleased]` block and a per-PR edit conflicts with whichever sibling merges first. Entry text for the coordinator:

- Pinned the PostgreSQL panel registry against both the XAML that renders its panels and the load path that fills them, resolving every one of the 27 registry collectors to its panels through the two names its loader already carries.
