### PR TITLE
Fixes #3090

### DIFF
--- a/Darling/Darling.Tests/AlertEngineTests.cs
+++ b/Darling/Darling.Tests/AlertEngineTests.cs
@@ -10,12 +10,12 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using PerformanceMonitor.Alerting;
 using PerformanceMonitor.Notifications;
 using Xunit;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -1993,19 +1993,6 @@ public sealed class AlertEngineTests
 
     private static string ReadStateStoreSource() =>
         ReadRepoFile(Path.Combine("Darling", "PerformanceMonitor.Darling.Service", "PgAlertStateStore.cs"));
-
-    /// <summary>Reads a repo-relative source file, walking up from this test file to find the repo root.</summary>
-    private static string ReadRepoFile(string relative, [CallerFilePath] string thisFile = "")
-    {
-        var dir = Path.GetDirectoryName(thisFile)!;
-        while (dir is not null && !File.Exists(Path.Combine(dir, relative)))
-        {
-            dir = Path.GetDirectoryName(dir);
-        }
-
-        Assert.NotNull(dir);
-        return File.ReadAllText(Path.Combine(dir!, relative));
-    }
 
     [Fact]
     public async Task DatabaseState_Disabled_DoesNotFetch()

--- a/Darling/Darling.Tests/ChartWindowDomainTests.cs
+++ b/Darling/Darling.Tests/ChartWindowDomainTests.cs
@@ -8,8 +8,8 @@
 
 using System;
 using System.IO;
