### PR TITLE
Fixes #3098

### DIFF
--- a/Darling/Darling.Tests/FleetCardCollectionStaleNamesItsPopulationTests.cs
+++ b/Darling/Darling.Tests/FleetCardCollectionStaleNamesItsPopulationTests.cs
@@ -1,0 +1,392 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using PerformanceMonitor.Common;
+using PerformanceMonitor.Darling.Service.Mcp;
+using Xunit;
+using static Darling.Tests.RepoFile;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #3098: the fleet card's amber collection flag is named for the population it has. It is
+/// <see cref="ServerFreshness.Stale"/> — how old the newest collection is, measured against the clock — and
+/// the card publishes it as <c>collection_stale</c>.
+///
+/// <para><b>Why a NAME is worth a test.</b> Two agents read this one field four different ways in a single
+/// day, from the payload plus the response around it, and a store query falsified every reading: cards
+/// flagging it with all 39 collectors <c>HEALTHY</c> and <c>failed_collector_count: 0</c>; the flag set by
+/// errors 15 to 26 hours outside the card's own published window; the flag clear while a collector row
+/// carried <c>errors: 2</c>; and the flag clear on all 43 cards while four <c>ERROR</c> rows sat INSIDE the
+/// window those cards stated. Every one of those was a reasonable reading of a name, and the value was
+/// correct the whole time. A field whose name misdescribes a correctly-computed value is worse than an
+/// unnamed one, because the name answers "what is this the value of" and nothing in the payload disagrees —
+/// so what these pins hold is the agreement between the name, the computation, and the prose the same code
+/// emits.</para>
+///
+/// <para><b>Two flags, two populations, and they are supposed to disagree.</b> Lite's card carries a flag of
+/// the same shape fed from <c>ErroringCollectors &gt; 0</c>; this one is fed from a clock. A server can
+/// collect on time with a collector failing, and can go quiet with every collector's last run a success, so
+/// the axes part company in normal operation. <see cref="LitesErrorFlag_StillNamesAnErrorCount"/> is what
+/// keeps that a decision rather than an oversight the tree-wide scan below quietly stepped around.</para>
+///
+/// <para><b>Scope.</b> Everything here sits on the classifier and on the serialized card — the surface
+/// #3098 was read off — and none of it touches WPF, so it runs on any host rather than only on the Windows
+/// leg of CI. The one link a behavioural test cannot reach is the reader's own assembly of a card, inside a
+/// private method behind nine store reads; that link is held by source text in
+/// <see cref="TheMcpCard_DerivesTheFlagFromFreshnessAndNothingElse"/>, against the same four lines the
+/// arithmetic below exercises directly.</para>
+/// </summary>
+public sealed class FleetCardCollectionStaleNamesItsPopulationTests
+{
+    private static readonly DateTime Now = new(2026, 9, 6, 12, 0, 0, DateTimeKind.Utc);
+
+    /// <summary>
+    /// The flag is the <see cref="ServerFreshness.Stale"/> band and no other, over every band there is. This
+    /// is the assertion the name makes, stated so that wiring the flag to anything else — an error count, a
+    /// window, a collection-log read — fails here rather than in a reader's head.
+    /// </summary>
+    [Fact]
+    public void TheFlag_IsExactlyTheStaleFreshnessBand()
+    {
+        var bands = Enum.GetValues<ServerFreshness>();
+
+        /* Enumerating the enum rather than listing four cases: a fifth band arriving with the flag set would
+           otherwise be a new population under an unchanged name, which is this issue again. */
+        Assert.Equal(4, bands.Length);
+
+        foreach (var band in bands)
+        {
+            Assert.Equal(
+                band == ServerFreshness.Stale,
+                ServerCollectionStatusRules.FlagsFor(band).CollectionStale);
+        }
+    }
+
+    /// <summary>
+    /// The flag moves with the clock and with nothing else. Every boundary is read off
+    /// <see cref="ServerHealthThresholds"/> rather than restated as 2 and 15, so this cannot pass while the
+    /// card has grown thresholds of its own (#1562).
+    /// </summary>
+    [Fact]
+    public void TheFlag_TracksHowOldTheNewestCollectionIs()
+    {
+        var stale = ServerHealthThresholds.StaleThreshold;
+        var offline = ServerHealthThresholds.OfflineThreshold;
+
+        Assert.False(Stale(TimeSpan.Zero));
+        Assert.False(Stale(stale));                                     // at the threshold, still fresh
+        Assert.True(Stale(stale + TimeSpan.FromSeconds(1)));            // past it, stale
+        Assert.True(Stale(offline));                                    // at the far edge, still stale
+        Assert.False(Stale(offline + TimeSpan.FromSeconds(1)));         // past it, offline — a different state
+        Assert.False(Stale(null));                                      // never collected — a bootstrap state
+
+        static bool Stale(TimeSpan? sinceLastCollection) =>
+            ServerCollectionStatusRules.FlagsFor(
+                ServerHealthClassifier.ClassifyFreshness(
+                    sinceLastCollection.HasValue ? Now - sinceLastCollection.Value : null, Now))
+                .CollectionStale;
+    }
+
+    /// <summary>
+    /// The four combinations of (collection age, collectors failing), each with the value both axes report.
+    /// Two of the four are the readings #3098 falsified — a flagged card with every collector healthy, and a
+    /// clear card with a collector failing — and here they are the expected answers rather than a puzzle.
+    /// </summary>
+    [Fact]
+    public void TheFlag_IsIndependentOfTheCollectorErrorCount()
+    {
+        var late = ServerHealthThresholds.StaleThreshold + TimeSpan.FromMinutes(1);
+        var current = TimeSpan.FromSeconds(5);
+
+        /* Collecting on time, nothing failing: neither axis has anything to say. */
+        var calm = Card(current, failing: 0);
+        Assert.False(calm.CollectionStale);
+        Assert.Equal(HealthSeverity.Healthy, calm.CollectorSeverity);
+        Assert.Equal(FleetHealthBand.Healthy, calm.Band);
+
+        /* The issue's first observation: flagged, with every collector healthy and none failing. Staleness is
+           not failure, so this is correct and the card names both axes for what they measure. */
+        var quiet = Card(late, failing: 0);
+        Assert.True(quiet.CollectionStale);
+        Assert.Equal(0, quiet.FailedCollectorCount);
+        Assert.Equal(HealthSeverity.Healthy, quiet.CollectorSeverity);
+        Assert.Equal(FleetHealthBand.Warning, quiet.Band);
+
+        /* The issue's sharpest observation, from the PostgreSQL-target store: band Warning, one collector
+           failing, and the collection flag CLEAR. The band is right and comes from the failing count; the
+           two fields answer different questions and neither is wrong. */
+        var failingButCurrent = Card(current, failing: 1);
+        Assert.False(failingButCurrent.CollectionStale);
+        Assert.Equal(1, failingButCurrent.FailedCollectorCount);
+        Assert.Equal(HealthSeverity.Warning, failingButCurrent.CollectorSeverity);
+        Assert.Equal(FleetHealthBand.Warning, failingButCurrent.Band);
+
+        /* Both at once, each still reported on its own axis. */
+        var both = Card(late, failing: 3);
+        Assert.True(both.CollectionStale);
+        Assert.Equal(HealthSeverity.Warning, both.CollectorSeverity);
+
+        /* Neither axis is a proxy for the other: the flag disagrees with "any collector failing" on half of
+           these, which is what makes one name for both readings unusable. */
+        var cards = new[] { calm, quiet, failingButCurrent, both };
+        Assert.Equal(2, cards.Count(c => c.CollectionStale != (c.FailedCollectorCount > 0)));
+    }
+
+    /// <summary>
+    /// The prose the card emits beside the flag says the same thing the flag is named for, and the failing
+    /// count gets its own clause. These are the two strings a human reads off a Warning card, and a card that
+    /// reported staleness as a collector error is how the name earned its reading.
+    /// </summary>
+    [Fact]
+    public void TheReasonString_AgreesWithTheFlagsName()
+    {
+        var quiet = Card(ServerHealthThresholds.StaleThreshold + TimeSpan.FromMinutes(1), failing: 0);
+        Assert.Equal("collection stale", DarlingFleetReader.BuildReason(quiet));
+
+        var failingButCurrent = Card(TimeSpan.FromSeconds(5), failing: 1);
+        var reason = DarlingFleetReader.BuildReason(failingButCurrent);
+        Assert.Equal("1 collector failing", reason);
+        Assert.DoesNotContain("stale", reason, StringComparison.Ordinal);
+
+        /* A card carrying both reports both, in their own clauses — the axes are additive in the prose
+           exactly as they are in the payload. */
+        var both = Card(ServerHealthThresholds.StaleThreshold + TimeSpan.FromMinutes(1), failing: 2);
+        Assert.Equal("2 collectors failing, collection stale", DarlingFleetReader.BuildReason(both));
+    }
+
+    /// <summary>
+    /// The reader's whole derivation, in the four lines that are all of it: classify the newest collection's
+    /// age, explode that band into the shared flags, take the flag, put it on the card. There is no error
+    /// count in the chain, no <c>collection_log</c> read, and no use of the roll-up's published window — which
+    /// is why the card's <c>window_start</c> / <c>window_end</c> never bounded it.
+    /// </summary>
+    [Fact]
+    public void TheMcpCard_DerivesTheFlagFromFreshnessAndNothingElse()
+    {
+        var reader = ReadRepoFileLf(
+            "Darling", "PerformanceMonitor.Darling.Service", "Mcp", "DarlingFleetReader.cs");
+
+        Assert.Contains(
+            "var freshness = ServerHealthClassifier.ClassifyFreshness(lastCollection, now);\n"
+          + "        var flags = ServerCollectionStatusRules.FlagsFor(freshness);",
+            reader, StringComparison.Ordinal);
+        Assert.Contains("var collectionStale = flags.CollectionStale;", reader, StringComparison.Ordinal);
+        Assert.Contains("CollectionStale = collectionStale,", reader, StringComparison.Ordinal);
+
+        /* And the field is published under the name that derivation earns. */
+        Assert.Contains(
+            "[JsonPropertyName(\"collection_stale\")] public bool CollectionStale { get; init; }",
+            reader, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The serialized card names the flag for its population and carries, in the same payload, everything a
+    /// reader needs to recompute it: <c>last_collection</c> for the age and <c>status</c> for the band that
+    /// age produced. That is #3098's acceptance criterion — the field's population is determinable from the
+    /// response alone — and it is why no companion timestamp was added: the card already published one.
+    /// </summary>
+    [Fact]
+    public void TheSerializedCard_LetsAReaderRecomputeTheFlag()
+    {
+        var card = new FleetServerCard
+        {
+            ServerId = 7,
+            DisplayName = "sql-01",
+            ServerName = "sql-01",
+            Band = FleetHealthBand.Warning,
+            Status = ServerCollectionStatus.Stale.Word(),
+            IsOnline = true,
+            CollectionStale = true,
+            LastCollectionTime = new DateTime(2026, 9, 6, 11, 50, 0, DateTimeKind.Unspecified),
+            FailedCollectorCount = 0,
+            HealthyCollectorCount = 39,
+            CollectorSeverity = HealthSeverity.Healthy,
+        };
+
+        var json = JsonSerializer.Serialize(card, DarlingFleetReader.JsonOptions);
+
+        JsonAssert.Contains("\"collection_stale\": true", json);
+        JsonAssert.Contains("\"last_collection\": \"2026-09-06T11:50:00\"", json);
+        JsonAssert.Contains("\"status\": \"Warning\"", json);
+
+        /* The error axis is still published, and still separately — the flag was renamed, not merged into
+           these. A card can hold this exact combination and be right about all four values. */
+        JsonAssert.Contains("\"failed_collector_count\": 0", json);
+        JsonAssert.Contains("\"healthy_collector_count\": 39", json);
+        JsonAssert.Contains("\"collector_severity\": \"Healthy\"", json);
+
+        /* No field on this card claims an error population it does not have. */
+        Assert.DoesNotContain(JsonSpelling, json, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The errors spelling is absent from every Darling surface — source, the web dashboard's scripts, the MCP
+    /// instructions, <c>Darling/README.md</c>, <c>llms.txt</c>, the root README and <c>docs/</c>. A rename
+    /// that survives in one document is the same defect with a smaller audience, and a documented name is the
+    /// one a reader trusts hardest.
+    ///
+    /// <para><b>Every file, not an extension allow-list.</b> The walk reads BYTES over everything under the
+    /// scanned roots, so a reference in a file type nobody thought of is found rather than skipped. Both
+    /// needles are assembled at run time from fragments, because this file is inside the scanned tree and a
+    /// scan that matches its own needle reports the search itself.</para>
+    ///
+    /// <para><c>CHANGELOG.md</c> is out of scope by construction — it is a record of what changed, so it
+    /// names the old field on purpose, and it is not a surface anyone reads a live payload against.</para>
+    /// </summary>
+    [Fact]
+    public void TheErrorsSpelling_IsGoneFromEveryDarlingSurface()
+    {
+        var scanned = ScannedFiles().ToList();
+
+        /* The walk is looking at something. A root that moved would otherwise make every assertion below
+           vacuously true, which is the failure mode a coverage check has and a pin must not. */
+        Assert.True(scanned.Count > 200, $"the walk found only {scanned.Count} files — a root has moved");
+
+        var carriesNewName = scanned
+            .Where(f => Holds(f.Value, "collection" + "_stale"))
+            .Select(f => f.Key)
+            .ToList();
+
+        Assert.Contains(carriesNewName, p => p.EndsWith(
+            Path.Combine("Mcp", "DarlingFleetReader.cs"), StringComparison.Ordinal));
+
+        var offenders = scanned
+            .Where(f => Holds(f.Value, JsonSpelling) || Holds(f.Value, ClrSpelling))
+            .Select(f => f.Key)
+            .ToList();
+
+        Assert.True(offenders.Count == 0,
+            "these Darling surfaces still name the flag for a population it does not have: "
+            + string.Join(", ", offenders));
+    }
+
+    /// <summary>
+    /// Lite's flag keeps the errors name, because in Lite the name is accurate: it is fed from the count of
+    /// collectors that are actually erroring, on a card whose status word comes from a live connection check
+    /// rather than from a clock. This is the must-pass half of the scan above — without it, "the errors
+    /// spelling is gone from the Darling trees" is equally satisfied by a scan whose roots exclude everything.
+    /// </summary>
+    [Fact]
+    public void LitesErrorFlag_StillNamesAnErrorCount()
+    {
+        var declaration = ReadRepoFileLf("Lite", "Services", "LocalDataService.Overview.cs");
+        Assert.Contains("public bool " + ClrSpelling + " { get; set; }", declaration, StringComparison.Ordinal);
+
+        var window = ReadRepoFileLf("Lite", "MainWindow.xaml.cs");
+        Assert.Contains(
+            "." + ClrSpelling + " = _collectorService.GetHealthSummary(server).ErroringCollectors > 0;",
+            window, StringComparison.Ordinal);
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────────────────────────────
+
+    /* Assembled from fragments so the literals never appear whole in a file the scan reads. */
+    private static readonly string JsonSpelling = string.Concat("has", "_collector", "_errors");
+    private static readonly string ClrSpelling = string.Concat("Has", "Collector", "Errors");
+
+    /// <summary>A fleet card at a given collection age with a given number of collectors failing, assembled
+    /// the way the reader assembles one: the flag comes out of a CLOCK through
+    /// <see cref="ServerCollectionStatusRules.FlagsFor"/> rather than out of an assignment, so the age really
+    /// is the input. Every other metric is calm, leaving the two collection axes as the only variables.</summary>
+    private static FleetServerCard Card(TimeSpan sinceLastCollection, int failing)
+    {
+        var lastCollection = Now - sinceLastCollection;
+        var flags = ServerCollectionStatusRules.FlagsFor(
+            ServerHealthClassifier.ClassifyFreshness(lastCollection, Now));
+
+        var metrics = new ServerHealthMetrics { CpuPercentForAlert = 4, FailedCollectorCount = failing };
+        var overall = ServerHealthClassifier.OverallMetricSeverity(metrics);
+
+        return new FleetServerCard
+        {
+            ServerId = 1,
+            DisplayName = "sql-01",
+            ServerName = "sql-01",
+            IsOnline = flags.IsOnline,
+            AwaitingFirstCollection = flags.AwaitingFirstCollection,
+            CollectionStale = flags.CollectionStale,
+            LastCollectionTime = lastCollection,
+            Status = ServerCollectionStatusRules
+                .Classify(flags.IsOnline, flags.CollectionStale, flags.AwaitingFirstCollection).Word(),
+            FailedCollectorCount = failing,
+            CollectorSeverity = ServerHealthClassifier.CollectorSeverity(failing),
+            OverallMetricSeverity = overall,
+            Band = ServerHealthClassifier.ClassifyBand(
+                flags.IsOnline, flags.AwaitingFirstCollection, flags.CollectionStale, overall),
+        };
+    }
+
+    /// <summary>Every file under the surfaces a consumer of this field can read, as bytes.</summary>
+    private static IEnumerable<KeyValuePair<string, byte[]>> ScannedFiles()
+    {
+        var roots = new[]
+        {
+            Path.Combine(Root, "PerformanceMonitor.Common"),
+            Path.Combine(Root, "Darling"),
+            Path.Combine(Root, "docs"),
+        };
+
+        foreach (var root in roots)
+        {
+            Assert.True(Directory.Exists(root), $"{root} is gone — this scan is walking nothing");
+
+            foreach (var file in Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories))
+            {
+                if (file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                    || file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                yield return new KeyValuePair<string, byte[]>(file, File.ReadAllBytes(file));
+            }
+        }
+
+        foreach (var name in new[] { "llms.txt", "README.md" })
+        {
+            var path = Path.Combine(Root, name);
+            Assert.True(File.Exists(path), $"{path} is gone — this scan is walking nothing");
+            yield return new KeyValuePair<string, byte[]>(path, File.ReadAllBytes(path));
+        }
+    }
+
+    /// <summary>Whether an ASCII needle occurs in a file's raw bytes. Bytes rather than decoded text so no
+    /// encoding, BOM or invalid sequence can hide a match, and so a binary file cannot throw the walk.</summary>
+    private static bool Holds(byte[] haystack, string needle)
+    {
+        var pattern = Encoding.ASCII.GetBytes(needle);
+
+        for (var i = 0; i + pattern.Length <= haystack.Length; i++)
+        {
+            var hit = true;
+
+            for (var j = 0; j < pattern.Length; j++)
+            {
+                if (haystack[i + j] != pattern[j])
+                {
+                    hit = false;
+                    break;
+                }
+            }
+
+            if (hit)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Darling/Darling.Tests/RepoFileAdoptionTests.cs
+++ b/Darling/Darling.Tests/RepoFileAdoptionTests.cs
@@ -79,14 +79,17 @@ public sealed class RepoFileAdoptionTests
     /// <summary>
     /// The pins whose anchors span a line break, and which therefore read LF-normalised text.
     ///
-    /// <para>These six carried the normalising helper before consolidation; the other twenty-eight
-    /// deliberately did not. The list is compared against the tree rather than trusted, for the reason in
-    /// this class's summary: moving a pin between the two readers changes whether its multi-line
-    /// assertions can fire at all.</para>
+    /// <para>Membership is a property of a pin's ANCHORS, not of its subject: a pin belongs here exactly
+    /// when one of its anchors crosses a newline. The list is compared against the tree rather than trusted,
+    /// for the reason in this class's summary — moving a pin between the two readers changes whether its
+    /// multi-line assertions can fire at all. Consolidation found six of the thirty-four carrying the
+    /// normalising helper and twenty-eight deliberately not; that was a census of one moment, and this is
+    /// the live set, so it carries no count of its own to go stale.</para>
     /// </summary>
     private static readonly string[] s_lfReaders =
     {
         "ChartWindowDomainTests.cs",
+        "FleetCardCollectionStaleNamesItsPopulationTests.cs",
         "FleetPageAttentionFilterTests.cs",
         "ServerPageTabsTests.cs",
         "StartupFailureTriageTests.cs",

--- a/Darling/Darling.Tests/ServerHealthClassifierTests.cs
+++ b/Darling/Darling.Tests/ServerHealthClassifierTests.cs
@@ -135,27 +135,27 @@ public sealed class ServerHealthClassifierTests
     [Fact]
     public void ClassifyBand_Offline_WhenNotOnline() =>
         Assert.Equal(FleetHealthBand.Offline,
-            ServerHealthClassifier.ClassifyBand(isOnline: false, awaitingFirstCollection: false, hasCollectorErrors: false, HealthSeverity.Healthy));
+            ServerHealthClassifier.ClassifyBand(isOnline: false, awaitingFirstCollection: false, collectionStale: false, HealthSeverity.Healthy));
 
     [Fact]
     public void ClassifyBand_AwaitingFirstCollection_IsWarning_NotOffline() =>
         Assert.Equal(FleetHealthBand.Warning,
-            ServerHealthClassifier.ClassifyBand(isOnline: null, awaitingFirstCollection: true, hasCollectorErrors: false, HealthSeverity.Healthy));
+            ServerHealthClassifier.ClassifyBand(isOnline: null, awaitingFirstCollection: true, collectionStale: false, HealthSeverity.Healthy));
 
     [Fact]
     public void ClassifyBand_CriticalMetric_IsCritical() =>
         Assert.Equal(FleetHealthBand.Critical,
-            ServerHealthClassifier.ClassifyBand(isOnline: true, awaitingFirstCollection: false, hasCollectorErrors: false, HealthSeverity.Critical));
+            ServerHealthClassifier.ClassifyBand(isOnline: true, awaitingFirstCollection: false, collectionStale: false, HealthSeverity.Critical));
 
     [Fact]
     public void ClassifyBand_StaleCollectionCalmMetrics_IsWarning() =>
         Assert.Equal(FleetHealthBand.Warning,
-            ServerHealthClassifier.ClassifyBand(isOnline: true, awaitingFirstCollection: false, hasCollectorErrors: true, HealthSeverity.Healthy));
+            ServerHealthClassifier.ClassifyBand(isOnline: true, awaitingFirstCollection: false, collectionStale: true, HealthSeverity.Healthy));
 
     [Fact]
     public void ClassifyBand_OnlineCalm_IsHealthy() =>
         Assert.Equal(FleetHealthBand.Healthy,
-            ServerHealthClassifier.ClassifyBand(isOnline: true, awaitingFirstCollection: false, hasCollectorErrors: false, HealthSeverity.Healthy));
+            ServerHealthClassifier.ClassifyBand(isOnline: true, awaitingFirstCollection: false, collectionStale: false, HealthSeverity.Healthy));
 
     /* ── worst-first score ── */
 

--- a/Darling/Darling.Tests/ViewerFleetRollupTests.cs
+++ b/Darling/Darling.Tests/ViewerFleetRollupTests.cs
@@ -139,7 +139,7 @@ public sealed class ViewerFleetRollupBuilderTests
         new() { DisplayName = name, ServerId = id, IsOnline = true, FailedCollectorCount = failed };
 
     private static ServerSummaryItem Stale(string name, int id) =>
-        new() { DisplayName = name, ServerId = id, IsOnline = true, HasCollectorErrors = true };
+        new() { DisplayName = name, ServerId = id, IsOnline = true, CollectionStale = true };
 
     private static ServerSummaryItem Offline(string name, int id) =>
         new() { DisplayName = name, ServerId = id, IsOnline = false };
@@ -186,7 +186,7 @@ public sealed class ViewerFleetRollupBuilderTests
     [Fact]
     public void ClassifyBand_StaleCollection_IsWarning()
     {
-        // Online but collection has gone stale (HasCollectorErrors) → the card's amber → fleet Warning,
+        // Online but collection has gone stale (CollectionStale) → the card's amber → fleet Warning,
         // even with every metric calm.
         Assert.Equal(FleetHealthBand.Warning, FleetRollup.ClassifyBand(Stale("s", 1)));
     }

--- a/Darling/Darling.Tests/ViewerOverviewExplainsItselfTests.cs
+++ b/Darling/Darling.Tests/ViewerOverviewExplainsItselfTests.cs
@@ -52,7 +52,7 @@ public sealed class ViewerOverviewExplainsItselfTests
         };
 
     private static ServerSummaryItem Stale(string name = "s1", int id = 3) =>
-        new() { DisplayName = name, ServerId = id, IsOnline = true, HasCollectorErrors = true };
+        new() { DisplayName = name, ServerId = id, IsOnline = true, CollectionStale = true };
 
     private static ServerSummaryItem Offline(string name = "o1", int id = 4) =>
         new() { DisplayName = name, ServerId = id, IsOnline = false };
@@ -228,7 +228,7 @@ public sealed class ViewerOverviewExplainsItselfTests
                 ServerId = 1,
                 IsOnline = o,
                 AwaitingFirstCollection = a,
-                HasCollectorErrors = st,
+                CollectionStale = st,
                 CpuPercent = c,
                 MaxBlockingWaitMs = blockMs,
                 FailedCollectorCount = failed,
@@ -289,7 +289,7 @@ public sealed class ViewerOverviewExplainsItselfTests
             "Darling", "PerformanceMonitor.Darling.Viewer", "ViewerDataService.Overview.cs"));
         Assert.Contains("public ServerCollectionStatus CardStatus =>", overview, StringComparison.Ordinal);
         Assert.Contains(
-            "ServerCollectionStatusRules.Classify(IsOnline, HasCollectorErrors, AwaitingFirstCollection);",
+            "ServerCollectionStatusRules.Classify(IsOnline, CollectionStale, AwaitingFirstCollection);",
             overview, StringComparison.Ordinal);
         Assert.Contains("public string StatusDisplay => CardStatus.Word();", overview, StringComparison.Ordinal);
         Assert.Contains("public SolidColorBrush StatusBrush => MakeBrush(CardStatus switch", overview, StringComparison.Ordinal);

--- a/Darling/Darling.Tests/ViewerServerChromeTests.cs
+++ b/Darling/Darling.Tests/ViewerServerChromeTests.cs
@@ -37,7 +37,7 @@ public sealed class ViewerServerChromeTests
         server.ApplyFreshness(now.AddSeconds(-30), now);
 
         Assert.True(server.IsOnline);
-        Assert.False(server.HasCollectorErrors);
+        Assert.False(server.CollectionStale);
         Assert.Equal("Online", server.DotStatus);
     }
 
