### PR TITLE
Fixes #3111

### DIFF
--- a/Darling/Darling.Tests/PostgresFaultOutcomeTests.cs
+++ b/Darling/Darling.Tests/PostgresFaultOutcomeTests.cs
@@ -480,12 +480,19 @@ public class PostgresFaultOutcomeTests
         Assert.IsNotAssignableFrom<NpgsqlException>(budgetExpiry);
 
         /* And the arm's filter carries the term that tells them apart. Pinned in source because an
-           exception filter cannot be invoked directly. */
+           exception filter cannot be invoked directly.
+
+           The two terms need not be ADJACENT, and requiring that was the wrong shape: #3111 added a third
+           conjunct between them, which reddened this pin without touching anything it asserts. What has to
+           hold is that both are conjuncts of the SAME filter, in this order — so the window forbids a brace
+           rather than counting newlines. A brace is what would mean the arm's body had begun, which is the
+           way the NpgsqlException term could be present in the file while absent from this filter, and it
+           is the only failure this pin was ever detecting through adjacency. */
         var worker = ReadSource(Path.Combine(
             "Darling", "PerformanceMonitor.Darling.Service", "DarlingWorker.cs"));
 
         Assert.Matches(
-            new Regex(@"&& ex is NpgsqlException\s*\r?\n\s*&& PostgresTargetProvider\.Instance\.Classify\("),
+            new Regex(@"&& ex is NpgsqlException[^{}]*?&& PostgresTargetProvider\.Instance\.Classify\("),
             worker);
     }
 

--- a/Darling/Darling.Tests/RdsLogUnavailableTests.cs
+++ b/Darling/Darling.Tests/RdsLogUnavailableTests.cs
@@ -102,7 +102,21 @@ public sealed class RdsLogUnavailableTests
         var source = File.ReadAllText(Path.Combine(RepoRoot(),
             "Darling", "PerformanceMonitor.Darling.Service", "Targets", "RdsPlanIngestor.cs"));
 
-        var catchIndex = source.IndexOf("catch (Exception ex) when (ex is not OperationCanceledException)", StringComparison.Ordinal);
+        /* Anchored to IngestAsync FIRST, because the catch signature is no longer unique in this file: the
+           COPY in WriteAsync carries an identically-spelled arm that stamps the phase and rethrows bare
+           (#3111). Taking the first occurrence in the file happens to be right today only because
+           IngestAsync is declared above WriteAsync, which is a fact about layout and not about either arm —
+           reorder the two methods and this pin would read the COPY's arm, find no
+           RdsLogUnavailableException in it, and report that the tolerant catch had regressed. Naming the
+           method makes the pin say which arm it means. */
+        var methodIndex = source.IndexOf(
+            "public async Task<RdsIngestOutcome> IngestAsync(", StringComparison.Ordinal);
+        Assert.True(methodIndex >= 0, "IngestAsync's declaration moved — this pin needs re-anchoring.");
+
+        var catchIndex = source.IndexOf(
+            "catch (Exception ex) when (ex is not OperationCanceledException)",
+            methodIndex,
+            StringComparison.Ordinal);
         Assert.True(catchIndex >= 0, "The ingestor's tolerant catch is gone — this pin needs re-anchoring.");
 
         var body = source[catchIndex..];

--- a/Darling/Darling.Tests/StoreCopyPhaseLivePostgresTests.cs
+++ b/Darling/Darling.Tests/StoreCopyPhaseLivePostgresTests.cs
@@ -35,6 +35,33 @@ namespace Darling.Tests;
 /// test and its negative control, they share the probe plumbing below, and separating them would leave the
 /// control one file away from the thing it controls. The cost is that one fast, storeless test is serialized
 /// with the live collection, which is cheaper than either alternative.</para>
+///
+/// <para><b>Which leg of <see cref="StoreWriteReattempt.IsSafeToReattempt"/> each test here covers, stated
+/// because it is not what the names suggest (#3111).</b> That gate is
+/// <c>IsTransportFault(fault) &amp;&amp; For(fault) == StoreCopyPhase.Start</c>, and the two legs are
+/// covered by different tests on different faults:</para>
+///
+/// <list type="bullet">
+/// <item><see cref="AFaultOutOfBeginBinaryImportCarriesStart_OnTheRealPath"/> covers the PHASE leg only.
+/// Its fault is measured, not assumed: an unopened connection makes the real
+/// <c>BeginBinaryImportAsync</c> raise <c>InvalidOperationException("Connection is not open")</c>, which is
+/// a start-phase fault that is NOT a transport fault — <see cref="PostgresTransportFault"/> walks the chain,
+/// finds no socket/stream/timeout link, and the outermost type is not an
+/// <see cref="NpgsqlException"/> either. So the full gate DECLINES that fault, and the test asserts exactly
+/// that rather than leaving the reader to infer a retry from it.</item>
+/// <item><see cref="ARealStartPhaseTimeoutIsATransportFaultAndTheGateAcceptsIt"/> covers BOTH legs, on the
+/// real path, on the population the gate exists for: a start-phase COPY timeout under store-side
+/// contention. It is the only test in the repository where a fault the runner itself produced is carried
+/// end to end into an accepted re-attempt decision.</item>
+/// <item><see cref="AFaultInsideTheRowLoopCarriesData_OnTheRealPath"/> is the phase leg's negative
+/// control.</item>
+/// </list>
+///
+/// <para><c>StoreWriteReattemptTests</c> covers the predicate's whole truth table, but it STAMPS its own
+/// faults and constructs its own transport shapes — so it pins the policy given a fault and deliberately
+/// owns nothing about which faults the runner really raises. That is the gap this class closes, and the
+/// reason it is worth naming: the transport leg was reachable only through hand-built exceptions, so
+/// nothing established that the faults the COPY actually produces satisfy it.</para>
 /// </summary>
 [Collection("live-postgres")]
 public class StoreCopyPhaseLivePostgresTests
@@ -57,6 +84,14 @@ public class StoreCopyPhaseLivePostgresTests
     /// fault — the importer never returned. The definition's <c>WritePayload</c> throws a distinctive
     /// exception, so if the row loop were ever reached this would surface as that fault instead of the
     /// connection's, and the assertion would name which.</para>
+    ///
+    /// <para><b>It covers the PHASE leg of the re-attempt gate and NOT the transport leg</b>, and the last
+    /// two assertions say so in the test rather than in prose. The fault this path really raises is an
+    /// <c>InvalidOperationException</c>, which is start-phase and is not transport — so
+    /// <see cref="StoreWriteReattempt.IsSafeToReattempt"/> declines it. Asserting that keeps the reader from
+    /// taking "a real start-phase fault on the real path" as evidence about a re-attempt, which is the
+    /// inference the class summary exists to head off, and it fails if either half of the gate is ever
+    /// loosened into accepting this shape.</para>
     /// </summary>
     [Fact]
     public async Task AFaultOutOfBeginBinaryImportCarriesStart_OnTheRealPath()
@@ -74,6 +109,96 @@ public class StoreCopyPhaseLivePostgresTests
             + "longer exercising the start phase.");
 
         Assert.Equal(StoreCopyPhase.Start, CollectorFaultCopyPhase.For(fault));
