### PR TITLE
Fixes #3088

### DIFF
--- a/Darling/Darling.Tests/PgPanelTabOwnershipTests.cs
+++ b/Darling/Darling.Tests/PgPanelTabOwnershipTests.cs
@@ -157,10 +157,12 @@ public sealed class PgPanelTabOwnershipTests
     /// Asked from this direction the loss has nowhere to hide: a grid nothing fills is named, whether the
     /// assignment was dropped by a bad read or deleted from the source.</para>
     ///
-    /// <para>Grids only. Four notes — <c>PgActivityNote</c>, <c>PgOverviewNote</c>, <c>PgStorageNote</c>,
-    /// <c>PgVacuumNote</c> — are static tab-level prose set in the markup and assigned by no loader, so
-    /// requiring a load path for every named control would need an exemption table. A grid is the case with
-    /// no legitimate exception: it exists to hold collected rows, and rows arrive on a load path.</para>
+    /// <para>Grids only, and the four exceptions are why. <c>PgOverviewNote</c>, <c>PgActivityNote</c>,
+    /// <c>PgVacuumNote</c> and <c>PgStorageNote</c> are tab-level framing prose assigned once in
+    /// <c>ApplyEngineTabSet</c> — tab setup, not a load path — so requiring a load path for every named
+    /// control would need an exemption table, and an exemption table is what this rule exists without. A
+    /// grid is the case with no legitimate exception: it holds collected rows, and rows arrive on a load
+    /// path.</para>
     /// </summary>
     [Fact]
     public void EveryPgGridOnAPgTab_IsFilledBySomePgTabsLoadPath()

--- a/Darling/Darling.Tests/PgPanelTabOwnershipTests.cs
+++ b/Darling/Darling.Tests/PgPanelTabOwnershipTests.cs
@@ -565,7 +565,12 @@ public sealed class PgPanelTabOwnershipTests
             var tab = $"Pg{arm.Groups["tab"].Value}Tab";
             var entry = $"LoadPg{arm.Groups["loader"].Value}Async";
 
-            Assert.Contains(entry, declarations);
+            /* Per-arm rather than a count: a floor on the declaration total cannot tell which entry point
+               went missing, and the tab whose loader is gone is exactly the tab that stops being checked. */
+            Assert.True(declarations.Contains(entry),
+                $"The dispatcher routes {tab} to {entry}, but no such declaration exists in "
+                + "ViewerServerTab.Postgres.cs. Every panel that tab renders would resolve to an empty load "
+                + "path, and an empty load path is what both rules below read as nothing to disagree about.");
 
             loadPaths[tab] = Transitive(entry, loaderCode, ranges, new HashSet<string>(StringComparer.Ordinal));
         }

--- a/Darling/Darling.Tests/PgPanelTabOwnershipTests.cs
+++ b/Darling/Darling.Tests/PgPanelTabOwnershipTests.cs
@@ -32,6 +32,22 @@ namespace Darling.Tests;
 ///
 /// <para>Ownership resolves to the OUTERMOST named <c>TabItem</c>, because Activity holds a sub-tab control
 /// and a panel inside its Blocking sub-tab is still loaded by <c>LoadPgActivityAsync</c>.</para>
+///
+/// <para><b>How the C# is read, and why it is not a regex of this file's own.</b> Both <c>.cs</c> files go
+/// through <see cref="CSharpSourceWalker"/> (#3052). The comment-stripping regex this file used to carry
+/// removed <c>///</c> and <c>//</c> lines and left <c>/* … */</c> blocks entirely — and this repo puts no
+/// asterisk on a block comment's continuation lines, so every continuation line was handed to the scanner as
+/// code. A comment explaining why a grid is filled somewhere else read as an assignment filling it HERE.
+/// The walk also makes the brace count that finds a loader body immune to a brace inside a string or char
+/// literal, which decided whether a body was read whole.</para>
+///
+/// <para>Because the walk blanks literal TEXT as well as comments, a scan that needed a literal's contents
+/// would have to read them out of the original source at the offset matched in the walked text (the
+/// <c>PgRegistryPanelPlacementTests.LiteralAt</c> idiom, sound because the two are character-aligned).
+/// Nothing here does: every token these regexes match — a control name, a member access, a method name, a
+/// <c>case</c> label — is code, and code survives the walk untouched.
+/// <see cref="EveryPgGridOnAPgTab_IsFilledBySomePgTabsLoadPath"/> is what goes red if that stops holding,
+/// naming the grid whose assignment the read could no longer see.</para>
 /// </summary>
 public sealed class PgPanelTabOwnershipTests
 {
@@ -55,6 +71,24 @@ public sealed class PgPanelTabOwnershipTests
     private static readonly Regex DispatcherArm = new(
         @"case\s+Pg(?<tab>\w+)InnerTabIndex:\s*\r?\n\s*await\s+LoadPg(?<loader>\w+)Async\(\);",
         RegexOptions.Compiled);
+
+    /// <summary>
+    /// A loader declaration. A field rather than an inline literal so <see cref="Read"/> can count the
+    /// declarations WITHOUT going through the brace scan — a scan that lost a method would otherwise be
+    /// counted by the same code that lost it, and a dropped method is silent everywhere downstream: every
+    /// panel it assigns simply stops being attributed to any tab.
+    /// </summary>
+    private static readonly Regex MethodDeclaration = new(
+        @"private\s+async\s+Task\s+(?<name>LoadPg[A-Za-z]+Async)\s*\(", RegexOptions.Compiled);
+
+    /// <summary>
+    /// A grid's <c>x:Name</c> in the raw XAML text, for the population cross-check in
+    /// <see cref="EveryPgGridOnAPgTab_IsFilledBySomePgTabsLoadPath"/>. Deliberately a second reading of the
+    /// same file that shares no code with the <see cref="XDocument"/> walk: the rule's success condition is
+    /// an EMPTY offender list, and a walk that resolved no grids would satisfy it without checking anything.
+    /// </summary>
+    private static readonly Regex XamlGridName = new(
+        @"x:Name=""(?<name>Pg[A-Za-z]+Grid)""", RegexOptions.Compiled);
 
     [Fact]
     public void EveryPanelAPgTabLoadPathFills_IsDeclaredInsideThatTab()
@@ -110,10 +144,64 @@ public sealed class PgPanelTabOwnershipTests
             + $"KnownOffTab and close the issue they cite:\n  {string.Join("\n  ", stale)}");
     }
 
+    /// <summary>
+    /// Every grid declared inside a PostgreSQL tab is filled by SOME PostgreSQL tab's load path.
+    ///
+    /// <para><b>This is what makes a partial loss loud.</b> The rule above is per-panel but it only ever
+    /// looks at panels the read FOUND, so anything the read drops makes it quieter rather than red: it
+    /// compares fewer pairs and reports a clean run. Its one floor — a tab's load path assigns at least one
+    /// panel — trips only when a whole tab is zeroed. Measured on the shipped tree: a stray <c>}</c> in a
+    /// literal at the top of <c>LoadPgIoAsync</c> takes the I/O tab from six panels to none and reds that
+    /// floor, and the same <c>}</c> one line later takes it from six to ONE and is completely green, with
+    /// four of the five lost panels belonging to the two loaders the truncation also stopped following.
+    /// Asked from this direction the loss has nowhere to hide: a grid nothing fills is named, whether the
+    /// assignment was dropped by a bad read or deleted from the source.</para>
+    ///
+    /// <para>Grids only. Four notes — <c>PgActivityNote</c>, <c>PgOverviewNote</c>, <c>PgStorageNote</c>,
+    /// <c>PgVacuumNote</c> — are static tab-level prose set in the markup and assigned by no loader, so
+    /// requiring a load path for every named control would need an exemption table. A grid is the case with
+    /// no legitimate exception: it exists to hold collected rows, and rows arrive on a load path.</para>
+    /// </summary>
+    [Fact]
+    public void EveryPgGridOnAPgTab_IsFilledBySomePgTabsLoadPath()
+    {
+        var (tabOf, loadPaths) = Read();
+
+        var grids = tabOf.Keys.Where(n => n.EndsWith("Grid", StringComparison.Ordinal))
+                              .ToHashSet(StringComparer.Ordinal);
+
+        /* The population, read a second time out of the raw markup by a regex that shares no code with the
+           XDocument walk above. The rule's success condition is an empty offender list, so a walk that
+           resolved no grids would pass it vacuously; and a walk that resolved SOME of them would pass it
+           just as quietly. Equality rather than a floor, because both readings answer the same question
+           over the same file and a disagreement is a finding either way. */
+        var declaredInMarkup = XamlGridName.Matches(ViewerFile("ViewerServerTab.xaml"))
+            .Select(m => m.Groups["name"].Value)
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.True(declaredInMarkup.Count >= 25,
+            $"Only {declaredInMarkup.Count} Pg…Grid x:Name attributes were found in ViewerServerTab.xaml. "
+            + "The PostgreSQL surface ships more grids than that, so the markup is not being read and every "
+            + "assertion below would be over the remainder.");
+
+        Assert.Equal(declaredInMarkup.OrderBy(g => g, StringComparer.Ordinal).ToList(),
+                     grids.OrderBy(g => g, StringComparer.Ordinal).ToList());
+
+        var filled = loadPaths.Values.SelectMany(p => p).ToHashSet(StringComparer.Ordinal);
+        var unfilled = grids.Where(g => !filled.Contains(g)).OrderBy(g => g, StringComparer.Ordinal).ToList();
+
+        Assert.True(unfilled.Count == 0,
+            "These grids are declared inside a PostgreSQL tab but no PostgreSQL tab's load path assigns "
+            + "them, so they render empty forever and an empty grid reads as 'nothing to report'. Either "
+            + "the assignment is gone, or it is in a method no dispatcher arm reaches, or the source read "
+            + "above lost it — check the loader that used to fill it before changing this rule:\n  "
+            + string.Join("\n  ", unfilled));
+    }
+
     [Fact]
     public void TheDispatcher_NamesEachTabAndItsLoaderConsistently()
     {
-        var shell = File.ReadAllText(Path.Combine(ViewerDirectory(), "ViewerServerTab.xaml.cs"));
+        var shell = CSharpSourceWalker.StripCommentsAndStrings(ViewerFile("ViewerServerTab.xaml.cs"));
         var arms = DispatcherArm.Matches(shell);
 
         Assert.True(arms.Count >= 6, $"Found {arms.Count} PostgreSQL dispatcher arms; the pattern no longer matches the switch.");
@@ -148,6 +236,137 @@ public sealed class PgPanelTabOwnershipTests
         Assert.Single(reported);
     }
 
