### PR TITLE
Fixes #3087

### DIFF
--- a/Darling/Darling.Tests/TsqlConventionGuardTests.cs
+++ b/Darling/Darling.Tests/TsqlConventionGuardTests.cs
@@ -560,6 +560,17 @@ public sealed class TsqlConventionGuardTests
 
         Assert.Empty(CoveredRules.Intersect(UncoveredRules, StringComparer.Ordinal));
 
+        /* The abbreviation ratchet, both directions and against the BULLET rather than the flattened
+           lists. The set equalities above are over a union, so they cannot see WHICH bullet a rule sits
+           under: moving UnabbreviatedTypes to the Functions bullet's Covered array satisfies every one of
+           them while the disposition map claims this check enforces a sentence the document does not have
+           it enforcing. Naming both sides is also what keeps the rule from drifting back to Uncovered
+           while the detector still emits it — a rule that fires under bookkeeping calling it unguarded is
+           the same defect class as a limitation nothing exercises. */
+        Assert.Contains(UnabbreviatedTypes, RuleBullets["Data types"].Covered);
+        Assert.DoesNotContain(UnabbreviatedTypes, RuleBullets["Data types"].Uncovered);
+        Assert.DoesNotContain(UnabbreviatedTypes, UncoveredRules);
+
         /* The split bullets, NAMED in RuleBullets' own summary rather than counted there. A second one
            would leave that prose incomplete without contradicting it, which is the quiet direction. */
         Assert.Equal(

--- a/Darling/Darling.Tests/TsqlConventionGuardTests.cs
+++ b/Darling/Darling.Tests/TsqlConventionGuardTests.cs
@@ -8,7 +8,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -104,9 +103,9 @@ public sealed class TsqlConventionGuardTests
     private const string BlockComments = "block-comments-not-double-dash";
     private const string NoTabs = "spaces-not-tabs";
     private const string LowercaseTypes = "data-types-lowercase";
+    private const string UnabbreviatedTypes = "data-types-unabbreviated";
 
     private const string UppercaseKeywords = "keywords-UPPERCASE";
-    private const string UnabbreviatedTypes = "data-types-unabbreviated";
     private const string SysnameForIdentifiers = "sysname-for-identifiers";
     private const string FourSpaceIndent = "indent-four-spaces";
     private const string AliasWithAs = "table-aliases-use-AS";
@@ -119,12 +118,11 @@ public sealed class TsqlConventionGuardTests
     /// not, and <c>Phrases</c> is the wording the checks were derived FROM — asserted still present, so an
     /// edit to the rule cannot leave a check enforcing something the document no longer says.
     ///
-    /// <para><b><c>Data types</c> and <c>Indentation</c> are split</b> rather than all-or-nothing, and
-    /// saying so is the point of the shape. <c>Data types</c> states two independent properties and only
-    /// one of them is checked here. <c>Indentation</c> bans tabs and prescribes a depth; the ban is a
-    /// token, the depth is a shape. That pair is NAMED rather than counted, and
+    /// <para><b><c>Indentation</c> is the one split bullet</b> rather than all-or-nothing, and saying so
+    /// is the point of the shape: it bans tabs and prescribes a depth, the ban is a token, the depth is a
+    /// shape, and only the token is checked here. It is NAMED rather than counted, and
     /// <see cref="TheDispositionMap_PartitionsTheBulletsContributingStates"/> holds the naming, so a
-    /// third split bullet cannot leave this prose quietly incomplete.
+    /// second split bullet cannot leave this prose quietly incomplete.
     /// A bullet with entries on both sides is honest about covering half of itself; a bullet listed as covered
     /// when it is not is the shape this issue was filed about.</para>
     /// </summary>
@@ -140,22 +138,18 @@ public sealed class TsqlConventionGuardTests
                     + "same words to a regex, and this codebase's SQL comments are long and discuss SQL."),
 
             ["Data types"] = new(
-                Covered: new[] { LowercaseTypes },
-                Uncovered: new[] { UnabbreviatedTypes },
+                Covered: new[] { LowercaseTypes, UnabbreviatedTypes },
+                Uncovered: Array.Empty<string>(),
                 Phrases: new[] { "lowercase", "never abbreviated", "`integer`", "`nvarchar(max)`", "`nvarchar(MAX)`" },
-                Note: "The CASE half is checked. The ABBREVIATION half is not, and the reason is remediation "
-                    + "cost rather than detectability: `int` where `integer` is meant stands at 33 sites in 7 "
-                    + "files, all of them inside T-SQL that runs against monitored production servers, some "
-                    + "in sp_executesql parameter declarations "
-                    + "(`N'@h varbinary(64), @stmt_start int, @stmt_end int'`) that nothing in this repository "
-                    + "executes. Rewriting live query strings belongs in a change whose subject is that "
-                    + "rewrite. That figure is DERIVED and pinned by "
-                    + "TheAbbreviationScopeNote_CountsTheSitesItClaims rather than written down once, so it "
-                    + "cannot quietly stop describing the tree — and when it reaches zero that pin says to "
-                    + "move this rule to the Covered side. A waiver list was considered and rejected: its key "
-                    + "would have to collapse repeated spellings within one member, so a 34th "
-                    + "`CONVERT(int, NULL)` beside the ones already there would satisfy it — a guard claiming "
-                    + "the rule while under-covering it, which is the shape #3081 was filed about."),
+                Note: "Both halves are tokens with a single correct replacement, which is what makes them "
+                    + "worth a guard. The CASE half reads the type vocabulary plus the `max` length spec, "
+                    + "which no vocabulary match can see on its own. The ABBREVIATION half is `int` where "
+                    + "`integer` is meant, and it is anchored on BOTH sides: without the trailing lookahead "
+                    + "`integer` itself contains the token under test, and without the leading lookbehind so "
+                    + "do `bigint`, `smallint` and `tinyint` — three type names this corpus writes and the "
+                    + "bullet does not object to. `dec` for `decimal` and `double precision` for `float` are "
+                    + "the other abbreviations T-SQL accepts and neither is in the detector: a stated bound "
+                    + "on the CHECK rather than on the rule."),
 
             ["Object names"] = new(
                 Covered: Array.Empty<string>(),
@@ -244,11 +238,11 @@ public sealed class TsqlConventionGuardTests
     /// <see cref="EverySqlServerCollectorDefinitionsFile_ContributesATsqlStatement"/> is the stronger version
     /// of the same idea: a per-SITE requirement derived from the catalog, which a total can never give.</para>
     ///
-    /// <para><b>There is deliberately no waiver list.</b> The nine pre-existing violations of the covered
-    /// subset — three <c>COUNT(*)</c>, one <c>--</c> comment, three type names spelled in capitals and two
-    /// <c>(MAX)</c> length specs — were fixed in the change that added this file, so the covered subset
-    /// measures zero on the tree with no exceptions carried. A waiver mechanism nobody needs is a mechanism
-    /// the next exception takes for granted.</para>
+    /// <para><b>There is deliberately no waiver list.</b> The covered subset measures zero on the tree
+    /// with no exceptions carried, and every rule in it got there by having the tree's existing violations
+    /// REWRITTEN rather than waived — the abbreviation rule's <c>int</c> spellings included. A rule whose
+    /// cost is paid by a waiver is a rule this guard only appears to hold, and a waiver mechanism nobody
+    /// needs is a mechanism the next exception takes for granted.</para>
     /// </summary>
     [Fact]
     public void NoTsqlStatementViolatesACoveredConvention()
@@ -566,55 +560,15 @@ public sealed class TsqlConventionGuardTests
 
         Assert.Empty(CoveredRules.Intersect(UncoveredRules, StringComparer.Ordinal));
 
-        /* The split bullets, NAMED in RuleBullets' own summary rather than counted there. A third one
+        /* The split bullets, NAMED in RuleBullets' own summary rather than counted there. A second one
            would leave that prose incomplete without contradicting it, which is the quiet direction. */
         Assert.Equal(
-            new[] { "Data types", "Indentation" },
+            new[] { "Indentation" },
             RuleBullets
                 .Where(b => b.Value.Covered.Length > 0 && b.Value.Uncovered.Length > 0)
                 .Select(b => b.Key)
                 .OrderBy(k => k, StringComparer.Ordinal)
                 .ToArray());
-    }
-
-    /// <summary>
-    /// The abbreviation rule is out of scope on a COST, and a cost stated once is a claim that goes stale by
-    /// exactly the mechanism this guard exists to stop. So the figure in
-    /// <see cref="RuleBullets"/>'s <c>Data types</c> note is derived from the same population the enforced
-    /// checks read, and compared to what the note says.
-    ///
-    /// <para><b>The direction that matters is DOWNWARD.</b> If those sites get fixed, the reason for
-    /// leaving the rule out disappears and this pin says so — a rule left uncovered because remediation was
-    /// expensive, after the remediation, is just an unguarded rule. The detector for it lives here and runs;
-    /// it is <see cref="Findings"/> that deliberately does not emit it.</para>
-    ///
-    /// <para>Non-vacuous in both halves: a scan that found nothing reds on the floor rather than agreeing
-    /// with a note that had also drifted to zero, and a note whose figures stopped being parseable reds
-    /// rather than comparing nothing.</para>
-    /// </summary>
-    [Fact]
-    public void TheAbbreviationScopeNote_CountsTheSitesItClaims()
-    {
-        var (sites, files) = AbbreviatedTypeSites();
-
-        Assert.True(
-            sites > 0,
-            "no abbreviated data type is left in the corpus. That is the good outcome and it makes the "
-            + "scope note wrong: move UnabbreviatedTypes from the Data types bullet's Uncovered side to its "
-            + "Covered side, emit it from Findings, and give it a hazard fixture. If instead the count is "
-            + "zero because the scan broke, NoTsqlStatementViolatesACoveredConvention's floors will say so.");
-
-        var note = RuleBullets["Data types"].Note;
-        var claim = Regex.Match(note, @"(?<sites>\d+) sites in (?<files>\d+) files");
-
-        Assert.True(
-            claim.Success,
-            "the Data types note no longer states its cost as \"<n> sites in <n> files\", so nothing holds "
-            + "the figure it rests on. Keep the phrasing parseable, or drop the number from the note and "
-            + "delete this pin with it. Note text: " + note);
-
-        Assert.Equal(sites, int.Parse(claim.Groups["sites"].Value, CultureInfo.InvariantCulture));
-        Assert.Equal(files, int.Parse(claim.Groups["files"].Value, CultureInfo.InvariantCulture));
     }
 
     /// <summary>