+
+        /* The scope of what this fault establishes, asserted. It is start-phase and it is not transport,
+           so the conjunction declines it — measured on the fault the path produces rather than assumed
+           from its type name. */
+        Assert.False(PostgresTransportFault.IsTransportFault(fault));
+        Assert.False(StoreWriteReattempt.IsSafeToReattempt(fault));
+    }
+
+    /// <summary>
+    /// The transport leg of <see cref="StoreWriteReattempt.IsSafeToReattempt"/>, on the real path, on a real
+    /// fault (#3111) — and with it the first end-to-end demonstration that the gate ACCEPTS something.
+    ///
+    /// <para><b>Why the sibling above does not cover this.</b> Its fault is an
+    /// <c>InvalidOperationException</c>: start-phase, but not a transport fault, so the conjunction
+    /// declines it. Every accepting case in the suite was a hand-stamped, hand-constructed exception. That
+    /// left the load-bearing claim — that a COPY start-phase stall really is a transport fault and
+    /// therefore really is re-attempted — resting on fixtures asserting their own shape, which is the
+    /// failure mode where a predicate passes its tests while being wrong about its subject.</para>
+    ///
+    /// <para><b>How the condition is induced, and why this shape.</b> A collector for an exceptional state
+    /// proves only that it parses when the state is absent, so the stall is produced rather than waited
+    /// for: a second session holds <c>ACCESS EXCLUSIVE</c> on the COPY's target table, which makes the
+    /// backend block acquiring its own lock BEFORE it can answer <c>CopyInResponse</c> — exactly the
+    /// regime <see cref="StoreCopyPhase.Start"/> describes, and exactly what a store-contention hypothesis
+    /// predicts. <c>CommandTimeout</c> is cut to a few seconds because the start phase runs on the
+    /// connection's own value and the default is Npgsql's undocumented 30 s; the connection string is
+    /// DERIVED from the live one rather than rebuilt, so the harness's host, port and credentials cannot
+    /// drift from it.</para>
+    ///
+    /// <para>Nothing is written and nothing needs cleaning: the lock is taken in a transaction that rolls
+    /// back, and the COPY never completes a row. Serialization with the rest of the live collection is what
+    /// makes a table lock safe to take at all, and this class already carries that attribute.</para>
+    /// </summary>
+    [Fact]
+    public async Task ARealStartPhaseTimeoutIsATransportFaultAndTheGateAcceptsIt()
+    {
+        var pg = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(pg), "Set DARLING_TEST_PG to run the transport-leg instance check.");
+
+        var ct = TestContext.Current.CancellationToken;
+        await using var dataSource = NpgsqlDataSource.Create(pg!);
+        await using (var migrateConnection = await dataSource.OpenConnectionAsync(ct))
+        {
+            await PerformanceMonitor.Darling.Storage.PgMigrations.MigrateAsync(migrateConnection, ct);
+        }
+
+        /* The blocker. ACCESS EXCLUSIVE conflicts with the ROW EXCLUSIVE a COPY takes, so the COPY's
+           backend waits on the lock manager and never reaches CopyInResponse. Rolled back, so the lock is
+           the whole of its effect. */
+        await using var blocker = await dataSource.OpenConnectionAsync(ct);
+        await using var blockerTransaction = await blocker.BeginTransactionAsync(ct);
+        await using (var takeLock = new NpgsqlCommand(
+            $"LOCK TABLE collect.{PhaseProbeTable} IN ACCESS EXCLUSIVE MODE", blocker, blockerTransaction))
+        {
+            await takeLock.ExecuteNonQueryAsync(ct);
+        }
+
+        /* Derived, not rebuilt: only the deadline differs from the live connection string. Its own data
+           source, so the physical connection is new and cannot be a pooled one that predates the store's
+           database-level search_path. */
+        var bounded = new NpgsqlConnectionStringBuilder(pg!)
+        {
+            CommandTimeout = StartPhaseTimeoutSeconds,
+        }.ConnectionString;
+
+        await using var boundedSource = NpgsqlDataSource.Create(bounded);
+        await using var connection = await boundedSource.OpenConnectionAsync(ct);
+
+        var fault = await CopyFaultAsync(
+            new PhaseProbeDefinition(PhaseProbeTable), boundedSource, connection, ct);
+
+        Assert.False(
+            fault is PhaseProbeReachedTheRowLoopException,
+            "the row loop must not be reachable while the COPY target is locked: WritePayload ran, so the "
+            + "blocker did not block and this test is measuring the data phase.");
+
+        /* The phase leg. */
+        Assert.Equal(StoreCopyPhase.Start, CollectorFaultCopyPhase.For(fault));
+
+        /* THE LEG THIS TEST EXISTS FOR — and the premise underneath it, so a pass cannot come from the
+           chain walk's NpgsqlException fallback while the fault is really something else. */
+        Assert.IsAssignableFrom<NpgsqlException>(fault);
+        Assert.IsType<TimeoutException>(fault.GetBaseException());
+        Assert.True(PostgresTransportFault.IsTransportFault(fault));
+
+        /* Both legs, so the gate accepts — the one claim no other test in the repository makes about a
+           fault the runner itself raised. */
+        Assert.True(StoreWriteReattempt.IsSafeToReattempt(fault));
+
+        await blockerTransaction.RollbackAsync(ct);
     }
 
     /// <summary>
@@ -100,7 +225,8 @@ public class StoreCopyPhaseLivePostgresTests
         }
 
         await using var connection = await dataSource.OpenConnectionAsync(ct);
-        var fault = await CopyFaultAsync(new PhaseProbeDefinition("wait_stats"), dataSource, connection, ct);
+        var fault = await CopyFaultAsync(
+            new PhaseProbeDefinition(PhaseProbeTable), dataSource, connection, ct);
 
         Assert.True(
             fault is PhaseProbeReachedTheRowLoopException,
@@ -114,17 +240,39 @@ public class StoreCopyPhaseLivePostgresTests
     private const string UnreachableStore = "Host=127.0.0.1;Port=1;Username=probe;Database=probe";
 
     /// <summary>
+    /// The real store table both live tests COPY into, named once because the transport-leg test also has
+    /// to LOCK it and the two spellings must be the same table — a lock on a different one would let the
+    /// COPY through and the test would silently measure the data phase instead. The store's own
+    /// database-level <c>search_path</c> puts <c>collect</c> first, so the definition's bare
+    /// <c>TargetTable</c> resolves to it while the <c>LOCK</c> qualifies it explicitly.
+    /// </summary>
+    private const string PhaseProbeTable = "wait_stats";
+
+    /// <summary>
+    /// The deadline the blocked start phase runs out of. Small because the start phase is bounded by the
+    /// CONNECTION's <c>CommandTimeout</c> rather than by the importer's own — that is the residual #3095
+    /// reports — and the default there is Npgsql's undocumented 30 s, which is dead time in every CI run.
+    /// </summary>
+    private const int StartPhaseTimeoutSeconds = 3;
+
+    /// <summary>
     /// Drives the SHIPPED private COPY body and returns the fault it raised. Reflection because the method
     /// is private and <c>InternalsVisibleTo</c> does not reach private members; a rename breaks this
     /// loudly, which is the correct failure for a test whose whole subject is that method.
     ///
     /// <para><b>Takes its connection and data source rather than owning them, and has no <c>finally</c>.</b>
-    /// Every caller holds both under <c>await using</c>, so disposal is the language's job. That is not
-    /// stylistic: a <c>DisposeAsync</c> in a <c>finally</c> can throw and REPLACE the body's exception,
-    /// which on this helper is the entire result being measured — and it is the same hazard
-    /// <c>LiveCleanupConversionRatchetTests</c> exists to stamp out. <c>LiveStoreCleanup</c> is not the
-    /// remedy here because there is nothing to clean: the COPY always faults, so no attempt commits a row.
-    /// </para>
+    /// Every caller holds both under <c>await using</c>, so disposal is the language's job — and the reason
+    /// is ORDERING, which turns on the fact that this helper RETURNS the fault instead of letting it
+    /// propagate. By the time a <c>finally</c> here would run, the <c>catch</c> below has already converted
+    /// the fault into this method's return value, so there is no in-flight exception for a throwing
+    /// <c>DisposeAsync</c> to replace; what it would replace is the returned exception object itself, and it
+    /// would do so BEFORE any caller had read a single assertion off it. Leaving disposal to each caller's
+    /// <c>await using</c> puts it at the end of the test method, after every assertion about the fault has
+    /// run — so a dispose that throws can only fail a test whose measurement is already complete, rather
+    /// than destroy the measurement. Same family of hazard as the one
+    /// <c>LiveCleanupConversionRatchetTests</c> exists to stamp out, differing in what is at risk.
+    /// <c>LiveStoreCleanup</c> is not the remedy here because there is nothing to clean: the COPY always
+    /// faults, so no attempt commits a row.</para>
     /// </summary>
     private static async Task<Exception> CopyFaultAsync(
         PhaseProbeDefinition definition,

--- a/Darling/Darling.Tests/StoreCopyPhaseLivePostgresTests.cs
+++ b/Darling/Darling.Tests/StoreCopyPhaseLivePostgresTests.cs
@@ -224,9 +224,19 @@ public class StoreCopyPhaseLivePostgresTests
             await PerformanceMonitor.Darling.Storage.PgMigrations.MigrateAsync(migrateConnection, ct);
         }
 
-        await using var connection = await dataSource.OpenConnectionAsync(ct);
+        /* The COPY connection comes from a data source built AFTER the migration, and that is load-bearing
+           rather than tidy. PgMigrations sets the store's search_path at DATABASE level, which a session
+           picks up only when its physical connection is opened — and Npgsql pools, so a connection taken
+           from the source above can be the very one the migrate ran on, carrying the search_path from
+           before the ALTER. The definition's TargetTable is bare, so on a store being migrated for the
+           FIRST time the COPY then fails 42P01 "relation wait_stats does not exist": Begin never returns,
+           the row loop is not entered, and this test fails claiming the data phase was unreachable. It
+           survives in a suite where some earlier live class has already migrated, which is the worst
+           version of the bug — measured on a fresh store, on PostgreSQL 16.15 and 17.11. */
+        await using var copySource = NpgsqlDataSource.Create(pg!);
+        await using var connection = await copySource.OpenConnectionAsync(ct);
         var fault = await CopyFaultAsync(
-            new PhaseProbeDefinition(PhaseProbeTable), dataSource, connection, ct);
+            new PhaseProbeDefinition(PhaseProbeTable), copySource, connection, ct);
 
         Assert.True(
             fault is PhaseProbeReachedTheRowLoopException,

--- a/Darling/Darling.Tests/StoreCopyPhaseTests.cs
+++ b/Darling/Darling.Tests/StoreCopyPhaseTests.cs
@@ -331,12 +331,23 @@ public class StoreCopyPhaseTests
     /// <c>BeginBinaryImportAsync</c> — and the file list below is compared against what the scan found
     /// rather than trusted as its input.</para>
     ///
-    /// <para><b>The set equality is load-bearing for something specific.</b>
+    /// <para><b>The set equality is load-bearing for something specific, and it runs BOTH ways.</b>
     /// <see cref="CollectorFaultCopyPhase.IsProvenStoreWrite"/> reads "carries a phase" as "is a store
-    /// write", which is sound only while the stamping sites are all store COPYs and nothing else. A new
-    /// COPY site enlarges the population that predicate speaks for, and a new STAMPING site outside a COPY
-    /// would break its premise outright — so both have to be seen, and a list that grows silently would
-    /// show neither.</para>
+    /// write", and that is a biconditional: every COPY must stamp, and only a COPY may stamp. A new COPY
+    /// site enlarges the population the predicate speaks for; a stamping site OUTSIDE a COPY breaks its
+    /// premise outright and hands a target read the store-write label. Both are asserted, against the
+    /// discovered sets rather than against a list — see the two set assertions, which is where the second
+    /// direction lives, because the per-file loop can only speak about files it visited.</para>
+    ///
+    /// <para><b>What the stamping detector can and cannot see, stated rather than implied.</b> It matches a
+    /// QUALIFIED <c>CollectorFaultCopyPhase.Stamp(</c> in stripped code. Two things are therefore out of its
+    /// reach, and only one of them is closed here. A <c>using static</c> on the axis would make
+    /// <c>Stamp(</c> legal unqualified: that route is swept for and asserted empty, so the scan reports the
+    /// blind spot instead of reading clean past it. An unqualified call from INSIDE
+    /// <c>CollectorFaultCopyPhase.cs</c> itself is not covered and is deliberately out of scope — that file
+    /// is the axis's own definition rather than a fault path, and it holds the declaration the whole
+    /// pattern is named for, so it cannot be distinguished from a call by a text scan. Reflection is not
+    /// covered either, and nothing in this repository reaches an internal static that way.</para>
     ///
     /// <para>Read STRIPPED: this family names <c>BeginBinaryImportAsync</c> and both phase values
     /// repeatedly in prose, and <see cref="CollectorFaultCopyPhase"/> and <see cref="StoreWriteReattempt"/>
@@ -365,6 +376,8 @@ public class StoreCopyPhaseTests
             + "the service project, so nothing below is asserting anything about the COPY sites");
 
         var copySites = new SortedDictionary<string, string>(StringComparer.Ordinal);
