### PR TITLE
Part of #3099

### DIFF
--- a/Darling/Darling.Tests/StoreCopyPhaseLivePostgresTests.cs
+++ b/Darling/Darling.Tests/StoreCopyPhaseLivePostgresTests.cs
@@ -61,7 +61,12 @@ public class StoreCopyPhaseLivePostgresTests
     [Fact]
     public async Task AFaultOutOfBeginBinaryImportCarriesStart_OnTheRealPath()
     {
-        var fault = await CopyFaultAsync(new PhaseProbeDefinition());
+        await using var dataSource = NpgsqlDataSource.Create(UnreachableStore);
+        /* Deliberately NOT opened: that is what makes the real BeginBinaryImportAsync refuse before it
+           reaches a socket, which is a start-phase fault and needs no store. */
+        await using var connection = new NpgsqlConnection(UnreachableStore);
+
+        var fault = await CopyFaultAsync(new PhaseProbeDefinition(), dataSource, connection);
 
         Assert.False(
             fault is PhaseProbeReachedTheRowLoopException,
@@ -112,77 +117,64 @@ public class StoreCopyPhaseLivePostgresTests
     /// Drives the SHIPPED private COPY body and returns the fault it raised. Reflection because the method
     /// is private and <c>InternalsVisibleTo</c> does not reach private members; a rename breaks this
     /// loudly, which is the correct failure for a test whose whole subject is that method.
+    ///
+    /// <para><b>Takes its connection and data source rather than owning them, and has no <c>finally</c>.</b>
+    /// Every caller holds both under <c>await using</c>, so disposal is the language's job. That is not
+    /// stylistic: a <c>DisposeAsync</c> in a <c>finally</c> can throw and REPLACE the body's exception,
+    /// which on this helper is the entire result being measured — and it is the same hazard
+    /// <c>LiveCleanupConversionRatchetTests</c> exists to stamp out. <c>LiveStoreCleanup</c> is not the
+    /// remedy here because there is nothing to clean: the COPY always faults, so no attempt commits a row.
+    /// </para>
     /// </summary>
     private static async Task<Exception> CopyFaultAsync(
         PhaseProbeDefinition definition,
-        NpgsqlDataSource? dataSource = null,
-        NpgsqlConnection? connection = null,
+        NpgsqlDataSource dataSource,
+        NpgsqlConnection connection,
         CancellationToken cancellationToken = default)
     {
-        var ownsDataSource = dataSource is null;
-        dataSource ??= NpgsqlDataSource.Create(UnreachableStore);
-        var ownsConnection = connection is null;
-        /* Deliberately NOT opened in the default case - see the test's remarks. */
-        connection ??= new NpgsqlConnection(UnreachableStore);
+        var runner = new DarlingCollectorRunner(dataSource, new CollectorDeltaCalculator());
+        var method = typeof(DarlingCollectorRunner)
+            .GetMethod("CopyBatchOnceAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(method);
+
+        var server = new ServerRuntime
+        {
+            Config = new MonitoredServer { Name = "phase-probe", Host = "phase-probe-host" },
+            ConnectionString = "Server=phase-probe-host",
+            Target = new CollectorTargetInfo { SqlMajorVersion = 16 },
+            StorageName = "phase-probe-host",
+            ServerId = -3099,
+            EngineEdition = 3,
+        };
+
+        var context = new CollectorContext
+        {
+            ServerId = server.ServerId,
+            ServerName = server.StorageName,
+            CollectionTime = DateTime.UtcNow,
+            Deltas = new CollectorDeltaCalculator(),
+            Target = server.Target,
+        };
+
+        var task = (Task)method!.MakeGenericMethod(typeof(int)).Invoke(
+            runner,
+            new object?[]
+            {
+                connection, definition, new List<int> { 1 }, server,
+                DateTime.UtcNow, context, cancellationToken,
+            })!;
 
         try
         {
-            var runner = new DarlingCollectorRunner(dataSource, new CollectorDeltaCalculator());
-            var method = typeof(DarlingCollectorRunner)
-                .GetMethod("CopyBatchOnceAsync", BindingFlags.NonPublic | BindingFlags.Instance);
-            Assert.NotNull(method);
-
-            var server = new ServerRuntime
-            {
-                Config = new MonitoredServer { Name = "phase-probe", Host = "phase-probe-host" },
-                ConnectionString = "Server=phase-probe-host",
-                Target = new CollectorTargetInfo { SqlMajorVersion = 16 },
-                StorageName = "phase-probe-host",
-                ServerId = -3099,
-                EngineEdition = 3,
-            };
-
-            var context = new CollectorContext
-            {
-                ServerId = server.ServerId,
-                ServerName = server.StorageName,
-                CollectionTime = DateTime.UtcNow,
-                Deltas = new CollectorDeltaCalculator(),
-                Target = server.Target,
-            };
-
-            var task = (Task)method!.MakeGenericMethod(typeof(int)).Invoke(
-                runner,
-                new object?[]
-                {
-                    connection, definition, new List<int> { 1 }, server,
-                    DateTime.UtcNow, context, cancellationToken,
-                })!;
-
-            try
-            {
-                await task;
-            }
-            catch (Exception ex)
-            {
-                return ex;
-            }
-
-            Assert.Fail("the COPY body was expected to fault");
-            throw new InvalidOperationException("unreachable");
+            await task;
         }
-        finally
+        catch (Exception ex)
         {
-            if (ownsConnection)
-            {
-                await connection.DisposeAsync();
-            }
-
-            if (ownsDataSource)
-            {
-                await dataSource.DisposeAsync();
-            }
+            return ex;
         }
+
+        Assert.Fail("the COPY body was expected to fault");
+        throw new InvalidOperationException("unreachable");
     }
 
     private sealed class PhaseProbeReachedTheRowLoopException : Exception

--- a/Darling/Darling.Tests/StoreCopyPhaseLivePostgresTests.cs
+++ b/Darling/Darling.Tests/StoreCopyPhaseLivePostgresTests.cs
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+using PerformanceMonitor.Collectors;
+using PerformanceMonitor.Darling.Service;
+using PerformanceMonitor.Darling.Service.Targets;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// The INSTANCE half of #3095's phase contract: what the source pins in <see cref="StoreCopyPhaseTests"/>
+/// structurally cannot see (#3099).
+///
+/// <para><b>Split out rather than serializing its pure sibling.</b> The data-phase check reads the shared
+/// <c>DARLING_TEST_PG</c> store, which makes its whole class a live class —
+/// <c>LivePostgresCollectionHygieneTests</c> requires that, and its preferred remedy is exactly this shape:
+/// a mostly-pure class keeps its purity and the live test moves to its own <c>...LivePostgresTests</c>.
+/// Putting <c>[Collection("live-postgres")]</c> on <see cref="StoreCopyPhaseTests"/> instead would serialize
+/// seven source-text pins against every other live class in the suite for no reason.</para>
+///
+/// <para>The start-phase check needs no store and is kept here anyway: it and the data-phase check are a
+/// test and its negative control, they share the probe plumbing below, and separating them would leave the
+/// control one file away from the thing it controls. The cost is that one fast, storeless test is serialized
+/// with the live collection, which is cheaper than either alternative.</para>
+/// </summary>
+[Collection("live-postgres")]
+public class StoreCopyPhaseLivePostgresTests
+{
+    /// <summary>
+    /// A fault out of the REAL <c>BeginBinaryImportAsync</c>, on the real write path, carries
+    /// <see cref="StoreCopyPhase.Start"/>.
+    ///
+    /// <para><b>Why this exists alongside the source pin above, not instead of it.</b> The two fail
+    /// differently and neither covers the other's blind spot. The pin catches every edit of a shape it
+    /// anticipated — a moved transition, a second one, an explicit <c>Stamp(ex, Start)</c> — and is blind
+    /// to constructions nobody thought of; the gap that let a bare post-loop
+    /// <c>copyPhase = StoreCopyPhase.Start;</c> pass all five of its assertions was exactly that. This
+    /// test is indifferent to how the source got there: it runs the path and reads the stamp off a real
+    /// exception, so an unanticipated construction that produces the wrong phase fails here even when
+    /// every regex still matches.</para>
+    ///
+    /// <para>No live store is needed and that is the point of using an UNOPENED connection: the real
+    /// <c>BeginBinaryImportAsync</c> refuses before it reaches a socket, which is precisely a start-phase
+    /// fault — the importer never returned. The definition's <c>WritePayload</c> throws a distinctive
+    /// exception, so if the row loop were ever reached this would surface as that fault instead of the
+    /// connection's, and the assertion would name which.</para>
+    /// </summary>
+    [Fact]
+    public async Task AFaultOutOfBeginBinaryImportCarriesStart_OnTheRealPath()
+    {
+        var fault = await CopyFaultAsync(new PhaseProbeDefinition());
+
+        Assert.False(
+            fault is PhaseProbeReachedTheRowLoopException,
+            "the row loop must not be reachable when Begin refuses: WritePayload ran, so this test is no "
+            + "longer exercising the start phase.");
+
+        Assert.Equal(StoreCopyPhase.Start, CollectorFaultCopyPhase.For(fault));
+    }
+
+    /// <summary>
+    /// The negative control, and without it the test above proves much less: it would pass just as well if
+    /// <c>Start</c> were stamped unconditionally on every COPY fault. Here the row loop IS reached — the
+    /// definition's <c>WritePayload</c> throws once Begin has returned — and the stamp must read
+    /// <see cref="StoreCopyPhase.Data"/>.
+    ///
+    /// <para>Begin has to succeed for the loop to be entered, so this one needs a real store and is gated
+    /// on <c>DARLING_TEST_PG</c> like the rest of the live suite. The COPY targets a table that does not
+    /// exist only in the negative case above; here it targets a real one so Begin returns.</para>
+    /// </summary>
+    [Fact]
+    public async Task AFaultInsideTheRowLoopCarriesData_OnTheRealPath()
+    {
+        var pg = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(pg), "Set DARLING_TEST_PG to run the data-phase instance check.");
+
+        var ct = TestContext.Current.CancellationToken;
+        await using var dataSource = NpgsqlDataSource.Create(pg!);
+        await using (var migrateConnection = await dataSource.OpenConnectionAsync(ct))
+        {
+            await PerformanceMonitor.Darling.Storage.PgMigrations.MigrateAsync(migrateConnection, ct);
+        }
+
+        await using var connection = await dataSource.OpenConnectionAsync(ct);
+        var fault = await CopyFaultAsync(new PhaseProbeDefinition("wait_stats"), dataSource, connection, ct);
+
+        Assert.True(
+            fault is PhaseProbeReachedTheRowLoopException,
+            $"Begin must have returned so the row loop is entered; got {fault.GetType().Name}: {fault.Message}");
+
+        Assert.Equal(StoreCopyPhase.Data, CollectorFaultCopyPhase.For(fault));
+    }
+
+    /* ── probe plumbing ── */
+
+    private const string UnreachableStore = "Host=127.0.0.1;Port=1;Username=probe;Database=probe";
+
+    /// <summary>
+    /// Drives the SHIPPED private COPY body and returns the fault it raised. Reflection because the method
+    /// is private and <c>InternalsVisibleTo</c> does not reach private members; a rename breaks this
+    /// loudly, which is the correct failure for a test whose whole subject is that method.
+    /// </summary>
+    private static async Task<Exception> CopyFaultAsync(
+        PhaseProbeDefinition definition,
+        NpgsqlDataSource? dataSource = null,
+        NpgsqlConnection? connection = null,
+        CancellationToken cancellationToken = default)
+    {
+        var ownsDataSource = dataSource is null;
+        dataSource ??= NpgsqlDataSource.Create(UnreachableStore);
+        var ownsConnection = connection is null;
+        /* Deliberately NOT opened in the default case - see the test's remarks. */
+        connection ??= new NpgsqlConnection(UnreachableStore);
+
+        try
+        {
+            var runner = new DarlingCollectorRunner(dataSource, new CollectorDeltaCalculator());
+            var method = typeof(DarlingCollectorRunner)
+                .GetMethod("CopyBatchOnceAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+
+            var server = new ServerRuntime
+            {
+                Config = new MonitoredServer { Name = "phase-probe", Host = "phase-probe-host" },
+                ConnectionString = "Server=phase-probe-host",
+                Target = new CollectorTargetInfo { SqlMajorVersion = 16 },
+                StorageName = "phase-probe-host",
+                ServerId = -3099,
+                EngineEdition = 3,
+            };
+
+            var context = new CollectorContext
+            {
+                ServerId = server.ServerId,
+                ServerName = server.StorageName,
+                CollectionTime = DateTime.UtcNow,
+                Deltas = new CollectorDeltaCalculator(),
+                Target = server.Target,
+            };
+
+            var task = (Task)method!.MakeGenericMethod(typeof(int)).Invoke(
+                runner,
+                new object?[]
+                {
+                    connection, definition, new List<int> { 1 }, server,
+                    DateTime.UtcNow, context, cancellationToken,
+                })!;
+
+            try
+            {
+                await task;
+            }
+            catch (Exception ex)
+            {
+                return ex;
+            }
+
+            Assert.Fail("the COPY body was expected to fault");
+            throw new InvalidOperationException("unreachable");
+        }
+        finally
+        {
+            if (ownsConnection)
+            {
+                await connection.DisposeAsync();
+            }
+
+            if (ownsDataSource)
+            {
+                await dataSource.DisposeAsync();
+            }
+        }
+    }
+
+    private sealed class PhaseProbeReachedTheRowLoopException : Exception
+    {
+        public PhaseProbeReachedTheRowLoopException() : base("WritePayload was reached") { }
+    }
+
+    /// <summary>
+    /// A minimal non-diverting definition. Non-diverting matters: a diverting collector opens a
+    /// transaction BEFORE the try, which on an unopened connection would throw outside the stamped region
+    /// and the probe would read Unknown for a reason that has nothing to do with the phase.
+    /// </summary>
+    private sealed class PhaseProbeDefinition : CollectorDefinitionBase<int>
+    {
+        private readonly string _table;
+
+        public PhaseProbeDefinition(string table = "phase_probe_no_such_table") => _table = table;
+
+        public override string Name => "phase_probe";
+
+        public override string TargetTable => _table;
+
+        public override IReadOnlyList<CollectorColumn> PayloadColumns { get; } =
+            new[] { new CollectorColumn("wait_type", CollectorColumnType.Varchar) };
+
+        public override CollectorQuery BuildQuery(CollectorContext context)
+            => throw new NotSupportedException("the probe never fetches");
+
+        public override ValueTask<List<int>> ReadAsync(
+            DbDataReader reader, CollectorContext context, CancellationToken cancellationToken)
+            => throw new NotSupportedException("the probe never fetches");
+
+        /* Throws so the row loop is DETECTABLE: in the start-phase case it must never run, and in the
+           data-phase case it is how the loop is entered and then faulted. */
+        public override void WritePayload(int row, ICollectorRowWriter writer, CollectorContext context)
+            => throw new PhaseProbeReachedTheRowLoopException();
+    }
+}

--- a/Darling/Darling.Tests/StoreCopyPhaseTests.cs
+++ b/Darling/Darling.Tests/StoreCopyPhaseTests.cs
@@ -7,7 +7,12 @@
  */
 
 using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Reflection;
 using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
 using Npgsql;
 using PerformanceMonitor.Collectors;
 using PerformanceMonitor.Darling.Service;
@@ -213,6 +218,21 @@ public class StoreCopyPhaseTests
            which phase is in force. */
         Assert.Equal(1, Regex.Matches(runner, @"copyPhase = StoreCopyPhase\.Data;").Count);
 
+        /* And exactly one assignment of Start — the declaration itself, which this pattern matches as a
+           substring of `var copyPhase = ...`. SYMMETRIC with the Data count above, and it closes the one
+           construction the other four assertions here are all blind to: a bare
+           `copyPhase = StoreCopyPhase.Start;` added anywhere below the row loop. That mutation keeps the
+           Data count at one, does not move the transition, and is not a Stamp call, so it passes every
+           other assertion in this test — while making a post-row-loop fault carry Start.
+
+           Which is not merely a wrong label. StoreWriteReattempt.IsSafeToReattempt re-runs a collector's
+           batch on Start, so a fault that had already written rows would be re-attempted: the batch is
+           duplicated into aggregates that cannot separate the copies, and every delta is re-derived
+           against an already-advanced CollectorDeltaCalculator baseline and committed as a zero. The
+           realistic route in is a reset for a second COPY in this method, which is exactly the edit that
+           would not touch anything else here. */
+        Assert.Equal(1, Regex.Matches(runner, @"copyPhase = StoreCopyPhase\.Start;").Count);
+
         /* The fault arm stamps whatever phase was live and rethrows BARE — no wrapping, so the type,
            message, stack and inner chain reaching the handlers upstream are unchanged. */
         Assert.Matches(
@@ -293,5 +313,188 @@ public class StoreCopyPhaseTests
 
         Assert.Contains("The unbounded start phase is tracked on #3095.", runner, StringComparison.Ordinal);
         Assert.DoesNotContain("Tracked as a residual on #2874.", runner, StringComparison.Ordinal);
+    }
+    /* ── the instance half: what a source pin structurally cannot see (#3099) ── */
+
+    /// <summary>
+    /// A fault out of the REAL <c>BeginBinaryImportAsync</c>, on the real write path, carries
+    /// <see cref="StoreCopyPhase.Start"/>.
+    ///
+    /// <para><b>Why this exists alongside the source pin above, not instead of it.</b> The two fail
+    /// differently and neither covers the other's blind spot. The pin catches every edit of a shape it
+    /// anticipated — a moved transition, a second one, an explicit <c>Stamp(ex, Start)</c> — and is blind
+    /// to constructions nobody thought of; the gap that let a bare post-loop
+    /// <c>copyPhase = StoreCopyPhase.Start;</c> pass all five of its assertions was exactly that. This
+    /// test is indifferent to how the source got there: it runs the path and reads the stamp off a real
+    /// exception, so an unanticipated construction that produces the wrong phase fails here even when
+    /// every regex still matches.</para>
+    ///
+    /// <para>No live store is needed and that is the point of using an UNOPENED connection: the real
+    /// <c>BeginBinaryImportAsync</c> refuses before it reaches a socket, which is precisely a start-phase
+    /// fault — the importer never returned. The definition's <c>WritePayload</c> throws a distinctive
+    /// exception, so if the row loop were ever reached this would surface as that fault instead of the
+    /// connection's, and the assertion would name which.</para>
+    /// </summary>
+    [Fact]
+    public async Task AFaultOutOfBeginBinaryImportCarriesStart_OnTheRealPath()
+    {
+        var fault = await CopyFaultAsync(new PhaseProbeDefinition());
+
+        Assert.False(
+            fault is PhaseProbeReachedTheRowLoopException,
+            "the row loop must not be reachable when Begin refuses: WritePayload ran, so this test is no "
+            + "longer exercising the start phase.");
+
+        Assert.Equal(StoreCopyPhase.Start, CollectorFaultCopyPhase.For(fault));
+    }
+
+    /// <summary>
+    /// The negative control, and without it the test above proves much less: it would pass just as well if
+    /// <c>Start</c> were stamped unconditionally on every COPY fault. Here the row loop IS reached — the
+    /// definition's <c>WritePayload</c> throws once Begin has returned — and the stamp must read
+    /// <see cref="StoreCopyPhase.Data"/>.
+    ///
+    /// <para>Begin has to succeed for the loop to be entered, so this one needs a real store and is gated
+    /// on <c>DARLING_TEST_PG</c> like the rest of the live suite. The COPY targets a table that does not
+    /// exist only in the negative case above; here it targets a real one so Begin returns.</para>
+    /// </summary>
+    [Fact]
+    public async Task AFaultInsideTheRowLoopCarriesData_OnTheRealPath()
+    {
+        var pg = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(pg), "Set DARLING_TEST_PG to run the data-phase instance check.");
+
+        var ct = TestContext.Current.CancellationToken;
+        await using var dataSource = NpgsqlDataSource.Create(pg!);
+        await using (var migrateConnection = await dataSource.OpenConnectionAsync(ct))
+        {
+            await PerformanceMonitor.Darling.Storage.PgMigrations.MigrateAsync(migrateConnection, ct);
+        }
+
+        await using var connection = await dataSource.OpenConnectionAsync(ct);
+        var fault = await CopyFaultAsync(new PhaseProbeDefinition("wait_stats"), dataSource, connection, ct);
+
+        Assert.True(
+            fault is PhaseProbeReachedTheRowLoopException,
+            $"Begin must have returned so the row loop is entered; got {fault.GetType().Name}: {fault.Message}");
+
+        Assert.Equal(StoreCopyPhase.Data, CollectorFaultCopyPhase.For(fault));
+    }
+
+    /* ── probe plumbing ── */
+
+    private const string UnreachableStore = "Host=127.0.0.1;Port=1;Username=probe;Database=probe";
+
+    /// <summary>
+    /// Drives the SHIPPED private COPY body and returns the fault it raised. Reflection because the method
+    /// is private and <c>InternalsVisibleTo</c> does not reach private members; a rename breaks this
+    /// loudly, which is the correct failure for a test whose whole subject is that method.
+    /// </summary>
+    private static async Task<Exception> CopyFaultAsync(
+        PhaseProbeDefinition definition,
+        NpgsqlDataSource? dataSource = null,
+        NpgsqlConnection? connection = null,
+        CancellationToken cancellationToken = default)
+    {
+        var ownsDataSource = dataSource is null;
+        dataSource ??= NpgsqlDataSource.Create(UnreachableStore);
+        var ownsConnection = connection is null;
+        /* Deliberately NOT opened in the default case - see the test's remarks. */
+        connection ??= new NpgsqlConnection(UnreachableStore);
+
+        try
+        {
+            var runner = new DarlingCollectorRunner(dataSource, new CollectorDeltaCalculator());
+            var method = typeof(DarlingCollectorRunner)
+                .GetMethod("CopyBatchOnceAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+
+            var server = new ServerRuntime
+            {
+                Config = new MonitoredServer { Name = "phase-probe", Host = "phase-probe-host" },
+                ConnectionString = "Server=phase-probe-host",
+                Target = new CollectorTargetInfo { SqlMajorVersion = 16 },
+                StorageName = "phase-probe-host",
+                ServerId = -3099,
+                EngineEdition = 3,
+            };
+
+            var context = new CollectorContext
+            {
+                ServerId = server.ServerId,
+                ServerName = server.StorageName,
+                CollectionTime = DateTime.UtcNow,
+                Deltas = new CollectorDeltaCalculator(),
+                Target = server.Target,
+            };
+
+            var task = (Task)method!.MakeGenericMethod(typeof(int)).Invoke(
+                runner,
+                new object?[]
+                {
+                    connection, definition, new List<int> { 1 }, server,
+                    DateTime.UtcNow, context, cancellationToken,
+                })!;
+
+            try
+            {
+                await task;
+            }
+            catch (Exception ex)
+            {
+                return ex;
+            }
+
+            Assert.Fail("the COPY body was expected to fault");
+            throw new InvalidOperationException("unreachable");
+        }
+        finally
+        {
+            if (ownsConnection)
+            {
+                await connection.DisposeAsync();
+            }
+
+            if (ownsDataSource)
+            {
+                await dataSource.DisposeAsync();
+            }
+        }
+    }
+
+    private sealed class PhaseProbeReachedTheRowLoopException : Exception
+    {
+        public PhaseProbeReachedTheRowLoopException() : base("WritePayload was reached") { }
+    }
+
+    /// <summary>
+    /// A minimal non-diverting definition. Non-diverting matters: a diverting collector opens a
+    /// transaction BEFORE the try, which on an unopened connection would throw outside the stamped region
+    /// and the probe would read Unknown for a reason that has nothing to do with the phase.
+    /// </summary>
+    private sealed class PhaseProbeDefinition : CollectorDefinitionBase<int>
+    {
+        private readonly string _table;
+
+        public PhaseProbeDefinition(string table = "phase_probe_no_such_table") => _table = table;
+
+        public override string Name => "phase_probe";
+
+        public override string TargetTable => _table;
+
+        public override IReadOnlyList<CollectorColumn> PayloadColumns { get; } =
+            new[] { new CollectorColumn("wait_type", CollectorColumnType.Varchar) };
+
+        public override CollectorQuery BuildQuery(CollectorContext context)
+            => throw new NotSupportedException("the probe never fetches");
+
+        public override ValueTask<List<int>> ReadAsync(
+            DbDataReader reader, CollectorContext context, CancellationToken cancellationToken)
+            => throw new NotSupportedException("the probe never fetches");
+
+        /* Throws so the row loop is DETECTABLE: in the start-phase case it must never run, and in the
+           data-phase case it is how the loop is entered and then faulted. */
+        public override void WritePayload(int row, ICollectorRowWriter writer, CollectorContext context)
+            => throw new PhaseProbeReachedTheRowLoopException();
     }
 }

--- a/Darling/Darling.Tests/StoreCopyPhaseTests.cs
+++ b/Darling/Darling.Tests/StoreCopyPhaseTests.cs
@@ -7,12 +7,7 @@
  */
 
 using System;
-using System.Collections.Generic;
-using System.Data.Common;
-using System.Reflection;
 using System.Text.RegularExpressions;
-using System.Threading;
-using System.Threading.Tasks;
 using Npgsql;
 using PerformanceMonitor.Collectors;
 using PerformanceMonitor.Darling.Service;
@@ -204,19 +199,19 @@ public class StoreCopyPhaseTests
 
         /* Start is the value in force before the COPY is opened. */
         Assert.Matches(
-            new Regex(@"var copyPhase = StoreCopyPhase\.Start;[\s\S]{0,600}?BeginBinaryImportAsync\("),
+            new Regex(@"var copyPhase\s*=\s*StoreCopyPhase\.Start;[\s\S]{0,600}?BeginBinaryImportAsync\("),
             runner);
 
         /* The transition sits between Begin and the first row, and nothing sends a row before it. The
            bounded window admits the deadline assignment and the writer hand-off, and would not admit a
            transition moved below the loop. */
         Assert.Matches(
-            new Regex(@"BeginBinaryImportAsync\([\s\S]{0,200}?\{\s*copyPhase = StoreCopyPhase\.Data;"),
+            new Regex(@"BeginBinaryImportAsync\([\s\S]{0,200}?\{\s*copyPhase\s*=\s*StoreCopyPhase\.Data;"),
             runner);
 
         /* Exactly one transition, and it is to Data. Two would mean a second, unreviewed opinion about
            which phase is in force. */
-        Assert.Equal(1, Regex.Matches(runner, @"copyPhase = StoreCopyPhase\.Data;").Count);
+        Assert.Equal(1, Regex.Matches(runner, @"copyPhase\s*=\s*StoreCopyPhase\.Data;").Count);
 
         /* And exactly one assignment of Start — the declaration itself, which this pattern matches as a
            substring of `var copyPhase = ...`. SYMMETRIC with the Data count above, and it closes the one
@@ -231,7 +226,12 @@ public class StoreCopyPhaseTests
            against an already-advanced CollectorDeltaCalculator baseline and committed as a zero. The
            realistic route in is a reset for a second COPY in this method, which is exactly the edit that
            would not touch anything else here. */
-        Assert.Equal(1, Regex.Matches(runner, @"copyPhase = StoreCopyPhase\.Start;").Count);
+        /* Both counts, and the two positional patterns above, spell the assignment `\s*=\s*` rather
+           than with literal single spaces: `copyPhase=StoreCopyPhase.Start;` is valid C# and evaded every
+           literal form. Low probability — a formatter normalises it and this repo's style is consistent —
+           but the cost of closing it is four characters, and a pin that a reformat can slip past is not a
+           pin. */
+        Assert.Equal(1, Regex.Matches(runner, @"copyPhase\s*=\s*StoreCopyPhase\.Start;").Count);
 
         /* The fault arm stamps whatever phase was live and rethrows BARE — no wrapping, so the type,
            message, stack and inner chain reaching the handlers upstream are unchanged. */
@@ -313,188 +313,5 @@ public class StoreCopyPhaseTests
 
         Assert.Contains("The unbounded start phase is tracked on #3095.", runner, StringComparison.Ordinal);
         Assert.DoesNotContain("Tracked as a residual on #2874.", runner, StringComparison.Ordinal);
-    }
-    /* ── the instance half: what a source pin structurally cannot see (#3099) ── */
-
-    /// <summary>
-    /// A fault out of the REAL <c>BeginBinaryImportAsync</c>, on the real write path, carries
-    /// <see cref="StoreCopyPhase.Start"/>.
-    ///
-    /// <para><b>Why this exists alongside the source pin above, not instead of it.</b> The two fail
-    /// differently and neither covers the other's blind spot. The pin catches every edit of a shape it
-    /// anticipated — a moved transition, a second one, an explicit <c>Stamp(ex, Start)</c> — and is blind
-    /// to constructions nobody thought of; the gap that let a bare post-loop
-    /// <c>copyPhase = StoreCopyPhase.Start;</c> pass all five of its assertions was exactly that. This
-    /// test is indifferent to how the source got there: it runs the path and reads the stamp off a real
-    /// exception, so an unanticipated construction that produces the wrong phase fails here even when
-    /// every regex still matches.</para>
-    ///
-    /// <para>No live store is needed and that is the point of using an UNOPENED connection: the real
-    /// <c>BeginBinaryImportAsync</c> refuses before it reaches a socket, which is precisely a start-phase
-    /// fault — the importer never returned. The definition's <c>WritePayload</c> throws a distinctive
-    /// exception, so if the row loop were ever reached this would surface as that fault instead of the
-    /// connection's, and the assertion would name which.</para>
-    /// </summary>
-    [Fact]
-    public async Task AFaultOutOfBeginBinaryImportCarriesStart_OnTheRealPath()
-    {
-        var fault = await CopyFaultAsync(new PhaseProbeDefinition());
-
-        Assert.False(
-            fault is PhaseProbeReachedTheRowLoopException,
-            "the row loop must not be reachable when Begin refuses: WritePayload ran, so this test is no "
-            + "longer exercising the start phase.");
-
-        Assert.Equal(StoreCopyPhase.Start, CollectorFaultCopyPhase.For(fault));
-    }
-
-    /// <summary>
-    /// The negative control, and without it the test above proves much less: it would pass just as well if
-    /// <c>Start</c> were stamped unconditionally on every COPY fault. Here the row loop IS reached — the
-    /// definition's <c>WritePayload</c> throws once Begin has returned — and the stamp must read
-    /// <see cref="StoreCopyPhase.Data"/>.
-    ///
-    /// <para>Begin has to succeed for the loop to be entered, so this one needs a real store and is gated
-    /// on <c>DARLING_TEST_PG</c> like the rest of the live suite. The COPY targets a table that does not
-    /// exist only in the negative case above; here it targets a real one so Begin returns.</para>
-    /// </summary>
-    [Fact]
-    public async Task AFaultInsideTheRowLoopCarriesData_OnTheRealPath()
-    {
-        var pg = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
-        Assert.SkipWhen(string.IsNullOrEmpty(pg), "Set DARLING_TEST_PG to run the data-phase instance check.");
-
-        var ct = TestContext.Current.CancellationToken;
-        await using var dataSource = NpgsqlDataSource.Create(pg!);
-        await using (var migrateConnection = await dataSource.OpenConnectionAsync(ct))
-        {
-            await PerformanceMonitor.Darling.Storage.PgMigrations.MigrateAsync(migrateConnection, ct);
-        }
-
-        await using var connection = await dataSource.OpenConnectionAsync(ct);
-        var fault = await CopyFaultAsync(new PhaseProbeDefinition("wait_stats"), dataSource, connection, ct);
-
-        Assert.True(
-            fault is PhaseProbeReachedTheRowLoopException,
-            $"Begin must have returned so the row loop is entered; got {fault.GetType().Name}: {fault.Message}");
-
-        Assert.Equal(StoreCopyPhase.Data, CollectorFaultCopyPhase.For(fault));
-    }
-
-    /* ── probe plumbing ── */
-
-    private const string UnreachableStore = "Host=127.0.0.1;Port=1;Username=probe;Database=probe";
-
-    /// <summary>
-    /// Drives the SHIPPED private COPY body and returns the fault it raised. Reflection because the method
-    /// is private and <c>InternalsVisibleTo</c> does not reach private members; a rename breaks this
-    /// loudly, which is the correct failure for a test whose whole subject is that method.
-    /// </summary>
-    private static async Task<Exception> CopyFaultAsync(
-        PhaseProbeDefinition definition,
-        NpgsqlDataSource? dataSource = null,
-        NpgsqlConnection? connection = null,
-        CancellationToken cancellationToken = default)
-    {
-        var ownsDataSource = dataSource is null;
-        dataSource ??= NpgsqlDataSource.Create(UnreachableStore);
-        var ownsConnection = connection is null;
-        /* Deliberately NOT opened in the default case - see the test's remarks. */
-        connection ??= new NpgsqlConnection(UnreachableStore);
-
-        try
-        {
-            var runner = new DarlingCollectorRunner(dataSource, new CollectorDeltaCalculator());
-            var method = typeof(DarlingCollectorRunner)
-                .GetMethod("CopyBatchOnceAsync", BindingFlags.NonPublic | BindingFlags.Instance);
-            Assert.NotNull(method);
-
-            var server = new ServerRuntime
-            {
-                Config = new MonitoredServer { Name = "phase-probe", Host = "phase-probe-host" },
-                ConnectionString = "Server=phase-probe-host",
-                Target = new CollectorTargetInfo { SqlMajorVersion = 16 },
-                StorageName = "phase-probe-host",
-                ServerId = -3099,
-                EngineEdition = 3,
-            };
-
-            var context = new CollectorContext
-            {
-                ServerId = server.ServerId,
-                ServerName = server.StorageName,
-                CollectionTime = DateTime.UtcNow,
-                Deltas = new CollectorDeltaCalculator(),
-                Target = server.Target,
-            };
-
-            var task = (Task)method!.MakeGenericMethod(typeof(int)).Invoke(
-                runner,
-                new object?[]
-                {
-                    connection, definition, new List<int> { 1 }, server,
-                    DateTime.UtcNow, context, cancellationToken,
-                })!;
-
-            try
-            {
-                await task;
-            }
-            catch (Exception ex)
-            {
-                return ex;
-            }
-
-            Assert.Fail("the COPY body was expected to fault");
-            throw new InvalidOperationException("unreachable");
-        }
-        finally
-        {
-            if (ownsConnection)
-            {
-                await connection.DisposeAsync();
-            }
-
-            if (ownsDataSource)
-            {
-                await dataSource.DisposeAsync();
-            }
-        }
-    }
-
-    private sealed class PhaseProbeReachedTheRowLoopException : Exception
-    {
-        public PhaseProbeReachedTheRowLoopException() : base("WritePayload was reached") { }
-    }
-
-    /// <summary>
-    /// A minimal non-diverting definition. Non-diverting matters: a diverting collector opens a
-    /// transaction BEFORE the try, which on an unopened connection would throw outside the stamped region
-    /// and the probe would read Unknown for a reason that has nothing to do with the phase.
-    /// </summary>
-    private sealed class PhaseProbeDefinition : CollectorDefinitionBase<int>
-    {
-        private readonly string _table;
-
-        public PhaseProbeDefinition(string table = "phase_probe_no_such_table") => _table = table;
-
-        public override string Name => "phase_probe";
-
-        public override string TargetTable => _table;
-
-        public override IReadOnlyList<CollectorColumn> PayloadColumns { get; } =
-            new[] { new CollectorColumn("wait_type", CollectorColumnType.Varchar) };
-
-        public override CollectorQuery BuildQuery(CollectorContext context)
-            => throw new NotSupportedException("the probe never fetches");
-
-        public override ValueTask<List<int>> ReadAsync(
-            DbDataReader reader, CollectorContext context, CancellationToken cancellationToken)
-            => throw new NotSupportedException("the probe never fetches");
-
-        /* Throws so the row loop is DETECTABLE: in the start-phase case it must never run, and in the
-           data-phase case it is how the loop is entered and then faulted. */
-        public override void WritePayload(int row, ICollectorRowWriter writer, CollectorContext context)
-            => throw new PhaseProbeReachedTheRowLoopException();
     }
 }

