### PR TITLE
One runtime log level gates Lite, so lowering the timing line actually silences it

### DIFF
--- a/Darling/Darling.Tests/RepoFileAdoptionTests.cs
+++ b/Darling/Darling.Tests/RepoFileAdoptionTests.cs
@@ -41,10 +41,12 @@ namespace Darling.Tests;
 /// boundary rather than a limitation.</para>
 ///
 /// <para><b>It sweeps <c>Darling.Tests</c> only</b>, because <see cref="TestDirectory"/> is this file's own
-/// directory. <c>Lite.Tests</c> carries five private <c>ReadRepoFile</c> declarations of its own —
+/// directory. <c>Lite.Tests</c> carries six private <c>ReadRepoFile</c> declarations of its own —
 /// <c>DetachedCollectorGateTests</c>, <c>GridPayloadColumnOrderPinTests</c>,
-/// <c>LiteOverviewCardExplainsItselfTests</c>, <c>LiteSidebarDotRendersTheCardStatusTests</c> and
-/// <c>QueryStoreServerGateTests</c> — and this says nothing about them. They are the same pattern in the
+/// <c>LiteLogLevelGateTests</c>, <c>LiteOverviewCardExplainsItselfTests</c>,
+/// <c>LiteSidebarDotRendersTheCardStatusTests</c> and <c>QueryStoreServerGateTests</c> — and this says
+/// nothing about them. That count is prose rather than an assertion, so it goes stale silently; a seventh
+/// arriving is exactly the drift the sibling pin below would catch if it existed. They are the same pattern in the
 /// sibling project, and <see cref="RepoFile"/> is shareable with it by the one <c>Compile Include</c> line
 /// that already brings <see cref="CSharpSourceWalker"/> across. Whoever takes that has to widen this sweep
 /// or add a sibling pin in <c>Lite.Tests</c>; a reader consolidated there while this scan still looks at one

--- a/Lite.Tests/LiteLogLevelGateTests.cs
+++ b/Lite.Tests/LiteLogLevelGateTests.cs
@@ -258,6 +258,56 @@ public sealed class LiteLogLevelGateTests : IDisposable
     }
 
     /// <summary>
+    /// <para>The same property through the ADAPTER, at every level and every minimum: an
+    /// <c>ILogger&lt;T&gt;</c> call reaches the log exactly when <see cref="AppLogger.IsEnabled"/> says its
+    /// level is on.</para>
+    ///
+    /// <para><b>Why the static sweep above is not enough.</b> That one calls the four entry points by
+    /// name, so it never exercises the adapter's MAPPING — and the mapping is where the two gates can
+    /// disagree, because it collapses two levels onto one sink twice. Those two collapses are not
+    /// symmetric: <c>Trace</c>/<c>Debug</c> lands on the higher of the pair, so admitting the outer level
+    /// already admits the sink's, while <c>Error</c>/<c>Critical</c> lands on the LOWER, where it does not.
+    /// A minimum of <c>Critical</c> therefore admitted a Critical line at the adapter and dropped it at the
+    /// sink, making a documented level silence the log as completely as <c>None</c>. Sweeping the product
+    /// of levels and minima is what makes that reachable rather than relying on someone noticing the
+    /// asymmetry.</para>
+    /// </summary>
+    [Fact]
+    public void EveryLevelThroughTheAdapter_ReachesTheLogExactlyWhenItIsEnabled()
+    {
+        var levels = new[]
+        {
+            LogLevel.Trace, LogLevel.Debug, LogLevel.Information,
+            LogLevel.Warning, LogLevel.Error, LogLevel.Critical,
+        };
+
+        var minima = levels.Append(LogLevel.None).ToArray();
+        ILogger<RemoteCollectorService> logger = new AppLoggerAdapter<RemoteCollectorService>();
+
+        foreach (var minimum in minima)
+        {
+            AppLogger.SetMinimumLevel(minimum);
+
+            foreach (var level in levels)
+            {
+                var tag = Guid.NewGuid().ToString("N");
+                AppLogger.DrainBufferedLines();
+
+                logger.Log(level, default, $"probe {tag}", null, (s, _) => s);
+
+                var reached = Tagged(tag).Count > 0;
+
+                Assert.True(
+                    reached == AppLogger.IsEnabled(level),
+                    $"with the minimum at {minimum}, an ILogger call at {level} "
+                        + (reached ? "reached" : "did not reach")
+                        + $" the log while IsEnabled({level}) is {AppLogger.IsEnabled(level)}. The adapter's "
+                        + "mapping must not re-decide a level the gate has already answered (#3104).");
+            }
+        }
+    }
+
+    /// <summary>
     /// Raising the minimum puts the line back, which is the half a gate alone does not deliver. Suppressing
     /// a diagnostic and deleting one look identical in a log; the difference is whether an operator can
     /// reach it, and that is what this asserts.

--- a/Lite.Tests/LiteLogLevelGateTests.cs
+++ b/Lite.Tests/LiteLogLevelGateTests.cs
@@ -62,11 +62,18 @@ public sealed class LiteLogLevelGateTests : IDisposable
     };
 
     /// <summary>
-    /// The POSITIVE CONTROL's template, taken from the same callback so it shares every condition with the
-    /// timing line except the one under test. Its job is to fail when the resolution machinery below has
-    /// stopped working: without it, "the timing line is not admitted" is equally consistent with a scan
-    /// that matched nothing useful and a gate that admits nothing at all — an empty read that cannot be
-    /// told from a real absence, which is the shape of the defect this file exists for.
+    /// The POSITIVE CONTROL's template. Its job is to fail when the resolution machinery below has stopped
+    /// working: without it, "the timing line is not admitted" is equally consistent with a scan that
+    /// matched nothing useful and a gate that admits nothing at all — an empty read that cannot be told
+    /// from a real absence, which is the shape of the defect this file exists for.
+    ///
+    /// <para><b>Two sites in that file carry this template</b> — the Azure SQL DB per-database loop and the
+    /// fan-out completion callback the timing line is emitted from — so the one NEAREST the matched timing
+    /// site is the one taken, rather than the first met walking the file. Both resolve to
+    /// <c>LogWarning</c> today, so the choice changes no result now; it is what makes the control share the
+    /// timing line's surroundings, which is the property that makes it a control rather than another
+    /// arbitrary warning. Selecting the first would silently attach it to a different branch the moment
+    /// either site moved.</para>
     /// </summary>
     private const string ControlMarker = "hit its per-database collection bound";
 
@@ -318,21 +325,25 @@ public sealed class LiteLogLevelGateTests : IDisposable
                 + "configuration only (#3104).");
     }
 
-    /// <summary>One timing emit site: the call, the level it maps to, and the template it emits.</summary>
-    private readonly record struct Site(string Method, LogLevel Level, string Template);
+    /// <summary>
+    /// One emit site: the call, the level it maps to, the template it emits, and where in the file it sits.
+    /// The offset is carried only to pick the control nearest a timing site.
+    /// </summary>
+    private readonly record struct Site(string Method, LogLevel Level, string Template, int Offset);
 
     /// <summary>
-    /// Every per-cycle timing emit site in the run path, plus the control site, resolved out of the real
-    /// source. The emitting call sits ahead of the literal and the literal is its first argument, so the
-    /// LAST call ahead of it is the one. Read out of the comment-and-literal-stripped text so a
-    /// <c>.LogInformation(</c> named in a comment above the site cannot be mistaken for the site's own call.
+    /// Every per-cycle timing emit site in the run path, plus the control site nearest the first of them,
+    /// resolved out of the real source. The emitting call sits ahead of the literal and the literal is its
+    /// first argument, so the LAST call ahead of it is the one. Read out of the comment-and-literal-stripped
+    /// text so a <c>.LogInformation(</c> named in a comment above the site cannot be mistaken for the site's
+    /// own call.
     /// </summary>
     private static List<Site> TimingSites(out Site? control)
     {
         var source = ReadRepoFile(EmitFile);
         var code = CSharpSourceWalker.StripCommentsAndStrings(source);
         var sites = new List<Site>();
-        control = null;
+        var controls = new List<Site>();
 
         foreach (var (start, body) in CSharpSourceWalker.StringLiteralBodies(source))
         {
@@ -346,17 +357,18 @@ public sealed class LiteLogLevelGateTests : IDisposable
 
             var call = LogCall.Matches(code[..start]).LastOrDefault();
             var method = call is null ? "(no log call found)" : call.Groups[1].Value;
-            var site = new Site(method, LevelOf(method), body.Trim());
+            var site = new Site(method, LevelOf(method), body.Trim(), start);
 
-            if (isTiming)
-            {
-                sites.Add(site);
-            }
-            else
-            {
-                control ??= site;
-            }
+            (isTiming ? sites : controls).Add(site);
         }
+
+        /* Nearest the timing site, so the control shares its surroundings. With no timing site there is
+           nothing to be near, and the floor assertion is what should fail there rather than this. */
+        var ranked = sites.Count > 0
+            ? controls.OrderBy(c => Math.Abs(c.Offset - sites[0].Offset)).ToList()
+            : controls;
+
+        control = ranked.Count > 0 ? ranked[0] : null;
 
         return sites;
     }

--- a/Lite.Tests/LiteLogLevelGateTests.cs
+++ b/Lite.Tests/LiteLogLevelGateTests.cs
@@ -279,16 +279,23 @@ public sealed class LiteLogLevelGateTests : IDisposable
             .ToList();
 
     /// <summary>
-    /// <para>No logging decision in <see cref="AppLogger"/> is made by the preprocessor. This is a SOURCE
-    /// pin because no runtime assertion can be: a test is compiled in one configuration and can only ever
-    /// observe that one, so a <c>#if DEBUG</c> around a write is invisible to every other pin in this file
-    /// while making all of them configuration-dependent — green under Release, and speaking for nothing but
-    /// Release, which is not the configuration a developer runs locally.</para>
+    /// <para>No logging decision in <see cref="AppLogger"/> is made by the preprocessor. Conditional
+    /// compilation selects a verbosity at BUILD time, so the shipped Release artifact has exactly one and
+    /// no setting can reach it: a level lowered onto a compiled-out write is silenced permanently rather
+    /// than by default, which is the difference between suppressing a diagnostic and deleting it.</para>
     ///