@@ -51,7 +51,7 @@ public sealed class ViewerServerChromeTests
         server.ApplyFreshness(now.AddMinutes(-5), now);
 
         Assert.True(server.IsOnline);
-        Assert.True(server.HasCollectorErrors);
+        Assert.True(server.CollectionStale);
         Assert.Equal("Warning", server.DotStatus);
     }
 

--- a/Darling/Darling.Tests/ViewerSidebarDotRendersTheCardStatusTests.cs
+++ b/Darling/Darling.Tests/ViewerSidebarDotRendersTheCardStatusTests.cs
@@ -94,7 +94,7 @@ public sealed class ViewerSidebarDotRendersTheCardStatusTests
                overlay read them directly, so two surfaces agreeing on the word while disagreeing on
                IsOnline would still paint differently. */
             Assert.Equal(card.IsOnline, dot.IsOnline);
-            Assert.Equal(card.HasCollectorErrors, dot.HasCollectorErrors);
+            Assert.Equal(card.CollectionStale, dot.CollectionStale);
             Assert.Equal(card.AwaitingFirstCollection, dot.AwaitingFirstCollection);
 
             Assert.True(seen.Add(dot.CardStatus), $"two inputs produced the same state; {where}");
@@ -260,7 +260,7 @@ public sealed class ViewerSidebarDotRendersTheCardStatusTests
 
         var rules = ReadRepoFileLf(Path.Combine("PerformanceMonitor.Common", "ServerHealthBands.cs"));
         Assert.Contains(
-            "public static ServerCollectionStatus Classify(bool? isOnline, bool hasCollectorErrors, bool awaitingFirstCollection) =>",
+            "public static ServerCollectionStatus Classify(bool? isOnline, bool collectionStale, bool awaitingFirstCollection) =>",
             rules, StringComparison.Ordinal);
 
         /* The dot tells the reader which axis it is on, rather than leaving them to infer it from a colour —
@@ -407,7 +407,7 @@ public sealed class ViewerSidebarDotRendersTheCardStatusTests
         foreach (var band in Enum.GetValues<ServerFreshness>())
         {
             var flags = ServerCollectionStatusRules.FlagsFor(band);
-            var viaFlags = ServerCollectionStatusRules.Classify(flags.IsOnline, flags.HasCollectorErrors, flags.AwaitingFirstCollection);
+            var viaFlags = ServerCollectionStatusRules.Classify(flags.IsOnline, flags.CollectionStale, flags.AwaitingFirstCollection);
 
             Assert.Equal(expected[band], ServerCollectionStatusRules.FromFreshness(band));
             Assert.Equal(expected[band], viaFlags);
@@ -462,7 +462,7 @@ public sealed class ViewerSidebarDotRendersTheCardStatusTests
             ServerName = "SQL2022",
             ServerId = 1,
             IsOnline = flags.IsOnline,
-            HasCollectorErrors = flags.HasCollectorErrors,
+            CollectionStale = flags.CollectionStale,
             AwaitingFirstCollection = flags.AwaitingFirstCollection,
         };
 

--- a/Darling/Darling.Tests/ViewerW2aTests.cs
+++ b/Darling/Darling.Tests/ViewerW2aTests.cs
@@ -232,7 +232,7 @@ public sealed class ViewerServerSummaryDisplayTests
         var item = new ServerSummaryItem { LastCollectionTime = Now.AddSeconds(-30) };
         item.ApplyFreshness(Now);
         Assert.True(item.IsOnline);
-        Assert.False(item.HasCollectorErrors);
+        Assert.False(item.CollectionStale);
         Assert.False(item.IsOffline);
         Assert.Equal("Online", item.StatusDisplay);
     }
@@ -243,7 +243,7 @@ public sealed class ViewerServerSummaryDisplayTests
         var item = new ServerSummaryItem { LastCollectionTime = Now.AddMinutes(-5) };
         item.ApplyFreshness(Now);
         Assert.True(item.IsOnline);
-        Assert.True(item.HasCollectorErrors);
+        Assert.True(item.CollectionStale);
         Assert.False(item.IsOffline);
         Assert.Equal("Warning", item.StatusDisplay);
     }
@@ -263,7 +263,7 @@ public sealed class ViewerServerSummaryDisplayTests
         Assert.Null(neverCollected.IsOnline);
         Assert.False(neverCollected.IsOffline);
         Assert.True(neverCollected.AwaitingFirstCollection);
-        Assert.False(neverCollected.HasCollectorErrors);
+        Assert.False(neverCollected.CollectionStale);
         Assert.Equal("Awaiting first collection", neverCollected.StatusDisplay);
 
         /* And a later real collection clears the awaiting state through the same path. */

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingFleetReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingFleetReader.cs
@@ -400,10 +400,10 @@ GROUP BY server_id, collector_name";
         var flags = ServerCollectionStatusRules.FlagsFor(freshness);
         var isOnline = flags.IsOnline;
         var awaitingFirstCollection = flags.AwaitingFirstCollection;