--- a/Darling/Darling.Tests/StoreWriteReattemptTests.cs
+++ b/Darling/Darling.Tests/StoreWriteReattemptTests.cs
@@ -354,14 +354,6 @@ public class StoreWriteReattemptTests
         Assert.Contains(
             "private async Task<int> CopyBatchOnceAsync<TRow>(", source, StringComparison.Ordinal);
 
-        /* The COPY must live in its own method so the failed attempt's importer and transaction are
-           disposed before the re-attempt runs — a retry entered with an aborted transaction still on the
-           connection fails on 25P02 rather than on anything to do with the store. */
-        /* The generic declaration is `CopyBatchOnceAsync<TRow>(`, so it does not match this needle: these
-           are the CALL sites, and there must be exactly the two attempt delegates. */
-        var copyCalls = Offsets(source, "CopyBatchOnceAsync(").ToArray();
-        Assert.Equal(2, copyCalls.Length);
-
         var runAsync = source.IndexOf("StoreWriteReattempt.RunAsync(", StringComparison.Ordinal);
         var afterRunAsync = source.IndexOf("if (outcome.Reattempted)", StringComparison.Ordinal);
         Assert.True(
@@ -369,29 +361,57 @@ public class StoreWriteReattemptTests
             "the shipped store write must route through StoreWriteReattempt.RunAsync and read the outcome " +
             "it returns.");
 