@@ -715,6 +669,18 @@ public sealed class TsqlConventionGuardTests
             ("DECLARE @sql nvarchar(MAX); SELECT @sql = N'x' FROM sys.databases AS d;", LowercaseTypes),
             /* Mixed case is not lowercase either. */
             ("DECLARE @db SysName; SELECT @db = d.name FROM sys.databases AS d;", LowercaseTypes),
+            /* The ABBREVIATION half of the same bullet, and every fixture for it is spelled LOWERCASE on
+               purpose: the case half then stays silent, so what these record is the abbreviation check
+               firing rather than a second rule covering for it. */
+            ("SELECT c = CONVERT(int, w.waiting_tasks_count) FROM sys.dm_os_wait_stats AS w OPTION(RECOMPILE);", UnabbreviatedTypes),
+            ("DECLARE @on_pos int; SELECT @on_pos = CHARINDEX(N' on ', @@VERSION);", UnabbreviatedTypes),
+            /* A DDL type position, which is where nine of the corpus's own spellings sat. */
+            ("SET NOCOUNT ON; CREATE TABLE #file_space (database_id int NOT NULL); SELECT 1 FROM sys.databases AS d;", UnabbreviatedTypes),
+            /* An sp_executesql PARAMETER DECLARATION, which is where the corpus's remaining doubt sat: it
+               is a type position like any other, `integer` is accepted in it, and the engine binds the two
+               spellings to the same type. Verified against a live SQL Server rather than reasoned about,
+               because nothing in this repository executes that path. */
+            ("EXEC sys.sp_executesql N'SELECT probe = @a;', N'@a int', @a = 1;", UnabbreviatedTypes),
         };
 
         var flagged = new List<string>();