-        var hasCollectorErrors = flags.HasCollectorErrors;
+        var collectionStale = flags.CollectionStale;
 
         var overall = ServerHealthClassifier.OverallMetricSeverity(metrics);
-        var band = ServerHealthClassifier.ClassifyBand(isOnline, awaitingFirstCollection, hasCollectorErrors, overall);
+        var band = ServerHealthClassifier.ClassifyBand(isOnline, awaitingFirstCollection, collectionStale, overall);
 
         /* Per-server platform (design D4): the reliable signal the composer's measure auto-greying matches a
            measure's appliesTo against — see ClassifyPlatform for the edition mapping and why AWS RDS / msdb are
@@ -428,10 +428,10 @@ GROUP BY server_id, collector_name";
             IsSilenced = server.IsSilenced,
             Tags = tags ?? (IReadOnlyList<FleetTag>)Array.Empty<FleetTag>(),
             Band = band,
-            Status = StatusLabel(isOnline, awaitingFirstCollection, hasCollectorErrors),
+            Status = StatusLabel(isOnline, awaitingFirstCollection, collectionStale),
             IsOnline = isOnline,
             AwaitingFirstCollection = awaitingFirstCollection,
-            HasCollectorErrors = hasCollectorErrors,
+            CollectionStale = collectionStale,
             LastCollectionTime = lastCollection,
             CpuPercent = cpuPercent,
             OtherProcessCpuPercent = otherCpu,
@@ -569,8 +569,12 @@ GROUP BY server_id, collector_name";
     }
 
     /// <summary>A short "why it needs attention" line for a ranked server, from the card's own banded metrics —
-    /// mirrors the WPF <c>FleetRollup.BuildReason</c> content over the pre-banded card.</summary>
-    private static string BuildReason(FleetServerCard c)
+    /// mirrors the WPF <c>FleetRollup.BuildReason</c> content over the pre-banded card.
+    ///
+    /// <para>Internal so the prose can be asserted against the card it describes. The clause a flag produces
+    /// is the plainest statement of what that flag means, and #3098 is a field whose name and whose clause
+    /// said different things for long enough that four readings of the name were wrong.</para></summary>
+    internal static string BuildReason(FleetServerCard c)
     {
         if (c.IsOnline == false)
         {
@@ -618,7 +622,7 @@ GROUP BY server_id, collector_name";
             parts.Add($"{c.FailedCollectorCount} collector{(c.FailedCollectorCount == 1 ? "" : "s")} failing");
         }
 
-        if (c.HasCollectorErrors)
+        if (c.CollectionStale)
         {
             parts.Add("collection stale");
         }
@@ -629,8 +633,8 @@ GROUP BY server_id, collector_name";
     /// <summary>The card's status word. Delegates to the one ladder every Darling surface renders (#2473):
     /// this file's own copy agreed with the WPF card, but the WPF sidebar row's copy did not, and three
     /// agreeing copies plus one that does not is still four places where the answer is decided.</summary>
-    private static string StatusLabel(bool? isOnline, bool awaitingFirstCollection, bool hasCollectorErrors) =>
-        ServerCollectionStatusRules.Classify(isOnline, hasCollectorErrors, awaitingFirstCollection).Word();
+    private static string StatusLabel(bool? isOnline, bool awaitingFirstCollection, bool collectionStale) =>
+        ServerCollectionStatusRules.Classify(isOnline, collectionStale, awaitingFirstCollection).Word();
 
     /// <summary>
     /// Classifies a server's raw SERVERPROPERTY('EngineEdition') into the RELIABLE per-server platform flags the
@@ -1006,7 +1010,26 @@ public sealed class FleetServerCard
     [JsonPropertyName("status")] public string Status { get; init; } = "";
     [JsonPropertyName("is_online")] public bool? IsOnline { get; init; }
     [JsonPropertyName("awaiting_first_collection")] public bool AwaitingFirstCollection { get; init; }
-    [JsonPropertyName("has_collector_errors")] public bool HasCollectorErrors { get; init; }
+
+    /// <summary>
+    /// The newest collection has lagged past <see cref="ServerHealthThresholds.StaleThreshold"/> without being
+    /// old enough to call the server dark — <see cref="ServerFreshness.Stale"/>, from
+    /// <see cref="ServerCollectionStatusRules.FlagsFor"/>. It is what bands an otherwise-calm card Warning.
+    ///
+    /// <para><b>Derivable from this same payload, which is the point.</b> The flag is a function of
+    /// <c>last_collection</c> against the roll-up's <c>generated_at</c>, and <c>status</c> reads
+    /// <c>"Warning"</c> whenever it is true on a reachable server. A reader who cannot check a field's name
+    /// against its population has to trust the name, and #3098 measured what that costs on this one: two
+    /// agents drew four wrong conclusions from it in a single day, one of them a retracted claim about WHEN a
+    /// cluster of collector errors happened. Every field on this card that cannot be recomputed from the card
+    /// is one more that has to be trusted.</para>
+    ///
+    /// <para><b>Not an error signal, and there are two that are.</b> <c>failed_collector_count</c> counts
+    /// collectors currently failing and <c>collector_severity</c> bands it. Those and this one disagree
+    /// routinely and correctly: a server can collect on time with a collector failing, and can go quiet with
+    /// every collector's last run a success.</para>
+    /// </summary>
+    [JsonPropertyName("collection_stale")] public bool CollectionStale { get; init; }
     [JsonPropertyName("last_collection")] public DateTime? LastCollectionTime { get; init; }
 
     [JsonPropertyName("cpu_percent")] public double? CpuPercent { get; init; }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Fleet.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Fleet.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2026 Erik Darling, Darling Data LLC
  *
  * This file is part of the SQL Server Performance Monitor.
@@ -596,7 +596,7 @@ public sealed class FleetRollup
     /// Collapses a card's health to one fleet band — REUSING #1426's banding, mirroring
     /// <see cref="ServerSummaryItem.CardBorderBrush"/>: offline collection → Offline; else the card's
     /// worst metric band (<see cref="ServerSummaryItem.OverallMetricSeverity"/>) maps Critical → Critical,
-    /// Warning → Warning, and a stale collection (<see cref="ServerSummaryItem.HasCollectorErrors"/>) is
+    /// Warning → Warning, and a stale collection (<see cref="ServerSummaryItem.CollectionStale"/>) is
     /// Warning too; otherwise Healthy. No new thresholds are introduced here.
     /// </summary>
     public static FleetHealthBand ClassifyBand(ServerSummaryItem s) =>
@@ -606,7 +606,7 @@ public sealed class FleetRollup
                whatever IsOnline says, so an online card carrying a stray marker banded Warning while the card
                said "Online" and had nothing to report — a third reading of the same pair. See ServerCollectionStatus. */
             s.CardStatus == ServerCollectionStatus.AwaitingFirstCollection,
