### PR TITLE
Reject the refresh watch line's 480 s alternative on an ordering, not a tally

### DIFF
--- a/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
+++ b/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
@@ -89,6 +89,9 @@ public sealed class RefreshCeilingProvenancePinTests
     private const string CompressionMinutesDeclaration =
         "public static readonly IReadOnlyList<int> CompressionPhaseMinutes";
 
+    private const string WarningLineDeclaration =
+        "public const int RefreshSlotWarningSeconds";
+
     private static int Ceiling => TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds;
 
     private static int Slot => TimescaleSupport.RefreshPhaseSlotSeconds;
@@ -101,10 +104,12 @@ public sealed class RefreshCeilingProvenancePinTests
     /// The pinned sentences, and the ONLY place a pattern is written down — <see cref="Verify"/> looks them up
     /// by name, so the sweep and the assertions cannot end up testing different regexes.
     ///
-    /// <para>Two members carry figures derived from the ceiling: the constant itself, and
-    /// <see cref="TimescaleSupport.CompressionPhaseMinutes"/>, whose exclude-whole reasoning quotes it in
-    /// MINUTES. Each pattern names the doc run it is read out of, so none of them can match a similar
-    /// sentence elsewhere in a four-thousand-line file.</para>
+    /// <para>The runs pinned here are the ones stating figures derived from the ceiling or from the grid
+    /// step it is sized against, wherever they live. Which run a pin reads is carried in its own
+    /// <c>Declaration</c> and its pattern names words from that run, so none of them can match a similar
+    /// sentence elsewhere in a four-thousand-line file. That set is deliberately NOT enumerated here:
+    /// <see cref="Pins"/> is the enumeration, a prose copy of it would be a frozen list beside a growing
+    /// one, and this file exists to stop exactly that.</para>
     ///
     /// <para><b>ASCII-only patterns on purpose, and the reason is <see cref="DocProseFor"/> rather than
     /// anything in the patterns themselves.</b> It normalises <c>—</c> and <c>–</c> to <c>-</c>
@@ -217,6 +222,25 @@ public sealed class RefreshCeilingProvenancePinTests
             "the minutes left on the table",
             CompressionMinutesDeclaration,
             @"The other ([0-9]+) minutes of the slot are past the refresh",
+            true);
+
+        /* The watch line's REJECTED alternative. The figure is derived arithmetic - the slot less one guard
+           band - so it is pinned to that arithmetic here, and the PATTERN spans the ordering words the
+           prose rejects it on, so a rejection restated as a tally of readings is a parse miss rather than
+           a silent pass. Whether that ordering still HOLDS is asserted against the constants and the
+           shipped classifier in TimescaleSupportTests, where it is reachable: Verify is a fail-fast chain
+           and a constant moved far enough to flip the ordering trips an earlier clause first, so a copy of
+           the comparison here would be a pin that cannot fail.
+
+           An ordering rather than a share of the readings, and that is the pin's whole point (#3107). A
+           share of a population is not a stable reason for a threshold: it changes as the population grows
+           without the threshold or the decision changing at all, so a pin on it would go red for a reason
+           that is not a defect - and a pin on it going GREEN says nothing about whether the decision still
+           holds. The ordering has neither property. */
+        yield return (
+            "the rejected alternative watch line",
+            WarningLineDeclaration,
+            @"<see cref=""CompressionPhaseGuardMinutes""/> band, ([0-9]+) s, and it sits BELOW <see cref=""HeaviestHourlyRefreshObservedCeilingSeconds""/>",
             true);
 
         yield return (
@@ -609,6 +633,16 @@ public sealed class RefreshCeilingProvenancePinTests
             $"stated population size {deferred[0]} against {population.Length} listed");
         Require(deferred[1] == min, $"stated low {deferred[1]} s against {min} s listed");
         Require(deferred[2] == max, $"stated high {deferred[2]} s against {max} s listed");
