### PR TITLE
Bound pg_index_bloat by what pgstatindex is applied to, not by a join qual

### DIFF
--- a/Darling/Darling.Tests/PgIndexBloatBudgetLivePostgresTests.cs
+++ b/Darling/Darling.Tests/PgIndexBloatBudgetLivePostgresTests.cs
@@ -78,27 +78,34 @@ public sealed class PgIndexBloatBudgetLivePostgresTests
         await using var connection = new NpgsqlConnection(connectionString);
         await connection.OpenAsync(ct);
 
-        /* pgstattuple is contrib and ships with the bundled runtime, so this is expected to succeed. A rig
-           without it is a rig limitation rather than a product defect, hence skip rather than fail — but
-           the reason is stated, because a silently-skipped execution test is the thing this test exists to
-           object to. */
-        var pgstattupleAvailable = true;
-        try
+        /* pgstattuple is contrib and ships with the bundled runtime. SCHEMA public is not decoration: the
+           store's search_path is "collect, config, public", so a bare CREATE EXTENSION installs the
+           extension into collect, and the collector - which qualifies the function public.pgstatindex on
+           purpose - then fails with 42883 while the extension is, by every other measure, installed. That
+           schema is the product's real precondition, so this establishes it rather than working around it. */
+        await TryExecuteAsync(connection, "CREATE EXTENSION IF NOT EXISTS pgstattuple SCHEMA public", ct);
+
+        /* IF NOT EXISTS makes the SCHEMA clause a no-op against a store that already installed it
+           elsewhere, so the placement is repaired rather than assumed. */
+        if (!await PgstatindexResolvesInPublicAsync(connection, ct))
         {
-            await ExecuteAsync(connection, "CREATE EXTENSION IF NOT EXISTS pgstattuple", ct);
-        }
-        catch (PostgresException)
-        {
-            pgstattupleAvailable = false;
+            await TryExecuteAsync(connection, "ALTER EXTENSION pgstattuple SET SCHEMA public", ct);
         }
 
-        Assert.SkipWhen(!pgstattupleAvailable,
-            "pgstattuple is not installable on this rig, so pgstatindex cannot be invoked at all.");
+        /* The precondition is asserted as the FUNCTION being callable where the collector calls it, never
+           as CREATE EXTENSION having returned without error. Those two came apart on the first CI run of
+           this test - the create succeeded and the function was unreachable - which is why this reads the
+           catalog instead of trusting the DDL. A rig that still cannot offer it is a rig limitation and
+           skips with that reason stated. */
+        Assert.SkipWhen(
+            !await PgstatindexResolvesInPublicAsync(connection, ct),
+            "public.pgstatindex is not callable on this rig, so the collector's query cannot run at all.");
 
         /* The SHIPPED string, from the collector the service dispatches - not a copy of it. Literals,
            shape and all. */
         var sql = PgIndexBloatCollector.Instance.BuildQuery(MakeContext()).Text;
 
+        var bodySucceeded = false;
         try
         {
             await ExecuteAsync(connection, $"DROP SCHEMA IF EXISTS {ProbeSchema} CASCADE", ct);
@@ -147,12 +154,18 @@ public sealed class PgIndexBloatBudgetLivePostgresTests
             var loops = await ReadPgstatindexLoopsAsync(connection, sql, ct);
 
             Assert.Equal(counts.Measured, loops);
+
+            bodySucceeded = true;
         }
         finally
         {
-            await using var cleanup = new NpgsqlConnection(connectionString);
-            await cleanup.OpenAsync(CancellationToken.None);
-            await ExecuteAsync(cleanup, $"DROP SCHEMA IF EXISTS {ProbeSchema} CASCADE", CancellationToken.None);
+            /* #1902: teardown goes through the shared helper, on its own connection and its own lifetime.
+               Opening one by hand leaves the throw-from-finally that replaces the body's exception, which
+               is how a real failure gets reported as cleanup noise. */
+            await LiveStoreCleanup.RunAsync(connectionString!, bodySucceeded, async (cleanup, cleanupCt) =>
+            {
+                await ExecuteAsync(cleanup, $"DROP SCHEMA IF EXISTS {ProbeSchema} CASCADE", cleanupCt);
+            });
         }
     }
 
@@ -231,6 +244,44 @@ public sealed class PgIndexBloatBudgetLivePostgresTests
     {
         await using var command = new NpgsqlCommand(sql, connection);
         await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Whether the collector's own qualified call target exists. Overloads are not distinguished — any
+    /// <c>pgstatindex</c> in <c>public</c> means the extension is where the query expects it.
+    /// </summary>
+    private static async Task<bool> PgstatindexResolvesInPublicAsync(
+        NpgsqlConnection connection, CancellationToken cancellationToken)
+    {
+        await using var command = new NpgsqlCommand(
+            """
+            SELECT count(*)::int                AS overloads
+            FROM pg_catalog.pg_proc AS p
+            JOIN pg_catalog.pg_namespace AS n
+              ON n.oid = p.pronamespace
+            WHERE n.nspname = 'public'
+            AND   p.proname = 'pgstatindex'
+            """,
+            connection);
+
+        return (int)(await command.ExecuteScalarAsync(cancellationToken))! > 0;
+    }
+
+    /// <summary>
+    /// Runs a precondition statement whose success is verified by the catalog rather than by its own
+    /// return, so a failure here is not the finding — an unreachable function is, and it is checked
+    /// directly.
+    /// </summary>
+    private static async Task TryExecuteAsync(
+        NpgsqlConnection connection, string sql, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await ExecuteAsync(connection, sql, cancellationToken);
+        }
+        catch (PostgresException)
+        {
+        }
     }
 
     private static CollectorContext MakeContext() => new()

