### PR TITLE
Fixes #3060

### DIFF
--- a/Darling/Darling.Tests/DarlingSelfAlertTests.cs
+++ b/Darling/Darling.Tests/DarlingSelfAlertTests.cs
@@ -2611,11 +2611,14 @@ VALUES ($1, $2, $3, $4, $5, 0, $6, NULL, 0, 0, 0)", connection);
             $"a default of {TimescaleSupport.RefreshSlotPercentOfHourlyCadence}% is earlier than it has to be "
             + $"for {TimescaleSupport.RefreshPhaseSlots} slots");
 
-        /* The seed must survive its own clamp. A step fine enough to drive the derived default below the
-           [5, 100] floor would have the clamp silently raise it back above one slot — the same defect in a
-           new place, so the clamp is tied to the grid here rather than left to be discovered. */
-        var clamped = Math.Clamp(TimescaleSupport.RefreshSlotPercentOfHourlyCadence, 5, 100);
-        Assert.Equal(TimescaleSupport.RefreshSlotPercentOfHourlyCadence, clamped);
+        /* The seed must survive its own clamp, asserted through the REAL clamp rather than a copy of its
+           bounds — a step fine enough to drive the derived default below the floor would have the clamp
+           silently raise it back above one slot, which is the same defect in a new place. */
+        var config = new DarlingConfig();
+        config.Alerts.StoreJobCadenceWarnPercent = TimescaleSupport.RefreshSlotPercentOfHourlyCadence;
+        Assert.Equal(
+            TimescaleSupport.RefreshSlotPercentOfHourlyCadence,
+            new DarlingAlertSettings(config).StoreJobCadenceWarnPercent);
 
         /* V57's column default is the already-applied twin of the C# seed and cannot move without a rung;
            the store column wins on a fresh store, so a derived seed that drifts from it would ship a default

--- a/Darling/Darling.Tests/DarlingSelfAlertTests.cs
+++ b/Darling/Darling.Tests/DarlingSelfAlertTests.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Globalization;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql;
@@ -173,8 +174,10 @@ public sealed class DarlingSelfAlertTests
         /// <summary>#1696 (V37): AG disconnect re-fire minutes. Default 0 = off, the shipped behavior.</summary>
         public int AgDisconnectRefireMinutes { get; set; }
 
-        /// <summary>#2136 (V57): the Store Job Over Cadence warning percent. Default is the shipped 25.</summary>
-        public int StoreJobCadenceWarnPercent { get; set; } = 25;
+        /// <summary>#2136 (V57): the Store Job Over Cadence warning percent. Default is the shipped one,
+        /// taken from the product rather than restated — a literal here would let the harness agree with a
+        /// frozen default and hide exactly the drift #3060's pins exist to catch.</summary>
+        public int StoreJobCadenceWarnPercent { get; set; } = TimescaleSupport.RefreshSlotPercentOfHourlyCadence;
 
         public DateTime Now { get; set; } = new(2026, 7, 1, 12, 0, 0, DateTimeKind.Utc);
 
@@ -2537,25 +2540,90 @@ VALUES ($1, $2, $3, $4, $5, 0, $6, NULL, 0, 0, 0)", connection);
 
     /* ---------------- #2136 Store Job Over Cadence ---------------- */
 
+    /* The cadence every hourly store policy has, and the denominator the warning knob is a share of. */
+    private const long HourlyCadenceMs = 3_600_000;
+
+    /* ONE refresh slot, in ms, derived from the grid rather than written down — 3,600,000 divided by
+       RefreshPhaseSlots. #3060: the shipped knob default is that same quotient expressed as a percent, so
+       every boundary case below moves with RefreshPhaseStepMinutes instead of agreeing with it by accident. */
+    private const long RefreshSlotMs = HourlyCadenceMs / TimescaleSupport.RefreshPhaseSlots;
+
     private static StoreJobCadenceReading CadenceJob(
-        long id = 1028, long? durMs = 900_000, long schedMs = 3_600_000,
+        long id = 1028, long? durMs = RefreshSlotMs, long schedMs = HourlyCadenceMs,
         string name = "policy_compression query_store_stats") =>
         new(id, name, durMs, schedMs);
 
+    /* A refresh policy's label, in the shape JobCadenceReadSql builds it: proc_name first, then the
+       hypertable. Whether the remedy text may say "extend schedule_interval" turns on this. */
+    private static StoreJobCadenceReading RefreshCadenceJob(long? durMs = RefreshSlotMs) =>
+        CadenceJob(id: 1054, durMs: durMs,
+            name: TimescaleSupport.RefreshPolicyProcName + " query_store_stats_interval_hourly");
+
     [Fact]
