### PR TITLE
Fixes #3063

### DIFF
--- a/Lite.Tests/CrossAppGuardCiGateTests.cs
+++ b/Lite.Tests/CrossAppGuardCiGateTests.cs
@@ -35,6 +35,13 @@ namespace Lite.Tests;
 /// <para>Only references that RESOLVE on disk are required, which drops message strings and the filter
 /// patterns other guards assert on (those carry glob characters and are excluded outright). The glob matcher
 /// is self-validated against known answers below, so a matcher bug fails loudly instead of green-washing.</para>
+///
+/// <para><b>Two populations, because a cross-app read is not always C#.</b> A linked compile —
+/// <c>&lt;Compile Include="..\Darling\Darling.Tests\X.cs" /&gt;</c> — is a read of exactly the kind this
+/// guard exists to require be filter-reachable, and #3063 was filed because a <c>*.cs</c>-only scan could not
+/// see one: the file was never opened. So the scan reads project XML as well, and the MSBuild path
+/// normaliser is self-validated against known answers alongside the glob matcher, for the same reason —
+/// a relative <c>Include=</c> resolving to the WRONG repo-rooted path finds nothing and passes.</para>
 /// </summary>
 public class CrossAppGuardCiGateTests
 {
@@ -64,6 +71,97 @@ public class CrossAppGuardCiGateTests
 
         Assert.True(Matches("README.md", "README.md"));
         Assert.False(Matches("README.md", "Lite/README.md"));
+    }
+
+    /// <summary>
+    /// The MSBuild half of the self-validation above, and for the same reason: a relative
+    /// <c>Include=</c> that normalised to the WRONG repo-rooted path would match no filter pattern and
+    /// find no file on disk, so <see cref="Resolve"/> would drop it and every coverage check would pass
+    /// having seen nothing. The first case is #3059's linked compile — the reference #3063 exists for.
+    /// </summary>
+    [Fact]
+    public void TheMsBuildPathNormaliser_AgreesWithKnownAnswers()
+    {
+        var repo = RepoRoot();
+        var liteTests = Path.Combine(repo, LiteTestsDir);
+        var darlingTests = Path.Combine(repo, DarlingTestsDir.Replace('/', Path.DirectorySeparatorChar));
+
+        Assert.Equal(
+            "Darling/Darling.Tests/CSharpSourceWalker.cs",
+            RepoRooted(repo, liteTests, @"..\Darling\Darling.Tests\CSharpSourceWalker.cs", "Darling"));
+
+        /* Forward slashes are legal in MSBuild too, and so is a redundant segment. */
+        Assert.Equal(
+            "Darling/Darling.Tests/CSharpSourceWalker.cs",
+            RepoRooted(repo, liteTests, "../Darling/./Darling.Tests/CSharpSourceWalker.cs", "Darling"));
+
+        /* The other direction is two levels up, out of Darling/Darling.Tests. */
+        Assert.Equal(
+            "Lite/Services/DataImportService.cs",
+            RepoRooted(repo, darlingTests, @"..\..\Lite\Services\DataImportService.cs", "Lite"));
+
+        /* Same app, so not this guard's business — and the discrimination a relative path cannot make
+           until it is resolved, since both spellings open with the same "..\". */
+        Assert.Null(RepoRooted(repo, liteTests, @"..\Lite\Mcp\McpHostService.cs", "Darling"));
+        Assert.Null(RepoRooted(repo, liteTests, @"Fixtures\SystemHealth\*.xml", "Darling"));
+
+        /* A wildcard over the other app IS a read, so it becomes the directory it enumerates. Spelled
+           against a directory that does not exist, deliberately: an expected value written as a real
+           "Darling/..." literal is itself matched by the C# stage above, and would put a path nothing
+           actually reads into the found set. The normaliser never touches the disk, so a fictional
+           directory tests it exactly as well. */
+        Assert.Equal(
+            "Darling/NoSuchArea/Fixtures",
+            RepoRooted(repo, liteTests, @"..\Darling\NoSuchArea\Fixtures\*.xml", "Darling"));
+
+        /* Out of the tree entirely, and not a path at all. */
+        Assert.Null(RepoRooted(repo, liteTests, @"..\..\Darling\X.cs", "Darling"));
+        Assert.Null(RepoRooted(repo, liteTests, "xunit.v3", "Darling"));
+    }
+
+    /// <summary>
+    /// The population is what failed in #3063, so it is pinned directly rather than left implied.
+    ///
+    /// <para>The collector enumerated <c>*.cs</c> only, so a cross-app read expressed as
+    /// <c>&lt;Compile Include="..\Darling\Darling.Tests\X.cs" /&gt;</c> was invisible — the file holding it
+    /// was never opened. A widened collector that reaches no project files passes exactly as the narrow one
+    /// did, which would be the same defect committed by its own fix. So the file that WOULD carry such a
+    /// reference is required to be in the population, by name, rather than merely counted.</para>
+    ///
+    /// <para><see cref="ImportedBuildFiles"/> is reported and not floored: there is no
+    /// <c>Directory.Build.props</c> or <c>Directory.Build.targets</c> in this repository today, and asserting
+    /// one exists would be asserting a fiction. It is in the population so the first one is read.</para>
+    /// </summary>
+    [Fact]
+    public void ThePopulationReachesTheProjectFiles_AndNotOnlyTheCSharp()
+    {
+        var repo = RepoRoot();
+
+        var expectations = new[]
+        {
+            (Project: LiteTestsDir, OtherApp: "Darling", Manifest: $"{LiteTestsDir}/Lite.Tests.csproj"),
+            (Project: DarlingTestsDir, OtherApp: "Lite", Manifest: $"{DarlingTestsDir}/Darling.Tests.csproj"),
+        };
+
+        foreach (var (project, otherApp, manifest) in expectations)
+        {
+            var scan = Scan(repo, project, otherApp);
+
+            Assert.True(scan.CSharpFiles > 0, $"the C# stage opened no files under {project}");
+
+            Assert.True(
+                scan.ProjectFiles.Contains(manifest, StringComparer.Ordinal),
+                $"the MSBuild stage did not open {manifest}, so an Include= naming {otherApp} there would " +
+                $"be invisible. Opened: [{string.Join(", ", scan.ProjectFiles)}]");
+
+            /* Build output holds a copy of the project file on any machine that has built the suite; a
+               scan that read it would assert on an artifact, and on this repo's own CI that copy is the
+               one a stale build left behind. */
+            Assert.DoesNotContain(
+                scan.ProjectFiles,
+                p => p.Contains("/bin/", StringComparison.Ordinal) ||
+                     p.Contains("/obj/", StringComparison.Ordinal));
+        }
     }
 
     [Fact]
@@ -162,44 +260,76 @@ public class CrossAppGuardCiGateTests
             yaml[step..Math.Min(step + 400, yaml.Length)],
             StringComparison.Ordinal);
 
-        foreach (var reference in CrossAppReferences(repo, scannedProject, otherApp))
+        var scan = Scan(repo, scannedProject, otherApp);
+
+        /* #3063: a widened population that reaches no project files passes exactly as the *.cs-only one
+           did, which is the defect committed by its own fix. Each stage is floored by name, because
+           "found no references" and "opened no files" are otherwise the same green. */
+        Assert.True(scan.CSharpFiles > 0, $"the C# stage opened no files under {scannedProject}");
+        Assert.True(
+            scan.ProjectFiles.Count > 0,
+            $"the MSBuild stage opened no project files under {scannedProject}, so a cross-app reference " +
+            "written as an Include= attribute is invisible again");
+
+        /* This guard's failure direction is not noticing, so a path it CANNOT read has to be loud rather
+           than absent from the found set. */
+        Assert.True(
+            scan.UnevaluablePaths.Count == 0,
+            "MSBuild path attributes this scan cannot evaluate, so it cannot say whether they cross apps — " +
+            "spell the path literally, or teach RepoRooted the property:\n  " +
+            string.Join("\n  ", scan.UnevaluablePaths));
+
+        foreach (var reference in scan.References)
         {
             if (!patterns.Any(p => Matches(p, reference.Probe)))
             {
                 failures.Add(
-                    $"{scannedProject} reads {reference.Raw} but the '{filterName}' filter does not reach it " +
-                    $"(probe path: {reference.Probe})");
+                    $"{scannedProject} reads {reference.Raw} (named in {reference.Origin}) but the " +
+                    $"'{filterName}' filter does not reach it (probe path: {reference.Probe})");
             }
         }
     }
 
+    /// <summary>What one scan found, carried together with what it opened to find it. One value rather
+    /// than a bare reference list, because a found set is not interpretable without the population that
+    /// produced it — an empty population and an empty answer are the same green.</summary>
+    private readonly record struct CrossAppScan(
+        int CSharpFiles,
+        IReadOnlyList<string> ProjectFiles,
+        IReadOnlyList<string> ImportedBuildFiles,
+        IReadOnlyList<string> UnevaluablePaths,
+        IReadOnlyList<(string Raw, string Probe, string Origin)> References);
+
+    /* The MSBuild attributes that can carry a path to another app's file. Remove= is deliberately
+       absent: dropping an item from a glob is not a read of it. */
+    private static readonly Regex MsBuildPathAttribute = new(
+        "\\b(?:Include|Update|Project|HintPath)\\s*=\\s*(?:\"(?<dq>[^\"]*)\"|'(?<sq>[^']*)')",
+        RegexOptions.Compiled);
+
     /// <summary>Repo-relative paths naming <paramref name="otherApp"/> that a test in
     /// <paramref name="project"/> reads, paired with a concrete file path to test coverage against.</summary>
