### PR TITLE
Fixes #3101

### DIFF
--- a/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
+++ b/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
@@ -20,22 +20,31 @@ namespace Darling.Tests;
 
 /// <summary>
 /// Drift guard between <see cref="TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds"/>'s recorded
-/// provenance and the arithmetic that provenance rests on (#3069).
+/// DERIVATION and the arithmetic that derivation consists of (#3069, #3101).
 ///
-/// <para><b>Why this exists.</b> The constant's doc comment used to present 864 s as the highest figure
-/// recorded under the narrowed window, alongside three companions "climbing with volume rather than
-/// settling". A ten-run status-verified series then rose to 594 s and settled back, and the 864 s run turned
-/// out to end one second AFTER the boundary the whole issue splits on — so its regime membership is
-/// undetermined. The comment records the distribution now. A distribution written in prose has no way to
-/// notice that its own summary no longer follows from it, which is how the superseded characterisation
-/// survived, so every summary figure is derived here and the prose is required to agree.</para>
+/// <para><b>Why this exists.</b> The constant is the maximum of a published population, and the doc comment
+/// states the population, the exclusion rule that produced it, and the summary figures that follow from it.
+/// Every one of those relationships is checkable and none of them is checked by the compiler: a population
+/// written in prose has no way to notice that its own summary no longer follows from it, and a summary is
+/// exactly what a later reader will cite. So the estimator is re-computed here from the series the comment
+/// publishes and the constant is required to equal it, which is the difference between a value someone can
+/// re-derive and a value someone has to trust.</para>
 ///
-/// <para><b>Derive, don't restate.</b> Nothing below hardcodes 864, 900, 36, 306 or 338. Every expected value
-/// comes either from the constants (<see cref="TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds"/>,
+/// <para><b>Derive, don't restate.</b> Nothing below hardcodes the ceiling, the slot, the margin or any
+/// summary figure. Every expected value comes either from the constants
+/// (<see cref="TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds"/>,
 /// <see cref="TimescaleSupport.RefreshPhaseSlotSeconds"/>,
 /// <see cref="TimescaleSupport.RefreshPhaseStepMinutes"/>,
-/// <see cref="TimescaleSupport.RefreshSlotWarningSeconds"/>) or from the SERIES THE COMMENT ITSELF PUBLISHES.
-/// A pin that restated the summary would go stale by precisely the mechanism it exists to stop.</para>
+/// <see cref="TimescaleSupport.RefreshSlotWarningSeconds"/>) or from the POPULATION THE COMMENT ITSELF
+/// PUBLISHES. A pin that restated the summary would go stale by precisely the mechanism it exists to
+/// stop.</para>
+///
+/// <para><b>One pin is written to expire, deliberately.</b> The comment's reason for taking the maximum
+/// rather than a percentile is partly that at this sample size the 95th percentile IS the maximum by nearest
+/// rank. <see cref="Verify"/> checks that, so the pin goes red once the population grows past the point where
+/// it holds — which is the moment the maximum-versus-percentile decision genuinely has to be re-taken rather
+/// than inherited. A check that simply kept passing would let the stated reason quietly stop being the real
+/// one.</para>
 ///
 /// <para><b>Which numeral KIND these are, because the repo handles two differently and neither #3072 nor
 /// #3073 says so out loud.</b> A numeral that restates an adjacent list gets DELETION offered in its
@@ -43,16 +52,19 @@ namespace Darling.Tests;
 /// numeral that is program output gets "fix the pattern rather than the count", because a transcript has
 /// to keep showing what the tool really prints. <c>ReadmeDerivedCountPinTests</c> implements both halves
 /// and states neither, so the rule has to be inferred from the disagreement between two of its own
-/// failure texts. All thirteen patterns here are the first kind — derived arithmetic restated in prose —
-/// which is why deletion is offered throughout; and this paragraph is NARRATION of an existing rule, not
-/// a counted claim, so nothing checks it and nothing should.</para>
+/// failure texts. Every pattern here is the first kind — derived arithmetic restated in prose — which is
+/// why deletion is offered throughout; and this paragraph is NARRATION of an existing rule, not a counted
+/// claim, so nothing checks it and nothing should. It states no count of patterns either, for the same
+/// reason: a numeral over a list that grows is the defect this file is about, one level up.</para>
 ///
-/// <para><b>What is deliberately NOT pinned, said plainly rather than left looking covered.</b> The two
+/// <para><b>What is deliberately NOT pinned, said plainly rather than left looking covered.</b> The
 /// snapshot readings are quoted evidence, not derived quantities — nothing in the code can know them — so
 /// they are held only by the DISJOINTNESS the paragraph is about (see
 /// <see cref="TheInadmissibleReadings_CannotBeFoldedIntoTheStatusVerifiedSeries"/>), which is the failure
 /// mode that matters: an unfiltered reading migrating into the population a constant may be set from. The
-/// clock time of the unobserved run and the pre-narrowing band are likewise evidence and carry no pin.</para>
+/// pre-narrowing band and the 3.8x ratio drawn against it are likewise evidence — that band is #3012's
+/// measurement and no constant here spells it — so they carry no pin. The excluded run's 1.45x ratio to the
+/// population maximum IS pinned, because both of its terms are stated here.</para>
 ///
 /// <para><b>The guard is itself guarded, three ways.</b> Every extraction asserts its pattern MATCHED before
 /// a value is compared. <see cref="EveryNumericPin_ReportsAnInjectedDrift"/> bumps each captured number ONE
@@ -96,49 +108,69 @@ public sealed class RefreshCeilingProvenancePinTests
     ///
     /// <para><b>ASCII-only patterns on purpose, and the reason is <see cref="DocProseFor"/> rather than
     /// anything in the patterns themselves.</b> It normalises <c>—</c> and <c>–</c> to <c>-</c>
-    /// before any pattern runs, so not one of the thirteen has to match a dash variant — and not one does.
+    /// before any pattern runs, so not one of them has to match a dash variant — and not one does.
     /// Matching a dash through a source-encoding round trip is a way for a pattern to stop matching for a
     /// reason that has nothing to do with what it guards, and normalising at the extractor removes that at
     /// the source instead of working around it thirteen times. The single literal hyphen below, in
     /// <c>([0-9]+)-second slot</c>, is a plain ASCII hyphen in the prose rather than a normalised
     /// dash.</para>
