### PR TITLE
Fixes #3095

### DIFF
--- a/Darling/Darling.Tests/RepoFileAdoptionTests.cs
+++ b/Darling/Darling.Tests/RepoFileAdoptionTests.cs
@@ -93,6 +93,7 @@ public sealed class RepoFileAdoptionTests
         "FleetPageAttentionFilterTests.cs",
         "ServerPageTabsTests.cs",
         "StartupFailureTriageTests.cs",
+        "StoreCopyPhaseTests.cs",
         "ViewTemplatesTests.cs",
         "ViewerSidebarDotRendersTheCardStatusTests.cs",
     };

--- a/Darling/Darling.Tests/StoreCopyPhaseTests.cs
+++ b/Darling/Darling.Tests/StoreCopyPhaseTests.cs
@@ -1,0 +1,296 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Text.RegularExpressions;
+using Npgsql;
+using PerformanceMonitor.Collectors;
+using PerformanceMonitor.Darling.Service;
+using PerformanceMonitor.Darling.Service.Targets;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// Pins that a collector store-write fault raised in the COPY's START phase is reported distinguishably
+/// from one raised in its DATA phase (#3095).
+///
+/// <para><b>The defect.</b> <c>DarlingCollectorRunner.WriteBatchAsync</c> bounds the data phase with
+/// <c>ServiceCommandDeadlines.CollectionSweepSeconds</c> on <c>NpgsqlBinaryImporter.Timeout</c>, and that
+/// property does not reach <c>BeginBinaryImportAsync</c> above it — Begin awaits <c>CopyInResponse</c>
+/// under the connection's <c>CommandTimeout</c>, which Npgsql 10.0.3 exposes read-only with no per-call
+/// overload, so the start phase runs on the undocumented 30 s default. Both phases surface as
+/// <c>Exception while reading from stream</c>, so neither the message nor the outermost type separated
+/// them, and the start phase is where a lock wait stalls.</para>
+///
+/// <para><b>What makes this more than a log improvement.</b> A start-phase fault has started no row, so a
+/// <c>COPY ... FROM STDIN</c> cannot have committed and no <c>CollectorDeltaCalculator</c> baseline has
+/// moved — <c>WritePayload</c> runs in the row loop below Begin. Data-phase faults have neither property.
+/// So the phase is what lets a consumer scope a re-attempt to the population where one is safe, and it has
+/// to be readable programmatically rather than only out of a sentence.</para>
+/// </summary>
+public class StoreCopyPhaseTests
+{
+    /// <summary>
+    /// The message BOTH phases produce. Every discrimination test here uses it for both exceptions, so a
+    /// test that passes cannot be passing on a difference in text.
+    /// </summary>
+    private const string SharedMessage = "Exception while reading from stream";
+
+    /// <summary>A start-phase fault as it really arrives: an Npgsql exception wrapping a client-side deadline.</summary>
+    private static NpgsqlException StartFault()
+    {
+        var fault = new NpgsqlException(SharedMessage, new TimeoutException());
+        CollectorFaultCopyPhase.Stamp(fault, StoreCopyPhase.Start);
+        return fault;
+    }
+
+    /// <summary>A data-phase fault, textually identical to <see cref="StartFault"/>.</summary>
+    private static NpgsqlException DataFault()
+    {
+        var fault = new NpgsqlException(SharedMessage, new TimeoutException());
+        CollectorFaultCopyPhase.Stamp(fault, StoreCopyPhase.Data);
+        return fault;
+    }
+
+    /// <summary>
+    /// The headline claim, and the assertion this change exists to make true: two faults whose messages
+    /// are byte-identical are told apart, by a caller and by a reader.
+    ///
+    /// <para>The unstamped pair is the control. It establishes that the two exceptions really are
+    /// indistinguishable without the stamp — so the discrimination above is coming from the phase and not
+    /// from anything incidental to how the fixtures were built. Without that control this test would pass
+    /// just as happily against two exceptions that differed for some other reason.</para>
+    /// </summary>
+    [Fact]
+    public void AStartPhaseFaultIsDistinguishableFromADataPhaseFaultWithTheSameMessage()
+    {
+        var start = StartFault();
+        var data = DataFault();
+
+        /* The premise: nothing about the exceptions themselves separates them. */
+        Assert.Equal(start.Message, data.Message);
+        Assert.Equal(start.GetType(), data.GetType());
+
+        /* Programmatically — this is the half a consumer gates on. */
+        Assert.Equal(StoreCopyPhase.Start, CollectorFaultCopyPhase.For(start));
+        Assert.Equal(StoreCopyPhase.Data, CollectorFaultCopyPhase.For(data));
+        Assert.NotEqual(CollectorFaultCopyPhase.For(start), CollectorFaultCopyPhase.For(data));
+
+        /* And in the reported text — the half an operator reads, in the app log and in collection_log. */
+        Assert.NotEqual(CollectorFaultCopyPhase.Describe(start), CollectorFaultCopyPhase.Describe(data));
+        Assert.Contains(CollectorFaultCopyPhase.StartPhaseLabel, CollectorFaultCopyPhase.Describe(start), StringComparison.Ordinal);
+        Assert.Contains(CollectorFaultCopyPhase.DataPhaseLabel, CollectorFaultCopyPhase.Describe(data), StringComparison.Ordinal);
+
+        /* Neither loses the original message, which is still the thing that says what went wrong. */
+        Assert.Contains(SharedMessage, CollectorFaultCopyPhase.Describe(start), StringComparison.Ordinal);
+        Assert.Contains(SharedMessage, CollectorFaultCopyPhase.Describe(data), StringComparison.Ordinal);
+
+        /* THE CONTROL: unstamped, the same two exceptions are indistinguishable by every route above. */
+        var unstampedStart = new NpgsqlException(SharedMessage, new TimeoutException());
+        var unstampedData = new NpgsqlException(SharedMessage, new TimeoutException());
+
+        Assert.Equal(
+            CollectorFaultCopyPhase.For(unstampedStart), CollectorFaultCopyPhase.For(unstampedData));
+        Assert.Equal(
+            CollectorFaultCopyPhase.Describe(unstampedStart), CollectorFaultCopyPhase.Describe(unstampedData));
+        Assert.Equal(SharedMessage, CollectorFaultCopyPhase.Describe(unstampedStart));
+    }
+
+    /// <summary>
+    /// The absence of a stamp is <see cref="StoreCopyPhase.Unknown"/> and must never read as
+    /// <see cref="StoreCopyPhase.Start"/>.
+    ///
+    /// <para>This is the direction that matters, because <c>Start</c> is the value that authorises
+    /// something: a consumer scoping a re-attempt to it relies on "no rows sent", and a fault whose phase
+    /// was never recorded establishes nothing of the kind. Reading total is what keeps a missing stamp —
+    /// a read-only <c>Data</c> bag, a fault from a path with no stamping arm, the post-COPY dimension
+    /// flush — costing a diagnostic rather than granting a guarantee.</para>
+    /// </summary>
+    [Fact]
+    public void AnUnstampedFaultReadsAsUnknownAndNeverAsStart()
+    {
+        Assert.Equal(StoreCopyPhase.Unknown, CollectorFaultCopyPhase.For(new InvalidOperationException()));
+        Assert.Equal(StoreCopyPhase.Unknown, CollectorFaultCopyPhase.For(null));
+
+        /* A payload of the wrong type is not a phase. */
+        var wrongType = new InvalidOperationException(SharedMessage);
+        wrongType.Data[CollectorFaultCopyPhase.DataKey] = "Start";
+        Assert.Equal(StoreCopyPhase.Unknown, CollectorFaultCopyPhase.For(wrongType));
+
+        /* Stamping Unknown records nothing rather than recording "Unknown" as a finding. */
+        var unknownStamp = new InvalidOperationException(SharedMessage);
+        CollectorFaultCopyPhase.Stamp(unknownStamp, StoreCopyPhase.Unknown);
+        Assert.Equal(StoreCopyPhase.Unknown, CollectorFaultCopyPhase.For(unknownStamp));
+
+        /* And the message of an unphased fault is returned unchanged — the same instance, so the
+           OutOfMemoryException landing pad this feeds allocates nothing on that path. */
+        var plain = new InvalidOperationException(SharedMessage);
+        Assert.Same(plain.Message, CollectorFaultCopyPhase.Describe(plain));
+        Assert.Equal(string.Empty, CollectorFaultCopyPhase.Describe(null));
+
+        /* Zero, so the default of the enum is the one that grants nothing. */
+        Assert.Equal(StoreCopyPhase.Unknown, default(StoreCopyPhase));
+    }
+
+    /// <summary>
+    /// A stamp already present is kept. The innermost frame to catch a fault is the one that knows which
+    /// phase raised it, so a wider frame must not be able to relabel a <c>Data</c> fault as <c>Start</c> —
+    /// which is the single relabel that would turn an unsafe re-attempt into an authorised one.
+    /// </summary>
+    [Fact]
+    public void AnExistingPhaseIsNotOverwrittenByAWiderFrame()
+    {
+        var fault = DataFault();
+
+        CollectorFaultCopyPhase.Stamp(fault, StoreCopyPhase.Start);
+
+        Assert.Equal(StoreCopyPhase.Data, CollectorFaultCopyPhase.For(fault));
+    }
+
+    /// <summary>
+    /// The phase rides on <see cref="Exception.Data"/> and therefore cannot change what the classifier
+    /// sees — the same reason <see cref="CollectorFaultDatabase"/> is not a wrapper either.
+    ///
+    /// <para>Load-bearing beyond tidiness: fault classification on this path keys on the exception's TYPE
+    /// and its inner chain, and so does any predicate asking whether a fault is a retryable transport
+    /// fault. Wrapping would re-route every one of those in order to improve a sentence. The phase has to
+    /// be an INDEPENDENT axis, so that "is this a transport fault" and "was it the start phase" can be
+    /// asked of the same exception without either disturbing the other.</para>
+    /// </summary>
+    [Fact]
+    public void StampingThePhaseDoesNotChangeHowTheFaultClassifies()
+    {
+        var fault = new NpgsqlException(SharedMessage, new TimeoutException());
+        var before = PostgresTargetProvider.Instance.Classify(fault, yieldsOnLockTimeout: false);
+
+        CollectorFaultCopyPhase.Stamp(fault, StoreCopyPhase.Start);
+
+        Assert.Equal(before, PostgresTargetProvider.Instance.Classify(fault, yieldsOnLockTimeout: false));
+        Assert.Equal(CollectorTargetFault.CommandTimeout, before);
+        Assert.IsType<NpgsqlException>(fault);
+
+        /* The type, message and inner chain are all untouched, which is what the arms upstream read. */
+        Assert.Equal(SharedMessage, fault.Message);
+        Assert.IsType<TimeoutException>(fault.InnerException);
+    }
+
+    /// <summary>
+    /// The wiring, pinned in source: no pure test can reach <c>WriteBatchAsync</c>'s COPY, because it
+    /// needs a live store connection, a definition and a server runtime. What can go wrong here is which
+    /// value is live at which point, and every one of those mistakes compiles and runs.
+    ///
+    /// <para>The ordering assertion is the one that matters. <c>Start</c> must mean strictly "the importer
+    /// never came back", so the transition to <c>Data</c> has to sit INSIDE the importer block and BEFORE
+    /// the row loop: outside it, a fault that had already sent rows would be reported as the phase a
+    /// consumer treats as safe to re-attempt.</para>
+    /// </summary>
+    [Fact]
+    public void TheCopyWriteStampsTheStartPhaseUntilBeginReturns()
+    {
+        var runner = RepoFile.ReadRepoFileLf(
+            "Darling", "PerformanceMonitor.Darling.Service", "DarlingCollectorRunner.cs");
+
+        /* Start is the value in force before the COPY is opened. */
+        Assert.Matches(
+            new Regex(@"var copyPhase = StoreCopyPhase\.Start;[\s\S]{0,600}?BeginBinaryImportAsync\("),
+            runner);
+
+        /* The transition sits between Begin and the first row, and nothing sends a row before it. The
+           bounded window admits the deadline assignment and the writer hand-off, and would not admit a
+           transition moved below the loop. */
+        Assert.Matches(
+            new Regex(@"BeginBinaryImportAsync\([\s\S]{0,200}?\{\s*copyPhase = StoreCopyPhase\.Data;"),
+            runner);
+
+        /* Exactly one transition, and it is to Data. Two would mean a second, unreviewed opinion about
+           which phase is in force. */
+        Assert.Equal(1, Regex.Matches(runner, @"copyPhase = StoreCopyPhase\.Data;").Count);
+
+        /* The fault arm stamps whatever phase was live and rethrows BARE — no wrapping, so the type,
+           message, stack and inner chain reaching the handlers upstream are unchanged. */
+        Assert.Matches(
+            new Regex(@"catch \(Exception ex\) when \(ex is not OperationCanceledException\)\s*\{\s*"
+                      + @"CollectorFaultCopyPhase\.Stamp\(ex, copyPhase\);\s*throw;\s*\}"),
+            runner);
+
+        /* A cancelled sweep is not a COPY phase: it says the service is stopping, not which protocol
+           exchange was in flight, and it must not be readable as a recoverable start-phase stall. */
+        Assert.DoesNotContain(
+            "CollectorFaultCopyPhase.Stamp(ex, StoreCopyPhase.Start)", runner, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The reporting site, pinned in source for the same reason: the general fault arm is where a store
+    /// COPY fault actually lands, and it must name the phase in BOTH places it reports.
+    ///
+    /// <para>Which arm it lands in is not obvious and is why this is pinned rather than assumed. The store
+    /// connection is Npgsql whatever the monitored target's engine is, so a store-write fault is not a
+    /// <c>PostgresException</c> and does not reach the SQLSTATE arm, and it does not satisfy the
+    /// PostgreSQL-target timeout arm's engine term either. It falls all the way through to the general
+    /// arm, whose message was a bare <c>ex.Message</c>.</para>
+    ///
+    /// <para>Both call sites are asserted because the <c>collection_log</c> row is the instrument any
+    /// measurement of this population reads. Naming the phase only in the app log would leave the stored
+    /// rows exactly as ambiguous as they are without this change, which is the half doing the damage.</para>
+    /// </summary>
+    [Fact]
+    public void TheGeneralFaultArmNamesTheCopyPhaseInBothTheLogAndTheStoredRow()
+    {
+        var worker = RepoFile.ReadRepoFileLf(
+            "Darling", "PerformanceMonitor.Darling.Service", "DarlingWorker.cs");
+
+        /* Composed once, from the helper, inside the general arm. */
+        Assert.Equal(1, Regex.Matches(
+            worker, @"var message = CollectorFaultCopyPhase\.Describe\(ex\);").Count);
+
+        /* The app log line takes it. */
+        Assert.Matches(
+            new Regex(@"var message = CollectorFaultCopyPhase\.Describe\(ex\);[\s\S]{0,400}?"
+                      + @"=> ERROR: \{Message\}"",\s*\n\s*server\.Config\.DisplayName, collectorName, message\);"),
+            worker);
+
+        /* And so does the collection_log row this arm writes — exactly one such row. */
+        Assert.Equal(1, Regex.Matches(
+            worker,
+            @"collectorName, ""ERROR"", 0, runClock\.ElapsedMilliseconds, 0, message, fanout: null").Count);
+
+        /* Neither reverts to the bare message. These are the two expressions this arm carried before, and
+           they are what a revert would restore — a revert that compiles, runs, and reports both phases
+           identically.
+
+           BOTH detectors are anchored to this arm's own ERROR status rather than to an argument list.
+           Several arms in this method pass a bare `ex.Message` legitimately — the XE-capture-down warning
+           logs one and its SESSION_MISSING row stores one — so a bare substring would fail on a
+           neighbour and read as a defect here. */
+        Assert.Equal(0, Regex.Matches(
+            worker,
+            @"=> ERROR: \{Message\}"",\s*\n\s*server\.Config\.DisplayName, collectorName, ex\.Message\);").Count);
+        Assert.Equal(0, Regex.Matches(
+            worker,
+            @"collectorName, ""ERROR"", 0, runClock\.ElapsedMilliseconds, 0, ex\.Message, fanout: null").Count);
+    }
+
+    /// <summary>
+    /// The source comment at the COPY's deadline points at the OPEN issue for the residual it describes.
+    ///
+    /// <para>#2874 closed <c>completed</c> on 2026-09-05 having narrowed this regime rather than closed
+    /// it, and the comment recording the residual was the only tracker it had — so the closure left the
+    /// residual with no open home, which is why #3095 was filed. A reader who finds the comment first must
+    /// not be sent to a closed issue and conclude the start phase was fixed.</para>
+    /// </summary>
+    [Fact]
+    public void TheCopyDeadlineCommentPointsAtTheOpenIssueForTheStartPhase()
+    {
+        var runner = RepoFile.ReadRepoFileLf(
+            "Darling", "PerformanceMonitor.Darling.Service", "DarlingCollectorRunner.cs");
+
+        Assert.Contains("The unbounded start phase is tracked on #3095.", runner, StringComparison.Ordinal);
+        Assert.DoesNotContain("Tracked as a residual on #2874.", runner, StringComparison.Ordinal);
+    }
+}

--- a/Darling/Darling.Tests/StoreCopyPhaseTests.cs
+++ b/Darling/Darling.Tests/StoreCopyPhaseTests.cs
@@ -13,6 +13,7 @@ using PerformanceMonitor.Collectors;
 using PerformanceMonitor.Darling.Service;
 using PerformanceMonitor.Darling.Service.Targets;
 using Xunit;
+using static Darling.Tests.RepoFile;
 
 namespace Darling.Tests;
 
@@ -193,7 +194,7 @@ public class StoreCopyPhaseTests
     [Fact]
     public void TheCopyWriteStampsTheStartPhaseUntilBeginReturns()
     {
-        var runner = RepoFile.ReadRepoFileLf(
+        var runner = ReadRepoFileLf(
             "Darling", "PerformanceMonitor.Darling.Service", "DarlingCollectorRunner.cs");
 
         /* Start is the value in force before the COPY is opened. */
@@ -242,7 +243,7 @@ public class StoreCopyPhaseTests
     [Fact]
     public void TheGeneralFaultArmNamesTheCopyPhaseInBothTheLogAndTheStoredRow()
     {
-        var worker = RepoFile.ReadRepoFileLf(
+        var worker = ReadRepoFileLf(
             "Darling", "PerformanceMonitor.Darling.Service", "DarlingWorker.cs");
 
         /* Composed once, from the helper, inside the general arm. */
@@ -287,7 +288,7 @@ public class StoreCopyPhaseTests
     [Fact]
     public void TheCopyDeadlineCommentPointsAtTheOpenIssueForTheStartPhase()
     {
-        var runner = RepoFile.ReadRepoFileLf(
+        var runner = ReadRepoFileLf(
             "Darling", "PerformanceMonitor.Darling.Service", "DarlingCollectorRunner.cs");
 
         Assert.Contains("The unbounded start phase is tracked on #3095.", runner, StringComparison.Ordinal);

--- a/Darling/PerformanceMonitor.Darling.Service/CollectorFaultCopyPhase.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/CollectorFaultCopyPhase.cs
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+
+namespace PerformanceMonitor.Darling.Service;
+
+/// <summary>
+/// Which phase of a collector's binary COPY into the store a fault was raised in (#3095).
+/// </summary>
+internal enum StoreCopyPhase
+{
+    /// <summary>
+    /// No phase was recorded. Every fault on the store-write path that is not the COPY itself lands here:
+    /// the dimension flush and the transaction commit that follow the COPY (#1767), and any fault whose
+    /// stamp could not be written.
+    ///
+    /// <para>Zero, so it is what an unstamped exception reads as, and it must never be treated as
+    /// <see cref="Start"/>. A consumer asking "is a re-attempt safe" has to require <see cref="Start"/>
+    /// positively — the absence of a stamp establishes nothing about whether rows were sent.</para>
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// Raised by <c>BeginBinaryImportAsync</c> itself, which sends the <c>COPY</c> and awaits
+    /// <c>CopyInResponse</c>. The importer never returned, so no row was ever started and no byte of
+    /// payload was sent.
+    ///
+    /// <para>Two properties follow from that, and they are the reason this value exists rather than a
+    /// log-only string: a <c>COPY ... FROM STDIN</c> cannot commit without row data, so the store is
+    /// byte-identical; and <c>CollectorDeltaCalculator</c> advances its baseline inside
+    /// <c>WritePayload</c>, which runs in the row loop below, so no baseline has moved either.</para>
+    /// </summary>
+    Start = 1,
+
+    /// <summary>
+    /// Raised anywhere from the importer being returned through <c>CompleteAsync</c> — the row loop's
+    /// <c>StartRowAsync</c> / <c>Write</c> / <c>CompleteAsync</c>, which
+    /// <c>ServiceCommandDeadlines.CollectionSweepSeconds</c> bounds.
+    ///
+    /// <para>Neither of <see cref="Start"/>'s properties holds here: rows may have been sent, a fault
+    /// while the commit acknowledgment is in flight can leave the server committed, and every delta
+    /// baseline the loop reached has already advanced.</para>
+    /// </summary>
+    Data = 2,
+}
+
+/// <summary>
+/// Carries the <see cref="StoreCopyPhase"/> a collector store-write fault happened in, ON the exception,
+/// so a handler upstream can tell the two phases apart (#3095).
+///
+/// <para><b>Why this is needed at all.</b> <c>DarlingCollectorRunner.WriteBatchAsync</c> bounds the COPY's
+/// data phase with <c>ServiceCommandDeadlines.CollectionSweepSeconds</c> on
+/// <c>NpgsqlBinaryImporter.Timeout</c>, but that property does not reach <c>BeginBinaryImportAsync</c>
+/// above it: Begin awaits <c>CopyInResponse</c> under the CONNECTION's <c>CommandTimeout</c>, which Npgsql
+/// 10.0.3 exposes read-only and offers no per-call overload for, so the start phase runs on Npgsql's
+/// undocumented 30 s default. Both phases surface as <c>Exception while reading from stream</c> — an
+/// <c>NpgsqlException</c> wrapping a <c>TimeoutException</c> for a client-side deadline and an
+/// <c>IOException</c> for a lost connection, rendering as the same text either way — so neither the
+/// message nor the outermost type separates a start-phase stall from a data-phase one. The start phase is
+/// where a lock wait stalls, which makes it the phase a store-contention hypothesis predicts and the one
+/// that was structurally undetectable.</para>
+///
+/// <para><b>Why <see cref="Exception.Data"/> and not a wrapper exception.</b> The same reasoning
+/// <see cref="CollectorFaultDatabase"/> records: fault classification on this path keys on the exception's
+/// TYPE and SQLSTATE — <c>PostgresTargetProvider.Classify</c> asks whether it is a
+/// <c>PostgresException</c>, an <c>NpgsqlException</c>, or wraps a <c>TimeoutException</c>, and the
+/// reconnect decision in <c>DarlingWorker</c>'s general handler asks the same question. Wrapping would
+/// change the type every one of those checks sees and silently re-route the fault. It would also break any
+/// retry predicate that walks the inner chain for a transport fault, which is the consumer this exists to
+/// serve. <c>Data</c> rides along and alters nothing, so the phase is an INDEPENDENT axis: a caller ANDs
+/// "is this a transport fault" with "was it the start phase" and neither answer disturbs the other.</para>
+///
+/// <para><b>How a caller consumes it.</b> <see cref="For"/> returns the phase programmatically, and
+/// <see cref="Describe"/> renders it into the message an operator reads. A consumer gating a re-attempt on
+/// safety requires <c>For(ex) == StoreCopyPhase.Start</c>; <see cref="StoreCopyPhase.Unknown"/> and
+/// <see cref="StoreCopyPhase.Data"/> both decline, which is the direction that costs nothing when the
+/// stamp is missing.</para>
+///
+/// <para>Reading is total: an unstamped exception, or one whose payload is not a
+/// <see cref="StoreCopyPhase"/>, reads as <see cref="StoreCopyPhase.Unknown"/> and
+/// <see cref="Describe"/> returns the message unchanged. So every fault that is not a COPY fault behaves
+/// exactly as it does with no phase in the picture.</para>
+/// </summary>
+internal static class CollectorFaultCopyPhase
+{
+    /// <summary>The <see cref="Exception.Data"/> key. Named, so a test asserts the same identity the
+    /// producer uses rather than retyping the string and proving only its own transcription.</summary>
+    internal const string DataKey = "PerformanceMonitor.FaultedCopyPhase";
+
+    /// <summary>
+    /// How <see cref="StoreCopyPhase.Start"/> is named in a message. It states the awaited protocol
+    /// message and the consequence — no rows sent — because those are what tell the reader why this
+    /// failure is the recoverable one, and a bare phase name would not.
+    /// </summary>
+    internal const string StartPhaseLabel =
+        "COPY start phase (awaiting CopyInResponse on the connection's own CommandTimeout, no rows sent)";
+
+    /// <summary>
+    /// How <see cref="StoreCopyPhase.Data"/> is named in a message. It names the deadline that bounds it,
+    /// so the reader can tell a data-phase failure from the start phase by the budget it ran out of rather
+    /// than by inferring a phase from a duration.
+    /// </summary>
+    internal const string DataPhaseLabel =
+        "COPY data phase (rows in flight under the collection-sweep deadline)";
+
+    /// <summary>
+    /// Records <paramref name="phase"/> on <paramref name="exception"/>. Best-effort, for
+    /// <see cref="CollectorFaultDatabase.Stamp"/>'s reason: losing a phase from a diagnostic must never
+    /// turn into a second fault on the failure path.
+    ///
+    /// <para>An existing stamp is kept rather than overwritten. The innermost frame to catch a fault is the
+    /// one that knows which phase raised it, so a later, wider frame must not be able to relabel a
+    /// <see cref="StoreCopyPhase.Data"/> fault as <see cref="StoreCopyPhase.Start"/> — that is the one
+    /// direction in which a wrong answer authorises something.</para>
+    /// </summary>
+    internal static void Stamp(Exception? exception, StoreCopyPhase phase)
+    {
+        if (exception is null || phase == StoreCopyPhase.Unknown)
+        {
+            return;
+        }
+
+        try
+        {
+            if (exception.Data[DataKey] is StoreCopyPhase)
+            {
+                return;
+            }
+
+            exception.Data[DataKey] = phase;
+        }
+        catch
+        {
+            /* Intentionally empty - see the summary. A read-only or fixed-size Data bag costs the fault its
+               phase and nothing else; throwing here would replace a classified fault with an unclassified
+               one, which is the opposite of what this exists to do. */
+        }
+    }
+
+    /// <summary>
+    /// The stamped phase, or <see cref="StoreCopyPhase.Unknown"/> when the exception carries none — which
+    /// is the normal case for every fault that is not a collector store write.
+    /// </summary>
+    internal static StoreCopyPhase For(Exception? exception)
+    {
+        try
+        {
+            if (exception?.Data[DataKey] is StoreCopyPhase phase)
+            {
+                return phase;
+            }
+        }
+        catch
+        {
+            /* Same reasoning as Stamp: fall back rather than fault while reporting a fault. */
+        }
+
+        return StoreCopyPhase.Unknown;
+    }
+
+    /// <summary>
+    /// The exception's message with its COPY phase named, or the message unchanged when there is no phase
+    /// to name.
+    ///
+    /// <para>This is the half a human reads. <see cref="For"/> is the half a caller acts on, and they are
+    /// separate on purpose: a consumer deciding whether a re-attempt is safe must not have to match a
+    /// sentence, and the sentence must be free to be rewritten without breaking that consumer.</para>
+    ///
+    /// <para>The no-phase path returns the very string it was given, allocating nothing, because the
+    /// general fault handler this feeds is also the landing pad for an
+    /// <see cref="OutOfMemoryException"/>.</para>
+    /// </summary>
+    internal static string Describe(Exception? exception)
+    {
+        var message = exception?.Message ?? string.Empty;
+
+        return For(exception) switch
+        {
+            StoreCopyPhase.Start => $"{StartPhaseLabel}: {message}",
+            StoreCopyPhase.Data => $"{DataPhaseLabel}: {message}",
+            _ => message,
+        };
+    }
+}

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingCollectorRunner.cs
@@ -2456,52 +2456,87 @@ public sealed class DarlingCollectorRunner
         /* Naive-UTC storage — see PgCollectorRowWriter. */
         var storedCollectionTime = DateTime.SpecifyKind(collectionTime, DateTimeKind.Unspecified);
 
-        using (var importer = await pgConnection.BeginBinaryImportAsync(
-            PgCollectorRowWriter.CopyCommandFor(definition), cancellationToken))
+        /* #3095: which COPY phase a fault came out of, stamped onto the exception by the arm below so a
+           handler upstream can tell a start-phase failure from a data-phase one. Both render as
+           "Exception while reading from stream", so nothing about the exception itself carries this.
+
+           Start until Begin returns, and the transition sits INSIDE the block for that reason: Start has to
+           mean strictly "the importer never came back", because that is the state whose two properties a
+           consumer relies on — no row started, so a COPY ... FROM STDIN cannot have committed, and no
+           delta baseline moved, since CollectorDeltaCalculator advances inside WritePayload below. A
+           fault anywhere past this line forfeits both, so it must read as Data even where it happens to
+           have sent nothing. The unsafe mislabel is the one that would report Start for a fault that had
+           already sent rows; this ordering makes that unreachable rather than unlikely.
+
+           The dimension flush and commit after the block are deliberately left unstamped: they are not the
+           COPY, and Unknown is the honest answer for them. */
+        var copyPhase = StoreCopyPhase.Start;
+
+        try
         {
-            /* #2874: the COPY's own deadline — and a DIFFERENT property from every other site in this
-               regime. NpgsqlBinaryImporter.Timeout is a TimeSpan on the importer, not the int seconds of
-               NpgsqlCommand.CommandTimeout, and there is neither an NpgsqlCommand nor a CreateCommand here,
-               so no regex written for either command shape can see this site. Left unset it is initialised
-               from the connection's CommandTimeout, so this write — PgCollectorRowWriter.CopyCommandFor over
-               every collector, every server, every cycle — inherited the same undocumented 30 s default as
-               the rest of the regime while being invisible to every pin that closed them.
-
-               It takes the SAME constant because it is the same regime: no enclosing budget, one sweep permit
-               and one borrowed store connection held for the duration, retried on the collector's own cadence.
-
-               And it NARROWS rather than closes. Measured against Npgsql 10.0.3: this bounds StartRowAsync /
-               Write / CompleteAsync, but NOT the BeginBinaryImportAsync above it. Begin sends the COPY and
-               awaits CopyInResponse under the CONNECTION's CommandTimeout, which Npgsql exposes read-only and
-               BeginBinaryImportAsync has no overload for — so the start phase, which is where a lock wait
-               stalls, stays on 30 s. Both phases surface as "Exception while reading from stream", which is
-               why the distinction is invisible in a log. Deliberately not closed by putting CommandTimeout on
-               the shared data source's connection string: that would silently re-bound every site this sweep
-               has not reached yet. Tracked as a residual on #2874. */
-            importer.Timeout = TimeSpan.FromSeconds(ServiceCommandDeadlines.CollectionSweepSeconds);
-
-            writer.Importer = importer;
-
-            foreach (var row in rows)
+            using (var importer = await pgConnection.BeginBinaryImportAsync(
+                PgCollectorRowWriter.CopyCommandFor(definition), cancellationToken))
             {
-                await importer.StartRowAsync(cancellationToken);
+                copyPhase = StoreCopyPhase.Data;
 
-                if (definition.IncludesCollectionId)
+                /* #2874: the COPY's own deadline — and a DIFFERENT property from every other site in this
+                   regime. NpgsqlBinaryImporter.Timeout is a TimeSpan on the importer, not the int seconds of
+                   NpgsqlCommand.CommandTimeout, and there is neither an NpgsqlCommand nor a CreateCommand here,
+                   so no regex written for either command shape can see this site. Left unset it is initialised
+                   from the connection's CommandTimeout, so this write — PgCollectorRowWriter.CopyCommandFor over
+                   every collector, every server, every cycle — inherited the same undocumented 30 s default as
+                   the rest of the regime while being invisible to every pin that closed them.
+
+                   It takes the SAME constant because it is the same regime: no enclosing budget, one sweep permit
+                   and one borrowed store connection held for the duration, retried on the collector's own cadence.
+
+                   And it NARROWS rather than closes. Measured against Npgsql 10.0.3: this bounds StartRowAsync /
+                   Write / CompleteAsync, but NOT the BeginBinaryImportAsync above it. Begin sends the COPY and
+                   awaits CopyInResponse under the CONNECTION's CommandTimeout, which Npgsql exposes read-only and
+                   BeginBinaryImportAsync has no overload for — so the start phase, which is where a lock wait
+                   stalls, stays on 30 s. Both phases surface as "Exception while reading from stream", which is
+                   why the distinction is invisible in a log; the copyPhase stamp above is what separates them,
+                   and it does not bound anything. Deliberately not closed by putting CommandTimeout on the
+                   shared data source's connection string: that would silently re-bound every site this sweep
+                   has not reached yet. The unbounded start phase is tracked on #3095. */
+                importer.Timeout = TimeSpan.FromSeconds(ServiceCommandDeadlines.CollectionSweepSeconds);
+
+                writer.Importer = importer;
+
+                foreach (var row in rows)
                 {
-                    writer.Value(CollectionIdGenerator.Next());
+                    await importer.StartRowAsync(cancellationToken);
+
+                    if (definition.IncludesCollectionId)
+                    {
+                        writer.Value(CollectionIdGenerator.Next());
+                    }
+
+                    writer.Value(storedCollectionTime)
+                          .Value(server.ServerId)
+                          .Value(server.StorageName);
+
+                    writer.BeginPayload();
+                    definition.WritePayload(row, writer, context);
+                    writer.EndPayload(definition.PayloadColumns.Count);
+                    rowsWritten++;
                 }
 
-                writer.Value(storedCollectionTime)
-                      .Value(server.ServerId)
-                      .Value(server.StorageName);
-
-                writer.BeginPayload();
-                definition.WritePayload(row, writer, context);
-                writer.EndPayload(definition.PayloadColumns.Count);
-                rowsWritten++;
+                await importer.CompleteAsync(cancellationToken);
             }
+        }
+        /* Stamped, then rethrown bare: the fault keeps its own type, message and stack, so every
+           classification arm upstream — PostgresTargetProvider.Classify, the reconnect decision in
+           DarlingWorker's general handler, and any predicate walking the inner chain for a transport
+           fault — sees exactly what it sees today. The phase rides alongside as an independent axis.
 
-            await importer.CompleteAsync(cancellationToken);
+           OperationCanceledException is excluded because a stopping token is not a COPY phase: it says the
+           service is shutting down, not which protocol exchange was in flight, and a consumer must not be
+           able to read a shutdown as a recoverable start-phase stall. */
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            CollectorFaultCopyPhase.Stamp(ex, copyPhase);
+            throw;
         }
 
         if (transaction is not null)

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -6586,8 +6586,25 @@ LIMIT 1";
         }
         catch (Exception ex)
         {
+            /* #3095: the COPY phase is named when the fault carries one. This arm is where a collector's
+               binary COPY into the STORE lands — the store connection is Npgsql whatever the target's
+               engine is, so a store-write fault reaches neither the SQLSTATE arm above (it is not a
+               PostgresException) nor the PostgreSQL-target timeout arm (that one requires a PostgreSQL
+               target) — and "Exception while reading from stream" is all it said. Both COPY phases produce
+               that same string, and the start phase is the one still on the connection's undocumented 30 s
+               default, so the message could not say which deadline had been reached.
+
+               Computed once and used for BOTH the app log and the collection_log row, because the stored
+               row is the instrument any measurement of this population reads; naming the phase only in the
+               app log would leave the store's own error rows as ambiguous as they are today.
+
+               Total by construction: a fault with no phase — which is every fault that is not a COPY —
+               gets the very string it has now, with nothing allocated. That matters here specifically,
+               because this arm is also the OutOfMemoryException landing pad. */
+            var message = CollectorFaultCopyPhase.Describe(ex);
+
             _logger.LogError("  [{Server}] {Collector} => ERROR: {Message}",
-                server.Config.DisplayName, collectorName, ex.Message);
+                server.Config.DisplayName, collectorName, message);
 
             /* A dead connection poisons every collector — force a reconnect + reprobe. The Postgres arm
                matters as much as the SQL Server one and is deliberately NARROWER than "any
@@ -6625,7 +6642,7 @@ LIMIT 1";
                    Read from the stopwatch rather than from the exception, because most faults carry
                    no duration at all. */
                 await DarlingObservability.LogCollectionAsync(
-                    _postgres!, runtime, collectorName, "ERROR", 0, runClock.ElapsedMilliseconds, 0, ex.Message, fanout: null, phases: null, drain: null, fetchPhases: null, sweepPeerMaxMs: peerMaxAtDispatchMs, _logger, cancellationToken);
+                    _postgres!, runtime, collectorName, "ERROR", 0, runClock.ElapsedMilliseconds, 0, message, fanout: null, phases: null, drain: null, fetchPhases: null, sweepPeerMaxMs: peerMaxAtDispatchMs, _logger, cancellationToken);
             }
             catch
             {


### PR DESCRIPTION
A collector store-write fault raised by `BeginBinaryImportAsync` is now reported distinguishably from one raised in the COPY's data phase, both to a caller and to a reader.

`WriteBatchAsync` sets `importer.Timeout` to `ServiceCommandDeadlines.CollectionSweepSeconds`, which bounds `StartRowAsync` / `Write` / `CompleteAsync` and does not reach the `BeginBinaryImportAsync` above it: Begin sends the `COPY` and awaits `CopyInResponse` under the connection's `CommandTimeout`, which Npgsql 10.0.3 exposes read-only with no per-call overload. So the start phase runs on the undocumented 30 s default, and it is the phase where a lock wait stalls. Both phases surface as `Exception while reading from stream` — an `NpgsqlException` wrapping a `TimeoutException` for a client-side deadline and an `IOException` for a lost connection, rendering as the same text either way — so neither the message nor the outermost type separated them.

This does not bound the start phase. Npgsql 10.0.3 offers nothing to bound it with, and putting `CommandTimeout` on the shared data source's connection string would re-bound every site in the process to fix one call site, which is the defect #2874 removed rather than a fix for it.

## The mechanism, and why it is not a wrapper exception

`CollectorFaultCopyPhase.Stamp` records a `StoreCopyPhase` on `Exception.Data`, following the reasoning `CollectorFaultDatabase` already records: fault classification on this path keys on the exception's TYPE and SQLSTATE, and so does the reconnect decision in `DarlingWorker`'s general handler. Wrapping would change the type every one of those checks sees and silently re-route the fault. It would also break a retry predicate that walks the inner chain for a transport fault, which is the consumer this exists for. `Data` rides along and alters nothing, so the phase is an **independent axis**: a caller ANDs "is this a transport fault" with "was it the start phase" and neither answer disturbs the other. `StampingThePhaseDoesNotChangeHowTheFaultClassifies` asserts the classification, the type, the message and the inner chain are all unchanged by stamping.

**A caller consumes it as `CollectorFaultCopyPhase.For(ex)`, not as a string.** `Describe(ex)` is the reader's half and is deliberately separate, so a consumer deciding whether a re-attempt is safe never has to match a sentence, and the sentence stays free to be rewritten.

## The three values, and which one grants anything

`Start` means strictly that the importer never came back. Two properties follow, and they are why this is a value rather than a log string: no row was started, so a `COPY … FROM STDIN` cannot have committed — the store is byte-identical rather than probably-unchanged — and no `CollectorDeltaCalculator` baseline has moved, because that advances inside `WritePayload`, which runs in the row loop below Begin. `Data` covers the importer being returned through `CompleteAsync` and forfeits both. `Unknown` is zero and is what an unstamped fault reads as: the post-COPY dimension flush and commit, which are not the COPY, and any fault whose stamp could not be written.

**`Unknown` must never be read as `Start`**, because `Start` is the value that authorises something. The transition to `Data` therefore sits inside the importer block rather than after it, so a fault that had already sent rows cannot be labelled the phase a consumer treats as safe; `Stamp` keeps an existing phase rather than overwriting it, so a wider frame cannot relabel a `Data` fault as `Start`; and `Describe` returns the message it was given when there is no phase, allocating nothing, because the arm it feeds is also the `OutOfMemoryException` landing pad.

`OperationCanceledException` is excluded from the stamping arm. A stopping token says the service is shutting down, not which protocol exchange was in flight, and it must not be readable as a recoverable start-phase stall.

## Where the phase surfaces

`DarlingWorker`'s general fault arm, which is where a collector's COPY into the store actually lands — the store connection is Npgsql whatever the monitored target's engine is, so a store-write fault is not a `PostgresException` and does not reach the SQLSTATE arm, and it does not satisfy the PostgreSQL-target timeout arm's engine term either. The phase is composed once and used for both the app log line and the `collection_log` row, because the stored row is the instrument any measurement of this population reads; naming the phase only in the app log would leave the store's own error rows as ambiguous as they were.

**The duration-band alternative noted on the issue is not implemented, and deliberately not.** A statistical band is not a fact about a given failure, so it cannot gate a decision, and it collapses silently the moment `CollectionSweepSeconds` is set to 30.

## The stale pointer

`DarlingCollectorRunner`'s COPY-deadline comment tracked the residual as "a residual on #2874". #2874 closed `completed` on 2026-09-05 having narrowed this regime rather than closed it, which is what left the residual with no open home and is why #3095 was filed; the comment now names #3095. `TheCopyDeadlineCommentPointsAtTheOpenIssueForTheStartPhase` asserts both halves, so a reader who finds the comment first is not sent to a closed issue and left to conclude the start phase was fixed. **#2874 being closed is not evidence this was fixed.**

## Tests

`StoreCopyPhaseTests`. The headline test builds two `NpgsqlException`s with byte-identical messages and identical types, stamps one `Start` and one `Data`, and asserts they are separated both by `For` and by `Describe` — then asserts, as its control, that the same two exceptions **unstamped** are indistinguishable by every one of those routes. Without that control the test would pass just as happily against two fixtures that differed for some other reason.

The wiring is pinned in source, because no pure test reaches this COPY: it needs a live store connection, a definition and a server runtime, and what can go wrong is which value is live at which point — every one of which compiles and runs. The ordering assertion is the load-bearing one.

Red-proofed by three independent reversions, each confirmed to red the assertion that covers it and to produce a test summary:

| reversion | assertion that reds |
|---|---|
| `Stamp` made a no-op | `AStartPhaseFaultIsDistinguishableFromADataPhaseFaultWithTheSameMessage`, on `Assert.Equal(StoreCopyPhase.Start, For(start))` — expected `Start`, actual `Unknown` |
| the phase transition moved below the row loop | `TheCopyWriteStampsTheStartPhaseUntilBeginReturns` |
| `ex.Message` restored at both reporting sites | `TheGeneralFaultArmNamesTheCopyPhaseInBothTheLogAndTheStoredRow` |

`CollectionSweepCommandTimeoutTests` was re-run whole against the restructured method, since `EveryCopyWriter_SetsTheImporterDeadline` reads a bounded statement window from the `BeginBinaryImportAsync` match and the restructure moves what is in it: 34 cases, all green, and `ExpectedCopyWriterSites` is unchanged because no COPY site was added. `DocCommentHygieneTests`, `CommentFilterAdoptionTests`, `FleetIdentifierScrubTests`, `RepoFileAdoptionTests`, `CommandDeadlineScannerAdoptionTests`, `CollectorRunnerConnectionEngineTests` and `PostgresFaultOutcomeTests` were run as well, being the whole-tree guards that see a new service source or a new pin — 170 cases green in total, on macOS through a `net10.0` console harness compiling the shipped test sources unchanged.

`StoreCopyPhaseTests` is registered in `RepoFileAdoptionTests.s_lfReaders`. Its anchors span line breaks, so it takes the LF-normalising reader; the adoption scan reads the unqualified call form, so a qualified call would have left an LF-reading pin outside the set that guards it.

## Relationship to #3099

#3099's first implementation was withdrawn by its own author because a re-attempt after a body-phase fault writes zeros for every delta column. The start phase is upstream of all of that, so a re-attempt scoped to `For(ex) == StoreCopyPhase.Start` is safe against both that defect and the at-least-once duplicate window. **This change implements no retry** — it makes the phase available so #3099 can decide, and it is also the only thing that decomposes that issue's single-message failure population at all.

## CHANGELOG

For the `[Unreleased]` / `Fixed` block, plus a `[#3095]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/3095` link reference:

- **A COPY start-phase store-write failure is now distinguishable from a data-phase one, by a caller and not only in a log** ([#3095]) - `DarlingCollectorRunner.WriteBatchAsync` sets `importer.Timeout` to `ServiceCommandDeadlines.CollectionSweepSeconds`, which bounds `StartRowAsync` / `Write` / `CompleteAsync` and does not reach the `BeginBinaryImportAsync` above it: Begin awaits `CopyInResponse` under the connection's `CommandTimeout`, which Npgsql 10.0.3 exposes read-only with no per-call overload, so the start phase runs on the undocumented 30 s default and it is where a lock wait stalls. **Both phases surface as `Exception while reading from stream`** - an `NpgsqlException` wrapping a `TimeoutException` for a client-side deadline and an `IOException` for a lost connection, rendering as the same text either way - so neither the message nor the outermost type separated them, and any analysis of collector store-write errors had a validity limit it could not see. `CollectorFaultCopyPhase` now stamps a `StoreCopyPhase` onto `Exception.Data` rather than wrapping, for the reason `CollectorFaultDatabase` records: classification on this path keys on the exception's TYPE and SQLSTATE, so wrapping would re-route every arm - and it would break a predicate walking the inner chain for a transport fault, which is the consumer this exists for. The phase is an **independent axis**, so a caller ANDs "transport fault" with "start phase" and neither answer disturbs the other. **`Start` means strictly that the importer never came back**, which is what makes it the safe population: no row was started, so a `COPY … FROM STDIN` cannot have committed, and no `CollectorDeltaCalculator` baseline moved, since that advances inside `WritePayload` in the row loop below Begin. `Unknown` is zero and covers the post-COPY dimension flush and any unwritten stamp; it must never read as `Start`, so the transition to `Data` sits INSIDE the importer block, `Stamp` keeps an existing phase rather than overwriting it, and `OperationCanceledException` is excluded because a stopping token is not a COPY phase. `DarlingWorker`'s general fault arm - where a store COPY fault actually lands, being neither a `PostgresException` nor a PostgreSQL-target fault - now names the phase in the app log **and** in the `collection_log` row, the stored row being the instrument any measurement of this population reads. **The duration-band alternative is deliberately not implemented**: a statistical band is not a fact about a given failure and it collapses silently if `CollectionSweepSeconds` is ever set to 30. The COPY-deadline comment's pointer moves from #2874 - closed `completed` on 2026-09-05 having narrowed this regime rather than closed it - to #3095, so a reader finding the comment first is not sent to a closed issue.

## Out of scope, reported rather than fixed

Three other `BeginBinaryImportAsync` sites carry the identical structural residual and are not touched here: `Targets/RdsPlanIngestor.cs:178`, `Targets/RdsCpuIngestor.cs:259` and `Targets/RdsDeadlockIngestor.cs:186`. They are the RDS ingestors rather than the collector store write, they do not report through `RunOneAsync`'s general arm, and #3095's scope note is explicit that the issue is the collector COPY and its log ambiguity.

A separate pre-existing mis-attribution, found while establishing which arm a store fault lands in: for a server whose monitored target is **PostgreSQL**, a store-write timeout satisfies the PostgreSQL-target timeout arm's engine term and is described by `PostgresTimeoutExplanation` as a target read deadline, naming a monitored database that had nothing to do with it. Independent of this change and not fixed here.

Fixes #3095