-    public async Task JobOverCadence_WarningTier_FiresAtTheKnobPercent()
+    public async Task JobOverCadence_WarningTier_FiresAtOneRefreshSlot_TheShippedDefault()
     {
         var h = new Harness();
         var e = h.Build();
 
-        /* 900s of 3600s = exactly 25%, the shipped default — the boundary is inclusive. */
+        /* A run of exactly one refresh slot against the shipped default, which IS one slot as a percent of
+           cadence (#3060). The boundary is inclusive, and BOTH sides derive from RefreshPhaseSlots — so a
+           grid moved to a different step moves the reading and the threshold together and this stays the
+           boundary case rather than falling silently to one side of a frozen literal. */
         await e.ApplyStoreJobCadenceAsync(new[] { CadenceJob() }, Ct);
 
         var fired = Assert.Single(h.Deliverer.Outcomes);
         Assert.Equal(DarlingSelfAlertEvaluator.JobCadenceMetric, fired.MetricName);
         Assert.Equal(AlertSeverityLevel.Warning, fired.Severity);
         Assert.Equal("storejob:1028", fired.ServerKey);  /* prefixed so it never parses as a server_id */
-        Assert.Contains("25% of its schedule interval", fired.ShortMessage, StringComparison.Ordinal);
+
+        /* The threshold the alert reports is the derived default, not a coincident 25. */
+        Assert.Equal(
+            $"{TimescaleSupport.RefreshSlotPercentOfHourlyCadence}%", fired.ThresholdValue);
+
+        var renderedPercent = (100.0 * RefreshSlotMs / HourlyCadenceMs).ToString("F0", CultureInfo.InvariantCulture);
+        Assert.Contains($"{renderedPercent}% of its schedule interval", fired.ShortMessage, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// #3060: the shipped default is one refresh slot, and the derivation is what makes that a decision
+    /// rather than the accident it was. Cross-multiplied on purpose — two literals agreeing is exactly what a
+    /// change that freezes one of them produces, so the assertion has to be the identity and not the pair.
+    /// </summary>
+    [Fact]
+    public void JobCadenceDefault_IsOneRefreshSlot_AndFiresNoLaterThanOne()
+    {
+        /* The product's own seed, so the harness above cannot agree with a stale product default. */
+        Assert.Equal(
+            TimescaleSupport.RefreshSlotPercentOfHourlyCadence,
+            new AlertsConfig().StoreJobCadenceWarnPercent);
+
+        /* Fires at or BEFORE one slot, for any grid step: percent * slots <= 100. This is the guarantee the
+           issue was filed on — a knob unrelated to the step fires AFTER the point it exists to precede. */
+        Assert.True(
+            TimescaleSupport.RefreshSlotPercentOfHourlyCadence * TimescaleSupport.RefreshPhaseSlots <= 100,
+            $"a default of {TimescaleSupport.RefreshSlotPercentOfHourlyCadence}% over "
+            + $"{TimescaleSupport.RefreshPhaseSlots} slots fires past one slot — after the compression grid's "
+            + "stated precondition is already false, which is the failure #3060 is about");
+
+        /* And is the LATEST value that does, so the derivation buys the guarantee without buying noise. */
+        Assert.True(
+            (TimescaleSupport.RefreshSlotPercentOfHourlyCadence + 1) * TimescaleSupport.RefreshPhaseSlots > 100,
+            $"a default of {TimescaleSupport.RefreshSlotPercentOfHourlyCadence}% is earlier than it has to be "
+            + $"for {TimescaleSupport.RefreshPhaseSlots} slots");
+
+        /* The seed must survive its own clamp. A step fine enough to drive the derived default below the
+           [5, 100] floor would have the clamp silently raise it back above one slot — the same defect in a
+           new place, so the clamp is tied to the grid here rather than left to be discovered. */
+        var clamped = Math.Clamp(TimescaleSupport.RefreshSlotPercentOfHourlyCadence, 5, 100);
+        Assert.Equal(TimescaleSupport.RefreshSlotPercentOfHourlyCadence, clamped);
+
+        /* V57's column default is the already-applied twin of the C# seed and cannot move without a rung;
+           the store column wins on a fresh store, so a derived seed that drifts from it would ship a default
+           nobody chose. */
+        var v57 = PgMigrations.Scripts.Single(m => m.Version == 57);
+        Assert.Contains(
+            $"store_job_cadence_warn_percent integer NOT NULL DEFAULT {TimescaleSupport.RefreshSlotPercentOfHourlyCadence}",
+            v57.Sql, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -2564,11 +2632,91 @@ VALUES ($1, $2, $3, $4, $5, 0, $6, NULL, 0, 0, 0)", connection);
         var h = new Harness();
         var e = h.Build();
 
-        /* 249s of 3600s ≈ 7% — the production store's worst job today. Must not fire at the default 25. */
+        /* 249s of 3600s ≈ 6.9% — inside the body of the measured distribution on both production stores
+           (p99 is 6.1% on the busier one, #3060), so it must not fire at the shipped default. */
         await e.ApplyStoreJobCadenceAsync(new[] { CadenceJob(durMs: 249_000) }, Ct);
 
         Assert.Empty(h.Deliverer.Outcomes);
         Assert.Empty(h.History.Records);
+    }
+
+    /// <summary>
+    /// #3060, the user-facing half: the remedy an operator reads must not tell them to widen an interval
+    /// that doubles as an <c>end_offset</c>. Asserted on BOTH arms in one test, because the claim is a
+    /// difference — a test that only checked the refresh arm would pass just as well if the advice had been
+    /// softened for every job, which is the outcome that was rejected.
+    /// </summary>
+    [Fact]
+    public async Task JobOverCadence_RemedyOmitsTheIntervalOnlyForRefreshPolicies()
+    {
+        var h = new Harness();
+        var e = h.Build();
+
+        await e.ApplyStoreJobCadenceAsync(new[] { RefreshCadenceJob() }, Ct);
+        var refresh = Assert.Single(h.Deliverer.Outcomes);
+
+        Assert.DoesNotContain("extend the job's schedule_interval", refresh.DetailText, StringComparison.Ordinal);
+        Assert.Contains("Do NOT widen this job's schedule_interval", refresh.DetailText, StringComparison.Ordinal);
+        Assert.Contains("end_offset", refresh.DetailText, StringComparison.Ordinal);
+        /* Naming the lever that does work is the point; "don't do that" alone leaves the operator nowhere. */
+        Assert.Contains("Narrow the refresh window", refresh.DetailText, StringComparison.Ordinal);
+
+        /* A compression policy has no end_offset, so it keeps the concrete advice unhedged. */
+        var h2 = new Harness();
+        var e2 = h2.Build();
+        await e2.ApplyStoreJobCadenceAsync(new[] { CadenceJob() }, Ct);
+        var compression = Assert.Single(h2.Deliverer.Outcomes);
+
+        Assert.Contains("extend the job's schedule_interval deliberately", compression.DetailText, StringComparison.Ordinal);
+        Assert.DoesNotContain("end_offset", compression.DetailText, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The predicate behind that branch, and the fact it reports. Both refresh tiers pass the SAME constant
+    /// as <c>end_offset</c> and <c>schedule_interval</c>, read out of the emitted statement rather than
+    /// restated — so the predicate cannot outlive the equality, and a policy builder changed to pass
+    /// different values goes red here instead of shipping advice that has quietly become correct.
+    /// </summary>
+    [Fact]
+    public void RefreshPolicies_PassTheScheduleIntervalAsTheEndOffsetToo_WhichThePredicateReports()
+    {
+        foreach (var view in TimescaleSupport.HourlyRefreshPhaseOrder)
+        {
+            AssertEndOffsetEqualsScheduleInterval(TimescaleSupport.AddHourlyRefreshPolicySql(view));
+        }
+
+        AssertEndOffsetEqualsScheduleInterval(
+            TimescaleSupport.AddDailyRefreshPolicySql("query_store_stats_daily"));
+
+        /* The label the read builds is proc_name FIRST, which is the whole basis of the match. */
+        Assert.Contains("j.proc_name || coalesce(' ' || j.hypertable_name, '')",
+            TimescaleSupport.JobCadenceReadSql, StringComparison.Ordinal);
+
+        Assert.True(TimescaleSupport.ScheduleIntervalDoublesAsEndOffset(
+            TimescaleSupport.RefreshPolicyProcName + " query_store_stats_interval_hourly"));
+        /* The telemetry label carries a [job_id] suffix; same leading token, same answer. */
+        Assert.True(TimescaleSupport.ScheduleIntervalDoublesAsEndOffset(
+            TimescaleSupport.RefreshPolicyProcName + " query_store_stats_interval_hourly [1054]"));
+        /* A hypertable-less job is the bare proc name. */
+        Assert.True(TimescaleSupport.ScheduleIntervalDoublesAsEndOffset(TimescaleSupport.RefreshPolicyProcName));
+
+        Assert.False(TimescaleSupport.ScheduleIntervalDoublesAsEndOffset("policy_compression query_store_stats"));
+        Assert.False(TimescaleSupport.ScheduleIntervalDoublesAsEndOffset("policy_retention query_store_stats"));
+        Assert.False(TimescaleSupport.ScheduleIntervalDoublesAsEndOffset("policy_telemetry"));
+        Assert.False(TimescaleSupport.ScheduleIntervalDoublesAsEndOffset(null));
+        Assert.False(TimescaleSupport.ScheduleIntervalDoublesAsEndOffset(""));
+        /* Prefix, not substring: a hypertable named after the policy must not borrow its answer. */
+        Assert.False(TimescaleSupport.ScheduleIntervalDoublesAsEndOffset(
+            "policy_compression " + TimescaleSupport.RefreshPolicyProcName));
+    }
+
+    private static void AssertEndOffsetEqualsScheduleInterval(string policySql)
+    {
+        var endOffset = Regex.Match(policySql, @"end_offset => INTERVAL '([^']+)'");
+        var schedule = Regex.Match(policySql, @"schedule_interval => INTERVAL '([^']+)'");
+
+        Assert.True(endOffset.Success && schedule.Success, $"could not read both intervals out of: {policySql}");
+        Assert.Equal(endOffset.Groups[1].Value, schedule.Groups[1].Value);
     }
 
     [Fact]

--- a/Darling/Darling.Tests/DarlingSelfAlertTests.cs
+++ b/Darling/Darling.Tests/DarlingSelfAlertTests.cs
@@ -179,6 +179,11 @@ public sealed class DarlingSelfAlertTests
         /// frozen default and hide exactly the drift #3060's pins exist to catch.</summary>
         public int StoreJobCadenceWarnPercent { get; set; } = TimescaleSupport.RefreshSlotPercentOfHourlyCadence;
 
+        /// <summary>#3060: set false to build the evaluator with the knob seam UNSUPPLIED, so the
+        /// constructor's own fallback is what judges. Otherwise that fallback is a product default no test
+        /// ever reaches — the shape a stale literal survives in.</summary>
+        public bool WireCadenceKnob { get; set; } = true;
+
         public DateTime Now { get; set; } = new(2026, 7, 1, 12, 0, 0, DateTimeKind.Utc);
 
         /// <summary>#1681: captures what the evaluator writes to the service log, so the firing/recovery pair
@@ -196,7 +201,7 @@ public sealed class DarlingSelfAlertTests
             agLagAlertSeconds: () => AgLagAlertSeconds,
             agRedoQueueAlertKb: () => AgRedoQueueAlertKb,
             agDisconnectRefireMinutes: () => AgDisconnectRefireMinutes,
-            storeJobCadenceWarnPercent: () => StoreJobCadenceWarnPercent);
+            storeJobCadenceWarnPercent: WireCadenceKnob ? () => StoreJobCadenceWarnPercent : null);
     }
 
     /* ---------------- #991 Availability Group fixtures ---------------- */
@@ -2548,6 +2553,11 @@ VALUES ($1, $2, $3, $4, $5, 0, $6, NULL, 0, 0, 0)", connection);
        every boundary case below moves with RefreshPhaseStepMinutes instead of agreeing with it by accident. */
     private const long RefreshSlotMs = HourlyCadenceMs / TimescaleSupport.RefreshPhaseSlots;
 
+    /* One second under whatever the shipped knob resolves to — derived from the THRESHOLD, not from the
+       slot, because the two coincide only while the grid step divides 100. */
+    private const long JustUnderTheKnobMs =
+        HourlyCadenceMs * TimescaleSupport.RefreshSlotPercentOfHourlyCadence / 100 - 1_000;
+
     private static StoreJobCadenceReading CadenceJob(
         long id = 1028, long? durMs = RefreshSlotMs, long schedMs = HourlyCadenceMs,
         string name = "policy_compression query_store_stats") =>
@@ -2627,6 +2637,30 @@ VALUES ($1, $2, $3, $4, $5, 0, $6, NULL, 0, 0, 0)", connection);
         Assert.Contains(
             $"store_job_cadence_warn_percent integer NOT NULL DEFAULT {TimescaleSupport.RefreshSlotPercentOfHourlyCadence}",
             v57.Sql, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// #3060: the constructor's fallback for an unsupplied knob seam is the same derived slot, exercised
+    /// through the fallback rather than asserted about it. It is the copy of this number that no wired test
+    /// reaches, so it is the one a stale literal would have survived in.
+    /// </summary>
+    [Fact]
+    public async Task JobOverCadence_WithTheKnobSeamUnsupplied_StillJudgesAtOneRefreshSlot()
+    {
+        var h = new Harness { WireCadenceKnob = false };
+        var e = h.Build();
+
+        await e.ApplyStoreJobCadenceAsync(new[] { CadenceJob() }, Ct);
+        var fired = Assert.Single(h.Deliverer.Outcomes);
+        Assert.Equal($"{TimescaleSupport.RefreshSlotPercentOfHourlyCadence}%", fired.ThresholdValue);
+
+        /* And a second under that same fallback's threshold stays silent, so the assertion above is a
+           threshold and not merely "it fires on anything". Derived from the threshold rather than from the
+           slot: the two coincide only while the step divides 100. */
+        var quiet = new Harness { WireCadenceKnob = false };
+        var e2 = quiet.Build();
+        await e2.ApplyStoreJobCadenceAsync(new[] { CadenceJob(durMs: JustUnderTheKnobMs) }, Ct);
+        Assert.Empty(quiet.Deliverer.Outcomes);
     }
 
     [Fact]

--- a/Darling/Darling.Tests/TimescaleContinuousAggregateTests.cs
+++ b/Darling/Darling.Tests/TimescaleContinuousAggregateTests.cs
@@ -224,6 +224,53 @@ public sealed class TimescaleContinuousAggregateTests
     }
 
     /// <summary>
+    /// #3060: the seam between the grid and #2136's Store Job Over Cadence knob, asserted in SECONDS —
+    /// the unit that alert actually compares — against <see cref="TimescaleSupport.RefreshPhaseSlotSeconds"/>.
+    ///
+    /// <para><b>Why in seconds as well as in percent.</b> The knob is a percent of a job's own schedule
+    /// interval and the grid is a number of minutes, and nothing made those two commensurable: the default
+    /// landing exactly on one slot was an accident of two independent decisions, so a grid moved to a
+    /// 10-minute step would have left the alert firing at 900 s against a 600 s slot — after the point it
+    /// exists to precede. The percent-side identity lives with the alert; this is the same claim restated in
+    /// the unit an operator reads off the alert text, so neither form can be satisfied alone.</para>
+    ///
+    /// <para><b>The tiling assertion is not a tautology.</b> Under integer division a step that does not
+    /// divide 60 leaves <c>RefreshPhaseSlotSeconds * RefreshPhaseSlots</c> SHORT of the cadence — a
+    /// 7-minute step gives 8 slots of 420 s, 3,360 s of a 3,600 s hour — and every "a slot is a quarter of
+    /// the cadence" statement in the product silently stops being true. Pinned against
+    /// <see cref="TimescaleSupport.HourlyRefreshScheduleSpan"/> rather than a literal hour so the cadence
+    /// enters as the product's own value.</para>
+    /// </summary>
+    [Fact]
+    public void TheRefreshGrid_TilesTheHourlyCadence_AndTheCadenceKnobFiresNoLaterThanOneSlot()
+    {
+        var cadenceSeconds = TimescaleSupport.RefreshPhaseSlotSeconds * TimescaleSupport.RefreshPhaseSlots;
+
+        Assert.Equal(TimescaleSupport.HourlyRefreshScheduleSpan, TimeSpan.FromSeconds(cadenceSeconds));
+
+        var knobFiresAtSeconds = cadenceSeconds * TimescaleSupport.RefreshSlotPercentOfHourlyCadence / 100;
+
+        Assert.True(
+            knobFiresAtSeconds <= TimescaleSupport.RefreshPhaseSlotSeconds,
+            $"the shipped cadence knob fires at {knobFiresAtSeconds}s against a "
+            + $"{TimescaleSupport.RefreshPhaseSlotSeconds}s slot — past the width the compression phase grid "
+            + "assumes a refresh fits inside, so the alert would arrive after #3035's precondition is false");
+
+        /* And within one percentage point of the slot, so the derivation is the LATEST value that clears it
+           rather than an arbitrary early one. One point of cadence is the finest step the knob has. */
+        Assert.True(
+            knobFiresAtSeconds + cadenceSeconds / 100 > TimescaleSupport.RefreshPhaseSlotSeconds,
+            $"the shipped cadence knob fires at {knobFiresAtSeconds}s against a "
+            + $"{TimescaleSupport.RefreshPhaseSlotSeconds}s slot — earlier than it needs to be");
+
+        /* #3044's watch line sits inside the same slot, so the two signals are ordered rather than
+           competing: the grid's own watch speaks first, the cadence alert at the wall. */
+        Assert.True(
+            TimescaleSupport.RefreshSlotWarningSeconds <= TimescaleSupport.RefreshPhaseSlotSeconds,
+            "the refresh slot watch line must sit inside the slot it watches");
+    }
+
+    /// <summary>
     /// The grid's actual invariant, over EVERY contended relation rather than the one family the incident
     /// evidence named.
     ///

--- a/Darling/Darling.Tests/ViewerControlPlaneStage3bTests.cs
+++ b/Darling/Darling.Tests/ViewerControlPlaneStage3bTests.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using PerformanceMonitor.Collectors;
 using PerformanceMonitor.Darling.Service;
 using PerformanceMonitor.Darling.Viewer;
+using PerformanceMonitor.Darling.Storage;
 using Xunit;
 
 namespace Darling.Tests;
@@ -484,6 +485,33 @@ public sealed class ViewerControlCommandParityTests
         /* Without a target it fails — the viewer only ever sends it with a server id. */
         Assert.Equal(CommandKind.Fail,
             DarlingCommandExecutor.ResolvePlan(new ClaimedCommand(1, ViewerDataService.CommandFetchPlan, null, args, "viewer")).Kind);
+    }
+}
+
+/// <summary>
+/// #3060: the viewer row's shipped default for the Store Job Over Cadence knob is the refresh slot, not a
+/// literal. Pinned here rather than beside the alert's own pins because this is the only surface that can
+/// reach <see cref="AlertSettingsRow"/>.
+///
+/// <para><b>Why this copy is load-bearing and not decoration.</b>
+/// <c>SettingsWindow.BuildAlertRowFromControls</c> assigns the textbox value only when it parses INSIDE the
+/// clamp, so out-of-range or unparseable input leaves whatever this initializer holds and persists it to the
+/// store. A frozen literal here would therefore survive a moved refresh grid and arm the alert past the slot
+/// it exists to precede — the same failure the evaluator's fallback, <c>AlertsConfig</c>'s initializer and
+/// the Restore-Defaults button were derived to avoid. Found by review, not by these tests.</para>
+/// </summary>
+public sealed class ViewerAlertRowCadenceDefaultTests
+{
+    [Fact]
+    public void TheViewerRowsCadenceDefault_IsOneRefreshSlot()
+    {
+        Assert.Equal(
+            TimescaleSupport.RefreshSlotPercentOfHourlyCadence,
+            AlertSettingsRow.Defaults().StoreJobCadenceWarnPercent);
+
+        /* And it clears the clamp SettingsWindow validates against, so the initializer can never be the
+           value that gets rejected on its way back in. */
+        Assert.InRange(AlertSettingsRow.Defaults().StoreJobCadenceWarnPercent, 5, 100);
     }
 }
 

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingAlertSettings.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingAlertSettings.cs
@@ -75,9 +75,28 @@ public sealed class DarlingAlertSettings : IAlertEngineSettings, IAlertSettings
     public int SelfDiskFreeWarnPercent => Math.Clamp(_config.Alerts.SelfDiskFreeWarnPercent, 0, 100);
     public int CollectionStaleMinutes => Math.Clamp(_config.Alerts.CollectionStaleMinutes, 5, 1440);
 
