### PR TITLE
Fixes #3061

### DIFF
--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpPgDeadlockTools.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpPgDeadlockTools.cs
@@ -20,7 +20,7 @@ namespace PerformanceMonitor.Darling.Service.Mcp;
 [McpServerToolType]
 public sealed class DarlingMcpPgDeadlockTools
 {
-    [McpServerTool(Name = "get_pg_deadlocks"), Description("Gets PostgreSQL deadlocks that were reported in the window, newest first, with the victim process, how many sessions were in the cycle, the lock modes and resources involved, and the victim's full statement text. PostgreSQL writes a complete deadlock report to its server log at default settings and needs nothing ENABLED on the target, unlike plan capture - but that is not the same as unsuppressable. log_error_verbosity = terse drops the DETAIL field, which is where the wait graph and every participant's SQL live, so the ERROR line is still logged and this tool still returns nothing. If this comes back empty, check log_error_verbosity on the target (and log_min_messages) before concluding the server does not deadlock; get_pg_database_stats' cumulative deadlock counter is the independent test. Each row is one DISTINCT deadlock, and a deadlock that genuinely recurred appears as a separate row because the participating process IDs differ. times_seen counts how often the collector saw that SAME report, and what a value means depends on the transport. Where the collector reads the log file itself it re-reads an overlapping tail every cycle on purpose, so one report is seen several times and times_seen climbs while it stays in the window. On RDS and Aurora the log API is consume-once, so a report is normally seen once and times_seen normally stays 1: there a low value is the ordinary state and NOT a partial count, so do not read 1 as 'seen once so far, expect more'. It is not guaranteed to be 1 there either - the collector holds its resume position in memory, so a restart re-reads a bounded tail, and a window whose write did not land is offered again - so treat times_seen as a sighting count whose meaning depends on the transport, and never as a count of deadlocks on either. Use get_pg_deadlock_detail with a deadlock_hash for the full wait graph and every participant's SQL.")]
+    [McpServerTool(Name = "get_pg_deadlocks"), Description("Gets PostgreSQL deadlocks that were reported in the window, newest first, with the victim process, how many sessions were in the cycle, the lock modes and resources involved, and the victim's full statement text. PostgreSQL writes a complete deadlock report to its server log at default settings and needs nothing ENABLED on the target, unlike plan capture - but that is not the same as unsuppressable. log_error_verbosity = terse drops the DETAIL field, which is where the wait graph and every participant's SQL live, so the ERROR line is still logged and this tool still returns nothing. If this comes back empty, check log_error_verbosity on the target (and log_min_messages) before concluding the server does not deadlock; get_pg_database_stats' cumulative deadlock counter is the independent test. There is a third precondition and it is the least visible: lc_messages. PostgreSQL translates its own messages under a non-English locale, the SEVERITY LABEL INCLUDED, so a target writing FEHLER: rather than ERROR: matches nothing here and returns the same empty result a quiet server does. get_pg_server_config carries the target's lc_messages (pass include_defaults if it does not appear, because the compiled default is the empty value - and empty is itself inconclusive rather than safe, since the server then takes its language from its own environment, which no query can see). The pg_plan_capture_readiness collector judges it as the message_locale facet. Each row is one DISTINCT deadlock, and a deadlock that genuinely recurred appears as a separate row because the participating process IDs differ. times_seen counts how often the collector saw that SAME report, and what a value means depends on the transport. Where the collector reads the log file itself it re-reads an overlapping tail every cycle on purpose, so one report is seen several times and times_seen climbs while it stays in the window. On RDS and Aurora the log API is consume-once, so a report is normally seen once and times_seen normally stays 1: there a low value is the ordinary state and NOT a partial count, so do not read 1 as 'seen once so far, expect more'. It is not guaranteed to be 1 there either - the collector holds its resume position in memory, so a restart re-reads a bounded tail, and a window whose write did not land is offered again - so treat times_seen as a sighting count whose meaning depends on the transport, and never as a count of deadlocks on either. Use get_pg_deadlock_detail with a deadlock_hash for the full wait graph and every participant's SQL.")]
     public static async Task<string> GetPgDeadlocks(
         NpgsqlDataSource postgres,
         [Description("Server name or display name.")] string? server_name = null,
@@ -49,12 +49,18 @@ public sealed class DarlingMcpPgDeadlockTools
                     ?? McpHelpers.Status(
                         "no_deadlocks",
                         $"No deadlock was reported on {resolved.ServerName} in the last {hours_back} "
-                        + "hour(s). Two different things produce that and they are worth telling apart: the "
-                        + "server had no deadlocks, which is the healthy answer; or the log could not be "
-                        + "read, which get_pg_plan_capture_readiness reports on because plan capture reads "
-                        + "the same file the same way. pg_stat_database's cumulative deadlock counter, in "
-                        + "get_pg_database_stats, is the independent check - if it moved and nothing is "
-                        + "here, the log is the problem rather than the server.");
+                        + "hour(s). THREE different things produce that and they are worth telling apart: "
+                        + "the server had no deadlocks, which is the healthy answer; the log could not be "
+                        + "read; or the log was read and PostgreSQL did not write it in English. The "
+                        + "pg_plan_capture_readiness collector judges all three, because plan capture reads "
+                        + "the same file the same way - the last one as its message_locale facet (#3061). "
+                        + "That third cause is the one nothing else hints at: lc_messages translates "
+                        + "PostgreSQL's own messages including the severity label, so a target writing "
+                        + "FEHLER: rather than ERROR: matches nothing and looks exactly like a quiet "
+                        + "server. get_pg_server_config carries the target's lc_messages. "
+                        + "pg_stat_database's cumulative deadlock counter, in get_pg_database_stats, is "
+                        + "the independent check for all three - if it moved and nothing is here, the log "
+                        + "is the problem rather than the server.");
             }
 
             return JsonSerializer.Serialize(new
@@ -121,9 +127,11 @@ public sealed class DarlingMcpPgDeadlockTools
                       ?? McpHelpers.Status(
                           "empty",
                           $"No deadlock graph is stored for {resolved.ServerName}. Either the server had no "
-                          + "deadlocks, which is the healthy answer, or its log could not be read - "
+                          + "deadlocks, which is the healthy answer, or its log could not be read, or it "
+                          + "was read in a language this does not match - PostgreSQL translates its own "
+                          + "messages under a non-English lc_messages, severity label included (#3061). "
                           + "get_pg_database_stats carries pg_stat_database's cumulative deadlock counter, "
-                          + "which tells those apart.")
+                          + "which tells the healthy case from the other two.")
                     : McpHelpers.Status(
                           "empty",
                           $"No deadlock with hash '{deadlock_hash}' is stored for {resolved.ServerName}. A "

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpPgPlanTools.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpPgPlanTools.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2026 Erik Darling, Darling Data LLC
  *
  * This file is part of the SQL Server Performance Monitor Lite.

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpPgPlanTools.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpPgPlanTools.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2026 Erik Darling, Darling Data LLC
  *
  * This file is part of the SQL Server Performance Monitor Lite.
@@ -144,7 +144,8 @@ public sealed class DarlingMcpPgPlanTools
                 "This server cannot capture execution plans yet, so an empty result here says nothing about "
                 + "the query. Unsatisfied precondition(s), from pg_plan_capture_readiness: "
                 + string.Join(" | ", unmet)
-                + " — get_pg_plan_capture_readiness has the full detail and the remedy for each.");
+                + " — the pg_plan_capture_readiness collector stores the full detail and the remedy "
+                + "beside each observation.");
         }
 
         var subject = wantedQueryId is null ? "any statement" : "this statement";

--- a/Darling/PerformanceMonitor.Darling.Storage/DarlingPgPlanCaptureReadinessReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/DarlingPgPlanCaptureReadinessReader.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2026 Erik Darling, Darling Data LLC
  *
  * This file is part of the SQL Server Performance Monitor.

--- a/Darling/PerformanceMonitor.Darling.Storage/DarlingPgPlanCaptureReadinessReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/DarlingPgPlanCaptureReadinessReader.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2026 Erik Darling, Darling Data LLC
  *
  * This file is part of the SQL Server Performance Monitor.
@@ -28,8 +28,15 @@ namespace PerformanceMonitor.Darling.Storage;
 /// <c>library_loaded</c> gates <c>capture_threshold</c>, and <c>extension_available</c> explains whether
 /// either is even possible — so sorting the unsatisfied ones to the top would break the sequence a reader
 /// has to follow. <c>extension_available</c> first, then <c>library_loaded</c>, then
-/// <c>capture_threshold</c>, then <c>plan_text_setting</c>, then <c>plan_attribution</c>: could it, does
-/// it, is it capturing, in what form, and can what it captures be joined to the statement it came from.</para>
+/// <c>capture_threshold</c>, then <c>plan_text_setting</c>, then <c>plan_attribution</c>, then
+/// <c>message_locale</c>: could it, does it, is it capturing, in what form, can what it captures be joined
+/// to the statement it came from, and is it written in a language anything here can read.</para>
+///
+/// <para><b><c>message_locale</c> is last on purpose (#3061), not least.</b> It is the only facet that can
+/// be unmet while every other one is met — a fully configured, perfectly attributed capture whose anchor
+/// line is translated is still unreadable — so it reads as the final gate rather than a prerequisite. That
+/// placement is a presentation choice and nothing more: for the DEADLOCK read it is the only facet that
+/// applies at all, since deadlock reports need nothing enabled on the target.</para>
 ///
 /// <para>Shared by the WPF tab and the MCP surface so there is one copy of this SQL, per #2530.</para>
 /// </summary>
@@ -55,8 +62,8 @@ public static class DarlingPgPlanCaptureReadinessReader
        different sorts and need the subquery.
 
        The facet order is spelled as a CASE rather than left to alphabetical, which would give