-            s.HasCollectorErrors,
+            s.CollectionStale,
             s.OverallMetricSeverity);
 
     /// <summary>
@@ -666,7 +666,7 @@ public sealed class FleetRollup
         {
             parts.Add($"{s.FailedCollectorCount} collector{(s.FailedCollectorCount == 1 ? "" : "s")} failing");
         }
-        if (s.HasCollectorErrors)
+        if (s.CollectionStale)
         {
             parts.Add("collection stale");
         }

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Overview.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.Overview.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2026 Erik Darling, Darling Data LLC
  *
  * This file is part of the SQL Server Performance Monitor.
@@ -416,8 +416,11 @@ public sealed class ServerSummaryItem
     public System.Collections.Generic.IReadOnlyList<ServerTagPill> TagPills { get; set; } =
         System.Array.Empty<ServerTagPill>();
 
-    /// <summary>Warning (amber) state — in the viewer this means the collection has gone stale.</summary>
-    public bool HasCollectorErrors { get; set; }
+    /// <summary>Warning (amber) state: the newest collection has lagged past
+    /// <see cref="ServerHealthThresholds.StaleThreshold"/>. Freshness only — collectors that are failing are
+    /// counted by <see cref="FailedCollectorCount"/> and banded by <see cref="CollectorSeverity"/>, and the two
+    /// axes disagree routinely and correctly (#3098).</summary>
+    public bool CollectionStale { get; set; }
 
     /// <summary>
     /// True when no collection has EVER landed for this server (<see cref="ServerFreshness.NeverCollected"/>):