-    /// <summary>#2136: the Store Job Over Cadence warning percent. Clamped [5, 100] — below 5 would fire
-    /// on healthy jobs (the production worst runs ~7% of cadence), and at 100 the Warning tier merges
-    /// into the fixed Critical tier, so higher values would only disable the warning silently.</summary>
+    /// <summary>#2136: the Store Job Over Cadence warning percent. Clamped [5, 100].
+    ///
+    /// <para><b>The ceiling is structural.</b> At 100 the Warning tier merges into the fixed Critical tier,
+    /// so higher values would only disable the warning silently.</para>
+    ///
+    /// <para><b>The floor is 5 because the distribution is bimodal, NOT because the worst job runs ~7% of
+    /// cadence</b> — #2136 said the latter and it is measurably wrong (#3060). Measured over
+    /// <c>collect.store_metrics</c>' <c>object_kind = 'background_job'</c> series on both production
+    /// 42-server stores: the store carrying the Query Store workload has p50 0.003%, p90 0.056%, p99 6.1%,
+    /// p99.9 69.6% and a MAXIMUM of 369.5% of cadence over 48,030 readings (2026-08-17 to 2026-09-06); its
+    /// sibling has p50 0.003%, p90 0.016%, p99 0.29% and a maximum of 62.6% over 64,646 readings
+    /// (2026-08-09 to 2026-09-06). So the worst is 53x the figure #2136 cited, and the tail is owned almost
+    /// entirely by the continuous-aggregate refresh family.</para>
+    ///
+    /// <para><b>Which changes the reasoning and not the number.</b> A floor exists to stop a setting that
+    /// fires on the healthy body of the distribution, and 5 is still ~90x the 90th percentile and three
+    /// orders of magnitude above the median — 1.1% of readings on the busier store reach it at all. Moving
+    /// it buys nothing in either direction: only 73 of those 48,030 readings sit in [5, 7), so raising the
+    /// floor to the old rationale's own number would change almost no outcome, and lowering it would admit
+    /// settings that fire on compression policies doing ordinary work. Left at 5 deliberately — an
+    /// operator-facing knob's bound is not something to move as a side effect of correcting the sentence
+    /// that justified it.</para></summary>
     public int StoreJobCadenceWarnPercent => Math.Clamp(_config.Alerts.StoreJobCadenceWarnPercent, 5, 100);
     public int CollectionFailureThreshold => Math.Clamp(_config.Alerts.CollectionFailureThreshold, 1, 1000);
 

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingConfig.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingConfig.cs
@@ -639,8 +639,7 @@ public sealed class AlertsConfig
     /// refresh slot — rather than a literal, so it moves with <c>RefreshPhaseStepMinutes</c>. It computed to
     /// the same 25 this shipped with; see that constant for why the equality was previously an accident and
     /// what the derivation guarantees. V57's column default is the already-applied twin of this seed and