-    private static IEnumerable<(string Raw, string Probe)> CrossAppReferences(
-        string repo, string project, string otherApp)
+    private static CrossAppScan Scan(string repo, string project, string otherApp)
     {
-        var seen = new SortedSet<string>(StringComparer.Ordinal);
+        /* Keyed by the reference, valued by every file that named it, so a failure says where to go. */
+        var seen = new SortedDictionary<string, SortedSet<string>>(StringComparer.Ordinal);
+        var unevaluable = new List<string>();
         var projectRoot = Path.Combine(repo, project.Replace('/', Path.DirectorySeparatorChar));
         if (!Directory.Exists(projectRoot))
         {
             throw new DirectoryNotFoundException($"test project not found: {project}");
         }
 
-        foreach (var file in Directory.EnumerateFiles(projectRoot, "*.cs", SearchOption.AllDirectories))
+        var csharpFiles = 0;
+        foreach (var file in TrackedFiles(projectRoot, "*.cs"))
         {
-            /* Build output carries copies of product source; scanning it would assert on artifacts. */
-            if (file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal) ||
-                file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
-            {
-                continue;
-            }
-
+            csharpFiles++;
             var text = File.ReadAllText(file);
+            var origin = Rooted(repo, file);
 
             /* "Darling/Some/Path.cs" and the backslash spelling some Windows-facing pins use. */
             foreach (Match m in Regex.Matches(text, "\"(" + Regex.Escape(otherApp) + "[/\\\\][^\"]+)\""))
             {
-                seen.Add(m.Groups[1].Value.Replace('\\', '/'));
+                Note(seen, m.Groups[1].Value.Replace('\\', '/'), origin);
             }
 
             /* Path.Combine("Darling", "Darling.Tests", "X.cs") */
@@ -211,15 +341,211 @@ public class CrossAppGuardCiGateTests
                     .ToArray();
                 if (segments.Length > 0)
                 {
-                    seen.Add(otherApp + "/" + string.Join("/", segments));
+                    Note(seen, otherApp + "/" + string.Join("/", segments), origin);
                 }
             }
         }
 
-        foreach (var raw in seen)
+        /* The second population, and the one #3063 was filed for. Neither matcher above can see a linked
+           compile: the path is relative and backslashed, so their otherApp anchor never fires — but that
+           is downstream of the real reason, which is that project XML is not a *.cs file and was never
+           opened. The project's own files first, then the build files MSBuild imports into it unnamed. */
+        var projectFiles = TrackedFiles(projectRoot, "*.csproj")
+            .OrderBy(f => f, StringComparer.Ordinal)
+            .ToList();
+        var importedBuildFiles = ImportedBuildFiles(repo, projectRoot).ToList();
+
+        foreach (var file in projectFiles)
         {
+            ReadMsBuildPaths(repo, file, Path.GetDirectoryName(file)!, otherApp, seen, unevaluable);
+        }
+
+        foreach (var file in importedBuildFiles)
+        {
+            /* MSBuild resolves a relative item path in an IMPORTED file against the consuming project's
+               directory, not the imported file's own — which is why these resolve against projectRoot
+               even for a Directory.Build.props sitting at the repo root. */
+            ReadMsBuildPaths(repo, file, projectRoot, otherApp, seen, unevaluable);
+        }
+
+        return new CrossAppScan(
+            csharpFiles,
+            projectFiles.Select(f => Rooted(repo, f)).ToList(),
+            importedBuildFiles.Select(f => Rooted(repo, f)).ToList(),
+            unevaluable,
+            Resolve(repo, seen).ToList());
+    }
+
+    /// <summary>Every file that names a reference is recorded, not just the first. The two populations
+    /// can name the same path — a linked compile and a pin that reads the linked file both do — and a
+    /// failure that reported only one of them would say the reference came from the C# and leave the
+    /// project entry looking unread.</summary>
+    private static void Note(SortedDictionary<string, SortedSet<string>> seen, string raw, string origin)
+    {
+        if (!seen.TryGetValue(raw, out var origins))
+        {
+            origins = new SortedSet<string>(StringComparer.Ordinal);
+            seen[raw] = origins;
+        }
+
+        origins.Add(origin);
+    }
+
+    /// <summary>Files of one pattern under <paramref name="root"/>, minus build output — that carries
+    /// copies of product source, and scanning it would assert on artifacts.</summary>
+    private static IEnumerable<string> TrackedFiles(string root, string pattern) =>
+        Directory.EnumerateFiles(root, pattern, SearchOption.AllDirectories)
+            .Where(f =>
+                !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal) &&
+                !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal));
+
+    /// <summary>The build files MSBuild imports into a project without being named: any
+    /// <c>Directory.Build.props</c> / <c>Directory.Build.targets</c> from the project directory up to and
+    /// including the repo root.
+    ///
+    /// <para>There are none in this repository today, and nothing here asserts there are. They are in the
+    /// population because an <c>ItemGroup</c> in one can legally carry a cross-app <c>Compile Include</c> —
+    /// for a file OUTSIDE the project cone there is no duplicate-item conflict with the SDK's later default
+    /// glob, so it works — which is the same invisible shape as a <c>.csproj</c> entry in a file no
+    /// <c>.csproj</c> scan would open. The point is that the first one is read rather than this test needing
+    /// to be edited first.</para></summary>
+    private static IEnumerable<string> ImportedBuildFiles(string repo, string projectRoot)
+    {
+        var root = Path.GetFullPath(repo).TrimEnd(Path.DirectorySeparatorChar);
+
+        for (var dir = new DirectoryInfo(Path.GetFullPath(projectRoot)); dir is not null; dir = dir.Parent)
+        {
+            foreach (var name in new[] { "Directory.Build.props", "Directory.Build.targets" })
+            {
+                var candidate = Path.Combine(dir.FullName, name);
+                if (File.Exists(candidate))
+                {
+                    yield return candidate;
+                }
+            }
+
+            if (string.Equals(
+                    dir.FullName.TrimEnd(Path.DirectorySeparatorChar), root, StringComparison.Ordinal))
+            {
+                break;
+            }
+        }
+    }
+
+    /// <summary>The <paramref name="otherApp"/> paths one MSBuild file names, repo-rooted into
+    /// <paramref name="seen"/>.</summary>
+    private static void ReadMsBuildPaths(
+        string repo,
+        string file,
+        string projectDir,
+        string otherApp,
+        SortedDictionary<string, SortedSet<string>> seen,
+        List<string> unevaluable)
+    {
+        var text = File.ReadAllText(file);
+        var origin = Rooted(repo, file);
+        var thisFileDir = Path.GetDirectoryName(file)! + Path.DirectorySeparatorChar;
+
+        foreach (Match m in MsBuildPathAttribute.Matches(text))
+        {
+            var raw = m.Groups["dq"].Success ? m.Groups["dq"].Value : m.Groups["sq"].Value;
+
+            /* The two properties a hand-written cross-app include actually uses. */
+            var expanded = raw
+                .Replace("$(MSBuildThisFileDirectory)", thisFileDir, StringComparison.Ordinal)
+                .Replace("$(MSBuildProjectDirectory)", projectDir, StringComparison.Ordinal);
+
+            if (expanded.Contains("$(", StringComparison.Ordinal) ||
+                expanded.Contains("%(", StringComparison.Ordinal))
+            {
+                /* Only MSBuild can evaluate what is left. Recorded rather than dropped, so the caller
+                   can be loud about a path this guard cannot read. */
+                unevaluable.Add($"{origin}: {raw}");
+                continue;
+            }
+
+            var rooted = RepoRooted(repo, projectDir, expanded, otherApp);
+            if (rooted is not null)
+            {
+                Note(seen, rooted, origin);
+            }
+        }
+    }
+
+    /// <summary>One MSBuild path attribute, expressed the way the rest of this class reasons about paths:
+    /// repo-rooted, forward slashes.
+    ///
+    /// <para>This is the whole difficulty of #3063's fix. An <c>Include=</c> is RELATIVE to the project
+    /// directory and spelled with backslashes (<c>..\Darling\Darling.Tests\X.cs</c>), so it names no app at
+    /// all until it is resolved — the <paramref name="otherApp"/> anchor the C# matchers open with cannot
+    /// fire on it, and applying that anchor AFTER normalisation is what leaves every coverage decision
+    /// downstream of here unchanged.</para>
+    ///
+    /// <para>Null when the path names something other than <paramref name="otherApp"/>, resolves outside the
+    /// repository, or is not a path at all (a <c>PackageReference</c>'s Include is a package id).</para></summary>
+    private static string? RepoRooted(string repo, string projectDir, string raw, string otherApp)
+    {
+        if (raw.Length == 0)
+        {
+            return null;
+        }
+
+        var native = raw.Replace('\\', Path.DirectorySeparatorChar)
+                        .Replace('/', Path.DirectorySeparatorChar);
+
+        string full;
+        try
+        {
+            full = Path.GetFullPath(Path.Combine(projectDir, native));
+        }
+        catch (ArgumentException)
+        {
+            return null;
+        }
+
+        var prefix = Path.GetFullPath(repo).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        if (!full.StartsWith(prefix, StringComparison.Ordinal))
+        {
+            /* Outside the tree, so no path filter could name it. */
+            return null;
+        }
+
+        var rooted = full[prefix.Length..].Replace(Path.DirectorySeparatorChar, '/');
+
+        /* An MSBuild wildcard is a real file set. In C# source a glob is the opposite — there the pattern
+           IS the assertion, which is why Resolve excludes those outright — so reduce it to the directory
+           it enumerates and let the directory arm probe it, rather than dropping a genuine read. */
+        var wildcard = rooted.IndexOfAny(new[] { '*', '?' });
+        if (wildcard >= 0)
+        {
+            var cut = rooted.LastIndexOf('/', wildcard);
+            if (cut <= 0)
+            {
+                return null;
+            }
+
+            rooted = rooted[..cut];
+        }
+
+        return rooted.Equals(otherApp, StringComparison.Ordinal)
+            || rooted.StartsWith(otherApp + "/", StringComparison.Ordinal)
+                ? rooted
+                : null;
+    }
+
+    /// <summary>Each collected reference paired with a concrete file path to test coverage against.</summary>
+    private static IEnumerable<(string Raw, string Probe, string Origin)> Resolve(
+        string repo, SortedDictionary<string, SortedSet<string>> seen)
+    {
+        foreach (var (raw, named) in seen)
+        {
+            /* Every file that named it, so a failure points at all of them. */
+            var origin = string.Join(", ", named);
+
             /* A reference carrying glob syntax is an assertion ABOUT the filter (WatermarkPolicyTests does
-               this), not a file read. Excluded rather than matched, or the guard would assert on itself. */
+               this), not a file read. Excluded rather than matched, or the guard would assert on itself.
+               MSBuild wildcards never arrive here — RepoRooted reduces those to a directory, because in
+               project XML a wildcard IS a read. */
             if (raw.IndexOfAny(new[] { '*', '!', '(', ')', '{', '}' }) >= 0)
             {
                 continue;
@@ -229,16 +555,25 @@ public class CrossAppGuardCiGateTests
 
             if (File.Exists(onDisk))
             {
-                yield return (raw, raw);
+                yield return (raw, raw, origin);
             }
             else if (Directory.Exists(onDisk))
             {
                 /* Directory reads are EnumerateCsFiles-shaped, so coverage of *.cs inside it is the ask. */
-                yield return (raw + " (directory)", raw.TrimEnd('/') + "/CoverageProbe.cs");
+                yield return (raw + " (directory)", raw.TrimEnd('/') + "/CoverageProbe.cs", origin);
             }
 
             /* Anything that resolves to neither is a message string or a moved file — not this test's business. */
         }
+    }
+
+    /// <summary>A repo-relative, forward-slash spelling of an absolute path, for messages.</summary>
+    private static string Rooted(string repo, string absolute)
+    {
+        var prefix = Path.GetFullPath(repo).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        return absolute.StartsWith(prefix, StringComparison.Ordinal)
+            ? absolute[prefix.Length..].Replace(Path.DirectorySeparatorChar, '/')
+            : absolute;
     }
 
     /// <summary>The quoted pattern entries of one dorny/paths-filter area block.</summary>