-       capture_threshold, extension_available, library_loaded, plan_attribution, plan_text_setting - close to
-       the reverse of the order somebody has to act in. */
+       capture_threshold, extension_available, library_loaded, message_locale, plan_attribution,
+       plan_text_setting - close to the reverse of the order somebody has to act in. */
     public const string PgPlanCaptureReadinessSql = """
         SELECT facet, is_satisfied, observed, detail, collection_time
         FROM (
@@ -74,7 +81,8 @@ public static class DarlingPgPlanCaptureReadinessReader
                      WHEN 'capture_threshold'   THEN 3
                      WHEN 'plan_text_setting'   THEN 4
                      WHEN 'plan_attribution'    THEN 5
-                     ELSE 6
+                     WHEN 'message_locale'      THEN 6
+                     ELSE 7
                  END,
                  facet
         LIMIT $4

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Postgres.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerServerTab.Postgres.cs
@@ -540,12 +540,15 @@ public partial class ViewerServerTab
     ///
     /// <para><b>An empty grid is the healthy answer AND the shape of a log that cannot be read or cannot be
     /// parsed</b>, which is why the note names the other checks rather than leaving them. Deadlock reports
-    /// need nothing ENABLED on the target, unlike plan capture, but they are not unsuppressable. Two things
-    /// have to hold: the log must be readable, which the Vacuum tab's plan-capture readiness panel
-    /// reports on because it reads the same file, AND it must carry DETAIL, which <c>log_error_verbosity = terse</c>
-    /// strips along with the whole graph. pg_stat_database's cumulative deadlock counter is the independent
-    /// test: if that moved and this is empty, the log is the problem — unreadable or too terse — rather
-    /// than the server (#3030).</para>
+    /// need nothing ENABLED on the target, unlike plan capture, but they are not unsuppressable. THREE
+    /// things have to hold: the log must be readable, which the Vacuum tab's plan-capture readiness panel
+    /// reports on because it reads the same file; it must carry DETAIL, which <c>log_error_verbosity = terse</c>
+    /// strips along with the whole graph; and it must be written in ENGLISH, because the parser matches
+    /// PostgreSQL's own message text and PostgreSQL translates it — severity label included — under any
+    /// other <c>lc_messages</c> (#3061, reported as the readiness panel's <c>message_locale</c> facet).
+    /// pg_stat_database's cumulative deadlock counter is the independent test for all three: if that moved
+    /// and this is empty, the log is the problem — unreadable, too terse, or not in a language this reads —
+    /// rather than the server (#3030).</para>
     /// </summary>
     private async Task LoadPgDeadlocksAsync(DateTime startUtc, DateTime endUtc)
     {
@@ -562,8 +565,10 @@ public partial class ViewerServerTab
 
         PgDeadlocksNote.Text = PanelNote("pg_deadlocks", rows.Count,
             "No deadlock was reported in this window. That is the healthy answer, and it is also what an "
-            + "unreadable server log looks like — the Vacuum tab's plan-capture readiness panel reads the "
-            + "same file and says which it is.")
+            + "unreadable server log looks like — or one PostgreSQL wrote in another language, since this "
+            + "grid is filled by matching English message text. The Vacuum tab's plan-capture readiness "
+            + "panel reads the same file and reports both: whether it can be read, and whether "
+            + "lc_messages leaves the messages in English.")
             + (rows.Count == 0
                 ? string.Empty
                 : "  Sightings counts how often the collector saw the SAME report while it stayed inside "
@@ -665,10 +670,14 @@ public partial class ViewerServerTab
                     : "At least one precondition is unmet, so either no execution plans are being captured "
                       + "by auto_explain here or the ones that are cannot be attributed. Read the rows in "
                       + "order — extension_available, library_loaded, capture_threshold, plan_text_setting, "
-                      + "plan_attribution — each names the specific step and, on Aurora/RDS, whether it "
-                      + "needs a parameter-group change and a reboot rather than a SET. plan_attribution is "
-                      + "the one that is easy to miss: auto_explain puts no query id in the plan itself, so "
-                      + "without %Q in log_line_prefix every captured plan is an orphan.";
+                      + "plan_attribution, message_locale — each names the specific step and, on Aurora/RDS, "
+                      + "whether it needs a parameter-group change and a reboot rather than a SET. "
+                      + "plan_attribution is the one that is easy to miss: auto_explain puts no query id in "
+                      + "the plan itself, so without %Q in log_line_prefix every captured plan is an orphan. "
+                      + "message_locale is the one that reaches further than this panel: it reports whether "
+                      + "the target writes its log messages in English, which every log read here matches, "
+                      + "so an unmet one also means the Blocking sub-tab's deadlock grid cannot be trusted "
+                      + "to be empty for the healthy reason.";
     }
 
     /// <summary>

--- a/Lite.Tests/PgPlanCaptureReadinessCollectorDefinitionTests.cs
+++ b/Lite.Tests/PgPlanCaptureReadinessCollectorDefinitionTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2026 Erik Darling, Darling Data LLC
  *
  * This file is part of the SQL Server Performance Monitor.

--- a/Lite.Tests/PgPlanCaptureReadinessCollectorDefinitionTests.cs
+++ b/Lite.Tests/PgPlanCaptureReadinessCollectorDefinitionTests.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2026 Erik Darling, Darling Data LLC
  *
  * This file is part of the SQL Server Performance Monitor.
@@ -119,7 +119,7 @@ public class PgPlanCaptureReadinessCollectorDefinitionTests
     {
         var sql = PgPlanCaptureReadinessCollector.Instance.BuildQuery(MakeContext()).Text;
 
-        var facets = new[] { "library_loaded", "capture_threshold", "extension_available", "plan_text_setting", "plan_attribution" };
+        var facets = new[] { "library_loaded", "capture_threshold", "extension_available", "plan_text_setting", "plan_attribution", "message_locale" };
         foreach (var facet in facets)
         {
             Assert.Contains($"'{facet}'::text", sql, StringComparison.Ordinal);

--- a/Lite.Tests/PgTargetMessageLocaleFacetTests.cs
+++ b/Lite.Tests/PgTargetMessageLocaleFacetTests.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2026 Erik Darling, Darling Data LLC
  *
  * This file is part of the SQL Server Performance Monitor.

--- a/Lite.Tests/PgTargetMessageLocaleFacetTests.cs
+++ b/Lite.Tests/PgTargetMessageLocaleFacetTests.cs
@@ -1,0 +1,419 @@
+﻿/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using Lite.Tests.Helpers;
+using PerformanceMonitor.Collectors;
+using Xunit;
+
+namespace Lite.Tests;
+
+/// <summary>
+/// #3061: the <c>message_locale</c> facet on <c>pg_plan_capture_readiness</c>.
+///
+/// <para><b>What this is defending.</b> Four target-side readers match PostgreSQL's ENGLISH message text in
+/// a customer-owned instance's server log. PostgreSQL translates its own messages under <c>lc_messages</c>,
+/// the severity label included, so on a target running any other locale they go blind — and for
+/// <c>pg_deadlocks</c> the blind state and the healthy state are the same empty result. The facet turns that
+/// silent zero into a named unmet precondition. Making the parsers locale-aware was explicitly NOT the
+/// scope; saying the precondition is unmet is the honest alternative to pretending to read.</para>
+///
+/// <para><b>Why the assertions look like this.</b> The issue's own standard: a pin that merely checks the
+/// English tokens are still present cannot see this class of defect at all. So the locale predicate is
+/// EXTRACTED FROM THE SHIPPED QUERY and evaluated against real locale names, rather than retyped here —
+/// a retyped copy proves the transcription works, which is not the claim. PostgreSQL cannot be run on the
+/// development host, so <see cref="ThePredicateUsesOnlySyntaxThatMeansTheSameThingInBothEngines"/> earns
+/// the right to evaluate those patterns with .NET's engine by first pinning that they use only syntax
+/// whose meaning is identical in PostgreSQL's ARE and in .NET. That is the honest limit of what is provable
+/// here, and it is stated rather than implied.</para>
+/// </summary>
+public sealed class PgTargetMessageLocaleFacetTests
+{
+    private static readonly RecordingCollectorDeltaCalculator s_deltas = new();
+
+    private static string Sql()
+        => PgPlanCaptureReadinessCollector.Instance.BuildQuery(new CollectorContext
+        {
+            ServerId = 42,
+            ServerName = "pg-target",
+            CollectionTime = new DateTime(2026, 9, 5, 12, 0, 0, DateTimeKind.Utc),
+            Deltas = s_deltas,
+            Target = new CollectorTargetInfo
+            {
+                Engine = CollectorTargetEngine.PostgreSql,
+                PostgresMajorVersion = 16,
+            },
+            ExcludedDatabases = Array.Empty<string>(),
+        }).Text;
+
+    /* Both halves of the locale test, lifted out of the SHIPPED query with the operator that carries their
+       case sensitivity: `~` is case-sensitive and `~*` is not, and which one each pattern gets is
+       load-bearing rather than incidental. Anchored on the coalesce over message_locale so this cannot
+       accidentally pick up the shared_preload_libraries regex, which is the only other one in the file. */
+    private static List<(string Pattern, bool CaseSensitive)> ExtractLocalePredicate(string sql)
+        => Regex.Matches(sql, @"message_locale, ''\)\s*(~\*?)\s*'([^']*)'")
+                .Select(m => (m.Groups[2].Value, m.Groups[1].Value == "~"))
+                .ToList();
+
+    private static bool IsSatisfied(string sql, string localeValue)
+        => ExtractLocalePredicate(sql)
+           .Any(p => Regex.IsMatch(
+                         localeValue,
+                         p.Pattern,
+                         p.CaseSensitive ? RegexOptions.None : RegexOptions.IgnoreCase));
+
+    /// <summary>
+    /// The facet exists, is its own row, and judges <c>lc_messages</c> — read through the shared settings
+    /// CTE in the two-argument MISSING_OK form like every other GUC this collector consumes.
+    /// </summary>
+    [Fact]
+    public void TheMessageLocaleFacet_IsASeparateRow_AndReadsLcMessagesThroughTheSharedCte()
+    {
+        var sql = Sql();
+
+        Assert.Contains("'message_locale'::text", sql, StringComparison.Ordinal);
+
+        var reads = Regex.Matches(sql, @"current_setting\(\s*'lc_messages'\s*,\s*true\s*\)");
+        Assert.True(
+            reads.Count == 1,
+            $"lc_messages is read {reads.Count} times in the MISSING_OK form. It must be read exactly once, "
+            + "in the settings CTE, for the reason shared_preload_libraries is: one fact derived twice is "
+            + "how two facets come to disagree about it.");
+
+        Assert.True(
+            sql.LastIndexOf("current_setting('lc_messages'", StringComparison.Ordinal)
+                < sql.IndexOf("UNION ALL", StringComparison.Ordinal),
+            "lc_messages is read inside a facet branch rather than the shared settings CTE.");
+    }
+
+    /// <summary>
+    /// NOT gated on whether auto_explain is loaded, and the reason is stronger than
+    /// <c>plan_attribution</c>'s: the deadlock read depends on this locale with no auto_explain in the
+    /// picture at all, so a target that will never load the library still needs the answer.
+    /// </summary>
+    [Fact]
+    public void TheFacet_IsNotGatedOnTheLibraryBeingLoaded()
+    {
+        var sql = Sql();
+
+        var branchStart = sql.IndexOf("'message_locale'::text", StringComparison.Ordinal);
+        Assert.True(branchStart >= 0, "the message_locale facet is missing");
+
+        var satisfiedAt = sql.IndexOf("p.english_messages", branchStart, StringComparison.Ordinal);
+        Assert.True(satisfiedAt > branchStart, "message_locale's is_satisfied column moved; rescope this test");
+
+        var satisfiedExpression = sql[branchStart..(satisfiedAt + "p.english_messages".Length)];
+
+        Assert.DoesNotContain("p.loaded", satisfiedExpression, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The locale test is derived ONCE and consulted by both the <c>is_satisfied</c> column and the detail
+    /// arms. This is the #2605 shape — one fact derived in five places, where the fifth forgot and asserted
+    /// the opposite of the other four — and a facet whose verdict and whose prose disagree is worse than no
+    /// facet, because the prose is what a reader acts on.
+    /// </summary>
+    [Fact]
+    public void TheLocaleTest_IsDerivedOnce_AndBothTheVerdictAndTheProseReadThatOneCopy()
+    {
+        var sql = Sql();
+
+        var predicate = ExtractLocalePredicate(sql);
+        Assert.Equal(2, predicate.Count);
+
+        foreach (var (pattern, _) in predicate)
+        {
+            var occurrences = Regex.Matches(sql, Regex.Escape(pattern)).Count;
+            Assert.True(
+                occurrences == 1,
+                $"the locale pattern {pattern} appears {occurrences} times. It must appear once, as a "
+                + "derived column, or the verdict and the remedy text can drift apart.");
+        }
+
+        /* And the facet branch reaches it by name rather than recomputing it. */
+        var branch = sql[sql.IndexOf("'message_locale'::text", StringComparison.Ordinal)..];
+        Assert.Contains("p.english_messages", branch, StringComparison.Ordinal);
+        Assert.Contains("p.locale_unset", branch, StringComparison.Ordinal);
+        Assert.DoesNotContain("current_setting", branch, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The licence to evaluate PostgreSQL's regexes with .NET's engine, which is what
+    /// <see cref="TheSatisfiedSet_IsOnlyLocalesPostgresLeavesUntranslated"/> does. No live PostgreSQL is
+    /// reachable from the development host, so the patterns have to be run somewhere else — and that is only
+    /// honest if they use nothing whose meaning differs between the two engines. This pins that: bare
+    /// alternation, anchors, literal characters and a single escaped dot. No class shorthands
+    /// (<c>\d</c>, <c>\w</c>, <c>\s</c>, <c>\b</c>), no POSIX bracket classes, no quantifiers, no
+    /// lookaround, no back-references, no embedded-option prefixes.
+    /// </summary>
+    [Fact]
+    public void ThePredicateUsesOnlySyntaxThatMeansTheSameThingInBothEngines()
+    {
+        foreach (var (pattern, _) in ExtractLocalePredicate(Sql()))
+        {
+            Assert.Matches(new Regex(@"^[A-Za-z0-9_^$()|.\\@-]+$"), pattern);
+
+            foreach (var forbidden in new[] { "(?", "[[:", "\\d", "\\w", "\\s", "\\b", "{", "*", "+", "?" })
+            {
+                Assert.DoesNotContain(forbidden, pattern, StringComparison.Ordinal);
+            }
+
+            /* The only escape used is \. — anything else escaped is a divergence risk this has not checked. */
+            foreach (Match escape in Regex.Matches(pattern, @"\\(.)"))
+            {
+                Assert.Equal(".", escape.Groups[1].Value);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The assertion the issue asked for, stated as the RELATION rather than as either side: the locales the
+    /// facet calls satisfied are exactly the ones under which PostgreSQL leaves its message catalogue
+    /// untranslated, so a target running anything else FAILS TO BE SATISFIED rather than silently missing.
+    ///
+    /// <para><b>The adversarial values are the point of this test</b>, and one of them was found by
+    /// mutating the shipped predicate rather than by reasoning about it. The mistake that matters is
+    /// DROPPING THE ANCHOR: <c>Czech_Czech Republic.1250</c> and <c>Chinese (Simplified)_China.936</c> are
+    /// real Windows locale names that begin with a literal upper-case <c>C</c>, so an unanchored
+    /// <c>^C</c> reports both as the C locale — a translated catalogue declared readable, which is the exact
+    /// answer this facet exists to prevent. Neither is visible to a test built only from plausible values.
+    /// </para>
+    ///
+    /// <para><b>What is NOT load-bearing, established by mutation and recorded so nobody re-adds it:</b>
+    /// case sensitivity on the C family. <c>ca_ES</c> (Catalan) and <c>cs_CZ</c> (Czech) are kept below
+    /// because they are the obvious near-misses, but the ANCHOR rejects them however case is treated — a
+    /// case-insensitive C test was mutated in and every assertion here still passed. So the predicate
+    /// matches case-insensitively on purpose: no language has the ISO code <c>c</c>, and
+    /// <c>posix</c>/<c>POSIX</c> spelling variation is real. <c>posix</c> below is what fails if someone
+    /// tightens it back.</para>
+    /// </summary>
+    [Theory]
+    // The C family: no catalogue to load, so nothing to translate.
+    [InlineData("C", true)]
+    [InlineData("C.UTF-8", true)]
+    [InlineData("C.utf8", true)]
+    [InlineData("POSIX", true)]
+    // Case-insensitively, on purpose - see the type comment. This is what a tightened C test breaks.
+    [InlineData("posix", true)]
+    [InlineData("POSIX.UTF-8", true)]
+    // The catalogue's own source language: gettext hands back the msgid unchanged.
+    [InlineData("en_US.UTF-8", true)]
+    [InlineData("en_US.utf8", true)]
+    [InlineData("en_GB.UTF-8", true)]
+    [InlineData("en_AU", true)]
+    [InlineData("en", true)]
+    // The Windows form of the same.
+    [InlineData("English_United States.1252", true)]
+    // Translated catalogues, which is the whole exposure.
+    [InlineData("de_DE.UTF-8", false)]
+    [InlineData("de_DE", false)]
+    [InlineData("fr_FR.UTF-8", false)]
+    [InlineData("ja_JP.UTF-8", false)]
+    [InlineData("ru_RU.UTF-8", false)]
+    [InlineData("zh_CN.UTF-8", false)]
+    [InlineData("pt_BR.UTF-8", false)]
+    [InlineData("es_ES.UTF-8", false)]
+    // ADVERSARIAL - the case-sensitivity mistake.
+    [InlineData("ca_ES.UTF-8", false)]
+    [InlineData("ca_ES@valencia", false)]
+    [InlineData("cs_CZ.UTF-8", false)]
+    // ADVERSARIAL - the anchoring mistake, in the Windows naming form.
+    [InlineData("Czech_Czech Republic.1250", false)]
+    [InlineData("Chinese (Simplified)_China.936", false)]
+    public void TheSatisfiedSet_IsOnlyLocalesPostgresLeavesUntranslated(string locale, bool expected)
+    {
+        var actual = IsSatisfied(Sql(), locale);
+
+        Assert.True(
+            actual == expected,
+            expected
+                ? $"lc_messages = '{locale}' leaves PostgreSQL's messages in English, but the facet reports "
+                  + "it UNSATISFIED - so a target that this product can read is being told it cannot be."
+                : $"lc_messages = '{locale}' makes PostgreSQL TRANSLATE its own messages, severity label "
+                  + "included, but the facet reports it SATISFIED - so every log read on this target finds "
+                  + "nothing while the facet says the precondition is met. For pg_deadlocks that is "
+                  + "indistinguishable from a server that did not deadlock, which is the #3030 failure "
+                  + "shape this facet exists to prevent.");
+    }
+
+    /// <summary>
+    /// An EMPTY <c>lc_messages</c> is a third state, and it resolves to UNSATISFIED. PostgreSQL then takes
+    /// its message language from the server process's own environment, which no SQL read can see — so this
+    /// is UNKNOWN, not English. Unsatisfied is the direction the reader already takes for a NULL
+    /// (<c>DarlingPgPlanCaptureReadinessReader</c>: claiming readiness we cannot prove is the failure that
+    /// matters), and the detail arm carries the difference so the row does not overclaim the other way
+    /// either — the <c>extension_available</c> convention, where a negative is inconclusive and says so.
+    /// </summary>
+    [Fact]
+    public void AnEmptyLocale_IsUnsatisfied_ButItsDetailSaysUnknownRatherThanTranslated()
+    {
+        var sql = Sql();
+
+        Assert.False(
+            IsSatisfied(sql, string.Empty),
+            "an empty lc_messages reports SATISFIED. The server takes its message language from its own "
+            + "environment there, which no query can see, so this is a precondition that cannot be proven "
+            + "and must not read as met.");
+
+        /* And the is_satisfied COLUMN is that predicate and nothing else. The check above evaluates the
+           extracted patterns, so on its own it cannot see the facet's verdict being widened downstream -
+           `p.english_messages OR p.locale_unset` would leave every pattern untouched and turn unknown into
+           satisfied, which is the precise inversion this facet exists to prevent. */
+        var branchStart = sql.IndexOf("'message_locale'::text", StringComparison.Ordinal);
+        var satisfiedAt = sql.IndexOf("p.english_messages", branchStart, StringComparison.Ordinal);
+        var afterSatisfied = satisfiedAt + "p.english_messages".Length;
+        var verdictLine = sql[satisfiedAt..sql.IndexOf("CASE", afterSatisfied, StringComparison.Ordinal)];
+
+        Assert.True(
+            verdictLine.Trim() == "p.english_messages,",
+            "the message_locale verdict is not the derived predicate alone - it reads "
+            + $"'{verdictLine.Trim()}'. Anything ORed or ANDed on here changes what SATISFIED means without "
+            + "touching the predicate the rest of this class checks.");
+
+        /* Its own flag, so it gets its own arm rather than being folded into the translated case. */
+        Assert.Contains("AS locale_unset", sql, StringComparison.Ordinal);
+        Assert.Contains("WHEN p.locale_unset", sql, StringComparison.Ordinal);
+
+        /* Anchored on the arm's own opening text rather than on a newline: the query is a verbatim string,
+           so its line endings are the source file's CRLF on every platform and Environment.NewLine would
+           disagree with them on the Linux build. */
+        var branch = sql[sql.IndexOf("'message_locale'::text", StringComparison.Ordinal)..];
+        var unsetArm = branch[branch.IndexOf("THEN 'lc_messages is EMPTY", StringComparison.Ordinal)..];
+        unsetArm = unsetArm[..unsetArm.IndexOf("WHEN p.english_messages", StringComparison.Ordinal)];
+
+        /* The distinction a reader acts on: unknown, not wrong. */
+        Assert.Contains("UNKNOWN", unsetArm, StringComparison.Ordinal);
+        Assert.DoesNotContain("TRANSLATES", unsetArm, StringComparison.Ordinal);
+
+        /* And it must still say the empty result means nothing, or "unknown" reads as "probably fine". */
+        Assert.Contains("unknown meaning", unsetArm, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The unsatisfied remedy has to name the deadlock trap specifically, because that is the only one of
+    /// the affected reads whose blind state is also its healthy state. A generic "the log may not be
+    /// readable" sends the reader nowhere: what they need is that zero deadlocks means nothing here, and
+    /// that <c>pg_stat_database</c>'s counter is a NUMBER and therefore locale-proof.
+    /// </summary>
+    [Fact]
+    public void TheTranslatedRemedy_NamesTheDeadlockTrap_AndTheLocaleProofIndependentCheck()
+    {
+        var sql = Sql();
+        var branch = sql[sql.IndexOf("'message_locale'::text", StringComparison.Ordinal)..];
+        var translatedArm = branch[branch.IndexOf("ELSE 'PostgreSQL TRANSLATES", StringComparison.Ordinal)..];
+
+        /* The concrete demonstration, not an abstraction about catalogues. */
+        Assert.Contains("FEHLER:", translatedArm, StringComparison.Ordinal);
+        Assert.Contains("ERROR:", translatedArm, StringComparison.Ordinal);
+
+        /* The indistinguishability, which is the actual defect. */
+        Assert.Contains("indistinguishable", translatedArm, StringComparison.Ordinal);
+
+        /* The one instrument that survives a translated catalogue, because it is a counter. */
+        Assert.Contains("pg_stat_database", translatedArm, StringComparison.Ordinal);
+
+        /* auto_explain has no severity-independent anchor to retreat to, so the remedy must not imply one. */
+        Assert.Contains("00000", translatedArm, StringComparison.Ordinal);
+
+        /* The remedy itself, and that it is a reload rather than a reboot. */
+        Assert.Contains("lc_messages = ''C''", translatedArm, StringComparison.Ordinal);
+        Assert.Contains("reload", translatedArm, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The RELATION between the parsers and the facet, which is what makes this more than a spelling pin:
+    /// every target-side reader that anchors on PostgreSQL's own message text is discovered FROM SOURCE, and
+    /// each anchored severity label must be one of the untranslated upper-case tokens the satisfied locale
+    /// set guarantees. A fifth reader anchored on a token outside that vocabulary fails here; so does
+    /// widening the facet to a locale that would translate one.
+    ///
+    /// <para>Discovery is derived rather than listed, and the discovered set is asserted non-empty in its
+    /// own right — a source walk that silently finds nothing would make this pass on an empty set, which is
+    /// the failure mode that turns a guard into false confidence.</para>
+    /// </summary>
+    [Fact]
+    public void EveryTargetSideLogReader_AnchorsOnATokenTheSatisfiedLocaleSetGuarantees()
+    {
+        var sql = Sql();
+        var collectorDir = Path.Combine(RepoRoot(), "PerformanceMonitor.Collectors");
+
+        /* PostgreSQL's untranslated severity vocabulary at the head of a log entry. Upper-case ASCII on
+           purpose: under any locale the facet calls satisfied these are what error_severity() writes, and
+           under one it does not they are precisely what it does NOT write. */
+        var untranslated = new[] { "DEBUG", "LOG", "INFO", "NOTICE", "WARNING", "ERROR", "FATAL", "PANIC", "DETAIL", "STATEMENT", "HINT", "CONTEXT" };
+
+        var anchored = new SortedDictionary<string, SortedSet<string>>(StringComparer.Ordinal);
+
+        foreach (var file in Directory.EnumerateFiles(collectorDir, "Pg*.cs", SearchOption.TopDirectoryOnly))
+        {
+            var text = File.ReadAllText(file);
+
+            /* A log-message anchor is an upper-case label followed by the DOUBLE SPACE PostgreSQL writes
+               after it. That double space is what makes this specific enough not to collect the product's
+               own status vocabulary, which is why it is not relaxed to a single one. Nothing is filtered
+               here on purpose: everything found is asserted below, so a token outside the vocabulary fails
+               rather than being quietly dropped by the discovery step. */
+            var labels = Regex.Matches(text, @"([A-Z]{3,}):  ")
+                              .Select(m => m.Groups[1].Value)
+                              .ToList();
+
+            if (labels.Count > 0)
+            {
+                anchored[Path.GetFileName(file)] = new SortedSet<string>(labels, StringComparer.Ordinal);
+            }
+        }
+
+        /* #3061 enumerated four: PgDeadlockLogParser, PgDeadlocksCollector, PgPlanLogParser and
+           PgPlanCaptureCollector. The walk rediscovers them rather than being handed the list, so a fifth
+           reader is covered automatically - but a walk that came back short would make this pass on a set
+           it never examined, which is the shape that turns a guard into false confidence. */
+        Assert.True(
+            anchored.Count >= 4,
+            $"the source walk over {collectorDir} found {anchored.Count} target-side log reader(s), fewer "
+            + "than the four #3061 enumerated. Either one was removed, or the discovery pattern stopped "
+            + "matching and this test is now guarding nothing.");
+
+        foreach (var (file, labels) in anchored)
+        {
+            foreach (var label in labels)
+            {
+                Assert.True(
+                    untranslated.Contains(label, StringComparer.Ordinal),
+                    $"{file} anchors on the log label '{label}', which is not one of the untranslated "
+                    + "tokens PostgreSQL writes under the locales pg_plan_capture_readiness calls "
+                    + "satisfied. Either the token is wrong or the facet's satisfied set no longer "
+                    + "guarantees it.");
+            }
+        }
+
+        /* And the facet those readers now rest on must actually be there. Deleting it silently returns
+           every file above to the state #3061 was filed on. */
+        Assert.True(
+            sql.Contains("'message_locale'::text", StringComparison.Ordinal),
+            "the message_locale facet is gone, so these target-side log readers have no precondition "
+            + $"reporting their locale dependency again: {string.Join(", ", anchored.Keys)}");
+    }
+
+    private static string RepoRoot([CallerFilePath] string thisFile = "")
+    {
+        var dir = Path.GetDirectoryName(thisFile);
+        while (dir is not null
+               && !File.Exists(Path.Combine(dir, "PerformanceMonitor.sln"))
+               && !Directory.Exists(Path.Combine(dir, ".git")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        return dir ?? throw new InvalidOperationException("repository root not found above this test file.");
+    }
+}

--- a/Lite.Tests/PgTargetMessageLocaleFacetTests.cs
+++ b/Lite.Tests/PgTargetMessageLocaleFacetTests.cs
@@ -333,9 +333,9 @@ public sealed class PgTargetMessageLocaleFacetTests
     /// <summary>
     /// The RELATION between the parsers and the facet, which is what makes this more than a spelling pin:
     /// every target-side reader that anchors on PostgreSQL's own message text is discovered FROM SOURCE, and
-    /// each anchored severity label must be one of the untranslated upper-case tokens the satisfied locale
-    /// set guarantees. A fifth reader anchored on a token outside that vocabulary fails here; so does
-    /// widening the facet to a locale that would translate one.
+    /// each anchored log label must be one the satisfied locale set actually guarantees. A fifth reader
+    /// anchored on a label outside that vocabulary fails here; so does widening the facet to a locale that
+    /// would not write one.
     ///
     /// <para>Discovery is derived rather than listed, and the discovered set is asserted non-empty in its
     /// own right — a source walk that silently finds nothing would make this pass on an empty set, which is
@@ -356,16 +356,44 @@ public sealed class PgTargetMessageLocaleFacetTests
         var sql = Sql();
         var collectorDir = Path.Combine(RepoRoot(), "PerformanceMonitor.Collectors");
 
-        /* PostgreSQL's untranslated severity vocabulary at the head of a log entry. Upper-case ASCII on
-           purpose: under any locale the facet calls satisfied these are what error_severity() writes, and
-           under one it does not they are precisely what it does NOT write. */
-        var untranslated = new[] { "DEBUG", "LOG", "INFO", "NOTICE", "WARNING", "ERROR", "FATAL", "PANIC", "DETAIL", "STATEMENT", "HINT", "CONTEXT" };
+        /* The log labels PostgreSQL writes under a locale the facet calls SATISFIED. That is deliberately
+           the only claim this list makes, because the converse is false and was measured rather than
+           assumed: on PostgreSQL 17.11 under lc_messages = 'de_DE.UTF-8', `ERROR:` becomes `FEHLER:`,
+           `HINT:` becomes `TIPP:` and `CONTEXT:` becomes `ZUSAMMENHANG:` - but `DETAIL:` comes through
+           UNCHANGED. So "translated locale" does not mean "every label differs", and a guard resting on
+           that would be resting on something untrue.
+
+           It does not save the parser. PgDeadlockLogParser's block regex requires BOTH the
+           `ERROR:  deadlock detected` line AND the `DETAIL:  ` line, so the surviving half matches while
+           the report is still lost whole - the same all-or-nothing the parser's own doc comment describes
+           for log_error_verbosity = terse. Measured: the shipped Extract() over a real server log holding
+           one German and one English report returned ONE, the English one.
+
+           And a German report would lose its edges even if the block matched: the mode renders as
+           `ShareLock-Sperre`, and the edge pattern's mode group is `[A-Za-z ]+`, which excludes the
+           hyphen. */
+        var englishLabels = new[] { "DEBUG", "LOG", "INFO", "NOTICE", "WARNING", "ERROR", "FATAL", "PANIC", "DETAIL", "STATEMENT", "HINT", "CONTEXT" };
 
         var anchored = new SortedDictionary<string, SortedSet<string>>(StringComparer.Ordinal);
 
         foreach (var file in Directory.EnumerateFiles(collectorDir, "Pg*.cs", SearchOption.TopDirectoryOnly))
         {
             var text = File.ReadAllText(file);
+
+            /* Is this file a log reader at all? Gated on the SQL function that reads the log rather than
+               on a filename list, which would rot, and rather than on the labels themselves, which would
+               be circular. All four readers #3061 enumerated name pg_read_file; nothing else in this
+               directory does.
+
+               This gate is load-bearing and was added because the test caught its own author: the
+               readiness collector's type header quotes the real German line, double space and all, to
+               document what was measured - and the walk found FEHLER there and correctly failed. The file
+               that REPORTS the precondition is not a file that rests on it, and asking whether it reads a
+               log is the honest way to tell those apart. */
+            if (!text.Contains("pg_read_file", StringComparison.Ordinal))
+            {
+                continue;
+            }
 
             /* A log-message anchor is an upper-case label followed by the DOUBLE SPACE PostgreSQL writes
                after it. That double space is what makes this specific enough not to collect the product's
@@ -397,11 +425,10 @@ public sealed class PgTargetMessageLocaleFacetTests
             foreach (var label in labels)
             {
                 Assert.True(
-                    untranslated.Contains(label, StringComparer.Ordinal),
-                    $"{file} anchors on the log label '{label}', which is not one of the untranslated "
-                    + "tokens PostgreSQL writes under the locales pg_plan_capture_readiness calls "
-                    + "satisfied. Either the token is wrong or the facet's satisfied set no longer "
-                    + "guarantees it.");
+                    englishLabels.Contains(label, StringComparer.Ordinal),
+                    $"{file} anchors on the log label '{label}', which is not one PostgreSQL writes under "
+                    + "the locales pg_plan_capture_readiness calls satisfied. Either the token is wrong or "
+                    + "the facet's satisfied set no longer guarantees it.");
             }
         }
 

--- a/Lite.Tests/PgTargetMessageLocaleFacetTests.cs
+++ b/Lite.Tests/PgTargetMessageLocaleFacetTests.cs
@@ -340,6 +340,15 @@ public sealed class PgTargetMessageLocaleFacetTests
     /// <para>Discovery is derived rather than listed, and the discovered set is asserted non-empty in its
     /// own right — a source walk that silently finds nothing would make this pass on an empty set, which is
     /// the failure mode that turns a guard into false confidence.</para>
+    ///
+    /// <para><b>Why raw text and not <c>CSharpSourceWalker</c>,</b> which #2913 made the shared authority
+    /// and #3058 used for the store-side half of this: that walker strips comments, and here comments are
+    /// part of what is being guarded. These readers document their anchors in prose beside the regex, so a
+    /// comment still claiming <c>ERROR:</c> after the literal moved is documentation drift worth failing on.
+    /// The walker answers "what does the compiler see"; this asks "does anything in this file rest on an
+    /// English log label", and the second question wants the wider read. Being comment-inclusive only ever
+    /// adds tokens to the set every one of which is then asserted, so it cannot mask a change — a literal
+    /// mutated to <c>FEHLER:</c> is discovered and fails whether or not its comment moved with it.</para>
     /// </summary>
     [Fact]
     public void EveryTargetSideLogReader_AnchorsOnATokenTheSatisfiedLocaleSetGuarantees()

--- a/PerformanceMonitor.Collectors/PgPlanCaptureReadinessCollector.cs
+++ b/PerformanceMonitor.Collectors/PgPlanCaptureReadinessCollector.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2026 Erik Darling, Darling Data LLC
  *
  * This file is part of the SQL Server Performance Monitor.

--- a/PerformanceMonitor.Collectors/PgPlanCaptureReadinessCollector.cs
+++ b/PerformanceMonitor.Collectors/PgPlanCaptureReadinessCollector.cs
@@ -148,7 +148,17 @@ WITH settings AS (
            PGC_SUPERUSER by context - a superuser can SET it - but it carries no GUC_SUPERUSER_ONLY flag, so
            any role may read it. The decisive evidence is next door rather than in the docs: this collector
            already reads shared_preload_libraries this way and #2564/#2605 measured that against a live
-           Aurora target, and shared_preload_libraries is the more restricted of the two. */
+           Aurora target, and shared_preload_libraries is the more restricted of the two.
+
+           WHAT THIS CANNOT SEE, and the facet says so on the row rather than leaving it implied: a log
+           entry is written by the backend that raised it, in THAT backend's lc_messages, and the setting
+           is overridable per role and per database. This read resolves on the monitoring connection, so
+           it is the server's value only when nothing overrode it - which is the ordinary case, since the
+           setting normally comes from postgresql.conf or from nowhere. The direction that matters is a
+           global de_DE with an override putting the MONITORING role at C: the facet would then read
+           satisfied about a server whose backends translate. Distinguishing it means reading
+           pg_settings.source rather than the resolved value, which is a refinement and not this change;
+           naming the limit is what stops the row being over-read in the meantime. */
         current_setting('lc_messages', true)                                     AS message_locale
 ),
 probe AS (
@@ -340,7 +350,12 @@ SELECT
         WHEN p.english_messages
             THEN 'PostgreSQL writes its messages untranslated under this locale, so the log reads that match '
                  || 'English message text can find their anchor. That is a precondition being met, not a '
-                 || 'claim that anything was read.'
+                 || 'claim that anything was read. One limit on how far to trust this row: lc_messages is '
+                 || 'overridable per role and per database, and a log entry is written in the language of '
+                 || 'the backend that raised it, while this value is the one the monitoring connection '
+                 || 'resolved. They are the same wherever the setting comes from postgresql.conf or from '
+                 || 'nowhere, which is the ordinary case - but an override aimed at the monitoring role '
+                 || 'alone would make this row agree with itself and not with the server.'
         ELSE 'PostgreSQL TRANSLATES its own messages under this locale, the severity label included - a '
              || 'German catalogue writes FEHLER: where an English one writes ERROR:. Every log read this '
              || 'product performs matches English message text, so on this target they find nothing. THE '

--- a/PerformanceMonitor.Collectors/PgPlanCaptureReadinessCollector.cs
+++ b/PerformanceMonitor.Collectors/PgPlanCaptureReadinessCollector.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2026 Erik Darling, Darling Data LLC
  *
  * This file is part of the SQL Server Performance Monitor.
@@ -39,6 +39,24 @@ namespace PerformanceMonitor.Collectors;
 /// <para><b>What it must NOT claim.</b> That the library is loaded is not the same fact as plans being
 /// captured, and neither is the same as us being able to READ them — auto_explain writes to the server log,
 /// which is a separate problem (#2566/#2567). This records readiness only, and the column names say so.</para>
+///
+/// <para><b>Why a message locale is a readiness facet (#3061).</b> Reading a captured plan is still
+/// #2566/#2567's and this claims nothing about it — but one PRECONDITION for reading is a configuration
+/// state on the target, which is exactly what this collector reports. Every log read this product performs
+/// matches PostgreSQL's ENGLISH message text, and <c>lc_messages</c> decides whether the target writes any:
+/// a German catalogue writes <c>FEHLER:</c> where an English one writes <c>ERROR:</c>, and the severity
+/// label is translated along with everything else. The <c>message_locale</c> facet reports that setting so
+/// an empty read becomes a NAMED unmet precondition rather than a silent zero.</para>
+///
+/// <para><b>It is the deadlock read, not the plan read, that makes this urgent.</b> Zero rows is the healthy
+/// resting state for <c>pg_deadlocks</c>, so a locale-blinded parser and a server that simply did not
+/// deadlock produce identical output and nothing else distinguishes them — the #3030 failure shape from a
+/// new cause. Plan capture is worse-placed for a fallback but less dangerous for being noticed:
+/// <c>auto_explain</c> writes at LOG level with SQLSTATE <c>00000</c>, so there is no error code to key on
+/// even under <c>csvlog</c>, but nobody mistakes a missing plan for a healthy answer. Both the
+/// <c>get_pg_deadlocks</c> empty-result advice and the WPF deadlock panel already point HERE for whether
+/// the log can be read at all; before this facet, neither could see the one precondition that is
+/// invisible.</para>
 ///
 /// <para>Core catalog surfaces only (<c>pg_settings</c>, <c>pg_available_extensions</c>), both readable by any
 /// role, so this runs on every PostgreSQL target including standbys — a replica's parameter group can differ
@@ -95,6 +113,12 @@ public sealed class PgPlanCaptureReadinessCollector : PostgresCollectorDefinitio
                                it every captured plan is an orphan that cannot be joined to the statement it
                                belongs to - and the failure looks like the feature working, which is why
                                this is a facet rather than a footnote.
+         message_locale      - lc_messages. Whether the target writes its messages in the language every
+                               log read here matches, which decides whether ANY of them can find an anchor.
+                               Judged rather than merely recorded: a facet that reported the value and drew
+                               no conclusion would leave the reader exactly where the empty result already
+                               left them. Its own comment carries which locales count as satisfied, and why
+                               an EMPTY value is a third state rather than a translated one.
 
        current_setting(..., true) throughout — the MISSING_OK form. Reading a GUC that does not exist because
        the library was never loaded is the NORMAL case here, and the two-argument form answers NULL instead of
@@ -119,7 +143,13 @@ WITH settings AS (
         current_setting('shared_preload_libraries', true)                        AS preload,
         current_setting('auto_explain.log_min_duration', true)                   AS threshold,
         current_setting('auto_explain.log_format', true)                         AS log_format,
-        current_setting('log_line_prefix', true)                                 AS line_prefix
+        current_setting('log_line_prefix', true)                                 AS line_prefix,
+        /* current_setting rather than a pg_settings subquery, matching the four above. lc_messages is
+           PGC_SUPERUSER by context - a superuser can SET it - but it carries no GUC_SUPERUSER_ONLY flag, so
+           any role may read it. The decisive evidence is next door rather than in the docs: this collector
+           already reads shared_preload_libraries this way and #2564/#2605 measured that against a live
+           Aurora target, and shared_preload_libraries is the more restricted of the two. */
+        current_setting('lc_messages', true)                                     AS message_locale
 ),
 probe AS (
     SELECT
@@ -127,12 +157,41 @@ probe AS (
         s.threshold,
         s.log_format,
         s.line_prefix,
+        s.message_locale,
         /* BOUNDARY-AWARE, not a substring. shared_preload_libraries is a comma-separated list, and a plain
            substring test reports true for any library whose name merely CONTAINS this one (measured: both
            my_auto_explain_shim and auto_explain_extra false-positive that way). */
         coalesce(s.preload, '') ~ '(^|,)\s*auto_explain\s*(,|$)'                 AS loaded,
         EXISTS (SELECT 1 FROM pg_catalog.pg_available_extensions WHERE name = 'auto_explain') AS catalogued,
-        (SELECT max(default_version) FROM pg_catalog.pg_available_extensions WHERE name = 'auto_explain') AS catalog_version
+        (SELECT max(default_version) FROM pg_catalog.pg_available_extensions WHERE name = 'auto_explain') AS catalog_version,
+        /* DERIVED ONCE, for the reason library_loaded is: the shipped #2605 bug was one fact derived in
+           five places where the fifth forgot, and this fact is consulted by both the is_satisfied column
+           and the detail arms of its facet. A second copy is how they come to disagree.
+
+           SATISFIED means a locale that PROVABLY leaves PostgreSQL's message catalogue untranslated, never
+           one that merely looks acceptable. Two families qualify: the C family (C, POSIX, and any
+           C.<codeset> such as C.UTF-8) has no catalogue to load at all, and the English locales are the
+           catalogue's own source language, so gettext hands back the msgid unchanged.
+
+           THE ANCHOR IS THE LOAD-BEARING HALF, and it is the ONLY one - a mutation removing it was the one
+           that got through a first draft of the test. Unanchored, '^C' passes Czech_Czech Republic.1250 and
+           Chinese (Simplified)_China.936, both real Windows locale names beginning with a literal C, and
+           reports a TRANSLATED catalogue as readable. Anchored, they are rejected however the comparison
+           treats case, which is why the test is case-INSENSITIVE: no language has the ISO code 'c', so a
+           name whose first character is C and whose second is a dot or nothing is the C locale under any
+           spelling convention, and matching case-insensitively tolerates the POSIX/posix variation at no
+           cost. Case sensitivity here would only produce false NEGATIVES.
+
+           'english' is matched beside 'en' because that is the form a Windows PostgreSQL reports
+           (English_United States.1252). The longer alternative is written first so the result does not
+           depend on the regex engine's alternation order. */
+        coalesce(s.message_locale, '') ~* '^(C|POSIX)(\.|$)'
+            OR coalesce(s.message_locale, '') ~* '^(english|en)(_|\.|@|$)'     AS english_messages,
+        /* Its own flag, not the negation of the one above. An EMPTY lc_messages means PostgreSQL takes the
+           message language from the server PROCESS's environment, which no SQL read can see - so it is
+           UNKNOWN rather than translated, and it gets its own detail arm because what a reader may conclude
+           from an empty deadlock result differs between the two. */
+        coalesce(s.message_locale, '') = ''                                      AS locale_unset
     FROM settings AS s
 )
 SELECT
@@ -249,6 +308,51 @@ SELECT
              || 'itself - the id appears ONLY in the log line prefix - so plans captured without it cannot '
              || 'be joined to the statement they belong to. Add %Q to log_line_prefix; it is a dynamic '
              || 'parameter and needs no restart.'
+    END
+FROM probe AS p
+
+UNION ALL
+
+SELECT
+    'message_locale'::text,
+    /* NOT gated on loaded, and for a stronger reason than plan_attribution's: lc_messages governs whether
+       ANY of this product's log reads can find their anchor, and the deadlock read depends on it with no
+       auto_explain in the picture at all. A locale that hides deadlocks is worth reporting on a server that
+       will never load auto_explain.
+
+       An unset locale reads as UNSATISFIED, which is the same direction the reader takes for a NULL: a
+       precondition this cannot prove must not be presented as met. The detail arm says it is unknown rather
+       than wrong, so the row does not overclaim in the other direction either - the extension_available
+       convention, where a negative is inconclusive and says so. */
+    p.english_messages,
+    CASE
+        WHEN p.locale_unset THEN '(empty - the server takes its message language from its own environment)'
+        ELSE p.message_locale
+    END,
+    CASE
+        WHEN p.locale_unset
+            THEN 'lc_messages is EMPTY, so PostgreSQL takes its message language from the server process''s '
+                 || 'environment - which no SQL read can see. That makes this UNKNOWN, not wrong: the '
+                 || 'messages may well be English. But every log read this product performs matches English '
+                 || 'message text, so an empty deadlock or plan result from this target is an empty result '
+                 || 'of unknown meaning rather than an answer. Set lc_messages = ''C'' to make it knowable; '
+                 || 'it is a dynamic parameter and needs a reload, not a restart.'
+        WHEN p.english_messages
+            THEN 'PostgreSQL writes its messages untranslated under this locale, so the log reads that match '
+                 || 'English message text can find their anchor. That is a precondition being met, not a '
+                 || 'claim that anything was read.'
+        ELSE 'PostgreSQL TRANSLATES its own messages under this locale, the severity label included - a '
+             || 'German catalogue writes FEHLER: where an English one writes ERROR:. Every log read this '
+             || 'product performs matches English message text, so on this target they find nothing. THE '
+             || 'DEADLOCK READ IS THE DANGEROUS ONE: zero deadlocks is also the healthy answer, so a '
+             || 'blinded read and a server that did not deadlock are indistinguishable - use '
+             || 'pg_stat_database''s cumulative deadlock counter, which is a number rather than text, '
+             || 'before believing an empty deadlock result from here. Plan capture has no error code to '
+             || 'fall back on either: auto_explain writes at LOG level with SQLSTATE 00000, so there is no '
+             || 'severity-independent anchor even under csvlog. Set lc_messages = ''C''; it is a dynamic '
+             || 'parameter and needs a reload. One honest caveat: this reports what the product can '
+             || 'CONFIRM, not a verdict on your build - a PostgreSQL compiled without NLS support writes '
+             || 'English whatever this is set to, and SQL cannot see that.'
     END
 FROM probe AS p";
 

--- a/PerformanceMonitor.Collectors/PgPlanCaptureReadinessCollector.cs
+++ b/PerformanceMonitor.Collectors/PgPlanCaptureReadinessCollector.cs
@@ -43,10 +43,20 @@ namespace PerformanceMonitor.Collectors;
 /// <para><b>Why a message locale is a readiness facet (#3061).</b> Reading a captured plan is still
 /// #2566/#2567's and this claims nothing about it — but one PRECONDITION for reading is a configuration
 /// state on the target, which is exactly what this collector reports. Every log read this product performs
-/// matches PostgreSQL's ENGLISH message text, and <c>lc_messages</c> decides whether the target writes any:
-/// a German catalogue writes <c>FEHLER:</c> where an English one writes <c>ERROR:</c>, and the severity
-/// label is translated along with everything else. The <c>message_locale</c> facet reports that setting so
-/// an empty read becomes a NAMED unmet precondition rather than a silent zero.</para>
+/// matches PostgreSQL's ENGLISH message text, and <c>lc_messages</c> decides whether the target writes any.
+/// The <c>message_locale</c> facet reports that setting so an empty read becomes a NAMED unmet precondition
+/// rather than a silent zero.</para>
+///
+/// <para><b>Measured, not inferred</b> — PostgreSQL 17.11 with <c>lc_messages = 'de_DE.UTF-8'</c>, a real
+/// deadlock provoked and read back out of the server log. The line is
+/// <c>FEHLER:  Verklemmung (Deadlock) entdeckt</c>: the severity label AND the message body. <c>HINT:</c>
+/// becomes <c>TIPP:</c> and <c>CONTEXT:</c> becomes <c>ZUSAMMENHANG:</c>, while <c>DETAIL:</c> comes
+/// through UNCHANGED — so a translated catalogue does not mean every label differs, and nothing here should
+/// rest on that. It does not help the parser: the block pattern needs the <c>ERROR:</c> line and the
+/// <c>DETAIL:</c> line together, so the surviving half matches and the report is still lost whole. Against
+/// one log holding a German report and an English one, <c>PgDeadlockLogParser.Extract</c> returned ONE —
+/// the English — and a caller cannot tell a partial answer from a complete one. The mode also renders
+/// <c>ShareLock-Sperre</c>, whose hyphen the edge pattern's <c>[A-Za-z ]+</c> group excludes.</para>
 ///
 /// <para><b>It is the deadlock read, not the plan read, that makes this urgent.</b> Zero rows is the healthy
 /// resting state for <c>pg_deadlocks</c>, so a locale-blinded parser and a server that simply did not


### PR DESCRIPTION
Fixes #3061.

## The defect

Four target-side readers match PostgreSQL's ENGLISH message text in a **customer-owned** instance's server log: `PgDeadlockLogParser`, `PgDeadlocksCollector`, `PgPlanLogParser`, `PgPlanCaptureCollector`. PostgreSQL translates its own messages under `lc_messages`, the severity label included — a German catalogue writes `FEHLER:` where an English one writes `ERROR:` — so on a target running any other locale they go blind.

**`pg_deadlocks` is the dangerous one because zero rows is the healthy state.** A locale-blinded parser and a server that simply did not deadlock produce identical output, and nothing distinguished them. That is #3030's failure shape from a new cause. Plan capture is worse-placed for a fallback — `auto_explain` writes at LOG level with SQLSTATE `00000`, so there is no error code to key on even under `csvlog` — but nobody mistakes a missing plan for a healthy answer.

Every claim in the issue was re-verified against `origin/dev` before building: both collectors are `AppliesTo => true` (`PgDeadlocksCollector.cs:127`, `PgPlanCaptureCollector.cs:152`), the lock-mode group is `[A-Za-z ]+` (`PgDeadlockLogParser.cs:124`), and `PgServerConfigCollector` selects `pg_catalog.pg_settings` with no `WHERE`, so every monitored target's `lc_messages` was already in the store and simply never read.

## The change, and NO migration rung

`pg_plan_capture_readiness` gains a **`message_locale`** facet. **This is code-only — no schema change, no migration rung, no `SchemaVersion` bump, no pin to move.** The row-per-facet shape means a new precondition is a query change, exactly as #2538 established when it added `plan_attribution` the same way. A code-only install stays a code-only install.

It is not gated on `library_loaded`, for a stronger reason than `plan_attribution`'s: the deadlock read depends on this locale with no `auto_explain` in the picture at all, so a target that will never load the library still needs the answer.

## Judged, not observational — and why

**Judged.** `plan_text_setting` is the collector's observational precedent and its reasoning does not transfer: any `log_format` value proves capture is happening, so recording it is a complete answer. Here every value that is not English means the read returns nothing, so a facet that reported `de_DE.UTF-8` and drew no conclusion would leave the reader exactly where the empty result already left them. The whole point is to convert a silent zero into a *named unmet precondition*, and a facet that judges nothing cannot do that.

**Satisfied is only what can be PROVEN untranslated**, not what looks acceptable. Two families: the C family (`C`, `POSIX`, any `C.<codeset>`) has no catalogue to load, and the English locales are the catalogue's own source language so gettext returns the msgid unchanged. `english`/`English_*` is matched beside `en_*` because that is the form a Windows PostgreSQL reports.

**An unset or empty value is UNKNOWN, and resolves to unsatisfied with its own detail arm.** PostgreSQL then takes its message language from the server process's environment, which no SQL read can see. Unsatisfied is the direction the read surface already takes for a NULL — `DarlingPgPlanCaptureReadinessReader`: claiming readiness we cannot prove is the failure that matters — but the row must not overclaim in the other direction either, so the arm says the messages *may well be* English and that the empty result is one of unknown meaning rather than an answer. That is the `extension_available` convention, where a negative is inconclusive and says so. `locale_unset` is its own derived flag rather than the negation of the other, because what a reader may conclude differs between the two even though the remedy is the same.

**One honest caveat is on the row itself**: a PostgreSQL compiled without NLS support writes English whatever `lc_messages` is set to, and SQL cannot see that. The unsatisfied arm reports what the product can confirm rather than a verdict on the reader's build.

### The predicate's anchor is the load-bearing half, and mutation testing corrected me on which half

The first draft's comment claimed case sensitivity on the C test was load-bearing, citing `ca_ES` (Catalan) and `cs_CZ` (Czech). **That claim was wrong** and a mutation flipping `~` to `~*` came back green: the anchor on a following `.`-or-end rejects those regardless of case. The predicate now matches **case-insensitively** on purpose — no language has the ISO code `c`, and `posix`/`POSIX` spelling variation is real, so case sensitivity here would produce only false negatives. The comment says this rather than the old claim, and `posix` is in the theory data as the case that fails if someone tightens it back.

What the anchor actually stops is the Windows naming form: `Czech_Czech Republic.1250` and `Chinese (Simplified)_China.936` both begin with a literal upper-case `C`, so an unanchored `^C` declares a translated catalogue readable. Variant 3 below is that mutation.

The locale test is **derived once** in the `probe` CTE and read by both the verdict and the prose. That is the #2605 shape this collector already paid for — one fact derived in five places where the fifth forgot — and a facet whose verdict and whose remedy text disagree is worse than no facet, because the prose is what a reader acts on.

### The one limit the row states about itself

`lc_messages` is **overridable per role and per database**, and a log entry is written in the `lc_messages` of the backend that raised it, while this read resolves on the monitoring connection. Those agree wherever the setting comes from `postgresql.conf` or from nowhere, which is the ordinary case. The direction that matters is a global `de_DE` with an override putting the *monitoring role* at `C`: the facet would then read satisfied about a server whose backends translate. The satisfied arm says so on the row, because that is exactly where false confidence would live, and the codebase already knows this hazard — `PgServerConfigCollector`'s own doc comment separates server configuration from session noise for the same reason. Distinguishing it means reading `pg_settings.source` rather than the resolved value, which is a refinement rather than this change; naming the limit is what stops the row being over-read in the meantime.

`current_setting('lc_messages', true)`, matching the four GUCs beside it. `lc_messages` is `PGC_SUPERUSER` by context but carries no `GUC_SUPERUSER_ONLY` flag, so any role may read it; the decisive evidence is next door rather than in the docs — this collector already reads `shared_preload_libraries` that way and #2564/#2605 measured that against a live Aurora target, and `shared_preload_libraries` is the more restricted of the two.

## The empty-result advice now names the third cause

`get_pg_deadlocks` told the reader to check `log_error_verbosity` and `log_min_messages` before concluding the server does not deadlock, and could not mention the one precondition that is invisible. Every existing claim in that description is intact — #3028's `times_seen`-per-transport passage untouched, `get_pg_database_stats`' cumulative counter still named as the independent test — with locale added as an explicitly third and least-visible precondition. `get_pg_deadlock_detail`'s empty answer, the WPF deadlock panel note and the readiness panel note carry the same third cause.

`pg_stat_database`'s counter is now framed as **locale-proof because it is a number rather than text**, which is why it survives a translated catalogue and is the right instrument to reach for.

### One incidental correction, because it was in the sentence being rewritten

Two MCP messages pointed readers at **`get_pg_plan_capture_readiness`, which is not a tool that exists** — `pg_plan_capture_readiness` is the single deliberate exception to the read-coverage ratchet (`ServerPageTabsTests`, `KnownUnreadable = 1`). One of the two was the `no_deadlocks` message this PR rewrites, so leaving it would have re-endorsed a false pointer; the other is the same one-word defect with the same one-word fix, and splitting a defect across a PR and an issue is worse than fixing both. Both now name the collector, which is the idiom `DarlingMcpPgPlanTools` already uses two lines above ("from pg_plan_capture_readiness"). No tool was added and the ratchet is untouched.

The larger question this exposes — the ratchet's justification is that the readiness output is "a single row of configuration state, a panel rather than a question anyone asks an agent", and it is now six rows one of which qualifies every deadlock read an agent performs — is filed rather than decided here.

## `StoreLogSweep` is a FOURTH thing, not in scope

#3061 raises it and does not decide it. Established rather than assumed: `DarlingWorker.cs:4454` calls `StoreLogSweep.SweepAsync` with **no managed-store gate**, wrapped in its own `catch` precisely because a bring-your-own store's owner may withhold `pg_read_server_files`. So the claim is correct — a BYO store's log is classified under its owner's locale, and #3058 (merged) pins the *managed* conf only, so that exposure survives both PRs.

It is out of scope for three reasons rather than one:

- **Structurally unreachable from here.** This facet is a target collector dispatched through `CollectorCatalog.AppliesTo` against a registered server. A BYO store is not a monitored target and has no `server_id`, so no facet can carry a fact about it.
- **The mechanism would differ.** For a target the product must judge from collected data. For a BYO store it *holds the connection*, so the check is a startup or self-monitoring assertion in the `StoreSelfMetrics` / self-alert surface, not a collector.
- **The remedy would differ.** For a target the advice is "ask the owner to set `lc_messages = 'C'`". For a BYO store the product could instead refuse to classify — routing an unrecognised severity to `unclassified`-retained rather than dropping its text — which is a `StoreLogClassifier` behaviour change, and the safety-direction inversion #3053 identified arriving via a locale the product can read but cannot pin.

## Explicitly not done

**The parsers are not locale-aware**, and this PR does not start that job. Translating PostgreSQL's message catalogue into a matcher is large and fragile; saying the precondition is unmet is the honest alternative to pretending to read. The facet is sufficient for the failure #3061 was filed on — an empty result that reads as an answer — because it makes the empty result *named*. It does not make a non-English target's deadlocks collectable, and nothing here implies otherwise.

## Verification

`PgTargetMessageLocaleFacetTests`, 8 methods / 32 executed cases. `Darling.Tests` and `Lite.Tests` cannot run on macOS, so the REAL test files were compiled into a throwaway net10.0 xunit v3 host (the actual `.cs` via `<Compile Include>`, not copies, so `[CallerFilePath]` resolves to the real source path and the source-discovery pin reads the real `PerformanceMonitor.Collectors` directory). 50 tests total with the existing `PgPlanCaptureReadinessCollectorDefinitionTests` suite alongside it; all 8 new methods were confirmed present by name in `-list tests`, and `Skipped: 0, Not Run: 0` on every run.

The assertion the issue asked for is stated as the **relation**, not either side. `EveryTargetSideLogReader_AnchorsOnATokenTheSatisfiedLocaleSetGuarantees` **discovers the readers from source** rather than being handed a list, and independently rediscovered exactly the four #3061 enumerated, anchoring on exactly `ERROR`, `DETAIL` and `LOG`. Each discovered label must be one of PostgreSQL's untranslated upper-case tokens; a fifth reader is covered automatically, and a reader anchored outside that vocabulary fails. Nothing is filtered at the discovery step — everything found is asserted, so a bad token cannot be quietly dropped.

`ThePredicateUsesOnlySyntaxThatMeansTheSameThingInBothEngines` earns the right to evaluate PostgreSQL's regexes with .NET's engine, and the container run below then confirmed the two engines agree on every value: it pins that both patterns use bare alternation, anchors, literal characters and a single escaped dot, with no class shorthands, POSIX bracket classes, quantifiers, lookaround, back-references or embedded-option prefixes. The predicate is **extracted from the shipped query text** with the operator that carries its case sensitivity, never retyped — a retyped copy proves the transcription works, which is not the claim.

### Red-proofed ten ways, each on a different named assertion

Run against a COPY of the tree at the committed SHA, restored between variants. Every variant produced test output, so every one compiled — the one that came back green (`~` → `~*` on the C family) was not counted; it was a genuine gap and it changed the code and the comment, as described above.

| Variant | Failing assertion |
|---|---|
| Delete the `message_locale` branch | `TheMessageLocaleFacet_IsASeparateRow_AndReadsLcMessagesThroughTheSharedCte` (+ `EveryFacet_IsASeparateRow`, 7 total) |
| Make the C test case-SENSITIVE | `TheSatisfiedSet_…(locale: "posix", expected: True)` |
| Drop the `(\.\|$)` anchor from the C test | `TheSatisfiedSet_…(locale: "Czech_Czech Republic.1250", expected: False)` (5 cases) |
| Add `de` to the English alternation | `TheSatisfiedSet_…(locale: "de_DE.UTF-8", expected: False)` |
| Verdict becomes `p.english_messages OR p.locale_unset` | `AnEmptyLocale_IsUnsatisfied_ButItsDetailSaysUnknownRatherThanTranslated` |
| Verdict becomes `p.loaded AND p.english_messages` | `TheFacet_IsNotGatedOnTheLibraryBeingLoaded` |
| Inline a second copy of the predicate in the detail `CASE` | `TheLocaleTest_IsDerivedOnce_AndBothTheVerdictAndTheProseReadThatOneCopy` |
| `PgDeadlockLogParser` anchors on `FEHLER:` | `EveryTargetSideLogReader_AnchorsOnATokenTheSatisfiedLocaleSetGuarantees` |
| Strip `pg_stat_database` from the unsatisfied remedy | `TheTranslatedRemedy_NamesTheDeadlockTrap_AndTheLocaleProofIndependentCheck` |
| `[[:punct:]]` in place of `\.` in the English pattern | `ThePredicateUsesOnlySyntaxThatMeansTheSameThingInBothEngines` |

The verdict-column pin exists because of that fifth variant: the empty-locale check evaluates the *extracted patterns*, so on its own it could not see the facet's verdict being widened downstream — `OR p.locale_unset` leaves every pattern untouched and turns unknown into satisfied. The pin asserts the `is_satisfied` column is the derived predicate and nothing else.

### Verified against a real PostgreSQL, which changed several claims

A throwaway PostgreSQL **17.11** (`--enable-nls`, German catalogue present) was stood up in Docker and the defect induced end to end. Four things came out of running it rather than reasoning about it:

**1. The shipped query runs verbatim, and `lc_messages` needs no privilege.** `BuildQuery(ctx).Text` was dumped to a file and fed to `psql` unmodified — 6 rows, and the `message_locale` row read `observed = C`, `is_satisfied = t` on a `--locale=C` cluster. Read by an **unprivileged role holding only `pg_monitor`**, so the privilege inference above is now a measurement: no `GUC_SUPERUSER_ONLY` gate, no added requirement. Structural sanity on the shipped text alongside it: 230 single quotes (even), parens balanced at zero, 5 `UNION ALL` for 6 facet literals.

**2. PostgreSQL's own regex engine agrees with .NET on all 26 locale values.** The two patterns were extracted from the shipped SQL with their operators and evaluated server-side against the exact table the theory uses. Identical verdicts: 12 satisfied (C family + English forms, `posix` included), 14 not (empty, every translated locale, and all four adversarial values). The cross-engine licence `ThePredicateUsesOnlySyntaxThatMeansTheSameThingInBothEngines` argues for is no longer only an argument.

**3. The facet reports unsatisfied on a real German server.** `lc_messages` was set to `de_DE.UTF-8` (locale generated with `locale-gen`), the server restarted, and the shipped query re-run: `message_locale | f | de_DE.UTF-8` with the translated-catalogue remedy.

**4. A real deadlock, and the parser drops it silently.** Provoked with crossed updates on a two-row table. The server log line is:

```
2026-09-06 01:52:26.537 UTC [72] FEHLER:  Verklemmung (Deadlock) entdeckt
```

The severity label **and** the message body. `HINT:` becomes `TIPP:` and `CONTEXT:` becomes `ZUSAMMENHANG:` — but **`DETAIL:` comes through unchanged**, which was not expected and which the test previously claimed the opposite of. That claim is corrected: the vocabulary list now only asserts what PostgreSQL writes under a *satisfied* locale, because "translated locale" does not mean "every label differs".

`DETAIL:` surviving does not help. `PgDeadlockLogParser`'s block pattern requires the `ERROR:  deadlock detected` line **and** the `DETAIL:  ` line, so the surviving half matches and the report is lost whole — the same all-or-nothing its own doc comment describes for `log_error_verbosity = terse`. An English control deadlock was then provoked on the same server, same table, same statements, so **one log held both reports** (an adversarial fixture: two situations in one sample). The shipped `PgDeadlockLogParser.Extract` over that log returned **1 report, the English one** — victim pid 132, not the German pid 72. A caller cannot tell that partial answer from a complete one, which is the defect exactly.

The mode also renders `ShareLock-Sperre`. The edge pattern's mode group is `[A-Za-z ]+`, which excludes the hyphen — so #3061's "doubly exposed" claim is confirmed, with a sharper mechanism than a merely localised mode name.

### Still not verified

- **No live customer-owned target was involved, and none is reachable from here.** The two Darling stores this session can read hold SQL Server targets only, and the PostgreSQL store has no MCP in this session. So the facet has never run through the *collector pipeline* against a real monitored PostgreSQL target — the query was executed by hand against a container. What is unverified is the dispatch and the store write, not the SQL or its verdict.
- **`lc_messages` overridden per role or per database was not exercised**, so the limit the satisfied arm states is reasoned, not measured.
- 9 build warnings, all pre-existing and in files this does not touch.

### CI has now run, and the new tests demonstrably executed

All 8 checks pass on `e0b2bd326`, `mergeStateStatus: CLEAN`. Durations rule out a fast-path: `build` 564s, `Darling PostgreSQL tests` 255s, `Darling Linux build` 107s.

The Windows suites cannot run on macOS, so locally the real test files were compiled into a throwaway net10.0 xunit v3 host. On CI they ran for real, and the proof is a **counted delta against a baseline** rather than a grep that found nothing: `Lite.Tests` reported `Total: 3363, Skipped: 0, Not Run: 0` on `dev` before this branch (run 34003834378) and `Total: 3395, Skipped: 0, Not Run: 0` on this head — **exactly +32**, which is the 32 cases this PR adds (7 facts plus a 25-case theory). `Skipped: 0` for the whole suite settles the skip enumeration outright: nothing in `Lite.Tests` was skipped, so none of these were. The 317 skips elsewhere in the run are all `Darling.Tests.*LiveTests` / Timescale / scratch-Postgres cases needing a live store, and neither new nor existing readiness test appears among them.

`Darling whole-tree guards` completing in 15s is its designed behaviour, not a silent no-op: its gate runs the whole-tree guards only when the main `build` job *skipped* the Darling suite, and here `build` ran all 7,769 of them.

## CHANGELOG entry text — deliberately NOT applied

Every concurrent lane appends to the same `[Unreleased]` block, so a per-PR edit conflicts with whichever sibling merges first and the loser's entry has to be re-applied by hand after a rebase. The entry is therefore written out in full here, ready to paste, and applied by whoever merges. That the block is otherwise kept current PR-by-PR is exactly why: the entries correspond 1:1 with merged PRs *because* they land at merge, not in the diff. This is a standing convention for this queue rather than a judgement about this change.


```
- **A monitored PostgreSQL target's `lc_messages` is now a named precondition rather than an invisible one** ([#3061]) - four target-side readers match PostgreSQL's ENGLISH message text in a customer-owned instance's server log, and PostgreSQL translates its own messages under `lc_messages` with the severity label included, so a German catalogue writes `FEHLER:` where an English one writes `ERROR:`. `pg_deadlocks` is the dangerous case because **zero rows is the healthy state**: a locale-blinded parser and a server that simply did not deadlock produced identical output and nothing distinguished them, which is #3030's failure shape from a new cause. Plan capture has no error code to fall back on either - `auto_explain` writes at LOG level with SQLSTATE `00000`, so there is no severity-independent anchor even under `csvlog`. `pg_plan_capture_readiness` gains a `message_locale` facet and **needs no migration** - the row-per-facet shape means a new precondition is a query change, the same way `plan_attribution` was (#2538). The data was already collected and never read: `PgServerConfigCollector` selects `pg_settings` with no `WHERE`. Judged rather than merely recorded, because a facet that reported `de_DE.UTF-8` and drew no conclusion leaves the reader where the empty result already left them - and satisfied only for locales that can be **proven** untranslated, the C family and the English locales. An unset value is a **third state**: the server then takes its language from its own environment, which no query can see, so it reads as unsatisfied with a detail arm saying UNKNOWN rather than translated, the `extension_available` convention where a negative is inconclusive and says so. The load-bearing half of the predicate is the ANCHOR, not case sensitivity, and mutation testing is what established that: `Czech_Czech Republic.1250` and `Chinese (Simplified)_China.936` are real Windows locale names beginning with a literal `C`, so an unanchored `^C` declares a translated catalogue readable, while a case-insensitive test rejects them anyway - the first draft's comment claimed the opposite and a green mutation caught it. `get_pg_deadlocks`, `get_pg_deadlock_detail`, the WPF deadlock panel and the readiness panel all name the third cause now, with `pg_stat_database`'s cumulative counter framed as locale-proof because it is a number rather than text. Two of those messages had pointed at `get_pg_plan_capture_readiness`, which is not a tool that exists; they name the collector instead. **Not** an attempt to make the parsers locale-aware: saying the precondition is unmet is the honest alternative to pretending to read.
```