-    /// cannot move without a rung, which
-    /// DarlingSelfAlertTests pins.</para></summary>
+    /// cannot move without a rung, which DarlingSelfAlertTests pins.</para></summary>
     [JsonPropertyName("storeJobCadenceWarnPercent")]
     public int StoreJobCadenceWarnPercent { get; set; } = TimescaleSupport.RefreshSlotPercentOfHourlyCadence;
 

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingConfig.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingConfig.cs
@@ -15,6 +15,7 @@ using System.Net.Sockets;
 using System.Text.Json;
 using PerformanceMonitor.Collectors;
 using PerformanceMonitor.Common;
+using PerformanceMonitor.Darling.Storage;
 using System.Text.Json.Serialization;
 using PerformanceMonitor.Notifications;
 
@@ -632,9 +633,16 @@ public sealed class AlertsConfig
 
     /// <summary>#2136: the Store Job Over Cadence warning threshold — a store background job whose
     /// last run reaches this percent of its own schedule interval fires the Warning tier. The
-    /// Critical tier is fixed at 100 (a job outrunning its cadence compounds refresh lag).</summary>
+    /// Critical tier is fixed at 100 (a job outrunning its cadence compounds refresh lag).
+    ///
+    /// <para>#3060: the default is <see cref="TimescaleSupport.RefreshSlotPercentOfHourlyCadence"/> — one
+    /// refresh slot — rather than a literal, so it moves with <c>RefreshPhaseStepMinutes</c>. It computed to
+    /// the same 25 this shipped with; see that constant for why the equality was previously an accident and
+    /// what the derivation guarantees. V57's column default is the already-applied twin of this seed and
+    /// cannot move without a rung, which
+    /// DarlingSelfAlertTests pins.</para></summary>
     [JsonPropertyName("storeJobCadenceWarnPercent")]
-    public int StoreJobCadenceWarnPercent { get; set; } = 25;
+    public int StoreJobCadenceWarnPercent { get; set; } = TimescaleSupport.RefreshSlotPercentOfHourlyCadence;
 
     [JsonPropertyName("longRunningJobEnabled")]
     public bool LongRunningJobEnabled { get; set; } = true;

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingSelfAlertEvaluator.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingSelfAlertEvaluator.cs
@@ -377,9 +377,12 @@ internal sealed class DarlingSelfAlertEvaluator
         _agLagAlertSeconds = agLagAlertSeconds ?? (() => 300);
         _agRedoQueueAlertKb = agRedoQueueAlertKb ?? (() => 0);
         _agDisconnectRefireMinutes = agDisconnectRefireMinutes ?? (() => 0);
-        /* Unsupplied falls back to the V57 DDL default, so an evaluator built without the seam behaves
-           like a store at its shipped defaults (the AG-seam discipline). */
-        _storeJobCadenceWarnPercent = storeJobCadenceWarnPercent ?? (() => 25);
+        /* Unsupplied falls back to the shipped default, so an evaluator built without the seam behaves
+           like a store at its shipped defaults (the AG-seam discipline). Taken from the constant rather
+           than restated (#3060): a literal here is a third copy of the same number that a moved refresh
+           grid would leave behind, and this one would fire past the slot silently. */
+        _storeJobCadenceWarnPercent =
+            storeJobCadenceWarnPercent ?? (() => TimescaleSupport.RefreshSlotPercentOfHourlyCadence);
         _readFailures = readFailures;
     }
 

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingSelfAlertEvaluator.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingSelfAlertEvaluator.cs
@@ -1650,6 +1650,15 @@ internal sealed class DarlingSelfAlertEvaluator
     /// threshold. A job with no schedule interval or no completed run yet has no cadence to breach and is
     /// skipped without touching its standing state (no signal, the agent-status discipline). Gated on the
     /// master alerts switch. Internal so it pins directly with a recording deliverer + controllable clock.