--- a/Lite.Tests/CrossAppGuardCiGateTests.cs
+++ b/Lite.Tests/CrossAppGuardCiGateTests.cs
@@ -107,7 +107,7 @@ public class CrossAppGuardCiGateTests
 
         /* A wildcard over the other app IS a read, so it becomes the directory it enumerates. Spelled
            against a directory that does not exist, deliberately: an expected value written as a real
-           "Darling/..." literal is itself matched by the C# stage above, and would put a path nothing
+           repo-rooted path is itself matched by the C# stage above, and would put a path nothing
            actually reads into the found set. The normaliser never touches the disk, so a fictional
            directory tests it exactly as well. */
         Assert.Equal(
@@ -117,6 +117,35 @@ public class CrossAppGuardCiGateTests
         /* Out of the tree entirely, and not a path at all. */
         Assert.Null(RepoRooted(repo, liteTests, @"..\..\Darling\X.cs", "Darling"));
         Assert.Null(RepoRooted(repo, liteTests, "xunit.v3", "Darling"));
+    }
+
+    /// <summary>
+    /// A reference counts only when the path it resolved to spells it back, on every host.
+    ///
+    /// <para><c>Directory.Exists</c> answers according to the HOST's path rules, and Windows trims
+    /// trailing periods from a path component: a <c>Darling</c> segment followed by three dots resolves
+    /// to <c>Darling</c> there and to nothing on macOS or Linux. This guard runs on Windows in CI and
+    /// gets verified on macOS, and the divergence is not hypothetical — a three-dot path written
+    /// illustratively inside a comment in THIS file was matched by the C# stage, resolved on Windows
+    /// only, and failed the coverage check in a way no local run could reproduce. Every case below
+    /// answers identically on all three platforms.</para>
+    /// </summary>
+    [Fact]
+    public void TheOnDiskProbe_AnswersTheSameOnEveryHost()
+    {
+        var repo = RepoRoot();
+
+        Assert.NotNull(OnDisk(repo, DarlingTestsDir));
+        Assert.NotNull(OnDisk(repo, DarlingTestsDir + "/CSharpSourceWalker.cs"));
+
+        /* Trailing periods: Windows resolves this to the Darling directory, other hosts to nothing.
+           Neither is a read of anything, so both must say so. */
+        Assert.Null(OnDisk(repo, "Darling/..."));
+
+        /* A dot segment resolves everywhere, and still is not the path it was written as. */
+        Assert.Null(OnDisk(repo, DarlingTestsDir + "/."));
+
+        Assert.Null(OnDisk(repo, "Darling/NoSuchArea/Fixtures"));
     }
 
     /// <summary>
@@ -130,7 +159,8 @@ public class CrossAppGuardCiGateTests
     ///
     /// <para><see cref="ImportedBuildFiles"/> is reported and not floored: there is no
     /// <c>Directory.Build.props</c> or <c>Directory.Build.targets</c> in this repository today, and asserting
-    /// one exists would be asserting a fiction. It is in the population so the first one is read.</para>
+    /// one exists would be asserting a fiction. It is in the population so the first one is read, and it
+    /// takes only the NEAREST of each name, as MSBuild does.</para>
     /// </summary>
     [Fact]
     public void ThePopulationReachesTheProjectFiles_AndNotOnlyTheCSharp()
@@ -399,27 +429,41 @@ public class CrossAppGuardCiGateTests
                 !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal) &&
                 !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal));
 
-    /// <summary>The build files MSBuild imports into a project without being named: any
-    /// <c>Directory.Build.props</c> / <c>Directory.Build.targets</c> from the project directory up to and
-    /// including the repo root.
+    /// <summary>The build files MSBuild imports into a project without being named.
     ///
     /// <para>There are none in this repository today, and nothing here asserts there are. They are in the
     /// population because an <c>ItemGroup</c> in one can legally carry a cross-app <c>Compile Include</c> —
     /// for a file OUTSIDE the project cone there is no duplicate-item conflict with the SDK's later default
     /// glob, so it works — which is the same invisible shape as a <c>.csproj</c> entry in a file no
     /// <c>.csproj</c> scan would open. The point is that the first one is read rather than this test needing
-    /// to be edited first.</para></summary>
+    /// to be edited first.</para>
+    ///
+    /// <para><b>Nearest wins, per name, because that is what MSBuild does.</b>
+    /// <c>Microsoft.Common.props</c> probes upward for ONE <c>Directory.Build.props</c> and stops; it does
+    /// not chain through every one above the project, and it probes the two names independently. Collecting
+    /// all of them would attribute an item group to a project that never imports it, and a guard whose
+    /// findings are not trustworthy stops being read.</para>
+    ///
+    /// <para>A nearest file that deliberately chains to its parent does so through an <c>Import</c> whose
+    /// path is a property function, and <see cref="ReadMsBuildPaths"/> reports an unevaluable path as a
+    /// failure rather than ignoring it — so the chain is loud, not silently uncollected. That is the right
+    /// direction for a guard whose whole defect class is not noticing.</para></summary>
     private static IEnumerable<string> ImportedBuildFiles(string repo, string projectRoot)
     {
         var root = Path.GetFullPath(repo).TrimEnd(Path.DirectorySeparatorChar);
+        var names = new[] { "Directory.Build.props", "Directory.Build.targets" };
+        var found = new HashSet<string>(StringComparer.Ordinal);
 
-        for (var dir = new DirectoryInfo(Path.GetFullPath(projectRoot)); dir is not null; dir = dir.Parent)
+        for (var dir = new DirectoryInfo(Path.GetFullPath(projectRoot));
+             dir is not null && found.Count < names.Length;
+             dir = dir.Parent)
         {
-            foreach (var name in new[] { "Directory.Build.props", "Directory.Build.targets" })
+            foreach (var name in names)
             {
                 var candidate = Path.Combine(dir.FullName, name);
-                if (File.Exists(candidate))
+                if (!found.Contains(name) && File.Exists(candidate))
                 {
+                    found.Add(name);
                     yield return candidate;
                 }
             }
@@ -551,20 +595,47 @@ public class CrossAppGuardCiGateTests
                 continue;
             }
 
-            var onDisk = Path.Combine(repo, raw.Replace('/', Path.DirectorySeparatorChar));
+            /* Anything that resolves to nothing is a message string or a moved file — not this test's
+               business. */
+            var onDisk = OnDisk(repo, raw);
+            if (onDisk is null)
+            {
+                continue;
+            }
 
             if (File.Exists(onDisk))
             {
                 yield return (raw, raw, origin);
             }
-            else if (Directory.Exists(onDisk))
+            else
             {
                 /* Directory reads are EnumerateCsFiles-shaped, so coverage of *.cs inside it is the ask. */
                 yield return (raw + " (directory)", raw.TrimEnd('/') + "/CoverageProbe.cs", origin);
             }
-
-            /* Anything that resolves to neither is a message string or a moved file — not this test's business. */
         }
+    }
+
+    /// <summary>The on-disk path a repo-rooted reference names, or null when it names nothing real.
+    ///
+    /// <para>The round-trip is the load-bearing part. <c>Directory.Exists</c> answers according to the
+    /// HOST's path rules, and Windows trims trailing periods from a path component — so
+    /// <c>Darling</c> followed by a three-dot segment resolves to <c>Darling</c> there and to nothing on
+    /// macOS or Linux. This guard runs on Windows in CI and gets verified on macOS, so a reference counts
+    /// only when the path it resolved to spells it back, and the answer is the same on every host.</para></summary>
+    private static string? OnDisk(string repo, string raw)
+    {
+        var candidate = Path.Combine(repo, raw.Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(candidate) && !Directory.Exists(candidate))
+        {
+            return null;
+        }
+
+        return string.Equals(
+                Rooted(repo, Path.GetFullPath(candidate)),
+                raw.TrimEnd('/'),
+                StringComparison.Ordinal)
+            ? candidate
+            : null;
     }
 
     /// <summary>A repo-relative, forward-slash spelling of an absolute path, for messages.</summary>

--- a/Lite.Tests/CrossAppGuardCiGateTests.cs
+++ b/Lite.Tests/CrossAppGuardCiGateTests.cs
@@ -150,6 +150,12 @@ public class CrossAppGuardCiGateTests
                 </Reference>
                 <Reference Include="Other" HintPath="..\Other\C.dll" />
                 <Compile Remove="..\Other\Removed.cs" />
+                <Reference Include="Gated">
+                  <HintPath Condition="'$(Platform)'=='x64'">..\Other\x64\Gated.dll</HintPath>
+                </Reference>
+                <Reference Include="Angled">
+                  <HintPath Condition="'$(V)'>'1'">..\Other\Angled.dll</HintPath>
+                </Reference>
               </ItemGroup>
               <Import Project="..\Other\D.props" />
             </Project>
@@ -163,11 +169,18 @@ public class CrossAppGuardCiGateTests
                 "SomeLib",
                 "Other",
                 @"..\Other\C.dll",
+                "Gated",
+                "Angled",
                 @"..\Other\D.props",
 