+        var stampSites = new SortedSet<string>(StringComparer.Ordinal);
+        var aliasedAxis = new SortedSet<string>(StringComparer.Ordinal);
 
         foreach (var file in sources)
         {
@@ -374,6 +387,19 @@ public class StoreCopyPhaseTests
             if (code.Contains("BeginBinaryImportAsync(", StringComparison.Ordinal))
             {
                 copySites.Add(Path.GetFileName(file), code);
+            }
+
+            if (code.Contains("CollectorFaultCopyPhase.Stamp(", StringComparison.Ordinal))
+            {
+                stampSites.Add(Path.GetFileName(file));
+            }
+
+            /* The one route the qualified-call test above cannot see: a `using static` on the axis makes
+               `Stamp(` legal unqualified, and the fault it stamps would be indistinguishable from a COPY's.
+               Collected here so the scan reports its own blind spot rather than reading clean past it. */
+            if (Regex.IsMatch(code, @"using\s+static\s+[\w.]*\bCollectorFaultCopyPhase\s*;"))
+            {
+                aliasedAxis.Add(Path.GetFileName(file));
             }
         }
 
@@ -386,6 +412,31 @@ public class StoreCopyPhaseTests
                 "RdsPlanIngestor.cs",
             },
             copySites.Keys.ToArray());
+
+        /* THE CONVERSE, and the half the per-file loop below structurally cannot reach: no file OUTSIDE
+           that set stamps a phase at all.
+
+           `IsProvenStoreWrite` reads "carries a phase" as "is a store write", and its soundness is a
+           BICONDITIONAL — every COPY stamps, AND only a COPY stamps. The loop below establishes the first
+           by visiting the discovered files; nothing in it can say anything about a file it never visited.
+           Add `CollectorFaultCopyPhase.Stamp(` to any target-read path and that fault carries a phase, so
+           `IsProvenStoreWrite` answers true, so DarlingWorker's PostgreSQL-target arm excludes it — and a
+           genuine target read loses the sentence that correctly describes it and is reported as a store
+           write. That is the confident-wrong direction that predicate's own remarks argue is the expensive
+           one, arrived at from the other side.
+
+           Equality rather than a subset, in one statement rather than two: a COPY site that stopped
+           stamping is also a defect, and the per-file assertions below already name it precisely. */
+        Assert.Equal(copySites.Keys.ToArray(), stampSites.ToArray());
+
+        /* And the scan's own blind spot, asserted empty rather than assumed so. */
+        Assert.True(
+            aliasedAxis.Count == 0,
+            "these files carry `using static ... CollectorFaultCopyPhase`, which lets Stamp( be called "
+            + "unqualified and makes the stamping-site scan above blind to it: "
+            + string.Join(", ", aliasedAxis)
+            + ". Either drop the using or widen the detector — an unqualified stamp on a target-read path "
+            + "is exactly what IsProvenStoreWrite cannot survive.");
 
         /* Every assertion below carries the FILE NAME in its message. A bare Assert.Matches inside a
            foreach over a discovered population reports which pattern failed and not which member failed

--- a/Darling/Darling.Tests/StoreCopyPhaseTests.cs
+++ b/Darling/Darling.Tests/StoreCopyPhaseTests.cs
@@ -7,6 +7,9 @@
  */
 
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 using Npgsql;
 using PerformanceMonitor.Collectors;
@@ -313,5 +316,232 @@ public class StoreCopyPhaseTests
 
         Assert.Contains("The unbounded start phase is tracked on #3095.", runner, StringComparison.Ordinal);
         Assert.DoesNotContain("Tracked as a residual on #2874.", runner, StringComparison.Ordinal);
