### PR TITLE
Fixes #3102

### DIFF
--- a/Darling/Darling.Tests/PerCycleTimingLogLevelTests.cs
+++ b/Darling/Darling.Tests/PerCycleTimingLogLevelTests.cs
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using PerformanceMonitor.Darling.Service;
+using Xunit;
+using static Darling.Tests.RepoFile;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// <para>Pins the level of the per-cycle collector timing telemetry (#3102) — the run lines that decompose
+/// a collector's cost, which are emitted once per collector per server per cycle and once per DATABASE on
+/// the collectors that fan out.</para>
+///
+/// <para><b>Why a level is worth a test at all.</b> The cost of these lines was never disk. At fleet scale
+/// they are ~2M lines a day of near-uniform text, and the collector <c>ERROR</c>, <c>PERMISSIONS</c> and
+/// store-cancellation lines the log is actually opened for are dozens a day inside that. The consequence is
+/// not "the log is large", it is that an empty grep result against this file stopped meaning absence: the
+/// signal is rare, the surrounding text is repetitive, and the interesting lines are the irregular ones a
+/// pattern written from memory is likeliest to miss. A log whose empty results cannot be trusted has lost
+/// the property it exists for, which is why this is pinned rather than left to review.</para>
+///
+/// <para><b>The rule being applied is already the repo's,</b> stated on the fault path:
+/// <see cref="DarlingCollectorRunner.LogPerDatabaseFaultSplit"/>'s remarks say a phase line must not be
+/// louder than the error it decomposes, and give the generic arm Debug because one database being offline is
+/// routine. A run that SUCCEEDED has no error beside it at all, so the success-path splits take the same
+/// treatment. Nothing is deleted: the sample is the artifact for per-cycle attribution, and a periodic
+/// distribution cannot answer "what did this collector do at 04:12".</para>
+///
+/// <para><b>The seam that makes a level change work here is not obvious, and the wrong reading of it says
+/// this change is inert.</b> <c>DarlingFileLoggerProvider</c>'s own <c>IsEnabled</c> accepts every level
+/// except <c>None</c>, so read alone it looks like a provider that writes Debug unconditionally. The gate is
+/// upstream, in the logger FACTORY: <c>AddLogging</c> registers a default
+/// <c>LoggerFilterOptions.MinLevel</c> of <c>Information</c>, and the service adds no configuration that
+/// lowers it, so a Debug call is dropped before any provider sees it. Both halves are asserted below,
+/// because either one alone is consistent with the opposite conclusion.</para>
+///
+/// <para><b>What this does NOT cover.</b> No line RATE is measured here — the emission is asserted as a
+/// level, and the ~2M/day figure comes from a field log, not from anything runnable. The source scan reads
+/// the two files the collector run path lives in and identifies a timing line by the parameter names in its
+/// message template, so a future timing line spelled with different placeholders is outside its net; the
+/// floor assertion is what keeps a net that has stopped matching from reading as a clean pass. Lite's twin
+/// line is deliberately untouched and is NOT covered: <c>AppLoggerAdapter</c> is constructed directly rather
+/// than through a factory and answers <c>IsEnabled(Debug)</c> true, so the same edit there suppresses
+/// nothing and would need a gate of its own first.</para>
+/// </summary>
+public sealed class PerCycleTimingLogLevelTests : IDisposable
+{
+    /// <summary>
+    /// The two files the collector run path emits from. Both are read, so a line moved from one to the other
+    /// stays inside the net.
+    /// </summary>
+    private static readonly string[] EmitFiles =
+    {
+        "DarlingWorker.cs",
+        "DarlingCollectorRunner.cs",
+    };
+
+    /// <summary>
+    /// What makes a message template a per-cycle TIMING line: a phase or total named with its own
+    /// placeholder. Matched against the literal's body rather than against source lines, so a template split
+    /// across lines is still one match and a doc comment that discusses <c>drain:</c> in prose is not a
+    /// match at all.
+    /// </summary>
+    private static readonly string[] TimingMarkers =
+    {
+        "sql:{SqlMs}ms",
+        "open:{OpenMs}ms",
+        "drain:{DrainMs}ms",
+        "plan_fetch:{PlanFetchMs}ms",
+        "text_fetch:{TextFetchMs}ms",
+        "pg:{PgMs}ms",
+    };
+
+    /// <summary>
+    /// How many timing templates the two files hold today: eight success-path lines plus the fault split.
+    /// A FLOOR rather than an equality, so adding a tenth at Debug is not a failure while a net that has
+    /// stopped matching — the silent way a scan like this rots — drops below it and fails. The number is the
+    /// only frozen thing here, and it fails toward red.
+    /// </summary>
+    private const int KnownTimingTemplates = 9;
+
+    /// <summary>The nearest <c>.LogSomething(</c> ahead of a literal, which is the call emitting it.</summary>
+    private static readonly Regex LogCall = new(@"\.(Log[A-Za-z]*)\s*\(", RegexOptions.CultureInvariant);
+
+    private readonly string _tempRoot =
+        Path.Combine(Path.GetTempPath(), "darling-timing-level-tests", Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_tempRoot))
+            {
+                Directory.Delete(_tempRoot, recursive: true);
+            }
+        }
+        catch
+        {
+            /* Best-effort test cleanup. */
+        }
+    }
+
+    /// <summary>
+    /// Every per-cycle timing template in the collector run path is emitted BELOW the default level. The
+    /// success sites are Debug outright; the one exception is the fault split, which takes its arm's level
+    /// from the caller by design (pinned in <see cref="PerDatabaseFaultPathSplitTests"/>) and so is
+    /// identified by its method rather than exempted by its text.
+    /// </summary>
+    [Fact]
+    public void EveryPerCycleTimingLineIsEmittedBelowTheDefaultLevel()
+    {
+        var found = new List<(string File, string Method, string Template)>();
+
+        foreach (var file in EmitFiles)
+        {
+            var source = ReadRepoFile("Darling", "PerformanceMonitor.Darling.Service", file);
+            var code = CSharpSourceWalker.StripCommentsAndStrings(source);
+
+            foreach (var (start, body) in CSharpSourceWalker.StringLiteralBodies(source))
+            {
+                if (!TimingMarkers.Any(marker => body.Contains(marker, StringComparison.Ordinal)))
+                {
+                    continue;
+                }
+
+                /* The emitting call sits ahead of the literal, and the literal is the first argument on the
+                   success sites and the second on the fault split, so the LAST call ahead of it is the one.
+                   Read out of the stripped text so a `.LogInformation(` mentioned in a comment above the
+                   site cannot be mistaken for the site's own call. */
+                var call = LogCall.Matches(code[..start]).LastOrDefault();
+
+                found.Add((
+                    file,
+                    call is null ? "(no log call found)" : call.Groups[1].Value,
+                    body.Trim()));
+            }
+        }
+
+        /* The floor first: a marker set that has stopped matching returns an empty list, and every
+           assertion below it passes vacuously on an empty list. This is the one that fails instead. */
+        Assert.True(
+            found.Count >= KnownTimingTemplates,
+            $"expected at least {KnownTimingTemplates} per-cycle timing templates across {string.Join(", ", EmitFiles)}, "
+                + $"found {found.Count} — the marker set has stopped matching the emit sites, so the levels below were not checked:"
+                + string.Concat(found.Select(f => $"{Environment.NewLine}  {f.File}: {f.Method}")));
+
+        var louder = found
+            .Where(f => f.Method is not ("LogDebug" or "LogTrace" or "Log"))
+            .ToList();
+
+        Assert.True(
+            louder.Count == 0,
+            "per-cycle collector timing must not be emitted at or above the default Information level (#3102):"
+                + string.Concat(louder.Select(f => $"{Environment.NewLine}  {f.File}: {f.Method} — {f.Template}")));
+
+        /* And the success sites specifically are Debug, not merely "not Information". Without this, deleting
+           the lines outright would also satisfy the assertion above. */
+        var debugSites = found.Count(f => f.Method == "LogDebug");
+
+        Assert.True(
+            debugSites >= KnownTimingTemplates - 1,
+            $"expected at least {KnownTimingTemplates - 1} timing templates at LogDebug (every success-path site; "
+                + $"the fault split takes its caller's level), found {debugSites}");
+    }
+
+    /// <summary>
+    /// <para>The shipped default drops Debug before any provider sees it, AND the file provider is not
+    /// itself the gate — so raising the minimum is what puts these lines in the FILE rather than only on a
+    /// console.</para>
+    ///
+    /// <para>Carries its own POSITIVE CONTROL: the same call at Information is asserted to land in the same
+    /// file through the same harness. Without it, a Debug line missing from the file is equally consistent
+    /// with the provider never having been wired up, which is the failure this whole issue is about — an
+    /// empty read that cannot be told from a real absence.</para>
+    /// </summary>
+    [Fact]
+    public void TheDefaultLevelDropsDebug_AndTheFileProviderIsNotTheGate()
+    {
+        var provider = new DarlingFileLoggerProvider(Path.Combine(_tempRoot, "default"), _ => { });
+
+        using (var factory = LoggerFactory.Create(builder => builder.AddProvider(provider)))
+        {
+            var logger = factory.CreateLogger("PerformanceMonitor.Darling.Service.DarlingWorker");
+
+            Assert.False(logger.IsEnabled(LogLevel.Debug));
+            Assert.True(logger.IsEnabled(LogLevel.Information));
+
+            logger.LogDebug("SUPPRESSED sql:{SqlMs}ms", 12);
+            logger.LogInformation("POSITIVE-CONTROL connect edge");
+            provider.Flush();
+        }
+
+        var written = File.ReadAllText(provider.CurrentLogFile());
+
+        /* The control proves this harness can see a line at all, so the absence below is an absence. */
+        Assert.Contains("POSITIVE-CONTROL connect edge", written, StringComparison.Ordinal);
+        Assert.DoesNotContain("SUPPRESSED", written, StringComparison.Ordinal);
+
+        /* The provider itself accepts Debug. So the suppression above is the FACTORY's minimum, and turning
+           that minimum up delivers Debug to this file rather than to the console alone. */
+        Assert.True(provider.CreateLogger("PerformanceMonitor.Darling.Service.DarlingWorker")
+            .IsEnabled(LogLevel.Debug));
+    }
+
+    /// <summary>
+    /// The capability is not lost, it is configured — and it is reachable scoped to the service's own
+    /// namespace, so measuring the collector run path does not also turn on every other component's Debug
+    /// output. This is the claim <c>Darling/README.md</c>'s "Logs" section makes to an operator.
+    /// </summary>
+    [Fact]
+    public void NamespaceScopedConfigurationRestoresTheTimingLinesToTheFile()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Logging:LogLevel:PerformanceMonitor.Darling.Service"] = "Debug",
+            })
+            .Build();
+
+        var provider = new DarlingFileLoggerProvider(Path.Combine(_tempRoot, "raised"), _ => { });
+
+        using (var factory = LoggerFactory.Create(builder =>
+        {
+            builder.AddConfiguration(configuration.GetSection("Logging"));
+            builder.AddProvider(provider);
+        }))
+        {
+            var collector = factory.CreateLogger("PerformanceMonitor.Darling.Service.DarlingCollectorRunner");
+            Assert.True(collector.IsEnabled(LogLevel.Debug));
+
+            collector.LogDebug("RESTORED  [{Server}] {Collector} => {Rows} rows (sql:{SqlMs}ms, pg:{PgMs}ms)",
+                "alpha", "wait_stats", 42, 7, 3);
+
+            /* Scoping is the point of naming the namespace rather than Default: an unrelated component's
+               Debug output stays off, so raising this one does not re-bury the log from another direction. */
+            var unrelated = factory.CreateLogger("PerformanceMonitor.Darling.Viewer.ViewerDataService");
+            Assert.False(unrelated.IsEnabled(LogLevel.Debug));
+            unrelated.LogDebug("UNRELATED should stay suppressed");
+
+            provider.Flush();
+        }
+
+        var written = File.ReadAllText(provider.CurrentLogFile());
+
+        Assert.Contains("RESTORED", written, StringComparison.Ordinal);
+        Assert.Contains("sql:7ms", written, StringComparison.Ordinal);
+        Assert.DoesNotContain("UNRELATED", written, StringComparison.Ordinal);
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
@@ -1417,10 +1417,15 @@ public sealed class DarlingCollectorRunner
                        collection_log's sql_duration_ms. Neither of the two options it named was taken. Only
                        the DECLARATION moved above the try; the START stayed exactly where it was, so the
                        interval is unchanged, dbSqlMs is the same number, and no second stopwatch measures a