+    ///
+    /// <para><b>The remedy names one exception, and does not hedge for everyone else (#3060).</b> "Extend
+    /// the job's schedule_interval" is right for a compression or retention policy and actively wrong for a
+    /// continuous-aggregate refresh, whose interval is also its <c>end_offset</c> — an operator following it
+    /// there alters what the store materializes in order to quiet an alert. The branch is
+    /// <see cref="TimescaleSupport.ScheduleIntervalDoublesAsEndOffset"/>, keyed on the policy proc, so the
+    /// one family that cannot take the advice is told the lever that does work while the other three keep
+    /// the concrete sentence. Softening it for all four instead would have made every alert vaguer to fix
+    /// one of them.</para>
     /// </summary>
     internal async Task ApplyStoreJobCadenceAsync(
         IReadOnlyList<StoreJobCadenceReading> jobs, CancellationToken cancellationToken)
@@ -1692,8 +1701,16 @@ internal sealed class DarlingSelfAlertEvaluator
                                 : "These runtimes scale with raw data volume, so this is the early warning that the " +
                                   "store is outgrowing its job schedule — an onboarding wave moves this number first. ") +
                             "Compare the job's duration series in collect.store_metrics (object_kind = " +
-                            "'background_job') to see the trend, and either reduce raw volume, extend the job's " +
-                            "schedule_interval deliberately, or scale the store host.",
+                            "'background_job') to see the trend, and " +
+                            (TimescaleSupport.ScheduleIntervalDoublesAsEndOffset(job.JobName)
+                                ? "either reduce raw volume or scale the store host. Do NOT widen this job's " +
+                                  "schedule_interval: on a continuous-aggregate refresh policy it is also the " +
+                                  "aggregate's end_offset, so widening it changes what the refresh " +
+                                  "materializes — a wider still-filling tail is left unmaterialized, and on " +
+                                  "the hourly tier the Query Store backfill horizon derived from it shortens " +
+                                  "too. Narrow the refresh window or re-phase the grid instead."
+                                : "either reduce raw volume, extend the job's schedule_interval deliberately, " +
+                                  "or scale the store host."),
                         severity: critical ? AlertSeverityLevel.Critical : AlertSeverityLevel.Warning,
                         shortMessage: $"{label} ran {percent:F0}% of its schedule interval",
                         numericCurrentValue: Math.Round(percent, 1),

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -1687,9 +1687,15 @@ WITH NO DATA";
     /// <para><b>What this does NOT do.</b> It does not bound what an operator may SET. The knob stays
     /// clamped [5, 100] and a value above this one fires after the slot — deliberately, because the knob
     /// judges families that have no slot, and silently retuning a live fleet's setting to satisfy this
-    /// constant would be a worse trade than the alert arriving late for one family. The slot is a property
-    /// of the grid and is bounded there (see
-    /// <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/> and #3044), not here.</para>
+    /// constant would be a worse trade than the alert arriving late for one family. The slot itself is
+    /// watched independently of this knob, on the grid's own terms, by #3044's
+    /// <see cref="RefreshSlotWarningSeconds"/> line — so raising the knob cannot leave the grid's
+    /// precondition unattended, which is what makes leaving the clamp alone the cheaper trade.</para>
+    ///
+    /// <para>Expressed over <see cref="RefreshPhaseSlots"/> rather than over
+    /// <see cref="RefreshPhaseSlotSeconds"/> because a percent of cadence needs no seconds at all; the two
+    /// are the same wall, and TimescaleContinuousAggregateTests asserts the fire point in SECONDS against
+    /// <see cref="RefreshPhaseSlotSeconds"/> so the identity is checked in the unit the alert compares.</para>
     /// </summary>
     public const int RefreshSlotPercentOfHourlyCadence = 100 / RefreshPhaseSlots;
 

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -1660,6 +1660,40 @@ WITH NO DATA";
     public const int RefreshPhaseSlots = 60 / RefreshPhaseStepMinutes;
 
     /// <summary>
+    /// One refresh slot as a percent of the hourly cadence — and the value #2136's Store Job Over Cadence
+    /// warning knob ships as its default (<c>AlertsConfig.StoreJobCadenceWarnPercent</c>).
+    ///
+    /// <para><b>Why that alert's default belongs to the refresh grid rather than to the alert.</b> The knob
+    /// judges every store background job against a share of its own schedule interval, and the tightest
+    /// STRUCTURAL ceiling in the population it judges is this one: an hourly continuous-aggregate refresh
+    /// that outgrows its slot breaks the precondition #3035's compression phase grid rests on, because
+    /// excluding one slot is then no longer enough to keep a refresh out of a compression window. A
+    /// compression or retention policy at the same share of cadence is merely notable. So the default is the
+    /// slot, stated as the slot.</para>
+    ///
+    /// <para><b>It computed to 25 before #3060 as well, and that was a coincidence.</b> The knob was a
+    /// literal with no reference to <see cref="RefreshPhaseStepMinutes"/>, so a grid moved to a 10-minute
+    /// step would have left it firing at 900 s against a 600 s slot — AFTER the condition it exists to
+    /// precede rather than before it. Derived, that cannot happen, and the equality is a decision rather
+    /// than an accident of two independent ones.</para>
+    ///
+    /// <para><b>Integer division is load-bearing, not a rounding artifact.</b> Flooring is what guarantees
+    /// the warning fires at or BEFORE one slot for every possible <see cref="RefreshPhaseSlots"/> —
+    /// <c>this * RefreshPhaseSlots &lt;= 100</c> — while <c>(this + 1) * RefreshPhaseSlots &gt; 100</c> keeps
+    /// it the LATEST value that still does, so the derivation buys the guarantee without buying noise.
+    /// Both are pinned cross-multiplied by TimescaleContinuousAggregateTests rather than as literals,
+    /// because two literals can both be rubber-stamped by a change that freezes one.</para>
+    ///
+    /// <para><b>What this does NOT do.</b> It does not bound what an operator may SET. The knob stays
+    /// clamped [5, 100] and a value above this one fires after the slot — deliberately, because the knob
+    /// judges families that have no slot, and silently retuning a live fleet's setting to satisfy this
+    /// constant would be a worse trade than the alert arriving late for one family. The slot is a property
+    /// of the grid and is bounded there (see
+    /// <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/> and #3044), not here.</para>
+    /// </summary>
+    public const int RefreshSlotPercentOfHourlyCadence = 100 / RefreshPhaseSlots;
+
+    /// <summary>
     /// The hourly refresh policies in phase order — the ONLY thing that decides which slot a policy gets, and
     /// it is keyed on the VIEW name.
     ///
@@ -1919,6 +1953,41 @@ WITH NO DATA";
             DailyRefreshScheduleInterval,
             DailyRefreshScheduleInterval,
             phaseMinutes: null);