+    }
+
+    /* ══ #3111: the axis covers EVERY store COPY, and one consumer routes on that ══════════════════════ */
+
+    /// <summary>
+    /// Every binary COPY the service performs stamps the phase — DISCOVERED, not listed (#3111).
+    ///
+    /// <para><b>Why a scan rather than three more file names.</b> The axis landed on
+    /// <c>DarlingCollectorRunner</c> alone while three structurally identical COPYs carried the same
+    /// residual untouched, and a pin naming the four would have exactly that failure mode one COPY later:
+    /// a fifth site would be absent from the list, absent from the axis, and absent from anything that
+    /// reds. So the population is derived from the source — every file whose CODE calls
+    /// <c>BeginBinaryImportAsync</c> — and the file list below is compared against what the scan found
+    /// rather than trusted as its input.</para>
+    ///
+    /// <para><b>The set equality is load-bearing for something specific.</b>
+    /// <see cref="CollectorFaultCopyPhase.IsProvenStoreWrite"/> reads "carries a phase" as "is a store
+    /// write", which is sound only while the stamping sites are all store COPYs and nothing else. A new
+    /// COPY site enlarges the population that predicate speaks for, and a new STAMPING site outside a COPY
+    /// would break its premise outright — so both have to be seen, and a list that grows silently would
+    /// show neither.</para>
+    ///
+    /// <para>Read STRIPPED: this family names <c>BeginBinaryImportAsync</c> and both phase values
+    /// repeatedly in prose, and <see cref="CollectorFaultCopyPhase"/> and <see cref="StoreWriteReattempt"/>
+    /// discuss the call without making it. Read raw, those two would be swept as COPY sites and the
+    /// structural assertions below would fail against files that perform no COPY at all.</para>
+    /// </summary>
+    [Fact]
+    public void EveryStoreCopyInTheServiceStampsTheCopyPhase()
+    {
+        var serviceDirectory = Path.Combine(
+            Root, "Darling", "PerformanceMonitor.Darling.Service");
+
+        var sources = Directory
+            .EnumerateFiles(serviceDirectory, "*.cs", SearchOption.AllDirectories)
+            .Where(f =>
+                !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal) &&
+                !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .OrderBy(f => f, StringComparer.Ordinal)
+            .ToList();
+
+        /* The floor that stops every assertion below passing on an empty sweep — a wrong directory returns
+           no files, and no files satisfy "every COPY site is instrumented" perfectly. */
+        Assert.True(
+            sources.Count >= 100,
+            $"the sweep found only {sources.Count} .cs files under {serviceDirectory} — it is not reading "
+            + "the service project, so nothing below is asserting anything about the COPY sites");
+
+        var copySites = new SortedDictionary<string, string>(StringComparer.Ordinal);
+
+        foreach (var file in sources)
+        {
+            var code = CSharpSourceWalker.StripCommentsAndStrings(
+                File.ReadAllText(file).Replace("\r\n", "\n", StringComparison.Ordinal));
+
+            if (code.Contains("BeginBinaryImportAsync(", StringComparison.Ordinal))
+            {
+                copySites.Add(Path.GetFileName(file), code);
+            }
+        }
+
+        Assert.Equal(
+            new[]
+            {
+                "DarlingCollectorRunner.cs",
+                "RdsCpuIngestor.cs",
+                "RdsDeadlockIngestor.cs",
+                "RdsPlanIngestor.cs",
+            },
+            copySites.Keys.ToArray());
+
+        /* Every assertion below carries the FILE NAME in its message. A bare Assert.Matches inside a
+           foreach over a discovered population reports which pattern failed and not which member failed
+           it, which on a four-file sweep is the difference between a diagnosis and a re-run. */
+        foreach (var (name, code) in copySites)
+        {
+            /* Start is the value in force before the COPY is opened. The comment region between the two is
+               whitespace in stripped text, so `\s*` spans it exactly — rather than a character budget a
+               longer comment would silently outgrow. */
+            Assert.True(
+                Regex.IsMatch(code, @"var copyPhase\s*=\s*StoreCopyPhase\.Start;\s*try\s*\{\s*using \(var importer"),
+                $"{name}: Start must be the phase in force before the COPY is opened, declared immediately "
+                + "ahead of the try that guards it");
+
+            /* The transition sits between Begin and the first row. Bounded so it would not admit one moved
+               below the row loop. */
+            Assert.True(
+                Regex.IsMatch(code, @"BeginBinaryImportAsync\([\s\S]{0,200}?\{\s*copyPhase\s*=\s*StoreCopyPhase\.Data;"),
+                $"{name}: the transition to Data must sit inside the importer block and before the first "
+                + "row, or a fault that had already sent rows would report the phase a re-attempt trusts");
+
+            /* Exactly one of each, symmetric, for TheCopyWriteStampsTheStartPhaseUntilBeginReturns' reason:
+               a bare `copyPhase = StoreCopyPhase.Start;` below the row loop passes every positional
+               assertion here while making a fault that had already sent rows read as re-attemptable. */
+            Assert.True(
+                Regex.Matches(code, @"copyPhase\s*=\s*StoreCopyPhase\.Start;").Count == 1,
+                $"{name}: exactly one assignment of Start — the declaration — is allowed; a second one "
+                + "anywhere below the row loop is the mutation every other assertion here is blind to");
+            Assert.True(
+                Regex.Matches(code, @"copyPhase\s*=\s*StoreCopyPhase\.Data;").Count == 1,
+                $"{name}: exactly one transition to Data is allowed; two would be a second, unreviewed "
+                + "opinion about which phase is in force");
+
+            /* The fault arm stamps whatever phase was live and rethrows BARE, so the type, message and
+               inner chain reaching every classification arm upstream are unchanged. */
+            Assert.True(
+                Regex.IsMatch(
+                    code,
+                    @"catch \(Exception ex\) when \(ex is not OperationCanceledException\)\s*\{\s*"
+                    + @"CollectorFaultCopyPhase\.Stamp\(ex, copyPhase\);\s*throw;\s*\}"),
+                $"{name}: the COPY needs the stamp-and-rethrow-bare arm, excluding cancellation — a "
+                + "stopping token says the service is shutting down, not which exchange was in flight");
+
+            /* And no site hard-stamps Start. It can only arise from the variable's initial state, which is
+               what makes "Start means the importer never came back" a property of the control flow rather
+               than of somebody's judgement at a catch site. */
+            Assert.DoesNotContain(
+                "CollectorFaultCopyPhase.Stamp(ex, StoreCopyPhase.Start)", code, StringComparison.Ordinal);
+        }
+    }
+
+    /// <summary>
+    /// A proven store write is EXACTLY a fault carrying a phase, and the predicate declines in the
+    /// direction that costs least (#3111).
+    ///
+    /// <para>The <see cref="StoreCopyPhase.Unknown"/> case is the one that matters and it is an
+    /// under-claim on purpose: the dimension flush and the transaction commit after the COPY (#1767) are
+    /// genuine store writes that carry no stamp, and they read false here. The predicate therefore
+    /// separates a population it is CERTAIN about from everything else — which is the direction that leaves
+    /// an unproven store write with a vaguer message rather than handing a target-read remedy to something
+    /// that never touched the target.</para>
+    /// </summary>
+    [Fact]
+    public void AProvenStoreWriteIsExactlyAFaultCarryingACopyPhase()
+    {
+        Assert.True(CollectorFaultCopyPhase.IsProvenStoreWrite(StartFault()));
+        Assert.True(CollectorFaultCopyPhase.IsProvenStoreWrite(DataFault()));
+
+        /* Unstamped: the post-COPY flush and commit, and every target read. */
+        Assert.False(CollectorFaultCopyPhase.IsProvenStoreWrite(
+            new NpgsqlException(SharedMessage, new TimeoutException())));
+        Assert.False(CollectorFaultCopyPhase.IsProvenStoreWrite(new InvalidOperationException()));
+        Assert.False(CollectorFaultCopyPhase.IsProvenStoreWrite(null));
+
+        /* A payload of the wrong type is not a phase, so it cannot buy the routing decision either. */
+        var wrongType = new InvalidOperationException(SharedMessage);
+        wrongType.Data[CollectorFaultCopyPhase.DataKey] = "Start";
+        Assert.False(CollectorFaultCopyPhase.IsProvenStoreWrite(wrongType));
+    }
+
+    /// <summary>
+    /// The two sentences a PostgreSQL-target <c>CommandTimeout</c> can now receive are DIFFERENT, and the
+    /// store-write one carries none of the target-read remedy (#3111).
+    ///
+    /// <para><b>The defect this asserts against.</b> A store write is Npgsql whatever the monitored
+    /// target's engine is, so a COPY timeout on a PostgreSQL target satisfied every term of the
+    /// target-timeout arm's filter and received its client-side sentence — whose remedy is
+    /// read-specific: <c>Npgsql cancelled the read mid-stream ... shrinking the work is the right one</c>.
+    /// Shrinking a read is not the remedy for a COPY blocked on a store-side lock, and an operator acts on
+    /// a confident instruction.</para>
+    ///
+    /// <para>Both halves are asserted, because only the pair is evidence. That the store-write message
+    /// omits the read remedy proves nothing on its own — an empty string would satisfy it — so the
+    /// target-read sentence is asserted to CONTAIN the phrases the other must not, which is what
+    /// establishes that the two populations genuinely diverge rather than that one of them is missing.</para>
+    /// </summary>
+    [Fact]
+    public void AStoreWriteTimeoutIsDescribedAsAStoreWriteAndCarriesNoTargetReadRemedy()
+    {
+        var storeWrite = CollectorFaultCopyPhase.Describe(StartFault());
+
+        /* Which SIDE failed, first — the thing an operator needs before the rest is actionable. */
+        Assert.Contains("store-write", storeWrite, StringComparison.Ordinal);
+        Assert.Contains("no rows sent", storeWrite, StringComparison.Ordinal);
+
+        /* And none of the target-read remedy. */
+        Assert.DoesNotContain("shrinking the work", storeWrite, StringComparison.Ordinal);
+        Assert.DoesNotContain("cancelled the read", storeWrite, StringComparison.Ordinal);
+
+        /* The control: those phrases are real and they are what this fault no longer receives. Without
+           this half the assertions above would pass against any string that happened not to say them. */
+        var targetRead = DarlingWorker.PostgresTimeoutExplanation(
+            "pg_index_bloat", "appdb", elapsedMs: 30_000, serverCancelled: false);
+
+        Assert.Contains("shrinking the work", targetRead, StringComparison.Ordinal);
+        Assert.Contains("cancelled the read", targetRead, StringComparison.Ordinal);
+        Assert.DoesNotContain("store-write", targetRead, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The routing itself, pinned in source: the exclusion is a term of the arm's FILTER, not a branch
+    /// inside it (#3111).
+    ///
+    /// <para>No pure test can reach this — it is a <c>when</c> clause on one <c>catch</c> in a sweep body
+    /// that needs a runtime, a store and a live collector — and the distinction it pins is invisible to a
+    /// test that could. Inside the arm, a store write would already have been claimed by it: the fault
+    /// would not reach the general arm below, so it would get neither the phase named in its
+    /// <c>collection_log</c> row nor the reprobe decision that arm makes. Excluding it in the filter is
+    /// what makes the fall-through happen, and "the general arm handles it" is the whole design.</para>
+    ///
+    /// <para>The ordering assertion is separate and cheap: the exclusion has to sit ABOVE the
+    /// <c>Classify</c> call, so the arm answers "is this even a target read" before it spends a
+    /// classification on it.</para>
+    /// </summary>
+    [Fact]
+    public void TheTargetTimeoutArmExcludesAProvenStoreWriteInItsFilter()
+    {
+        var worker = ReadRepoFileLf(
+            "Darling", "PerformanceMonitor.Darling.Service", "DarlingWorker.cs");
+
+        /* Exactly one exclusion, so a second arm cannot grow its own opinion about the same question. */
+        Assert.Equal(1, Regex.Matches(
+            worker, @"&& !CollectorFaultCopyPhase\.IsProvenStoreWrite\(ex\)").Count);
+
+        /* A filter term of the engine-gated arm, above the Classify call, and reached before the arm's
+           body — the window admits the intervening comment and would not admit a term moved after the
+           classification or a check moved inside the braces. */
+        Assert.Matches(
+            new Regex(@"Target\.Engine == CollectorTargetEngine\.PostgreSql[\s\S]{0,4000}?"
+                      + @"&& !CollectorFaultCopyPhase\.IsProvenStoreWrite\(ex\)[\s\S]{0,200}?"
+                      + @"&& PostgresTargetProvider\.Instance\.Classify\("),
+            worker);
+
+        /* And it is NOT expressed as a branch inside the arm, which would keep the fault out of the
+           general arm and cost it both the phase in its stored row and that arm's reprobe decision. */
+        Assert.DoesNotContain(
+            "if (CollectorFaultCopyPhase.IsProvenStoreWrite(ex))", worker, StringComparison.Ordinal);
     }
 }

--- a/Darling/PerformanceMonitor.Darling.Service/CollectorFaultCopyPhase.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/CollectorFaultCopyPhase.cs
@@ -89,7 +89,16 @@ internal enum StoreCopyPhase
 /// <see cref="Describe"/> renders it into the message an operator reads. A consumer gating a re-attempt on
 /// safety requires <c>For(ex) == StoreCopyPhase.Start</c>; <see cref="StoreCopyPhase.Unknown"/> and
 /// <see cref="StoreCopyPhase.Data"/> both decline, which is the direction that costs nothing when the
-/// stamp is missing.</para>
+/// stamp is missing. <see cref="IsProvenStoreWrite"/> asks the coarser question — which SIDE of the
+/// service the fault came from — for the consumer that needs to route rather than to retry.</para>
+///
+/// <para><b>Every COPY the service performs stamps a phase</b>, not just the collector runner's:
+/// <c>DarlingCollectorRunner.CopyBatchOnceAsync</c> and the three AWS-API ingestors
+/// (<see cref="Targets.RdsPlanIngestor"/>, <see cref="Targets.RdsCpuIngestor"/>,
+/// <see cref="Targets.RdsDeadlockIngestor"/>) share the shape and therefore share the residual, so they
+/// share the axis. That uniformity is what lets a consumer treat "carries a phase" as a fact about the
+/// whole service rather than about one method — see <see cref="IsProvenStoreWrite"/>, which is only sound
+/// while it holds.</para>
 ///
 /// <para>Reading is total: an unstamped exception, or one whose payload is not a
 /// <see cref="StoreCopyPhase"/>, reads as <see cref="StoreCopyPhase.Unknown"/> and
@@ -107,16 +116,26 @@ internal static class CollectorFaultCopyPhase
     /// message and the consequence — no rows sent — because those are what tell the reader why this
     /// failure is the recoverable one, and a bare phase name would not.
     /// </summary>
+    /// <remarks>
+    /// <b>"store-write" leads, and it is the word doing the work for a reader.</b> Every arm this label can
+    /// reach also reports faults from READING the monitored server, and a bare "COPY" only names the store
+    /// to someone who already knows this product performs no COPY against a target. An operator holding a
+    /// <c>collection_log</c> row needs to know which SIDE failed before anything else in the sentence is
+    /// actionable — the remedy for a store write under contention has nothing in common with the remedy
+    /// for a target read that overran its deadline.
+    /// </remarks>
     internal const string StartPhaseLabel =
-        "COPY start phase (awaiting CopyInResponse on the connection's own CommandTimeout, no rows sent)";
+        "store-write COPY start phase (awaiting CopyInResponse on the connection's own CommandTimeout, "
+        + "no rows sent)";
 
     /// <summary>
     /// How <see cref="StoreCopyPhase.Data"/> is named in a message. It names the deadline that bounds it,
     /// so the reader can tell a data-phase failure from the start phase by the budget it ran out of rather
     /// than by inferring a phase from a duration.
     /// </summary>
+    /// <remarks>Leads with "store-write" for <see cref="StartPhaseLabel"/>'s reason.</remarks>
     internal const string DataPhaseLabel =
-        "COPY data phase (rows in flight under the collection-sweep deadline)";
+        "store-write COPY data phase (rows in flight under the collection-sweep deadline)";
 
     /// <summary>
     /// Records <paramref name="phase"/> on <paramref name="exception"/>. Best-effort, for
@@ -175,6 +194,26 @@ internal static class CollectorFaultCopyPhase
 
         return StoreCopyPhase.Unknown;
     }