-    /// <para>It is also the difference between suppressing a line and deleting it. Conditional compilation
-    /// selects a verbosity at build time, so the shipped Release artifact has exactly one and no setting can
-    /// change it; a level lowered onto a compiled-out write is silenced permanently rather than by
-    /// default.</para>
+    /// <para><b>What this adds over the sweep above, measured rather than assumed.</b> A <c>#if DEBUG</c>
+    /// around <c>Debug</c>'s write does fail
+    /// <see cref="EveryStaticEntryPoint_HonoursTheMinimum_AndTheAdapterAgrees"/> — but a DIFFERENT
+    /// assertion in each configuration, because the two configurations disagree about what the sink does: a
+    /// Debug build fails at minimum <c>Information</c> (it wrote when the gate said no) and a Release build
+    /// fails at minimum <c>Trace</c> (it wrote nothing when the gate said yes). So the sweep reports a level
+    /// table that does not match, and which mismatch you are shown depends on how you built; this names the
+    /// cause, identically in both. The sweep also only covers the four entry points and seven minima it
+    /// enumerates, so a directive around any other decision here is invisible to it and visible to this.</para>
+    ///
+    /// <para>Read out of stripped source, so this type's own discussion of conditional compilation — and
+    /// <see cref="AppLogger"/>'s — is not itself read as conditional compilation.</para>
     /// </summary>
     [Fact]
     public void NoLoggingDecision_IsMadeByThePreprocessor()

--- a/Lite.Tests/LiteLogLevelGateTests.cs
+++ b/Lite.Tests/LiteLogLevelGateTests.cs
@@ -41,9 +41,21 @@ namespace PerformanceMonitorLite.Tests;
 /// admission decision, not a rate. The source scan reads one file and identifies the timing line by the
 /// placeholders in its message template, so a future timing line spelled with different placeholders is
 /// outside its net; the floor assertion is what keeps a net that has stopped matching from reading as a
-/// clean pass. Nothing here exercises <c>App.LoadLogMinimumLevel</c>'s settings read — that runs inside
-/// WPF startup, and its key is covered by <c>SettingsSampleTests</c> in both directions.</para>
+/// clean pass. <c>App.LoadLogMinimumLevel</c>'s file read is not exercised — that runs inside WPF startup
+/// — so what is pinned of it is the part that decides: the token vocabulary, through the same
+/// <see cref="AppLogger.TryParseMinimumLevel"/> the loader calls. The key's presence in the shipped sample
+/// is covered by <c>SettingsSampleTests</c> in both directions.</para>
 /// </summary>
+/// <remarks>
+/// The collection exists because these pins move <see cref="AppLogger"/>'s process-wide minimum, briefly
+/// as far as <see cref="LogLevel.None"/>, and a concurrently-running class whose service logs during that
+/// window loses the line — unrecoverably, since tag-filtering a buffer cannot bring back a line never
+/// enqueued. That is #1965, which <c>app-alert-statics</c> was created for. No other class makes runtime
+/// <c>AppLogger</c> calls today, and a collection name only serialises classes that SHARE it, so this
+/// serialises nothing yet: it is the named place for the next class touching this static to join, and it
+/// is worth stating that it protects nothing on its own rather than implying it already does.
+/// </remarks>
+[Collection("app-logger-statics")]
 public sealed class LiteLogLevelGateTests : IDisposable
 {
     /// <summary>The file the per-database collection timing line is emitted from.</summary>
@@ -323,6 +335,48 @@ public sealed class LiteLogLevelGateTests : IDisposable
                 + ". Verbosity has to be a runtime value — a preprocessor gate cannot be configured on the "
                 + "shipped Release build, and it makes every suppression pin in this file answer for one "
                 + "configuration only (#3104).");
+    }
+
+    /// <summary>
+    /// <para>The accepted vocabulary is exactly the seven names the sample documents — because the
+    /// rejected half is what decides whether a typo costs one setting or the whole log.</para>
+    ///
+    /// <para><c>Enum.TryParse</c> alone accepts a NUMBER, and an undefined one is the dangerous case:
+    /// <c>"999"</c> parses to <c>(LogLevel)999</c>, which no real level can reach, so every line
+    /// including <see cref="LogLevel.Error"/> is dropped — logging off entirely, from a setting whose
+    /// stated contract is that a bad value costs itself and is named at startup. Asserted as the pair that
+    /// matters: the token is rejected AND the level handed back is the default, since a caller reading the
+    /// level without the bool is how the silent version happens.</para>
+    /// </summary>
+    [Fact]
+    public void TheSettingsVocabulary_TakesTheDocumentedNamesAndNothingElse()
+    {
+        foreach (var (token, expected) in new (string?, LogLevel)[]
+        {
+            ("Trace", LogLevel.Trace),
+            ("Debug", LogLevel.Debug),
+            ("information", LogLevel.Information),
+            ("WARNING", LogLevel.Warning),
+            ("Error", LogLevel.Error),
+            ("Critical", LogLevel.Critical),
+            ("None", LogLevel.None),
+        })
+        {
+            Assert.True(AppLogger.TryParseMinimumLevel(token, out var got), $"'{token}' was rejected");
+            Assert.Equal(expected, got);
+        }
+
+        /* "3" and "6" are DEFINED levels spelled as numbers: undocumented vocabulary rather than a hazard,
+           rejected so the accepted set is the set the failure message names. "999" and "-1" are the ones
+           that would silence everything. */
+        foreach (var token in new string?[] { "999", "-1", "42", "3", "6", "banana", "Debug ", "", "  ", null })
+        {
+            Assert.False(
+                AppLogger.TryParseMinimumLevel(token, out var got),
+                $"'{token}' was accepted as a log level");
+
+            Assert.Equal(AppLogger.DefaultMinimumLevel, got);
+        }
     }
 
     /// <summary>

