### PR TITLE
THROWAWAY: markdown-only diff to observe the Darling gate's skip arm

### DIFF
--- a/Darling/docs/L3116-skip-arm-probe.md
+++ b/Darling/docs/L3116-skip-arm-probe.md
@@ -1,0 +1,7 @@
+# Skip-arm probe (throwaway)
+
+Validation artifact for the acceptance criteria of #3116: a pull request whose only change matches
+`Darling/**/*.md` must still leave `Darling PostgreSQL tests` skipping `Run Darling PG tests`.
+
+Branched off the fix so the gate being exercised is the shared gate at
+`.github/darling-paths-filter.yml`. Deleted once the job's step list has been read.


### PR DESCRIPTION
Validation artifact for #3122, not for merge. Both branches are deleted once the step list has been read.

The diff against this pull request's base is one added `Darling/**/*.md` file and nothing else, and the base already carries #3122's shared gate — so the gate being exercised here is the new one. #3122 cannot demonstrate this arm itself: its change touches `build.yml`, which every filter in that file names, so it fires all of them.

The base branch also carries one throwaway commit widening `on.pull_request.branches` to include itself. Without it `build.yml` never dispatches for a pull request into a feature branch, which is why the first attempt at this (#3123) registered only `check-branches`. That commit is on the throwaway base only, never on #3122.

What to read: `Darling PostgreSQL tests` reports success with `Run Darling PG tests` **skipped**, and its notice says how many files changed and names them instead of asserting a cause.