### PR TITLE
Fixes #3069

### DIFF
--- a/Darling/Darling.Tests/CommentFilterAdoptionTests.cs
+++ b/Darling/Darling.Tests/CommentFilterAdoptionTests.cs
@@ -210,6 +210,204 @@ public sealed class CommentFilterAdoptionTests
             walked.Split('\n').Length);
     }
 
+    /* ───────────────── the census's own summary, which nothing was holding (#3069) ───────────────── */
+
+    /// <summary>
+    /// The kind labels every entry in <see cref="s_bounded"/> must open with, mapped to the counted claim in
+    /// this class's summary that describes them.
+    ///
+    /// <para>An enumeration for the same reason the map above is one — but note the direction: an entry
+    /// carrying a kind that is NOT here fails <see cref="KindCounts"/> loudly rather than going uncounted,
+    /// so a new kind cannot slip past by being unrecognised. That is the opposite of the way a wildcard
+    /// grows.</para>
+    /// </summary>
+    private static readonly (string Label, string Claim)[] s_kinds =
+    {
+        ("COLLECTS", "collect a doc-comment run"),
+        ("STATED BOUND", "reads a stated, measured bound"),
+        ("NOT C#", "filters SQL"),
+        ("DEMONSTRATES", "demonstrates the shape"),
+    };
+
+    /// <summary>
+    /// The numeral words this class's summary is allowed to spell its counts with. Prose reads better with
+    /// words than digits here, so the mapping is explicit rather than the digits-only convention
+    /// <c>ReadmeDerivedCountPinTests</c> uses over Markdown.
+    ///
+    /// <para><b>The bound, stated because it is the load-bearing part.</b> A count that outgrew this
+    /// vocabulary does not silently pass — the pattern stops matching and
+    /// <see cref="TheCensusSummary_CountsTheMapItDescribes"/> fails with a parse miss. Wrong toward the
+    /// worse label, which is the only direction worth being wrong in for a guard.</para>
+    /// </summary>
+    private static readonly string[] s_numeralWords =
+        { "Zero", "One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten" };
+
+    /// <summary>
+    /// This class's summary describes the map below it by COUNT — "Four kinds live here", then one claim per
+    /// kind — and until #3069 nothing held the two together. The prose read "Two collect a doc-comment run"
+    /// while THREE entries already did, so it was stale by one before #3069 added a fourth, and would have
+    /// been stale by two after.
+    ///
+    /// <para><b>Why a pin rather than the corrected word.</b> Fixing the word fixes this instance. The
+    /// asymmetry is the defect: <see cref="EveryLinePrefixCommentFilter_StatesTheBoundItRestsOn"/> catches a
+    /// new MEMBER of the census by name, and nothing caught the census's own SUMMARY drifting — in a file
+    /// whose entire job is adoption tracking. A counted claim that has drifted once unattended will drift
+    /// again.</para>
+    ///
+    /// <para><b>All five claims are pinned, not four.</b> The kind total and one claim per kind. A partial
+    /// pin on a summary that reads as fully pinned is worse than none, so if a claim were genuinely
+    /// underivable it would be said here rather than left out quietly. None is: the kinds come from the
+    /// entry TEXT and the counts from the map.</para>
+    /// </summary>
+    [Fact]
+    public void TheCensusSummary_CountsTheMapItDescribes()
+    {
+        VerifySummaryCounts(CensusSummaryProse(), KindCounts(s_bounded.Values), s_bounded.Count);
+    }
+
+    /// <summary>
+    /// Non-vacuity, in both directions and for the mapping in between — because the cheapest way this pin
+    /// passes while the summary is wrong is that the extraction never yields a numeral at all, and a
+    /// word-versus-digit mismatch would do exactly that.
+    /// </summary>
+    [Fact]
+    public void TheCensusSummaryPin_ReportsDriftFromEitherSide()
+    {
+        var prose = CensusSummaryProse();
+        var real = KindCounts(s_bounded.Values);
+        var injected = 0;
+
+        /* (a) the PROSE moves. One claim at a time, so each of the five is individually load-bearing. */
+        foreach (var (_, claim) in s_kinds.Select(k => (k.Label, k.Claim)).Append((string.Empty, "kinds live here")))
+        {
+            var pattern = new Regex($@"({string.Join("|", s_numeralWords)}) {Regex.Escape(claim)}");
+            var match = pattern.Match(prose);
+            Assert.True(match.Success, $"the summary no longer states a count for '{claim}', so its pin is vacuous.");
+
+            var wrong = s_numeralWords[(Array.IndexOf(s_numeralWords, match.Groups[1].Value) + 1) % s_numeralWords.Length];
+            var mutated = prose.Remove(match.Groups[1].Index, match.Groups[1].Length).Insert(match.Groups[1].Index, wrong);
+            Assert.NotEqual(prose, mutated);
+            Assert.ThrowsAny<Exception>(() => VerifySummaryCounts(mutated, real, s_bounded.Count));
+            injected++;
+        }
+
+        Assert.Equal(s_kinds.Length + 1, injected);
+
+        /* (b) the MAP moves and the prose does not — a fifth COLLECTS entry added without a copy-edit. */
+        var withAnother = KindCounts(s_bounded.Values.Append("COLLECTS a doc run. A synthetic entry, for this test only."));
+        Assert.ThrowsAny<Exception>(() => VerifySummaryCounts(prose, withAnother, s_bounded.Count + 1));
+
+        /* (c) an entry whose kind is not recognised must FAIL rather than go uncounted, or the breakdown
+               could silently stop summing to the map. */
+        Assert.ThrowsAny<Exception>(() => KindCounts(s_bounded.Values.Append("SOMETHING ELSE. an unlabelled bound.")));
+
+        /* (d) and the word mapping itself: a count spelled outside the vocabulary reds rather than passing,
+               which is the failure mode a digits-only pin would not have had to think about. */
+        Assert.ThrowsAny<Exception>(() => VerifySummaryCounts(
+            prose.Replace("kinds live here", "kinds live in here", StringComparison.Ordinal),
+            real,
+            s_bounded.Count));
+    }
+
+    /// <summary>
+    /// Each kind label paired with how many entries open with it. Throws when an entry matches none, so the
+    /// breakdown can never quietly stop accounting for the whole map.
+    /// </summary>
+    private static Dictionary<string, int> KindCounts(IEnumerable<string> bounds)
+    {
+        var counts = s_kinds.ToDictionary(k => k.Label, _ => 0, StringComparer.Ordinal);
+
+        foreach (var bound in bounds)
+        {
+            var label = s_kinds.FirstOrDefault(k => bound.StartsWith(k.Label, StringComparison.Ordinal)).Label;
+            Assert.False(label is null,
+                $"this entry opens with no recognised kind: \"{bound[..Math.Min(60, bound.Length)]}…\". Every "
+                + "entry must name its kind, because the class summary states one count per kind and "
+                + "TheCensusSummary_CountsTheMapItDescribes derives those counts from this text. Add the new "
+                + "kind to s_kinds and give it a claim in the summary.");
+            counts[label!]++;
+        }
+
+        return counts;
+    }
+
+    /// <summary>
+    /// The summary's counted claims against <paramref name="counts"/>. Separated from the map so
+    /// <see cref="TheCensusSummaryPin_ReportsDriftFromEitherSide"/> can drive it with a synthetic census and
+    /// prove the map side reds too, which reading the real map could never show.
+    /// </summary>
+    private static void VerifySummaryCounts(string prose, Dictionary<string, int> counts, int total)
+    {
+        Assert.Equal(total, counts.Values.Sum());
+        Assert.True(total > 0, "the census is empty, so every count below would be vacuously satisfiable.");
+
+        var claims = s_kinds
+            .Select(k => (k.Claim, Expected: counts[k.Label]))
+            .Append(("kinds live here", counts.Count(c => c.Value > 0)))
+            .ToArray();
+
+        foreach (var (claim, expected) in claims)
+        {
+            var pattern = new Regex($@"({string.Join("|", s_numeralWords)}) {Regex.Escape(claim)}");
+            var match = pattern.Match(prose);
+
+            Assert.True(match.Success,
+                $"this class's summary no longer states a count for \"{claim}\" as one of "
+                + $"{string.Join("/", s_numeralWords)}. It describes s_bounded by count, so keep the claim "
+                + "parseable, spell the numeral as a word from that list — or delete the count from the "
+                + "prose and remove it from s_kinds' claim, which is equally acceptable (#3069).");
+
+            var actual = Array.IndexOf(s_numeralWords, match.Groups[1].Value);
+            Assert.True(actual == expected,
+                $"the summary says {match.Groups[1].Value} ({actual}) {claim}, but the census holds "
+                + $"{expected}. Fix the word in the summary rather than this pin.");
+        }
+    }
+
+    /// <summary>
+    /// <see cref="s_bounded"/>'s OWN doc comment — which is where the counted claims live, not the class
+    /// summary. Normalised the way <c>RefreshCeilingProvenancePinTests.DocProseFor</c> normalises the ones it
+    /// reads: emphasis tags and dash style removed, so a copy-edit that only reformats cannot break a count
+    /// pin.
+    ///
+    /// <para>Anchored on the map's declaration rather than the class's, and the difference is not academic:
+    /// aiming this at the class summary is a mistake this pin caught on its first run, because the wrong doc
+    /// run yields prose with no counted claim in it at all and the extraction fails loudly instead of
+    /// comparing nothing.</para>
+    /// </summary>
+    private static string CensusSummaryProse([CallerFilePath] string thisFile = "")
+    {
+        var source = File.ReadAllText(thisFile);
+        var declaration = source.IndexOf(
+            "private static readonly Dictionary<string, string> s_bounded", StringComparison.Ordinal);
+        Assert.True(declaration > 0, "could not find s_bounded's declaration, so its summary could not be read.");
+
+        var lines = source[..declaration].Split('\n');
+        var run = new List<string>();
+
+        for (var index = lines.Length - 2; index >= 0; index--)
+        {
+            var line = lines[index].Trim('\r', ' ', '\t');
+            if (!line.StartsWith("///", StringComparison.Ordinal))
+            {
+                break;
+            }
+
+            run.Insert(0, line.Length > 3 ? line[3..].Trim() : string.Empty);
+        }
+
+        var prose = string.Join(" ", run)
+            .Replace("<b>", string.Empty, StringComparison.Ordinal)
+            .Replace("</b>", string.Empty, StringComparison.Ordinal)
+            .Replace('\u2014', '-')
+            .Replace('\u2013', '-');
+        prose = Regex.Replace(prose, @"\s+", " ").Trim();
+
+        Assert.StartsWith("<summary>", prose, StringComparison.Ordinal);
+        Assert.EndsWith("</summary>", prose, StringComparison.Ordinal);
+        return prose;
+    }
+
     /// <summary>
     /// Every <c>StartsWith</c> call in <paramref name="text"/> whose first argument is a comment prefix, as
     /// the offset of the call.

--- a/Darling/Darling.Tests/CommentFilterAdoptionTests.cs
+++ b/Darling/Darling.Tests/CommentFilterAdoptionTests.cs
@@ -75,7 +75,7 @@ public sealed class CommentFilterAdoptionTests
     /// <see cref="AnalysisPassTokenThreadingTests"/> gives: the way a wildcard grows is that nobody has to
     /// name a new entry.
     ///
-    /// <para>Four kinds live here and they are not the same kind. Two <b>collect</b> a doc-comment run,
+    /// <para>Four kinds live here and they are not the same kind. Four <b>collect</b> a doc-comment run,
     /// where the prefix is what defines the run. One reads a <b>stated, measured</b> bound off a named file.
     /// One filters <b>SQL</b>, which the C# walk cannot help with. One <b>demonstrates</b> the shape on an
     /// arranged fixture, which is this file.</para>
@@ -102,6 +102,17 @@ public sealed class CommentFilterAdoptionTests
         ["Darling.Tests/DocCommentHygieneTests.cs"] =
             "COLLECTS a doc run. DocRuns groups contiguous /// lines into the run that documents one member, "
             + "which is the subject of the whole class rather than an approximation of it.",
+
+        ["Darling.Tests/RefreshCeilingProvenancePinTests.cs"] =
+            "COLLECTS a doc run. DocProseFor walks the contiguous /// run above a named declaration and "
+            + "collapses it, so that a pattern can span the wrapping of the prose it reads figures out of. "
+            + "The prefix defines the run rather than approximating comment-stripping, and asking for the "
+            + "walker would leave nothing to read - the figures being pinned live only in comments. Stated "
+            + "bound: the walk STOPS at the first line that is not /// -prefixed, so a block comment between "
+            + "the doc run and its declaration would truncate it. That direction is loud rather than quiet, "
+            + "because the collected prose is then asserted to open at <summary> and close at </summary> "
+            + "before any figure is compared - a truncated walk fails there instead of silently pinning half "
+            + "a comment.",
 
         ["Lite.Tests/LiteSidebarDotRendersTheCardStatusTests.cs"] =
             "STATED BOUND, and asking for the walker would BREAK it. Its doc comment records the measurement: "