@@ -646,7 +649,7 @@ public sealed class ServerSummaryItem
         ? ViewerTimeHelper.ForDisplay(LastCollectionTime.Value).ToString("HH:mm:ss")
         : "Never";
 
-    /* Collection status. The (IsOnline, HasCollectorErrors, AwaitingFirstCollection) triple is resolved by
+    /* Collection status. The (IsOnline, CollectionStale, AwaitingFirstCollection) triple is resolved by
        ServerCollectionStatusRules.Classify and nowhere else in the viewer — the sidebar row's dot carried its
        own four-state copy until #2473, which is how a never-collected server got a grey "Unknown" dot beside
        this card's amber "Awaiting first collection". Everything downstream — the word, the colour, the
@@ -656,7 +659,7 @@ public sealed class ServerSummaryItem
 
        The null arm distinguishes "not reached yet" (bootstrap) from a legacy unknown. */
     public ServerCollectionStatus CardStatus =>
-        ServerCollectionStatusRules.Classify(IsOnline, HasCollectorErrors, AwaitingFirstCollection);
+        ServerCollectionStatusRules.Classify(IsOnline, CollectionStale, AwaitingFirstCollection);
 
     public string StatusDisplay => CardStatus.Word();
 
@@ -764,7 +767,7 @@ public sealed class ServerSummaryItem
             {
                 HealthSeverity.Critical => s_criticalBrush,
                 HealthSeverity.Warning => s_warningBrush,
-                _ => HasCollectorErrors || AwaitingFirstCollection ? MakeBrush("#FFD54F") : MakeBrush("#2a2d35"),
+                _ => CollectionStale || AwaitingFirstCollection ? MakeBrush("#FFD54F") : MakeBrush("#2a2d35"),
             };
         }
     }