+    /// <summary>
+    /// The control for the step every rule here stands on: <see cref="MethodRanges"/> counts braces, so a
+    /// brace inside a string or char literal decides whether a loader's body is read whole. Arranged rather
+    /// than measured on the shipped tree, because the shipped tree happens to balance its literal braces
+    /// today — it holds no brace in any literal at all — and "safe today because they happen to balance" is
+    /// the standing assumption this file exists to refuse.
+    ///
+    /// <para>Both directions are asserted, so the walk is shown to be what saves it rather than asserted to
+    /// be. A <c>}</c> in a literal ends the raw count early and TRUNCATES the body, silently dropping every
+    /// control assignment after it and every loader it would have followed. A <c>{</c> in a literal never
+    /// lets the count return to zero: mid-file the scan OVER-EXTENDS into the methods below and attributes
+    /// their panels to this tab, and at end of file it finds no closing brace at all and the method is
+    /// DROPPED. None of the three shows up as an error downstream — a truncated body just yields fewer
+    /// panels, and fewer panels is a quieter rule, not a failing one.</para>
+    /// </summary>
+    [Fact]
+    public void TheMethodWalk_ReadsABodyWhoseLiteralsHoldUnbalancedBraces_AndTheRawCountDoesNot()
+    {
+        /* A closing brace inside a literal: the raw count reaches zero at it and stops there. */
+        const string truncates = """
+            private async Task LoadPgProbeAsync()
+            {
+                PgProbeNote.Text = "no autovacuum has run } yet";
+                PgProbeGrid.ItemsSource = rows;
+            }
+            """;
+
+        var walkedCode = CSharpSourceWalker.StripCommentsAndStrings(truncates);
+        var walked = MethodRanges(walkedCode);
+        var raw = MethodRanges(truncates);
+
+        var walkedBody = truncates[walked["LoadPgProbeAsync"].Start..walked["LoadPgProbeAsync"].End];
+        Assert.Equal(2, ControlAssignment.Matches(walkedBody).Count);
+        Assert.Contains("PgProbeGrid", walkedBody, StringComparison.Ordinal);
+
+        var rawBody = truncates[raw["LoadPgProbeAsync"].Start..raw["LoadPgProbeAsync"].End];
+        Assert.Single(ControlAssignment.Matches(rawBody));
+        Assert.DoesNotContain("PgProbeGrid", rawBody, StringComparison.Ordinal);
+
+        /* And the diagnosis in Read() is what turns that truncation into a red rather than a quieter rule. */
+        Assert.Null(BodyDiagnosis(walkedCode, walked["LoadPgProbeAsync"].Start, walked["LoadPgProbeAsync"].End));
+        Assert.Equal("truncated", BodyDiagnosis(walkedCode, raw["LoadPgProbeAsync"].Start, raw["LoadPgProbeAsync"].End));
+
+        /* An OPENING brace in a char literal is the other direction. Mid-file the raw count runs on into the
+           method below and takes its panels with it, which is the over-extension the diagnosis names. */
+        const string overExtends = """
+            partial class ViewerServerTab
+            {
+                private async Task LoadPgProbeAsync()
+                {
+                    var opener = '{';
+                    PgProbeGrid.ItemsSource = rows;
+                }
+
+                private async Task LoadPgOtherAsync()
+                {
+                    PgOtherGrid.ItemsSource = rows;
+                }
+            }
+            """;
+
+        var overCode = CSharpSourceWalker.StripCommentsAndStrings(overExtends);
+        var overWalked = MethodRanges(overCode);
+        var overRaw = MethodRanges(overExtends);
+
+        Assert.DoesNotContain("PgOtherGrid",
+            overExtends[overWalked["LoadPgProbeAsync"].Start..overWalked["LoadPgProbeAsync"].End],
+            StringComparison.Ordinal);
+        Assert.Contains("PgOtherGrid",
+            overExtends[overRaw["LoadPgProbeAsync"].Start..overRaw["LoadPgProbeAsync"].End],
+            StringComparison.Ordinal);
+
+        Assert.Null(BodyDiagnosis(overCode, overWalked["LoadPgProbeAsync"].Start, overWalked["LoadPgProbeAsync"].End));
+        Assert.Equal("over-extended", BodyDiagnosis(overCode, overRaw["LoadPgProbeAsync"].Start, overRaw["LoadPgProbeAsync"].End));
+
+        /* At end of file the same brace finds no closing brace at all and the method is dropped outright,
+           which no per-body diagnosis can name because there is no body to diagnose. That is what the
+           declaration count in Read() is for, and MethodDeclaration is the field it counts with — it sees
+           the declaration whether or not the scan resolved a body for it. */
+        const string drops = """
+            private async Task LoadPgProbeAsync()
+            {
+                var opener = '{';
+                PgProbeGrid.ItemsSource = rows;
+            }
+            """;
+
+        Assert.True(MethodRanges(CSharpSourceWalker.StripCommentsAndStrings(drops)).ContainsKey("LoadPgProbeAsync"));
+        Assert.Empty(MethodRanges(drops));
+        Assert.Single(MethodDeclaration.Matches(drops));
+    }
+
+    /// <summary>
+    /// The other half of the same adoption, on an arranged body for the same reason: the shipped
+    /// <c>ViewerServerTab.Postgres.cs</c> carries fourteen multi-line block comments spanning
+    /// thirty-five continuation lines and none of them happens to name a control today, so nothing on the
+    /// tree can show what the regex did with one that does.
+    ///
+    /// <para>This repo writes no asterisk on a continuation line, so the old regex — <c>///</c> lines and
+    /// <c>//</c> to end of line — left every continuation line in the code stream. A comment saying a grid
+    /// is filled on ANOTHER tab therefore read as an assignment filling it HERE, and the rule reported the
+    /// panel it had just been told about. Both directions asserted, so the walk is shown to be what fixes
+    /// it.</para>
+    /// </summary>
+    [Fact]
+    public void TheSourceRead_IgnoresAControlNamedInABlockCommentsContinuationLine()
+    {
+        const string source = """
+            private async Task LoadPgProbeAsync()
+            {
+                /* Wraparound is not filled from here even though the same reader carries it. Vacuum owns
+                   it, and PgWraparoundGrid.ItemsSource = that tab's rows on that tab's load path. */
+                PgProbeGrid.ItemsSource = rows;
+            }
+            """;
+
+        var walked = CSharpSourceWalker.StripCommentsAndStrings(source);
+        var walkedNames = ControlAssignment.Matches(walked).Select(m => m.Groups["name"].Value).ToList();
+        Assert.Equal(new[] { "PgProbeGrid" }, walkedNames);
+
+        /* The regex this file used to carry, inline so the comparison is against the shape that shipped
+           rather than a description of it. The first line of the comment is not the problem — the
+           continuation line is, and only a block-comment-aware read can tell them apart. */
+        var lineCommentsOnly = Regex.Replace(
+            Regex.Replace(source, @"^[ \t]*///.*$", string.Empty, RegexOptions.Multiline),
+            @"//.*$", string.Empty, RegexOptions.Multiline);
+
+        var regexNames = ControlAssignment.Matches(lineCommentsOnly).Select(m => m.Groups["name"].Value).ToList();
+        Assert.Equal(new[] { "PgWraparoundGrid", "PgProbeGrid" }, regexNames);
+    }
+
     private static string ViewerDirectory()
     {
         var root = FindRepoRoot();
@@ -158,15 +377,16 @@ public sealed class PgPanelTabOwnershipTests
         return Path.Combine(root!, "Darling", "PerformanceMonitor.Darling.Viewer");
     }
 