-                /* The element spelling is collected after the attributes, and is the case the attribute
-                   matcher alone cannot see at all. */
+                /* The element spellings are collected after the attributes, and are the cases the
+                   attribute matcher alone cannot see at all. The last two carry their own attribute on
+                   the open tag - Condition, for a platform-specific hint path - and the last one's
+                   Condition holds a raw '>', which is legal in an attribute value and would end the tag
+                   early for a matcher that scanned to the next angle bracket. */
                 @"..\Other\bin\SomeLib.dll",
+                @"..\Other\x64\Gated.dll",
+                @"..\Other\Angled.dll",
             },
             MsBuildPaths(Xml));
 
@@ -446,8 +459,12 @@ public class CrossAppGuardCiGateTests
        reference written the ordinary way, silently invisible. Include, Update and Import's Project are
        item operations rather than metadata and have no element spelling, so this one matcher covers the
        whole difference between the two grammars. */
+    /* The open tag carries its own attributes - Condition is the usual one, for a platform-specific
+       hint path - so they are skipped by matching quoted values rather than by "anything up to the next
+       >". An attribute value may legally contain a raw > (only < and & must be escaped), and
+       [^>]* would end the tag inside it. */
     private static readonly Regex MsBuildPathElement = new(
-        "<HintPath\\s*>([^<]*)</HintPath\\s*>",
+        "<HintPath(?:\\s+[\\w:.-]+\\s*=\\s*(?:\"[^\"]*\"|'[^']*'))*\\s*>([^<]*)</HintPath\\s*>",
         RegexOptions.Compiled);
 
     /// <summary>Repo-relative paths naming <paramref name="otherApp"/> that a test in

--- a/Lite.Tests/CrossAppGuardCiGateTests.cs
+++ b/Lite.Tests/CrossAppGuardCiGateTests.cs
@@ -125,6 +125,57 @@ public class CrossAppGuardCiGateTests
     }
 
     /// <summary>
+    /// Both MSBuild spellings, because MSBuild accepts both and the element one is the common form.
+    ///
+    /// <para><c>HintPath</c> is item METADATA, and metadata may be written as an attribute or as a child
+    /// element — the element form being what Visual Studio emits for a legacy <c>&lt;Reference&gt;</c>.
+    /// Reading only the attribute form would be #3063 recurring one attribute over: the scan would
+    /// advertise a population wider than the one it has, which is the actual shape of that defect.
+    /// <c>Include</c>, <c>Update</c> and <c>Import</c>'s <c>Project</c> are item operations rather than
+    /// metadata and have no element spelling.</para>
+    ///
+    /// <para>Fed the shipped matchers rather than a retyped copy, so the pin cannot pass while the code
+    /// drifts underneath it.</para>
+    /// </summary>
+    [Fact]
+    public void TheMsBuildMatchers_ReadBothSpellings()
+    {
+        const string Xml = """
+            <Project>
+              <ItemGroup>
+                <Compile Include="..\Other\A.cs" Link="A.cs" />
+                <None Update='..\Other\B.xml' />
+                <Reference Include="SomeLib">
+                  <HintPath>..\Other\bin\SomeLib.dll</HintPath>
+                </Reference>
+                <Reference Include="Other" HintPath="..\Other\C.dll" />
+                <Compile Remove="..\Other\Removed.cs" />
+              </ItemGroup>
+              <Import Project="..\Other\D.props" />
+            </Project>
+            """;
+
+        Assert.Equal(
+            new[]
+            {
+                @"..\Other\A.cs",
+                @"..\Other\B.xml",
+                "SomeLib",
+                "Other",
+                @"..\Other\C.dll",
+                @"..\Other\D.props",
+
+                /* The element spelling is collected after the attributes, and is the case the attribute
+                   matcher alone cannot see at all. */
+                @"..\Other\bin\SomeLib.dll",
+            },
+            MsBuildPaths(Xml));
+
+        /* Remove= is absent by design: dropping an item from a glob is not a read of it. */
+        Assert.DoesNotContain(@"..\Other\Removed.cs", MsBuildPaths(Xml));
+    }
+
+    /// <summary>
     /// A reference counts only when the path it resolved to spells it back, on every host.
     ///
     /// <para><c>Directory.Exists</c> answers according to the HOST's path rules, and Windows trims
@@ -389,6 +440,16 @@ public class CrossAppGuardCiGateTests
         "\\b(?:Include|Update|Project|HintPath)\\s*=\\s*(?:\"(?<dq>[^\"]*)\"|'(?<sq>[^']*)')",
         RegexOptions.Compiled);
 
+    /* HintPath is item METADATA, and MSBuild lets metadata be written as an attribute OR as a child
+       element — the element form being what Visual Studio emits for a legacy <Reference>. Reading only
+       the attribute spelling would be this issue recurring one attribute over: a cross-app assembly
+       reference written the ordinary way, silently invisible. Include, Update and Import's Project are
+       item operations rather than metadata and have no element spelling, so this one matcher covers the
+       whole difference between the two grammars. */
+    private static readonly Regex MsBuildPathElement = new(
+        "<HintPath\\s*>([^<]*)</HintPath\\s*>",
+        RegexOptions.Compiled);
+
     /// <summary>Repo-relative paths naming <paramref name="otherApp"/> that a test in
     /// <paramref name="project"/> reads, paired with a concrete file path to test coverage against.</summary>
     private static CrossAppScan Scan(string repo, string project, string otherApp)
@@ -542,6 +603,14 @@ public class CrossAppGuardCiGateTests
         return (probed, found);
     }
 