@@ -793,7 +796,7 @@ public sealed class ServerSummaryItem
     {
         var flags = ServerCollectionStatusRules.FlagsFor(ClassifyFreshness(LastCollectionTime, nowUtc));
         IsOnline = flags.IsOnline;
-        HasCollectorErrors = flags.HasCollectorErrors;
+        CollectionStale = flags.CollectionStale;
         AwaitingFirstCollection = flags.AwaitingFirstCollection;
     }
 

--- a/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.cs
+++ b/Darling/PerformanceMonitor.Darling.Viewer/ViewerDataService.cs
@@ -24,7 +24,7 @@ namespace PerformanceMonitor.Darling.Viewer;
 /// One row of the servers table, as the viewer's server list shows it. Was a positional record; it is now
 /// a class because the ported Lite server-row chrome needs mutable, change-notifying runtime state on each
 /// row — the favorite star (<see cref="IsFavorite"/>, matched from the viewer's registry) and the
-/// collection-freshness status dot (<see cref="IsOnline"/> / <see cref="HasCollectorErrors"/> /
+/// collection-freshness status dot (<see cref="IsOnline"/> / <see cref="CollectionStale"/> /
 /// <see cref="AwaitingFirstCollection"/> → <see cref="CardStatus"/> → <see cref="DotStatus"/>) update in
 /// place on the refresh timers without resetting the list's selection.
 /// The Postgres-sourced fields stay immutable (get-only); only the sidebar overlay state is settable.