+    private static string ViewerFile(string name) => File.ReadAllText(Path.Combine(ViewerDirectory(), name));
+
     /// <summary>
     /// (control -> outermost named Pg tab, tab -> every panel its load path assigns).
     /// </summary>
     private static (Dictionary<string, string> TabOf, Dictionary<string, HashSet<string>> LoadPaths) Read()
     {
-        var dir = ViewerDirectory();
         var x = XName.Get("Name", "http://schemas.microsoft.com/winfx/2006/xaml");
 
-        var doc = XDocument.Load(Path.Combine(dir, "ViewerServerTab.xaml"));
+        var doc = XDocument.Parse(ViewerFile("ViewerServerTab.xaml"));
         var tabOf = new Dictionary<string, string>(StringComparer.Ordinal);
         foreach (var element in doc.Descendants())
         {
@@ -188,27 +408,100 @@ public sealed class PgPanelTabOwnershipTests
             }
         }
 
-        var source = Strip(File.ReadAllText(Path.Combine(dir, "ViewerServerTab.Postgres.cs")));
-        var bodies = MethodBodies(source);
+        /* Two names, deliberately. The brace scan is handed the WALKED text, and every range it returns is
+           re-checked against that same walked text below — but the re-check has to be able to disagree with
+           the scan, so what the scan reads and what the diagnosis reads are separate reads of separate
+           variables rather than one variable used twice. Point MethodRanges at loaderSource and the
+           diagnosis still says truncated; that is the difference between a re-check and a restatement. */
+        var loaderSource = ViewerFile("ViewerServerTab.Postgres.cs");
+        var loaderCode = CSharpSourceWalker.StripCommentsAndStrings(loaderSource);
+        var ranges = MethodRanges(loaderCode);
+
+        /* The scan's own integrity, asserted before anything is derived from it, and against the walked
+           source INDEPENDENTLY of what the scan was handed. Every failure below is silent downstream: a
+           truncated or dropped body assigns fewer panels, and fewer panels makes the rules above quieter
+           rather than red. Naming the method here is the difference between "this loader's body was not
+           read whole" and a panel count nobody looks at. */
+        var declarations = MethodDeclaration.Matches(loaderCode)
+            .Select(m => m.Groups["name"].Value)
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.True(declarations.Count >= 15,
+            $"Only {declarations.Count} LoadPg…Async declarations were found in ViewerServerTab.Postgres.cs. "
+            + "There is one per dispatcher arm plus the helpers they call, so the declaration regex is no "
+            + "longer matching the file — and every assertion below is over what it found, including the "
+            + "ones whose success condition is an empty list.");
+
+        var dropped = declarations.Where(d => !ranges.ContainsKey(d))
+                                  .OrderBy(d => d, StringComparer.Ordinal)
+                                  .ToList();
+
+        Assert.True(dropped.Count == 0,
+            "These loaders are declared in ViewerServerTab.Postgres.cs but the brace scan resolved no body "
+            + "for them, so every panel they assign is attributed to no tab at all and both rules above go "
+            + "quieter rather than red. The scan reads walked source, where a brace inside a literal or a "
+            + "comment cannot count — so this is the scan failing, not the source:\n  "
+            + string.Join("\n  ", dropped));
+
+        var truncated = new List<string>();
+        var overExtended = new List<string>();
+        foreach (var (method, (start, end)) in ranges.OrderBy(r => r.Key, StringComparer.Ordinal))
+        {
+            /* Truncation and over-extension are named apart because they are different defects with
+               different fixes and they lie in opposite directions: one drops this method's panels, the
+               other steals the next method's. A single "malformed" list would leave the reader to work out
+               which. */
+            switch (BodyDiagnosis(loaderCode, start, end))
+            {
+                case "truncated":
+                    truncated.Add($"{method} (line {LineOf(loaderCode, start)}, scan ended at line {LineOf(loaderCode, end - 1)})");
+                    break;
+                case "over-extended":
+                    overExtended.Add($"{method} (line {LineOf(loaderCode, start)}, scan ran to line {LineOf(loaderCode, end - 1)})");
+                    break;
+            }
+        }
+
+        Assert.True(truncated.Count == 0,
+            "The brace scan ended before these loaders' own closing brace, so their bodies are TRUNCATED: "
+            + "every control assignment after the cut is dropped, and so is every loader they would have "
+            + "called — which takes that loader's panels with it. The rules above then compare fewer pairs "
+            + "and report a clean run:\n  " + string.Join("\n  ", truncated));
+
+        Assert.True(overExtended.Count == 0,
+            "The brace scan returned to depth zero before the end of these ranges, so it ran PAST the "
+            + "loader it was reading and the methods below it are now part of its body. Their panels are "
+            + "attributed to this tab, which invents off-tab pairs rather than hiding them:\n  "
+            + string.Join("\n  ", overExtended));
 
         var loadPaths = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
-        foreach (Match arm in DispatcherArm.Matches(File.ReadAllText(Path.Combine(dir, "ViewerServerTab.xaml.cs"))))
+        var shell = CSharpSourceWalker.StripCommentsAndStrings(ViewerFile("ViewerServerTab.xaml.cs"));
+        foreach (Match arm in DispatcherArm.Matches(shell))
         {
             var tab = $"Pg{arm.Groups["tab"].Value}Tab";
             var entry = $"LoadPg{arm.Groups["loader"].Value}Async";
-            loadPaths[tab] = Transitive(entry, bodies, new HashSet<string>(StringComparer.Ordinal));
+
+            Assert.Contains(entry, declarations);
+
+            loadPaths[tab] = Transitive(entry, loaderCode, ranges, new HashSet<string>(StringComparer.Ordinal));
         }
 
         return (tabOf, loadPaths);
     }
 
-    private static HashSet<string> Transitive(string method, Dictionary<string, string> bodies, HashSet<string> seen)
+    private static HashSet<string> Transitive(
+        string method,
+        string code,
+        Dictionary<string, (int Start, int End)> ranges,
+        HashSet<string> seen)
     {
         var found = new HashSet<string>(StringComparer.Ordinal);
-        if (!seen.Add(method) || !bodies.TryGetValue(method, out var body))
+        if (!seen.Add(method) || !ranges.TryGetValue(method, out var range))
         {
             return found;
         }
+
+        var body = code[range.Start..range.End];
 
         foreach (Match m in ControlAssignment.Matches(body))
         {
@@ -220,46 +513,102 @@ public sealed class PgPanelTabOwnershipTests
             var callee = m.Groups["name"].Value;
             if (callee != method)
             {
-                found.UnionWith(Transitive(callee, bodies, seen));
+                found.UnionWith(Transitive(callee, code, ranges, seen));
             }
         }
 
         return found;
     }
 
-    /// <summary>Doc comments and line comments out, so prose naming a grid cannot read as an assignment.</summary>
-    private static string Strip(string source) =>
-        Regex.Replace(Regex.Replace(source, @"^[ \t]*///.*$", string.Empty, RegexOptions.Multiline),
-                      @"//.*$", string.Empty, RegexOptions.Multiline);
-
-    private static Dictionary<string, string> MethodBodies(string source)
+    /// <summary>
+    /// Each <c>LoadPg…Async</c>'s body as a half-open range over the code it is given.
+    ///
+    /// <para>The brace count is only sound over WALKED text, and that is measured rather than assumed:
+    /// <see cref="TheMethodWalk_ReadsABodyWhoseLiteralsHoldUnbalancedBraces_AndTheRawCountDoesNot"/> runs it
+    /// both ways over the same arranged body. Ranges rather than substrings so
+    /// <see cref="BodyDiagnosis"/> can re-check where the scan stopped, which a substring has already
+    /// thrown away.</para>
+    /// </summary>
+    private static Dictionary<string, (int Start, int End)> MethodRanges(string code)
     {
-        var bodies = new Dictionary<string, string>(StringComparer.Ordinal);
-        foreach (Match m in Regex.Matches(source, @"private\s+async\s+Task\s+(?<name>LoadPg[A-Za-z]+Async)\s*\("))
+        var ranges = new Dictionary<string, (int Start, int End)>(StringComparer.Ordinal);
+        foreach (Match m in MethodDeclaration.Matches(code))
         {
             var depth = 0;
             var started = false;
-            for (var i = m.Index; i < source.Length; i++)
+            for (var i = m.Index; i < code.Length; i++)
             {
-                if (source[i] == '{')
+                if (code[i] == '{')
                 {
                     depth++;
                     started = true;
                 }
-                else if (source[i] == '}')
+                else if (code[i] == '}')
                 {
                     depth--;
                     if (started && depth == 0)
                     {
-                        bodies[m.Groups["name"].Value] = source[m.Index..(i + 1)];
+                        ranges[m.Groups["name"].Value] = (m.Index, i + 1);
                         break;
                     }
                 }
             }
         }
 
-        return bodies;
+        return ranges;
     }