--- a/Darling/Darling.Tests/PgIndexBloatBudgetLivePostgresTests.cs
+++ b/Darling/Darling.Tests/PgIndexBloatBudgetLivePostgresTests.cs
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+using PerformanceMonitor.Collectors;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// <c>pg_index_bloat</c>'s work budget bounds what the statement READS, measured by running the shipped
+/// query against a live PostgreSQL and counting how many times <c>pgstatindex</c> was actually invoked.
+///
+/// <para><b>Why this test executes instead of asserting on query text.</b> The budget has been introduced
+/// twice — a count (#2617) and a byte figure (#2997) — and both shipped as a further qual on a
+/// <c>LEFT JOIN LATERAL</c> to the function. Both were pinned by <c>Assert.Contains</c>-style checks that
+/// found the qual and passed. Neither bounded anything: the planner cannot skip an inner side it has not
+/// evaluated, so the function ran once per candidate row and the qual only decided whether its answer was
+/// kept. The output was correct every time — right row count, right <c>skipped_reason</c> on every skipped
+/// index — while the statement read every b-tree index on the instance and died on its deadline having
+/// reported nothing. <b>No assertion on the text of the query can tell those two apart</b>, because the
+/// broken one and the fixed one differ in what the executor does, not in what the SQL says.</para>
+///
+/// <para><b>Why it lives in Darling.Tests.</b> Darling is what runs this collector in production —
+/// <c>DarlingWorker</c> registers <c>pg_index_bloat</c> against
+/// <see cref="PgIndexBloatCollector.Instance"/> — and the target where the collector has never returned a
+/// row is a Darling target. This suite is also the only one with a live PostgreSQL to execute against.</para>
+///
+/// <para><b>The invariant, and why it cannot pass vacuously.</b> Three numbers are read out of the shipped
+/// query itself rather than written here: <c>C</c>, the candidate rows it returns; <c>M</c>, those it
+/// reports as measured; and <c>L</c>, the <c>Actual Loops</c> on the <c>pgstatindex</c> function-scan node
+/// of its own <c>EXPLAIN ANALYZE</c>. The test asserts <c>L == M</c> — the function was invoked only for
+/// the indexes the budget admitted — and <c>M &lt; C</c>, which is what makes the first assertion
+/// meaningful: on a database where everything fits the budget, <c>L == M == C</c> holds under the broken
+/// shape too. Measured both ways on PostgreSQL 17.11 with 215 candidates against the 200-index count
+/// bound: the ON-clause form gives <c>C=215, M=200, L=215</c>, this one <c>C=215, M=200, L=200</c>.</para>
+///
+/// <para>Nothing about the query is rewritten for the test — not the literals, not the shape. The count
+/// bound is the one made to bind, because pushing the candidate set past 200 costs a few hundred empty
+/// indexes while pushing it past the byte budget would cost gigabytes. The two bounds are enforced by the
+/// same <c>WHERE</c> on the same relation, so exercising either exercises the mechanism.</para>
+///
+/// <para>Creates its own schema and drops it, so it leaves nothing for the fixture's residue diff — which
+/// watches <c>collect</c> and would not see this schema anyway.</para>
+/// </summary>
+[Collection("live-postgres")]
+public sealed class PgIndexBloatBudgetLivePostgresTests
+{
+    /// <summary>
+    /// Enough throwaway b-tree indexes to carry the candidate set past the collector's 200-index count
+    /// bound on its own, without depending on how many indexes the live store happens to contain. They are
+    /// built on a tiny table so each is a page or two and <c>pgstatindex</c> over the admitted 200 is
+    /// trivial work.
+    /// </summary>
+    private const int ProbeIndexCount = 210;
+
+    private const string ProbeSchema = "darling_test_pg_index_bloat_budget";
+
+    [Fact]
+    public async Task TheWorkBudgetBoundsWhatIsRead_NotOnlyWhatIsReported_AgainstLivePostgres()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the pg_index_bloat work-budget test.");
+
+        var ct = TestContext.Current.CancellationToken;
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(ct);
+
+        /* pgstattuple is contrib and ships with the bundled runtime, so this is expected to succeed. A rig
+           without it is a rig limitation rather than a product defect, hence skip rather than fail — but
+           the reason is stated, because a silently-skipped execution test is the thing this test exists to
+           object to. */
+        var pgstattupleAvailable = true;
+        try
+        {
+            await ExecuteAsync(connection, "CREATE EXTENSION IF NOT EXISTS pgstattuple", ct);
+        }
+        catch (PostgresException)
+        {
+            pgstattupleAvailable = false;
+        }
+
+        Assert.SkipWhen(!pgstattupleAvailable,
+            "pgstattuple is not installable on this rig, so pgstatindex cannot be invoked at all.");
+
+        /* The SHIPPED string, from the collector the service dispatches - not a copy of it. Literals,
+           shape and all. */
+        var sql = PgIndexBloatCollector.Instance.BuildQuery(MakeContext()).Text;
+
+        try
+        {
+            await ExecuteAsync(connection, $"DROP SCHEMA IF EXISTS {ProbeSchema} CASCADE", ct);
+            await ExecuteAsync(connection, $"CREATE SCHEMA {ProbeSchema}", ct);
+            await ExecuteAsync(
+                connection,
+                $"CREATE TABLE {ProbeSchema}.candidates AS SELECT g AS id FROM generate_series(1, 200) AS g",
+                ct);
+
+            /* Distinct expression indexes rather than distinct columns, so one narrow table carries all of
+               them. */
+            await ExecuteAsync(
+                connection,
+                $"""
+                 DO $$
+                 BEGIN
+                     FOR n IN 1..{ProbeIndexCount.ToString(CultureInfo.InvariantCulture)} LOOP
+                         EXECUTE format(
+                             'CREATE INDEX ix_probe_%s ON {ProbeSchema}.candidates ((id + %s))',
+                             lpad(n::text, 4, '0'), n);
+                     END LOOP;
+                 END $$
+                 """,
+                ct);
+
+            /* C and M come from the query's own output. M is counted by skipped_reason rather than by a
+               measurement column: the CASE arms are the exact complement of the gate, so a NULL reason IS
+               "this index was admitted", and it stays correct however pgstatindex renders an odd index
+               (an empty one reports avg_leaf_density as NaN, which is not NULL and would count either
+               way). */
+            var counts = await ReadCountsAsync(connection, sql, ct);
+
+            Assert.True(
+                counts.Candidates > counts.Measured,
+                $"the probe left every one of {counts.Candidates} candidates inside the budget, so this run "
+                + "cannot tell a budget that bounds reads from one that only labels rows - L == M == C holds "
+                + "either way. Raise ProbeIndexCount above the collector's count bound");
+
+            /* Every admitted index must have come back WITH a measurement. A gate that filters the
+               function's input rather than its output can drop an admitted row if the join back is wrong,
+               and that row would arrive carrying neither a measurement nor a reason - reported, and
+               silently blank. */
+            Assert.Equal(0, counts.AdmittedButUnmeasured);
+
+            /* And L: how many times the executor actually entered pgstatindex. This is the whole test. */
+            var loops = await ReadPgstatindexLoopsAsync(connection, sql, ct);
+
+            Assert.Equal(counts.Measured, loops);
+        }
+        finally
+        {
+            await using var cleanup = new NpgsqlConnection(connectionString);
+            await cleanup.OpenAsync(CancellationToken.None);
+            await ExecuteAsync(cleanup, $"DROP SCHEMA IF EXISTS {ProbeSchema} CASCADE", CancellationToken.None);
+        }
+    }
+
+    /// <summary>
+    /// Wraps the shipped query so its own output supplies the expectations, rather than this test carrying
+    /// a second copy of the budget arithmetic that could agree with a wrong answer.
+    /// </summary>
+    private static async Task<(int Candidates, int Measured, int AdmittedButUnmeasured)> ReadCountsAsync(
+        NpgsqlConnection connection, string sql, CancellationToken cancellationToken)
+    {
+        await using var command = new NpgsqlCommand(
+            $"""
+             SELECT count(*)::int                                                              AS candidates,
+                    count(*) FILTER (WHERE q.skipped_reason IS NULL)::int                      AS measured,
+                    count(*) FILTER (WHERE q.skipped_reason IS NULL
+                                     AND q.avg_leaf_density IS NULL)::int                      AS admitted_unmeasured
+             FROM ({sql}) AS q
+             """,
+            connection);
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        Assert.True(await reader.ReadAsync(cancellationToken));
+
+        return (reader.GetInt32(0), reader.GetInt32(1), reader.GetInt32(2));
+    }
+
+    /// <summary>
+    /// <c>Actual Loops</c> on the <c>pgstatindex</c> function-scan node, which is the executor's own count
+    /// of how many times it entered the function. JSON rather than the text plan because the number is
+    /// being asserted on: a regex over indented plan text is one formatting change away from matching the
+    /// wrong node, or nothing.
+    /// </summary>
+    private static async Task<int> ReadPgstatindexLoopsAsync(
+        NpgsqlConnection connection, string sql, CancellationToken cancellationToken)
+    {
+        await using var command = new NpgsqlCommand(
+            $"EXPLAIN (ANALYZE, FORMAT JSON, TIMING OFF, COSTS OFF, SUMMARY OFF)\n{sql}",
+            connection);
+
+        var planJson = (string?)await command.ExecuteScalarAsync(cancellationToken);
+        Assert.False(string.IsNullOrEmpty(planJson));
+
+        using var document = JsonDocument.Parse(planJson!);
+        var loops = FunctionScanLoops(document.RootElement[0].GetProperty("Plan"), "pgstatindex").ToArray();
+
+        /* Exactly one such node: the query calls the function once, in one place. Two would mean the
+           measurement below is describing only part of the work. */
+        Assert.Single(loops);
+
+        return loops[0];
+    }
+
+    private static System.Collections.Generic.IEnumerable<int> FunctionScanLoops(
+        JsonElement node, string functionName)
+    {
+        if (node.TryGetProperty("Function Name", out var name)
+            && string.Equals(name.GetString(), functionName, StringComparison.Ordinal))
+        {
+            yield return node.GetProperty("Actual Loops").GetInt32();
+        }
+
+        if (node.TryGetProperty("Plans", out var children))
+        {
+            foreach (var child in children.EnumerateArray())
+            {
+                foreach (var loops in FunctionScanLoops(child, functionName))
+                {
+                    yield return loops;
+                }
+            }
+        }
+    }
+
+    private static async Task ExecuteAsync(
+        NpgsqlConnection connection, string sql, CancellationToken cancellationToken)
+    {
+        await using var command = new NpgsqlCommand(sql, connection);
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    private static CollectorContext MakeContext() => new()
+    {
+        ServerId = 42,
+        ServerName = "pg-target",
+        CollectionTime = new DateTime(2026, 9, 7, 12, 0, 0, DateTimeKind.Utc),
+        Deltas = NoDeltas.Instance,
+        Target = new CollectorTargetInfo
+        {
+            Engine = CollectorTargetEngine.PostgreSql,
+            PostgresMajorVersion = 17,
+        },
+        ExcludedDatabases = Array.Empty<string>(),
+    };
+
+    private sealed class NoDeltas : ICollectorDeltaCalculator
+    {
+        public static readonly NoDeltas Instance = new();
+
+        public long CalculateDelta(int serverId, string collectorName, string key, long currentValue,
+            DateTime? collectionTime = null, int maxGapSeconds = 0) => 0;
+
+        public long CalculateDeltaWithInterval(int serverId, string collectorName, string key,
+            long currentValue, out int intervalSeconds, DateTime? collectionTime = null,
+            int maxGapSeconds = 0)
+        {
+            intervalSeconds = 60;
+            return 0;
+        }
+    }
+}