-        /* Both COPY call sites must be the re-attempt's OWN arguments. A write that bypassed the helper — or
-           a helper reached through an indirection — would put a call outside this span. */
-        foreach (var call in copyCalls)
+        /* The generic declarations are `...<TRow>(`, so they do not match these needles: these are the CALL
+           sites. Every one of them must be an argument of the re-attempt — a write that bypassed the
+           helper, or reached it through an indirection, would put a call outside this span. */
+        var freshCalls = Offsets(source, "CopyOnAFreshConnectionAsync(").ToArray();
+        Assert.Equal(2, freshCalls.Length); /* the first-attempt fallback, and the re-attempt */
+
+        var sharedConnectionCopy = Offsets(source, "CopyBatchOnceAsync(").ToArray();
+        Assert.Equal(2, sharedConnectionCopy.Length); /* the shared-connection attempt, and the fresh one */
+
+        foreach (var call in freshCalls)
         {
             Assert.True(
                 call > runAsync && call < afterRunAsync,
-                "every call to the COPY must sit inside StoreWriteReattempt.RunAsync's argument list; a " +
-                $"call at offset {call} does not.");
+                "every fresh-connection attempt must be an argument of StoreWriteReattempt.RunAsync; a " +
+                $"call at offset {call} is not.");
         }
 
         var argumentList = source[runAsync..afterRunAsync];
 
+        /* The re-attempt is the fresh-connection path, and it must not reach for the caller's handle: the
+           first attempt's connector is dead, so a second COPY on it fails on the protocol and the sample
+           is lost anyway — the whole fix, silently undone. */
         var rewrite = argumentList.IndexOf("rewrite:", StringComparison.Ordinal);
         var onReattempt = argumentList.IndexOf("onReattempt:", StringComparison.Ordinal);
         Assert.True(rewrite >= 0 && onReattempt > rewrite, "expected the rewrite and onReattempt arguments");
 
         var rewriteDelegate = argumentList[rewrite..onReattempt];
-
-        /* The re-attempt must open its OWN store connection and must not mention the caller's. The first
-           attempt's connector is dead, so a second COPY on the caller's handle fails on the protocol and
-           the sample is lost anyway — which is the whole fix, silently undone. */
-        Assert.Contains("_postgres.OpenConnectionAsync(token)", rewriteDelegate, StringComparison.Ordinal);
+        Assert.Contains("CopyOnAFreshConnectionAsync(", rewriteDelegate, StringComparison.Ordinal);
         Assert.DoesNotContain("pgConnection", rewriteDelegate, StringComparison.Ordinal);
+
+        /* And "fresh" has to mean fresh: the one method both paths route through opens its own connection
+           from the data source and never touches the caller's. */
+        var freshMethod = source.IndexOf(
+            "private async Task<int> CopyOnAFreshConnectionAsync<TRow>(", StringComparison.Ordinal);
+        Assert.True(freshMethod >= 0, "expected DarlingCollectorRunner.CopyOnAFreshConnectionAsync");
+
+        /* Bounded by the NEXT member declaration, found generically, rather than by the name of whichever
+           method happens to follow — the bound then moves with a reordering instead of silently taking in
+           a neighbour's body. */
+        var nextDeclaration = Offsets(source, "    private ").First(at => at > freshMethod);
+        var freshBody = source[freshMethod..nextDeclaration];
+        Assert.Contains("_postgres.OpenConnectionAsync(", freshBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("pgConnection", freshBody, StringComparison.Ordinal);
+
+        /* A first attempt whose shared connection is already broken must go to a fresh one too, decided on
+           the connection's STATE. On a fan-out every batch after the first faulting one inherits a broken
+           connection, and what that throws need not be a transport fault this arm would recognise —
+           plan_correction enumerates on every non-Azure target and declares no WatermarkColumn, so it both
+           fans out and cannot re-read a sample it loses that way. */
+        Assert.Contains(
+            "pgConnection.State == ConnectionState.Open", argumentList, StringComparison.Ordinal);
 
         Assert.Contains("context.StoreWriteReattempts++", source[afterRunAsync..], StringComparison.Ordinal);
     }

--- a/Darling/Darling.Tests/StoreWriteReattemptTests.cs
+++ b/Darling/Darling.Tests/StoreWriteReattemptTests.cs
@@ -35,9 +35,34 @@ public class StoreWriteReattemptTests
 {
     /* The shipped failure, constructed the way the repo's other pins construct it: an NpgsqlException
        wrapping the inner fault, because that is what Npgsql hands back and the outer type and message are
-       identical for a client deadline and a lost connection. */
+       identical for a client deadline and a lost connection.
+
+       Stamped START, because that is the only phase a re-attempt is sound in and therefore the only one
+       these policy tests can drive. The stamp is applied through the SHIPPED producer rather than by
+       writing Exception.Data directly, so the key these tests assert against is the key the runner
+       writes — a retyped string would prove only its own transcription. */
     private static NpgsqlException StreamFault(Exception? inner = null)
-        => new("Exception while reading from stream", inner ?? new IOException("connection reset"));
+        => Stamped(
+            new NpgsqlException("Exception while reading from stream", inner ?? new IOException("connection reset")),
+            StoreCopyPhase.Start);
+
+    private static T Stamped<T>(T fault, StoreCopyPhase phase) where T : Exception
+    {
+        CollectorFaultCopyPhase.Stamp(fault, phase);
+        return fault;
+    }
+
+    /* A transport fault from the COPY's DATA phase: rows may have been sent, a commit acknowledgment may
+       have been lost, and every delta baseline the row loop reached has advanced. */
+    private static NpgsqlException DataPhaseFault()
+        => Stamped(
+            new NpgsqlException("Exception while reading from stream", new TimeoutException()),
+            StoreCopyPhase.Data);
+
+    /* An UNSTAMPED transport fault — what the dimension flush and the transaction commit after the COPY
+       raise (#1767), both of which genuinely can commit. Reads as Unknown. */
+    private static NpgsqlException UnstampedFault()
+        => new("Exception while reading from stream", new IOException("connection reset"));
 
     /* A server REPLY. The public constructor takes (message, severity, invariantSeverity, sqlState). */
     private static PostgresException ServerReply(string sqlState)
@@ -147,7 +172,10 @@ public class StoreWriteReattemptTests
                 write: _ =>
                 {
                     attempts++;
-                    throw ServerReply(sqlState);
+                    /* Stamped START on purpose: the phase axis would ACCEPT this, so a decline here can
+                       only be the server-reply axis doing its job. Unstamped, the test would pass for the
+                       wrong reason. */
+                    throw Stamped(ServerReply(sqlState), StoreCopyPhase.Start);
                 },
                 rewrite: _ =>
                 {
@@ -175,7 +203,9 @@ public class StoreWriteReattemptTests
                 write: _ =>
                 {
                     attempts++;
-                    throw new NpgsqlException("Exception while reading from stream", ServerReply("57014"));
+                    throw Stamped(
+                        new NpgsqlException("Exception while reading from stream", ServerReply("57014")),
+                        StoreCopyPhase.Start);
                 },
                 rewrite: _ =>
                 {
@@ -197,7 +227,9 @@ public class StoreWriteReattemptTests
             StreamFault(new TimeoutException("client-side command deadline")),
             StreamFault(new IOException("connection to server lost")),
             StreamFault(new SocketException(104)),
-            new NpgsqlException("Exception while writing to stream"),
+            /* Stamped like the rest: this test is about the transport SHAPES the predicate accepts, and
+               leaving one unstamped would make it fail on the phase axis and look like a shape rejection. */
+            Stamped(new NpgsqlException("Exception while writing to stream"), StoreCopyPhase.Start),
         })
         {
             var reattempted = false;
@@ -215,6 +247,92 @@ public class StoreWriteReattemptTests
             Assert.True(reattempted, $"{fault.GetType().Name}/{fault.InnerException?.GetType().Name} must be re-attempted");
             Assert.True(outcome.Reattempted);
         }
+    }
+
+    // ── the phase gate: the only thing that makes a re-attempt sound ──
+
+    /// <summary>
+    /// A DATA-phase transport fault is never re-attempted, and this is the assertion the whole change
+    /// rests on. Past the COPY's start phase a fault may have sent rows and may have lost its commit
+    /// acknowledgment, and — the part no connection-level reasoning reaches — <c>WritePayload</c> has
+    /// already run for every row the loop touched, advancing each <c>CollectorDeltaCalculator</c>
+    /// baseline. A second pass would therefore re-derive every delta against its own new baseline and
+    /// commit a row of zeros. That is worse than the lost sample: a zero delta reads as a genuinely idle
+    /// interval, carries no error, and never self-corrects.
+    /// </summary>
+    [Fact]
+    public async Task ADataPhaseFaultIsNeverReattempted()
+    {
+        var attempts = 0;
+
+        await Assert.ThrowsAsync<NpgsqlException>(async () =>
+            await StoreWriteReattempt.RunAsync(
+                write: _ =>
+                {
+                    attempts++;
+                    throw DataPhaseFault();
+                },
+                rewrite: _ =>
+                {
+                    attempts++;
+                    return Task.FromResult(1);
+                },
+                onReattempt: _ => { },
+                CancellationToken.None));
+
+        Assert.Equal(1, attempts);
+    }
+
+    /// <summary>
+    /// An UNSTAMPED transport fault declines too. <c>Start</c> is required positively rather than
+    /// <c>Data</c> being excluded, so a fault carrying no phase — the dimension flush and the transaction
+    /// commit that follow the COPY (#1767), both of which can commit — costs a sample instead of
+    /// authorising a duplicate. A predicate written the other way round would re-attempt everything it
+    /// failed to recognise, which is the direction that costs.
+    /// </summary>
+    [Fact]
+    public async Task AnUnstampedFaultIsNeverReattempted()
+    {
+        var attempts = 0;
+
+        await Assert.ThrowsAsync<NpgsqlException>(async () =>
+            await StoreWriteReattempt.RunAsync(
+                write: _ =>
+                {
+                    attempts++;
+                    throw UnstampedFault();
+                },
+                rewrite: _ =>
+                {
+                    attempts++;
+                    return Task.FromResult(1);
+                },
+                onReattempt: _ => { },
+                CancellationToken.None));
+
+        Assert.Equal(1, attempts);
+    }
+
+    /// <summary>
+    /// The gate is the CONJUNCTION of two independent axes, so each one alone must decline. A start-phase
+    /// fault that is a server REPLY is not re-attempted, and a transport fault outside the start phase is
+    /// not either — neither axis can carry the decision by itself.
+    /// </summary>
+    [Fact]
+    public void IsSafeToReattemptRequiresBothAxes()
+    {
+        Assert.True(StoreWriteReattempt.IsSafeToReattempt(StreamFault()));
+
+        /* transport, wrong phase */
+        Assert.False(StoreWriteReattempt.IsSafeToReattempt(DataPhaseFault()));
+        Assert.False(StoreWriteReattempt.IsSafeToReattempt(UnstampedFault()));
+
+        /* right phase, but a server reply rather than transport */
+        Assert.False(StoreWriteReattempt.IsSafeToReattempt(
+            Stamped(ServerReply("57014"), StoreCopyPhase.Start)));
+        Assert.False(StoreWriteReattempt.IsSafeToReattempt(
+            Stamped(new NpgsqlException("Exception while reading from stream", ServerReply("53100")),
+                    StoreCopyPhase.Start)));
     }
 
     // ── cancellation ──

