### PR TITLE
Fixes #3083

### DIFF
--- a/Darling/Darling.Tests/CommentFilterAdoptionTests.cs
+++ b/Darling/Darling.Tests/CommentFilterAdoptionTests.cs
@@ -105,7 +105,10 @@ public sealed class CommentFilterAdoptionTests
 
         ["Darling.Tests/DocCommentHygieneTests.cs"] =
             "COLLECTS a doc run. DocRuns groups contiguous /// lines into the run that documents one member, "
-            + "which is the subject of the whole class rather than an approximation of it.",
+            + "and DocCommentBlocks groups the strictly contiguous ones into the one XML fragment a cref is "
+            + "parsed out of (#3083). Both are the subject of that class rather than an approximation of "
+            + "comment-stripping - and its cref rule DOES ask for the walker, for the identifier universe it "
+            + "resolves targets against.",
 
         ["Darling.Tests/RefreshCeilingProvenancePinTests.cs"] =
             "COLLECTS a doc run. DocProseFor walks the contiguous /// run above a named declaration and "

--- a/Darling/Darling.Tests/DocCommentHygieneTests.cs
+++ b/Darling/Darling.Tests/DocCommentHygieneTests.cs
@@ -900,8 +900,7 @@ public sealed class DocCommentHygieneTests
         var onDisk = Directory.EnumerateFiles(root, "*.csproj", SearchOption.AllDirectories)
             .Select(p => Path.GetRelativePath(root, p).Replace('\\', '/'))
             .Where(p => !HasBuildOutputSegment(p))
-            .Where(p => p.Contains('/', StringComparison.Ordinal))
-            .Select(p => p[..p.LastIndexOf('/')])
+            .Select(DirectoryOf)
             .Distinct(StringComparer.Ordinal)
             .ToHashSet(StringComparer.Ordinal);
 
@@ -934,11 +933,13 @@ public sealed class DocCommentHygieneTests
 
         foreach (var project in projects)
         {
+            /* TopDirectoryOnly for the root project, because IsUnder gives it only the files sitting
+               directly there — every deeper file belongs to some other project or to none. */
             var onDisk = Directory
                 .EnumerateFiles(
                     Path.Combine(root, project.Replace('/', Path.DirectorySeparatorChar)),
                     "*.cs",
-                    SearchOption.AllDirectories)
+                    project.Length == 0 ? SearchOption.TopDirectoryOnly : SearchOption.AllDirectories)
                 .Count(f => !HasBuildOutputSegment(Path.GetRelativePath(root, f)));
 
             census.ByProject.TryGetValue(project, out var counts);
@@ -986,6 +987,51 @@ public sealed class DocCommentHygieneTests
         {
             Assert.NotEmpty(CrefSegments(degenerate));
         }
+    }
+
+    /// <summary>
+    /// A project at the repository ROOT is a project directory like any other: it is derived, it is
+    /// floored, and its files are attributed to it.
+    ///
+    /// <para><b>Driven on an arranged population because the tree has no such project.</b> The review on
+    /// #3086 found that a separator-less path was filtered out of BOTH sides of
+    /// <see cref="TheDerivedProjectListCoversEveryProjectInTheTree"/>'s difference, which made that check
+    /// structurally unable to report the one thing it exists to report. Waiting for a root-level
+    /// <c>.csproj</c> to appear before exercising the path is the shape #3079 rejected three times: a case
+    /// nothing drives is a case nobody knows is broken.</para>
+    /// </summary>
+    [Fact]
+    public void TheRootIsAProjectDirectoryLikeAnyOther()
+    {
+        Assert.Equal(string.Empty, DirectoryOf("RootProject.csproj"));
+        Assert.Equal("Nested", DirectoryOf("Nested/Project.csproj"));
+        Assert.Equal("A/B", DirectoryOf("A/B/Project.csproj"));
+
+        /* A file at the root belongs to the root project and to nothing deeper; a file one level down does
+           not belong to the root. Both directions, because getting either wrong silently moves files
+           between projects and the per-project floors would then be counting the wrong tree. */
+        Assert.True(IsUnder("RootFile.cs", string.Empty));
+        Assert.False(IsUnder("Nested/File.cs", string.Empty));
+        Assert.True(IsUnder("Nested/File.cs", "Nested"));
+        Assert.False(IsUnder("RootFile.cs", "Nested"));
+        /* A separator is still required, so a tree merely PREFIXED by a project's name is not that
+           project — the #3067 property, restated here because IsUnder is where it now lives. */
+        Assert.False(IsUnder("NestedExtra/File.cs", "Nested"));
+
+        /* And through the census: the root project is populated, floored and counted. A deeper project in
+           the same population is the negative control, so "everything lands in the root" cannot pass. */
+        var census = BuildCrefCensus(
+            new[]
+            {
+                ("RootFile.cs", "/// <summary><see cref=\"Marker\"/></summary>\nclass Marker { }"),
+                ("Nested/File.cs", "/// <summary><see cref=\"Marker\"/></summary>\nclass Marker { }"),
+            },
+            new[] { string.Empty, "Nested" });
+
+        AssertCrefPopulationFloors(census, new[] { string.Empty, "Nested" }, Array.Empty<string>());
+
+        Assert.Equal((1, 1, 1), census.ByProject[string.Empty]);
+        Assert.Equal((1, 1, 1), census.ByProject["Nested"]);
     }
 
     /// <summary>
@@ -1593,8 +1639,7 @@ public sealed class DocCommentHygieneTests
 
         foreach (var (path, text) in sources)
         {
-            var project = byLength.FirstOrDefault(
-                p => path.StartsWith(p + "/", StringComparison.Ordinal));
+            var project = byLength.FirstOrDefault(p => IsUnder(path, p));
 
             void Add(int files, int blocks, int crefs)
             {
@@ -1810,17 +1855,51 @@ public sealed class DocCommentHygieneTests
     }
 
     /// <summary>
+    /// The directory part of a repo-relative forward-slashed path, with the repository ROOT spelled as the
+    /// empty string.
+    ///
+    /// <para><b>Why the root is a value and not a filtered-out case, which is the review finding on
+    /// #3086.</b> The obvious guard against <c>LastIndexOf('/')</c> returning -1 is to drop
+    /// separator-less paths — and dropping them is what makes the check below structurally unable to see
+    /// them. <see cref="TheDerivedProjectListCoversEveryProjectInTheTree"/> compares the solution's
+    /// project directories against the ones on disk, and the SAME filter gated both sides: a
+    /// <c>.csproj</c> at the repository root was excluded from both, so the difference was empty for it by
+    /// construction and it would never have been given a per-project floor. A guard blind to exactly the
+    /// case its own prose warns about is worse than one that never claimed the coverage. There is no such
+    /// project today, which is why <see cref="TheRootIsAProjectDirectoryLikeAnyOther"/> drives it on an
+    /// arranged population instead of waiting for one.</para>
+    /// </summary>
+    private static string DirectoryOf(string relativePath)
+    {
+        var separator = relativePath.LastIndexOf('/');
+
+        return separator < 0 ? string.Empty : relativePath[..separator];
+    }
+
+    /// <summary>
+    /// Whether <paramref name="relativePath"/> is a file of the project rooted at
+    /// <paramref name="directory"/> — where the empty directory means the repository root, and a file is
+    /// only ITS file when it sits directly there.
+    ///
+    /// <para>Shared by the attribution in <see cref="BuildCrefCensus"/> and by the counts read back
+    /// against it, so the two cannot come to disagree about which project a file belongs to.</para>
+    /// </summary>
+    private static bool IsUnder(string relativePath, string directory) =>
+        directory.Length == 0
+            ? !relativePath.Contains('/', StringComparison.Ordinal)
+            : relativePath.StartsWith(directory + "/", StringComparison.Ordinal);
+
+    /// <summary>
     /// Every project directory the solution builds, repo-relative and forward-slashed, derived from
-    /// <c>PerformanceMonitor.sln</c> rather than written down.
+    /// <c>PerformanceMonitor.sln</c> rather than written down. A project at the repository root comes back
+    /// as the empty string rather than being dropped — see <see cref="DirectoryOf"/>.
     /// </summary>
     private static IReadOnlyList<string> SolutionProjectDirectories(string root)
     {
         var solution = File.ReadAllText(Path.Combine(root, "PerformanceMonitor.sln"));
 
         var directories = Regex.Matches(solution, "\"([^\"]+\\.csproj)\"")
-            .Select(m => m.Groups[1].Value.Replace('\\', '/'))
-            .Where(p => p.Contains('/', StringComparison.Ordinal))
-            .Select(p => p[..p.LastIndexOf('/')])
+            .Select(m => DirectoryOf(m.Groups[1].Value.Replace('\\', '/')))
             .Distinct(StringComparer.Ordinal)
             .OrderBy(p => p, StringComparer.Ordinal)
             .ToArray();

--- a/Darling/Darling.Tests/DocCommentHygieneTests.cs
+++ b/Darling/Darling.Tests/DocCommentHygieneTests.cs
@@ -685,20 +685,20 @@ public sealed class DocCommentHygieneTests
     /// stopped being true, and #3079 found three such cases were not even reachable where they were first
     /// written.</para>
     /// </summary>
-    private static readonly (string Target, string Limit)[] CrefShapesTheResolverAccepts =
+    private static readonly (string Target, bool Resolves, string Limit)[] CrefShapesTheResolverAccepts =
     {
-        ("CollectorCatalog.AppliesTo(NoSuchTypeAnywhere)",
+        ("CollectorCatalog.AppliesTo(NoSuchTypeAnywhere)", true,
             "PARAMETER LISTS are discarded at the first '(', so overload identity is never checked and a "
             + "parameter type that does not exist cannot be seen."),
 
-        ("ICollectorDefinition{NoSuchTypeAnywhere}",
+        ("ICollectorDefinition{NoSuchTypeAnywhere}", true,
             "GENERIC ARGUMENTS are discarded with the braces, so neither arity nor the arguments themselves "
             + "are checked."),
 
-        ("CollectorCatalog.NoSuchMemberButAppliesTo",
-            "NOTHING is checked about a name's position: this segment is not a member of CollectorCatalog "
-            + "and does not resolve — included as the negative control for the entry below, so the two "
-            + "cannot be read as the same claim."),
+        ("CollectorCatalog.NoSuchMemberButAppliesTo", false,
+            "THE NEGATIVE CONTROL, and it is a row rather than a comment so that a resolver which said yes "
+            + "to everything could not satisfy the two rows above. Nothing here checks a name's POSITION "
+            + "either, but this segment is spelled nowhere, so it does not resolve."),
     };
 
     /// <summary>
@@ -860,6 +860,7 @@ public sealed class DocCommentHygieneTests
         var onDisk = Directory.EnumerateFiles(root, "*.csproj", SearchOption.AllDirectories)
             .Select(p => Path.GetRelativePath(root, p).Replace('\\', '/'))
             .Where(p => !HasBuildOutputSegment(p))
+            .Where(p => p.Contains('/', StringComparison.Ordinal))
             .Select(p => p[..p.LastIndexOf('/')])
             .Distinct(StringComparer.Ordinal)
             .ToHashSet(StringComparer.Ordinal);
@@ -1385,8 +1386,9 @@ public sealed class DocCommentHygieneTests
                 $"the bound for '{target}' opens with no recognised kind: "
                 + $"\"{bound[..Math.Min(60, bound.Length)]}…\". Every entry has to name its kind, because "
                 + "two of the three are defects awaiting repair and the third is this resolver's own "
-                + "boundary, and nothing else distinguishes them. Add the kind to CrefBoundKinds if it is "
-                + "genuinely new.");
+                + "boundary, and nothing else distinguishes them. The kinds are:\n"
+                + string.Join("\n", CrefBoundKinds.Select(k => $"  {k.Label} — {k.Meaning}"))
+                + "\n\nAdd a kind to CrefBoundKinds if this one is genuinely new.");
 
             Assert.True(
                 string.Equals(label, "MARKER", StringComparison.Ordinal)
@@ -1396,6 +1398,7 @@ public sealed class DocCommentHygieneTests
                 + "label is decidable from the target, so a hand label that disagrees with it is wrong.");
         }
 
+        Assert.All(CrefCarryingElements.Values, bound => Assert.NotEmpty(bound));
         Assert.All(SolutionProjectsWithoutCrefs.Values, bound => Assert.NotEmpty(bound));
         Assert.All(ProjectDirectoriesOutsideTheSolution.Values, bound => Assert.NotEmpty(bound));
     }
@@ -1417,10 +1420,8 @@ public sealed class DocCommentHygieneTests
 
         /* The accepted shapes. The third row is a negative control, so "everything resolves" cannot pass
            this. */