@@ -808,6 +774,20 @@ public sealed class TsqlConventionGuardTests
             "SELECT largest = MAX(MAX) FROM dbo.metrics AS mt OPTION(RECOMPILE);",
             /* @@ROWCOUNT spelled inside a comment, which is where this codebase discusses it. */
             "SELECT d.name FROM sys.databases AS d /* ROWCOUNT_BIG(), never @@ROWCOUNT */ OPTION(RECOMPILE);",
+            /* The abbreviation check's near misses. Every token here CONTAINS `int` and none of them is
+               the violation, so this is where an unanchored or greedy match reds. `integer` is the
+               CORRECT spelling — a detector matching it would report every rewritten site as the
+               violation the rewrite removed, which is every site in the corpus. `bigint`,
+               `smallint` and `tinyint` are type names this corpus writes; the leading lookbehind is the
+               only thing holding them. */
+            "DECLARE @a integer, @b bigint, @c smallint, @d tinyint; SELECT @a = d.database_id FROM sys.databases AS d;",
+            /* An identifier merely CONTAINING the token, at each end: `int_col` is held by the trailing
+               lookahead's `_` and `sysint` by the lookbehind. Synthetic — ordinary SQL, absent from this
+               corpus — and the two directions are separate cases because one anchor cannot hold both. */
+            "SELECT int_col = d.database_id, sysint = d.source_database_id FROM sys.databases AS d OPTION(RECOMPILE);",
+            /* A VARIABLE named @int, which is what the `@` in the lookbehind is for: after a sigil the
+               token is a name, and this codebase's dynamic SQL is full of parameter names. */
+            "DECLARE @int integer; SELECT @int = COUNT_BIG(*) FROM sys.databases AS d;",
         };
 
         foreach (var sql in benign)
@@ -910,11 +890,6 @@ public sealed class TsqlConventionGuardTests
             (UppercaseKeywords,
                 "select w.wait_type from sys.dm_os_wait_stats as w where w.wait_time_ms > 0 option(recompile);"),
 
-            /* Data types, abbreviation half: `int` where the bullet says `integer`. Lowercase, so the half
-               that IS covered stays silent — which is precisely the split being recorded. */
-            (UnabbreviatedTypes,
-                "SELECT c = CONVERT(int, w.waiting_tasks_count) FROM sys.dm_os_wait_stats AS w OPTION(RECOMPILE);"),
-
             /* Object names: an identifier column typed nvarchar(128) rather than sysname. */
             (SysnameForIdentifiers,
                 "SELECT database_name = CONVERT(nvarchar(128), d.name) FROM sys.databases AS d OPTION(RECOMPILE);"),
@@ -972,11 +947,14 @@ public sealed class TsqlConventionGuardTests
 
     /* ───────────────────────── the checks ───────────────────────── */
 
-    private static readonly string[] CoveredRules = { CountBig, RowcountBig, BlockComments, NoTabs, LowercaseTypes };
+    private static readonly string[] CoveredRules =
+    {
+        CountBig, RowcountBig, BlockComments, NoTabs, LowercaseTypes, UnabbreviatedTypes,
+    };
 
     private static readonly string[] UncoveredRules =
     {
-        UppercaseKeywords, UnabbreviatedTypes, SysnameForIdentifiers, FourSpaceIndent,
+        UppercaseKeywords, SysnameForIdentifiers, FourSpaceIndent,
         AliasWithAs, ColumnAliasForm, TrailingCommas,
     };
 
@@ -1127,58 +1105,34 @@ public sealed class TsqlConventionGuardTests
             }
         }
 
+        /* The abbreviation half of the same bullet, off the SAME view as the case check above — so a type
+           name inside a blanked `FOR XML` or `AT TIME ZONE` cannot supply one either. */
+        foreach (Match match in AbbreviatedTypeUse.Matches(forTypes))
+        {
+            findings.Add(new(UnabbreviatedTypes, Where(sql, match.Index, $"the data type `{match.Value}` — data types are never abbreviated, so `integer`")));
+        }
+
         return findings;
     }
 
     /// <summary>
-    /// <c>int</c> where <c>CONTRIBUTING.md</c> says <c>integer</c> — the one rule whose detector lives here
-    /// and whose findings <see cref="Findings"/> deliberately does not emit. Kept so the out-of-scope
-    /// decision rests on a measurement that is re-taken on every run rather than on a number somebody wrote
-    /// down once, and so switching the rule on later is a one-line change instead of a rediscovery.
+    /// <c>int</c> where <c>CONTRIBUTING.md</c> says <c>integer</c>.
     ///