+
+        /* THE REJECTED ALTERNATIVE watch line, held to the arithmetic the prose derives it as. Slot less one
+           guard band, in seconds, so a moved grid step moves it and the sentence cannot keep quoting a
+           figure the grid no longer produces. */
+        var alternative = Read("the rejected alternative watch line");
+        var derivedAlternative = Slot - TimescaleSupport.CompressionPhaseGuardMinutes * 60;
+        Require(alternative[0] == derivedAlternative,
+            $"the rejected alternative is stated as {alternative[0]} s against {derivedAlternative} s derived "
+            + $"from the {Slot} s slot less one {TimescaleSupport.CompressionPhaseGuardMinutes}-minute guard "
+            + "band");
 
         /* And nothing in the pin list went unused: a pattern that is never asserted against reads, from the
            list, exactly like one that is. */

--- a/Darling/Darling.Tests/TimescaleSupportTests.cs
+++ b/Darling/Darling.Tests/TimescaleSupportTests.cs
@@ -2528,6 +2528,77 @@ LIMIT 1", connection))
     }
 
     /// <summary>
+    /// The reason <see cref="TimescaleSupport.RefreshSlotWarningSeconds"/> rejects the lower alternative its
+    /// doc comment names: slot less one <see cref="TimescaleSupport.CompressionPhaseGuardMinutes"/> band
+    /// sits BELOW <see cref="TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds"/>, where the
+    /// chosen line sits above it (#3107).
+    ///
+    /// <para><b>What the rejection claims is a difference in VERDICT, and it is asserted in the two halves
+    /// that difference actually has.</b> The line is a compile-time constant, so the classifier cannot be
+    /// re-run against the alternative and nothing here pretends to: what is checked is the RULE
+    /// (<see cref="TimescaleSupport.ClassifyRefreshSlotHeadroom"/> warns at or past its line and not one
+    /// second below it) and the INEQUALITY (the recorded ceiling is at or past the alternative, and below
+    /// the chosen line). Together those two say the ceiling warns under the alternative and does not under
+    /// the chosen line, which is the whole of the difference.</para>
+    ///
+    /// <para><b>An ordering, deliberately, and not a share of the readings.</b> How large a fraction of any
+    /// quoted population a threshold would fire on moves as that population grows while the threshold and
+    /// the decision behind it stand still, so it cannot be pinned in a way that goes red only on a defect.
+    /// The ordering against the recorded ceiling moves only when one of the two constants moves, and then
+    /// the decision genuinely does have to be re-taken.</para>
+    ///
+    /// <para>The lead-time leg cuts the OTHER way and is asserted in that direction, because a reader
+    /// checking the rejection is owed the fact that it does not help: the lower line leaves MORE room
+    /// between itself and the slot, so it warns earlier rather than later.</para>
+    /// </summary>
+    [Fact]
+    public void TheRejectedWatchLineAlternative_SitsBelowTheRecordedCeiling_WhileTheChosenLineSitsAbove()
+    {
+        /* Derived as the prose derives it, then held to the literal too — a re-derivation-only assertion
+           agrees with any derivation, including one frozen at 480. */
+        var alternative =
+            TimescaleSupport.RefreshPhaseSlotSeconds - (TimescaleSupport.CompressionPhaseGuardMinutes * 60);
+        Assert.Equal(480, alternative);
+        Assert.True(
+            alternative < TimescaleSupport.RefreshSlotWarningSeconds,
+            "the alternative is no longer the LOWER of the two lines, so the paragraph rejecting it as too "
+            + "low is about something else now");
+
+        /* THE REJECTION, as the verdicts it produces. The figure the compression grid is sized against is
+           routine under the chosen line and a warning under the alternative: a line that warns on the load
+           the grid is built to absorb is the crying-wolf failure the five-sixths choice exists to avoid. */
+        var ceiling = TimescaleSupport.HeaviestHourlyRefreshObservedCeilingSeconds;
+        Assert.Equal(
+            TimescaleSupport.RefreshSlotHeadroom.InsideSlot,
+            TimescaleSupport.ClassifyRefreshSlotHeadroom(ceiling));
+        Assert.True(
+            ceiling >= alternative,
+            $"the {alternative} s alternative no longer sits below the {ceiling} s recorded ceiling, so the "
+            + "doc comment's sole stated reason for rejecting it is false — re-take the five-sixths decision "
+            + "(#3044, #3107) rather than editing this assertion");
+        Assert.True(
+            ceiling < TimescaleSupport.RefreshSlotWarningSeconds,
+            $"the chosen {TimescaleSupport.RefreshSlotWarningSeconds} s line no longer sits above the "
+            + $"{ceiling} s recorded ceiling, so it rejects the alternative on a property it has itself "
+            + "stopped having");
+
+        /* The rule the two inequalities above are read through: at or past the line warns, one second
+           below it does not. Without this the ordering would be arithmetic with no stated consequence. */
+        Assert.Equal(
+            TimescaleSupport.RefreshSlotHeadroom.ApproachingSlot,
+            TimescaleSupport.ClassifyRefreshSlotHeadroom(TimescaleSupport.RefreshSlotWarningSeconds));
+        Assert.Equal(
+            TimescaleSupport.RefreshSlotHeadroom.InsideSlot,
+            TimescaleSupport.ClassifyRefreshSlotHeadroom(TimescaleSupport.RefreshSlotWarningSeconds - 1));
+
+        /* And the lead time each line leaves, as the two figures rather than as the inequality between them
+           — which is the same inequality asserted above and would add nothing on its own. The lower line
+           leaves the larger margin, so lead time argues FOR it and cannot be part of its rejection. */
+        Assert.Equal(420, TimescaleSupport.RefreshPhaseSlotSeconds - alternative);
+        Assert.Equal(150, TimescaleSupport.RefreshPhaseSlotSeconds - TimescaleSupport.RefreshSlotWarningSeconds);
+    }
+
+    /// <summary>
     /// The reading carries the derived answers, so a caller cannot log the seconds and drop the verdict — and
     /// the headroom goes NEGATIVE past the wall rather than clamping, because how far through the wall a run
     /// went is what sizes the re-derivation.

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -1921,9 +1921,16 @@ WITH NO DATA";
     /// time: the remaining sixth is 150 s here, while the walk that carries this job through the hour advances
     /// by its own runtime each cycle (see the finish-to-start note on
     /// <see cref="SetCompressionSchedulePhaseSql"/>), so the warning lands while the job still finishes inside