-        foreach (var (target, limit) in CrefShapesTheResolverAccepts)
+        foreach (var (target, expected, limit) in CrefShapesTheResolverAccepts)
         {
-            var expected = !limit.StartsWith("NOTHING", StringComparison.Ordinal);
-
             Assert.True(
                 CrefResolves(target, census.CodeIdentifiers) == expected,
                 $"'{target}' should{(expected ? " " : " NOT ")}resolve; its recorded limit says "

--- a/Darling/Darling.Tests/DocCommentHygieneTests.cs
+++ b/Darling/Darling.Tests/DocCommentHygieneTests.cs
@@ -709,7 +709,7 @@ public sealed class DocCommentHygieneTests
     /// <para>Measured on this branch's base with <c>GenerateDocumentationFile</c> switched on from the
     /// command line — no project file was changed, and none is changed by this PR: the flag remains the
     /// parked decision from #3025. That run reports 71 <c>CS1574</c> occurrences on 70 lines. This resolver
-    /// sees 7 of those lines. The three rows below are the three reasons for the other 63, and together they
+    /// sees 7 of those lines. The rows below are the reasons for the other 63, and together they
     /// are why this guard is complementary to that flag rather than a substitute for it — while the 12
     /// <c>MARKER</c> targets above are the traffic in the other direction, which the flag would never
     /// report.</para>
@@ -727,6 +727,15 @@ public sealed class DocCommentHygieneTests
             "USINGS. Namespace imports are ignored here. PgMigrations.cs carries no using for the "
             + "collectors' namespace, so this name is out of scope for the compiler even though the "
             + "project references the assembly that declares it."),
+
+        ("Darling/PerformanceMonitor.Darling.Viewer",
+            "PerformanceMonitorLite.Analysis.Recommendations.LiteRecommendationItem",
+            "ASSEMBLIES. Resolution is repository-wide and knows nothing about assembly boundaries. This "
+            + "target is a Lite type, cref'd from the Darling viewer, which does not reference the Lite "
+            + "assembly — its own doc comment says so in the next sentence. The compiler cannot resolve it "
+            + "and never will; this resolver does, because a name spelled in Lite's tree is a name spelled "
+            + "in the repository. That is the same property that lets one guard cover both SKUs, so it is "
+            + "the boundary and the design at once rather than a defect to be repaired."),
 
         ("Darling/Darling.Tests", "Write(char)",
             "OVERLOADS. The parameter list is discarded, and the name alone is spelled all over the tree. "

--- a/Darling/Darling.Tests/DocCommentHygieneTests.cs
+++ b/Darling/Darling.Tests/DocCommentHygieneTests.cs
@@ -410,10 +410,12 @@ public sealed class DocCommentHygieneTests
     /// census over both.
     ///
     /// <para><b>Why cached.</b> A scan reads and comment-strips every <c>.cs</c> file in the repository,
-    /// and eleven members here plus one nineteen-row <c>[Theory]</c> need the same answer — thirty walks of
-    /// the same unchanged tree per run, which is most of this class's cost, and the review bot on #3086
-    /// counted them before anyone timed them. The result is a pure function of on-disk state and nothing in
-    /// a test run changes that state. Measured on the local harness: 34s to 3.5s.</para>
+    /// and every real-tree pin here needs the same answer, one of them once per row of a
+    /// <c>[Theory]</c> — dozens of walks of the same unchanged tree per run, which was most of this class's
+    /// cost. Deliberately not stated as a count: it is a number nothing derives, and this class already
+    /// carries one sentence rewritten for going stale by exactly that. The result is a pure function of
+    /// on-disk state and nothing in a test run changes that state. Measured on the local harness, same
+    /// suite either way: 34.2s to 3.4s.</para>
     ///
     /// <para><b>What deliberately does NOT come through here.</b> Every pin that drives the sweep with an
     /// ARRANGED population calls <see cref="BuildCrefCensus"/> directly, because a census built from a

--- a/Darling/Darling.Tests/DocCommentHygieneTests.cs
+++ b/Darling/Darling.Tests/DocCommentHygieneTests.cs
@@ -1080,6 +1080,14 @@ public sealed class DocCommentHygieneTests
                 .SelectMany(b => CrefReference.Matches(string.Join("\n", b.Select(l => l.Text))))
                 .Select(m => m.Groups["target"].Value)
                 .ToArray());
+
+        /* And through the census, which is the part that ships. A blanking helper the sweep does not call
+           is the shape DocCommentHygieneTests already warns about one rule up: a predicate nothing calls
+           leaves the rule reading everything, and this pin would pass either way. */
+        Assert.Equal(
+            new[] { "RealReference" },
+            BuildCrefCensus(new[] { ("AppOne/File.cs", fixture) }, new[] { "AppOne" })
+                .Sites.Select(s => s.Target).ToArray());
     }
 
     /// <summary>

--- a/Darling/Darling.Tests/DocCommentHygieneTests.cs
+++ b/Darling/Darling.Tests/DocCommentHygieneTests.cs
@@ -735,11 +735,13 @@ public sealed class DocCommentHygieneTests
     ///
     /// <para>Measured on this branch's base with <c>GenerateDocumentationFile</c> switched on from the
     /// command line — no project file was changed, and none is changed by this PR: the flag remains the
-    /// parked decision from #3025. That run reports 71 <c>CS1574</c> occurrences on 70 lines. This resolver
-    /// sees 7 of those lines. The rows below are the reasons for the other 63, and together they
-    /// are why this guard is complementary to that flag rather than a substitute for it — while the 12
-    /// <c>MARKER</c> targets above are the traffic in the other direction, which the flag would never
-    /// report.</para>
+    /// parked decision from #3025. That run reports 71 <c>CS1574</c> occurrences on 70 lines, and this
+    /// resolver's unresolved set meets that set on 8 of them — 7 for the same reason, plus
+    /// <c>JsonEncodedText.Encode(string)</c>, where the two mechanisms happen to reject the same line for
+    /// unrelated reasons and which is labelled accordingly. The rows below are the reasons for the other
+    /// 62, and together they are why this guard is complementary to that flag rather than a substitute for
+    /// it — while the 12 <c>MARKER</c> targets above are the traffic in the other direction, which the flag
+    /// would never report.</para>
     /// </summary>
     private static readonly (string Project, string Target, string Reason)[]
         LiveSitesOutsideTheResolversReach =
@@ -797,7 +799,7 @@ public sealed class DocCommentHygieneTests
     /// declarations misses the ones this codebase actually writes — a tuple-returning static, a property
     /// whose type is a nested generic — and every miss is a spurious offender in a set compared for
     /// equality. Measured before choosing: a declaration index reported 385 unresolvable targets against
-    /// this one's 31, and the extra 354 were dominated by real members it had failed to parse. An index that
+    /// this one's 31, and the difference was dominated by real members it had failed to parse. An index that
     /// is too WIDE loses recall, which the recorded limits above state; one that is too NARROW manufactures
     /// offenders, and a guard that cries wolf gets its allow-list widened until it says nothing.</para>
     /// </summary>
@@ -1197,6 +1199,20 @@ public sealed class DocCommentHygieneTests
             new[] { "RealReference" },
             BuildCrefCensus(new[] { ("AppOne/File.cs", fixture) }, new[] { "AppOne" })
                 .Sites.Select(s => s.Target).ToArray());
+
+        /* And on real input, because a blanking step that has nothing to blank is a step nobody would
+           notice the loss of. Derived rather than stated as a count: what matters is that the tree holds
+           at least one such line, not how many. */
+        var blanked = RepoSources(RepositoryScan.Value.Root).Sum(s =>
+            s.Text.Split('\n').Count(l => l.TrimStart().StartsWith("///", StringComparison.Ordinal))
+            - WithStringLiteralsBlanked(s.Text).Split('\n')
+                .Count(l => l.TrimStart().StartsWith("///", StringComparison.Ordinal)));
+
+        Assert.True(blanked > 0,
+            "no /// line anywhere in the repository sits inside a string literal, so the blanking step is "
+            + "inert on real input and only the fixture above says it works. The fixtures in this very "
+            + "file were the only such lines when this landed, so a red here most likely means one of them "
+            + "was reformatted.");
     }
 
     /// <summary>
@@ -1640,11 +1656,11 @@ public sealed class DocCommentHygieneTests
     /// version of the cref rule duly read the crefs out of its own test data and reported them as
     /// offenders in the tree.</para>
     ///