-    /// <para><c>int</c> is the only abbreviation the bullet's own examples name and the only one this corpus
-    /// contains; <c>dec</c> for <c>decimal</c> and <c>double precision</c> for <c>float</c> are the others
-    /// T-SQL accepts, and neither appears. That is a stated bound on the FIGURE, not on the rule.</para>
+    /// <para><b>Both anchors are load-bearing, and each is held by a benign fixture.</b> The trailing
+    /// lookahead is what stops <c>integer</c> — the correct spelling — matching on its own first three
+    /// characters, which would make every fix report itself as the violation it fixed. The leading
+    /// lookbehind is what stops <c>bigint</c>, <c>smallint</c> and <c>tinyint</c>, three type names this
+    /// corpus writes and the bullet does not object to, and it carries <c>.</c> so a column reference
+    /// <c>t.int</c> is not one either. No capture group, deliberately: a group around the token is how a
+    /// greedy match absorbs the thing under test.</para>
+    ///
+    /// <para><c>int</c> is the only abbreviation the bullet's own examples name; <c>dec</c> for
+    /// <c>decimal</c> and <c>double precision</c> for <c>float</c> are the others T-SQL accepts and neither
+    /// is checked here. That is a stated bound on the CHECK, not on the rule.</para>
     /// </summary>
     private static readonly Regex AbbreviatedTypeUse = new(
         @"(?<![A-Za-z0-9_@#$.])int(?![A-Za-z0-9_])",
         RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant);
-
-    /// <summary>How many abbreviated data types the corpus holds, and in how many files. Reads the SAME
-    /// population and the SAME code view as the enforced checks, so the cost recorded for leaving the rule
-    /// out is the cost the rule would actually find.</summary>
-    private static (int Sites, int Files) AbbreviatedTypeSites()
-    {
-        var sites = 0;
-        var files = new HashSet<string>(StringComparer.Ordinal);
-
-        foreach (var (_, roots, _) in ScannedTrees)
-        {
-            foreach (var path in SourceFiles(roots))
-            {
-                foreach (var (_, body) in CSharpSourceWalker.StringLiteralBodies(File.ReadAllText(path)))
-                {
-                    if (!IsTsqlStatement(body))
-                    {
-                        continue;
-                    }
-
-                    var view = Blank(
-                        CodeAndDynamicSql(body, SpanKinds(body)),
-                        TypeNameClauseCollisions);
-                    var found = AbbreviatedTypeUse.Matches(view).Count;
-
-                    if (found > 0)
-                    {
-                        sites += found;
-                        files.Add(path);
-                    }
-                }
-            }
-        }
-
-        return (sites, files.Count);
-    }
 
     private static bool IsLowercase(string token) =>
         token.All(c => !char.IsLetter(c) || char.IsLower(c));

--- a/Darling/Darling.Tests/TsqlConventionGuardTests.cs
+++ b/Darling/Darling.Tests/TsqlConventionGuardTests.cs
@@ -560,16 +560,20 @@ public sealed class TsqlConventionGuardTests
 
         Assert.Empty(CoveredRules.Intersect(UncoveredRules, StringComparer.Ordinal));
 
-        /* The abbreviation ratchet, both directions and against the BULLET rather than the flattened
-           lists. The set equalities above are over a union, so they cannot see WHICH bullet a rule sits
-           under: moving UnabbreviatedTypes to the Functions bullet's Covered array satisfies every one of
-           them while the disposition map claims this check enforces a sentence the document does not have
-           it enforcing. Naming both sides is also what keeps the rule from drifting back to Uncovered
-           while the detector still emits it — a rule that fires under bookkeeping calling it unguarded is
-           the same defect class as a limitation nothing exercises. */
+        /* The abbreviation ratchet, at the BULLET rather than through the flattened lists. Both
+           equalities above are over a UNION of every bullet's arrays, so neither can see which bullet a
+           rule sits under: moving UnabbreviatedTypes to the Functions bullet's Covered array satisfies
+           all of them, and the map then claims this guard enforces a sentence CONTRIBUTING.md does not
+           have it enforcing. This is the direction nothing else holds.
+
+           The OTHER direction — the rule drifting back to Uncovered while Findings still emits it — is
+           already held, and stating where is what keeps a decorative assertion from being added here
+           later. Putting it back on the Uncovered side makes the flattened Uncovered union disagree with
+           UncoveredRules two assertions up; adding it to UncoveredRules as well instead trips the
+           disjointness one line up, because Covered still holds it. A DoesNotContain here could
+           therefore never be the assertion that reds, and an assertion that cannot fail is the shape
+           #3081 was filed about. */
         Assert.Contains(UnabbreviatedTypes, RuleBullets["Data types"].Covered);
-        Assert.DoesNotContain(UnabbreviatedTypes, RuleBullets["Data types"].Uncovered);
-        Assert.DoesNotContain(UnabbreviatedTypes, UncoveredRules);
 
         /* The split bullets, NAMED in RuleBullets' own summary rather than counted there. A second one
            would leave that prose incomplete without contradicting it, which is the quiet direction. */

--- a/Darling/Darling.Tests/TsqlConventionGuardTests.cs
+++ b/Darling/Darling.Tests/TsqlConventionGuardTests.cs
@@ -689,7 +689,9 @@ public sealed class TsqlConventionGuardTests
                firing rather than a second rule covering for it. */
             ("SELECT c = CONVERT(int, w.waiting_tasks_count) FROM sys.dm_os_wait_stats AS w OPTION(RECOMPILE);", UnabbreviatedTypes),
             ("DECLARE @on_pos int; SELECT @on_pos = CHARINDEX(N' on ', @@VERSION);", UnabbreviatedTypes),