-    /// its slot and the grid's stated precondition is still TRUE. A tempting alternative — slot less one
-    /// <see cref="CompressionPhaseGuardMinutes"/> band, 480 s — was rejected on those same readings: it would
-    /// have fired on three of the five.</para>
+    /// its slot and the grid's stated precondition is still TRUE. The alternative that tempts here is the
+    /// slot less one <see cref="CompressionPhaseGuardMinutes"/> band, 480 s, and it sits BELOW
+    /// <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/>: it would warn on the very run the
+    /// compression grid is sized against, and that ORDERING is the whole of its rejection. It is stated as
+    /// an ordering rather than as a share of the readings because a share is not stable: the same 480 s line
+    /// covers a different fraction of every population it is held against, and the populations here grow,
+    /// while its position against the recorded ceiling moves only when one of those two constants does and
+    /// is pinned on that relationship rather than on either figure. Lead time does NOT rule the lower line
+    /// out and is not offered as if it did: a line further below the slot warns EARLIER, so the comparison
+    /// against the ceiling has to carry the decision on its own.</para>
     ///
     /// <para><b>This line sits ABOVE <see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/>, and that is
     /// what makes a crossing mean something.</b> 750 s is <b>26% above</b> the largest run the narrowed


### PR DESCRIPTION
Fixes #3107

`RefreshSlotWarningSeconds`' doc comment rejected the 480 s alternative on a count of the five readings quoted a sentence earlier, and that count was the only stated reason. The count is wrong: at or above 480 s the five readings (335, 594, 465, 359, 293) contain **594 alone — one of five, not three**. 465 is the near miss at 15 s below the line; the other three sit 121-187 s below it.

## What the paragraph says now

The rejection is stated as an **ordering** rather than as a share of the readings: 480 s sits below `HeaviestHourlyRefreshObservedCeilingSeconds`, so it would warn on the very run the compression grid is sized against. That is a comparison between two constants — one derived (slot less one `CompressionPhaseGuardMinutes` band), one recorded — and it does not move when the population it was once counted over grows.

