### PR TITLE
Fixes #3076

### DIFF
--- a/Lite.Tests/CrossAppGuardCiGateTests.cs
+++ b/Lite.Tests/CrossAppGuardCiGateTests.cs
@@ -153,6 +153,16 @@ public class CrossAppGuardCiGateTests
 
         [$"{LiteTestsDir}/LiteSidebarDotRendersTheCardStatusTests.cs"] =
             "WHOLE-TREE READ. The second key of that same bounded set, same sweep, same reason.",
+
+        [$"{LiteTestsDir} (directory)"] =
+            "WHOLE-TREE READ, and the one #3076 made visible. ControlPlaneReloadDurabilityTests' "
+            + "NeitherFixHasALiteTwinToDriftFrom sweeps { \"Lite\", \"Lite.Tests\", "
+            + "\"PerformanceMonitor.Common\" } through Path.Combine and EnumerateFiles, so it reads "
+            + "every *.cs under Lite's test project as well as under Lite. Nothing narrower than "
+            + "Lite.Tests/** reaches a tree enumeration, and in the darling filter that entry would "
+            + "buy no guard execution — same measurement as the entries above. The companion "
+            + "reference from the same sweep, Lite (directory), needs no exemption: the darling "
+            + "filter's derived Lite/**/*.cs entry already reaches it.",
     };
 
     /// <summary>The exact command <c>darling-tree-guards</c> has to run for anything in
@@ -213,7 +223,10 @@ public class CrossAppGuardCiGateTests
             var combined = Path.Combine("Lite.Tests", "Fixtures", "SystemHealth");
             var prefixedRoot = "LiteTests/NotOurs.cs";
             var longerRoot = "Lite.TestsExtra/NotOurs.cs";
