### PR TITLE
THROWAWAY: PerformanceMonitor.Collectors-only diff to observe the Darling gate's run arm

### DIFF
--- a/PerformanceMonitor.Collectors/PgIndexBloatCollector.cs
+++ b/PerformanceMonitor.Collectors/PgIndexBloatCollector.cs
@@ -6,6 +6,8 @@
  * Licensed under the MIT License. See LICENSE file in the project root for full license information.
  */
 
+/* THROWAWAY: a shared-library edit, to observe the Darling gate's run arm. Never merged. */
+
 using System;
 using System.Collections.Generic;
 using System.Data.Common;


### PR DESCRIPTION
Validation artifact for #3122, not for merge. Deleted once the step list has been read.

The diff against this pull request's base is one file under `PerformanceMonitor.Collectors/` and nothing else — the same shape as #3114, the pull request that exposed #3116, whose `Darling PostgreSQL tests` reported success in 17s having skipped every step. The base carries #3122's shared gate, so what runs here is the new gate against the exact diff shape the old one dropped.

The base also carries a throwaway commit widening `on.pull_request.branches` to include itself, without which `build.yml` never dispatches for a pull request into a feature branch. That commit is on the throwaway base only, never on #3122.

What to read: `Darling PostgreSQL tests` runs `Run Darling PG tests` to completion, and its notice names the matched file.