### PR TITLE
THROWAWAY: exercise the Darling gate's skip arm with a markdown-only diff

### DIFF
--- a/Darling/docs/L3116-skip-arm-probe.md
+++ b/Darling/docs/L3116-skip-arm-probe.md
@@ -1,0 +1,8 @@
+# Skip-arm probe (throwaway)
+
+Validation artifact for the acceptance criteria of #3116: a pull request whose only change is a file
+matching `Darling/**/*.md` must still leave `Darling PostgreSQL tests` skipping `Run Darling PG tests`.
+
+This branch is based on the fix branch, so the gate being exercised is the shared gate at
+`.github/darling-paths-filter.yml` rather than the one on `dev`. The pull request that carries this file
+is closed and its branch deleted once the job's step list has been read.


### PR DESCRIPTION
Validation artifact for #3122, not for merge.

Based on `L3116-pg-gate-shared-libs` rather than `dev`, so the diff against this pull request's base is one added `Darling/**/*.md` file and the gate being exercised is the shared gate that branch introduces. #3122's own change touches `build.yml`, which every filter in that file names, so it fires all of them and cannot demonstrate a skip.

What to read here: `Darling PostgreSQL tests` must report success with `Run Darling PG tests` **skipped**, and its notice must say how many files changed and name them rather than assert a cause.

Closed and its branch deleted once that step list has been read.