-            var bareDirectory = "Lite.Tests";
+            var sweep = new[] { "Lite", "Lite.Tests", "PerformanceMonitor.Common" }
+                .Select(d => Path.Combine(root, d))
+                .Where(Directory.Exists)
+                .SelectMany(d => Directory.EnumerateFiles(d, "*.cs", SearchOption.AllDirectories));
             """;
 
         Assert.Equal(
@@ -234,13 +247,194 @@ public class CrossAppGuardCiGateTests
                    this shape one directory over. Collected after the quoted paths, hence last. */
                 "Lite.Tests/Fixtures/SystemHealth",
 
-                /* Absent, and each for its own reason: LiteTests/ shares no boundary with either root;
-                   Lite.TestsExtra/ is prefixed BY the longer root and is still not it; and a bare
-                   directory name with no separator was never in this matcher's language, before or
-                   after the widening (ControlPlaneReloadDurabilityTests names one, and this pin
-                   records that the scan does not see it rather than implying it does). */
+                /* #3076, and the reason the `sweep` line above is spelled exactly as
+                   ControlPlaneReloadDurabilityTests spells it: both roots named bare, with no
+                   separator on either, in a text that composes a whole path per collection element.
+                   Both are found and they are found SEPARATELY — the test root is not folded into the
+                   app root, which is what a shorter-root absorption would produce and what would then
+                   drop Lite.Tests out of the set entirely. Longest root first, as Roots is ordered. */
+                "Lite.Tests",
+                "Lite",
+
+                /* Absent, and each for its own reason: LiteTests/ shares no boundary with either
+                   root, and Lite.TestsExtra/ is prefixed BY the longer root and is still not it. Both
+                   would introduce a value nothing else in this set carries, so a widening into a
+                   prefix match is visible here.
+
+                   The spellings that remain UNFOUND after #3076 are NOT recorded here, deliberately.
+                   This text carries a genuine sweep, so both roots are in the expected set already,
+                   and arm three yields a root at most once per collection — an extra accepting site
+                   could not change the set, and a case whose firing is invisible records nothing. They
+                   are in TheCSharpMatchers_StillCannotSeeTheseSpellings instead, one text each, where
+                   the expected answer is empty and any firing shows. */
             },
             CSharpPaths(Text, LiteTrees).ToArray());
+    }
+
+    /// <summary>
+    /// The cross-app reads this matcher STILL cannot see, each with live instances, each written down
+    /// rather than left to be rediscovered — which is what #3063, #3067 and #3076 each were.
+    ///
+    /// <para>One text per spelling, so the expected answer is EMPTY and a widening that starts firing
+    /// on one of them shows up as a value appearing where none belongs. Folded into the fixture above
+    /// they would record nothing: that text carries a genuine sweep, so both roots are already in its
+    /// expected set, and an extra accepting site could not change it.</para>
+    ///
+    /// <para><b>Every case carries a positive control through the same matcher.</b> An empty answer is
+    /// the success condition here, and the other thing that produces an empty answer is a matcher that
+    /// has stopped working — the failure this whole class exists to catch. So each text is also fed
+    /// with the same read spelled WITH a separator, and that has to be found. A dead
+    /// <see cref="CSharpPaths"/> fails the control while satisfying every emptiness assertion.</para>
+    ///
+    /// <para>None of these is unguarded in CI. All three name files under the Lite app tree, which the
+    /// <c>darling</c> filter's derived <c>*.cs</c> entry reaches, so the suites run; the gap is in what
+    /// this guard can SAY, and therefore in what an exemption could ever be written for.</para>
+    ///
+    /// <para>One SKU rather than both, unlike <see cref="TheBareDirectoryArm_IsLiveForBothSkus"/>: each
+    /// case names the live instances it stands for and all of them are Lite-side, so a text derived per
+    /// SKU would carry a claim that is false for the other one. What is symmetric here is the matcher,
+    /// and that is pinned for both SKUs there.</para>
+    /// </summary>
+    [Fact]
+    public void TheCSharpMatchers_StillCannotSeeTheseSpellings()
+    {
+        /* A collection whose elements are SEGMENTS of one path rather than whole paths, recomposed by
+           a helper. The real read is Lite/Controls. The bare arm deliberately does not fire: reporting
+           `Lite` for a read of Lite/Controls would replace a precise reference with a whole tree.
+           ScopedLoadOrderingTests carries two (s_finOps, s_liteWindows), ViewerScopedPaintGuardTests a
+           third. */
+        const string SegmentCollection = """
+            var segmentList = new[] { "Lite", "Controls" };
+            var viaHelper = SourceFile(segmentList, "FinOpsTab.xaml.cs");
+            """;
+
+        /* The collection declared in one member and projected in another, so the two are never
+           adjacent and the gate cannot see them together. XamlStaticResourceHygieneTests is exactly
+           this shape; its whole-tree read of Lite is reported anyway, because
+           ControlPlaneReloadDurabilityTests produces the same reference from its own sweep — which is
+           luck, not coverage, and is the reason this case is here. */
+        const string CrossMemberCollection = """
+            private static readonly string[] Scopes = { "Lite" };
+            var crossMember = Scopes.Select(d => Path.Combine(root, d));
+            """;
+
+        /* Path.Combine with the base in a VARIABLE. The second arm requires the root literal FIRST, so
+           the specific file is never resolved. QueryStoreStatePruneTests and CollectorStateContractTests
+           carry live instances. */
+        const string VariableBase = """
+            var variableBase = Path.Combine(root, "Lite", "Analysis", "NotSeen.cs");
+            """;
+
+        foreach (var text in new[] { SegmentCollection, CrossMemberCollection, VariableBase })
+        {
+            Assert.Empty(CSharpPaths(text, LiteTrees));
+
+            /* The control. Same text, same matcher, plus the read spelled the way this matcher DOES
+               see — so an empty answer above means "this spelling is unfound" rather than "nothing is
+               found any more". */
+            Assert.Equal(
+                new[] { "Lite/Analysis/NotSeen.cs" },
+                CSharpPaths(text + "\r\nvar spelled = \"Lite/Analysis/NotSeen.cs\";\r\n", LiteTrees));
+        }
+    }
+
+    /// <summary>
+    /// #3076's arm, for BOTH SKUs and in one code path, with the fixture text DERIVED from each SKU's
+    /// own tree names rather than written out per arm.
+    ///
+    /// <para>Two things need saying at once, and neither is provable from the live tree. The arm has to
+    /// be live on the Lite arm as well as the Darling one — measured, <c>Lite.Tests</c> has no bare
+    /// directory read of a Darling root today, so a floor taken over the live scan there would be
+    /// satisfied by an arm that had stopped working entirely. And it has to be live on the DARLING SKU,
+    /// whose test root contains a separator and is therefore already visible to the first arm, so an
+    /// implementation that quietly special-cased "roots without a separator" would look identical here
+    /// until the day Darling's test project moved out to a sibling.</para>
+    ///
+    /// <para>Both expectations are taken off <see cref="SkuTrees.AppDir"/> and
+    /// <see cref="SkuTrees.TestsDir"/> — the NAMED members — while the matcher anchors on
+    /// <see cref="SkuTrees.Roots"/>. A root dropped from <c>Roots</c> therefore reds here rather than
+    /// disappearing from both sides of a comparison that derived them from the same list, which is how
+    /// a fixture agrees with itself.</para>
+    ///
+    /// <para>The negative halves are the point as much as the positive one. Without the gate this arm
+    /// reports every quoted mention of a root, which measured over this repository is 37 sites in
+    /// <c>Darling.Tests</c> and 20 in <c>Lite.Tests</c>, and the Lite arm has no backstop to exempt the
+    /// reference that would produce.</para>
+    /// </summary>
+    [Fact]
+    public void TheBareDirectoryArm_IsLiveForBothSkus()
+    {
+        foreach (var other in new[] { LiteTrees, DarlingTrees })
+        {
+            /* The live shape: a collection of bare roots, projected one element to one whole path. */
+            var swept =
+                $"var sweep = new[] {{ \"{other.AppDir}\", \"{other.TestsDir}\", \"PerformanceMonitor.Common\" }}\n"
+                + "    .Select(d => Path.Combine(root, d))\n"
+                + "    .SelectMany(d => Directory.EnumerateFiles(d, \"*.cs\", SearchOption.AllDirectories));\n";
+
+            /* Both roots, once each. A root that already carries a separator is ALSO seen by the first
+               arm, so it arrives twice; the duplicate is asserted rather than normalised away, and the
+               claim being made is about the distinct set. */
+            Assert.Equal(
+                new[] { other.AppDir, other.TestsDir }.OrderBy(r => r, StringComparer.Ordinal),
+                CSharpPaths(swept, other).Distinct().OrderBy(r => r, StringComparer.Ordinal));
+
+            /* Anti-vacuity, stated separately because the equality above holds for an empty set the day
+               someone writes an empty expectation next to an empty answer. */
+            Assert.Contains(other.TestsDir, CSharpPaths(swept, other));
+            Assert.Contains(other.AppDir, CSharpPaths(swept, other));
+
+            /* The precision half: the SAME roots, bare, with no per-element composition anywhere in the
+               text. This is the shape of all 20 Lite-arm sites and 35 of the 37 Darling-arm ones —
+               tuple labels, assertion keys, and this class's own root constants — and the arm must see
+               none of them. Nothing else in the text carries a separator, so an empty answer here is
+               the whole answer rather than the residue of one. */
+            var prose =
+                $"private const string AppDir = \"{other.AppDir}\";\n"
+                + $"private const string TestsDir = \"{other.TestsDir}\";\n"
+                + $"var scopes = new[] {{ (\"{other.AppDir}\", 1) }};\n"
+                + $"Assert.Equal(0, perStore[\"{other.AppDir}\"]);\n";
+
+            Assert.Equal(
+                /* Except the one a root containing a separator hands to the FIRST arm, which is not
+                   gated and never was. Derived, so the Lite SKU expects nothing and the Darling SKU
+                   expects its test root, without either being written down as a special case. */
+                new[] { other.AppDir, other.TestsDir }
+                    .Where(r => r.Contains('/', StringComparison.Ordinal)),
+                CSharpPaths(prose, other));
+
+            /* The absorption red-proof, and the reason the gate insists the element be the LAST
+               argument. This text carries a lambda, a Path.Combine and the element — everything the
+               gate looks for except the element being the whole path — and the group before it must
+               not absorb `root, d, "Fixtures"` into a match. If it did, every segment composition in
+               the repository would turn its first segment into a whole-tree reference, which is the
+               noisy widening #3076 exists to reject. */
+            var segments =
+                $"var files = new[] {{ \"{other.AppDir}\", \"{other.TestsDir}\" }}\n"
+                + "    .Select(d => Path.Combine(root, d, \"Fixtures\"));\n";
+
+            Assert.Equal(
+                new[] { other.AppDir, other.TestsDir }
+                    .Where(r => r.Contains('/', StringComparison.Ordinal)),
+                CSharpPaths(segments, other));
+
+            /* A collection element merely PREFIXED by a root is not that root, and it is a DIFFERENT
+               tree. Elements are compared for equality rather than by prefix, so neither root can
+               claim these. Written as its own case because equality and a prefix test agree on every
+               element that IS a root — the two only diverge on an element like this one, so a fixture
+               without it leaves the choice between them unpinned. The separator-carrying spelling is
+               still reported by the FIRST arm, which anchors on a root followed by a separator and is
+               right to: Darling/Darling.TestsExtra opens with the Darling root and a separator, so it
+               IS a path under that root, unlike Lite.TestsExtra which is a sibling of one. */
+            var prefixed =
+                $"var files = new[] {{ \"{other.AppDir}Extra\", \"{other.TestsDir}Extra\" }}\n"
+                + "    .Select(d => Path.Combine(root, d));\n";
+
+            Assert.Equal(
+                new[] { other.AppDir + "Extra", other.TestsDir + "Extra" }
+                    .Where(r => r.Contains('/', StringComparison.Ordinal)),
+                CSharpPaths(prefixed, other));
+        }
     }
 
     /// <summary>
@@ -787,14 +981,86 @@ public class CrossAppGuardCiGateTests
         "<HintPath(?:\\s+[\\w:.-]+\\s*=\\s*(?:\"[^\"]*\"|'[^']*'))*\\s*>([^<]*)</HintPath\\s*>",
         RegexOptions.Compiled);
 
-    /// <summary>The paths one C# file's text names that belong to <paramref name="other"/>, in the two
-    /// spellings this repository's pins use, repo-rooted and forward-slashed.
+    /// <summary>A collection literal whose elements are each projected to a WHOLE path below a base,
+    /// rather than to one segment of one:
+    /// <c>new[] { "Lite", "Lite.Tests" }.Select(d =&gt; Path.Combine(root, d))</c>.
+    ///
+    /// <para><b>This is what makes a bare directory name a path, and it is the whole discrimination
+    /// #3076 turns on.</b> <c>"Lite"</c> and <c>"Darling"</c> are quoted bare all over both test
+    /// projects — as tuple labels, as assertion keys, as this class's own root constants — and the
+    /// majority of the ones that touch a path at all are the FIRST SEGMENT of a longer literal
+    /// composition, <c>Path.Combine("Lite", "Services", "X.cs")</c>, which
+    /// <see cref="CSharpPaths"/>' second arm already resolves to the specific file. Reporting
+    /// <c>Lite</c> for one of those would replace a precise reference with a whole tree, which is a
+    /// LOSS of information, not a gain. Here the element is the last argument, so there is no further
+    /// literal segment and the element is the entire path — a bare root in that position names the
+    /// tree.</para>
+    ///
+    /// <para><b>The collection is matched together with the projection, not looked for anywhere in the
+    /// same file.</b> A file-wide gate reads well and self-reports immediately: this class declares
+    /// <c>DarlingAppDir = "Darling"</c> and carries a fixture text containing the projection, so a
+    /// gate satisfied file-wide turned THIS file into a bare-directory read of <c>Darling</c> that the
+    /// <c>lite</c> filter cannot reach — on the arm that deliberately has no exemption list. The bare
+    /// root has to be an ELEMENT of the collection being projected, which is a local fact and cannot
+    /// be manufactured by a fixture one member over. The element is compared for EQUALITY against the
+    /// root rather than searched for as a quoted substring, so the shorter root cannot claim the
+    /// longer one's characters here by any amount of backtracking.</para>
+    ///
+    /// <para>Any method taking the lambda, not <c>.Select</c> specifically: <c>.SelectMany</c> carries
+    /// the same projection, and an enumerated list of LINQ operators is how the next spelling gets
+    /// missed. The base may itself be a call — <c>Path.Combine(RepoRoot(), d)</c> — so one level of
+    /// nesting is allowed inside it, matched as balanced pairs rather than "anything up to the next
+    /// <c>)</c>", which would end the argument list inside the nested call.</para>
+    ///
+    /// <para><b>The element must be the LAST argument.</b>
+    /// <c>Path.Combine(root, d, "Fixtures")</c> is a segment composition wearing a lambda, and the
+    /// group before the element cannot absorb its way into matching one: after consuming
+    /// <c>root, d, "Fixtures"</c> there is no <c>, d)</c> left to match, and every shorter split fails
+    /// the same way. Pinned in <see cref="TheBareDirectoryArm_IsLiveForBothSkus"/>, because a group
+    /// that DID absorb the token under test is exactly how a regex pin passes while blind.</para></summary>
+    private static readonly Regex WholePathPerElement = new(
+        @"(?:new\[\]\s*\{|\[)(?<elements>[^{}\[\]]*)[\}\]]\s*\.\w+\(\s*(?<id>\w+)\s*=>\s*"
+        + @"Path\.Combine\((?:[^()]|\([^()]*\))*,\s*\k<id>\s*\)",
+        RegexOptions.Compiled);
+
+    /// <summary>The paths one C# file's text names that belong to <paramref name="other"/>, in the
+    /// three spellings this repository's pins use, repo-rooted and forward-slashed.
     ///
     /// <para><b>The anchor is every root the SKU owns, which is #3067.</b> Anchored on the app directory
     /// alone, <c>Lite.Tests/X.cs</c> matched neither <c>Lite/</c> nor anything else and left the found
     /// set silently — the failure direction this whole class exists to close. A root still has to be
     /// followed by a SEPARATOR, so a tree merely PREFIXED by a root's name (<c>Lite.TestsExtra/</c>) is
     /// no more a read of that SKU than it was before.</para>
+    ///
+    /// <para><b>A directory named without a separator is still a path, which is #3076.</b>
+    /// <c>ControlPlaneReloadDurabilityTests</c> sweeps <c>new[] { "Lite", "Lite.Tests", … }</c> through
+    /// <c>Path.Combine(root, d)</c> and <c>Directory.EnumerateFiles</c>, so it reads Lite's whole tree
+    /// AND Lite's whole test tree, and neither string carries the separator the first two arms need.
+    /// Accepting a bare root on the strength of the STRING alone is what would make that fix worse than
+    /// the miss. Measured over this tree: the spelling occurs at 37 quoted sites in
+    /// <c>Darling.Tests</c> and 20 in <c>Lite.Tests</c>; all 57 survive an on-disk-existence filter,
+    /// because a root IS a real directory and that filter therefore discriminates nothing here; and 2
+    /// survive being required to be USED as a directory. On the Lite arm the surviving count is zero,
+    /// which is the correct answer — every one of its 20 is a label, an assertion key or one of this
+    /// class's own root constants — and a string-only anchor would instead have manufactured a
+    /// <c>Darling</c> reference that the <c>lite</c> filter cannot reach, on the one arm that
+    /// deliberately has no exemption list to record it in.</para>
+    ///
+    /// <para><b>What this still cannot see, recorded rather than implied.</b> A collection whose
+    /// elements are SEGMENTS of one path rather than whole paths — <c>["Lite", "Controls"]</c>
+    /// recomposed by a helper — names <c>Lite/Controls</c>, and no arm here reaches it;
+    /// <c>ScopedLoadOrderingTests</c> and <c>ViewerScopedPaintGuardTests</c> carry three live
+    /// instances. A collection declared in one member and projected in another is invisible for the
+    /// reason the paragraph above gives, and <c>XamlStaticResourceHygieneTests</c> is that shape — its
+    /// whole-tree read of Lite happens to be reported anyway, because the same reference arrives from
+    /// <c>ControlPlaneReloadDurabilityTests</c>. And <c>Path.Combine(root, "Lite", "Services", "X.cs")</c>,
+    /// with the base as a VARIABLE, is missed by the second arm, which requires the root literal
+    /// first; <c>QueryStoreStatePruneTests</c> and <c>CollectorStateContractTests</c> carry live
+    /// instances of that one. All of them name files under the Lite app tree, which the
+    /// <c>darling</c> filter's derived <c>*.cs</c> entry already reaches, so as with #3063 and #3067
+    /// the gap is in what this guard can SAY, not in what CI runs. Each has its own case, with its own
+    /// text and its own positive control, in
+    /// <see cref="TheCSharpMatchers_StillCannotSeeTheseSpellings"/>.</para>
     ///
     /// <para>Shared by the walk and by the pin that reads it back, for the same reason
     /// <see cref="MsBuildPaths"/> is: a retyped copy in a test is free to agree with itself while the
@@ -822,6 +1088,28 @@ public class CrossAppGuardCiGateTests
                 if (segments.Length > 0)
                 {
                     yield return root + "/" + string.Join("/", segments);
+                }
+            }
+        }
+
+        /* #3076: "Lite" on its own, as an element of a collection projected one element to one whole
+           path. Elements are compared for EQUALITY against each root, so the shorter root cannot claim
+           the longer one's characters — "Lite" is simply not the string "Lite.Tests". A root that
+           CONTAINS a separator (Darling/Darling.Tests) is found by the first arm as well and
+           unconditionally; the duplicate is expected rather than normalised away, so a later change
+           that starts collapsing yields reds and gets read. Note() keys by reference, so a duplicate
+           costs the scan nothing. */
+        foreach (Match m in WholePathPerElement.Matches(text))
+        {
+            var elements = Regex.Matches(m.Groups["elements"].Value, "\"([^\"]+)\"")
+                .Select(s => s.Groups[1].Value)
+                .ToArray();
+
+            foreach (var root in other.Roots)
+            {
+                if (elements.Contains(root, StringComparer.Ordinal))
+                {
+                    yield return root;
                 }
             }
         }

--- a/Lite.Tests/CrossAppGuardCiGateTests.cs
+++ b/Lite.Tests/CrossAppGuardCiGateTests.cs
@@ -364,7 +364,15 @@ public class CrossAppGuardCiGateTests
     [Fact]
     public void TheBareDirectoryArm_IsLiveForBothSkus()
     {
-        foreach (var other in new[] { LiteTrees, DarlingTrees })
+        var skus = new[] { LiteTrees, DarlingTrees };
+
+        /* Every assertion below lives inside a loop, and a loop over nothing satisfies all of them.
+           Floored at the number of SKUs this class gates a suite for, so a third one reds here and
+           gets a case rather than inheriting whichever arm's behaviour it happens to land on — which
+           is the shape of #3067, and the reason both arms are spelled identically to begin with. */
+        Assert.Equal(2, skus.Length);
+
+        foreach (var other in skus)
         {
             /* The live shape: a collection of bare roots, projected one element to one whole path. */
             var swept =


### PR DESCRIPTION
`CrossAppGuardCiGateTests`' C# stage anchored a cross-app path on a root followed by a **separator**, so a read spelled as a bare directory name carried nothing to anchor on and left the found set silently. `Darling/Darling.Tests/ControlPlaneReloadDurabilityTests.cs:346` sweeps `new[] { "Lite", "Lite.Tests", "PerformanceMonitor.Common" }` through `Path.Combine(root, d)` and `Directory.EnumerateFiles(..., AllDirectories)` — a whole-tree read of Lite AND of Lite's test project — and the guard saw neither string. Verified on this branch's `dev` base before editing: still line 346, still that shape.

This is the anchor's *shape*, the third distinct spelling after #3063 (the population) and #3067 (the anchor's breadth). Widening #3067's anchor does not reach it: a `.` is not a separator and neither is end-of-string.

## The measurement

Three numbers, per arm, taken through the shipped matcher and the shipped filter/glob code by reflection rather than a retyped copy.

| | bare quoted root tokens | surviving on-disk existence | surviving used-as-a-directory |
|---|---|---|---|
| `Darling.Tests` (scanning for Lite's roots) | 37 | 37 | **2** |
| `Lite.Tests` (scanning for Darling's roots) | 20 | 20 | **0** |

**The on-disk filter discriminates nothing here, and that is the finding that kills option 2.** A root IS a real top-level directory, so every one of the 57 sites round-trips. `Resolve`'s existence check cannot separate a read from a mention when the string under test is a directory name by construction.

**The `lite` arm is where the naive widening actually fails, not the `darling` arm.** Accepting a bare root on the string alone puts `Darling (directory)` in the Lite arm's found set, probe path `Darling/CoverageProbe.cs`, which no `lite` filter pattern reaches — the three `Darling/**` entries are `PerformanceMonitor.Darling.Viewer/**`, `Darling.Tests/**` and `PerformanceMonitor.Darling.Service/**`, none of which covers a file directly under `Darling/`. And the Lite arm carries `backstopped: null` deliberately, so there is nowhere to record it. Measured, not argued — the mutation is reproducible (M2 below) and prints:

```
Lite.Tests reads Darling (directory) (named in Lite.Tests/AlertReadFailureSurfaceTests.cs,
Lite.Tests/AlertSettingsControlWiringTests.cs, Lite.Tests/CollectionOutputBesideCostTests.cs,
Lite.Tests/CrossAppGuardCiGateTests.cs, Lite.Tests/LiteOverviewCardExplainsItselfTests.cs,
Lite.Tests/MainWindowAccessKeyTests.cs, Lite.Tests/McpAlertSettingsKeyTests.cs,
Lite.Tests/ParitySource.cs, Lite.Tests/QueryStoreSliceTieBreakSourceTests.cs,
Lite.Tests/ThemeParityLiteDarlingTests.cs, Lite.Tests/WatermarkPolicyTests.cs,
Lite.Tests/WindowWorkAreaTests.cs) but the 'lite' filter does not reach it
```

Twelve origin files, one of them this class's own `private const string DarlingAppDir = "Darling";`. There is no honest remedy: `Darling/**` in the `lite` filter would make every Darling change build and publish Lite, and an exemption on that arm does not exist.

## The shape chosen, and why the others lose on that evidence

**Accepted: a bare root that is an ELEMENT of a collection projected one element to one whole path** — `new[] { "Lite", … }.Select(d => Path.Combine(root, d))`. The element is the *last* `Path.Combine` argument, so there is no further literal segment and the element is the entire path below the base.

Losers, each on a measured number:

- **String alone / on-disk round-trip (issue options 2 and the naive widening).** 37 and 20 sites, `Darling` unreachable on the arm with no exemption list. The issue speculated the noise "might be zero"; it is not, and the reason is that `Resolve`'s filter is blind to this input class.
- **Statement-window "touches a directory API"** (the issue's option 1, read literally). Cuts 37 → 27 and 20 → 15 — and the survivors are dominated by `Path.Combine("Lite", "Services", "X.cs")`, where the bare token is the FIRST SEGMENT of a longer literal path that the second arm already resolves to the specific file. Reporting `Lite` for one of those replaces a precise reference with a whole tree: a loss of information, not a gain. It also still emits `Darling` on the Lite arm, so it buys nothing where it matters.
- **File-scoped gate** (the projection anywhere in the same file). This is what I wrote first, and it self-reports immediately: this class declares `DarlingAppDir = "Darling"` and now carries a fixture text containing a projection, so a file-wide gate turned *this file* into an unreachable bare-directory read of `Darling`. Recorded in the `WholePathPerElement` doc comment, because it reads well and is wrong.
- **Requiring the read be spelled with a separator** (option 3). A convention nothing enforces.
- **Leaving it to the backstop** (option 4). The issue's own dead end: an exemption list can only record references the detector produces.

The accepted shape gives 2 surviving sites, both on `ControlPlaneReloadDurabilityTests.cs:346`, and 2 new references — `Lite` and `Lite.Tests`. Reference-level precision is exact: `{Lite, Lite.Tests}` where the reads are, `{}` where they are not. The gate is local, so a fixture one member over cannot manufacture a reference. Incidental confirmation: this PR's own doc comments added two more bare `"Darling"` prose mentions to `Lite.Tests` (20 → 22 tokens) and the gate rejected both.

## Symmetry

The arm iterates `other.Roots` and compares elements for equality — there is no arm-specific branch, and the Lite arm's zero is the *correct* answer rather than an inert code path. The issue asked whether `Lite.Tests` has a bare-directory read of a Darling root today: **it does not**, checked rather than assumed, and the two candidates that come closest are prose (`ParitySource.RepoRoot` probes `Directory.Exists(Path.Combine(dir.FullName, "Darling"))` as a repo-root signature, and this class's own root constants).

Because the live tree cannot floor the Lite arm, `TheBareDirectoryArm_IsLiveForBothSkus` floors it instead: one loop over both `SkuTrees`, fixture text **derived from each SKU's own tree names**, so neither SKU is a special case and the Darling side — whose test root contains a separator and is therefore already visible to the first arm — cannot pass by an implementation that quietly skipped separator-carrying roots. Expectations are taken off the named `AppDir`/`TestsDir` members while the matcher anchors on `Roots`, so a root dropped from `Roots` reds rather than vanishing from both sides of a self-derived comparison.

## Coverage

`Lite.Tests (directory)` joins `DarlingTestsBackstopped`, on the bound the four existing entries rest on and gated by the same `WholeTreeBackstopIsIntact` predicate. `Lite (directory)`, the companion reference from the same sweep, needs no exemption — the `darling` filter's derived `Lite/**/*.cs` entry reaches it. Nothing in `build.yml` changes.

That entry doubles as the live-tree floor for the new arm: the set is compared for **equality** in both directions, so if the arm ever stops finding `Lite.Tests`, the exemption goes stale and fails (M1/M3 below).

## Spellings that remain unfound, and where that is recorded

`TheCSharpMatchers_StillCannotSeeTheseSpellings` — one text per spelling, expected answer **empty**, so a widening that starts firing on one shows as a value appearing where none belongs. Each carries a **positive control** through the same matcher (the same read spelled with a separator, which must be found), because emptiness is the success condition and a dead matcher is the other thing that produces it.

1. **A collection of SEGMENTS recomposed by a helper** — `["Lite", "Controls"]`. Real read is `Lite/Controls`. Live: `ScopedLoadOrderingTests` (`s_finOps`, `s_liteWindows`), `ViewerScopedPaintGuardTests`.
2. **A collection declared in one member, projected in another** — `XamlStaticResourceHygieneTests` is this shape. Its whole-tree read of Lite is reported anyway because `ControlPlaneReloadDurabilityTests` produces the same reference, which is luck, not coverage.
3. **`Path.Combine(root, "Lite", "Services", "X.cs")` with the base in a VARIABLE** — the second arm requires the root literal first. Live: `QueryStoreStatePruneTests`, `CollectorStateContractTests`.

All three name files under the Lite app tree, which `darling`'s derived `*.cs` entry reaches, so the suites run — as with #3063 and #3067 the gap is in what the guard can *say*.

`TheCSharpMatchers_SeeASiblingTestProject_AndNothingMerelyPrefixedByIt`'s `bareDirectory` case moves from absent-by-design to **found**, spelled exactly as the live instance spells it, and the set is asserted by equality.

## Red-proof evidence

Every mutation was applied to a **committed** tree and restored with `git checkout --`, verified by grepping for the patched symbol (not the diffstat). Build success is asserted as a step distinct from running: the harness deletes the dll, checks the build's exit code, re-checks the dll exists, and reports its mtime — which advanced on every run below. Each mutation carries a `MUTATION_*` marker so it is observable in the source it patched.

| | mutation | pins that went red | the assertion that failed |
|---|---|---|---|
| M1 | arm 3 made dead (gate replaced with a never-matching pattern) | 3 | `still exempts Lite.Tests (directory), but Darling/Darling.Tests no longer has a read of it`; `Expected: ["Lite", "Lite.Tests"] Actual: []`; fixture set lost `"Lite.Tests"`, `"Lite"` |
| M2 | gate removed — bare root on the string alone | 2 | the 12-origin `reads Darling (directory)` failure quoted above; `prose` case `Expected: [] Actual: ["Lite.Tests", "Lite"]` |
| M3 | arm 3 restricted to `AppDir` only (#3067's shape, one arm over) | 3 | stale-exemption failure; `Expected: ["Lite", "Lite.Tests"] Actual: ["Lite"]`; fixture `differs at index 4` |
| M4 | arm 3 restricted to `TestsDir` only (M3's mirror) | 2 | `Expected: "Lite" Actual: "Lite.Tests"`; fixture lost `"Lite"` |
| M5 | element no longer required to be the LAST `Path.Combine` argument | 1 | `segments` case `Expected: [] Actual: ["Lite.Tests", "Lite"]` — the greedy group absorbing the token under test |
| M6 | element matched by PREFIX instead of equality | 1 | `prefixed` case `Expected: [] Actual: ["Lite.Tests", "Lite"]` |
| M7 | the `Lite.Tests (directory)` exemption removed | 1 | both directions at once: `reads Lite.Tests (directory) … but the 'darling' filter does not reach it` *and* the stale-key failure |
| M8 | the two-SKU loop emptied | 1 | `Expected: 2 Actual: 0` — the loop floor |

Every assertion in `TheBareDirectoryArm_IsLiveForBothSkus` lives inside the two-SKU loop, and a loop over nothing satisfies all of them — so the SKU count is floored at 2, which also means a third SKU reds and gets a case of its own rather than inheriting whichever arm it lands on. M8 is that floor's own red-proof.

**M6 did not red on the first attempt** and the pin was fixed rather than the finding dropped. Equality and a prefix test agree on every element that *is* a root; they diverge only on an element like `Lite.TestsExtra`, which no fixture had. The `prefixed` case in `TheBareDirectoryArm_IsLiveForBothSkus` exists because of that, and M6 reds against it.

M2 also revealed that the three limitation cases were unobservable where I first put them — inside the fixture whose expected set already contains both roots, where arm 3 yields a root at most once per collection, so an extra accepting site could not change the answer. They were moved to their own texts with empty expectations, which is why `TheCSharpMatchers_StillCannotSeeTheseSpellings` exists as a separate pin.

## How it was run

`Lite.Tests` is `net10.0-windows` with `UseWPF` and cannot run on macOS, so the **actual** `CrossAppGuardCiGateTests.cs` was compiled into a throwaway `net10.0` xunit v3 console harness staged in the gitignored `Lite.Tests/bin/`, with the `.csproj` passed explicitly. `RepoRoot()` resolves via `[CallerFilePath]`, so no symlinks were needed. The harness is red-proofed for reading the edited file: M1's failure quotes strings that exist only in the edit, and every stack frame names `.../wt-3076/Lite.Tests/CrossAppGuardCiGateTests.cs`.

Final: **12 tests, `Failed: 0`, `Not Run: 0`, `Skipped: 0`, absent from any SKIP list** — 10 on the `dev` base plus the two new pins, and this class has no `[Theory]`, so `[Fact]` count and test count are the same number. A second harness compiling the Darling-side guards that sweep `Lite.Tests` as source — `CommentFilterAdoptionTests` and `DocCommentHygieneTests` with `CSharpSourceWalker` — reports **42 tests, `Failed: 0`, `Not Run: 0`**, and was itself red-proofed by injecting an unclosed `<summary>` into the edited file (it failed naming `Lite.Tests/CrossAppGuardCiGateTests.cs:274`). The real `Lite.Tests.csproj` builds with `-p:EnableWindowsTargeting=true`: 0 errors, 9 pre-existing warnings, none in this file.

Fixes #3076