+    ///
+    /// <para><b>Every group is <c>[0-9]+</c> and never <c>[0-9]</c>, including the ones that read a single
+    /// decimal place.</b> <see cref="EveryNumericPin_ReportsAnInjectedDrift"/> bumps a captured number
+    /// WIDTH-PRESERVING, so a group holding a 9 comes back as two digits — and a one-digit group then stops
+    /// matching, which that sweep reports as a broken pattern rather than as a caught drift. Widening costs
+    /// no strictness, because <see cref="Verify"/> compares each captured value against the derived one
+    /// either way: prose stating a tenth as two digits is caught by the comparison instead of by the
+    /// regex.</para>
     /// </summary>
     private static IEnumerable<(string Name, string Declaration, string Pattern, bool DriftSwept)> Pins()
     {
         yield return (
-            "the transition run's clock arithmetic",
+            "the boundary timestamp",
+            CeilingDeclaration,
+            @"narrowing boundary of <c>([0-9][0-9]):([0-9][0-9]):([0-9][0-9])</c>",
+            true);
+
+        yield return (
+            "the excluded run's clock arithmetic",
             CeilingDeclaration,
             @"<c>([0-9][0-9]):([0-9][0-9]):([0-9][0-9])</c> to <c>([0-9][0-9]):([0-9][0-9]):([0-9][0-9])</c>",
             true);
 
         yield return (
-            "the boundary timestamp",
+            "the excluded run's duration",
             CeilingDeclaration,
-            @"<c>([0-9][0-9]):([0-9][0-9]):([0-9][0-9])</c>, one second BEFORE",
+            @"boundary day, ([0-9]+) s, excluded for starting before the boundary",
             true);
 
         yield return (
-            "the run count",
+            "the excluded run's ratio to the population maximum",
             CeilingDeclaration,
-            @"([0-9]+) consecutive runs",
+            @"([0-9]+)\.([0-9]+)x slower than the largest reading",
             true);
 
         yield return (
-            "the published series",
+            "the boundary day's tail",
             CeilingDeclaration,
-            @"<c>([0-9]+(?:, [0-9]+)+)</c> seconds",
+            @"every run that day after the boundary: <c>([0-9]+(?:, [0-9]+)+)</c> seconds",
             true);
 
         yield return (
-            "the clean-series summary",
+            "the days after the boundary",
             CeilingDeclaration,
-            @"remaining ([0-9]+) run from ([0-9]+) s to ([0-9]+) s, mean ([0-9]+) s, middle reading ([0-9]+) s",
+            @"The days after it: <c>([0-9]+(?:, [0-9]+)+)</c> seconds",
             true);
 
         yield return (
-            "the slot-clearance contrast",
+            "the population summary",
             CeilingDeclaration,
-            @"clears the slot by ([0-9]+) s, where this constant clears it by ([0-9]+) s",
+            @"Together ([0-9]+) runs spanning ([0-9]+) s to ([0-9]+) s, mean ([0-9]+)\.([0-9]+) s, median ([0-9]+) s",
+            true);
+
+        yield return (
+            "the percentile decision",
+            CeilingDeclaration,
+            @"by nearest rank over ([0-9]+) readings the 95th percentile IS the largest of them, and the 90th is ([0-9]+) s, only ([0-9]+) s below it",
             true);
 
         /* ARITY-FREE, and that is the point rather than a convenience. This list gains a reading every hour
@@ -158,32 +190,44 @@ public sealed class RefreshCeilingProvenancePinTests
             false);
 
         yield return (
-            "the downward-edit consequence",
-            CeilingDeclaration,
-            @"toward the observed ([0-9]+) s would leave ([0-9]+) s of margin in place of ([0-9]+) s",
-            true);
-
-        yield return (
             "the low the grid is deliberately not sized against",
             CeilingDeclaration,
-            @"not against the ([0-9]+) s low",
+            @"against the ([0-9]+) s low",
             true);
 
         yield return (
             "the margin sentence",
             CeilingDeclaration,
-            @"At ([0-9]+) s against a ([0-9]+)-second slot the margin is already only ([0-9]+) seconds",
+            @"At ([0-9]+) s against a ([0-9]+)-second slot the margin is ([0-9]+) seconds",
             true);
 
         yield return (
             "the exclude-whole occupancy sentence",
             CompressionMinutesDeclaration,
-            @"occupies ([0-9]+)\.([0-9]) of the ([0-9]+) minutes",
+            @"occupies ([0-9]+)\.([0-9]+) of the ([0-9]+) minutes",
+            true);
+
+        yield return (
+            "the guard-band arithmetic the exclusion rests on",
+            CompressionMinutesDeclaration,
+            @"band is ([0-9]+), so applying the ordinary band to this slot would admit ([0-9]+) minutes that sit INSIDE the refresh",
+            true);
+
+        yield return (
+            "the minutes left on the table",
+            CompressionMinutesDeclaration,
+            @"The other ([0-9]+) minutes of the slot are past the refresh",
+            true);
+
+        yield return (
+            "the population size and range the exclusion defers to",
+            CompressionMinutesDeclaration,
+            @"population is ([0-9]+) readings and still moving \(([0-9]+) s to ([0-9]+) s within the clean regime\)",
             true);
     }
 
     [Fact]
-    public void EveryProvenanceClaim_FollowsFromTheConstantsAndThePublishedSeries()
+    public void EveryDerivationClaim_FollowsFromTheConstantsAndThePublishedPopulation()
     {
         Verify(ReadTimescaleSupportSource());
     }
@@ -203,7 +247,7 @@ public sealed class RefreshCeilingProvenancePinTests
         var source = ReadTimescaleSupportSource();
         var prose = DocProseFor(source, CeilingDeclaration);
 
-        var series = Numbers(prose, "the published series");
+        var series = CleanPopulation(prose);
         var snapshot = Numbers(prose, "the inadmissible snapshot readings");
 
         Assert.NotEmpty(series);
@@ -280,9 +324,9 @@ public sealed class RefreshCeilingProvenancePinTests
     /// pattern STILL MATCHES, then require verification to fail with something other than a parse miss.
     ///
     /// <para>One number at a time rather than all at once is the point of the shape. It is what makes each
-    /// individual reading in the published series load-bearing — a bump to a middle-ranked reading changes
-    /// neither the range nor the middle, and is caught only because the mean is stated too. Bumping every
-    /// group together would have hidden that.</para>
+    /// individual reading in the published population load-bearing — a bump to a middle-ranked reading
+    /// changes neither the range, the maximum nor the median, and is caught only because the mean is stated
+    /// too. Bumping every group together would have hidden that.</para>
     /// </summary>
     [Fact]
     public void EveryNumericPin_ReportsAnInjectedDrift()
@@ -368,34 +412,42 @@ public sealed class RefreshCeilingProvenancePinTests
     /// figures the prose states to one decimal are held to being exactly stateable to one decimal.
     /// </summary>
     [Fact]
-    public void TheDerivedFiguresAreExactlyStateable_AndTheCleanSeriesSitsWhereTheProseSaysItDoes()
+    public void TheDerivedFiguresAreExactlyStateable_AndTheConstantIsThePopulationMaximum()
     {
         /* CompressionPhaseMinutes quotes the ceiling in minutes to one decimal, which is only faithful while
-           the ceiling is an exact tenth of a minute: 14.4 for a 14.41666 value is a rounded claim wearing an
+           the ceiling is an exact tenth of a minute: 9.9 for a 9.91666 value is a rounded claim wearing an
            exact one's clothes. */
         Assert.Equal(0, Ceiling * 10 % 60);
 
-        var clean = CleanSeries(DocProseFor(ReadTimescaleSupportSource(), CeilingDeclaration));
-        Assert.NotEmpty(clean);
+        var population = CleanPopulation(DocProseFor(ReadTimescaleSupportSource(), CeilingDeclaration));
+        Assert.NotEmpty(population);
 
-        /* The mean is stated as a whole number of seconds. */
-        Assert.Equal(0, clean.Sum() % clean.Length);
+        /* THE DERIVATION, as one assertion: this constant IS the maximum of the published population. Not
+           "above it" - equal to it, because the comment says the estimator is the maximum and a value merely
+           above the maximum is the unestablished-bound shape the derivation replaces. */
+        Assert.Equal(population.Max(), Ceiling);
 
-        /* The relationship the whole resolution turns on, as an assertion over the WHOLE inventory rather
-           than one true clause standing in for it: every cleanly post-boundary run came in under the value
-           the grid is sized against, which is what makes that value safe without making it measured. */
-        Assert.All(clean, reading => Assert.True(reading < Ceiling,
-            $"a cleanly post-boundary reading of {reading} s is at or past the {Ceiling} s the compression "
-            + "grid is sized against, so the ceiling is no longer above the observed range and #3069's "
-            + "resolution — record the provenance, leave the value — no longer holds."));
-        Assert.All(clean, reading => Assert.True(reading < WatchLine,
-            $"a cleanly post-boundary reading of {reading} s is at or past the {WatchLine} s watch line, so "
-            + "the doc comment's claim that every clean reading is below it is false."));
+        /* The mean is stated to one decimal and the median as a whole number, so both have to be exactly
+           stateable in those shapes. */
+        Assert.Equal(0, population.Sum() * 10 % population.Length);
+        var sorted = population.OrderBy(v => v).ToArray();
+        Assert.Equal(0, (sorted[(sorted.Length - 1) / 2] + sorted[sorted.Length / 2]) % 2);
 
-        /* The contrast the prose draws: the undetermined run is in the warning band, the clean ones are not. */
-        Assert.True(Ceiling >= WatchLine,
-            "the ceiling no longer classifies as a warning, so the doc comment's contrast between it and the "
-            + "clean series is stale.");
+        /* The relationship the grid depends on, over the WHOLE population rather than one true clause
+           standing in for it: every clean run fits inside the slot, and inside the routine band. */
+        Assert.All(population, reading => Assert.True(reading < Slot,
+            $"a clean post-boundary reading of {reading} s is at or past the {Slot} s refresh slot, so the "
+            + "compression grid's stated precondition is false and #3035 has to be re-derived rather than "
+            + "renumbered"));
+        Assert.All(population, reading => Assert.True(reading < WatchLine,
+            $"a clean post-boundary reading of {reading} s is at or past the {WatchLine} s watch line, so "
+            + "the doc comment's claim that every reading in the population is below it is false"));
+
+        /* And the contrast the prose draws: the watch line sits ABOVE the derived ceiling, which is what
+           makes a crossing news rather than a restatement of the grid's own sizing figure. */
+        Assert.True(Ceiling < WatchLine,
+            "the ceiling now classifies as a warning, so the doc comment's claim that the watch line sits "
+            + "above the observed range is stale.");
     }
 
     /* ─────────────────────────────── verification ─────────────────────────────── */
@@ -418,47 +470,56 @@ public sealed class RefreshCeilingProvenancePinTests
             return Numbers(DocProseFor(source, DeclarationFor(name)), name);
         }
 
-        var series = Read("the published series");
-        Require(series.Length > 0, "the published series parsed to nothing");
+        var tail = Read("the boundary day's tail");
+        var after = Read("the days after the boundary");
+        Require(tail.Length > 0, "the boundary day's tail parsed to nothing");
+        Require(after.Length > 0, "the days after the boundary parsed to nothing");
 
-        /* THE LINK TO THE CONSTANT. The comment's first reading IS this constant — that is what makes the
-           transition-run paragraph about this number rather than about some other run. */
-        Require(series.Count(v => v == Ceiling) == 1,
-            $"the published series {Join(series)} does not contain {Ceiling} exactly once, so the comment's "
-            + "transition-run paragraph is no longer about the value of this constant");
-
-        var clean = CleanSeries(ceilingProse);
-        Require(clean.Length == series.Length - 1, "setting the transition run aside did not leave one fewer reading");
-        Require(clean.Length > 0, "the clean series is empty, so every summary figure below would be vacuous");
-        Require(clean.Sum() % clean.Length == 0,
-            "the clean series' mean is no longer a whole number of seconds, so the prose cannot state it as "
-            + "one — restate it rather than removing this check");
-
-        var sorted = clean.OrderBy(v => v).ToArray();
+        var population = tail.Concat(after).ToArray();
+        var sorted = population.OrderBy(v => v).ToArray();
         var min = sorted[0];
         var max = sorted[^1];
-        var middle = sorted[sorted.Length / 2];
-        var mean = clean.Sum() / clean.Length;
+        var mean10 = population.Sum() * 10 / population.Length;
+        var median = (sorted[(sorted.Length - 1) / 2] + sorted[sorted.Length / 2]) / 2;
 
-        var runCount = Read("the run count");
-        Require(runCount[0] == series.Length,
-            $"the comment says {runCount[0]} consecutive runs and then lists {series.Length}");
+        /* THE DERIVATION, and the one relationship everything else here is decoration on: the constant is
+           the maximum of the population the comment publishes. */
+        Require(max == Ceiling,
+            $"the published population {Join(sorted)} has maximum {max} s, but this constant holds "
+            + $"{Ceiling} s — the comment says the estimator is the maximum, so one of the two is wrong");
 
-        var summary = Read("the clean-series summary");
-        Require(summary[0] == clean.Length, $"stated clean count {summary[0]} against {clean.Length} listed");
+        Require(population.Sum() * 10 % population.Length == 0,
+            "the population's mean is no longer an exact tenth of a second, so the prose cannot state it to "
+            + "one decimal — restate it rather than removing this check");
+        Require((sorted[(sorted.Length - 1) / 2] + sorted[sorted.Length / 2]) % 2 == 0,
+            "the population's median is no longer a whole number of seconds, so the prose cannot state it as "
+            + "one — restate it rather than removing this check");
+
+        var summary = Read("the population summary");
+        Require(summary[0] == population.Length,
+            $"stated count {summary[0]} against {population.Length} listed");
         Require(summary[1] == min, $"stated low {summary[1]} s against {min} s listed");
         Require(summary[2] == max, $"stated high {summary[2]} s against {max} s listed");
-        Require(summary[3] == mean, $"stated mean {summary[3]} s against {mean} s computed");
-        Require(summary[4] == middle, $"stated middle {summary[4]} s against {middle} s computed");
+        Require(summary[3] * 10 + summary[4] == mean10,
+            $"stated mean {summary[3]}.{summary[4]} s against {mean10 / 10}.{mean10 % 10} s computed");
+        Require(summary[5] == median, $"stated median {summary[5]} s against {median} s computed");
 
-        var clearance = Read("the slot-clearance contrast");
-        Require(clearance[0] == Slot - max, $"stated clearance {clearance[0]} s against {Slot - max} s derived");
-        Require(clearance[1] == Slot - Ceiling, $"stated margin {clearance[1]} s against {Slot - Ceiling} s derived");
-
-        var downward = Read("the downward-edit consequence");
-        Require(downward[0] == max, $"stated observed maximum {downward[0]} s against {max} s listed");
-        Require(downward[1] == Slot - max, $"stated replacement margin {downward[1]} s against {Slot - max} s derived");
-        Require(downward[2] == Slot - Ceiling, $"stated current margin {downward[2]} s against {Slot - Ceiling} s derived");
+        /* THE ESTIMATOR CHOICE, checked rather than asserted in prose — and written to EXPIRE. The comment
+           takes the maximum partly because at this sample size the 95th percentile is the maximum by nearest
+           rank; when the population grows past that, this goes red and the decision gets re-taken instead of
+           inherited. */
+        var percentile = Read("the percentile decision");
+        Require(percentile[0] == population.Length,
+            $"stated sample size {percentile[0]} against {population.Length} listed");
+        Require(NearestRank(sorted, 95) == max,
+            $"the 95th percentile of {Join(sorted)} is {NearestRank(sorted, 95)} s and no longer the "
+            + $"{max} s maximum, so the comment's stated reason for taking the maximum rather than a "
+            + "percentile has expired. RE-TAKE the decision (issue #3101 records the trade) rather than "
+            + "editing this assertion — that is what this pin is for");
+        Require(percentile[1] == NearestRank(sorted, 90),
+            $"stated 90th percentile {percentile[1]} s against {NearestRank(sorted, 90)} s computed");
+        Require(percentile[2] == max - NearestRank(sorted, 90),
+            $"stated gap {percentile[2]} s against {max - NearestRank(sorted, 90)} s derived");
 
         var low = Read("the low the grid is deliberately not sized against");
         Require(low[0] == min, $"stated low {low[0]} s against {min} s listed");