--- a/Lite.Tests/PgIndexBloatCollectorDefinitionTests.cs
+++ b/Lite.Tests/PgIndexBloatCollectorDefinitionTests.cs
@@ -200,10 +200,11 @@ public class PgIndexBloatCollectorDefinitionTests
     /// The CYCLE has a work budget, not just each index (#2617).
     ///
     /// <para><b>This is the assertion that would have caught a collector which never returned a row.</b>
-    /// <c>pgstatindex</c> reads every page it is pointed at, and the 20 GB ceiling bounds one index while
-    /// nothing bounded the statement. Measured on a live Aurora target: 1,517 indexes totalling 461 GB in a
-    /// single statement, which never finished and dropped the connection mid-read — <c>rows_ever = 0</c> for
-    /// the collector's entire life. The local rig had two indexes, so the question never arose there.</para>
+    /// <c>pgstatindex</c> reads every page it is pointed at, and the per-index ceiling bounds one index
+    /// while nothing bounded the statement. Measured on a live Aurora target: 1,517 indexes totalling
+    /// 461 GB in a single statement, which never finished and dropped the connection mid-read —
+    /// <c>rows_ever = 0</c> for the collector's entire life. The local rig had two indexes, so the question
+    /// never arose there.</para>
     /// </summary>
     [Fact]
     public void TheCycleHasAWorkBudget_NotJustAPerIndexCeiling()
@@ -288,10 +289,12 @@ public class PgIndexBloatCollectorDefinitionTests
     ///
     /// <para><b>This is the assertion that would have caught eleven consecutive failures.</b> The count
     /// budget from #2617 and the 300-second override from #2618 were both in place and both pinned, and
-    /// the collector still died every single run with <c>rows = 0</c> — because 200 sub-ceiling indexes
-    /// on a real Aurora target admit 286 GB, and <c>pgstatindex</c> reads every page of every one of
-    /// them. A count bounds pages only where count correlates with bytes, and the one target that had
-    /// the extension installed was the counterexample.</para>
+    /// the collector still died every single run with <c>rows = 0</c> — because on a real Aurora target,
+    /// at a 20 GB per-index ceiling, the 200 largest sub-ceiling indexes admitted 286 GB, and
+    /// <c>pgstatindex</c> reads every page of every one of them. A count bounds pages only where count
+    /// correlates with bytes, and the one target that had the extension installed was the counterexample.
+    /// The figure is quoted with the ceiling it was measured at because both are inputs to it: which
+    /// indexes count as sub-ceiling is what the ceiling decides.</para>
     ///
     /// <para>The bound has to select what the function is applied TO. Labelling rows over the budget
     /// while still passing every one of them to the function is precisely the shape that shipped: correct
@@ -311,10 +314,12 @@ public class PgIndexBloatCollectorDefinitionTests
     /// Only the indexes that will actually be READ may spend the budget.
     ///
     /// <para>An over-ceiling index is never handed to <c>pgstatindex</c>, so it costs no pages. Charging
-    /// it to the byte budget anyway would spend the allowance on work nobody does — and not marginally:
-    /// on the target this bounds, the three over-ceiling indexes total 71 GB against a 20 GB budget, so
-    /// the unfiltered running total would exhaust the budget before the first measurable index and the
-    /// collector would return zero measurements for a second, entirely new reason.</para>
+    /// it to the byte budget anyway would spend the allowance on work nobody does — and not marginally.
+    /// The over-ceiling indexes sort FIRST under size DESC and can exceed the whole budget between them,
+    /// so the unfiltered running total would be over budget before the first measurable index and the
+    /// collector would return zero measurements for a second, entirely new reason. Measured on a real
+    /// Aurora target at a 20 GB ceiling: three over-ceiling indexes totalling 71 GB, against a budget of
+    /// 20 GB.</para>
     /// </summary>
     [Fact]
     public void TheByteBudget_ChargesOnlyTheIndexesItWillActuallyRead()

--- a/Lite.Tests/PgIndexBloatCollectorDefinitionTests.cs
+++ b/Lite.Tests/PgIndexBloatCollectorDefinitionTests.cs
@@ -41,6 +41,20 @@ public class PgIndexBloatCollectorDefinitionTests
         }).Text;
 
     /// <summary>
+    /// The body of the <c>in_budget</c> CTE — the one relation the work bounds are allowed to filter, and
+    /// the relation <c>pgstatindex</c> is applied to. Read out of the shipped query rather than looked for
+    /// anywhere in it, so a bound that drifted back out into a join qual fails rather than still matching.
+    /// </summary>
+    private static string InBudgetBody(string sql)
+    {
+        var body = Regex.Match(sql, @"in_budget AS \((?<body>[\s\S]*?)\n\),");
+
+        Assert.True(body.Success, "the query no longer has an in_budget relation for the work bounds to filter");
+
+        return body.Groups["body"].Value;
+    }
+
+    /// <summary>
     /// Only b-trees may reach the function. Verified against a live server: GIN, BRIN and hash each raise
     /// <c>relation "x" is not a btree index</c>, so a single one of them would fail the collection every
     /// cycle.
@@ -68,12 +82,57 @@ public class PgIndexBloatCollectorDefinitionTests
     }
 
     /// <summary>
-    /// A LEFT join, so an index over the measurement ceiling still produces a row. A cross join would drop
-    /// exactly the indexes most likely to be holding reclaimable space.
+    /// <c>pgstatindex</c> is applied to the GATED relation, and reached by a CROSS join to it.
+    ///
+    /// <para><b>The distinction this pin exists for.</b> A gate written as a qual on a
+    /// <c>LEFT JOIN LATERAL</c> to the function reads like a gate and bounds nothing. The planner has no
+    /// way to skip an inner side it has not evaluated, so the function is invoked once per candidate row
+    /// and the qual only decides whether its answer is kept. Measured on PostgreSQL 17.11 with the
+    /// shipped query text against real b-tree indexes and five candidates of which one was in budget: the
+    /// ON-clause form plans as <c>Nested Loop Left Join</c> with <c>Rows Removed by Join Filter: 4</c>
+    /// over a <c>Function Scan on pgstatindex ... loops=5</c>. Feeding the function a filtered relation
+    /// instead gives <c>loops=1</c> for byte-identical output.</para>
+    ///
+    /// <para>So the property is not "which join keyword" but "what relation the function is applied to",
+    /// and a cross join to a relation that already contains only rows this statement intends to read
+    /// drops nothing — the skipped ones rejoin through
+    /// <see cref="EverySkippedIndexStillReturnsARow_ThroughTheOuterJoin"/>'s outer join.</para>
     /// </summary>
     [Fact]