-            /* A DDL type position, which is where nine of the corpus's own spellings sat. */
+            /* A DDL type position rather than an expression one: a temp table's and a table variable's
+               column types were both among the corpus's own spellings, and a check anchored only on
+               CONVERT( would have missed every one of them. */
             ("SET NOCOUNT ON; CREATE TABLE #file_space (database_id int NOT NULL); SELECT 1 FROM sys.databases AS d;", UnabbreviatedTypes),
             /* An sp_executesql PARAMETER DECLARATION, which is where the corpus's remaining doubt sat: it
                is a type position like any other, `integer` is accepted in it, and the engine binds the two

--- a/Darling/PerformanceMonitor.Darling.Analysis/PgPlanFetcher.cs
+++ b/Darling/PerformanceMonitor.Darling.Analysis/PgPlanFetcher.cs
@@ -184,7 +184,7 @@ OPTION(RECOMPILE);";
             var query = $@"
 EXECUTE {quotedDbName}.sys.sp_executesql
     N'{SqlHandlePlanInnerSql}',
-    N'@h varbinary(64), @stmt_start int, @stmt_end int',
+    N'@h varbinary(64), @stmt_start integer, @stmt_end integer',
     @h, @stmt_start, @stmt_end;";
 
             await using var command = new SqlCommand(query, connection) { CommandTimeout = 30 };

--- a/Lite.Tests/MemoryCollectorsDefinitionTests.cs
+++ b/Lite.Tests/MemoryCollectorsDefinitionTests.cs
@@ -32,7 +32,7 @@ public sealed class MemoryStatsCollectorDefinitionTests
 
         /* Azure: committed-target approximation + NULL workers (#857 elastic-pool grant wall). */
         Assert.Contains("committed_target_kb", azure, StringComparison.Ordinal);
-        Assert.Contains("current_workers_count = CONVERT(int, NULL)", azure, StringComparison.Ordinal);
+        Assert.Contains("current_workers_count = CONVERT(integer, NULL)", azure, StringComparison.Ordinal);
         Assert.DoesNotContain("sys.dm_os_schedulers", azure, StringComparison.Ordinal);
 
         /* On-prem/MI: real memory DMV + live worker count. */

--- a/Lite/Services/LocalDataService.FinOps.Recommendations.cs
+++ b/Lite/Services/LocalDataService.FinOps.Recommendations.cs
@@ -33,7 +33,7 @@ public partial class LocalDataService
            check, so the outer batch still compiles on platforms without it. */
         const string sql = @"
 DECLARE @role nvarchar(20) = N'Standalone';
-IF CONVERT(int, ISNULL(SERVERPROPERTY('IsHadrEnabled'), 0)) = 1
+IF CONVERT(integer, ISNULL(SERVERPROPERTY('IsHadrEnabled'), 0)) = 1
    AND OBJECT_ID(N'sys.dm_hadr_availability_replica_states') IS NOT NULL
 BEGIN
     DECLARE @detected nvarchar(20);
@@ -78,13 +78,13 @@ SELECT @role;";
            basic_features ships in every supported version (2016+), so no
            column-existence check is needed. */
         const string sql = @"
-DECLARE @count int = 0;
-IF CONVERT(int, ISNULL(SERVERPROPERTY('IsHadrEnabled'), 0)) = 1
+DECLARE @count integer = 0;
+IF CONVERT(integer, ISNULL(SERVERPROPERTY('IsHadrEnabled'), 0)) = 1
    AND OBJECT_ID(N'sys.availability_groups') IS NOT NULL
 BEGIN
     EXEC sys.sp_executesql
         N'SELECT @c = CONVERT(integer, COUNT_BIG(*)) FROM sys.availability_groups WHERE basic_features = 0;',
-        N'@c int OUTPUT', @c = @count OUTPUT;
+        N'@c integer OUTPUT', @c = @count OUTPUT;
 END;
 SELECT @count;";
         try

--- a/Lite/Services/LocalDataService.FinOps.ServerProperties.cs
+++ b/Lite/Services/LocalDataService.FinOps.ServerProperties.cs
@@ -33,7 +33,7 @@ public partial class LocalDataService
 DECLARE
     @storage_sql nvarchar(max) =
         CASE
-            WHEN CONVERT(int, SERVERPROPERTY('EngineEdition')) = 5
+            WHEN CONVERT(integer, SERVERPROPERTY('EngineEdition')) = 5
             THEN N'SELECT @gb = SUM(CAST(size AS bigint)) * 8.0 / 1024.0 / 1024.0 FROM sys.database_files'
             ELSE N'SELECT @gb = SUM(CAST(size AS bigint)) * 8.0 / 1024.0 / 1024.0 FROM sys.master_files'
         END,
@@ -50,7 +50,7 @@ IF OBJECT_ID(N'sys.dm_os_host_info', N'V') IS NOT NULL
 IF @host_os IS NULL
 BEGIN
     DECLARE @ver nvarchar(4000) = @@VERSION;
-    DECLARE @on_pos int = CHARINDEX(N' on ', @ver);
+    DECLARE @on_pos integer = CHARINDEX(N' on ', @ver);
     IF @on_pos > 0
         SET @host_os = LTRIM(SUBSTRING(@ver, @on_pos + 4, LEN(@ver)));
 END;
@@ -58,7 +58,7 @@ END;
 /* Availability Group replica role. The DMV is referenced only inside
    OBJECT_ID-guarded dynamic SQL, so this batch still compiles on Azure SQL
    Database and non-AG instances — both leave @ag_role at 'Standalone' (#980). */
-IF CONVERT(int, ISNULL(SERVERPROPERTY('IsHadrEnabled'), 0)) = 1
+IF CONVERT(integer, ISNULL(SERVERPROPERTY('IsHadrEnabled'), 0)) = 1
    AND OBJECT_ID(N'sys.dm_hadr_availability_replica_states') IS NOT NULL
 BEGIN
     DECLARE @ag_detected nvarchar(20);