@@ -468,25 +529,35 @@ public sealed class RefreshCeilingProvenancePinTests
         Require(margin[1] == Slot, $"stated slot {margin[1]} s against {Slot} s");
         Require(margin[2] == Slot - Ceiling, $"stated margin {margin[2]} s against {Slot - Ceiling} s derived");
 
-        /* Clock arithmetic. The transition-run finding IS this subtraction: the run ends one second after the
-           boundary, which is why its regime membership cannot be settled from the data in hand. */
-        var run = Read("the transition run's clock arithmetic");
+        /* The EXCLUDED run. Its clock arithmetic has to reproduce its own stated duration, it has to end one
+           second after the stated boundary, and its ratio to the population maximum has to be the ratio the
+           prose draws — which is what keeps that paragraph about this population rather than free-floating. */
+        var run = Read("the excluded run's clock arithmetic");
         var started = Seconds(run[0], run[1], run[2]);
         var ended = Seconds(run[3], run[4], run[5]);
-        Require(ended - started == Ceiling,
-            $"the quoted run spans {ended - started} s, not the {Ceiling} s this constant holds");
+        var excluded = Read("the excluded run's duration");
+        Require(ended - started == excluded[0],
+            $"the quoted run spans {ended - started} s, not the {excluded[0]} s stated for it");
+        Require(excluded[0] > Ceiling,
+            $"the excluded run's {excluded[0]} s is no longer above the {Ceiling} s population maximum, so "
+            + "the prose's \"slower than the largest reading\" is false");
 
         var boundary = Read("the boundary timestamp");
         Require(ended - Seconds(boundary[0], boundary[1], boundary[2]) == 1,
-            "the quoted run no longer ends exactly one second after the quoted boundary, so the "
-            + "transition-run reading the whole provenance paragraph rests on is not what the numbers say");
+            "the quoted run no longer ends exactly one second after the quoted boundary, so the circularity "
+            + "the open-question paragraph is about is not what the numbers say");
+
+        var ratio = Read("the excluded run's ratio to the population maximum");
+        Require(ratio[0] * 100 + ratio[1] == excluded[0] * 100 / Ceiling,
+            $"stated ratio {ratio[0]}.{ratio[1]}x against {excluded[0] * 100 / Ceiling / 100}."
+            + $"{excluded[0] * 100 / Ceiling % 100}x derived from {excluded[0]} s over {Ceiling} s");
 
         /* The snapshot readings stay out of the admissible population, HOWEVER MANY of them there are. */
         var snapshot = Read("the inadmissible snapshot readings");
         Require(snapshot.Length > 0, "the inadmissible snapshot readings parsed to nothing");
-        Require(!snapshot.Intersect(series).Any(),
-            $"an unfiltered snapshot reading appears in the status-verified series {Join(series)}, so the two "
-            + "populations have been run together");
+        Require(!snapshot.Intersect(population).Any(),
+            $"an unfiltered snapshot reading appears in the status-verified population {Join(sorted)}, so "
+            + "the two populations have been run together");
 
         /* THE CLOSING SCOPE, which is what stops that list reading as a complete enumeration of an open
            set. The series it quotes gains a reading every hour, so an unscoped list is a frozen enumeration
@@ -507,7 +578,8 @@ public sealed class RefreshCeilingProvenancePinTests
             + "enumeration and keep only the rule, which is the timeless part and the paragraph's real "
             + "subject");
 
-        /* CompressionPhaseMinutes' exclude-whole reasoning, in minutes. */
+        /* CompressionPhaseMinutes' exclude-whole reasoning: the ceiling in minutes, the guard band against
+           it, and the minutes the exclusion declines to recover. */
         Require(Ceiling * 10 % 60 == 0,
             "the ceiling is no longer an exact tenth of a minute, so the occupancy figure cannot be stated to "
             + "one decimal");
@@ -517,12 +589,45 @@ public sealed class RefreshCeilingProvenancePinTests
             $"stated tenth of a minute {occupancy[1]} against {Ceiling * 10 / 60 % 10}");
         Require(occupancy[2] == SlotMinutes, $"stated slot {occupancy[2]} minutes against {SlotMinutes}");
 
+        var minutesInsideTheRefresh = (Ceiling + 59) / 60;
+        var band = Read("the guard-band arithmetic the exclusion rests on");
+        Require(band[0] == TimescaleSupport.CompressionPhaseGuardMinutes,
+            $"stated guard band {band[0]} minutes against {TimescaleSupport.CompressionPhaseGuardMinutes}");
+        Require(band[1] == minutesInsideTheRefresh - TimescaleSupport.CompressionPhaseGuardMinutes,
+            $"stated {band[1]} band minutes inside the refresh against "
+            + $"{minutesInsideTheRefresh - TimescaleSupport.CompressionPhaseGuardMinutes} derived — if this "
+            + "reached zero the band would clear the refresh and the exclude-whole reasoning would no longer "
+            + "hold, so re-read #3035 rather than restating the figure");
+
+        var onTheTable = Read("the minutes left on the table");
+        Require(onTheTable[0] == SlotMinutes - minutesInsideTheRefresh,
+            $"stated {onTheTable[0]} minutes past the refresh against "
+            + $"{SlotMinutes - minutesInsideTheRefresh} derived");
+
+        var deferred = Read("the population size and range the exclusion defers to");
+        Require(deferred[0] == population.Length,
+            $"stated population size {deferred[0]} against {population.Length} listed");
+        Require(deferred[1] == min, $"stated low {deferred[1]} s against {min} s listed");
+        Require(deferred[2] == max, $"stated high {deferred[2]} s against {max} s listed");
+
         /* And nothing in the pin list went unused: a pattern that is never asserted against reads, from the
            list, exactly like one that is. */
         var unused = Pins().Select(p => p.Name).Where(n => !consumed.Contains(n)).ToArray();
         Require(unused.Length == 0,
             "these pinned sentences are declared but never verified, so they guard nothing: "
             + string.Join(", ", unused));
+    }
+
+    /// <summary>
+    /// The nearest-rank percentile of an ASCENDING population — <c>ceil(p/100 * n)</c>, 1-based, which is
+    /// the definition the doc comment's percentile argument is stated in. Integer arithmetic throughout, so
+    /// no rounding mode can move the rank.
+    /// </summary>
+    private static int NearestRank(int[] sortedAscending, int percentile)
+    {
+        Require(sortedAscending.Length > 0, "no population, so no percentile");
+        var rank = (percentile * sortedAscending.Length + 99) / 100;
+        return sortedAscending[Math.Clamp(rank, 1, sortedAscending.Length) - 1];
     }
 
     /// <summary>
@@ -538,27 +643,15 @@ public sealed class RefreshCeilingProvenancePinTests
         Regex.IsMatch(sql, @"last_run_status\s*=\s*'Success'");
 
     /// <summary>
-    /// The published series with the ONE undetermined-regime reading set aside — matched against this
-    /// constant rather than taken by position, so a reordered list cannot silently set a different run aside.
+    /// The clean post-boundary population: both published lists, concatenated. Read from the two patterns
+    /// rather than from one, because the comment publishes them separately — the boundary day's tail is a
+    /// census of that day and the days after it are a sample, and collapsing the two into a single list in
+    /// the prose would erase a distinction the estimator's stated limitation rests on.
     /// </summary>
-    private static int[] CleanSeries(string prose)
-    {
-        var removed = false;
-        var clean = new List<int>();
-        foreach (var reading in Numbers(prose, "the published series"))
-        {
-            if (!removed && reading == Ceiling)
-            {
-                removed = true;
-                continue;
-            }
-
-            clean.Add(reading);
-        }
-
-        Require(removed, $"the published series does not contain {Ceiling}, so nothing was set aside");
-        return clean.ToArray();
-    }
+    private static int[] CleanPopulation(string prose) =>
+        Numbers(prose, "the boundary day's tail")
+            .Concat(Numbers(prose, "the days after the boundary"))
+            .ToArray();
 
     private static int Seconds(int hours, int minutes, int seconds) => (hours * 60 + minutes) * 60 + seconds;
 
@@ -745,10 +838,10 @@ public sealed class RefreshCeilingProvenancePinTests
     /// explicit value is used by the population-merge mutation. Either way the bump preserves WIDTH, so a
     /// zero-padded clock component cannot break the pattern it is being tested against.</para>
     ///
-    /// <para>Addressed by ORDINAL rather than by value, because a bare string replace of "36" would rewrite
-    /// every 36 in the file and prove something other than what it was aimed at — and because repeated
-    /// values (36 appears four times in this doc run, 306 twice, 9 three times) have to stay individually
-    /// addressable.</para>
+    /// <para>Addressed by ORDINAL rather than by value, because a bare string replace of a figure would
+    /// rewrite every copy of it in the file and prove something other than what it was aimed at — and
+    /// because a doc run that states the same value in several places (a reading that is also the maximum,
+    /// a population size quoted twice) has to keep each copy individually addressable.</para>
     /// </summary>
     private static string? RewriteNumberInDocRun(
         string source, string declaration, string pattern, int ordinal, string? replacement)

--- a/Darling/Darling.Tests/TimescaleContinuousAggregateTests.cs
+++ b/Darling/Darling.Tests/TimescaleContinuousAggregateTests.cs
@@ -133,8 +133,8 @@ public sealed class TimescaleContinuousAggregateTests
     /// retention re-materialized roughly three quarters of the hypertable every hour. Measured on the
     /// production store: the heaviest hourly refresh ran 3,301-6,330 s against its own 1-hour cadence — 118-175%
     /// of it, so each run started into the tail of the last — while rows arriving per hour FELL ~3x. On the
-    /// narrowed window the same refresh runs 864 s, 24% of cadence, which is what makes the overlap
-    /// structurally impossible rather than merely absent.</para>
+    /// narrowed window the same refresh's largest clean run is 594 s, 16.5% of cadence, which is what makes
+    /// the overlap structurally impossible rather than merely absent.</para>
     ///
     /// <para>Asserted for EVERY hourly view rather than the heavy one alone: the defect was a shared default,
     /// so a fix that reached only the aggregate named in the incident would leave twelve behind.</para>
@@ -167,9 +167,9 @@ public sealed class TimescaleContinuousAggregateTests
     /// <summary>
     /// TREATMENT TWO of #3012, pinned ALONE so that reverting it is red here even if the narrowing survives.
     ///
-    /// <para>The heaviest hourly refresh is still ~33x its lightest sibling on the narrowed window, so 864 s
-    /// has to be invisible to everything else rather than merely short. Two things do that, and the second is
-    /// the less obvious one:</para>
+    /// <para>The heaviest hourly refresh is still more than 4x the recorded ceiling for any other one on the
+    /// narrowed window, so its 594 s has to be invisible to everything else rather than merely short. Two
+    /// things do that, and the second is the less obvious one:</para>
     ///
     /// <para><b>Distinct minutes of the hour.</b> A refresh holds <c>AccessShareLock</c> on what it reads; a
     /// compression policy on that same hypertable queues an <c>AccessExclusiveLock</c> request behind it; and a

--- a/Darling/Darling.Tests/TimescaleContinuousAggregateTests.cs
+++ b/Darling/Darling.Tests/TimescaleContinuousAggregateTests.cs
@@ -133,8 +133,9 @@ public sealed class TimescaleContinuousAggregateTests
     /// retention re-materialized roughly three quarters of the hypertable every hour. Measured on the
     /// production store: the heaviest hourly refresh ran 3,301-6,330 s against its own 1-hour cadence — 118-175%
     /// of it, so each run started into the tail of the last — while rows arriving per hour FELL ~3x. On the