--- a/Darling/Darling.Tests/StoreWriteReattemptTests.cs
+++ b/Darling/Darling.Tests/StoreWriteReattemptTests.cs
@@ -88,11 +88,15 @@ public class StoreWriteReattemptTests
     /// A failure on BOTH attempts still reports the error rather than silently succeeding. A retry that
     /// swallowed a persistent fault would trade one lost sample for a store nobody can tell is refusing
     /// writes.
+    ///
+    /// <para>There is deliberately no "and stored nothing" assertion here. Both delegates throw before
+    /// touching anything, so a sink would be empty however <see cref="StoreWriteReattempt.RunAsync"/>
+    /// behaved — an assertion that cannot fail, which is worse than none because it reads as coverage. The
+    /// claim that survives is that no value is returned at all, which is what the throw is.</para>
     /// </summary>
     [Fact]
-    public async Task AFailureOnBothAttempts_ReportsTheError_AndStoresNothing()
+    public async Task AFailureOnBothAttempts_ReportsTheError()
     {
-        var stored = new List<string>();
         var attempts = 0;
         Exception? loggedFirstAttempt = null;
 
@@ -112,7 +116,6 @@ public class StoreWriteReattemptTests
                 CancellationToken.None));
 
         Assert.Equal(2, attempts);
-        Assert.Empty(stored);
         Assert.Equal("second", thrown.InnerException?.Message);
 
         /* The first attempt is not chained onto the thrown exception, so the ONLY thing that keeps it from

--- a/Darling/Darling.Tests/StoreWriteReattemptTests.cs
+++ b/Darling/Darling.Tests/StoreWriteReattemptTests.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
@@ -333,6 +334,13 @@ public class StoreWriteReattemptTests
     /// <para>Pinned against the source because <c>WriteBatchAsync</c> is private and needs a constructed
     /// runner plus a live store to call. Every assertion here is a call site rather than logic: the policy
     /// tests above would all stay green if the write simply stopped using it.</para>
+    ///
+    /// <para><b>Scoped by counting rather than by slicing between two declarations.</b> The earlier form
+    /// took the text between <c>WriteBatchAsync</c> and <c>CopyBatchOnceAsync</c> and asserted the helper
+    /// call appeared in it — and stayed green against a variant where the write called something else,
+    /// because the slice swallowed anything declared in the gap. Counting every call to the COPY and
+    /// requiring each one to sit inside the re-attempt's own argument list cannot be satisfied that
+    /// way.</para>
     /// </summary>
     [Fact]
     public void TheShippedStoreWriteRoutesThroughTheReattemptOnAFreshConnection()
@@ -340,32 +348,49 @@ public class StoreWriteReattemptTests
         var source = File.ReadAllText(FindRepoFile(
             Path.Combine("Darling", "PerformanceMonitor.Darling.Service", "DarlingCollectorRunner.cs")));
 
-        var write = source.IndexOf("private async Task<int> WriteBatchAsync<TRow>(", StringComparison.Ordinal);
-        Assert.True(write >= 0, "expected DarlingCollectorRunner.WriteBatchAsync");
-
-        var copyOnce = source.IndexOf("private async Task<int> CopyBatchOnceAsync<TRow>(", StringComparison.Ordinal);
-        Assert.True(
-            copyOnce > write,
-            "the COPY must live in its own method, so the failed attempt's importer and transaction are " +
-            "disposed before the re-attempt runs — a retry entered with an aborted transaction still on " +
-            "the connection fails on 25P02 rather than on anything to do with the store.");
-
-        /* Scope every assertion below to WriteBatchAsync's own body. */
-        var body = source[write..copyOnce];
-
-        Assert.Contains("StoreWriteReattempt.RunAsync(", body, StringComparison.Ordinal);
-
         Assert.Contains(
-            "await _postgres.OpenConnectionAsync(token)", body, StringComparison.Ordinal);
+            "private async Task<int> CopyBatchOnceAsync<TRow>(", source, StringComparison.Ordinal);
 
-        var rewrite = body.IndexOf("rewrite:", StringComparison.Ordinal);
-        var freshConnection = body.IndexOf("_postgres.OpenConnectionAsync(token)", StringComparison.Ordinal);
+        /* The COPY must live in its own method so the failed attempt's importer and transaction are
+           disposed before the re-attempt runs — a retry entered with an aborted transaction still on the
+           connection fails on 25P02 rather than on anything to do with the store. */
+        /* The generic declaration is `CopyBatchOnceAsync<TRow>(`, so it does not match this needle: these
+           are the CALL sites, and there must be exactly the two attempt delegates. */
+        var copyCalls = Offsets(source, "CopyBatchOnceAsync(").ToArray();
+        Assert.Equal(2, copyCalls.Length);
+
+        var runAsync = source.IndexOf("StoreWriteReattempt.RunAsync(", StringComparison.Ordinal);
+        var afterRunAsync = source.IndexOf("if (outcome.Reattempted)", StringComparison.Ordinal);
         Assert.True(
-            rewrite >= 0 && freshConnection > rewrite,
-            "the re-attempt must open its OWN store connection. The first attempt's connector is dead, so " +
-            "a second COPY on the caller's handle fails on the protocol and the sample is lost anyway.");
+            runAsync >= 0 && afterRunAsync > runAsync,
+            "the shipped store write must route through StoreWriteReattempt.RunAsync and read the outcome " +
+            "it returns.");
 
-        Assert.Contains("context.StoreWriteReattempts++", body, StringComparison.Ordinal);
+        /* Both COPY call sites must be the re-attempt's OWN arguments. A write that bypassed the helper — or
+           a helper reached through an indirection — would put a call outside this span. */
+        foreach (var call in copyCalls)
+        {
+            Assert.True(
+                call > runAsync && call < afterRunAsync,
+                "every call to the COPY must sit inside StoreWriteReattempt.RunAsync's argument list; a " +
+                $"call at offset {call} does not.");
+        }
+
+        var argumentList = source[runAsync..afterRunAsync];
+
+        var rewrite = argumentList.IndexOf("rewrite:", StringComparison.Ordinal);
+        var onReattempt = argumentList.IndexOf("onReattempt:", StringComparison.Ordinal);
+        Assert.True(rewrite >= 0 && onReattempt > rewrite, "expected the rewrite and onReattempt arguments");
+
+        var rewriteDelegate = argumentList[rewrite..onReattempt];
+
+        /* The re-attempt must open its OWN store connection and must not mention the caller's. The first
+           attempt's connector is dead, so a second COPY on the caller's handle fails on the protocol and
+           the sample is lost anyway — which is the whole fix, silently undone. */
+        Assert.Contains("_postgres.OpenConnectionAsync(token)", rewriteDelegate, StringComparison.Ordinal);
+        Assert.DoesNotContain("pgConnection", rewriteDelegate, StringComparison.Ordinal);
+
+        Assert.Contains("context.StoreWriteReattempts++", source[afterRunAsync..], StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -424,6 +449,20 @@ public class StoreWriteReattemptTests
     }
 
     /* ── helpers ── */