-                       second interval that a reader would then have to reconcile with this one. */
+                       second interval that a reader would then have to reconcile with this one.
+
+                       #3102: Debug, matching the enumerated branch's block below and the generic fault
+                       arm's own level. A database that SUCCEEDED has no error for its split to sit beside,
+                       which is exactly LogPerDatabaseFaultSplit's rule about a phase line being louder
+                       than the thing it decomposes. */
                     if (context.PerDatabasePhasesFrom(dbSqlMs) is { } dbPhases)
                     {
-                        _logger?.LogInformation(
+                        _logger?.LogDebug(
                             "  [{Server}] {Collector} [{Database}] sql:{SqlMs}ms = connect:{ConnectMs}ms + open:{OpenMs}ms + drain:{DrainMs}ms + other:{OtherMs}ms ({Rows} rows, pg:{PgMs}ms)",
                             server.Config.DisplayName, definition.Name, databaseName, dbSqlMs,
                             dbPhases.ConnectMs, dbPhases.OpenMs, dbPhases.DrainMs, dbPhases.OtherMs,
@@ -1946,7 +1951,14 @@ public sealed class DarlingCollectorRunner
                         /* Per-DATABASE line for non-empty batches (#1565): the per-server summary blends
                            every database into one number, which hid a single busy database's 50s burst
                            behind four quiet siblings. Quiet databases (0 rows — the 2-of-3 cycles between
-                           Query Store's 900s flushes) stay silent. */
+                           Query Store's 900s flushes) stay silent.
+
+                           #3102: every line in this block is Debug, below the default filter. This is the
+                           branch that multiplies — one line per DATABASE per cycle, and two or three of
+                           them for a collector that fetches plans or text — so it is where the level
+                           decision is worth the most and where a per-cycle timing on the default log
+                           displaces the errors the log is opened for. Suppressed, not removed: the whole
+                           block returns at Debug (Darling/README.md, "Logs"). */
                         if (batchCount > 0)
                         {
                             /* #2164: open vs drain, because they have different fixes. A pass that is nearly
@@ -1966,7 +1978,7 @@ public sealed class DarlingCollectorRunner
                                    so every other collector's line is byte-identical to before. */
                                 if (context.PerItemPlanFetchMs > 0 || context.PerItemTextFetchMs > 0)
                                 {
-                                    _logger?.LogInformation("  [{Server}] {Collector} [{Database}] => {Rows} rows (sql:{SqlMs}ms = wm:{WatermarkMs}ms + open:{OpenMs}ms + drain:{DrainMs}ms + plan_fetch:{PlanFetchMs}ms + text_fetch:{TextFetchMs}ms, pg:{PgMs}ms)",
+                                    _logger?.LogDebug("  [{Server}] {Collector} [{Database}] => {Rows} rows (sql:{SqlMs}ms = wm:{WatermarkMs}ms + open:{OpenMs}ms + drain:{DrainMs}ms + plan_fetch:{PlanFetchMs}ms + text_fetch:{TextFetchMs}ms, pg:{PgMs}ms)",
                                         server.Config.DisplayName, definition.Name, item, batchCount, itemSqlMs,
                                         context.PerItemWatermarkMs, context.PerItemOpenMs, context.DrainMsFrom(itemSqlMs),
                                         context.PerItemPlanFetchMs, context.PerItemTextFetchMs, itemStorageMs);
@@ -1978,7 +1990,7 @@ public sealed class DarlingCollectorRunner
                                        line and a fetchless collector prints none. */
                                     if (context.PerItemPlanFetchMs > 0)
                                     {
-                                        _logger?.LogInformation("  [{Server}] {Collector} [{Database}] plan_fetch:{PlanFetchMs}ms = probe:{ProbeMs}ms + target:{TargetMs}ms + write:{WriteMs}ms + other:{OtherMs}ms ({Chunks} chunk(s), {Ids} ids, {ProbeIds} probed)",
+                                        _logger?.LogDebug("  [{Server}] {Collector} [{Database}] plan_fetch:{PlanFetchMs}ms = probe:{ProbeMs}ms + target:{TargetMs}ms + write:{WriteMs}ms + other:{OtherMs}ms ({Chunks} chunk(s), {Ids} ids, {ProbeIds} probed)",
                                             server.Config.DisplayName, definition.Name, item, context.PerItemPlanFetchMs,
                                             context.PerItemPlanProbeMs, context.PerItemPlanTargetMs, context.PerItemPlanWriteMs,
                                             context.PlanFetchOtherMs, context.PerItemPlanChunks, context.PerItemPlanIdsAttempted,
@@ -1987,7 +1999,7 @@ public sealed class DarlingCollectorRunner
 
                                     if (context.PerItemTextFetchMs > 0)
                                     {
-                                        _logger?.LogInformation("  [{Server}] {Collector} [{Database}] text_fetch:{TextFetchMs}ms = probe:{ProbeMs}ms + target:{TargetMs}ms + write:{WriteMs}ms + other:{OtherMs}ms ({Chunks} chunk(s), {Ids} ids, {ProbeIds} probed)",
+                                        _logger?.LogDebug("  [{Server}] {Collector} [{Database}] text_fetch:{TextFetchMs}ms = probe:{ProbeMs}ms + target:{TargetMs}ms + write:{WriteMs}ms + other:{OtherMs}ms ({Chunks} chunk(s), {Ids} ids, {ProbeIds} probed)",
                                             server.Config.DisplayName, definition.Name, item, context.PerItemTextFetchMs,
                                             context.PerItemTextProbeMs, context.PerItemTextTargetMs, context.PerItemTextWriteMs,
                                             context.TextFetchOtherMs, context.PerItemTextChunks, context.PerItemTextIdsAttempted,
@@ -1996,14 +2008,14 @@ public sealed class DarlingCollectorRunner
                                 }
                                 else
                                 {
-                                    _logger?.LogInformation("  [{Server}] {Collector} [{Database}] => {Rows} rows (sql:{SqlMs}ms = wm:{WatermarkMs}ms + open:{OpenMs}ms + drain:{DrainMs}ms, pg:{PgMs}ms)",
+                                    _logger?.LogDebug("  [{Server}] {Collector} [{Database}] => {Rows} rows (sql:{SqlMs}ms = wm:{WatermarkMs}ms + open:{OpenMs}ms + drain:{DrainMs}ms, pg:{PgMs}ms)",
                                         server.Config.DisplayName, definition.Name, item, batchCount, itemSqlMs,
                                         context.PerItemWatermarkMs, context.PerItemOpenMs, context.DrainMsFrom(itemSqlMs), itemStorageMs);
                                 }
                             }
                             else
                             {
-                                _logger?.LogInformation("  [{Server}] {Collector} [{Database}] => {Rows} rows (sql:{SqlMs}ms, pg:{PgMs}ms)",
+                                _logger?.LogDebug("  [{Server}] {Collector} [{Database}] => {Rows} rows (sql:{SqlMs}ms, pg:{PgMs}ms)",
                                     server.Config.DisplayName, definition.Name, item, batchCount, itemSqlMs, itemStorageMs);
                             }
                         }

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingFileLoggerProvider.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingFileLoggerProvider.cs
@@ -18,8 +18,8 @@ namespace PerformanceMonitor.Darling.Service;
 
 /// <summary>
 /// The service's rolling file log — an <see cref="ILoggerProvider"/> so every existing
-/// <c>ILogger</c> call site (collector run lines, connect edges, reload notices, errors) lands in a
-/// greppable file with zero changes at the call sites. This is the service's PRIMARY diagnostic
+/// <c>ILogger</c> call site (connect edges, reload notices, warnings, errors) lands in a greppable
+/// file with zero changes at the call sites. This is the service's PRIMARY diagnostic
 /// surface: the Windows Event Log provider is also wired, but its event source can only be created
 /// by an elevated principal — the recommended <c>NT SERVICE</c> virtual account cannot, so on a
 /// by-the-book install the Event Log silently receives nothing until the installer pre-creates the
@@ -36,6 +36,16 @@ namespace PerformanceMonitor.Darling.Service;
 /// <para>Directory: <c>%ProgramData%\PerformanceMonitorDarling\logs</c> — the machine-level Darling
 /// folder the managed store already lives under (<c>...\pg</c>), created by the service account on
 /// first use exactly like the data directory. File: <c>darling-service_yyyyMMdd.log</c>.</para>
+///
+/// <para><b>This provider is not the level gate, and reading it as one inverts the conclusion.</b>
+/// <c>FileLogger.IsEnabled</c> accepts every level except <see cref="LogLevel.None"/>, which reads like a
+/// provider that writes <c>Debug</c> unconditionally and therefore like a call site's level being
+/// decorative. The gate is upstream: <c>AddLogging</c> registers a default
+/// <c>LoggerFilterOptions.MinLevel</c> of <see cref="LogLevel.Information"/>, so a <c>Debug</c> call is
+/// dropped by the factory and never reaches any provider — the permissive test here is what makes
+/// <c>Debug</c> land in the FILE once configuration raises that minimum, rather than only on the console.
+/// Both halves are asserted in <c>PerCycleTimingLogLevelTests</c>; #3102 is the level decision that
+/// depends on them.</para>
 /// </summary>
 public sealed class DarlingFileLoggerProvider : ILoggerProvider
 {

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -6248,7 +6248,20 @@ LIMIT 1";
         try
         {
             var result = await run(runner, runtime, cancellationToken);
-            _logger.LogInformation("  [{Server}] {Collector} => {Rows} rows (sql:{SqlMs}ms, pg:{PgMs}ms)",
+
+            /* #3102: Debug, which is BELOW the default filter's Information, for the same reason the
+               per-database fault split takes its arm's level — see LogPerDatabaseFaultSplit's remarks. A
+               timing on the default log with no reason beside it is the shape to avoid, and a run that
+               SUCCEEDED has no reason beside it at all. The level is the whole of the choice: the message,
+               its gates and its numbers are untouched, so the parsers outside this repo see the identical
+               text the moment the level is turned up.
+
+               Not deleted and not aggregated, because the sample IS the artifact here: attributing one
+               server's one cycle needs that cycle's own numbers, and a periodic distribution cannot answer
+               "what did this collector do at 04:12". Reachable per-namespace rather than all-or-nothing, so
+               measuring the store-write path does not also turn on every other Debug line in the process
+               (Darling/README.md, "Logs"). */
+            _logger.LogDebug("  [{Server}] {Collector} => {Rows} rows (sql:{SqlMs}ms, pg:{PgMs}ms)",
                 server.Config.DisplayName, collectorName, result.Rows, result.SqlMs, result.StorageMs);
 
             /* #2851: the server-scoped phase split rides its OWN line, for the same reason #2811's fetch
@@ -6263,7 +6276,7 @@ LIMIT 1";
                read #2796 clocked at 50s cold is free. */
             if (result.ServerPhasesMeasured)
             {
-                _logger.LogInformation(
+                _logger.LogDebug(
                     "  [{Server}] {Collector} sql:{SqlMs}ms = open:{OpenMs}ms + drain:{DrainMs}ms + other:{OtherMs}ms (wm:{WatermarkMs}ms store-side, outside sql)",
                     server.Config.DisplayName, collectorName, result.SqlMs,
                     result.ServerOpenMs, result.ServerDrainMs, result.ServerOtherMs, result.ServerWatermarkMs);

--- a/Darling/README.md
+++ b/Darling/README.md
@@ -130,7 +130,7 @@ The same executable serves interactive debugging and service installation; the W
 Darling\PerformanceMonitor.Darling.Service\bin\Release\net10.0\PerformanceMonitor.Darling.Service.exe
 ```
 
-Watch the log output: you should see the config load (`Loaded configuration from ...`), the store migrate (`Postgres store ready (schema v44, ...)` — the number is whatever the current migration count is), the TimescaleDB detection result, per-server connects, and then per-collector run lines with row counts.
+Watch the log output: you should see the config load (`Loaded configuration from ...`), the store migrate (`Postgres store ready (schema v44, ...)` — the number is whatever the current migration count is), the TimescaleDB detection result, and per-server connects. Per-collector run lines with row counts are at `Debug` and so are not in that output by default — add `--Logging:LogLevel:PerformanceMonitor.Darling.Service=Debug` to the command above to watch a first sweep collector by collector, or read the outcomes back from `collection_log` and the Viewer's Collection Health tab, which record every run at any level. See [Logs](#logs).
 
 ### Run on Linux (Docker Compose or systemd) {#1804}
 
@@ -894,7 +894,17 @@ No raw tier is ever dropped before the aggregate that preserves it has caught up
 
 ### Logs
 
-The service's PRIMARY log is a **rolling file** under `%ProgramData%\PerformanceMonitorDarling\logs\darling-service_yyyyMMdd.log` — every collector run line, connect edge, reload notice, warning, and error lands there (buffered writes, one file per day, 14-day retention, and a logging failure can never crash the service). Console runs write the same file plus console output.
+The service's PRIMARY log is a **rolling file** under `%ProgramData%\PerformanceMonitorDarling\logs\darling-service_yyyyMMdd.log` — connect edges, reload notices, warnings, and errors land there (buffered writes, one file per day, 14-day retention, and a logging failure can never crash the service). Console runs write the same file plus console output.
+
+**Per-cycle collector timing is at `Debug`, which the default level does not write.** The run lines that decompose a collector's cost — `=> N rows (sql:Nms, pg:Nms)`, the `open:` / `drain:` / `other:` phase split, and the `plan_fetch:` / `text_fetch:` sub-splits — are emitted once per collector per server per cycle, and per *database* on the collectors that fan out. At fleet scale that is millions of lines a day, all of it shaped alike, and the errors and `PERMISSIONS` lines the log is actually opened for are dozens a day sitting inside it. Suppressing them by default is what keeps a grep of this file able to distinguish *not present* from *not found*.
+
+Turn them on when you are measuring, with any standard .NET logging configuration source — an environment variable on the service, a `--Logging:LogLevel:...` argument on a console run, or an `appsettings.json` beside the exe:
+
+```
+Logging__LogLevel__PerformanceMonitor.Darling.Service=Debug
+```
+
+Scope it to the namespace as above rather than setting `Logging__LogLevel__Default`, which also turns on every other component's `Debug` output. Nothing about the lines themselves changes when the level is turned up — same text, same numbers, same one-line-per-shape layout — so anything parsing them keeps working. The store carries the same timings independently of the log: `collection_log` records `duration_ms` and `sql_duration_ms` per collector run per server at every level, and the Collection Health tab and `get_collector_cost` read them, so the distribution is available without raising verbosity at all.
 
 Warnings and errors also go to the **Windows Application event log** (source `PerformanceMonitor Darling`) — but only if that event source exists. Registering an event source requires elevation, and the recommended `NT SERVICE` virtual account cannot do it, so run the `New-EventLog` line in the install steps above (or any elevated run of the exe) once; without it, Windows silently drops the events and the file log is your only surface. Collection outcomes are also queryable in the store itself — `collection_log` records every collector run per server with status and timings, and the viewer's Collection Health tab renders exactly that.
 


### PR DESCRIPTION
Fixes #3102

The eight success-path per-cycle timing lines in the collector run path move from `LogInformation` to `LogDebug`. Nothing else about them changes — same templates, same gates, same numbers, same one-line-per-shape layout — so every parser outside this repo sees byte-identical text the moment the level is turned up.

## The level they were actually at, since the issue flagged it as unverified

All of them were `Information`, which is the default filter's minimum, so all of them were written on a default log. The emit sites:

| file | site | shape |
|---|---|---|
| `DarlingWorker.cs` | server-scoped summary | `=> N rows (sql:Nms, pg:Nms)` |
| `DarlingWorker.cs` | server-scoped phase split | `sql:N = open: + drain: + other: (wm:N store-side, outside sql)` |
| `DarlingCollectorRunner.cs` | per-database split (Azure SQL DB arm) | `sql:N = connect: + open: + drain: + other: (N rows, pg:N)` |
| `DarlingCollectorRunner.cs` | enumerated, with fetch | `=> N rows (sql:N = wm: + open: + drain: + plan_fetch: + text_fetch:, pg:N)` |
| `DarlingCollectorRunner.cs` | `plan_fetch:` sub-split | `plan_fetch:N = probe: + target: + write: + other:` |
| `DarlingCollectorRunner.cs` | `text_fetch:` sub-split | `text_fetch:N = probe: + target: + write: + other:` |
| `DarlingCollectorRunner.cs` | enumerated, no fetch | `=> N rows (sql:N = wm: + open: + drain:, pg:N)` |
| `DarlingCollectorRunner.cs` | enumerated, unmeasured | `=> N rows (sql:Nms, pg:Nms)` |

The third variant the issue attributes to `plan_correction` is the `plan_fetch:` sub-split: that collector fans out per database and takes the with-fetch arm, so it emits three lines per database per cycle where an ordinary collector emits one.

The fault-path split is untouched. `LogPerDatabaseFaultSplit` already takes its level from its arm — Warning for the budget arm, Debug for the generic one — and its remarks already state the rule this change applies: a phase line must not be louder than the error it decomposes. The success path had no error beside it at all, which is why Information was the wrong level for it rather than a defensible trade.

## Why a level change and not the other two remedies

**A periodic aggregate would have destroyed the thing the instrumentation was added for.** The distribution is already available and always has been, at every log level: `collection_log` records `duration_ms` and `sql_duration_ms` per collector run per server, and Collection Health and `get_collector_cost` read it. What the log uniquely holds is the individual sample — which server, which collector, which cycle, which database — and that is exactly what an aggregate discards. Replacing per-cycle lines with a summary would have cost the capability while leaving the store's rollup duplicated in a second place.

**A separate error sink treats the symptom and leaves the log degraded.** The issue's own framing is that the source is what changed: every future instrument pointed at this file is now likelier to be wrong, silently, because a well-formed empty result is indistinguishable from absence. Routing errors elsewhere fixes the reads someone remembers to point at the new sink and leaves the primary surface exactly as unreadable, plus it splits one diagnostic surface into two that have to be correlated by timestamp.

**The level change is also the one that matches what is already here.** `LogDebug` is the established idiom for routine per-cycle accounting in these very files — `DarlingCollectorRunner` already had twelve `LogDebug` sites, including the per-collector `Collected N rows for server` summary — so this makes the success-path splits consistent with their neighbours rather than introducing a pattern.

## The seam that makes this work, which reads the opposite way at a glance

`DarlingFileLoggerProvider.FileLogger.IsEnabled` returns true for every level except `None`. Read on its own that says the provider writes Debug unconditionally, and therefore that a level change here is inert. It is not: the gate is the logger **factory**, not the provider. `AddLogging` registers a default `LoggerFilterOptions.MinLevel` of `Information` and the service adds no configuration that lowers it, so a Debug call is dropped before any provider is consulted. Measured on the service's own host shape (`Host.CreateApplicationBuilder`, no `appsettings.json` in the tree): `MinLevel` is `Information` with zero filter rules, and `IsEnabled(Debug)` is false.

The permissive test in the provider is what makes the capability recoverable rather than console-only — once the minimum is raised, Debug lands in the file. Both halves are asserted, because either one alone is consistent with the opposite conclusion. A note to that effect is now on the provider's remarks, since the next person to read it will reach the wrong conclusion for the same reason.

## The capability is configured, not removed

Verified working on that host shape, per-namespace and all-namespaces, via environment variable, command line, and `appsettings.json`:

```
Logging__LogLevel__PerformanceMonitor.Darling.Service=Debug
```

`Darling/README.md`'s "Logs" section documents this, and recommends scoping to the namespace rather than setting `Default`, which would turn on every other component's Debug output and re-bury the log from another direction.

Two doc claims that the change made false are corrected rather than left: the "Logs" section said *every collector run line* lands in the file, and the first-run walkthrough told a new operator to watch for *per-collector run lines with row counts*. Both now say where those lines are and how to get them back, and the walkthrough points at `collection_log` and Collection Health as the surfaces that record every run at any level.

## What is left at Information, since that is the acceptance criterion

The issue asks that an operator looking for collector errors not need an exact-match filter. That is a claim about what *remains*, so every surviving `Information` site was read rather than assumed — 34 in `DarlingWorker.cs` and 7 in `DarlingCollectorRunner.cs`, down from 36 and 13. Every one is event-driven: startup and shutdown, config load and control-plane reload, connect edges and reconnects, registry add/remove, backfill and sweep-width transitions, the `YIELDED` lock-timeout guards, skipped-this-tick notices, and the MCP command verbs. The two that looked per-cycle are not — `collection body has waited Ns for a free slot` is latched to once per episode by `QueuedInfoThisEpisode`, and `collection body completed after Ns` is gated on one of those channels having been surfaced first, so a body that finished under both thresholds logs nothing.

One line is per-server-per-cycle and stays: `pg_statement_text => N statement text(s) refreshed`, which fires only for PostgreSQL targets. It is left alone deliberately rather than overlooked — it is one line rather than two or three, it reports rows stored rather than a timing decomposition, and it fires only on a store whose target count is a handful, so the argument this issue rests on (an inverted prior produced by ~2M near-uniform lines) does not hold there. If PostgreSQL-target log volume ever becomes a complaint, the measurement that should decide it is that store's own lines-per-day against its error rate, the same pair that decided this one.

## Test

`Darling/Darling.Tests/PerCycleTimingLogLevelTests.cs`, three pins:

- `EveryPerCycleTimingLineIsEmittedBelowTheDefaultLevel` walks both files with `CSharpSourceWalker`, identifies a timing template by the phase placeholders in its body, and resolves the emitting call out of the comment-and-string-stripped text. Every one must be `LogDebug`, `LogTrace`, or the fault path's caller-supplied `Log`. It carries a floor of nine templates, because a marker set that has stopped matching returns an empty list and every assertion over an empty list passes vacuously.
- `TheDefaultLevelDropsDebug_AndTheFileProviderIsNotTheGate` drives the real `DarlingFileLoggerProvider` through a real factory and reads the file back. It carries its own positive control: the same call at Information is asserted to land in the same file through the same harness, so the Debug line's absence is an absence rather than a provider that was never wired up. That is the discipline the issue's comment argues for, applied to the test that would otherwise be its best example of the failure.
- `NamespaceScopedConfigurationRestoresTheTimingLinesToTheFile` raises the minimum for the service namespace only, asserts the Debug line reaches the file, and asserts an unrelated namespace stays suppressed.

### Red-proof

`Darling.Tests` targets `net10.0-windows` and cannot execute on macOS, so the three test sources were compiled unchanged into a `net10.0` console harness against the real service assembly. Every run below printed a summary, so none of them is a variant that silently failed to compile.

Reverting both service files to the base and keeping the test: **`Total: 3, Failed: 1, Not Run: 0`**. `EveryPerCycleTimingLineIsEmittedBelowTheDefaultLevel` went red on the *louder-than-default* assertion, naming all eight reverted sites and their level:

```
FAIL  EveryPerCycleTimingLineIsEmittedBelowTheDefaultLevel
      per-cycle collector timing must not be emitted at or above the default Information level (#3102):
  DarlingWorker.cs: LogInformation — [{Server}] {Collector} => {Rows} rows (sql:{SqlMs}ms, pg:{PgMs}ms)
  ... 7 more
```

The other two passed on the reverted tree, correctly: they pin the filter mechanism, which is independent of the level at the emit sites.

The floor was mutation-tested separately, since a guard that cannot fail is worse than none. Mutating every marker so the net matches nothing: **`Total: 3, Failed: 1, Not Run: 0`**, red on `expected at least 9 per-cycle timing templates ... found 0 — the marker set has stopped matching the emit sites, so the levels below were not checked`. So the scan cannot rot into a silent pass.

Restored: **`Total: 3, Failed: 0, Not Run: 0`**.

## Out of scope, reported rather than fixed

**Lite's twin line is deliberately untouched, because the same edit there suppresses nothing.** `RemoteCollectorService.DefinitionRunner.cs` has the per-database `=> N rows (sql:Nms, duckdb:Nms)` line at `LogInformation`, and it looks like the same defect. It is not the same fix: `AppLoggerAdapter` is constructed directly (`new AppLoggerAdapter<RemoteCollectorService>()`) rather than obtained from a factory, so no `LoggerFilterOptions` is in the path and its own `IsEnabled` is `logLevel >= LogLevel.Debug` — Debug is enabled unconditionally. Moving that call to `LogDebug` would change nothing about Lite's log while making it look covered, which is worse than leaving it. Lite needs a level gate of its own first; its per-collector summary at line 868 is already `LogDebug` and lands in the log regardless, which is the evidence that the gate is missing rather than that the level is wrong. Worth its own issue if fleet-scale Lite logs ever become a complaint — at a handful of servers the volume is not the problem it is here.

## CHANGELOG entry

Not applied here, per the one-entry-per-lane convention. Text for the coordinator:

- **Darling: per-cycle collector timing telemetry moves to `Debug`** ([#3102]) — the eight success-path run lines that decompose a collector's cost (`=> N rows (sql:Nms, pg:Nms)`, the `open:`/`drain:`/`other:` phase split, the per-database split, and the `plan_fetch:`/`text_fetch:` sub-splits) were emitted at `Information` and therefore written on a default log: roughly two lines per collector per server per cycle, and three per *database* for the collectors that fan out, which on a 42-server store is ~2M lines a day of near-uniform text. The cost was never disk. It was that the collector `ERROR`, `PERMISSIONS` and store-cancellation lines the log is read for are dozens a day inside that, so an empty grep result against the file became likelier to be a bad filter than a true absence — a change in what a reading MEANS, which had already produced a false negative in a live investigation. The lines are unchanged in text, gates and numbers, and return in full with `Logging__LogLevel__PerformanceMonitor.Darling.Service=Debug` (documented in `Darling/README.md`, scoped to the namespace so raising it does not turn on every other component's `Debug`); the distribution was never only in the log, since `collection_log` records `duration_ms` and `sql_duration_ms` per run at every level. The fault-path split is untouched — it already takes its arm's level, and its remarks already carried the rule this applies: a phase line must not be louder than the error it decomposes, and a run that succeeded has no error beside it. Lite's twin line is deliberately left alone because the same edit there suppresses nothing: `AppLoggerAdapter` is built without a filter and enables `Debug` unconditionally, so it needs a gate before it needs a level.