+
+    /// <summary>
+    /// <c>null</c> when <c>code[start..end]</c> is one whole method body — it opens a brace, returns to
+    /// depth zero exactly once, and does so on the last character. Otherwise the name of the failure:
+    /// <c>"truncated"</c> when the range ends anywhere but its own closing brace, <c>"over-extended"</c>
+    /// when depth returns to zero before the end and the scan therefore kept reading.
+    ///
+    /// <para>Checked over the walked text, so a brace inside a literal or a comment is not a brace here —
+    /// which is the whole point: the diagnosis has to disagree with a scan that counted one.</para>
+    /// </summary>
+    private static string? BodyDiagnosis(string code, int start, int end)
+    {
+        if (end <= start || end > code.Length || code[end - 1] != '}')
+        {
+            return "truncated";
+        }
+
+        var depth = 0;
+        var opened = false;
+
+        for (var i = start; i < end; i++)
+        {
+            if (code[i] == '{')
+            {
+                depth++;
+                opened = true;
+            }
+            else if (code[i] == '}')
+            {
+                depth--;
+                if (depth < 0)
+                {
+                    return "over-extended";
+                }
+
+                if (depth == 0 && i != end - 1)
+                {
+                    return "over-extended";
+                }
+            }
+        }
+
+        return opened && depth == 0 ? null : "truncated";
+    }
+
+    /// <summary>
+    /// The 1-based line <paramref name="offset"/> falls on. Sound over walked text because
+    /// <see cref="CSharpSourceWalker.StripCommentsAndStrings"/> preserves every newline, so the walked text
+    /// is line-aligned with the file a reader will open.
+    /// </summary>
+    private static int LineOf(string code, int offset) =>
+        code.AsSpan(0, Math.Clamp(offset, 0, code.Length)).Count('\n') + 1;
 
     /// <summary>Same walk-up idiom as <c>DocCommentHygieneTests.FindRepoRoot</c>.</summary>
     private static string? FindRepoRoot()

--- a/Darling/Darling.Tests/PgPanelTabOwnershipTests.cs
+++ b/Darling/Darling.Tests/PgPanelTabOwnershipTests.cs
@@ -527,6 +527,37 @@ public sealed class PgPanelTabOwnershipTests
             + "comment cannot count — so this is the scan failing, not the source:\n  "
             + string.Join("\n  ", dropped));
 
+        /* The check above is the only one here that CANNOT disagree with the scan on today's wiring, and
+           saying so is better than implying otherwise: MethodRanges and BodyDiagnosis read the same walked
+           text and do the same brace walk, so the diagnosis is a tripwire for a future edit repointing the
+           scan at other text, not an active check against the shipped file.
+
+           This one is active, and independent by construction: a body may not extend past a LATER
+           declaration. The bound comes from MethodDeclaration's match OFFSETS rather than from any brace,
+           so a scan that over-extends for any reason at all - a real unbalanced code brace, a walker
+           regression, a rewritten scan - swallows the next loader whole and is named here. */
+        var declarationStarts = MethodDeclaration.Matches(loaderCode)
+            .Select(m => (Name: m.Groups["name"].Value, m.Index))
+            .OrderBy(m => m.Index)
+            .ToList();
+
+        var swallowed = new List<string>();
+        foreach (var (method, (start, end)) in ranges.OrderBy(r => r.Key, StringComparer.Ordinal))
+        {
+            var next = declarationStarts.FirstOrDefault(dcl => dcl.Index > start, (Name: string.Empty, Index: int.MaxValue));
+            if (end > next.Index)
+            {
+                swallowed.Add($"{method} (line {LineOf(loaderCode, start)}) runs to line {LineOf(loaderCode, end - 1)}, "
+                    + $"past {next.Name} at line {LineOf(loaderCode, next.Index)}");
+            }
+        }
+
+        Assert.True(swallowed.Count == 0,
+            "These loader bodies extend past a later loader's own declaration, so that loader's panels are "
+            + "attributed to this one's tab and both rules above compare pairs the source never wrote. The "
+            + "bound is the next declaration's offset, not a brace count, so this is the scan over-running "
+            + "whatever the reason:\n  " + string.Join("\n  ", swallowed));
+
         var truncated = new List<string>();
         var overExtended = new List<string>();
         foreach (var (method, (start, end)) in ranges.OrderBy(r => r.Key, StringComparer.Ordinal))

--- a/Darling/Darling.Tests/PgPanelTabOwnershipTests.cs
+++ b/Darling/Darling.Tests/PgPanelTabOwnershipTests.cs
@@ -85,10 +85,23 @@ public sealed class PgPanelTabOwnershipTests
     /// A grid's <c>x:Name</c> in the raw XAML text, for the population cross-check in
     /// <see cref="EveryPgGridOnAPgTab_IsFilledBySomePgTabsLoadPath"/>. Deliberately a second reading of the
     /// same file that shares no code with the <see cref="XDocument"/> walk: the rule's success condition is
-    /// an EMPTY offender list, and a walk that resolved no grids would satisfy it without checking anything.
+    /// an EMPTY offender list, and a walk that resolved no grids — or some of them — would satisfy it
+    /// without checking anything.
     /// </summary>
     private static readonly Regex XamlGridName = new(
         @"x:Name=""(?<name>Pg[A-Za-z]+Grid)""", RegexOptions.Compiled);
+
+    /// <summary>
+    /// An XML comment, removed before <see cref="XamlGridName"/> reads the markup.
+    ///
+    /// <para>This file's whole subject one artifact over, and it was worth measuring rather than assuming:
+    /// <c>XDocument.Descendants()</c> yields <c>XElement</c> only, so a commented-out declaration is
+    /// invisible to the walk, while a regex over raw text reads it as live. The shipped markup carries 147
+    /// XML comment nodes and none of them holds a grid name today; planted, one made the cross-check red
+    /// with a bare collection diff on markup that was perfectly correct. A commented-out declaration is not
+    /// a declaration on either side of the comparison.</para>
+    /// </summary>
+    private static readonly Regex XamlComment = new(@"<!--.*?-->", RegexOptions.Compiled | RegexOptions.Singleline);
 
     [Fact]
     public void EveryPanelAPgTabLoadPathFills_IsDeclaredInsideThatTab()
@@ -100,34 +113,7 @@ public sealed class PgPanelTabOwnershipTests
         Assert.True(tabOf.Count >= 40, $"Only {tabOf.Count} named controls resolved to a Pg tab; the XAML walk is not finding the tree.");
         Assert.True(loadPaths.Count >= 6, $"Only {loadPaths.Count} dispatcher arms found; the tab-to-loader map is not being read.");
 
-        var offenders = new List<string>();
-        var exemptionsSeen = new HashSet<string>(StringComparer.Ordinal);
-
-        foreach (var (tab, panels) in loadPaths.OrderBy(p => p.Key, StringComparer.Ordinal))
-        {
-            Assert.True(panels.Count > 0, $"{tab}'s load path assigns no panel at all, so nothing about it is verified.");
-
-            foreach (var panel in panels.OrderBy(p => p, StringComparer.Ordinal))
-            {
-                if (!tabOf.TryGetValue(panel, out var declaredIn))
-                {
-                    continue; /* not declared in this XAML at all — another file's control, not this rule's business */
-                }
-
-                if (declaredIn == tab)
-                {
-                    continue;
-                }
-
-                if (KnownOffTab.TryGetValue(panel, out var issue))
-                {
-                    exemptionsSeen.Add(panel);
-                    continue;
-                }
-
-                offenders.Add($"{panel} is filled by {tab}'s load path but is declared inside {declaredIn}");
-            }
-        }
+        var (offenders, exemptionsSeen) = OffTabPanels(tabOf, loadPaths);
 
         Assert.True(offenders.Count == 0,
             "A PostgreSQL panel is filled by one tab's load path and rendered on another, so it is empty "
@@ -177,7 +163,8 @@ public sealed class PgPanelTabOwnershipTests
            resolved no grids would pass it vacuously; and a walk that resolved SOME of them would pass it
            just as quietly. Equality rather than a floor, because both readings answer the same question
            over the same file and a disagreement is a finding either way. */
-        var declaredInMarkup = XamlGridName.Matches(ViewerFile("ViewerServerTab.xaml"))
+        var markup = XamlComment.Replace(ViewerFile("ViewerServerTab.xaml"), string.Empty);
+        var declaredInMarkup = XamlGridName.Matches(markup)
             .Select(m => m.Groups["name"].Value)
             .ToHashSet(StringComparer.Ordinal);
 
@@ -186,8 +173,23 @@ public sealed class PgPanelTabOwnershipTests
             + "The PostgreSQL surface ships more grids than that, so the markup is not being read and every "
             + "assertion below would be over the remainder.");
 
-        Assert.Equal(declaredInMarkup.OrderBy(g => g, StringComparer.Ordinal).ToList(),
-                     grids.OrderBy(g => g, StringComparer.Ordinal).ToList());
+        var walkMissed = declaredInMarkup.Except(grids, StringComparer.Ordinal)
+                                         .OrderBy(g => g, StringComparer.Ordinal).ToList();
+        var walkInvented = grids.Except(declaredInMarkup, StringComparer.Ordinal)
+                                .OrderBy(g => g, StringComparer.Ordinal).ToList();
+
+        Assert.True(walkMissed.Count == 0,
+            "The markup declares these grids but the XDocument walk did not resolve any of them to a "
+            + "PostgreSQL TabItem, so the rule below silently stops covering them. Either the walk is "
+            + "broken, or the grid really is declared outside the PostgreSQL tabs — which is worth "
+            + "deciding rather than absorbing, because a control named Pg…Grid somewhere else is confusing "
+            + "on its own terms:\n  " + string.Join("\n  ", walkMissed));
+
+        Assert.True(walkInvented.Count == 0,
+            "The XDocument walk resolved these grid names but the raw markup does not declare them in the "
+            + "form this cross-check reads (x:Name=\"…\"). The two readings answer the same question over "
+            + "the same file, so a disagreement means one of them is no longer reading it:\n  "
+            + string.Join("\n  ", walkInvented));
 
         var filled = loadPaths.Values.SelectMany(p => p).ToHashSet(StringComparer.Ordinal);
         var unfilled = grids.Where(g => !filled.Contains(g)).OrderBy(g => g, StringComparer.Ordinal).ToList();