-    public void TheFunctionJoin_IsLeft_SoSkippedIndexesStillAppear()
-        => Assert.Matches(new Regex(@"LEFT JOIN LATERAL\s+public\.pgstatindex"), Sql());
+    public void TheFunctionCall_IsAppliedToTheGatedRelation()
+    {
+        var sql = Sql();
+
+        Assert.Matches(
+            new Regex(@"FROM in_budget AS b\s+CROSS JOIN LATERAL\s+public\.pgstatindex"), sql);
+    }
+
+    /// <summary>
+    /// No work bound may sit on the nullable side of an outer join. This is the CATEGORY that produced
+    /// both #2617's count budget and #2997's byte budget as labels rather than bounds: each was placed as
+    /// a further qual on the same <c>LEFT JOIN LATERAL</c>, each was pinned, and the collector went on
+    /// reading every index on the instance.
+    ///
+    /// <para>Stated as an absence rather than as a shape, because the failure has already arrived twice by
+    /// two different expressions and the next one will not look like either. As long as the function is
+    /// never on the nullable side of an outer join, no qual on such a join can be paying for work — which
+    /// is what makes this checkable without a planner.</para>
+    /// </summary>
+    [Fact]
+    public void NoWorkBoundSitsOnTheNullableSideOfAnOuterJoin()
+    {
+        var sql = Sql();
+
+        Assert.DoesNotContain("LEFT JOIN LATERAL", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("RIGHT JOIN LATERAL", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("FULL JOIN LATERAL", sql, StringComparison.Ordinal);
+
+        /* The one outer join left joins an already-computed relation, so its ON clause cannot buy pages.
+           It must therefore carry the identity of the join and nothing that looks like a budget. */
+        var outerOn = Regex.Match(sql, @"LEFT JOIN measured AS m\s*\n\s*ON ([^\n]+)");
+        Assert.True(outerOn.Success, "the measurements are no longer joined back by a plain LEFT JOIN");
+        Assert.Equal("m.index_oid = k.index_oid", outerOn.Groups[1].Value.Trim());
+    }
 
     /// <summary>
     /// Skipping is recorded, never silent. A size cap that made indexes disappear would read as "no bloat
@@ -154,9 +213,45 @@ public class PgIndexBloatCollectorDefinitionTests
         /* Ranked by size so the measured ones are where bloat is worth reclaiming. */
         Assert.Contains("row_number() OVER (ORDER BY k.index_bytes DESC", sql, StringComparison.Ordinal);
 
-        /* And the budget gates the LATERAL, which is the thing that costs pages. Gating only the
-           skipped_reason would label rows correctly while still reading every index. */
-        Assert.Matches(new Regex(@"LEFT JOIN LATERAL[\s\S]*?size_rank\s*<=\s*\d+"), sql);
+        /* And the count bound selects the relation handed to the function, which is the thing that costs
+           pages. Bounding only the skipped_reason would label rows correctly while still reading every
+           index. */
+        Assert.Matches(new Regex(@"size_rank\s*<=\s*\d+"), InBudgetBody(sql));
+    }
+
+    /// <summary>
+    /// The gate relation is fenced with <c>OFFSET 0</c>, on the same argument as the candidate set: when
+    /// the failure mode is that the collector returns nothing at all, the bound should not rest on the
+    /// planner choosing to push a filter down through a CTE.
+    /// </summary>
+    [Fact]
+    public void TheGateRelation_IsFencedLikeTheCandidateSet()
+        => Assert.Contains("OFFSET 0", InBudgetBody(Sql()), StringComparison.Ordinal);
+
+    /// <summary>
+    /// Every candidate still returns exactly one row, even though the bounds are now a <c>WHERE</c>.
+    ///
+    /// <para>The bounds moved into a relation of their own precisely so they could be a <c>WHERE</c> — but
+    /// a <c>WHERE</c> that reached the OUTPUT would drop the skipped indexes, and an index missing from
+    /// the result reads as one that does not exist rather than one that was not measured. So the final
+    /// <c>FROM</c> has to be the UNGATED relation, with the measurements joined back onto it.</para>
+    /// </summary>
+    [Fact]
+    public void EverySkippedIndexStillReturnsARow_ThroughTheOuterJoin()
+    {
+        var sql = Sql();
+
+        /* The result is driven by ranked, which no bound has filtered. */
+        Assert.Matches(new Regex(@"END::text\s+AS skipped_reason\s*\nFROM ranked AS k"), sql);
+
+        /* And the bounds live only in the gate relation, never in the final SELECT's own filters. */
+        var gateEnd = sql.IndexOf("measured AS (", StringComparison.Ordinal);
+
+        Assert.True(gateEnd >= 0, "the measurements are no longer computed in a relation of their own");
+
+        var afterGate = sql[gateEnd..];
+        Assert.DoesNotMatch(new Regex(@"WHERE[\s\S]*?size_rank\s*<="), afterGate);
+        Assert.DoesNotMatch(new Regex(@"WHERE[\s\S]*?measured_bytes_through_here\s*<="), afterGate);
     }
 
     /// <summary>
@@ -171,8 +266,10 @@ public class PgIndexBloatCollectorDefinitionTests
 
         Assert.Contains("not measured this cycle (work budget)", sql, StringComparison.Ordinal);
 
-        /* No WHERE that would remove them from the result set. */
-        Assert.DoesNotMatch(new Regex(@"WHERE[^;]*size_rank\s*<="), sql);
+        /* The bound is a WHERE, which is what makes it a bound — so what stops it removing rows from the
+           RESULT is that it filters a relation of its own.
+           EverySkippedIndexStillReturnsARow_ThroughTheOuterJoin is the pin on that. */
+        Assert.Matches(new Regex(@"in_budget AS \([\s\S]*?WHERE[\s\S]*?size_rank\s*<="), sql);
     }
 
     /// <summary>
@@ -196,9 +293,10 @@ public class PgIndexBloatCollectorDefinitionTests
     /// them. A count bounds pages only where count correlates with bytes, and the one target that had
     /// the extension installed was the counterexample.</para>
     ///
-    /// <para>The gate has to sit on the LATERAL. Labelling rows over the budget while still passing
-    /// every one of them to the function is precisely the shape that shipped: correct
-    /// <c>skipped_reason</c> text on a statement that reads the whole instance anyway.</para>
+    /// <para>The bound has to select what the function is applied TO. Labelling rows over the budget
+    /// while still passing every one of them to the function is precisely the shape that shipped: correct
+    /// <c>skipped_reason</c> text on a statement that reads the whole instance anyway — see
+    /// <see cref="TheFunctionCall_IsAppliedToTheGatedRelation"/> for the measurement.</para>
     /// </summary>
     [Fact]
     public void TheCycleBudget_BoundsBytes_NotJustIndexCount()
@@ -206,8 +304,7 @@ public class PgIndexBloatCollectorDefinitionTests
         var sql = Sql();
 
         Assert.Contains("measured_bytes_through_here", sql, StringComparison.Ordinal);
-        Assert.Matches(
-            new Regex(@"LEFT JOIN LATERAL[\s\S]*?measured_bytes_through_here\s*<=\s*\d+"), sql);
+        Assert.Matches(new Regex(@"measured_bytes_through_here\s*<=\s*\d+"), InBudgetBody(sql));
     }
 
     /// <summary>
@@ -309,4 +406,43 @@ public class PgIndexBloatCollectorDefinitionTests
             $"the cycle budget ({PgIndexBloatCollector.CycleMeasureBudgetBytes}) is below the per-index "
             + $"ceiling ({PgIndexBloatCollector.MeasureCeilingBytes}), so any index between the two can "
             + "never be measured while still being reported as merely deferred");
+
+    /// <summary>
+    /// The budget, the deadline and the assumed block rate have to agree, and this is the assertion that
+    /// makes any one of the three answerable to the other two.
+    ///
+    /// <para><b>Why the three were never related before.</b> Each had its own justification and no pin
+    /// compared them, so a budget could be — and was — chosen from an estimate of bulk throughput while
+    /// the deadline it had to fit inside was decided separately. <c>pgstatindex</c> walks the index one
+    /// block at a time with no prefetch, so its cost is a count of potentially-synchronous single-block
+    /// reads; on network-attached storage a sequential-throughput figure overstates the achievable rate by
+    /// orders of magnitude, and that is the arithmetic error that a per-byte argument cannot see.</para>
+    ///
+    /// <para><b>Half the deadline, not all of it.</b> The remainder pays for the catalog scan, connection
+    /// setup, and the tail index admitted while the running total was still just under budget — that index
+    /// is charged for itself, so the last admission can be almost a whole index past the point where the
+    /// budget was nearly spent.</para>
+    ///
+    /// <para>The rate is an assumption and is named as one. This pin does not make it true; it makes
+    /// raising the budget state a rate, and makes raising the rate state why.</para>
+    /// </summary>
+    [Fact]
+    public void TheCycleBudget_FitsTheDeadline_AtThePessimisticBlockRate()
+    {
+        var deadlineSeconds = PgIndexBloatCollector.Instance.CommandTimeoutSecondsOverride;
+
+        Assert.NotNull(deadlineSeconds);
+
+        var blocks = PgIndexBloatCollector.CycleMeasureBudgetBytes / PgIndexBloatCollector.BlockSizeBytes;
+        var seconds = blocks / (double)PgIndexBloatCollector.PessimisticBlocksPerSecond;
+        var allowed = deadlineSeconds.Value / 2.0;
+
+        Assert.True(
+            seconds <= allowed,
+            $"a full cycle budget of {PgIndexBloatCollector.CycleMeasureBudgetBytes} bytes is {blocks} "
+            + $"blocks, which at {PgIndexBloatCollector.PessimisticBlocksPerSecond} blocks/s takes "
+            + $"{seconds:F0}s — past the {allowed:F0}s that leaves half of the {deadlineSeconds}s command "
+            + "deadline for everything else. Lower the budget, or argue the rate up and say on what "
+            + "measurement");
+    }
 }