-    /// narrowed window the same refresh's largest clean run is 594 s, 16.5% of cadence, which is what makes
-    /// the overlap structurally impossible rather than merely absent.</para>
+    /// narrowed window the same refresh finishes well inside one phase slot, which is what makes the overlap
+    /// structurally impossible rather than merely absent. The figure and its derivation live on
+    /// TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds rather than being restated here.</para>
     ///
     /// <para>Asserted for EVERY hourly view rather than the heavy one alone: the defect was a shared default,
     /// so a fix that reached only the aggregate named in the incident would leave twelve behind.</para>
@@ -168,8 +169,8 @@ public sealed class TimescaleContinuousAggregateTests
     /// TREATMENT TWO of #3012, pinned ALONE so that reverting it is red here even if the narrowing survives.
     ///
     /// <para>The heaviest hourly refresh is still more than 4x the recorded ceiling for any other one on the
-    /// narrowed window, so its 594 s has to be invisible to everything else rather than merely short. Two
-    /// things do that, and the second is the less obvious one:</para>
+    /// narrowed window, so what it does take has to be invisible to everything else rather than merely
+    /// short. Two things do that, and the second is the less obvious one:</para>
     ///
     /// <para><b>Distinct minutes of the hour.</b> A refresh holds <c>AccessShareLock</c> on what it reads; a
     /// compression policy on that same hypertable queues an <c>AccessExclusiveLock</c> request behind it; and a

--- a/Darling/Darling.Tests/TimescaleSupportTests.cs
+++ b/Darling/Darling.Tests/TimescaleSupportTests.cs
@@ -2312,6 +2312,17 @@ LIMIT 1", connection))
             $"the {TimescaleSupport.CompressionPhaseGuardMinutes}-minute guard band is no longer 3x the "
             + $"{TimescaleSupport.OtherHourlyRefreshObservedCeilingSeconds}s recorded ceiling for a non-heaviest hourly refresh");
 
+        /* And the ASYMMETRY between the two recorded ceilings, which is what HeaviestHourlyRefreshView's
+           "under a quarter of it" and RefreshPhaseStepMinutes' "more than 4x" both rest on. Those are the
+           only two places the asymmetry is stated in prose, and neither is derivable from the grid, so
+           without this they can go stale in either direction while every other pin stays green. */
+        Assert.True(
+            TimescaleSupport.OtherHourlyRefreshObservedCeilingSeconds * 4 < TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds,
+            $"the heaviest hourly refresh's {TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds}s "
+            + $"recorded ceiling is no longer more than 4x the {TimescaleSupport.OtherHourlyRefreshObservedCeilingSeconds}s "
+            + "recorded for any other one, so the asymmetry the grid's shape is justified by has narrowed — "
+            + "re-read HeaviestHourlyRefreshView and RefreshPhaseStepMinutes rather than editing this");
+
         var refreshSlots = TimescaleSupport.HourlyRefreshPhaseOrder
             .Select(TimescaleSupport.RefreshPhaseMinutesFor)
             .Distinct()
@@ -2402,12 +2413,15 @@ LIMIT 1", connection))
         Assert.DoesNotContain(lastMinuteInsideTheRefresh, TimescaleSupport.CompressionPhaseMinutes);
 
         /* And the ceiling is strictly below the watch line, which is what makes a live reading in the warning
-           band news rather than a restatement of the grid's own sizing figure. */
+           band news rather than a restatement of the grid's own sizing figure. The GAP is pinned too, since
+           RefreshSlotWarningSeconds states it as a percentage and a percentage in prose cannot notice that
+           its own two terms have moved. */
         Assert.True(
             ceiling < TimescaleSupport.RefreshSlotWarningSeconds,
             $"the recorded ceiling is {ceiling}s against a {TimescaleSupport.RefreshSlotWarningSeconds}s watch "
             + "line, so the figure the grid is sized against classifies as a warning and the watch reports the "
             + "grid's own sizing rather than anything new");
+        Assert.Equal(26, (TimescaleSupport.RefreshSlotWarningSeconds - ceiling) * 100 / ceiling);
     }
 
     /* ─────────────────── #3044: the watch on the LIVE figure, not the constant ─────────────────── */

--- a/Darling/Darling.Tests/TimescaleSupportTests.cs
+++ b/Darling/Darling.Tests/TimescaleSupportTests.cs
@@ -2270,7 +2270,7 @@ LIMIT 1", connection))
     /// after each refresh slot, and none of them is inside the heaviest refresh's slot at all.
     ///
     /// <para><b>Not "different from the refresh minutes".</b> That weaker property is satisfied by :07, and
-    /// :07 sits squarely inside the 864 s the heaviest hourly refresh occupies from :00 — a compression tick
+    /// :07 sits squarely inside the 594 s the heaviest hourly refresh occupies from :00 — a compression tick
     /// there is exactly the arrangement #3012's convoy formed on. What has to hold is a DISTANCE from each
     /// refresh START, because the convoy needs compression's <c>AccessExclusiveLock</c> request to arrive
     /// while a refresh already holds its shared lock.</para>
@@ -2291,7 +2291,7 @@ LIMIT 1", connection))
            comment reads as unconditional to whoever finds it next. Raising the recorded ceiling past the
            slot width therefore has to FAIL here rather than be renumbered through, because past that
            point the refresh runs into its neighbour and the grid needs redesigning. */
-        Assert.Equal(864, TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds);
+        Assert.Equal(594, TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds);
         Assert.Equal(140, TimescaleSupport.OtherHourlyRefreshObservedCeilingSeconds);
         Assert.True(
             TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds < TimescaleSupport.RefreshPhaseStepMinutes * 60,
@@ -2358,6 +2358,58 @@ LIMIT 1", connection))
             TimescaleSupport.CompressionPhaseMinutes.Count);
     }
 
+    /// <summary>
+    /// The relationship the recorded ceiling exists to hold: NO compression minute starts while the heaviest
+    /// hourly refresh is still running. Measured in SECONDS from that refresh's own start, against the
+    /// constant, so the two things that could break it — the ceiling rising, or the grid moving a minute
+    /// closer — are both red here.
+    ///
+    /// <para><b>Why this is separate from the guard-band check above.</b> That one asks whether each
+    /// compression minute clears the refresh in ITS OWN slot, which is a statement about the band. This asks
+    /// whether it clears the HEAVIEST refresh, whose runtime is the only one long enough to reach past its
+    /// slot at all, and the answer has to be expressed in the ceiling rather than in minutes or the
+    /// constant's value stops being load-bearing.</para>
+    ///
+    /// <para><b>The discriminating case is asserted too.</b> A comparison over a grid that already clears the
+    /// refresh by a wide margin is satisfied by almost anything, so the minute that WOULD violate it is
+    /// computed and shown to violate it. Without that, a check that had stopped measuring the right quantity
+    /// would still be green.</para>
+    /// </summary>
+    [Fact]
+    public void NoCompressionMinuteStartsWhileTheHeaviestRefreshIsStillRunning()
+    {
+        var heaviestSlot = TimescaleSupport.RefreshPhaseMinutesFor(TimescaleSupport.HeaviestHourlyRefreshView);
+        var ceiling = TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds;
+
+        static int SecondsPastStart(int minute, int start) => (minute - start + 60) % 60 * 60;
+
+        Assert.NotEmpty(TimescaleSupport.CompressionPhaseMinutes);
+        foreach (var minute in TimescaleSupport.CompressionPhaseMinutes)
+        {
+            Assert.True(
+                SecondsPastStart(minute, heaviestSlot) >= ceiling,
+                $":{minute.ToString("00", CultureInfo.InvariantCulture)} starts "
+                + $"{SecondsPastStart(minute, heaviestSlot)}s after the heaviest refresh's "
+                + $":{heaviestSlot.ToString("00", CultureInfo.InvariantCulture)} start, which is inside the "
+                + $"{ceiling}s that refresh is recorded as taking — the compression grid is no longer clear of "
+                + "the refresh it is placed against (#3035/#3101)");
+        }
+
+        /* The comparison discriminates: the last minute still inside the refresh must fail it. Derived from
+           the ceiling rather than written down, so it moves with the constant. */
+        var lastMinuteInsideTheRefresh = (heaviestSlot + (ceiling - 1) / 60) % 60;
+        Assert.True(SecondsPastStart(lastMinuteInsideTheRefresh, heaviestSlot) < ceiling);
+        Assert.DoesNotContain(lastMinuteInsideTheRefresh, TimescaleSupport.CompressionPhaseMinutes);
+
+        /* And the ceiling is strictly below the watch line, which is what makes a live reading in the warning
+           band news rather than a restatement of the grid's own sizing figure. */
+        Assert.True(
+            ceiling < TimescaleSupport.RefreshSlotWarningSeconds,
+            $"the recorded ceiling is {ceiling}s against a {TimescaleSupport.RefreshSlotWarningSeconds}s watch "
+            + "line, so the figure the grid is sized against classifies as a warning and the watch reports the "
+            + "grid's own sizing rather than anything new");
+    }
+
     /* ─────────────────── #3044: the watch on the LIVE figure, not the constant ─────────────────── */
 
     /// <summary>
@@ -2402,18 +2454,17 @@ LIMIT 1", connection))
     /// <summary>
     /// The classifier's bands, pinned on the numbers #3044 was filed on rather than on invented ones.
     ///
-    /// <para><b>The load-bearing assertion is the one on the recorded ceiling.</b> 864 s classifies as
-    /// APPROACHING, which is the entire issue expressed as a test: the constant the compression grid is sized
-    /// against is already inside the warning band, 36 seconds clear of invalidating itself, and until now
-    /// nothing in the product looked at the live figure at all. The five readings taken during #3044's review
-    /// all classify INSIDE, which is the anti-crying-wolf half — including the 594 s peak, at 66.0% of the
-    /// slot.</para>
+    /// <para><b>The load-bearing assertion is the one on the recorded ceiling.</b> It classifies as INSIDE,
+    /// and the watch line sits ABOVE it — so a live reading in the warning band is this job exceeding its own
+    /// recorded range rather than a restatement of the figure the compression grid is sized against. The five
+    /// readings taken during #3044's review all classify INSIDE too, which is the anti-crying-wolf half; the
+    /// largest of them, at 66.0% of the slot, IS the recorded ceiling.</para>
     ///
     /// <para>Both boundaries are pinned inclusive on purpose: the wall matches the build-time assertion's
     /// <c>&lt;</c>, so a value AT the slot width fails both.</para>
     /// </summary>
     [Fact]
-    public void TheRefreshSlotClassifier_BandsTheLiveReadings_AndPutsTheRecordedCeilingInTheWarningBand()
+    public void TheRefreshSlotClassifier_BandsTheLiveReadings_AndKeepsTheWatchLineAboveTheRecordedCeiling()
     {
         /* The five live readings from #3044's review, in the order they were taken. */
         foreach (var seconds in new double[] { 335, 594, 465, 359, 293 })
@@ -2423,11 +2474,16 @@ LIMIT 1", connection))
                 TimescaleSupport.ClassifyRefreshSlotHeadroom(seconds));
         }
 