--- a/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
+++ b/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
@@ -138,19 +138,7 @@ public sealed class RefreshCeilingProvenancePinTests
         yield return (
             "the slot-clearance contrast",
             CeilingDeclaration,
-            @"largest of the ([0-9]+) clears the slot by ([0-9]+) s, where this constant clears it by ([0-9]+) s",
-            true);
-
-        yield return (
-            "the issue's median figure",
-            CeilingDeclaration,
-            @"median of the same window as ~([0-9]+) s",
-            true);
-
-        yield return (
-            "why the issue's median is not reproducible",
-            CeilingDeclaration,
-            @"([0-9]+) is the midpoint of ([0-9]+) and ([0-9]+), so a median over ([0-9]+) of the ([0-9]+) rather than the ([0-9]+) clean",
+            @"clears the slot by ([0-9]+) s, where this constant clears it by ([0-9]+) s",
             true);
 
         /* ARITY-FREE, and that is the point rather than a convenience. This list gains a reading every hour
@@ -464,22 +452,8 @@ public sealed class RefreshCeilingProvenancePinTests
         Require(summary[4] == middle, $"stated middle {summary[4]} s against {middle} s computed");
 
         var clearance = Read("the slot-clearance contrast");
-        Require(clearance[0] == clean.Length, $"stated clean count {clearance[0]} against {clean.Length} listed");
-        Require(clearance[1] == Slot - max, $"stated clearance {clearance[1]} s against {Slot - max} s derived");
-        Require(clearance[2] == Slot - Ceiling, $"stated margin {clearance[2]} s against {Slot - Ceiling} s derived");
-
-        var statedMedian = Read("the issue's median figure");
-        var why = Read("why the issue's median is not reproducible");
-        Require(why[0] == statedMedian[0],
-            $"the paragraph explains {why[0]} s while quoting the issue's figure as {statedMedian[0]} s");
-        Require(why[1] + why[2] == 2 * why[0],
-            $"{why[0]} is not the midpoint of {why[1]} and {why[2]}, so the explanation is arithmetically wrong");
-        Require(clean.Contains(why[1]) && clean.Contains(why[2]),
-            $"the midpoint pair {why[1]}/{why[2]} is not drawn from the published series {Join(clean)}");
-        Require(why[3] == clean.Length - 1,
-            $"an even-count median over the published rows drops one, so {clean.Length - 1} not {why[3]}");
-        Require(why[4] == series.Length, $"stated total {why[4]} against {series.Length} listed");
-        Require(why[5] == clean.Length, $"stated clean count {why[5]} against {clean.Length} listed");
+        Require(clearance[0] == Slot - max, $"stated clearance {clearance[0]} s against {Slot - max} s derived");
+        Require(clearance[1] == Slot - Ceiling, $"stated margin {clearance[1]} s against {Slot - Ceiling} s derived");
 
         var downward = Read("the downward-edit consequence");
         Require(downward[0] == max, $"stated observed maximum {downward[0]} s against {max} s listed");

--- a/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
+++ b/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
@@ -93,49 +93,49 @@ public sealed class RefreshCeilingProvenancePinTests
         yield return (
             "the transition run's clock arithmetic",
             CeilingDeclaration,
-            @"refresh policy \S <c>([0-9][0-9]):([0-9][0-9]):([0-9][0-9])</c> to <c>([0-9][0-9]):([0-9][0-9]):([0-9][0-9])</c> on the boundary day",
+            @"<c>([0-9][0-9]):([0-9][0-9]):([0-9][0-9])</c> to <c>([0-9][0-9]):([0-9][0-9]):([0-9][0-9])</c>",
             true);
 
         yield return (
             "the boundary timestamp",
             CeilingDeclaration,
-            @"refresh policies at <c>([0-9][0-9]):([0-9][0-9]):([0-9][0-9])</c>, one second BEFORE",
+            @"<c>([0-9][0-9]):([0-9][0-9]):([0-9][0-9])</c>, one second BEFORE",
             true);
 
         yield return (
             "the run count",
             CeilingDeclaration,
-            @"([0-9]+) consecutive runs of this job's refresh policy",
+            @"([0-9]+) consecutive runs",
             true);
 
         yield return (
             "the published series",
             CeilingDeclaration,
-            @"<c>([0-9]+(?:, [0-9]+)+)</c> seconds\.",
+            @"<c>([0-9]+(?:, [0-9]+)+)</c> seconds",
             true);
 
         yield return (
             "the clean-series summary",
             CeilingDeclaration,
-            @"the remaining ([0-9]+) run from <b>([0-9]+) s to ([0-9]+) s</b>, mean <b>([0-9]+) s</b>, middle reading <b>([0-9]+) s</b>",
+            @"remaining ([0-9]+) run from ([0-9]+) s to ([0-9]+) s, mean ([0-9]+) s, middle reading ([0-9]+) s",
             true);
 
         yield return (
             "the slot-clearance contrast",
             CeilingDeclaration,
-            @"The largest of the ([0-9]+) clears the slot by <b>([0-9]+) s</b>, where this constant clears it by ([0-9]+) s\.",
+            @"largest of the ([0-9]+) clears the slot by ([0-9]+) s, where this constant clears it by ([0-9]+) s",
             true);
 
         yield return (
             "the issue's median figure",
             CeilingDeclaration,
-            @"the median of the same window as ~<b>([0-9]+) s</b>",
+            @"median of the same window as ~([0-9]+) s",
             true);
 
         yield return (
             "why the issue's median is not reproducible",
             CeilingDeclaration,
-            @"([0-9]+) is the midpoint of ([0-9]+) and ([0-9]+), so a median over ([0-9]+) of the ([0-9]+) rather than the ([0-9]+) clean ones",
+            @"([0-9]+) is the midpoint of ([0-9]+) and ([0-9]+), so a median over ([0-9]+) of the ([0-9]+) rather than the ([0-9]+) clean",
             true);
 
         /* NOT drift-swept, for the reason in the class summary: these two are quoted readings, so bumping a
@@ -145,13 +145,13 @@ public sealed class RefreshCeilingProvenancePinTests
         yield return (
             "the inadmissible snapshot pair",
             CeilingDeclaration,
-            @"Two further readings of <b>([0-9]+) s</b> and <b>([0-9]+) s</b> come from the hourly",
+            @"readings of ([0-9]+) s and ([0-9]+) s come from",
             false);
 
         yield return (
             "the downward-edit consequence",
             CeilingDeclaration,
-            @"correcting toward the observed ([0-9]+) s would leave ([0-9]+) s of margin in place of ([0-9]+) s",
+            @"toward the observed ([0-9]+) s would leave ([0-9]+) s of margin in place of ([0-9]+) s",
             true);
 
         yield return (
@@ -169,7 +169,7 @@ public sealed class RefreshCeilingProvenancePinTests
         yield return (
             "the exclude-whole occupancy sentence",
             CompressionMinutesDeclaration,
-            @"occupies ([0-9]+)\.([0-9]) of the ([0-9]+) minutes in its slot",
+            @"occupies ([0-9]+)\.([0-9]) of the ([0-9]+) minutes",
             true);
     }
 
@@ -201,13 +201,26 @@ public sealed class RefreshCeilingProvenancePinTests
         Assert.NotEmpty(snapshot);
         Assert.Empty(series.Intersect(snapshot));
 
-        var mutated = source.Replace(
-            $"readings of <b>{snapshot[0]} s</b>",
-            $"readings of <b>{series[^1]} s</b>",
-            StringComparison.Ordinal);
+        /* Injected through the same ordinal rewrite the drift sweep uses, rather than by string-replacing
+           the reading. A bare Replace would depend on the surrounding emphasis tags - the very coupling
+           DocProseFor now normalises away - and would silently find nothing if someone unbolded the figure,
+           which is a mutation that proves nothing wearing a caught drift's clothes. */
+        var snapshotPattern = PatternFor("the inadmissible snapshot pair");
+        var firstReading = OrdinalOfFirstNumberInGroups(prose, snapshotPattern);
+        Assert.True(firstReading >= 0, "the snapshot pair's pattern captured no number, so its pin is vacuous.");
+
+        var mutated = RewriteNumberInDocRun(
+            source,
+            CeilingDeclaration,
+            snapshotPattern,
+            firstReading,
+            series[^1].ToString(CultureInfo.InvariantCulture));
+
+        Assert.True(mutated is not null,
+            "could not inject a series reading into the snapshot pair, so nothing was proved.");
         Assert.NotEqual(source, mutated);
 
-        var failure = Assert.ThrowsAny<Exception>(() => Verify(mutated));
+        var failure = Assert.ThrowsAny<Exception>(() => Verify(mutated!));
         Assert.DoesNotContain(ParseMiss, failure.Message, StringComparison.Ordinal);
     }
 
@@ -527,8 +540,20 @@ public sealed class RefreshCeilingProvenancePinTests
         var match = Regex.Match(prose, pattern);
         Require(match.Success,
             $"{ParseMiss}: {name} is no longer present in TimescaleSupport.cs in the pinned shape "
-            + $"({pattern}). It restates figures derived from the ceiling constant, so keep it parseable — or "
-            + "delete the figure from the prose and remove this pin with it (#3069).");
+            + $"({pattern}). Three fixes are all correct and you should pick by INTENT, not by whichever is "
+            + "quickest:\n"
+            + "  (1) the wording moved but the figures still agree - UPDATE THIS PATTERN in "
+            + "RefreshCeilingProvenancePinTests.Pins(). This is sanctioned rather than a loophole, because "
+            + "EveryNumericPin_ReportsAnInjectedDrift re-derives every case from the pattern you write: "
+            + "loosen it until it stops guarding and that test goes red, so a pattern cannot be widened into "
+            + "a no-op.\n"
+            + "  (2) a figure is now WRONG - fix the prose, not this pin. The comparison below names the "
+            + "derived value.\n"
+            + "  (3) the figure is no longer worth stating - DELETE IT FROM THE PROSE and drop this pin with "
+            + "it. Equally acceptable; a pin must not become the reason to keep a sentence nobody wants "
+            + "(#3072's rule, #3069's pin).\n"
+            + "Emphasis tags and dash style are already normalised away by DocProseFor, so a pure typo or "
+            + "reformatting fix that touches none of these words needs no change here.");
 
         return match.Groups.Cast<Group>().Skip(1)
             .SelectMany(g => Regex.Matches(g.Value, "[0-9]+").Select(m => m.Value))
@@ -568,7 +593,17 @@ public sealed class RefreshCeilingProvenancePinTests
 
         Require(run.Count > 0, $"{ParseMiss}: '{declaration}' carries no doc comment run");
 
-        var prose = Regex.Replace(string.Join(" ", run), @"\s+", " ").Trim();
+        /* NORMALISED before any pattern sees it, so two whole classes of copy-edit cannot break a pin:
+           <b> emphasis (bolding or unbolding a figure) and dash style (em, en or plain hyphen). That is
+           #3077's review complaint met at the extractor rather than argued with. What a pattern still has
+           to name is the handful of words that identify WHICH CLAIM a number belongs to, and that is not
+           removable — see the class summary on why a claim-blind numeral bag cannot do this job. */
+        var prose = string.Join(" ", run)
+            .Replace("<b>", string.Empty, StringComparison.Ordinal)
+            .Replace("</b>", string.Empty, StringComparison.Ordinal)
+            .Replace('\u2014', '-')
+            .Replace('\u2013', '-');
+        prose = Regex.Replace(prose, @"\s+", " ").Trim();
         Require(prose.StartsWith("<summary>", StringComparison.Ordinal),
             $"{ParseMiss}: the doc run above '{declaration}' does not begin at its <summary>, so the walk "
             + "reached the top of a truncated block");
@@ -618,6 +653,51 @@ public sealed class RefreshCeilingProvenancePinTests
     /// zero-padded clock component cannot break the pattern it is being tested against.</para>
     /// </summary>
     private static string? BumpNumberInsideGroups(string source, string declaration, string pattern, int ordinal)