--- a/PerformanceMonitor.Collectors/PgIndexBloatCollector.cs
+++ b/PerformanceMonitor.Collectors/PgIndexBloatCollector.cs
@@ -39,6 +39,15 @@ namespace PerformanceMonitor.Collectors;
 /// applied a plain <c>WHERE</c> first and the naive form worked, but correctness here should not depend on
 /// plan shape when the failure is total.</para>
 ///
+/// <para><b>Every bound on work selects what the function is applied TO.</b> Same category as the btree
+/// filter above, and the reason the whole query is shaped the way it is. A bound written as a qual on a
+/// <c>LEFT JOIN LATERAL</c> to the function does not bound anything: the planner cannot skip an inner side
+/// it has not evaluated, so the function runs once per candidate row and the qual only chooses whether to
+/// keep the answer. The result is a statement that reads the entire instance while every
+/// <c>skipped_reason</c> in its output is correct, which is indistinguishable from a working collector in
+/// anything except whether it ever returns. So the size ceiling and both work budgets select the
+/// <c>in_budget</c> relation, and the measurements are joined back afterwards.</para>
+///
 /// <para><b>Nothing is silently skipped.</b> The cost of this function is a full read of the index —
 /// measured at exactly <c>relpages</c> blocks, 62,840 for a 491 MB index — so very large indexes are passed
 /// over rather than read daily. They still get a ROW, with the measurements NULL and
@@ -57,47 +66,86 @@ public sealed class PgIndexBloatCollector : PostgresCollectorDefinitionBase<PgIn
     }
 
     /// <summary>
-    /// Indexes at or above this many bytes are recorded but not measured. The read is proportional to index
-    /// size, so this bounds the daily cost; 20 GB is roughly 2.6 million blocks, a few seconds of I/O.
+    /// Indexes at or above this many bytes are recorded but not measured. The read is proportional to
+    /// index size, so this bounds what any single index can cost.
+    ///
+    /// <para>It moves in lockstep with <see cref="CycleMeasureBudgetBytes"/>, because the cycle budget may
+    /// never sit below it: the band between the two would be indexes that are legitimate candidates,
+    /// earn no "too large" reason, and yet exceed the whole cycle on their own first row every run.
+    /// Lowering one without the other manufactures exactly that band.</para>
     /// </summary>
-    public const long MeasureCeilingBytes = 20L * 1024 * 1024 * 1024;
+    public const long MeasureCeilingBytes = 2L * 1024 * 1024 * 1024;
 
     /// <summary>
-    /// How many bytes of index ONE CYCLE will measure in total, largest first. Independent of
-    /// <see cref="MeasureCeilingBytes"/> on purpose: that one bounds a single index, this one bounds
-    /// the statement, and #2617 shipped the first believing it covered the second.
+    /// PostgreSQL's block size. <c>pgstatindex</c> is charged per BLOCK rather than per byte, so this is
+    /// the unit the budget's cost argument is actually stated in.
     ///
-    /// <para><b>Why 20 GB and not more.</b> The only hard datum is a negative one: 286 GB of
-    /// sub-ceiling index did NOT finish inside the 300-second deadline on a live Aurora target, so
-    /// effective throughput there is below 0.95 GB/s and the true figure is unknown - a cut-off run
-    /// gives a lower bound on its own duration and nothing else. The "a few seconds of I/O" figure in
-    /// <see cref="MeasureCeilingBytes"/>' own summary is an estimate that was never measured, and the
-    /// live failure bounds it well away from that. So this is set an order of magnitude below the
-    /// number that failed rather than derived from a throughput nobody has.</para>
+    /// <para>Compile-time on the server (<c>BLCKSZ</c>) and 8 KB on every build this runs against,
+    /// including Aurora. A server built with a different value would make the arithmetic below optimistic
+    /// by that ratio, which is one more reason the rate it is multiplied by is a pessimistic one.</para>
+    /// </summary>
+    public const int BlockSizeBytes = 8192;
+
+    /// <summary>
+    /// The block rate <see cref="CycleMeasureBudgetBytes"/> is sized against, and the reason the budget is
+    /// a small number rather than a large one.
+    ///
+    /// <para><b>Why a block rate and not a byte throughput.</b> <c>pgstatindex</c> walks the index one
+    /// block at a time through the buffer manager with no prefetch, so its cost is a count of
+    /// potentially-synchronous single-block reads rather than a bulk transfer. On network-attached storage
+    /// each miss is a round trip, so per-block LATENCY sets the rate and a sequential-throughput figure
+    /// overstates it by orders of magnitude.</para>
+    ///
+    /// <para>This value is an assumption, not a measurement — no SUCCESS row has ever supplied a duration
+    /// for this collector — so it is deliberately pessimistic, and
+    /// <c>TheCycleBudget_FitsTheDeadline_AtThePessimisticBlockRate</c> pins the budget, the deadline and
+    /// this rate together so that raising any one of them has to argue against the other two.</para>
+    /// </summary>
+    public const int PessimisticBlocksPerSecond = 2_000;
+
+    /// <summary>
+    /// How many bytes of index ONE ATTEMPT will measure in total, largest first. Independent of
+    /// <see cref="MeasureCeilingBytes"/> in what it measures: that one bounds a single index, this one
+    /// bounds the statement.
+    ///
+    /// <para><b>Per ATTEMPT, which on this collector is per DATABASE.</b>
+    /// <see cref="RunsPerDatabase"/> is true and each database gets its own statement under its own
+    /// command deadline, so this is the bound the deadline is actually compared against. A sweep over N
+    /// databases can therefore measure up to N times this figure in total, spread across N statements.
+    /// The deadline is per statement, so that is the right granularity for the bound, but it is not a
+    /// bound on a sweep.</para>
+    ///
+    /// <para><b>Why 2 GB.</b> Not from a throughput measurement — none exists for this collector, and a
+    /// deadline-cut run bounds only its own duration, never a rate. It is derived instead from the cost
+    /// model in <see cref="PessimisticBlocksPerSecond"/>: 2 GB is 262,144 blocks, which at 2,000
+    /// blocks/s is about 131 seconds, inside half of
+    /// <see cref="CommandTimeoutSecondsOverride"/>. The remaining headroom pays for the catalog scan,
+    /// connection setup, and the tail index admitted while the running total was still just under
+    /// budget.</para>
     ///
     /// <para><b>What would justify raising it.</b> A SUCCESS row's own
-    /// <c>collection_log.sql_duration_ms</c>. That number did not exist when this was chosen - the
-    /// ERROR arm recorded a literal zero for every one of the eleven failures - and recording it
-    /// (#2997) is what turns the next raise into a measurement instead of another guess.</para>
+    /// <c>collection_log.sql_duration_ms</c> (#2997), which is a measured rate for this instance and
+    /// this index population rather than the assumed one above. Until such a row exists, every value
+    /// here is an argument rather than a measurement, and the small end of the argument is the one that
+    /// produces the row.</para>
     ///
-    /// <para><b>It must never drop BELOW <see cref="MeasureCeilingBytes"/>, and that it currently
-    /// equals it is a floor rather than a coincidence.</b> The two bounds are independent in what they
-    /// measure - one index versus the statement - but a cycle budget under the per-index ceiling opens a
-    /// band between them in which an index can never be measured at all: it is under the ceiling, so it
-    /// is a legitimate candidate and gets no "too large" reason, yet it alone exceeds the whole cycle,
-    /// so it is over budget on its own first row every single run. It would be labelled
+    /// <para><b>It must never drop BELOW <see cref="MeasureCeilingBytes"/>, and that it equals it is a
+    /// floor rather than a coincidence.</b> A cycle budget under the per-index ceiling opens a band
+    /// between them in which an index can never be measured at all: it is under the ceiling, so it is a
+    /// legitimate candidate and gets no "too large" reason, yet it alone exceeds the whole cycle, so it
+    /// is over budget on its own first row every single run. It would be labelled
     /// <c>not measured this cycle</c> forever, which is precisely the "deferred" reading that this
     /// collector refuses to let stand for "never". Equal is the tightest value with no such band, and
     /// <c>TheCycleBudget_IsNeverBelowThePerIndexCeiling</c> pins it.</para>
     ///