+
+    /// <summary>
+    /// Every offset at which <paramref name="needle"/> occurs. Enumerated rather than counted so a pin can
+    /// say WHERE a call sits, which is the assertion that survives a method being inserted nearby.
+    /// </summary>
+    private static IEnumerable<int> Offsets(string haystack, string needle)
+    {
+        for (var at = haystack.IndexOf(needle, StringComparison.Ordinal);
+             at >= 0;
+             at = haystack.IndexOf(needle, at + 1, StringComparison.Ordinal))
+        {
+            yield return at;
+        }
+    }
 
     private static string FindRepoFile(string relativePath)
     {

--- a/Darling/Darling.Tests/StoreWriteReattemptTests.cs
+++ b/Darling/Darling.Tests/StoreWriteReattemptTests.cs
@@ -1,0 +1,442 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+using PerformanceMonitor.Collectors;
+using PerformanceMonitor.Darling.Service;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// #3099: a collector's store write that fails on a transport fault gets ONE re-attempt on a fresh
+/// connection, and the acceptance criterion is that the failure costs no sample.
+///
+/// <para>The policy is exercised through <see cref="StoreWriteReattempt.RunAsync"/> with attempt delegates
+/// that move rows into a sink, because the COPY it wraps is reachable only through a live store and a
+/// constructed runner. What the delegates cannot see — that the shipped write routes through this at all,
+/// and that the re-attempt takes a FRESH connection rather than the caller's dead one — is pinned against
+/// the source below. Neither half is sufficient alone: #2213's whole lesson here was a feature whose SQL
+/// was proven for weeks and whose call sites had never learned the seam existed.</para>
+/// </summary>
+public class StoreWriteReattemptTests
+{
+    /* The shipped failure, constructed the way the repo's other pins construct it: an NpgsqlException
+       wrapping the inner fault, because that is what Npgsql hands back and the outer type and message are
+       identical for a client deadline and a lost connection. */
+    private static NpgsqlException StreamFault(Exception? inner = null)
+        => new("Exception while reading from stream", inner ?? new IOException("connection reset"));
+
+    /* A server REPLY. The public constructor takes (message, severity, invariantSeverity, sqlState). */
+    private static PostgresException ServerReply(string sqlState)
+        => new("no", "ERROR", "ERROR", sqlState);
+
+    private static readonly string[] Batch = { "row-1", "row-2", "row-3" };
+
+    // ── the acceptance criterion ──
+
+    /// <summary>
+    /// A failed first write followed by a successful re-attempt STORES THE ROWS and reports success.
+    ///
+    /// <para>The sink is asserted rather than the return value alone: a helper that returned the right
+    /// count while writing nothing would satisfy a count-only assertion, and "no sample is lost" is a claim
+    /// about the store's contents, not about an integer.</para>
+    /// </summary>
+    [Fact]
+    public async Task AFailedFirstWriteFollowedByASuccessfulReattempt_StoresTheRows_AndReportsSuccess()
+    {
+        var stored = new List<string>();
+        var attempts = 0;
+
+        var outcome = await StoreWriteReattempt.RunAsync(
+            write: _ =>
+            {
+                attempts++;
+                throw StreamFault();
+            },
+            rewrite: _ =>
+            {
+                attempts++;
+                stored.AddRange(Batch);
+                return Task.FromResult(Batch.Length);
+            },
+            onReattempt: _ => { },
+            CancellationToken.None);
+
+        Assert.Equal(2, attempts);
+        Assert.Equal(Batch, stored);
+        Assert.Equal(Batch.Length, outcome.RowsWritten);
+        Assert.True(
+            outcome.Reattempted,
+            "the outcome must report that the rows arrived on the second attempt — a successful-on-retry " +
+            "cycle that looks identical to a first-attempt success is the signal #3099 asks to keep.");
+    }
+
+    /// <summary>
+    /// A failure on BOTH attempts still reports the error rather than silently succeeding. A retry that
+    /// swallowed a persistent fault would trade one lost sample for a store nobody can tell is refusing
+    /// writes.
+    /// </summary>
+    [Fact]
+    public async Task AFailureOnBothAttempts_ReportsTheError_AndStoresNothing()
+    {
+        var stored = new List<string>();
+        var attempts = 0;
+        Exception? loggedFirstAttempt = null;
+
+        var thrown = await Assert.ThrowsAsync<NpgsqlException>(async () =>
+            await StoreWriteReattempt.RunAsync(
+                write: _ =>
+                {
+                    attempts++;
+                    throw StreamFault(new TimeoutException("first"));
+                },
+                rewrite: _ =>
+                {
+                    attempts++;
+                    throw StreamFault(new TimeoutException("second"));
+                },
+                onReattempt: ex => loggedFirstAttempt = ex,
+                CancellationToken.None));
+
+        Assert.Equal(2, attempts);
+        Assert.Empty(stored);
+        Assert.Equal("second", thrown.InnerException?.Message);
+
+        /* The first attempt is not chained onto the thrown exception, so the ONLY thing that keeps it from
+           vanishing is the callback — which is where the host logs it. */
+        Assert.Equal("first", (loggedFirstAttempt as NpgsqlException)?.InnerException?.Message);
+    }
+
+    // ── what does and does not earn a second attempt ──
+
+    /// <summary>
+    /// A server reply is never re-attempted. It arrives as a <see cref="PostgresException"/>: the backend
+    /// received the statement and answered, so an identical second attempt gets an identical answer, and
+    /// re-attempting past a SQLSTATE turns a legible error into a silent one. 57014 is in the list because
+    /// it is the store cancelling us — #3099 observed it on the store's read paths, and a
+    /// <c>statement_timeout</c> on the write side is a configured limit, not a dropped connection.
+    /// </summary>
+    [Theory]
+    [InlineData("57014")] /* query_canceled — the store's own statement_timeout */
+    [InlineData("23505")] /* unique violation */
+    [InlineData("42P01")] /* undefined table */
+    [InlineData("22P02")] /* invalid text representation */
+    [InlineData("53100")] /* disk full */
+    public async Task AServerReplyIsNeverReattempted(string sqlState)
+    {
+        var attempts = 0;
+
+        await Assert.ThrowsAsync<PostgresException>(async () =>
+            await StoreWriteReattempt.RunAsync(
+                write: _ =>
+                {
+                    attempts++;
+                    throw ServerReply(sqlState);
+                },
+                rewrite: _ =>
+                {
+                    attempts++;
+                    return Task.FromResult(0);
+                },
+                onReattempt: _ => { },
+                CancellationToken.None));
+
+        Assert.Equal(1, attempts);
+    }
+
+    /// <summary>
+    /// A server reply wrapped in transport machinery is still a server reply. The chain is walked and the
+    /// <see cref="PostgresException"/> test wins at every level, so wrapping cannot smuggle a SQLSTATE past
+    /// the predicate.
+    /// </summary>
+    [Fact]
+    public async Task AWrappedServerReplyIsNeverReattempted()
+    {
+        var attempts = 0;
+
+        await Assert.ThrowsAsync<NpgsqlException>(async () =>
+            await StoreWriteReattempt.RunAsync(
+                write: _ =>
+                {
+                    attempts++;
+                    throw new NpgsqlException("Exception while reading from stream", ServerReply("57014"));
+                },
+                rewrite: _ =>
+                {
+                    attempts++;
+                    return Task.FromResult(0);
+                },
+                onReattempt: _ => { },
+                CancellationToken.None));
+
+        Assert.Equal(1, attempts);
+    }
+
+    /// <summary>Every transport shape the store write can fault with earns the second attempt.</summary>
+    [Fact]
+    public async Task EveryTransportShapeEarnsTheSecondAttempt()
+    {
+        foreach (var fault in new Exception[]
+        {
+            StreamFault(new TimeoutException("client-side command deadline")),
+            StreamFault(new IOException("connection to server lost")),
+            StreamFault(new SocketException(104)),
+            new NpgsqlException("Exception while writing to stream"),
+        })
+        {
+            var reattempted = false;
+
+            var outcome = await StoreWriteReattempt.RunAsync(
+                write: _ => throw fault,
+                rewrite: _ =>
+                {
+                    reattempted = true;
+                    return Task.FromResult(1);
+                },
+                onReattempt: _ => { },
+                CancellationToken.None);
+
+            Assert.True(reattempted, $"{fault.GetType().Name}/{fault.InnerException?.GetType().Name} must be re-attempted");
+            Assert.True(outcome.Reattempted);
+        }
+    }
+
+    // ── cancellation ──
+
+    /// <summary>
+    /// A cancelled token suppresses the re-attempt, and the transport fault still propagates as itself. The
+    /// re-attempt must not outlive an orderly stop holding a sweep permit and a store connection against a
+    /// store the same process is shutting down; and the write must not be relabelled a cancellation on the
+    /// way out, or the fault arms record the wrong thing about the cycle that lost the sample.
+    /// </summary>
+    [Fact]
+    public async Task ACancelledTokenSuppressesTheReattempt_AndTheTransportFaultStillPropagates()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+        var attempts = 0;
+
+        await Assert.ThrowsAsync<NpgsqlException>(async () =>
+            await StoreWriteReattempt.RunAsync(
+                write: _ =>
+                {
+                    attempts++;
+                    throw StreamFault();
+                },
+                rewrite: _ =>
+                {
+                    attempts++;
+                    return Task.FromResult(1);
+                },
+                onReattempt: _ => { },
+                cts.Token));
+
+        Assert.Equal(1, attempts);
+    }
+
+    /// <summary>An actual cancellation is never reclassified as a transport fault.</summary>
+    [Fact]
+    public async Task ACancellationIsNeverReattempted()
+    {
+        var attempts = 0;
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await StoreWriteReattempt.RunAsync(
+                write: _ =>
+                {
+                    attempts++;
+                    throw new OperationCanceledException();
+                },
+                rewrite: _ =>
+                {
+                    attempts++;
+                    return Task.FromResult(1);
+                },
+                onReattempt: _ => { },
+                CancellationToken.None));
+
+        Assert.Equal(1, attempts);
+    }
+
+    // ── how the cycle records it ──
+
+    /// <summary>
+    /// The note is a COUNT, and it is absent when nothing needed a second attempt. Zero re-attempts must
+    /// leave the collection_log message column exactly as an ordinary cycle leaves it, or every row in the
+    /// fleet gains a sentence that says nothing.
+    /// </summary>
+    [Fact]
+    public void TheNoteIsAbsentWithoutAReattemptAndCountsThemWhenThereAre()
+    {
+        Assert.Null(DarlingCollectorRunner.StoreWriteReattemptNote(0));
+        Assert.Null(DarlingCollectorRunner.StoreWriteReattemptNote(-1));
+
+        var one = DarlingCollectorRunner.StoreWriteReattemptNote(1);
+        Assert.NotNull(one);
+        Assert.Contains("1 store write", one, StringComparison.Ordinal);
+        Assert.Contains("#3099", one, StringComparison.Ordinal);
+
+        /* A fan-out writes once per database, so the count is what separates a blip from a store in
+           trouble — the reason this is not a bool. */
+        Assert.Contains("30 store write", DarlingCollectorRunner.StoreWriteReattemptNote(30)!, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The note composes with the channels it can co-occur with rather than displacing them. A per-database
+    /// cycle can lose databases AND re-attempt a write; whichever note were assigned second would erase the
+    /// other.
+    /// </summary>
+    [Fact]
+    public void TheNoteMergesWithTheOtherNoteChannelsInsteadOfReplacingThem()
+    {
+        var merged = EnumeratedCollectorDriver.MergeNotes(
+            "3 of 30 database(s) failed", DarlingCollectorRunner.StoreWriteReattemptNote(2));
+
+        Assert.NotNull(merged);
+        Assert.Contains("3 of 30 database(s) failed", merged, StringComparison.Ordinal);
+        Assert.Contains("2 store write", merged, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The context field starts at zero, so an ordinary cycle composes no note without the host having to
+    /// reset anything.
+    /// </summary>
+    [Fact]
+    public void AFreshContextReportsNoReattempts()
+        => Assert.Equal(0, new CollectorContext
+        {
+            ServerId = 1,
+            ServerName = "store-write-reattempt",
+            CollectionTime = DateTime.UtcNow,
+            Deltas = null!,
+            Target = new CollectorTargetInfo(),
+        }.StoreWriteReattempts);
+
+    // ── the wiring the delegates above cannot see ──
+
+    /// <summary>
+    /// That the SHIPPED store write routes through the re-attempt at all, that the re-attempt opens a FRESH
+    /// connection instead of reusing the caller's dead one, and that the count reaches the run's note.
+    ///
+    /// <para>Pinned against the source because <c>WriteBatchAsync</c> is private and needs a constructed
+    /// runner plus a live store to call. Every assertion here is a call site rather than logic: the policy
+    /// tests above would all stay green if the write simply stopped using it.</para>
+    /// </summary>
+    [Fact]
+    public void TheShippedStoreWriteRoutesThroughTheReattemptOnAFreshConnection()
+    {
+        var source = File.ReadAllText(FindRepoFile(
+            Path.Combine("Darling", "PerformanceMonitor.Darling.Service", "DarlingCollectorRunner.cs")));
+
+        var write = source.IndexOf("private async Task<int> WriteBatchAsync<TRow>(", StringComparison.Ordinal);
+        Assert.True(write >= 0, "expected DarlingCollectorRunner.WriteBatchAsync");
+
+        var copyOnce = source.IndexOf("private async Task<int> CopyBatchOnceAsync<TRow>(", StringComparison.Ordinal);
+        Assert.True(
+            copyOnce > write,
+            "the COPY must live in its own method, so the failed attempt's importer and transaction are " +
+            "disposed before the re-attempt runs — a retry entered with an aborted transaction still on " +
+            "the connection fails on 25P02 rather than on anything to do with the store.");
+
+        /* Scope every assertion below to WriteBatchAsync's own body. */
+        var body = source[write..copyOnce];
+
+        Assert.Contains("StoreWriteReattempt.RunAsync(", body, StringComparison.Ordinal);
+
+        Assert.Contains(
+            "await _postgres.OpenConnectionAsync(token)", body, StringComparison.Ordinal);
+
+        var rewrite = body.IndexOf("rewrite:", StringComparison.Ordinal);
+        var freshConnection = body.IndexOf("_postgres.OpenConnectionAsync(token)", StringComparison.Ordinal);
+        Assert.True(
+            rewrite >= 0 && freshConnection > rewrite,
+            "the re-attempt must open its OWN store connection. The first attempt's connector is dead, so " +
+            "a second COPY on the caller's handle fails on the protocol and the sample is lost anyway.");
+
+        Assert.Contains("context.StoreWriteReattempts++", body, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// That the cycle's re-attempt count reaches the <c>collection_log</c> row, merged into the note the
+    /// success return already carries.
+    ///
+    /// <para><b>Recording it is the point, not a courtesy.</b> Before the re-attempt a transport fault
+    /// wrote an ERROR row, and those rows are the entire measurement behind #3099's in-window versus
+    /// out-window error-rate ratio. A silent retry removes the lost sample and the only instrument that can
+    /// check whether the association the fix was diagnosed from is real.</para>
+    /// </summary>
+    [Fact]
+    public void TheReattemptCountReachesTheCollectionLogNote()
+    {
+        var source = File.ReadAllText(FindRepoFile(
+            Path.Combine("Darling", "PerformanceMonitor.Darling.Service", "DarlingCollectorRunner.cs")));
+
+        var merge = source.IndexOf(
+            "StoreWriteReattemptNote(context.StoreWriteReattempts)", StringComparison.Ordinal);
+        Assert.True(
+            merge >= 0,
+            "the cycle's re-attempt count must be composed into the run's collection_log note. Without it " +
+            "a write that faulted and then succeeded writes a row indistinguishable from one that never " +
+            "faulted at all.");
+
+        var successReturn = source.IndexOf(
+            "rowsWritten, sqlMs, storageMs, collectionNote", StringComparison.Ordinal);
+        Assert.True(
+            successReturn > merge,
+            "the merge must happen BEFORE the success return that carries the note, and after every write " +
+            "on all three dispatch paths.");
+    }
+
+    /// <summary>
+    /// That the re-attempt does NOT introduce a new collection_log status. Eight readers across the
+    /// service, the MCP, both viewers and Lite treat <c>status IN ('SUCCESS', 'SKIPPED')</c> as success; a
+    /// sixth value would read as a failure in every one of them and suppress <c>last_success</c> for a
+    /// cycle that stored every row and advanced its watermark. That is #2673's defect with the sign
+    /// flipped.
+    /// </summary>
+    [Fact]
+    public void TheReattemptDoesNotInventANewCollectionLogStatus()
+    {
+        foreach (var file in new[] { "DarlingCollectorRunner.cs", "StoreWriteReattempt.cs" })
+        {
+            var source = File.ReadAllText(FindRepoFile(
+                Path.Combine("Darling", "PerformanceMonitor.Darling.Service", file)));
+
+            foreach (var invented in new[] { "\"RETRIED\"", "\"REATTEMPTED\"", "\"SUCCESS_ON_RETRY\"", "\"DEGRADED\"" })
+            {
+                Assert.DoesNotContain(invented, source, StringComparison.Ordinal);
+            }
+        }
+
+        Assert.Equal("SUCCESS", EnumeratedCollectorDriver.ClassifyReturnedRun(abandoned: false));
+    }
+
+    /* ── helpers ── */
+
+    private static string FindRepoFile(string relativePath)
+    {
+        var dir = AppContext.BaseDirectory;
+        for (int i = 0; i < 10 && dir is not null; i++)
+        {
+            var candidate = Path.Combine(dir, relativePath);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new FileNotFoundException($"Could not locate {relativePath} walking up from {AppContext.BaseDirectory}");
+    }
+}

--- a/Darling/Darling.Tests/StoreWriteReattemptTests.cs
+++ b/Darling/Darling.Tests/StoreWriteReattemptTests.cs
@@ -448,8 +448,9 @@ public class StoreWriteReattemptTests
     }
 
     /// <summary>
-    /// That the re-attempt does NOT introduce a new collection_log status. Eight readers across the
-    /// service, the MCP, both viewers and Lite treat <c>status IN ('SUCCESS', 'SKIPPED')</c> as success; a
+    /// That the re-attempt does NOT introduce a new collection_log status. Seven query clauses across five
+    /// files — Lite's collection-health read, the self-alert evaluator's two, both MCP readers and the
+    /// viewer's two — treat <c>status IN ('SUCCESS', 'SKIPPED')</c> as success; a
     /// sixth value would read as a failure in every one of them and suppress <c>last_success</c> for a
     /// cycle that stored every row and advanced its watermark. That is #2673's defect with the sign
     /// flipped.

--- a/Darling/PerformanceMonitor.Darling.Service/CollectorFaultCopyPhase.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/CollectorFaultCopyPhase.cs
@@ -35,6 +35,15 @@ internal enum StoreCopyPhase
     /// log-only string: a <c>COPY ... FROM STDIN</c> cannot commit without row data, so the store is
     /// byte-identical; and <c>CollectorDeltaCalculator</c> advances its baseline inside
     /// <c>WritePayload</c>, which runs in the row loop below, so no baseline has moved either.</para>
+    ///
+    /// <para><b>A RE-ATTEMPT DECISION now rests on this, not just a diagnostic.</b>
+    /// <see cref="StoreWriteReattempt.IsSafeToReattempt"/> requires this value positively before it will
+    /// re-run a collector's batch, and it does so for exactly the two properties above: without the first
+    /// the re-attempt could duplicate the batch, and without the second it would re-derive every delta
+    /// against an already-advanced baseline and commit a fabricated zero. So anything that widens when
+    /// this value can be produced — a wider <c>try</c> around the COPY, a new stamping call site, or a
+    /// frame allowed to relabel <see cref="Data"/> as this — changes what a retry is authorised to do,
+    /// and the tests on the consumer side stamp their own faults and will not catch it.</para>
     /// </summary>
     Start = 1,
 
@@ -117,7 +126,10 @@ internal static class CollectorFaultCopyPhase
     /// <para>An existing stamp is kept rather than overwritten. The innermost frame to catch a fault is the
     /// one that knows which phase raised it, so a later, wider frame must not be able to relabel a
     /// <see cref="StoreCopyPhase.Data"/> fault as <see cref="StoreCopyPhase.Start"/> — that is the one
-    /// direction in which a wrong answer authorises something.</para>
+    /// direction in which a wrong answer authorises something, and what it authorises is named:
+    /// <see cref="StoreWriteReattempt.IsSafeToReattempt"/> re-runs the batch on
+    /// <see cref="StoreCopyPhase.Start"/>, so a relabelled fault buys a duplicated write and a delta
+    /// column of zeros rather than a merely misleading log line.</para>
     /// </summary>
     internal static void Stamp(Exception? exception, StoreCopyPhase phase)
     {

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
@@ -2566,6 +2566,29 @@ public sealed class DarlingCollectorRunner
     /// the transaction are both disposed before the re-attempt runs — a retry that fired while the failed
     /// attempt's transaction was still in scope would re-enter with an aborted transaction on the
     /// connection and fail on 25P02 rather than on anything to do with the store.
+    ///
+    /// <para><b>The re-attempt this feeds is at-least-once, not exactly-once, and the window is here.</b>
+    /// A transport fault raised BEFORE the commit acknowledgment is awaited leaves the store untouched, and
+    /// that is the ordinary case. A fault raised WHILE awaiting it — <c>CompleteAsync</c>'s CommandComplete,
+    /// or <c>CommitAsync</c>'s on the diverting path — can leave the server committed while the client sees
+    /// a retryable exception, and the re-attempt then lands the batch a second time. The copies are not
+    /// identical rows and nothing downstream can collapse them:
+    /// <see cref="ICollectorSchemaInfo.IncludesCollectionId"/> is true for every collector but running_jobs,
+    /// so <c>CollectionIdGenerator.Next()</c> stamps each row of each attempt with its own id.</para>
+    ///
+    /// <para><b>The cost is a doubled hour, and it is accepted.</b> <c>collection_id</c> is in no continuous
+    /// aggregate's <c>GROUP BY</c> — it does not appear in TimescaleSupport at all — so both copies land in
+    /// the same bucket and 18 <c>sum()</c> views double it. The bucket is materialised and raw retention is
+    /// four days, so the wrong figure outlives the rows that explain it, and each daily rollup reads its
+    /// hourly view rather than raw, so it inherits the doubling. The trade is a one-round-trip window
+    /// against a sample lost on EVERY failed write, and the loss is the certainty.</para>
+    ///
+    /// <para><b>It has a signature.</b> A doubled batch doubles the bucket's <c>sample_count</c>, so an hour
+    /// at twice its neighbours' count is the tell — and it reads off the aggregate itself, with no raw rows
+    /// needed. That column exists on five of the eighteen: query_stats_hourly, procedure_stats_hourly,
+    /// query_stats_db_hourly, query_store_stats_hourly and query_store_stats_interval_hourly. It covers the
+    /// two null-watermark collectors the re-attempt is chiefly for; it is absent from every daily view, so
+    /// the anomaly is findable one tier above where it propagates.</para>
     /// </summary>
     private async Task<int> CopyBatchOnceAsync<TRow>(
         NpgsqlConnection pgConnection,

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
@@ -2461,18 +2461,24 @@ public sealed class DarlingCollectorRunner
            pause short enough to be safe is noise against that window: no delay is purchasable here. The
            accepted cost is that a write's worst case is two command deadlines rather than one.
 
-           The caller's connection stays broken, so on a fan-out each remaining batch faults once and
-           re-attempts on its own fresh connection. Wasteful and bounded — and strictly better than ending
-           the cycle at the first fault, where the later items are never even read. */
+           The FIRST attempt also goes to a fresh connection when the caller's is no longer open, and that
+           is not tidiness. The caller's connection is shared across a fan-out's batches (#2819 has the
+           Query Store plan and text fetches borrowing the same one), and a transport fault breaks it — so
+           every batch after the first faulting one inherits a connection that cannot be used, and what it
+           throws then need not be a transport fault this arm would recognise. Deciding on the connection's
+           own STATE rather than on the shape of a later exception keeps those batches out of that
+           classification entirely. plan_correction is the collector that makes it matter: it enumerates on
+           every non-Azure target and declares no WatermarkColumn, so it both fans out and cannot re-read a
+           sample it lost. The cost is that a faulted cycle's remaining batches hold two store connections
+           at a time on that server rather than one, for the rest of the cycle. */
         var outcome = await StoreWriteReattempt.RunAsync(
-            write: token => CopyBatchOnceAsync(
-                pgConnection, definition, rows, server, collectionTime, context, token),
-            rewrite: async token =>
-            {
-                await using var freshConnection = await _postgres.OpenConnectionAsync(token);
-                return await CopyBatchOnceAsync(
-                    freshConnection, definition, rows, server, collectionTime, context, token);
-            },
+            write: async token => pgConnection.State == ConnectionState.Open
+                ? await CopyBatchOnceAsync(
+                    pgConnection, definition, rows, server, collectionTime, context, token)
+                : await CopyOnAFreshConnectionAsync(
+                    definition, rows, server, collectionTime, context, token),
+            rewrite: token => CopyOnAFreshConnectionAsync(
+                definition, rows, server, collectionTime, context, token),
             onReattempt: firstAttempt => _logger?.LogWarning(
                 firstAttempt,
                 StoreWriteReattemptLogTemplate,
@@ -2534,6 +2540,25 @@ public sealed class DarlingCollectorRunner
         reattempts <= 0
             ? null
             : string.Format(CultureInfo.InvariantCulture, s_storeWriteReattemptNote, reattempts);
+
+    /// <summary>
+    /// One attempt at the batch on a store connection of its own, borrowed for the attempt and returned
+    /// when it ends (#3099). Both the re-attempt and a first attempt whose shared connection is already
+    /// broken route through here, so "a fresh connection" is one named method with one body rather than two
+    /// copies that could drift.
+    /// </summary>
+    private async Task<int> CopyOnAFreshConnectionAsync<TRow>(
+        ICollectorDefinition<TRow> definition,
+        List<TRow> rows,
+        ServerRuntime server,
+        DateTime collectionTime,
+        CollectorContext context,
+        CancellationToken cancellationToken)
+    {
+        await using var freshConnection = await _postgres.OpenConnectionAsync(cancellationToken);
+        return await CopyBatchOnceAsync(
+            freshConnection, definition, rows, server, collectionTime, context, cancellationToken);
+    }
 
     /// <summary>
     /// ONE attempt at the batch: the binary COPY, and for the diverting collectors the transaction that

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
@@ -12,7 +12,9 @@ using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
@@ -2325,6 +2327,14 @@ public sealed class DarlingCollectorRunner
            Kept ABOVE the return rather than inside the argument list: DarlingEmptyEnumerationNoteTests pins
            this call's arguments as one whitespace-collapsed run, so a comment between them breaks a pin
            whose actual job is to catch a DROPPED argument. */
+        /* #3099: merged rather than assigned, and read HERE — one place, after every write on all three
+           dispatch paths — because the count is a per-cycle total and the fan-out paths write once per
+           item. Merging keeps a re-attempt from displacing the probe-failure or partial-database note it
+           can legitimately co-occur with; MergeNotes composes null away, so an ordinary cycle carries
+           exactly the note it carried before. */
+        collectionNote = EnumeratedCollectorDriver.MergeNotes(
+            collectionNote, StoreWriteReattemptNote(context.StoreWriteReattempts));
+
         return new CollectorRunResult(
             rowsWritten, sqlMs, storageMs, collectionNote, fanout.Result,
             ServerPhasesMeasured: serverPhasesMeasured,
@@ -2434,6 +2444,113 @@ public sealed class DarlingCollectorRunner
             return 0;
         }
 
+        /* #3099: ONE re-attempt on a transport fault, and it is lossless because `rows` is still the
+           parameter this method was handed — the batch is in memory, the store is byte-identical (a failed
+           COPY commits nothing, and the diverting collectors' explicit transaction rolls back with it), and
+           the watermark has not moved. Without it a transport fault costs the whole cycle: collectors with
+           a WatermarkColumn re-read the same range next cycle and lose nothing, but the base default in
+           CollectorDefinitionBase is `WatermarkColumn => null` — those are cumulative-counter snapshots
+           with no way to ask for that instant again, so the sample is simply gone.
+
+           The re-attempt takes a FRESH connection, and that is the mechanism rather than any wait: the first
+           attempt's connector is dead — the same reasoning DarlingManagedPostgres' post-start loop records —
+           so a second attempt on the caller's handle would fail on the protocol rather than on the store.
+           There is deliberately no delay between them. The sweep permit and the caller's borrowed store
+           connection are both held for the duration, so a pause long enough to outlast the store's own
+           hourly continuous-aggregate refresh (hundreds of seconds) would hold both for minutes, while any
+           pause short enough to be safe is noise against that window: no delay is purchasable here. The
+           accepted cost is that a write's worst case is two command deadlines rather than one.
+
+           The caller's connection stays broken, so on a fan-out each remaining batch faults once and
+           re-attempts on its own fresh connection. Wasteful and bounded — and strictly better than ending
+           the cycle at the first fault, where the later items are never even read. */
+        var outcome = await StoreWriteReattempt.RunAsync(
+            write: token => CopyBatchOnceAsync(
+                pgConnection, definition, rows, server, collectionTime, context, token),
+            rewrite: async token =>
+            {
+                await using var freshConnection = await _postgres.OpenConnectionAsync(token);
+                return await CopyBatchOnceAsync(
+                    freshConnection, definition, rows, server, collectionTime, context, token);
+            },
+            onReattempt: firstAttempt => _logger?.LogWarning(
+                firstAttempt,
+                StoreWriteReattemptLogTemplate,
+                definition.Name, server.Config.DisplayName, rows.Count, firstAttempt.Message),
+            cancellationToken);
+
+        if (outcome.Reattempted)
+        {
+            /* Incremented only once the rows are actually stored: a re-attempt that also fails throws out
+               of RunAsync into RunOneAsync's fault arms, which record ERROR and never read this. So the
+               count means "stored on the second attempt", never "tried twice". */
+            context.StoreWriteReattempts++;
+        }
+
+        return outcome.RowsWritten;
+    }
+
+    /// <summary>
+    /// The template for the re-attempt's log line (#3099). A named constant so a pin can assert the shipped
+    /// string, and Warning rather than Debug because a store that drops collector writes is a finding even
+    /// when the row is recovered — the level is what keeps it on the default filter, where the log-based
+    /// measurement that found this reads.
+    /// </summary>
+    internal const string StoreWriteReattemptLogTemplate =
+        "{Collector} on '{Server}': the store write of {Rows} row(s) failed on a transport fault " +
+        "({Message}) — re-attempting once on a fresh store connection (#3099). The batch is still in " +
+        "memory and nothing was committed, so a successful re-attempt costs no sample.";
+
+    /// <summary>
+    /// The collection_log note for a cycle that stored its rows only after a re-attempt (#3099). <c>{0}</c>
+    /// = how many of the cycle's writes needed one.
+    ///
+    /// <para><b>The status stays SUCCESS, and the note is what makes the re-attempt visible.</b> A new
+    /// status value would be read as a failure by every consumer of
+    /// <c>status IN ('SUCCESS', 'SKIPPED')</c> — eight readers across the service, the MCP, both viewers
+    /// and Lite — and would suppress <c>last_success</c> for a cycle that genuinely stored every row and
+    /// advanced its watermark. That is #2673's defect with the sign flipped, and the same reasoning that
+    /// put the whole-cycle-budget message in this channel rather than inventing a sixth status.</para>
+    ///
+    /// <para>Recording it at all is not decoration. Before the re-attempt a transport fault wrote a
+    /// collection_log ERROR row, and those rows are the measurement behind #3099's own in-window versus
+    /// out-window error-rate ratio. A silent retry would remove the sample loss AND the only instrument
+    /// that can check whether the association it was diagnosed from is real.</para>
+    /// </summary>
+    internal const string StoreWriteReattemptNoteFormat =
+        "{0} store write(s) this cycle stored their rows only on a re-attempt after a transport fault " +
+        "(#3099); no rows were lost";
+
+    /// <summary><see cref="StoreWriteReattemptNoteFormat"/> parsed once (CA1863).</summary>
+    private static readonly CompositeFormat s_storeWriteReattemptNote =
+        CompositeFormat.Parse(StoreWriteReattemptNoteFormat);
+
+    /// <summary>
+    /// The note for this cycle's store-write re-attempts, or null when none of them needed one — the shape
+    /// every other note producer here takes, so <see cref="EnumeratedCollectorDriver.MergeNotes"/> composes
+    /// it with the probe-failure and partial-failure channels without a special case.
+    /// </summary>
+    internal static string? StoreWriteReattemptNote(int reattempts) =>
+        reattempts <= 0
+            ? null
+            : string.Format(CultureInfo.InvariantCulture, s_storeWriteReattemptNote, reattempts);
+
+    /// <summary>
+    /// ONE attempt at the batch: the binary COPY, and for the diverting collectors the transaction that
+    /// wraps it and its dimension flush. Separate from <see cref="WriteBatchAsync"/> so the importer and
+    /// the transaction are both disposed before the re-attempt runs — a retry that fired while the failed
+    /// attempt's transaction was still in scope would re-enter with an aborted transaction on the
+    /// connection and fail on 25P02 rather than on anything to do with the store.
+    /// </summary>
+    private async Task<int> CopyBatchOnceAsync<TRow>(
+        NpgsqlConnection pgConnection,
+        ICollectorDefinition<TRow> definition,
+        List<TRow> rows,
+        ServerRuntime server,
+        DateTime collectionTime,
+        CollectorContext context,
+        CancellationToken cancellationToken)
+    {
         var rowsWritten = 0;
         var writer = new PgCollectorRowWriter();
 

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
@@ -2513,8 +2513,9 @@ public sealed class DarlingCollectorRunner
     ///
     /// <para><b>The status stays SUCCESS, and the note is what makes the re-attempt visible.</b> A new
     /// status value would be read as a failure by every consumer of
-    /// <c>status IN ('SUCCESS', 'SKIPPED')</c> — eight readers across the service, the MCP, both viewers
-    /// and Lite — and would suppress <c>last_success</c> for a cycle that genuinely stored every row and
+    /// <c>status IN ('SUCCESS', 'SKIPPED')</c> — seven query clauses across five files: Lite's
+    /// collection-health read, the self-alert evaluator's <c>last_success</c> and <c>recent_success</c>, both
+    /// MCP readers, and the viewer's two — and would suppress <c>last_success</c> for a cycle that stored every row and
     /// advanced its watermark. That is #2673's defect with the sign flipped, and the same reasoning that
     /// put the whole-cycle-budget message in this channel rather than inventing a sixth status.</para>
     ///

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
@@ -2444,11 +2444,17 @@ public sealed class DarlingCollectorRunner
             return 0;
         }
 
-        /* #3099: ONE re-attempt on a transport fault, and it is lossless because `rows` is still the
-           parameter this method was handed — the batch is in memory, the store is byte-identical (a failed
-           COPY commits nothing, and the diverting collectors' explicit transaction rolls back with it), and
-           the watermark has not moved. Without it a transport fault costs the whole cycle: collectors with
-           a WatermarkColumn re-read the same range next cycle and lose nothing, but the base default in
+        /* #3099: ONE re-attempt, gated on the COPY's START phase, and lossless because `rows` is still
+           the parameter this method was handed. The gate is what makes it lossless rather than merely
+           cheap: a start-phase fault sent no row, so a COPY ... FROM STDIN cannot have committed and the
+           store is byte-identical, and it ran no WritePayload, so no delta baseline moved. Both are
+           forfeit past that point — see CopyBatchOnceAsync, which stamps the phase and carries the
+           argument. StoreWriteReattempt.IsSafeToReattempt requires Start positively, so an unstamped
+           fault and a data-phase fault both decline and cost a sample rather than authorising a duplicate
+           or a fabricated zero.
+
+           What it recovers: a start-phase transport fault used to cost the whole cycle. Collectors with a
+           WatermarkColumn re-read the same range next cycle and lose nothing, but the base default in
            CollectorDefinitionBase is `WatermarkColumn => null` — those are cumulative-counter snapshots
            with no way to ask for that instant again, so the sample is simply gone.
 
@@ -2465,9 +2471,9 @@ public sealed class DarlingCollectorRunner
            is not tidiness. The caller's connection is shared across a fan-out's batches (#2819 has the
            Query Store plan and text fetches borrowing the same one), and a transport fault breaks it — so
            every batch after the first faulting one inherits a connection that cannot be used, and what it
-           throws then need not be a transport fault this arm would recognise. Deciding on the connection's
-           own STATE rather than on the shape of a later exception keeps those batches out of that
-           classification entirely. plan_correction is the collector that makes it matter: it enumerates on
+           throws then need not carry a phase stamp at all, and an unstamped fault declines. Deciding on the
+           connection's own STATE rather than on the shape or stamping of a later exception keeps those
+           batches out of that question entirely. plan_correction is the collector that makes it matter: it enumerates on
            every non-Azure target and declares no WatermarkColumn, so it both fans out and cannot re-read a
            sample it lost. The cost is that a faulted cycle's remaining batches hold two store connections
            at a time on that server rather than one, for the rest of the cycle. */
@@ -2568,28 +2574,19 @@ public sealed class DarlingCollectorRunner
     /// attempt's transaction was still in scope would re-enter with an aborted transaction on the
     /// connection and fail on 25P02 rather than on anything to do with the store.
     ///
-    /// <para><b>The re-attempt this feeds is at-least-once, not exactly-once, and the window is here.</b>
-    /// A transport fault raised BEFORE the commit acknowledgment is awaited leaves the store untouched, and
-    /// that is the ordinary case. A fault raised WHILE awaiting it — <c>CompleteAsync</c>'s CommandComplete,
-    /// or <c>CommitAsync</c>'s on the diverting path — can leave the server committed while the client sees
-    /// a retryable exception, and the re-attempt then lands the batch a second time. The copies are not
-    /// identical rows and nothing downstream can collapse them:
-    /// <see cref="ICollectorSchemaInfo.IncludesCollectionId"/> is true for every collector but running_jobs,
-    /// so <c>CollectionIdGenerator.Next()</c> stamps each row of each attempt with its own id.</para>
+    /// <para><b>The phase this method stamps is what makes a re-attempt sound, and only the start phase
+    /// is.</b> #3095's <c>StoreCopyPhase</c> transition sits inside the COPY block below, so
+    /// <c>Start</c> means strictly "the importer never came back": no row started, so a
+    /// <c>COPY ... FROM STDIN</c> cannot have committed, and <c>WritePayload</c> never ran, so no
+    /// <c>CollectorDeltaCalculator</c> baseline moved. <see cref="StoreWriteReattempt.IsSafeToReattempt"/>
+    /// requires that value positively.</para>
     ///
-    /// <para><b>The cost is a doubled hour, and it is accepted.</b> <c>collection_id</c> is in no continuous
-    /// aggregate's <c>GROUP BY</c> — it does not appear in TimescaleSupport at all — so both copies land in
-    /// the same bucket and 18 <c>sum()</c> views double it. The bucket is materialised and raw retention is
-    /// four days, so the wrong figure outlives the rows that explain it, and each daily rollup reads its
-    /// hourly view rather than raw, so it inherits the doubling. The trade is a one-round-trip window
-    /// against a sample lost on EVERY failed write, and the loss is the certainty.</para>
-    ///
-    /// <para><b>It has a signature.</b> A doubled batch doubles the bucket's <c>sample_count</c>, so an hour
-    /// at twice its neighbours' count is the tell — and it reads off the aggregate itself, with no raw rows
-    /// needed. That column exists on five of the eighteen: query_stats_hourly, procedure_stats_hourly,
-    /// query_stats_db_hourly, query_store_stats_hourly and query_store_stats_interval_hourly. It covers the
-    /// two null-watermark collectors the re-attempt is chiefly for; it is absent from every daily view, so
-    /// the anomaly is findable one tier above where it propagates.</para>
+    /// <para><b>Both properties are why the row loop below must never be re-run.</b> Past the transition a
+    /// fault may have sent rows and may have lost a commit acknowledgment in flight, and every baseline
+    /// the loop reached has advanced — so a second pass would re-derive each delta against its own new
+    /// baseline and write a zero. A zero delta reads as a genuinely idle interval, carries no error and
+    /// never self-corrects, which is strictly worse than the lost sample the re-attempt exists to prevent.
+    /// <c>WritePayload</c> is not a pure function of its row, and that is the reason.</para>
     /// </summary>
     private async Task<int> CopyBatchOnceAsync<TRow>(
         NpgsqlConnection pgConnection,

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingManagedPostgres.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingManagedPostgres.cs
@@ -1965,24 +1965,14 @@ public sealed class DarlingManagedPostgres
     /// Whether an exception is a transport-level fault worth retrying (socket reset, stream write failure,
     /// timeout) rather than a definitive answer from a working server (bad password, missing role).
     /// <see cref="PostgresException"/> means the server replied, so it is never transient by this test.
+    ///
+    /// <para>The predicate itself lives in <see cref="PostgresTransportFault"/>, shared with the collector
+    /// runner's store-write re-attempt. The RETRY POLICY stays here — six attempts two seconds apart, sized
+    /// for the post-start shared-memory race above — because that is what differs between the two regimes;
+    /// the question asked of the exception does not.</para>
     /// </summary>
     private static bool IsTransientConnectionFault(Exception exception)
-    {
-        for (var current = exception; current is not null; current = current.InnerException)
-        {
-            if (current is PostgresException)
-            {
-                return false;
-            }
-
-            if (current is SocketException or IOException or TimeoutException)
-            {
-                return true;
-            }
-        }
-
-        return exception is NpgsqlException;
-    }
+        => PostgresTransportFault.IsTransportFault(exception);
 
     private string ReadStoredPassword()
     {

--- a/Darling/PerformanceMonitor.Darling.Service/PostgresTransportFault.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/PostgresTransportFault.cs
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.IO;
+using System.Net.Sockets;
+using Npgsql;
+
+namespace PerformanceMonitor.Darling.Service;
+
+/// <summary>
+/// The one predicate behind every "is this store fault worth another attempt" decision in this project:
+/// a transport-level fault (socket reset, stream read/write failure, client-side deadline) rather than a
+/// definitive answer from a working server.
+///
+/// <para><b>A <see cref="PostgresException"/> anywhere in the chain is never a transport fault.</b> It
+/// means the backend received the statement and replied — a duplicate key, a missing relation, bad input
+/// syntax, a full disk, or its own <c>statement_timeout</c> cancelling us at SQLSTATE 57014. Every one of
+/// those returns the identical answer to an identical second attempt, so re-attempting buys nothing and
+/// costs a second round trip against a store that just said no. The reply is also the evidence: a caller
+/// that re-attempts past a SQLSTATE turns a legible, actionable error into a silent one.</para>
+///
+/// <para><b>Two callers, one predicate, deliberately.</b>
+/// <see cref="DarlingCollectorRunner"/>'s store write re-attempts once, immediately, on a fresh
+/// connection; <see cref="DarlingManagedPostgres"/>'s first-connection-after-start loop re-attempts six
+/// times with a two-second pause. The POLICIES differ because the regimes do — one runs mid-sweep on a
+/// live service holding a sweep permit, the other runs once during startup with nothing else in flight —
+/// but the question each asks of the exception is the same question, and two copies of it would be free
+/// to disagree the moment either grew an arm. What varies belongs at the call site; this does not.</para>
+///
+/// <para>The chain is walked rather than the outermost type tested, because Npgsql wraps: a client-side
+/// command deadline arrives as an <see cref="NpgsqlException"/> whose inner exception is a
+/// <see cref="TimeoutException"/>, and a lost connection as one wrapping an <see cref="IOException"/>.
+/// Both render as the same "Exception while reading from stream" text, which is why the outermost type
+/// and the message can distinguish neither from the other nor from a server reply.</para>
+/// </summary>
+internal static class PostgresTransportFault
+{
+    /// <summary>
+    /// True when <paramref name="exception"/> is a transport-level fault. The <see cref="PostgresException"/>
+    /// test comes FIRST at every level of the chain, so a server reply wrapped in transport machinery still
+    /// answers false.
+    /// </summary>
+    internal static bool IsTransportFault(Exception exception)
+    {
+        for (var current = exception; current is not null; current = current.InnerException)
+        {
+            if (current is PostgresException)
+            {
+                return false;
+            }
+
+            if (current is SocketException or IOException or TimeoutException)
+            {
+                return true;
+            }
+        }
+
+        return exception is NpgsqlException;
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Service/StoreWriteReattempt.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/StoreWriteReattempt.cs
@@ -60,6 +60,18 @@ internal static class StoreWriteReattempt
     /// the lost sample this exists to prevent, because a zero delta reads as a genuinely idle interval,
     /// carries no error, and never self-corrects.</para>
     ///
+    /// <para><b>This conjunct is only as sound as the stamping site, which is in another file.</b> It
+    /// means something exactly because <c>Start</c> is in force ONLY until <c>BeginBinaryImportAsync</c>
+    /// returns and can never be applied to a fault raised once the row loop has begun — a property of
+    /// <see cref="DarlingCollectorRunner"/>'s COPY block, not of this predicate, and one that a reader
+    /// auditing the gate cannot see from here. It is pinned by
+    /// <c>TheCopyWriteStampsTheStartPhaseUntilBeginReturns</c> in <c>Darling.Tests/StoreCopyPhaseTests.cs</c>,
+    /// whose load-bearing assertion is that NO site hard-stamps <c>Start</c> at all, so the value can only
+    /// arise from the variable's initial state. Widening that <c>try</c>, or adding a stamping call site,
+    /// changes what this gate authorises. The tests in <c>StoreWriteReattemptTests</c> stamp their own
+    /// faults, so they pin the predicate GIVEN a stamp and deliberately own nothing on the producer
+    /// side.</para>
+    ///
     /// <para><see cref="StoreCopyPhase.Unknown"/> declines, and that is deliberate rather than incidental:
     /// it is what an unstamped exception reads as, and it covers the dimension flush and transaction
     /// commit that follow the COPY (#1767) — which genuinely can commit. Requiring

--- a/Darling/PerformanceMonitor.Darling.Service/StoreWriteReattempt.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/StoreWriteReattempt.cs
@@ -41,8 +41,39 @@ internal readonly record struct StoreWriteOutcome(int RowsWritten, bool Reattemp
 internal static class StoreWriteReattempt
 {
     /// <summary>
-    /// Runs <paramref name="write"/>; on a transport fault, calls <paramref name="onReattempt"/> with the
-    /// first attempt's exception and then runs <paramref name="rewrite"/> once.
+    /// Whether re-running the batch is SOUND — two independent questions ANDed, and both are required.
+    ///
+    /// <para><b>A transport fault</b> (<see cref="PostgresTransportFault.IsTransportFault"/>) means the
+    /// failure was the connection rather than a reply, so a second attempt can plausibly differ. A
+    /// <see cref="Npgsql.PostgresException"/> anywhere in the chain is the backend answering, and an
+    /// identical second attempt gets an identical answer.</para>
+    ///
+    /// <para><b>The COPY's start phase</b> (#3095's <see cref="StoreCopyPhase"/>) means the re-attempt is
+    /// exactly-once and delta-safe, and nothing else does. <see cref="StoreCopyPhase.Start"/> is raised by
+    /// <c>BeginBinaryImportAsync</c> itself, so the importer never returned: no row was started, hence a
+    /// <c>COPY ... FROM STDIN</c> cannot have committed, and <c>WritePayload</c> never ran, hence no
+    /// <c>CollectorDeltaCalculator</c> baseline moved. Both properties are forfeit the moment the row loop
+    /// begins — a fault under <see cref="StoreCopyPhase.Data"/> may have sent rows, may have had its
+    /// commit acknowledgment lost in flight, and has advanced every baseline the loop reached. Re-running
+    /// it would duplicate the batch into aggregates that cannot separate the copies, and would re-derive
+    /// each delta against an already-advanced baseline and commit a fabricated zero — which is worse than
+    /// the lost sample this exists to prevent, because a zero delta reads as a genuinely idle interval,
+    /// carries no error, and never self-corrects.</para>
+    ///
+    /// <para><see cref="StoreCopyPhase.Unknown"/> declines, and that is deliberate rather than incidental:
+    /// it is what an unstamped exception reads as, and it covers the dimension flush and transaction
+    /// commit that follow the COPY (#1767) — which genuinely can commit. Requiring
+    /// <see cref="StoreCopyPhase.Start"/> POSITIVELY means a missing stamp costs a sample instead of
+    /// authorising a duplicate.</para>
+    /// </summary>
+    internal static bool IsSafeToReattempt(Exception fault) =>
+        PostgresTransportFault.IsTransportFault(fault)
+        && CollectorFaultCopyPhase.For(fault) == StoreCopyPhase.Start;
+
+    /// <summary>
+    /// Runs <paramref name="write"/>; on a fault that <see cref="IsSafeToReattempt"/> accepts, calls
+    /// <paramref name="onReattempt"/> with the first attempt's exception and then runs
+    /// <paramref name="rewrite"/> once.
     ///
     /// <para>A failure on the SECOND attempt propagates. That is deliberate: the caller's fault arms record
     /// it as an ERROR exactly as they record a single failure today, so a store that is genuinely refusing
@@ -61,14 +92,14 @@ internal static class StoreWriteReattempt
             return new StoreWriteOutcome(await write(cancellationToken), Reattempted: false);
         }
         /* Ahead of the filter rather than relying on it to answer false. A cancellation must never be
-           reclassified as a transport fault, and an arm whose correctness rests on a predicate NOT matching
-           is one predicate edit away from re-attempting through a shutdown. */
+           reclassified as a re-attemptable fault, and an arm whose correctness rests on a predicate NOT
+           matching is one predicate edit away from re-attempting through a shutdown. */
         catch (OperationCanceledException)
         {
             throw;
         }
         catch (Exception firstAttempt) when (
-            !cancellationToken.IsCancellationRequested && PostgresTransportFault.IsTransportFault(firstAttempt))
+            !cancellationToken.IsCancellationRequested && IsSafeToReattempt(firstAttempt))
         {
             onReattempt(firstAttempt);
             return new StoreWriteOutcome(await rewrite(cancellationToken), Reattempted: true);

--- a/Darling/PerformanceMonitor.Darling.Service/StoreWriteReattempt.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/StoreWriteReattempt.cs
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PerformanceMonitor.Darling.Service;
+
+/// <summary>
+/// What one store write did (#3099). One value rather than a row count plus an out-parameter, so a caller
+/// cannot take the rows and drop the fact that they arrived on the second try — which is the whole signal.
+/// </summary>
+internal readonly record struct StoreWriteOutcome(int RowsWritten, bool Reattempted);
+
+/// <summary>
+/// The once-only re-attempt policy for a collector's store write (#3099), as a pure function of two
+/// attempt delegates so it can be exercised without a store: the host supplies the COPY, this supplies the
+/// decision about whether a failure gets a second one.
+///
+/// <para><b>Once, not a loop.</b> A batch is one cycle's sample of a source that keeps producing; the next
+/// scheduled cycle is the second retry, and it costs nothing to wait for. What the immediate re-attempt
+/// buys is the sample that would otherwise be unrecoverable, on the collectors whose
+/// <c>WatermarkColumn</c> is the base <c>null</c> — a watermarked collector re-reads the same range next
+/// cycle and never needed this.</para>
+///
+/// <para><b>Both attempts run on the caller's token, and a cancelled token suppresses the re-attempt
+/// entirely.</b> The token here is the service's stopping token rather than a deadline, so honouring it
+/// costs nothing in the population this exists for — a store-contention fault on a running service has no
+/// cancellation in flight. What it prevents is a re-attempt that outlives an orderly stop while holding a
+/// sweep permit and a store connection, against a bundled store the same process is shutting down: the one
+/// case where a second attempt is guaranteed to be useless. The suppression is in the filter rather than a
+/// throw inside the arm, so a write that fails during a stop still reports its own transport fault instead
+/// of being relabelled a cancellation.</para>
+/// </summary>
+internal static class StoreWriteReattempt
+{
+    /// <summary>
+    /// Runs <paramref name="write"/>; on a transport fault, calls <paramref name="onReattempt"/> with the
+    /// first attempt's exception and then runs <paramref name="rewrite"/> once.
+    ///
+    /// <para>A failure on the SECOND attempt propagates. That is deliberate: the caller's fault arms record
+    /// it as an ERROR exactly as they record a single failure today, so a store that is genuinely refusing
+    /// writes stays loud. The first attempt's exception is not chained onto it — it has already gone to
+    /// <paramref name="onReattempt"/>, which is where the host logs it, and burying it as an inner
+    /// exception would put two different faults in one message column.</para>
+    /// </summary>
+    internal static async Task<StoreWriteOutcome> RunAsync(
+        Func<CancellationToken, Task<int>> write,
+        Func<CancellationToken, Task<int>> rewrite,
+        Action<Exception> onReattempt,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return new StoreWriteOutcome(await write(cancellationToken), Reattempted: false);
+        }
+        /* Ahead of the filter rather than relying on it to answer false. A cancellation must never be
+           reclassified as a transport fault, and an arm whose correctness rests on a predicate NOT matching
+           is one predicate edit away from re-attempting through a shutdown. */
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception firstAttempt) when (
+            !cancellationToken.IsCancellationRequested && PostgresTransportFault.IsTransportFault(firstAttempt))
+        {
+            onReattempt(firstAttempt);
+            return new StoreWriteOutcome(await rewrite(cancellationToken), Reattempted: true);
+        }
+    }
+}

--- a/PerformanceMonitor.Collectors/CollectorContext.cs
+++ b/PerformanceMonitor.Collectors/CollectorContext.cs
@@ -566,6 +566,22 @@ public sealed class CollectorContext
     /// host reads it right after building that database's query.
     /// </summary>
     public bool CatchupClampApplied { get; set; }
+
+    /// <summary>
+    /// How many of this cycle's store writes stored their rows only on a second attempt (#3099). Set by the
+    /// host, never by a definition, like the phase and drain fields above.
+    ///
+    /// <para>A COUNT rather than a flag because the fan-out paths write once per database or per enumerated
+    /// item: "one batch of thirty re-attempted" and "every batch re-attempted" are a momentary blip and a
+    /// store in trouble, and a bool cannot tell them apart. Zero — the default, and what an ordinary cycle
+    /// leaves it at — is the honest reading of "no write needed a second attempt", not "unmeasured", because
+    /// the host increments unconditionally on the one path that can.</para>
+    ///
+    /// <para>Read once per cycle, after the writes, to compose the collection_log note. The count is what
+    /// keeps the re-attempt visible in the store: a write that fails and then succeeds writes a SUCCESS row,
+    /// and without this the row is indistinguishable from a write that never faulted at all.</para>
+    /// </summary>
+    public int StoreWriteReattempts { get; set; }
 }
 
 /// <summary>


### PR DESCRIPTION
Implements the first of #3099's three suggested directions: a collector's binary COPY into the store that fails on a transport fault **in the COPY's start phase** gets one re-attempt on a fresh store connection. Before this there is no retry anywhere on the path — the `retry`/`backoff` hits in `DarlingCollectorRunner` are #2776's plan-fetch width backoff and #2673's budget-abandon, both meaning "the next scheduled cycle".

**`Part of #3099`, not `Fixes`.** This touches the collector COPY write path only. #3099 is evidenced across a wider population — its own report shows the same error text on store *reads* (`Collection-health self-alert failed`, `Failed to check forced-plan failures`), which this does not touch and which lose an alert evaluation rather than a sample. The closing condition belongs on the issue, not inherited from a title here.

## The gate is the design, not a precaution

`WriteBatchAsync` splits into a wrapper and `CopyBatchOnceAsync`, which holds the COPY and (for the #1767 diverting collectors) the transaction wrapping it and its dimension flush. The split is load-bearing: the importer and the transaction must be disposed before a second attempt, or it re-enters with an aborted transaction and fails on 25P02 rather than on anything to do with the store.

`StoreWriteReattempt.IsSafeToReattempt` ANDs two independent axes, and **both are required**:

- **a transport fault** — `SocketException` / `IOException` / `TimeoutException` anywhere in the inner chain, else `NpgsqlException` at the top. `PostgresException` anywhere in the chain is the backend answering (duplicate key, missing relation, bad input, full disk, its own `statement_timeout` at 57014); an identical second attempt gets an identical answer, and re-attempting past a SQLSTATE turns a legible error into a silent one. The chain is walked with the `PostgresException` test **first at every level**, so wrapping cannot smuggle a SQLSTATE past the predicate.
- **#3095's `StoreCopyPhase.Start`** — required *positively*.

**Why the phase axis is what makes this correct.** Re-running the batch re-runs `WritePayload`, and `WritePayload` is not a pure function of its row: it derives deltas through `CollectorDeltaCalculator`, whose `AddOrUpdate` returns `(currentValue, …)` on every arm — so asking for a delta *advances the baseline as a side effect*. A second pass over rows the first attempt already rendered therefore computes `currentValue - currentValue = 0` and commits a zero for every delta column. That affects **8 collectors** (`QueryStats` 8 calls, `FileIoStats` 8, `ProcedureStats` 7, `Spinlock` 4, `LatchStats` 3, `WaitStats` 3, `MemoryGrants` 2, `PerfmonStats` 1) — three of them the null-watermark collectors this re-attempt exists for. A zero delta reads as a genuinely idle interval, carries no error, and never self-corrects; that is strictly worse than the lost sample.

`StoreCopyPhase.Start` is the one state where neither hazard exists. It is raised by `BeginBinaryImportAsync` itself, so the importer never returned: no row was started, hence a `COPY … FROM STDIN` cannot have committed, and `WritePayload` never ran, hence no baseline moved. #3095 puts the `Start`→`Data` transition *inside* the COPY block precisely so `Start` cannot mean anything looser.

**So the re-attempt is exactly-once, not at-least-once.** There is no lost-commit-ack window and no aggregate duplication to disclose, because the only phase it fires in cannot have committed.

**`Unknown` declines, and that is deliberate.** It is what an unstamped exception reads as, and it covers the dimension flush and the transaction commit *after* the COPY (#1767) — which genuinely can commit. Requiring `Start` positively means a missing stamp costs a sample instead of authorising a duplicate. A predicate written as "not `Data`" would re-attempt everything it failed to recognise; that variant is pinned red.

## What it recovers, at its real size

Honest sizing, because only the cost was quantified before:

- The population is **start-phase transport faults of collector COPY writes**, and only the five null-watermark collectors lose anything at all — a `WatermarkColumn` collector's watermark is `MAX(column)` over rows *already stored*, so a failed write cannot advance it and the next cycle re-reads the same range.
- On the current regime that is **order tens of failures per day fleet-wide** before the phase and null-watermark narrowing, which takes it lower again by a factor I have not measured. The base rate is a coordinator measurement I did not take myself; I am carrying it with that provenance rather than restating it as mine.
- **The three-day 1,074 figure is not the right denominator** and is not used here: it is regime-mixed and largely pre-fix, so sizing against it overstates by roughly an order of magnitude.

Smaller on both sides than the first draft of this description implied, and it should be argued at that size. What does not shrink is the *character* of the loss: on a null-watermark collector the sample is unrecoverable, and the data is sitting in memory when the write fails.

The base default in `CollectorDefinitionBase` is `WatermarkColumn => null`; the affected set is `query_stats`, `procedure_stats`, `file_io_stats`, `plan_cache_stats`, `plan_correction`.

## Cancellation

Both attempts run on the caller's `cancellationToken`, and a token already cancelled suppresses the re-attempt entirely.

That token is the service's stopping token, not a deadline, so honouring it costs nothing in the population this exists for. What it prevents is a re-attempt outliving an orderly stop while holding a sweep permit and a store connection, against a bundled store the same process is shutting down — the one case where a second attempt is guaranteed useless. The suppression sits in the exception filter rather than as a throw inside the arm, so a write failing during a stop still reports its own transport fault instead of being relabelled a cancellation. Accepted consequence: a write that fails *because* of shutdown loses its sample exactly as today.

`OperationCanceledException` is caught and rethrown ahead of the filter rather than left to the predicate answering false — an arm whose correctness rests on a predicate *not* matching is one predicate edit away from re-attempting through a shutdown.

## No delay, and why none is purchasable

The mechanism is the fresh connection, not a wait: the first attempt's connector is dead — the reasoning `DarlingManagedPostgres`'s post-start loop already records — so a second COPY on the caller's handle would fail on the protocol rather than on the store.

A delay is not available here at any useful length. The sweep permit and the caller's borrowed store connection are both held for the duration, so a pause long enough to outlast the store's own hourly continuous-aggregate refresh (hundreds of seconds, per #3099's duration series) would hold both for minutes, while any pause short enough to be safe is noise against that window. The accepted cost is that a write's worst case is two command deadlines rather than one.

## How it is recorded

The status stays SUCCESS. A new value would be read as a failure by every consumer of `status IN ('SUCCESS', 'SKIPPED')` — seven query clauses across five files (Lite's collection-health read, the self-alert evaluator's `last_success` and `recent_success`, both MCP readers, and the Darling viewer's two) — and would suppress `last_success` for a cycle that stored every row and advanced its watermark. That is #2673's defect with the sign flipped, and the same reasoning that put the whole-cycle-budget message in the note channel rather than inventing a sixth status.

The cycle is distinguished by two things:

- a Warning log line naming the collector, the server, the row count and the first attempt's message, from a named template constant so a pin can assert the shipped string. Warning rather than Debug because a store that drops collector writes is a finding even when the row is recovered, and the level is what keeps it on the default filter — where the log-based measurement that found this reads. (Deliberate under #3103's new regime, which moved per-cycle *timing* to Debug.)
- a count on the run's `collection_log` row, composed into the existing #1837 note channel through `EnumeratedCollectorDriver.MergeNotes`. Merged rather than assigned, read once after every write on all three dispatch paths, so a re-attempt cannot displace the probe-failure or partial-database note it can co-occur with. A count rather than a flag because the fan-out paths write once per database or per item.

Recording it is not a courtesy: a transport fault currently writes a `collection_log` ERROR row, and those rows are the measurement behind #3099's in-window versus out-window rate ratio and the prediction registered against it. A silent retry would remove the lost sample **and** the instrument that checks whether the association it was diagnosed from is real.

## Known cost

The caller's connection stays broken for the rest of the cycle, and on a fan-out it is shared across every batch (#2819 has the Query Store plan and text fetches borrowing the same one). Each batch after the faulting one detects it by **state** and sends its *first* attempt to a fresh connection — so there is no wasted first attempt and no second Warning line; a faulted cycle logs **one** Warning, for the batch that faulted. Deciding on the connection's own state rather than on a later exception's shape or stamping keeps those batches out of the phase question entirely.

**The cost is connection holds.** For the remainder of a faulted cycle that server holds two store connections at a time rather than one: the caller's broken handle, still checked out until its `await using` unwinds, plus the fresh one each batch borrows. #2819's re-derivation of `MaxPoolSize = 24` sized the pool at the sweep width on peak concurrent holds being one per swept server, so this is the 2x multiplier that bound moved away from — reachable only if many swept servers fault in the same cycle. Repairing the caller's handle in place would need the callers to hold a re-openable connection: wider than this change.

`plan_correction` is why the state check matters rather than being tidiness: it enumerates on every non-Azure target and declares no `WatermarkColumn`, so it both fans out and cannot re-read a lost sample.

`WriteBackfillBatchAsync` inherits the re-attempt, since it routes through `WriteBatchAsync`. Its context is not attached to a `CollectorRunResult`, so its note reaches nothing; the Warning line still fires.

## Scope

Direction 1 only. #3095's start-phase deadline is merged (#3110) and this consumes its phase axis rather than duplicating it. Refresh scheduling is untouched.

## Tests

`StoreWriteReattemptTests`, 20 cases. The policy runs through `StoreWriteReattempt.RunAsync` with attempt delegates that move rows into a sink, because the COPY it wraps is reachable only through a live store and a constructed runner. What delegates cannot see — that the shipped write routes through it at all, and that the re-attempt takes a fresh connection rather than the caller's dead one — is pinned against the source. Neither half is sufficient alone.

Phase stamps in the tests are applied through the **shipped producer** (`CollectorFaultCopyPhase.Stamp`), not by writing `Exception.Data` directly, so the key asserted is the key the runner writes rather than a retyped string.

Every assertion is red-proofed against a mutation that keeps the tree compiling:

| mutation | red |
|---|---|
| phase conjunct removed | `ADataPhaseFaultIsNeverReattempted`, `AnUnstampedFaultIsNeverReattempted`, `IsSafeToReattemptRequiresBothAxes` |
| gate written `!= Data` instead of `== Start` | `AnUnstampedFaultIsNeverReattempted`, `IsSafeToReattemptRequiresBothAxes` (the `Data` test stays green — the two declining phases are pinned separately) |
| transport conjunct removed | all five `AServerReplyIsNeverReattempted` rows + `AWrappedServerReplyIsNeverReattempted` |
| re-attempt removed | `AFailedFirstWriteFollowedByASuccessfulReattempt_StoresTheRows_AndReportsSuccess` |
| re-attempt swallows its own failure | `AFailureOnBothAttempts_ReportsTheError` — "nothing was thrown" |
| write bypasses the helper | `TheShippedStoreWriteRoutesThroughTheReattemptOnAFreshConnection` |
| helper reached through a same-signature shim | same test (this variant defeated the pin's first form) |
| re-attempt reuses `pgConnection` | same test, fresh-call count |
| broken-connection first-attempt fallback removed | same test, fresh-call count |
| `CopyOnAFreshConnectionAsync` stops opening its own connection | same test, helper-body assertion |
| note merge dropped | `TheReattemptCountReachesTheCollectionLogNote` |

### The gate's other half lives in #3110, and both directions now say so

`IsSafeToReattempt`'s `Start` conjunct means something only because `Start` is in force until `BeginBinaryImportAsync` returns and can never apply to a fault raised once the row loop has begun. That is a property of the COPY block, pinned in a third file, and an auditor reading the gate could find neither. So the gate's doc now names the stamping site and `TheCopyWriteStampsTheStartPhaseUntilBeginReturns`, and `StoreCopyPhase.Start` and `Stamp` now say a re-attempt decision is downstream — because whoever widens that `try` or adds a stamping call site is the person who needs to know.

### A hole in that pin, closed

The pin constrained transitions **to `Data`** (exactly one, correctly positioned) and explicit `Stamp(ex, Start)` calls (exactly zero). It never constrained bare **assignments** to `Start`. I confirmed the counts in the merged runner — `copyPhase = StoreCopyPhase.Start;` occurs 1, `Stamp(ex, StoreCopyPhase.Start)` occurs 0 — then proved it exploitable: adding `copyPhase = StoreCopyPhase.Start;` below the row loop left **all 75 tests green**, while making a post-row-loop fault carry `Start`. Since the gate re-runs the batch on `Start`, that is a duplicated write and a delta column of zeros with nothing red.

A symmetric count assertion closes it, red-proofed with that same mutation (1→2). Both counts and both positional patterns now spell the assignment `\s*=\s*` rather than with literal single spaces — `copyPhase=StoreCopyPhase.Start;` is valid C# and evaded every literal form; that variant is red-proofed too.

### And the instance pair, because the pin and the instance test fail differently

Not instead of the pin — neither covers the other's blind spot, and I have that in both directions rather than as an argument:

| mutation | source pin | instance test |
|---|---|---|
| bare `= Start;` below the row loop | **RED** (count 1→2) | passes — the loop is never reached |
| `Begin` hoisted outside the stamped `try` | passes — all six regexes still match | **RED** — `Start` → `Unknown` |

A source pin catches every edit *of a shape it anticipated* and is blind to constructions nobody thought of, which is precisely what the hole above was. The instance test runs the real path and reads the stamp off a real exception, so a construction producing the wrong phase fails even when every regex matches.

The two instance tests live in `StoreCopyPhaseLivePostgresTests` under `[Collection("live-postgres")]`, not in `StoreCopyPhaseTests`. They reach the shared `DARLING_TEST_PG` store, which makes their class a live class — and `LivePostgresCollectionHygieneTests` prefers exactly this remedy: a mostly-pure class keeps its purity and the live tests move out, rather than serializing seven source-text pins against every other live class. The vacuity guards travel with the tests.

The **start case needs no store** — an unopened connection makes the real `BeginBinaryImportAsync` refuse before it reaches a socket, which *is* a start-phase fault — so it runs everywhere and I red-proofed it locally. Its definition's `WritePayload` throws a distinctive exception, so a reachable row loop would be named rather than silently changing what the test measures. The **data case** needs `Begin` to succeed, so it is gated on `DARLING_TEST_PG` and its first execution is CI's live job; I could not run it on macOS and am not claiming otherwise. It is the negative control that stops the start case passing under an unconditional `Start` stamp.

The server-reply rows are stamped `Start` on purpose: the phase axis would *accept* them, so their decline can only be the type axis doing its job. Unstamped they would pass for the wrong reason.

The rows-storing assertion checks the sink rather than the return value alone — a helper returning the right count while writing nothing would satisfy a count-only assertion, and "no sample is lost" is a claim about the store's contents.

`CollectionSweepCommandTimeoutTests` (the sweep's own deadline scanner) and `DarlingPayloadProbeFailureTests` run against the change and stay green. `PayloadDimensionTests`' exactly-one-occurrence-and-ordering pin on `importer.CompleteAsync` / `PayloadDimensionWriter.FlushAsync` / `transaction.CommitAsync`, and `DarlingEmptyEnumerationNoteTests`' whitespace-collapsed argument-list pin, were verified by hand against the shipped source — both classes need the WPF Viewer project and cannot compile in a macOS harness.

## CHANGELOG entry

```
- Fixed: a collector's store write that fails on a transport fault in the COPY's start phase is re-attempted once on a fresh store connection instead of costing the cycle. A start-phase fault sent no rows and ran no payload writer, so the store is byte-identical and no delta baseline has moved, which makes the re-attempt exactly-once and lossless; collectors with no watermark column previously lost one sample outright. A data-phase fault, an unstamped fault and any server reply (any SQLSTATE) all decline, and a cancelled token suppresses the re-attempt. A cycle that stored its rows on the second attempt says so on its collection_log row and in a warning log line. (#3099, consuming #3095's phase axis)
```