+
+    /// <summary>The TimescaleDB policy proc behind a continuous-aggregate refresh job — what
+    /// <c>timescaledb_information.jobs.proc_name</c> reports, and the leading token of the job label both
+    /// <see cref="JobCadenceReadSql"/> and <see cref="StoreSelfMetrics.BackgroundJobInsertSql"/>
+    /// build.</summary>
+    public const string RefreshPolicyProcName = "policy_refresh_continuous_aggregate";
+
+    /// <summary>
+    /// Whether a background job's <c>schedule_interval</c> is ALSO its <c>end_offset</c>, decided from the
+    /// job label the store telemetry names it by.
+    ///
+    /// <para><b>It is the same argument twice for every refresh policy this product creates.</b>
+    /// <see cref="AddHourlyRefreshPolicySql"/> passes <see cref="HourlyRefreshScheduleInterval"/> as both,
+    /// and <see cref="AddDailyRefreshPolicySql"/> passes <see cref="DailyRefreshScheduleInterval"/> as both;
+    /// TimescaleContinuousAggregateTests pins that equality out of the EMITTED statement, so this predicate
+    /// cannot outlive the fact it reports.</para>
+    ///
+    /// <para><b>Which makes "widen the interval" a collection change here, not a relaxed deadline</b> — the
+    /// half of #3060 an operator actually hits. On the hourly tier it does three things at once: the refresh
+    /// materializes a narrower window, a wider still-filling tail is left unmaterialized, and
+    /// <c>QueryStoreBackfill.RollupStoreHorizon</c> — derived as <see cref="HourlyRefreshStartSpan"/> minus
+    /// that interval — silently shortens with it. Advice that is correct for a compression or retention
+    /// policy alters what gets collected here.</para>
+    ///
+    /// <para>Keyed on <c>proc_name</c> rather than the view or the job id: the policy proc is what decides
+    /// whether the interval carries a second meaning, it is uniform across every deployment, and job ids are
+    /// per-deployment (the <see cref="HourlyRefreshPhaseOrder"/> reasoning). The label is
+    /// <c>proc_name</c> followed by a space or by nothing, so an exact-or-prefixed-token match is the whole
+    /// test — never a substring, which would also match a hypertable that happened to be named after a
+    /// policy.</para>
+    /// </summary>
+    public static bool ScheduleIntervalDoublesAsEndOffset(string? jobLabel)
+        => jobLabel is not null
+            && (jobLabel.Equals(RefreshPolicyProcName, StringComparison.Ordinal)
+                || jobLabel.StartsWith(RefreshPolicyProcName + " ", StringComparison.Ordinal));
 
     /// <summary>
     /// The refresh policy for a continuous aggregate: materialize
@@ -3840,23 +3909,19 @@ WHERE j.proc_name LIKE '%compression%'
     }
 
     /// <summary>
-    /// Every background job's last-run duration against its own schedule interval (#2136) — the readings
-    /// the Store Job Over Cadence self-alert judges. <c>job_stats</c> for the same reason the #1778
-    /// observability path uses it (maintained unconditionally; the per-execution history table is empty
-    /// unless job-execution logging is on). Only a SUCCESSFUL last run judges: a failed run's duration is
-    /// not a cadence signal, and job failures are their own condition (<c>total_failures</c> rides the
-    /// V56 telemetry). Tolerant like <see cref="ReadStuckCompressionJobsAsync"/> — a plain-PG store or a
-    /// hiccup yields no readings, never an exception.
+    /// The #2136 job-cadence catalog read, public for the reason <see cref="RetentionHoldReadSql"/> is: one
+    /// of its projections is now load-bearing for what an ALERT SAYS, so it belongs in CI rather than only
+    /// in a throwaway harness. <see cref="StoreJobCadenceReading.JobName"/> is built <c>proc_name</c> FIRST,
+    /// which is what lets <see cref="ScheduleIntervalDoublesAsEndOffset"/> decide whether widening this
+    /// job's interval would move an <c>end_offset</c>; reversing the concatenation would keep collecting
+    /// perfectly good readings while silently restoring the wrong remedy text.
+    ///
+    /// <para><c>job_stats</c> for the same reason the #1778 observability path uses it (maintained
+    /// unconditionally; the per-execution history table is empty unless job-execution logging is on). Only
+    /// a SUCCESSFUL last run judges: a failed run's duration is not a cadence signal, and job failures are
+    /// their own condition (<c>total_failures</c> rides the V56 telemetry).</para>
     /// </summary>