-        /* THE ISSUE, as an assertion: the number the grid is sized against is itself a warning. */
+        /* THE RELATIONSHIP, as an assertion: the number the grid is sized against is INSIDE the slot and
+           below the watch line, so the warning band is reserved for readings the record has no instance of. */
         Assert.Equal(
-            TimescaleSupport.RefreshSlotHeadroom.ApproachingSlot,
+            TimescaleSupport.RefreshSlotHeadroom.InsideSlot,
             TimescaleSupport.ClassifyRefreshSlotHeadroom(
                 TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds));
+        Assert.True(
+            TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds < TimescaleSupport.RefreshSlotWarningSeconds,
+            "the recorded ceiling classifies as a warning again, so the watch line no longer reports anything "
+            + "the grid's own sizing figure does not already say");
 
         /* Boundaries, inclusive both times. */
         Assert.Equal(
@@ -2469,15 +2525,17 @@ LIMIT 1", connection))
             TimescaleSupport.HeaviestHourlyRefreshView,
             TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds);
 
-        Assert.Equal(TimescaleSupport.RefreshSlotHeadroom.ApproachingSlot, atTheCeiling.Headroom);
-        Assert.Equal(36, atTheCeiling.ClearOfSlotSeconds);
-        Assert.Equal(96.0, atTheCeiling.PercentOfSlot, 1);
+        /* The recorded ceiling: 66.0% of the slot, 306 s clear, and inside the routine band. */
+        Assert.Equal(TimescaleSupport.RefreshSlotHeadroom.InsideSlot, atTheCeiling.Headroom);
+        Assert.Equal(306, atTheCeiling.ClearOfSlotSeconds);
+        Assert.Equal(66.0, atTheCeiling.PercentOfSlot, 1);
 
-        /* The 594 s peak: 66.0% of the slot, 306 s clear — the figures #3044 calibrated against. */
-        var peak = new HeaviestRefreshSlotReading(TimescaleSupport.HeaviestHourlyRefreshView, 594);
-        Assert.Equal(TimescaleSupport.RefreshSlotHeadroom.InsideSlot, peak.Headroom);
-        Assert.Equal(306, peak.ClearOfSlotSeconds);
-        Assert.Equal(66.0, peak.PercentOfSlot, 1);
+        /* The watch line, which is where APPROACHING starts: 83.3% of the slot, 150 s clear. */
+        var atTheWatchLine = new HeaviestRefreshSlotReading(
+            TimescaleSupport.HeaviestHourlyRefreshView, TimescaleSupport.RefreshSlotWarningSeconds);
+        Assert.Equal(TimescaleSupport.RefreshSlotHeadroom.ApproachingSlot, atTheWatchLine.Headroom);
+        Assert.Equal(150, atTheWatchLine.ClearOfSlotSeconds);
+        Assert.Equal(83.3, atTheWatchLine.PercentOfSlot, 1);
 
         var through = new HeaviestRefreshSlotReading(TimescaleSupport.HeaviestHourlyRefreshView, 1200);
         Assert.Equal(TimescaleSupport.RefreshSlotHeadroom.SlotExceeded, through.Headroom);
@@ -2499,15 +2557,17 @@ LIMIT 1", connection))
 
         var inside = new CapturingTestLogger();
         TimescaleSupport.LogHeaviestRefreshSlotHeadroom(
-            new HeaviestRefreshSlotReading(TimescaleSupport.HeaviestHourlyRefreshView, 594), inside);
+            new HeaviestRefreshSlotReading(
+                TimescaleSupport.HeaviestHourlyRefreshView,
+                TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds),
+            inside);
         Assert.StartsWith("Debug:", inside.Joined, StringComparison.Ordinal);
         Assert.Contains(TimescaleSupport.HeaviestHourlyRefreshView, inside.Joined, StringComparison.Ordinal);
 
         var approaching = new CapturingTestLogger();
         TimescaleSupport.LogHeaviestRefreshSlotHeadroom(
             new HeaviestRefreshSlotReading(
-                TimescaleSupport.HeaviestHourlyRefreshView,
-                TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds),
+                TimescaleSupport.HeaviestHourlyRefreshView, TimescaleSupport.RefreshSlotWarningSeconds),
             approaching);
         Assert.StartsWith("Warning:", approaching.Joined, StringComparison.Ordinal);
 
@@ -2623,16 +2683,16 @@ LIMIT 1", connection))
             "the slot watch no longer fires before #2136's default cadence warning, so it adds no lead time");
 
         /* And the evidence that #2136 does not know this job's size, as a number rather than as prose:
-           the recorded ceiling is 24.0% of the same cadence, one point under the 25% default, while the
-           clamp in DarlingAlertSettings is justified on "the production worst runs ~7% of cadence" — 252 s,
-           less than a third of it. Pinned so the doc comment's claim cannot quietly stop being true. */
+           the recorded ceiling is 16.5% of the same cadence, while the clamp in DarlingAlertSettings is
+           justified on "the production worst runs ~7% of cadence" — 252 s, under half of it. Pinned so the
+           doc comment's claim cannot quietly stop being true. */
         Assert.Equal(
-            24.0,
+            16.5,
             100.0 * TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds / hourlyCadenceSeconds,
             1);
         Assert.True(
-            hourlyCadenceSeconds * 7 / 100 < TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds / 3,
-            "the ~7%-of-cadence figure #2136's clamp is justified on is no longer far below the heaviest "
+            hourlyCadenceSeconds * 7 / 100 * 2 < TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds,
+            "the ~7%-of-cadence figure #2136's clamp is justified on is no longer under half the heaviest "
             + "refresh's recorded ceiling, so the two calibrations may have been reconciled — re-read both");
     }
 
@@ -2981,7 +3041,7 @@ LIMIT 1", connection))
     /// only that each phase is one of the four slots, so a reordering that permutes which view gets which
     /// minute passes it. The compression grid is built by excluding the slot
     /// <see cref="TimescaleSupport.HeaviestHourlyRefreshView"/> occupies, so that permutation is exactly the
-    /// edit that could put a compression minute back inside 864 s of refresh while every other pin in the
+    /// edit that could put a compression minute back inside 594 s of refresh while every other pin in the
     /// tree stayed green. Both halves are asserted: the full assignment, and the heaviest view's slot.</para>
     /// </summary>
     [Fact]

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -1573,7 +1573,8 @@ WITH NO DATA";
     /// hypertable rather than with ingest. Measured on the production store: the heaviest hourly refresh
     /// (<see cref="QueryStoreStatsIntervalHourlyView"/>) ran 3,301-6,330 s against a 1-hour cadence —
     /// <b>118-175% of its own schedule interval</b> — while rows arriving per hour FELL ~3x over the same
-    /// period. Narrowed to 1 day the same refresh runs <b>864 s, 24% of cadence</b>. The direction of that
+    /// period. Narrowed to 1 day the same refresh's largest clean run is <b>594 s, 16.5% of cadence</b> (the
+    /// derivation is on <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/>). The direction of that
     /// measurement is the whole argument: duration tracking window size while ingest moves the other way is
     /// what rules out "more rows to materialize" and rules in "too much window".</para>
     ///
@@ -1585,7 +1586,8 @@ WITH NO DATA";
     /// next run started into the tail of the previous one, and the convoy sustained itself. Below cadence it
     /// cannot form, which is why this number and <see cref="RefreshPhaseStepMinutes"/> are complements rather
     /// than alternatives: narrowing is what makes the heavy refresh finish, phasing is what keeps its
-    /// remaining 864 s out of everyone else's way.</para>
+    /// remaining <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/> seconds out of everyone else's
+    /// way.</para>
     ///
     /// <para><b>What still has to fit inside it, now stated as a relationship rather than left to a
     /// constant.</b> Two things need the window to reach back far enough. Live collectors only ever append
@@ -1640,15 +1642,20 @@ WITH NO DATA";
     /// phased across the hour instead of all starting together.
     ///
     /// <para><b>Phasing alone is not the fix and neither is narrowing alone.</b>
-    /// <see cref="HourlyRefreshStartOffset"/> is what brought the heavy refresh from 6,330 s to 864 s; this is
-    /// what keeps those 864 s from being visible to anything else, because the refresh that is running is not
-    /// the one a compression policy or a sibling refresh is about to want. The heaviest hourly refresh is
-    /// still ~33x its lightest sibling on the narrowed window, so the two treatments address different halves
-    /// and dropping either one reopens the door.</para>
+    /// <see cref="HourlyRefreshStartOffset"/> is what brought the heavy refresh from 6,330 s to a clean
+    /// maximum of <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/> s; this is what keeps those
+    /// seconds from being visible to anything else, because the refresh that is running is not the one a
+    /// compression policy or a sibling refresh is about to want. The heaviest hourly refresh is still more
+    /// than 4x the recorded ceiling for any other one
+    /// (<see cref="OtherHourlyRefreshObservedCeilingSeconds"/>), so the two treatments address different
+    /// halves and dropping either one reopens the door.</para>
     ///
     /// <para><b>15 minutes over four slots is the configuration that was measured</b>, not a round number: the
     /// production store's <c>query_store_stats</c> job family was moved to :00/:15/:30/:45 and the first full
-    /// staggered cycle came back 26 s / 2 s / 864 s / 140 s with zero ungranted locks on every sample since.
+    /// staggered cycle came back 26 s / 2 s / 864 s / 140 s with zero ungranted locks on every sample since —
+    /// a cycle that STRADDLES the narrowing boundary
+    /// (<see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/>), so its four figures record what the
+    /// stagger did to lock waits and are not samples of the narrowed regime's cost.
     /// Spreading all thirteen hourly policies across thirteen distinct minutes would contend less still, and
     /// is the obvious next refinement — but it is not what the numbers above were taken on.</para>
     /// </summary>
@@ -1766,51 +1773,81 @@ WITH NO DATA";
     /// <para>On the narrowed <see cref="HourlyRefreshStartOffset"/> window it is still by far the largest job
     /// on the grid — see <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/> for the number the grid is
     /// sized against and for the operating envelope that number defines. Every other hourly refresh is an
-    /// order of magnitude smaller (<see cref="OtherHourlyRefreshObservedCeilingSeconds"/>), and that asymmetry
-    /// is what the grid below is shaped by: one slot treated as FULL, the rest as occupied only at their
+    /// under a quarter of it (<see cref="OtherHourlyRefreshObservedCeilingSeconds"/>), and that asymmetry is
+    /// what the grid below is shaped by: one slot excluded WHOLE, the rest treated as occupied only at their
     /// start.</para>
     /// </summary>
     public const string HeaviestHourlyRefreshView = QueryStoreStatsIntervalHourlyView;
 
     /// <summary>
-    /// The runtime the compression grid is sized against for <see cref="HeaviestHourlyRefreshView"/>. ONE
-    /// recorded run, and NOT a measured maximum of the narrowed <see cref="HourlyRefreshStartOffset"/>
-    /// regime — the difference is the whole of #3069, and the paragraphs below state it rather than leaving
-    /// the number to imply a provenance it does not have.
+    /// The runtime the compression grid is sized against for <see cref="HeaviestHourlyRefreshView"/>: the
+    /// LARGEST run in the clean narrowed-window population, on the one store that carries this workload.
     ///