+    /// <summary>Every path-bearing value one MSBuild file's XML names, in both spellings MSBuild
+    /// accepts. Shared by the walk and by the pin that reads it back, so the pin cannot drift from what
+    /// ships.</summary>
+    private static IEnumerable<string> MsBuildPaths(string xml) =>
+        MsBuildPathAttribute.Matches(xml)
+            .Select(m => m.Groups["dq"].Success ? m.Groups["dq"].Value : m.Groups["sq"].Value)
+            .Concat(MsBuildPathElement.Matches(xml).Select(m => m.Groups[1].Value.Trim()));
+
     /// <summary>The <paramref name="otherApp"/> paths one MSBuild file names, repo-rooted into
     /// <paramref name="seen"/>.</summary>
     private static void ReadMsBuildPaths(
@@ -556,10 +625,8 @@ public class CrossAppGuardCiGateTests
         var origin = Rooted(repo, file);
         var thisFileDir = Path.GetDirectoryName(file)! + Path.DirectorySeparatorChar;
 
-        foreach (Match m in MsBuildPathAttribute.Matches(text))
+        foreach (var raw in MsBuildPaths(text))
         {
-            var raw = m.Groups["dq"].Success ? m.Groups["dq"].Value : m.Groups["sq"].Value;
-
             /* The two properties a hand-written cross-app include actually uses. */
             var expanded = raw
                 .Replace("$(MSBuildThisFileDirectory)", thisFileDir, StringComparison.Ordinal)

--- a/Lite.Tests/CrossAppGuardCiGateTests.cs
+++ b/Lite.Tests/CrossAppGuardCiGateTests.cs
@@ -122,6 +122,17 @@ public class CrossAppGuardCiGateTests
         /* Out of the tree entirely, and not a path at all. */
         Assert.Null(RepoRooted(repo, liteTests, @"..\..\Darling\X.cs", "Darling"));
         Assert.Null(RepoRooted(repo, liteTests, "xunit.v3", "Darling"));
+
+        /* The base directory is the whole answer for an Import inside an imported build file, and the
+           two rules disagree there. A repo-root Directory.Build.props writing
+           <Import Project="Darling\Shared.targets" /> means <repo>/Darling/Shared.targets, because
+           Import resolves against its own file. Resolved against the CONSUMING project it would be
+           Lite.Tests/Darling/Shared.targets, which fails the anchor and disappears - a silent miss, not
+           a wrong answer, which is why it is pinned from both bases. */
+        Assert.Equal(
+            "Darling/Shared.targets",
+            RepoRooted(repo, repo, @"Darling\Shared.targets", "Darling"));
+        Assert.Null(RepoRooted(repo, liteTests, @"Darling\Shared.targets", "Darling"));
     }
 
     /// <summary>
@@ -164,28 +175,75 @@ public class CrossAppGuardCiGateTests
         Assert.Equal(
             new[]
             {
-                @"..\Other\A.cs",
-                @"..\Other\B.xml",
-                "SomeLib",
-                "Other",
-                @"..\Other\C.dll",
-                "Gated",
-                "Angled",
-                @"..\Other\D.props",
+                /* Item paths resolve against the consuming project, so RelativeToItsOwnFile is false for
+                   every one of them. Import's Project is the single exception, and getting that wrong is
+                   a silent miss rather than a wrong answer: it would resolve one directory off, fail the
+                   otherApp anchor, and vanish. */
+                (@"..\Other\A.cs", false),
+                (@"..\Other\B.xml", false),
+                ("SomeLib", false),
+                ("Other", false),
+                (@"..\Other\C.dll", false),
+                ("Gated", false),
+                ("Angled", false),
+                (@"..\Other\D.props", true),
 
                 /* The element spellings are collected after the attributes, and are the cases the
                    attribute matcher alone cannot see at all. The last two carry their own attribute on
                    the open tag - Condition, for a platform-specific hint path - and the last one's
                    Condition holds a raw '>', which is legal in an attribute value and would end the tag
                    early for a matcher that scanned to the next angle bracket. */
-                @"..\Other\bin\SomeLib.dll",
-                @"..\Other\x64\Gated.dll",
-                @"..\Other\Angled.dll",
+                (@"..\Other\bin\SomeLib.dll", false),
+                (@"..\Other\x64\Gated.dll", false),
+                (@"..\Other\Angled.dll", false),
             },
             MsBuildPaths(Xml));
 
         /* Remove= is absent by design: dropping an item from a glob is not a read of it. */
-        Assert.DoesNotContain(@"..\Other\Removed.cs", MsBuildPaths(Xml));
+        Assert.DoesNotContain(
+            MsBuildPaths(Xml),
+            p => p.Raw.Equals(@"..\Other\Removed.cs", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The two base directories, exercised through the shipped read rather than through
+    /// <see cref="RepoRooted"/> alone.
+    ///
+    /// <para>An <c>Import</c>'s <c>Project</c> resolves against the file CONTAINING it; an item's path
+    /// resolves against the CONSUMING project. For a <c>.csproj</c> those are the same directory, so the
+    /// divergence only appears in an imported build file — and there is none in this repository, which
+    /// is why this is driven with synthetic XML rather than repo content.</para>
+    ///
+    /// <para>Both spellings below name a file under the other app, and <b>neither single base produces
+    /// both answers</b>: one base for everything drops the <c>Import</c> (it lands under the consuming
+    /// project) or drops the item (it climbs out of the repository). So the assertion is two-sided in
+    /// both directions at once. It matters because the wrong base is a SILENT miss — the reference fails
+    /// the anchor and vanishes, rather than resolving to something visibly wrong.</para>
+    /// </summary>
+    [Fact]
+    public void TheTwoResolutionBases_AreBothUsedWhereTheyDiverge()
+    {
+        var repo = RepoRoot();
+        var seen = new SortedDictionary<string, SortedSet<string>>(StringComparer.Ordinal);
+        var unevaluable = new List<string>();
+
+        ReadMsBuildPaths(
+            repo,
+            "<Project>"
+                + "<Import Project=\"Darling\\NoSuchArea\\Imported.targets\" />"
+                + "<ItemGroup><None Include=\"..\\Darling\\NoSuchArea\\Item.cs\" /></ItemGroup>"
+                + "</Project>",
+            origin: "Directory.Build.props",
+            projectDir: Path.Combine(repo, LiteTestsDir),
+            ownDir: repo,
+            otherApp: "Darling",
+            seen,
+            unevaluable);
+
+        Assert.Empty(unevaluable);
+        Assert.Equal(
+            new[] { "Darling/NoSuchArea/Imported.targets", "Darling/NoSuchArea/Item.cs" },
+            seen.Keys);
     }
 
     /// <summary>
@@ -475,7 +533,7 @@ public class CrossAppGuardCiGateTests
     /* The MSBuild attributes that can carry a path to another app's file. Remove= is deliberately
        absent: dropping an item from a glob is not a read of it. */
     private static readonly Regex MsBuildPathAttribute = new(
-        "\\b(?:Include|Update|Project|HintPath)\\s*=\\s*(?:\"(?<dq>[^\"]*)\"|'(?<sq>[^']*)')",
+        "\\b(?<name>Include|Update|Project|HintPath)\\s*=\\s*(?:\"(?<dq>[^\"]*)\"|'(?<sq>[^']*)')",
         RegexOptions.Compiled);
 
     /* HintPath is item METADATA, and MSBuild lets metadata be written as an attribute OR as a child
@@ -543,15 +601,27 @@ public class CrossAppGuardCiGateTests
 
         foreach (var file in projectFiles)
         {
-            ReadMsBuildPaths(repo, file, Path.GetDirectoryName(file)!, otherApp, seen, unevaluable);
+            /* A .csproj is its own consumer, so both bases are its directory. */
+            var dir = Path.GetDirectoryName(file)!;
+            ReadMsBuildPaths(
+                repo, File.ReadAllText(file), Rooted(repo, file), dir, dir, otherApp, seen, unevaluable);
         }
 
         foreach (var file in importedBuildFiles)
         {
-            /* MSBuild resolves a relative item path in an IMPORTED file against the consuming project's
-               directory, not the imported file's own — which is why these resolve against projectRoot
-               even for a Directory.Build.props sitting at the repo root. */
-            ReadMsBuildPaths(repo, file, projectRoot, otherApp, seen, unevaluable);
+            /* The two bases diverge here, and both are needed. MSBuild resolves a relative ITEM path in
+               an imported file against the consuming project's directory — which is why these get
+               projectRoot even for a Directory.Build.props sitting at the repo root — while an Import's
+               own Project attribute resolves against the file that contains it. */
+            ReadMsBuildPaths(
+                repo,
+                File.ReadAllText(file),
+                Rooted(repo, file),
+                projectRoot,
+                Path.GetDirectoryName(file)!,
+                otherApp,
+                seen,
+                unevaluable);
         }
 
         return new CrossAppScan(
@@ -657,31 +727,46 @@ public class CrossAppGuardCiGateTests
     private static bool NeedsMsBuildToEvaluate(string path) =>
         MsBuildExpressionForms.Any(form => path.Contains(form, StringComparison.Ordinal));
 
-    /// <summary>Every path-bearing value one MSBuild file's XML names, in both spellings MSBuild
-    /// accepts. Shared by the walk and by the pin that reads it back, so the pin cannot drift from what
-    /// ships.</summary>
-    private static IEnumerable<string> MsBuildPaths(string xml) =>
+    /// <summary>Every path-bearing value one MSBuild file's XML names, in both spellings MSBuild accepts,
+    /// each paired with WHICH directory MSBuild resolves it against.
+    ///
+    /// <para>The two rules differ and the difference is load-bearing. An item's path
+    /// (<c>Include</c> / <c>Update</c> / <c>HintPath</c>) is relative to the CONSUMING project's
+    /// directory — that is why <c>$(MSBuildThisFileDirectory)</c> has to exist. <c>Import</c>'s
+    /// <c>Project</c> is relative to the directory of the file CONTAINING the import. They coincide for a
+    /// <c>.csproj</c>, which is its own consumer, and diverge for an imported build file — which is
+    /// precisely where a cross-app <c>Import</c> would live.</para>
+    ///
+    /// <para>Shared by the walk and by the pin that reads it back, so the pin cannot drift from what
+    /// ships.</para></summary>
+    private static IEnumerable<(string Raw, bool RelativeToItsOwnFile)> MsBuildPaths(string xml) =>
         MsBuildPathAttribute.Matches(xml)
-            .Select(m => m.Groups["dq"].Success ? m.Groups["dq"].Value : m.Groups["sq"].Value)
-            .Concat(MsBuildPathElement.Matches(xml).Select(m => m.Groups[1].Value.Trim()));
+            .Select(m => (
+                Raw: m.Groups["dq"].Success ? m.Groups["dq"].Value : m.Groups["sq"].Value,
+                RelativeToItsOwnFile: m.Groups["name"].Value.Equals("Project", StringComparison.Ordinal)))
+            .Concat(MsBuildPathElement.Matches(xml)
+                .Select(m => (Raw: m.Groups[1].Value.Trim(), RelativeToItsOwnFile: false)));
 
     /// <summary>The <paramref name="otherApp"/> paths one MSBuild file names, repo-rooted into
     /// <paramref name="seen"/>.</summary>
     private static void ReadMsBuildPaths(
         string repo,
-        string file,
+        string xml,
+        string origin,
         string projectDir,
+        string ownDir,
         string otherApp,
         SortedDictionary<string, SortedSet<string>> seen,
         List<string> unevaluable)
     {
-        var text = File.ReadAllText(file);
-        var origin = Rooted(repo, file);
-        var thisFileDir = Path.GetDirectoryName(file)! + Path.DirectorySeparatorChar;
+        /* $(MSBuildThisFileDirectory) carries a trailing separator by MSBuild's own convention, and a
+           path is written expecting it. */
+        var thisFileDir = ownDir.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
 
-        foreach (var raw in MsBuildPaths(text))
+        foreach (var (raw, relativeToItsOwnFile) in MsBuildPaths(xml))
         {
-            /* The two properties a hand-written cross-app include actually uses. */
+            /* The two properties a hand-written cross-app include actually uses. Both mean what they say
+               regardless of which base the value itself resolves against. */
             var expanded = raw
                 .Replace("$(MSBuildThisFileDirectory)", thisFileDir, StringComparison.Ordinal)
                 .Replace("$(MSBuildProjectDirectory)", projectDir, StringComparison.Ordinal);
@@ -696,7 +781,12 @@ public class CrossAppGuardCiGateTests
                 continue;
             }
 
-            var rooted = RepoRooted(repo, projectDir, expanded, otherApp);
+            var rooted = RepoRooted(
+                repo,
+                relativeToItsOwnFile ? thisFileDir : projectDir,
+                expanded,
+                otherApp);
+
             if (rooted is not null)
             {
                 Note(seen, rooted, origin);

--- a/Lite.Tests/CrossAppGuardCiGateTests.cs
+++ b/Lite.Tests/CrossAppGuardCiGateTests.cs
@@ -562,11 +562,13 @@ public class CrossAppGuardCiGateTests
     /// <para>A nearest file that deliberately chains to its parent does so through an <c>Import</c> whose
     /// path is a property function, and <see cref="ReadMsBuildPaths"/> reports an unevaluable path as a
     /// failure rather than ignoring it — so the chain is loud, not silently uncollected. That is the right
-    /// direction for a guard whose whole defect class is not noticing.</para></summary>
-    /// <para>Every location looked at is returned alongside what was there. A stage that probed nowhere
-    /// and a stage that probed everywhere and found nothing both leave an empty found list, and on a tree
-    /// with no such file anywhere — this one — a count floor cannot tell them apart without redding on a
-    /// clean checkout. The probe list can, so it is what gets floored.</para>
+    /// direction for a guard whose whole defect class is not noticing.</para>
+    ///
+    /// <para><b>Every location looked at is returned alongside what was there</b>, which is why this
+    /// hands back <c>Probed</c> as well as <c>Found</c>. A stage that probed nowhere and a stage that
+    /// probed everywhere and found nothing both leave an empty found list, and on a tree with no such
+    /// file anywhere — this one — a count floor cannot tell them apart without redding on a clean
+    /// checkout. The probe list can, so it is what gets floored.</para></summary>
     private static (List<string> Probed, List<string> Found) ImportedBuildFiles(
         string repo, string projectRoot)
     {

--- a/Lite.Tests/CrossAppGuardCiGateTests.cs
+++ b/Lite.Tests/CrossAppGuardCiGateTests.cs
@@ -49,6 +49,11 @@ public class CrossAppGuardCiGateTests
     private const string LiteTestsDir = "Lite.Tests";
     private const string DarlingTestsDir = "Darling/Darling.Tests";
 
+    /* The build files MSBuild imports into a project without being named, in the order it probes
+       them. Shared by the walk and by the pin that floors where the walk looked. */
+    private static readonly string[] BuildFileNames =
+        { "Directory.Build.props", "Directory.Build.targets" };
+
     [Fact]
     public void TheGlobMatcher_AgreesWithKnownAnswers()
     {
@@ -191,6 +196,43 @@ public class CrossAppGuardCiGateTests
                 scan.ProjectFiles,
                 p => p.Contains("/bin/", StringComparison.Ordinal) ||
                      p.Contains("/obj/", StringComparison.Ordinal));
+
+            /* The imported-build-file half needs the same protection as ProjectFiles above and cannot
+               have it in the same shape: nothing in this repository imports a Directory.Build.props, so
+               flooring the found COUNT would red on a clean tree. What is floored instead is that the
+               collector reached the locations MSBuild itself would probe — the two names in every
+               directory from the project up to and including the repo root — so "we looked and there
+               were none" is distinguishable from "we never looked". The chain is re-derived here from
+               the project path rather than read back off the walk. */
+            var directories = new List<string>();
+            for (var d = project; ; )
+            {
+                directories.Add(d);
+                var cut = d.LastIndexOf('/');
+                if (cut < 0)
+                {
+                    break;
+                }
+
+                d = d[..cut];
+            }
+
+            directories.Add(string.Empty);
+
+            Assert.Equal(
+                directories.SelectMany(d => BuildFileNames.Select(n => d.Length == 0 ? n : $"{d}/{n}")),
+                scan.ImportedBuildProbes);
+
+            /* And what it opened is exactly the NEAREST existing probe of each name, which is MSBuild's
+               own rule. Holds at zero, so a clean tree passes honestly rather than by not being asked. */
+            Assert.Equal(
+                BuildFileNames
+                    .Select(n => scan.ImportedBuildProbes.FirstOrDefault(
+                        p => p.EndsWith(n, StringComparison.Ordinal) &&
+                             File.Exists(Path.Combine(repo, p.Replace('/', Path.DirectorySeparatorChar)))))
+                    .Where(p => p is not null)
+                    .OrderBy(p => p, StringComparer.Ordinal),
+                scan.ImportedBuildFiles.OrderBy(p => p, StringComparer.Ordinal));
         }
     }
 
@@ -301,6 +343,16 @@ public class CrossAppGuardCiGateTests
             $"the MSBuild stage opened no project files under {scannedProject}, so a cross-app reference " +
             "written as an Include= attribute is invisible again");
 
+        /* The imported-build-file stage is floored on where it LOOKED, not on what it found: there is no
+           Directory.Build.props anywhere in this repository, so a count floor would red on a clean tree
+           while still not distinguishing "probed nowhere" from "probed and found none". */
+        Assert.True(
+            scan.ImportedBuildProbes.Count > 0,
+            $"the imported-build-file stage probed nowhere for {scannedProject}, so an item group in a " +
+            "Directory.Build.props or .targets is invisible. Probed: " +
+            $"[{string.Join(", ", scan.ImportedBuildProbes)}], opened: " +
+            $"[{string.Join(", ", scan.ImportedBuildFiles)}]");
+
         /* This guard's failure direction is not noticing, so a path it CANNOT read has to be loud rather
            than absent from the found set. */
         Assert.True(
@@ -326,6 +378,7 @@ public class CrossAppGuardCiGateTests
     private readonly record struct CrossAppScan(
         int CSharpFiles,
         IReadOnlyList<string> ProjectFiles,
+        IReadOnlyList<string> ImportedBuildProbes,
         IReadOnlyList<string> ImportedBuildFiles,
         IReadOnlyList<string> UnevaluablePaths,
         IReadOnlyList<(string Raw, string Probe, string Origin)> References);
@@ -383,7 +436,7 @@ public class CrossAppGuardCiGateTests
         var projectFiles = TrackedFiles(projectRoot, "*.csproj")
             .OrderBy(f => f, StringComparer.Ordinal)
             .ToList();
-        var importedBuildFiles = ImportedBuildFiles(repo, projectRoot).ToList();
+        var (importedProbes, importedBuildFiles) = ImportedBuildFiles(repo, projectRoot);
 
         foreach (var file in projectFiles)
         {
@@ -401,6 +454,7 @@ public class CrossAppGuardCiGateTests
         return new CrossAppScan(
             csharpFiles,
             projectFiles.Select(f => Rooted(repo, f)).ToList(),
+            importedProbes.Select(f => Rooted(repo, f)).ToList(),
             importedBuildFiles.Select(f => Rooted(repo, f)).ToList(),
             unevaluable,
             Resolve(repo, seen).ToList());
@@ -448,23 +502,33 @@ public class CrossAppGuardCiGateTests
     /// path is a property function, and <see cref="ReadMsBuildPaths"/> reports an unevaluable path as a
     /// failure rather than ignoring it — so the chain is loud, not silently uncollected. That is the right
     /// direction for a guard whose whole defect class is not noticing.</para></summary>
-    private static IEnumerable<string> ImportedBuildFiles(string repo, string projectRoot)
+    /// <para>Every location looked at is returned alongside what was there. A stage that probed nowhere
+    /// and a stage that probed everywhere and found nothing both leave an empty found list, and on a tree
+    /// with no such file anywhere — this one — a count floor cannot tell them apart without redding on a
+    /// clean checkout. The probe list can, so it is what gets floored.</para>
+    private static (List<string> Probed, List<string> Found) ImportedBuildFiles(
+        string repo, string projectRoot)
     {
         var root = Path.GetFullPath(repo).TrimEnd(Path.DirectorySeparatorChar);
-        var names = new[] { "Directory.Build.props", "Directory.Build.targets" };
-        var found = new HashSet<string>(StringComparer.Ordinal);
+        var probed = new List<string>();
+        var found = new List<string>();
+        var claimed = new HashSet<string>(StringComparer.Ordinal);
 
-        for (var dir = new DirectoryInfo(Path.GetFullPath(projectRoot));
-             dir is not null && found.Count < names.Length;
-             dir = dir.Parent)
+        for (var dir = new DirectoryInfo(Path.GetFullPath(projectRoot)); dir is not null; dir = dir.Parent)
         {
-            foreach (var name in names)
+            foreach (var name in BuildFileNames)
             {
                 var candidate = Path.Combine(dir.FullName, name);
-                if (!found.Contains(name) && File.Exists(candidate))
+
+                /* Probing continues to the root even once a name is claimed. The walk costs two
+                   File.Exists calls per directory, and a probe list that stopped early could not be
+                   floored against the locations MSBuild would consider. */
+                probed.Add(candidate);
+
+                if (!claimed.Contains(name) && File.Exists(candidate))
                 {
-                    found.Add(name);
-                    yield return candidate;
+                    claimed.Add(name);
+                    found.Add(candidate);
                 }
             }
 
@@ -474,6 +538,8 @@ public class CrossAppGuardCiGateTests
                 break;
             }
         }
+
+        return (probed, found);
     }
 
     /// <summary>The <paramref name="otherApp"/> paths one MSBuild file names, repo-rooted into

--- a/Lite.Tests/CrossAppGuardCiGateTests.cs
+++ b/Lite.Tests/CrossAppGuardCiGateTests.cs
@@ -189,6 +189,31 @@ public class CrossAppGuardCiGateTests
     }
 
     /// <summary>
+    /// A value this scan cannot resolve has to be reported, not dropped.
+    ///
+    /// <para>An unrecognised MSBuild expression is the worst case for this guard: it falls through as a
+    /// literal relative path, resolves to nothing, and vanishes from the found set — silently, which is
+    /// the direction #3063 exists to close. So the classification covers every form MSBuild evaluates
+    /// rather than the two that happen to be common. There are three, and no fourth: a property or
+    /// property function, item metadata, and an item list or transform.</para>
+    /// </summary>
+    [Fact]
+    public void TheEvaluabilityCheck_CoversEveryMsBuildExpressionForm()
+    {
+        Assert.True(NeedsMsBuildToEvaluate(@"$(RepoRoot)Darling\X.cs"));
+        Assert.True(NeedsMsBuildToEvaluate(@"$([MSBuild]::GetPathOfFileAbove('Directory.Build.props'))"));
+        Assert.True(NeedsMsBuildToEvaluate(@"%(RecursiveDir)X.cs"));
+
+        /* An item list, and an item transform - neither carries $( or %( anywhere. */
+        Assert.True(NeedsMsBuildToEvaluate("@(SharedSources)"));
+        Assert.True(NeedsMsBuildToEvaluate(@"@(SharedSources->'..\Darling\%(Filename)%(Extension)')"));
+
+        /* A literal path is readable, and so is one that merely contains the sigils unparenthesised. */
+        Assert.False(NeedsMsBuildToEvaluate(@"..\Darling\Darling.Tests\CSharpSourceWalker.cs"));
+        Assert.False(NeedsMsBuildToEvaluate("Fixtures/100%-coverage@home.xml"));
+    }
+
+    /// <summary>
     /// A reference counts only when the path it resolved to spells it back, on every host.
     ///
     /// <para><c>Directory.Exists</c> answers according to the HOST's path rules, and Windows trims
@@ -622,6 +647,16 @@ public class CrossAppGuardCiGateTests
         return (probed, found);
     }
 
+    /* Every expression form MSBuild evaluates, and there is no fourth: a property or property function,
+       item metadata, and an item list or transform. Anything carrying one of these is a path this scan
+       cannot read, and it has to say so rather than let the value fall through as a literal relative
+       path that resolves to nothing and disappears. */
+    private static readonly string[] MsBuildExpressionForms = { "$(", "%(", "@(" };
+
+    /// <summary>Whether a path attribute's value can only be resolved by MSBuild itself.</summary>
+    private static bool NeedsMsBuildToEvaluate(string path) =>
+        MsBuildExpressionForms.Any(form => path.Contains(form, StringComparison.Ordinal));
+
     /// <summary>Every path-bearing value one MSBuild file's XML names, in both spellings MSBuild
     /// accepts. Shared by the walk and by the pin that reads it back, so the pin cannot drift from what
     /// ships.</summary>
@@ -651,11 +686,12 @@ public class CrossAppGuardCiGateTests
                 .Replace("$(MSBuildThisFileDirectory)", thisFileDir, StringComparison.Ordinal)
                 .Replace("$(MSBuildProjectDirectory)", projectDir, StringComparison.Ordinal);
 
-            if (expanded.Contains("$(", StringComparison.Ordinal) ||
-                expanded.Contains("%(", StringComparison.Ordinal))
+            if (NeedsMsBuildToEvaluate(expanded))
             {
                 /* Only MSBuild can evaluate what is left. Recorded rather than dropped, so the caller
-                   can be loud about a path this guard cannot read. */
+                   can be loud about a path this guard cannot read. An unrecognised expression would
+                   otherwise fall through as a literal relative path, resolve to nothing, and vanish —
+                   which is this guard's own defect class. */
                 unevaluable.Add($"{origin}: {raw}");
                 continue;
             }


### PR DESCRIPTION
`CrossAppGuardCiGateTests` exists to require that when one SKU's test project reads the other's source, that read is reachable by the CI path filter gating its suite. It enumerated `*.cs` and matched path string literals inside that C#, so it never opened a `.csproj` — and a cross-app read expressed as a linked compile was structurally invisible to it.

Not because the path spelling was unusual. Because the population was `*.cs`.

## What was invisible

#3059 (#3052) shares one file between the SKUs with a linked compile rather than a copy:

```xml
<Compile Include="..\Darling\Darling.Tests\CSharpSourceWalker.cs" Link="CSharpSourceWalker.cs" />
```

That is a cross-app source read of exactly the kind this guard exists to require be filter-reachable. Neither existing matcher can see it, and the anchor is a red herring on the way to the real reason: an `Include=` path is **relative** (`..\Darling\…`), backslashed, and not repo-rooted, so `otherApp[/\\]` never fires — but it would not matter if it did, because project XML is not a `*.cs` file and was never read.

**Nothing was unguarded, and this is not a coverage gap.** #3059's reference is reachable by the `lite` filter's existing `Darling/Darling.Tests/**/!(*.md)` entry, and #3059 records why a `darling`-filter entry was rejected — naming `Lite.Tests/**` there would gate the live-PostgreSQL `darling-pg` job on all 298 of Lite's test files. What was missing is the guard's ability to *know* that. The next linked compile between the SKUs got no assertion at all.

**The failure direction is what justifies the work.** This guard fails toward *not noticing*: a missed reference is silent, and only a red test gets looked at. Same reasoning recorded in #3052 about the identical filter being loud when it drives an assertion and silent when it drives a number.

## What changed

One file, `Lite.Tests/CrossAppGuardCiGateTests.cs`. No workflow, product or filter change.

**A second population.** Alongside `*.cs`, the scan now reads the project's own `*.csproj` files and any `Directory.Build.props` / `Directory.Build.targets` from the project directory up to and including the repo root. `bin/` and `obj/` stay excluded on both stages.

**Two resolution bases, because MSBuild has two rules.** An item's path (`Include` / `Update` / `HintPath`) resolves against the **consuming project's** directory — the whole reason `$(MSBuildThisFileDirectory)` exists — while an `Import`'s `Project` resolves against the directory of the **file containing it**. Those coincide for a `.csproj`, which is its own consumer, and diverge for an imported build file, which is exactly where a cross-app `Import` would live. `ReadMsBuildPaths` takes the XML and both bases rather than a path, so the divergence is pinned through the shipped read and not through `RepoRooted` alone — the wrong base is a *silent* miss (the reference fails the anchor and vanishes), so a pin that cannot see a caller passing the wrong base is not a pin.

**A sibling matcher, `RepoRooted`, rather than a second anchor.** It resolves an MSBuild path attribute against the project directory and expresses it repo-rooted with forward slashes — the form the coverage logic already reasons about — so everything downstream of it is unchanged. Applying the `otherApp` anchor *after* normalisation is the whole point: a relative path names no app until it is resolved, and `..\Lite\…` and `..\Darling\…` are indistinguishable before that.

- `Include`, `Update`, `Project` (on `Import`) and `HintPath` are read. `Remove=` deliberately is not: dropping an item from a glob is not a read of it.
- **`HintPath` is read in both MSBuild spellings, and the element may carry its own attributes.** `Condition` is the usual one (a platform-specific hint path). Attributes are skipped by matching *quoted values* rather than by scanning to the next `>`, because an attribute value may legally contain a raw `>` — only `<` and `&` must be escaped — and a bracket-scanning matcher would end the tag inside the value. Both cases are pinned.
- **`HintPath` is read in both MSBuild spellings.** It is item *metadata*, and metadata may be written as an attribute or as a child element — the element form being what Visual Studio emits for a legacy `<Reference>`, and the form a hand-written cross-app assembly reference would take. `Include`, `Update` and `Import`'s `Project` are item operations rather than metadata and have no element spelling, so one element matcher covers the whole difference between the two grammars. Measured: `HintPath` appears in **no** project file in this repository (`grep` over every `.csproj`/`.props`/`.targets` finds it only in this test file), so nothing is live — but advertising a population wider than the one actually read is the shape of this very defect, one attribute over, so the code now honours the claim rather than the claim being narrowed.
- An MSBuild **wildcard is a real file set**, unlike a glob in C# source where the pattern *is* the assertion (`WatermarkPolicyTests` pins filter entries, and those are excluded outright). So a wildcard reduces to the directory it enumerates and takes the existing directory-probe arm.
- Paths resolving outside the repository are dropped — no path filter can name them.
- `$(MSBuildThisFileDirectory)` and `$(MSBuildProjectDirectory)` are expanded. Anything still carrying an MSBuild expression is **reported and fails the check**, not dropped: a path this guard cannot read has to be visible, given which direction it fails in. Zero on `dev` today. The recognised forms are all three MSBuild has — a property or property function `$(…)`, item metadata `%(…)`, and an item list or transform `@(…)` — named in one place rather than accumulated as special cases, because an unrecognised expression falls through as a literal relative path, resolves to nothing, and vanishes silently. An unparenthesised `%` or `@` in a filename stays readable, and that negative is pinned too.

**A reference counts only when the path it resolved to spells it back.** `Directory.Exists` answers according to the *host's* path rules, and Windows trims trailing periods from a path component — so a `Darling` segment followed by three dots resolves to `Darling` there and to nothing on macOS or Linux. This guard runs on Windows in CI and gets verified on macOS, and the divergence was not hypothetical: see the CI round below. `OnDisk` round-trips the resolution, so the answer is identical on all three platforms.

**`ImportedBuildFiles` takes the nearest file of each name and stops**, which is what `Microsoft.Common.props` actually does — it probes upward for one `Directory.Build.props` and does not chain, and the two names probe independently. Collecting every one above the project would attribute an item group to a project that never imports it, and a guard whose findings are not trustworthy stops being read. A nearest file that deliberately chains to its parent does so through an `Import` whose path is a property function, which the unevaluable check above reports as a failure rather than ignoring — so the chain is loud, not silently uncollected.

**Every stage is floored, and the build-file stage is floored on where it LOOKED.** A widened collector that opens nothing passes exactly as the narrow one did — that is the defect committed by its own fix, and it applies to each half separately.

- The project-file half: `ThePopulationReachesTheProjectFiles_AndNotOnlyTheCSharp` requires the specific manifest (`Lite.Tests/Lite.Tests.csproj`, `Darling/Darling.Tests/Darling.Tests.csproj`) to be *in* the population rather than merely counting files, and asserts no `bin/`/`obj/` copy got in. That last one is non-vacuous: the local verification host below puts a real `.csproj` under `Lite.Tests/bin/`.
- The imported-build-file half **cannot** take a count floor. Nothing in this repository imports a `Directory.Build.props`, so requiring a non-empty found set would red on a clean tree — and it still would not distinguish *probed nowhere* from *probed and found none*, which is the only distinction that matters. So the walk records every location it looked at, and the pin floors **that**: the two names in every directory from the project up to and including the repo root, re-derived in the test from the project path rather than read back off the walk. What it opened is pinned as exactly the nearest existing probe of each name — an equality that holds at zero, so a clean tree passes because it was asked, not because it wasn't. The probe and found lists are both in the failure message.

**`TheMsBuildMatchers_ReadBothSpellings`** pins both grammars against the shipped matchers rather than a retyped copy, including that `Remove=` stays out.

**`TheOnDiskProbe_AnswersTheSameOnEveryHost`** pins the host-independence directly, including the exact three-dot path that reached CI.

**`TheMsBuildPathNormaliser_AgreesWithKnownAnswers`** self-validates the normaliser against known answers, the same way `TheGlobMatcher_AgreesWithKnownAnswers` already does and for the same reason — a normaliser that resolved to the *wrong* repo-rooted path would match no filter pattern, find no file on disk, be dropped, and every coverage check would pass having seen nothing.

**Failures now name every file that named the reference.** The two populations can name the same path — a linked compile and a pin that reads the linked file both do — and reporting only the first would say it came from the C# and leave the project entry looking unread.

## `Directory.Build.props` / `.targets`: established, not assumed

**There is neither file anywhere in this repository today** (only `Directory.Packages.props`, which carries `PackageVersion` items and no paths). They are in the population anyway, and nothing asserts they exist.

The reason they belong is mechanical rather than hypothetical: MSBuild imports them into every project without being named, and an `ItemGroup` in one can legally carry a cross-app `Compile Include`. For a file **outside** the project cone there is no duplicate-item conflict with the SDK's later default glob, so it works — the same invisible shape as a `.csproj` entry, in a file no `.csproj` scan would open. Proven both ways below.

One correctness note: MSBuild resolves a relative item path in an *imported* file against the **consuming project's** directory, not the imported file's own. These resolve against the project root accordingly, which is why a repo-root `Directory.Build.props` is read correctly rather than one directory off.

## Correcting the framing this came from

#3059's adjacent finding described the detector as keying on `Lite/` and `Darling/` "while `Lite.Tests` is a sibling of `Lite`". Reading the source, the sibling relationship is not the operative cause of #3059's invisibility — the `*.cs`-only population is, and #3059's own reference lives at `Darling/Darling.Tests/…`, which is *inside* `Darling/` and would have anchored fine. Fixed here as a population problem.

**The sibling asymmetry is real, though, and it is not empty — see below.** It is a separate fix that forces a decision this PR is not the place to take.

## Verification

`Lite.Tests` targets `net10.0-windows` and cannot run on macOS. The real `CrossAppGuardCiGateTests.cs` was compiled into a throwaway `net10.0` xunit v3 host named `Lite.Tests`, staged inside the gitignored `Lite.Tests/bin/` so `[CallerFilePath]`'s walk-up resolves against the real repo root and every pin reads real repo content. The `.csproj` was passed to `dotnet build` explicitly.

`Lite.Tests` also builds clean with `-p:EnableWindowsTargeting=true`; the warning profile is byte-identical to `dev`'s (9 warnings, none in this file).

**Green: 9 of 9.** `Total: 9, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0`. MTP prints no per-test `Passed` line, so each was additionally run **by name on its own** and reported `Total: 1, Failed: 0, Not Run: 0` — a silent grep against a green check cannot tell a pass from a test that never ran. On CI the whole Lite suite moved `3363 -> 3367` across these commits with `Failed: 0, Skipped: 0, Not Run: 0`, which is the count-based confirmation that the four added tests really executed there.

### The load-bearing proof, on the real tree

**#3059 merged into `dev` at 01:24:59Z (`13061c4eb`) while this was being built, so this is measured against the live reference rather than a synthetic.** `origin/dev` is merged in here, and the `Compile Include` is present at `Lite.Tests/Lite.Tests.csproj:29`.

The reference is *covered* by the `lite` filter, so a detecting guard and a blind one both go green on it. The discrimination is to remove the covering `lite` entry (`Darling/Darling.Tests/**/!(*.md)`) and see which collector notices:

| On merged `dev`, `lite` entry removed | Result |
|---|---|
| this PR's collector | fails, naming `Darling/Darling.Tests/CSharpSourceWalker.cs` **(named in `Lite.Tests/CrossAppGuardCiGateTests.cs`, `Lite.Tests/Lite.Tests.csproj`)** |
| `dev`'s collector, same tree | fails on other references, and **never mentions `CSharpSourceWalker.cs`** — the defect |

`build.yml` was restored and the working tree verified clean afterwards.

### The CI round, and what it actually caught

The first push went **red on `build`**: `Total: 3365, Failed: 1`, with

```
Lite.Tests reads Darling/... (directory) (named in Lite.Tests/CrossAppGuardCiGateTests.cs)
  but the 'lite' filter does not reach it (probe path: Darling/.../CoverageProbe.cs)
```

**It was not the MSBuild normalisation.** Two things say so, both from that same run. The origin list names only `Lite.Tests/CrossAppGuardCiGateTests.cs` and *not* `Lite.Tests/Lite.Tests.csproj` — this PR records every file that named a reference precisely so that reads unambiguously. And `TheMsBuildPathNormaliser_AgreesWithKnownAnswers`, which asserts `Assert.Equal("Darling/Darling.Tests/CSharpSourceWalker.cs", RepoRooted(…, @"..\Darling\Darling.Tests\CSharpSourceWalker.cs", "Darling"))` — the resolved form, exactly, not merely that something was found — **passed on Windows in that run**. `RepoRooted` never string-trims `..`; it is `Path.GetFullPath` against the project directory followed by a repo-relative rebase, and the ellipsis is not a spelling it can produce.

What produced it was a *comment in this file*. I had written an illustrative three-dot path inside a quoted string while explaining why the wildcard case uses a fictional directory, and the **pre-existing C# string-literal matcher** — unchanged from `dev` — matched it, exactly as it matches `"Darling/Some/Path.cs"` on `dev` today. Those existing decoys are inert only because they resolve to nothing. This one resolved on Windows and not on macOS, which is why every local run was green.

So it is a real defect in a real direction, and the fix is the category rather than the instance: the comment no longer spells a path, **and** `OnDisk` now requires the round-trip, so no host's path normalisation can invent a reference again. No `build.yml` filter entry was added — that would have encoded the malformed path into CI config permanently.

### Red-proofed twenty-five more ways

Each mutation fails a different named assertion, and each was reverted and re-run green.

| Mutation | Fails |
|---|---|
| `.csproj` removed from the population | both floors: "the MSBuild stage opened no project files under Lite.Tests", and "did not open `Lite.Tests/Lite.Tests.csproj` … Opened: []" |
| normalisation resolves against the repo root instead of the project directory | `TheMsBuildPathNormaliser_AgreesWithKnownAnswers` (`Expected: "Darling/Darling.Tests/CSharpSourceWalker.cs"`, `Actual: null`), and the coverage failure loses the `.csproj` origin |
| `lite` filter loses `Darling/PerformanceMonitor.Darling.Viewer/**/!(*.md)` | the coverage check, naming 10 `.cs`-sourced references with their origin files — the existing C# detection is intact, not traded away |
| a repo-root `Directory.Build.props` carrying `<None Include="..\Darling\Darling.Tests\CSharpSourceWalkerTests.cs" />` | detected and attributed to `Directory.Build.props` |
| …with the walk-up cut to the project directory only | the same reference disappears — the walk-up range is load-bearing |
| the same include spelled `$(RepoRoot)Darling\…` | the unevaluable check, printing `Directory.Build.props: $(RepoRoot)Darling\…` rather than silently missing it |
| the same include spelled `$(MSBuildThisFileDirectory)Darling\…` | detected — the expansion works |
| `..\..\Darling\X.cs` (out of tree), `xunit.v3` (a package id) | `Assert.Null` in the normaliser self-check |
| a wildcard over the other app | reduced to its directory by the self-check's known answer |
| the `OnDisk` round-trip removed | `TheOnDiskProbe_AnswersTheSameOnEveryHost` — `Assert.Null` on the dot-segment case, which is the macOS-runnable twin of the Windows trailing-period case |
| a repo-root `Directory.Build.props` with **nothing nearer** | detected, attributed to `Directory.Build.props` |
| the same, plus a nearer `Lite.Tests/Directory.Build.props` | the root file is **no longer collected** — nearest-wins holds, and the `.csproj` detection is untouched in the same run |
| the nearer file chain-imports its parent via `$([MSBuild]::GetPathOfFileAbove(...))` | the unevaluable check, printing `Lite.Tests/Directory.Build.props: $([MSBuild]::GetPathOfFileAbove(…))` — loud rather than silently uncollected |
| the build-file walk records no probe (the stage goes dead) | **two** assertions: the probe-location equality, and the `Check` floor printing `probed nowhere for Lite.Tests … Probed: [], opened: []` |
| the walk stops at the project directory instead of the repo root | the probe-location equality — a short reach is not a legal answer |
| nearest-wins reverted to collect-everything, with a root **and** a nearer `Directory.Build.props` both present | the nearest-existing-per-name equality, at index 0. With nearest-wins intact the same tree is green |
| a **real** cross-app `<HintPath>` child element injected into `Lite.Tests.csproj` | detected and attributed to `Lite.Tests/Lite.Tests.csproj` alone — the MSBuild stage, with no C# origin |
| the element matcher dropped from the shipped matcher set | `TheMsBuildMatchers_ReadBothSpellings`, and the injected `<HintPath>` reference disappears from the found set |
| a **real** `<HintPath Condition="'$(Platform)'=='x64'">..\Darling\…</HintPath>` injected into `Lite.Tests.csproj` | detected and attributed to `Lite.Tests/Lite.Tests.csproj` alone |
| the element matcher narrowed back to the attribute-free form | the spelling pin, and the Condition-bearing reference vanishes from the found set |
| a **real** `<Compile Include="@(SharedSources)" />` injected into `Lite.Tests.csproj` | the unevaluable check, reporting `Lite.Tests/Lite.Tests.csproj: @(SharedSources)` |
| `@(` dropped from the recognised expression forms | `TheEvaluabilityCheck_CoversEveryMsBuildExpressionForm`, and that reference disappears from the report entirely |
| a **real** `<Import Project="Darling\Darling.Tests\Shared.targets" />` in a repo-root `Directory.Build.props` | detected and attributed to `Directory.Build.props` |
| one resolution base for everything — the consuming project | `TheTwoResolutionBases_AreBothUsedWhereTheyDiverge`, and the real `Import` above vanishes silently |
| one resolution base for everything — the file's own directory | the same pin, from the other side: the item climbs out of the repository |

### Not verified

- **Nothing ran on Windows or Linux.** CI's `build`, `Darling Linux build` and `Darling PostgreSQL tests` are the arbiters for the full suites; only this one class was executed locally. `Darling.Tests` was not run at all — nothing here changes it.
- The rest of `Lite.Tests` was not executed. This class is self-contained; it reads the repo and `build.yml` and touches no product code.
- No live store, monitored server or workflow run was involved. Test-only change.
- The `Directory.Build.props` / `.targets` arms are proven against a **synthesised** file, because none exists in the repo. That is the whole reason they are in the population and unfloored.
- The Windows trailing-period behaviour itself was **not** re-executed on Windows after the fix; the round-trip is pinned by its macOS-runnable twin (a dot segment, which resolves on every host and still is not the path it was written as) and by the reference no longer appearing. CI's `build` is the arbiter.

## Adjacent finding, deliberately not fixed here

**`Darling.Tests` reads two files under `Lite.Tests/` today, and the guard cannot see either — via the anchor, not the population.**

- `Darling/Darling.Tests/QueryHighDopStaleMaxDopParityTests.cs:479` — `const string twin = "Lite.Tests/QueryHighDopStaleMaxDopParityTests.cs";`, then `File.Exists` + parse.
- `Darling/Darling.Tests/ParameterSensitivityFiringSignatureParityTests.cs:336` — the same shape.

For that arm `otherApp` is `Lite`, and the anchor is `Lite[/\\]`. `Lite.Tests/` does not match `Lite/`, so both reads are outside the found set. This one is *live*, unlike the population gap this PR closes, which had no instance on `dev` until #3059 merged.

It is not fixed here because fixing it forces a decision rather than a repair: the `darling` filter names `Lite/**/*.cs` and `Lite/**/*.xaml` but not `Lite.Tests/**`, so detecting these makes the guard red, and the two ways out are the `darling`-filter entry #3059 already weighed and rejected, or a new "covered by `darling-tree-guards`" exemption concept — which, since that job runs the Darling suite whenever the `darling` filter leaves it skipped, would make the whole `Darling.Tests` arm of this guard vacuous. Both are design calls, and neither is a population fix.

**Nothing is unguarded by it either**, for that same reason: a `Lite.Tests`-only change leaves `darling-tests` reporting `skipped`, and `darling-tree-guards` then runs the whole Darling suite. Filed as #3067 with the three options and the measurement that should choose between them, rather than smuggled in here.

## CHANGELOG entry text

Not applied — every lane appends to the same `[Unreleased]` block.

```
- The cross-app CI-gate guard now reads project files as well as C# source, so a cross-app source read
  expressed as an MSBuild `Compile Include` is seen rather than silently missed. Both scan stages are
  floored by name, because a widened scan that opens no project files would pass exactly as the narrow
  one did. (#3063)
```