-using System.Runtime.CompilerServices;
 using Xunit;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -38,25 +38,25 @@ namespace Darling.Tests;
 /// </summary>
 public sealed class ChartWindowDomainTests
 {
-    private static string ChartsJs => ReadRepoFile(Path.Combine(
+    private static string ChartsJs => ReadRepoFileLf(Path.Combine(
         "Darling", "PerformanceMonitor.Darling.Service", "wwwroot", "js", "charts.js"));
 
-    private static string UtilJs => ReadRepoFile(Path.Combine(
+    private static string UtilJs => ReadRepoFileLf(Path.Combine(
         "Darling", "PerformanceMonitor.Darling.Service", "wwwroot", "js", "util.js"));
 
-    private static string PanelsJs => ReadRepoFile(Path.Combine(
+    private static string PanelsJs => ReadRepoFileLf(Path.Combine(
         "Darling", "PerformanceMonitor.Darling.Service", "wwwroot", "js", "panels.js"));
 
-    private static string ServerTabsJs => ReadRepoFile(Path.Combine(
+    private static string ServerTabsJs => ReadRepoFileLf(Path.Combine(
         "Darling", "PerformanceMonitor.Darling.Service", "wwwroot", "js", "pages", "server-tabs.js"));
 
-    private static string ComposeJs => ReadRepoFile(Path.Combine(
+    private static string ComposeJs => ReadRepoFileLf(Path.Combine(
         "Darling", "PerformanceMonitor.Darling.Service", "wwwroot", "js", "compose.js"));
 
-    private static string EndpointsCs => ReadRepoFile(Path.Combine(
+    private static string EndpointsCs => ReadRepoFileLf(Path.Combine(
         "Darling", "PerformanceMonitor.Darling.Service", "DarlingWebEndpoints.cs"));
 
-    private static string ComposeSpecCs => ReadRepoFile(Path.Combine(
+    private static string ComposeSpecCs => ReadRepoFileLf(Path.Combine(
         "Darling", "PerformanceMonitor.Darling.Service", "Compose", "ComposeSpec.cs"));
 
     /// <summary>
@@ -173,17 +173,4 @@ public sealed class ChartWindowDomainTests
         Assert.Contains("public const int MaxWindowHours = 24 * 90;", ComposeSpecCs, StringComparison.Ordinal);
     }
 
-    private static string ReadRepoFile(string relative, [CallerFilePath] string thisFile = "")
-    {
-        for (var dir = new DirectoryInfo(Path.GetDirectoryName(thisFile)!); dir is not null; dir = dir.Parent)
-        {
-            var candidate = Path.Combine(dir.FullName, relative);
-            if (File.Exists(candidate))
-            {
-                return File.ReadAllText(candidate).Replace("\r\n", "\n", StringComparison.Ordinal);
-            }
-        }
-
-        throw new FileNotFoundException($"Could not locate {relative} walking up from {thisFile}");
-    }
 }

--- a/Darling/Darling.Tests/ChartWindowDomainTests.cs
+++ b/Darling/Darling.Tests/ChartWindowDomainTests.cs
@@ -172,5 +172,4 @@ public sealed class ChartWindowDomainTests
         Assert.Contains("Math.min(rawHours, MAX_COMPOSE_WINDOW_HOURS)", compose, StringComparison.Ordinal);
         Assert.Contains("public const int MaxWindowHours = 24 * 90;", ComposeSpecCs, StringComparison.Ordinal);
     }
-
 }

--- a/Darling/Darling.Tests/CollectionLogFanoutRollupStoreTests.cs
+++ b/Darling/Darling.Tests/CollectionLogFanoutRollupStoreTests.cs
@@ -13,6 +13,7 @@ using PerformanceMonitor.Darling.Service.Mcp;
 using PerformanceMonitor.Darling.Storage;
 using PerformanceMonitor.Darling.Viewer;
 using Xunit;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -256,7 +257,7 @@ public class CollectionLogFanoutRollupStoreTests
         /* Derived, not remembered: every collector source that overrides BuildEnumerationQuery drives the
            enumeration fan-out, so a sixth one starting to enumerate fails here instead of quietly falling
            out of the description. */
-        var collectorsDir = System.IO.Path.Combine(RepoRoot(), "PerformanceMonitor.Collectors");
+        var collectorsDir = System.IO.Path.Combine(RepoFile.Root, "PerformanceMonitor.Collectors");
         var enumerating = System.IO.Directory
             .EnumerateFiles(collectorsDir, "*Collector.cs", System.IO.SearchOption.TopDirectoryOnly)
             .Where(f => System.IO.File.ReadAllText(f).Contains("override CollectorQuery? BuildEnumerationQuery", StringComparison.Ordinal))
@@ -303,21 +304,5 @@ public class CollectionLogFanoutRollupStoreTests
 
     private static string ReadViewerSource() =>
         ReadRepoFile(System.IO.Path.Combine("Darling", "PerformanceMonitor.Darling.Viewer", "ViewerDataService.cs"));
-
-    private static string ReadRepoFile(string relative) =>
-        System.IO.File.ReadAllText(System.IO.Path.Combine(RepoRoot(), relative));
-
-    private static string RepoRoot([System.Runtime.CompilerServices.CallerFilePath] string thisFile = "")
-    {
-        for (var dir = new System.IO.DirectoryInfo(System.IO.Path.GetDirectoryName(thisFile)!); dir is not null; dir = dir.Parent)
-        {
-            if (System.IO.Directory.Exists(System.IO.Path.Combine(dir.FullName, "PerformanceMonitor.Common")))
-            {
-                return dir.FullName;
-            }
-        }
-
-        throw new System.IO.DirectoryNotFoundException($"Could not locate the repo root walking up from {thisFile}");
-    }
 
 }

--- a/Darling/Darling.Tests/CollectionOutputBesideCostTests.cs
+++ b/Darling/Darling.Tests/CollectionOutputBesideCostTests.cs
@@ -531,5 +531,4 @@ public sealed class CollectionOutputBesideCostTests
 
         return map;
     }
-
 }

--- a/Darling/Darling.Tests/CollectionOutputBesideCostTests.cs
+++ b/Darling/Darling.Tests/CollectionOutputBesideCostTests.cs
@@ -15,6 +15,7 @@ using System.Text.RegularExpressions;
 using PerformanceMonitor.Common;
 using PerformanceMonitor.Darling.Service.Mcp;
 using Xunit;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -215,7 +216,10 @@ public sealed class CollectionOutputBesideCostTests
            Derived from the note rather than listed beside it, so a name added to the note later is checked
            without this test being edited - and vocabulary spans BOTH tools plus the collector-cost tool the
            note disclaims, because one string serves both SKUs. */
-        var vocabulary = string.Concat(ToolSources.Select(ReadRepoFile))
+        /* A lambda rather than the `Select(ReadRepoFile)` method group: the shared reader takes `params
+           string[]`, which serves both the pre-combined and the segment-list spelling with one method, and a
+           params method group does not convert to Func<string, string>. */
+        var vocabulary = string.Concat(ToolSources.Select(s => ReadRepoFile(s)))
             + ReadRepoFile(Path.Combine(
                 "Darling", "PerformanceMonitor.Darling.Service", "Mcp", "DarlingMcpCollectorCostTools.cs"));
 
@@ -528,17 +532,4 @@ public sealed class CollectionOutputBesideCostTests
         return map;
     }
 
-    private static string ReadRepoFile(string relative) =>
-        File.ReadAllText(Path.Combine(RepoRoot(), relative));
-
-    private static string RepoRoot()
-    {
-        var directory = new DirectoryInfo(AppContext.BaseDirectory);
-        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "PerformanceMonitor.sln")))
-        {
-            directory = directory.Parent;
-        }
-
-        return directory?.FullName ?? throw new InvalidOperationException("PerformanceMonitor.sln not found above the test output directory.");
-    }
 }

--- a/Darling/Darling.Tests/DarlingCliCommandsTests.cs
+++ b/Darling/Darling.Tests/DarlingCliCommandsTests.cs
@@ -9,7 +9,6 @@
 using System;
 using System.Linq;
 using System.IO;
-using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,6 +18,7 @@ using PerformanceMonitor.Darling.Service.Hosting;
 using Xunit;
 using Host = PerformanceMonitor.Darling.Service.Mcp.DarlingMcpHostService;
 using WebHost = PerformanceMonitor.Darling.Service.Mcp.DarlingWebHostService;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -1629,19 +1629,6 @@ public sealed class DarlingMissingCredentialMessageTests
             }
             """);
         return configPath;
-    }
-
-    /* Locate the repo from this file — the DarlingEnumerationProbeFailureTests idiom; no build-output copying. */
-    private static string ReadRepoFile(string relative, [CallerFilePath] string thisFile = "")
-    {
-        var dir = Path.GetDirectoryName(thisFile)!;
-        while (dir is not null && !File.Exists(Path.Combine(dir, relative)))
-        {
-            dir = Path.GetDirectoryName(dir);
-        }
-
-        Assert.NotNull(dir);
-        return File.ReadAllText(Path.Combine(dir!, relative));
     }
 
     private static int CountOccurrences(string haystack, string needle)

--- a/Darling/Darling.Tests/DarlingDeployRollbackRetentionTests.cs
+++ b/Darling/Darling.Tests/DarlingDeployRollbackRetentionTests.cs
@@ -852,5 +852,4 @@ public sealed class DarlingDeployRollbackRetentionTests
             /* A leftover temp tree is not a test failure. */
         }
     }
-
 }

--- a/Darling/Darling.Tests/DarlingDeployRollbackRetentionTests.cs
+++ b/Darling/Darling.Tests/DarlingDeployRollbackRetentionTests.cs
@@ -14,6 +14,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using PerformanceMonitor.Darling.Service;
 using Xunit;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -852,30 +853,4 @@ public sealed class DarlingDeployRollbackRetentionTests
         }
     }
 
-    private static string ReadRepoFile(string relativePath)
-    {
-        var root = FindRepoRoot();
-        Assert.NotNull(root);
-        var path = Path.Combine(root!, relativePath);
-        Assert.True(File.Exists(path), $"expected {path} to exist");
-        return File.ReadAllText(path);
-    }
-
-    /// <summary>Walks up from the test output directory to the repo root (the directory holding
-    /// <c>PerformanceMonitor.sln</c>) — the same idiom <c>DarlingFileSecurityTests</c> uses.</summary>
-    private static string? FindRepoRoot()
-    {
-        var directory = new DirectoryInfo(AppContext.BaseDirectory);
-        for (var i = 0; i < 10 && directory is not null; i++)
-        {
-            if (File.Exists(Path.Combine(directory.FullName, "PerformanceMonitor.sln")))
-            {
-                return directory.FullName;
-            }
-
-            directory = directory.Parent;
-        }
-
-        return null;
-    }
 }

--- a/Darling/Darling.Tests/DarlingEmptyEnumerationNoteTests.cs
+++ b/Darling/Darling.Tests/DarlingEmptyEnumerationNoteTests.cs
@@ -8,13 +8,13 @@
 
 using System;
 using System.IO;
-using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using PerformanceMonitor.Collectors;
 using PerformanceMonitor.Common;
 using PerformanceMonitor.Darling.Service;
 using PerformanceMonitor.Darling.Viewer;
 using Xunit;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -341,19 +341,6 @@ public sealed class DarlingEmptyEnumerationNoteTests
         Assert.NotEqual(
             CollectorHealthClassifier.FormatCollectionNote(row.LastNote, row.NoteCount, row.TotalRuns),
             row.NoteFormatted);
-    }
-
-    /* Locate the repo from this file — the DarlingLockTimeoutYieldTests idiom; no build-output copying. */
-    private static string ReadRepoFile(string relative, [CallerFilePath] string thisFile = "")
-    {
-        var dir = Path.GetDirectoryName(thisFile)!;
-        while (dir is not null && !File.Exists(Path.Combine(dir, relative)))
-        {
-            dir = Path.GetDirectoryName(dir);
-        }
-
-        Assert.NotNull(dir);
-        return File.ReadAllText(Path.Combine(dir!, relative));
     }
 
     /// <summary>

--- a/Darling/Darling.Tests/DarlingEnumerationProbeFailureTests.cs
+++ b/Darling/Darling.Tests/DarlingEnumerationProbeFailureTests.cs
@@ -9,11 +9,11 @@
 using System;
 using System.Data;
 using System.IO;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using PerformanceMonitor.Collectors;
 using Xunit;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -316,16 +316,4 @@ public sealed class DarlingEnumerationProbeFailureTests
         return dataSet.CreateDataReader();
     }
 
-    /* Locate the repo from this file — the DarlingLockTimeoutYieldTests idiom; no build-output copying. */
-    private static string ReadRepoFile(string relative, [CallerFilePath] string thisFile = "")
-    {
-        var dir = Path.GetDirectoryName(thisFile)!;
-        while (dir is not null && !File.Exists(Path.Combine(dir, relative)))
-        {
-            dir = Path.GetDirectoryName(dir);
-        }
-
-        Assert.NotNull(dir);
-        return File.ReadAllText(Path.Combine(dir!, relative));
-    }
 }

--- a/Darling/Darling.Tests/DarlingEnumerationProbeFailureTests.cs
+++ b/Darling/Darling.Tests/DarlingEnumerationProbeFailureTests.cs
@@ -315,5 +315,4 @@ public sealed class DarlingEnumerationProbeFailureTests
 
         return dataSet.CreateDataReader();
     }
-
 }

--- a/Darling/Darling.Tests/DarlingFileSecurityTests.cs
+++ b/Darling/Darling.Tests/DarlingFileSecurityTests.cs
@@ -617,5 +617,4 @@ public sealed class DarlingFileSecurityTests
             "the per-file verification must run AFTER the owner step, or it certifies a state the installer " +
             "then changes.");
     }
-
 }

--- a/Darling/Darling.Tests/DarlingFileSecurityTests.cs
+++ b/Darling/Darling.Tests/DarlingFileSecurityTests.cs
@@ -15,6 +15,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
 using PerformanceMonitor.Darling.Service;
 using Xunit;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -617,30 +618,4 @@ public sealed class DarlingFileSecurityTests
             "then changes.");
     }
 
-    private static string ReadRepoFile(string relativePath)
-    {
-        var root = FindRepoRoot();
-        Assert.NotNull(root);
-        var path = Path.Combine(root, relativePath);
-        Assert.True(File.Exists(path), $"expected {path} to exist");
-        return File.ReadAllText(path);
-    }
-
-    /// <summary>Walks up from the test output directory to the repo root (the directory holding
-    /// <c>PerformanceMonitor.sln</c>) — the same idiom <c>DarlingFirewallCheckTests</c> uses.</summary>
-    private static string? FindRepoRoot()
-    {
-        var directory = new DirectoryInfo(AppContext.BaseDirectory);
-        for (var i = 0; i < 10 && directory is not null; i++)
-        {
-            if (File.Exists(Path.Combine(directory.FullName, "PerformanceMonitor.sln")))
-            {
-                return directory.FullName;
-            }
-
-            directory = directory.Parent;
-        }
-
-        return null;
-    }
 }

--- a/Darling/Darling.Tests/DarlingFirewallCheckTests.cs
+++ b/Darling/Darling.Tests/DarlingFirewallCheckTests.cs
@@ -1115,5 +1115,4 @@ public class DarlingFirewallCheckTests
 
         return branch;
     }
-
 }

--- a/Darling/Darling.Tests/DarlingFirewallCheckTests.cs
+++ b/Darling/Darling.Tests/DarlingFirewallCheckTests.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using PerformanceMonitor.Darling.Service;
 using PerformanceMonitor.Darling.Service.Mcp;
 using Xunit;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -1115,30 +1116,4 @@ public class DarlingFirewallCheckTests
         return branch;
     }
 
-    private static string ReadRepoFile(string relativePath)
-    {
-        var root = FindRepoRoot();
-        Assert.NotNull(root);
-        var path = Path.Combine(root, relativePath);
-        Assert.True(File.Exists(path), $"expected {path} to exist");
-        return File.ReadAllText(path);
-    }
-
-    /// <summary>Walks up from the test output directory to the repo root (the directory holding
-    /// <c>PerformanceMonitor.sln</c>) — the same idiom <c>DocCommentHygieneTests</c> uses.</summary>
-    private static string? FindRepoRoot()
-    {
-        var directory = new DirectoryInfo(AppContext.BaseDirectory);
-        for (var i = 0; i < 10 && directory is not null; i++)
-        {
-            if (File.Exists(Path.Combine(directory.FullName, "PerformanceMonitor.sln")))
-            {
-                return directory.FullName;
-            }
-
-            directory = directory.Parent;
-        }
-
-        return null;
-    }
 }

--- a/Darling/Darling.Tests/DarlingHardenFilesVerbTests.cs
+++ b/Darling/Darling.Tests/DarlingHardenFilesVerbTests.cs
@@ -8,9 +8,9 @@
 
 using System;
 using System.IO;
-using System.Runtime.CompilerServices;
 using PerformanceMonitor.Darling.Service;
 using Xunit;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -213,17 +213,4 @@ public class DarlingHardenFilesVerbTests
         Assert.Contains("WellKnownSidType.LocalSystemSid", body, StringComparison.Ordinal);
     }
 
-    private static string ReadRepoFile(string relative, [CallerFilePath] string thisFile = "")
-    {
-        for (var dir = new DirectoryInfo(Path.GetDirectoryName(thisFile)!); dir is not null; dir = dir.Parent)
-        {
-            var candidate = Path.Combine(dir.FullName, relative);
-            if (File.Exists(candidate))
-            {
-                return File.ReadAllText(candidate);
-            }
-        }
-
-        throw new FileNotFoundException($"Could not locate {relative} walking up from {thisFile}");
-    }
 }

--- a/Darling/Darling.Tests/DarlingHardenFilesVerbTests.cs
+++ b/Darling/Darling.Tests/DarlingHardenFilesVerbTests.cs
@@ -212,5 +212,4 @@ public class DarlingHardenFilesVerbTests
         Assert.Contains("LocalSystem", body, StringComparison.Ordinal);
         Assert.Contains("WellKnownSidType.LocalSystemSid", body, StringComparison.Ordinal);
     }
-
 }

--- a/Darling/Darling.Tests/DarlingInstallLocationTests.cs
+++ b/Darling/Darling.Tests/DarlingInstallLocationTests.cs
@@ -616,5 +616,4 @@ function Get-CimInstance {
         end = -1;
         return string.Empty;
     }
-
 }

--- a/Darling/Darling.Tests/DarlingInstallLocationTests.cs
+++ b/Darling/Darling.Tests/DarlingInstallLocationTests.cs
@@ -12,6 +12,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Text;
 using Xunit;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -616,30 +617,4 @@ function Get-CimInstance {
         return string.Empty;
     }
 
-    private static string ReadRepoFile(string relativePath)
-    {
-        var root = FindRepoRoot();
-        Assert.NotNull(root);
-        var path = Path.Combine(root!, relativePath);
-        Assert.True(File.Exists(path), $"expected {path} to exist");
-        return File.ReadAllText(path);
-    }
-
-    /// <summary>Walks up from the test output directory to the repo root (the directory holding
-    /// <c>PerformanceMonitor.sln</c>) — the same idiom <c>DarlingFileSecurityTests</c> uses.</summary>
-    private static string? FindRepoRoot()
-    {
-        var directory = new DirectoryInfo(AppContext.BaseDirectory);
-        for (var i = 0; i < 10 && directory is not null; i++)
-        {
-            if (File.Exists(Path.Combine(directory.FullName, "PerformanceMonitor.sln")))
-            {
-                return directory.FullName;
-            }
-
-            directory = directory.Parent;
-        }
-
-        return null;
-    }
 }

--- a/Darling/Darling.Tests/DarlingLockTimeoutYieldTests.cs
+++ b/Darling/Darling.Tests/DarlingLockTimeoutYieldTests.cs
@@ -7,8 +7,8 @@
  */
 
 using System.IO;
-using System.Runtime.CompilerServices;
 using Xunit;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -39,16 +39,4 @@ public sealed class DarlingLockTimeoutYieldTests
         Assert.Contains("FILTER (WHERE status = 'ERROR')", source);
     }
 
-    /* Locate the repo from this file — the AlertFiringLogTests idiom; no build-output copying. */
-    private static string ReadRepoFile(string relative, [CallerFilePath] string thisFile = "")
-    {
-        var dir = Path.GetDirectoryName(thisFile)!;
-        while (dir is not null && !File.Exists(Path.Combine(dir, relative)))
-        {
-            dir = Path.GetDirectoryName(dir);
-        }
-
-        Assert.NotNull(dir);
-        return File.ReadAllText(Path.Combine(dir!, relative));
-    }
 }

--- a/Darling/Darling.Tests/DarlingLockTimeoutYieldTests.cs
+++ b/Darling/Darling.Tests/DarlingLockTimeoutYieldTests.cs
@@ -38,5 +38,4 @@ public sealed class DarlingLockTimeoutYieldTests
         var source = ReadRepoFile(Path.Combine("Darling", "PerformanceMonitor.Darling.Storage", "DailySummarySql.cs"));
         Assert.Contains("FILTER (WHERE status = 'ERROR')", source);
     }
-
 }

--- a/Darling/Darling.Tests/DarlingMcpAlertToolsTests.cs
+++ b/Darling/Darling.Tests/DarlingMcpAlertToolsTests.cs
@@ -24,6 +24,7 @@ using PerformanceMonitor.Darling.Storage;
 using Xunit;
 
 using Reader = PerformanceMonitor.Darling.Service.Mcp.DarlingAlertReader;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -390,19 +391,6 @@ public sealed class DarlingMcpAlertToolsSurfaceAndSqlTests
         StoreJobCadenceWarnPercent: 80,
         FileGrowthEnabled: true, FileGrowthRiseMb: 1024, FileGrowthVolumePercent: 10,
         FileGrowthLookbackMinutes: 60);
-
-    private static string ReadRepoFile(
-        string relative, [System.Runtime.CompilerServices.CallerFilePath] string thisFile = "")
-    {
-        for (var dir = new System.IO.DirectoryInfo(System.IO.Path.GetDirectoryName(thisFile)!);
-             dir is not null; dir = dir.Parent)
-        {
-            var candidate = System.IO.Path.Combine(dir.FullName, relative);
-            if (System.IO.File.Exists(candidate)) return System.IO.File.ReadAllText(candidate);
-        }
-
-        throw new System.IO.FileNotFoundException($"Could not locate {relative}");
-    }
 
     [Fact]
     public void AlertSettingsSql_ReadsSingleGlobalRow()

--- a/Darling/Darling.Tests/DarlingRuntimePreflightTests.cs
+++ b/Darling/Darling.Tests/DarlingRuntimePreflightTests.cs
@@ -320,5 +320,4 @@ public class DarlingRuntimePreflightTests
         end = -1;
         return string.Empty;
     }
-
 }

--- a/Darling/Darling.Tests/DarlingRuntimePreflightTests.cs
+++ b/Darling/Darling.Tests/DarlingRuntimePreflightTests.cs
@@ -12,6 +12,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Text;
 using Xunit;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -320,24 +321,4 @@ public class DarlingRuntimePreflightTests
         return string.Empty;
     }
 
-    /// <summary>Walks up from the test output directory to the repo root (the directory holding
-    /// <c>PerformanceMonitor.sln</c>).</summary>
-    private static string ReadRepoFile(string relativePath)
-    {
-        var directory = new DirectoryInfo(AppContext.BaseDirectory);
-        for (var i = 0; i < 10 && directory is not null; i++)
-        {
-            if (File.Exists(Path.Combine(directory.FullName, "PerformanceMonitor.sln")))
-            {
-                var path = Path.Combine(directory.FullName, relativePath);
-                Assert.True(File.Exists(path), $"expected {path} to exist");
-                return File.ReadAllText(path);
-            }
-
-            directory = directory.Parent;
-        }
-
-        Assert.Fail("could not find the repo root (the directory holding PerformanceMonitor.sln)");
-        return string.Empty;
-    }
 }

--- a/Darling/Darling.Tests/DarlingServiceInstallLocationTests.cs
+++ b/Darling/Darling.Tests/DarlingServiceInstallLocationTests.cs
@@ -13,6 +13,7 @@ using System.Text;
 using Microsoft.Extensions.Logging;
 using PerformanceMonitor.Darling.Service;
 using Xunit;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -424,26 +425,6 @@ public sealed class DarlingServiceInstallLocationTests
             Assert.True(report < at,
                 $"the install-location diagnosis must run BEFORE {what}, or the operator reads the downstream failure first (#2185)");
         }
-    }
-
-    /// <summary>Walks up from the test output directory to the repo root — the same idiom
-    /// <see cref="DarlingInstallLocationTests"/> uses.</summary>
-    private static string ReadRepoFile(string relativePath)
-    {
-        var directory = new DirectoryInfo(AppContext.BaseDirectory);
-        for (var i = 0; i < 10 && directory is not null; i++)
-        {
-            var candidate = Path.Combine(directory.FullName, relativePath);
-            if (File.Exists(Path.Combine(directory.FullName, "PerformanceMonitor.sln")) && File.Exists(candidate))
-            {
-                return File.ReadAllText(candidate);
-            }
-
-            directory = directory.Parent;
-        }
-
-        Assert.Fail($"could not find {relativePath} above {AppContext.BaseDirectory}");
-        return string.Empty;
     }
 
     /// <summary>Counts lines per level as well as capturing them: "exactly one critical" is the assertion, and

--- a/Darling/Darling.Tests/FileGrowthAlertStoreTests.cs
+++ b/Darling/Darling.Tests/FileGrowthAlertStoreTests.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using PerformanceMonitor.Darling.Storage;
 using PerformanceMonitor.Darling.Viewer;
 using Xunit;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -147,17 +148,4 @@ public class FileGrowthAlertStoreTests
     private static string ReadViewerSource() =>
         ReadRepoFile("Darling", "PerformanceMonitor.Darling.Viewer", "ViewerDataService.cs");
 
-    private static string ReadRepoFile(params string[] parts)
-    {
-        var relative = System.IO.Path.Combine(parts);
-        var dir = System.IO.Path.GetDirectoryName(ThisFile())!;
-        while (dir is not null && !System.IO.File.Exists(System.IO.Path.Combine(dir, relative)))
-        {
-            dir = System.IO.Path.GetDirectoryName(dir);
-        }
-
-        return System.IO.File.ReadAllText(System.IO.Path.Combine(dir!, relative));
-    }
-
-    private static string ThisFile([System.Runtime.CompilerServices.CallerFilePath] string path = "") => path;
 }

--- a/Darling/Darling.Tests/FileGrowthAlertStoreTests.cs
+++ b/Darling/Darling.Tests/FileGrowthAlertStoreTests.cs
@@ -147,5 +147,4 @@ public class FileGrowthAlertStoreTests
 
     private static string ReadViewerSource() =>
         ReadRepoFile("Darling", "PerformanceMonitor.Darling.Viewer", "ViewerDataService.cs");
-
 }

--- a/Darling/Darling.Tests/FinOpsSubTabIndexPinTests.cs
+++ b/Darling/Darling.Tests/FinOpsSubTabIndexPinTests.cs
@@ -111,5 +111,4 @@ public sealed class FinOpsSubTabIndexPinTests
             .Select(m => m.Groups[1].Value)
             .ToList();
     }
-
 }

--- a/Darling/Darling.Tests/FinOpsSubTabIndexPinTests.cs
+++ b/Darling/Darling.Tests/FinOpsSubTabIndexPinTests.cs
@@ -10,9 +10,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using Xunit;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -112,21 +112,4 @@ public sealed class FinOpsSubTabIndexPinTests
             .ToList();
     }
 
-    /// <summary>
-    /// Walks up from this source file until the requested path resolves — the idiom the #1949 grid pins
-    /// use. Deliberately NOT a <c>.git</c> probe: in a git WORKTREE <c>.git</c> is a FILE, not a directory,
-    /// so a <c>Directory.Exists</c> check walks past the root and the pin fails everywhere feature work
-    /// actually happens.
-    /// </summary>
-    private static string ReadRepoFile(string relativePath, [CallerFilePath] string callerPath = "")
-    {
-        var dir = Path.GetDirectoryName(callerPath);
-        while (dir is not null && !File.Exists(Path.Combine(dir, relativePath)))
-        {
-            dir = Path.GetDirectoryName(dir);
-        }
-
-        Assert.True(dir is not null, $"{relativePath} not found walking up from the test source");
-        return File.ReadAllText(Path.Combine(dir!, relativePath));
-    }
 }

--- a/Darling/Darling.Tests/FleetPageAttentionFilterTests.cs
+++ b/Darling/Darling.Tests/FleetPageAttentionFilterTests.cs
@@ -10,11 +10,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Text.Json;
 using PerformanceMonitor.Common;
 using PerformanceMonitor.Darling.Service.Mcp;
 using Xunit;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -43,7 +43,7 @@ public sealed class FleetPageAttentionFilterTests
 {
     /// <summary>The shipped module, newlines normalised so a multi-line anchor holds whether the checkout gave
     /// this file CRLF (.gitattributes says it does) or LF.</summary>
-    private static string FleetJs => ReadRepoFile(Path.Combine(
+    private static string FleetJs => ReadRepoFileLf(Path.Combine(
         "Darling", "PerformanceMonitor.Darling.Service", "wwwroot", "js", "pages", "fleet.js"));
 
     /// <summary>
@@ -136,7 +136,7 @@ public sealed class FleetPageAttentionFilterTests
         Assert.Contains("\"all \" + total + \" matching servers are healthy\"", FleetJs, StringComparison.Ordinal);
         Assert.Contains("attentionCountText(shown, total, term !== \"\")", FleetJs, StringComparison.Ordinal);
 
-        var viewer = ReadRepoFile(Path.Combine(
+        var viewer = ReadRepoFileLf(Path.Combine(
             "Darling", "PerformanceMonitor.Darling.Viewer", "ViewerDataService.Fleet.cs"));
         Assert.Contains("$\"showing {shown} of {total}\"", viewer, StringComparison.Ordinal);
         Assert.Contains("$\"all {total} servers are healthy\"", viewer, StringComparison.Ordinal);
@@ -164,7 +164,7 @@ public sealed class FleetPageAttentionFilterTests
            util.js's noticeStrip idiom for the same kind of non-fatal live notice. Also raised in review. */
         Assert.Contains("role: \"status\"", FleetJs, StringComparison.Ordinal);
 
-        var css = ReadRepoFile(Path.Combine(
+        var css = ReadRepoFileLf(Path.Combine(
             "Darling", "PerformanceMonitor.Darling.Service", "wwwroot", "css", "app.css"));
         Assert.Contains(".attention-note.warn", css, StringComparison.Ordinal);
         Assert.Contains(".attention-note.ok", css, StringComparison.Ordinal);
@@ -195,7 +195,7 @@ public sealed class FleetPageAttentionFilterTests
     [Fact]
     public void FleetAndViewCardGrids_StretchWithAutoFit_NotAutoFill()
     {
-        var app = ReadRepoFile(Path.Combine(
+        var app = ReadRepoFileLf(Path.Combine(
             "Darling", "PerformanceMonitor.Darling.Service", "wwwroot", "css", "app.css"));
         /* .grid keeps its 1fr max (shared with triage); .server-grid also has a 260px min now, but its max is
            460px, so this 1fr-specific string still pins .grid alone. */
@@ -203,7 +203,7 @@ public sealed class FleetPageAttentionFilterTests
         /* No grid track in app.css uses auto-fill (the .stats comment says the word but not "repeat(auto-fill"). */
         Assert.DoesNotContain("repeat(auto-fill", app, StringComparison.Ordinal);
 
-        var editor = ReadRepoFile(Path.Combine(
+        var editor = ReadRepoFileLf(Path.Combine(
             "Darling", "PerformanceMonitor.Darling.Service", "wwwroot", "css", "editor.css"));
         Assert.Contains("repeat(auto-fit, minmax(260px, 1fr))", editor, StringComparison.Ordinal);
         Assert.DoesNotContain("repeat(auto-fill", editor, StringComparison.Ordinal);
@@ -225,7 +225,7 @@ public sealed class FleetPageAttentionFilterTests
     [Fact]
     public void FleetServerCardGrids_CapTrackWidth_AndKeepTheScopeOffTriage()
     {
-        var app = ReadRepoFile(Path.Combine(
+        var app = ReadRepoFileLf(Path.Combine(
             "Darling", "PerformanceMonitor.Darling.Service", "wwwroot", "css", "app.css"));
         Assert.Contains(".server-grid {", app, StringComparison.Ordinal);
         /* Cap + centre asserted as a contiguous block, so the centring is pinned to .server-grid rather than
@@ -246,14 +246,14 @@ public sealed class FleetPageAttentionFilterTests
         Assert.Contains(".tag-group-grid { margin: 0.5rem 0 0.2rem; justify-content: start; }", app, StringComparison.Ordinal);
 
         /* Both server-card grids (flat + tag-group) must carry the class, or the cap misses one view. */
-        var fleet = ReadRepoFile(Path.Combine(
+        var fleet = ReadRepoFileLf(Path.Combine(
             "Darling", "PerformanceMonitor.Darling.Service", "wwwroot", "js", "pages", "fleet.js"));
         Assert.Contains("class: \"grid server-grid\"", fleet, StringComparison.Ordinal);
         Assert.Contains("class: \"grid server-grid tag-group-grid\"", fleet, StringComparison.Ordinal);
 
         /* Scope guard: the triage grid stays bare .grid (full-width span-2 cards + notice strips), so a global
            cap must not have leaked onto it — the reason the cap is a class, not a change to .grid. */
-        var triage = ReadRepoFile(Path.Combine(
+        var triage = ReadRepoFileLf(Path.Combine(
             "Darling", "PerformanceMonitor.Darling.Service", "wwwroot", "js", "pages", "triage.js"));
         Assert.DoesNotContain("server-grid", triage, StringComparison.Ordinal);
     }
@@ -371,7 +371,7 @@ public sealed class FleetPageAttentionFilterTests
 
         /* One shared builder: the detail header RENDERS the same metricBands (the load-bearing call, not just
            the import), so the fix covers both surfaces and they cannot drift. */
-        var server = ReadRepoFile(Path.Combine(
+        var server = ReadRepoFileLf(Path.Combine(
             "Darling", "PerformanceMonitor.Darling.Service", "wwwroot", "js", "pages", "server.js"));
         Assert.Contains("import { metricBands }", server, StringComparison.Ordinal);
         Assert.Contains("metricBands(card)", server, StringComparison.Ordinal);
@@ -389,17 +389,4 @@ public sealed class FleetPageAttentionFilterTests
         return count;
     }
 
-    private static string ReadRepoFile(string relative, [CallerFilePath] string thisFile = "")
-    {
-        for (var dir = new DirectoryInfo(Path.GetDirectoryName(thisFile)!); dir is not null; dir = dir.Parent)
-        {
-            var candidate = Path.Combine(dir.FullName, relative);
-            if (File.Exists(candidate))
-            {
-                return File.ReadAllText(candidate).Replace("\r\n", "\n", StringComparison.Ordinal);
-            }
-        }
-
-        throw new FileNotFoundException($"Could not locate {relative} walking up from {thisFile}");
-    }
 }

--- a/Darling/Darling.Tests/FleetPageAttentionFilterTests.cs
+++ b/Darling/Darling.Tests/FleetPageAttentionFilterTests.cs
@@ -388,5 +388,4 @@ public sealed class FleetPageAttentionFilterTests
         }
         return count;
     }
-
 }

--- a/Darling/Darling.Tests/LaneAxisAlignerTests.cs
+++ b/Darling/Darling.Tests/LaneAxisAlignerTests.cs
@@ -306,5 +306,4 @@ public sealed class LaneAxisAlignerTests
         Assert.True(end > open, $"{what}: SyncXAxes body is unbalanced");
         return source[open..(end + 1)];
     }
-
 }

--- a/Darling/Darling.Tests/LaneAxisAlignerTests.cs
+++ b/Darling/Darling.Tests/LaneAxisAlignerTests.cs
@@ -9,10 +9,10 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using PerformanceMonitor.Ui;
 using ScottPlot;
 using Xunit;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -307,20 +307,4 @@ public sealed class LaneAxisAlignerTests
         return source[open..(end + 1)];
     }
 
-    /// <summary>
-    /// Walks up from this source file until the requested path resolves - the idiom the #1949 grid pins use.
-    /// Deliberately NOT a <c>.git</c> probe: in a git WORKTREE <c>.git</c> is a FILE, not a directory, so a
-    /// <c>Directory.Exists</c> check walks past the root and the pin fails everywhere feature work happens.
-    /// </summary>
-    private static string ReadRepoFile(string relativePath, [CallerFilePath] string callerPath = "")
-    {
-        var dir = Path.GetDirectoryName(callerPath);
-        while (dir is not null && !File.Exists(Path.Combine(dir, relativePath)))
-        {
-            dir = Path.GetDirectoryName(dir);
-        }
-
-        Assert.True(dir is not null, $"{relativePath} not found walking up from the test source");
-        return File.ReadAllText(Path.Combine(dir!, relativePath));
-    }
 }

--- a/Darling/Darling.Tests/MigrationDataMovingRungCensusPins.cs
+++ b/Darling/Darling.Tests/MigrationDataMovingRungCensusPins.cs
@@ -14,6 +14,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using PerformanceMonitor.Darling.Storage;
 using Xunit;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -690,21 +691,4 @@ public sealed class MigrationDataMovingRungCensusPins
                 $"  V{f.Version.ToString(CultureInfo.InvariantCulture)} ({f.Name}): {f.Shape} on "
                 + $"{f.Table}, created by {f.CreatedBy}"));
 
-    /// <summary>
-    /// Reads a repo-relative source file by walking up from the test binary — the same delivery
-    /// <c>CollectionLogDrainForensicsStoreTests</c> uses for this very file, so the pin reads the REAL
-    /// constant rather than a copy that could go stale in the direction the pin exists to catch.
-    /// </summary>
-    private static string ReadRepoFile(string relativePath)
-    {
-        var dir = AppContext.BaseDirectory;
-
-        while (dir is not null && !File.Exists(Path.Combine(dir, relativePath)))
-        {
-            dir = Directory.GetParent(dir)?.FullName;
-        }
-
-        Assert.NotNull(dir);
-        return File.ReadAllText(Path.Combine(dir!, relativePath));
-    }
 }

--- a/Darling/Darling.Tests/MigrationDataMovingRungCensusPins.cs
+++ b/Darling/Darling.Tests/MigrationDataMovingRungCensusPins.cs
@@ -690,5 +690,4 @@ public sealed class MigrationDataMovingRungCensusPins
             findings.Select(f =>
                 $"  V{f.Version.ToString(CultureInfo.InvariantCulture)} ({f.Name}): {f.Shape} on "
                 + $"{f.Table}, created by {f.CreatedBy}"));
-
 }

--- a/Darling/Darling.Tests/PerDatabaseFaultPathSplitTests.cs
+++ b/Darling/Darling.Tests/PerDatabaseFaultPathSplitTests.cs
@@ -11,13 +11,13 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
-using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using System.Threading;
 using Microsoft.Extensions.Logging;
 using PerformanceMonitor.Collectors;
 using PerformanceMonitor.Darling.Service;
 using Xunit;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -544,20 +544,6 @@ public sealed class PerDatabaseFaultPathSplitTests
         Assert.True(end > start, "The per-database branch's closing anchor moved.");
 
         return runner[start..end];
-    }
-
-    private static string ReadRepoFile(string relative, [CallerFilePath] string thisFile = "")
-    {
-        for (var dir = new DirectoryInfo(Path.GetDirectoryName(thisFile)!); dir is not null; dir = dir.Parent)
-        {
-            var candidate = Path.Combine(dir.FullName, relative);
-            if (File.Exists(candidate))
-            {
-                return File.ReadAllText(candidate);
-            }
-        }
-
-        throw new FileNotFoundException($"Could not locate {relative} walking up from {thisFile}");
     }
 
     private sealed class Recorder : ILogger

--- a/Darling/Darling.Tests/PgDeadlockLogTimezoneTests.cs
+++ b/Darling/Darling.Tests/PgDeadlockLogTimezoneTests.cs
@@ -69,5 +69,4 @@ public sealed class PgDeadlockLogTimezoneTests
         Assert.Contains("([^ \\n]+) \\[(\\d+)\\]", source, System.StringComparison.Ordinal);
         Assert.DoesNotContain("\\w+ \\[(\\d+)\\]", source, System.StringComparison.Ordinal);
     }
-
 }

--- a/Darling/Darling.Tests/PgDeadlockLogTimezoneTests.cs
+++ b/Darling/Darling.Tests/PgDeadlockLogTimezoneTests.cs
@@ -7,8 +7,8 @@
  */
 
 using System.IO;
-using System.Runtime.CompilerServices;
 using Xunit;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -70,16 +70,4 @@ public sealed class PgDeadlockLogTimezoneTests
         Assert.DoesNotContain("\\w+ \\[(\\d+)\\]", source, System.StringComparison.Ordinal);
     }
 
-    /* Locate the repo from this file — the DarlingLockTimeoutYieldTests idiom; no build-output copying. */
-    private static string ReadRepoFile(string relative, [CallerFilePath] string thisFile = "")
-    {
-        var dir = Path.GetDirectoryName(thisFile)!;
-        while (dir is not null && !File.Exists(Path.Combine(dir, relative)))
-        {
-            dir = Path.GetDirectoryName(dir);
-        }
-
-        Assert.NotNull(dir);
-        return File.ReadAllText(Path.Combine(dir!, relative));
-    }
 }

--- a/Darling/Darling.Tests/QueryStoreTopWindowTests.cs
+++ b/Darling/Darling.Tests/QueryStoreTopWindowTests.cs
@@ -118,5 +118,4 @@ public class QueryStoreTopWindowTests
         /* plan_id is the reason: it is a grouping key here and absent from every rollup. */
         Assert.Contains("plan_id", DarlingDataReader.QueryStoreTopSql, StringComparison.Ordinal);
     }
-
 }

--- a/Darling/Darling.Tests/QueryStoreTopWindowTests.cs
+++ b/Darling/Darling.Tests/QueryStoreTopWindowTests.cs
@@ -8,9 +8,9 @@
 
 using System;
 using System.IO;
-using System.Runtime.CompilerServices;
 using PerformanceMonitor.Darling.Service.Mcp;
 using Xunit;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -119,17 +119,4 @@ public class QueryStoreTopWindowTests
         Assert.Contains("plan_id", DarlingDataReader.QueryStoreTopSql, StringComparison.Ordinal);
     }
 
-    private static string ReadRepoFile(string relative, [CallerFilePath] string thisFile = "")
-    {
-        for (var dir = new DirectoryInfo(Path.GetDirectoryName(thisFile)!); dir is not null; dir = dir.Parent)
-        {
-            var candidate = Path.Combine(dir.FullName, relative);
-            if (File.Exists(candidate))
-            {
-                return File.ReadAllText(candidate);
-            }
-        }
-
-        throw new FileNotFoundException($"Could not locate {relative} walking up from {thisFile}");
-    }
 }

--- a/Darling/Darling.Tests/RepoFile.cs
+++ b/Darling/Darling.Tests/RepoFile.cs
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// <para>Reads a file out of this repository by its repo-root-relative path — the one implementation every
+/// source-text pin in this project shares. Thirty-four classes each carried their own private
+/// <c>ReadRepoFile</c> before this, the same treatment <see cref="CSharpSourceWalker"/> gave the five copies
+/// of the source walk in #2913 and <see cref="CommandDeadlineScanner"/> gave the copies of the deadline
+/// judgement in #2938. Those copies had already drifted by the time they were consolidated, and this set had
+/// drifted further: thirty-four declarations carrying EIGHT different resolution semantics.</para>
+///
+/// <para><b>The root is found from this file's own compile-time path, not from the test binary's
+/// directory.</b> Nine of the copies walked up from <c>AppContext.BaseDirectory</c>, which ties a read of
+/// SOURCE to wherever the OUTPUT landed — a coupling with nothing to do with the question being asked, and
+/// one that silently changes answer when the runner's working layout changes. The path baked in by
+/// <see cref="CallerFilePathAttribute"/> names the tree the assembly was compiled from, which is the tree
+/// these pins are reading. Resolved from THIS file rather than from each caller, so there is one answer
+/// rather than one per call site; the invariant that keeps those identical — every pin living in this one
+/// directory — is asserted in <see cref="RepoFileResolutionEquivalenceTests"/> rather than assumed.</para>
+///
+/// <para><b>The root is a MARKER, not the target file.</b> Twenty-two of the copies walked up probing for
+/// the RELATIVE PATH itself, so the root they resolved varied with the argument, and a path that did not
+/// exist anywhere walked to the filesystem root and then dereferenced a null or read the wrong thing. One
+/// marker gives one root for every read, and a missing file reports the absolute path it looked for.</para>
+///
+/// <para><b>Raw and LF-normalised are two methods because they were two behaviours.</b> Twenty-eight copies
+/// returned the file as it sits on disk and six normalised CRLF to LF, and each pin's anchors were written
+/// against what its own helper returned. This checkout is CRLF (<c>.gitattributes</c> is
+/// <c>* text=auto eol=crlf</c>), so folding the two together would change what twenty-eight pins' anchors
+/// match — a multi-line <c>DoesNotContain</c> that cannot currently fire would start firing, and a
+/// multi-line <c>Contains</c> that cannot currently match would start matching. That is a behaviour change
+/// and not a de-duplication, so the choice stays at the call site and stays visible in the method name.</para>
+///
+/// <para><b><c>params</c> rather than two overloads.</b> The copies split between a single pre-combined
+/// relative path and a variadic segment list; one <c>params</c> parameter accepts both spellings with no
+/// overload to resolve between, so no call site had to change shape to adopt this. Separators are
+/// normalised because three call sites spell their path with forward slashes.</para>
+///
+/// <para><b>That there is exactly ONE of these is asserted, not stated.</b>
+/// <see cref="RepoFileAdoptionTests"/> re-derives the declaring set from the tree, so a thirty-fifth private
+/// copy arriving by paste fails the build instead of joining the family silently — which is how these
+/// thirty-four came to exist. It carries the boundary of what that scan can and cannot see.</para>
+///
+/// <para>No xunit dependency, matching <see cref="CSharpSourceWalker"/>: a failure here is a
+/// <see cref="FileNotFoundException"/> naming the absolute path, which reads the same in a test runner and
+/// leaves this file shareable with <c>Lite.Tests</c> by <c>Compile Include</c> the way #2913 sanctioned.</para>
+/// </summary>
+internal static class RepoFile
+{
+    /// <summary>The tracked file that marks the repository root. A file rather than a directory, and the
+    /// solution rather than <c>.git</c>, because a git WORKTREE has a <c>.git</c> FILE — so a
+    /// <c>Directory.Exists(".git")</c> probe silently walks past the root of every worktree checkout.</summary>
+    private const string RootMarker = "PerformanceMonitor.sln";
+
+    /// <summary>The absolute path of the repository root.</summary>
+    internal static string Root => ResolveRoot();
+
+    /// <summary>Reads a repo file exactly as it sits on disk.</summary>
+    internal static string ReadRepoFile(params string[] segments)
+    {
+        var full = PathTo(segments);
+
+        if (!File.Exists(full))
+        {
+            throw new FileNotFoundException(
+                $"source not found, this pin would read nothing: {full}", full);
+        }
+
+        return File.ReadAllText(full);
+    }
+
+    /// <summary>Reads a repo file with CRLF normalised to LF, for pins whose anchors span a line break.
+    /// An anchor that embeds the wrong newline matches NOTHING and reads as clean, so the pins that write
+    /// multi-line anchors take this one and the rest deliberately do not.</summary>
+    internal static string ReadRepoFileLf(params string[] segments) =>
+        ReadRepoFile(segments).Replace("\r\n", "\n", StringComparison.Ordinal);
+
+    /// <summary>The absolute path a repo-root-relative spelling resolves to. Existence is NOT checked here:
+    /// callers naming a DIRECTORY use <see cref="Root"/> directly, and the file check belongs with the
+    /// read that would otherwise return nothing.
+    ///
+    /// <para>Internal rather than private so <see cref="RepoFileResolutionEquivalenceTests"/> can compare
+    /// the PATH each replaced resolver produced against the path this one produces. Inferring that from
+    /// content instead would be satisfied by two different files that happen to hold the same bytes — and
+    /// this repository is full of deliberate parity copies, which is the reason that pin exists.</para></summary>
+    internal static string PathTo(params string[] segments)
+    {
+        if (segments is null || segments.Length == 0)
+        {
+            throw new ArgumentException("at least one path segment is required", nameof(segments));
+        }
+
+        /* Both separators, so a path spelled either way resolves on either host. */
+        var relative = Path.Combine(segments)
+            .Replace('/', Path.DirectorySeparatorChar)
+            .Replace('\\', Path.DirectorySeparatorChar);
+
+        return Path.Combine(Root, relative);
+    }
+
+    private static string ResolveRoot([CallerFilePath] string thisFile = "")
+    {
+        var start = Path.GetDirectoryName(thisFile);
+
+        if (string.IsNullOrEmpty(start))
+        {
+            throw new DirectoryNotFoundException(
+                "RepoFile.cs has no compile-time directory to walk up from. A deterministic build that "
+              + "rewrites CallerFilePath (PathMap) would do this, and every source-text pin in this project "
+              + "resolves through here.");
+        }
+
+        for (var dir = new DirectoryInfo(start); dir is not null; dir = dir.Parent)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, RootMarker)))
+            {
+                return dir.FullName;
+            }
+        }
+
+        throw new DirectoryNotFoundException(
+            $"Could not locate {RootMarker} walking up from {thisFile}. This resolves from the compile-time "
+          + "path of RepoFile.cs, so it fails when the assembly was built from a source tree that is no "
+          + "longer on disk.");
+    }
+}

--- a/Darling/Darling.Tests/RepoFileAdoptionTests.cs
+++ b/Darling/Darling.Tests/RepoFileAdoptionTests.cs
@@ -17,8 +17,9 @@ using Xunit;
 namespace Darling.Tests;
 
 /// <summary>
-/// That <see cref="RepoFile"/> is the ONLY repo-file reader in this project — asserted, rather than stated
-/// in prose and left to rot.
+/// That <see cref="RepoFile"/> is the only repo-file reader in <c>Darling.Tests</c> — asserted, rather than
+/// stated in prose and left to rot. <c>Darling.Tests</c> and not "the repository": the scope is this one
+/// test project, and the paragraph on what the scan cannot see says what that leaves out.
 ///
 /// <para><b>This exists because the prose version failed for thirty-four consecutive classes.</b> Every one
 /// of them wanted to read a repo file, none of them found an authority to call, each wrote its own, and the
@@ -36,12 +37,26 @@ namespace Darling.Tests;
 /// <c>DoesNotContain</c> would stop being ABLE to fire and report clean forever. Switching a pin off the LF
 /// reader is therefore a decision, and it reds here so it gets made on purpose.</para>
 ///
-/// <para><b>What this scan cannot see, stated rather than implied.</b> It matches a DECLARATION named
-/// <c>ReadRepoFile</c> or <c>ReadRepoFileLf</c>, so a private re-implementation under some other name
-/// evades it — the regex anchors on the name, and a name is all one file's text offers. It also says nothing
-/// about the fifty-three classes in this project that still carry their own repo-ROOT walk without a reader
-/// on top of it; that is the same duplication one layer down, it is a larger population than this one was,
-/// and it is deliberately not in scope here.</para>
+/// <para><b>What this scan cannot see, stated rather than implied.</b> Three things, and the first is a
+/// boundary rather than a limitation.</para>
+///
+/// <para><b>It sweeps <c>Darling.Tests</c> only</b>, because <see cref="TestDirectory"/> is this file's own
+/// directory. <c>Lite.Tests</c> carries five private <c>ReadRepoFile</c> declarations of its own —
+/// <c>DetachedCollectorGateTests</c>, <c>GridPayloadColumnOrderPinTests</c>,
+/// <c>LiteOverviewCardExplainsItselfTests</c>, <c>LiteSidebarDotRendersTheCardStatusTests</c> and
+/// <c>QueryStoreServerGateTests</c> — and this says nothing about them. They are the same pattern in the
+/// sibling project, and <see cref="RepoFile"/> is shareable with it by the one <c>Compile Include</c> line
+/// that already brings <see cref="CSharpSourceWalker"/> across. Whoever takes that has to widen this sweep
+/// or add a sibling pin in <c>Lite.Tests</c>; a reader consolidated there while this scan still looks at one
+/// directory would be consolidated with nothing asserting it stayed that way.</para>
+///
+/// <para><b>It matches a DECLARATION by NAME</b> — <c>ReadRepoFile</c> or <c>ReadRepoFileLf</c> — so a
+/// private re-implementation under some other name evades it. The regex anchors on the name, and a name is
+/// all one file's text offers.</para>
+///
+/// <para><b>It says nothing about the fifty-three classes here that carry their own repo-ROOT walk</b>
+/// without a reader on top of it. That is the same duplication one layer down, it is a larger population
+/// than this one was, and it is deliberately not in scope.</para>
 /// </summary>
 public sealed class RepoFileAdoptionTests
 {

--- a/Darling/Darling.Tests/RepoFileAdoptionTests.cs
+++ b/Darling/Darling.Tests/RepoFileAdoptionTests.cs
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// That <see cref="RepoFile"/> is the ONLY repo-file reader in this project — asserted, rather than stated
+/// in prose and left to rot.
+///
+/// <para><b>This exists because the prose version failed for thirty-four consecutive classes.</b> Every one
+/// of them wanted to read a repo file, none of them found an authority to call, each wrote its own, and the
+/// set drifted into EIGHT different resolution semantics — probing for the target versus finding a marker,
+/// walking from the pin's source path versus from the test binary's directory, three different markers, and
+/// two different answers about newlines. Nothing failed while that happened, because a private helper is
+/// invisible to everything except the class holding it. The same failure mode #2913 removed from the source
+/// walk and #2938 from the deadline judgement, and the same fix: one authority, and a build that reds when
+/// a second one appears.</para>
+///
+/// <para><b>The LF-adopting set is pinned separately, and it is the half that would fail silently.</b> A
+/// missing declaration is a compile error; a pin switched from <see cref="RepoFile.ReadRepoFileLf"/> to
+/// <see cref="RepoFile.ReadRepoFile"/> is not. This checkout is CRLF, so an anchor spanning a line break
+/// cannot match raw text at all: a positive assertion would fail loudly, but a
+/// <c>DoesNotContain</c> would stop being ABLE to fire and report clean forever. Switching a pin off the LF
+/// reader is therefore a decision, and it reds here so it gets made on purpose.</para>
+///
+/// <para><b>What this scan cannot see, stated rather than implied.</b> It matches a DECLARATION named
+/// <c>ReadRepoFile</c> or <c>ReadRepoFileLf</c>, so a private re-implementation under some other name
+/// evades it — the regex anchors on the name, and a name is all one file's text offers. It also says nothing
+/// about the fifty-three classes in this project that still carry their own repo-ROOT walk without a reader
+/// on top of it; that is the same duplication one layer down, it is a larger population than this one was,
+/// and it is deliberately not in scope here.</para>
+/// </summary>
+public sealed class RepoFileAdoptionTests
+{
+    private const string Authority = "RepoFile.cs";
+
+    /// <summary>A method DECLARATION of the shared reader's name: an accessibility modifier, no <c>;</c> or
+    /// <c>=</c> before the name, then the name and its parameter list. Matched against STRIPPED source, so
+    /// the doc comments in this family that quote the reader by name are not mistaken for declarations of
+    /// it.</summary>
+    private static readonly Regex Declaration = new(
+        @"^[ \t]*(?:private|internal|public|protected)[^\r\n;=]*?\bReadRepoFile(?:Lf)?\s*\(",
+        RegexOptions.Multiline | RegexOptions.Compiled);
+
+    private static readonly Regex RawCall = new(
+        @"(?<![\w.])ReadRepoFile\s*\(", RegexOptions.Compiled);
+
+    private static readonly Regex LfCall = new(
+        @"(?<![\w.])ReadRepoFileLf\s*\(", RegexOptions.Compiled);
+
+    /// <summary>
+    /// The pins whose anchors span a line break, and which therefore read LF-normalised text.
+    ///
+    /// <para>These six carried the normalising helper before consolidation; the other twenty-eight
+    /// deliberately did not. The list is compared against the tree rather than trusted, for the reason in
+    /// this class's summary: moving a pin between the two readers changes whether its multi-line
+    /// assertions can fire at all.</para>
+    /// </summary>
+    private static readonly string[] s_lfReaders =
+    {
+        "ChartWindowDomainTests.cs",
+        "FleetPageAttentionFilterTests.cs",
+        "ServerPageTabsTests.cs",
+        "StartupFailureTriageTests.cs",
+        "ViewTemplatesTests.cs",
+        "ViewerSidebarDotRendersTheCardStatusTests.cs",
+    };
+
+    [Fact]
+    public void ExactlyOneFile_DeclaresTheSharedRepoFileReader()
+    {
+        var (files, declarers, rawAdopters, lfAdopters) = Survey();
+
+        /* A floor rather than an equality, and the same one the rest of this family uses: it catches a sweep
+           that read the wrong directory and then reported clean on nothing. The claims that matter are the
+           set equalities, which move whenever a declaration or an adopter does. */
+        Assert.True(
+            files.Count >= 400,
+            $"the sweep found only {files.Count} .cs files under {TestDirectory()} — it is not reading the "
+          + "test project, so every assertion below would pass for a reason unrelated to the defect");
+
+        Assert.Equal(new[] { Authority }, declarers.ToArray());
+
+        /* The authority being alone is satisfied just as well by an authority nothing calls, which is why
+           the adopting population is floored on its own. Thirty-four classes were migrated onto it; a floor
+           under that catches the reader being quietly abandoned while this file keeps passing. */
+        var adopters = rawAdopters.Concat(lfAdopters).Distinct(StringComparer.Ordinal).ToArray();
+
+        Assert.True(
+            adopters.Length >= 30,
+            $"only {adopters.Length} classes call the shared reader. Thirty-four were migrated onto it, so "
+          + "either pins were deleted or they have gone back to reading files some other way — in which "
+          + "case the single-declaration assertion above is guarding an authority nobody uses");
+    }
+
+    [Fact]
+    public void TheLfReadingPins_AreExactlyTheOnesDeclaredHere()
+    {
+        var (_, _, _, lfAdopters) = Survey();
+
+        Assert.Equal(
+            s_lfReaders.OrderBy(f => f, StringComparer.Ordinal).ToArray(),
+            lfAdopters.ToArray());
+
+        /* The floor that makes the equality above mean something. An empty tree satisfies an empty
+           expectation, and this list is short enough that a scan reading nothing looks plausible. */
+        Assert.NotEmpty(s_lfReaders);
+    }
+
+    private static (List<string> Files, List<string> Declarers, List<string> RawAdopters, List<string> LfAdopters)
+        Survey()
+    {
+        var directory = TestDirectory();
+
+        /* bin/ and obj/ excluded the way CrossAppGuardCiGateTests excludes them: obj/ carries generated
+           sources, and a throwaway verification harness staged under bin/ would otherwise be swept as if it
+           were a pin. AllDirectories rather than TopDirectoryOnly so a pin that lands in a future
+           subdirectory is still counted — the flat layout today is not an invariant anything asserts. */
+        var files = Directory
+            .EnumerateFiles(directory, "*.cs", SearchOption.AllDirectories)
+            .Where(f =>
+                !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal) &&
+                !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .OrderBy(f => f, StringComparer.Ordinal)
+            .ToList();
+
+        var declarers = new List<string>();
+        var rawAdopters = new List<string>();
+        var lfAdopters = new List<string>();
+
+        foreach (var file in files)
+        {
+            var name = Path.GetFileName(file);
+
+            /* STRIPPED, for the reason CommandDeadlineScannerAdoptionTests gives: this family discusses the
+               shared reader at length in doc comments and names both methods, so read raw, every file in it
+               would look like an adopter and several like declarers. */
+            var code = CSharpSourceWalker.StripCommentsAndStrings(File.ReadAllText(file));
+
+            if (Declaration.IsMatch(code))
+            {
+                declarers.Add(name);
+            }
+
+            if (name.Equals(Authority, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (LfCall.IsMatch(code))
+            {
+                lfAdopters.Add(name);
+            }
+
+            /* RawCall matches the Lf spelling too — its name is a prefix — so a file is a raw adopter only
+               once every Lf call is accounted for. Counted by occurrence rather than by presence, so a class
+               that legitimately uses both readers lands in both lists instead of one arbitrarily. */
+            if (RawCall.Matches(code).Count > LfCall.Matches(code).Count)
+            {
+                rawAdopters.Add(name);
+            }
+        }
+
+        declarers.Sort(StringComparer.Ordinal);
+        rawAdopters.Sort(StringComparer.Ordinal);
+        lfAdopters.Sort(StringComparer.Ordinal);
+
+        return (files, declarers, rawAdopters, lfAdopters);
+    }
+
+    private static string TestDirectory([CallerFilePath] string thisFile = "")
+        => Path.GetDirectoryName(thisFile)!;
+}

--- a/Darling/Darling.Tests/RepoFileResolutionEquivalenceTests.cs
+++ b/Darling/Darling.Tests/RepoFileResolutionEquivalenceTests.cs
@@ -1,0 +1,309 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// That <see cref="RepoFile"/> resolves to the SAME absolute path each of the eight resolvers it replaced
+/// resolved to, for a live call site of every one of them.
+///
+/// <para><b>This is the defect a green build hides.</b> Consolidating thirty-four private readers is a
+/// mechanical change whose every missed call site is a compile error — which is the good case. What a
+/// compile cannot see is a replacement whose PATH RESOLUTION differs from the one it replaced: a
+/// <see cref="CallerFilePathAttribute"/> walk and an <c>AppContext.BaseDirectory</c> walk-up do not resolve
+/// the same root from the same call site, a probe for the target file resolves a root that varies with the
+/// argument, and a marker of <c>PerformanceMonitor.Common</c> is not the marker
+/// <c>PerformanceMonitor.sln</c> is. Every pin downstream reads a file and asserts on its text, so a
+/// resolver that lands on a DIFFERENT file still returns a string and still runs its assertions — against
+/// the wrong source. Nothing else in the suite would say so.</para>
+///
+/// <para><b>The replaced resolvers are reproduced here rather than described.</b> A sentence claiming they
+/// agree is the artefact that rots; the code that used to run, run beside the code that replaced it, is
+/// not. These five path shapes are transcriptions of what the thirty-four declarations actually did, and
+/// they are the only copies of them left in the tree.</para>
+///
+/// <para><b>Why one shared answer is safe, asserted and not assumed.</b> Twenty-six of the replaced
+/// resolvers walked up from the CALLING pin's own source path, so their answer depended on where that pin
+/// lived. <see cref="RepoFile"/> resolves once from its own path instead, which is identical only while
+/// every pin sits in the same directory it does — so
+/// <see cref="EveryAdoptingPin_IsASiblingOfTheSharedReader"/> asserts that, and a pin moved into a
+/// subdirectory reds there rather than silently resolving from a different starting point.</para>
+/// </summary>
+public sealed class RepoFileResolutionEquivalenceTests
+{
+    /// <summary>A call site that really exists, paired with the resolver that used to serve it.</summary>
+    private sealed record Case(string Shape, string Pin, Func<string, string?> Resolve, string[] Segments, bool Lf);
+
+    private static Case[] Cases(string sourceDirectory) => new[]
+    {
+        /* 17 of the 34. Walks up from the pin's own source directory PROBING for the relative path itself,
+           so the root it resolves varies with the argument. AlertEngineTests is one. */
+        new Case(
+            "ProbeFromSource-raw",
+            "AlertEngineTests",
+            r => ProbeFromSourceDirectory(sourceDirectory, r),
+            new[] { "Darling", "PerformanceMonitor.Darling.Viewer", "ViewerDataService.DatabaseStates.cs" },
+            false),
+
+        /* 4 of the 34. The same walk, normalising CRLF to LF on the way out. */
+        new Case(
+            "ProbeFromSource-lf",
+            "ChartWindowDomainTests",
+            r => ProbeFromSourceDirectory(sourceDirectory, r),
+            new[] { "Darling", "PerformanceMonitor.Darling.Service", "wwwroot", "js", "charts.js" },
+            true),
+
+        /* 1 of the 34, and the shape the cross-app guard's census calls VariadicSegmentHelper: the same
+           walk again, reached through a params segment list with no Path.Combine at the call site. */
+        new Case(
+            "ProbeFromSource-variadic",
+            "FileGrowthAlertStoreTests",
+            r => ProbeFromSourceDirectory(sourceDirectory, r),
+            new[] { "Lite", "Services", "LocalDataService.FileGrowth.cs" },
+            false),
+
+        /* 8 of the 34. Walks up from the TEST BINARY's directory to the solution file, bounded at ten
+           levels. This is the shape whose answer depends on where the output landed rather than on where
+           the source is, and after this consolidation nothing outside this file resolves that way. */
+        new Case(
+            "SlnMarkerFromBaseDirectory",
+            "DarlingFileSecurityTests",
+            MarkerFromBaseDirectory,
+            new[] { "Darling", "tools", "install-darling.ps1" },
+            false),
+
+        /* 1 of the 34. From the test binary's directory again, but PROBING for the target and unbounded.
+           Its live call site spells the path with forward slashes, which is why RepoFile normalises
+           separators rather than trusting Path.Combine to. */
+        new Case(
+            "ProbeFromBaseDirectory",
+            "MigrationDataMovingRungCensusPins",
+            ProbeFromBaseDirectory,
+            new[] { "Darling/PerformanceMonitor.Darling.Storage/PgMigrations.cs" },
+            false),
+
+        /* 1 of the 34. A marker again, but the marker is a DIRECTORY named PerformanceMonitor.Common. */
+        new Case(
+            "CommonDirMarkerFromSource-raw",
+            "CollectionLogFanoutRollupStoreTests",
+            r => MarkerDirectoryFromSourceDirectory(sourceDirectory, r),
+            new[] { "Lite", "Mcp", "McpHealthTools.cs" },
+            false),
+
+        /* 1 of the 34. The same marker, normalising to LF. */
+        new Case(
+            "CommonDirMarkerFromSource-lf",
+            "ViewerSidebarDotRendersTheCardStatusTests",
+            r => MarkerDirectoryFromSourceDirectory(sourceDirectory, r),
+            new[] { "PerformanceMonitor.Common", "ServerHealthBands.cs" },
+            true),
+
+        /* 1 of the 34. Accepts the solution file OR a .git DIRECTORY as the root marker — which is the one
+           replaced resolver that would have walked past the root of a git WORKTREE, where .git is a file.
+           RepoFile takes the solution file alone for that reason. */
+        new Case(
+            "SlnOrGitMarkerFromSource",
+            "StartupFailureTriageTests",
+            r => SlnOrGitFromSourceDirectory(sourceDirectory, r),
+            new[] { "Darling/PerformanceMonitor.Darling.Service/Program.cs" },
+            true),
+    };
+
+    [Fact]
+    public void EveryReplacedResolver_ResolvesTheSameAbsolutePath_AsTheSharedOne()
+    {
+        var cases = Cases(TestDirectory());
+
+        /* A duplicated shape name is a shape silently dropped while every remaining case still reports a
+           pass, so the names are required distinct rather than merely present. The census in
+           CrossAppGuardCiGateTests floors itself the same way. */
+        Assert.Equal(cases.Length, cases.Select(c => c.Shape).Distinct(StringComparer.Ordinal).Count());
+
+        /* Eight, because eight is what the thirty-four declarations measured out to. A case deleted to make
+           a red go away is the cheapest way this test passes while the thing it guards is broken. */
+        Assert.Equal(8, cases.Length);
+
+        foreach (var (shape, pin, resolve, segments, lf) in cases)
+        {
+            var relative = Path.Combine(segments).Replace('/', Path.DirectorySeparatorChar);
+
+            var was = resolve(relative);
+
+            /* The floor that makes the comparison below mean anything. A replaced resolver that finds
+               NOTHING agrees with every possible answer once both sides are null, and two of these five
+               shapes return null rather than throwing when they run out of parents. */
+            Assert.False(
+                string.IsNullOrEmpty(was),
+                $"the replaced '{shape}' resolver ({pin}) found nothing for {relative}. Either the "
+              + "representative call site no longer exists, or — for the two shapes that start at "
+              + "AppContext.BaseDirectory — the test binary is no longer inside the repository, in which "
+              + "case this pin cannot compare what it exists to compare");
+
+            var now = RepoFile.PathTo(segments);
+
+            Assert.Equal(Path.GetFullPath(was!), Path.GetFullPath(now));
+
+            /* Rooted and present and non-empty: "the same path" is also satisfied by two identical
+               relative strings that name nothing, and by a file that exists and is empty — against which
+               every Contains assertion downstream passes vacuously. */
+            Assert.True(Path.IsPathRooted(now), $"{shape}: {now} is not an absolute path");
+            Assert.True(File.Exists(now), $"{shape}: {now} does not exist");
+
+            var text = lf ? RepoFile.ReadRepoFileLf(segments) : RepoFile.ReadRepoFile(segments);
+            Assert.NotEmpty(text);
+
+            /* And the CONTENT the pin actually consumes, which is where the raw/LF split lives. Compared
+               against the bytes on disk put through the transform that pin's own helper applied, so a
+               reader that resolved the right file and then handed back the wrong newlines still reds. */
+            var onDisk = File.ReadAllText(was!);
+            Assert.Equal(lf ? onDisk.Replace("\r\n", "\n", StringComparison.Ordinal) : onDisk, text);
+        }
+    }
+
+    [Fact]
+    public void TheSharedReader_StillFailsOnAPathThatDoesNotExist()
+    {
+        /* The discrimination control. Every assertion above compares two answers, and a resolver that
+           concatenated its argument onto anything at all and declared success would satisfy all of them —
+           both sides being wrong in the same way. This is the case that must NOT resolve. */
+        var missing = new[] { "Darling", "Darling.Tests", "NoSuchFileExists.cs" };
+
+        Assert.Throws<FileNotFoundException>(() => RepoFile.ReadRepoFile(missing));
+        Assert.Throws<FileNotFoundException>(() => RepoFile.ReadRepoFileLf(missing));
+
+        /* And the same argument through the resolver that probes for its target, which reports absence by
+           returning null rather than by throwing. */
+        Assert.Null(ProbeFromSourceDirectory(TestDirectory(), Path.Combine(missing)));
+
+        /* The positive half, so "throws" is not merely what this helper does with every input. */
+        Assert.NotEmpty(RepoFile.ReadRepoFile("PerformanceMonitor.sln"));
+    }
+
+    [Fact]
+    public void EveryAdoptingPin_IsASiblingOfTheSharedReader()
+    {
+        var directory = TestDirectory();
+
+        var elsewhere = Directory
+            .EnumerateFiles(directory, "*.cs", SearchOption.AllDirectories)
+            .Where(f =>
+                !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal) &&
+                !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .Where(f => !string.Equals(Path.GetDirectoryName(f), directory, StringComparison.Ordinal))
+            .Where(f => CSharpSourceWalker
+                .StripCommentsAndStrings(File.ReadAllText(f))
+                .Contains("ReadRepoFile", StringComparison.Ordinal))
+            .Select(f => Path.GetRelativePath(directory, f))
+            .OrderBy(f => f, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Empty(elsewhere);
+
+        /* The population floor. "No pin outside this directory" is trivially true of a sweep that found no
+           pins at all, and this assertion's whole subject is where the pins are. */
+        var siblings = Directory
+            .EnumerateFiles(directory, "*.cs", SearchOption.TopDirectoryOnly)
+            .Count(f => CSharpSourceWalker
+                .StripCommentsAndStrings(File.ReadAllText(f))
+                .Contains("ReadRepoFile", StringComparison.Ordinal));
+
+        Assert.True(
+            siblings >= 30,
+            $"only {siblings} files beside RepoFile.cs mention the shared reader, so the emptiness "
+          + "asserted above is not evidence that the pins are all siblings");
+    }
+
+    /* ---- The resolvers this consolidation replaced, transcribed. ---- */
+
+    /// <summary>Walks up from the pin's own source directory probing for the relative path itself.</summary>
+    private static string? ProbeFromSourceDirectory(string sourceDirectory, string relative)
+    {
+        for (var dir = new DirectoryInfo(sourceDirectory); dir is not null; dir = dir.Parent)
+        {
+            var candidate = Path.Combine(dir.FullName, relative);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>Walks up from the test binary's directory to the solution file, bounded at ten levels.</summary>
+    private static string? MarkerFromBaseDirectory(string relative)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        for (var i = 0; i < 10 && directory is not null; i++)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "PerformanceMonitor.sln")))
+            {
+                return Path.Combine(directory.FullName, relative);
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+
+    /// <summary>Walks up from the test binary's directory probing for the target, unbounded.</summary>
+    private static string? ProbeFromBaseDirectory(string relative)
+    {
+        var dir = AppContext.BaseDirectory;
+
+        while (dir is not null && !File.Exists(Path.Combine(dir, relative)))
+        {
+            dir = Directory.GetParent(dir)?.FullName;
+        }
+
+        return dir is null ? null : Path.Combine(dir, relative);
+    }
+
+    /// <summary>Walks up from the pin's own source directory to a directory named
+    /// <c>PerformanceMonitor.Common</c>.</summary>
+    private static string? MarkerDirectoryFromSourceDirectory(string sourceDirectory, string relative)
+    {
+        for (var dir = new DirectoryInfo(sourceDirectory); dir is not null; dir = dir.Parent)
+        {
+            if (Directory.Exists(Path.Combine(dir.FullName, "PerformanceMonitor.Common")))
+            {
+                return Path.Combine(dir.FullName, relative);
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>Walks up from the pin's own source directory accepting the solution file or a <c>.git</c>
+    /// directory as the marker.</summary>
+    private static string? SlnOrGitFromSourceDirectory(string sourceDirectory, string relative)
+    {
+        var dir = sourceDirectory;
+
+        while (dir is not null
+               && !File.Exists(Path.Combine(dir, "PerformanceMonitor.sln"))
+               && !Directory.Exists(Path.Combine(dir, ".git")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        return dir is null ? null : Path.Combine(dir, relative.Replace('/', Path.DirectorySeparatorChar));
+    }
+
+    private static string TestDirectory([CallerFilePath] string thisFile = "")
+        => Path.GetDirectoryName(thisFile)!;
+}

--- a/Darling/Darling.Tests/ServerPageTabsTests.cs
+++ b/Darling/Darling.Tests/ServerPageTabsTests.cs
@@ -10,11 +10,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using PerformanceMonitor.Collectors;
 using PerformanceMonitor.Darling.Service;
 using Xunit;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -47,16 +47,16 @@ namespace Darling.Tests;
 /// </summary>
 public sealed class ServerPageTabsTests
 {
-    private static string ServerTabsJs => ReadRepoFile(Path.Combine(
+    private static string ServerTabsJs => ReadRepoFileLf(Path.Combine(
         "Darling", "PerformanceMonitor.Darling.Service", "wwwroot", "js", "pages", "server-tabs.js"));
 
-    private static string ServerJs => ReadRepoFile(Path.Combine(
+    private static string ServerJs => ReadRepoFileLf(Path.Combine(
         "Darling", "PerformanceMonitor.Darling.Service", "wwwroot", "js", "pages", "server.js"));
 
-    private static string AppJs => ReadRepoFile(Path.Combine(
+    private static string AppJs => ReadRepoFileLf(Path.Combine(
         "Darling", "PerformanceMonitor.Darling.Service", "wwwroot", "js", "app.js"));
 
-    private static string EditorJs => ReadRepoFile(Path.Combine(
+    private static string EditorJs => ReadRepoFileLf(Path.Combine(
         "Darling", "PerformanceMonitor.Darling.Service", "wwwroot", "js", "editor.js"));
 
     /// <summary>
@@ -430,7 +430,7 @@ public sealed class ServerPageTabsTests
 
         /* And the registry in panels.js is that same vocabulary — the C# validator and the browser renderer
            agreeing is what lets a stored view and a built-in page share one seam. */
-        var panels = ReadRepoFile(Path.Combine(
+        var panels = ReadRepoFileLf(Path.Combine(
             "Darling", "PerformanceMonitor.Darling.Service", "wwwroot", "js", "panels.js"));
         foreach (var v in vocabulary)
         {
@@ -457,7 +457,7 @@ public sealed class ServerPageTabsTests
     public void WebDashboard_DegradesOverRangeGracefully_AndDropsTheTrayChannel()
     {
         /* One shared helper carries the over-range degrade. */
-        var util = ReadRepoFile(Path.Combine(
+        var util = ReadRepoFileLf(Path.Combine(
             "Darling", "PerformanceMonitor.Darling.Service", "wwwroot", "js", "util.js"));
         Assert.Contains("export function readErrorStrip(message)", util, StringComparison.Ordinal);
         Assert.Contains("exceeds maximum of (\\d+) hours", util, StringComparison.Ordinal);
@@ -471,10 +471,10 @@ public sealed class ServerPageTabsTests
 
         /* Parity: both the loader and the composites route read errors through the helper — no read-error site
            left on the raw path, or the tab mixes friendly notices with raw API strings. */
-        var panels = ReadRepoFile(Path.Combine(
+        var panels = ReadRepoFileLf(Path.Combine(
             "Darling", "PerformanceMonitor.Darling.Service", "wwwroot", "js", "panels.js"));
         Assert.Contains("readErrorStrip(res.message)", panels, StringComparison.Ordinal);
-        var serverTabs = ReadRepoFile(Path.Combine(
+        var serverTabs = ReadRepoFileLf(Path.Combine(
             "Darling", "PerformanceMonitor.Darling.Service", "wwwroot", "js", "pages", "server-tabs.js"));
         Assert.Contains("readErrorStrip(res.message)", serverTabs, StringComparison.Ordinal);
         Assert.Contains("readErrorStrip(trend.message)", serverTabs, StringComparison.Ordinal);
@@ -482,10 +482,10 @@ public sealed class ServerPageTabsTests
         Assert.DoesNotContain("errorStrip(trend.message)", serverTabs, StringComparison.Ordinal);
 
         /* #2781 on BOTH surfaces that render the status cell. */
-        var alerts = ReadRepoFile(Path.Combine(
+        var alerts = ReadRepoFileLf(Path.Combine(
             "Darling", "PerformanceMonitor.Darling.Service", "wwwroot", "js", "pages", "alerts.js"));
         Assert.Contains("a.notification_type !== \"tray\"", alerts, StringComparison.Ordinal);
-        var triage = ReadRepoFile(Path.Combine(
+        var triage = ReadRepoFileLf(Path.Combine(
             "Darling", "PerformanceMonitor.Darling.Service", "wwwroot", "js", "pages", "triage.js"));
         Assert.Contains("a.notification_type !== \"tray\"", triage, StringComparison.Ordinal);
     }
@@ -695,7 +695,7 @@ public sealed class ServerPageTabsTests
            recognised token, and the RAW TOKEN for one this build has never heard of — because the describer's
            "an unrecognised engine" is a mid-sentence fragment and reads as the wrong part of speech beside
            "SQL Server". */
-        var reader = ReadRepoFile(Path.Combine(
+        var reader = ReadRepoFileLf(Path.Combine(
             "Darling", "PerformanceMonitor.Darling.Service", "Mcp", "DarlingFleetReader.cs"));
         Assert.Contains("string.IsNullOrWhiteSpace(EngineKind) ? null", reader, StringComparison.Ordinal);
         Assert.Contains(
@@ -818,7 +818,7 @@ public sealed class ServerPageTabsTests
         /* And renderPanel is what renders both, from the descriptor field the helpers set. The line guard fires
            at EXACTLY zero rows: at one row renderLineChart draws the lone bucket as a marker, and a descriptor
            that never had an emptyText (every stored view authored before this) still falls through unchanged. */
-        var panels = ReadRepoFile(Path.Combine(
+        var panels = ReadRepoFileLf(Path.Combine(
             "Darling", "PerformanceMonitor.Darling.Service", "wwwroot", "js", "panels.js"));
         Assert.Contains("desc.emptyText || \"No rows in this window.\"", panels, StringComparison.Ordinal);
         Assert.Contains("if (!points.length && desc.emptyText) return emptyStrip(desc.emptyText);", panels, StringComparison.Ordinal);
@@ -852,7 +852,7 @@ public sealed class ServerPageTabsTests
     [Fact]
     public void SingleBucketSeries_RendersAsAMarker_NotTheWarmingUpStrip()
     {
-        var charts = ReadRepoFile(Path.Combine(
+        var charts = ReadRepoFileLf(Path.Combine(
             "Darling", "PerformanceMonitor.Darling.Service", "wwwroot", "js", "charts.js"));
 
         /* The whole-chart gate is zero-only now; a single row is data and proceeds to the geometry below. */
@@ -1004,17 +1004,4 @@ public sealed class ServerPageTabsTests
         }
     }
 
-    private static string ReadRepoFile(string relative, [CallerFilePath] string thisFile = "")
-    {
-        for (var dir = new DirectoryInfo(Path.GetDirectoryName(thisFile)!); dir is not null; dir = dir.Parent)
-        {
-            var candidate = Path.Combine(dir.FullName, relative);
-            if (File.Exists(candidate))
-            {
-                return File.ReadAllText(candidate).Replace("\r\n", "\n", StringComparison.Ordinal);
-            }
-        }
-
-        throw new FileNotFoundException($"Could not locate {relative} walking up from {thisFile}");
-    }
 }

--- a/Darling/Darling.Tests/ServerPageTabsTests.cs
+++ b/Darling/Darling.Tests/ServerPageTabsTests.cs
@@ -1003,5 +1003,4 @@ public sealed class ServerPageTabsTests
             yield return (m.Groups[1].Value, keys);
         }
     }
-
 }

--- a/Darling/Darling.Tests/ServerScopePhaseSplitTests.cs
+++ b/Darling/Darling.Tests/ServerScopePhaseSplitTests.cs
@@ -11,10 +11,10 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using PerformanceMonitor.Collectors;
 using PerformanceMonitor.Darling.Service;
 using Xunit;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -422,20 +422,6 @@ public sealed class ServerScopePhaseSplitTests
         CollectionTime = new DateTime(2026, 9, 4, 0, 0, 0, DateTimeKind.Utc),
         Deltas = new CollectorDeltaCalculator(),
     };
-
-    private static string ReadRepoFile(string relative, [CallerFilePath] string thisFile = "")
-    {
-        for (var dir = new DirectoryInfo(Path.GetDirectoryName(thisFile)!); dir is not null; dir = dir.Parent)
-        {
-            var candidate = Path.Combine(dir.FullName, relative);
-            if (File.Exists(candidate))
-            {
-                return File.ReadAllText(candidate);
-            }
-        }
-
-        throw new FileNotFoundException($"Could not locate {relative} walking up from {thisFile}");
-    }
 
     [Fact]
     public void PhaseStamps_AreReachableFromExceptionHandlers_SoAThrowingPhaseStillReportsItsTime()

--- a/Darling/Darling.Tests/StartupFailureTriageTests.cs
+++ b/Darling/Darling.Tests/StartupFailureTriageTests.cs
@@ -11,11 +11,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Sockets;
-using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using Npgsql;
 using PerformanceMonitor.Darling.Service;
 using Xunit;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -351,7 +351,7 @@ public class StartupFailureTriageTests
     public void TheApplierCommitsEachRungsDdlAndItsStampInOneTransaction()
     {
         var applier = Slice(
-            ReadRepoFile("Darling/PerformanceMonitor.Darling.Storage/PgMigrations.cs"),
+            ReadRepoFileLf("Darling/PerformanceMonitor.Darling.Storage/PgMigrations.cs"),
             "private static async Task<int> MigrateLockedAsync",
             "\n    }\n");
 
@@ -628,7 +628,7 @@ public class StartupFailureTriageTests
         var storeSite = ExtractRetrySite(worker, "storeRetryBudget");
         Assert.Contains("StartupFailureTriage", storeSite, StringComparison.Ordinal);
 
-        var guard = ReadRepoFile("Darling/PerformanceMonitor.Darling.Service/Program.cs");
+        var guard = ReadRepoFileLf("Darling/PerformanceMonitor.Darling.Service/Program.cs");
         var guardArm = Slice(guard, "Another PerformanceMonitor Darling service instance already holds", "return 4;");
         Assert.DoesNotContain("StartupFailureTriage", guardArm, StringComparison.Ordinal);
     }
@@ -698,29 +698,6 @@ public class StartupFailureTriageTests
     }
 
     private static string ReadWorkerSource()
-        => ReadRepoFile("Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs");
+        => ReadRepoFileLf("Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs");
 
-    private static string ReadRepoFile(string relative)
-    {
-        var path = Path.Combine(RepoRoot(), relative.Replace('/', Path.DirectorySeparatorChar));
-        Assert.True(File.Exists(path), $"source not found, this pin would read nothing: {path}");
-        /* Normalised to LF. The checkout is CRLF (.gitattributes is eol=crlf) but an anchor that
-           embeds the wrong newline matches NOTHING and reads as clean, so no anchor in this file
-           carries a line ending at all. */
-        return File.ReadAllText(path).Replace("\r\n", "\n", StringComparison.Ordinal);
-    }
-
-    private static string RepoRoot([CallerFilePath] string thisFile = "")
-    {
-        var dir = Path.GetDirectoryName(thisFile)!;
-        while (dir is not null
-               && !File.Exists(Path.Combine(dir, "PerformanceMonitor.sln"))
-               && !Directory.Exists(Path.Combine(dir, ".git")))
-        {
-            dir = Path.GetDirectoryName(dir);
-        }
-
-        Assert.NotNull(dir);
-        return dir!;
-    }
 }

--- a/Darling/Darling.Tests/StartupFailureTriageTests.cs
+++ b/Darling/Darling.Tests/StartupFailureTriageTests.cs
@@ -699,5 +699,4 @@ public class StartupFailureTriageTests
 
     private static string ReadWorkerSource()
         => ReadRepoFileLf("Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs");
-
 }

--- a/Darling/Darling.Tests/ViewTemplatesTests.cs
+++ b/Darling/Darling.Tests/ViewTemplatesTests.cs
@@ -245,5 +245,4 @@ public sealed class ViewTemplatesTests
         Assert.DoesNotContain("get_analysis_findings", js, StringComparison.Ordinal);
         Assert.DoesNotContain("get_query_store_top", js, StringComparison.Ordinal);
     }
-
 }

--- a/Darling/Darling.Tests/ViewTemplatesTests.cs
+++ b/Darling/Darling.Tests/ViewTemplatesTests.cs
@@ -10,10 +10,10 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using PerformanceMonitor.Darling.Service;
 using Xunit;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -38,10 +38,10 @@ namespace Darling.Tests;
 /// </summary>
 public sealed class ViewTemplatesTests
 {
-    private static string TemplatesJs => ReadRepoFile(Path.Combine(
+    private static string TemplatesJs => ReadRepoFileLf(Path.Combine(
         "Darling", "PerformanceMonitor.Darling.Service", "wwwroot", "js", "view-templates.js"));
 
-    private static string ViewsJs => ReadRepoFile(Path.Combine(
+    private static string ViewsJs => ReadRepoFileLf(Path.Combine(
         "Darling", "PerformanceMonitor.Darling.Service", "wwwroot", "js", "pages", "views.js"));
 
     /// <summary>
@@ -246,17 +246,4 @@ public sealed class ViewTemplatesTests
         Assert.DoesNotContain("get_query_store_top", js, StringComparison.Ordinal);
     }
 
-    private static string ReadRepoFile(string relative, [CallerFilePath] string thisFile = "")
-    {
-        for (var dir = new DirectoryInfo(Path.GetDirectoryName(thisFile)!); dir is not null; dir = dir.Parent)
-        {
-            var candidate = Path.Combine(dir.FullName, relative);
-            if (File.Exists(candidate))
-            {
-                return File.ReadAllText(candidate).Replace("\r\n", "\n", StringComparison.Ordinal);
-            }
-        }
-
-        throw new FileNotFoundException($"Could not locate {relative} walking up from {thisFile}");
-    }
 }

--- a/Darling/Darling.Tests/ViewerFleetRollupTests.cs
+++ b/Darling/Darling.Tests/ViewerFleetRollupTests.cs
@@ -1134,5 +1134,4 @@ public sealed class ViewerFleetDeadlockCoverageTests
         }
         return count;
     }
-
 }

--- a/Darling/Darling.Tests/ViewerFleetRollupTests.cs
+++ b/Darling/Darling.Tests/ViewerFleetRollupTests.cs
@@ -18,6 +18,7 @@ using PerformanceMonitor.Common;
 using PerformanceMonitor.Darling.Storage;
 using PerformanceMonitor.Darling.Viewer;
 using Xunit;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -1134,17 +1135,4 @@ public sealed class ViewerFleetDeadlockCoverageTests
         return count;
     }
 
-    private static string ReadRepoFile(string relative) =>
-        File.ReadAllText(Path.Combine(RepoRoot(), relative));
-
-    private static string RepoRoot()
-    {
-        var directory = new DirectoryInfo(AppContext.BaseDirectory);
-        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "PerformanceMonitor.sln")))
-        {
-            directory = directory.Parent;
-        }
-
-        return directory?.FullName ?? throw new InvalidOperationException("PerformanceMonitor.sln not found above the test output directory.");
-    }
 }

--- a/Darling/Darling.Tests/ViewerGridPayloadColumnOrderPinTests.cs
+++ b/Darling/Darling.Tests/ViewerGridPayloadColumnOrderPinTests.cs
@@ -452,5 +452,4 @@ public sealed class ViewerGridPayloadColumnOrderPinTests
             ? []
             : TopLevelElements(element[(openEnd + 1)..closeStart]);
     }
-
 }

--- a/Darling/Darling.Tests/ViewerGridPayloadColumnOrderPinTests.cs
+++ b/Darling/Darling.Tests/ViewerGridPayloadColumnOrderPinTests.cs
@@ -10,9 +10,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using Xunit;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -453,16 +453,4 @@ public sealed class ViewerGridPayloadColumnOrderPinTests
             : TopLevelElements(element[(openEnd + 1)..closeStart]);
     }
 
-    /* Locate the repo from this file — the DarlingLockTimeoutYieldTests idiom; no build-output copying. */
-    private static string ReadRepoFile(string relative, [CallerFilePath] string thisFile = "")
-    {
-        var dir = Path.GetDirectoryName(thisFile)!;
-        while (dir is not null && !File.Exists(Path.Combine(dir, relative)))
-        {
-            dir = Path.GetDirectoryName(dir);
-        }
-
-        Assert.NotNull(dir);
-        return File.ReadAllText(Path.Combine(dir!, relative));
-    }
 }

--- a/Darling/Darling.Tests/ViewerOverviewExplainsItselfTests.cs
+++ b/Darling/Darling.Tests/ViewerOverviewExplainsItselfTests.cs
@@ -499,5 +499,4 @@ public sealed class ViewerOverviewExplainsItselfTests
         }
         return count;
     }
-
 }

--- a/Darling/Darling.Tests/ViewerOverviewExplainsItselfTests.cs
+++ b/Darling/Darling.Tests/ViewerOverviewExplainsItselfTests.cs
@@ -10,10 +10,10 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using PerformanceMonitor.Common;
 using PerformanceMonitor.Darling.Viewer;
 using Xunit;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -500,17 +500,4 @@ public sealed class ViewerOverviewExplainsItselfTests
         return count;
     }
 
-    private static string ReadRepoFile(string relative, [CallerFilePath] string thisFile = "")
-    {
-        for (var dir = new DirectoryInfo(Path.GetDirectoryName(thisFile)!); dir is not null; dir = dir.Parent)
-        {
-            var candidate = Path.Combine(dir.FullName, relative);
-            if (File.Exists(candidate))
-            {
-                return File.ReadAllText(candidate);
-            }
-        }
-
-        throw new FileNotFoundException($"Could not locate {relative} walking up from {thisFile}");
-    }
 }

--- a/Darling/Darling.Tests/ViewerServerInventoryEnabledTests.cs
+++ b/Darling/Darling.Tests/ViewerServerInventoryEnabledTests.cs
@@ -9,8 +9,8 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using Xunit;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -152,17 +152,4 @@ public class ViewerServerInventoryEnabledTests
         Assert.DoesNotContain("StaticResource", column, StringComparison.Ordinal);
     }
 
-    private static string ReadRepoFile(string relative, [CallerFilePath] string thisFile = "")
-    {
-        for (var dir = new DirectoryInfo(Path.GetDirectoryName(thisFile)!); dir is not null; dir = dir.Parent)
-        {
-            var candidate = Path.Combine(dir.FullName, relative);
-            if (File.Exists(candidate))
-            {
-                return File.ReadAllText(candidate);
-            }
-        }
-
-        throw new FileNotFoundException($"Could not locate {relative} walking up from {thisFile}");
-    }
 }

--- a/Darling/Darling.Tests/ViewerServerInventoryEnabledTests.cs
+++ b/Darling/Darling.Tests/ViewerServerInventoryEnabledTests.cs
@@ -151,5 +151,4 @@ public class ViewerServerInventoryEnabledTests
         var column = xaml[(xaml.LastIndexOf('<', at))..(xaml.IndexOf("/>", at, StringComparison.Ordinal) + 2)];
         Assert.DoesNotContain("StaticResource", column, StringComparison.Ordinal);
     }
-
 }

--- a/Darling/Darling.Tests/ViewerSettingsMemberRecoveryTests.cs
+++ b/Darling/Darling.Tests/ViewerSettingsMemberRecoveryTests.cs
@@ -538,5 +538,4 @@ public sealed class ViewerSettingsMemberRecoveryTests : IDisposable
 
         return count;
     }
-
 }

--- a/Darling/Darling.Tests/ViewerSettingsMemberRecoveryTests.cs
+++ b/Darling/Darling.Tests/ViewerSettingsMemberRecoveryTests.cs
@@ -10,12 +10,12 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using PerformanceMonitor.Common;
 using PerformanceMonitor.Darling.Viewer;
 using Xunit;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -539,17 +539,4 @@ public sealed class ViewerSettingsMemberRecoveryTests : IDisposable
         return count;
     }
 
-    private static string ReadRepoFile(string relative, [CallerFilePath] string thisFile = "")
-    {
-        for (var dir = new DirectoryInfo(Path.GetDirectoryName(thisFile)!); dir is not null; dir = dir.Parent)
-        {
-            var candidate = Path.Combine(dir.FullName, relative);
-            if (File.Exists(candidate))
-            {
-                return File.ReadAllText(candidate);
-            }
-        }
-
-        throw new FileNotFoundException($"Could not locate {relative} walking up from {thisFile}");
-    }
 }

--- a/Darling/Darling.Tests/ViewerSidebarDotRendersTheCardStatusTests.cs
+++ b/Darling/Darling.Tests/ViewerSidebarDotRendersTheCardStatusTests.cs
@@ -633,5 +633,4 @@ public sealed class ViewerSidebarDotRendersTheCardStatusTests
 
         return kept.ToString();
     }
-
 }

--- a/Darling/Darling.Tests/ViewerSidebarDotRendersTheCardStatusTests.cs
+++ b/Darling/Darling.Tests/ViewerSidebarDotRendersTheCardStatusTests.cs
@@ -10,11 +10,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Text;
 using PerformanceMonitor.Common;
 using PerformanceMonitor.Darling.Viewer;
 using Xunit;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -188,7 +188,7 @@ public sealed class ViewerSidebarDotRendersTheCardStatusTests
     [Fact]
     public void TheSidebarDot_IsBoundToItsTooltip()
     {
-        var xaml = ReadRepoFile(Path.Combine("Darling", "PerformanceMonitor.Darling.Viewer", "MainWindow.xaml"));
+        var xaml = ReadRepoFileLf(Path.Combine("Darling", "PerformanceMonitor.Darling.Viewer", "MainWindow.xaml"));
 
         var at = xaml.IndexOf("{Binding Server.DotStatus}", StringComparison.Ordinal);
         Assert.True(at > 0, "the sidebar status dot is gone — find where it moved before editing this test");
@@ -221,7 +221,7 @@ public sealed class ViewerSidebarDotRendersTheCardStatusTests
             Assert.Equal("Double-click the row to open this server's tab", lines[^1]);
         }
 
-        var xaml = ReadRepoFile(Path.Combine("Darling", "PerformanceMonitor.Darling.Viewer", "MainWindow.xaml"));
+        var xaml = ReadRepoFileLf(Path.Combine("Darling", "PerformanceMonitor.Darling.Viewer", "MainWindow.xaml"));
         Assert.Contains("MouseDoubleClick=\"ServerList_MouseDoubleClick\"", xaml, StringComparison.Ordinal);
     }
 
@@ -258,7 +258,7 @@ public sealed class ViewerSidebarDotRendersTheCardStatusTests
         /* The severity is not lost — it is reported on the axis it belongs to. */
         Assert.Equal(HealthSeverity.Critical, onFire.OverallMetricSeverity);
 
-        var rules = ReadRepoFile(Path.Combine("PerformanceMonitor.Common", "ServerHealthBands.cs"));
+        var rules = ReadRepoFileLf(Path.Combine("PerformanceMonitor.Common", "ServerHealthBands.cs"));
         Assert.Contains(
             "public static ServerCollectionStatus Classify(bool? isOnline, bool hasCollectorErrors, bool awaitingFirstCollection) =>",
             rules, StringComparison.Ordinal);
@@ -293,7 +293,7 @@ public sealed class ViewerSidebarDotRendersTheCardStatusTests
     [Fact]
     public void TheStatusWords_AreWrittenInExactlyOnePlace()
     {
-        var rulesFile = Path.Combine(RepoRoot(), "PerformanceMonitor.Common", "ServerHealthBands.cs");
+        var rulesFile = Path.Combine(RepoFile.Root, "PerformanceMonitor.Common", "ServerHealthBands.cs");
         var forbidden = new[] { "\"Online\"", "\"Offline\"", "\"Unknown\"", "\"Awaiting first collection\"", "\"AwaitingFirstCollection\"" };
 
         /* Part A: the phrase only this ladder spells, anywhere in the three trees. A copy with all five
@@ -354,7 +354,7 @@ public sealed class ViewerSidebarDotRendersTheCardStatusTests
             + string.Join("; ", offenders));
 
         /* And they are written in the one function every surface renders. */
-        var rules = ReadRepoFile(Path.Combine("PerformanceMonitor.Common", "ServerHealthBands.cs"));
+        var rules = ReadRepoFileLf(Path.Combine("PerformanceMonitor.Common", "ServerHealthBands.cs"));
         Assert.Contains("public static string Word(this ServerCollectionStatus status) => status switch", rules, StringComparison.Ordinal);
         Assert.Contains("public static string McpToken(this ServerCollectionStatus status) => status switch", rules, StringComparison.Ordinal);
         Assert.Contains("public static string Headline(this ServerCollectionStatus status) => status switch", rules, StringComparison.Ordinal);
@@ -382,7 +382,7 @@ public sealed class ViewerSidebarDotRendersTheCardStatusTests
             .ToList();
         Assert.Equal(new[] { ServerCollectionStatus.AwaitingFirstCollection }, differing);
 
-        var tools = ReadRepoFile(Path.Combine(
+        var tools = ReadRepoFileLf(Path.Combine(
             "Darling", "PerformanceMonitor.Darling.Service", "Mcp", "DarlingMcpDataTools.cs"));
         Assert.DoesNotContain("TimeSpan.FromMinutes(2)", tools, StringComparison.Ordinal);
         Assert.DoesNotContain("TimeSpan.FromMinutes(15)", tools, StringComparison.Ordinal);
@@ -428,7 +428,7 @@ public sealed class ViewerSidebarDotRendersTheCardStatusTests
     [Fact]
     public void TheGuard_RunsOnEveryTreeItScans()
     {
-        var workflow = ReadRepoFile(Path.Combine(".github", "workflows", "build.yml"));
+        var workflow = ReadRepoFileLf(Path.Combine(".github", "workflows", "build.yml"));
 
         var step = workflow.IndexOf("- name: Run Darling tests", StringComparison.Ordinal);
         Assert.True(step > 0, "the step that runs Darling.Tests was renamed — re-point this assertion before editing it");
@@ -474,7 +474,7 @@ public sealed class ViewerSidebarDotRendersTheCardStatusTests
     /// Ellipse that actually owns them rather than out of the whole file (MainWindow.xaml has other dots).</summary>
     private static Dictionary<string, string> SidebarDotTriggers()
     {
-        var xaml = ReadRepoFile(Path.Combine("Darling", "PerformanceMonitor.Darling.Viewer", "MainWindow.xaml"));
+        var xaml = ReadRepoFileLf(Path.Combine("Darling", "PerformanceMonitor.Darling.Viewer", "MainWindow.xaml"));
 
         var at = xaml.IndexOf("{Binding Server.DotStatus}", StringComparison.Ordinal);
         Assert.True(at > 0, "the sidebar status dot is gone — find where it moved before editing this test");
@@ -507,9 +507,9 @@ public sealed class ViewerSidebarDotRendersTheCardStatusTests
     {
         var roots = new[]
         {
-            Path.Combine(RepoRoot(), "PerformanceMonitor.Common"),
-            Path.Combine(RepoRoot(), "Darling", "PerformanceMonitor.Darling.Viewer"),
-            Path.Combine(RepoRoot(), "Darling", "PerformanceMonitor.Darling.Service"),
+            Path.Combine(RepoFile.Root, "PerformanceMonitor.Common"),
+            Path.Combine(RepoFile.Root, "Darling", "PerformanceMonitor.Darling.Viewer"),
+            Path.Combine(RepoFile.Root, "Darling", "PerformanceMonitor.Darling.Service"),
         };
 
         foreach (var root in roots)
@@ -634,19 +634,4 @@ public sealed class ViewerSidebarDotRendersTheCardStatusTests
         return kept.ToString();
     }
 
-    private static string RepoRoot([CallerFilePath] string thisFile = "")
-    {
-        for (var dir = new DirectoryInfo(Path.GetDirectoryName(thisFile)!); dir is not null; dir = dir.Parent)
-        {
-            if (Directory.Exists(Path.Combine(dir.FullName, "PerformanceMonitor.Common")))
-            {
-                return dir.FullName;
-            }
-        }
-
-        throw new DirectoryNotFoundException($"Could not locate the repo root walking up from {thisFile}");
-    }
-
-    private static string ReadRepoFile(string relative) =>
-        File.ReadAllText(Path.Combine(RepoRoot(), relative)).Replace("\r\n", "\n", StringComparison.Ordinal);
 }

--- a/Lite.Tests/CrossAppGuardCiGateTests.cs
+++ b/Lite.Tests/CrossAppGuardCiGateTests.cs
@@ -416,9 +416,17 @@ public class CrossAppGuardCiGateTests
                 """),
 
             /* Segments handed to a user-defined helper, with no Path.Combine and no file API anywhere in
-               the expression. FileGrowthAlertStoreTests reads Lite/Services this way, and the helper name
-               is not a token anything can anchor on: measured at #3082, Darling.Tests carries 34 separate
-               private ReadRepoFile declarations, one per class, with differing signatures. */
+               the expression. FileGrowthAlertStoreTests reads Lite/Services this way.
+
+               The objection at #3082 was that the helper name is not a token anything can anchor on,
+               because Darling.Tests then carried a separate private ReadRepoFile declaration per class,
+               with differing signatures. Those were consolidated onto one shared reader whose
+               single-declaration invariant RepoFileAdoptionTests asserts, so the name IS anchorable now:
+               an arm keyed on it, with a root literal in its first segment argument, would be structure
+               rather than the semantic pass the remaining shapes need. That is a DECISION and not a free
+               improvement, and it is not taken here — the widening still buys a name for coverage that is
+               already correct, since this shape's reference lands under a tree the filter gating this
+               suite reaches. CSharpPaths' doc comment carries what each widening has cost. */
             ("VariadicSegmentHelper", LiteTrees.AppDir, """
                 var lite = ReadRepoFile("Lite", "Services", "LocalDataService.FileGrowth.cs");
                 """),


### PR DESCRIPTION
Fixes #3090.

`Darling.Tests` carried 34 private `ReadRepoFile` declarations across eight path-resolution semantics. They are now one `internal static RepoFile` in `Darling/Darling.Tests/RepoFile.cs`, in the shape #2913 sanctioned for `CSharpSourceWalker` — one file, no `ProjectReference`, `Compile Include`-shareable with `Lite.Tests` — plus two pins that hold the invariant and prove the resolution did not move.

38 files, +742 / -630. Three commits: the consolidation; a whitespace-only follow-up dropping the blank line the helper removals left ahead of 26 classes' closing braces (measured: 2 of 458 `Darling.Tests` files are written that way on `dev`, so it was introduced rather than matched); and the review finding below, scoping the adoption pin's summary to `Darling.Tests` and naming the five `Lite.Tests` declarations it does not sweep.

## The four decisions, and what each rejected

**The root resolves from `RepoFile.cs`'s own compile-time path, not from the test binary's directory.** Nine of the replaced resolvers walked up from `AppContext.BaseDirectory`, which ties a read of *source* to wherever the *output* landed. After this change nothing outside the equivalence pin resolves that way. Resolved once from `RepoFile.cs` rather than per caller, so there is one answer instead of 34 — which is identical only while every pin is a sibling of it, so that is asserted rather than assumed.

**The root is a marker (`PerformanceMonitor.sln`), not the target file.** 22 of the replaced resolvers walked up probing for the relative path itself, so the root they resolved varied with the argument and a path that existed nowhere walked to the filesystem root before dereferencing a null. The marker is the solution file rather than `.git` because in a git **worktree** `.git` is a *file*, so a `Directory.Exists(".git")` probe walks straight past the root — one replaced resolver had that shape.

**Raw and LF-normalised stayed two methods, because they were two behaviours.** 28 returned the file as it sits on disk; 6 normalised CRLF to LF. This checkout is CRLF, so folding them together would change what 28 pins' anchors match — a multi-line `DoesNotContain` that currently *cannot fire* would start firing, and a multi-line `Contains` that currently cannot match would start matching. That is a behaviour change, not a de-duplication, so the choice stays at the call site and visible in the method name. Making the 28 consistent is a separate question with its own risk profile and is not answered here; measured, none of the 28 carries a multi-line anchor that is vacuous today.

**`params string[]` rather than overloads.** The declarations split between a pre-combined relative path and a variadic segment list; one `params` parameter serves both spellings, so **125 of 126 call sites needed no change**. Enumerated at the merge base with the repo's own `CSharpSourceWalker.StripCommentsAndStrings` rather than tallied by pattern: 161 `ReadRepoFile` occurrences = 34 declarations + 125 invocations + 1 method group + 1 inside a comment. Call sites are the invocations plus the method group; declarations are not call sites, and a method group has no open paren, so counting `ReadRepoFile(` gives 159 and excludes the one site that is the exception. That exception is the method group: `CollectionOutputBesideCostTests` passed `ReadRepoFile` to `Select`, and a `params` method group does not convert to `Func<string, string>`. Adapted to a lambda rather than adding a single-string overload — one call site is not worth the extra resolution surface.

## Path-resolution equivalence — the defect a green build hides

This touches 34 files, so the build is the primary instrument and a missed call site is a compile error, which is the good case. What a compile cannot catch is a replacement whose resolution *differs*: a pin that lands on a different file still returns a string and still runs its assertions.

`RepoFileResolutionEquivalenceTests` transcribes all five replaced path shapes and asserts, for a live call site of each of the eight measured combinations, that the shared reader produces the **same absolute path** and the **same content**. Path rather than content alone, because two files holding equal bytes would satisfy a content-only comparison and this repository is full of deliberate parity copies. Floors beside it: the replaced resolver must have found something (two of the five return `null` rather than throwing, and null agrees with null), the path must be rooted and exist, and the content must be non-empty — against which every downstream `Contains` passes vacuously.

Verified locally by compiling the **actual** `.cs` files — not copies, so `[CallerFilePath]` records the real paths — into a throwaway net10.0 xunit v3 harness under the gitignored `bin/`. `Build succeeded` asserted separately from running, since a failed build leaves the runner on a stale dll printing a clean `Failed: 0`.

| | result |
|---|---|
| `Darling.Tests` / `Lite.Tests` (`-p:EnableWindowsTargeting=true`) | `Build succeeded`, 0 errors, warning profile **identical** to pristine `dev` |
| the 3 new pins | `Total: 5, Failed: 0, Skipped: 0, Not Run: 0` |
| the real `CrossAppGuardCiGateTests`, all 12 | `Total: 12, Failed: 0, Skipped: 0, Not Run: 0` |

That last row is not incidental: the new equivalence pin contains `new[] { "Lite", ... }` literals, which the guard's #3076 arm reads as a cross-app tree reference. It did not break, but that was measured rather than assumed.

Mutation-tested, committed first, baseline re-run **last** and clean:

| mutation | result |
|---|---|
| a 35th private `ReadRepoFile` pasted into a class | compiles; `ExactlyOneFile_DeclaresTheSharedRepoFileReader` red |
| a pin switched off the LF reader | `TheLfReadingPins_AreExactlyTheOnesDeclaredHere` red |
| `ResolveRoot` returns the parent of the real root | equivalence red |
| `ReadRepoFileLf` stops normalising newlines | equivalence red (the **content** half) |
| a missing file read returns empty instead of failing | `TheSharedReader_StillFailsOnAPathThatDoesNotExist` red |
| one equivalence case deleted to clear a red | equivalence red on its own case count |
| census fixture respelled the way the matcher *does* see | the real guard's census red — the harness is live, not vacuous |

One honest negative: swapping `ResolveRoot` back to `AppContext.BaseDirectory` does **not** red locally. Both origins agree while the binary sits inside the repo; they diverge only where it does not. The pin discriminates the resolved root and the content, not the origin — and the reason to prefer the source path is that it does not depend on where the output landed, which is an argument the pin cannot make for itself.

## The guard's census, and the follow-up named rather than done

`TheCSharpMatchers_StillCannotSeeTheseSpellings` carried a counted claim about exactly this — "`Darling.Tests` carries 34 separate private `ReadRepoFile` declarations" — as the reason `VariadicSegmentHelper` was ruled out of a regex widening. That count is now wrong, and a stale count is a partial list with a numeral welded on, so the entry is reworded: the name **is** anchorable now, and an arm keyed on it with a root literal in its first segment argument would be *structure* rather than the semantic pass the remaining shapes need.

**That arm is not added here.** Per `CSharpPaths`' doc comment, precision in that matcher is bought with structure and the bill arrives each time; #3082 settled three shapes as a decision rather than a gap, and the reference this shape would produce already lands under a tree the filter gating that suite reaches — so the widening buys a *name* for coverage that is already correct. It is a separate, measurable follow-up with its own red-proof, and **#3084's census is where its acceptance criteria live**.

## Out of scope, measured

53 classes in `Darling.Tests` still carry their own repo-**root** walk with no reader on top of it (62 before this change, 9 of which overlapped the 34 and are gone). That is the same duplication one layer down and a larger population than this one was; `RepoFile.Root` is now the landing place for it. `Lite.Tests` separately has 5 private `ReadRepoFile` declarations of its own, which `RepoFileAdoptionTests` does not scan. Neither is touched here.

## CHANGELOG entry

```
- Consolidated the 34 private `ReadRepoFile` helpers in `Darling.Tests` onto one shared `RepoFile`
  authority, in the `Compile Include` shape #2913 sanctioned, reconciling eight different
  path-resolution semantics onto one. A derived count assertion names a 35th private copy instead of
  tolerating it, and the resolution equivalence of every replaced shape is pinned rather than assumed
  (#3090).
```