@@ -139,18 +139,20 @@ public sealed class DarlingServer : INotifyPropertyChanged
         }
     }
 
-    private bool _hasCollectorErrors;
+    private bool _collectionStale;
 
-    /// <summary>Warning (amber) state — in the viewer this means the collection has gone stale.</summary>
-    public bool HasCollectorErrors
+    /// <summary>Warning (amber) state: the newest collection has lagged past
+    /// <see cref="ServerHealthThresholds.StaleThreshold"/>. Freshness only, and named for it — a collector that
+    /// is failing is a different axis, reported by the Collection Health tab (#3098).</summary>
+    public bool CollectionStale
     {
-        get => _hasCollectorErrors;
+        get => _collectionStale;
         set
         {
-            if (_hasCollectorErrors != value)
+            if (_collectionStale != value)
             {
-                _hasCollectorErrors = value;
-                OnPropertyChanged(nameof(HasCollectorErrors));
+                _collectionStale = value;
+                OnPropertyChanged(nameof(CollectionStale));
                 RaiseDotChanged();
             }
         }
@@ -187,7 +189,7 @@ public sealed class DarlingServer : INotifyPropertyChanged
     /// with one discriminant there is no flag combination left for the renderings to disagree about.
     /// </summary>
     public ServerCollectionStatus CardStatus =>
-        ServerCollectionStatusRules.Classify(IsOnline, HasCollectorErrors, AwaitingFirstCollection);
+        ServerCollectionStatusRules.Classify(IsOnline, CollectionStale, AwaitingFirstCollection);
 
     /// <summary>
     /// Sidebar status-dot vocabulary — the SAME words the Overview card's <c>StatusDisplay</c> shows, because
@@ -246,7 +248,7 @@ public sealed class DarlingServer : INotifyPropertyChanged
         var flags = ServerCollectionStatusRules.FlagsFor(
             ServerSummaryItem.ClassifyFreshness(lastCollectionUtc, nowUtc));
         IsOnline = flags.IsOnline;
-        HasCollectorErrors = flags.HasCollectorErrors;
+        CollectionStale = flags.CollectionStale;
         AwaitingFirstCollection = flags.AwaitingFirstCollection;
     }
 

--- a/PerformanceMonitor.Common/ServerHealthBands.cs
+++ b/PerformanceMonitor.Common/ServerHealthBands.cs
@@ -87,11 +87,22 @@ namespace PerformanceMonitor.Common
     /// Returning them together is what makes dropping one a visible edit rather than an omission.
     /// </summary>
     /// <param name="IsOnline">Reachability: true = fresh or stale, false = offline, null = not reached yet.</param>
-    /// <param name="HasCollectorErrors">The amber warning flag — in Darling, a stale collection.</param>
+    /// <param name="CollectionStale">The amber warning flag: the newest collection has lagged past
+    /// <see cref="ServerHealthThresholds.StaleThreshold"/> but is not old enough to call the server dark. It is
+    /// <see cref="ServerFreshness.Stale"/> and nothing else — no error count, no <c>collection_log</c> read.
+    ///
+    /// <para><b>It is named for freshness because that is its whole population, and the name is load-bearing.</b>
+    /// Lite carries a flag of the same shape on its own card (<c>ServerCardStatusRules.Classify</c>) fed from
+    /// <c>ErroringCollectors &gt; 0</c> — collectors that are actually failing. Two agents made four wrong
+    /// inferences from this one in a day (#3098), every one of them a reasonable reading of a name that said
+    /// errors, and the reading each time was falsified by the store: cards flagged with every collector
+    /// <c>HEALTHY</c>, and cards clear with <c>ERROR</c> rows inside their own published window. Failure is
+    /// reported on the axis that measures it — <c>failed_collector_count</c> and
+    /// <see cref="ServerHealthClassifier.CollectorSeverity"/>.</para></param>
     /// <param name="AwaitingFirstCollection">No collection has EVER landed (a bootstrap state, not an outage).</param>
     public readonly record struct ServerCollectionFlags(
         bool? IsOnline,
-        bool HasCollectorErrors,
+        bool CollectionStale,
         bool AwaitingFirstCollection);
 
     /// <summary>