+        => RewriteNumberInDocRun(source, declaration, pattern, ordinal, replacement: null);
+
+    /// <summary>
+    /// The doc-run-wide ordinal of the first integer that <paramref name="pattern"/> actually CAPTURES, or -1
+    /// when it captures none. Ordinals are counted over the whole run because that is the coordinate
+    /// <see cref="RewriteNumberInDocRun"/> maps back onto the source.
+    /// </summary>
+    private static int OrdinalOfFirstNumberInGroups(string prose, string pattern)
+    {
+        var match = Regex.Match(prose, pattern);
+        if (!match.Success)
+        {
+            return -1;
+        }
+
+        var numbers = Regex.Matches(prose, "[0-9]+");
+        for (var ordinal = 0; ordinal < numbers.Count; ordinal++)
+        {
+            var number = numbers[ordinal];
+            if (match.Groups.Cast<Group>().Skip(1).Any(g =>
+                    g.Success && number.Index >= g.Index && number.Index + number.Length <= g.Index + g.Length))
+            {
+                return ordinal;
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// Rewrites the <paramref name="ordinal"/>-th integer of the declaration's doc run in a COPY of
+    /// <paramref name="source"/>, but only when that integer sits inside one of <paramref name="pattern"/>'s
+    /// capture groups — otherwise null, so a caller can skip it.
+    ///
+    /// <para><paramref name="replacement"/> null means "add one", which is what the drift sweep wants; an
+    /// explicit value is used by the population-merge mutation. Either way the bump preserves WIDTH, so a
+    /// zero-padded clock component cannot break the pattern it is being tested against.</para>
+    ///
+    /// <para>Addressed by ORDINAL rather than by value, because a bare string replace of "36" would rewrite
+    /// every 36 in the file and prove something other than what it was aimed at — and because repeated
+    /// values (36 appears four times in this doc run, 306 twice, 9 three times) have to stay individually
+    /// addressable.</para>
+    /// </summary>
+    private static string? RewriteNumberInDocRun(
+        string source, string declaration, string pattern, int ordinal, string? replacement)
     {
         var prose = DocProseFor(source, declaration);
         var match = Regex.Match(prose, pattern);
@@ -651,8 +731,9 @@ public sealed class RefreshCeilingProvenancePinTests
             return null;
         }
 
-        var bumped = (int.Parse(number.Value, CultureInfo.InvariantCulture) + 1)
-            .ToString(CultureInfo.InvariantCulture)
+        var bumped = (replacement
+                ?? (int.Parse(number.Value, CultureInfo.InvariantCulture) + 1)
+                    .ToString(CultureInfo.InvariantCulture))
             .PadLeft(number.Value.Length, '0');
 
         var offset = start + sourceNumbers[ordinal].Index;

--- a/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
+++ b/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
@@ -138,14 +138,20 @@ public sealed class RefreshCeilingProvenancePinTests
             @"([0-9]+) is the midpoint of ([0-9]+) and ([0-9]+), so a median over ([0-9]+) of the ([0-9]+) rather than the ([0-9]+) clean",
             true);
 
-        /* NOT drift-swept, for the reason in the class summary: these two are quoted readings, so bumping a
-           digit only produces another number the code cannot contradict. Their real hazard is being folded
-           into the admissible series, which
-           TheInadmissibleReadings_CannotBeFoldedIntoTheStatusVerifiedSeries mutates for directly. */
+        /* ARITY-FREE, and that is the point rather than a convenience. This list gains a reading every hour
+           the job runs - it went from two to three while #3077 was in review - so a pattern shaped
+           "(N) s and (N) s" would encode the count and go stale on the next snapshot. Encoding a count in a
+           regex is the stale-enumeration defect with a test wrapped around it, which is the exact thing this
+           file exists to prevent. One group holding the whole list, flattened by Numbers().
+
+           NOT drift-swept either: these are quoted readings, so bumping a digit only produces another number
+           the code cannot contradict. What IS checked is the rule the paragraph is actually about - see
+           TheInadmissibleReadings_CannotBeFoldedIntoTheStatusVerifiedSeries and the as-at scope guard in
+           Verify. */
         yield return (
-            "the inadmissible snapshot pair",
+            "the inadmissible snapshot readings",
             CeilingDeclaration,
-            @"readings of ([0-9]+) s and ([0-9]+) s come from",
+            @"\(([0-9]+ s(?:, [0-9]+ s)*)\) say the series stayed flat",
             false);
 
         yield return (
@@ -195,7 +201,7 @@ public sealed class RefreshCeilingProvenancePinTests
         var prose = DocProseFor(source, CeilingDeclaration);
 
         var series = Numbers(prose, "the published series");
-        var snapshot = Numbers(prose, "the inadmissible snapshot pair");
+        var snapshot = Numbers(prose, "the inadmissible snapshot readings");
 
         Assert.NotEmpty(series);
         Assert.NotEmpty(snapshot);
@@ -205,7 +211,7 @@ public sealed class RefreshCeilingProvenancePinTests
            the reading. A bare Replace would depend on the surrounding emphasis tags - the very coupling
            DocProseFor now normalises away - and would silently find nothing if someone unbolded the figure,
            which is a mutation that proves nothing wearing a caught drift's clothes. */
-        var snapshotPattern = PatternFor("the inadmissible snapshot pair");
+        var snapshotPattern = PatternFor("the inadmissible snapshot readings");
         var firstReading = OrdinalOfFirstNumberInGroups(prose, snapshotPattern);
         Assert.True(firstReading >= 0, "the snapshot pair's pattern captured no number, so its pin is vacuous.");
 
@@ -455,12 +461,21 @@ public sealed class RefreshCeilingProvenancePinTests
             "the quoted run no longer ends exactly one second after the quoted boundary, so the "
             + "transition-run reading the whole provenance paragraph rests on is not what the numbers say");
 
-        /* The snapshot readings stay out of the admissible population. */
-        var snapshot = Read("the inadmissible snapshot pair");
+        /* The snapshot readings stay out of the admissible population, HOWEVER MANY of them there are. */
+        var snapshot = Read("the inadmissible snapshot readings");
         Require(snapshot.Length > 0, "the inadmissible snapshot readings parsed to nothing");
         Require(!snapshot.Intersect(series).Any(),
             $"an unfiltered snapshot reading appears in the status-verified series {Join(series)}, so the two "
             + "populations have been run together");
+
+        /* THE SCOPE MARKER, which is what stops that list reading as a complete enumeration. The series it
+           quotes gains a reading every hour, so a list without an as-at is a frozen enumeration wearing a
+           complete one's clothes - #3072's defect exactly. Checked for PRESENCE and not for value: the
+           timestamp is evidence, and pinning it to a derived quantity would be inventing a bound. */
+        Require(Regex.IsMatch(ceilingProse, @"Snapshot readings as at <c>[0-9][0-9]:[0-9][0-9]Z</c> \("),
+            "the snapshot readings are no longer scoped by an as-at stamp, so the list now reads as a "
+            + "complete enumeration of a series that gains a reading every hour this job runs. Restore the "
+            + "scope, or drop the enumeration and keep only the rule - the rule is the timeless part");
 
         /* CompressionPhaseMinutes' exclude-whole reasoning, in minutes. */
         Require(Ceiling * 10 % 60 == 0,

--- a/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
+++ b/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
@@ -151,7 +151,7 @@ public sealed class RefreshCeilingProvenancePinTests
         yield return (
             "the inadmissible snapshot readings",
             CeilingDeclaration,
-            @"\(([0-9]+ s(?:, [0-9]+ s)*)\) say the series stayed flat",
+            @"\(([0-9]+ s(?:, [0-9]+ s)*)\) says the series stayed flat",
             false);
 
         yield return (
@@ -468,14 +468,24 @@ public sealed class RefreshCeilingProvenancePinTests
             $"an unfiltered snapshot reading appears in the status-verified series {Join(series)}, so the two "
             + "populations have been run together");
 
-        /* THE SCOPE MARKER, which is what stops that list reading as a complete enumeration. The series it
-           quotes gains a reading every hour, so a list without an as-at is a frozen enumeration wearing a
-           complete one's clothes - #3072's defect exactly. Checked for PRESENCE and not for value: the
-           timestamp is evidence, and pinning it to a derived quantity would be inventing a bound. */
-        Require(Regex.IsMatch(ceilingProse, @"Snapshot readings as at <c>[0-9][0-9]:[0-9][0-9]Z</c> \("),
-            "the snapshot readings are no longer scoped by an as-at stamp, so the list now reads as a "
-            + "complete enumeration of a series that gains a reading every hour this job runs. Restore the "
-            + "scope, or drop the enumeration and keep only the rule - the rule is the timeless part");
+        /* THE CLOSING SCOPE, which is what stops that list reading as a complete enumeration of an open
+           set. The series it quotes gains a reading every hour, so an unscoped list is a frozen enumeration
+           wearing a complete one's clothes - #3072's defect exactly.
+
+           And the scope has to CLOSE the population rather than merely date it. "up to <hh:mmZ>" names a
+           window that has ended; "the readings so far" carries a scope and rots anyway, because a doc
+           comment has no timestamp of its own for a relative phrase to be read against. So the pattern
+           demands the closing preposition and an absolute stamp, not just any stamp.
+
+           Checked for PRESENCE and not for value: the timestamp is evidence, and pinning it to a derived
+           quantity would be inventing a bound this constant does not have. */
+        Require(
+            Regex.IsMatch(ceilingProse, @"complete set of snapshot readings up to <c>[0-9][0-9]:[0-9][0-9]Z</c> \("),
+            "the snapshot readings are no longer bounded by a CLOSED window, so the list reads as a complete "
+            + "enumeration of a series that gains a reading every hour this job runs. Restore a scope that "
+            + "has ended (\"up to <hh:mmZ>\"), not one relative to whenever it is read - or drop the "
+            + "enumeration and keep only the rule, which is the timeless part and the paragraph's real "
+            + "subject");
 
         /* CompressionPhaseMinutes' exclude-whole reasoning, in minutes. */
         Require(Ceiling * 10 % 60 == 0,

--- a/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
+++ b/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
@@ -356,12 +356,13 @@ public sealed class RefreshCeilingProvenancePinTests
     {
         var consumed = new HashSet<string>(StringComparer.Ordinal);
         var ceilingProse = DocProseFor(source, CeilingDeclaration);
-        var compressionProse = DocProseFor(source, CompressionMinutesDeclaration);
 
+        /* Which doc run a pin is read out of comes from the PIN'S OWN Declaration, never from its name — a
+           renamed pin must not be able to change which prose its pattern is aimed at. */
         int[] Read(string name)
         {
             consumed.Add(name);
-            return Numbers(name == "the exclude-whole occupancy sentence" ? compressionProse : ceilingProse, name);
+            return Numbers(DocProseFor(source, DeclarationFor(name)), name);
         }
 
         var series = Read("the published series");
@@ -499,13 +500,21 @@ public sealed class RefreshCeilingProvenancePinTests
 
     /* ─────────────────────────────── parsing ─────────────────────────────── */
 
-    private static string PatternFor(string name)
+    /// <summary>
+    /// The one pin with this name. Requires EXACTLY one, so a duplicated name cannot leave two patterns
+    /// competing for the same assertions with only one of them ever read.
+    /// </summary>
+    private static (string Name, string Declaration, string Pattern, bool DriftSwept) PinFor(string name)
     {
         var pins = Pins().Where(p => string.Equals(p.Name, name, StringComparison.Ordinal)).ToArray();
         Require(pins.Length == 1,
             $"{ParseMiss}: '{name}' resolves to {pins.Length} pins rather than exactly one");
-        return pins[0].Pattern;
+        return pins[0];
     }
+
+    private static string PatternFor(string name) => PinFor(name).Pattern;
+
+    private static string DeclarationFor(string name) => PinFor(name).Declaration;
 
     /// <summary>
     /// Every integer captured by the named pin, flattened — a group holding a comma-separated list

--- a/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
+++ b/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
@@ -1,0 +1,674 @@
+﻿/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using PerformanceMonitor.Darling.Storage;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Drift guard between <see cref="TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds"/>'s recorded
+/// provenance and the arithmetic that provenance rests on (#3069).
+///
+/// <para><b>Why this exists.</b> The constant's doc comment used to present 864 s as the highest figure
+/// recorded under the narrowed window, alongside three companions "climbing with volume rather than
+/// settling". A ten-run status-verified series then rose to 594 s and settled back, and the 864 s run turned
+/// out to end one second AFTER the boundary the whole issue splits on — so its regime membership is
+/// undetermined. The comment records the distribution now. A distribution written in prose has no way to
+/// notice that its own summary no longer follows from it, which is how the superseded characterisation
+/// survived, so every summary figure is derived here and the prose is required to agree.</para>
+///
+/// <para><b>Derive, don't restate.</b> Nothing below hardcodes 864, 900, 36, 306 or 338. Every expected value
+/// comes either from the constants (<see cref="TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds"/>,
+/// <see cref="TimescaleSupport.RefreshPhaseSlotSeconds"/>,
+/// <see cref="TimescaleSupport.RefreshPhaseStepMinutes"/>,
+/// <see cref="TimescaleSupport.RefreshSlotWarningSeconds"/>) or from the SERIES THE COMMENT ITSELF PUBLISHES.
+/// A pin that restated the summary would go stale by precisely the mechanism it exists to stop.</para>
+///
+/// <para><b>What is deliberately NOT pinned, said plainly rather than left looking covered.</b> The two
+/// snapshot readings are quoted evidence, not derived quantities — nothing in the code can know them — so
+/// they are held only by the DISJOINTNESS the paragraph is about (see
+/// <see cref="TheInadmissibleReadings_CannotBeFoldedIntoTheStatusVerifiedSeries"/>), which is the failure
+/// mode that matters: an unfiltered reading migrating into the population a constant may be set from. The
+/// clock time of the unobserved run and the pre-narrowing band are likewise evidence and carry no pin.</para>
+///
+/// <para><b>The guard is itself guarded, three ways.</b> Every extraction asserts its pattern MATCHED before
+/// a value is compared. <see cref="EveryNumericPin_ReportsAnInjectedDrift"/> bumps each captured number ONE
+/// AT A TIME in a mutated copy and requires the identical verification to fail — after separately asserting
+/// the pattern still matches, so a mutation that merely broke a regex cannot pass as a caught drift. And
+/// <see cref="Verify"/> requires that it CONSUMED every pin in <see cref="Pins"/>, because a pattern defined
+/// in the list and never asserted against anything looks exactly like a pattern doing work.</para>
+/// </summary>
+public sealed class RefreshCeilingProvenancePinTests
+{
+    /// <summary>
+    /// Marks a verification failure caused by a pattern no longer matching, so
+    /// <see cref="EveryNumericPin_ReportsAnInjectedDrift"/> can tell "the pin caught the drift" from "the pin
+    /// stopped being able to see anything" — which are the same exception otherwise, and the second of which
+    /// would let the sweep report success for a guard that had gone blind.
+    /// </summary>
+    private const string ParseMiss = "PIN PARSE MISS";
+
+    private const string CeilingDeclaration =
+        "public const int HeaviestHourlyRefreshObservedCeilingSeconds";
+
+    private const string CompressionMinutesDeclaration =
+        "public static readonly IReadOnlyList<int> CompressionPhaseMinutes";
+
+    private static int Ceiling => TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds;
+
+    private static int Slot => TimescaleSupport.RefreshPhaseSlotSeconds;
+
+    private static int SlotMinutes => TimescaleSupport.RefreshPhaseStepMinutes;
+
+    private static int WatchLine => TimescaleSupport.RefreshSlotWarningSeconds;
+
+    /// <summary>
+    /// The pinned sentences, and the ONLY place a pattern is written down — <see cref="Verify"/> looks them up
+    /// by name, so the sweep and the assertions cannot end up testing different regexes.
+    ///
+    /// <para>Two members carry figures derived from the ceiling: the constant itself, and
+    /// <see cref="TimescaleSupport.CompressionPhaseMinutes"/>, whose exclude-whole reasoning quotes it in
+    /// MINUTES. Each pattern names the doc run it is read out of, so none of them can match a similar
+    /// sentence elsewhere in a four-thousand-line file.</para>
+    ///
+    /// <para>ASCII-only patterns on purpose. The prose carries em dashes, and matching one through a
+    /// source-encoding round trip is a way for a pattern to stop matching for a reason that has nothing to do
+    /// with what it guards; <c>\S</c> stands in for the dash instead.</para>
+    /// </summary>
+    private static IEnumerable<(string Name, string Declaration, string Pattern, bool DriftSwept)> Pins()
+    {
+        yield return (
+            "the transition run's clock arithmetic",
+            CeilingDeclaration,
+            @"refresh policy \S <c>([0-9][0-9]):([0-9][0-9]):([0-9][0-9])</c> to <c>([0-9][0-9]):([0-9][0-9]):([0-9][0-9])</c> on the boundary day",
+            true);
+
+        yield return (
+            "the boundary timestamp",
+            CeilingDeclaration,
+            @"refresh policies at <c>([0-9][0-9]):([0-9][0-9]):([0-9][0-9])</c>, one second BEFORE",
+            true);
+
+        yield return (
+            "the run count",
+            CeilingDeclaration,
+            @"([0-9]+) consecutive runs of this job's refresh policy",
+            true);
+
+        yield return (
+            "the published series",
+            CeilingDeclaration,
+            @"<c>([0-9]+(?:, [0-9]+)+)</c> seconds\.",
+            true);
+
+        yield return (
+            "the clean-series summary",
+            CeilingDeclaration,
+            @"the remaining ([0-9]+) run from <b>([0-9]+) s to ([0-9]+) s</b>, mean <b>([0-9]+) s</b>, middle reading <b>([0-9]+) s</b>",
+            true);
+
+        yield return (
+            "the slot-clearance contrast",
+            CeilingDeclaration,
+            @"The largest of the ([0-9]+) clears the slot by <b>([0-9]+) s</b>, where this constant clears it by ([0-9]+) s\.",
+            true);
+
+        yield return (
+            "the issue's median figure",
+            CeilingDeclaration,
+            @"the median of the same window as ~<b>([0-9]+) s</b>",
+            true);
+
+        yield return (
+            "why the issue's median is not reproducible",
+            CeilingDeclaration,
+            @"([0-9]+) is the midpoint of ([0-9]+) and ([0-9]+), so a median over ([0-9]+) of the ([0-9]+) rather than the ([0-9]+) clean ones",
+            true);
+
+        /* NOT drift-swept, for the reason in the class summary: these two are quoted readings, so bumping a
+           digit only produces another number the code cannot contradict. Their real hazard is being folded
+           into the admissible series, which
+           TheInadmissibleReadings_CannotBeFoldedIntoTheStatusVerifiedSeries mutates for directly. */
+        yield return (
+            "the inadmissible snapshot pair",
+            CeilingDeclaration,
+            @"Two further readings of <b>([0-9]+) s</b> and <b>([0-9]+) s</b> come from the hourly",
+            false);
+
+        yield return (
+            "the downward-edit consequence",
+            CeilingDeclaration,
+            @"correcting toward the observed ([0-9]+) s would leave ([0-9]+) s of margin in place of ([0-9]+) s",
+            true);
+
+        yield return (
+            "the low the grid is deliberately not sized against",
+            CeilingDeclaration,
+            @"not against the ([0-9]+) s low",
+            true);
+
+        yield return (
+            "the margin sentence",
+            CeilingDeclaration,
+            @"At ([0-9]+) s against a ([0-9]+)-second slot the margin is already only ([0-9]+) seconds",
+            true);
+
+        yield return (
+            "the exclude-whole occupancy sentence",
+            CompressionMinutesDeclaration,
+            @"occupies ([0-9]+)\.([0-9]) of the ([0-9]+) minutes in its slot",
+            true);
+    }
+
+    [Fact]
+    public void EveryProvenanceClaim_FollowsFromTheConstantsAndThePublishedSeries()
+    {
+        Verify(ReadTimescaleSupportSource());
+    }
+
+    /// <summary>
+    /// The paragraph's whole job is to keep the unfiltered self-metrics readings OUT of the population a
+    /// constant may be set from, so the mutation is the merge itself rather than a digit bump: put a
+    /// status-verified reading in the snapshot pair's place and require verification to fail.
+    ///
+    /// <para>Both populations are asserted NON-EMPTY first. Disjointness is a claim about an absence, and an
+    /// absence is also exactly what a pattern matching nothing produces — so emptiness has to be excluded
+    /// before the disjointness result says anything at all.</para>
+    /// </summary>
+    [Fact]
+    public void TheInadmissibleReadings_CannotBeFoldedIntoTheStatusVerifiedSeries()
+    {
+        var source = ReadTimescaleSupportSource();
+        var prose = DocProseFor(source, CeilingDeclaration);
+
+        var series = Numbers(prose, "the published series");
+        var snapshot = Numbers(prose, "the inadmissible snapshot pair");
+
+        Assert.NotEmpty(series);
+        Assert.NotEmpty(snapshot);
+        Assert.Empty(series.Intersect(snapshot));
+
+        var mutated = source.Replace(
+            $"readings of <b>{snapshot[0]} s</b>",
+            $"readings of <b>{series[^1]} s</b>",
+            StringComparison.Ordinal);
+        Assert.NotEqual(source, mutated);
+
+        var failure = Assert.ThrowsAny<Exception>(() => Verify(mutated));
+        Assert.DoesNotContain(ParseMiss, failure.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The doc says the snapshot readings are inadmissible BECAUSE that series carries no status column,
+    /// while the two reads a constant may be set from filter to successful runs. That is a claim about
+    /// shipped SQL, so it is checked against the shipped strings rather than restated in prose.
+    ///
+    /// <para><b>The predicate is red-proofed in both directions on synthetic copies.</b> A predicate that
+    /// could only ever return <c>true</c> would satisfy the two positive lines and prove nothing whatever
+    /// about the negative one — and the negative one is the load-bearing half, since it is the reason two
+    /// real readings are excluded from the record.</para>
+    /// </summary>
+    [Fact]
+    public void TheInadmissibilityClaim_MatchesTheShippedSql()
+    {
+        const string filter = "last_run_status = 'Success'";
+
+        Assert.True(FiltersToSuccessfulRuns(TimescaleSupport.HeaviestRefreshRuntimeSql),
+            "HeaviestRefreshRuntimeSql no longer filters to successful runs, so the ceiling's doc comment is "
+            + "wrong about which reads a constant may be set from (#3069).");
+        Assert.True(FiltersToSuccessfulRuns(TimescaleSupport.JobCadenceReadSql),
+            "JobCadenceReadSql no longer filters to successful runs, so the ceiling's doc comment is wrong "
+            + "about #2136's read (#3069).");
+
+        Assert.False(FiltersToSuccessfulRuns(StoreSelfMetrics.BackgroundJobInsertSql),
+            "the self-metrics background-job snapshot now filters on run status, so the two readings the "
+            + "ceiling's doc comment excludes as unfiltered may in fact be admissible — re-read that "
+            + "paragraph rather than deleting this assertion (#3069).");
+        Assert.DoesNotContain("last_run_status", StoreSelfMetrics.BackgroundJobInsertSql, StringComparison.Ordinal);
+
+        /* Red-proof, both directions, so neither result above can be an artefact of a one-sided predicate. */
+        Assert.False(FiltersToSuccessfulRuns(
+            TimescaleSupport.HeaviestRefreshRuntimeSql.Replace(filter, "1 = 1", StringComparison.Ordinal)));
+        Assert.True(FiltersToSuccessfulRuns(
+            StoreSelfMetrics.BackgroundJobInsertSql + "\nWHERE js." + filter));
+
+        /* And the paragraph names all three reads, so a rewrite cannot quietly drop the one carrying the
+           reasoning. Member names rather than prose, because these are the crefs the claim is anchored on. */
+        var prose = DocProseFor(ReadTimescaleSupportSource(), CeilingDeclaration);
+        Assert.Contains(nameof(TimescaleSupport.HeaviestRefreshRuntimeSql), prose, StringComparison.Ordinal);
+        Assert.Contains(nameof(TimescaleSupport.JobCadenceReadSql), prose, StringComparison.Ordinal);
+        Assert.Contains(nameof(StoreSelfMetrics.BackgroundJobInsertSql), prose, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Non-vacuity for every drift-swept pin, one captured number at a time: bump it in a COPY, assert the
+    /// pattern STILL MATCHES, then require verification to fail with something other than a parse miss.
+    ///
+    /// <para>One number at a time rather than all at once is the point of the shape. It is what makes each
+    /// individual reading in the published series load-bearing — a bump to a middle-ranked reading changes
+    /// neither the range nor the middle, and is caught only because the mean is stated too. Bumping every
+    /// group together would have hidden that.</para>
+    /// </summary>
+    [Fact]
+    public void EveryNumericPin_ReportsAnInjectedDrift()
+    {
+        var source = ReadTimescaleSupportSource();
+        var swept = 0;
+
+        foreach (var (name, declaration, pattern, driftSwept) in Pins())
+        {
+            var prose = DocProseFor(source, declaration);
+            var match = Regex.Match(prose, pattern);
+            Assert.True(match.Success, $"{name}: pattern matched nothing, so its pin is vacuous.");
+
+            if (!driftSwept)
+            {
+                continue;
+            }
+
+            var numbers = Regex.Matches(prose, "[0-9]+").Count;
+
+            for (var ordinal = 0; ordinal < numbers; ordinal++)
+            {
+                var mutated = BumpNumberInsideGroups(source, declaration, pattern, ordinal);
+                if (mutated is null)
+                {
+                    continue;
+                }
+
+                Assert.NotEqual(source, mutated);
+
+                /* The mutation must leave the pattern matching. If it did not, the failure below would be a
+                   parse miss wearing a caught drift's clothes. */
+                Assert.True(Regex.IsMatch(DocProseFor(mutated, declaration), pattern),
+                    $"{name}: bumping captured number #{ordinal} broke the pattern, so this case proves "
+                    + "nothing. Narrow the pattern rather than dropping the case.");
+
+                var failure = Assert.ThrowsAny<Exception>(() => Verify(mutated));
+                Assert.DoesNotContain(ParseMiss, failure.Message, StringComparison.Ordinal);
+                swept++;
+            }
+        }
+
+        /* A sweep that enumerated nothing satisfies every assertion above. The floor is the count of captured
+           numbers across the drift-swept pins, so it also fails if a pin's groups stop being reachable. */
+        var expected = Pins().Where(p => p.DriftSwept).Sum(p => CapturedNumberCount(source, p.Declaration, p.Pattern));
+        Assert.True(expected > 0, "no drift-swept pin captured any number, so the sweep is vacuous.");
+        Assert.Equal(expected, swept);
+    }
+
+    /// <summary>
+    /// The pure arithmetic, kept out of the parsing so it reads without a regex in the way — and so the two
+    /// figures the prose states to one decimal are held to being exactly stateable to one decimal.
+    /// </summary>
+    [Fact]
+    public void TheDerivedFiguresAreExactlyStateable_AndTheCleanSeriesSitsWhereTheProseSaysItDoes()
+    {
+        /* CompressionPhaseMinutes quotes the ceiling in minutes to one decimal, which is only faithful while
+           the ceiling is an exact tenth of a minute: 14.4 for a 14.41666 value is a rounded claim wearing an
+           exact one's clothes. */
+        Assert.Equal(0, Ceiling * 10 % 60);
+
+        var clean = CleanSeries(DocProseFor(ReadTimescaleSupportSource(), CeilingDeclaration));
+        Assert.NotEmpty(clean);
+
+        /* The mean is stated as a whole number of seconds. */
+        Assert.Equal(0, clean.Sum() % clean.Length);
+
+        /* The relationship the whole resolution turns on, as an assertion over the WHOLE inventory rather
+           than one true clause standing in for it: every cleanly post-boundary run came in under the value
+           the grid is sized against, which is what makes that value safe without making it measured. */
+        Assert.All(clean, reading => Assert.True(reading < Ceiling,
+            $"a cleanly post-boundary reading of {reading} s is at or past the {Ceiling} s the compression "
+            + "grid is sized against, so the ceiling is no longer above the observed range and #3069's "
+            + "resolution — record the provenance, leave the value — no longer holds."));
+        Assert.All(clean, reading => Assert.True(reading < WatchLine,
+            $"a cleanly post-boundary reading of {reading} s is at or past the {WatchLine} s watch line, so "
+            + "the doc comment's claim that every clean reading is below it is false."));
+
+        /* The contrast the prose draws: the undetermined run is in the warning band, the clean ones are not. */
+        Assert.True(Ceiling >= WatchLine,
+            "the ceiling no longer classifies as a warning, so the doc comment's contrast between it and the "
+            + "clean series is stale.");
+    }
+
+    /* ─────────────────────────────── verification ─────────────────────────────── */
+
+    /// <summary>
+    /// Every claim, checked against the constants and against the series the comment publishes. Throws on the
+    /// first disagreement; parse misses carry <see cref="ParseMiss"/> so the drift sweep can tell them apart.
+    /// Finishes by requiring that it consumed every pin, so a pattern cannot sit in the list doing nothing.
+    /// </summary>
+    private static void Verify(string source)
+    {
+        var consumed = new HashSet<string>(StringComparer.Ordinal);
+        var ceilingProse = DocProseFor(source, CeilingDeclaration);
+        var compressionProse = DocProseFor(source, CompressionMinutesDeclaration);
+
+        int[] Read(string name)
+        {
+            consumed.Add(name);
+            return Numbers(name == "the exclude-whole occupancy sentence" ? compressionProse : ceilingProse, name);
+        }
+
+        var series = Read("the published series");
+        Require(series.Length > 0, "the published series parsed to nothing");
+
+        /* THE LINK TO THE CONSTANT. The comment's first reading IS this constant — that is what makes the
+           transition-run paragraph about this number rather than about some other run. */
+        Require(series.Count(v => v == Ceiling) == 1,
+            $"the published series {Join(series)} does not contain {Ceiling} exactly once, so the comment's "
+            + "transition-run paragraph is no longer about the value of this constant");
+
+        var clean = CleanSeries(ceilingProse);
+        Require(clean.Length == series.Length - 1, "setting the transition run aside did not leave one fewer reading");
+        Require(clean.Length > 0, "the clean series is empty, so every summary figure below would be vacuous");
+        Require(clean.Sum() % clean.Length == 0,
+            "the clean series' mean is no longer a whole number of seconds, so the prose cannot state it as "
+            + "one — restate it rather than removing this check");
+
+        var sorted = clean.OrderBy(v => v).ToArray();
+        var min = sorted[0];
+        var max = sorted[^1];
+        var middle = sorted[sorted.Length / 2];
+        var mean = clean.Sum() / clean.Length;
+
+        var runCount = Read("the run count");
+        Require(runCount[0] == series.Length,
+            $"the comment says {runCount[0]} consecutive runs and then lists {series.Length}");
+
+        var summary = Read("the clean-series summary");
+        Require(summary[0] == clean.Length, $"stated clean count {summary[0]} against {clean.Length} listed");
+        Require(summary[1] == min, $"stated low {summary[1]} s against {min} s listed");
+        Require(summary[2] == max, $"stated high {summary[2]} s against {max} s listed");
+        Require(summary[3] == mean, $"stated mean {summary[3]} s against {mean} s computed");
+        Require(summary[4] == middle, $"stated middle {summary[4]} s against {middle} s computed");
+
+        var clearance = Read("the slot-clearance contrast");
+        Require(clearance[0] == clean.Length, $"stated clean count {clearance[0]} against {clean.Length} listed");
+        Require(clearance[1] == Slot - max, $"stated clearance {clearance[1]} s against {Slot - max} s derived");
+        Require(clearance[2] == Slot - Ceiling, $"stated margin {clearance[2]} s against {Slot - Ceiling} s derived");
+
+        var statedMedian = Read("the issue's median figure");
+        var why = Read("why the issue's median is not reproducible");
+        Require(why[0] == statedMedian[0],
+            $"the paragraph explains {why[0]} s while quoting the issue's figure as {statedMedian[0]} s");
+        Require(why[1] + why[2] == 2 * why[0],
+            $"{why[0]} is not the midpoint of {why[1]} and {why[2]}, so the explanation is arithmetically wrong");
+        Require(clean.Contains(why[1]) && clean.Contains(why[2]),
+            $"the midpoint pair {why[1]}/{why[2]} is not drawn from the published series {Join(clean)}");
+        Require(why[3] == clean.Length - 1,
+            $"an even-count median over the published rows drops one, so {clean.Length - 1} not {why[3]}");
+        Require(why[4] == series.Length, $"stated total {why[4]} against {series.Length} listed");
+        Require(why[5] == clean.Length, $"stated clean count {why[5]} against {clean.Length} listed");
+
+        var downward = Read("the downward-edit consequence");
+        Require(downward[0] == max, $"stated observed maximum {downward[0]} s against {max} s listed");
+        Require(downward[1] == Slot - max, $"stated replacement margin {downward[1]} s against {Slot - max} s derived");
+        Require(downward[2] == Slot - Ceiling, $"stated current margin {downward[2]} s against {Slot - Ceiling} s derived");
+
+        var low = Read("the low the grid is deliberately not sized against");
+        Require(low[0] == min, $"stated low {low[0]} s against {min} s listed");
+
+        var margin = Read("the margin sentence");
+        Require(margin[0] == Ceiling, $"stated ceiling {margin[0]} s against {Ceiling} s");
+        Require(margin[1] == Slot, $"stated slot {margin[1]} s against {Slot} s");
+        Require(margin[2] == Slot - Ceiling, $"stated margin {margin[2]} s against {Slot - Ceiling} s derived");
+
+        /* Clock arithmetic. The transition-run finding IS this subtraction: the run ends one second after the
+           boundary, which is why its regime membership cannot be settled from the data in hand. */
+        var run = Read("the transition run's clock arithmetic");
+        var started = Seconds(run[0], run[1], run[2]);
+        var ended = Seconds(run[3], run[4], run[5]);
+        Require(ended - started == Ceiling,
+            $"the quoted run spans {ended - started} s, not the {Ceiling} s this constant holds");
+
+        var boundary = Read("the boundary timestamp");
+        Require(ended - Seconds(boundary[0], boundary[1], boundary[2]) == 1,
+            "the quoted run no longer ends exactly one second after the quoted boundary, so the "
+            + "transition-run reading the whole provenance paragraph rests on is not what the numbers say");
+
+        /* The snapshot readings stay out of the admissible population. */
+        var snapshot = Read("the inadmissible snapshot pair");
+        Require(snapshot.Length > 0, "the inadmissible snapshot readings parsed to nothing");
+        Require(!snapshot.Intersect(series).Any(),
+            $"an unfiltered snapshot reading appears in the status-verified series {Join(series)}, so the two "
+            + "populations have been run together");
+
+        /* CompressionPhaseMinutes' exclude-whole reasoning, in minutes. */
+        Require(Ceiling * 10 % 60 == 0,
+            "the ceiling is no longer an exact tenth of a minute, so the occupancy figure cannot be stated to "
+            + "one decimal");
+        var occupancy = Read("the exclude-whole occupancy sentence");
+        Require(occupancy[0] == Ceiling / 60, $"stated whole minutes {occupancy[0]} against {Ceiling / 60}");
+        Require(occupancy[1] == Ceiling * 10 / 60 % 10,
+            $"stated tenth of a minute {occupancy[1]} against {Ceiling * 10 / 60 % 10}");
+        Require(occupancy[2] == SlotMinutes, $"stated slot {occupancy[2]} minutes against {SlotMinutes}");
+
+        /* And nothing in the pin list went unused: a pattern that is never asserted against reads, from the
+           list, exactly like one that is. */
+        var unused = Pins().Select(p => p.Name).Where(n => !consumed.Contains(n)).ToArray();
+        Require(unused.Length == 0,
+            "these pinned sentences are declared but never verified, so they guard nothing: "
+            + string.Join(", ", unused));
+    }
+
+    private static bool FiltersToSuccessfulRuns(string sql) =>
+        Regex.IsMatch(sql, @"last_run_status\s*=\s*'Success'");
+
+    /// <summary>
+    /// The published series with the ONE undetermined-regime reading set aside — matched against this
+    /// constant rather than taken by position, so a reordered list cannot silently set a different run aside.
+    /// </summary>
+    private static int[] CleanSeries(string prose)
+    {
+        var removed = false;
+        var clean = new List<int>();
+        foreach (var reading in Numbers(prose, "the published series"))
+        {
+            if (!removed && reading == Ceiling)
+            {
+                removed = true;
+                continue;
+            }
+
+            clean.Add(reading);
+        }
+
+        Require(removed, $"the published series does not contain {Ceiling}, so nothing was set aside");
+        return clean.ToArray();
+    }
+
+    private static int Seconds(int hours, int minutes, int seconds) => (hours * 60 + minutes) * 60 + seconds;
+
+    private static string Join(IEnumerable<int> values) =>
+        "[" + string.Join(", ", values.Select(v => v.ToString(CultureInfo.InvariantCulture))) + "]";
+
+    /* ─────────────────────────────── parsing ─────────────────────────────── */
+
+    private static string PatternFor(string name)
+    {
+        var pins = Pins().Where(p => string.Equals(p.Name, name, StringComparison.Ordinal)).ToArray();
+        Require(pins.Length == 1,
+            $"{ParseMiss}: '{name}' resolves to {pins.Length} pins rather than exactly one");
+        return pins[0].Pattern;
+    }
+
+    /// <summary>
+    /// Every integer captured by the named pin, flattened — a group holding a comma-separated list
+    /// contributes each of its members, so the series pattern and the single-figure patterns read the same
+    /// way and the drift sweep can address any of them by ordinal.
+    /// </summary>
+    private static int[] Numbers(string prose, string name)
+    {
+        var pattern = PatternFor(name);
+        var match = Regex.Match(prose, pattern);
+        Require(match.Success,
+            $"{ParseMiss}: {name} is no longer present in TimescaleSupport.cs in the pinned shape "
+            + $"({pattern}). It restates figures derived from the ceiling constant, so keep it parseable — or "
+            + "delete the figure from the prose and remove this pin with it (#3069).");
+
+        return match.Groups.Cast<Group>().Skip(1)
+            .SelectMany(g => Regex.Matches(g.Value, "[0-9]+").Select(m => m.Value))
+            .Select(v => int.Parse(v, CultureInfo.InvariantCulture))
+            .ToArray();
+    }
+
+    /// <summary>
+    /// The doc-comment run immediately above <paramref name="declaration"/>, stripped of its <c>///</c>
+    /// markers and collapsed to one line so a pattern can span the wrapping.
+    ///
+    /// <para><b>Anti-truncation.</b> The run is required to open with <c>&lt;summary&gt;</c> and close with
+    /// <c>&lt;/summary&gt;</c>. A walk that stopped early would still hand back plausible prose, and every
+    /// pattern that happened to sit in the part it read would still match — which is a guard reporting a
+    /// clean tree from half a file.</para>
+    /// </summary>
+    private static string DocProseFor(string source, string declaration)
+    {
+        var declarationIndex = source.IndexOf(declaration, StringComparison.Ordinal);
+        Require(declarationIndex > 0,
+            $"{ParseMiss}: could not find '{declaration}' in TimescaleSupport.cs, so no doc run could be read");
+
+        var lines = source[..declarationIndex].Split('\n');
+        var run = new List<string>();
+
+        /* The final element is the indentation on the declaration's own line, so the run starts above it. */
+        for (var index = lines.Length - 2; index >= 0; index--)
+        {
+            var line = lines[index].Trim('\r', ' ', '\t');
+            if (!line.StartsWith("///", StringComparison.Ordinal))
+            {
+                break;
+            }
+
+            run.Insert(0, line.Length > 3 ? line[3..].Trim() : string.Empty);
+        }
+
+        Require(run.Count > 0, $"{ParseMiss}: '{declaration}' carries no doc comment run");
+
+        var prose = Regex.Replace(string.Join(" ", run), @"\s+", " ").Trim();
+        Require(prose.StartsWith("<summary>", StringComparison.Ordinal),
+            $"{ParseMiss}: the doc run above '{declaration}' does not begin at its <summary>, so the walk "
+            + "reached the top of a truncated block");
+        Require(prose.EndsWith("</summary>", StringComparison.Ordinal),
+            $"{ParseMiss}: the doc run above '{declaration}' does not end at its </summary>, so the walk "
+            + "stopped short of the declaration");
+
+        return prose;
+    }
+
+    /// <summary>
+    /// Where a declaration's doc run begins and ends in the raw source. The run's digits appear in the same
+    /// order as the collapsed prose's — the only things stripped are <c>///</c> markers and whitespace, and
+    /// no number is ever split across a wrap — which is what lets the sweep address a number by ordinal in
+    /// one and rewrite it in the other.
+    /// </summary>
+    private static (int Start, int End) DocRunSpan(string source, string declaration)
+    {
+        var declarationIndex = source.IndexOf(declaration, StringComparison.Ordinal);
+        Require(declarationIndex > 0, $"{ParseMiss}: could not find '{declaration}' in TimescaleSupport.cs");
+
+        var start = source.LastIndexOf("/// <summary>", declarationIndex, StringComparison.Ordinal);
+        Require(start > 0 && start < declarationIndex,
+            $"{ParseMiss}: could not find the opening of '{declaration}''s doc run");
+        return (start, declarationIndex);
+    }
+
+    /* ─────────────────────────────── mutation ─────────────────────────────── */
+
+    private static int CapturedNumberCount(string source, string declaration, string pattern)
+    {
+        var prose = DocProseFor(source, declaration);
+        var match = Regex.Match(prose, pattern);
+        return !match.Success
+            ? 0
+            : match.Groups.Cast<Group>().Skip(1).Sum(g => Regex.Matches(g.Value, "[0-9]+").Count);
+    }
+
+    /// <summary>
+    /// Adds one to the <paramref name="ordinal"/>-th integer of the declaration's doc run, in a copy of
+    /// <paramref name="source"/>, but only when that integer is inside one of
+    /// <paramref name="pattern"/>'s capture groups — otherwise null, so the sweep skips it.
+    ///
+    /// <para>Addressed by ORDINAL rather than by value, because a bare string replace of "36" would rewrite
+    /// every 36 in the file and prove something other than what it was aimed at, and because repeated values
+    /// (two 36s, two 306s, three 9s) have to stay individually addressable. The bump preserves width, so a
+    /// zero-padded clock component cannot break the pattern it is being tested against.</para>
+    /// </summary>
+    private static string? BumpNumberInsideGroups(string source, string declaration, string pattern, int ordinal)
+    {
+        var prose = DocProseFor(source, declaration);
+        var match = Regex.Match(prose, pattern);
+        if (!match.Success)
+        {
+            return null;
+        }
+
+        var proseNumbers = Regex.Matches(prose, "[0-9]+");
+        if (ordinal >= proseNumbers.Count)
+        {
+            return null;
+        }
+
+        var number = proseNumbers[ordinal];
+        var inAGroup = match.Groups.Cast<Group>().Skip(1).Any(g =>
+            g.Success && number.Index >= g.Index && number.Index + number.Length <= g.Index + g.Length);
+        if (!inAGroup)
+        {
+            return null;
+        }
+
+        var (start, end) = DocRunSpan(source, declaration);
+        var sourceNumbers = Regex.Matches(source[start..end], "[0-9]+");
+
+        /* The two sequences must correspond exactly, or an ordinal in one does not name the same number in
+           the other and the mutation would land somewhere unintended. */
+        if (sourceNumbers.Count != proseNumbers.Count
+            || !string.Equals(sourceNumbers[ordinal].Value, number.Value, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var bumped = (int.Parse(number.Value, CultureInfo.InvariantCulture) + 1)
+            .ToString(CultureInfo.InvariantCulture)
+            .PadLeft(number.Value.Length, '0');
+
+        var offset = start + sourceNumbers[ordinal].Index;
+        return source.Remove(offset, number.Value.Length).Insert(offset, bumped);
+    }
+
+    private static void Require(bool condition, string message)
+    {
+        if (!condition)
+        {
+            throw new PinDriftException(message);
+        }
+    }
+
+    private sealed class PinDriftException(string message) : Exception(message);
+
+    private static string ReadTimescaleSupportSource([CallerFilePath] string thisFile = "")
+    {
+        var path = Path.GetFullPath(Path.Combine(
+            Path.GetDirectoryName(thisFile)!, "..", "PerformanceMonitor.Darling.Storage", "TimescaleSupport.cs"));
+
+        Assert.True(File.Exists(path),
+            $"TimescaleSupport.cs was not found at '{path}'. This guard parses the REAL file (resolved from "
+            + "[CallerFilePath], so there is no copy to go stale); restore the path rather than pointing it "
+            + "at a fixture.");
+        return File.ReadAllText(path);
+    }
+}

--- a/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
+++ b/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
@@ -37,6 +37,16 @@ namespace Darling.Tests;
 /// <see cref="TimescaleSupport.RefreshSlotWarningSeconds"/>) or from the SERIES THE COMMENT ITSELF PUBLISHES.
 /// A pin that restated the summary would go stale by precisely the mechanism it exists to stop.</para>
 ///
+/// <para><b>Which numeral KIND these are, because the repo handles two differently and neither #3072 nor
+/// #3073 says so out loud.</b> A numeral that restates an adjacent list gets DELETION offered in its
+/// failure message — dropping the sentence is as correct an outcome as correcting the figure — while a
+/// numeral that is program output gets "fix the pattern rather than the count", because a transcript has
+/// to keep showing what the tool really prints. <c>ReadmeDerivedCountPinTests</c> implements both halves
+/// and states neither, so the rule has to be inferred from the disagreement between two of its own
+/// failure texts. All thirteen patterns here are the first kind — derived arithmetic restated in prose —
+/// which is why deletion is offered throughout; and this paragraph is NARRATION of an existing rule, not
+/// a counted claim, so nothing checks it and nothing should.</para>
+///
 /// <para><b>What is deliberately NOT pinned, said plainly rather than left looking covered.</b> The two
 /// snapshot readings are quoted evidence, not derived quantities — nothing in the code can know them — so
 /// they are held only by the DISJOINTNESS the paragraph is about (see

--- a/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
+++ b/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
@@ -94,9 +94,14 @@ public sealed class RefreshCeilingProvenancePinTests
     /// MINUTES. Each pattern names the doc run it is read out of, so none of them can match a similar
     /// sentence elsewhere in a four-thousand-line file.</para>
     ///
-    /// <para>ASCII-only patterns on purpose. The prose carries em dashes, and matching one through a
-    /// source-encoding round trip is a way for a pattern to stop matching for a reason that has nothing to do
-    /// with what it guards; <c>\S</c> stands in for the dash instead.</para>
+    /// <para><b>ASCII-only patterns on purpose, and the reason is <see cref="DocProseFor"/> rather than
+    /// anything in the patterns themselves.</b> It normalises <c>—</c> and <c>–</c> to <c>-</c>
+    /// before any pattern runs, so not one of the thirteen has to match a dash variant — and not one does.
+    /// Matching a dash through a source-encoding round trip is a way for a pattern to stop matching for a
+    /// reason that has nothing to do with what it guards, and normalising at the extractor removes that at
+    /// the source instead of working around it thirteen times. The single literal hyphen below, in
+    /// <c>([0-9]+)-second slot</c>, is a plain ASCII hyphen in the prose rather than a normalised
+    /// dash.</para>
     /// </summary>
     private static IEnumerable<(string Name, string Declaration, string Pattern, bool DriftSwept)> Pins()
     {
@@ -340,6 +345,37 @@ public sealed class RefreshCeilingProvenancePinTests
     }
 
     /// <summary>
+    /// The class summary claims that no pattern has to match a dash variant, because
+    /// <see cref="DocProseFor"/> normalises <c>—</c> and <c>–</c> away before any pattern runs. That is a
+    /// claim about the pattern list, so it is enforced here rather than left standing in prose.
+    ///
+    /// <para><b>Why bother, given this is a test file's own comment.</b> The review that produced this
+    /// assertion found the previous version of that paragraph justifying the ASCII-only patterns by a
+    /// <c>\S</c> dash stand-in that had been deleted three commits earlier — a comment claiming a mechanism
+    /// the code no longer implemented, which is the exact defect this whole file exists to catch, one level
+    /// up. The cheapest fix was to correct the sentence; the durable one is to make the sentence unable to
+    /// go stale in that direction again.</para>
+    /// </summary>
+    [Fact]
+    public void NoPattern_NeedsToMatchADashVariant_WhichIsWhatTheNormalisationBuys()
+    {
+        var pins = Pins().ToArray();
+        Assert.NotEmpty(pins);
+
+        Assert.All(pins, pin => Assert.True(
+            pin.Pattern.All(character => character <= 127),
+            $"{pin.Name}'s pattern carries a non-ASCII character. The class summary says none has to, "
+            + "because DocProseFor normalises dash variants to a plain hyphen before any pattern runs — so "
+            + "either the normalisation stopped covering this case or that paragraph is now wrong."));
+
+        /* And the normalisation itself, on an arranged input rather than on the tree: without this, "the
+           patterns can be ASCII-only because the extractor normalises" is a claim with nothing behind it. */
+        Assert.DoesNotContain('\u2014', DashNormalisationProbe);
+        Assert.DoesNotContain('\u2013', DashNormalisationProbe);
+        Assert.Contains("a - b - c", DashNormalisationProbe, StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// The pure arithmetic, kept out of the parsing so it reads without a regex in the way — and so the two
     /// figures the prose states to one decimal are held to being exactly stateable to one decimal.
     /// </summary>
@@ -514,6 +550,15 @@ public sealed class RefreshCeilingProvenancePinTests
             "these pinned sentences are declared but never verified, so they guard nothing: "
             + string.Join(", ", unused));
     }
+
+    /// <summary>
+    /// <see cref="DocProseFor"/>'s dash and emphasis normalisation, applied to an arranged doc run so the
+    /// claim can be checked without depending on which dashes happen to be in the real comment today.
+    /// </summary>
+    private static string DashNormalisationProbe =>
+        DocProseFor(
+            "    /// <summary>\r\n    /// a \u2014 b \u2013 c <b>d</b>\r\n    /// </summary>\r\n    probe marker;\r\n",
+            "probe marker");
 
     private static bool FiltersToSuccessfulRuns(string sql) =>
         Regex.IsMatch(sql, @"last_run_status\s*=\s*'Success'");

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -1819,9 +1819,12 @@ WITH NO DATA";
     /// <c>last_run_status = 'Success'</c>. An unfiltered series can carry an aborted run's duration, so NO
     /// reading from it may set this constant — a statement about the SOURCE, deliberately not about any
     /// particular reading, because that series gains one every hour this job runs and an enumeration of it
-    /// would be stale within the hour. Snapshot readings as at <c>04:20Z</c> (342 s, 348 s, 286 s) say the
-    /// series stayed flat, which is corroboration and nothing more. They are kept out of the ten above for
-    /// the rule's sake rather than for tidiness.</para>
+    /// would be stale within the hour. The complete set of snapshot readings up to <c>04:20Z</c>
+    /// (342 s, 348 s, 286 s) says the series stayed flat, which is corroboration and nothing more. Note the
+    /// scope has to CLOSE the population, not merely date it: "up to 04:20Z" is a window that has ended and
+    /// will still be true next year, where "the readings so far" carries a scope and rots anyway, because a
+    /// doc comment has no timestamp of its own to be read relative to. They are kept out of the ten above
+    /// for the rule's sake rather than for tidiness.</para>
     ///
     /// <para><b>Why the value is unchanged in BOTH directions, which is #3069's whole resolution.</b> Upward
     /// is asserted as a failure by design (#3055) — see the slot paragraph below. Downward is the subtler

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -1807,15 +1807,21 @@ WITH NO DATA";
     /// of 335 and 359, so a median over 8 of the 10 rather than the 9 clean ones — which is why the figure
     /// held here is the one the listed series yields.)</para>
     ///
-    /// <para><b>The hole, and two readings that are corroboration only.</b> The run starting near
-    /// <c>00:35:05</c> was never observed: by the next look the catalog's last-run figure had already
-    /// advanced past it. Two further readings of <b>342 s</b> and <b>348 s</b> come from the hourly
-    /// self-metrics snapshot (<see cref="StoreSelfMetrics.BackgroundJobInsertSql"/>,
-    /// <c>object_kind = 'background_job'</c>), which records <c>last_run_duration</c> with NO STATUS COLUMN
-    /// AT ALL — while <see cref="HeaviestRefreshRuntimeSql"/> and #2136's <see cref="JobCadenceReadSql"/>
-    /// both filter <c>last_run_status = 'Success'</c>. An unfiltered series can carry an aborted run's
-    /// duration, so those two say the series stayed flat and are NOT ADMISSIBLE in setting this constant.
-    /// They are kept out of the ten above for that reason rather than for tidiness.</para>
+    /// <para><b>The hole.</b> The run starting near <c>00:35:05</c> was never observed: by the next look
+    /// the catalog's last-run figure had already advanced past it. That is a gap in the ten above, not a
+    /// reading that was dropped.</para>
+    ///
+    /// <para><b>And the rule that keeps a whole SERIES out of this constant, stated as a rule because the
+    /// series keeps growing.</b> The hourly self-metrics snapshot
+    /// (<see cref="StoreSelfMetrics.BackgroundJobInsertSql"/>, <c>object_kind = 'background_job'</c>)
+    /// records <c>last_run_duration</c> with NO STATUS COLUMN AT ALL, while
+    /// <see cref="HeaviestRefreshRuntimeSql"/> and #2136's <see cref="JobCadenceReadSql"/> both filter
+    /// <c>last_run_status = 'Success'</c>. An unfiltered series can carry an aborted run's duration, so NO
+    /// reading from it may set this constant — a statement about the SOURCE, deliberately not about any
+    /// particular reading, because that series gains one every hour this job runs and an enumeration of it
+    /// would be stale within the hour. Snapshot readings as at <c>04:20Z</c> (342 s, 348 s, 286 s) say the
+    /// series stayed flat, which is corroboration and nothing more. They are kept out of the ten above for
+    /// the rule's sake rather than for tidiness.</para>
     ///
     /// <para><b>Why the value is unchanged in BOTH directions, which is #3069's whole resolution.</b> Upward
     /// is asserted as a failure by design (#3055) — see the slot paragraph below. Downward is the subtler

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -1773,15 +1773,62 @@ WITH NO DATA";
     public const string HeaviestHourlyRefreshView = QueryStoreStatsIntervalHourlyView;
 
     /// <summary>
-    /// The longest run recorded for <see cref="HeaviestHourlyRefreshView"/> under the narrowed
-    /// <see cref="HourlyRefreshStartOffset"/> window, and the number the compression grid is sized against.
+    /// The runtime the compression grid is sized against for <see cref="HeaviestHourlyRefreshView"/>. ONE
+    /// recorded run, and NOT a measured maximum of the narrowed <see cref="HourlyRefreshStartOffset"/>
+    /// regime — the difference is the whole of #3069, and the paragraphs below state it rather than leaving
+    /// the number to imply a provenance it does not have.
     ///
-    /// <para><b>The measured range, so a later reader can tell whether they are still inside it.</b> Before
-    /// the narrowing this job ran 3,301-6,330 s against a 1-hour cadence. Under the 1-day window the highest
-    /// figure recorded is the 864 s here; the drift chart's most recent readings for the same job are
-    /// <b>194 s, 225 s and 335 s</b>, climbing with volume rather than settling. The grid is sized against the
-    /// 864 s ceiling and not against the 194 s low, because a slot chosen against the low would be correct
-    /// only at the load it was chosen at.</para>
+    /// <para><b>WHERE IT CAME FROM.</b> One run of this job's refresh policy — <c>13:30:00</c> to
+    /// <c>13:44:24</c> on the boundary day, on the one store that carries this workload — read from that
+    /// store's per-run job history with an explicit <c>succeeded</c> column that said <c>t</c>. The narrowed
+    /// <see cref="HourlyRefreshStartOffset"/> reached that store's refresh policies at <c>13:44:23</c>, one
+    /// second BEFORE this run ended. So it is either the TRANSITION run — in flight while
+    /// <c>start_offset</c> was narrowed underneath it, therefore neither cleanly pre- nor post-treatment —
+    /// or the boundary timestamp was itself derived from this run's completion, in which case the boundary
+    /// and this constant are the SAME OBSERVATION and cannot corroborate each other. Separating those two
+    /// needs clock times nobody has read.</para>
+    ///
+    /// <para><b>Which is why "conservative" is the wrong word for it, safe though it is.</b> Conservative
+    /// reads as measured-then-rounded-up, and nothing measured this as a ceiling. It is a reading whose
+    /// REGIME MEMBERSHIP IS UNDETERMINED, which happens to exceed every cleanly post-boundary run observed:
+    /// a partly-narrowed window simply costs more than a fully-narrowed one. So the value bounds the grid
+    /// safely WITHOUT HAVING BEEN ESTABLISHED AS A BOUND. The safety is incidental; the provenance is still
+    /// owed, and the read that would settle it is named at the end of this comment.</para>
+    ///
+    /// <para><b>THE POST-BOUNDARY DISTRIBUTION, recorded here because a constant with one sample behind it
+    /// reads exactly like a constant with a distribution behind it.</b> 10 consecutive runs of this job's
+    /// refresh policy, each read with an explicit <c>succeeded</c> column and every one of them <c>t</c>, in
+    /// start order across the ten hours after the boundary:
+    /// <c>864, 194, 222, 225, 335, 594, 465, 359, 293, 355</c> seconds. Set the first aside for the reason
+    /// above and the remaining 9 run from <b>194 s to 594 s</b>, mean <b>338 s</b>, middle reading
+    /// <b>335 s</b> — every one of them below <see cref="RefreshSlotWarningSeconds"/>. The largest of the 9
+    /// clears the slot by <b>306 s</b>, where this constant clears it by 36 s. (#3069 records the median of
+    /// the same window as ~<b>347 s</b>; the rows published there do not produce that — 347 is the midpoint
+    /// of 335 and 359, so a median over 8 of the 10 rather than the 9 clean ones — which is why the figure
+    /// held here is the one the listed series yields.)</para>
+    ///
+    /// <para><b>The hole, and two readings that are corroboration only.</b> The run starting near
+    /// <c>00:35:05</c> was never observed: by the next look the catalog's last-run figure had already
+    /// advanced past it. Two further readings of <b>342 s</b> and <b>348 s</b> come from the hourly
+    /// self-metrics snapshot (<see cref="StoreSelfMetrics.BackgroundJobInsertSql"/>,
+    /// <c>object_kind = 'background_job'</c>), which records <c>last_run_duration</c> with NO STATUS COLUMN
+    /// AT ALL — while <see cref="HeaviestRefreshRuntimeSql"/> and #2136's <see cref="JobCadenceReadSql"/>
+    /// both filter <c>last_run_status = 'Success'</c>. An unfiltered series can carry an aborted run's
+    /// duration, so those two say the series stayed flat and are NOT ADMISSIBLE in setting this constant.
+    /// They are kept out of the ten above for that reason rather than for tidiness.</para>
+    ///
+    /// <para><b>Why the value is unchanged in BOTH directions, which is #3069's whole resolution.</b> Upward
+    /// is asserted as a failure by design (#3055) — see the slot paragraph below. Downward is the subtler
+    /// trap: correcting toward the observed 594 s would leave 306 s of margin in place of 36 s, and the
+    /// reason the heaviest slot is excluded WHOLE rather than guarded
+    /// (<see cref="CompressionPhaseMinutes"/>) rests on that 36 s being real. A downward edit therefore
+    /// reopens #3035's exclude-vs-guard decision rather than merely re-provenancing a number. What settles
+    /// either direction is one read that has not been taken: the status-filtered per-bucket split of the
+    /// full per-run series (<c>collect.store_metrics</c>, <c>object_kind = 'background_job'</c>) on the
+    /// boundary timestamp, giving count, median and maximum each side of it. The grid is sized against the
+    /// high figure and not against the 194 s low for the original reason — a slot chosen against the low
+    /// would be correct only at the load it was chosen at — and before the narrowing this job ran
+    /// 3,301-6,330 s against a 1-hour cadence, which is what invalidation looks like.</para>
     ///
     /// <para><b>THE OPERATING ENVELOPE, stated because it is a condition and not a property.</b> #3012's
     /// convoy needed a refresh and a compression policy to want the same relation at the same time. Two things

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -1802,10 +1802,11 @@ WITH NO DATA";
     /// <c>864, 194, 222, 225, 335, 594, 465, 359, 293, 355</c> seconds. Set the first aside for the reason
     /// above and the remaining 9 run from <b>194 s to 594 s</b>, mean <b>338 s</b>, middle reading
     /// <b>335 s</b> — every one of them below <see cref="RefreshSlotWarningSeconds"/>. The largest of the 9
-    /// clears the slot by <b>306 s</b>, where this constant clears it by 36 s. (#3069 records the median of
-    /// the same window as ~<b>347 s</b>; the rows published there do not produce that — 347 is the midpoint
-    /// of 335 and 359, so a median over 8 of the 10 rather than the 9 clean ones — which is why the figure
-    /// held here is the one the listed series yields.)</para>
+    /// clears the slot by <b>306 s</b>, where this constant clears it by 36 s. (#3069 quotes ~347 s as the
+    /// median of the same window. The rows published there do not reproduce it, so the figure held here is
+    /// the one the listed series yields — which is what the middle reading above is pinned to. The quoted
+    /// figure is left as a quotation rather than re-derived here, because an arithmetic aside about a
+    /// superseded external number is coupling with nothing behind it.)</para>
     ///
     /// <para><b>The hole.</b> The run starting near <c>00:35:05</c> was never observed: by the next look
     /// the catalog's last-run figure had already advanced past it. That is a gap in the ten above, not a


### PR DESCRIPTION
`HeaviestHourlyRefreshObservedCeilingSeconds` keeps the value 864. What changes is what its doc comment claims about where that value came from, plus a pin that holds every figure derived from it to agreeing with the series the comment now publishes.

## What the doc said, and what it says now

**Before**, the constant was introduced as "the longest run recorded ... under the narrowed `HourlyRefreshStartOffset` window", and its measured-range paragraph read: under the 1-day window the highest figure recorded is the 864 s here, with the drift chart's most recent readings for the same job at **194 s, 225 s and 335 s**, "climbing with volume rather than settling".

Both halves of that are now superseded. The companions did not keep climbing — the same job went on to 594 s and settled back into the 300s — and 864 s is not demonstrably a maximum of the narrowed regime at all.

**Now** the comment states, in this order:

- **Where the number came from.** One run, `13:30:00` to `13:44:24` on the boundary day, on the one store that carries this workload, read from that store's per-run job history with an explicit `succeeded` column that said `t`.
- **The transition-run ambiguity.** The narrowed `HourlyRefreshStartOffset` reached that store's refresh policies at `13:44:23` — one second *before* that run ended. So either 864 s is the transition run, in flight while `start_offset` was narrowed underneath it and therefore neither cleanly pre- nor post-treatment; or the boundary timestamp was itself derived from that run's completion, in which case the boundary and the constant are the same observation and cannot corroborate each other. Separating those two needs clock times nobody has read.
- **Why "conservative" is the wrong word for it, safe though it is.** Conservative reads as measured-then-rounded-up, and nothing measured this as a ceiling. It is a reading whose regime membership is undetermined which happens to exceed every cleanly post-boundary run observed — a partly-narrowed window simply costs more than a fully-narrowed one. The value bounds the grid safely *without having been established as a bound*: the safety is incidental and the provenance is still owed.
- **The distribution**, with the summary figures the published rows actually yield.
- **The hole**, and the rule that keeps the whole unstatused series out of this constant, below.
- **Why the value is unchanged in both directions**, below.

## The series, and its status provenance

Ten consecutive runs of this job's refresh policy, each read with an explicit `succeeded` column and every one of them `t`, in start order across the ten hours after the boundary:

`864, 194, 222, 225, 335, 594, 465, 359, 293, 355` seconds.

Setting the first aside for the reason above, the remaining nine run from **194 s to 594 s**, mean **338 s**, middle reading **335 s** — every one below `RefreshSlotWarningSeconds`. The largest clears the 900 s slot by **306 s**, where the constant clears it by 36 s.

Three things are recorded about the series rather than smoothed over:

- **One run was never observed** — the one starting near `00:35:05`. By the next look the catalog's last-run figure had already advanced past it.
- **No reading from the hourly self-metrics snapshot may set this constant** — stated as a rule about the source rather than as a list of the readings it excludes, for the reason in the scope section below. `StoreSelfMetrics.BackgroundJobInsertSql` (`object_kind = 'background_job'`) records `last_run_duration` with no status column at all, while `HeaviestRefreshRuntimeSql` and #2136's `JobCadenceReadSql` both filter `last_run_status = 'Success'`, so an unfiltered series can carry an aborted run's duration. A test checks that reason against the shipped SQL rather than restating it.
- **#3069's comment records the median of the same window as ~347 s, and the rows published there do not produce that.** 347 is the midpoint of 335 and 359, so it is an even-count median over eight of the ten rather than the nine clean ones; the nine clean rows have a middle of 335 s. The doc holds the figure its own listed series yields, and says why the other one differs.

## Why the value is unchanged, in both directions

**Upward** is asserted as a failure by design. `TimescaleSupportTests` carries `HeaviestHourlyRefreshObservedCeilingSeconds < RefreshPhaseStepMinutes * 60`, built by #3055 so the number could not be renumbered through — past the slot width the refresh runs into its neighbour and the grid needs redesigning, not renumbering. Nothing here touches that assertion.

**Downward** is the subtler trap, and it is why the honest reading of the observation does not license editing the number. Correcting toward the observed 594 s would leave 306 s of margin in place of 36 s — and the reason `CompressionPhaseMinutes` excludes the heaviest slot **whole rather than guarding it** rests on that 36 s being real. At 864 s the run occupies 14.4 of the slot's 15 minutes, so no minute of it a `CompressionPhaseGuardMinutes` band could recover; at 594 s it occupies 9.9, and minutes 10 through 14 of that slot become recoverable. A downward edit therefore reopens #3035's exclude-vs-guard design decision rather than merely re-provenancing a number, and eleven hours of one quiet night does not settle that.

So the resolution is the one #3069 states for itself — the post-fix distribution came back with its maximum inside the slot, so the constant gets its provenance recorded and the grid stands as designed. `RefreshSlotWarningSeconds`, the build-time assertion and #3035's grid are all untouched, and no migration rung is added.

## The pin, and the evidence that it can fail

`RefreshCeilingProvenancePinTests` parses the real `TimescaleSupport.cs` (resolved from `[CallerFilePath]`, so there is no second copy to go stale) and requires every figure the comment states to follow from the constants or from the series the comment itself publishes. Nothing in it hardcodes 864, 900, 36, 306 or 338.

What it derives:

- the series contains `HeaviestHourlyRefreshObservedCeilingSeconds` exactly once — the link that makes the transition-run paragraph about *this* number
- the stated run count equals the listed rows; the stated low, high, mean and middle equal what the listed rows compute
- the stated slot clearance equals `RefreshPhaseSlotSeconds` minus the listed maximum, and the stated margin equals it minus the constant
- the quoted run's own clock arithmetic: `end - start` equals the constant, and `end - boundary` equals exactly one second — the transition-run finding, as a subtraction
- `occupies 14.4 of the 15 minutes` equals the constant in minutes and `RefreshPhaseStepMinutes`, with a separate assertion that the constant is still an exact tenth of a minute so a rounded claim cannot wear an exact one's clothes
- `Assert.All` over the whole clean inventory — every cleanly post-boundary reading is below the constant and below the watch line — rather than one true clause standing in for the set, with the population asserted non-empty first
- the inadmissibility reason against the shipped strings: `HeaviestRefreshRuntimeSql` and `JobCadenceReadSql` filter to successful runs, `BackgroundJobInsertSql` does not and carries no status column at all. The predicate is red-proofed in both directions on synthetic copies, because a predicate that could only return `true` would satisfy the two positive lines and prove nothing about the negative one — which is the load-bearing half.

**Red-proof, run on the committed tree.** `EveryNumericPin_ReportsAnInjectedDrift` bumps each captured number **one at a time** in a mutated copy, asserts the pattern still matches (so a mutation that merely broke a regex cannot pass as a caught drift), then requires verification to fail with something other than a parse miss. It ran **45** injections and all 45 were caught; the count is asserted equal to the captured-number total, so a sweep that enumerated nothing goes red rather than green. One at a time is the point: a bump to a middle-ranked series reading changes neither the range nor the middle, and is caught only because the mean is stated too. `Verify` also requires it consumed every pin in `Pins()`, so a pattern cannot sit in the list looking like it guards something.

Twelve hand-injected mutations were run separately against the real files, each with a build-exit check distinct from the run so a stale dll could not print a clean `Failed: 0`:

| mutation | result |
|---|---|
| constant `864` -> `870` (still inside the slot, still above the watch line, still an exact tenth) | 2 tests red |
| one **non-extremal** series reading `222` -> `223` (range and middle unchanged) | 2 tests red |
| stated mean `338` -> `339` | red |
| stated clearance `306` -> `305` | 2 tests red |
| boundary clock `13:44:23` -> `13:44:22` | 2 tests red |
| midpoint pair `359` -> `358` | 2 tests red |
| occupancy `14.4` -> `14.5`; slot `15` -> `16` | red, each |
| a pinned sentence reworded so the pattern misses | 3 tests red |
| the series loses a row but keeps its stated count | 2 tests red |
| `BackgroundJobInsertSql` gains a status filter | red |
| `HeaviestRefreshRuntimeSql` loses its status filter | red |
| a pin declared in `Pins()` that `Verify` never consumes | red |

One mutation that did **not** go red is worth recording: rewording a paragraph heading nothing asserts on. That is a mutation aimed at text the assertions do not read, so it is not a test of the pin — not a gap in it.

## Verification, and its scope

`Darling.Tests` cannot run on macOS, so the actual test sources were compiled into throwaway `net10.0` xunit v3 harnesses staged in the gitignored project `bin/`, each with a build-exit check separate from the run:

- the new pin: **5 tests, Failed 0, Skipped 0, Not Run 0**
- `TimescaleSupportTests`: **46 tests, Failed 0, Not Run 0**, 15 skipped and every one of them a `_AgainstDevPostgres` live-store test. The three facts that read this constant were also run individually by name — `CompressionPhaseGrid_ClearsEveryRefreshSlotsGuardBand_AndTheHeaviestRefreshsSlotWhole`, `TheRefreshSlotReading_CarriesItsOwnVerdict_AndReportsOverrunAsNegativeHeadroom`, `TheRefreshSlotLogLine_IsLeveledByBand_AndSaysNothingWithoutAReading` — each `Total: 1, Failed: 0`.
- `DocCommentHygieneTests`: **40 tests, Failed 0**, and proved to be reading the edited file by injecting a stacked `<summary>` into the new doc run and watching two of its facts go red.

`PerformanceMonitor.Darling.Storage` and `Darling.Tests` both build with `-p:EnableWindowsTargeting=true` and 0 errors; the 49 analyzer warnings on `Darling.Tests` are all pre-existing xUnit nags in other files, none in the new one. CI's Windows `build` job remains the arbiter for the full suite.

**What is still outstanding, and is not claimed here:** the status-filtered per-bucket split of the full per-run series (`collect.store_metrics`, `object_kind = 'background_job'`) on the boundary timestamp, giving count, median and maximum each side of it. That is the read that would give the constant real provenance in either direction, it needs a session against the one store that carries this workload, and it was not taken. The doc comment names it as the outstanding read rather than leaving a future reader to rediscover that it is missing.

## One whole-tree guard this had to join, and a stale count beside it

The first CI round came back with **exactly one** failure across both suites — `Lite.Tests` 3402/0, `Darling.Tests` 7794 with a single red, so the new pin's own tests passed on Windows and on the Linux Postgres job. The red was `CommentFilterAdoptionTests.EveryLinePrefixCommentFilter_StatesTheBoundItRestsOn`: `DocProseFor` walks the contiguous `///` run above a declaration, which is a line-prefix comment filter, and that guard requires every such site to be enumerated with the bound it rests on.

It is registered as the **COLLECTS a doc run** kind — the same kind `DocCommentHygieneTests` and both `AnalysisPassTokenThreadingTests` twins are on. The prefix defines the run rather than approximating comment-stripping, and asking for `CSharpSourceWalker` would leave nothing to read, since the figures being pinned live only in comments. The stated bound is that the walk stops at the first non-`///` line, so a block comment between the doc run and its declaration truncates it — and that direction is loud rather than quiet, because the collected prose is asserted to open at `<summary>` and close at `</summary>` before any figure is compared.

**The kind count in that class's own doc comment was already stale.** It read "Four kinds live here ... **Two** collect a doc-comment run" against three such entries, so it was wrong by one before this PR and would have been wrong by two after. Corrected to "Four" in the same commit rather than filed, since it is one word adjacent to the line being added and this change is what makes it worse.

Red-proofed locally rather than assumed: removing the new census entry reproduces the exact CI failure, same expected/actual pair (`Lite.Tests/AnalysisPassTokenThreadingTests.cs` against `Darling.Tests/RefreshCeilingProvenancePinTests.cs` at index 4), which is also what confirms the local harness reads the same tree CI does. All four harnesses re-run green afterwards with build exit codes checked separately: pin 5/0, `CommentFilterAdoptionTests` 2/0, `DocCommentHygieneTests` 40/0, `TimescaleSupportTests` 46/0.

## Review round two: the pin's prose coupling, cut where it was cuttable and defended where it was not

The review granted the arithmetic and objected to maintenance surface — ~80 lines of prose tied to 13 near-verbatim patterns, where a copy-edit touching no number reds CI. Two thirds of that was fair.

**Fixed at the extractor.** `DocProseFor` strips `<b>` emphasis and normalises em/en dashes to a hyphen before any pattern runs, so all seven `<b>` couplings and the `\S` dash stand-in are gone. Patterns are trimmed to the span bracketing their numbers: **122 verbatim anchor words down to 96**, with the drift sweep still at **45 injections** — so the reduction cost nothing in coverage. The population-merge mutation now addresses its number by ordinal through the same source-rewrite the sweep uses, instead of string-replacing an emphasis-tagged reading, which would have found nothing if someone unbolded it.

**The failure message now names all three correct fixes** — update the pattern, fix the prose, or delete the figure and drop the pin — and says why editing a pattern is sanctioned rather than a loophole: `EveryNumericPin_ReportsAnInjectedDrift` re-derives every case from the pattern you write, so one widened into a no-op goes red. #3073 already ships that same protection (`EveryPin_ReportsAnInjectedDrift`), and its own handling of the third outcome is split three ways: the prose-pin *message* lists two outcomes and omits pattern-editing; a code comment above that assertion (`ReadmeDerivedCountPinTests.cs:198-200`) discourages it, scoped to a formulaic README inventory sentence; and its `--test-connection` denominator sweep directs it outright (`:147`, *"Fix the pattern rather than the count."*). So this message states, for the prose kind, the outcome the prose-pin message left unstated — on the mechanism #3073 already carried that makes it safe. Not a divergence from policy, and not an oversight being corrected either: a deliberate split, stated here for the kind that invites editing.

**The multiset alternative was measured, not argued away.** The doc run holds 65 numerals, 39 distinct, and the derived figures repeat: `36` four times, `594`/`194`/`335`/`9` three times each, `306`/`864`/`10` twice. Set-semantics containment false-passes on three of four injected single-figure corruptions, catching only `338` — the one figure stated exactly once. A count-bearing multiset would catch them only by encoding per-figure occurrence counts, which is the restatement the bar bans and which reds on any rewording that mentions a figure once more or less. The underlying reason is that a numeral bag cannot police *which claim* a number belongs to, and `36` versus `306` — same constant, same slot, different sentence — is exactly the error a future editor makes.

## The census summary, pinned rather than filed

`CommentFilterAdoptionTests` had to gain an entry for the new pin's `///` walk (the **COLLECTS a doc run** kind, alongside `DocCommentHygieneTests` and both `AnalysisPassTokenThreadingTests` twins). While registering it, `s_bounded`'s doc comment turned out to describe the census by count and to be wrong: it read "**Two** collect a doc-comment run" while **three** entries already did — stale by one before this PR, and it would have been stale by two after. 4 COLLECTS + 1 stated bound + 1 SQL + 1 demonstrator = 7 keys, which is the map's size.

**The durable finding is the asymmetry:** that guard catches a new **member** by name and nothing caught its own **summary** drifting, in a file whose entire job is adoption tracking. So the summary is now pinned rather than just corrected. All **five** counted claims are derived — the kind total plus one claim per kind — from the map and its entry text; none was underivable, and the kind labels are required to account for every entry so the breakdown cannot quietly stop summing to the map.

Note this loose-on-prose/strict-on-numbers shape is available *here* precisely because a count survives arbitrary rewording as long as the numeral is still there. It is not available for a figure whose meaning depends on which sentence it sits in, which is why the thirteen patterns stay.

Red-proofed four ways, each confirmed red then reverted: prose count wrong against the map; a numeral spelled outside the word vocabulary (the word-to-digit mapping is the load-bearing part, since the prose spells counts as words); a fifth `COLLECTS` entry added with the prose untouched; an entry whose bound names no recognised kind. The pin also caught a mistake of mine on its first run — it was anchored on the class summary rather than on `s_bounded`'s own doc comment, and the wrong doc run yields prose with no counted claim in it, so it failed loudly instead of comparing nothing.

## One more thing the prose was carrying alone

The build-time assertion `CompressionPhaseGuardMinutes * 60 < HeaviestHourlyRefreshObservedCeilingSeconds` **still passes at 594** (420 < 594). So it does not protect the exclude-whole decision at all: the reasoning that no minute of the heaviest slot is guard-recoverable was carried by the doc comment with nothing asserting it. That is not fixed here — fixing it means re-deriving #3035 — but it is now stated where the next reader will find it, and it is on #3069.

## CI

Round two on `c25b262be` was **fully green: all 8 checks**, including the Windows `build` at 8m15s, `Darling PostgreSQL tests` at 4m13s and `Darling whole-tree guards`. Round one's only failure was the census entry, now fixed. Round three is running on `1811b3a66`.

## The snapshot enumeration, and the scope rule it taught

A third snapshot reading (286 s, at the 04:20Z self-metrics snapshot, `total_runs` 331→332) arrived while this PR was in review, and it made one sentence wrong: *"Two further readings of 342 s and 348 s come from the hourly self-metrics snapshot"*. Unlike the ten-run series — which is scoped to a window that has ended and so cannot be falsified by a later run — that sentence carried no scope and read as a complete enumeration of a set that grows every hour this job runs. A frozen enumeration wearing a complete one's clothes, which is #3072's defect and the thing this PR's own pin exists to prevent.

**Fixed by deleting the count, not by writing "Three"** — #3073's delete class. The paragraph's real subject is the inadmissibility *rule*: the self-metrics snapshot records `last_run_duration` with no status column while `HeaviestRefreshRuntimeSql` and `JobCadenceReadSql` both filter `last_run_status = 'Success'`, so **no** reading from it may set this constant. That is a statement about the source and does not go stale. The readings stay as illustration, scoped.

**The pin had the same defect with a test wrapped around it.** Its pattern was `readings of ([0-9]+) s and ([0-9]+) s come from` — the arity was the count, encoded in a regex. It now captures the whole list however long. Proven both directions: appending a fourth reading and cutting back to one both stay **green**, while folding a status-verified series value into the list reds on disjointness.

**And the scope has to CLOSE the population, not merely date it.** "The readings so far" carries a scope and rots anyway, because a doc comment has no timestamp of its own for a relative phrase to be read against. The prose says *"the complete set of snapshot readings up to 04:20Z"* — a window that has ended — and the pin demands the closing preposition with an absolute stamp. Red-proofed: replacing it with a relative scope reds, and dropping it entirely reds.

The scope marker is checked for **presence, not value**. The timestamp is evidence; pinning it to a derived quantity would be inventing a bound this constant does not have.

## The provenance correction is now corroborated by contact, not only by absence

An overlap did occur: the refresh ran 03:52:17→03:57:03 and a compression policy fired at 03:52:57, forty seconds into it. **Contact made the refresh faster, not slower** — 286 s, the fastest reading of its tracked series. So the one mechanism that could have pushed the real post-boundary maximum back toward 864 s and retroactively justified that number did not occur under direct contact. **594 s stands as the post-boundary maximum.**

Carrying the bound honestly: the compression run was 0.9 s, which is consistent with *compressed quickly without contention* or with *found little eligible at 04:00 on a Sunday*, and `last_run_duration` alone cannot separate them. That ambiguity is on the compression side and does not weaken the refresh-side measurement, which is direct. Durations and run counts are observed; start times are derived from the finish-to-start rule.

## Re-verified after `origin/dev` moved, and one credit correction

`origin/dev` advanced to `0f888e90c` (#3075) while this was in review, and it touched **the same file** — `CommentFilterAdoptionTests.cs` — with `git merge-tree` reporting zero conflicts, which is the case worth checking rather than trusting. #3075's edit is confined to that class's **summary** (the `build.yml` filter paragraph); this branch edits `s_bounded`'s own doc comment and the map below it, so they do not overlap. `origin/dev` is merged in here so CI runs the combined tree rather than two halves.

Every count re-derived after the merge, not assumed: 4 `COLLECTS` + 1 stated bound + 1 SQL + 1 demonstrator = **7** map keys; the drift sweep still at **45** injections; all four local harnesses green on the merged tree. Worth noting the check that matters is the pin itself — a grep for `COLLECTS` now returns 5, because it also matches `s_kinds`' own label table, which is exactly why the count is derived from the map in code rather than counted by eye.

**Credit correction: the `CommentFilterAdoptionTests` "Two → Four" fix repaired a pre-existing stale count, not an adjustment for this PR's entry.** Three entries already collected a doc run when the prose said "Two". Adding the fourth made it wrong by two instead of one, but the drift predates this branch.

**One thing left for #3075's lane rather than taken here.** That PR's new summary text says `CrossAppGuardCiGateTests` "does see the two `Lite.Tests` keys below" — a fresh counted claim of exactly the kind this PR pins, one doc run away from the one now pinned, and derivable (count map keys prefixed `Lite.Tests/`). It is correct today. It is not pinned here because it is another lane's just-landed prose and the census pin deliberately covers `s_bounded`'s doc run only; flagging rather than silently extending.

## The two-kinds numeral policy, written down where the second implementation of it lives

This reasoning has now been derived from scratch twice by different readers, and both times it lived only in a review thread. It is repo policy and it is sharper than anything either #3072 or #3073 states individually:

> A numeral that **restates an adjacent list** gets deletion offered in its failure message — dropping the sentence is as correct as correcting the figure. A numeral that is **program output** gets *"fix the pattern rather than the count"*, because a transcript has to keep showing what the tool really prints.

`ReadmeDerivedCountPinTests` implements both halves and states neither, so the rule has to be inferred from the disagreement between two of its own failure texts. Three sentences now sit in this class's summary, citing both issues, naming which kind the thirteen patterns here are — derived arithmetic restated in prose, hence the deletion escape throughout — and marked explicitly as **narration of an existing rule rather than a counted claim**, so nothing pins it. A pin on a sentence about pinning is where this stops being useful.

## A stale justification in this PR's own new file, and why it was re-pointed rather than deleted

Review found `RefreshCeilingProvenancePinTests.cs:97-99` justifying its ASCII-only patterns by a `\S` dash stand-in — a mechanism deleted three commits earlier, when `DocProseFor` gained dash normalisation. Verified before fixing: **zero of the thirteen patterns use `\S`, and zero carry a non-ASCII character**; the one literal hyphen, in `([0-9]+)-second slot`, is a plain ASCII hyphen in the prose.

That is exactly the defect this file exists to catch — a comment claiming a mechanism the code no longer implements — occurring one level up, in the guard's own commentary, about its own patterns. Conceded rather than argued.

**Re-pointed, not deleted, because only the reason was wrong.** The patterns are still ASCII-only on purpose; what makes that possible is `DocProseFor` normalising `—` and `–` to a plain hyphen before any pattern runs, so none of the thirteen has to match a dash variant. Deleting the sentence would have lost a true and load-bearing fact.

**Corrected *and* enforced,** since the replacement sentence makes a checkable claim and leaving it as prose would repeat the mistake more slowly. `NoPattern_NeedsToMatchADashVariant_WhichIsWhatTheNormalisationBuys` asserts no pattern carries a non-ASCII character, and drives the real `DocProseFor` over an arranged doc run so the normalisation claim has something behind it. Red-proofed both ways: an em dash injected into a pattern reds, and neutering the em-dash normalisation reds — the latter caught by this test alone.

**The asymmetry this is the second instance of.** `CommentFilterAdoptionTests` caught a new *member* of its census while nothing caught its own *summary* drifting; these pins watch `TimescaleSupport.cs`'s doc run while nothing watches this file's own prose. The boundary is probably right — pinning a test file's commentary is where this stops paying — but two instances make it a pattern rather than an incident, and it is named in the lane report rather than built, because the honest scope of this fix is one sentence and one assertion.

## Proportionality, and the two patterns that did not earn their place

Review's second concern was the ratio: ~1,054 lines of regex-driven prose verification against a doc comment on a constant whose value does not change. Legitimate, and the second concern on this axis — the first produced 122 → 96 anchor words. Applying the reviewer's own framing to a re-audit produced a real cut: **13 → 11 patterns, 94 → 69 anchor words, 45 → 37 injections.**

**The ratio conflates two things.** The coupling to prose is **11 patterns, mean 6.3 anchor words each**. The rest — the injection sweep, the ordinal source-rewrite, `Verify`'s consumption check, the anti-truncation guards, and 177 lines of doc comment — is what makes the pin trustworthy, and **none of it needs editing when the prose changes**; a copy-editor touches at most one pattern per reworded sentence. 337 of the 844 lines are comments and blanks.

**Dropped as incidental:** two patterns pinning seven captures of arithmetic that explained why #3069's `~347 s` median is not reproducible from its own published rows. That figure has no referent in this codebase, nothing downstream depends on it, and the reading it contrasted with is already pinned against the series. The derivation is out of the prose and both pins are gone with it; `~347 s` remains a bare quotation — the same category as the snapshot readings, correctly unpinned. A third pattern captured the clean count for the third time; that capture is gone too.

**The 11 that remain each derive a figure from the constants or from the published series**, and each was wrong or unprovenanced in the version this PR replaces: the series itself (must contain the constant exactly once), `end − start == 864`, `end − boundary == 1`, stated count vs rows listed, the five clean-series statistics, `Slot − max` / `Slot − Ceiling` twice over, `Ceiling`/`Slot`/margin, `Ceiling / 60` and `RefreshPhaseStepMinutes`, the series minimum, and the snapshot readings' disjointness and closed scope.

**Bound on the claim, because overselling the pin would be the same mistake as the `\S` sentence.** The constant's *value* is not what this guards and is not unguarded either — `TimescaleSupportTests` carries the build-time envelope assertion and `peak.ClearOfSlotSeconds` independently pins 306. This pin guards the **provenance narrative**, which is what nothing else could guard and precisely what #3069 was filed about.

Coverage re-proved after the cut, each red then reverted: middle reading `335 → 336`; clearance `306 → 305`; constant `864 → 870`; a non-extremal series reading `222 → 223`, caught only via the stated mean; margin `36 → 63`.