--- a/Lite.Tests/LiteLogLevelGateTests.cs
+++ b/Lite.Tests/LiteLogLevelGateTests.cs
@@ -1,0 +1,385 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using Darling.Tests;
+using Microsoft.Extensions.Logging;
+using PerformanceMonitorLite.Services;
+using Xunit;
+
+namespace PerformanceMonitorLite.Tests;
+
+/// <summary>
+/// <para>Pins that Lite's per-database collection timing line is SUPPRESSED at the default configuration
+/// (#3104), and that the level it carries and the gate deciding its fate are the same decision.</para>
+///
+/// <para><b>Why suppression rather than the call site's level.</b> A pin reading "this site is
+/// <c>LogDebug</c>" passes whether or not anything is quieter, which is the failure this issue is about:
+/// Lite has no logger factory, so there is no <c>LoggerFilterOptions</c> in the path and nothing upstream
+/// of <see cref="AppLoggerAdapter{T}"/> to filter on. Every assertion here therefore runs the level the
+/// source actually carries through the real gate, instead of comparing it to a name.</para>
+///
+/// <para><b>Two gates had to agree, and they are the reason this file is four pins rather than one.</b>
+/// <see cref="AppLoggerAdapter{T}.IsEnabled"/> decides whether a component's call is admitted, and
+/// <see cref="AppLogger"/>'s static methods decide whether the admitted call is written. A minimum level
+/// consulted by only one of them is worse than none: a level change would silence the line while the
+/// setting that is supposed to bring it back does nothing, and both halves read as working from either
+/// side alone. So the adapter's answer, the sink's answer, their agreement, and the round trip back up are
+/// each asserted.</para>
+///
+/// <para><b>What this does NOT cover.</b> No log VOLUME is measured — the emission is asserted as an
+/// admission decision, not a rate. The source scan reads one file and identifies the timing line by the
+/// placeholders in its message template, so a future timing line spelled with different placeholders is
+/// outside its net; the floor assertion is what keeps a net that has stopped matching from reading as a
+/// clean pass. Nothing here exercises <c>App.LoadLogMinimumLevel</c>'s settings read — that runs inside
+/// WPF startup, and its key is covered by <c>SettingsSampleTests</c> in both directions.</para>
+/// </summary>
+public sealed class LiteLogLevelGateTests : IDisposable
+{
+    /// <summary>The file the per-database collection timing line is emitted from.</summary>
+    private const string EmitFile = "Lite/Services/RemoteCollectorService.DefinitionRunner.cs";
+
+    /// <summary>
+    /// What makes a message template the per-cycle TIMING line: the two phase totals named with their own
+    /// placeholders. Matched against the literal's BODY rather than against source lines, so a template
+    /// split across lines is still one match and a comment discussing <c>sql:</c> in prose is not a match
+    /// at all.
+    /// </summary>
+    private static readonly string[] TimingMarkers =
+    {
+        "sql:{SqlMs}ms",
+        "duckdb:{DuckMs}ms",
+    };
+
+    /// <summary>
+    /// The POSITIVE CONTROL's template, taken from the same callback so it shares every condition with the
+    /// timing line except the one under test. Its job is to fail when the resolution machinery below has
+    /// stopped working: without it, "the timing line is not admitted" is equally consistent with a scan
+    /// that matched nothing useful and a gate that admits nothing at all — an empty read that cannot be
+    /// told from a real absence, which is the shape of the defect this file exists for.
+    /// </summary>
+    private const string ControlMarker = "hit its per-database collection bound";
+
+    /// <summary>
+    /// How many timing templates that file holds today. A FLOOR rather than an equality, so adding another
+    /// one below the default level is not a failure while a net that has stopped matching — the silent way
+    /// a scan like this rots — drops beneath it and fails. The only frozen number here, and it fails toward
+    /// red.
+    /// </summary>
+    private const int KnownTimingTemplates = 1;
+
+    /// <summary>The nearest <c>.LogSomething(</c> ahead of a literal, which is the call emitting it.</summary>
+    private static readonly Regex LogCall = new(@"\.(Log[A-Za-z]*)\s*\(", RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// The level in force is process-wide, so every pin that moves it puts it back. Restored to the
+    /// DEFAULT rather than to a captured value on purpose: nothing else in this suite touches it, so a
+    /// value captured at construction that was not the default would mean an earlier test leaked, and
+    /// carrying that leak forward would hide it.
+    /// </summary>
+    public void Dispose() => AppLogger.SetMinimumLevel(AppLogger.DefaultMinimumLevel);
+
+    /// <summary>
+    /// The default, which every other pin here is relative to. <c>Information</c> matches what a default
+    /// .NET logging factory filters at and what Darling's service is gated at (#3102), so a level chosen
+    /// against one SKU's log means the same thing against the other's.
+    /// </summary>
+    [Fact]
+    public void TheDefaultMinimum_IsInformation()
+    {
+        Assert.Equal(LogLevel.Information, AppLogger.DefaultMinimumLevel);
+        Assert.Equal(LogLevel.Information, AppLogger.MinimumLevel);
+    }
+
+    /// <summary>
+    /// The acceptance criterion: the per-database timing line, at whatever level the source actually
+    /// carries, is not admitted by the gate a default install runs with — and the warning beside it is.
+    /// </summary>
+    [Fact]
+    public void ThePerDatabaseTimingLine_IsSuppressedAtTheDefaultConfiguration()
+    {
+        var sites = TimingSites(out var control);
+        var gate = new AppLoggerAdapter<RemoteCollectorService>();
+
+        /* The control first. A resolution failure makes every "not admitted" assertion below pass for the
+           wrong reason, so the thing that would mask it is what fails. */
+        Assert.NotNull(control);
+        Assert.True(
+            gate.IsEnabled(control!.Value.Level),
+            $"the collection-bound warning resolved to {control.Value.Method} ({control.Value.Level}), which the "
+                + "default gate does not admit. Either the gate suppresses everything — in which case the "
+                + "timing assertion below proves nothing — or the level resolution is wrong.");
+
+        Assert.True(
+            sites.Count >= KnownTimingTemplates,
+            $"expected at least {KnownTimingTemplates} per-cycle timing template in {EmitFile}, found "
+                + $"{sites.Count} — the marker set has stopped matching the emit site, so the levels below "
+                + "were not checked.");
+
+        var admitted = sites.Where(s => gate.IsEnabled(s.Level)).ToList();
+
+        Assert.True(
+            admitted.Count == 0,
+            "per-database collection timing must not be admitted at Lite's default log level (#3104):"
+                + string.Concat(admitted.Select(s =>
+                    $"{Environment.NewLine}  {s.Method} ({s.Level}) — {s.Template}")));
+    }
+
+    /// <summary>
+    /// <para>End to end: the timing line does not reach the log at the default, and the warning emitted
+    /// beside it in the same callback does. Driven through the real <see cref="AppLoggerAdapter{T}"/> into
+    /// the real <see cref="AppLogger"/>, so it answers for the whole path rather than for either gate's
+    /// opinion of it.</para>
+    ///
+    /// <para>The warning is the POSITIVE CONTROL and it travels the same adapter, the same sink and the same
+    /// drain, so the timing line's absence is an absence rather than a logger that was never wired up.</para>
+    /// </summary>
+    [Fact]
+    public void TheTimingLine_DoesNotReachTheLog_AndTheWarningBesideItDoes()
+    {
+        var sites = TimingSites(out _);
+        Assert.True(sites.Count >= KnownTimingTemplates, "the timing site was not located; see the pin above");
+
+        var emitted = sites[0].Level;
+        ILogger<RemoteCollectorService> logger = new AppLoggerAdapter<RemoteCollectorService>();
+
+        /* Tagged so concurrently-running tests logging into the same process-wide buffer cannot be mistaken
+           for this one's lines, and so this one's cannot be mistaken for theirs. */
+        var tag = Guid.NewGuid().ToString("N");
+
+        AppLogger.DrainBufferedLines();
+        logger.Log(emitted, default, $"timing {tag}", null, (s, _) => s);
+        logger.LogWarning("control {Tag}", tag);
+        var written = Tagged(tag);
+
+        Assert.Single(written);
+        Assert.Contains("control", written[0], StringComparison.Ordinal);
+        Assert.DoesNotContain("timing", written[0], StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// <para>The sink's OWN gate, and the adapter's agreement with it, swept across every minimum rather
+    /// than probed at the default.</para>
+    ///
+    /// <para><b>Why this is separate from the end-to-end pin above.</b> The adapter short-circuits on its
+    /// own <c>IsEnabled</c> before it ever calls a static method here, so a sink that had no gate — or one
+    /// that disagreed with the adapter — is completely invisible from that direction. That is the failure
+    /// mode worth catching: the level a caller sets would gate admission while the sink wrote or dropped on
+    /// some other basis, and the two would only diverge for a caller that reaches the sink directly, which
+    /// twenty of Lite's log sites do. So this calls the static entry points themselves and asserts the
+    /// property rather than a case: a line is written exactly when <see cref="AppLogger.IsEnabled"/> says
+    /// so, at every minimum, for every level.</para>
+    ///
+    /// <para>The sweep carries its own controls at both ends. At <c>Trace</c> all four entry points must
+    /// write, so a drain that observes nothing fails here instead of reading as four correct suppressions;
+    /// at <c>None</c> none of them may, so a gate that cannot suppress fails too.</para>
+    /// </summary>
+    [Fact]
+    public void EveryStaticEntryPoint_HonoursTheMinimum_AndTheAdapterAgrees()
+    {
+        var levels = new[]
+        {
+            LogLevel.Trace, LogLevel.Debug, LogLevel.Information,
+            LogLevel.Warning, LogLevel.Error, LogLevel.Critical, LogLevel.None,
+        };
+
+        var gate = new AppLoggerAdapter<RemoteCollectorService>();
+
+        foreach (var minimum in levels)
+        {
+            AppLogger.SetMinimumLevel(minimum);
+
+            foreach (var level in levels)
+            {
+                Assert.Equal(AppLogger.IsEnabled(level), gate.IsEnabled(level));
+            }
+
+            var tag = Guid.NewGuid().ToString("N");
+            AppLogger.DrainBufferedLines();
+
+            AppLogger.Debug("L3104", $"debug {tag}");
+            AppLogger.Info("L3104", $"info {tag}");
+            AppLogger.Warn("L3104", $"warn {tag}");
+            AppLogger.Error("L3104", $"error {tag}");
+
+            var written = string.Join(Environment.NewLine, Tagged(tag));
+
+            /* The entry point is named by the level it writes at, so the expectation is IsEnabled itself
+               rather than a second table of levels that could drift away from it. */
+            var expected = new (string Word, LogLevel Level)[]
+            {
+                ("debug", LogLevel.Debug),
+                ("info", LogLevel.Information),
+                ("warn", LogLevel.Warning),
+                ("error", LogLevel.Error),
+            };
+
+            foreach (var (word, level) in expected)
+            {
+                var appears = written.Contains($"{word} {tag}", StringComparison.Ordinal);
+
+                Assert.True(
+                    appears == AppLogger.IsEnabled(level),
+                    $"with the minimum at {minimum}, AppLogger.{word} "
+                        + (appears ? "wrote" : "wrote nothing")
+                        + $" while IsEnabled({level}) is {AppLogger.IsEnabled(level)}. The sink and the gate "
+                        + "must be one decision (#3104).");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Raising the minimum puts the line back, which is the half a gate alone does not deliver. Suppressing
+    /// a diagnostic and deleting one look identical in a log; the difference is whether an operator can
+    /// reach it, and that is what this asserts.
+    /// </summary>
+    [Fact]
+    public void RaisingTheMinimum_RestoresTheTimingLine()
+    {
+        var sites = TimingSites(out _);
+        Assert.True(sites.Count >= KnownTimingTemplates, "the timing site was not located; see the pin above");
+
+        var emitted = sites[0].Level;
+        ILogger<RemoteCollectorService> logger = new AppLoggerAdapter<RemoteCollectorService>();
+        var tag = Guid.NewGuid().ToString("N");
+
+        AppLogger.SetMinimumLevel(emitted);
+
+        Assert.True(
+            logger.IsEnabled(emitted),
+            $"the gate still rejects {emitted} after the minimum was set to it, so the setting cannot bring "
+                + "the timing lines back and is a knob that does nothing.");
+
+        AppLogger.DrainBufferedLines();
+        logger.Log(emitted, default, $"timing {tag}", null, (s, _) => s);
+        var written = Tagged(tag);
+
+        Assert.Single(written);
+        Assert.Contains("timing", written[0], StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// This test's own lines out of the buffer. Filtered by tag rather than taken wholesale because the
+    /// buffer is process-wide: any test class running in parallel is logging into it, and a count over
+    /// everything drained would be a count of the suite's timing.
+    /// </summary>
+    private static List<string> Tagged(string tag) =>
+        AppLogger.DrainBufferedLines()
+            .Where(l => l.Contains(tag, StringComparison.Ordinal))
+            .ToList();
+
+    /// <summary>
+    /// <para>No logging decision in <see cref="AppLogger"/> is made by the preprocessor. This is a SOURCE
+    /// pin because no runtime assertion can be: a test is compiled in one configuration and can only ever
+    /// observe that one, so a <c>#if DEBUG</c> around a write is invisible to every other pin in this file
+    /// while making all of them configuration-dependent — green under Release, and speaking for nothing but
+    /// Release, which is not the configuration a developer runs locally.</para>
+    ///
+    /// <para>It is also the difference between suppressing a line and deleting it. Conditional compilation
+    /// selects a verbosity at build time, so the shipped Release artifact has exactly one and no setting can
+    /// change it; a level lowered onto a compiled-out write is silenced permanently rather than by
+    /// default.</para>
+    /// </summary>
+    [Fact]
+    public void NoLoggingDecision_IsMadeByThePreprocessor()
+    {
+        /* Stripped, so the discussion of conditional compilation in this type's own remarks is not read as
+           conditional compilation. */
+        var code = CSharpSourceWalker.StripCommentsAndStrings(
+            ReadRepoFile("Lite/Services/AppLogger.cs"));
+
+        var directives = Regex
+            .Matches(code, @"^[ \t]*#(if|elif|else|endif)\b", RegexOptions.Multiline)
+            .Select(m => m.Value.Trim())
+            .ToList();
+
+        Assert.True(
+            directives.Count == 0,
+            "AppLogger carries conditional compilation: " + string.Join(", ", directives)
+                + ". Verbosity has to be a runtime value — a preprocessor gate cannot be configured on the "
+                + "shipped Release build, and it makes every suppression pin in this file answer for one "
+                + "configuration only (#3104).");
+    }
+
+    /// <summary>One timing emit site: the call, the level it maps to, and the template it emits.</summary>
+    private readonly record struct Site(string Method, LogLevel Level, string Template);
+
+    /// <summary>
+    /// Every per-cycle timing emit site in the run path, plus the control site, resolved out of the real
+    /// source. The emitting call sits ahead of the literal and the literal is its first argument, so the
+    /// LAST call ahead of it is the one. Read out of the comment-and-literal-stripped text so a
+    /// <c>.LogInformation(</c> named in a comment above the site cannot be mistaken for the site's own call.
+    /// </summary>
+    private static List<Site> TimingSites(out Site? control)
+    {
+        var source = ReadRepoFile(EmitFile);
+        var code = CSharpSourceWalker.StripCommentsAndStrings(source);
+        var sites = new List<Site>();
+        control = null;
+
+        foreach (var (start, body) in CSharpSourceWalker.StringLiteralBodies(source))
+        {
+            var isTiming = TimingMarkers.All(m => body.Contains(m, StringComparison.Ordinal));
+            var isControl = body.Contains(ControlMarker, StringComparison.Ordinal);
+
+            if (!isTiming && !isControl)
+            {
+                continue;
+            }
+
+            var call = LogCall.Matches(code[..start]).LastOrDefault();
+            var method = call is null ? "(no log call found)" : call.Groups[1].Value;
+            var site = new Site(method, LevelOf(method), body.Trim());
+
+            if (isTiming)
+            {
+                sites.Add(site);
+            }
+            else
+            {
+                control ??= site;
+            }
+        }
+
+        return sites;
+    }
+
+    /// <summary>
+    /// The <c>ILogger</c> extension's name as the level it emits at. An unrecognised name maps to
+    /// <see cref="LogLevel.Information"/> — the default minimum, so it reads as ADMITTED and fails the
+    /// suppression assertion rather than passing it. A resolution failure must not look like a quiet line.
+    /// </summary>
+    private static LogLevel LevelOf(string method) => method switch
+    {
+        "LogTrace" => LogLevel.Trace,
+        "LogDebug" => LogLevel.Debug,
+        "LogInformation" => LogLevel.Information,
+        "LogWarning" => LogLevel.Warning,
+        "LogError" => LogLevel.Error,
+        "LogCritical" => LogLevel.Critical,
+        _ => LogLevel.Information,
+    };
+
+    private static string ReadRepoFile(string relativePath, [CallerFilePath] string thisFile = "")
+    {
+        var dir = Path.GetDirectoryName(thisFile)!;
+        var parts = relativePath.Split('/');
+        while (dir is not null && !File.Exists(Path.Combine(new[] { dir }.Concat(parts).ToArray())))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        Assert.NotNull(dir);
+        return File.ReadAllText(Path.Combine(new[] { dir! }.Concat(parts).ToArray()));
+    }
+}

--- a/Lite.Tests/LiteLogLevelGateTests.cs
+++ b/Lite.Tests/LiteLogLevelGateTests.cs
@@ -365,25 +365,43 @@ public sealed class LiteLogLevelGateTests : IDisposable
     ///
     /// <para>Read out of stripped source, so this type's own discussion of conditional compilation — and
     /// <see cref="AppLogger"/>'s — is not itself read as conditional compilation.</para>
+    ///
+    /// <para><b>Two detectors, because asking "what legal spelling of this defect would a single one miss"
+    /// turns up two.</b> A directive may be written <c>#␠if</c> — whitespace between the <c>#</c> and the
+    /// name is legal C# and compiles — so the pattern allows it rather than requiring them adjacent. And
+    /// <c>[Conditional("DEBUG")]</c> reaches the same end with no directive at all: it removes every CALL
+    /// to the method in an assembly built without the symbol, so a logging entry point wearing it is
+    /// compiled out of Release exactly as a <c>#if</c> body is. Both were verified legal and both were
+    /// invisible to the adjacent-<c>#if</c> form this started as.</para>
+    ///
+    /// <para><b>What it still cannot see</b>, since a scan's blind spot is a property of the detector: it
+    /// reads <see cref="AppLogger"/> only, so a <c>[Conditional]</c> on some other type this one calls, or
+    /// a directive in <see cref="AppLoggerAdapter{T}"/>, is out of scope — the runtime sweeps are what
+    /// answer for the adapter. It also keys on the ATTRIBUTE name, so an alias would evade it.</para>
     /// </summary>
     [Fact]
     public void NoLoggingDecision_IsMadeByThePreprocessor()
     {
         /* Stripped, so the discussion of conditional compilation in this type's own remarks is not read as
-           conditional compilation. */
+           conditional compilation. The Conditional check needs the attribute's ARGUMENT gone too, which
+           stripping gives it: `Conditional(` followed by a blanked literal still matches on the name. */
         var code = CSharpSourceWalker.StripCommentsAndStrings(
             ReadRepoFile("Lite/Services/AppLogger.cs"));
 
-        var directives = Regex
-            .Matches(code, @"^[ \t]*#(if|elif|else|endif)\b", RegexOptions.Multiline)
-            .Select(m => m.Value.Trim())
+        var found = Regex
+            .Matches(code, @"^[ \t]*#[ \t]*(if|elif|else|endif)\b", RegexOptions.Multiline)
+            .Select(m => $"directive {m.Value.Trim()}")
+            .Concat(Regex
+                .Matches(code, @"\[\s*Conditional(Attribute)?\s*\(", RegexOptions.CultureInvariant)
+                .Select(_ => "[Conditional] attribute"))
             .ToList();
 
         Assert.True(
-            directives.Count == 0,
-            "AppLogger carries conditional compilation: " + string.Join(", ", directives)
-                + ". Verbosity has to be a runtime value — a preprocessor gate cannot be configured on the "
-                + "shipped Release build, and it makes every suppression pin in this file answer for one "
+            found.Count == 0,
+            "AppLogger gates a write at COMPILE time: " + string.Join(", ", found)
+                + ". Verbosity has to be a runtime value — a compile-time gate cannot be configured on the "
+                + "shipped Release build, so a level lowered onto it is a deletion rather than a "
+                + "suppression, and it makes the suppression pins in this file answer for one build "
                 + "configuration only (#3104).");
     }
 

--- a/Lite.Tests/LiteLogLevelGateTests.cs
+++ b/Lite.Tests/LiteLogLevelGateTests.cs
@@ -463,13 +463,36 @@ public sealed class LiteLogLevelGateTests : IDisposable
     private readonly record struct Site(string Method, LogLevel Level, string Template, int Offset);
 
     /// <summary>
-    /// Every per-cycle timing emit site in the run path, plus the control site nearest the first of them,
-    /// resolved out of the real source. The emitting call sits ahead of the literal and the literal is its
-    /// first argument, so the LAST call ahead of it is the one. Read out of the comment-and-literal-stripped
-    /// text so a <c>.LogInformation(</c> named in a comment above the site cannot be mistaken for the site's
-    /// own call.
+    /// The source scan, done ONCE for the whole class. Four pins ask for it and the file does not change
+    /// during a run, so repeating it was three redundant reads of a ~900-line file plus three more
+    /// comment-and-literal walks and a regex over a large prefix. That is CPU this class spends beside
+    /// sixty-one test classes whose store writes wait on a process-wide lock with a five-second budget
+    /// (<c>DuckDbInitializer.s_dbLock</c>) — so avoidable work in a helper is not free to the run even
+    /// though this class touches no store itself.
+    /// </summary>
+    private static readonly Lazy<(List<Site> Sites, Site? Control)> s_scan =
+        new(() =>
+        {
+            var sites = ScanSource(out var control);
+            return (sites, control);
+        });
+
+    /// <summary>
+    /// Every per-cycle timing emit site in the run path, plus the control site nearest the first of them.
     /// </summary>
     private static List<Site> TimingSites(out Site? control)
+    {
+        control = s_scan.Value.Control;
+        return s_scan.Value.Sites;
+    }
+
+    /// <summary>
+    /// The scan itself, resolved out of the real source. The emitting call sits ahead of the literal and
+    /// the literal is its first argument, so the LAST call ahead of it is the one. Read out of the
+    /// comment-and-literal-stripped text so a <c>.LogInformation(</c> named in a comment above the site
+    /// cannot be mistaken for the site's own call.
+    /// </summary>
+    private static List<Site> ScanSource(out Site? control)
     {
         var source = ReadRepoFile(EmitFile);
         var code = CSharpSourceWalker.StripCommentsAndStrings(source);

--- a/Lite.Tests/LiteLogLevelGateTests.cs
+++ b/Lite.Tests/LiteLogLevelGateTests.cs
@@ -374,10 +374,19 @@ public sealed class LiteLogLevelGateTests : IDisposable
     /// compiled out of Release exactly as a <c>#if</c> body is. Both were verified legal and both were
     /// invisible to the adjacent-<c>#if</c> form this started as.</para>
     ///
+    /// <para>The attribute pattern is deliberately LOOSE — the bare token followed by <c>(</c>, with no
+    /// attribute brackets or qualifier required. The tight form that required <c>[</c> immediately before
+    /// it missed <c>[System.Diagnostics.Conditional("DEBUG")]</c>, which is how anyone who has not imported
+    /// the namespace writes it; a list position (<c>[Other, Conditional(…)]</c>) and a <c>global::</c>
+    /// prefix evaded it for the same reason. Loose costs a false red on an unrelated member that happened
+    /// to be called <c>Conditional</c>, which is a question someone answers in a minute. Tight costs a
+    /// silent miss of the exact defect, which is what this whole issue is about.</para>
+    ///
     /// <para><b>What it still cannot see</b>, since a scan's blind spot is a property of the detector: it
     /// reads <see cref="AppLogger"/> only, so a <c>[Conditional]</c> on some other type this one calls, or
     /// a directive in <see cref="AppLoggerAdapter{T}"/>, is out of scope — the runtime sweeps are what
-    /// answer for the adapter. It also keys on the ATTRIBUTE name, so an alias would evade it.</para>
+    /// answer for the adapter. It also keys on the attribute's NAME, so an alias
+    /// (<c>using C = System.Diagnostics.ConditionalAttribute;</c>) would evade it.</para>
     /// </summary>
     [Fact]
     public void NoLoggingDecision_IsMadeByThePreprocessor()
@@ -392,8 +401,8 @@ public sealed class LiteLogLevelGateTests : IDisposable
             .Matches(code, @"^[ \t]*#[ \t]*(if|elif|else|endif)\b", RegexOptions.Multiline)
             .Select(m => $"directive {m.Value.Trim()}")
             .Concat(Regex
-                .Matches(code, @"\[\s*Conditional(Attribute)?\s*\(", RegexOptions.CultureInvariant)
-                .Select(_ => "[Conditional] attribute"))
+                .Matches(code, @"\bConditional(?:Attribute)?\s*\(", RegexOptions.CultureInvariant)
+                .Select(m => $"attribute {m.Value.Trim()}"))
             .ToList();
 
         Assert.True(

--- a/Lite.Tests/LiteLogLevelGateTests.cs
+++ b/Lite.Tests/LiteLogLevelGateTests.cs
@@ -47,13 +47,30 @@ namespace PerformanceMonitorLite.Tests;
 /// is covered by <c>SettingsSampleTests</c> in both directions.</para>
 /// </summary>
 /// <remarks>
-/// The collection exists because these pins move <see cref="AppLogger"/>'s process-wide minimum, briefly
-/// as far as <see cref="LogLevel.None"/>, and a concurrently-running class whose service logs during that
-/// window loses the line — unrecoverably, since tag-filtering a buffer cannot bring back a line never
-/// enqueued. That is #1965, which <c>app-alert-statics</c> was created for. No other class makes runtime
-/// <c>AppLogger</c> calls today, and a collection name only serialises classes that SHARE it, so this
-/// serialises nothing yet: it is the named place for the next class touching this static to join, and it
-/// is worth stating that it protects nothing on its own rather than implying it already does.
+/// <para>The collection exists because these pins move <see cref="AppLogger"/>'s process-wide minimum,
+/// briefly as far as <see cref="LogLevel.None"/>, and a concurrently-running class whose service logs
+/// during that window loses the line — unrecoverably, since tag-filtering a buffer cannot bring back a
+/// line that was never enqueued. That is the #1965 shape, which <c>app-alert-statics</c> was created
+/// for.</para>
+///
+/// <para><b>The interaction is real and currently harmless, which are two separate facts.</b> Five other
+/// classes hand an <see cref="AppLoggerAdapter{T}"/> to a service that logs —
+/// <c>AnalysisNotificationTests</c>, <c>MuteRuleServiceTests</c>, <c>PagerDutyWebhookTests</c>,
+/// <c>RemainingEmptyReadsToolTests</c> and <c>WebhookCooldownSeedTests</c>, against 28 log sites across
+/// four services — and each sits in its own default collection, so they run in parallel with the sweeps
+/// here and their lines really can be dropped. Nothing fails, because this class is the only reader of
+/// the sink anywhere in the suite: no other test asserts on log output, so a dropped line changes no
+/// assertion. The condition that would make it bite is any of those five reading the log, and then they
+/// join <c>app-logger-statics</c>.</para>
+///
+/// <para><b>Why a separate name rather than joining <c>app-alert-statics</c>.</b> Its five members touch
+/// <c>App</c>'s alert-settings statics and make no <c>AppLogger</c> calls at all, so joining them would
+/// serialise this class against classes that cannot race with it while still not serialising the five
+/// that can. A collection name only serialises classes that SHARE it, so this one serialises nothing
+/// today — it is the named place for a class that reads the log to join, and saying so is the point.
+/// Re-sharding the suite's parallelism is deliberately not done here: it is a change to the scheduling of
+/// a suite whose store writes wait on a process-wide lock with a five-second budget, and this is a change
+/// about a log gate.</para>
 /// </remarks>
 [Collection("app-logger-statics")]
 public sealed class LiteLogLevelGateTests : IDisposable

--- a/Lite/App.xaml.cs
+++ b/Lite/App.xaml.cs
@@ -677,8 +677,8 @@ public partial class App : Application
     /// <summary>
     /// Records that settings.json is present but unparseable: to the log immediately (buffered until
     /// <c>AppLogger.Initialize</c>) and to <see cref="s_unreadableSettingsProblem"/> for the single dialog
-    /// shown once the main window is up. First caller wins, because both loaders read the same file and
-    /// would otherwise say the same thing twice.
+    /// shown once the main window is up. First caller wins, because all three loaders read the same file
+    /// and would otherwise say the same thing three times.
     ///
     /// <para>There is deliberately no counterpart for an ABSENT file. A first run has no settings.json,
     /// defaults are the correct answer, and a warning there would be pure noise — which is precisely why
@@ -701,7 +701,8 @@ public partial class App : Application
     }
 
     /// <summary>
-    /// Every settings.json key whose VALUE was the wrong shape, accumulated across both loaders and consumed
+    /// Every settings.json key whose VALUE was the wrong shape, accumulated across all three loaders and
+    /// consumed
     /// once by <see cref="ReportUnreadableSettingsToUser"/> (#2444).
     ///
     /// <para>Separate from <see cref="s_unreadableSettingsProblem"/> because they are different failures with
@@ -740,10 +741,10 @@ public partial class App : Application
             }
         }
 
-        /* Says "every other key this loader read", not "every other setting in the file": both loaders call
-           this and LoadDefaultTimeRange runs first, so a claim about the whole file would be written before
-           the alert settings had been read at all. The dialog CAN make the whole-file claim, because it is
-           shown once, after both loaders have run. */
+        /* Says "every other key this loader read", not "every other setting in the file": three loaders
+           call this — LoadLogMinimumLevel first, then LoadDefaultTimeRange, then LoadAlertSettings — so a
+           claim about the whole file would be written before the later ones had read anything. The dialog
+           CAN make the whole-file claim, because it is shown once, after all three have run. */
         AppLogger.Error("Settings",
             $"settings.json parsed, but {problems.Count} value(s) in it could not be read and are at their " +
             "defaults for this session. Only the keys named here fell back -- every other key this loader " +

--- a/Lite/App.xaml.cs
+++ b/Lite/App.xaml.cs
@@ -444,10 +444,10 @@ public partial class App : Application
             ConfigDirectory,
             new[] { "ignored_wait_types.json", "collection_schedule.json" });
 
-        // Load settings
+        // Load settings. The log level goes first so it governs every line the loaders below buffer.
+        LoadLogMinimumLevel();
         LoadDefaultTimeRange();
         LoadAlertSettings();
-        LoadLogMinimumLevel();
 
         // Wire the shared-UI time conversion hook before any chart/crosshair can
         // render. The lambda reads CurrentDisplayMode at call time, so later
@@ -862,11 +862,13 @@ public partial class App : Application
     }
 
     /// <summary>
-    /// Applies the configured log verbosity (#3104). Runs BEFORE <see cref="AppLogger.Initialize"/> so the
-    /// level is in force for the first line written, including <c>Initialize</c>'s own.
+    /// Applies the configured log verbosity (#3104). The FIRST settings loader and well before
+    /// <see cref="AppLogger.Initialize"/>, so the level governs every line the loaders after it buffer as
+    /// well as <c>Initialize</c>'s own — a level applied halfway through startup would leave whichever
+    /// lines happened to precede it, which is a verbosity decided by call order.
     ///
-    /// <para>No UI: this is the knob that makes the per-cycle collector timing lines recoverable after they
-    /// were gated below the default, and its audience is someone reading a log to diagnose a collection
+    /// <para>No UI: this is the knob that makes the per-database collection timing lines recoverable now
+    /// that they sit below the default, and its audience is someone reading a log to diagnose a collection
     /// failure, not someone browsing Settings. An unrecognised token leaves the default in force and is
     /// reported through the shared reporter, so a typo costs its own setting and is named at startup rather
     /// than silently turning logging down.</para>
@@ -876,7 +878,8 @@ public partial class App : Application
         var settings = SettingsFileGuard.Read(Path.Combine(ConfigDirectory, "settings.json"));
         if (settings.State == SettingsFileState.Unreadable)
         {
-            /* The unreadable file is already reported by LoadDefaultTimeRange, which runs first. */
+            /* Reported by LoadDefaultTimeRange rather than here, so one unreadable file produces one
+               report no matter how many loaders meet it. */
             return;
         }
 

--- a/Lite/App.xaml.cs
+++ b/Lite/App.xaml.cs
@@ -897,7 +897,7 @@ public partial class App : Application
             {
                 var token = val.TextOrNull();
 
-                if (Enum.TryParse<Microsoft.Extensions.Logging.LogLevel>(token, ignoreCase: true, out var level))
+                if (AppLogger.TryParseMinimumLevel(token, out var level))
                 {
                     AppLogger.SetMinimumLevel(level);
                 }

--- a/Lite/App.xaml.cs
+++ b/Lite/App.xaml.cs
@@ -447,6 +447,7 @@ public partial class App : Application
         // Load settings
         LoadDefaultTimeRange();
         LoadAlertSettings();
+        LoadLogMinimumLevel();
 
         // Wire the shared-UI time conversion hook before any chart/crosshair can
         // render. The lambda reads CurrentDisplayMode at call time, so later
@@ -857,6 +858,72 @@ public partial class App : Application
             AppLogger.Warn("Settings",
                 $"settings.json key 'default_time_range_hours' could not be read ({ex.Message}); the " +
                 $"default of {DefaultTimeRangeHours} hours is in use.");
+        }
+    }
+
+    /// <summary>
+    /// Applies the configured log verbosity (#3104). Runs BEFORE <see cref="AppLogger.Initialize"/> so the
+    /// level is in force for the first line written, including <c>Initialize</c>'s own.
+    ///
+    /// <para>No UI: this is the knob that makes the per-cycle collector timing lines recoverable after they
+    /// were gated below the default, and its audience is someone reading a log to diagnose a collection
+    /// failure, not someone browsing Settings. An unrecognised token leaves the default in force and is
+    /// reported through the shared reporter, so a typo costs its own setting and is named at startup rather
+    /// than silently turning logging down.</para>
+    /// </summary>
+    private static void LoadLogMinimumLevel()
+    {
+        var settings = SettingsFileGuard.Read(Path.Combine(ConfigDirectory, "settings.json"));
+        if (settings.State == SettingsFileState.Unreadable)
+        {
+            /* The unreadable file is already reported by LoadDefaultTimeRange, which runs first. */
+            return;
+        }
+
+        if (settings.Text == null)
+        {
+            return;
+        }
+
+        try
+        {
+            using var doc = System.Text.Json.JsonDocument.Parse(settings.Text);
+            var read = new SettingsReader(doc.RootElement);
+
+            if (read.TryGetProperty("log_minimum_level", out var val))
+            {
+                var token = val.TextOrNull();
+
+                if (Enum.TryParse<Microsoft.Extensions.Logging.LogLevel>(token, ignoreCase: true, out var level))
+                {
+                    AppLogger.SetMinimumLevel(level);
+                }
+                else if (token != null)
+                {
+                    /* A string that is not one of the level names. TextOrNull has already reported a value
+                       that is not a string at all, so only the vocabulary is left to check here — and it
+                       goes through the shared reporter so it reaches the startup dialog beside any other
+                       key that fell back, rather than only the log. */
+                    ReportBadSettingValues(new[]
+                    {
+                        new SettingsValueProblem(
+                            "log_minimum_level",
+                            $"holds \"{token}\", which is not one of Trace, Debug, Information, Warning, "
+                                + $"Error, Critical or None; {AppLogger.DefaultMinimumLevel} is in use"),
+                    });
+                }
+            }
+
+            ReportBadSettingValues(read.Problems);
+        }
+        catch (Exception ex)
+        {
+            /* Every value read is shape-checked rather than caught, so nothing EXPECTED lands here. Kept
+               because an unexpected throw must not take startup down — and this runs before the logger
+               exists, so there is nowhere to record it other than the buffer Initialize will flush. */
+            AppLogger.Warn("Settings",
+                $"settings.json key 'log_minimum_level' could not be read ({ex.Message}); " +
+                $"{AppLogger.DefaultMinimumLevel} is in use.");
         }
     }
 

--- a/Lite/Services/AppLogger.cs
+++ b/Lite/Services/AppLogger.cs
@@ -8,9 +8,11 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Threading;
+using Microsoft.Extensions.Logging;
 
 namespace PerformanceMonitorLite.Services;
 
@@ -18,9 +20,40 @@ namespace PerformanceMonitorLite.Services;
 /// Simple file-based application logger. Writes to logs/ directory with daily rotation.
 /// Thread-safe with buffered writes. Files older than <see cref="RetentionDays"/> are swept at
 /// <see cref="Initialize"/> so the log directory never grows without bound.
+///
+/// <para><b>This type owns the whole app's level gate.</b> <see cref="IsEnabled"/> is the one decision
+/// point, and <see cref="AppLoggerAdapter{T}"/> defers to it so a component logging through
+/// <c>ILogger&lt;T&gt;</c> and a component calling the static methods here get the same answer. Lite has
+/// no logger factory — every <c>ILogger&lt;T&gt;</c> in the app is a directly-constructed
+/// <see cref="AppLoggerAdapter{T}"/> — so there is no <c>LoggerFilterOptions</c> anywhere in the path and
+/// nothing upstream of this to filter on (#3104).
+/// </para>
 /// </summary>
 public static class AppLogger
 {
+    /// <summary>
+    /// The level a line must reach to be written, absent a configured one.
+    ///
+    /// <para><see cref="LogLevel.Information"/> is the level a default .NET logging factory filters at, and
+    /// the level Darling's service is gated at (#3102), so both SKUs answer "does this line appear on a
+    /// default install" the same way and a level chosen on one reads the same on the other.</para>
+    /// </summary>
+    internal const LogLevel DefaultMinimumLevel = LogLevel.Information;
+
+    /// <summary>
+    /// The level in force, read on every call so it can be raised at startup from settings.json and
+    /// lowered again without a restart.
+    ///
+    /// <para><b>Runtime rather than conditional compilation, which is the decision this field records.</b>
+    /// A <c>#if DEBUG</c> around a write is a gate no operator can reach: the shipped artifact is Release,
+    /// so the level it selects is the only level that install will ever have, and raising it needs a
+    /// rebuild rather than a setting. It also makes the app's own tests unable to speak for the artifact —
+    /// a suppression test compiled Release and one compiled Debug get opposite answers about the same
+    /// source, so a green suite proves nothing about what ships. One runtime value has one answer in every
+    /// configuration.</para>
+    /// </summary>
+    private static volatile LogLevel s_minimumLevel = DefaultMinimumLevel;
+
     /// <summary>
     /// How long a rotated <c>lite_yyyyMMdd.log</c> is kept. "Daily rotation" only ever meant a NEW
     /// file per day — nothing deleted the old ones, so the directory grew for the life of the install
@@ -39,6 +72,27 @@ public static class AppLogger
     {
         s_flushTimer = new Timer(_ => Flush(), null, Timeout.Infinite, Timeout.Infinite);
     }
+
+    /// <summary>The level currently in force. A line below it is not written.</summary>
+    public static LogLevel MinimumLevel => s_minimumLevel;
+
+    /// <summary>
+    /// Raises or lowers the level. Called from startup once settings.json has been read, and safe to call
+    /// at any time — the next call to <see cref="IsEnabled"/> sees it.
+    /// </summary>
+    public static void SetMinimumLevel(LogLevel level) => s_minimumLevel = level;
+
+    /// <summary>
+    /// Whether a line at <paramref name="level"/> would be written. The gate for both this type's static
+    /// methods and <see cref="AppLoggerAdapter{T}"/>, so the level an operator sets is the level every
+    /// component in the app is held to.
+    ///
+    /// <para><see cref="LogLevel.None"/> is never enabled. It is the "log nothing" sentinel rather than a
+    /// severity, so ordering it against the minimum — where it compares highest of all — would make it the
+    /// one level nothing can suppress.</para>
+    /// </summary>
+    public static bool IsEnabled(LogLevel level) =>
+        level != LogLevel.None && level >= s_minimumLevel;
 
     public static void Initialize(string logDirectory)
     {
@@ -84,16 +138,24 @@ public static class AppLogger
 
     public static void Info(string source, string message)
     {
+        if (!IsEnabled(LogLevel.Information)) return;
+
         Log("INFO", source, message);
     }
 
     public static void Warn(string source, string message)
     {
+        if (!IsEnabled(LogLevel.Warning)) return;
+
         Log("WARN", source, message);
     }
 
     public static void Error(string source, string message, Exception? ex = null)
     {
+        /* Gated once here rather than inside Log, so an exception's stack and its whole inner chain are
+           admitted or dropped together — a half-written error is harder to read than none. */
+        if (!IsEnabled(LogLevel.Error)) return;
+
         if (ex != null)
         {
             Log("ERROR", source, $"{message} | {ex.GetType().Name}: {ex.Message}");
@@ -130,15 +192,35 @@ public static class AppLogger
 
     public static void Debug(string source, string message)
     {
-#if DEBUG
+        if (!IsEnabled(LogLevel.Debug)) return;
+
         Log("DEBUG", source, message);
-#endif
     }
 
     private static void Log(string level, string source, string message)
     {
         var line = $"{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff} [{level,-5}] [{source}] {message}";
         s_buffer.Enqueue(line);
+    }
+
+    /// <summary>
+    /// Removes and returns everything buffered but not yet written, so a test can observe whether a call
+    /// was ADMITTED by the gate.
+    ///
+    /// <para>The seam exists because <see cref="Initialize"/> is not usable from a test: it repoints the
+    /// whole process's logging at the caller's directory and starts a timer against it, which is the
+    /// constraint <c>AppLoggerRetentionTests</c> documents for the same reason. Nothing in the app calls
+    /// this — <see cref="Flush"/> owns the buffer in production and drains it to the file.</para>
+    /// </summary>
+    internal static List<string> DrainBufferedLines()
+    {
+        var lines = new List<string>();
+        while (s_buffer.TryDequeue(out var line))
+        {
+            lines.Add(line);
+        }
+
+        return lines;
     }
 
     public static void Flush()

--- a/Lite/Services/AppLogger.cs
+++ b/Lite/Services/AppLogger.cs
@@ -94,6 +94,46 @@ public static class AppLogger
     public static bool IsEnabled(LogLevel level) =>
         level != LogLevel.None && level >= s_minimumLevel;
 
+    /// <summary>
+    /// A settings.json token as a level. False — with <paramref name="level"/> left at
+    /// <see cref="DefaultMinimumLevel"/> — for anything that is not one of the seven NAMES, so a caller
+    /// that ignores the result still gets a usable level rather than whatever the token decoded to.
+    ///
+    /// <para><b>Names only, and both checks below reject something the other accepts.</b>
+    /// <c>Enum.TryParse</c> succeeds on a NUMBER, which goes wrong two ways: an undefined one
+    /// (<c>"999"</c>) becomes a minimum no real level can reach, so every line including
+    /// <see cref="LogLevel.Error"/> is dropped and nothing is reported — a verbosity setting silencing
+    /// the log completely is the opposite of what it is for — and a defined one (<c>"3"</c>) is accepted
+    /// vocabulary this setting has never documented. The letter check turns both into a reported token.
+    /// <c>Enum.IsDefined</c> then holds the invariant independently of how the token was spelled, so a
+    /// future spelling the letter check lets through cannot become an out-of-range minimum.</para>
+    /// </summary>
+    public static bool TryParseMinimumLevel(string? token, out LogLevel level)
+    {
+        level = DefaultMinimumLevel;
+
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return false;
+        }
+
+        foreach (var c in token)
+        {
+            if (!char.IsAsciiLetter(c))
+            {
+                return false;
+            }
+        }
+
+        if (!Enum.TryParse(token, ignoreCase: true, out LogLevel parsed) || !Enum.IsDefined(parsed))
+        {
+            return false;
+        }
+
+        level = parsed;
+        return true;
+    }
+
     public static void Initialize(string logDirectory)
     {
         s_logDirectory = logDirectory;

--- a/Lite/Services/AppLogger.cs
+++ b/Lite/Services/AppLogger.cs
@@ -46,11 +46,11 @@ public static class AppLogger
     ///
     /// <para><b>Runtime rather than conditional compilation, which is the decision this field records.</b>
     /// A <c>#if DEBUG</c> around a write is a gate no operator can reach: the shipped artifact is Release,
-    /// so the level it selects is the only level that install will ever have, and raising it needs a
-    /// rebuild rather than a setting. It also makes the app's own tests unable to speak for the artifact —
-    /// a suppression test compiled Release and one compiled Debug get opposite answers about the same
-    /// source, so a green suite proves nothing about what ships. One runtime value has one answer in every
-    /// configuration.</para>
+    /// so the level that directive selects is the only level an install will ever have, and changing it
+    /// needs a rebuild rather than a setting — which makes a level lowered onto such a write a deletion
+    /// rather than a suppression. It also splits the app's own tests from the artifact: the same source
+    /// writes the line under one configuration and not the other, so what a suite observed depends on how
+    /// it was built. One runtime value has one answer in every configuration.</para>
     /// </summary>
     private static volatile LogLevel s_minimumLevel = DefaultMinimumLevel;
 

--- a/Lite/Services/AppLogger.cs
+++ b/Lite/Services/AppLogger.cs
@@ -190,11 +190,28 @@ public static class AppLogger
         Log("WARN", source, message);
     }
 
-    public static void Error(string source, string message, Exception? ex = null)
+    public static void Error(string source, string message, Exception? ex = null) =>
+        Error(LogLevel.Error, source, message, ex);
+
+    /// <summary>
+    /// The error sink, gated on the level the CALLER logged at rather than on
+    /// <see cref="LogLevel.Error"/>.
+    ///
+    /// <para><b>Why the level is a parameter.</b> <see cref="AppLoggerAdapter{T}"/> routes both
+    /// <see cref="LogLevel.Error"/> and <see cref="LogLevel.Critical"/> here, so a fixed
+    /// <c>IsEnabled(Error)</c> would answer for the wrong level on the Critical half: at a minimum of
+    /// <c>Critical</c> the adapter admits a Critical line and this gate then drops it, which makes
+    /// <c>Critical</c> silence the log as completely as <c>None</c> — a documented level quietly meaning
+    /// something else. The <c>Trace</c>/<c>Debug</c> pair does not have the same problem in the other
+    /// direction, because there the sink is the HIGHER of the two: admitting <c>Trace</c> requires a
+    /// minimum at or below it, which already admits <c>Debug</c>. Taking the level makes both pairs answer
+    /// from one comparison instead of relying on that asymmetry holding.</para>
+    /// </summary>
+    internal static void Error(LogLevel level, string source, string message, Exception? ex)
     {
         /* Gated once here rather than inside Log, so an exception's stack and its whole inner chain are
            admitted or dropped together — a half-written error is harder to read than none. */
-        if (!IsEnabled(LogLevel.Error)) return;
+        if (!IsEnabled(level)) return;
 
         if (ex != null)
         {

--- a/Lite/Services/AppLoggerAdapter.cs
+++ b/Lite/Services/AppLoggerAdapter.cs
@@ -14,6 +14,15 @@ namespace PerformanceMonitorLite.Services;
 /// <summary>
 /// Bridges the static AppLogger to the ILogger&lt;T&gt; interface so services
 /// that accept ILogger&lt;T&gt; can log to the same file as the rest of the app.
+///
+/// <para><b>The gate is <see cref="AppLogger.IsEnabled"/>, not a rule of this type's own (#3104).</b> Lite
+/// constructs these directly rather than resolving them from a logger factory, so there is no
+/// <c>LoggerFilterOptions</c> upstream to filter on and this <see cref="IsEnabled"/> is the only thing a
+/// caller's level is ever compared against. Answering it from a level fixed here rather than from the sink
+/// puts the app's verbosity decision in two places: a caller lowering a site to <c>Debug</c> would move it
+/// from one admitted level to another admitted level while the sink dropped it anyway, so the level a site
+/// carries and the level that decides its fate could disagree with nothing to reveal it. Deferring leaves
+/// one answer, which is also the answer <see cref="AppLogger"/>'s own static callers get.</para>
 /// </summary>
 public sealed class AppLoggerAdapter<T> : ILogger<T>
 {
@@ -21,7 +30,7 @@ public sealed class AppLoggerAdapter<T> : ILogger<T>
 
     public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
 
-    public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Debug;
+    public bool IsEnabled(LogLevel logLevel) => AppLogger.IsEnabled(logLevel);
 
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
     {

--- a/Lite/Services/AppLoggerAdapter.cs
+++ b/Lite/Services/AppLoggerAdapter.cs
@@ -52,7 +52,11 @@ public sealed class AppLoggerAdapter<T> : ILogger<T>
                 break;
             case LogLevel.Error:
             case LogLevel.Critical:
-                AppLogger.Error(_categoryName, message, exception);
+                /* The level travels with the call. Both arms land on one sink, and that sink gates on what
+                   it is handed — without it, the Critical arm would be gated as an Error and a minimum of
+                   Critical would drop the very lines it names. The two arms still render as ERROR, which
+                   is this switch's own collapse and predates the gate. */
+                AppLogger.Error(logLevel, _categoryName, message, exception);
                 break;
         }
     }

--- a/Lite/Services/RemoteCollectorService.DefinitionRunner.cs
+++ b/Lite/Services/RemoteCollectorService.DefinitionRunner.cs
@@ -703,10 +703,16 @@ public partial class RemoteCollectorService
 
                         /* Per-DATABASE line for non-empty batches (#1565): the per-server summary blends
                            every database into one number, hiding a single busy database's burst behind
-                           quiet siblings. Quiet databases (0 rows) stay silent. */
+                           quiet siblings. Quiet databases (0 rows) stay silent.
+
+                           At Debug, matching Darling's twin timing lines (#3102) and this file's own
+                           per-collector summary: it is per-database-per-cycle accounting of a run that
+                           SUCCEEDED, so there is no error beside it that it could be decomposing, and it
+                           crowds out the collection failures the log is opened for. The sample is not lost
+                           — raise log_minimum_level to Debug and every one of them is back, unchanged. */
                         if (batchCount > 0)
                         {
-                            _logger?.LogInformation("  [{Server}] {Collector} [{Database}] => {Rows} rows (sql:{SqlMs}ms, duckdb:{DuckMs}ms)",
+                            _logger?.LogDebug("  [{Server}] {Collector} [{Database}] => {Rows} rows (sql:{SqlMs}ms, duckdb:{DuckMs}ms)",
                                 server.DisplayName, definition.Name, item, batchCount, itemSqlMs, itemStorageMs);
                         }
 

--- a/Lite/config/settings.sample.json
+++ b/Lite/config/settings.sample.json
@@ -147,6 +147,21 @@
   // still checks when you open it, and installs in place from there.
   "check_for_updates_on_startup": true,
 
+  // ---- Log verbosity ------------------------------------------------------------------------------
+  // NO UI. How much reaches logs\lite_<date>.log:
+  //   "Trace" | "Debug" | "Information" | "Warning" | "Error" | "Critical" | "None"
+  // Case-insensitive; an unrecognised name leaves the default in force and is named in the
+  // startup dialog. A line below this level is never written.
+  //
+  // "Debug" adds the per-database collection timing lines — one per database per collector per
+  // cycle, "[server] collector [db] => N rows (sql:Nms, duckdb:Nms)" — which is what to set when
+  // you need to see which database in a collection is slow. They are off by default because at
+  // that rate they bury the collection failures the log is usually opened for.
+  //
+  // Applied at startup, so a change needs a restart. Collection success and failure are recorded
+  // in DuckDB's collection_log table at every level, including "None".
+  "log_minimum_level": "Information",
+
   // ---- Teams / Slack / generic / PagerDuty webhooks --------------------------------------------------
   // The URLs, the generic headers JSON and the PagerDuty routing key are SECRETS and live in
   // Windows Credential Manager, never in this file. Only these plain prefs are stored here.

--- a/README.md
+++ b/README.md
@@ -408,6 +408,10 @@ Most tools accept optional `server_name` and `hours_back` parameters. If only on
 
 Application logs are written to the `logs/` folder. Collection success/failure is also logged to the `collection_log` table in DuckDB.
 
+Verbosity is the `log_minimum_level` key in `settings.json` (no UI — see `Lite/config/settings.sample.json`), one of `Trace`, `Debug`, `Information`, `Warning`, `Error`, `Critical` or `None`. It defaults to `Information` and is read at startup, so a change needs a restart.
+
+Set it to `Debug` when you need the per-database collection timing lines — `[server] collector [db] => N rows (sql:Nms, duckdb:Nms)`, one per database per collector per cycle. They are below the default because at that rate they bury the collection failures the log is usually opened for; the aggregate they decompose is in `collection_log`'s `duration_ms`, which is recorded at every level.
+
 Common issues:
 
 1. **No data after connecting** — Wait for the first collection cycle (1–5 minutes). Check logs for connection errors.


### PR DESCRIPTION
Issue: #3104 — closed by hand after merge, since a PR targeting `dev` never triggers a closing keyword against a `main` default branch.

Lite's log gate becomes one runtime minimum level, and the per-database collection timing line moves below it. `AppLogger.IsEnabled(LogLevel)` is now the single decision point; `AppLoggerAdapter<T>.IsEnabled` defers to it, and `AppLogger`'s static entry points consult it too, so a component logging through `ILogger<T>` and a component calling `AppLogger.Info` directly get the same answer. The error sink takes the level it was handed rather than assuming `Error`, because the adapter routes both `Error` and `Critical` onto it — gating it as `Error` would make a minimum of `Critical` admit a Critical line at the adapter and drop it at the sink, silencing the log as completely as `None`. The `Trace`/`Debug` collapse is safe only because its sink is the higher of the pair; passing the level removes the reliance on that asymmetry. `log_minimum_level` in `settings.json` sets it, defaulting to `Information`.

## Which was wrong, the line's level or the gate — the gate, on two counts

The issue diagnoses one wrongness in the gate. There is a second, and it inverts the issue's prediction about what a level change would do.

**`AppLoggerAdapter.IsEnabled` returned `logLevel >= LogLevel.Debug`, and `AppLogger.Debug`'s write was inside `#if DEBUG`.** Every published artifact and every CI test job is built `-c Release` (`build.yml` lines 299–341, 370–386; `nightly.yml` 127–160), so in everything that ships or is tested, that write did not exist. The two therefore disagreed in the shipped configuration: `IsEnabled(Debug)` answered true about a sink that had already discarded `Debug` at compile time. That is `IsEnabled`'s only job, and it is also the pair that no single reading can settle — the adapter alone says `Debug` is on, the sink alone says it is off, and which is true depends on a `-c` flag neither file mentions.

So the issue's mechanism holds for a Debug build and reverses for a Release one. **A level change is not inert in the shipped artifact; it is a permanent gag.** Lowering the line to `LogDebug` against `#if DEBUG` does not leave the log "the same size" — it removes the line from every install with no setting able to bring it back, because conditional compilation selects verbosity at build time. Of the two failure modes worth avoiding here, that is the one that silently deletes a diagnostic rather than the one that silently keeps it.

`#if DEBUG` at `AppLogger.cs:133` was the **only** conditional compilation anywhere in `Lite/`, and no Lite call site reads `IsEnabled` to skip work, so replacing it with a runtime minimum has one behavioural consequence and it is at the default: none. Every `LogDebug` site (30) and `AppLogger.Debug` site (20) wrote nothing in Release before and writes nothing at `Information` now; `Information` and above are untouched. What changes is that they are now *reachable*. A local Debug build gets quieter — that output has never existed in a shipped or CI-tested artifact, and the knob replaces it without a rebuild.

The line's level was also wrong, but downstream of that: per-database-per-cycle accounting of a run that **succeeded** has no error beside it to decompose, which is the rule `DarlingCollectorRunner.LogPerDatabaseFaultSplit` already states and #3102 already applied. It could not be fixed first — a level needs a gate to mean anything.

## Lite-only

`AppLogger` and `AppLoggerAdapter` are both `Lite/Services/`, namespace `PerformanceMonitorLite.Services`. Nothing in `PerformanceMonitor.Alerting`, `.Notifications`, `.Collectors` or `.Analysis` changes, and Darling is untouched — #3102 is measured and complete there, and its gate is the logger factory it actually has.

The one cross-cutting effect worth naming: those shared components take `ILogger<T>`, and under Lite that `ILogger<T>` is always an `AppLoggerAdapter`. So a shared component's `LogDebug` is now gated by Lite's setting when hosted by Lite, and by `LoggerFilterOptions` when hosted by Darling. That is the two SKUs agreeing rather than diverging: both default to `Information`, so "does this line appear on a default install" has one answer across both, which it did not before.

## Restoring the line

`log_minimum_level` is documented in `Lite/config/settings.sample.json` (with the level vocabulary and what `Debug` adds) and in the root README's Troubleshooting → Lite section. It is read first among the settings loaders, before `AppLogger.Initialize`, so the level governs every line startup buffers rather than only the ones emitted after it is read — a level applied halfway through is a verbosity decided by call order. The token has to be one of the seven level NAMES: `Enum.TryParse` alone also accepts a number, and an undefined one is the case that matters — `"999"` parses to `(LogLevel)999`, a minimum no real level can reach, so every line including `Error` is dropped with nothing reported. `AppLogger.TryParseMinimumLevel` requires letters and a defined member, and hands back the default on rejection so a caller reading the level without the bool cannot get the silent version. A rejected token is named in the existing #2444 startup dialog beside any other key that fell back.

The aggregate the line decomposes was never only in the log: `collection_log` records `duration_ms`, `sql_duration_ms`, `duckdb_duration_ms`, `fanout_item_count` and `slowest_item` per run at every level, including `None`.

## Test

`Lite.Tests/LiteLogLevelGateTests.cs`, eight pins. None asserts that a call site carries a level; each runs the level the source actually carries through the real gate.

- **`ThePerDatabaseTimingLine_IsSuppressedAtTheDefaultConfiguration`** — the acceptance criterion. Walks `RemoteCollectorService.DefinitionRunner.cs` with `CSharpSourceWalker`, identifies the timing template by its two phase placeholders, resolves the emitting call out of the comment-and-string-stripped text, maps it to a `LogLevel`, and asserts the real `AppLoggerAdapter<RemoteCollectorService>` does not admit it. Carries a floor, and a positive control taken from the same callback — the collection-bound `LogWarning` — asserted *first*, because a resolution failure is what would make every "not admitted" assertion below it pass for the wrong reason. An unresolvable call maps to `Information`, so it reads as admitted and fails rather than passing.
- **`TheTimingLine_DoesNotReachTheLog_AndTheWarningBesideItDoes`** — the same thing end to end, adapter into sink, with the warning travelling the same path as its control.
- **`EveryStaticEntryPoint_HonoursTheMinimum_AndTheAdapterAgrees`** — the sink's own gate, swept across all seven minima. Separate from the pin above because the adapter short-circuits before it ever calls a static method, so a sink with no gate is invisible from that direction and twenty Lite sites reach it directly. Asserts a line is written exactly when `IsEnabled` says so, and that the adapter's answer equals the sink's for every level at every minimum. Controls at both ends: at `Trace` all four must write, at `None` none may.
- **`RaisingTheMinimum_RestoresTheTimingLine`** — the half a gate alone does not deliver. Suppressing a diagnostic and deleting one look identical in a log; the difference is whether an operator can reach it.
- **`NoLoggingDecision_IsMadeByThePreprocessor`** — a source pin, because the runtime pins' *reason* for failing on a compile-time gate is configuration-dependent (below). Two detectors, because asking what legal spelling a single one would miss turned up two: whitespace is allowed between the `#` and the directive name, and `[Conditional("DEBUG")]` reaches the same end with no directive at all — it removes every call to the method in an assembly built without the symbol. The attribute pattern is the bare token, not a bracket-anchored one, because the anchored form missed `[System.Diagnostics.Conditional(…)]`, a list position and a `global::` prefix. The remark names what it still cannot see.
- **`EveryLevelThroughTheAdapter_ReachesTheLogExactlyWhenItIsEnabled`** — the same property over the product of levels and minima, driven through `ILogger<T>`. Separate from the static sweep because that one calls the entry points by name and so never exercises the adapter's MAPPING, which is where the two gates can disagree: it collapses two levels onto one sink twice, and the two collapses are not symmetric.
- **`TheSettingsVocabulary_TakesTheDocumentedNamesAndNothingElse`** — the accepted set is exactly the seven documented names, and the *rejected* half is asserted as a pair: the token is refused AND the level handed back is the default. `"999"`, `"-1"` and `"42"` are the ones that would silence the log entirely; `"3"` and `"6"` are defined levels spelled as numbers, refused so the accepted set is the set the failure message names.
- **`TheDefaultMinimum_IsInformation`** — the value the others are relative to.

The class declares an `app-logger-statics` collection, since these pins move the process-wide minimum as far as `None` and a concurrently-running class whose service logs in that window loses the line unrecoverably (#1965, which `app-alert-statics` exists for). No other class makes runtime `AppLogger` calls today and a collection name only serialises classes that share it, so it serialises nothing yet — it is the named place for the next one to join, and the remark says so rather than implying it already protects.

### Ran, on this Mac, against the real assembly

`Lite.Tests` targets `net10.0-windows` and cannot execute here, so `LiteLogLevelGateTests.cs` was compiled **unchanged** into a `net10.0` console harness with an xUnit shim, referencing the built `PerformanceMonitorLite.dll` — the real `AppLogger`, the real `AppLoggerAdapter`, the real `RemoteCollectorService`, the real source files on disk. Nothing was substituted or rewritten. Run against **both** a Debug and a Release build of Lite: `Total: 8, Failed: 0, Not Run: 0` on each, which is itself the result — the pins now give the same answer in both configurations.

`Lite.Tests/SettingsSampleTests.cs` was compiled into a second harness the same way, since the new key has to satisfy #2418's symmetry in both directions: `Total: 7, Failed: 0, Not Run: 0`.

The source scan runs once per class rather than once per pin — four pins ask for the same walk of a ~900-line file, and this suite shares one process-wide store lock (`DuckDbInitializer.s_dbLock`) with sixty-one classes whose writes have a five-second budget, so avoidable CPU in a helper is a cost to the run even from a class that opens no connection.

`origin/dev` is merged in (not rebased), and the eight pins plus `Darling.Tests`' `RepoFileAdoptionTests` — including its exact-set `TheLfReadingPins_AreExactlyTheOnesDeclaredHere`, the shape a newly added file reddens with no textual conflict — were executed on the merged tree via the same shim, `Failed: 0` on both. That pin was mutation-checked in the harness too, so its green is a wired green.

Both Darling checks are real runs on this diff rather than path-gated no-ops: it touches `Darling/Darling.Tests/`, so `Filter darling = true`, the PG job's gate step printed "Darling code (or this workflow) changed", and `Darling.Tests` reports `Failed: 0, Not Run: 0`. `Darling whole-tree guards` skips its steps and says why — the `build` job already ran that suite on this commit. The Lite suite reports `Failed: 0, Skipped: 0, Not Run: 0`, and `Filter lite = true` names the added test file, which is what says these pins were discovered rather than compiled and ignored.

**A note on judging that by the suite TOTAL, because it is a check several of us have leaned on and it is approximate.** Across this branch's runs `Lite.Tests` moved 3437 → 3441 and `Darling.Tests` 7912 → 7913 across a commit that added no test at all — it memoized a helper and added a method and a field. Some cases in these suites are theories whose case count derives from scanning repo members, so ordinary source edits move the total. "Total went up by N, so my N tests ran" is therefore a smell test and not a proof in either direction: a delta that does not match the number of tests added is not evidence of a missing test, and a matching delta is not evidence that a specific test ran. What does answer it is `Skipped: 0` with `Not Run: 0` plus the path filter naming the file, or `--log | grep` for the test name. I did not chase the drift to the specific theory.

### Red-proof

Committed before each mutation, and Lite rebuilt after each one — the harness links the built DLL, so a restored source with a stale binary carries the previous mutation forward silently. That happened once mid-run and is the reason the final numbers above were taken from a clean tree.

| Mutation | Result |
|---|---|
| timing line back to `LogInformation` | `Failed: 2` — the suppression pin names the admitted site, the end-to-end pin sees two tagged lines |
| `#if DEBUG` restored at the sink, Debug build | `Failed: 2` — sweep: "with the minimum at Information, `AppLogger.debug` wrote while `IsEnabled(Debug)` is False"; source pin names the directive |
| `#if DEBUG` restored at the sink, **Release** build | `Failed: 3` — sweep fails at the *other* end: "with the minimum at Trace, `AppLogger.debug` wrote nothing while `IsEnabled(Debug)` is True" |
| adapter gate back to `logLevel >= LogLevel.Debug` | `Failed: 2` — suppression pin and the adapter/sink agreement |
| sink's `Debug` gate deleted | `Failed: 1` — the sweep, which is the only pin that can see it |
| timing marker set mutated to match nothing | `Failed: 4` — the floor fires with "the marker set has stopped matching the emit site, so the levels below were not checked" |
| control marker mutated to match nothing | `Failed: 2` — the control's own null check, ahead of any suppression claim |
| the token guard reverted to a bare `Enum.TryParse` | `Failed: 1` — `'999' was accepted as a log level` |
| directive written `#  if` (legal C#) | `Failed: 3` — the source pin names `directive #  if`; the form requiring them adjacent missed it |
| `[Conditional("DEBUG")]` on the `Debug` sink, four spellings — bare, `System.Diagnostics.`-qualified, `global::`-qualified, and in a list beside another attribute | all four named by the source pin. The bracket-anchored pattern this started as caught only the bare one, which is what motivated the loose token |
| error sink gated on `Error` instead of the level handed to it | `Failed: 1` — "with the minimum at Critical, an ILogger call at Critical did not reach the log while `IsEnabled(Critical)` is True". The static sweep stays green on this one, which is why the adapter sweep exists |

The two `#if DEBUG` rows are why the source pin exists, and they also **corrected a claim in this branch**: its remarks first said the directive was invisible to the runtime pins. Measurement says otherwise — the sweep catches it in both configurations, but via a different assertion in each, so what it reports is a level table that does not match and which mismatch you are shown depends on how you built. The comment now says that instead. The source pin's independent value is naming the cause identically in both, and covering the decisions the sweep does not enumerate.

## Deliberately not in this change

- **No log volume is measured.** The emission is asserted as an admission decision, not a rate. Lite's log volume is not a reported problem and this is a latent trap, exactly as the issue scopes it.
- **No Settings-window control.** `log_minimum_level` is file-only, matching `check_for_updates_on_startup` and the other no-UI keys; its audience is someone already reading a log file.
- **The other 29 `LogDebug` and 19 `AppLogger.Debug` sites keep their levels.** Their output is unchanged at the default and this change does not re-litigate any of them.
- **`MethodProfiler.SetEnabled` and `QueryLogger.SetEnabled` are still called by nothing.** The two sibling loggers carry runtime toggles no code reaches — the shape this change followed, and the same latent gap one step over. Not folded in: they are separate files with separate retention and separate audiences, and bundling them would put three loggers' verbosity policy in one diff. Worth its own issue if their output ever becomes a complaint.

## CHANGELOG entry

Not applied here, per the one-entry-per-lane convention. Text for the coordinator:

- **Lite: log verbosity becomes a setting, and per-database collection timing moves below the default** ([#3104]) — `AppLoggerAdapter` answered `IsEnabled(Debug)` from a hard-coded `>= Debug` while `AppLogger.Debug`'s write sat inside `#if DEBUG`, so the level a caller carried and the level that decided its fate were two different decisions that disagreed in the only configuration that ships. Lite builds Release, so every `LogDebug` in the app wrote nothing while the adapter reported it enabled — and lowering a line to `Debug` to quiet it would not have quieted anything visible, it would have deleted the line from every install with no setting able to restore it. Both are now one runtime minimum level: `AppLogger.IsEnabled` is the single gate, the adapter defers to it, the static entry points consult it, and `log_minimum_level` in `settings.json` sets it (`Trace` through `None`, default `Information`, documented in `Lite/config/settings.sample.json` and the README's Lite troubleshooting section). Behaviour at the default is byte-identical to before — the same 50 Debug sites stay silent, `Information` and above are untouched — but they are now reachable without a rebuild. The per-database collection timing line (`[server] collector [db] => N rows (sql:Nms, duckdb:Nms)`, one per database per collector per cycle) moves to `Debug` on the rule Darling's fault split already stated and #3102 already applied: a phase line must not be louder than the error it decomposes, and a run that succeeded has no error beside it. It returns in full at `Debug`, and the aggregate it decomposes was never only in the log — `collection_log` records `duration_ms`, `sql_duration_ms`, `duckdb_duration_ms` and `slowest_item` per run at every level.