@@ -114,14 +125,14 @@ namespace PerformanceMonitor.Common
     public static class ServerCollectionStatusRules
     {
         /// <summary>
-        /// The (<c>IsOnline</c>, <c>HasCollectorErrors</c>, <c>AwaitingFirstCollection</c>) triple, resolved.
+        /// The (<c>IsOnline</c>, <c>CollectionStale</c>, <c>AwaitingFirstCollection</c>) triple, resolved.
         /// The order matters and is the #2429 reading: an online server's flags win over an awaiting marker,
         /// so a stale card cannot also claim to be awaiting its first collection.
         /// </summary>
-        public static ServerCollectionStatus Classify(bool? isOnline, bool hasCollectorErrors, bool awaitingFirstCollection) =>
+        public static ServerCollectionStatus Classify(bool? isOnline, bool collectionStale, bool awaitingFirstCollection) =>
             isOnline switch
             {
-                true when hasCollectorErrors => ServerCollectionStatus.Stale,
+                true when collectionStale => ServerCollectionStatus.Stale,
                 true => ServerCollectionStatus.Online,
                 false => ServerCollectionStatus.Offline,
                 _ => awaitingFirstCollection ? ServerCollectionStatus.AwaitingFirstCollection : ServerCollectionStatus.Unknown,
@@ -150,7 +161,7 @@ namespace PerformanceMonitor.Common
         public static ServerCollectionStatus FromFreshness(ServerFreshness freshness)
         {
             var flags = FlagsFor(freshness);
-            return Classify(flags.IsOnline, flags.HasCollectorErrors, flags.AwaitingFirstCollection);
+            return Classify(flags.IsOnline, flags.CollectionStale, flags.AwaitingFirstCollection);
         }
 
         /// <summary>The words a human reads. They are also the <c>DataTrigger</c> values the WPF sidebar keys
@@ -474,7 +485,7 @@ namespace PerformanceMonitor.Common
         /// a never-collected (queued-during-bootstrap) server -> Warning (attention-worthy but not the red overlay);
         /// else the card's worst metric band, with a stale collection also Warning.
         /// </summary>
-        public static FleetHealthBand ClassifyBand(bool? isOnline, bool awaitingFirstCollection, bool hasCollectorErrors, HealthSeverity overallMetricSeverity)
+        public static FleetHealthBand ClassifyBand(bool? isOnline, bool awaitingFirstCollection, bool collectionStale, HealthSeverity overallMetricSeverity)
         {
             if (isOnline == false)
             {
@@ -490,7 +501,7 @@ namespace PerformanceMonitor.Common
             {
                 HealthSeverity.Critical => FleetHealthBand.Critical,
                 HealthSeverity.Warning => FleetHealthBand.Warning,
-                _ => hasCollectorErrors ? FleetHealthBand.Warning : FleetHealthBand.Healthy,
+                _ => collectionStale ? FleetHealthBand.Warning : FleetHealthBand.Healthy,
             };
         }
 


### PR DESCRIPTION
`has_collector_errors` on the `get_fleet_overview` / `/api/fleet` card was populated by `ServerCollectionStatusRules.FlagsFor(ServerHealthClassifier.ClassifyFreshness(lastCollection, now))` and by nothing else — no error count, no `collection_log` read, no use of the window the card publishes. Its value was correct; its name described a different population, and the same code already emitted `"collection stale"` as the card's reason for it. That single fact accounts for all four falsified readings in #3098: staleness is not failure, freshness compares `last_collection` against `now` rather than against `window_start`/`window_end`, and the flag was never counting anything.

**The defect was the name, so the fix is the name.** The card publishes `collection_stale`, and the CLR flag behind it is `ServerCollectionFlags.CollectionStale` across `PerformanceMonitor.Common` and every Darling surface that renders the one #2473 ladder — the WPF Overview card, the sidebar dot, the fleet roll-up and the service-side reader. `Classify` and `ClassifyBand` take `collectionStale`.

## Renaming was viable, and here is what established that

Every consumer of the published name, enumerated:

| consumer | reads `has_collector_errors`? |
|---|---|
| web dashboard (`wwwroot/js/pages/fleet.js`, `app.js`) | **no** — it renders `status`, `awaiting_first_collection`, `is_online`, `failed_collector_count`, `healthy_collector_count`, `collector_severity` |
| MCP tool schema, `DarlingMcpInstructions.cs`, `Darling/README.md`, root `README.md`, `llms.txt`, `docs/` | **no** — none of them names a fleet-card field |
| `DarlingFleetDtoJsonTests.FleetServerCard_SerializesSnakeCase_WithStringBands`, which pins the card's snake_case field names | **no** — the field was absent from its pinned list |
| WPF viewer | not by that name — it computes its own flags from `FlagsFor` |

So the JSON name had exactly one declaration site and zero readers. The one external cost is an MCP client keying on the old name, which after this reads absent-and-falsy. That is the same failure mode removing the field would have, and it is the cost of a field whose every observed reading was wrong: keeping the name keeps the wrong readings. An affected client recovers the value from the same payload — `status == "Warning"` on a reachable server, or `last_collection` against `generated_at`.

**Lite keeps `HasCollectorErrors`, and that is the sharpest part of this.** Lite's identically-shaped flag is fed from `ErroringCollectors > 0` on Lite's own `ServerCardStatusRules` ladder, which shares no code with `ServerCollectionStatusRules`. One identifier named two different populations across the two SKUs; now each name matches its own. `LitesErrorFlag_StillNamesAnErrorCount` holds that as a decision rather than as the gap a scoped scan stepped around.

**The case against a deprecation alias is not the count of wrong readings.** One of the readers reports that its own artifacts carried three standing wrong characterisations of the old field, and that at the third it had written *"I am recording it as unknown, do not date from it"* and then proposed a further theory in the next sentence (reported by that reader, not measured here). A name that keeps generating plausible theories keeps generating them even for a reader who has explicitly decided to stop, which is what an alias would preserve.

**No companion timestamp was added.** #3098's option 1 asked for one; the card already carries `last_collection`, which is the exact input the flag is a function of. What was missing was a name connecting them, not a value.

## Tests

`Darling/Darling.Tests/FleetCardCollectionStaleNamesItsPopulationTests.cs`, eight facts, none touching WPF so they run off the Windows leg of CI as well as on it:

- the flag is exactly `ServerFreshness.Stale` over every band, with the band count asserted so a fifth band cannot join the flag's population silently
- it tracks collection age across both thresholds, every boundary read off `ServerHealthThresholds` rather than restated as 2 and 15
- the four `(collection age, collectors failing)` combinations, including the two #3098 falsified — a flagged card with 0 failing and 39 healthy, and the PostgreSQL-store card at `band: Warning`, `failed_collector_count: 1`, flag clear — plus the count of combinations where the two axes disagree, which is what makes one name for both unusable
- the reason clause agrees with the name, and a card carrying both axes reports both (`DarlingFleetReader.BuildReason` is now `internal` for this: the clause a flag produces is the plainest statement of what the flag means)
- the reader's four-line derivation, by source text, because cards are assembled inside a private method behind nine store reads
- the serialized card carries `collection_stale` beside `last_collection` and `status` — #3098's acceptance criterion, that the population is determinable from the response alone — and still publishes the error axis separately
- the errors spelling is absent from every Darling surface: a byte-level walk over **every file** under `PerformanceMonitor.Common`, `Darling` and `docs`, plus `llms.txt` and the root README, so a reference in a file type nobody enumerated is found rather than skipped. Both needles are assembled at run time, because the test file is inside the walked tree and a scan that matches its own needle reports the search. `CHANGELOG.md` is out of scope by construction — it records what changed, so it names the old field on purpose.

Every assertion was red-proofed by reverting what it guards, each run producing a test summary:

| reverted | red |
|---|---|
| `FlagsFor`'s `Stale` arm stops setting the flag | 4 of 8, including the population and independence facts |
| `ClassifyFreshness`'s stale boundary made inclusive | the threshold fact |
| `CollectorSeverity` stops banding one failing collector | the independence and reason facts |
| reason clause changed to an error phrase | the reason fact |
| the flag re-derived from `collectors.Failing > 0` | the derivation pin |
| the published JSON name changed | the serialization fact, the derivation pin, and the walk's own must-pass control |
| the errors spelling planted in `Darling/README.md` | the tree-wide walk |
| the errors spelling planted in `wwwroot/js/pages/fleet.js` | the tree-wide walk |
| Lite's flag no longer fed from its error count | the must-pass Lite control |

Pre-existing pins updated in place rather than around: the source-text anchors in `ViewerSidebarDotRendersTheCardStatusTests` and `ViewerOverviewExplainsItselfTests` pin that the sidebar dot and the Overview card render the one shared ladder, so they carry the parameter's spelling and were re-spelled with it. Lite's two equivalents pin Lite's ladder and are untouched. `DarlingFleetDtoJsonTests`' field list is also untouched: it pins the names the browser consumes, and the browser does not consume this one.

## CHANGELOG entry text

For the `[Unreleased]` block, under Changed:

- **The fleet card's collection flag is named for what it measures** ([#3098], reported from two agents' readings) - `has_collector_errors` on `get_fleet_overview` / `/api/fleet` was derived from collection freshness and nothing else - no error count, no `collection_log` read, no window - and the card's own reason string already called it "collection stale". It is now `collection_stale`. Two agents drew four wrong conclusions from the old name in one day, each falsified by a store query and each a reasonable reading of the name: cards flagged with all 39 collectors `HEALTHY` and `failed_collector_count: 0`, the flag set by errors 15 to 26 hours outside the card's published window, and the flag clear on all 43 cards while `ERROR` rows sat inside the window those cards stated. The error axis is unchanged and still separate - `failed_collector_count` and `collector_severity` - and the card already carried `last_collection`, the value the flag is a function of, so a reader can now recompute it from the response alone. **Breaking for an MCP client keying on the old field name**; the value is recoverable from `status` or from `last_collection` against `generated_at`. Lite's `HasCollectorErrors` is unaffected: it is fed from a real error count, on a different ladder, where the name is accurate.