-    /// <para><b>WHERE IT CAME FROM.</b> One run of this job's refresh policy — <c>13:30:00</c> to
-    /// <c>13:44:24</c> on the boundary day, on the one store that carries this workload — read from that
-    /// store's per-run job history with an explicit <c>succeeded</c> column that said <c>t</c>. The narrowed
-    /// <see cref="HourlyRefreshStartOffset"/> reached that store's refresh policies at <c>13:44:23</c>, one
-    /// second BEFORE this run ended. So it is either the TRANSITION run — in flight while
-    /// <c>start_offset</c> was narrowed underneath it, therefore neither cleanly pre- nor post-treatment —
-    /// or the boundary timestamp was itself derived from this run's completion, in which case the boundary
-    /// and this constant are the SAME OBSERVATION and cannot corroborate each other. Separating those two
-    /// needs clock times nobody has read.</para>
+    /// <para><b>THE DERIVATION, recorded as a method and not only as a value, because a value cannot be
+    /// re-derived by the next reader and a method can (#3101).</b> POPULATION: runs of this job's refresh
+    /// policy under the narrowed <see cref="HourlyRefreshStartOffset"/> window, each read from that store's
+    /// per-run job history with an explicit <c>succeeded</c> column that said <c>t</c>. EXCLUSION RULE:
+    /// every run that started at or before the narrowing boundary of <c>13:44:23</c> is out, whatever its
+    /// duration — membership is decided by position against the boundary, never by whether a reading looks
+    /// like it belongs. SPAN: the boundary day's remaining hours, plus the days after it. ESTIMATOR: the
+    /// maximum. RefreshCeilingProvenancePinTests holds this constant equal to the maximum of the population
+    /// published below and TimescaleSupportTests holds the grid clear of it, so the value and the method
+    /// cannot drift apart without a red test.</para>
     ///
-    /// <para><b>Which is why "conservative" is the wrong word for it, safe though it is.</b> Conservative
-    /// reads as measured-then-rounded-up, and nothing measured this as a ceiling. It is a reading whose
-    /// REGIME MEMBERSHIP IS UNDETERMINED, which happens to exceed every cleanly post-boundary run observed:
-    /// a partly-narrowed window simply costs more than a fully-narrowed one. So the value bounds the grid
-    /// safely WITHOUT HAVING BEEN ESTABLISHED AS A BOUND. The safety is incidental; the provenance is still
-    /// owed, and the read that would settle it is named at the end of this comment.</para>
+    /// <para><b>THE POPULATION ITSELF, published so the estimator can be recomputed rather than taken on
+    /// trust.</b> The boundary day's tail, every run that day after the boundary: <c>194, 222, 225, 335,
+    /// 594, 465, 359, 293, 355</c> seconds. The days after it: <c>219, 225, 299, 376, 418, 546, 515</c>
+    /// seconds. Together <b>16 runs</b> spanning <b>194 s to 594 s</b>, mean <b>352.5 s</b>, median
+    /// <b>345 s</b> — every one of them below <see cref="RefreshSlotWarningSeconds"/>.</para>
     ///
-    /// <para><b>THE POST-BOUNDARY DISTRIBUTION, recorded here because a constant with one sample behind it
-    /// reads exactly like a constant with a distribution behind it.</b> 10 consecutive runs of this job's
-    /// refresh policy, each read with an explicit <c>succeeded</c> column and every one of them <c>t</c>, in
-    /// start order across the ten hours after the boundary:
-    /// <c>864, 194, 222, 225, 335, 594, 465, 359, 293, 355</c> seconds. Set the first aside for the reason
-    /// above and the remaining 9 run from <b>194 s to 594 s</b>, mean <b>338 s</b>, middle reading
-    /// <b>335 s</b> — every one of them below <see cref="RefreshSlotWarningSeconds"/>. The largest of the 9
-    /// clears the slot by <b>306 s</b>, where this constant clears it by 36 s. (#3069 quotes ~347 s as the
-    /// median of the same window. The rows published there do not reproduce it, so the figure held here is
-    /// the one the listed series yields — which is what the middle reading above is pinned to. The quoted
-    /// figure is left as a quotation rather than re-derived here, because an arithmetic aside about a
-    /// superseded external number is coupling with nothing behind it.)</para>
+    /// <para><b>MAXIMUM, NOT A PERCENTILE PLUS MARGIN — decided rather than defaulted, and the trade stated
+    /// because the two answers diverge as the population grows.</b> What this constant sizes is a SCHEDULING
+    /// exclusion, and the cost of undersizing it is one lock convoy (#3012's measured harm) that no later
+    /// run amortises. A percentile is a statement about an ACCEPTED RATE OF EXCEEDANCE, and the rate this
+    /// bound may accept over the record it is derived from is zero — so the estimator is the maximum. The
+    /// sample size says the same thing from the other end: by nearest rank over <b>16 readings</b> the 95th
+    /// percentile IS the largest of them, and the 90th is <b>546 s</b>, only <b>48 s</b> below it, so a
+    /// percentile buys no headroom here and only discards the readings the bound exists for. No margin is
+    /// added on top either: the clearance is <see cref="RefreshPhaseSlotSeconds"/> minus this value, stated
+    /// where it is used, so a reader sees a bound and its margin as two numbers instead of one padded
+    /// one.</para>
     ///
-    /// <para><b>The hole.</b> The run starting near <c>00:35:05</c> was never observed: by the next look
-    /// the catalog's last-run figure had already advanced past it. That is a gap in the ten above, not a
-    /// reading that was dropped.</para>
+    /// <para><b>What would change that answer, written down so it is not re-reasoned from scratch.</b> A
+    /// population large enough for a high percentile to sit meaningfully below the maximum — which this one
+    /// is not, and the pin on the 95th goes red when it becomes so — or this maximum ceasing to be a lower
+    /// bound on the truth. The second is the live limitation, and it is a property of the READ rather than
+    /// of the estimator: the boundary day's runs are a census of that day after the boundary, while the days
+    /// after it are a SAMPLE, because the sweep that reads this and the refresh that produces it tick on
+    /// independent anchors (see <see cref="HeaviestRefreshRuntimeSql"/>). So the figure bounds the runs that
+    /// were OBSERVED. The census read that would drop that qualifier exists and is named rather than left
+    /// implied: <c>timescaledb_information.job_history</c>, whose <c>succeeded</c> column this store has
+    /// because <c>DarlingManagedPostgres.BuildConfAppend</c> turns
+    /// <c>timescaledb.enable_job_execution_logging</c> on (#1681) — read as every run since the boundary
+    /// rather than sampled, giving count, median and maximum each side of it.</para>
+    ///
+    /// <para><b>THE RUN THE EXCLUSION RULE REMOVES, recorded because a figure that looks like a ceiling and
+    /// is not one is how the wrong number gets cited.</b> One run, <c>13:30:00</c> to <c>13:44:24</c> on the
+    /// boundary day, 864 s, excluded for starting before the boundary — and disqualified independently of
+    /// any timestamp, by the durations alone: it is <b>3.8x</b> faster than the fastest run the 3-day window
+    /// ever produced (3,301 s, of a 3,301-6,330 s band) and <b>1.45x</b> slower than the largest reading in
+    /// the population above. Too fast for one regime and too slow for the other, so it is a sample of
+    /// neither and can bound neither. Why it is that fast is NOT established — the plausible candidate is
+    /// that the 6,330 s run before it had already cleared most of the backlog — and it is recorded as
+    /// unexplained precisely so the low figure is not read as evidence that the narrowing had partly taken
+    /// effect.</para>
+    ///
+    /// <para><b>ONE READING IS LEFT OPEN, and the derivation above does not rest on it: whether the boundary
+    /// timestamp is independent of the excluded run's completion.</b> No independent record of the narrowing
+    /// has been found — the boundary day's service log carries no <c>alter_job</c>, no <c>start_offset</c>,
+    /// no <c>StartOffset</c>, no <c>refresh policy</c> and no <c>HourlyRefreshStartOffset</c> line, on a
+    /// filter proved live by a positive control against the same file, so that is a real negative rather
+    /// than a dead filter. The boundary therefore cannot have come from a service-log ALTER, which leaves
+    /// the circular possibility live: it may have been read off the job history, plausibly off the excluded
+    /// run's own completion a fraction of a second later, in which case the boundary and that run's
+    /// exclusion are ONE OBSERVATION and cannot corroborate each other. That is NOT asserted as settled in
+    /// either direction. What would settle it is a record of the ALTER independent of the job history, and
+    /// none has been found — and nothing above needs one, because the exclusion rule is positional and the
+    /// excluded run is disqualified by its duration alone.</para>
     ///
     /// <para><b>And the rule that keeps a whole SERIES out of this constant, stated as a rule because the
     /// series keeps growing.</b> The hourly self-metrics snapshot
@@ -1824,20 +1861,11 @@ WITH NO DATA";
     /// (342 s, 348 s, 286 s) says the series stayed flat, which is corroboration and nothing more. Note the
     /// scope has to CLOSE the population, not merely date it: "up to 04:20Z" is a window that has ended and
     /// will still be true next year, where "the readings so far" carries a scope and rots anyway, because a
-    /// doc comment has no timestamp of its own to be read relative to. They are kept out of the ten above
-    /// for the rule's sake rather than for tidiness.</para>
+    /// doc comment has no timestamp of its own to be read relative to. They are kept out of the population
+    /// above for the rule's sake rather than for tidiness.</para>
     ///
-    /// <para><b>Why the value is unchanged in BOTH directions, which is #3069's whole resolution.</b> Upward
-    /// is asserted as a failure by design (#3055) — see the slot paragraph below. Downward is the subtler
-    /// trap: correcting toward the observed 594 s would leave 306 s of margin in place of 36 s, and the
-    /// reason the heaviest slot is excluded WHOLE rather than guarded
-    /// (<see cref="CompressionPhaseMinutes"/>) rests on that 36 s being real. A downward edit therefore
-    /// reopens #3035's exclude-vs-guard decision rather than merely re-provenancing a number. What settles
-    /// either direction is one read that has not been taken: the status-filtered per-bucket split of the
-    /// full per-run series (<c>collect.store_metrics</c>, <c>object_kind = 'background_job'</c>) on the
-    /// boundary timestamp, giving count, median and maximum each side of it. The grid is sized against the
-    /// high figure and not against the 194 s low for the original reason — a slot chosen against the low
-    /// would be correct only at the load it was chosen at — and before the narrowing this job ran
+    /// <para><b>Why the grid is sized against the high figure and not the low.</b> A slot chosen against the
+    /// 194 s low would be correct only at the load it was chosen at, and before the narrowing this job ran
     /// 3,301-6,330 s against a 1-hour cadence, which is what invalidation looks like.</para>
     ///
     /// <para><b>THE OPERATING ENVELOPE, stated because it is a condition and not a property.</b> #3012's
@@ -1854,13 +1882,14 @@ WITH NO DATA";
     /// overlap at all.</para>
     ///
     /// <para><b>So: the small-residual reading holds while this job completes well inside its slot, and what