-    public static async Task<IReadOnlyList<StoreJobCadenceReading>> ReadJobCadenceReadingsAsync(
-        NpgsqlConnection connection, ILogger? logger, CancellationToken cancellationToken = default)
-    {
-        if (connection is null)
-        {
-            throw new ArgumentNullException(nameof(connection));
-        }
-
-        const string sql = @"
+    public const string JobCadenceReadSql = @"
 SELECT
     j.job_id,
     j.proc_name || coalesce(' ' || j.hypertable_name, ''),
@@ -3866,10 +3931,24 @@ FROM timescaledb_information.job_stats AS js
 JOIN timescaledb_information.jobs AS j USING (job_id)
 WHERE js.last_run_status = 'Success'";
 
+    /// <summary>
+    /// Every background job's last-run duration against its own schedule interval (#2136) — the readings the
+    /// Store Job Over Cadence self-alert judges. Tolerant like
+    /// <see cref="ReadStuckCompressionJobsAsync"/> — a plain-PG store or a hiccup yields no readings, never
+    /// an exception. See <see cref="JobCadenceReadSql"/> for the statement and its decisions.
+    /// </summary>
+    public static async Task<IReadOnlyList<StoreJobCadenceReading>> ReadJobCadenceReadingsAsync(
+        NpgsqlConnection connection, ILogger? logger, CancellationToken cancellationToken = default)
+    {
+        if (connection is null)
+        {
+            throw new ArgumentNullException(nameof(connection));
+        }
+
         var readings = new List<StoreJobCadenceReading>();
         try
         {
-            using var command = new NpgsqlCommand(sql, connection) { CommandTimeout = JobCatalogReadTimeoutSeconds };
+            using var command = new NpgsqlCommand(JobCadenceReadSql, connection) { CommandTimeout = JobCatalogReadTimeoutSeconds };
             await using var reader = await command.ExecuteReaderAsync(cancellationToken);
             while (await reader.ReadAsync(cancellationToken))
             {

--- a/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/SettingsWindow.xaml.cs
@@ -17,6 +17,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Navigation;
+using PerformanceMonitor.Darling.Storage;
 using PerformanceMonitor.Notifications;
 using PerformanceMonitor.Ui;
 
@@ -940,7 +941,11 @@ public partial class SettingsWindow : Window
         AlertSelfDiskWarnPercentBox.Text = "10";
         AlertCollectionStaleMinutesBox.Text = "30";
         AlertCollectionFailureThresholdBox.Text = "10";
-        AlertStoreJobCadenceWarnPercentBox.Text = "25";
+        /* #3060: derived, unlike its neighbours, because this one is not merely a mirrored default — it is
+           one refresh slot as a share of the hourly cadence, and a reset that handed out a stale 25 after
+           the grid moved would arm the alert past the point it exists to precede. */
+        AlertStoreJobCadenceWarnPercentBox.Text =
+            TimescaleSupport.RefreshSlotPercentOfHourlyCadence.ToString(CultureInfo.InvariantCulture);
         AnalysisNotifyCooldownBox.Text = "360";
         AlertPvsThresholdPercentBox.Text = "40";
         AlertPvsFloorGbBox.Text = "1";

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.AlertSettings.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.AlertSettings.cs
@@ -13,6 +13,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Npgsql;
 using NpgsqlTypes;
+using PerformanceMonitor.Darling.Storage;
 
 namespace PerformanceMonitor.Darling.Viewer;
 
@@ -354,7 +355,12 @@ public sealed class AlertSettingsRow
     public int DiskCriticalFreePercent { get; set; } = 3;
     public int DiskCriticalFreeGb { get; set; } = 2;
     public int AnalysisNotifyCooldownMinutes { get; set; } = 360;
-    public int StoreJobCadenceWarnPercent { get; set; } = 25;
+    /* #3060: derived, unlike its neighbours, because this one is not merely a mirrored column default
+       — it is one refresh slot as a share of the hourly cadence. BuildAlertRowFromControls only
+       overwrites it when the textbox parses inside the clamp, so out-of-range input persists whatever
+       sits here, and a stale 25 after the grid moved would arm the alert past the point it exists to
+       precede. */
+    public int StoreJobCadenceWarnPercent { get; set; } = TimescaleSupport.RefreshSlotPercentOfHourlyCadence;
 
     /* #2391: defaults mirror the V79 column defaults, so a viewer prefilling against a store that has
        not seeded the row shows what the store would have given it. Ships OFF, per #2349. */


### PR DESCRIPTION
Closes #3060.

#2136's Store Job Over Cadence alert judges every store background job against a percent of its own `schedule_interval`. Two things about it were wrong for the hourly continuous-aggregate refresh family, and they are separate decisions with separate reasoning.

## 1. The remedy: name the exception, do not soften the advice

The alert told the operator to "extend the job's `schedule_interval` deliberately". For a continuous-aggregate refresh policy that interval is also the aggregate's `end_offset` — `AddHourlyRefreshPolicySql` passes `HourlyRefreshScheduleInterval` as both arguments and `AddDailyRefreshPolicySql` passes `DailyRefreshScheduleInterval` as both — so widening it does not relax a deadline. It moves what the refresh materializes, leaves a wider still-filling tail unmaterialized, and on the hourly tier silently shortens `QueryStoreBackfill.RollupStoreHorizon`, which is derived as `HourlyRefreshStartSpan` minus that same interval. An operator following the instruction alters collection in order to quiet an alert.

**Named as an exception rather than reworded for everyone**, because the sentence is correct and concrete for `policy_compression`, `policy_retention` and `policy_telemetry` — three of the four families — and a hedge that made it vague for all four would trade a real remedy for a caveat. The branch is `TimescaleSupport.ScheduleIntervalDoublesAsEndOffset`, keyed on the policy proc: the refresh family is told not to widen it, why, and which lever does work (narrow the refresh window, re-phase the grid — the #3012 treatments that took this job from 6,330 s to 864 s in the first place). Everyone else keeps the sentence unchanged.

`ReadJobCadenceReadingsAsync`'s statement is promoted to a public `JobCadenceReadSql` for the reason `RetentionHoldReadSql` is public: the label is built `proc_name` FIRST, and that projection is now load-bearing for what an alert *says*. Reversing the concatenation would keep collecting perfectly good readings while silently restoring the wrong advice, so it is pinned in CI rather than only in a harness.

## 2. The coupling: derive the default, pin the identity, leave the clamp alone

The warning knob's default was a literal `25`, which happened to equal one refresh slot as a percent of the hourly cadence (`RefreshPhaseSlots = 4`, so `100 / 4`). Nothing tied it to `RefreshPhaseStepMinutes`, so the equality that made it look calibrated was an accident of two independent decisions — and a grid moved to a 10-minute step would have left the alert firing at 900 s against a 600 s slot, *after* the point it exists to precede.

It is now `TimescaleSupport.RefreshSlotPercentOfHourlyCadence = 100 / RefreshPhaseSlots`. The integer division is load-bearing rather than a rounding artifact: flooring is what guarantees the alert fires at or before one slot for *any* step, while a ceiling would fire after it on any step that does not divide 100.

Pinned as cross-multiplied identities in two units, because two literals can both be rubber-stamped by a change that freezes one:

- `percent * RefreshPhaseSlots <= 100` — fires no later than one slot.
- `(percent + 1) * RefreshPhaseSlots > 100` — and is the latest value that does, so the derivation buys the guarantee without buying noise.
- In seconds, against #3044's now-merged `RefreshPhaseSlotSeconds`, which is the unit the alert text reports: `cadenceSeconds * percent / 100 <= RefreshPhaseSlotSeconds`, with `cadenceSeconds = RefreshPhaseSlotSeconds * RefreshPhaseSlots` asserted equal to `HourlyRefreshScheduleSpan`. That tiling assertion is not a tautology under integer division — a 7-minute step gives 8 slots of 420 s, 3,360 s of a 3,600 s hour, and every "a slot is a quarter of the cadence" statement in the product stops being true.
- The seed survives its own clamp, asserted through the real `DarlingAlertSettings` clamp rather than a copy of its bounds: a step fine enough to drive the derived default under the floor of 5 would have the clamp silently raise it back above one slot, which is the same defect in a new place.
- V57's column default equals the derived seed. The store column wins on a fresh store and cannot move without a rung, so a derived seed that drifts from it would ship a default nobody chose. This is the assertion that goes red on a step change, which is correct: moving the grid should force an explicit rung decision rather than happen quietly.

Four other copies of the same number are now derived from it: the evaluator's unsupplied-seam fallback, `AlertsConfig`'s property initializer, the Settings window's reset-to-defaults, and `AlertSettingsRow`'s initializer. The fallback is reached from a test (the harness can leave the seam unwired) because it is the copy no wired test touches, which is the shape a stale literal survives in.

`AlertSettingsRow`'s copy was found by review, not by these tests, and it is the one that gets **persisted**: `SettingsWindow.BuildAlertRowFromControls` assigns the textbox value only when it parses *inside* the clamp, so out-of-range or unparseable input leaves the row initializer's value and writes that to the store. A frozen literal there would outlive a moved refresh grid on the one path an operator can reach without noticing. Fixed here rather than filed, because it is the same category the rest of this change closes; pinned by `ViewerAlertRowCadenceDefaultTests`, which sits with the Viewer-referencing tests because that is the only place `AlertSettingsRow` is reachable.

**The clamp's `[5, 100]` reach is deliberately unchanged, and this is a decision rather than an omission.** Rejecting or silently clamping a value an operator has already set is a behaviour change on a live fleet: someone who set 50 to quiet a busy store would start getting warnings at 25 with no notice. The knob also judges families that have no slot at all, for which a value above one slot is a legitimate choice. And the coverage this would have been protecting — "the grid's precondition can be false with nothing said" — is closed by #3044's `RefreshSlotWarningSeconds` watch, which derives its line from the step and is independent of this knob. So a value above the derived default fires after the slot, and the slot is watched on the grid's own terms. That is stated in the constant's doc comment rather than left to be discovered.

**No second alert.** #3055 (#3044) took the logged-warning form because this seam is occupied and a signal at the slot width would double-fire with #2136 on the same job, reading and hour. Nothing here adds a signal; it retunes and rewords the occupant.

## 3. The "~7% of cadence" clamp justification was measurably wrong

`DarlingAlertSettings` justified the floor of 5 on "the production worst runs ~7% of cadence". Measured from `collect.store_metrics` where `object_kind = 'background_job'` (the #2136 / V56 series, which carries `last_run_duration_ms` and `schedule_interval_ms` per job per hourly sweep), read read-only on both production 42-server stores:

| | store carrying the Query Store workload since #2296 | sibling store |
|---|---|---|
| window | 2026-08-17 16:46 to 2026-09-06 00:20 UTC | 2026-08-09 17:50 to 2026-09-06 00:17 UTC |
| readings | 48,030 | 64,646 |
| p50 | 0.003% | 0.003% |
| p90 | 0.056% | 0.016% |
| p99 | 6.15% | 0.29% |
| p99.9 | 69.55% | 2.61% |
| **max** | **369.47%** (13,301 s on a 3,600 s cadence) | 62.58% (2,253 s) |
| readings >= 5% | 533 (1.11%) | 46 (0.07%) |
| readings >= 7% | 460 (0.96%) | 32 (0.05%) |
| readings >= 25% | 229 (0.48%) | 10 (0.02%) |
| readings >= 100% | 31 (0.06%) | 0 |

By family on the busier store: `policy_refresh_continuous_aggregate` is 9,334 readings with p95 5.21%, p99 45.32% and that 369.47% maximum; `policy_compression` is 29,538 readings with p99 0.18% and a 74.41% maximum; `policy_retention`, `policy_telemetry` and `policy_job_stat_history_retention` never exceed 0.02%. The tail is one family, and mostly one job.

So the worst is 53x the figure the comment cited, and the comment described neither store.

**The floor stays at 5, and the reasoning is replaced rather than the number.** A floor exists to stop a setting that fires on the healthy body of the distribution, and 5 is still roughly 90x the 90th percentile and three orders of magnitude above the median; 1.11% of readings on the busier store reach it at all. Moving it buys nothing in either direction — only 73 of those 48,030 readings sit in `[5, 7)`, so raising the floor to the old rationale's own number would change almost no outcome, and lowering it would admit settings that fire on compression policies doing ordinary work. Changing an operator-facing bound as a side effect of correcting the sentence that justified it would be the wrong way to make that decision, so it is not made here.

**What this series does NOT establish**, stated because an earlier draft of this description over-read it: that window is ~18.5 days before the #3012 treatment landed on that store (2026-09-05 13:44:23Z) against ~10.6 hours after it, so its aggregate figures characterise the regime the fix removed. They are the right evidence for "the clamp was calibrated against a population this job is not in" and the wrong evidence for any claim about the post-fix envelope. That distinction, and the fact that `HeaviestHourlyRefreshObservedCeilingSeconds = 864` currently rests on a single post-fix reading, are filed as #3069 rather than argued here.

## Verification

`Darling.Tests` cannot run on macOS, so the real test files were compiled into a throwaway net10.0 xunit v3 host named `Darling.Tests` staged outside the tree. `DarlingSelfAlertTests` + `TimescaleContinuousAggregateTests`: **154 total, 0 failed, 2 skipped, 0 not run**. Broadened with `TimescaleSupportTests`: **200 total, 0 failed, 17 skipped, 0 not run**. MTP prints no per-test `Passed` lines, so the skips were enumerated by name — all 17 are the pre-existing `DARLING_TEST_PG`-gated live-store tests (`*_AgainstDevPostgres`, plus the two `LiveStoreReads_*`). No test added here is gated, so this PR's own skip count is zero. All seven touched tests were also run by name in isolation: **7 total, 0 skipped, 0 not run**, so none of them silently resolves to nothing.

Red-proofed 14 ways against a **separate copy** at the committed SHA, each variant compiling cleanly (a variant that comes back green with no output never compiled and does not count) and each failing a different named assertion:

| mutation | fails on |
|---|---|
| `ScheduleIntervalDoublesAsEndOffset` forced false | `JobOverCadence_RemedyOmits...` — `DoesNotContain`: the refresh job got the interval advice |
| forced **true** (the blanket rewording that was rejected) | `JobOverCadence_RemedyOmits...` — `Contains`: the compression job lost the concrete sentence |
| prefix match relaxed to `Contains` | `RefreshPolicies_PassTheScheduleInterval...` — `Assert.False` on a hypertable named after the policy |
| hourly `end_offset` no longer the schedule interval | `RefreshPolicies_...` — `Assert.Equal` in `AssertEndOffsetEqualsScheduleInterval` |
| the alternative lever dropped from the remedy | `JobOverCadence_RemedyOmits...` — `Contains "Narrow the refresh window"` |
| label concatenation reversed in `JobCadenceReadSql` | `RefreshPolicies_...` — the `j.proc_name \|\| coalesce(...)` projection pin |
| step 15 to 10, **both obvious literals rubber-stamped** | `JobCadenceDefault_...` — V57's column default no longer matches the derived seed |
| as above, plus the config default frozen at `25` | `JobCadenceDefault_...` — `Expected: 16, Actual: 25` on the config-default equality |
| as above, plus the **constant itself** frozen at `25` | `TheRefreshGrid_Tiles...` — "the shipped cadence knob fires at 900s against a 600s slot"; and `JobOverCadence_WarningTier_FiresAtOneRefreshSlot` on `Assert.Single` |
| derivation floored one point early | `JobCadenceDefault_...` and `TheRefreshGrid_...` — the two tightness assertions |
| grid step of 7 minutes (does not divide 60) | `TheRefreshGrid_...` — `Expected 01:00:00, Actual 00:56:00` |
| unsupplied-seam fallback frozen at `25`, step at 10 | `JobOverCadence_WithTheKnobSeamUnsupplied_...` — `Assert.Single`, the collection was empty |

The rubber-stamp rows are the ones that matter: with `Assert.Equal(15, RefreshPhaseStepMinutes)` and `Assert.Equal(4, RefreshPhaseSlots)` both re-pinned to whatever the code now says — the way a literal pin actually gets rubber-stamped — the cross-multiplied identities and the V57 default are the only things left that catch a frozen knob.

## Review disposition

`claude[bot]` reviewed twice.

**First pass** raised one finding outside the diff — `AlertSettingsRow`'s literal `25` — and it was correct and is fixed above. Recorded here rather than as a reply because the bot posted an issue comment, not a review thread, so there is no thread to answer in or resolve. Its other four verifications (the V57 equality, the `JobName`-not-`label` call site, the new `using`s introducing no cycle, and no Lite parity gap) match what this change intends.

**Second pass** found no blocking issues and independently confirmed the load-bearing premises in the shipped code rather than in the assertions: that `AddHourlyRefreshPolicySql`/`AddDailyRefreshPolicySql` really do pass one interval as both arguments today, that all four shipped copies of the literal are now derived, and that V57's DDL default is correctly left alone with a test pinning it instead. Its one note was that the PR description did not match the diff — correct at the time it looked: a sibling lane had overwritten the shared scratchpad file this description is kept in, and the wrong body was briefly published here. Restored, and the scratchpad filename is now lane-scoped.

## Not verified

- **No live TimescaleDB store is reachable from a dev machine**, so nothing here that touches a catalog was executed. `JobCadenceReadSql`'s text is unchanged from what has been running in production since #2136; only its visibility moved.
- **The Settings window's reset value is derived but unpinned, and `ViewerAlertRowCadenceDefaultTests` was not executed locally.** Both sit behind the WPF Viewer, which cannot run on macOS; the reset value is a code-behind literal in a block of ~25 sibling literals with no test surface, and instantiating the window in a test is not worth the fragility. The new row-default pin compiles here and runs in CI's Windows `build` job — it is not in the locally-executed counts above.
- **The XAML `Text="25"` placeholder on the textbox is the last remaining literal and is deliberately left.** Markup cannot reference a `const` without a converter, and both the load path and `ResetToDefaults` overwrite it. Its one residual path is narrow but real — a silent load failure followed by a save would persist 25, because 25 parses inside the clamp — and it is named here rather than changed because `SettingsWindow.xaml` is being worked by another lane and a markup edit is not worth the conflict.
- **Whether the wrong remedy has actually been delivered was not confirmed.** The readings above are past both the Warning and the Critical tier, so it should have fired, but the read of the store's own `config_alert_log` did not complete — the SSO session expired before it ran. The distribution above came from a completed read on both stores.
- The two measured windows are **different lengths** (19.3 days and 27.3 days), because the busier store's `background_job` series begins at the #2296 split. Percentiles are comparable; absolute counts are not.

## CHANGELOG

Deliberately not in the diff — every lane appends to the same `## [Unreleased]` block, so a per-PR edit conflicts with whichever sibling merges first. Text to apply:

```
- **Store Job Over Cadence no longer tells an operator to change what the store collects** ([#3060]) - the
  alert's remedy advised extending the job's `schedule_interval`, which is right for a compression or
  retention policy and actively wrong for a continuous-aggregate refresh, whose interval is also the
  aggregate's `end_offset`: widening it moves what the refresh materialises and shortens the Query Store
  backfill horizon derived from it. The refresh family now gets that exception plus the lever that does work;
  the other three keep the concrete advice unhedged. The warning knob's default was a literal 25 that
  happened to equal one refresh slot as a percent of cadence, with nothing tying it to
  `RefreshPhaseStepMinutes` - a grid moved to a 10-minute step would have left it firing at 900 s against a
  600 s slot, after the point it exists to precede. It is now derived from `RefreshPhaseSlots`, with the
  identity pinned cross-multiplied in both percent and seconds, and the same constant feeding the
  unsupplied-seam fallback, the viewer's alert-settings row, and the Settings window's reset. The clamp's
  [5, 100] reach is unchanged on purpose: it judges families that have no slot, and the slot itself is
  watched independently by [#3044]. The clamp's "~7% of cadence" justification is corrected against the
  measured series - the real worst is 369% of cadence and the tail is one refresh job - with the floor left
  at 5 on the corrected reasoning.
```