-    /// <para><b>Accepted consequence.</b> At equality a single index just under the ceiling consumes
-    /// almost the whole cycle - on the target this was built for the largest sub-ceiling index is
-    /// 19.68 GB, so that run measures essentially that one index. That is the right answer for a
-    /// largest-first budget (it is the most reclaimable index on the instance) and every other index
-    /// still returns a row carrying its size and its reason, but it does mean coverage of the tail
-    /// depends on the measured set rotating, which it does not yet.</para>
+    /// <para><b>Accepted consequence.</b> An index at or above the ceiling is reported at its size with
+    /// the ceiling's own reason and is never measured — on a large target that includes the biggest and
+    /// most reclaimable indexes on the instance. That is a real gap, and it is stated in the row rather
+    /// than hidden: the alternative on offer is not "measure them" but "measure nothing", which is what
+    /// an unbounded statement delivers. Coverage of the tail additionally depends on the measured set
+    /// rotating, which it does not do.</para>
     /// </summary>
-    public const long CycleMeasureBudgetBytes = 20L * 1024 * 1024 * 1024;
+    public const long CycleMeasureBudgetBytes = 2L * 1024 * 1024 * 1024;
 
     /// <param name="AvgLeafDensity">The server's own figure, 0–100. NOT a bloat percentage — a healthy
     /// index sits near 90, so subtracting from 100 invents roughly 10 points of bloat that is not there.</param>
@@ -123,12 +171,22 @@ public sealed class PgIndexBloatCollector : PostgresCollectorDefinitionBase<PgIn
         double? LeafFragmentation,
         string? SkippedReason);
 
