### PR TITLE
Fixes #3094

### DIFF
--- a/Darling/Darling.Tests/CSharpMemberMap.cs
+++ b/Darling/Darling.Tests/CSharpMemberMap.cs
@@ -1,0 +1,514 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// <para>Which C# MEMBER a character offset falls inside, for source-scanning pins that have to name the
+/// member an offending literal is written in. Built on <see cref="CSharpSourceWalker"/>, so a modifier
+/// inside a comment and a brace inside a literal are neither of them code (#2913, #3052).</para>
+///
+/// <para><b>Two pins were carrying byte-identical copies of a broken resolver, and one of them was making
+/// a DECISION with it.</b> #3094 is about the copy in <c>TsqlConventionGuardTests</c>, where a wrong member
+/// name only mislabelled an offender — costly, because that list is the guard's whole output when it reds,
+/// but inert. <c>StoreSqlClockDisciplineTests</c> had the same regex and fed its answer into
+/// <c>Waived.Contains(file + ":" + member)</c>, so a wrong name there could break a legitimate waiver into
+/// a false red or — in the direction that costs — collide with a waived key and silently swallow a real
+/// bare-clock finding. Fixing the message-only copy and leaving the deciding one is shipping the inert half
+/// of a defect, which is why this is one authority and not two corrected copies. Same treatment
+/// <see cref="CSharpSourceWalker"/> gave five hand-rolled maskers in #2913 and <c>RepoFile</c> gave 34 path
+/// walks in #3090.</para>
+///
+/// <para><b>The access modifier at the start of a line is the whole discriminator</b>, and
+/// <see cref="DeclarationHead"/> carries the argument for it. The predecessor asked for an identifier, a
+/// parenthesised anything and an opening brace, which describes most C# statements: measured across the
+/// T-SQL guard's corpus it labelled 48 of 160 literals with a bare keyword or nothing, and across the store
+/// tree it answered <c>if</c>, <c>using</c>, <c>while</c>, <c>Select</c> and <c>NpgsqlCommand</c> at 21
+/// more sites.</para>
+///
+/// <para><b>What it cannot see is stated on each member rather than discovered later</b>, and every such
+/// shape resolves to <see cref="Unknown"/> — a label a reader escalates, not a plausible name a reader
+/// trusts. A caller is expected to red on <see cref="Unknown"/> rather than absorb it.</para>
+/// </summary>
+internal static class CSharpMemberMap
+{
+    /// <summary>
+    /// The start of a MEMBER declaration at type scope: an access modifier at the beginning of a line,
+    /// followed by any run of the other modifiers.
+    ///
+    /// <para><b>The access modifier is the whole discriminator, and requiring it is what this regex is
+    /// for.</b> Its predecessor took "the nearest name above the literal" from a pattern that also matched
+    /// <c>if (…) {</c>, <c>catch (…) {</c>, <c>new SqlConnectionStringBuilder(…) {</c> and any local
+    /// <c>string x =</c>. Measured on the tree it shipped against (#3094), 48 of the corpus's 160 T-SQL
+    /// literals were labelled with a bare keyword or nothing at all, and several more with a local
+    /// variable or the type being constructed — a figure about a resolver that no longer exists, which is
+    /// why it is the one number written down here. A local cannot
+    /// carry an access modifier and neither can a statement keyword, so anchoring on one excludes every
+    /// shape that misattributed rather than blacklisting them one at a time.</para>
+    ///
+    /// <para><b>What it therefore cannot see, stated rather than discovered later.</b> A member with no
+    /// access modifier (an <c>enum</c> or <c>interface</c> member, or a field written
+    /// <c>static readonly …</c>) is not a declaration here, and neither is an attribute argument, which
+    /// sits above its own member's declaration line. A literal in one of those resolves to
+    /// <see cref="Unknown"/> — and <c>TsqlConventionGuardTests.EveryTsqlLiteralInTheCorpus_IsAttributedToADeclaredMember</c>
+    /// reds on it by name. Widening the modifier list to admit a bare <c>const</c> or <c>static</c> would
+    /// re-admit the local-variable case, so the resolution fails toward the worse label instead: an honest
+    /// <c>&lt;unknown&gt;</c> a reader escalates, not a plausible name a reader trusts.</para>
+    ///
+    /// <para><b>That widening is guarded by this comment and by five fixture rows, and by nothing else.</b>
+    /// A re-admitted local produces an identifier-shaped label, and
+    /// <c>TsqlConventionGuardTests.EveryTsqlLiteralInTheCorpus_IsAttributedToADeclaredMember</c> can only see a label that
+    /// is a keyword or nothing — so it would report a clean run across the rest of the corpus. Its doc
+    /// comment states the same bound from the other side; if you are here to widen the list, read
+    /// it.</para>
+    ///
+    /// <para><b>The trailing lookahead excludes an ACCESSOR</b>, which is the one place an access modifier
+    /// appears INSIDE another member's body. <c>ArchiveService.IsArchiving</c> is the whole population and
+    /// the reason the exclusion is here rather than in a comment: its <c>private set =&gt; …</c> matched as
+    /// a declaration of its own, which put a declaration start inside the property that holds it and made
+    /// <c>TsqlConventionGuardTests.TheMemberScan_ReadsEveryDeclarationWhole</c> report the property as over-extended. It is
+    /// the only accessor in the scanned trees carrying an access modifier — which is why the exclusion is
+    /// here rather than in a note saying it might one day be needed, and why no count of them is written
+    /// down: that number changes on any commit and nothing would hold it true. An accessor is not a member
+    /// a literal is attributed to; the property is.</para>
+    /// </summary>
+    internal static readonly Regex DeclarationHead = new(
+        @"^[ \t]*(?:public|private|protected|internal)\b"
+        + @"(?:[ \t]+(?:public|private|protected|internal|abstract|async|const|event|explicit|extern"
+        + @"|implicit|new|override|partial|readonly|required|sealed|static|unsafe|virtual|volatile))*[ \t]+"
+        + @"(?!(?:get|set|init|add|remove)\b[ \t]*(?:=>|\{|;))",
+        RegexOptions.Multiline | RegexOptions.Compiled);
+
+    /// <summary>What <see cref="EnclosingMember"/> reports when no member declaration contains the
+    /// offset.</summary>
+    internal const string Unknown = "<unknown>";
+
+    /// <summary>
+    /// Whether a declaration can hold a literal (a method, property, field, constructor) or only other
+    /// declarations (a <c>class</c>, <c>record</c>, <c>enum</c>, …).
+    ///
+    /// <para>Types are in the declaration list rather than filtered out of it because a member's range is
+    /// bounded by the NEXT declaration of either kind, and a nested type is the next thing after the member
+    /// above it. They are excluded from attribution and from
+    /// <c>TsqlConventionGuardTests.TheMemberScan_ReadsEveryDeclarationWhole</c>: a type's body legitimately contains every
+    /// declaration below it, which is the exact shape that assertion calls an over-run.</para>
+    /// </summary>
+    internal enum DeclarationKind
+    {
+        /// <summary>A method, property, field, event or constructor — something a literal can be inside.</summary>
+        Member,
+
+        /// <summary>A <c>class</c>, <c>struct</c>, <c>record</c>, <c>interface</c>, <c>enum</c> or
+        /// <c>delegate</c>.</summary>
+        Type,
+    }
+
+    /// <summary>
+    /// One declaration as a half-open range over walked source, plus where the NEXT declaration starts.
+    ///
+    /// <para><c>NextStart</c> is carried because it is the one bound on <c>End</c> that does not come from
+    /// the brace walk: it is a regex match offset, so it can DISAGREE with a brace count that ran past the
+    /// method it was reading. #3089 found the same thing about the same shape — a re-check that reads the
+    /// same text and repeats the same walk is a tautology, not a check.</para>
+    ///
+    /// <para><c>End</c> is <c>-1</c> when the brace walk never closed the body.</para>
+    /// </summary>
+    internal readonly record struct DeclaredRange(
+        string Name,
+        DeclarationKind Kind,
+        int Start,
+        int End,
+        int NextStart);
+
+    /// <summary>Every declaration in one file, beside the walked source they are offsets into.</summary>
+    internal sealed record MemberMap(string Code, IReadOnlyList<DeclaredRange> Declarations);
+
+    /// <summary>
+    /// Every declaration in <paramref name="text"/>, read through <see cref="CSharpSourceWalker"/> so a
+    /// modifier in a comment and a brace in a literal are neither of them code (#2913, #3052). The walk
+    /// preserves every character position, so an offset into the walked text is the same offset into the
+    /// file — which is what lets <see cref="EnclosingMember"/> take the literal offset the scan already has.
+    /// </summary>
+    internal static MemberMap Of(string text)
+    {
+        var code = CSharpSourceWalker.StripCommentsAndStrings(text);
+        var heads = DeclarationHead.Matches(code);
+        var declarations = new List<DeclaredRange>(heads.Count);
+
+        for (var i = 0; i < heads.Count; i++)
+        {
+            var head = heads[i];
+            var after = head.Index + head.Length;
+            var (name, kind) = DeclaredName(code, after);
+
+            declarations.Add(new DeclaredRange(
+                name,
+                kind,
+                head.Index,
+                DeclarationEnd(code, after),
+                i + 1 < heads.Count ? heads[i + 1].Index : code.Length));
+        }
+
+        return new MemberMap(code, declarations);
+    }
+
+    /// <summary>
+    /// The declared name and kind, reading forward from just past the modifiers.
+    ///
+    /// <para>Tokenised rather than pattern-matched because the name's position depends on the shape: it is
+    /// the identifier before the parameter list on a method, before <c>=&gt;</c> or <c>{</c> on a property,
+    /// and before <c>=</c> on a field. A single regex for all three has to guess which <c>(</c> it is
+    /// looking at, and <c>ScannedTrees</c> is the counter-example that decides it — a
+    /// <c>(string, string[], string)[]</c> tuple type whose FIRST <c>(</c> is part of the type, so "the
+    /// identifier before the first paren" reads <c>readonly</c>. The scan tells them apart by position
+    /// rather than by shape: a type's parentheses come before any identifier has been read, a parameter
+    /// list's come after one.</para>
+    ///
+    /// <para><b>Every branch here is load-bearing, which took measuring rather than reasoning.</b> An
+    /// earlier draft also required the <c>(</c> to follow the name with only whitespace between, and moved
+    /// the name's end onto the <c>&gt;</c> that closed a generic argument list so that a generic method
+    /// would still qualify. Both were removed after dumping EVERY declaration in the scanned trees with
+    /// and without them and diffing: identical, every name, every file. They were a pair that only existed
+    /// to cancel each other out — and because each masked the other's removal, testing them one at a time
+    /// reported both as benign. No mutation of either could red a test, which is the tell.</para>
+    /// </summary>
+    private static (string Name, DeclarationKind Kind) DeclaredName(string code, int from)
+    {
+        var typeKeyword = Regex.Match(
+            code[from..Math.Min(from + 64, code.Length)],
+            @"^(?:(?:record|partial|readonly|ref)[ \t]+)*(?<kw>class|struct|record|interface|enum|delegate)\b[ \t]+(?<name>[A-Za-z_][A-Za-z0-9_]*)");
+
+        if (typeKeyword.Success)
+        {
+            return (typeKeyword.Groups["name"].Value, DeclarationKind.Type);
+        }
+
+        string? last = null;
+        var paren = 0;
+        var bracket = 0;
+        var angle = 0;
+
+        for (var i = from; i < code.Length; i++)
+        {
+            var c = code[i];
+
+            if (char.IsLetter(c) || c == '_')
+            {
+                var j = i;
+
+                while (j < code.Length && (char.IsLetterOrDigit(code[j]) || code[j] == '_'))
+                {
+                    j++;
+                }
+
+                if (paren == 0 && bracket == 0 && angle == 0)
+                {
+                    last = code[i..j];
+                }
+
+                i = j - 1;
+                continue;
+            }
+
+            switch (c)
+            {
+                case '(':
+                    /* A parameter list ends the name; a TYPE's parentheses do not, and the difference is
+                       that a type's come before any identifier has been read. That is the whole reason
+                       this is a scan and not a regex — ScannedTrees and DefinitionsWithoutSql in this file
+                       are (string, string[], string)[] tuples whose first ( belongs to the type, so
+                       "the identifier before the first paren" answers readonly.
+
+                       It has to return here rather than fall through to = / { / ; : a generic member's
+                       constraint clause sits between the parameter list and the body, and where T : class
+                       is three more depth-zero identifiers. Constrained in
+                       TheResolver_AttributesByScope_NotByTheNearestNameAbove is the pin. */
+                    if (paren == 0 && bracket == 0 && angle == 0 && last is not null)
+                    {
+                        return (last, DeclarationKind.Member);
+                    }
+
+                    paren++;
+                    break;
+
+                case ')':
+                    paren--;
+                    break;
+
+                case '[':
+                    bracket++;
+                    break;
+
+                case ']':
+                    bracket--;
+                    break;
+
+                /* Type arguments, tracked so a ( or a ; inside one cannot end the name — Func<(int, int)>
+                   is the shape, and TheResolver_AttributesByScope_NotByTheNearestNameAbove reds without
+                   this on the plainer Dictionary<,> form. Only opened directly after an identifier, so a
+                   comparison operator in an initialiser cannot open one; a stray > cannot drive the depth
+                   negative and strand every check below it. */
+                case '<':
+                    if (paren == 0 && bracket == 0 && angle == 0 && last is not null)
+                    {
+                        angle++;
+                    }
+
+                    break;
+
+                case '>':
+                    if (angle > 0)
+                    {
+                        angle--;
+                    }
+
+                    break;
+
+                case '=':
+                case '{':
+                case ';':
+                    if (paren == 0 && bracket == 0 && angle == 0)
+                    {
+                        return (last ?? Unknown, DeclarationKind.Member);
+                    }
+
+                    break;
+
+                default:
+                    break;
+            }
+        }
+
+        return (last ?? Unknown, DeclarationKind.Member);
+    }
+
+    /// <summary>
+    /// One past the declaration's last character: the <c>;</c> that ends a field or an expression-bodied
+    /// member, or the <c>}</c> that closes a braced body. <c>-1</c> when a body opened and never closed.
+    ///
+    /// <para>Deliberately UNBOUNDED — it reads to the end of the file rather than stopping at the next
+    /// declaration, so <see cref="DeclaredRange.NextStart"/> stays an independent bound that a runaway
+    /// count can be caught by. Clamping here would make the two agree by construction.</para>
+    ///
+    /// <para><b>A braced group does not always end the declaration.</b> An accessor list can be followed
+    /// by <c>= initialiser;</c>, and on an auto-property that initialiser is where a literal lives. This
+    /// is the one truncation <see cref="ShapeOf"/> is structurally unable to report — a range that stops
+    /// short of its own member is still closed and still well under
+    /// <see cref="DeclaredRange.NextStart"/>, so it reads as
+    /// <see cref="RangeShape.WholeMember"/> — which is why it is handled here rather than described as a
+    /// bound. <c>Auto</c> in <c>TsqlConventionGuardTests.TheResolver_AttributesByScope_NotByTheNearestNameAbove</c> is the
+    /// pin; found in review of #3097, where it resolved to <see cref="Unknown"/> in silence.</para>
+    /// </summary>
+    private static int DeclarationEnd(string code, int from)
+    {
+        var paren = 0;
+        var bracket = 0;
+
+        for (var i = from; i < code.Length; i++)
+        {
+            var c = code[i];
+
+            if (c == '(')
+            {
+                paren++;
+            }
+            else if (c == ')')
+            {
+                paren--;
+            }
+            else if (c == '[')
+            {
+                bracket++;
+            }
+            else if (c == ']')
+            {
+                bracket--;
+            }
+            else if (paren != 0 || bracket != 0)
+            {
+                continue;
+            }
+            else if (c == ';')
+            {
+                return i + 1;
+            }
+            else if (c == '{')
+            {
+                var close = BraceGroupEnd(code, i);
+
+                if (close < 0)
+                {
+                    return -1;
+                }
+
+                /* An accessor list can be followed by "= initialiser;", and on an auto-property that
+                   initialiser is exactly where a literal lives:
+
+                       public string QueryText { get; set; } = "SELECT …";
+
+                   Returning at the accessor list's closing brace ends the range BEFORE the literal, so
+                   the literal is contained by nothing and labelled <unknown> — and neither arm of
+                   ShapeOf can see it, because a range that stops short of its own member is still well
+                   under NextStart and still closed. That is a truncation with no detector, which is the
+                   one shape this scan must not produce.
+
+                   An '=' is the only thing that can legally follow the brace inside the same
+                   declaration; anything else there belongs to the next one, so the brace ends this
+                   range. */
+                var after = close;
+
+                while (after < code.Length && char.IsWhiteSpace(code[after]))
+                {
+                    after++;
+                }
+
+                if (after < code.Length && code[after] == '=')
+                {
+                    i = after;
+                    continue;
+                }
+
+                return close;
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>One past the <c>}</c> that closes the brace group opening at <paramref name="open"/>, or
+    /// <c>-1</c> if it never closes.</summary>
+    private static int BraceGroupEnd(string code, int open)
+    {
+        var depth = 0;
+
+        for (var j = open; j < code.Length; j++)
+        {
+            if (code[j] == '{')
+            {
+                depth++;
+            }
+            else if (code[j] == '}' && --depth == 0)
+            {
+                return j + 1;
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// The member a literal belongs to: the innermost member declaration whose range CONTAINS the offset.
+    ///
+    /// <para><b>Containment is not what fixed the measured sites, and saying so precisely matters.</b> The
+    /// predecessor had no containment test at all — whatever matched last before the offset won, inside the
+    /// literal's member or not — but what actually produced the 48 wrong labels was the pattern it matched
+    /// WITH, and <see cref="DeclarationHead"/> is where that is fixed. Measured over the corpus: asking for
+    /// the innermost CONTAINING member and asking for the nearest member declaration ABOVE the offset give
+    /// the same answer at all 160 T-SQL sites. So containment is hardening, for the one direction the
+    /// declaration regex cannot cover — a literal that is inside no member at all (an attribute argument,
+    /// or anything below a body the brace walk lost) resolves to <see cref="Unknown"/> here instead of
+    /// borrowing the name of whichever member happens to sit above it. It is pinned by
+    /// <see cref="TheMemberScan_ReadsABodyWhoseLiteralHoldsABrace_AndARawCountDoesNot"/>, which is an
+    /// arranged case rather than a site on the tree, and that is the honest status of it.</para>
+    /// </summary>
+    internal static string EnclosingMember(MemberMap map, int offset)
+    {
+        var name = Unknown;
+        var innermost = -1;
+
+        foreach (var declaration in map.Declarations)
+        {
+            if (declaration.Kind != DeclarationKind.Member
+                || declaration.End < 0
+                || offset < declaration.Start
+                || offset >= declaration.End
+                || declaration.Start <= innermost)
+            {
+                continue;
+            }
+
+            name = declaration.Name;
+            innermost = declaration.Start;
+        }
+
+        return name;
+    }
+
+    /// <summary>What the brace walk actually returned for one declaration.</summary>
+    internal enum RangeShape
+    {
+        /// <summary>One whole declaration, ending inside its own bounds.</summary>
+        WholeMember,
+
+        /// <summary>A body opened and never closed, so every literal below it is attributed to nothing.</summary>
+        Unterminated,
+
+        /// <summary>The walk ran past the next declaration, so that member's literals are attributed
+        /// here.</summary>
+        OverExtended,
+    }
+
+    /// <summary>
+    /// Which of three shapes a declaration's range is.
+    ///
+    /// <para><b>The two failing shapes are complementary, not redundant.</b>
+    /// <see cref="RangeShape.OverExtended"/> compares the brace walk against a regex offset, so it can
+    /// disagree with the walk — but it is structurally blind at the END of the file, where the last
+    /// declaration has no successor to run past. That tail is what
+    /// <see cref="RangeShape.Unterminated"/> still covers, because a runaway there simply never closes.
+    /// #3089 measured the same pair on the same kind of scan and both arms are pinned here.</para>
+    /// </summary>
+    internal static RangeShape ShapeOf(DeclaredRange declaration) =>
+        declaration.End < 0 ? RangeShape.Unterminated
+        : declaration.End > declaration.NextStart ? RangeShape.OverExtended
+        : RangeShape.WholeMember;
+
+    /// <summary>
+    /// The 1-based line <paramref name="offset"/> falls on. Sound over both the file and the walked text:
+    /// <see cref="CSharpSourceWalker.StripCommentsAndStrings"/> preserves every newline and every character
+    /// position.
+    /// </summary>
+    internal static int LineOf(string text, int offset) =>
+        text.AsSpan(0, Math.Clamp(offset, 0, text.Length)).Count('\n') + 1;
+
+    /// <summary>
+    /// The declaration walk over RAW source. <b>Not a resolution path — a control fixture.</b>
+    ///
+    /// <para>It exists so a test can assert that <see cref="CSharpSourceWalker"/> is what saves the scan,
+    /// in both directions, with a one-token difference from the shipped path: <see cref="Of"/> is this
+    /// function with <see cref="CSharpSourceWalker.StripCommentsAndStrings"/> applied first. Named for what
+    /// it is so nobody reaches for it as an alternative to <see cref="Of"/>, which is what a plausible name
+    /// like <c>RawDeclarations</c> invites. Its only caller is
+    /// <c>TsqlConventionGuardTests.TheMemberScan_ReadsABodyWhoseLiteralHoldsABrace_AndARawCountDoesNot</c>.</para>
+    /// </summary>
+    internal static MemberMap OfRawSourceForControlTestsOnly(string text)
+    {
+        var heads = DeclarationHead.Matches(text);
+        var declarations = new List<DeclaredRange>(heads.Count);
+
+        for (var i = 0; i < heads.Count; i++)
+        {
+            var head = heads[i];
+            var after = head.Index + head.Length;
+            var (name, kind) = DeclaredName(text, after);
+
+            declarations.Add(new DeclaredRange(
+                name,
+                kind,
+                head.Index,
+                DeclarationEnd(text, after),
+                i + 1 < heads.Count ? heads[i + 1].Index : text.Length));
+        }
+
+        return new MemberMap(text, declarations);
+    }
+}

--- a/Darling/Darling.Tests/StoreSqlClockDisciplineTests.cs
+++ b/Darling/Darling.Tests/StoreSqlClockDisciplineTests.cs
@@ -135,6 +135,9 @@ public sealed class StoreSqlClockDisciplineTests
             var text = File.ReadAllText(path);
             var name = Path.GetFileName(path);
 
+            /* Built at most once per file, and only when a finding needs a name. */
+            CSharpMemberMap.MemberMap? members = null;
+
             foreach (var (start, body) in CSharpSourceWalker.StringLiteralBodies(text))
             {
                 literals++;
@@ -148,8 +151,14 @@ public sealed class StoreSqlClockDisciplineTests
 
                 foreach (var finding in MixedClockComparisons(body, columns))
                 {
-                    var member = EnclosingMember(text, start);
+                    members ??= CSharpMemberMap.Of(text);
+                    var member = CSharpMemberMap.EnclosingMember(members, start);
 
+                    /* The waiver key is file:member, so a wrong member name is a wrong DECISION here and
+                       not merely a wrong message: it can miss a legitimate waiver, or collide with an
+                       unrelated one and swallow a real finding. #3094 replaced the copy of the resolver
+                       this file used to carry, which answered `if`, `using`, `while`, `Select` and
+                       `NpgsqlCommand` at 21 sites in this very tree. */
                     if (Waived.Contains(name + ":" + member))
                     {
                         continue;
@@ -685,29 +694,6 @@ public sealed class StoreSqlClockDisciplineTests
         }
 
         return sb.ToString();
-    }
-
-    /// <summary>The member a literal belongs to, for the waiver key and the failure message: the nearest
-    /// declaration above it.</summary>
-    private static string EnclosingMember(string text, int offset)
-    {
-        var head = text[..Math.Min(offset, text.Length)];
-
-        var matches = Regex.Matches(
-            head,
-            @"(?:const\s+string|static\s+string|string)\s+(?<name>[A-Za-z_][A-Za-z0-9_]*)\s*(?:=|=>)|(?<name2>[A-Za-z_][A-Za-z0-9_]*)\s*\([^)]*\)\s*(?:=>|\{)");
-
-        for (var i = matches.Count - 1; i >= 0; i--)
-        {
-            var name = matches[i].Groups["name"].Success ? matches[i].Groups["name"].Value : matches[i].Groups["name2"].Value;
-
-            if (!string.IsNullOrEmpty(name))
-            {
-                return name;
-            }
-        }
-
-        return "<unknown>";
     }
 
     private static string Collapse(string span)

--- a/Darling/Darling.Tests/TsqlConventionGuardTests.cs
+++ b/Darling/Darling.Tests/TsqlConventionGuardTests.cs
@@ -2217,8 +2217,10 @@ public sealed class TsqlConventionGuardTests
     /// <para><b>The access modifier is the whole discriminator, and requiring it is what this regex is
     /// for.</b> Its predecessor took "the nearest name above the literal" from a pattern that also matched
     /// <c>if (…) {</c>, <c>catch (…) {</c>, <c>new SqlConnectionStringBuilder(…) {</c> and any local
-    /// <c>string x =</c> — so 48 of the corpus's 160 T-SQL literals were labelled with a bare keyword or
-    /// nothing at all, and several more with a local variable or the type being constructed. A local cannot
+    /// <c>string x =</c>. Measured on the tree it shipped against (#3094), 48 of the corpus's 160 T-SQL
+    /// literals were labelled with a bare keyword or nothing at all, and several more with a local
+    /// variable or the type being constructed — a figure about a resolver that no longer exists, which is
+    /// why it is the one number written down here. A local cannot
     /// carry an access modifier and neither can a statement keyword, so anchoring on one excludes every
     /// shape that misattributed rather than blacklisting them one at a time.</para>
     ///
@@ -2235,9 +2237,11 @@ public sealed class TsqlConventionGuardTests
     /// appears INSIDE another member's body. <c>ArchiveService.IsArchiving</c> is the whole population and
     /// the reason the exclusion is here rather than in a comment: its <c>private set =&gt; …</c> matched as
     /// a declaration of its own, which put a declaration start inside the property that holds it and made
-    /// <see cref="TheMemberScan_ReadsEveryDeclarationWhole"/> report the property as over-extended — one
-    /// member out of the 18,205 the sweep reads. An accessor is not a member a literal is attributed to;
-    /// the property is.</para>
+    /// <see cref="TheMemberScan_ReadsEveryDeclarationWhole"/> report the property as over-extended. It is
+    /// the only accessor in the scanned trees carrying an access modifier — which is why the exclusion is
+    /// here rather than in a note saying it might one day be needed, and why no count of them is written
+    /// down: that number changes on any commit and nothing would hold it true. An accessor is not a member
+    /// a literal is attributed to; the property is.</para>
     /// </summary>
     private static readonly Regex DeclarationHead = new(
         @"^[ \t]*(?:public|private|protected|internal)\b"
@@ -2334,10 +2338,10 @@ public sealed class TsqlConventionGuardTests
     /// <para><b>Every branch here is load-bearing, which took measuring rather than reasoning.</b> An
     /// earlier draft also required the <c>(</c> to follow the name with only whitespace between, and moved
     /// the name's end onto the <c>&gt;</c> that closed a generic argument list so that a generic method
-    /// would still qualify. Both were removed after dumping all 20,308 declarations in the scanned trees
-    /// with and without them and diffing: identical, every name, every file. They were a pair that only
-    /// existed to cancel each other out, and no mutation of either one could red a test — which is the
-    /// tell.</para>
+    /// would still qualify. Both were removed after dumping EVERY declaration in the scanned trees with
+    /// and without them and diffing: identical, every name, every file. They were a pair that only existed
+    /// to cancel each other out — and because each masked the other's removal, testing them one at a time
+    /// reported both as benign. No mutation of either could red a test, which is the tell.</para>
     /// </summary>
     private static (string Name, DeclarationKind Kind) DeclaredName(string code, int from)
     {

--- a/Darling/Darling.Tests/TsqlConventionGuardTests.cs
+++ b/Darling/Darling.Tests/TsqlConventionGuardTests.cs
@@ -1121,9 +1121,32 @@ public sealed class TsqlConventionGuardTests
     /// and <c>foreach</c> are not member names in any C# program, so a label that is one is wrong without
     /// anything having to agree about how members are found. <see cref="Unknown"/> is the other arm, and it
     /// is the resolver's own admission — it is what a shape the declaration regex cannot read resolves to,
-    /// which is why that regex is allowed to be narrow. The two arms bracket the resolver from both sides:
-    /// one refuses a wrong answer, the other refuses no answer, and there is no third thing it can
-    /// return.</para>
+    /// which is why that regex is allowed to be narrow.</para>
+    ///
+    /// <para><b>What these two arms bracket is keyword-or-nothing, NOT wrong-or-nothing, and the
+    /// difference is the whole limitation of this assertion.</b> A label that is a plausible
+    /// user-defined identifier but not the enclosing member passes both arms in silence. That is not a
+    /// hypothetical shape: of the four misattributions
+    /// <see cref="MemberAttributionSites"/> was built from, only <c>if</c> was a keyword —
+    /// <c>SqlConnectionStringBuilder</c> (a BCL type), <c>optimizeForSequentialKey</c> and <c>sql</c>
+    /// (locals) are all identifier-shaped, so THREE of the four are shapes this test cannot see. They are
+    /// pinned by exact comparison at five sites; a regression to that shape anywhere in the rest of the
+    /// corpus is undetected here and is caught only if it happens to land on one of those five.</para>
+    ///
+    /// <para><b>The consequence worth naming: widening <see cref="DeclarationHead"/>'s modifier list is
+    /// fixture-guarded only.</b> That field's own note explains that admitting a bare <c>const</c> or
+    /// <c>static</c> would re-admit the local-variable case — and a re-admitted local produces an
+    /// identifier-shaped label, which is precisely what this assertion is blind to. So the guard against
+    /// that widening is a comment on <see cref="DeclarationHead"/> plus five fixture rows, not a
+    /// corpus-scale test. The two comments point at each other deliberately.</para>
+    ///
+    /// <para><b>And the obvious detector is a trap, so it is deliberately absent.</b> Asserting that the
+    /// label appears among <c>map.Declarations</c>' names cannot fail: <see cref="EnclosingMember"/>
+    /// returns <see cref="DeclaredRange.Name"/> taken from that very map, so the check and the thing it
+    /// validates are the same value read twice. It is #3089's tautology one artifact over, and a pin that
+    /// cannot fail is worse than a limitation that is written down — it converts this paragraph into
+    /// false confidence. Closing the gap for real needs a second, independent derivation of "which member
+    /// is this offset in", which is a bigger change than the message this PR fixes.</para>
     /// </summary>
     [Fact]
     public void EveryTsqlLiteralInTheCorpus_IsAttributedToADeclaredMember()
@@ -2239,6 +2262,13 @@ public sealed class TsqlConventionGuardTests
     /// reds on it by name. Widening the modifier list to admit a bare <c>const</c> or <c>static</c> would
     /// re-admit the local-variable case, so the resolution fails toward the worse label instead: an honest
     /// <c>&lt;unknown&gt;</c> a reader escalates, not a plausible name a reader trusts.</para>
+    ///
+    /// <para><b>That widening is guarded by this comment and by five fixture rows, and by nothing else.</b>
+    /// A re-admitted local produces an identifier-shaped label, and
+    /// <see cref="EveryTsqlLiteralInTheCorpus_IsAttributedToADeclaredMember"/> can only see a label that
+    /// is a keyword or nothing — so it would report a clean run across the rest of the corpus. Its doc
+    /// comment states the same bound from the other side; if you are here to widen the list, read
+    /// it.</para>
     ///
     /// <para><b>The trailing lookahead excludes an ACCESSOR</b>, which is the one place an access modifier
     /// appears INSIDE another member's body. <c>ArchiveService.IsArchiving</c> is the whole population and

--- a/Darling/Darling.Tests/TsqlConventionGuardTests.cs
+++ b/Darling/Darling.Tests/TsqlConventionGuardTests.cs
@@ -270,8 +270,9 @@ public sealed class TsqlConventionGuardTests
                 var name = Path.GetFileName(path);
                 var isAnchor = string.Equals(path, anchorPath, StringComparison.Ordinal);
 
-                /* Once per file, not once per finding: the map walks the whole source. */
-                var members = MemberMapOf(text);
+                /* Once per file at most, and only once a finding needs it: the map walks the whole
+                   source, and most scanned files hold no T-SQL at all. */
+                MemberMap? members = null;
 
                 foreach (var (start, body) in CSharpSourceWalker.StringLiteralBodies(text))
                 {
@@ -292,6 +293,7 @@ public sealed class TsqlConventionGuardTests
 
                     foreach (var (rule, detail) in Findings(body))
                     {
+                        members ??= MemberMapOf(text);
                         offenders.Add(
                             $"{name}:{LineOf(text, start)} in {EnclosingMember(members, start)} "
                             + $"[{rule}] {detail}");
@@ -1380,6 +1382,8 @@ public sealed class TsqlConventionGuardTests
             {
                 private const string Preceding = "SELECT 1 FROM sys.databases;";
 
+                public string Auto { get; set; } = "SELECT 7 FROM sys.schemas;";
+
                 private static readonly (string Name, string Sql)[] Table =
                 {
                     ("first", "SELECT 5 FROM sys.tables;"),
@@ -1425,7 +1429,7 @@ public sealed class TsqlConventionGuardTests
         /* Both members were read, and read as members — a map that resolved neither would satisfy every
            equality below by returning <unknown> twice, which is not the same answer. */
         Assert.Equal(
-            new[] { "Constrained", "First", "Preceding", "Second", "Table" },
+            new[] { "Auto", "Constrained", "First", "Preceding", "Second", "Table" },
             map.Declarations.Where(d => d.Kind == DeclarationKind.Member)
                             .Select(d => d.Name)
                             .OrderBy(n => n, StringComparer.Ordinal)
@@ -1462,6 +1466,12 @@ public sealed class TsqlConventionGuardTests
         Assert.Equal(
             "Constrained",
             EnclosingMember(map, source.IndexOf("SELECT 6", StringComparison.Ordinal)));
+
+        /* An AUTO-PROPERTY with an initialiser, where the braced group is the accessor list and the
+           literal is after it. This is the shape whose truncation ShapeOf cannot report — the range
+           would stop at the accessor list's } , still closed and still under NextStart — so it is the
+           one case where a wrong range is silent everywhere and only this assertion is left. */
+        Assert.Equal("Auto", EnclosingMember(map, source.IndexOf("SELECT 7", StringComparison.Ordinal)));
 
         /* The difference. Move the same literal text from the second member into the first and the answer
            has to follow it; an answer driven by the nearest name above would not move, because the names
@@ -2497,6 +2507,15 @@ public sealed class TsqlConventionGuardTests
     /// <para>Deliberately UNBOUNDED — it reads to the end of the file rather than stopping at the next
     /// declaration, so <see cref="DeclaredRange.NextStart"/> stays an independent bound that a runaway
     /// count can be caught by. Clamping here would make the two agree by construction.</para>
+    ///
+    /// <para><b>A braced group does not always end the declaration.</b> An accessor list can be followed
+    /// by <c>= initialiser;</c>, and on an auto-property that initialiser is where a literal lives. This
+    /// is the one truncation <see cref="ShapeOf"/> is structurally unable to report — a range that stops
+    /// short of its own member is still closed and still well under
+    /// <see cref="DeclaredRange.NextStart"/>, so it reads as
+    /// <see cref="RangeShape.WholeMember"/> — which is why it is handled here rather than described as a
+    /// bound. <c>Auto</c> in <see cref="TheResolver_AttributesByScope_NotByTheNearestNameAbove"/> is the
+    /// pin; found in review of #3097, where it resolved to <see cref="Unknown"/> in silence.</para>
     /// </summary>
     private static int DeclarationEnd(string code, int from)
     {
@@ -2533,21 +2552,62 @@ public sealed class TsqlConventionGuardTests
             }
             else if (c == '{')
             {
-                var depth = 0;
+                var close = BraceGroupEnd(code, i);
 
-                for (var j = i; j < code.Length; j++)
+                if (close < 0)
                 {
-                    if (code[j] == '{')
-                    {
-                        depth++;
-                    }
-                    else if (code[j] == '}' && --depth == 0)
-                    {
-                        return j + 1;
-                    }
+                    return -1;
                 }
 
-                return -1;
+                /* An accessor list can be followed by "= initialiser;", and on an auto-property that
+                   initialiser is exactly where a literal lives:
+
+                       public string QueryText { get; set; } = "SELECT …";
+
+                   Returning at the accessor list's closing brace ends the range BEFORE the literal, so
+                   the literal is contained by nothing and labelled <unknown> — and neither arm of
+                   ShapeOf can see it, because a range that stops short of its own member is still well
+                   under NextStart and still closed. That is a truncation with no detector, which is the
+                   one shape this scan must not produce.
+
+                   An '=' is the only thing that can legally follow the brace inside the same
+                   declaration; anything else there belongs to the next one, so the brace ends this
+                   range. */
+                var after = close;
+
+                while (after < code.Length && char.IsWhiteSpace(code[after]))
+                {
+                    after++;
+                }
+
+                if (after < code.Length && code[after] == '=')
+                {
+                    i = after;
+                    continue;
+                }
+
+                return close;
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>One past the <c>}</c> that closes the brace group opening at <paramref name="open"/>, or
+    /// <c>-1</c> if it never closes.</summary>
+    private static int BraceGroupEnd(string code, int open)
+    {
+        var depth = 0;
+
+        for (var j = open; j < code.Length; j++)
+        {
+            if (code[j] == '{')
+            {
+                depth++;
+            }
+            else if (code[j] == '}' && --depth == 0)
+            {
+                return j + 1;
             }
         }
 

--- a/Darling/Darling.Tests/TsqlConventionGuardTests.cs
+++ b/Darling/Darling.Tests/TsqlConventionGuardTests.cs
@@ -1087,13 +1087,13 @@ public sealed class TsqlConventionGuardTests
 
             Assert.Equal(site.Member, EnclosingMember(map, start));
 
-                /* The line half of the label, cross-checked by a DIFFERENT derivation: LineOf counts
+            /* The line half of the label, cross-checked by a DIFFERENT derivation: LineOf counts
                newlines in a span, this reads the file as lines and finds the anchor's own line. The
-               literal starts at or above its anchor, so the reported line must not be past it. Asserting
-               instead that the line falls inside the resolved member's range would be a tautology —
-               the member was selected by containing this very offset and LineOf is monotonic in it, so
-               the comparison could not disagree with what it validates (#3089's finding about the same
-               shape). */
+               literal starts at or above its anchor, so the reported line must not be past it.
+               Asserting instead that the line falls inside the resolved member's range would be a
+               tautology — the member was selected by containing this very offset and LineOf is
+               monotonic in it, so the comparison could not disagree with what it validates (#3089's
+               finding about the same shape). */
             var line = LineOf(text, start);
             var anchorLine = Array.FindIndex(
                 File.ReadAllLines(path),

--- a/Darling/Darling.Tests/TsqlConventionGuardTests.cs
+++ b/Darling/Darling.Tests/TsqlConventionGuardTests.cs
@@ -1114,7 +1114,9 @@ public sealed class TsqlConventionGuardTests
     /// and <c>foreach</c> are not member names in any C# program, so a label that is one is wrong without
     /// anything having to agree about how members are found. <see cref="Unknown"/> is the other arm, and it
     /// is the resolver's own admission — it is what a shape the declaration regex cannot read resolves to,
-    /// which is why the regex is allowed to be narrow.</para>
+    /// which is why that regex is allowed to be narrow. The two arms bracket the resolver from both sides:
+    /// one refuses a wrong answer, the other refuses no answer, and there is no third thing it can
+    /// return.</para>
     /// </summary>
     [Fact]
     public void EveryTsqlLiteralInTheCorpus_IsAttributedToADeclaredMember()
@@ -1144,7 +1146,7 @@ public sealed class TsqlConventionGuardTests
                     map ??= MemberMapOf(text);
                     var member = EnclosingMember(map, start);
 
-                    if (member == Unknown || CSharpStatementKeywords.Contains(member))
+                    if (member == Unknown || CSharpKeywords.Contains(member))
                     {
                         offenders.Add(
                             $"{Path.GetRelativePath(repo, path).Replace('\\', '/')}:{LineOf(text, start)} "
@@ -1173,15 +1175,33 @@ public sealed class TsqlConventionGuardTests
     }
 
     /// <summary>
-    /// Statement keywords, which no member can be named. The independent half of the assertion above:
-    /// it agrees with nothing in the resolver, so it cannot pass because the resolver and the check make
-    /// the same mistake. Every one of these was a real label on the tree as it shipped except where noted.
+    /// Every C# reserved keyword, none of which can be an identifier and therefore none of which can be a
+    /// member name.
+    ///
+    /// <para><b>The independent half of the assertion above.</b> It agrees with nothing in the resolver, so
+    /// it cannot pass by the resolver and the check making the same mistake — which a second derivation of
+    /// "what are this file's members" would be free to do. The whole reserved set rather than the statement
+    /// keywords that were actually observed (<c>if</c>, <c>catch</c>, <c>foreach</c>): a resolver that
+    /// starts returning a MODIFIER or a built-in type name is the same defect one token over, and
+    /// <c>readonly</c> is the measured instance — dropping the "a parameter list directly follows the
+    /// name" test in <see cref="DeclaredName"/> makes a tuple-typed field resolve to <c>readonly</c>, which
+    /// a list of statement keywords would have let through.</para>
     /// </summary>
-    private static readonly HashSet<string> CSharpStatementKeywords = new(StringComparer.Ordinal)
+    private static readonly HashSet<string> CSharpKeywords = new(StringComparer.Ordinal)
     {
-        "if", "else", "for", "foreach", "while", "do", "switch", "case", "default", "try", "catch",
-        "finally", "using", "lock", "return", "throw", "new", "checked", "unchecked", "fixed", "await",
-        "yield", "break", "continue", "goto", "var", "get", "set", "init", "add", "remove", "when",
+        "abstract", "as", "base", "bool", "break", "byte", "case", "catch", "char", "checked", "class",
+        "const", "continue", "decimal", "default", "delegate", "do", "double", "else", "enum", "event",
+        "explicit", "extern", "false", "finally", "fixed", "float", "for", "foreach", "goto", "if",
+        "implicit", "in", "int", "interface", "internal", "is", "lock", "long", "namespace", "new",
+        "null", "object", "operator", "out", "override", "params", "private", "protected", "public",
+        "readonly", "ref", "return", "sbyte", "sealed", "short", "sizeof", "stackalloc", "static",
+        "string", "struct", "switch", "this", "throw", "true", "try", "typeof", "uint", "ulong",
+        "unchecked", "unsafe", "ushort", "using", "virtual", "void", "volatile", "while",
+
+        /* Contextual, and every one of them can begin a statement or an accessor, so a label that is one
+           is a scan that stopped at the wrong token rather than a member with an unusual name. */
+        "add", "async", "await", "get", "init", "partial", "record", "remove", "required", "set", "var",
+        "when", "where", "yield",
     };
 
     /// <summary>
@@ -1330,6 +1350,17 @@ public sealed class TsqlConventionGuardTests
             {
                 private const string Preceding = "SELECT 1 FROM sys.databases;";
 
+                private static readonly (string Name, string Sql)[] Table =
+                {
+                    ("first", "SELECT 5 FROM sys.tables;"),
+                };
+
+                public string Constrained<T>(T value)
+                    where T : class
+                {
+                    return "SELECT 6 FROM sys.types;" + value?.ToString();
+                }
+
                 public string First(string database)
                 {
                     const string sql = "SELECT 2 FROM sys.objects;";
@@ -1364,7 +1395,7 @@ public sealed class TsqlConventionGuardTests
         /* Both members were read, and read as members — a map that resolved neither would satisfy every
            equality below by returning <unknown> twice, which is not the same answer. */
         Assert.Equal(
-            new[] { "First", "Preceding", "Second" },
+            new[] { "Constrained", "First", "Preceding", "Second", "Table" },
             map.Declarations.Where(d => d.Kind == DeclarationKind.Member)
                             .Select(d => d.Name)
                             .OrderBy(n => n, StringComparer.Ordinal)
@@ -1387,6 +1418,20 @@ public sealed class TsqlConventionGuardTests
 
         /* And below all four of them at once, which no single real site arranges. */
         Assert.Equal("Second", EnclosingMember(map, source.IndexOf("SELECT 4", StringComparison.Ordinal)));
+
+        /* A TUPLE-TYPED field, whose first ( belongs to the type rather than to a parameter list. This is
+           the shape that decides how the name is read at all: "the identifier before the first paren"
+           answers readonly here, and readonly is a modifier, not a member. ScannedTrees and
+           DefinitionsWithoutSql in this very file are both this shape. */
+        Assert.Equal("Table", EnclosingMember(map, source.IndexOf("SELECT 5", StringComparison.Ordinal)));
+
+        /* A GENERIC member with a constraint, where the parameter list follows the > that closed the type
+           parameters rather than the name itself. Left unhandled the scan reads past the parameter list
+           into the constraint and answers class. Nine members in the scanned trees carry a where-clause,
+           so the shape is real; none of them holds T-SQL, which is why it is arranged here. */
+        Assert.Equal(
+            "Constrained",
+            EnclosingMember(map, source.IndexOf("SELECT 6", StringComparison.Ordinal)));
 
         /* The difference. Move the same literal text from the second member into the first and the answer
            has to follow it; an answer driven by the nearest name above would not move, because the names
@@ -2282,9 +2327,17 @@ public sealed class TsqlConventionGuardTests
     /// and before <c>=</c> on a field. A single regex for all three has to guess which <c>(</c> it is
     /// looking at, and <c>ScannedTrees</c> is the counter-example that decides it — a
     /// <c>(string, string[], string)[]</c> tuple type whose FIRST <c>(</c> is part of the type, so "the
-    /// identifier before the first paren" reads <c>readonly</c>. Here a <c>(</c> only ends the scan when it
-    /// directly follows an identifier, which is what a parameter list does and what a tuple type does
-    /// not.</para>
+    /// identifier before the first paren" reads <c>readonly</c>. The scan tells them apart by position
+    /// rather than by shape: a type's parentheses come before any identifier has been read, a parameter
+    /// list's come after one.</para>
+    ///
+    /// <para><b>Every branch here is load-bearing, which took measuring rather than reasoning.</b> An
+    /// earlier draft also required the <c>(</c> to follow the name with only whitespace between, and moved
+    /// the name's end onto the <c>&gt;</c> that closed a generic argument list so that a generic method
+    /// would still qualify. Both were removed after dumping all 20,308 declarations in the scanned trees
+    /// with and without them and diffing: identical, every name, every file. They were a pair that only
+    /// existed to cancel each other out, and no mutation of either one could red a test — which is the
+    /// tell.</para>
     /// </summary>
     private static (string Name, DeclarationKind Kind) DeclaredName(string code, int from)
     {
@@ -2298,7 +2351,6 @@ public sealed class TsqlConventionGuardTests
         }
 
         string? last = null;
-        var lastEnd = -1;
         var paren = 0;
         var bracket = 0;
         var angle = 0;
@@ -2319,7 +2371,6 @@ public sealed class TsqlConventionGuardTests
                 if (paren == 0 && bracket == 0 && angle == 0)
                 {
                     last = code[i..j];
-                    lastEnd = j;
                 }
 
                 i = j - 1;
@@ -2329,11 +2380,17 @@ public sealed class TsqlConventionGuardTests
             switch (c)
             {
                 case '(':
-                    /* A parameter list directly follows the name; a tuple type does not follow one at
-                       all, and a generic method's name is followed by the >  that closed its type
-                       parameters — which is why lastEnd moves onto that > below. */
-                    if (paren == 0 && bracket == 0 && angle == 0 && last is not null
-                        && code.AsSpan(lastEnd, i - lastEnd).IsWhiteSpace())
+                    /* A parameter list ends the name; a TYPE's parentheses do not, and the difference is
+                       that a type's come before any identifier has been read. That is the whole reason
+                       this is a scan and not a regex — ScannedTrees and DefinitionsWithoutSql in this file
+                       are (string, string[], string)[] tuples whose first ( belongs to the type, so
+                       "the identifier before the first paren" answers readonly.
+
+                       It has to return here rather than fall through to = / { / ; : a generic member's
+                       constraint clause sits between the parameter list and the body, and where T : class
+                       is three more depth-zero identifiers. Constrained in
+                       TheResolver_AttributesByScope_NotByTheNearestNameAbove is the pin. */
+                    if (paren == 0 && bracket == 0 && angle == 0 && last is not null)
                     {
                         return (last, DeclarationKind.Member);
                     }
@@ -2353,9 +2410,13 @@ public sealed class TsqlConventionGuardTests
                     bracket--;
                     break;
 
+                /* Type arguments, tracked so a ( or a ; inside one cannot end the name — Func<(int, int)>
+                   is the shape, and TheResolver_AttributesByScope_NotByTheNearestNameAbove reds without
+                   this on the plainer Dictionary<,> form. Only opened directly after an identifier, so a
+                   comparison operator in an initialiser cannot open one; a stray > cannot drive the depth
+                   negative and strand every check below it. */
                 case '<':
-                    if (paren == 0 && bracket == 0 && angle == 0 && last is not null
-                        && code.AsSpan(lastEnd, i - lastEnd).IsWhiteSpace())
+                    if (paren == 0 && bracket == 0 && angle == 0 && last is not null)
                     {
                         angle++;
                     }
@@ -2366,11 +2427,6 @@ public sealed class TsqlConventionGuardTests
                     if (angle > 0)
                     {
                         angle--;
-
-                        if (angle == 0)
-                        {
-                            lastEnd = i + 1;
-                        }
                     }
 
                     break;
@@ -2460,9 +2516,17 @@ public sealed class TsqlConventionGuardTests
     /// <summary>
     /// The member a literal belongs to: the innermost member declaration whose range CONTAINS the offset.
     ///
-    /// <para>Containment is the whole change. The predecessor took the nearest matching name ABOVE the
-    /// offset with no containment test at all, so a name from the member above leaked into the member below
-    /// it and a local variable declared two lines up outranked the method holding both.</para>
+    /// <para><b>Containment is not what fixed the measured sites, and saying so precisely matters.</b> The
+    /// predecessor had no containment test at all — whatever matched last before the offset won, inside the
+    /// literal's member or not — but what actually produced the 48 wrong labels was the pattern it matched
+    /// WITH, and <see cref="DeclarationHead"/> is where that is fixed. Measured over the corpus: asking for
+    /// the innermost CONTAINING member and asking for the nearest member declaration ABOVE the offset give
+    /// the same answer at all 160 T-SQL sites. So containment is hardening, for the one direction the
+    /// declaration regex cannot cover — a literal that is inside no member at all (an attribute argument,
+    /// or anything below a body the brace walk lost) resolves to <see cref="Unknown"/> here instead of
+    /// borrowing the name of whichever member happens to sit above it. It is pinned by
+    /// <see cref="TheMemberScan_ReadsABodyWhoseLiteralHoldsABrace_AndARawCountDoesNot"/>, which is an
+    /// arranged case rather than a site on the tree, and that is the honest status of it.</para>
     /// </summary>
     private static string EnclosingMember(MemberMap map, int offset)
     {

--- a/Darling/Darling.Tests/TsqlConventionGuardTests.cs
+++ b/Darling/Darling.Tests/TsqlConventionGuardTests.cs
@@ -270,6 +270,9 @@ public sealed class TsqlConventionGuardTests
                 var name = Path.GetFileName(path);
                 var isAnchor = string.Equals(path, anchorPath, StringComparison.Ordinal);
 
+                /* Once per file, not once per finding: the map walks the whole source. */
+                var members = MemberMapOf(text);
+
                 foreach (var (start, body) in CSharpSourceWalker.StringLiteralBodies(text))
                 {
                     literalsScanned++;
@@ -289,7 +292,9 @@ public sealed class TsqlConventionGuardTests
 
                     foreach (var (rule, detail) in Findings(body))
                     {
-                        offenders.Add($"{name}:{EnclosingMember(text, start)} [{rule}] {detail}");
+                        offenders.Add(
+                            $"{name}:{LineOf(text, start)} in {EnclosingMember(members, start)} "
+                            + $"[{rule}] {detail}");
                     }
                 }
             }
@@ -962,6 +967,579 @@ public sealed class TsqlConventionGuardTests
             unguarded.Select(u => u.Rule).Distinct(StringComparer.Ordinal).OrderBy(r => r, StringComparer.Ordinal).ToArray());
     }
 
+    /* ───────────────────────── the offender label, pinned against the real tree ───────────────────────── */
+
+    /// <summary>
+    /// One site the offender label has to name correctly: a file, a distinctive substring of the T-SQL
+    /// literal that locates it, and the member that literal is written inside.
+    ///
+    /// <para><b>Located by anchor rather than by offset, because an offset is a frozen enumeration.</b>
+    /// All five of these are live source files that change most weeks, and a literal's character offset
+    /// moves when anything above it is edited. A pinned integer would go red for a reason unrelated to
+    /// attribution, and the next reader would repair it by updating the number — which silently retargets
+    /// the pin at whatever literal now sits there. The anchor is content, so it travels with the literal,
+    /// and <see cref="TheOffenderLabel_NamesTheMemberAtEverySiteInTheFixtureTable"/> requires it to match
+    /// exactly one literal in the file.</para>
+    ///
+    /// <para><c>UsedToReport</c> is what the predecessor said at that site, and <c>WasCorrect</c> says
+    /// whether that was right. It is not decoration: the table asserts its own rows are consistent with it,
+    /// so a row claiming to fix a misattribution whose expectation equals the old answer pins nothing and
+    /// reds. The <c>ServerPropertiesCollector</c> row is the one that was already correct and is carried
+    /// precisely so the change cannot be shown to work by breaking it.</para>
+    /// </summary>
+    private static readonly (string File, string Anchor, string Member, string UsedToReport, bool WasCorrect, string What)[]
+        MemberAttributionSites =
+    {
+        ("Darling/PerformanceMonitor.Darling.Analysis/PgPlanFetcher.cs",
+            "N'@h varbinary(64), @stmt_start integer, @stmt_end integer'",
+            "FetchPlanBySqlHandleAsync", "SqlConnectionStringBuilder", false,
+            "a TYPE being constructed. The nearest match above the literal was "
+            + "new SqlConnectionStringBuilder(connectionString) { … }, which is a class name, not a member "
+            + "of this file at all — so the label sent a reader to look for a member that does not exist "
+            + "here."),
+
+        ("Lite/Services/LocalDataService.FinOps.Recommendations.cs",
+            "DECLARE @role nvarchar(20) = N'Standalone';",
+            "GetAgReplicaRoleAsync", "sql", false,
+            "a LOCAL, and right for the wrong reason. The literal is the initialiser of const string sql, "
+            + "so the old pattern matched the variable it is assigned to — close enough to look correct and "
+            + "wrong as soon as the same method holds two queries, which is the shape three of the other "
+            + "sites in this file have."),
+
+        ("Lite/Services/LocalDataService.QueryStore.cs",
+            "FROM sys.query_store_plan AS qsp",
+            "FetchQueryStorePlanAsync", "if", false,
+            "a bare KEYWORD. if (quotedDbName == null) { matched the second alternative, which asked only "
+            + "for an identifier, a parenthesised anything and an opening brace — a description of most C# "
+            + "statements."),
+
+        ("PerformanceMonitor.Collectors/IndexObjectStatsCollector.cs",
+            "/* Size + row counts (one scan of dm_db_partition_stats) */",
+            "BuildPerDatabaseStatsBody", "optimizeForSequentialKey", false,
+            "a LOCAL again, and the one that reads most like a real answer: optimizeForSequentialKey is a "
+            + "string variable holding a column expression, so the label named a fragment of the query "
+            + "rather than the method that builds it."),
+
+        ("PerformanceMonitor.Collectors/ServerPropertiesCollector.cs",
+            "the deferred-object-ref pattern, NOT a version guard (#980)",
+            "QueryText", "QueryText", true,
+            "the case that was already RIGHT, because the literal is a member initialiser and the member's "
+            + "own declaration was the nearest match above it. Carried so the rewrite cannot be shown to "
+            + "work by breaking the shape that worked."),
+    };
+
+    /// <summary>
+    /// The label names the enclosing member at every site in the table.
+    ///
+    /// <para><b>Why the message matters as much as the detection.</b> Detection is untouched by any of
+    /// this — the same literals are read, the same rules fire, the offender COUNT is identical. But the
+    /// offender list is the guard's entire output at the moment it reds, and it was sending readers to a
+    /// type name, a local variable or the word <c>if</c>. A guard that detects correctly and then
+    /// misdirects is worse than one that says nothing, because the reader has no reason to doubt it.</para>
+    /// </summary>
+    [Fact]
+    public void TheOffenderLabel_NamesTheMemberAtEverySiteInTheFixtureTable()
+    {
+        var repo = RepoRoot();
+        var checked_ = 0;
+
+        foreach (var site in MemberAttributionSites)
+        {
+            /* A row that expects what the predecessor already said, while claiming to correct it, pins
+               nothing — and a row that claims the old answer was right while expecting a different one is
+               a contradiction. Both directions, so the table cannot quietly stop being a fixture. */
+            Assert.Equal(site.WasCorrect, string.Equals(site.Member, site.UsedToReport, StringComparison.Ordinal));
+
+            var path = Path.GetFullPath(
+                Path.Combine(repo, site.File.Replace('/', Path.DirectorySeparatorChar)));
+
+            Assert.True(
+                File.Exists(path),
+                $"the fixture site {site.File} no longer exists, so this row checks nothing. Move the row "
+                + "to wherever the literal went rather than deleting it — the shape it pins is the point, "
+                + "not the file.");
+
+            var text = File.ReadAllText(path);
+            var map = MemberMapOf(text);
+
+            /* The offset is DERIVED from the anchor, through the same literal walk the scan uses, so the
+               site cannot drift onto a different literal and cannot be pinned to a stale integer. */
+            var located = CSharpSourceWalker.StringLiteralBodies(text)
+                .Where(l => l.Text.Contains(site.Anchor, StringComparison.Ordinal))
+                .ToList();
+
+            Assert.True(
+                located.Count == 1,
+                $"the anchor for {site.File} matched {located.Count} string literals, so it no longer "
+                + $"identifies one site. Anchor: {site.Anchor}");
+
+            var (start, body) = located[0];
+
+            /* And it has to be in the population, or the row records nothing about a guard that only ever
+               labels T-SQL. #3079's shape: a fixture the population filters out first. */
+            Assert.True(
+                IsTsqlStatement(body),
+                $"the literal anchored in {site.File} is no longer read as a T-SQL statement, so the guard "
+                + "would never label it and this row is vacuous.");
+
+            Assert.Equal(site.Member, EnclosingMember(map, start));
+
+            /* The line is the half of the label that cannot be wrong — it is a newline count over
+               character-aligned text — so it is what a reader still has when attribution fails. Pinned
+               here as being inside the resolved member rather than as a number, for the same reason the
+               offset is not pinned. */
+            var line = LineOf(text, start);
+            var member = map.Declarations.Single(
+                d => d.Kind == DeclarationKind.Member && d.Name == site.Member
+                     && start >= d.Start && start < d.End);
+
+            Assert.InRange(line, LineOf(text, member.Start), LineOf(text, member.End - 1));
+
+            checked_++;
+        }
+
+        Assert.Equal(MemberAttributionSites.Length, checked_);
+    }
+
+    /// <summary>
+    /// Every T-SQL literal in the whole corpus is attributed to something that can be a member name.
+    ///
+    /// <para><b>This is what turns five fixture rows into the population.</b> The table above pins the
+    /// sites that were measured; this pins the ones nobody looked at, and on the tree as it shipped it is
+    /// the assertion that carried the finding: 48 of the 160 T-SQL literals the scan reads were labelled
+    /// with a bare C# keyword or with nothing at all. A per-site table can never say that, because the
+    /// sites it does not name are exactly where the next one will be.</para>
+    ///
+    /// <para>The keyword list is the check that shares no code with the resolver: <c>if</c>, <c>catch</c>
+    /// and <c>foreach</c> are not member names in any C# program, so a label that is one is wrong without
+    /// anything having to agree about how members are found. <see cref="Unknown"/> is the other arm, and it
+    /// is the resolver's own admission — it is what a shape the declaration regex cannot read resolves to,
+    /// which is why the regex is allowed to be narrow.</para>
+    /// </summary>
+    [Fact]
+    public void EveryTsqlLiteralInTheCorpus_IsAttributedToADeclaredMember()
+    {
+        var repo = RepoRoot();
+        var literals = 0;
+        var offenders = new List<string>();
+
+        foreach (var (tree, roots, _) in ScannedTrees)
+        {
+            var inTree = 0;
+
+            foreach (var path in SourceFiles(roots))
+            {
+                var text = File.ReadAllText(path);
+                MemberMap? map = null;
+
+                foreach (var (start, body) in CSharpSourceWalker.StringLiteralBodies(text))
+                {
+                    if (!IsTsqlStatement(body))
+                    {
+                        continue;
+                    }
+
+                    literals++;
+                    inTree++;
+                    map ??= MemberMapOf(text);
+                    var member = EnclosingMember(map, start);
+
+                    if (member == Unknown || CSharpStatementKeywords.Contains(member))
+                    {
+                        offenders.Add(
+                            $"{Path.GetRelativePath(repo, path).Replace('\\', '/')}:{LineOf(text, start)} "
+                            + $"-> '{member}'");
+                    }
+                }
+            }
+
+            Assert.True(
+                inTree > 0,
+                $"the {tree} tree contributed no T-SQL literal, so nothing here was attributed at all and "
+                + "this assertion is vacuous there.");
+        }
+
+        Assert.True(literals > 0, "the literal walk extracted no T-SQL from the corpus");
+
+        Assert.True(
+            offenders.Count == 0,
+            $"{offenders.Count} of {literals} T-SQL literals are labelled with a C# statement keyword or "
+            + "with nothing, so the offender list this guard prints when it reds would send a reader to the "
+            + "wrong place — or to no place. Either the member is declared in a shape DeclarationHead does "
+            + "not read (an accessor, an attribute argument, or a member with no access modifier — all "
+            + "stated on that field), or the brace walk lost the body, which "
+            + nameof(TheMemberScan_ReadsEveryDeclarationWhole) + " names separately."
+            + Environment.NewLine + string.Join(Environment.NewLine, offenders));
+    }
+
+    /// <summary>
+    /// Statement keywords, which no member can be named. The independent half of the assertion above:
+    /// it agrees with nothing in the resolver, so it cannot pass because the resolver and the check make
+    /// the same mistake. Every one of these was a real label on the tree as it shipped except where noted.
+    /// </summary>
+    private static readonly HashSet<string> CSharpStatementKeywords = new(StringComparer.Ordinal)
+    {
+        "if", "else", "for", "foreach", "while", "do", "switch", "case", "default", "try", "catch",
+        "finally", "using", "lock", "return", "throw", "new", "checked", "unchecked", "fixed", "await",
+        "yield", "break", "continue", "goto", "var", "get", "set", "init", "add", "remove", "when",
+    };
+
+    /// <summary>
+    /// Every member declaration's range is one whole member.
+    ///
+    /// <para><b>Attribution is silent when this fails, which is why it is asserted separately.</b> A
+    /// truncated body stops containing the literals below the cut, and a literal contained by nothing is
+    /// labelled <see cref="Unknown"/> — loud. But an OVER-EXTENDED body keeps containing them, and it
+    /// contains the next member's literals too, so it hands out a name that is confidently wrong and
+    /// nothing above notices. That is the direction that needs its own check.</para>
+    ///
+    /// <para>The two arms are complementary rather than redundant, and both are pinned by
+    /// <see cref="TheMemberScan_IsBoundedByTheNextDeclaration_AndByTheBraceWalkAtTheEndOfTheFile"/>:
+    /// the over-run arm compares the brace walk against a regex offset, so it is independent of the walk
+    /// but structurally blind at the end of the file, where there is no next declaration to run past. The
+    /// unterminated arm is what covers that tail. #3089 measured the same pair on the same kind of
+    /// scan.</para>
+    ///
+    /// <para>The floors are derived, not counted. An exact declaration total would restate the size of the
+    /// tree and go stale on the next commit — the thing this guard's own fixture table is written to
+    /// avoid — so what is required is that every scanned tree contributed members and that the anchor file
+    /// did.</para>
+    /// </summary>
+    [Fact]
+    public void TheMemberScan_ReadsEveryDeclarationWhole()
+    {
+        var repo = RepoRoot();
+        var members = 0;
+        var truncated = new List<string>();
+        var overExtended = new List<string>();
+        var overlapping = new List<string>();
+
+        foreach (var (tree, roots, anchor) in ScannedTrees)
+        {
+            var inTree = 0;
+            var inAnchor = 0;
+            var anchorPath = Path.GetFullPath(
+                Path.Combine(repo, anchor.Replace('/', Path.DirectorySeparatorChar)));
+
+            foreach (var path in SourceFiles(roots))
+            {
+                var map = MemberMapOf(File.ReadAllText(path));
+                var relative = Path.GetRelativePath(repo, path).Replace('\\', '/');
+                var previousEnd = -1;
+                var previousName = string.Empty;
+
+                foreach (var declaration in map.Declarations)
+                {
+                    if (declaration.Kind != DeclarationKind.Member)
+                    {
+                        continue;
+                    }
+
+                    members++;
+                    inTree++;
+
+                    if (string.Equals(path, anchorPath, StringComparison.Ordinal))
+                    {
+                        inAnchor++;
+                    }
+
+                    var where = $"{relative}:{LineOf(map.Code, declaration.Start)} {declaration.Name}";
+
+                    switch (ShapeOf(declaration))
+                    {
+                        case RangeShape.Unterminated:
+                            truncated.Add(where);
+                            continue;
+
+                        case RangeShape.OverExtended:
+                            overExtended.Add(
+                                $"{where} runs to line {LineOf(map.Code, declaration.End - 1)}, past the "
+                                + $"declaration at line {LineOf(map.Code, declaration.NextStart)}");
+                            continue;
+
+                        case RangeShape.WholeMember:
+                        default:
+                            break;
+                    }
+
+                    /* Members do not nest, so two member ranges overlapping means one of them swallowed the
+                       other — the same defect the bound above catches, asked over the ranges rather than
+                       over the declaration offsets, and it stays meaningful for the last member in a file
+                       where the bound has nothing to compare against. */
+                    if (declaration.Start < previousEnd)
+                    {
+                        overlapping.Add($"{where} starts inside {previousName}");
+                    }
+
+                    previousEnd = declaration.End;
+                    previousName = declaration.Name;
+                }
+            }
+
+            Assert.True(inTree > 0, $"no member declaration was read anywhere in the {tree} tree");
+            Assert.True(
+                inAnchor > 0,
+                $"the {tree} tree's anchor file {anchor} contributed no member declaration, so the tree "
+                + "total above is being satisfied by other files.");
+        }
+
+        Assert.True(members > 0, "the declaration sweep read no member at all");
+
+        Assert.True(
+            truncated.Count == 0,
+            "these member bodies opened a brace that never closed, so every T-SQL literal below the "
+            + "opening brace is attributed to no member. Either the source's braces do not balance or the "
+            + "walk stopped understanding a delimiter:"
+            + Environment.NewLine + string.Join(Environment.NewLine, truncated));
+
+        Assert.True(
+            overExtended.Count == 0,
+            "these member bodies were read past the next declaration, so the literals in the members "
+            + "below them are labelled with THIS member's name — a confident wrong answer, which nothing "
+            + "downstream can see:"
+            + Environment.NewLine + string.Join(Environment.NewLine, overExtended));
+
+        Assert.True(
+            overlapping.Count == 0,
+            "these member ranges overlap. Members do not nest, so one range has swallowed another and the "
+            + "literals in the inner one are attributed by whichever starts later:"
+            + Environment.NewLine + string.Join(Environment.NewLine, overlapping));
+    }
+
+    /* ───────────────────────── the resolver, pinned on arranged source ───────────────────────── */
+
+    /// <summary>
+    /// The four shapes that misattributed, arranged so each one sits between the member declaration and
+    /// the literal — and the DIFFERENCE that makes it a control rather than a restatement: the same
+    /// arrangement is asked twice, once for a literal inside the first member and once for a literal
+    /// inside the second, and both answers have to move with the enclosing declaration.
+    ///
+    /// <para>Arranged rather than measured, because the point is the shape and not the file. Each of the
+    /// four is a real site in <see cref="MemberAttributionSites"/>; put together in one body they also
+    /// cover the case no single real site does, which is all four preceding the same literal — the old
+    /// resolver returned whichever was nearest, so which one it named depended on line order rather than
+    /// on scope.</para>
+    /// </summary>
+    [Fact]
+    public void TheResolver_AttributesByScope_NotByTheNearestNameAbove()
+    {
+        const string source = """
+            namespace Probe;
+
+            internal sealed class Subject
+            {
+                private const string Preceding = "SELECT 1 FROM sys.databases;";
+
+                public string First(string database)
+                {
+                    const string sql = "SELECT 2 FROM sys.objects;";
+                    return sql + database;
+                }
+
+                public string Second(string database)
+                {
+                    var builder = new SqlConnectionStringBuilder(database)
+                    {
+                        ConnectTimeout = 10,
+                    };
+
+                    if (builder is null)
+                    {
+                        return "SELECT 3 FROM sys.columns;";
+                    }
+
+                    foreach (var c in database)
+                    {
+                        _ = c;
+                    }
+
+                    const string inner = "SELECT 4 FROM sys.indexes;";
+                    return inner;
+                }
+            }
+            """;
+
+        var map = MemberMapOf(source);
+
+        /* Both members were read, and read as members — a map that resolved neither would satisfy every
+           equality below by returning <unknown> twice, which is not the same answer. */
+        Assert.Equal(
+            new[] { "First", "Preceding", "Second" },
+            map.Declarations.Where(d => d.Kind == DeclarationKind.Member)
+                            .Select(d => d.Name)
+                            .OrderBy(n => n, StringComparer.Ordinal)
+                            .ToArray());
+
+        Assert.Equal(
+            new[] { "Subject" },
+            map.Declarations.Where(d => d.Kind == DeclarationKind.Type).Select(d => d.Name).ToArray());
+
+        /* The member initialiser, which is the shape that already worked. */
+        Assert.Equal("Preceding", EnclosingMember(map, source.IndexOf("SELECT 1", StringComparison.Ordinal)));
+
+        /* A local const string in the SAME member — the LocalDataService shape. The old resolver named
+           the local, sql. */
+        Assert.Equal("First", EnclosingMember(map, source.IndexOf("SELECT 2", StringComparison.Ordinal)));
+
+        /* Inside an if, below a type construction with a brace — the PgPlanFetcher shape. The old
+           resolver named the type, SqlConnectionStringBuilder, then if once the block opened. */
+        Assert.Equal("Second", EnclosingMember(map, source.IndexOf("SELECT 3", StringComparison.Ordinal)));
+
+        /* And below all four of them at once, which no single real site arranges. */
+        Assert.Equal("Second", EnclosingMember(map, source.IndexOf("SELECT 4", StringComparison.Ordinal)));
+
+        /* The difference. Move the same literal text from the second member into the first and the answer
+           has to follow it; an answer driven by the nearest name above would not move, because the names
+           above it are unchanged. */
+        var moved = source.Replace(
+            "const string sql = \"SELECT 2 FROM sys.objects;\";",
+            "const string sql = \"SELECT 4 FROM sys.indexes;\";",
+            StringComparison.Ordinal);
+
+        Assert.NotEqual(source, moved);
+        Assert.Equal(
+            "First",
+            EnclosingMember(MemberMapOf(moved), moved.IndexOf("SELECT 4", StringComparison.Ordinal)));
+    }
+
+    /// <summary>
+    /// The scan reads a body whose literals hold unbalanced braces, and a raw brace count does not.
+    ///
+    /// <para>Arranged rather than measured, because the corpus balances its literal braces today — which
+    /// is precisely the standing assumption worth refusing. Both directions are asserted, so
+    /// <see cref="CSharpSourceWalker"/> is shown to be load-bearing rather than said to be: a <c>}</c> in
+    /// a literal ends a raw count early and truncates the body, so every literal after it is attributed
+    /// to nothing.</para>
+    /// </summary>
+    [Fact]
+    public void TheMemberScan_ReadsABodyWhoseLiteralHoldsABrace_AndARawCountDoesNot()
+    {
+        const string source = """
+            namespace Probe;
+
+            internal sealed class Subject
+            {
+                public string Body()
+                {
+                    var brace = "} SELECT 1 FROM sys.databases;";
+                    return brace + "SELECT 2 FROM sys.objects;";
+                }
+
+                public string After()
+                {
+                    return "SELECT 3 FROM sys.columns;";
+                }
+            }
+            """;
+
+        var offset = source.IndexOf("SELECT 2", StringComparison.Ordinal);
+
+        Assert.Equal("Body", EnclosingMember(MemberMapOf(source), offset));
+
+        /* The same declaration walk over RAW source, which is what every copy of this idiom did before
+           #3052 extracted the walker. The literal's } closes Body early, so the offset lands outside every
+           member range and resolves to nothing at all. */
+        var raw = RawDeclarations(source);
+        var body = raw.Declarations.Single(d => d.Name == "Body");
+
+        Assert.True(
+            offset >= body.End,
+            "the raw brace count no longer truncates Body, so this control is not arranging the thing it "
+            + "claims to. It needs a } inside a string literal in the body, ahead of the offset.");
+
+        Assert.Equal(Unknown, EnclosingMember(raw, offset));
+    }
+
+    /// <summary>
+    /// The two over-run arms fire on different source, so neither is redundant.
+    ///
+    /// <para><see cref="RangeShape.OverExtended"/> is the arm that can disagree with the brace walk,
+    /// because it compares the walk's answer against a regex match offset. It is also structurally blind
+    /// at the END of the file: the last declaration has no successor to run past, so a runaway there
+    /// satisfies it in silence. <see cref="RangeShape.Unterminated"/> is what still covers that tail.
+    /// Asserted on two arrangements rather than argued, and each names the arm the other one misses.</para>
+    /// </summary>
+    [Fact]
+    public void TheMemberScan_IsBoundedByTheNextDeclaration_AndByTheBraceWalkAtTheEndOfTheFile()
+    {
+        /* Mid-file: First's closing brace is missing, so the brace walk closes on Second's and swallows
+           it. The bound sees a declaration start inside the range. */
+        const string midFile = """
+            namespace Probe;
+
+            internal sealed class Subject
+            {
+                public string First()
+                {
+                    return "SELECT 1 FROM sys.databases;";
+
+                public string Second()
+                {
+                    return "SELECT 2 FROM sys.objects;";
+                }
+            }
+            """;
+
+        var mid = MemberMapOf(midFile);
+        var first = mid.Declarations.Single(d => d.Name == "First");
+
+        Assert.Equal(RangeShape.OverExtended, ShapeOf(first));
+        Assert.Equal(RangeShape.WholeMember, ShapeOf(mid.Declarations.Single(d => d.Name == "Second")));
+
+        /* End of file: the LAST member's body never closes. There is no later declaration, so the bound
+           is silent — NextStart is the end of the text and the range cannot exceed it — and only the
+           brace walk's own failure to close can see it. */
+        const string atEndOfFile = """
+            namespace Probe;
+
+            internal sealed class Subject
+            {
+                public string Only()
+                {
+                    return "SELECT 1 FROM sys.databases;";
+            """;
+
+        var tail = MemberMapOf(atEndOfFile);
+        var only = tail.Declarations.Single(d => d.Name == "Only");
+
+        Assert.Equal(RangeShape.Unterminated, ShapeOf(only));
+
+        /* And the bound really is blind here rather than merely quiet: the range end is the sentinel, so
+           the comparison the mid-file case turns on cannot fire. */
+        Assert.True(only.End < 0);
+        Assert.False(only.End > only.NextStart);
+    }
+
+    /// <summary>
+    /// The declaration walk over RAW source, for
+    /// <see cref="TheMemberScan_ReadsABodyWhoseLiteralHoldsABrace_AndARawCountDoesNot"/> only.
+    ///
+    /// <para>It exists so that control can assert the walker is what saves the scan, in both directions,
+    /// with a one-token difference from the shipped path — <see cref="MemberMapOf"/> is this function with
+    /// <see cref="CSharpSourceWalker.StripCommentsAndStrings"/> applied first. Nothing else calls it.</para>
+    /// </summary>
+    private static MemberMap RawDeclarations(string text)
+    {
+        var heads = DeclarationHead.Matches(text);
+        var declarations = new List<DeclaredRange>(heads.Count);
+
+        for (var i = 0; i < heads.Count; i++)
+        {
+            var head = heads[i];
+            var after = head.Index + head.Length;
+            var (name, kind) = DeclaredName(text, after);
+
+            declarations.Add(new DeclaredRange(
+                name,
+                kind,
+                head.Index,
+                DeclarationEnd(text, after),
+                i + 1 < heads.Count ? heads[i + 1].Index : text.Length));
+        }
+
+        return new MemberMap(text, declarations);
+    }
+
     /* ───────────────────────── the checks ───────────────────────── */
 
     private static readonly string[] CoveredRules =
@@ -1585,31 +2163,366 @@ public sealed class TsqlConventionGuardTests
         return bullets;
     }
 
-    /// <summary>The member a literal belongs to, for the failure message: the nearest declaration above
-    /// it.</summary>
-    private static string EnclosingMember(string text, int offset)
+    /* ───────────────────────── which member a literal sits in ───────────────────────── */
+
+    /// <summary>
+    /// The start of a MEMBER declaration at type scope: an access modifier at the beginning of a line,
+    /// followed by any run of the other modifiers.
+    ///
+    /// <para><b>The access modifier is the whole discriminator, and requiring it is what this regex is
+    /// for.</b> Its predecessor took "the nearest name above the literal" from a pattern that also matched
+    /// <c>if (…) {</c>, <c>catch (…) {</c>, <c>new SqlConnectionStringBuilder(…) {</c> and any local
+    /// <c>string x =</c> — so 48 of the corpus's 160 T-SQL literals were labelled with a bare keyword or
+    /// nothing at all, and several more with a local variable or the type being constructed. A local cannot
+    /// carry an access modifier and neither can a statement keyword, so anchoring on one excludes every
+    /// shape that misattributed rather than blacklisting them one at a time.</para>
+    ///
+    /// <para><b>What it therefore cannot see, stated rather than discovered later.</b> A member with no
+    /// access modifier (an <c>enum</c> or <c>interface</c> member, or a field written
+    /// <c>static readonly …</c>) is not a declaration here, and neither is an attribute argument, which
+    /// sits above its own member's declaration line. A literal in one of those resolves to
+    /// <see cref="Unknown"/> — and <see cref="EveryTsqlLiteralInTheCorpus_IsAttributedToADeclaredMember"/>
+    /// reds on it by name. Widening the modifier list to admit a bare <c>const</c> or <c>static</c> would
+    /// re-admit the local-variable case, so the resolution fails toward the worse label instead: an honest
+    /// <c>&lt;unknown&gt;</c> a reader escalates, not a plausible name a reader trusts.</para>
+    ///
+    /// <para><b>The trailing lookahead excludes an ACCESSOR</b>, which is the one place an access modifier
+    /// appears INSIDE another member's body. <c>ArchiveService.IsArchiving</c> is the whole population and
+    /// the reason the exclusion is here rather than in a comment: its <c>private set =&gt; …</c> matched as
+    /// a declaration of its own, which put a declaration start inside the property that holds it and made
+    /// <see cref="TheMemberScan_ReadsEveryDeclarationWhole"/> report the property as over-extended — one
+    /// member out of the 18,205 the sweep reads. An accessor is not a member a literal is attributed to;
+    /// the property is.</para>
+    /// </summary>
+    private static readonly Regex DeclarationHead = new(
+        @"^[ \t]*(?:public|private|protected|internal)\b"
+        + @"(?:[ \t]+(?:public|private|protected|internal|abstract|async|const|event|explicit|extern"
+        + @"|implicit|new|override|partial|readonly|required|sealed|static|unsafe|virtual|volatile))*[ \t]+"
+        + @"(?!(?:get|set|init|add|remove)\b[ \t]*(?:=>|\{|;))",
+        RegexOptions.Multiline | RegexOptions.Compiled);
+
+    /// <summary>What <see cref="EnclosingMember"/> reports when no member declaration contains the
+    /// offset.</summary>
+    private const string Unknown = "<unknown>";
+
+    /// <summary>
+    /// Whether a declaration can hold a literal (a method, property, field, constructor) or only other
+    /// declarations (a <c>class</c>, <c>record</c>, <c>enum</c>, …).
+    ///
+    /// <para>Types are in the declaration list rather than filtered out of it because a member's range is
+    /// bounded by the NEXT declaration of either kind, and a nested type is the next thing after the member
+    /// above it. They are excluded from attribution and from
+    /// <see cref="TheMemberScan_ReadsEveryDeclarationWhole"/>: a type's body legitimately contains every
+    /// declaration below it, which is the exact shape that assertion calls an over-run.</para>
+    /// </summary>
+    private enum DeclarationKind
     {
-        var head = text[..Math.Min(offset, text.Length)];
+        /// <summary>A method, property, field, event or constructor — something a literal can be inside.</summary>
+        Member,
 
-        var matches = Regex.Matches(
-            head,
-            @"(?:const\s+string|static\s+string|string)\s+(?<name>[A-Za-z_][A-Za-z0-9_]*)\s*(?:=|=>)"
-            + @"|(?<name2>[A-Za-z_][A-Za-z0-9_]*)\s*\([^)]*\)\s*(?:=>|\{)");
+        /// <summary>A <c>class</c>, <c>struct</c>, <c>record</c>, <c>interface</c>, <c>enum</c> or
+        /// <c>delegate</c>.</summary>
+        Type,
+    }
 
-        for (var i = matches.Count - 1; i >= 0; i--)
+    /// <summary>
+    /// One declaration as a half-open range over walked source, plus where the NEXT declaration starts.
+    ///
+    /// <para><c>NextStart</c> is carried because it is the one bound on <c>End</c> that does not come from
+    /// the brace walk: it is a regex match offset, so it can DISAGREE with a brace count that ran past the
+    /// method it was reading. #3089 found the same thing about the same shape — a re-check that reads the
+    /// same text and repeats the same walk is a tautology, not a check.</para>
+    ///
+    /// <para><c>End</c> is <c>-1</c> when the brace walk never closed the body.</para>
+    /// </summary>
+    private readonly record struct DeclaredRange(
+        string Name,
+        DeclarationKind Kind,
+        int Start,
+        int End,
+        int NextStart);
+
+    /// <summary>Every declaration in one file, beside the walked source they are offsets into.</summary>
+    private sealed record MemberMap(string Code, IReadOnlyList<DeclaredRange> Declarations);
+
+    /// <summary>
+    /// Every declaration in <paramref name="text"/>, read through <see cref="CSharpSourceWalker"/> so a
+    /// modifier in a comment and a brace in a literal are neither of them code (#2913, #3052). The walk
+    /// preserves every character position, so an offset into the walked text is the same offset into the
+    /// file — which is what lets <see cref="EnclosingMember"/> take the literal offset the scan already has.
+    /// </summary>
+    private static MemberMap MemberMapOf(string text)
+    {
+        var code = CSharpSourceWalker.StripCommentsAndStrings(text);
+        var heads = DeclarationHead.Matches(code);
+        var declarations = new List<DeclaredRange>(heads.Count);
+
+        for (var i = 0; i < heads.Count; i++)
         {
-            var name = matches[i].Groups["name"].Success
-                ? matches[i].Groups["name"].Value
-                : matches[i].Groups["name2"].Value;
+            var head = heads[i];
+            var after = head.Index + head.Length;
+            var (name, kind) = DeclaredName(code, after);
 
-            if (!string.IsNullOrEmpty(name))
+            declarations.Add(new DeclaredRange(
+                name,
+                kind,
+                head.Index,
+                DeclarationEnd(code, after),
+                i + 1 < heads.Count ? heads[i + 1].Index : code.Length));
+        }
+
+        return new MemberMap(code, declarations);
+    }
+
+    /// <summary>
+    /// The declared name and kind, reading forward from just past the modifiers.
+    ///
+    /// <para>Tokenised rather than pattern-matched because the name's position depends on the shape: it is
+    /// the identifier before the parameter list on a method, before <c>=&gt;</c> or <c>{</c> on a property,
+    /// and before <c>=</c> on a field. A single regex for all three has to guess which <c>(</c> it is
+    /// looking at, and <c>ScannedTrees</c> is the counter-example that decides it — a
+    /// <c>(string, string[], string)[]</c> tuple type whose FIRST <c>(</c> is part of the type, so "the
+    /// identifier before the first paren" reads <c>readonly</c>. Here a <c>(</c> only ends the scan when it
+    /// directly follows an identifier, which is what a parameter list does and what a tuple type does
+    /// not.</para>
+    /// </summary>
+    private static (string Name, DeclarationKind Kind) DeclaredName(string code, int from)
+    {
+        var typeKeyword = Regex.Match(
+            code[from..Math.Min(from + 64, code.Length)],
+            @"^(?:(?:record|partial|readonly|ref)[ \t]+)*(?<kw>class|struct|record|interface|enum|delegate)\b[ \t]+(?<name>[A-Za-z_][A-Za-z0-9_]*)");
+
+        if (typeKeyword.Success)
+        {
+            return (typeKeyword.Groups["name"].Value, DeclarationKind.Type);
+        }
+
+        string? last = null;
+        var lastEnd = -1;
+        var paren = 0;
+        var bracket = 0;
+        var angle = 0;
+
+        for (var i = from; i < code.Length; i++)
+        {
+            var c = code[i];
+
+            if (char.IsLetter(c) || c == '_')
             {
-                return name;
+                var j = i;
+
+                while (j < code.Length && (char.IsLetterOrDigit(code[j]) || code[j] == '_'))
+                {
+                    j++;
+                }
+
+                if (paren == 0 && bracket == 0 && angle == 0)
+                {
+                    last = code[i..j];
+                    lastEnd = j;
+                }
+
+                i = j - 1;
+                continue;
+            }
+
+            switch (c)
+            {
+                case '(':
+                    /* A parameter list directly follows the name; a tuple type does not follow one at
+                       all, and a generic method's name is followed by the >  that closed its type
+                       parameters — which is why lastEnd moves onto that > below. */
+                    if (paren == 0 && bracket == 0 && angle == 0 && last is not null
+                        && code.AsSpan(lastEnd, i - lastEnd).IsWhiteSpace())
+                    {
+                        return (last, DeclarationKind.Member);
+                    }
+
+                    paren++;
+                    break;
+
+                case ')':
+                    paren--;
+                    break;
+
+                case '[':
+                    bracket++;
+                    break;
+
+                case ']':
+                    bracket--;
+                    break;
+
+                case '<':
+                    if (paren == 0 && bracket == 0 && angle == 0 && last is not null
+                        && code.AsSpan(lastEnd, i - lastEnd).IsWhiteSpace())
+                    {
+                        angle++;
+                    }
+
+                    break;
+
+                case '>':
+                    if (angle > 0)
+                    {
+                        angle--;
+
+                        if (angle == 0)
+                        {
+                            lastEnd = i + 1;
+                        }
+                    }
+
+                    break;
+
+                case '=':
+                case '{':
+                case ';':
+                    if (paren == 0 && bracket == 0 && angle == 0)
+                    {
+                        return (last ?? Unknown, DeclarationKind.Member);
+                    }
+
+                    break;
+
+                default:
+                    break;
             }
         }
 
-        return "<unknown>";
+        return (last ?? Unknown, DeclarationKind.Member);
     }
+
+    /// <summary>
+    /// One past the declaration's last character: the <c>;</c> that ends a field or an expression-bodied
+    /// member, or the <c>}</c> that closes a braced body. <c>-1</c> when a body opened and never closed.
+    ///
+    /// <para>Deliberately UNBOUNDED — it reads to the end of the file rather than stopping at the next
+    /// declaration, so <see cref="DeclaredRange.NextStart"/> stays an independent bound that a runaway
+    /// count can be caught by. Clamping here would make the two agree by construction.</para>
+    /// </summary>
+    private static int DeclarationEnd(string code, int from)
+    {
+        var paren = 0;
+        var bracket = 0;
+
+        for (var i = from; i < code.Length; i++)
+        {
+            var c = code[i];
+
+            if (c == '(')
+            {
+                paren++;
+            }
+            else if (c == ')')
+            {
+                paren--;
+            }
+            else if (c == '[')
+            {
+                bracket++;
+            }
+            else if (c == ']')
+            {
+                bracket--;
+            }
+            else if (paren != 0 || bracket != 0)
+            {
+                continue;
+            }
+            else if (c == ';')
+            {
+                return i + 1;
+            }
+            else if (c == '{')
+            {
+                var depth = 0;
+
+                for (var j = i; j < code.Length; j++)
+                {
+                    if (code[j] == '{')
+                    {
+                        depth++;
+                    }
+                    else if (code[j] == '}' && --depth == 0)
+                    {
+                        return j + 1;
+                    }
+                }
+
+                return -1;
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// The member a literal belongs to: the innermost member declaration whose range CONTAINS the offset.
+    ///
+    /// <para>Containment is the whole change. The predecessor took the nearest matching name ABOVE the
+    /// offset with no containment test at all, so a name from the member above leaked into the member below
+    /// it and a local variable declared two lines up outranked the method holding both.</para>
+    /// </summary>
+    private static string EnclosingMember(MemberMap map, int offset)
+    {
+        var name = Unknown;
+        var innermost = -1;
+
+        foreach (var declaration in map.Declarations)
+        {
+            if (declaration.Kind != DeclarationKind.Member
+                || declaration.End < 0
+                || offset < declaration.Start
+                || offset >= declaration.End
+                || declaration.Start <= innermost)
+            {
+                continue;
+            }
+
+            name = declaration.Name;
+            innermost = declaration.Start;
+        }
+
+        return name;
+    }
+
+    /// <summary>What the brace walk actually returned for one declaration.</summary>
+    private enum RangeShape
+    {
+        /// <summary>One whole declaration, ending inside its own bounds.</summary>
+        WholeMember,
+
+        /// <summary>A body opened and never closed, so every literal below it is attributed to nothing.</summary>
+        Unterminated,
+
+        /// <summary>The walk ran past the next declaration, so that member's literals are attributed
+        /// here.</summary>
+        OverExtended,
+    }
+
+    /// <summary>
+    /// Which of three shapes a declaration's range is.
+    ///
+    /// <para><b>The two failing shapes are complementary, not redundant.</b>
+    /// <see cref="RangeShape.OverExtended"/> compares the brace walk against a regex offset, so it can
+    /// disagree with the walk — but it is structurally blind at the END of the file, where the last
+    /// declaration has no successor to run past. That tail is what
+    /// <see cref="RangeShape.Unterminated"/> still covers, because a runaway there simply never closes.
+    /// #3089 measured the same pair on the same kind of scan and both arms are pinned here.</para>
+    /// </summary>
+    private static RangeShape ShapeOf(DeclaredRange declaration) =>
+        declaration.End < 0 ? RangeShape.Unterminated
+        : declaration.End > declaration.NextStart ? RangeShape.OverExtended
+        : RangeShape.WholeMember;
+
+    /// <summary>
+    /// The 1-based line <paramref name="offset"/> falls on. Sound over both the file and the walked text:
+    /// <see cref="CSharpSourceWalker.StripCommentsAndStrings"/> preserves every newline and every character
+    /// position.
+    /// </summary>
+    private static int LineOf(string text, int offset) =>
+        text.AsSpan(0, Math.Clamp(offset, 0, text.Length)).Count('\n') + 1;
 
     private static string RepoRoot([CallerFilePath] string thisFile = "")
     {

--- a/Darling/Darling.Tests/TsqlConventionGuardTests.cs
+++ b/Darling/Darling.Tests/TsqlConventionGuardTests.cs
@@ -15,6 +15,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using PerformanceMonitor.Collectors;
 using Xunit;
+using static Darling.Tests.CSharpMemberMap;
 
 namespace Darling.Tests;
 
@@ -293,7 +294,7 @@ public sealed class TsqlConventionGuardTests
 
                     foreach (var (rule, detail) in Findings(body))
                     {
-                        members ??= MemberMapOf(text);
+                        members ??= Of(text);
                         offenders.Add(
                             $"{name}:{LineOf(text, start)} in {EnclosingMember(members, start)} "
                             + $"[{rule}] {detail}");
@@ -1062,7 +1063,7 @@ public sealed class TsqlConventionGuardTests
                 + "not the file.");
 
             var text = File.ReadAllText(path);
-            var map = MemberMapOf(text);
+            var map = Of(text);
 
             /* The offset is DERIVED from the anchor, through the same literal walk the scan uses, so the
                site cannot drift onto a different literal and cannot be pinned to a stale integer. */
@@ -1175,7 +1176,7 @@ public sealed class TsqlConventionGuardTests
 
                     literals++;
                     inTree++;
-                    map ??= MemberMapOf(text);
+                    map ??= Of(text);
                     var member = EnclosingMember(map, start);
 
                     if (member == Unknown || CSharpKeywords.Contains(member))
@@ -1275,7 +1276,7 @@ public sealed class TsqlConventionGuardTests
 
             foreach (var path in SourceFiles(roots))
             {
-                var map = MemberMapOf(File.ReadAllText(path));
+                var map = Of(File.ReadAllText(path));
                 var relative = Path.GetRelativePath(repo, path).Replace('\\', '/');
                 var previousEnd = -1;
                 var previousName = string.Empty;
@@ -1424,7 +1425,7 @@ public sealed class TsqlConventionGuardTests
             }
             """;
 
-        var map = MemberMapOf(source);
+        var map = Of(source);
 
         /* Both members were read, and read as members — a map that resolved neither would satisfy every
            equality below by returning <unknown> twice, which is not the same answer. */
@@ -1484,7 +1485,7 @@ public sealed class TsqlConventionGuardTests
         Assert.NotEqual(source, moved);
         Assert.Equal(
             "First",
-            EnclosingMember(MemberMapOf(moved), moved.IndexOf("SELECT 4", StringComparison.Ordinal)));
+            EnclosingMember(Of(moved), moved.IndexOf("SELECT 4", StringComparison.Ordinal)));
     }
 
     /// <summary>
@@ -1519,12 +1520,12 @@ public sealed class TsqlConventionGuardTests
 
         var offset = source.IndexOf("SELECT 2", StringComparison.Ordinal);
 
-        Assert.Equal("Body", EnclosingMember(MemberMapOf(source), offset));
+        Assert.Equal("Body", EnclosingMember(Of(source), offset));
 
         /* The same declaration walk over RAW source, which is what every copy of this idiom did before
            #3052 extracted the walker. The literal's } closes Body early, so the offset lands outside every
            member range and resolves to nothing at all. */
-        var raw = RawDeclarations(source);
+        var raw = OfRawSourceForControlTestsOnly(source);
         var body = raw.Declarations.Single(d => d.Name == "Body");
 
         Assert.True(
@@ -1565,7 +1566,7 @@ public sealed class TsqlConventionGuardTests
             }
             """;
 
-        var mid = MemberMapOf(midFile);
+        var mid = Of(midFile);
         var first = mid.Declarations.Single(d => d.Name == "First");
 
         Assert.Equal(RangeShape.OverExtended, ShapeOf(first));
@@ -1584,7 +1585,7 @@ public sealed class TsqlConventionGuardTests
                     return "SELECT 1 FROM sys.databases;";
             """;
 
-        var tail = MemberMapOf(atEndOfFile);
+        var tail = Of(atEndOfFile);
         var only = tail.Declarations.Single(d => d.Name == "Only");
 
         Assert.Equal(RangeShape.Unterminated, ShapeOf(only));
@@ -1593,36 +1594,6 @@ public sealed class TsqlConventionGuardTests
            the comparison the mid-file case turns on cannot fire. */
         Assert.True(only.End < 0);
         Assert.False(only.End > only.NextStart);
-    }
-
-    /// <summary>
-    /// The declaration walk over RAW source, for
-    /// <see cref="TheMemberScan_ReadsABodyWhoseLiteralHoldsABrace_AndARawCountDoesNot"/> only.
-    ///
-    /// <para>It exists so that control can assert the walker is what saves the scan, in both directions,
-    /// with a one-token difference from the shipped path — <see cref="MemberMapOf"/> is this function with
-    /// <see cref="CSharpSourceWalker.StripCommentsAndStrings"/> applied first. Nothing else calls it.</para>
-    /// </summary>
-    private static MemberMap RawDeclarations(string text)
-    {
-        var heads = DeclarationHead.Matches(text);
-        var declarations = new List<DeclaredRange>(heads.Count);
-
-        for (var i = 0; i < heads.Count; i++)
-        {
-            var head = heads[i];
-            var after = head.Index + head.Length;
-            var (name, kind) = DeclaredName(text, after);
-
-            declarations.Add(new DeclaredRange(
-                name,
-                kind,
-                head.Index,
-                DeclarationEnd(text, after),
-                i + 1 < heads.Count ? heads[i + 1].Index : text.Length));
-        }
-
-        return new MemberMap(text, declarations);
     }
 
     /* ───────────────────────── the checks ───────────────────────── */
@@ -2247,447 +2218,6 @@ public sealed class TsqlConventionGuardTests
 
         return bullets;
     }
-
-    /* ───────────────────────── which member a literal sits in ───────────────────────── */
-
-    /// <summary>
-    /// The start of a MEMBER declaration at type scope: an access modifier at the beginning of a line,
-    /// followed by any run of the other modifiers.
-    ///
-    /// <para><b>The access modifier is the whole discriminator, and requiring it is what this regex is
-    /// for.</b> Its predecessor took "the nearest name above the literal" from a pattern that also matched
-    /// <c>if (…) {</c>, <c>catch (…) {</c>, <c>new SqlConnectionStringBuilder(…) {</c> and any local
-    /// <c>string x =</c>. Measured on the tree it shipped against (#3094), 48 of the corpus's 160 T-SQL
-    /// literals were labelled with a bare keyword or nothing at all, and several more with a local
-    /// variable or the type being constructed — a figure about a resolver that no longer exists, which is
-    /// why it is the one number written down here. A local cannot
-    /// carry an access modifier and neither can a statement keyword, so anchoring on one excludes every
-    /// shape that misattributed rather than blacklisting them one at a time.</para>
-    ///
-    /// <para><b>What it therefore cannot see, stated rather than discovered later.</b> A member with no
-    /// access modifier (an <c>enum</c> or <c>interface</c> member, or a field written
-    /// <c>static readonly …</c>) is not a declaration here, and neither is an attribute argument, which
-    /// sits above its own member's declaration line. A literal in one of those resolves to
-    /// <see cref="Unknown"/> — and <see cref="EveryTsqlLiteralInTheCorpus_IsAttributedToADeclaredMember"/>
-    /// reds on it by name. Widening the modifier list to admit a bare <c>const</c> or <c>static</c> would
-    /// re-admit the local-variable case, so the resolution fails toward the worse label instead: an honest
-    /// <c>&lt;unknown&gt;</c> a reader escalates, not a plausible name a reader trusts.</para>
-    ///
-    /// <para><b>That widening is guarded by this comment and by five fixture rows, and by nothing else.</b>
-    /// A re-admitted local produces an identifier-shaped label, and
-    /// <see cref="EveryTsqlLiteralInTheCorpus_IsAttributedToADeclaredMember"/> can only see a label that
-    /// is a keyword or nothing — so it would report a clean run across the rest of the corpus. Its doc
-    /// comment states the same bound from the other side; if you are here to widen the list, read
-    /// it.</para>
-    ///
-    /// <para><b>The trailing lookahead excludes an ACCESSOR</b>, which is the one place an access modifier
-    /// appears INSIDE another member's body. <c>ArchiveService.IsArchiving</c> is the whole population and
-    /// the reason the exclusion is here rather than in a comment: its <c>private set =&gt; …</c> matched as
-    /// a declaration of its own, which put a declaration start inside the property that holds it and made
-    /// <see cref="TheMemberScan_ReadsEveryDeclarationWhole"/> report the property as over-extended. It is
-    /// the only accessor in the scanned trees carrying an access modifier — which is why the exclusion is
-    /// here rather than in a note saying it might one day be needed, and why no count of them is written
-    /// down: that number changes on any commit and nothing would hold it true. An accessor is not a member
-    /// a literal is attributed to; the property is.</para>
-    /// </summary>
-    private static readonly Regex DeclarationHead = new(
-        @"^[ \t]*(?:public|private|protected|internal)\b"
-        + @"(?:[ \t]+(?:public|private|protected|internal|abstract|async|const|event|explicit|extern"
-        + @"|implicit|new|override|partial|readonly|required|sealed|static|unsafe|virtual|volatile))*[ \t]+"
-        + @"(?!(?:get|set|init|add|remove)\b[ \t]*(?:=>|\{|;))",
-        RegexOptions.Multiline | RegexOptions.Compiled);
-
-    /// <summary>What <see cref="EnclosingMember"/> reports when no member declaration contains the
-    /// offset.</summary>
-    private const string Unknown = "<unknown>";
-
-    /// <summary>
-    /// Whether a declaration can hold a literal (a method, property, field, constructor) or only other
-    /// declarations (a <c>class</c>, <c>record</c>, <c>enum</c>, …).
-    ///
-    /// <para>Types are in the declaration list rather than filtered out of it because a member's range is
-    /// bounded by the NEXT declaration of either kind, and a nested type is the next thing after the member
-    /// above it. They are excluded from attribution and from
-    /// <see cref="TheMemberScan_ReadsEveryDeclarationWhole"/>: a type's body legitimately contains every
-    /// declaration below it, which is the exact shape that assertion calls an over-run.</para>
-    /// </summary>
-    private enum DeclarationKind
-    {
-        /// <summary>A method, property, field, event or constructor — something a literal can be inside.</summary>
-        Member,
-
-        /// <summary>A <c>class</c>, <c>struct</c>, <c>record</c>, <c>interface</c>, <c>enum</c> or
-        /// <c>delegate</c>.</summary>
-        Type,
-    }
-
-    /// <summary>
-    /// One declaration as a half-open range over walked source, plus where the NEXT declaration starts.
-    ///
-    /// <para><c>NextStart</c> is carried because it is the one bound on <c>End</c> that does not come from
-    /// the brace walk: it is a regex match offset, so it can DISAGREE with a brace count that ran past the
-    /// method it was reading. #3089 found the same thing about the same shape — a re-check that reads the
-    /// same text and repeats the same walk is a tautology, not a check.</para>
-    ///
-    /// <para><c>End</c> is <c>-1</c> when the brace walk never closed the body.</para>
-    /// </summary>
-    private readonly record struct DeclaredRange(
-        string Name,
-        DeclarationKind Kind,
-        int Start,
-        int End,
-        int NextStart);
-
-    /// <summary>Every declaration in one file, beside the walked source they are offsets into.</summary>
-    private sealed record MemberMap(string Code, IReadOnlyList<DeclaredRange> Declarations);
-
-    /// <summary>
-    /// Every declaration in <paramref name="text"/>, read through <see cref="CSharpSourceWalker"/> so a
-    /// modifier in a comment and a brace in a literal are neither of them code (#2913, #3052). The walk
-    /// preserves every character position, so an offset into the walked text is the same offset into the
-    /// file — which is what lets <see cref="EnclosingMember"/> take the literal offset the scan already has.
-    /// </summary>
-    private static MemberMap MemberMapOf(string text)
-    {
-        var code = CSharpSourceWalker.StripCommentsAndStrings(text);
-        var heads = DeclarationHead.Matches(code);
-        var declarations = new List<DeclaredRange>(heads.Count);
-
-        for (var i = 0; i < heads.Count; i++)
-        {
-            var head = heads[i];
-            var after = head.Index + head.Length;
-            var (name, kind) = DeclaredName(code, after);
-
-            declarations.Add(new DeclaredRange(
-                name,
-                kind,
-                head.Index,
-                DeclarationEnd(code, after),
-                i + 1 < heads.Count ? heads[i + 1].Index : code.Length));
-        }
-
-        return new MemberMap(code, declarations);
-    }
-
-    /// <summary>
-    /// The declared name and kind, reading forward from just past the modifiers.
-    ///
-    /// <para>Tokenised rather than pattern-matched because the name's position depends on the shape: it is
-    /// the identifier before the parameter list on a method, before <c>=&gt;</c> or <c>{</c> on a property,
-    /// and before <c>=</c> on a field. A single regex for all three has to guess which <c>(</c> it is
-    /// looking at, and <c>ScannedTrees</c> is the counter-example that decides it — a
-    /// <c>(string, string[], string)[]</c> tuple type whose FIRST <c>(</c> is part of the type, so "the
-    /// identifier before the first paren" reads <c>readonly</c>. The scan tells them apart by position
-    /// rather than by shape: a type's parentheses come before any identifier has been read, a parameter
-    /// list's come after one.</para>
-    ///
-    /// <para><b>Every branch here is load-bearing, which took measuring rather than reasoning.</b> An
-    /// earlier draft also required the <c>(</c> to follow the name with only whitespace between, and moved
-    /// the name's end onto the <c>&gt;</c> that closed a generic argument list so that a generic method
-    /// would still qualify. Both were removed after dumping EVERY declaration in the scanned trees with
-    /// and without them and diffing: identical, every name, every file. They were a pair that only existed
-    /// to cancel each other out — and because each masked the other's removal, testing them one at a time
-    /// reported both as benign. No mutation of either could red a test, which is the tell.</para>
-    /// </summary>
-    private static (string Name, DeclarationKind Kind) DeclaredName(string code, int from)
-    {
-        var typeKeyword = Regex.Match(
-            code[from..Math.Min(from + 64, code.Length)],
-            @"^(?:(?:record|partial|readonly|ref)[ \t]+)*(?<kw>class|struct|record|interface|enum|delegate)\b[ \t]+(?<name>[A-Za-z_][A-Za-z0-9_]*)");
-
-        if (typeKeyword.Success)
-        {
-            return (typeKeyword.Groups["name"].Value, DeclarationKind.Type);
-        }
-
-        string? last = null;
-        var paren = 0;
-        var bracket = 0;
-        var angle = 0;
-
-        for (var i = from; i < code.Length; i++)
-        {
-            var c = code[i];
-
-            if (char.IsLetter(c) || c == '_')
-            {
-                var j = i;
-
-                while (j < code.Length && (char.IsLetterOrDigit(code[j]) || code[j] == '_'))
-                {
-                    j++;
-                }
-
-                if (paren == 0 && bracket == 0 && angle == 0)
-                {
-                    last = code[i..j];
-                }
-
-                i = j - 1;
-                continue;
-            }
-
-            switch (c)
-            {
-                case '(':
-                    /* A parameter list ends the name; a TYPE's parentheses do not, and the difference is
-                       that a type's come before any identifier has been read. That is the whole reason
-                       this is a scan and not a regex — ScannedTrees and DefinitionsWithoutSql in this file
-                       are (string, string[], string)[] tuples whose first ( belongs to the type, so
-                       "the identifier before the first paren" answers readonly.
-
-                       It has to return here rather than fall through to = / { / ; : a generic member's
-                       constraint clause sits between the parameter list and the body, and where T : class
-                       is three more depth-zero identifiers. Constrained in
-                       TheResolver_AttributesByScope_NotByTheNearestNameAbove is the pin. */
-                    if (paren == 0 && bracket == 0 && angle == 0 && last is not null)
-                    {
-                        return (last, DeclarationKind.Member);
-                    }
-
-                    paren++;
-                    break;
-
-                case ')':
-                    paren--;
-                    break;
-
-                case '[':
-                    bracket++;
-                    break;
-
-                case ']':
-                    bracket--;
-                    break;
-
-                /* Type arguments, tracked so a ( or a ; inside one cannot end the name — Func<(int, int)>
-                   is the shape, and TheResolver_AttributesByScope_NotByTheNearestNameAbove reds without
-                   this on the plainer Dictionary<,> form. Only opened directly after an identifier, so a
-                   comparison operator in an initialiser cannot open one; a stray > cannot drive the depth
-                   negative and strand every check below it. */
-                case '<':
-                    if (paren == 0 && bracket == 0 && angle == 0 && last is not null)
-                    {
-                        angle++;
-                    }
-
-                    break;
-
-                case '>':
-                    if (angle > 0)
-                    {
-                        angle--;
-                    }
-
-                    break;
-
-                case '=':
-                case '{':
-                case ';':
-                    if (paren == 0 && bracket == 0 && angle == 0)
-                    {
-                        return (last ?? Unknown, DeclarationKind.Member);
-                    }
-
-                    break;
-
-                default:
-                    break;
-            }
-        }
-
-        return (last ?? Unknown, DeclarationKind.Member);
-    }
-
-    /// <summary>
-    /// One past the declaration's last character: the <c>;</c> that ends a field or an expression-bodied
-    /// member, or the <c>}</c> that closes a braced body. <c>-1</c> when a body opened and never closed.
-    ///
-    /// <para>Deliberately UNBOUNDED — it reads to the end of the file rather than stopping at the next
-    /// declaration, so <see cref="DeclaredRange.NextStart"/> stays an independent bound that a runaway
-    /// count can be caught by. Clamping here would make the two agree by construction.</para>
-    ///
-    /// <para><b>A braced group does not always end the declaration.</b> An accessor list can be followed
-    /// by <c>= initialiser;</c>, and on an auto-property that initialiser is where a literal lives. This
-    /// is the one truncation <see cref="ShapeOf"/> is structurally unable to report — a range that stops
-    /// short of its own member is still closed and still well under
-    /// <see cref="DeclaredRange.NextStart"/>, so it reads as
-    /// <see cref="RangeShape.WholeMember"/> — which is why it is handled here rather than described as a
-    /// bound. <c>Auto</c> in <see cref="TheResolver_AttributesByScope_NotByTheNearestNameAbove"/> is the
-    /// pin; found in review of #3097, where it resolved to <see cref="Unknown"/> in silence.</para>
-    /// </summary>
-    private static int DeclarationEnd(string code, int from)
-    {
-        var paren = 0;
-        var bracket = 0;
-
-        for (var i = from; i < code.Length; i++)
-        {
-            var c = code[i];
-
-            if (c == '(')
-            {
-                paren++;
-            }
-            else if (c == ')')
-            {
-                paren--;
-            }
-            else if (c == '[')
-            {
-                bracket++;
-            }
-            else if (c == ']')
-            {
-                bracket--;
-            }
-            else if (paren != 0 || bracket != 0)
-            {
-                continue;
-            }
-            else if (c == ';')
-            {
-                return i + 1;
-            }
-            else if (c == '{')
-            {
-                var close = BraceGroupEnd(code, i);
-
-                if (close < 0)
-                {
-                    return -1;
-                }
-
-                /* An accessor list can be followed by "= initialiser;", and on an auto-property that
-                   initialiser is exactly where a literal lives:
-
-                       public string QueryText { get; set; } = "SELECT …";
-
-                   Returning at the accessor list's closing brace ends the range BEFORE the literal, so
-                   the literal is contained by nothing and labelled <unknown> — and neither arm of
-                   ShapeOf can see it, because a range that stops short of its own member is still well
-                   under NextStart and still closed. That is a truncation with no detector, which is the
-                   one shape this scan must not produce.
-
-                   An '=' is the only thing that can legally follow the brace inside the same
-                   declaration; anything else there belongs to the next one, so the brace ends this
-                   range. */
-                var after = close;
-
-                while (after < code.Length && char.IsWhiteSpace(code[after]))
-                {
-                    after++;
-                }
-
-                if (after < code.Length && code[after] == '=')
-                {
-                    i = after;
-                    continue;
-                }
-
-                return close;
-            }
-        }
-
-        return -1;
-    }
-
-    /// <summary>One past the <c>}</c> that closes the brace group opening at <paramref name="open"/>, or
-    /// <c>-1</c> if it never closes.</summary>
-    private static int BraceGroupEnd(string code, int open)
-    {
-        var depth = 0;
-
-        for (var j = open; j < code.Length; j++)
-        {
-            if (code[j] == '{')
-            {
-                depth++;
-            }
-            else if (code[j] == '}' && --depth == 0)
-            {
-                return j + 1;
-            }
-        }
-
-        return -1;
-    }
-
-    /// <summary>
-    /// The member a literal belongs to: the innermost member declaration whose range CONTAINS the offset.
-    ///
-    /// <para><b>Containment is not what fixed the measured sites, and saying so precisely matters.</b> The
-    /// predecessor had no containment test at all — whatever matched last before the offset won, inside the
-    /// literal's member or not — but what actually produced the 48 wrong labels was the pattern it matched
-    /// WITH, and <see cref="DeclarationHead"/> is where that is fixed. Measured over the corpus: asking for
-    /// the innermost CONTAINING member and asking for the nearest member declaration ABOVE the offset give
-    /// the same answer at all 160 T-SQL sites. So containment is hardening, for the one direction the
-    /// declaration regex cannot cover — a literal that is inside no member at all (an attribute argument,
-    /// or anything below a body the brace walk lost) resolves to <see cref="Unknown"/> here instead of
-    /// borrowing the name of whichever member happens to sit above it. It is pinned by
-    /// <see cref="TheMemberScan_ReadsABodyWhoseLiteralHoldsABrace_AndARawCountDoesNot"/>, which is an
-    /// arranged case rather than a site on the tree, and that is the honest status of it.</para>
-    /// </summary>
-    private static string EnclosingMember(MemberMap map, int offset)
-    {
-        var name = Unknown;
-        var innermost = -1;
-
-        foreach (var declaration in map.Declarations)
-        {
-            if (declaration.Kind != DeclarationKind.Member
-                || declaration.End < 0
-                || offset < declaration.Start
-                || offset >= declaration.End
-                || declaration.Start <= innermost)
-            {
-                continue;
-            }
-
-            name = declaration.Name;
-            innermost = declaration.Start;
-        }
-
-        return name;
-    }
-
-    /// <summary>What the brace walk actually returned for one declaration.</summary>
-    private enum RangeShape
-    {
-        /// <summary>One whole declaration, ending inside its own bounds.</summary>
-        WholeMember,
-
-        /// <summary>A body opened and never closed, so every literal below it is attributed to nothing.</summary>
-        Unterminated,
-
-        /// <summary>The walk ran past the next declaration, so that member's literals are attributed
-        /// here.</summary>
-        OverExtended,
-    }
-
-    /// <summary>
-    /// Which of three shapes a declaration's range is.
-    ///
-    /// <para><b>The two failing shapes are complementary, not redundant.</b>
-    /// <see cref="RangeShape.OverExtended"/> compares the brace walk against a regex offset, so it can
-    /// disagree with the walk — but it is structurally blind at the END of the file, where the last
-    /// declaration has no successor to run past. That tail is what
-    /// <see cref="RangeShape.Unterminated"/> still covers, because a runaway there simply never closes.
-    /// #3089 measured the same pair on the same kind of scan and both arms are pinned here.</para>
-    /// </summary>
-    private static RangeShape ShapeOf(DeclaredRange declaration) =>
-        declaration.End < 0 ? RangeShape.Unterminated
-        : declaration.End > declaration.NextStart ? RangeShape.OverExtended
-        : RangeShape.WholeMember;
-
-    /// <summary>
-    /// The 1-based line <paramref name="offset"/> falls on. Sound over both the file and the walked text:
-    /// <see cref="CSharpSourceWalker.StripCommentsAndStrings"/> preserves every newline and every character
-    /// position.
-    /// </summary>
-    private static int LineOf(string text, int offset) =>
-        text.AsSpan(0, Math.Clamp(offset, 0, text.Length)).Count('\n') + 1;
 
     private static string RepoRoot([CallerFilePath] string thisFile = "")
     {

--- a/Darling/Darling.Tests/TsqlConventionGuardTests.cs
+++ b/Darling/Darling.Tests/TsqlConventionGuardTests.cs
@@ -1041,7 +1041,7 @@ public sealed class TsqlConventionGuardTests
     public void TheOffenderLabel_NamesTheMemberAtEverySiteInTheFixtureTable()
     {
         var repo = RepoRoot();
-        var checked_ = 0;
+        var exercised = 0;
 
         foreach (var site in MemberAttributionSites)
         {
@@ -1084,21 +1084,28 @@ public sealed class TsqlConventionGuardTests
 
             Assert.Equal(site.Member, EnclosingMember(map, start));
 
-            /* The line is the half of the label that cannot be wrong — it is a newline count over
-               character-aligned text — so it is what a reader still has when attribution fails. Pinned
-               here as being inside the resolved member rather than as a number, for the same reason the
-               offset is not pinned. */
+                /* The line half of the label, cross-checked by a DIFFERENT derivation: LineOf counts
+               newlines in a span, this reads the file as lines and finds the anchor's own line. The
+               literal starts at or above its anchor, so the reported line must not be past it. Asserting
+               instead that the line falls inside the resolved member's range would be a tautology —
+               the member was selected by containing this very offset and LineOf is monotonic in it, so
+               the comparison could not disagree with what it validates (#3089's finding about the same
+               shape). */
             var line = LineOf(text, start);
-            var member = map.Declarations.Single(
-                d => d.Kind == DeclarationKind.Member && d.Name == site.Member
-                     && start >= d.Start && start < d.End);
+            var anchorLine = Array.FindIndex(
+                File.ReadAllLines(path),
+                l => l.Contains(site.Anchor, StringComparison.Ordinal)) + 1;
 
-            Assert.InRange(line, LineOf(text, member.Start), LineOf(text, member.End - 1));
+            Assert.True(
+                anchorLine > 0 && line <= anchorLine,
+                $"the label for {site.File} reports line {line}, but the anchor is on line {anchorLine} "
+                + "of the file as read by lines. The reported line is what a reader opens the file at, so "
+                + "it must not point past the literal it labels.");
 
-            checked_++;
+            exercised++;
         }
 
-        Assert.Equal(MemberAttributionSites.Length, checked_);
+        Assert.Equal(MemberAttributionSites.Length, exercised);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #3094.

`EnclosingMember` built the member half of every offender string from a regex whose second alternative asked for an identifier, a parenthesised anything and an opening brace, with no containment test anywhere. **48 of the 160 T-SQL literals the scan reads were labelled with a bare C# keyword or with nothing at all** — 29 `if`, 11 `catch`, 7 `foreach`, 1 `<unknown>` — plus 3 with a type being constructed and 7 with a local variable.

**Detection is unchanged**: the same literals are read, the same rules fire, the offender count is identical. The offender list is the guard's whole output at the moment it reds, and it was sending readers to a type name, a local variable, or the word `if`.

## What replaces it

Member ranges are derived from **declaration-head match offsets over walked source** (`CSharpSourceWalker.StripCommentsAndStrings`, #2913/#3052 — not a hand-rolled mask), each carrying the **next declaration's start** as a bound that does not come from the brace walk. A literal is attributed to the innermost member whose range contains it.

The **access modifier at the start of a line is the whole discriminator**, and it is what excludes every shape that misattributed rather than blacklisting them one at a time: a statement keyword cannot carry one and neither can a local variable. What it therefore cannot read is stated on the field rather than discovered later — an accessor, an attribute argument, a member with no access modifier — and each of those resolves to `<unknown>`, which `EveryTsqlLiteralInTheCorpus_IsAttributedToADeclaredMember` reds on by name. Widening the modifier list to admit a bare `const` or `static` would re-admit the local-variable case, so the resolution **fails toward the worse label**: an honest `<unknown>` a reader escalates, not a plausible name a reader trusts.

The offender line now also carries the line number, which is the half of the label that cannot be wrong — a newline count over character-aligned text — so a reader still lands on the literal if attribution ever fails. It is cross-checked by a **second derivation**: `LineOf` counts newlines in a span, the pin reads the file as lines and finds the anchor's own line, and requires the reported line not to be past it. Asserting instead that the line falls inside the resolved member's range — which the first draft did — is a tautology: the member is selected by containing that exact offset and `LineOf` is monotonic in it, so the comparison cannot disagree with what it validates. #3089 named this shape on the same kind of scan, and it was worth catching in review of my own diff rather than in review of the PR.

## The fixture table

Located by a **distinctive anchor substring**, never an offset. All five are live source that changes most weeks; a pinned integer would red for a reason unrelated to attribution, and the next reader would repair it by updating the number — which silently retargets the pin at whatever literal now sits there. The anchor is content, so it travels with the literal, and the test requires it to match **exactly one** literal in the file and to still be in the population.

Each row also carries what the predecessor said and whether that was right, and the table **asserts its own rows against that**: a row claiming to fix a misattribution whose expectation equals the old answer pins nothing, and a row claiming the old answer was right while expecting a different one is a contradiction. Both directions.

| file | reported | now reports | why it went wrong |
|---|---|---|---|
| `Darling/PerformanceMonitor.Darling.Analysis/PgPlanFetcher.cs:184` | `SqlConnectionStringBuilder` | `FetchPlanBySqlHandleAsync` | a **type being constructed** — `new SqlConnectionStringBuilder(connectionString) {`. The label named something that is not a member of the file at all |
| `Lite/Services/LocalDataService.FinOps.Recommendations.cs:34` | `sql` | `GetAgReplicaRoleAsync` | a **local**, right for the wrong reason: the literal initialises `const string sql`. Wrong as soon as a method holds two queries, which three other sites in this same file are |
| `Lite/Services/LocalDataService.QueryStore.cs:845` | `if` | `FetchQueryStorePlanAsync` | a bare **keyword**, from `if (quotedDbName == null) {` |
| `PerformanceMonitor.Collectors/IndexObjectStatsCollector.cs:127` | `optimizeForSequentialKey` | `BuildPerDatabaseStatsBody` | a **local** holding a column expression — the label named a fragment of the query rather than the method that builds it, which is the one that reads most like a real answer |
| `PerformanceMonitor.Collectors/ServerPropertiesCollector.cs:60` | `QueryText` | `QueryText` | **already correct**, carried so the rewrite cannot be shown to work by breaking the shape that worked |

Two corrections to the brief this was worked from, both measured rather than argued. `IndexObjectStatsCollector`'s `optimizeForSequentialKey` is a local in the **same** member, not a name from a different one — the resolver's own reproduction of the shipped string is what settles it. And `IndexObjectStatsCollector.cs:437` reports `if` as well (`BuildEnumerationQuery`), while `.FinOps.Recommendations.cs` reports `if` at two more sites and `catch` at two others, all five of them `GetRecommendationsAsync` — so the file-level picture is worse than any single row: seven T-SQL literals, four labelled with a keyword.

## What turns five rows into the population

`EveryTsqlLiteralInTheCorpus_IsAttributedToADeclaredMember` asks the same question of all 160 sites. A per-site table can never say what that says, because the sites it does not name are exactly where the next one will be — and on the tree as it shipped this is the assertion that carried the finding.

Its keyword arm is **the check that shares no code with the resolver**: `if`, `catch` and `foreach` are not member names in any C# program, so a label that is one is wrong without anything having to agree about how members are found. A second derivation of "what are this file's members" would have been free to make the same mistake. It refuses the **whole reserved set** rather than the statement keywords actually observed, because a resolver returning a modifier or a built-in type name is the same defect one token over — and `readonly` is the measured instance, not a hypothetical: dropping the tuple-type test makes a tuple-typed field resolve to it, and a list of statement keywords would have let that through.

**What these two arms bracket is keyword-or-nothing, not wrong-or-nothing, and that is the stated limitation of this assertion.** A label that is a plausible user-defined identifier but not the enclosing member passes both arms in silence — and that is the majority shape here, not an edge case: of the four misattributions the fixture table was built from, **only `if` was a keyword.** `SqlConnectionStringBuilder` (a BCL type), `optimizeForSequentialKey` and `sql` (locals) are all identifier-shaped, so **three of the four are shapes the corpus test cannot see.** They are pinned by exact comparison at five sites and nowhere else; a regression to that shape anywhere in the other ~155 sites is caught only if it happens to land on one of the five.

The consequence worth naming, because it turns a comment into the only guard: **widening `DeclarationHead`'s modifier list is fixture-guarded only.** That field's own note explains that admitting a bare `const` or `static` would re-admit the local-variable case — and a re-admitted local produces an identifier-shaped label, which is exactly what the corpus assertion is blind to. Both doc comments now state that bound and cross-reference each other, so someone arriving to widen the list reads it from either side.

**No detector was added for the gap, deliberately.** The available one — assert the label appears among `map.Declarations`' names — cannot fail: `EnclosingMember` returns `DeclaredRange.Name` taken from that very map, so the check and the thing it validates are the same value read twice. That is #3089's tautology one artifact over, and a pin that cannot fail is worse than a limitation that is written down, because it converts the gap into false confidence. Closing it for real needs a second independent derivation of "which member is this offset in", which is a larger change than the message this PR fixes.

This paragraph is the amendment the review gate asked for, and it was a fair catch: the first draft asserted completeness the test does not have, in a file whose entire subject is labels that read as more trustworthy than they are. Measuring it moved the figure the wrong way — the report said two of four, and it is three.

`TheMemberScan_ReadsEveryDeclarationWhole` covers the direction attribution is silent about. A **truncated** body stops containing the literals below the cut, so they resolve to `<unknown>` and are loud; an **over-extended** one keeps containing them *and* the next member's, so it hands out a confident wrong answer that nothing downstream can see. Its floors are derived per tree and per anchor file, not counted — an exact declaration total would restate the size of the tree and go stale on the next commit, which is the thing the fixture table's anchors exist to avoid.

## Red-proof, per case

`Darling.Tests` is `net10.0-windows` with `UseWPF` and cannot run on macOS, so the real `TsqlConventionGuardTests.cs` and `CSharpSourceWalker.cs` were compiled into a throwaway `net10.0` xunit v3 host named `Darling.Tests`, staged in the **gitignored project `bin/`** — inside the repo, because `RepoRoot()` and `SourceFiles()` are `[CallerFilePath]`-anchored and a stage outside the tree cannot find `PerformanceMonitor.sln`. `Darling/Darling.Tests/` is excluded from the sweep's own glob, so the staged copies are not scanned. Every variant is a fresh staged copy; the worktree was never mutated, so no restore step could destroy anything. The `.csproj` is passed to `dotnet build` explicitly, `Build succeeded` is asserted separately from running, and a run producing no `TEST EXECUTION SUMMARY` is discarded rather than counted.

**Each fixture row is red-proofed on its own**, by reverting the helper to the pre-fix regex *and* trimming the table to that one row — so the row is shown to fail for its own reason rather than behind whichever row happens to be evaluated first:

| row, under revert | Expected | Actual |
|---|---|---|
| `PgPlanFetcher.cs` | `FetchPlanBySqlHandleAsync` | `SqlConnectionStringBuilder` |
| `LocalDataService.FinOps.Recommendations.cs` | `GetAgReplicaRoleAsync` | `sql` |
| `LocalDataService.QueryStore.cs` | `FetchQueryStorePlanAsync` | `if` |
| `IndexObjectStatsCollector.cs` | `BuildPerDatabaseStatsBody` | `optimizeForSequentialKey` |
| **`ServerPropertiesCollector.cs`** | **`QueryText`** | **green — `TheOffenderLabel_…` is absent from the FAIL list, `Failed: 4` where every other row gives 5** |

**That last line is the non-regression evidence, from both sides.** The row passes on the fixed code, and it passes under revert as well, so the site the predecessor already got right is untouched — and it is the only one of the five for which that is true.

The whole-file variants, each naming exactly the assertion it should:

| Variant | Reds | What it says |
|---|---|---|
| **(a)** the pre-fix helper restored (raw source + nearest-name-above regex) | `TheOffenderLabel_…`, `EveryTsqlLiteralInTheCorpus_…`, `TheMemberScan_ReadsEveryDeclarationWhole`, `TheResolver_AttributesByScope_…`, `TheMemberScan_ReadsABodyWhoseLiteralHoldsABrace_…` — **5** | `48 of 160 T-SQL literals are labelled with a C# statement keyword or with nothing`, then the list. This is #3094's central measurement, reproduced by the pin |
| **(b)** access modifier no longer required (`const`/`static`/`readonly` admitted) | `TheOffenderLabel_…`, `TheResolver_…`, `TheMemberScan_ReadsEveryDeclarationWhole` | the local-variable case comes straight back, and `AlertContextBuilders.cs:55 BuildBlockingContext runs to line 107, past the declaration at line 66` |
| **(c)** containment dropped (nearest member declaration *above*) | `TheMemberScan_ReadsABodyWhoseLiteralHoldsABrace_…` only | see the honest note below |
| **(d)** the walker dropped from the member map (raw source) | `TheMemberScan_ReadsEveryDeclarationWhole`, `TheMemberScan_ReadsABodyWhoseLiteralHoldsABrace_…` | **seven real members on the shipped tree**, led by `FactRiskDisclosure.cs:285 QuoteName` |
| **(e)** the accessor lookahead removed | `TheMemberScan_ReadsEveryDeclarationWhole` | `ArchiveService.cs:40 IsArchiving runs to line 44, past the declaration at line 43` |
| **(f)** the next-declaration bound removed | `TheMemberScan_IsBoundedByTheNextDeclaration_…` | `Expected: OverExtended` |
| **(g)** the unterminated arm removed | the same test's end-of-file half | `Expected: Unterminated` |
| **(l)** the parameter-list return removed from `DeclaredName` | `TheResolver_AttributesByScope_…` | a generic member's constraint clause is read as the name |
| **(m)** type-argument depth tracking removed | `TheResolver_AttributesByScope_…` | a `<`/`>` type resolves to the wrong token |
| **(n)** identifiers recorded at any depth | `TheResolver_AttributesByScope_…` | a tuple type's field name is lost |
| **(o)** `LineOf`'s newline count doubled | `TheOffenderLabel_…` | `reports line 367, but the anchor is on line 187 of the file as read by lines` — the line cross-check, which the tautology it replaced could not have caught |
| **(p)** the accessor-list continuation removed (the state review found) | `TheResolver_AttributesByScope_…` | `Auto`'s literal resolves to `<unknown>` |
| **(q)** `EnclosingMember` always returns `<unknown>` | `NoStoreSqlComparesANaiveTimestampToABareClock` + 4 | `DarlingModuleMap.cs:<unknown> — collection_time >= now() - interval '2 days'`. The sibling suite's waiver decision rides the shared resolver, shown rather than assumed |
| baseline, **last** | *(green, 14 tests)* | no mutation leaked; the staged copy was `cmp`-identical to the committed file and `git status` was empty |

Both discard paths were **exercised rather than assumed**, since a variant that comes back green having never compiled must not be counted: a deliberately wrong anchor reports `ANCHOR FAILURE` and stops before building, and a deliberately uncompilable edit reports `BUILD FAILED — DISCARD` and never runs. Every mutation asserts its anchor matches exactly once.

**They then earned it on a real accident, which is worth recording.** Renaming a local from `checked_` to `exercised` in this file staled two anchors in the per-row mutation script. The runner correctly reported `ANCHOR FAILURE` and then `BUILD FAILED — DISCARD` — but the shell wrapper collecting the results defaulted a missing failure message to the string `GREEN`, so the first re-run printed five rows of "green" for five variants that never ran. The row-level red-proof above was regenerated after making the reporter require a `Total:` line before it will call anything a pass. A harness that can print a pass it did not observe is the same defect as a pin that cannot fail, one level out, and it very nearly went into this description as a result.

### (c) is the honest one, and it changes what this PR claims

**Containment is not what fixed the measured sites.** Measured over the corpus: asking for the innermost *containing* member and asking for the nearest member declaration *above* the offset give the same answer at **all 160** T-SQL sites, so dropping containment reds only the arranged control. What produced the 48 wrong labels was the pattern the predecessor matched *with*, and `DeclarationHead` is where that is fixed. Containment is hardening for the one direction the declaration regex cannot cover — a literal inside no member at all resolves to `<unknown>` rather than borrowing the name of whichever member sits above it. That is its status, and the code comment says so rather than claiming more.

### (d) is the one that earned the walker on measurement rather than principle

`FactRiskDisclosure.QuoteName` is:

```csharp
private static string QuoteName(string identifier) =>
    string.IsNullOrEmpty(identifier) ? "[unknown]" : "[" + identifier.Replace("]", "]]") + "]";
```

Read raw, the `[` and `]` **inside those literals** unbalance the bracket depth the declaration scan tracks, so it never sees a depth-zero `;`, runs to the end of the file and reports the body as unterminated. Six more members do the same. Prior art's arranged case was a brace in a literal; this is a bracket, it is on the shipped tree today, and it is not hypothetical.

## Two dead branches removed, which took measuring rather than reasoning

An earlier draft of `DeclaredName` also required the `(` to follow the name with only whitespace between, and moved the name's end onto the `>` that closed a generic argument list so a generic method would still qualify. Neither could be made to red a test. Dumping **all 20,308 declarations in the scanned trees** with and without them and diffing gives **zero** differing lines — every name, every file. They were a pair that existed only to cancel each other out. Removed, and every branch left in that function is red-proofed by (l), (m) or (n).

## Verified, and not

`dotnet build Darling/Darling.Tests/Darling.Tests.csproj -p:EnableWindowsTargeting=true`: **0 errors**, 50 warnings, all pre-existing xunit-analyzer nags in other files and unchanged in count. The eight pre-existing `[Fact]`s in this file ran green in the harness against the real tree at every step, which is the evidence that detection is untouched — this file goes **8 → 14**.

The harness is not the CI job. `Darling.Tests` executes only on the Windows `build` job, and no WPF window was opened. Every claim here is about source as parsed.

## Review findings, both fixed

`claude[bot]` reviewed with empty review bodies and the substance in five inline comments (three of them the same finding, restated across two passes). Every finding was verified against the code rather than taken on report, and all are acted on. Replies on the threads themselves are pending Erik's go-ahead — the standing rule is that the first PR comment of a session is asked for first, and this session could not ask.

**1. `DeclarationEnd` truncated a member's range before a trailing initializer — correct, and bigger than reported.**

```csharp
public string QueryText { get; set; } = "SELECT 1 FROM sys.databases;";
```

The scan returned at the closing brace of the first top-level brace group. On an auto-property that group is the *accessor list*, so the range ended before the initializer, and a literal there was contained by nothing — labelled `<unknown>`, which is the failure this PR exists to remove. Reproduced before fixing: `Auto` resolved with `End` at the accessor list's `}`, the literal four characters later, and `EnclosingMember` returned `<unknown>`.

**Neither arm of `ShapeOf` can see it**, and that is what made it worth fixing rather than documenting: a range that stops short of its own member is still closed (not `Unterminated`) and still well under `NextStart` (not `OverExtended`), so it reads as `WholeMember`. It is the one truncation with no detector — precisely the gap the two arms were introduced to close, in a shape they cannot reach.

The report said the shape exists but no default is T-SQL today. Measured, the latent population is much larger than "a shape none of the fixtures exercise": **1,614 member ranges in the scanned trees were short by their initializer.** Now that the scan carries on past an accessor list when — and only when — the next non-whitespace character is `=`, all 1,614 end at their own terminating `;`. Nothing else moved: all 160 attributions are unchanged, no member becomes over-extended, and every range shape is still `WholeMember`. `Auto` in `TheResolver_AttributesByScope_…` is the pin, red-proofed by variant (p).

An `=` is the only thing that can legally follow the brace inside the same declaration — after a method body's `}` the next non-whitespace is `}`, a modifier, or `[` — so the continuation cannot run into the following member.

**2. The same broken resolver in a sibling file — correct, and it is the one that was making a decision.**

`StoreSqlClockDisciplineTests.cs` carried a byte-identical copy of the pre-fix regex, and its own doc comment said what for: *"for the waiver key and the failure message"*. It feeds the resolved name into `Waived.Contains(file + ":" + member)`.

That makes a wrong name there a wrong **decision**, not a wrong message. Three directions, and the third is the one that costs: it can report under the wrong member, it can miss a legitimate waiver and go red on waived code, or it can **collide with an unrelated waived key and silently swallow a real bare-clock finding**. My change fixed the message-only copy; leaving the deciding one and filing it is shipping the inert half of a defect, so it is fixed here.

The resolver now lives in `Darling/Darling.Tests/CSharpMemberMap.cs` and both pins use it — the treatment `CSharpSourceWalker` got in #2913 and `RepoFile` in #3090. Correcting the copy in place would leave two implementations of a thing that has already been shown to diverge, which is what those two extractions exist to stop.

Measured before moving anything: **21 of the 140 SQL literals in the store tree change label** — `if`, `using`, `while`, `Select` (a LINQ call) and `NpgsqlCommand` (a constructed type) — and **none of them is the one waived key.** `DarlingModuleMap.cs:RefreshSql` resolves to `RefreshSql` under both resolvers, because it is a `public const string` field, the shape the old regex got right. So the extraction changes 21 labels for the better and no waiver decision at all.

**The wiring is shown to be live rather than merely compiled**, which is #2213's lesson: variant (q) makes `EnclosingMember` always return `<unknown>`, and `NoStoreSqlComparesANaiveTimestampToABareClock` reds with `DarlingModuleMap.cs:<unknown> — collection_time >= now() - interval '2 days'`. The waiver misses, the waived finding surfaces, and that suite fails by name. A green build proves nothing about a seam; that does.

**3. The eager `MemberMapOf` in the scan — correct, and my own inconsistency.**

`NoTsqlStatementViolatesACoveredConvention` built the map for every file in every scanned tree, including the great majority with no T-SQL in them, while the sibling test added in the same PR did it lazily. Now `members ??= MemberMapOf(text)` at the point a finding needs it, which is the sibling's shape and the one I should have written.

## Out of scope, deliberately

- **Attribute arguments are not read.** An attribute list sits above its member's declaration line, so a T-SQL literal inside one resolves to `<unknown>`. Walking back over `[…]` blocks is ten lines, and nothing in the corpus would exercise it — a bound stated and left loud is worth more than machinery no test can distinguish, which is the lesson (h) above taught the hard way. `McpQueryTools.GetTopQueriesByCpu` is the near miss: its *parameter* attribute is inside the declaration and resolves fine; its *method* attribute would not, and is not in the population.
- **The two Pg pins' copies of the offset idiom are still their own.** `PgPanelTabOwnershipTests` and `PgRegistryPanelPlacementTests` carry narrower, `LoadPg…Async`-specific versions (#3089 declined the same extraction hours ago and noted the two had already diverged). They are message-only and neither drives a decision, which is what separates them from `StoreSqlClockDisciplineTests` above — that one is fixed here precisely because it decides. Folding the Pg pair into `CSharpMemberMap` is worth doing as its own change, against both at once, rather than reaching into files whose inline review anchors are current.
- **`ThePopulation_IsTsqlStatements_AndNothingElse` admits prose beginning with "If".** `McpQueryTools.cs:20` is a `[Description]` reading "If true, only return queries whose cached plan has EVER run at DOP > 1…", which opens with a T-SQL statement keyword and names a DMV, so it satisfies both halves of the population rule. Harmless — it violates no covered convention — and filed as a side finding rather than fixed here, because narrowing the population is a scope decision for that test and not for this one.

## CHANGELOG

Not edited here — every lane appends to the same `[Unreleased]` block and a per-PR edit conflicts with whichever sibling merges first. Entry text for the coordinator:

- Fixed the T-SQL convention guard naming the wrong member in its offender list: a type being constructed, a local variable, or a bare C# keyword at 48 of the 160 T-SQL literals it reads. A flagged literal is now attributed to the member whose declaration range contains it, read through the shared source walker, and the offender line carries the file line as well as the member. Detection is unchanged.