-    /// invalidates it is this number approaching <see cref="RefreshPhaseStepMinutes"/> x 60.</b> At 864 s
-    /// against a 900-second slot the margin is already only 36 seconds, which is why the heaviest slot is
-    /// excluded WHOLE rather than guarded, and why a value at or past the slot width is asserted as a failure
-    /// rather than accommodated: past that point the refresh runs into its neighbour and the grid needs
-    /// redesigning, not renumbering.</para>
+    /// invalidates it is this number approaching <see cref="RefreshPhaseStepMinutes"/> x 60.</b> At 594 s
+    /// against a 900-second slot the margin is 306 seconds, better than a third of the slot; the heaviest
+    /// slot is excluded WHOLE rather than guarded on the guard band being shorter than the refresh rather
+    /// than on the refresh filling the slot (see <see cref="CompressionPhaseMinutes"/>). A value at or past
+    /// the slot width is asserted as a failure rather than accommodated: past that point the refresh runs
+    /// into its neighbour and the grid needs redesigning, not renumbering.</para>
     /// </summary>
-    public const int HeaviestHourlyRefreshObservedCeilingSeconds = 864;
+    public const int HeaviestHourlyRefreshObservedCeilingSeconds = 594;
 
     /// <summary>
     /// The slot width in seconds — the bound
@@ -1897,12 +1926,13 @@ WITH NO DATA";
     /// <see cref="CompressionPhaseGuardMinutes"/> band, 480 s — was rejected on those same readings: it would
     /// have fired on three of the five.</para>
     ///
-    /// <para><b>This line sits BELOW <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/>, deliberately,
-    /// and that is not a contradiction.</b> 750 &lt; 864 means the recorded ceiling itself classifies as a
-    /// warning — which is exactly the state #3044 was filed on: the constant the grid is sized against is
-    /// already 96.0% of the slot, 36 seconds clear. So a live reading in this band is not news about the
-    /// ceiling; it is the signal that the store is back at the top of its own measured range, where the next
-    /// move is the one that invalidates the grid. Pinned as that relationship rather than as two numbers.</para>
+    /// <para><b>This line sits ABOVE <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/>, and that is
+    /// what makes a crossing mean something.</b> 750 s is <b>26% above</b> the largest run the narrowed
+    /// regime has been observed to produce, so a reading in this band is not "approaching a known ceiling" —
+    /// it is this job doing something its own record has no instance of, which is a different signal calling
+    /// for a different response. The relationship is what is pinned, not the two numbers: a ceiling that rose
+    /// past this line would put the grid's own sizing figure inside the warning band, and the pin says so
+    /// rather than leaving a reader to notice.</para>
     /// </summary>
     public const int RefreshSlotWarningSeconds = RefreshPhaseSlotSeconds * 5 / 6;
 
@@ -1955,9 +1985,27 @@ WITH NO DATA";
     }
 
     /// <summary>
-    /// The longest run recorded for any hourly refresh OTHER than
-    /// <see cref="HeaviestHourlyRefreshView"/> — the number <see cref="CompressionPhaseGuardMinutes"/> is
-    /// derived from. The first full staggered cycle came back 26 s / 2 s / 864 s / 140 s, so this is the 140.
+    /// The longest run recorded for any hourly refresh OTHER than <see cref="HeaviestHourlyRefreshView"/> —
+    /// the number the <see cref="CompressionPhaseGuardMinutes"/> margin is CHARACTERISED against. The first
+    /// full staggered cycle came back 26 s / 2 s / 864 s / 140 s, so this is the 140.
+    ///
+    /// <para><b>It carries the same regime-membership problem as the 864 in that list, and the difference is
+    /// what it is used FOR.</b> That cycle straddles the narrowing boundary
+    /// (<see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/>), and the narrowed
+    /// <see cref="HourlyRefreshStartOffset"/> reached every hourly policy rather than only the heaviest one,
+    /// so this reading's membership is undetermined in exactly the way the excluded run's is. What stops that
+    /// being the same defect is that NOTHING IS SIZED FROM IT:
+    /// <see cref="CompressionPhaseGuardMinutes"/> is derived from <see cref="RefreshPhaseStepMinutes"/>, and
+    /// this figure only says how much margin that derivation happens to leave — 3x, asserted by
+    /// TimescaleSupportTests, which is a check on the CHARACTERISATION rather than a bound the grid rests
+    /// on.</para>
+    ///
+    /// <para><b>Which is also why it is not re-derived here.</b> Re-deriving it needs a clean post-boundary
+    /// per-run series for the light refreshes, and no such series has been read — the census read named on
+    /// <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/> would supply it for these policies too. The
+    /// direction of the risk is stated rather than left to be discovered: a true light-refresh ceiling ABOVE
+    /// 140 s would make the 3x characterisation false, and the assertion is written to fail in that
+    /// direction.</para>
     /// </summary>
     public const int OtherHourlyRefreshObservedCeilingSeconds = 140;
 
@@ -1998,10 +2046,17 @@ WITH NO DATA";
     /// change would be INTRODUCING, not removing, so the grid keeps the spread and takes only the drift away.</para>
     ///
     /// <para><b>Why the heaviest slot is excluded whole rather than guarded.</b>
-    /// <see cref="HeaviestHourlyRefreshView"/> occupies 14.4 of the 15 minutes in its slot, so there is no
-    /// minute of that slot a <see cref="CompressionPhaseGuardMinutes"/> band could recover. Excluding it is
-    /// also what keeps the remaining minutes far from the only refresh that can reach forward: the nearest is
-    /// a full slot past the heaviest one, and the furthest is 59 minutes past it.</para>
+    /// <see cref="HeaviestHourlyRefreshView"/> occupies 9.9 of the 15 minutes in its slot and the
+    /// <see cref="CompressionPhaseGuardMinutes"/> band is 7, so applying the ordinary band to this slot would
+    /// admit 3 minutes that sit INSIDE the refresh — the band is the wrong size for it, which is the
+    /// arithmetic the exclusion rests on and the reason widening the band is not the alternative. The other
+    /// 5 minutes of the slot are past the refresh and are left on the table deliberately: recovering them
+    /// means sizing a band for one slot against a bound whose population is 16 readings and still moving
+    /// (194 s to 594 s within the clean regime), which is #3035's exclude-versus-guard decision to reopen
+    /// and not a renumbering.
+    /// Excluding the slot is also what keeps the remaining minutes far from the only refresh that can reach
+    /// forward: the nearest is a full slot past the heaviest one, and the furthest is 59 minutes past
+    /// it.</para>
     ///
     /// <para>Derived from the refresh grid, so a change to <see cref="RefreshPhaseStepMinutes"/> or to where
     /// the heaviest refresh sits moves these minutes with it rather than leaving behind a literal that used to
@@ -4219,10 +4274,10 @@ AND   js.last_run_status = 'Success'";
     /// <para><b>That the two lines coincide is a coincidence of two independent decisions, and the clearest
     /// evidence is that #2136 does not know this job's size.</b> Its clamp is justified in
     /// <c>DarlingAlertSettings</c> on the grounds that "the production worst runs ~7% of cadence" — 252 s —
-    /// while <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/> here records 864 s, which is <b>24.0%
-    /// of the same 3,600 s cadence</b>, one point under the 25% default. So the job this envelope is about is
-    /// already sitting just below a warning line calibrated as though it ran a third of its actual length,
-    /// and nothing connects the two numbers. #2136's own remedy text — "extend the job's schedule_interval" —
+    /// while <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/> here records 594 s, which is <b>16.5%
+    /// of the same 3,600 s cadence</b> — so the line #2136 lands on is calibrated as though this job ran
+    /// under half its actual length, and nothing connects the two numbers. #2136's own remedy text —
+    /// "extend the job's schedule_interval" —
     /// is actively wrong for this one, because <see cref="HourlyRefreshScheduleInterval"/> is also the
     /// <c>end_offset</c> and widening it changes what the aggregate materializes without touching the slot.
     /// A line derived from the slot, keyed on the view, naming the actual remedy, is the form that stays
@@ -4587,8 +4642,9 @@ public sealed record HeaviestRefreshSlotReading(string View, double LastRunSecon
     /// clamping would report every breach as a dead heat.</summary>
     public double ClearOfSlotSeconds => TimescaleSupport.RefreshPhaseSlotSeconds - LastRunSeconds;
 
-    /// <summary>This reading as a percentage of the slot — 96.0% for the 864 s recorded ceiling, which is the
-    /// margin #3044 was filed on.</summary>
+    /// <summary>This reading as a percentage of the slot — 66.0% for the recorded ceiling
+    /// (<see cref="TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds"/>), which is the margin the
+    /// #3044 watch is stated against.</summary>
     public double PercentOfSlot => 100.0 * LastRunSeconds / TimescaleSupport.RefreshPhaseSlotSeconds;
 }
 

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -1773,9 +1773,8 @@ WITH NO DATA";
     /// on the grid — see <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/> for the number the grid is
     /// sized against and for the operating envelope that number defines. Every other hourly refresh's own
     /// ceiling is under a quarter of it (<see cref="OtherHourlyRefreshObservedCeilingSeconds"/>), and that
-    /// asymmetry is
-    /// what the grid below is shaped by: one slot excluded WHOLE, the rest treated as occupied only at their
-    /// start.</para>
+    /// asymmetry is what the grid below is shaped by: one slot excluded WHOLE, the rest treated as occupied
+    /// only at their start.</para>
     /// </summary>
     public const string HeaviestHourlyRefreshView = QueryStoreStatsIntervalHourlyView;
 

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -1573,9 +1573,10 @@ WITH NO DATA";
     /// hypertable rather than with ingest. Measured on the production store: the heaviest hourly refresh
     /// (<see cref="QueryStoreStatsIntervalHourlyView"/>) ran 3,301-6,330 s against a 1-hour cadence —
     /// <b>118-175% of its own schedule interval</b> — while rows arriving per hour FELL ~3x over the same
-    /// period. Narrowed to 1 day the same refresh's largest clean run is <b>594 s, 16.5% of cadence</b> (the
-    /// derivation is on <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/>). The direction of that
-    /// measurement is the whole argument: duration tracking window size while ingest moves the other way is
+    /// period. Narrowed to 1 day the same refresh finishes <b>well inside one phase slot</b>, and the figure
+    /// with its derivation is on <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/> rather than
+    /// restated here — a percentage of cadence written twice goes stale in one of the two places. The
+    /// direction of that measurement is the whole argument: duration tracking window size while ingest moves the other way is
     /// what rules out "more rows to materialize" and rules in "too much window".</para>
     ///
     /// <para><b>Why a job that outran its cadence could not recover.</b> A refresh holds
@@ -1585,9 +1586,8 @@ WITH NO DATA";
     /// merely QUEUED, not held, even though their own locks are mutually compatible. At >100% of cadence the
     /// next run started into the tail of the previous one, and the convoy sustained itself. Below cadence it
     /// cannot form, which is why this number and <see cref="RefreshPhaseStepMinutes"/> are complements rather
-    /// than alternatives: narrowing is what makes the heavy refresh finish, phasing is what keeps its
-    /// remaining <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/> seconds out of everyone else's
-    /// way.</para>
+    /// than alternatives: narrowing is what makes the heavy refresh finish, phasing is what keeps what
+    /// remains of it out of everyone else's way.</para>
     ///
     /// <para><b>What still has to fit inside it, now stated as a relationship rather than left to a
     /// constant.</b> Two things need the window to reach back far enough. Live collectors only ever append
@@ -1642,13 +1642,12 @@ WITH NO DATA";
     /// phased across the hour instead of all starting together.
     ///
     /// <para><b>Phasing alone is not the fix and neither is narrowing alone.</b>