Correcting the numeral was the other option and is deliberately not what this does. A share is not a stable reason for a threshold: it changes as the population grows while the threshold and the decision behind it stand still, so a pin on it would go red for something that is not a defect, and its going green would say nothing about whether the decision still holds. The ordering has neither property. The same 480 s line reads as one of five against the readings in that paragraph and three of sixteen against the population `HeaviestHourlyRefreshObservedCeilingSeconds` publishes; neither number is in the comment.

The paragraph also now says out loud that **lead time cuts the other way** and is not offered as if it did not: a line further below the slot warns earlier, leaving 420 s of slot ahead of it against the chosen line's 150 s. So the ordering has to carry the rejection on its own, which it does.

Untouched: the five readings, the 32.6-66.0% band, the 83.3% line, the 150 s remaining sixth, and the next paragraph's 26%-above-the-ceiling property. Each was recomputed and each holds.

## Pins

`RefreshCeilingProvenancePinTests` gains a pin on a third doc run (`RefreshSlotWarningSeconds`). Its pattern spans the ordering words, not just the figure, so a rejection restated as a tally of readings is a parse miss rather than a silent pass — the earlier form of this sentence would have failed it. The figure itself is held to `RefreshPhaseSlotSeconds` less one `CompressionPhaseGuardMinutes` band, so a moved grid step moves it. The pattern needs no dash of any kind, which is what the class's ASCII-only claim rests on.

`TimescaleSupportTests` gains `TheRejectedWatchLineAlternative_SitsBelowTheRecordedCeiling_WhileTheChosenLineSitsAbove`, which holds the ordering itself: the alternative derived and pinned to its literal, the recorded ceiling at or past the alternative and below the chosen line, and the rule those are read through asserted against the shipped `ClassifyRefreshSlotHeadroom` — warns at its line, does not one second below. The line is a compile-time constant so the classifier cannot be re-run against the alternative, and nothing here pretends to; the claim is made in the two halves it actually has.

The ordering is asserted there rather than in `Verify`, because `Verify` is a fail-fast chain: any constant moved far enough to flip the ordering trips an earlier clause first, so a copy of the comparison there would be a pin that cannot fail.

`Pins()`' summary no longer says how many members carry ceiling-derived figures, and no longer enumerates them either — `Pins()` is the enumeration, and a prose copy of a growing list is the defect this file exists to catch.

## Verification

`Darling.Tests` targets `net10.0-windows` and cannot run on macOS, so the real `.cs` files were compiled into a `net10.0` console harness behind a minimal xUnit shim — `RefreshCeilingProvenancePinTests`, `DocCommentHygieneTests` and `FleetIdentifierScrubTests` whole, and the three `#3044`-region methods brace-matched verbatim out of `TimescaleSupportTests.cs`. 35 tests, all green. `DocCommentHygieneTests` matters here specifically: this is the first pinned pattern in the tree to carry `<see cref=...>` inside a string literal, and `ADocCommentInsideAStringLiteralIsNotPartOfThePopulation` and `EveryCrefTargetResolvesOrIsBounded` both confirm the cref sweep does not read it.

Red-first, three mutations, each restored:

- prose states 481 s against the derived 480 s → `EveryDerivationClaim_FollowsFromTheConstantsAndThePublishedPopulation` fails on the comparison
- the tally-shaped rejection returns → parse miss, and `EveryNumericPin_ReportsAnInjectedDrift` reports the pin vacuous
- recorded ceiling drops to 470, below the alternative → the new test fails naming the alternative, the ceiling and the decision to re-take

## CHANGELOG entry text

Not edited here, since every lane appends to the same `[Unreleased]` block. Proposed, under Fixed:

- `RefreshSlotWarningSeconds`' doc comment rejected the 480 s alternative on a miscount of the readings quoted beside it. The rejection is now an ordering against the recorded refresh ceiling, which does not move as that population grows, and is pinned as a relationship in both the doc-prose sweep and the classifier tests (#3107).