-    /// <para><b>Where it is exercised, measured rather than assumed.</b> Nine <c>///</c> lines in the
-    /// whole repository sit inside a string literal and every one of them is in THIS file — the fixtures
-    /// below are the only live instance, and there were none before them. So the blanking is exercised
-    /// where the guard can see it rather than somewhere it might be, which is the direction #3079 asked
-    /// for; the arithmetic is a count the sweep produces, not a number written down here.</para>
+    /// <para><b>Where it is exercised.</b> Every <c>///</c> line in this repository that sits inside a
+    /// string literal is in THIS file: the fixtures below are the only live instance, and there were none
+    /// before them. That the tree holds at least one is asserted rather than stated, in
+    /// <see cref="ADocCommentInsideAStringLiteralIsNotPartOfThePopulation"/>, which is the difference
+    /// #3079 asked for between a limitation recorded and a limitation exercised.</para>
     /// </summary>
     private static string WithStringLiteralsBlanked(string text)
     {

--- a/Darling/Darling.Tests/DocCommentHygieneTests.cs
+++ b/Darling/Darling.Tests/DocCommentHygieneTests.cs
@@ -16,8 +16,11 @@ using Xunit;
 namespace Darling.Tests;
 
 /// <summary>
-/// Repo-wide documentation hygiene (#1745). One rule today: no member carries two stacked
-/// <c>&lt;summary&gt;</c> blocks.
+/// Repo-wide documentation hygiene (#1745). The rules, each with its own section below: no member
+/// carries two stacked <c>&lt;summary&gt;</c> blocks, every doc run closes the
+/// <c>&lt;summary&gt;</c> elements it opens, and every cref names something this repository's code
+/// spells. Listed rather than counted, so the sentence cannot go stale by one the way it had before a
+/// third rule arrived (#3069's criterion, applied to this class's own prose).
 ///
 /// <para><b>Why this needs a test rather than a review.</b> XML documentation takes the LAST summary, so
 /// IntelliSense, generated docs and every analyzer render the correct text. The build is clean, nothing
@@ -64,10 +67,14 @@ namespace Darling.Tests;
 /// per-FILE tag count cannot — an unclosed run and an unopened one in the same file, whose counts
 /// cancel.</para>
 ///
-/// <para><b>Coverage limit, stated rather than assumed.</b> CI path filters are per-project, so this runs on
-/// any pull request that trips the <c>darling</c> or <c>core</c> filter, and on every nightly and release
-/// build — but a change touching ONLY Lite or Installer will not run it, and would be caught on the next
-/// nightly instead. It lives here because the repo's other source-parsing pins do
+/// <para><b>Coverage, stated rather than assumed.</b> CI path filters are per-project, so the build job
+/// runs this suite on any pull request that trips the <c>darling</c> or <c>core</c> filter — and where
+/// none of them fires, <c>build.yml</c>'s <c>darling-tree-guards</c> job runs the WHOLE suite instead,
+/// gated on the build job's step reporting <c>skipped</c>. So a change touching only Lite or only
+/// Installer does run these rules, in that job rather than in the build one; that backstop is the bound
+/// the cref rule's repository-wide sweep rests on, and it is the same bound
+/// <c>CrossAppGuardCiGateTests</c>' exemptions rest on. It lives here because the repo's other
+/// source-parsing pins do
 /// (<c>HostHeaderGuardTests</c>, <c>DarlingStoreUpgradeTests</c>), which is where someone looks for this
 /// kind of guard.</para>
 /// </summary>
@@ -371,6 +378,1289 @@ public sealed class DocCommentHygieneTests
         finally
         {
             root.Delete(recursive: true);
+        }
+    }
+
+    /* ───────────────── crefs: the mechanically checkable part of a doc comment (#3083) ───────────────── */
+
+    /// <summary>
+    /// One cref attribute value, verbatim, with the doc element that carried it and where it was read
+    /// from. The target is stored UNMODIFIED — every reduction the resolver performs happens in
+    /// <see cref="CrefSegments"/>, on a copy, so a malformed target is still reportable in the shape it was
+    /// written in.
+    /// </summary>
+    private readonly record struct CrefSite(string Path, int Line, string Element, string Target);
+
+    /// <summary>
+    /// What one scan produced: the population it read (per solution project, so a scan that lost a project
+    /// is distinguishable from one that read it and found nothing), every cref in it, and the identifier
+    /// universe those crefs resolve against.
+    ///
+    /// <para>Carried as one value rather than returned piecemeal so a caller cannot check the offenders and
+    /// skip the floors — the failure direction here is silent non-detection, and a scan that read nothing
+    /// reports zero offenders.</para>
+    /// </summary>
+    private sealed record CrefCensus(
+        IReadOnlyDictionary<string, (int Files, int DocBlocks, int Crefs)> ByProject,
+        IReadOnlyList<CrefSite> Sites,
+        IReadOnlySet<string> CodeIdentifiers);
+
+    /// <summary>
+    /// One cref, anchored on the ELEMENT that carries it rather than on the attribute alone.
+    ///
+    /// <para><b>Why the element, which cost a round to learn.</b> A cref is only a reference when it is an
+    /// attribute of a doc element. The attribute spelling occurs in prose too — this class discusses it,
+    /// and <c>ViewerTimeHelper</c> shows an ESCAPED example inside <c>&lt;c&gt;</c> — and an
+    /// attribute-only pattern reads all of those as references. That direction is loud rather than silent,
+    /// but it is loud in a file whose whole job is to talk about crefs, and the first version of this
+    /// extractor duly reported two offenders it had written itself. Anchoring on <c>&lt;element …</c>
+    /// excludes prose by construction, because <c>[^>]*?</c> cannot cross the <c>&gt;</c> that closes the
+    /// <c>&lt;c&gt;</c> tag, and an escaped <c>&amp;lt;see</c> has no <c>&lt;</c> to anchor on at all.</para>
+    ///
+    /// <para><b>The element name is CAPTURED, not enumerated.</b> An alternation of the element names
+    /// known today would silently miss a cref on <c>&lt;seealso&gt;</c> or <c>&lt;permission&gt;</c> the
+    /// first time one is written. Capturing it instead means nothing is missed, and
+    /// <see cref="TheElementsCarryingACrefAreTheOnesThisExtractorKnows"/> compares the set actually found
+    /// against <see cref="CrefCarryingElements"/> so a new one is noticed rather than absorbed.</para>
+    ///
+    /// <para><b>Both groups are negated classes and not <c>.*</c>.</b> A greedy value group spans from the
+    /// first quote to the LAST one on the joined block, swallowing every cref after the first into one
+    /// target that is then reported as a single unresolvable string — the token under test absorbed by the
+    /// group meant to isolate it. <see cref="TheCrefExtractorDoesNotAbsorbTheTokenUnderTest"/> drives both
+    /// forms over the same input and pins the difference, because the greedy form still yields A match and
+    /// still fails on garbage, so nothing else here would notice.</para>
+    /// </summary>
+    private static readonly Regex CrefReference = new(
+        @"<(?<element>[A-Za-z]+)\b[^>]*?cref\s*=\s*""(?<target>[^""]*)""",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// The doc elements found carrying a cref in this tree, with what each one is for. Compared for
+    /// EQUALITY against what the sweep finds, so an element kind that starts being used reds here and gets
+    /// read — the extractor does not filter on this list, so the failure costs a line of prose rather than
+    /// a missed reference.
+    /// </summary>
+    private static readonly Dictionary<string, string> CrefCarryingElements = new(StringComparer.Ordinal)
+    {
+        ["see"] = "An inline reference, and all but a handful of the crefs in the tree.",
+        ["inheritdoc"] = "Pulls documentation from the named member rather than the base one.",
+        ["exception"] = "Names the exception type a member throws.",
+    };
+
+    /// <summary>A whole C# identifier and nothing else — anchored at both ends, so a segment carrying a
+    /// stray <c>!</c>, <c>?</c>, brace, space or empty string fails rather than matching its legal
+    /// prefix.</summary>
+    private static readonly Regex WholeIdentifier = new(
+        @"\A[A-Za-z_][A-Za-z0-9_]*\z",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>Every identifier-shaped token in a span of code, which is how the universe below is
+    /// built.</summary>
+    private static readonly Regex IdentifierToken = new(
+        @"[A-Za-z_][A-Za-z0-9_]*",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>A doc-XML generic argument list — <c>{TRow}</c>, <c>{T, TResult}</c>. Balanced-free
+    /// (<c>[^{}]*</c>) on purpose: an UNCLOSED brace is then not removed, so the segment keeps it and fails
+    /// <see cref="WholeIdentifier"/> instead of being quietly repaired into something that resolves.</summary>
+    private static readonly Regex GenericArgumentList = new(
+        @"\{[^{}]*\}",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// The documentation-ID kind prefixes a source cref may legally carry, which the resolver strips before
+    /// reading the name.
+    ///
+    /// <para><b><c>!</c> is deliberately absent, and that omission is the guard's whole second half.</b>
+    /// <c>!:</c> is the ID string the compiler EMITS for a reference it could not resolve. A cref carrying
+    /// any <c>&lt;letter&gt;:</c> prefix is treated by the compiler as an already-resolved ID and passed
+    /// through without being resolved at all — so <c>cref="!:Whatever"</c> compiles silently, emits a dead
+    /// reference into the documentation XML, and is invisible to <c>CS1574</c> whether or not
+    /// <c>GenerateDocumentationFile</c> is ever turned on. Widening this list by one character would make
+    /// every such site resolve here as well. <see cref="TheResolverCannotLaunderAMalformedTarget"/> pins
+    /// that character.</para>
+    /// </summary>
+    private static readonly string[] DocIdKindPrefixes = { "T:", "M:", "P:", "F:", "E:", "N:" };
+
+    /// <summary>
+    /// The kind label every entry in <see cref="UnresolvedCrefTargets"/> must open with, and what that kind
+    /// asserts about the entry.
+    ///
+    /// <para>An enumeration, and the direction matters: an entry whose label is not here fails
+    /// <see cref="EveryBoundNamesARecognisedKind"/> loudly rather than being counted as whatever the
+    /// nearest match was. Two of the three kinds are real defects and one is a limit of this resolver;
+    /// collapsing them would let the count of defects fall as the resolver's blind spots grew, which is
+    /// the wrong direction for every number this class reports.</para>
+    /// </summary>
+    private static readonly (string Label, string Meaning)[] CrefBoundKinds =
+    {
+        ("MARKER", "carries the compiler's own !: unresolvable marker, so no compilation can object"),
+        ("DANGLING", "names a symbol that no code in this repository spells"),
+        ("OUTSIDE", "names a symbol outside this repository that no C# here spells, which this resolver "
+                    + "cannot see"),
+    };
+
+    /// <summary>
+    /// Every cref target in the tree that this resolver cannot resolve, with the bound its entry rests on.
+    /// Compared for EQUALITY, so a reference that gets FIXED forces its entry out rather than lingering as
+    /// a permission nobody needs, and a new one fails here.
+    ///
+    /// <para><b>Keyed by TARGET TEXT, not by site, and that is the bound.</b> A line number churns on every
+    /// edit above it and a path churns on every rename, so an allow-list keyed either way would be rewritten
+    /// constantly and read never. The cost is stated rather than hidden: a NEW occurrence of an
+    /// already-listed target — a second <c>!:</c> on a symbol already listed — does not fail here. It is a
+    /// new instance of a defect the list already records, and the rename or deletion this guard exists for
+    /// produces a target that is not on the list.</para>
+    ///
+    /// <para><b>What each kind means for the reader.</b> <c>MARKER</c> and <c>DANGLING</c> are defects, and
+    /// the list is where they are inventoried rather than fixed — mixing the repair into the change that
+    /// introduces the guard would make the guard's own red-proof unreadable (#3083). <c>OUTSIDE</c> is not a
+    /// defect: it is this resolver's boundary, recorded here rather than in prose so that a target which
+    /// starts being spelled in code forces its entry out. The three kinds are exercised separately in
+    /// <see cref="TheRecordedLimitsAreExercised"/>, because a boundary nobody drives is a claim rather than
+    /// a record (#3079).</para>
+    /// </summary>
+    private static readonly Dictionary<string, string> UnresolvedCrefTargets = new(StringComparer.Ordinal)
+    {
+        ["!:DarlingManagedRoles"] =
+            "MARKER. Names DarlingManagedRoles, which this repository declares in the Darling service. "
+            + "Whether deleting the two marker characters is the whole fix depends on the referencing "
+            + "project's own references and usings, so the repair is a separate change from this guard.",
+
+        ["!:DarlingManagedRoles.BuildProvisioningSql"] =
+            "MARKER. Names DarlingManagedRoles.BuildProvisioningSql, both of which this repository declares.",
+
+        ["!:DarlingManagedRoles.ReassertComposeStatementTimeoutAsync"] =
+            "MARKER. Names DarlingManagedRoles.ReassertComposeStatementTimeoutAsync, both declared here.",
+
+        ["!:DarlingRetention"] =
+            "MARKER. Names DarlingRetention, which this repository declares.",
+
+        ["!:DarlingSelfAlertEvaluator"] =
+            "MARKER. Names DarlingSelfAlertEvaluator, which this repository declares. Two sites, and only "
+            + "the target is keyed, so both are covered by this one entry.",
+
+        ["!:DarlingServerConnector"] =
+            "MARKER. Names DarlingServerConnector, which this repository declares.",
+
+        ["!:StallWaitProbePolicy.HardBudget"] =
+            "MARKER. Names StallWaitProbePolicy.HardBudget, both of which this repository declares.",
+
+        ["!:StorageVersion.SchemaVersion"] =
+            "MARKER. Names StorageVersion.SchemaVersion, both declared here — and it sits two lines below a "
+            + "cref to DarlingManagedRoles that resolves perfectly well, in the same doc block, which is how "
+            + "little there is to see when reading this class of defect by eye.",
+
+        ["!:TimescaleSupport"] =
+            "MARKER. Names TimescaleSupport, which this repository declares.",
+
+        ["!:TimescaleSupport.ChunkIntervalDays"] =
+            "MARKER. Names TimescaleSupport.ChunkIntervalDays, both of which this repository declares.",
+
+        ["!:TimescaleSupport.HypertableTables"] =
+            "MARKER. Names TimescaleSupport.HypertableTables, both of which this repository declares.",
+
+        ["!:ViewerSettings"] =
+            "MARKER. Names ViewerSettings, which this repository declares in the Darling viewer.",
+
+        ["PerformanceMonitor.Common.ServerHealthBands"] =
+            "DANGLING. Names the FILE PerformanceMonitor.Common/ServerHealthBands.cs; nothing in the "
+            + "repository declares a type called ServerHealthBands, so the reference has never pointed at "
+            + "anything. A <c> would say what was meant.",
+
+        ["QueryStoreTextState"] =
+            "DANGLING. The only other mention of this name in the tree is inside a block comment, so no "
+            + "such type exists. Written as the sibling of two states that do.",
+
+        ["TheMemberWalk_SeesAGenericMethodWithAConstraintClause"] =
+            "DANGLING. A test method name that nothing declares — the shape a rename leaves behind, and the "
+            + "exact failure direction this guard exists for.",
+
+        ["TryGetValidateConfigVerb"] =
+            "DANGLING. A member name spelled nowhere in any code in the repository.",
+
+        ["ViewerDataService.MonitoredServers"] =
+            "DANGLING. Names the partial-class FILE ViewerDataService.MonitoredServers.cs. The file is real; "
+            + "the member is not, and a cref resolves symbols rather than paths.",
+
+        ["ViewerServerTab.LivePlan.cs"] =
+            "DANGLING. A file path, .cs extension and all, written into a cref.",
+
+        ["ViewerServerTab.SystemHealthCharts"] =
+            "DANGLING. Names the partial-class FILE ViewerServerTab.SystemHealthCharts.cs, same shape as "
+            + "the entry above.",
+
+        ["COMException"] =
+            "OUTSIDE. System.Runtime.InteropServices.COMException, cref'd where the code catches its base "
+            + "ExternalException, so the derived name appears in no C# in the tree.",
+
+        ["CallerFilePathAttribute"] =
+            "OUTSIDE. C# elides the Attribute suffix at a usage site, so a tree that uses "
+            + "[CallerFilePath] everywhere spells the full type name nowhere. Five sites, all in the two "
+            + "test projects.",
+
+        ["CallerMemberNameAttribute"] =
+            "OUTSIDE. Same elision as the entry above.",
+
+        ["HostString.Host"] =
+            "OUTSIDE. Microsoft.AspNetCore.Http.HostString, reached through a property chain rather than "
+            + "named, so the type name appears in no code here.",
+
+        ["IConvertible"] =
+            "OUTSIDE. System.IConvertible, named only to explain what a conversion does NOT go through.",
+
+        ["JsonEncodedText.Encode(string)"] =
+            "OUTSIDE, and it is important that this entry says so rather than DANGLING: the compiler "
+            + "rejects this target too, but for the unrelated reason that the one-argument overload does "
+            + "not exist. This resolver cannot see that — it discards parameter lists entirely — and lists "
+            + "the target only because System.Text.Json.JsonEncodedText is spelled in no C# here. Right "
+            + "answer, different question; labelling it DANGLING would credit the resolver with a check it "
+            + "does not perform.",
+
+        ["ListBox"] =
+            "OUTSIDE. System.Windows.Controls.ListBox, used from XAML rather than from C#, so the C# "
+            + "identifier universe cannot contain it. Three sites, across both SKUs.",
+
+        ["NpgsqlBatch"] =
+            "OUTSIDE. Npgsql's batch type, named in prose about why the code does not use it.",
+
+        ["System.Diagnostics.ConditionalAttribute"] =
+            "OUTSIDE. Fully qualified, and elided at its usage site as [Conditional], so neither the "
+            + "namespace-qualified name nor the suffixed one appears in code.",
+
+        ["System.Windows.Controls.WrapPanel"] =
+            "OUTSIDE. A WPF panel type named in prose about layout; the XAML uses it, the C# does not.",
+
+        ["X509KeyStorageFlags.EphemeralKeySet"] =
+            "OUTSIDE. The flag is passed through a variable rather than named at the call site.",
+
+        ["X509KeyStorageFlags.PersistKeySet"] =
+            "OUTSIDE. Same as the entry above, the other flag of the pair.",
+    };
+
+    /// <summary>
+    /// The solution projects whose tree carries no cref at all, so the per-project cref floor cannot be
+    /// required of them. Compared for EQUALITY like every other bounded set here: a project that acquires
+    /// its first cref forces its entry out, and a project that loses its last one fails rather than
+    /// silently dropping below a floor nobody re-derived.
+    /// </summary>
+    private static readonly Dictionary<string, string> SolutionProjectsWithoutCrefs =
+        new(StringComparer.Ordinal)
+        {
+            ["deprecated/Installer"] =
+                "One .cs file, two doc-comment blocks, no cref in either. A deprecated WPF installer shell.",
+
+            ["deprecated/Installer.Tests"] =
+                "Doc comments but no cref in any of them. A deprecated test project.",
+        };
+
+    /// <summary>
+    /// Directories holding a <c>.csproj</c> that the solution does not build, so the per-project floor
+    /// cannot reach them. At equality, so a project ADDED to the solution is covered by the floor from
+    /// then on rather than sitting outside it unnoticed.
+    /// </summary>
+    private static readonly Dictionary<string, string> ProjectDirectoriesOutsideTheSolution =
+        new(StringComparer.Ordinal)
+        {
+            ["tools/CompactionRepro"] =
+                "A throwaway repro rig, deliberately outside the solution and pinning its own package "
+                + "version. Nothing here should be held to a documentation floor.",
+
+            ["tools/SliceRepairRepro"] =
+                "The second repro rig, same reasoning.",
+
+            ["Darling/tools/generate-ladder-fixture"] =
+                "A one-shot generator for a test fixture, run by hand and outside the solution. Nested "
+                + "inside a tree the floor DOES cover, which is why the comparison is over project "
+                + "directories rather than top-level trees.",
+        };
+
+    /// <summary>
+    /// Target SHAPES this resolver accepts that a compiler would not, each with the reduction that makes it
+    /// accept them — the fidelity boundary the issue named, written as assertions rather than as a
+    /// paragraph.
+    ///
+    /// <para>Every one is driven in <see cref="TheRecordedLimitsAreExercised"/> against the real identifier
+    /// universe and asserted to RESOLVE. A limit recorded only in prose is a limit nobody can tell has
+    /// stopped being true, and #3079 found three such cases were not even reachable where they were first
+    /// written.</para>
+    /// </summary>
+    private static readonly (string Target, string Limit)[] CrefShapesTheResolverAccepts =
+    {
+        ("CollectorCatalog.AppliesTo(NoSuchTypeAnywhere)",
+            "PARAMETER LISTS are discarded at the first '(', so overload identity is never checked and a "
+            + "parameter type that does not exist cannot be seen."),
+
+        ("ICollectorDefinition{NoSuchTypeAnywhere}",
+            "GENERIC ARGUMENTS are discarded with the braces, so neither arity nor the arguments themselves "
+            + "are checked."),
+
+        ("CollectorCatalog.NoSuchMemberButAppliesTo",
+            "NOTHING is checked about a name's position: this segment is not a member of CollectorCatalog "
+            + "and does not resolve — included as the negative control for the entry below, so the two "
+            + "cannot be read as the same claim."),
+    };
+
+    /// <summary>
+    /// Real sites in the tree where a cref resolves HERE and does not resolve for the compiler, each with
+    /// the reason the two answers differ. Asserted to be present in the census and asserted to resolve, so
+    /// the boundary is exercised on the input it describes rather than asserted about a fixture.
+    ///
+    /// <para>Measured on this branch's base with <c>GenerateDocumentationFile</c> switched on from the
+    /// command line — no project file was changed, and none is changed by this PR: the flag remains the
+    /// parked decision from #3025. That run reports 71 <c>CS1574</c> occurrences on 70 lines. This resolver
+    /// sees 7 of those lines. The three rows below are the three reasons for the other 63, and together they
+    /// are why this guard is complementary to that flag rather than a substitute for it — while the 12
+    /// <c>MARKER</c> targets above are the traffic in the other direction, which the flag would never
+    /// report.</para>
+    /// </summary>
+    private static readonly (string Project, string Target, string Reason)[]
+        LiveSitesOutsideTheResolversReach =
+    {
+        ("PerformanceMonitor.Collectors", "AppliesTo",
+            "SCOPE. A member name is resolved repo-wide, not against the type whose doc comment names it. "
+            + "CollectorTargetInfo's summary names AppliesTo, which is declared on the collector "
+            + "definitions and on CollectorCatalog rather than on CollectorTargetInfo, so the compiler has "
+            + "nothing in scope to bind it to. This is the largest of the three reasons by site count."),
+
+        ("Darling/PerformanceMonitor.Darling.Storage", "PlanCorrectionCollector",
+            "USINGS. Namespace imports are ignored here. PgMigrations.cs carries no using for the "
+            + "collectors' namespace, so this name is out of scope for the compiler even though the "
+            + "project references the assembly that declares it."),
+
+        ("Darling/Darling.Tests", "Write(char)",
+            "OVERLOADS. The parameter list is discarded, and the name alone is spelled all over the tree. "
+            + "The compiler resolves the whole signature against what is in scope, and in this nested "
+            + "private class nothing named Write is."),
+    };
+
+    /// <summary>
+    /// Every <c>cref</c> in the tree names something this repository's code spells, or is one of the
+    /// bounded exceptions above (#3083).
+    ///
+    /// <para><b>Why a cref and not the rest of a doc comment.</b> By the criterion #3069 settled — a comment
+    /// is worth pinning when it restates something derivable, and worth nothing but review when it explains
+    /// why — a cref is maximally derivable: it names a symbol that either exists or does not. It is also the
+    /// one part of a doc comment nothing in this repository checks, because no project sets
+    /// <c>GenerateDocumentationFile</c>, so the compiler never resolves a cref and a rename leaves the
+    /// reference aimed at nothing with every gate green.</para>
+    ///
+    /// <para><b>What resolution means here, stated because it is weaker than a compiler's and the
+    /// difference is the whole of what this guard can and cannot say.</b> A target resolves when every
+    /// dot-separated segment of it, after the reductions in <see cref="CrefSegments"/>, is an identifier
+    /// that appears in the repository's C# CODE — comments and string literals removed by
+    /// <see cref="CSharpSourceWalker.StripCommentsAndStrings"/>. So this asks "does anything here spell that
+    /// name", not "does that name bind in that context". It cannot see scope, usings, overloads or generic
+    /// arguments; those are recorded and driven in
+    /// <see cref="LiveSitesOutsideTheResolversReach"/> and <see cref="CrefShapesTheResolverAccepts"/>. What
+    /// it does see exactly is the failure mode the issue describes: a rename or a deletion that leaves the
+    /// old name spelled nowhere but in the doc comment pointing at it.</para>
+    ///
+    /// <para><b>The universe is code and not declarations, which is a choice and not a shortcut.</b> A
+    /// declaration-position index is the obvious form and it is strictly worse here: a regex over
+    /// declarations misses the ones this codebase actually writes — a tuple-returning static, a property
+    /// whose type is a nested generic — and every miss is a spurious offender in a set compared for
+    /// equality. Measured before choosing: a declaration index reported 385 unresolvable targets against
+    /// this one's 31, and the extra 354 were dominated by real members it had failed to parse. An index that
+    /// is too WIDE loses recall, which the recorded limits above state; one that is too NARROW manufactures
+    /// offenders, and a guard that cries wolf gets its allow-list widened until it says nothing.</para>
+    /// </summary>
+    [Fact]
+    public void EveryCrefTargetResolvesOrIsBounded()
+    {
+        var root = RepoRootOrFail();
+        var projects = SolutionProjectDirectories(root);
+        var census = BuildCrefCensus(RepoSources(root), projects);
+
+        /* The floors first, and inside this test rather than only in the one below it: a floor that lives
+           somewhere else does not protect THIS assertion, and this is the assertion that reports zero
+           offenders when the scan read nothing. */
+        AssertCrefPopulationFloors(census, projects, SolutionProjectsWithoutCrefs.Keys);
+
+        var unresolved = UnresolvedTargets(census);
+
+        /* The two directions are asserted separately first, because each needs a different instruction and
+           a collection diff gives neither. The equality below then holds them together, so a later edit
+           cannot leave one direction as the only gate. */
+        var appeared = unresolved.Keys.Except(UnresolvedCrefTargets.Keys, StringComparer.Ordinal).ToArray();
+
+        Assert.True(appeared.Length == 0,
+            "cref target(s) that resolve to nothing this repository spells:\n\n"
+            + string.Join("\n", appeared.Select(t =>
+                $"  {t}\n" + string.Join("\n", unresolved[t].Select(s => $"      {s.Path}:{s.Line}"))))
+            + "\n\nA cref names a symbol, so the usual cause is a rename or a deletion that left the "
+            + "reference behind, and the fix is to point it at what the text now means — or to make it "
+            + "<c>prose</c> if it never named a symbol at all, which is what a cref spelling a FILE name "
+            + "(Type.Partial.cs) always is.\n\n"
+            + "If the target is genuinely OUTSIDE this repository and no C# here spells it, add it to "
+            + "UnresolvedCrefTargets with the OUTSIDE kind and say why the name appears in no code — that "
+            + "is this resolver's stated boundary and not a defect. Do NOT add a real dangling reference "
+            + "there to make the build green; the two kinds are what the list is for.");
+
+        var gone = UnresolvedCrefTargets.Keys.Except(unresolved.Keys, StringComparer.Ordinal).ToArray();
+
+        Assert.True(gone.Length == 0,
+            "UnresolvedCrefTargets still lists cref target(s) that now resolve:\n\n  "
+            + string.Join("\n  ", gone)
+            + "\n\nDelete the entries. The list is the inventory of what is still broken, compared for "
+            + "equality precisely so a fixed reference does not leave a permission behind (#3075). If a "
+            + "target resolves because it stopped being written anywhere rather than because it was "
+            + "fixed, the entry still goes.");
+
+        Assert.Equal(
+            UnresolvedCrefTargets.Keys.OrderBy(k => k, StringComparer.Ordinal).ToArray(),
+            unresolved.Keys.OrderBy(k => k, StringComparer.Ordinal).ToArray());
+    }
+
+    /// <summary>
+    /// The population floors on their own, named so a reader can see what stops this family reporting a
+    /// clean tree it never read.
+    ///
+    /// <para><b>Per solution project, not per repository.</b> A single total is satisfied by one large
+    /// tree: <c>Darling</c> alone carries most of the crefs here, so a walk that silently stopped reading
+    /// <c>PerformanceMonitor.Collectors</c> or either SKU's app tree would still clear any global floor by a
+    /// wide margin. That is the shape #3067 was filed for and the one this class's own sweep is most
+    /// exposed to, since it walks the repository root rather than a named list of trees.</para>
+    ///
+    /// <para><b>The project list is DERIVED from <c>PerformanceMonitor.sln</c>, not written here.</b> A
+    /// hand-written list of trees is the same restatement this guard exists to catch: it goes stale the
+    /// moment a project is added, and it goes stale silently, because a floor over the trees you remembered
+    /// passes. Deriving it also means this file names no other SKU's directory as a literal, so it adds no
+    /// cross-app reference for <c>CrossAppGuardCiGateTests</c> to reach or exempt.</para>
+    /// </summary>
+    [Fact]
+    public void ThePopulationIsFlooredPerSolutionProject()
+    {
+        var root = RepoRootOrFail();
+        var projects = SolutionProjectDirectories(root);
+
+        AssertCrefPopulationFloors(
+            BuildCrefCensus(RepoSources(root), projects), projects, SolutionProjectsWithoutCrefs.Keys);
+    }
+
+    /// <summary>
+    /// The derived project list is the whole solution and the solution is the whole repository bar a named
+    /// pair — so the floor above is aimed at every tree rather than at whichever ones the parse happened to
+    /// return.
+    ///
+    /// <para>A parse that quietly returned a subset is the "floor aimed at the wrong tree" failure with an
+    /// extra step, and it would look exactly like health: fewer projects to floor, all of them passing.</para>
+    /// </summary>
+    [Fact]
+    public void TheDerivedProjectListCoversEveryProjectInTheTree()
+    {
+        var root = RepoRootOrFail();
+        var solution = SolutionProjectDirectories(root);
+
+        Assert.All(solution, project => Assert.True(
+            Directory.Exists(Path.Combine(root, project.Replace('/', Path.DirectorySeparatorChar))),
+            $"the solution names project directory '{project}', which does not exist — the parse has "
+            + "produced something that is not a path, and the floor is then aimed at nothing."));
+
+        var onDisk = Directory.EnumerateFiles(root, "*.csproj", SearchOption.AllDirectories)
+            .Select(p => Path.GetRelativePath(root, p).Replace('\\', '/'))
+            .Where(p => !HasBuildOutputSegment(p))
+            .Select(p => p[..p.LastIndexOf('/')])
+            .Distinct(StringComparer.Ordinal)
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.Equal(
+            ProjectDirectoriesOutsideTheSolution.Keys.OrderBy(k => k, StringComparer.Ordinal).ToArray(),
+            onDisk.Except(solution, StringComparer.Ordinal).OrderBy(k => k, StringComparer.Ordinal).ToArray());
+
+        Assert.Empty(solution.Except(onDisk, StringComparer.Ordinal));
+    }
+
+    /// <summary>
+    /// The floors really do fail on a starved population, and they fail PER PROJECT — each of the three
+    /// counts, for each project in turn, is individually load-bearing.
+    ///
+    /// <para>Driven on a synthetic census rather than the tree, because the claim is that removing one
+    /// project's contribution reds, and the tree cannot be asked to lose one. The real tree's own pass is
+    /// asserted above; without this, that pass could not tell a working floor from a vacuous one.</para>
+    /// </summary>
+    [Fact]
+    public void TheFloorsFailOnAStarvedPopulation()
+    {
+        var projects = new[] { "AppOne", "AppTwo/Nested" };
+
+        (string Path, string Text) Source(string project, bool docBlock, bool cref) =>
+            ($"{project}/File.cs",
+                (docBlock ? "/// <summary>" + (cref ? " <see cref=\"Marker\"/>" : string.Empty) + "</summary>\n"
+                          : string.Empty)
+                + "class Marker { }");
+
+        /* The control: all three counts present for both projects, and the floors pass. Without it every
+           throw below could be the fixture rather than the floor. */
+        var whole = projects.Select(p => Source(p, docBlock: true, cref: true)).ToArray();
+        var none = Array.Empty<string>();
+
+        AssertCrefPopulationFloors(BuildCrefCensus(whole, projects), projects, none);
+
+        Assert.ThrowsAny<Exception>(() => AssertCrefPopulationFloors(
+            BuildCrefCensus(Array.Empty<(string, string)>(), projects), projects, none));
+
+        /* And the list of projects itself: an empty one makes every per-project floor below iterate over
+           nothing, which is the shape a mis-parsed solution file produces. */
+        Assert.ThrowsAny<Exception>(() => AssertCrefPopulationFloors(
+            BuildCrefCensus(whole, projects), Array.Empty<string>(), none));
+
+        var starved = 0;
+        foreach (var project in projects)
+        {
+            /* (a) the project contributes no FILE — the sweep lost a tree. */
+            Assert.ThrowsAny<Exception>(() => AssertCrefPopulationFloors(
+                BuildCrefCensus(whole.Where(s => !s.Path.StartsWith(project, StringComparison.Ordinal)), projects),
+                projects,
+                none));
+
+            /* (b) it contributes files but no DOC BLOCK — the doc-comment collector stopped collecting. */
+            Assert.ThrowsAny<Exception>(() => AssertCrefPopulationFloors(
+                BuildCrefCensus(
+                    projects.Select(p => Source(p, docBlock: p != project, cref: true)),
+                    projects),
+                projects,
+                none));
+
+            /* (c) doc blocks but no CREF — the extractor stopped extracting. This is the one a global
+                   count cannot see, because the other project still supplies thousands. */
+            Assert.ThrowsAny<Exception>(() => AssertCrefPopulationFloors(
+                BuildCrefCensus(
+                    projects.Select(p => Source(p, docBlock: true, cref: p != project)),
+                    projects),
+                projects,
+                none));
+
+            starved++;
+        }
+
+        Assert.Equal(projects.Length, starved);
+    }
+
+    /// <summary>
+    /// The extractor isolates one target instead of absorbing the ones after it, and it reads a
+    /// REFERENCE rather than the attribute spelling wherever it appears.
+    ///
+    /// <para>Both rejected patterns are run over the same input and the difference asserted, because
+    /// neither fails obviously. The greedy value group still returns a match, and its one enormous target
+    /// still fails to resolve — so the tree would report ONE unresolvable entry per doc block instead of
+    /// the real set, the allow-list would be rewritten to match, and the guard would go green having
+    /// stopped resolving crefs altogether. The attribute-only anchor is worse in the other direction: it
+    /// reads prose ABOUT a cref as a cref, which this very class writes.</para>
+    /// </summary>
+    [Fact]
+    public void TheCrefExtractorDoesNotAbsorbTheTokenUnderTest()
+    {
+        const string two = "<see cref=\"AlphaTarget\"/> and <see cref=\"BetaTarget\"/>";
+
+        Assert.Equal(
+            new[] { "AlphaTarget", "BetaTarget" },
+            CrefReference.Matches(two).Select(m => m.Groups["target"].Value).ToArray());
+
+        var greedy = new Regex(@"<(?<element>[A-Za-z]+)\b[^>]*?cref\s*=\s*""(?<target>.*)""");
+
+        Assert.Equal(
+            new[] { "AlphaTarget\"/> and <see cref=\"BetaTarget" },
+            greedy.Matches(two).Select(m => m.Groups["target"].Value).ToArray());
+
+        /* The element anchor, in both prose shapes this repository writes: inside <c> and escaped. */
+        const string prose =
+            "an attribute named in prose, <c>cref=\"ProseNotAReference\"</c>, and an escaped example, "
+            + "<c>&lt;see cref=\"EscapedNotAReference\"/&gt;</c>";
+
+        Assert.Empty(CrefReference.Matches(prose));
+
+        var attributeOnly = new Regex(@"cref\s*=\s*""(?<target>[^""]*)""");
+
+        Assert.Equal(
+            new[] { "ProseNotAReference", "EscapedNotAReference" },
+            attributeOnly.Matches(prose).Select(m => m.Groups["target"].Value).ToArray());
+    }
+
+    /// <summary>
+    /// Which doc elements are found carrying a cref, compared for equality against
+    /// <see cref="CrefCarryingElements"/>.
+    ///
+    /// <para>The extractor captures the element name rather than matching a list of them, so a new element
+    /// kind cannot be MISSED — this pin exists so it cannot be missed silently either. A red here is one
+    /// line of prose and a check that the new element's crefs are being read the way its owner expects.</para>
+    /// </summary>
+    [Fact]
+    public void TheElementsCarryingACrefAreTheOnesThisExtractorKnows()
+    {
+        var root = RepoRootOrFail();
+        var census = BuildCrefCensus(RepoSources(root), SolutionProjectDirectories(root));
+
+        Assert.Equal(
+            CrefCarryingElements.Keys.OrderBy(k => k, StringComparer.Ordinal).ToArray(),
+            census.Sites.Select(s => s.Element).Distinct(StringComparer.Ordinal)
+                .OrderBy(k => k, StringComparer.Ordinal).ToArray());
+    }
+
+    /// <summary>
+    /// The population is <c>///</c> doc comments and nothing else, so a cref written inside a
+    /// <c>/* … */</c> block comment or a string literal is not a reference and is not resolved.
+    ///
+    /// <para><b>Exercised on the tree as well as on the fixture, which is the half that would rot.</b> This
+    /// repository really does discuss crefs inside block comments — one such comment exists precisely
+    /// because a scanner once matched a cref out of one and reported a phantom call site — and the text
+    /// there carries an ellipsis where a parameter list belongs, so admitting block comments to the
+    /// population would put a target in the offender set that is not a reference at all. The tree-wide
+    /// assertion below compares the two populations and requires the filter to be doing work on real
+    /// input.</para>
+    /// </summary>
+    [Fact]
+    public void TheCrefPopulationIsDocCommentsOnly()
+    {
+        const string fixture = """
+            /* A block comment discussing <see cref="Absent.FromTheDocPopulation(…)"/>, which is prose
+               about a reference rather than a reference. */
+            /// <summary>A doc comment carrying <see cref="PresentInTheDocPopulation"/>.</summary>
+            void M()
+            {
+                Log("a literal mentioning <see cref=\"AlsoAbsent\"/>");
+            }
+            """;
+
+        Assert.Equal(
+            new[] { "PresentInTheDocPopulation" },
+            DocCommentBlocks(fixture.Split('\n'))
+                .SelectMany(b => CrefReference.Matches(string.Join("\n", b.Select(l => l.Text))))
+                .Select(m => m.Groups["target"].Value)
+                .ToArray());
+
+        var root = RepoRootOrFail();
+        var sources = RepoSources(root).ToArray();
+        var inDocComments = BuildCrefCensus(sources, SolutionProjectDirectories(root)).Sites.Count;
+        var anywhere = sources.Sum(s => CrefReference.Matches(s.Text).Count);
+
+        Assert.True(anywhere > inDocComments,
+            $"every cref-shaped reference in the tree is inside a /// doc comment ({anywhere} found either "
+            + $"way, {inDocComments} in doc comments), so the doc-comment filter is not discriminating "
+            + "anything on real input and only the fixture above says it works. If the last such site was "
+            + "genuinely reformatted away, delete this assertion and say so — do not weaken it to >=, "
+            + "which is satisfied by a filter that does nothing.");
+    }
+
+    /// <summary>
+    /// A <c>///</c> line inside a string LITERAL is not a doc comment, and a doc comment carrying quotes
+    /// in its prose still is one.
+    ///
+    /// <para>Both halves, because the fix for the first can break the second. Blanking too much takes the
+    /// doc comments with the literals and the population empties — which the floors catch. Blanking too
+    /// little reads a test fixture's crefs as references in the tree, which nothing else here catches: the
+    /// targets are arranged names, they resolve against nothing, and they arrive in the offender set
+    /// looking exactly like real dangling references.</para>
+    /// </summary>
+    [Fact]
+    public void ADocCommentInsideAStringLiteralIsNotPartOfThePopulation()
+    {
+        const string fixture = """"
+            /// <summary>A real doc comment whose prose quotes "a string" and names
+            /// <see cref="RealReference"/>.</summary>
+            void M()
+            {
+                const string arranged = """
+                    /// <summary>Arranged test data naming <see cref="ArrangedReference"/>.</summary>
+                    """;
+            }
+            """";
+
+        var found = DocCommentBlocks(WithStringLiteralsBlanked(fixture).Split('\n'))
+            .SelectMany(b => CrefReference.Matches(string.Join("\n", b.Select(l => l.Text))))
+            .Select(m => m.Groups["target"].Value)
+            .ToArray();
+
+        Assert.Equal(new[] { "RealReference" }, found);
+
+        /* Without the blanking, the arranged data is read as a reference — the defect, reproduced. */
+        Assert.Equal(
+            new[] { "RealReference", "ArrangedReference" },
+            DocCommentBlocks(fixture.Split('\n'))
+                .SelectMany(b => CrefReference.Matches(string.Join("\n", b.Select(l => l.Text))))
+                .Select(m => m.Groups["target"].Value)
+                .ToArray());
+    }
+
+    /// <summary>
+    /// A cref is read from the whole doc block, so one that WRAPS across two <c>///</c> lines is extracted
+    /// rather than missed — in both places it can wrap.
+    ///
+    /// <para>The obvious form is a per-line regex, and its failure is silent in the worst direction: the
+    /// reference simply leaves the population, never resolved and never reported. XML collapses the line
+    /// break to whitespace and C# permits whitespace around the dot, so the compiler resolves such a cref;
+    /// this resolver has to see the same target or it is answering about a different population.</para>
+    ///
+    /// <para>Both shapes exist in this repository today and both are asserted on the tree: one cref has its
+    /// TARGET split across the break, and several have the break between <c>&lt;see</c> and its
+    /// <c>cref</c> attribute.</para>
+    /// </summary>
+    [Fact]
+    public void TheCrefExtractorReadsAcrossTheLineBreakInsideOneDocBlock()
+    {
+        static string[] TargetsIn(string block) => DocCommentBlocks(block.Split('\n'))
+            .SelectMany(b => CrefReference.Matches(string.Join("\n", b.Select(l => l.Text))))
+            .Select(m => m.Groups["target"].Value)
+            .ToArray();
+
+        /* (i) the target itself wraps. */
+        const string splitTarget = """
+            /// <summary>A target long enough to wrap: <see cref="WrappedTargetType.
+            /// WrappedTargetMember"/>.</summary>
+            """;
+
+        var wrapped = TargetsIn(splitTarget);
+        Assert.Single(wrapped);
+        Assert.Equal(new[] { "WrappedTargetType", "WrappedTargetMember" }, CrefSegments(wrapped[0]));
+
+        /* (ii) the break falls between the element and its attribute. */
+        const string splitElement = """
+            /// <summary>Prose long enough that the element wraps away from its attribute (<see
+            /// cref="WrappedElementTarget"/>).</summary>
+            """;
+
+        Assert.Equal(new[] { "WrappedElementTarget" }, TargetsIn(splitElement));
+
+        /* The per-line form, for the difference: it sees neither reference. */
+        Assert.Empty(splitTarget.Split('\n').SelectMany(l => CrefReference.Matches(l)));
+        Assert.Empty(splitElement.Split('\n').SelectMany(l => CrefReference.Matches(l)));
+
+        var root = RepoRootOrFail();
+        var sources = RepoSources(root).ToArray();
+        var census = BuildCrefCensus(sources, SolutionProjectDirectories(root));
+
+        Assert.Contains(census.Sites, site => site.Target.Contains('\n', StringComparison.Ordinal));
+
+        var perDocLine = sources.Sum(s => s.Text.Split('\n')
+            .Where(l => l.TrimStart().StartsWith("///", StringComparison.Ordinal))
+            .Sum(l => CrefReference.Matches(l).Count));
+
+        Assert.True(census.Sites.Count > perDocLine,
+            $"reading whole doc blocks found no more crefs than reading single lines would "
+            + $"({census.Sites.Count} against {perDocLine}), so no cref in the tree wraps and only the "
+            + "fixtures above say the joining works.");
+    }
+
+    /// <summary>
+    /// The reductions in <see cref="CrefSegments"/> cannot repair a malformed target into one that
+    /// resolves — the way this guard is likeliest to pass while broken, since every reduction it performs
+    /// is a chance to normalise away the shape it exists to catch.
+    ///
+    /// <para>Each case names a real repository symbol, so the only reason it can fail to resolve is the
+    /// malformation. A reduction that swallowed the malformation would make the case pass, and the positive
+    /// controls make sure a resolver that simply says NO to everything cannot pass instead.</para>
+    /// </summary>
+    [Theory]
+    /* Positive controls: these must resolve, or every negative below is vacuous. */
+    [InlineData(true, "CollectorCatalog")]
+    [InlineData(true, "CollectorCatalog.AppliesTo")]
+    [InlineData(true, "T:CollectorCatalog")]
+    [InlineData(true, "M:CollectorCatalog.AppliesTo")]
+    /* The one character that decides twelve of the entries above. !: is the compiler's own marker for a
+       reference it could not resolve; accepting it as a kind prefix would resolve every one of them. */
+    [InlineData(false, "!:CollectorCatalog")]
+    [InlineData(false, "!:CollectorCatalog.AppliesTo")]
+    /* Whitespace is trimmed at a segment's EDGES, because XML puts it there when a cref wraps. Inside a
+       segment it is not a legal identifier and must stay illegal. */
+    [InlineData(true, "CollectorCatalog. AppliesTo")]
+    [InlineData(false, "Collector Catalog")]
+    /* An empty segment: a doubled or trailing dot names nothing. */
+    [InlineData(false, "CollectorCatalog..AppliesTo")]
+    [InlineData(false, "CollectorCatalog.")]
+    [InlineData(false, ".CollectorCatalog")]
+    [InlineData(false, "")]
+    [InlineData(false, ".")]
+    /* An unclosed generic argument list is NOT stripped, so the brace stays and the segment stays
+       illegal. A balanced-anything pattern would have deleted it and resolved this. */
+    [InlineData(false, "CollectorCatalog{TRow")]
+    [InlineData(true, "CollectorCatalog{TRow}")]
+    /* Nullable annotations and stray punctuation are not identifiers and are not stripped. */
+    [InlineData(false, "CollectorCatalog?")]
+    [InlineData(false, "CollectorCatalog!")]
+    /* A prefix letter that is not one of the documented kinds is part of the name, not a prefix. */
+    [InlineData(false, "Z:CollectorCatalog")]
+    public void TheResolverCannotLaunderAMalformedTarget(bool resolves, string target)
+    {
+        var root = RepoRootOrFail();
+        var census = BuildCrefCensus(RepoSources(root), SolutionProjectDirectories(root));
+
+        Assert.True(census.CodeIdentifiers.Contains("CollectorCatalog"),
+            "the identifier universe does not contain a type this repository certainly declares, so every "
+            + "case here would fail for the wrong reason.");
+
+        Assert.True(
+            CrefResolves(target, census.CodeIdentifiers) == resolves,
+            $"'{target}' should{(resolves ? " " : " NOT ")}resolve. A reduction that repairs a malformed "
+            + "target into a resolvable one is how this whole family passes while resolving nothing.");
+    }
+
+    /// <summary>
+    /// The identifier universe is built from CODE and reports NO for a name that only prose spells — so the
+    /// resolver is neither a stub that says yes to everything nor one that reads its own doc comments back.
+    ///
+    /// <para>Both halves matter. A universe built without stripping comments would contain every name ever
+    /// mentioned, including the names in this class's own allow-list prose, and every dangling reference
+    /// would resolve against the comment that names it. A universe that came back empty would fail
+    /// everything, which the population floors catch — but a universe built over the WRONG text would not
+    /// be empty and nothing else here would notice.</para>
+    /// </summary>
+    [Fact]
+    public void TheIdentifierUniverseComesFromCodeAndNotFromProse()
+    {
+        var census = BuildCrefCensus(
+            new[]
+            {
+                ("AppOne/File.cs", """
+                    /// <summary>Prose naming OnlyInADocComment and <see cref="AlsoOnlyInACref"/>.</summary>
+                    class OnlyInCode
+                    {
+                        /* OnlyInABlockComment */
+                        const string S = "OnlyInALiteral";
+                    }
+                    """),
+            },
+            new[] { "AppOne" });
+
+        Assert.Contains("OnlyInCode", census.CodeIdentifiers);
+        Assert.DoesNotContain("OnlyInADocComment", census.CodeIdentifiers);
+        Assert.DoesNotContain("AlsoOnlyInACref", census.CodeIdentifiers);
+        Assert.DoesNotContain("OnlyInABlockComment", census.CodeIdentifiers);
+        Assert.DoesNotContain("OnlyInALiteral", census.CodeIdentifiers);
+
+        Assert.True(CrefResolves("OnlyInCode", census.CodeIdentifiers));
+        Assert.False(CrefResolves("AlsoOnlyInACref", census.CodeIdentifiers));
+    }
+
+    /// <summary>
+    /// The bounded set is compared for EQUALITY, in both directions — a target that stops being
+    /// unresolvable forces its entry out, and one that starts being unresolvable fails.
+    ///
+    /// <para>The direction that needs the pin is the first. A containment check would leave a fixed
+    /// reference's entry sitting in the list forever, and the list is the only inventory of what is still
+    /// broken; an inventory that only ever grows stops being read. #3075 is the shape this follows.</para>
+    /// </summary>
+    [Fact]
+    public void TheBoundedSetIsComparedForEquality()
+    {
+        var root = RepoRootOrFail();
+        var projects = SolutionProjectDirectories(root);
+        var census = BuildCrefCensus(RepoSources(root), projects);
+        var real = UnresolvedTargets(census).Keys.OrderBy(k => k, StringComparer.Ordinal).ToArray();
+
+        void Compare(IEnumerable<string> expected) => Assert.Equal(
+            expected.OrderBy(k => k, StringComparer.Ordinal).ToArray(),
+            real);
+
+        /* The control. */
+        Compare(UnresolvedCrefTargets.Keys);
+
+        /* (a) an entry whose reference was FIXED, still listed. Each key in turn, so no single entry is
+               carrying the whole comparison. */
+        var dropped = 0;
+        foreach (var key in UnresolvedCrefTargets.Keys)
+        {
+            Assert.ThrowsAny<Exception>(() => Compare(UnresolvedCrefTargets.Keys.Where(
+                k => !string.Equals(k, key, StringComparison.Ordinal))));
+            dropped++;
+        }
+
+        Assert.Equal(UnresolvedCrefTargets.Count, dropped);
+
+        /* (b) a new unresolvable target, unlisted. */
+        Assert.ThrowsAny<Exception>(() => Compare(
+            UnresolvedCrefTargets.Keys.Append("ANewlyRenamedAwayTargetName")));
+    }
+
+    /// <summary>
+    /// Every bound in <see cref="UnresolvedCrefTargets"/> opens with a kind from
+    /// <see cref="CrefBoundKinds"/>, and an unrecognised one FAILS rather than being counted as something
+    /// else.
+    ///
+    /// <para>Also cross-checked against the one kind that is mechanically decidable: a target carrying the
+    /// <c>!:</c> marker must be labelled <c>MARKER</c> and nothing else may be. A hand label that drifted
+    /// from the mechanism would let a real defect be filed as this resolver's own blind spot, which is the
+    /// direction that costs — it would move a fixable reference into the category the guard has decided not
+    /// to look at.</para>
+    /// </summary>
+    [Fact]
+    public void EveryBoundNamesARecognisedKind()
+    {
+        Assert.NotEmpty(UnresolvedCrefTargets);
+
+        foreach (var (target, bound) in UnresolvedCrefTargets)
+        {
+            var label = CrefBoundKinds
+                .Where(k => bound.StartsWith(k.Label, StringComparison.Ordinal))
+                .Select(k => k.Label)
+                .FirstOrDefault();
+
+            Assert.True(label is not null,
+                $"the bound for '{target}' opens with no recognised kind: "
+                + $"\"{bound[..Math.Min(60, bound.Length)]}…\". Every entry has to name its kind, because "
+                + "two of the three are defects awaiting repair and the third is this resolver's own "
+                + "boundary, and nothing else distinguishes them. Add the kind to CrefBoundKinds if it is "
+                + "genuinely new.");
+
+            Assert.True(
+                string.Equals(label, "MARKER", StringComparison.Ordinal)
+                    == target.StartsWith("!:", StringComparison.Ordinal),
+                $"'{target}' is labelled {label} but the !: marker "
+                + $"{(target.StartsWith("!:", StringComparison.Ordinal) ? "is" : "is not")} present. That "
+                + "label is decidable from the target, so a hand label that disagrees with it is wrong.");
+        }
+
+        Assert.All(SolutionProjectsWithoutCrefs.Values, bound => Assert.NotEmpty(bound));
+        Assert.All(ProjectDirectoriesOutsideTheSolution.Values, bound => Assert.NotEmpty(bound));
+    }
+
+    /// <summary>
+    /// Everything recorded as beyond this resolver's reach is DRIVEN — the accepted shapes against the real
+    /// universe, and the live sites against the real census.
+    ///
+    /// <para>#3079's finding, applied here: three limitations recorded in prose turned out to be
+    /// unobservable where they had been written, so the prose described a boundary nothing stood on. A
+    /// limit that is asserted goes red when it stops being true, which is the only way anyone finds out
+    /// that this resolver got sharper or blunter.</para>
+    /// </summary>
+    [Fact]
+    public void TheRecordedLimitsAreExercised()
+    {
+        var root = RepoRootOrFail();
+        var census = BuildCrefCensus(RepoSources(root), SolutionProjectDirectories(root));
+
+        /* The accepted shapes. The third row is a negative control, so "everything resolves" cannot pass
+           this. */
+        foreach (var (target, limit) in CrefShapesTheResolverAccepts)
+        {
+            var expected = !limit.StartsWith("NOTHING", StringComparison.Ordinal);
+
+            Assert.True(
+                CrefResolves(target, census.CodeIdentifiers) == expected,
+                $"'{target}' should{(expected ? " " : " NOT ")}resolve; its recorded limit says "
+                + $"\"{limit[..Math.Min(40, limit.Length)]}…\". A recorded boundary that has moved has to "
+                + "be re-stated, not left describing a resolver that no longer behaves that way.");
+        }
+
+        /* The live sites. Present in the census, and resolving — so both the site and the disagreement
+           with the compiler are still real. */
+        foreach (var (project, target, reason) in LiveSitesOutsideTheResolversReach)
+        {
+            var matches = census.Sites
+                .Where(s => s.Path.StartsWith(project + "/", StringComparison.Ordinal))
+                .Where(s => string.Equals(s.Target, target, StringComparison.Ordinal))
+                .ToArray();
+
+            Assert.True(matches.Length > 0,
+                $"no cref to '{target}' is left under '{project}', so the boundary this row records "
+                + $"({reason[..Math.Min(40, reason.Length)]}…) is no longer exercised anywhere. Find "
+                + "another live site for it or delete the row.");
+
+            Assert.All(matches, site => Assert.True(
+                CrefResolves(site.Target, census.CodeIdentifiers),
+                $"{site.Path}:{site.Line} no longer resolves here, so this row records a disagreement with "
+                + "the compiler that has stopped existing."));
+        }
+    }
+
+    /// <summary>
+    /// Every <c>cref</c> target this resolver cannot resolve, keyed by the target text and carrying the
+    /// sites it was read from — the value is what a failure message needs, and only the key is compared.
+    /// </summary>
+    private static SortedDictionary<string, List<CrefSite>> UnresolvedTargets(CrefCensus census)
+    {
+        var unresolved = new SortedDictionary<string, List<CrefSite>>(StringComparer.Ordinal);
+
+        foreach (var site in census.Sites)
+        {
+            if (CrefResolves(site.Target, census.CodeIdentifiers))
+            {
+                continue;
+            }
+
+            if (!unresolved.TryGetValue(site.Target, out var sites))
+            {
+                sites = new List<CrefSite>();
+                unresolved[site.Target] = sites;
+            }
+
+            sites.Add(site);
+        }
+
+        return unresolved;
+    }
+
+    /// <summary>
+    /// The three population counts, globally and then per solution project. Separated from the rule so the
+    /// starvation pin can drive it with a synthetic census, which reading the real tree could never
+    /// show.
+    /// </summary>
+    private static void AssertCrefPopulationFloors(
+        CrefCensus census, IReadOnlyList<string> projects, IEnumerable<string> withoutCrefs)
+    {
+        Assert.True(projects.Count > 0,
+            "no solution project was derived, so the per-project floors below iterate over nothing and "
+            + "every one of them passes vacuously.");
+
+        Assert.True(census.ByProject.Values.Sum(c => c.Files) > 0,
+            "the sweep scanned no files at all. Every rule reading this census reports a clean tree.");
+
+        Assert.True(census.Sites.Count > 0,
+            "the sweep extracted no cref from any file, so nothing is being resolved and the offender set "
+            + "is empty for want of input rather than for want of offenders.");
+
+        Assert.True(census.CodeIdentifiers.Count > 0,
+            "the identifier universe is empty, so nothing could resolve and the offender set would be "
+            + "every cref in the tree — loud, but for the wrong reason.");
+
+        foreach (var project in projects)
+        {
+            census.ByProject.TryGetValue(project, out var counts);
+
+            Assert.True(counts.Files > 0,
+                $"the sweep read no .cs file under solution project '{project}'. A repository-wide total "
+                + "is dominated by the largest tree, so a project dropped from the walk passes any global "
+                + "floor while contributing nothing (#3067).");
+
+            Assert.True(counts.DocBlocks > 0,
+                $"the sweep found no /// doc-comment block under '{project}', so the doc-comment collector "
+                + "read its files and produced nothing from them.");
+        }
+
+        Assert.Equal(
+            withoutCrefs.OrderBy(k => k, StringComparer.Ordinal).ToArray(),
+            projects
+                .Where(p => !census.ByProject.TryGetValue(p, out var c) || c.Crefs == 0)
+                .OrderBy(p => p, StringComparer.Ordinal)
+                .ToArray());
+    }
+
+    /// <summary>
+    /// One scan of <paramref name="sources"/>: the population per project, every cref, and the identifier
+    /// universe. Takes its sources as text rather than reading the disk itself, so every pin above can
+    /// drive it with an arranged population.
+    /// </summary>
+    private static CrefCensus BuildCrefCensus(
+        IEnumerable<(string Path, string Text)> sources, IReadOnlyList<string> projects)
+    {
+        /* Longest project path first, so a project nested inside another claims its own files. Nothing in
+           the solution is nested today; ordering it anyway means a later addition cannot silently be
+           counted against its parent. */
+        var byLength = projects.OrderByDescending(p => p.Length).ThenBy(p => p, StringComparer.Ordinal).ToArray();
+
+        var counts = new Dictionary<string, (int Files, int DocBlocks, int Crefs)>(StringComparer.Ordinal);
+        var sites = new List<CrefSite>();
+        var identifiers = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var (path, text) in sources)
+        {
+            var project = byLength.FirstOrDefault(
+                p => path.StartsWith(p + "/", StringComparison.Ordinal));
+
+            void Add(int files, int blocks, int crefs)
+            {
+                if (project is null)
+                {
+                    return;
+                }
+
+                counts.TryGetValue(project, out var current);
+                counts[project] = (current.Files + files, current.DocBlocks + blocks, current.Crefs + crefs);
+            }
+
+            Add(1, 0, 0);
+
+            /* String literals blanked FIRST. A /// line inside a raw-string fixture is indistinguishable
+               from a real doc comment to a line-prefix collector. Blanking literal TEXT while leaving comments
+               intact is the one transformation that separates them; StripCommentsAndStrings would take the
+               doc comments too, and there would be nothing left to collect. */
+            foreach (var block in DocCommentBlocks(WithStringLiteralsBlanked(text).Split('\n')))
+            {
+                Add(0, 1, 0);
+
+                var joined = string.Join("\n", block.Select(l => l.Text));
+
+                foreach (Match match in CrefReference.Matches(joined))
+                {
+                    /* The line the attribute OPENS on, which is where a reader has to go. Offsets are
+                       cumulative over the joined block plus one character per newline, so the arithmetic
+                       here and the join above cannot disagree. */
+                    var offset = 0;
+                    var line = block[0].Line;
+
+                    foreach (var (candidate, content) in block)
+                    {
+                        if (match.Index <= offset + content.Length)
+                        {
+                            line = candidate;
+                            break;
+                        }
+
+                        offset += content.Length + 1;
+                    }
+
+                    sites.Add(new CrefSite(
+                        path, line, match.Groups["element"].Value, match.Groups["target"].Value));
+                    Add(0, 0, 1);
+                }
+            }
+
+            foreach (Match token in IdentifierToken.Matches(CSharpSourceWalker.StripCommentsAndStrings(text)))
+            {
+                identifiers.Add(token.Value);
+            }
+        }
+
+        return new CrefCensus(counts, sites, identifiers);
+    }
+
+    /// <summary>
+    /// <paramref name="text"/> with every string literal's BODY blanked to spaces and its line structure
+    /// intact, so a <c>///</c>-prefixed line inside a literal is no longer <c>///</c>-prefixed.
+    ///
+    /// <para><b>Why this is not <see cref="CSharpSourceWalker.StripCommentsAndStrings"/>.</b> That one
+    /// blanks comments as well, and the population this feeds IS the comments. The walk is the same walk,
+    /// through <see cref="CSharpSourceWalker.StringLiteralBodies"/> — the mirror entry point — so a
+    /// delimiter one of them understands cannot desynchronise the other.</para>
+    ///
+    /// <para><b>The defect it closes, found by running this guard rather than by reading it.</b> A
+    /// line-prefix collector cannot tell a doc comment from a fixture that CONTAINS one, and the first
+    /// version of the cref rule duly read the crefs out of its own test data and reported them as
+    /// offenders in the tree.</para>
+    ///
+    /// <para><b>Where it is exercised, measured rather than assumed.</b> Nine <c>///</c> lines in the
+    /// whole repository sit inside a string literal and every one of them is in THIS file — the fixtures
+    /// below are the only live instance, and there were none before them. So the blanking is exercised
+    /// where the guard can see it rather than somewhere it might be, which is the direction #3079 asked
+    /// for; the arithmetic is a count the sweep produces, not a number written down here.</para>
+    /// </summary>
+    private static string WithStringLiteralsBlanked(string text)
+    {
+        var characters = text.ToCharArray();
+
+        foreach (var (start, body) in CSharpSourceWalker.StringLiteralBodies(text))
+        {
+            for (var i = 0; i < body.Length && start + i < characters.Length; i++)
+            {
+                if (characters[start + i] is not ('\n' or '\r'))
+                {
+                    characters[start + i] = ' ';
+                }
+            }
+        }
+
+        return new string(characters);
+    }
+
+    /// <summary>
+    /// Every STRICTLY contiguous run of <c>///</c> lines, with each line's number and its text after the
+    /// <c>///</c>.
+    ///
+    /// <para><b>Strictly contiguous, unlike <see cref="DocRuns"/>, and the difference is deliberate.</b>
+    /// That one continues a run across attribute lines because it is answering "which lines document this
+    /// member" (#2445). This one is answering "which lines are one XML fragment", which is what the
+    /// compiler parses a cref out of — an attribute line between two doc blocks separates two fragments,
+    /// and joining them could weld a target out of text that no parser ever sees together.</para>
+    /// </summary>
+    private static IEnumerable<IReadOnlyList<(int Line, string Text)>> DocCommentBlocks(string[] lines)
+    {
+        var block = new List<(int Line, string Text)>();
+
+        for (var i = 0; i <= lines.Length; i++)
+        {
+            var trimmed = i < lines.Length ? lines[i].TrimStart() : string.Empty;
+
+            if (i < lines.Length && trimmed.StartsWith("///", StringComparison.Ordinal))
+            {
+                block.Add((i + 1, trimmed[3..]));
+                continue;
+            }
+
+            if (block.Count > 0)
+            {
+                yield return block;
+                block = new List<(int Line, string Text)>();
+            }
+        }
+    }
+
+    /// <summary>
+    /// A cref target reduced to the dot-separated names it asserts exist. Every reduction is here, in one
+    /// place, so <see cref="TheResolverCannotLaunderAMalformedTarget"/> can drive all of them at once.
+    ///
+    /// <para>Reductions, in order: one documented kind prefix from <see cref="DocIdKindPrefixes"/>; the
+    /// parameter list from the first <c>(</c> onward; each balanced generic argument list; and whitespace at
+    /// each segment's edges, which is what XML leaves behind when a cref wraps across two lines. Nothing
+    /// else is touched — no punctuation is deleted, no brace is repaired, no interior whitespace is
+    /// collapsed — because each of those would turn a malformed target into a resolvable one, and this
+    /// resolver exists to notice malformed targets.</para>
+    /// </summary>
+    private static string[] CrefSegments(string target)
+    {
+        var text = target;
+
+        foreach (var prefix in DocIdKindPrefixes)
+        {
+            if (text.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                text = text[prefix.Length..];
+                break;
+            }
+        }
+
+        var parameters = text.IndexOf('(');
+        if (parameters >= 0)
+        {
+            text = text[..parameters];
+        }
+
+        text = GenericArgumentList.Replace(text, string.Empty);
+
+        return text.Split('.').Select(s => s.Trim()).ToArray();
+    }
+
+    /// <summary>
+    /// Whether every segment of <paramref name="target"/> is an identifier that
+    /// <paramref name="identifiers"/> holds.
+    /// </summary>
+    private static bool CrefResolves(string target, IReadOnlySet<string> identifiers)
+    {
+        var segments = CrefSegments(target);
+
+        return segments.Length > 0
+               && segments.All(s => WholeIdentifier.IsMatch(s) && identifiers.Contains(s));
+    }
+
+    /// <summary>
+    /// Every project directory the solution builds, repo-relative and forward-slashed, derived from
+    /// <c>PerformanceMonitor.sln</c> rather than written down.
+    /// </summary>
+    private static IReadOnlyList<string> SolutionProjectDirectories(string root)
+    {
+        var solution = File.ReadAllText(Path.Combine(root, "PerformanceMonitor.sln"));
+
+        var directories = Regex.Matches(solution, "\"([^\"]+\\.csproj)\"")
+            .Select(m => m.Groups[1].Value.Replace('\\', '/'))
+            .Where(p => p.Contains('/', StringComparison.Ordinal))
+            .Select(p => p[..p.LastIndexOf('/')])
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(p => p, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.NotEmpty(directories);
+
+        return directories;
+    }
+
+    /// <summary>
+    /// Every source file under <paramref name="root"/>, as a repo-relative forward-slashed path and its
+    /// text. The same set <see cref="SourceFiles"/> hands the other two rules, so a path excluded for one
+    /// is excluded for all three.
+    /// </summary>
+    private static IEnumerable<(string Path, string Text)> RepoSources(string root)
+    {
+        foreach (var file in SourceFiles(root))
+        {
+            yield return (Path.GetRelativePath(root, file).Replace('\\', '/'), File.ReadAllText(file));
         }
     }
 

--- a/Darling/Darling.Tests/DocCommentHygieneTests.cs
+++ b/Darling/Darling.Tests/DocCommentHygieneTests.cs
@@ -406,6 +406,31 @@ public sealed class DocCommentHygieneTests
         IReadOnlySet<string> CodeIdentifiers);
 
     /// <summary>
+    /// The real tree scanned ONCE per test run: the repo root, the solution's project directories, and the
+    /// census over both.
+    ///
+    /// <para><b>Why cached.</b> A scan reads and comment-strips every <c>.cs</c> file in the repository,
+    /// and eleven members here plus one nineteen-row <c>[Theory]</c> need the same answer — thirty walks of
+    /// the same unchanged tree per run, which is most of this class's cost, and the review bot on #3086
+    /// counted them before anyone timed them. The result is a pure function of on-disk state and nothing in
+    /// a test run changes that state. Measured on the local harness: 34s to 3.5s.</para>
+    ///
+    /// <para><b>What deliberately does NOT come through here.</b> Every pin that drives the sweep with an
+    /// ARRANGED population calls <see cref="BuildCrefCensus"/> directly, because a census built from a
+    /// fixture is the only way to assert that a floor reds on a starved one or that literal text is
+    /// excluded. Routing those through the cache would replace each of those claims with the tree's own
+    /// answer, which is the claim they exist to be independent of.</para>
+    /// </summary>
+    private static readonly Lazy<(string Root, IReadOnlyList<string> Projects, CrefCensus Census)>
+        RepositoryScan = new(() =>
+        {
+            var root = RepoRootOrFail();
+            var projects = SolutionProjectDirectories(root);
+
+            return (root, projects, BuildCrefCensus(RepoSources(root), projects));
+        });
+
+    /// <summary>
     /// One cref, anchored on the ELEMENT that carries it rather than on the attribute alone.
     ///
     /// <para><b>Why the element, which cost a round to learn.</b> A cref is only a reference when it is an
@@ -777,9 +802,7 @@ public sealed class DocCommentHygieneTests
     [Fact]
     public void EveryCrefTargetResolvesOrIsBounded()
     {
-        var root = RepoRootOrFail();
-        var projects = SolutionProjectDirectories(root);
-        var census = BuildCrefCensus(RepoSources(root), projects);
+        var (root, projects, census) = RepositoryScan.Value;
 
         /* The floors first, and inside this test rather than only in the one below it: a floor that lives
            somewhere else does not protect THIS assertion, and this is the assertion that reports zero
@@ -840,11 +863,9 @@ public sealed class DocCommentHygieneTests
     [Fact]
     public void ThePopulationIsFlooredPerSolutionProject()
     {
-        var root = RepoRootOrFail();
-        var projects = SolutionProjectDirectories(root);
+        var (_, projects, census) = RepositoryScan.Value;
 
-        AssertCrefPopulationFloors(
-            BuildCrefCensus(RepoSources(root), projects), projects, SolutionProjectsWithoutCrefs.Keys);
+        AssertCrefPopulationFloors(census, projects, SolutionProjectsWithoutCrefs.Keys);
     }
 
     /// <summary>
@@ -858,8 +879,7 @@ public sealed class DocCommentHygieneTests
     [Fact]
     public void TheDerivedProjectListCoversEveryProjectInTheTree()
     {
-        var root = RepoRootOrFail();
-        var solution = SolutionProjectDirectories(root);
+        var (root, solution, _) = RepositoryScan.Value;
 
         Assert.All(solution, project => Assert.True(
             Directory.Exists(Path.Combine(root, project.Replace('/', Path.DirectorySeparatorChar))),
@@ -899,9 +919,7 @@ public sealed class DocCommentHygieneTests
     [Fact]
     public void TheSweepReadsEveryFileUnderEverySolutionProject()
     {
-        var root = RepoRootOrFail();
-        var projects = SolutionProjectDirectories(root);
-        var census = BuildCrefCensus(RepoSources(root), projects);
+        var (root, projects, census) = RepositoryScan.Value;
 
         foreach (var project in projects)
         {
@@ -938,8 +956,7 @@ public sealed class DocCommentHygieneTests
     [Fact]
     public void TheRedundantArmsOfTheResolverRestOnPinnedProperties()
     {
-        var root = RepoRootOrFail();
-        var census = BuildCrefCensus(RepoSources(root), SolutionProjectDirectories(root));
+        var census = RepositoryScan.Value.Census;
 
         Assert.NotEmpty(census.CodeIdentifiers);
 
@@ -1077,8 +1094,7 @@ public sealed class DocCommentHygieneTests
     [Fact]
     public void TheElementsCarryingACrefAreTheOnesThisExtractorKnows()
     {
-        var root = RepoRootOrFail();
-        var census = BuildCrefCensus(RepoSources(root), SolutionProjectDirectories(root));
+        var census = RepositoryScan.Value.Census;
 
         Assert.Equal(
             CrefCarryingElements.Keys.OrderBy(k => k, StringComparer.Ordinal).ToArray(),
@@ -1118,10 +1134,12 @@ public sealed class DocCommentHygieneTests
                 .Select(m => m.Groups["target"].Value)
                 .ToArray());
 
-        var root = RepoRootOrFail();
-        var sources = RepoSources(root).ToArray();
-        var inDocComments = BuildCrefCensus(sources, SolutionProjectDirectories(root)).Sites.Count;
-        var anywhere = sources.Sum(s => CrefReference.Matches(s.Text).Count);
+        var (root, _, census) = RepositoryScan.Value;
+        var inDocComments = census.Sites.Count;
+
+        /* Re-read for the OTHER population — every cref-shaped reference in the file rather than only the
+           ones in a doc comment — which the census by construction does not carry. */
+        var anywhere = RepoSources(root).Sum(s => CrefReference.Matches(s.Text).Count);
 
         Assert.True(anywhere > inDocComments,
             $"every cref-shaped reference in the tree is inside a /// doc comment ({anywhere} found either "
@@ -1222,13 +1240,13 @@ public sealed class DocCommentHygieneTests
         Assert.Empty(splitTarget.Split('\n').SelectMany(l => CrefReference.Matches(l)));
         Assert.Empty(splitElement.Split('\n').SelectMany(l => CrefReference.Matches(l)));
 
-        var root = RepoRootOrFail();
-        var sources = RepoSources(root).ToArray();
-        var census = BuildCrefCensus(sources, SolutionProjectDirectories(root));
+        var (root, _, census) = RepositoryScan.Value;
 
         Assert.Contains(census.Sites, site => site.Target.Contains('\n', StringComparison.Ordinal));
 
-        var perDocLine = sources.Sum(s => s.Text.Split('\n')
+        /* Re-read for the per-LINE population, which is the comparison this pin is about and which the
+           census cannot supply. */
+        var perDocLine = RepoSources(root).Sum(s => s.Text.Split('\n')
             .Where(l => l.TrimStart().StartsWith("///", StringComparison.Ordinal))
             .Sum(l => CrefReference.Matches(l).Count));
 
@@ -1278,8 +1296,7 @@ public sealed class DocCommentHygieneTests
     [InlineData(false, "Z:CollectorCatalog")]
     public void TheResolverCannotLaunderAMalformedTarget(bool resolves, string target)
     {
-        var root = RepoRootOrFail();
-        var census = BuildCrefCensus(RepoSources(root), SolutionProjectDirectories(root));
+        var census = RepositoryScan.Value.Census;
 
         Assert.True(census.CodeIdentifiers.Contains("CollectorCatalog"),
             "the identifier universe does not contain a type this repository certainly declares, so every "
@@ -1339,9 +1356,7 @@ public sealed class DocCommentHygieneTests
     [Fact]
     public void TheBoundedSetIsComparedForEquality()
     {
-        var root = RepoRootOrFail();
-        var projects = SolutionProjectDirectories(root);
-        var census = BuildCrefCensus(RepoSources(root), projects);
+        var (root, projects, census) = RepositoryScan.Value;
         var real = UnresolvedTargets(census).Keys.OrderBy(k => k, StringComparer.Ordinal).ToArray();
 
         void Compare(IEnumerable<string> expected) => Assert.Equal(
@@ -1424,8 +1439,7 @@ public sealed class DocCommentHygieneTests
     [Fact]
     public void TheRecordedLimitsAreExercised()
     {
-        var root = RepoRootOrFail();
-        var census = BuildCrefCensus(RepoSources(root), SolutionProjectDirectories(root));
+        var census = RepositoryScan.Value.Census;
 
         /* The accepted shapes. The third row is a negative control, so "everything resolves" cannot pass
            this. */

--- a/Darling/Darling.Tests/DocCommentHygieneTests.cs
+++ b/Darling/Darling.Tests/DocCommentHygieneTests.cs
@@ -487,9 +487,11 @@ public sealed class DocCommentHygieneTests
         @"[A-Za-z_][A-Za-z0-9_]*",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
-    /// <summary>A doc-XML generic argument list — <c>{TRow}</c>, <c>{T, TResult}</c>. Balanced-free
-    /// (<c>[^{}]*</c>) on purpose: an UNCLOSED brace is then not removed, so the segment keeps it and fails
-    /// <see cref="WholeIdentifier"/> instead of being quietly repaired into something that resolves.</summary>
+    /// <summary>The INNERMOST doc-XML generic argument lists — <c>{TRow}</c>, <c>{T, TResult}</c>.
+    /// Balanced-free (<c>[^{}]*</c>) on purpose: an UNCLOSED brace is then not removed, so the segment
+    /// keeps it and fails <see cref="WholeIdentifier"/> instead of being quietly repaired into something
+    /// that resolves. Applied a level at a time by <see cref="StripGenericArguments"/>, because one pass
+    /// cannot match across a nested brace.</summary>
     private static readonly Regex GenericArgumentList = new(
         @"\{[^{}]*\}",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -721,6 +723,11 @@ public sealed class DocCommentHygieneTests
         ("ICollectorDefinition{NoSuchTypeAnywhere}", true,
             "GENERIC ARGUMENTS are discarded with the braces, so neither arity nor the arguments themselves "
             + "are checked."),
+
+        ("ICollectorDefinition{NoSuchTypeAnywhere, ICollectorDefinition{AlsoNoSuchType}}", true,
+            "NESTED GENERIC ARGUMENTS come off a level at a time, so the outer name is reached rather than "
+            + "left carrying a half-stripped brace. No such cref exists in the tree today; this row is "
+            + "what drives the loop, and without it the nesting would be an untested branch."),
 
         ("CollectorCatalog.NoSuchMemberButAppliesTo", false,
             "THE NEGATIVE CONTROL, and it is a row rather than a comment so that a resolver which said yes "
@@ -1307,6 +1314,10 @@ public sealed class DocCommentHygieneTests
        illegal. A balanced-anything pattern would have deleted it and resolved this. */
     [InlineData(false, "CollectorCatalog{TRow")]
     [InlineData(true, "CollectorCatalog{TRow}")]
+    /* Nested lists come off a level at a time; an unbalanced brace survives every level. */
+    [InlineData(true, "CollectorCatalog{TRow, CollectorCatalog{TRow}}")]
+    [InlineData(false, "CollectorCatalog{{TRow}")]
+    [InlineData(false, "CollectorCatalog{TRow}}")]
     /* Nullable annotations and stray punctuation are not identifiers and are not stripped. */
     [InlineData(false, "CollectorCatalog?")]
     [InlineData(false, "CollectorCatalog!")]
@@ -1713,11 +1724,45 @@ public sealed class DocCommentHygieneTests
     }
 
     /// <summary>
+    /// <paramref name="text"/> with every generic argument list removed, innermost first, until no more
+    /// come off.
+    ///
+    /// <para><b>Why a loop and not one pass.</b> <see cref="GenericArgumentList"/> cannot match across a
+    /// nested brace, so a single pass over <c>Dictionary{TKey,List{TValue}}</c> takes only the inner list
+    /// and leaves <c>Dictionary{TKey,List}</c> — a segment that then fails
+    /// <see cref="WholeIdentifier"/> and is reported unresolved although <c>Dictionary</c> is spelled all
+    /// over the tree. Loud rather than silent, but wrong, and the review on #3086 found it before any such
+    /// cref existed.</para>
+    ///
+    /// <para><b>What the loop still does NOT repair, which is the point.</b> Each pass removes only
+    /// BALANCED lists, so an unmatched brace survives every pass and the segment stays malformed:
+    /// <c>Foo{T</c> comes out unchanged, and <c>Foo{{T}</c> comes out as <c>Foo{</c>. Termination is by
+    /// construction — a pass that changes nothing ends it, and any pass that changes something has
+    /// removed at least two characters. Both directions are driven in
+    /// <see cref="TheResolverCannotLaunderAMalformedTarget"/>.</para>
+    /// </summary>
+    private static string StripGenericArguments(string text)
+    {
+        while (true)
+        {
+            var stripped = GenericArgumentList.Replace(text, string.Empty);
+
+            if (string.Equals(stripped, text, StringComparison.Ordinal))
+            {
+                return text;
+            }
+
+            text = stripped;
+        }
+    }
+
+    /// <summary>
     /// A cref target reduced to the dot-separated names it asserts exist. Every reduction is here, in one
     /// place, so <see cref="TheResolverCannotLaunderAMalformedTarget"/> can drive all of them at once.
     ///
     /// <para>Reductions, in order: one documented kind prefix from <see cref="DocIdKindPrefixes"/>; the
-    /// parameter list from the first <c>(</c> onward; each balanced generic argument list; and whitespace at
+    /// parameter list from the first <c>(</c> onward; every balanced generic argument list, innermost
+    /// first, via <see cref="StripGenericArguments"/>; and whitespace at
     /// each segment's edges, which is what XML leaves behind when a cref wraps across two lines. Nothing
     /// else is touched — no punctuation is deleted, no brace is repaired, no interior whitespace is
     /// collapsed — because each of those would turn a malformed target into a resolvable one, and this
@@ -1742,7 +1787,7 @@ public sealed class DocCommentHygieneTests
             text = text[..parameters];
         }
 
-        text = GenericArgumentList.Replace(text, string.Empty);
+        text = StripGenericArguments(text);
 
         return text.Split('.').Select(s => s.Trim()).ToArray();
     }

--- a/Darling/Darling.Tests/DocCommentHygieneTests.cs
+++ b/Darling/Darling.Tests/DocCommentHygieneTests.cs
@@ -872,6 +872,85 @@ public sealed class DocCommentHygieneTests
     }
 
     /// <summary>
+    /// The sweep reads EVERY source file under every solution project, counted against the disk.
+    ///
+    /// <para><b>Why this is a separate assertion from the floors, and the finding that produced it.</b>
+    /// Mutation-testing the per-project <c>Files &gt; 0</c> floor showed it survives: a project whose files
+    /// vanish from the sweep also loses its doc blocks, so the doc-block floor reds first and the file
+    /// floor never decides anything. That leaves the case the floors genuinely cannot see — a sweep that
+    /// reads SOME of a project's files. Doc blocks and crefs both stay well above zero, every floor passes,
+    /// and the guard is quietly running on a fraction of the tree.</para>
+    ///
+    /// <para>Both sides are derived: the census's count from the walk, and the expected count from the same
+    /// build-output filter the walk uses. So this is an equality between two derivations rather than
+    /// against a number written here, which is the only form that does not go stale as files are
+    /// added.</para>
+    /// </summary>
+    [Fact]
+    public void TheSweepReadsEveryFileUnderEverySolutionProject()
+    {
+        var root = RepoRootOrFail();
+        var projects = SolutionProjectDirectories(root);
+        var census = BuildCrefCensus(RepoSources(root), projects);
+
+        foreach (var project in projects)
+        {
+            var onDisk = Directory
+                .EnumerateFiles(
+                    Path.Combine(root, project.Replace('/', Path.DirectorySeparatorChar)),
+                    "*.cs",
+                    SearchOption.AllDirectories)
+                .Count(f => !HasBuildOutputSegment(Path.GetRelativePath(root, f)));
+
+            census.ByProject.TryGetValue(project, out var counts);
+
+            Assert.True(counts.Files == onDisk,
+                $"the sweep read {counts.Files} of the {onDisk} source file(s) under '{project}'. A partial "
+                + "read clears every population floor — the doc-block and cref counts stay far above zero — "
+                + "so nothing else here can tell it from a whole one.");
+        }
+    }
+
+    /// <summary>
+    /// The two arms of <see cref="CrefResolves"/> that cannot fail today rest on properties that are
+    /// pinned, so they are defence in depth rather than decoration.
+    ///
+    /// <para><b>Found by mutation testing, and worth keeping rather than deleting.</b> Unanchoring
+    /// <see cref="WholeIdentifier"/> changes no answer, because the universe is built from identifier
+    /// TOKENS and set membership therefore already implies identifier shape. Dropping the
+    /// <c>Length &gt; 0</c> arm changes no answer either, because <see cref="string.Split(char[])"/> never
+    /// returns an empty array. Both are true of code OUTSIDE
+    /// <see cref="CrefResolves"/> — how the universe is built, and how a target is split — and a change
+    /// there is exactly how a malformed target would start resolving. So the arms stay and the properties
+    /// they rest on are asserted here; a mutation that survives because a property holds is a different
+    /// thing from one that survives because nothing checks it.</para>
+    /// </summary>
+    [Fact]
+    public void TheRedundantArmsOfTheResolverRestOnPinnedProperties()
+    {
+        var root = RepoRootOrFail();
+        var census = BuildCrefCensus(RepoSources(root), SolutionProjectDirectories(root));
+
+        Assert.NotEmpty(census.CodeIdentifiers);
+
+        var shapeless = census.CodeIdentifiers.Where(i => !WholeIdentifier.IsMatch(i)).Take(5).ToArray();
+
+        Assert.True(shapeless.Length == 0,
+            "the identifier universe holds string(s) that are not whole identifiers: "
+            + $"[{string.Join(", ", shapeless.Select(s => $"'{s}'"))}]. Set membership no longer implies "
+            + "identifier shape, so WholeIdentifier in CrefResolves has become the only thing rejecting a "
+            + "malformed segment — check that it still does before relying on it.");
+
+        /* And the split arm: a degenerate target yields at least one segment, which is then compared and
+           rejected. If this ever came back empty, All(...) would be vacuously true and the target would
+           resolve. */
+        foreach (var degenerate in new[] { "", ".", "..", "   ", "!:", "{}", "T:", "()" })
+        {
+            Assert.NotEmpty(CrefSegments(degenerate));
+        }
+    }
+
+    /// <summary>
     /// The floors really do fail on a starved population, and they fail PER PROJECT — each of the three
     /// counts, for each project in turn, is individually load-bearing.
     ///
@@ -1629,6 +1708,11 @@ public sealed class DocCommentHygieneTests
     /// <summary>
     /// Whether every segment of <paramref name="target"/> is an identifier that
     /// <paramref name="identifiers"/> holds.
+    ///
+    /// <para>Both arms are redundant TODAY and kept deliberately;
+    /// <see cref="TheRedundantArmsOfTheResolverRestOnPinnedProperties"/> asserts the properties that make
+    /// them so, and says why deleting them would move the defence into code that does not know it is
+    /// holding it.</para>
     /// </summary>
     private static bool CrefResolves(string target, IReadOnlySet<string> identifiers)
     {


### PR DESCRIPTION
Doc comments across the tree carry `<see cref="…"/>` references and nothing resolved any of them. `DocCommentHygieneTests` grows a third rule: every cref in the repository names a symbol this repository's code spells, or is one of 31 bounded exceptions carrying the reason it cannot resolve.

## The count, re-derived, and why 22 is not it

The issue's figure of 22 came from another lane's scan and is not reproducible as any measurement I can construct. Three numbers, from two independent mechanisms:

| measurement | result |
| --- | --- |
| `CS1574` (compiler, `GenerateDocumentationFile` switched on **from the command line only** — no project file changed, here or in this PR) | **71 occurrences on 70 lines**, whole solution; 68 on 67 excluding `deprecated/`. This resolver's set meets it on **8** lines |
| this resolver's real defects | **19 targets / 20 sites** |
| this resolver's recorded boundary | 12 targets / 21 sites, labelled `OUTSIDE` |

22 is in the family of the second: a name-existence scan that does not trim whitespace around the dot, and counts one BCL overload case as a defect, lands on 21 targets / 22 sites. Both of those are artefacts. The two defensible numbers are 71 and 20, and they measure different things.

## Option 1 is not what this replaces, and the reason is measurable

`GenerateDocumentationFile` stays off and stays Erik's call from #3025. That run also prices the decision: turning it on surfaces **16,159 `CS1591`** sites and **514 `CS1573`** alongside the 71 `CS1574` (raw occurrence counts are ~2.8x those, because the WPF temp projects recompile the same sources and re-emit every warning), so it is a `NoWarn` design decision and not a flag flip.

More to the point, the two mechanisms do not subsume each other, and the direction that matters is the one nobody would guess:

**12 targets / 13 sites in this tree carry `cref="!:Something"`.** `!:` is the ID string the compiler *emits* for a reference it could not resolve, and a cref carrying any `<letter>:` prefix is treated as an already-resolved ID and passed through unresolved. So those 13 compile silently, emit a dead reference, and are invisible to `CS1574` **whether or not the flag is ever enabled**. Every one names a symbol this repository really declares. `ComposeSpec.cs:60` carries one two lines below a cref that resolves perfectly well, in the same doc block.

In the other direction the compiler sees 62 lines this resolver cannot, for four reasons, each recorded as a row in `LiveSitesOutsideTheResolversReach` and each asserted against a live site rather than described: member names resolved repo-wide instead of against the declaring type (`AppliesTo`), namespace imports ignored (`PlanCorrectionCollector`), assembly boundaries ignored entirely (`PerformanceMonitorLite.Analysis.Recommendations.LiteRecommendationItem`, cref'd from a viewer that does not reference the Lite assembly and says so in the next sentence of its own doc comment), and parameter lists discarded so overloads are never checked (`Write(char)`).

That third row is also the answer to "both SKUs": resolution is repository-wide precisely so one guard covers both trees, and ignoring assembly boundaries is that same property seen from the other side. It is the boundary and the design at once.

## What the guard is

- **Population**: every `.cs` file under the repo root, `bin`/`obj` excluded — the set the class's other two rules already read. Strictly contiguous `///` blocks, joined, with string-literal bodies blanked first.
- **Extraction**: anchored on the doc ELEMENT (`<see …`), element name captured rather than enumerated, value group a negated class.
- **Resolution**: every dot-separated segment, after four stated reductions, must be an identifier appearing in the repository's C# code with comments and string literals removed by `CSharpSourceWalker.StripCommentsAndStrings`.
- **The allow-list**: keyed by target text, compared for **set equality**, three kinds — `MARKER` (12), `DANGLING` (7), `OUTSIDE` (12) — with the label cross-checked against the one thing that is mechanically decidable. None of the 31 references is fixed here; mixing the repair in would make the guard's own red-proof unreadable.
- **Floors**: per solution project, and the project list is derived from `PerformanceMonitor.sln` rather than written down. A global total is dominated by `Darling`, which carries 4,384 of the 7,075 crefs, so a sweep that lost `PerformanceMonitor.Collectors` entirely would clear any global floor.

`files scanned > 0`, `doc blocks > 0` and `crefs extracted > 0` are separate assertions from `dangling == 0`, asserted per project, and asserted **inside** the rule as well as in their own test — a floor living somewhere else does not protect the assertion that reports zero offenders.

## Red-proof

18 mutations, each applied to a committed tree, run, restored, and the restore verified by grepping for the patched symbol. **Two survived and both were real:**

- the per-project `Files > 0` floor is subsumed by the doc-block floor, so it could never decide anything. The case it left open — a sweep reading *some* of a project's files — clears every floor. `TheSweepReadsEveryFileUnderEverySolutionProject` now counts the census against the disk.
- `WholeIdentifier` and the `Length > 0` arm of `CrefResolves` are both redundant today, for reasons that live in *other* code: the universe is built from identifier tokens, and `Split` never returns an empty array. They stay, and `TheRedundantArmsOfTheResolverRestOnPinnedProperties` asserts the two properties — injecting `!:X` into the universe reds it, and that mutation is exactly how the twelve `MARKER` entries would start resolving.

Killed, one pin each: accepting `!:` as a kind prefix; a greedy value group; an attribute-only anchor; dropping the literal blanking; a closed element alternation; per-line extraction; a truncated project list; a resolver stubbed to yes and to no; a universe built from raw text; an unclosed-brace repair; a mislabelled kind; a partial file read; pointing a recorded-boundary row at the wrong project; and a deliberately introduced cross-app literal, which reds `CrossAppGuardCiGateTests` and is how the paragraph below is measured rather than argued.

Every mutation was re-run after the caching change below and behaves identically, so the shared census weakened nothing — the pins that assert a floor reds on a starved population, or that literal text is excluded, still build their own census from an arranged one, which is the claim they exist to be independent of.

The extraction anchor and the literal blanking are both findings from *running* the guard: the first version reported two offenders it had written itself in its own prose, and a third out of its own test fixtures. A fourth arrived while addressing the review below — a `<see cref="TheoryAttribute"/>` written into a new doc comment, which the rule failed on immediately.

## The review bot's findings, all taken

**Cost.** `BuildCrefCensus` was called from ten `[Fact]`s plus every one of an eighteen-row `[Theory]`'s cases, each re-walking and comment-stripping every `.cs` file in the repository: 28 scans of an unchanged tree per run. Measured on the local harness, **34.2s to 3.4s** for the same 90 tests. The real tree is now scanned once behind a `Lazy`; every pin that drives an *arranged* population still builds its own census, deliberately, because routing those through the shared one would replace each of their claims with the tree's own answer.

**Nested generic arguments.** `\{[^{}]*\}` cannot match across a nested brace, so one pass over `Dictionary{TKey,List{TValue}}` took only the inner list and left `Dictionary{TKey,List}` — reported unresolved, loudly but wrongly, for a type spelled all over the tree. No such cref exists yet, which is why the bot found it and the guard could not. The lists now come off innermost-first until none remain, and an *unbalanced* brace still survives every pass and stays malformed, which is the property that keeps the loop from being a repair. Driven both ways: a row in `CrefShapesTheResolverAccepts` and three theory cases, and reverting the loop to a single pass reds five pins.

**The repository root filtered out of both sides of the project-coverage difference.** `DirectoryOf`'s crash guard against `p[..p.LastIndexOf('/')]` dropped separator-less paths, and it gated *both* `onDisk` and `SolutionProjectDirectories` — so a `.csproj` at the repository root was excluded from both operands of `onDisk.Except(solution)` identically. The difference was empty for it by construction, and it would never have received a per-project floor: a guard structurally unable to report the one thing it exists to report, which is the shape this class's own doc comment warns about. Both sides now route through a shared `DirectoryOf` with the root spelled as the empty string rather than dropped; `IsUnder` is the shared attribution predicate and carries #3067's separator property, so the census's attribution and the disk-side count cannot come to disagree about which project owns a file; and the root project's file count reads `SearchOption.TopDirectoryOnly`, without which a root project's recursive count swallows the whole tree and every per-project floor becomes meaningless. No `.csproj` sits at the root today, so `TheRootIsAProjectDirectoryLikeAnyOther` drives it on an arranged population — both helpers in both directions, plus a census round-trip with a deeper project as the negative control so "everything lands in the root" cannot pass. Reverting either half reds it.

## CI reachability

This rule reads Lite's tree and `deprecated/`, and per the section #3084 just added to `CONTRIBUTING.md`: `CrossAppGuardCiGateTests` cannot see the read, by construction — the sweep takes the repo root as a variable and names no root literal, which is the same position the class's existing two rules are already in. That is measured, not assumed: the guard's 12 tests pass on this change and go red when a `"Lite.Tests/…"` literal is inserted.

No filter entry is needed and none is added. The build job's `darling` filter already reaches `Lite/**/*.cs` and `Lite/**/*.xaml` (#2114, #2839), and where no area filter fires at all, `darling-tree-guards` runs the whole `Darling.Tests` suite gated on the build job's step reporting `skipped`. That backstop is the bound, it is now stated in the class summary, and it replaces a paragraph there that predated the job and claimed a Lite-only change would be caught "on the next nightly instead".

## Two stale claims in the file, corrected in passing

- the class summary said **"One rule today"** while two rules had shipped — stale before this PR, and stale by two after it. Rewritten as a list with no numeral, which is the #3069 disposition for a counted claim nothing derives.
- the coverage paragraph described the pre-`darling-tree-guards` world, as above.

The heading above carries no numeral for the same reason: it read "both taken" and enumerated two while three had been taken, the third having landed after that section was written. `description-drift` passes either way, so nothing catches it. A stale numeral in the description of the PR that removes stale numerals from the source is the same defect one level out.

## Verification

`Darling.Tests` and `Lite.Tests` are `net10.0-windows` and cannot execute on macOS, so the actual `.cs` files were compiled into a throwaway `net10.0` xunit v3 harness inside the gitignored project `bin/`: `DocCommentHygieneTests`, `CSharpSourceWalker`, `CommentFilterAdoptionTests`, and `CrossAppGuardCiGateTests` with `ParitySource`. Baseline run last, after every mutation was restored: **Total 90, Failed 0, Not Run 0, Skipped 0**. The build is asserted to have produced a fresh dll before each run, so a failed compile cannot leave the runner on a stale binary. CI remains the arbiter.