+
+    /// <summary>
+    /// True when the fault is PROVABLY a write to the store rather than a read of the monitored server,
+    /// which a recorded phase establishes by construction: the only sites that stamp one are the four
+    /// binary COPYs into the store, and nothing that touches a target can reach them.
+    ///
+    /// <para><b>The name is what it can establish, and the converse does NOT hold.</b> False means "not
+    /// proven", never "not a store write". <see cref="StoreCopyPhase.Unknown"/> is what the dimension flush
+    /// and the transaction commit after the COPY read as (#1767) — genuine store writes that carry no
+    /// stamp — alongside every target read. So this separates a population it is certain about from
+    /// everything else, and a caller may only act on the certain side.</para>
+    ///
+    /// <para><b>Which is the direction that costs least, and the asymmetry is the point.</b> The consumer is
+    /// <see cref="DarlingWorker"/>'s PostgreSQL-target timeout arm, whose sentence tells an operator to
+    /// shrink the work a read asked for. Applied to a store write that is confidently wrong advice about an
+    /// operation that never ran against the target, and an operator acts on it; withheld from a store write
+    /// this predicate could not prove, the fault keeps a message that is merely less specific. A missing
+    /// stamp therefore loses a routing decision rather than making one.</para>
+    /// </summary>
+    internal static bool IsProvenStoreWrite(Exception? exception) => For(exception) != StoreCopyPhase.Unknown;
 
     /// <summary>
     /// The exception's message with its COPY phase named, or the message unchanged when there is no phase

--- a/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/DarlingWorker.cs
@@ -6545,6 +6545,31 @@ LIMIT 1";
                too, so it still forces no reprobe, and now reports the budget's own message and the real
                elapsed time rather than a borrowed narrative. */
             && ex is NpgsqlException