@@ -219,23 +221,48 @@ public sealed class PgPanelTabOwnershipTests
         }
     }
 
+    /// <summary>
+    /// Plant an off-tab panel into the real tree and require the rule's OWN evaluation to report it.
+    ///
+    /// <para><b>It used to re-implement the predicate inline</b>, which made it a control that could not
+    /// fail: measured on this tree, a single <c>continue;</c> at the top of the rule's inner loop — the rule
+    /// reporting nothing at all, ever — left every test in this file green, this one included. A control
+    /// that re-implements the thing it controls cannot distinguish "the rule fires" from "my copy of the
+    /// rule fires", and it converts an open question into false confidence. It now calls
+    /// <see cref="OffTabPanels"/>, which is the rule.</para>
+    ///
+    /// <para>The DIFFERENCE between the unplanted and planted evaluations is what is asserted, not that the
+    /// planted one reports exactly one pair. Whether the shipped tree is clean is the rule's to say; making
+    /// one misplaced panel red this test as well would cost a reader the attribution.</para>
+    /// </summary>
     [Fact]
     public void TheDetector_FindsAnOffTabPanelPlantedIntoTheRealTree()
     {
-        /* Without this the rule above passes on any tree where the walk quietly returns nothing, and the
-           exemptions would be the only evidence it ever fires. Plant a panel that IS declared on one tab
-           and IS assigned by another tab's loader, and require it to be reported. */
         var (tabOf, loadPaths) = Read();
 
-        var vacuumPanel = tabOf.First(kv => kv.Value == "PgVacuumTab" && !KnownOffTab.ContainsKey(kv.Key)).Key;
-        var activityPanels = new HashSet<string>(loadPaths["PgActivityTab"], StringComparer.Ordinal) { vacuumPanel };
+        var vacuumPanel = tabOf.Where(kv => kv.Value == "PgVacuumTab" && !KnownOffTab.ContainsKey(kv.Key))
+                               .Select(kv => kv.Key)
+                               .OrderBy(p => p, StringComparer.Ordinal)
+                               .First();
 
-        var reported = activityPanels
-            .Where(p => tabOf.TryGetValue(p, out var t) && t != "PgActivityTab" && !KnownOffTab.ContainsKey(p))
-            .ToList();
+        var planted = loadPaths.ToDictionary(
+            p => p.Key,
+            p => new HashSet<string>(p.Value, StringComparer.Ordinal),
+            StringComparer.Ordinal);
 
-        Assert.Contains(vacuumPanel, reported);
-        Assert.Single(reported);
+        /* If the panel were already on Activity's load path, planting it would change nothing and this
+           control would pass against the unplanted tree — the fixture would have no arranged fact in it. */
+        Assert.True(planted["PgActivityTab"].Add(vacuumPanel),
+            $"{vacuumPanel} is already assigned by PgActivityTab's load path, so planting it arranges "
+            + "nothing. Pick a PgVacuumTab panel that Activity does not already fill.");
+
+        var (before, _) = OffTabPanels(tabOf, loadPaths);
+        var (after, _) = OffTabPanels(tabOf, planted);
+
+        var added = after.Except(before, StringComparer.Ordinal).ToList();
+
+        Assert.Single(added);
+        Assert.StartsWith($"{vacuumPanel} is filled by PgActivityTab's load path", added[0], StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -367,6 +394,53 @@ public sealed class PgPanelTabOwnershipTests
 
         var regexNames = ControlAssignment.Matches(lineCommentsOnly).Select(m => m.Groups["name"].Value).ToList();
         Assert.Equal(new[] { "PgWraparoundGrid", "PgProbeGrid" }, regexNames);
+    }
+
+    /// <summary>
+    /// The rule's evaluation, in one place: every (panel, tab) pair
+    /// <see cref="EveryPanelAPgTabLoadPathFills_IsDeclaredInsideThatTab"/> would report, and the exemptions
+    /// it consumed on the way.
+    ///
+    /// <para>A helper rather than the rule's own inline loop so that
+    /// <see cref="TheDetector_FindsAnOffTabPanelPlantedIntoTheRealTree"/> runs THIS and not a second copy of
+    /// it. The per-tab floor lives here too, because it is part of the same evaluation: a tab whose load
+    /// path assigns nothing has no pairs to disagree about, and an empty pair set is indistinguishable from
+    /// a clean one.</para>
+    /// </summary>
+    private static (List<string> Offenders, HashSet<string> ExemptionsSeen) OffTabPanels(
+        IReadOnlyDictionary<string, string> tabOf,
+        IReadOnlyDictionary<string, HashSet<string>> loadPaths)
+    {
+        var offenders = new List<string>();
+        var exemptionsSeen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var (tab, panels) in loadPaths.OrderBy(p => p.Key, StringComparer.Ordinal))
+        {
+            Assert.True(panels.Count > 0, $"{tab}'s load path assigns no panel at all, so nothing about it is verified.");
+
+            foreach (var panel in panels.OrderBy(p => p, StringComparer.Ordinal))
+            {
+                if (!tabOf.TryGetValue(panel, out var declaredIn))
+                {
+                    continue; /* not declared in this XAML at all - another file's control, not this rule's business */
+                }
+
+                if (declaredIn == tab)
+                {
+                    continue;
+                }
+
+                if (KnownOffTab.ContainsKey(panel))
+                {
+                    exemptionsSeen.Add(panel);
+                    continue;
+                }
+
+                offenders.Add($"{panel} is filled by {tab}'s load path but is declared inside {declaredIn}");
+            }
+        }
+
+        return (offenders, exemptionsSeen);
     }
 
     private static string ViewerDirectory()

--- a/Darling/Darling.Tests/PgPanelTabOwnershipTests.cs
+++ b/Darling/Darling.Tests/PgPanelTabOwnershipTests.cs
@@ -459,6 +459,11 @@ public sealed class PgPanelTabOwnershipTests
 
     /// <summary>
     /// (control -> outermost named Pg tab, tab -> every panel its load path assigns).
+    ///
+    /// <para>The population floors and the body-scan integrity assertions live here rather than in each
+    /// rule, because every rule divides by this chain and a rule's own floor cannot save it: "no offender"
+    /// and "no unfilled grid" are both satisfied by a read that resolved nothing. A parse that finds
+    /// nothing has to fail here, once, naming what it could not read.</para>
     /// </summary>
     private static (Dictionary<string, string> TabOf, Dictionary<string, HashSet<string>> LoadPaths) Read()
     {
@@ -506,9 +511,10 @@ public sealed class PgPanelTabOwnershipTests
 
         Assert.True(declarations.Count >= 15,
             $"Only {declarations.Count} LoadPg…Async declarations were found in ViewerServerTab.Postgres.cs. "
-            + "There is one per dispatcher arm plus the helpers they call, so the declaration regex is no "
-            + "longer matching the file — and every assertion below is over what it found, including the "
-            + "ones whose success condition is an empty list.");
+            + "The dispatcher arms' entry points are checked by name below, so this floor is aimed at the "
+            + "helpers they call: the regex could resolve every entry point while losing every helper, and "
+            + "every assertion below is over what it found — including those whose success condition is "
+            + "an empty list.");
 
         var dropped = declarations.Where(d => !ranges.ContainsKey(d))
                                   .OrderBy(d => d, StringComparer.Ordinal)

--- a/Darling/Darling.Tests/PgPanelTabOwnershipTests.cs
+++ b/Darling/Darling.Tests/PgPanelTabOwnershipTests.cs
@@ -136,10 +136,12 @@ public sealed class PgPanelTabOwnershipTests
     /// <para><b>This is what makes a partial loss loud.</b> The rule above is per-panel but it only ever
     /// looks at panels the read FOUND, so anything the read drops makes it quieter rather than red: it
     /// compares fewer pairs and reports a clean run. Its one floor — a tab's load path assigns at least one
-    /// panel — trips only when a whole tab is zeroed. Measured on the shipped tree: a stray <c>}</c> in a
-    /// literal at the top of <c>LoadPgIoAsync</c> takes the I/O tab from six panels to none and reds that
-    /// floor, and the same <c>}</c> one line later takes it from six to ONE and is completely green, with
-    /// four of the five lost panels belonging to the two loaders the truncation also stopped following.
+    /// panel — trips only when a whole tab is zeroed. Measured on the shipped tree with the brace scan run
+    /// over RAW source, which is the defect #3088 was filed for: a stray <c>}</c> in a literal at the top
+    /// of <c>LoadPgIoAsync</c> takes the I/O tab from six panels to none and reds that floor, and the same
+    /// <c>}</c> one line later takes it from six to ONE and is completely green — four of the five lost
+    /// panels belonging to the two loaders the truncation also stopped following. The walk stops that
+    /// particular cut; it does nothing about an assignment lost any other way, which is this rule's job.
     /// Asked from this direction the loss has nowhere to hide: a grid nothing fills is named, whether the
     /// assignment was dropped by a bad read or deleted from the source.</para>
     ///
@@ -370,7 +372,7 @@ public sealed class PgPanelTabOwnershipTests
     /// it.</para>
     /// </summary>
     [Fact]