-    /* The candidate set is fenced with OFFSET 0 so the btree filter and the size ceiling are applied BEFORE
-       pgstatindex is called on anything. See the type header for why that matters more than usual here.
+    /* The candidate set is fenced with OFFSET 0 so the btree filter is applied BEFORE pgstatindex is
+       called on anything. See the type header for why that matters more than usual here.
 
-       LEFT JOIN LATERAL, not CROSS JOIN LATERAL: an index over the ceiling produces no function row and must
-       still appear, carrying its skipped_reason. A cross join would drop exactly the rows a reader most
-       wants to know about.
+       Every gate that bounds WORK selects the function's INPUT relation (in_budget), and the function's
+       output is joined back onto the full candidate set afterwards. A gate written as a qual on a LEFT
+       JOIN LATERAL instead reads identically and bounds nothing: the planner has no way to skip an inner
+       side it has not evaluated, so the function runs for every candidate row and the qual only decides
+       whether to keep the answer. Measured on PostgreSQL 17.11 with a call-counting stand-in and ten
+       candidates of which one was in budget: the ON-clause form reported `Rows Removed by Join Filter: 9`
+       over a `Function Scan ... loops=10`, the fenced form `loops=1`, and the two returned byte-identical
+       rows. Correct labels over an unbounded read is the shape that produces them.
+
+       So skipped indexes reappear through the outer LEFT JOIN to `measured` rather than through a LEFT
+       JOIN LATERAL on the function itself. An index that is not measured must still be RETURNED carrying
+       its skipped_reason - dropping it would read as an index that does not exist - and this way it is
+       returned without being read.
 
        System schemas are excluded - their indexes are not something an operator reindexes on our advice.
 
@@ -165,22 +223,20 @@ WITH candidates AS (
     AND   n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
     OFFSET 0
 ),
-/* THE WORK BUDGET (#2617). The per-index ceiling below bounds one index; this bounds the CYCLE.
-   pgstatindex reads every page it is pointed at, so without this the statement reads the whole
-   instance: measured on a live Aurora target, 1,517 indexes totalling 461 GB in a single
-   statement, which never finished and dropped the connection mid-read. The collector had
-   returned zero rows for its entire life.
+/* THE ACCOUNTING for the work budget (#2617), and only the accounting - in_budget below is what
+   enforces it. pgstatindex reads every page it is pointed at, so an unbounded statement reads the
+   whole instance: measured on a live Aurora target, 1,517 indexes totalling 461 GB in a single
+   statement, which never finished and dropped the connection mid-read.
 
    Ranked by size and measured largest-first, because bloat that matters is concentrated in big
    indexes - a small index at 40% density is worth kilobytes. Everything past the budget is still
    RETURNED, with a reason, so the read never mistakes unmeasured for healthy.
 
-   TWO budgets now, and the BYTE one is what actually bounds the work (#2997). A count bounds pages
-   only where count correlates with bytes; on the first production target it did not, and the 200
-   largest sub-ceiling indexes admitted 286 GB in this one statement - so every run for the
-   collector's whole life died on the 300-second deadline having measured nothing, exactly as
-   described above but one dimension up. The count survives because it is legible, not because it
-   bounds anything: see CycleMeasureBudgetBytes for which of the two is load-bearing. */
+   TWO figures, and the BYTE one is what bounds the work (#2997). A count bounds pages only where
+   count correlates with bytes; on the first production target it did not, and the 200 largest
+   sub-ceiling indexes there admitted 286 GB. The count survives because it is legible - an operator
+   can predict the biggest N in a way they cannot predict a byte figure - not because it bounds
+   anything: see CycleMeasureBudgetBytes for which of the two is load-bearing. */
 ranked AS (
     SELECT
         k.*,
@@ -188,8 +244,9 @@ ranked AS (
         /* The running total of what will actually be READ, so the cycle can stop at a byte figure
            rather than a row count. FILTERed to sub-ceiling indexes because an over-ceiling one is
            never handed to pgstatindex and therefore costs no pages; charging it to the budget would
-           spend the whole allowance on indexes nobody reads. On the target this bounds, the three
-           over-ceiling indexes total 71 GB - more than the budget by themselves.
+           spend the whole allowance on indexes nobody reads. Since the over-ceiling indexes sort
+           first and can total more than the budget between them, the unfiltered form would exhaust
+           the allowance before the first measurable index and measure nothing at all.
 
            coalesce because a FILTERed window sum is NULL until its frame contains a matching row,
            and the over-ceiling indexes sort FIRST under size DESC. NULL <= budget is NULL rather
@@ -200,6 +257,35 @@ ranked AS (
                       ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW),
             0)::bigint                      AS measured_bytes_through_here
     FROM candidates AS k
+),
+/* THE GATE, and the only place the three bounds are enforced. Selecting the relation pgstatindex is
+   applied to is what makes them bounds; a qual on the function's join makes them labels. Fenced with
+   OFFSET 0 on the same argument as the candidate set - when the failure mode is that the collector
+   returns nothing at all, the bound should not rest on the planner choosing to push a filter down. */
+in_budget AS (
+    SELECT
+        k.index_oid                     AS index_oid
+    FROM ranked AS k
+    WHERE k.index_bytes < " + CeilingLiteral + @"
+    AND   k.size_rank  <= " + BudgetLiteral + @"
+    AND   k.measured_bytes_through_here <= " + CycleByteBudgetLiteral + @"
+    OFFSET 0
+),
+/* CROSS JOIN LATERAL here, because every row of in_budget is by construction one this statement has
+   decided to read. Nothing is dropped by the cross join: an index absent from in_budget still reaches
+   the result through the outer LEFT JOIN below, with its measurements NULL and a reason. */
+measured AS (
+    SELECT
+        b.index_oid                     AS index_oid,
+        s.tree_level                    AS tree_level,
+        s.internal_pages                AS internal_pages,
+        s.leaf_pages                    AS leaf_pages,
+        s.empty_pages                   AS empty_pages,
+        s.deleted_pages                 AS deleted_pages,
+        s.avg_leaf_density              AS avg_leaf_density,
+        s.leaf_fragmentation            AS leaf_fragmentation
+    FROM in_budget AS b
+    CROSS JOIN LATERAL public.pgstatindex(b.index_oid::regclass) AS s
 )
 SELECT
     current_database()::text            AS database_name,
@@ -207,13 +293,13 @@ SELECT
     k.table_name::text                  AS table_name,
     k.index_name::text                  AS index_name,
     k.index_bytes::bigint               AS index_bytes,
-    s.tree_level                        AS tree_level,
-    s.internal_pages::bigint            AS internal_pages,
-    s.leaf_pages::bigint                AS leaf_pages,
-    s.empty_pages::bigint               AS empty_pages,
-    s.deleted_pages::bigint             AS deleted_pages,
-    s.avg_leaf_density::double precision   AS avg_leaf_density,
-    s.leaf_fragmentation::double precision AS leaf_fragmentation,
+    m.tree_level                        AS tree_level,
+    m.internal_pages::bigint            AS internal_pages,
+    m.leaf_pages::bigint                AS leaf_pages,
+    m.empty_pages::bigint               AS empty_pages,
+    m.deleted_pages::bigint             AS deleted_pages,
+    m.avg_leaf_density::double precision   AS avg_leaf_density,
+    m.leaf_fragmentation::double precision AS leaf_fragmentation,
     CASE
         WHEN k.index_bytes >= " + CeilingLiteral + @"
             THEN 'index is larger than the measurement ceiling; pgstatindex reads every page, so it is '
@@ -231,30 +317,23 @@ SELECT
                  || 'recorded at its size so it is never mistaken for healthy.'
     END::text                           AS skipped_reason
 FROM ranked AS k
-LEFT JOIN LATERAL public.pgstatindex(k.index_oid::regclass) AS s
-  ON  k.index_bytes < " + CeilingLiteral + @"
-  AND k.size_rank  <= " + BudgetLiteral + @"
-  /* The gate that bounds the statement's real cost. Without this term the two above label rows
-     correctly while still reading every one of them - which is exactly how a 200-index budget
-     came to read 286 GB. */
-  AND k.measured_bytes_through_here <= " + CycleByteBudgetLiteral + @"
+/* Plain LEFT JOIN on the already-computed measurements, NOT a join to the function. Every candidate
+   appears exactly once; the ones in_budget excluded arrive here with their measurement columns NULL,
+   which is what the skipped_reason arms above describe. */
+LEFT JOIN measured AS m
+  ON m.index_oid = k.index_oid
 ORDER BY k.index_bytes DESC";
 
-    private const string CeilingLiteral = "21474836480";
+    private const string CeilingLiteral = "2147483648";
 
-    /* How many indexes one cycle will actually MEASURE, largest first: 200 indexes OR
-       CycleMeasureBudgetBytes, whichever comes first.
-
-       A count is the legible half and is kept for that reason - an operator can predict "the 200
-       biggest" in a way they cannot predict a byte figure. But legibility is not a bound: the cost
-       is per PAGE, and a count bounds pages only where count correlates with bytes. On the first
-       production target it did not, and the byte term below is what makes the pair a budget rather
-       than a label. */
+    /* The upper bound on how many indexes one attempt will MEASURE, largest first: 200 indexes OR
+       CycleMeasureBudgetBytes, whichever comes first. The byte figure is the one that binds on any
+       target large enough to matter; see the ranked CTE for why the count is kept anyway. */
     private const string BudgetLiteral = "200";
 
     /* Kept in the C# type system as well as in the SQL literal so a reader has one authoritative
        figure and TheBudgetLiterals_AgreeWithTheirConstants can pin that the two agree. */
-    private const string CycleByteBudgetLiteral = "21474836480";
+    private const string CycleByteBudgetLiteral = "2147483648";
 
     /// <summary>
     /// Five minutes, because even a bounded cycle of pages is real work and a slow single index
@@ -262,10 +341,10 @@ ORDER BY k.index_bytes DESC";
     /// the same override for the same reason (#1135).
     ///
     /// <para>This is a BACKSTOP, not the bound. The deadline cannot make an over-large statement
-    /// finish - it only decides how long the sweep waits before giving up, and for eleven
-    /// consecutive runs the answer was "the whole five minutes, then nothing". What bounds the work
-    /// is <see cref="CycleMeasureBudgetBytes"/>; a run that needs this deadline has already been
-    /// mis-budgeted.</para>
+    /// finish - it only decides how long the sweep waits before giving up, and a statement that does
+    /// not fit spends the whole five minutes and then reports nothing. What bounds the work is
+    /// <see cref="CycleMeasureBudgetBytes"/>, which is sized to fit inside HALF of this figure; a run
+    /// that needs the rest of the deadline has already been mis-budgeted.</para>
     ///
     /// <para>Npgsql's CommandTimeout is a socket READ timeout that every backend message restarts,
     /// so it bounds backend SILENCE rather than total elapsed time. <c>pgstatindex</c> sends nothing

--- a/PerformanceMonitor.Collectors/PgIndexBloatCollector.cs
+++ b/PerformanceMonitor.Collectors/PgIndexBloatCollector.cs
@@ -233,10 +233,12 @@ WITH candidates AS (
    RETURNED, with a reason, so the read never mistakes unmeasured for healthy.
 
    TWO figures, and the BYTE one is what bounds the work (#2997). A count bounds pages only where
-   count correlates with bytes; on the first production target it did not, and the 200 largest
-   sub-ceiling indexes there admitted 286 GB. The count survives because it is legible - an operator
-   can predict the biggest N in a way they cannot predict a byte figure - not because it bounds
-   anything: see CycleMeasureBudgetBytes for which of the two is load-bearing. */
+   count correlates with bytes; on the first production target it did not - at a 20 GB per-index
+   ceiling the 200 largest sub-ceiling indexes there admitted 286 GB, a figure that carries the
+   ceiling it was measured at because the ceiling is what decides which indexes are sub-ceiling. The
+   count survives because it is legible - an operator can predict the biggest N in a way they cannot
+   predict a byte figure - not because it bounds anything: see CycleMeasureBudgetBytes for which of
+   the two is load-bearing. */
 ranked AS (
     SELECT
         k.*,


### PR DESCRIPTION
`pg_index_bloat`'s size ceiling and both work budgets were quals on a `LEFT JOIN LATERAL` to `pgstatindex`. That placement bounds nothing: the planner cannot skip an inner side it has not evaluated, so the function is invoked once per candidate row and the qual only decides whether its answer is kept. Every attempt read every b-tree index on the instance — 1,517 indexes, 461 GB on the reported target — while every `skipped_reason` in the output was correct. So the collector has been indistinguishable from a working one in everything except whether it ever returns, across #2561's original shape, #2617's count budget and #2997's byte budget alike.

## What changed

The bounds select the relation `pgstatindex` is applied to. A fenced `in_budget` relation carries the ceiling, the count bound and the byte bound; `measured` cross-joins the function to that relation only; the final `SELECT` still drives off the ungated `ranked` and joins the measurements back. Every candidate returns exactly one row, unmeasured ones with their reason, which is the property the `LEFT JOIN LATERAL` was there to provide and the reason a bare `WHERE` on the output would be wrong.

This is the same category as the btree filter three lines above it, which is fenced with `OFFSET 0` for the same stated reason — correctness should not depend on plan shape when the failure is total. The budget was the one bound in the query that still rested on it.

The ceiling and the cycle budget both drop from 20 GB to 2 GB. They move together because the pinned invariant forbids the band between them, and 2 GB is derived rather than guessed: `pgstatindex` walks the index one block at a time with no prefetch, so its cost is a count of potentially-synchronous single-block reads, and a bulk-throughput estimate overstates the achievable rate by orders of magnitude on network-attached storage. 2 GB is 262,144 blocks, ~131 s at a pessimistic 2,000 blocks/s, inside half the 300 s deadline. The deadline is untouched, per the collector's own error text.

## The coverage that was missing, and where it now lives

`PgIndexBloatBudgetLivePostgresTests` (`Darling/Darling.Tests/`) runs the shipped query against a live PostgreSQL and counts `Actual Loops` on the `pgstatindex` function-scan node of its own `EXPLAIN ANALYZE`. Three numbers come out of the query itself rather than being written into the test: `C` candidates returned, `M` reported as measured, `L` invocations. It asserts `L == M`, and `M < C` so the first assertion cannot pass vacuously — where everything fits the budget, `L == M == C` holds under the broken shape too.

**No assertion on query text can distinguish these two shapes**, which is why both prior budgets shipped pinned and inert. The broken one and the fixed one differ in what the executor does, not in what the SQL says. Measured on PostgreSQL 17.11 with 215 candidates against the untouched 200-index count bound:

| | `origin/dev` | this branch |
|---|---|---|
| `C` candidates | 215 | 215 |
| `M` measured | 200 | 200 |
| `L` `pgstatindex` invocations | **215** | **200** |
| plan | `Nested Loop Left Join`, `Rows Removed by Join Filter: 15` | `Filter` on the input, then `loops=200` |

Nothing about the query is rewritten for that test — not the literals, not the shape. It belongs in Darling on its merits: `DarlingWorker` is what dispatches this collector, the target that has never returned a row is a Darling target, and this is the only suite with a live PostgreSQL to execute against.

Two things that test has to get right to run at all, both of them properties of the store rather than of the collector. It creates pgstattuple with `SCHEMA public`, because the store's `search_path` is `collect, config, public` and a bare `CREATE EXTENSION` therefore installs into `collect` — after which the collector's deliberately-qualified `public.pgstatindex` raises `42883` while the extension is by every other measure installed. The precondition is asserted as *the function being callable where the collector calls it*, read from the catalog, rather than as `CREATE EXTENSION` having returned without error; those two come apart exactly here. Teardown goes through `LiveStoreCleanup.RunAsync` with a `bodySucceeded` flag (#1902), so a cleanup failure cannot replace the body's exception — verified by the mutation below, which reports the assertion rather than cleanup noise and still drops the probe schema.

## What else is pinned

`TheCycleBudget_FitsTheDeadline_AtThePessimisticBlockRate` relates the budget, the deadline and a named rate assumption — three numbers that each had their own justification and nothing comparing them. It is the pin that makes raising any one of them argue against the other two.

`NoWorkBoundSitsOnTheNullableSideOfAnOuterJoin` is stated as an absence rather than a shape, because this failure has now arrived twice by two different expressions and the next one will not look like either.

`TheFunctionCall_IsAppliedToTheGatedRelation`, `TheGateRelation_IsFencedLikeTheCandidateSet` and `EverySkippedIndexStillReturnsARow_ThroughTheOuterJoin` cover the restructure; `TheCycleHasAWorkBudget_NotJustAPerIndexCeiling`, `TheCycleBudget_BoundsBytes_NotJustIndexCount` and `OverBudgetIndexesAreReturnedWithAReason` previously asserted the ON-clause placement *as* the fix and now read the bounds out of the gate relation instead.

Red-first, both halves, by mutation against the committed branch. Reverting only the two values fails the arithmetic pin (`1311s` against `150s` allowed). Splicing in `origin/dev`'s own `QueryText` and keeping the values fails 7 of the 21 Lite pins and fails the live test with `Expected: 200, Actual: 215` — it names the 15 indexes that were read and discarded.

## Verification scope

The live test and the 21 `PgIndexBloatCollectorDefinitionTests` facts were executed on `net10.0` by compiling the actual test files into console harnesses, against PostgreSQL 17.11; both suites target `net10.0-windows` and cannot run on macOS. CI is the arbiter for the suites as a whole.

**The acceptance criterion is not verifiable pre-merge.** It requires the next drifted attempt after a deploy to complete `SUCCESS` with a non-zero row count, so it is a POST-merge check. What is verified here is that the bound now binds, and that it binds without changing the answer. Whether 2 GB fits the deadline on the real target is an argument from a cost model, not a measurement — no SUCCESS row has ever supplied a duration for this collector, and producing the first one is what turns the next adjustment into a measurement.

Per #3109's own follow-up, verify against the **launch** instant, not the completion instant: the drift prediction holds only while every attempt dies on the same deadline, and the first attempt that does not breaks it.

## The bar for the post-merge check — the pre-registered one no longer applies

#3109's criteria (**~1,517 rows, ~200 carrying `avg_leaf_density`**) were set against a 20 GB ceiling. Both bounds are now 2 GB, so the second figure is wrong in a way that matters: **a run reporting ~200 measured would mean the byte budget is NOT binding**, which is the defect this PR fixes, not the success it used to describe. Stated here so the check has something to fail against rather than reading "it returned some rows" as success.

What is unchanged, and still the right first assertion:

- **~1,517 rows.** The budget removes no rows — every valid b-tree index outside the system schemas returns one, measured or with a reason. A row count far below this means something other than the budget is filtering.

What changes, with the arithmetic behind it. The 200 largest sub-20 GB indexes on that target totalled 286 GB, a mean of ~1.43 GB, so the distribution is dense right where the new 2 GB ceiling cuts. Largest-first into a 2 GB budget therefore admits very few:

- **Rows carrying `avg_leaf_density`: expected single digits**, floor 1, hard ceiling 200. Not ~200.
- **`SUM(index_bytes) WHERE avg_leaf_density IS NOT NULL` ≤ 2,147,483,648.** The sharpest check available and the one that tests this PR's actual claim — it is the budget, read straight off the stored rows. Over it means the bound is not binding in production.
- **`MAX(index_bytes) WHERE avg_leaf_density IS NOT NULL` < 2,147,483,648**, the ceiling.
- **Zero rows with `skipped_reason IS NULL AND avg_leaf_density IS NULL`** — every admitted index came back with a measurement.
- The largest indexes now carry the **ceiling** reason rather than the budget one, which is the honest label for permanently-unmeasured and the capability this trade gives up.

Three outcomes that must NOT be read as success:

- `rows > 0` with **zero** carrying density — the budget admitted nothing, a distinct failure with its own reason string.
- Measured bytes over 2 GB — labels correct, bound not binding.
- `sql_duration_ms` at or near 300,000 — still does not fit, and the next move is a smaller budget, not a longer deadline.

`sql_duration_ms` on the first SUCCESS is the number that retires the guesswork. ~131 s would vindicate the pessimistic 2,000 blocks/s; far below it means the rate assumption was too conservative and the budget can be raised **on a measurement** for the first time in this collector's life.

Two cautions for whoever runs the check. Verify against the **launch** instant, not completion — the drift line holds only while every attempt dies on the same deadline. And prefer `collection_log` plus a direct row count over reading only through `get_pg_index_bloat`: an empty b-tree index reports `avg_leaf_density` as `NaN`, and the reader's reclaimable-bytes cast raises `bigint out of range` on such a row, so a successful collection can present as a broken read. Filed separately; this change is what makes it live, since the collector previously returned nothing to store. **Where it bites is specific, and it is not the target in #3109.** An empty index is 8 KB and therefore sorts LAST under largest-first, so it is admitted only where a database's entire sub-ceiling index footprint fits inside the 2 GB budget — small databases, which this per-database collector meets on almost any real cluster. On a target whose sub-ceiling indexes run to hundreds of GB the budget is spent long before it reaches an 8 KB index, so the ordering rules it out there. Do not read a clean `get_pg_index_bloat` on the big target as evidence the NaN defect is absent.

## Deliberately left out

Rotation of the measured set. Coverage of the tail still depends on it and it still does not happen, so an index below the ceiling but past the budget is reported as deferred every run. That is recorded in `CycleMeasureBudgetBytes`' own summary as a standing gap rather than fixed here: it needs stored per-server state to be anything other than a clock trick, and it does not help the acceptance criterion, which is a first success.

Raising the budget on the strength of the new headroom. The point of the small value is to produce the `sql_duration_ms` that makes the next choice a measurement.

The `Darling PostgreSQL tests` path gate, which is #3116 and not this PR's to change. Worth stating plainly: on the first push here that job reported success in **17 seconds** with `Run Darling PG tests` skipped, because the filter is `Darling/**/!(*.md)` and this change began life entirely outside `Darling/`. The Darling test above makes the gate true as a side effect, but it earns its place on coverage grounds, not as a gate flip.

## CHANGELOG entry text

Not applied to `CHANGELOG.md` in this branch on purpose: every open lane appends to the same `[Unreleased]` block, so each one that edits the file conflicts with the rest. The entry is stated here for whoever sequences the merge.

`### Fixed`

- `pg_index_bloat`'s size ceiling and work budgets are enforced by selecting the relation `pgstatindex` is applied to, rather than by quals on a `LEFT JOIN LATERAL` to it. Placed on the join, they bounded nothing — the function ran once per candidate row and the qual only chose whether to keep its answer — so every attempt read every b-tree index on the instance while reporting correct skip reasons for the ones it had already paid for. The per-index ceiling and the cycle budget drop to 2 GB together, sized against a per-block read rate rather than a bulk-throughput estimate; a new pin relates the budget, the command deadline and that rate so none of the three can move alone; and a live-PostgreSQL test counts `pgstatindex` invocations on the shipped query, which is the only way to tell a budget that bounds reads from one that labels rows.