+            /* #3111: and NOT a write to the STORE. The engine term above was standing in for "this fault
+               came from reading the target", and for a store write that proxy is simply false — the store
+               connection is Npgsql whatever the target's engine is, so a COPY timeout satisfies both terms
+               above and lands here. Observed on a real fault: a start-phase COPY timeout under store-side
+               contention arrives as an NpgsqlException wrapping a TimeoutException, classifies
+               CommandTimeout, and reached this arm.
+
+               What it then got was the client-side sentence below, whose remedy is target-read-specific:
+               "Npgsql cancelled the read mid-stream ... the work asked for does not fit the deadline ...
+               shrinking the work is the right one." Shrinking a read is not the remedy for a COPY blocked
+               on a store-side lock, and a confident wrong instruction is worse than a vague one because an
+               operator acts on it.
+
+               #3095's phase axis is the discriminator this filter lacked: a recorded phase is only ever
+               written by a COPY into the store, so it identifies a store write BY CONSTRUCTION rather than
+               by inference. Excluded here rather than given a store-side sentence of its own, so that one
+               fault reports one way: the general arm below already renders the phase into both the app log
+               and the collection_log row, and it is where this same fault already lands on a SQL Server
+               target. A second authored sentence would make the identical store fault read differently
+               depending on the monitored target's engine, which the store write has nothing to do with.
+
+               Only the PROVEN population moves. An unstamped fault keeps #2997's sentence, so the post-COPY
+               dimension flush and commit (#1767) are still described as target reads — see
+               IsProvenStoreWrite for why that residual is the affordable direction. */
+            && !CollectorFaultCopyPhase.IsProvenStoreWrite(ex)
             && PostgresTargetProvider.Instance.Classify(ex, yieldsOnLockTimeout: false)
                == CollectorTargetFault.CommandTimeout)
         {
@@ -6587,12 +6612,14 @@ LIMIT 1";
         catch (Exception ex)
         {
             /* #3095: the COPY phase is named when the fault carries one. This arm is where a collector's
-               binary COPY into the STORE lands — the store connection is Npgsql whatever the target's
-               engine is, so a store-write fault reaches neither the SQLSTATE arm above (it is not a
-               PostgresException) nor the PostgreSQL-target timeout arm (that one requires a PostgreSQL
-               target) — and "Exception while reading from stream" is all it said. Both COPY phases produce
-               that same string, and the start phase is the one still on the connection's undocumented 30 s
-               default, so the message could not say which deadline had been reached.
+               binary COPY into the STORE lands, on EITHER engine, and that uniformity is deliberate: it
+               reaches neither the SQLSTATE arm above (it is not a PostgresException) nor the
+               PostgreSQL-target timeout arm (#3111 excludes a proven store write from it, since the store
+               connection is Npgsql whatever the target's engine is and the fault would otherwise satisfy
+               that arm's every term on a PostgreSQL target). "Exception while reading from stream" is all
+               it said: both COPY phases produce that same string, and the start phase is the one still on
+               the connection's undocumented 30 s default, so the message could not say which deadline had
+               been reached.
 
                Computed once and used for BOTH the app log and the collection_log row, because the stored
                row is the instrument any measurement of this population reads; naming the phase only in the

--- a/Darling/PerformanceMonitor.Darling.Service/Targets/RdsCpuIngestor.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Targets/RdsCpuIngestor.cs
@@ -256,41 +256,64 @@ public sealed class RdsCpuIngestor
         var writer = new PgCollectorRowWriter();
         var written = 0;
 
-        using (var importer = await connection.BeginBinaryImportAsync(
-            PgCollectorRowWriter.CopyCommandFor(definition), cancellationToken))
+        /* Which COPY phase a fault came out of, on the same terms as
+           DarlingCollectorRunner.CopyBatchOnceAsync — see CollectorFaultCopyPhase, which is the authority
+           for what each value means and what it authorises.
+
+           Start until Begin returns, and the transition sits INSIDE the block for that reason: Start has to
+           mean strictly "the importer never came back". A fault anywhere past that line may have sent rows,
+           so it must read as Data even where it happens to have sent none. */
+        var copyPhase = StoreCopyPhase.Start;
+
+        try
         {
-            /* #2874: the COPY's own deadline, on NpgsqlBinaryImporter.Timeout — a TimeSpan on a different type
-               from the rest of the regime, invisible to a command-shaped regex, and inherited from the
-               connection's CommandTimeout (30 s) when left unset. Same constant, same regime, and the same
-               narrows-not-closes caveat about the Begin phase as DarlingCollectorRunner.WriteBatchAsync. */
-            importer.Timeout = TimeSpan.FromSeconds(ServiceCommandDeadlines.CollectionSweepSeconds);
-
-            writer.Importer = importer;
-
-            foreach (var point in dataPoints)
+            using (var importer = await connection.BeginBinaryImportAsync(
+                PgCollectorRowWriter.CopyCommandFor(definition), cancellationToken))
             {
-                await importer.StartRowAsync(cancellationToken);
+                copyPhase = StoreCopyPhase.Data;
 
-                if (definition.IncludesCollectionId)
+                /* #2874: the COPY's own deadline, on NpgsqlBinaryImporter.Timeout — a TimeSpan on a different type
+                   from the rest of the regime, invisible to a command-shaped regex, and inherited from the
+                   connection's CommandTimeout (30 s) when left unset. Same constant, same regime, and the same
+                   narrows-not-closes caveat about the Begin phase as DarlingCollectorRunner.WriteBatchAsync. */
+                importer.Timeout = TimeSpan.FromSeconds(ServiceCommandDeadlines.CollectionSweepSeconds);
+
+                writer.Importer = importer;
+
+                foreach (var point in dataPoints)
                 {
-                    writer.Value(CollectionIdGenerator.Next());
+                    await importer.StartRowAsync(cancellationToken);
+
+                    if (definition.IncludesCollectionId)
+                    {
+                        writer.Value(CollectionIdGenerator.Next());
+                    }
+
+                    writer.Value(collectionTime)
+                          .Value(serverId)
+                          .Value(storageName);
+
+                    writer.BeginPayload();
+                    definition.WritePayload(
+                        new PgCpuUtilizationCollector.Row(
+                            DateTime.SpecifyKind(point.Timestamp!.Value, DateTimeKind.Utc), point.Value),
+                        writer,
+                        NullContext(serverId, storageName, collectionTime));
+                    writer.EndPayload(definition.PayloadColumns.Count);
+                    written++;
                 }
 
-                writer.Value(collectionTime)
-                      .Value(serverId)
-                      .Value(storageName);
-
-                writer.BeginPayload();
-                definition.WritePayload(
-                    new PgCpuUtilizationCollector.Row(
-                        DateTime.SpecifyKind(point.Timestamp!.Value, DateTimeKind.Utc), point.Value),
-                    writer,
-                    NullContext(serverId, storageName, collectionTime));
-                writer.EndPayload(definition.PayloadColumns.Count);
-                written++;
+                await importer.CompleteAsync(cancellationToken);
             }
-
-            await importer.CompleteAsync(cancellationToken);
+        }
+        /* Stamped, then rethrown bare, for CopyBatchOnceAsync's reason: the fault keeps its own type,
+           message and inner chain, so every classification arm upstream sees exactly what it sees without
+           this. OperationCanceledException is excluded because a stopping token says the service is shutting
+           down, not which protocol exchange was in flight. */
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            CollectorFaultCopyPhase.Stamp(ex, copyPhase);
+            throw;
         }
 
         _logger?.LogInformation(

--- a/Darling/PerformanceMonitor.Darling.Service/Targets/RdsDeadlockIngestor.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Targets/RdsDeadlockIngestor.cs
@@ -183,37 +183,60 @@ public sealed class RdsDeadlockIngestor
         var writer = new PgCollectorRowWriter();
         var written = 0;
 
-        using (var importer = await connection.BeginBinaryImportAsync(
-            PgCollectorRowWriter.CopyCommandFor(definition), cancellationToken))
+        /* Which COPY phase a fault came out of, on the same terms as
+           DarlingCollectorRunner.CopyBatchOnceAsync — see CollectorFaultCopyPhase, which is the authority
+           for what each value means and what it authorises.
+
+           Start until Begin returns, and the transition sits INSIDE the block for that reason: Start has to
+           mean strictly "the importer never came back". A fault anywhere past that line may have sent rows,
+           so it must read as Data even where it happens to have sent none. */
+        var copyPhase = StoreCopyPhase.Start;
+
+        try
         {
-            /* #2874: the COPY's own deadline, on NpgsqlBinaryImporter.Timeout — a TimeSpan on a different type
-               from the rest of the regime, invisible to a command-shaped regex, and inherited from the
-               connection's CommandTimeout (30 s) when left unset. Same constant, same regime, and the same
-               narrows-not-closes caveat about the Begin phase as DarlingCollectorRunner.WriteBatchAsync. */
-            importer.Timeout = TimeSpan.FromSeconds(ServiceCommandDeadlines.CollectionSweepSeconds);
-
-            writer.Importer = importer;
-
-            foreach (var row in rows)
+            using (var importer = await connection.BeginBinaryImportAsync(
+                PgCollectorRowWriter.CopyCommandFor(definition), cancellationToken))
             {
-                await importer.StartRowAsync(cancellationToken);
+                copyPhase = StoreCopyPhase.Data;
 
-                if (definition.IncludesCollectionId)
+                /* #2874: the COPY's own deadline, on NpgsqlBinaryImporter.Timeout — a TimeSpan on a different type
+                   from the rest of the regime, invisible to a command-shaped regex, and inherited from the
+                   connection's CommandTimeout (30 s) when left unset. Same constant, same regime, and the same
+                   narrows-not-closes caveat about the Begin phase as DarlingCollectorRunner.WriteBatchAsync. */
+                importer.Timeout = TimeSpan.FromSeconds(ServiceCommandDeadlines.CollectionSweepSeconds);
+
+                writer.Importer = importer;
+
+                foreach (var row in rows)
                 {
-                    writer.Value(CollectionIdGenerator.Next());
+                    await importer.StartRowAsync(cancellationToken);
+
+                    if (definition.IncludesCollectionId)
+                    {
+                        writer.Value(CollectionIdGenerator.Next());
+                    }
+
+                    writer.Value(collectionTime)
+                          .Value(serverId)
+                          .Value(storageName);
+
+                    writer.BeginPayload();
+                    definition.WritePayload(row, writer, NullContext(serverId, storageName, collectionTime));
+                    writer.EndPayload(definition.PayloadColumns.Count);
+                    written++;
                 }
 
-                writer.Value(collectionTime)
-                      .Value(serverId)
-                      .Value(storageName);
-
-                writer.BeginPayload();
-                definition.WritePayload(row, writer, NullContext(serverId, storageName, collectionTime));
-                writer.EndPayload(definition.PayloadColumns.Count);
-                written++;
+                await importer.CompleteAsync(cancellationToken);
             }
-
-            await importer.CompleteAsync(cancellationToken);
+        }
+        /* Stamped, then rethrown bare, for CopyBatchOnceAsync's reason: the fault keeps its own type,
+           message and inner chain, so every classification arm upstream sees exactly what it sees without
+           this. OperationCanceledException is excluded because a stopping token says the service is shutting
+           down, not which protocol exchange was in flight. */
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            CollectorFaultCopyPhase.Stamp(ex, copyPhase);
+            throw;
         }
 
         _logger?.LogInformation(

--- a/Darling/PerformanceMonitor.Darling.Service/Targets/RdsPlanIngestor.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Targets/RdsPlanIngestor.cs
@@ -175,37 +175,60 @@ public sealed class RdsPlanIngestor
         var writer = new PgCollectorRowWriter();
         var written = 0;
 
-        using (var importer = await connection.BeginBinaryImportAsync(
-            PgCollectorRowWriter.CopyCommandFor(definition), cancellationToken))
+        /* Which COPY phase a fault came out of, on the same terms as
+           DarlingCollectorRunner.CopyBatchOnceAsync — see CollectorFaultCopyPhase, which is the authority
+           for what each value means and what it authorises.
+
+           Start until Begin returns, and the transition sits INSIDE the block for that reason: Start has to
+           mean strictly "the importer never came back". A fault anywhere past that line may have sent rows,
+           so it must read as Data even where it happens to have sent none. */
+        var copyPhase = StoreCopyPhase.Start;
+
+        try
         {
-            /* #2874: the COPY's own deadline, on NpgsqlBinaryImporter.Timeout — a TimeSpan on a different type
-               from the rest of the regime, invisible to a command-shaped regex, and inherited from the
-               connection's CommandTimeout (30 s) when left unset. Same constant, same regime, and the same
-               narrows-not-closes caveat about the Begin phase as DarlingCollectorRunner.WriteBatchAsync. */
-            importer.Timeout = TimeSpan.FromSeconds(ServiceCommandDeadlines.CollectionSweepSeconds);
-
-            writer.Importer = importer;
-
-            foreach (var row in rows)
+            using (var importer = await connection.BeginBinaryImportAsync(
+                PgCollectorRowWriter.CopyCommandFor(definition), cancellationToken))
             {
-                await importer.StartRowAsync(cancellationToken);
+                copyPhase = StoreCopyPhase.Data;
 
-                if (definition.IncludesCollectionId)
+                /* #2874: the COPY's own deadline, on NpgsqlBinaryImporter.Timeout — a TimeSpan on a different type
+                   from the rest of the regime, invisible to a command-shaped regex, and inherited from the
+                   connection's CommandTimeout (30 s) when left unset. Same constant, same regime, and the same
+                   narrows-not-closes caveat about the Begin phase as DarlingCollectorRunner.WriteBatchAsync. */
+                importer.Timeout = TimeSpan.FromSeconds(ServiceCommandDeadlines.CollectionSweepSeconds);
+
+                writer.Importer = importer;
+
+                foreach (var row in rows)
                 {
-                    writer.Value(CollectionIdGenerator.Next());
+                    await importer.StartRowAsync(cancellationToken);
+
+                    if (definition.IncludesCollectionId)
+                    {
+                        writer.Value(CollectionIdGenerator.Next());
+                    }
+
+                    writer.Value(collectionTime)
+                          .Value(serverId)
+                          .Value(storageName);
+
+                    writer.BeginPayload();
+                    definition.WritePayload(row, writer, NullContext(serverId, storageName, collectionTime));
+                    writer.EndPayload(definition.PayloadColumns.Count);
+                    written++;
                 }
 
-                writer.Value(collectionTime)
-                      .Value(serverId)
-                      .Value(storageName);
-
-                writer.BeginPayload();
-                definition.WritePayload(row, writer, NullContext(serverId, storageName, collectionTime));
-                writer.EndPayload(definition.PayloadColumns.Count);
-                written++;
+                await importer.CompleteAsync(cancellationToken);
             }
-
-            await importer.CompleteAsync(cancellationToken);
+        }
+        /* Stamped, then rethrown bare, for CopyBatchOnceAsync's reason: the fault keeps its own type,
+           message and inner chain, so every classification arm upstream sees exactly what it sees without
+           this. OperationCanceledException is excluded because a stopping token says the service is shutting
+           down, not which protocol exchange was in flight. */
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            CollectorFaultCopyPhase.Stamp(ex, copyPhase);
+            throw;
         }
 
         _logger?.LogInformation(


### PR DESCRIPTION
Fixes #3111.

Both follow-ups #3110 left behind, plus the two prose notes that were the reason the issue exists rather than being a closed thought.

## 1. The three sibling COPY sites now carry the phase axis

`RdsPlanIngestor`, `RdsCpuIngestor` and `RdsDeadlockIngestor` each perform the identical binary COPY into the store and each carried the identical unclosed residual: `BeginBinaryImportAsync` awaits `CopyInResponse` under the connection's `CommandTimeout` while `importer.Timeout` bounds only the data phase, and both surface as `Exception while reading from stream`. All three now declare `var copyPhase = StoreCopyPhase.Start`, transition to `Data` inside the importer block before the first row, and stamp-and-rethrow-bare on the way out — the same shape and the same reasoning as `DarlingCollectorRunner.CopyBatchOnceAsync`, which stays the authority the three defer to rather than three copies of its prose.

The pin over them is a **scan, not a list**: `EveryStoreCopyInTheServiceStampsTheCopyPhase` discovers the population by finding every file in the service project whose stripped code calls `BeginBinaryImportAsync`, asserts that set equals the four known sites, and applies the five structural assertions to each with the file name in every failure message. A fifth COPY site reddens it whether or not it is instrumented, which is deliberate — see item 2 for what the set equality is load-bearing for.

The same sweep asserts the **converse**, which is the half the per-file loop structurally cannot reach: the set of files containing `CollectorFaultCopyPhase.Stamp(` **equals** the set containing `BeginBinaryImportAsync(`. `IsProvenStoreWrite`'s soundness is a biconditional — every COPY stamps, and only a COPY stamps — and a loop over discovered files can say nothing about a file it never visited. Add `Stamp(` to any target-read path and that fault carries a phase, so the predicate answers true, so the PostgreSQL-target arm excludes it, and a genuine target read is reported as a store write: the same confident-wrong direction `IsProvenStoreWrite`'s remarks argue against, arrived at from the other side. Equality rather than a subset, in one statement, because a COPY site that stopped stamping is also a defect.

That detector matches a *qualified* call, so the sweep also collects any `using static` on the axis — which would make `Stamp(` legal unqualified and blind the scan — and asserts that set empty. An unqualified call from inside `CollectorFaultCopyPhase.cs` itself is stated as out of scope: that file holds the declaration the pattern is named for, so a text scan cannot tell a call there from the definition, and it is the axis's own home rather than a fault path.

## 2. A store write no longer receives the PostgreSQL-target read remedy

The target-timeout arm's filter was `Target.Engine == PostgreSql && ex is NpgsqlException && Classify(ex) == CommandTimeout`. The engine term was standing in for "this fault came from reading the target", and for a store write that proxy is simply false: the store connection is Npgsql whatever the target's engine is, so a COPY timeout satisfies every term and lands there. The arm's remedy is read-specific — *"Npgsql cancelled the read mid-stream … the work asked for does not fit the deadline; raising the deadline is the wrong half of that and shrinking the work is the right one."*

The filter gains `&& !CollectorFaultCopyPhase.IsProvenStoreWrite(ex)`. A recorded phase is written only by a COPY into the store, so it identifies a store write by construction. Those faults fall through to the general arm, which since #3110 already renders the phase into both the app log and the `collection_log` row — chosen over authoring a second store-side sentence so that one fault reports one way, and because that arm is already where this same fault lands on a SQL Server target. A second sentence would make an identical store fault read differently depending on the monitored target's engine, which the store write has nothing to do with.

`StartPhaseLabel` and `DataPhaseLabel` now lead with `store-write`. Every arm those labels reach also reports faults from reading the target, and a bare "COPY" names the store only to a reader who already knows this product performs no COPY against one.

`IsProvenStoreWrite` is named for what it can establish: false means "not proven", never "not a store write". The post-COPY dimension flush and commit (#1767) are genuine store writes that read `Unknown`, and they keep #2997's sentence. That residual is stated in the predicate's own doc rather than papered over, and it is the affordable direction — a store write this predicate cannot prove gets a vaguer message, where the converse hands a confident target-read instruction to something that never touched the target.

### The database question, settled by observation

The issue asked for this to be measured rather than argued from the call site, and the report it could not confirm is **confirmed**. Driving the shipped `CopyBatchOnceAsync` against a live store with `ACCESS EXCLUSIVE` held on the COPY target produces a real start-phase timeout, and on it:

- the fault is `NpgsqlException` wrapping `TimeoutException`, classifies `CommandTimeout`, and did reach the target-read arm;
- `CollectorFaultDatabase.For(fault, runtime.ConnectedDatabase)` returns the **monitored target's** probe database. The store's own database name never appears, because the store-write path stamps no database and `For` therefore falls back to `ServerRuntime.ConnectedDatabase` — `current_database()` on the monitored server, from a different instance entirely.

So the arm named an unrelated database on a different server *and* gave read-specific advice. The author's guard against naming the wrong database is real but cannot help here: it protects the per-database fan-out case, and there is nothing to fall back to except the target. The fix makes the question moot for the proven population — `PostgresTimeoutExplanation` is no longer called for it — which is why no change was made to how the database resolves.

Measured before and after on that same real fault:

```
before: pg_wait_stats on database '<target-db>' hit its CLIENT-SIDE command deadline after 3,000 ms
        — … Npgsql cancelled the read mid-stream … shrinking the work is the right one. …
after:  store-write COPY start phase (awaiting CopyInResponse on the connection's own
        CommandTimeout, no rows sent): Exception while reading from stream
```

## 3. `IsSafeToReattempt`'s transport leg is now covered on the real path

The gate is `IsTransportFault(fault) && For(fault) == StoreCopyPhase.Start`, and the live test that exercised the real path covered only the phase leg. Measured rather than inferred: an unopened connection makes the real `BeginBinaryImportAsync` raise `InvalidOperationException("Connection is not open")`, which walks the chain to no socket/stream/timeout link and is not an `NpgsqlException` either — so it is start-phase, is **not** a transport fault, and the full gate declines it. Every accepting case in the suite was a hand-stamped, hand-constructed exception, which is the shape where a predicate passes its tests while being wrong about its subject.

`ARealStartPhaseTimeoutIsATransportFaultAndTheGateAcceptsIt` closes it: the `ACCESS EXCLUSIVE` blocker makes the backend wait on the lock manager before it can answer `CopyInResponse`, and the resulting fault is carried end to end into an accepted re-attempt decision — the first test here to make that claim about a fault the runner itself raised. It asserts the premise (`NpgsqlException` wrapping `TimeoutException`) as well as the conclusion, so a pass cannot come from the chain walk's `NpgsqlException` fallback while the fault is really something else. Nothing is written: the lock is taken in a transaction that rolls back and the COPY never completes a row.

Which leg each test covers is now stated in the class summary and asserted in the tests, not left to prose — the existing start-phase test asserts its own decline.

## 4. The `finally` justification says the actual reason

`CopyFaultAsync` recorded that a throwing `DisposeAsync` in a `finally` could replace the body's exception. It could not: the helper **returns** the fault, so by the time a `finally` would run the `catch` has already converted it into the return value and there is nothing in flight to replace. The real reason is ordering — what a throwing dispose would replace is the returned exception object, before any caller had read an assertion off it. Leaving disposal to each caller's `await using` puts it after every assertion, so a dispose that throws can only fail a test whose measurement is already complete.

## Incidental, and both found by measurement rather than by reading

**`AFaultInsideTheRowLoopCarriesData_OnTheRealPath` failed on a store being migrated for the first time.** `PgMigrations` sets `search_path` at database level, which a session picks up only when its physical connection is opened; Npgsql pools, so the COPY connection could be the very one the migrate ran on, carrying the path from before the `ALTER`. The definition's `TargetTable` is bare, so the COPY failed `42P01 relation "wait_stats" does not exist` — Begin never returned, and the test failed claiming the data phase was unreachable. It survives in a suite where an earlier live class has already migrated, which is the worst version of that. Reproduced on fresh 16.15 and 17.11 stores, fixed by taking the COPY connection from a data source built after the migration, and re-verified fresh on both. Fixed here rather than filed because it is the same method this PR edits and it would have read as this PR's flake.

**Two neighbouring pins re-anchored, deliberately.** `PostgresFaultOutcomeTests.OnlyAnNpgsqlFaultCanEarnTheAuthoredTimeoutNarrative` required `&& ex is NpgsqlException` to be *adjacent* to the `Classify` term; the new conjunct sits between them, which reddened it without touching anything it asserts. It now forbids an intervening brace instead of counting newlines — both terms must be conjuncts of the same filter, in order, which is the only failure adjacency was ever detecting. `RdsLogUnavailableTests.TheIngestorRethrows_RatherThanReturningZeroRowsOnFailure` took the first catch of that signature in the file, which is now ambiguous in all three ingestors; it anchors on `IngestAsync` first. Both were verified still to fire when their subject is removed, and the re-anchoring was shown to discriminate: with a decoy arm above `IngestAsync` the old form goes red while the new one stays correct.

## Deliberately not included

**The unbounded start phase itself.** #3095 closed `completed` when #3110 merged, having made the phase *distinguishable* rather than *bounded* — so the residual is again recorded only in a comment pointing at a closed issue, which is exactly the recursion `TheCopyDeadlineCommentPointsAtTheOpenIssueForTheStartPhase` was written to stop. That pin still passes, because it hardcodes `#3095` rather than asking whether the issue it names is open. Left untouched: the comment and the pin are #3110's, and whether the fix is a new tracker or a pin that can judge openness is a design call, not a drive-by edit. The three new ingestor comments deliberately point at `DarlingCollectorRunner` rather than at any issue number, so they add no new instances of it.

**A `ConnectionFatal` store-write fault still forces a TARGET reprobe.** A lost store socket during a COPY is an `NpgsqlException` wrapping `IOException`, which `Classify` answers `ConnectionFatal`, and the general arm's reprobe branch then nulls `server.Runtime` over a store problem. Pre-existing and unchanged by this PR — a `ConnectionFatal` store fault already reached that arm — and now fixable with the same axis, but it is a reconnect-behaviour defect rather than a message-attribution one. No reprobe behaviour changes here: the faults this PR moves classify `CommandTimeout`, which that branch does not match.

**The 190 repo-wide `xUnit2013` warnings**, per the issue.

## Verification

`Darling.Tests` is `net10.0-windows` and cannot run on macOS, so the pure and source-text tests were compiled into a `net10.0` console harness against the real build and executed: `StoreCopyPhaseTests` 11/11, `StoreWriteReattemptTests` + `PostgresFaultOutcomeTests` 57/58 (the one failure is the harness not supplying `[InlineData(null)]`, not a code failure), `RdsLogUnavailableTests` 16/16. `StoreCopyPhaseLivePostgresTests` 3/3 against live PostgreSQL 17.11 and 16.15, on fresh stores.

Every new pin was mutation-tested and each fires on exactly the mutation it is for: dropping a stamping arm, moving the `Data` transition below the row loop, adding a second bare `Start`, removing the filter term, moving it below `Classify`, reverting the labels, weakening `IsProvenStoreWrite` to `== Start`, adding a fifth COPY site, **stamping a phase from a non-COPY file** (`PostgresTransportFault.cs`, which reports the offending file by name), **adding a `using static` on the axis**, and **a COPY site that keeps its catch arm but stops stamping**. The two re-anchored pins were each verified still to fire when their subject is removed. The live transport-leg test goes red with the blocker neutered, reporting that the row loop was reached — so it cannot pass without the condition it induces.

### CHANGELOG entry text (not committed — every lane appends to the same `[Unreleased]` block)

```
- Extended #3095's COPY phase axis to the three AWS-API store ingestors (`RdsPlanIngestor`,
  `RdsCpuIngestor`, `RdsDeadlockIngestor`), so every binary COPY the service performs reports which
  phase a fault came out of, pinned by a scan asserting both that every COPY site stamps and that no
  other site does.
- A collector store-write timeout on a server whose target is PostgreSQL no longer receives the
  target-read remedy ("shrinking the work") or the monitored target's database name. The COPY phase
  identifies a store write by construction, and those faults now report as a store write in both the
  app log and `collection_log`.
```