-    public void TheSourceRead_IgnoresAControlNamedInABlockCommentsContinuationLine()
+    public void TheSourceRead_IgnoresAControlNamedOnABlockCommentContinuationLine()
     {
         const string source = """
             private async Task LoadPgProbeAsync()

--- a/Darling/Darling.Tests/PgPanelTabOwnershipTests.cs
+++ b/Darling/Darling.Tests/PgPanelTabOwnershipTests.cs
@@ -307,8 +307,8 @@ public sealed class PgPanelTabOwnershipTests
         Assert.DoesNotContain("PgProbeGrid", rawBody, StringComparison.Ordinal);
 
         /* And the diagnosis in Read() is what turns that truncation into a red rather than a quieter rule. */
-        Assert.Null(BodyDiagnosis(walkedCode, walked["LoadPgProbeAsync"].Start, walked["LoadPgProbeAsync"].End));
-        Assert.Equal("truncated", BodyDiagnosis(walkedCode, raw["LoadPgProbeAsync"].Start, raw["LoadPgProbeAsync"].End));
+        Assert.Equal(BodyShape.WholeMethod, BodyDiagnosis(walkedCode, walked["LoadPgProbeAsync"].Start, walked["LoadPgProbeAsync"].End));
+        Assert.Equal(BodyShape.Truncated, BodyDiagnosis(walkedCode, raw["LoadPgProbeAsync"].Start, raw["LoadPgProbeAsync"].End));
 
         /* An OPENING brace in a char literal is the other direction. Mid-file the raw count runs on into the
            method below and takes its panels with it, which is the over-extension the diagnosis names. */
@@ -339,8 +339,8 @@ public sealed class PgPanelTabOwnershipTests
             overExtends[overRaw["LoadPgProbeAsync"].Start..overRaw["LoadPgProbeAsync"].End],
             StringComparison.Ordinal);
 
-        Assert.Null(BodyDiagnosis(overCode, overWalked["LoadPgProbeAsync"].Start, overWalked["LoadPgProbeAsync"].End));
-        Assert.Equal("over-extended", BodyDiagnosis(overCode, overRaw["LoadPgProbeAsync"].Start, overRaw["LoadPgProbeAsync"].End));
+        Assert.Equal(BodyShape.WholeMethod, BodyDiagnosis(overCode, overWalked["LoadPgProbeAsync"].Start, overWalked["LoadPgProbeAsync"].End));
+        Assert.Equal(BodyShape.OverExtended, BodyDiagnosis(overCode, overRaw["LoadPgProbeAsync"].Start, overRaw["LoadPgProbeAsync"].End));
 
         /* At end of file the same brace finds no closing brace at all and the method is dropped outright,
            which no per-body diagnosis can name because there is no body to diagnose. That is what the
@@ -537,10 +537,10 @@ public sealed class PgPanelTabOwnershipTests
                which. */
             switch (BodyDiagnosis(loaderCode, start, end))
             {
-                case "truncated":
+                case BodyShape.Truncated:
                     truncated.Add($"{method} (line {LineOf(loaderCode, start)}, scan ended at line {LineOf(loaderCode, end - 1)})");
                     break;
-                case "over-extended":
+                case BodyShape.OverExtended:
                     overExtended.Add($"{method} (line {LineOf(loaderCode, start)}, scan ran to line {LineOf(loaderCode, end - 1)})");
                     break;
             }
@@ -648,19 +648,38 @@ public sealed class PgPanelTabOwnershipTests
     }
 
     /// <summary>
-    /// <c>null</c> when <c>code[start..end]</c> is one whole method body — it opens a brace, returns to
-    /// depth zero exactly once, and does so on the last character. Otherwise the name of the failure:
-    /// <c>"truncated"</c> when the range ends anywhere but its own closing brace, <c>"over-extended"</c>
-    /// when depth returns to zero before the end and the scan therefore kept reading.
+    /// What the brace scan actually returned for one method. An enum rather than a string or a nullable
+    /// flag because <see cref="Read"/> dispatches on it: a mistyped string case label would match nothing,
+    /// leave the offender list empty and report a clean run on a truncated body — the exact failure this
+    /// file exists to refuse, one level up. Mistyping a member is a compile error.
+    /// </summary>
+    private enum BodyShape
+    {
+        /// <summary>One whole method body, ending on the brace that closes it.</summary>
+        WholeMethod,
+
+        /// <summary>The scan stopped short, so every assignment after the cut is missing.</summary>
+        Truncated,
+
+        /// <summary>The scan ran past the method, so the ones below it are now part of this body.</summary>
+        OverExtended,
+    }
+
+    /// <summary>
+    /// Which of three shapes <c>code[start..end]</c> is. <see cref="BodyShape.WholeMethod"/> when it opens
+    /// a brace, returns to depth zero exactly once, and does so on the last character;
+    /// <see cref="BodyShape.Truncated"/> when the range ends anywhere but its own closing brace;
+    /// <see cref="BodyShape.OverExtended"/> when depth returns to zero before the end and the scan
+    /// therefore kept reading.
     ///
     /// <para>Checked over the walked text, so a brace inside a literal or a comment is not a brace here —
-    /// which is the whole point: the diagnosis has to disagree with a scan that counted one.</para>
+    /// which is the whole point: the diagnosis has to be able to disagree with a scan that counted one.</para>
     /// </summary>
-    private static string? BodyDiagnosis(string code, int start, int end)
+    private static BodyShape BodyDiagnosis(string code, int start, int end)
     {
         if (end <= start || end > code.Length || code[end - 1] != '}')
         {
-            return "truncated";
+            return BodyShape.Truncated;
         }
 
         var depth = 0;
@@ -678,17 +697,17 @@ public sealed class PgPanelTabOwnershipTests
                 depth--;
                 if (depth < 0)
                 {
-                    return "over-extended";
+                    return BodyShape.OverExtended;
                 }
 
                 if (depth == 0 && i != end - 1)
                 {
-                    return "over-extended";
+                    return BodyShape.OverExtended;
                 }
             }
         }
 
-        return opened && depth == 0 ? null : "truncated";
+        return opened && depth == 0 ? BodyShape.WholeMethod : BodyShape.Truncated;
     }
 
     /// <summary>

--- a/Darling/Darling.Tests/PgPanelTabOwnershipTests.cs
+++ b/Darling/Darling.Tests/PgPanelTabOwnershipTests.cs
@@ -527,15 +527,21 @@ public sealed class PgPanelTabOwnershipTests
             + "comment cannot count — so this is the scan failing, not the source:\n  "
             + string.Join("\n  ", dropped));
 
-        /* The check above is the only one here that CANNOT disagree with the scan on today's wiring, and
-           saying so is better than implying otherwise: MethodRanges and BodyDiagnosis read the same walked
-           text and do the same brace walk, so the diagnosis is a tripwire for a future edit repointing the
-           scan at other text, not an active check against the shipped file.
+        /* Two over-run checks, and they cover different inputs rather than one superseding the other.
 
-           This one is active, and independent by construction: a body may not extend past a LATER
-           declaration. The bound comes from MethodDeclaration's match OFFSETS rather than from any brace,
-           so a scan that over-extends for any reason at all - a real unbalanced code brace, a walker
-           regression, a rewritten scan - swallows the next loader whole and is named here. */
+           THIS one is active against the shipped file and independent by construction: a body may not
+           extend past a LATER declaration, and the bound is MethodDeclaration's match OFFSETS rather than
+           any brace. So a scan that over-runs for any reason at all - a real unbalanced code brace in the
+           source, which no source walker can help with, a walker regression, a rewritten scan - swallows
+           the next loader whole and is named here.
+
+           The brace re-check BELOW cannot disagree with the scan on today's wiring, and saying so is better
+           than implying otherwise: MethodRanges and BodyDiagnosis read the same walked text and do the same
+           walk, so the diagnosis always answers WholeMethod. It earns its place on the one input this bound
+           is blind to - the LAST loader in the file has no later declaration to swallow, so an over-run
+           there passes this check in silence and only the brace walk can see it. Repointing MethodRanges at
+           loaderSource is the other thing that makes it fire, which is why the raw text and the walked text
+           are separate locals. */
         var declarationStarts = MethodDeclaration.Matches(loaderCode)
             .Select(m => (Name: m.Groups["name"].Value, m.Index))
             .OrderBy(m => m.Index)


### PR DESCRIPTION
Fixes #3088.

The pair #3064 fixed in `PgRegistryPanelPlacementTests` and deferred in its sibling — plus two faults this file has that its sibling did not.

## What the regex was doing

`Strip` removed `///` lines and `//` to end of line and never looked for a block comment. This repo puts no asterisk on a continuation line, so the `//.*$` pass took only the opening `/*` line and handed every continuation line to `ControlAssignment` as code. `ViewerServerTab.Postgres.cs` holds 14 multi-line block comments spanning 35 continuation lines; none names a control today, which is the only reason nothing was red. `MethodBodies` then counted raw `{`/`}` over that output, so a brace inside a string or char literal decided whether a loader's body was read whole — and the file holds no brace in any literal today, which is the only reason that worked.

`ViewerServerTab.xaml.cs` was read fully raw at both of its call sites, so a commented-out `case Pg…InnerTabIndex: await LoadPg…Async();` read as a live dispatcher arm. Same defect, same two methods, fixed in the same pass rather than filed — the arm count is 7 either way, so this is hardening with no behaviour change to show.

## What the assertions cover that the walker does not

The walker stops the truncations that come from a literal brace. It does nothing about a body the scan loses for any other reason, and #3088's measurement is that such a loss is silent: the per-panel rule only ever looks at panels the read FOUND, so anything dropped makes it compare fewer pairs and report a clean run. Its one floor — a tab's load path assigns at least one panel — trips only when a whole tab is zeroed.

- **A body may not extend past a LATER declaration.** The bound is `MethodDeclaration`'s match *offsets*, not any brace, so it is independent of the scan by construction and is the one scan check that is **active against the shipped file** rather than a tripwire. Variant (n) is the proof: delete a loader's own closing brace from the source — a real code-brace imbalance, which no source walker can save anyone from — and this names `LoadPgIoAsync` and the loader it swallowed, while the brace re-check stays silent.
- **The brace re-check, which is a tripwire and is labelled as one.** `MethodRanges` and the diagnosis read the same walked text and do the same brace walk, so on today's wiring the diagnosis *cannot* disagree with the range it re-checks — it always resolves to `WholeMethod`. Its value is that repointing the scan at other text (variants (a) and (b): `MethodRanges(loaderSource)`) makes it fire immediately, naming the method. `loaderSource` and `loaderCode` are separate locals so that swap is a one-token edit and the diagnosis does not follow it. Worth stating plainly because the sibling makes the same arrangement and #3064's description implied more of it than the wiring earns.
- **The two over-run checks are complementary, not redundant.** The next-declaration bound is active but structurally blind at the *end of the file*: the last `LoadPg…Async` has no later declaration to swallow, so an over-run there passes it silently. That tail is exactly what the brace re-check still covers, and variant (o) is the proof — an unbalanced `{` in a literal in the last loader reds `overExtended` naming `LoadPgColumnStatsAsync` with the bound completely silent. No assertion in this file is unreachable.
- **Truncation and over-extension named apart**, because they are different defects with different fixes lying in opposite directions: one drops this method's panels, the other steals the next method's and invents off-tab pairs. A single "malformed" list would leave the reader to work out which. They are an **enum**, not strings: `Read()` dispatches on the result, and as strings a mistyped `case` label would match nothing, leave the offender list empty and report a clean run on a truncated body — the failure this file exists to refuse, one level up. The control test pins the returned value, not the label, so it would not have caught it either. Mistyping an enum member is a compile error.
- **A declaration-count assertion that names the dropped method**, counted with a `MethodDeclaration` regex field so it does not go through the brace scan. A scan that lost a method must not be counted by the same code that lost it, and a dropped method is silent everywhere downstream — every panel it assigns is attributed to no tab at all.
- **`EveryPgGridOnAPgTab_IsFilledBySomePgTabsLoadPath`**, which is what makes a PARTIAL loss loud. Asked from the grid's side, #3088's 6-panels-to-1 case has nowhere to hide: the four transitively-lost grids are named whether the assignment was dropped by a bad read or deleted from the source. Grids only — four notes (`PgOverviewNote`, `PgActivityNote`, `PgVacuumNote`, `PgStorageNote`) are tab-level framing prose assigned once in `ApplyEngineTabSet`, at tab setup rather than on any load path, so requiring a load path for every named control would need an exemption table and this rule has none.

Its population is read a second time out of the raw markup by a regex sharing no code with the `XDocument` walk — 29 both ways, and each direction of a disagreement is named. The rule's success condition is an empty offender list, so a walk that resolved no grids, or some of them, would pass it just as quietly.

## Read against #3064, this is not a port

This PR is explicitly "the same two defects in a sibling", so the question worth asking is whether this file has a defect that `PgRegistryPanelPlacementTests` did not — a search shaped by the sibling's pair is structurally incapable of finding one. It has two, and both are fixed here.

### Third: the file's own control could not fail

`TheDetector_FindsAnOffTabPanelPlantedIntoTheRealTree` exists to prove the rule fires — "without this the rule above passes on any tree where the walk quietly returns nothing". It planted an off-tab panel and required it to be reported, but re-implemented the rule's predicate inline instead of calling it. **Measured on `dev` and again on the first commit of this branch: a single `continue;` at the top of the rule's inner loop — the rule reporting nothing at all, ever — leaves every test in this file green, the detector included.** The sibling's control (`TheMethodWalk_…`) exercises the shipped helpers, so it never had this.

Both now call `OffTabPanels`, which *is* the rule. The detector asserts the **difference** between the unplanted and planted evaluations, not that the planted one reports exactly one pair — whether the shipped tree is clean is the rule's to say, and asserting it here as well would cost a reader the attribution. It also asserts the plant actually planted something (`HashSet.Add` returned true), because a fixture whose arranged fact was already true passes against the unplanted tree.

### Fourth: introduced by this PR's own cross-check, and it is this PR's subject one artifact over

The grid-population cross-check reads `x:Name="Pg…Grid"` out of the **raw** XAML text, deliberately sharing no code with the `XDocument` walk. But `Descendants()` yields `XElement` only and cannot see a comment node, and the shipped markup carries **147 XML comment nodes**. Planted, `<!-- <DataGrid x:Name="PgLegacyIoGrid" /> -->` made the cross-check red with a bare `Assert.Equal` collection diff on markup that was perfectly correct — a regex reading commented-out text as live, which is the defect this whole PR is about. XML comments are now removed before the regex reads, and the comparison names each direction with an actionable message instead of emitting a diff.

### The three axes, and what came back clean

- **Every other consumer of the stripped text.** `Strip`'s output fed only the loader-declaration regex and the brace counter; the body substrings fed `ControlAssignment` and `LoaderCall`. All four regexes run over regex-stripped and walker-stripped source give **identical match sets** on both `.cs` files — 89 control assignments, 35 loader calls, 21 declarations, 7 dispatcher arms — so the swap loses nothing and gains nothing on today's tree.
- **Every literal read.** Of the 278 string literals across the two files, **zero** are overlapped by any of the four regexes' matches, so nothing here reads a literal's contents and the swap cannot silently start returning blanks. It could not have read one before either: the old `Strip` *deleted* text (61,163 → 44,923 characters), so it was line-aligned but **not** character-aligned and reading the original at one of its offsets would have been ~16,000 characters wrong. That is also why the pre-fix file could not report a source offset, and why `LineOf` is sound now — the walker preserves every newline and every character position.
- **The XAML ownership resolution**, the assertion this file has and the sibling does not. It walks the `XDocument` tree rather than text, so it inherits nothing from the stripper, and a planted commented-out `x:Name` does not enter the map.

## Review notes, both acted on

Three `claude[bot]` passes so far, all on the **issue-comment** channel rather than as inline review comments — worth saying because `pulls/N/comments` and `pulls/N/reviews` were both empty at every point while these carried the whole substance. The third ran after the next-declaration bound landed, traced it and the `OffTabPanels` extraction, and found no blocking issues. The two notes from the first two:

- **`Assert.Contains(entry, declarations)` had no custom failure message**, inconsistent with the rest of the file. Fixed in `2569927d7`, which landed before the note was read; it now names the tab, the loader the dispatcher routes to it, and what an empty load path costs.
- **"the diagnosis can never disagree with the range it's re-checking there — structurally a tautology under today's wiring."** Correct, and traced: `MethodRanges` only ever sets `end` to a `}` that returns depth to zero, so over the same text every guard in `BodyDiagnosis` is unreachable and it always returns `WholeMethod`. The description over-claimed it as an independent re-check; that is corrected above, and the note prompted the **next-declaration bound**, which is independent of every brace and does fire against the live file. Variant (n) is its red-proof.

## Verification

`Darling.Tests` cannot run on macOS (`net10.0-windows`, `UseWPF`), so the real `PgPanelTabOwnershipTests.cs` and `CSharpSourceWalker.cs` were compiled into a throwaway `net10.0` xunit v3 host named `Darling.Tests`, staged outside the tree beside copies of the three files the test reads. Executing pins went from **3 to 6**, `Failed: 0`, `Skipped: 0`, `Not Run: 0`, absent from no SKIP list.

**Seven distinct named assertions are red-proofed, and each red variant hits exactly one of them** — truncation, the next-declaration bound, the over-extension arm, the offender list, grid coverage, the cross-check's `walkMissed` direction, and the planted-panel control. The eighth, the dropped-body list, is red-proofed by the arranged control rather than a tree mutation: dropping a body needs source whose braces never balance at all, which is not a shape the shipped file can be mutated into without one of the other seven firing first. Every variant is a fresh staged copy — the worktree was never mutated, so no restore step could destroy anything. The `.csproj` is passed to `dotnet build` explicitly (omit it and MSB1011 fires), `Build succeeded` is asserted as a step distinct from running, and a run producing no `TEST EXECUTION SUMMARY` is discarded rather than counted. The baseline ran LAST; the staged copy of the test file at that point was `cmp`-identical to the committed one and `git status` was empty.

The runner's two discard paths were **exercised rather than assumed**, since a variant that comes back green with no test output never compiled and must not be counted. A deliberately uncompilable edit reports `BUILD FAILED — DISCARD` and never runs; a deliberately wrong anchor reports `ANCHOR FAILURE` and stops before building. Every mutation asserts its anchor appears exactly once, which is how the CRLF line endings were caught on the first attempt instead of silently patching nothing.

| Variant | Named assertion that reds | What it says |
|---|---|---|
| **(a)** `_ = '}';` after the first assignment in `LoadPgIoAsync`, **scan reverted to raw** | the **truncation** assertion in the shared read | `LoadPgIoAsync (line 714, scan ended at line 721)` |
| **(b)** `_ = '{';` in the same place, scan reverted to raw | the **next-declaration bound** | `LoadPgIoAsync (line 714) runs to line 1017, past LoadPgBufferUsageAsync at line 739`. The bound is asserted first and catches this, so the brace re-check never sees it |
| **(o)** `_ = '{';` in a literal in the LAST loader, scan reverted to raw | the **over-extension** assertion | `LoadPgColumnStatsAsync (line 988, scan ran to line 1017)` — no later declaration exists, so the bound is silent and only this can see it |
| **(c)** a block comment in `LoadPgIoAsync` whose continuation line reads `PgWraparoundGrid.ItemsSource = …`, **`Strip` reverted to the regex** | `EveryPanelAPgTabLoadPathFills_IsDeclaredInsideThatTab`'s own offender list | `PgWraparoundGrid is filled by PgIoTab's load path but is declared inside PgVacuumTab` — a panel that is on no load path |
| **(d)** `await LoadPgWriteStatsAsync(...)` removed from `LoadPgIoAsync` (walk kept, scan sound) | `EveryPgGridOnAPgTab_IsFilledBySomePgTabsLoadPath` | `PgWriteStatsGrid` — and **only** this test reds |
| **(n)** a loader's own closing brace deleted from the source — a real code-brace imbalance, walk KEPT | the **next-declaration bound** | `LoadPgIoAsync (line 714) runs to line 1015, past LoadPgBufferUsageAsync at line 737`. The brace re-check, the truncation list and the dropped list all stay **silent** on this one |
| **(k)** `continue;` at the top of the rule's inner loop — the rule reports nothing, ever | `TheDetector_FindsAnOffTabPanelPlantedIntoTheRealTree` | `Assert.Single() Failure: The collection was empty`. **Green on all six before the third fix, and green on all three on `dev`** |
| **(m)** a live `PgStrandedGrid` declared outside every `Pg` TabItem | the cross-check's `walkMissed` direction | `PgStrandedGrid` — the markup declares it and the walk resolved it to no tab |
| (l) `<!-- <DataGrid x:Name="PgLegacyIoGrid" /> -->` planted into the markup | *(green — was red with a collection diff before the fourth fix)* | a commented-out declaration is not a declaration on either side |
| (e) variant (a)'s brace with the walk KEPT | *(green — the walk is what saves it)* | |
| (f) variant (c)'s comment with the walk KEPT | *(green — same)* | |
| (k) against the **pre-fix** file | *(green, 3 tests)* | the control has never been able to fail |
| (g) variant (d) against the **pre-fix** file | *(green, 3 tests)* | the grid rule is new coverage, not a restatement |
| (h) `_ = '}';` after the first assignment, **pre-fix** file | *(green, 3 tests)* | #3088's central claim: a partial truncation passes |
| (i) `_ = '}';` at the top of the body, **pre-fix** file | `panels.Count > 0` (line 74) | the incidental red — it caught the whole tab being zeroed, not the truncation |
| (j) variant (c)'s comment, **pre-fix** file | the offender list | the block-comment defect on the file as it shipped |
| baseline, last | *(green, 6 tests)* | no mutation leaked |

(a) and (b) each report `Failed: 3` rather than 1: the truncation and over-extension assertions live in the shared read, so all three rules that call it red on the same named assertion and the same method. (c), (d), (k) and (m) each red exactly one test.

(i) and (h) are the same mutation one line apart. (i) reds; (h) is green with `PgIoTab` down from six resolved panels to one, four of the five losses being `PgWriteStats*` and `PgBufferUsage*`, taken out by the two `await` calls the cut also removed.

`dotnet build Darling/Darling.Tests/Darling.Tests.csproj -p:EnableWindowsTargeting=true` is clean: 0 errors, 0 warnings attributable to this file (50 pre-existing xunit-analyzer warnings elsewhere in the project, unchanged).

### Windows CI, and how the new pins were confirmed to have executed

All four jobs green on `9c5785e9d`: `build` 8m14s, `Darling Linux build` 1m47s, `Darling PostgreSQL tests` 3m45s, `Darling whole-tree guards` 16s.

MTP prints no per-test lines, and the `build` log contains **no test names at all** — the only mentions of this file are the changed-file list in the guards step. So "confirm your new tests ran, by name" is not available here, and the counts are what settle it:

| | `Darling.Tests` | `Lite.Tests` |
|---|---|---|
| `dev` at `6ade64584` (this branch's base) | Total **7852**, Failed 0, Skipped 317, Not Run 0 | Total 3429, Failed 0, Skipped 0 |
| this branch at `9c5785e9d` | Total **7855**, Failed 0, Skipped **317**, Not Run 0 | Total **3429**, Failed 0, Skipped 0 |

**+3 total with Skipped unchanged.** Three net new `[Fact]`s (this file goes 3 → 6), so all three entered the executing population and neither they nor the three pre-existing ones landed in the skip set — which the totals alone could not have told apart. `Lite.Tests` is byte-for-byte the same count: the diff touches one file that no other project compiles, and `Lite.Tests` links only `CSharpSourceWalker.cs` from `Darling.Tests`, which is untouched.

### `Transitive`'s shared `seen` set, since the fourth review pass raised it

Checked rather than taken on trust. The union at the TOP level is sound: on a diamond `A→B→D`, `A→C→D`, the second visit to `D` short-circuits, so `C`'s own return value omits `D` — but `D`'s panels already arrived via `B`, and every return value is unioned upward, so `A` still sees `A ∪ B ∪ C ∪ D`. Unchanged by this PR either way; the refactor swapped a precomputed body dictionary for offset ranges and did not touch the traversal.

Measured, so the property is not just argued: the shipped loader graph is a **forest of depth-2 trees** — `LoadPgOverviewAsync`→3, `LoadPgActivityAsync`→4, `LoadPgStorageAsync`→3, `LoadPgIoAsync`→2, `LoadPgWaitsAsync`→1, `LoadPgReplicationAsync`→1, `LoadPgVacuumAsync`→0 — with **no node having two parents** inside any entry's subtree, and no loader reachable from two different dispatcher arms. So the diamond case is hypothetical on this tree.

The bound worth knowing if it stops being hypothetical: **only the top-level result is meaningful; a subtree's return value is deliberately incomplete.** Anyone reaching for per-loader attribution from a recursive call would get a wrong answer, and a shared loader between two tabs would attribute its panels to both — which the rule above would red on whichever tab does not declare them, correctly but with the attribution one level off.

## Not verified

Nothing renders on macOS: no WPF window was opened, no tab was clicked, no panel was drawn. Every claim here is about source and markup as parsed. `Darling.Tests` itself executes only on the Windows CI job, and the six pins were run in a throwaway host rather than in that project.

## Out of scope, deliberately

- **`LiteralAt` is not adopted, because nothing here reads a literal's contents** — measured, not assumed: zero of the four regexes' matches overlap any of the 278 string literals in the two files, and the match sets are identical before and after the swap. Adding the helper unused would be dead code. The bound is stated on the class and `EveryPgGridOnAPgTab_IsFilledBySomePgTabsLoadPath` is named as what reds if a grid ever starts being assigned through a name the walk blanks.
- **`MethodRanges`, `BodyDiagnosis` and `MethodDeclaration` are duplicated from the sibling rather than extracted.** `CommentFilterAdoptionTests` carries its own copy of the offset idiom too, so per-file copies are the standing pattern; extraction would touch a file that merged hours ago and whose inline review anchors are still current. Worth doing as its own change if a third adopter appears — and the two copies have already diverged, which is the argument for it.
- **Which repo-root resolver the tree should standardise on.** This file uses `AppContext.BaseDirectory` plus a ten-level walk-up for `PerformanceMonitor.sln` (the `DocCommentHygieneTests` idiom, and the reason it needs a "could not locate the repository root" assertion at all); the sibling uses `[CallerFilePath]`, whose comment says it "cannot resolve to the wrong tree or fail to resolve at all". Two files reading the same directory two ways. Not changed here, and not a strict ordering: `[CallerFilePath]` is baked at compile time, so a test using it can only ever read the real tree — which is more robust in CI and also makes copy-based mutation testing impossible, forcing mutations onto the working tree. Both suites were compiled into one assembly and run together to confirm this change disturbs neither: 13 tests, `Failed: 0`, `Not Run: 0`.
- **Panel ORDER**, and whether the four `ApplyEngineTabSet` notes should be on a load path at all. Both pre-existing and untested in either direction.
- The #3049 grid-row collision stays `XamlGridRowRangeTests`' to catch; nothing here reads `Grid.Row`.

## CHANGELOG

Not edited here — every lane appends to the same `[Unreleased]` block and a per-PR edit conflicts with whichever sibling merges first. Entry text for the coordinator:

- Hardened the PostgreSQL panel-ownership pin to read its two C# sources through the shared source walker, and to assert the loader-body scan it stands on: a truncated, over-extended or dropped body is now named at the method, every grid on a PostgreSQL tab must be filled by some tab's load path, and the planted-panel control now runs the rule it controls rather than a copy of it.