-    /// <see cref="HourlyRefreshStartOffset"/> is what brought the heavy refresh from 6,330 s to a clean
-    /// maximum of <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/> s; this is what keeps those
-    /// seconds from being visible to anything else, because the refresh that is running is not the one a
-    /// compression policy or a sibling refresh is about to want. The heaviest hourly refresh is still more
-    /// than 4x the recorded ceiling for any other one
-    /// (<see cref="OtherHourlyRefreshObservedCeilingSeconds"/>), so the two treatments address different
-    /// halves and dropping either one reopens the door.</para>
+    /// <see cref="HourlyRefreshStartOffset"/> is what brought the heavy refresh down from 6,330 s to
+    /// <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/>; this is what keeps what remains of it from
+    /// being visible to anything else, because the refresh that is running is not the one a compression
+    /// policy or a sibling refresh is about to want. The heaviest hourly refresh is still more than 4x the
+    /// recorded ceiling for any other one (<see cref="OtherHourlyRefreshObservedCeilingSeconds"/>), so the
+    /// two treatments address different halves and dropping either one reopens the door.</para>
     ///
     /// <para><b>15 minutes over four slots is the configuration that was measured</b>, not a round number: the
     /// production store's <c>query_store_stats</c> job family was moved to :00/:15/:30/:45 and the first full
@@ -1772,8 +1771,9 @@ WITH NO DATA";
     ///
     /// <para>On the narrowed <see cref="HourlyRefreshStartOffset"/> window it is still by far the largest job
     /// on the grid — see <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/> for the number the grid is
-    /// sized against and for the operating envelope that number defines. Every other hourly refresh is an
-    /// under a quarter of it (<see cref="OtherHourlyRefreshObservedCeilingSeconds"/>), and that asymmetry is
+    /// sized against and for the operating envelope that number defines. Every other hourly refresh's own
+    /// ceiling is under a quarter of it (<see cref="OtherHourlyRefreshObservedCeilingSeconds"/>), and that
+    /// asymmetry is
     /// what the grid below is shaped by: one slot excluded WHOLE, the rest treated as occupied only at their
     /// start.</para>
     /// </summary>


### PR DESCRIPTION
`TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds` is now **594** — the maximum of the clean post-narrowing population — and its doc comment records the method that produced it rather than only the number.

## The derivation

Population: every run of the heaviest hourly refresh's policy that **started strictly after** the narrowing boundary at `13:44:23`, read with an explicit `succeeded` column. The exclusion rule is positional: membership is decided by position against the boundary, never by whether a reading looks like it belongs. That is the boundary day's nine remaining runs plus seven readings from the days after it — **16 runs, 194 s to 594 s, mean 352.5 s, median 345 s**.

Estimator: the **maximum, not a percentile plus margin**, and the comment says which and why. What the constant sizes is a scheduling exclusion whose undersizing cost is one lock convoy (#3012's measured harm) that no later run amortises — a percentile is a statement about an accepted rate of exceedance, and the rate this bound may accept over its own record is zero. The sample size says the same from the other end: by nearest rank over 16 readings the 95th percentile *is* the maximum, and the 90th is 546 s, only 48 s below it, so a percentile buys no headroom and only discards the readings the bound exists for. No margin is added on top; the clearance is `RefreshPhaseSlotSeconds` minus the value, stated where it is used.

`Verify` checks the 95th-percentile claim, so the pin **goes red once the population grows past the point where the stated reason holds** — the moment the estimator decision has to be re-taken rather than inherited.

The `864 s` run is recorded as the run the exclusion rule removes, with its own disqualifying arithmetic: 3.8x faster than the fastest run the 3-day window produced and 1.45x slower than the largest reading in the population, so it is a sample of neither regime.

## What the previous comment established and this keeps

The inadmissible-source rule is unchanged and still enforced against shipped SQL: the self-metrics background-job snapshot carries no status column, so no reading from it may set this constant. Its closed as-at scope, its three named reads and the disjointness check all stand.

The boundary timestamp's own provenance is stated as **open**. No independent record of the narrowing exists — the boundary day's service log carries no `alter_job`, `start_offset`, `StartOffset`, `refresh policy` or `HourlyRefreshStartOffset` line, on a filter proved live by a positive control — so the boundary cannot have come from a service-log ALTER, and the circular possibility (read off the excluded run's own completion) remains live. **The comment does not assert a confirmation in either direction**, and the derivation does not need one: the exclusion rule is positional and the excluded run is disqualified by its duration alone.

## OtherHourlyRefreshObservedCeilingSeconds

Checked, and the same regime-membership problem **does** apply in kind: the 140 comes from the same first staggered cycle as the 864, that cycle straddles the boundary, and the narrowed window reached every hourly policy rather than only the heaviest. What stops it being the same defect is that nothing is *sized* from it — `CompressionPhaseGuardMinutes` is derived from `RefreshPhaseStepMinutes`, and the 140 only characterises how much margin that derivation leaves. It is not re-derived here because no clean post-boundary per-run series for the light refreshes has been read; the census read named on the heaviest ceiling would supply it. The direction of the risk is written down: a true light-refresh ceiling above 140 s would make the 3x characterisation false, and the assertion fails in that direction.

## Consumers

Every reference to the constant, and what changed at each:

- **`CompressionPhaseMinutes`** — the exclude-whole reasoning. At 9.9 minutes of a 15-minute slot the old claim that no minute could be recovered is false, so the reasoning is restated to the arithmetic that actually holds: the guard band is 7 minutes, so applying it to this slot would admit 3 minutes *inside* the refresh. The other 5 are left on the table deliberately, and recovering them is #3035's exclude-versus-guard decision to reopen against a bound with 16 readings behind it, not a renumbering. The grid itself is unchanged.
- **`RefreshSlotWarningSeconds`** — the watch line now sits **above** the ceiling rather than below it, which is the operational point: 750 s is 26% above anything the narrowed regime has produced, so a crossing is this job doing something its own record has no instance of rather than "approaching a known ceiling".
- **`ClassifyRefreshSlotHeadroom` / `HeaviestRefreshSlotReading` / `LogHeaviestRefreshSlotHeadroom`** — the constant classifies `InsideSlot` at 66.0% of the slot with 306 s clear, and logs at Debug. The `ApproachingSlot` and Warning cases are exercised from `RefreshSlotWarningSeconds` instead of from the constant.
- **`LogHeaviestRefreshSlotHeadroom`'s #2136 comparison** — 16.5% of the 3,600 s cadence rather than 24.0%, and the "~7% of cadence" clamp justification is now under half the ceiling rather than under a third.
- **`HeaviestHourlyRefreshView`, `HourlyRefreshStartOffset`, `RefreshPhaseStepMinutes`** — these restated the disqualified figure as the narrowed regime's cost. They now point at the constant instead of repeating a percentage of cadence, and the first staggered cycle's `26 / 2 / 864 / 140` is labelled as straddling the boundary.
- **`DarlingWorker`** — names the constant only in a comment about the build-time assertion; unaffected.
- **`TimescaleContinuousAggregateTests`** — the same two prose restatements, given the same treatment.

## Tests

`RefreshCeilingProvenancePinTests` now re-computes the estimator from the population the comment publishes and requires the constant to equal it, plus the count, range, mean, median, the percentile claim, the excluded run's clock arithmetic and its ratio to the maximum, and `CompressionPhaseMinutes`' occupancy, guard-band and deferral figures. Its own drift sweep bumps every captured number one at a time and requires the identical verification to fail, which red-proofs each published reading individually.

New: `NoCompressionMinuteStartsWhileTheHeaviestRefreshIsStillRunning` asserts the relationship the constant exists to hold — no compression minute starts within `HeaviestHourlyRefreshObservedCeilingSeconds` of the heaviest refresh's own start — measured in seconds and including its own discriminating case, so both the ceiling rising and the grid moving a minute closer are red. The ceiling-to-ceiling asymmetry (`>4x`) and the watch-line gap (26%) are asserted too, since those are the only places either is stated in prose.

Every pattern group in the pin file is `[0-9]+` rather than `[0-9]`: the drift sweep bumps width-preserving, so a one-digit group holding a 9 comes back as two digits and stops matching, which the sweep reports as a broken pattern rather than a caught drift.

## Verification

Windows-only suites cannot run on macOS, so the affected tests were compiled into a throwaway net10.0 console harness against an xUnit shim, linking `RefreshCeilingProvenancePinTests.cs` and `DocCommentHygieneTests.cs` verbatim and script-extracting the eight affected `TimescaleSupportTests` methods from the real file. **91 assertions, 0 failures.** Four mutations red-proofed it:

| mutation | assertion that went red |
|---|---|
| ceiling back to 864 | `EveryDerivationClaim...`: *"the published population [...] has maximum 594 s, but this constant holds 864 s"* — 8 tests red in total |
| heaviest slot no longer excluded from the grid | `NoCompressionMinuteStartsWhileTheHeaviestRefreshIsStillRunning`: *":07 starts 420s after the heaviest refresh's :00 start, which is inside the 594s that refresh is recorded as taking"* |
| ceiling to 550 with its literal pin renumbered to match | the `>4x` asymmetry assertion, and the 26% gap assertion (`Expected 26 Actual 36`) |
| other ceiling 140 to 149 | the literal pin, then the 3x guard-band assertion |

CI is the arbiter for the full suite.

## Out of scope, reported rather than fixed

`RefreshSlotWarningSeconds`' second paragraph says a 480 s line "would have fired on three of the five" readings it lists (335, 594, 465, 359, 293) — only one of those five is at or above 480. The figure is not pinned anywhere and predates this change, so it is left alone.

## CHANGELOG entry

- **`HeaviestHourlyRefreshObservedCeilingSeconds` is re-derived from the clean post-narrowing distribution and now records its own derivation method** ([#3101]) - the constant the compression phase grid is sized against was **864 s**, a single run that belongs to **neither regime**: at 863.7 s it is ~3.8x faster than the fastest run the pre-fix 3-day window ever produced (3,300.8 s) and ~1.45x slower than the largest clean post-fix run (593.5 s), so it cannot bound either distribution. It is now **594 s**, the maximum of the **16 status-verified runs that started strictly after the narrowing boundary** — the boundary day's nine remaining runs plus seven from the days since, 194 s to 594 s, mean 352.5 s, median 345 s - and the doc comment records the population, the exclusion rule and the estimator so the next reader can re-derive it instead of trusting it. **Maximum rather than a percentile plus margin, stated as a decision**: the undersizing cost is one lock convoy that no later run amortises, so the accepted exceedance rate is zero — and at 16 readings the 95th percentile *is* the maximum by nearest rank, which the pin checks so it goes red once the population grows past the point where that reason holds. The live cost of the old figure was operational rather than cosmetic: a 750 s warning line reads as comfortably inside an 864 s ceiling, where against the real maximum it is **26% above anything the narrowed regime has produced**, so a crossing is the regime doing something new rather than approaching a known bound. `CompressionPhaseMinutes` keeps excluding the heaviest slot whole, now on the arithmetic that holds at 9.9 minutes of occupancy — the 7-minute guard band would admit 3 minutes inside the refresh — and the five minutes past it are left deliberately rather than recovered against a bound with 16 readings behind it. **The boundary timestamp's own provenance is left open**: no independent record of the `alter_job` exists, so the circular possibility that it was read off the excluded run's completion remains live, and the derivation is built not to need it. `OtherHourlyRefreshObservedCeilingSeconds` (140) carries the same problem in kind — same straddling cycle — but sizes nothing, and re-deriving it needs a light-refresh series nobody has read.