@@ -78,7 +78,7 @@ SELECT
        show the actual product name + service tier (e.g. 'Azure SQL Database
        (General Purpose)') instead. */
     CASE
-        WHEN CONVERT(int, SERVERPROPERTY('EngineEdition')) = 5
+        WHEN CONVERT(integer, SERVERPROPERTY('EngineEdition')) = 5
         THEN N'Azure SQL Database'
              + ISNULL(N' (' +
                  CASE CONVERT(nvarchar(128), DATABASEPROPERTYEX(DB_NAME(), 'Edition'))
@@ -91,15 +91,15 @@ SELECT
     CONVERT(nvarchar(128), SERVERPROPERTY('ProductVersion')),
     CONVERT(nvarchar(128), SERVERPROPERTY('ProductLevel')),
     CONVERT(nvarchar(128), SERVERPROPERTY('ProductUpdateLevel')),
-    CONVERT(int, NULL),
+    CONVERT(integer, NULL),
     CONVERT(bigint, NULL),
     CONVERT(datetime, NULL),
     @storage_gb,
-    CONVERT(int, NULL),
-    CONVERT(int, NULL),
-    CONVERT(int, SERVERPROPERTY('EngineEdition')),
-    CONVERT(int, SERVERPROPERTY('IsHadrEnabled')),
-    CONVERT(int, SERVERPROPERTY('IsClustered')),
+    CONVERT(integer, NULL),
+    CONVERT(integer, NULL),
+    CONVERT(integer, SERVERPROPERTY('EngineEdition')),
+    CONVERT(integer, SERVERPROPERTY('IsHadrEnabled')),
+    CONVERT(integer, SERVERPROPERTY('IsClustered')),
     @host_os,
     @ag_role;";
 

--- a/Lite/Services/LocalDataService.QueryStats.cs
+++ b/Lite/Services/LocalDataService.QueryStats.cs
@@ -788,7 +788,7 @@ AND   tqp.query_plan IS NOT NULL
 ORDER BY
     qs.last_execution_time DESC
 OPTION(RECOMPILE);',
-    N'@h varbinary(64), @stmt_start int, @stmt_end int',
+    N'@h varbinary(64), @stmt_start integer, @stmt_end integer',
     @h, @stmt_start, @stmt_end;";
 
         using var command = new SqlCommand(query, connection) { CommandTimeout = 30 };

--- a/PerformanceMonitor.Collectors/DatabaseSizeStatsCollector.cs
+++ b/PerformanceMonitor.Collectors/DatabaseSizeStatsCollector.cs
@@ -71,8 +71,8 @@ SET NOCOUNT ON;
 
 CREATE TABLE #file_space
 (
-    database_id int NOT NULL,
-    file_id int NOT NULL,
+    database_id integer NOT NULL,
+    file_id integer NOT NULL,
     used_size_mb decimal(19,2) NULL,
     /* #2169: the file's CURRENT size, read in-database alongside SpaceUsed. sys.master_files.size is the
        size recorded at configuration time and does NOT track autogrowth for tempdb, so a grown tempdb
@@ -168,7 +168,7 @@ SELECT
     recovery_model_desc =
         d.recovery_model_desc,
     compatibility_level =
-        CONVERT(int, d.compatibility_level),
+        CONVERT(integer, d.compatibility_level),
     state_desc =
         d.state_desc,
     volume_mount_point =
@@ -233,8 +233,8 @@ DECLARE
     @database_sizes TABLE
 (
     database_name nvarchar(128) NULL,
-    database_id int NULL,
-    file_id int NULL,
+    database_id integer NULL,
+    file_id integer NULL,
     file_type_desc nvarchar(60) NULL,
     file_name nvarchar(128) NULL,
     physical_name nvarchar(260) NULL,
@@ -243,14 +243,14 @@ DECLARE
     auto_growth_mb decimal(19,2) NULL,
     max_size_mb decimal(19,2) NULL,
     recovery_model_desc nvarchar(12) NULL,
-    compatibility_level int NULL,
+    compatibility_level integer NULL,
     state_desc nvarchar(60) NULL,
     volume_mount_point nvarchar(256) NULL,
     volume_total_mb decimal(19,2) NULL,
     volume_free_mb decimal(19,2) NULL,
     is_percent_growth bit NULL,
-    growth_pct int NULL,
-    vlf_count int NULL
+    growth_pct integer NULL,
+    vlf_count integer NULL
 );
 
 INSERT
@@ -283,7 +283,7 @@ SELECT
     recovery_model_desc =
         CONVERT(nvarchar(12), DATABASEPROPERTYEX(DB_NAME(), N'Recovery')),
     compatibility_level =
-        CONVERT(int, NULL),
+        CONVERT(integer, NULL),
     state_desc =
         N'ONLINE',
     volume_mount_point =

--- a/PerformanceMonitor.Collectors/MemoryStatsCollector.cs
+++ b/PerformanceMonitor.Collectors/MemoryStatsCollector.cs
@@ -58,7 +58,7 @@ SELECT
     buffer_pool_mb = CONVERT(decimal(18,2), pc_buffer.cntr_value / 1024.0),
     plan_cache_mb = CONVERT(decimal(18,2), pc_plan.cntr_value * 8.0 / 1024.0),
     max_workers_count = osi.max_workers_count,
-    current_workers_count = CONVERT(int, NULL)
+    current_workers_count = CONVERT(integer, NULL)
 FROM sys.dm_os_sys_info AS osi
 CROSS JOIN
 (

--- a/PerformanceMonitor.Collectors/ServerPropertiesCollector.cs
+++ b/PerformanceMonitor.Collectors/ServerPropertiesCollector.cs
@@ -75,12 +75,12 @@ IF OBJECT_ID(N'sys.dm_os_host_info', N'V') IS NOT NULL
 IF @host_os IS NULL
 BEGIN
     DECLARE @ver nvarchar(4000) = @@VERSION;
-    DECLARE @on_pos int = CHARINDEX(N' on ', @ver);
+    DECLARE @on_pos integer = CHARINDEX(N' on ', @ver);
     IF @on_pos > 0
         SET @host_os = LTRIM(SUBSTRING(@ver, @on_pos + 4, LEN(@ver)));
 END;
 
-IF CONVERT(int, ISNULL(SERVERPROPERTY(N'IsHadrEnabled'), 0)) = 1
+IF CONVERT(integer, ISNULL(SERVERPROPERTY(N'IsHadrEnabled'), 0)) = 1
    AND OBJECT_ID(N'sys.dm_hadr_availability_replica_states') IS NOT NULL
 BEGIN
     DECLARE @ag_detected nvarchar(20);
@@ -129,7 +129,7 @@ SELECT
         /* Azure SQL DB reports the legacy 'SQL Azure' for SERVERPROPERTY('Edition');
            store the actual product name + service tier instead. */
         CASE
-            WHEN CONVERT(int, SERVERPROPERTY(N'EngineEdition')) = 5
+            WHEN CONVERT(integer, SERVERPROPERTY(N'EngineEdition')) = 5
             THEN N'Azure SQL Database'
                  + ISNULL(N' (' +
                      CASE CONVERT(nvarchar(128), DATABASEPROPERTYEX(DB_NAME(), N'Edition'))
@@ -146,7 +146,7 @@ SELECT
     product_update_level =
         CONVERT(nvarchar(128), SERVERPROPERTY(N'ProductUpdateLevel')),
     engine_edition =
-        CONVERT(int, SERVERPROPERTY(N'EngineEdition')),
+        CONVERT(integer, SERVERPROPERTY(N'EngineEdition')),
     cpu_count =
         @cpu_count,
     hyperthread_ratio =
@@ -163,7 +163,7 @@ SELECT
         CONVERT(bit, SERVERPROPERTY(N'IsClustered')),
     service_objective =
         CASE
-            WHEN CONVERT(int, SERVERPROPERTY(N'EngineEdition')) = 5
+            WHEN CONVERT(integer, SERVERPROPERTY(N'EngineEdition')) = 5
             THEN CONVERT(nvarchar(128), DATABASEPROPERTYEX(DB_NAME(), N'ServiceObjective'))
             ELSE NULL
         END,


### PR DESCRIPTION
**What this changes, and what to check hardest:**

- **33 abbreviated `int` type positions rewritten to `integer` across 7 files**, and `UnabbreviatedTypes` moved from the guard's `Uncovered` side to `Covered`.
- **One parity pin moved with its query** — `Lite.Tests/MemoryCollectorsDefinitionTests.cs:35`. Editing the query without it would have failed `build`.
- **Nothing reads the `sp_executesql` declaration back**, so normalisation cannot bite. The parse answer alone would not have established that.

---

`CONTRIBUTING.md`'s **Data types** bullet states two properties. #3085 enforced the case half and left the abbreviation half uncovered on a remediation cost, with that cost derived on every run rather than written down once. This pays the cost and moves the rule in scope, which is what `TheAbbreviationScopeNote_CountsTheSitesItClaims` was built to prompt.

## The count, re-derived

Driven through the guard's own `AbbreviatedTypeSites()` — same population, same code view, same `TypeNameClauseCollisions` blanking the enforced checks read — rather than a fresh grep: **33 sites in 7 files**, every one enumerating back to a distinct regex match. All 33 are rewritten, and the offsets edited were the detector's own match offsets, so no `int` in C# code was reachable from the rewrite.

| File | Sites |
|---|---|
| `Lite/Services/LocalDataService.FinOps.ServerProperties.cs` | 10 |
| `PerformanceMonitor.Collectors/DatabaseSizeStatsCollector.cs` | 9 |
| `PerformanceMonitor.Collectors/ServerPropertiesCollector.cs` | 5 |
| `Lite/Services/LocalDataService.FinOps.Recommendations.cs` | 4 |
| `Darling/PerformanceMonitor.Darling.Analysis/PgPlanFetcher.cs` | 2 |
| `Lite/Services/LocalDataService.QueryStats.cs` | 2 |
| `PerformanceMonitor.Collectors/MemoryStatsCollector.cs` | 1 |

## The in-scope move

`UnabbreviatedTypes` moves to the `Data types` bullet's `Covered` array, `Findings` emits it, it gains four hazard fixtures and three benign near-miss fixtures, its fixture is gone from `TheUncoveredRules_AreViolatedByFixturesThisGuardDoesNotFlag`, and the cost pin is deleted along with `AbbreviatedTypeSites()` and the note text it parsed. `Data types` stops being split, so the split-pair assertion names only `Indentation`.

**There is no waiver and no residual count.** All 33 converted, so nothing is left to waive and the cost pin has nothing left to count — `NoTsqlStatementViolatesACoveredConvention` now enforces zero directly, which is a stronger statement than a pinned figure.

## Was the rewritten T-SQL executed anywhere?

**Almost, but not quite, #3085's disclosure.** No query in this diff was executed against a SQL Server in the form the diff ships it. What *was* executed is a set of purpose-built read-only probes, on a **stage** RDS instance (**SQL Server 2022, 16.0.4215.2**) reached through an SSM port-forward — never a `prod-pos-*` monitored server. The probes exercised each of the shapes the 33 sites use, not the shipped strings themselves.

## The `sp_executesql` parameter declaration: parse *and* round trip

Three files carry a declaration string rather than a query body — `PgPlanFetcher.cs` and `LocalDataService.QueryStats.cs` both hold `N'@h varbinary(64), @stmt_start int, @stmt_end int'`, and `LocalDataService.FinOps.Recommendations.cs` holds `N'@c int OUTPUT'`, which the scope note never named. Nothing in this repository executes that path.

**The parse question came back yes, as expected, and on its own it is the weak claim.** `integer` is accepted in a declaration string; the engine reports the bound type as `int` with `max_length` 4. `CONVERT(integer, …)`, `DECLARE @x integer`, temp-table and table-variable columns typed `integer`, and the `OUTPUT` declaration form were each confirmed the same way, and `sys.dm_exec_describe_first_result_set` reports `integer` and `int` as the *same* type rather than merely both accepted.

**The question that could actually bite is normalisation, and it is answered in the repo.** SQL Server normalises the synonym, so anything reading the declaration *back* sees `int` — a passing parse would not establish that a downstream comparison still matches. Nothing reads it back:

- No `sys.parameters`, `sys.all_parameters` or `sys.types` anywhere in the shipped trees. These are ad-hoc `sp_executesql` batches, which have no `sys.parameters` rows to read.
- No metadata discovery on our own dynamic SQL — no `DeriveParameters`, no `describe_first_result_set` call outside the probe above.
- The declaration strings are not exposed as pinnable constants. `DarlingLivePlanFetchTests` does assert on those query strings, but on the inner statement's `qs.statement_start_offset = @stmt_start` predicate, which carries no `int` token.
- Client-side binding is `SqlDbType.Int` at all three sites, and since both spellings normalise to `int` the client and server types still agree.

So the live check earned its cost by establishing the normalisation half, not by confirming a synonym.

## Parity-pin check: #3085's conclusion does **not** carry over

#3085 established that none of the nine sites it fixed was verbatim-pinned. **These are different files and one of them is pinned.** Every string literal in `Lite.Tests` and `Darling/Darling.Tests` — 56,098 literals across 757 files — was checked for an `int` token *and* verbatim containment in one of the 7 edited files. One hit:

`Lite.Tests/MemoryCollectorsDefinitionTests.cs:35` asserts `Assert.Contains("current_workers_count = CONVERT(int, NULL)", azure, …)` against `MemoryStatsCollector`'s Azure variant. It moves with the query it pins.

Red-proofed rather than assumed: reverting the shipped query while leaving the pin at `integer` reds `MemoryStatsCollectorDefinitionTests.BuildQuery_SelectsVariantByTarget` with `Not found: "current_workers_count = CONVERT(integer, NULL)"`. Editing the query without the pin would have failed `build`.

## Red-proof

`Darling.Tests` and `Lite.Tests` are `net10.0-windows` and cannot run on macOS, so the **actual** test `.cs` files were compiled into throwaway `net10.0` xunit v3 harnesses staged in the gitignored `bin/`, with the `.csproj` passed explicitly. `Build succeeded` was asserted separately from running. Baseline last, every mutation restored and the tree verified clean after each.

| Mutation | Result |
|---|---|
| Revert **one** of the 33 sites (`ServerPropertiesCollector`) | `NoTsqlStatementViolatesACoveredConvention` **FAIL**, naming the rule: `[data-types-unabbreviated] line 73: the data type \`int\`` |
| Drop the detector's **trailing lookahead** | `TheDetector_FlagsEveryCoveredRule_AndNoBenignForm` **FAIL** — flagged the benign `CONVERT(integer, …)`, i.e. every rewritten site would report itself |
| Drop the detector's **leading lookbehind** | `TheDetector_…` **FAIL** — flagged `bigint` |
| Stop **emitting** the rule from `Findings` | `TheDetector_…` **FAIL**: `Not found: "data-types-unabbreviated"` |
| Rule drifts back to the bullet's **Uncovered** side | `TheDispositionMap_…` **FAIL** |
| Rule **reparented** to the `Functions` bullet | `TheDispositionMap_…` **FAIL** on the new bullet-level assertion |
| Revert the shipped query, leave the **parity pin** | `BuildQuery_SelectsVariantByTarget` **FAIL** |
| **Baseline (last)** | 8 / 8 guard tests and 16 / 16 harness2 tests, `Failed: 0`, `Not Run: 0`, no skips |

Both detector anchors are held by benign fixtures, so the greedy/unanchored failure mode reds rather than shipping.

## The ratchet, and one assertion removed for being unable to fail

The bullet-level `Assert.Contains(UnabbreviatedTypes, RuleBullets["Data types"].Covered)` is new because it is the one drift the existing set equalities cannot see — they are over the flattened *union* of every bullet's arrays, so reparenting the rule to another bullet satisfies all of them while the map claims the guard enforces a sentence the document does not have it enforcing. M7 above is that case.

Two `DoesNotContain` lines guarding the Uncovered direction were written and then **removed**: they sat after the flattened set equalities and the disjointness assertion, and every state that would trip them trips one of those first, so neither could ever be the assertion that reds. The comment now names what does hold that direction, so the decorative form does not come back. An assertion that reads as load-bearing while nothing holds it is the shape #3081 was filed about.

## CHANGELOG entry text

Not applied here — proposed text is in the inbox for the coordinator:

```
- Rewrote the 33 abbreviated `int` data types across 7 collector and service query strings to `integer`,
  and moved `CONTRIBUTING.md`'s data-type abbreviation rule from unguarded to enforced in
  `TsqlConventionGuardTests`. The guard's derived cost pin is retired with the cost it measured.
```

Fixes #3087

