### PR TITLE
Normalise pgstatindex NaN on the way out of the index-bloat read

### DIFF
--- a/Darling/Darling.Tests/DarlingPgIndexBloatNanLivePostgresTests.cs
+++ b/Darling/Darling.Tests/DarlingPgIndexBloatNanLivePostgresTests.cs
@@ -1,0 +1,407 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Npgsql;
+using PerformanceMonitor.Collectors;
+using PerformanceMonitor.Darling.Service.Mcp;
+using PerformanceMonitor.Darling.Storage;
+using Xunit;
+
+namespace Darling.Tests;
+
+/// <summary>
+/// An EMPTY b-tree index does not take <c>get_pg_index_bloat</c> down, and it does not disappear from it
+/// either (#3121).
+///
+/// <para><b>What was wrong.</b> <c>pgstatindex</c> has no leaf pages to average over on an empty index, so it
+/// reports <c>avg_leaf_density</c> and <c>leaf_fragmentation</c> as NaN. The store column is
+/// <c>double precision</c>, so the NaN is representable and PERSISTS — one such row is re-read on every later
+/// call until it ages out. The read guarded the column with <c>IS NULL</c>, which NaN passes, and the
+/// surviving expression cast NaN to <c>bigint</c> and raised <c>22003</c>. That failed the WHOLE read, not
+/// the row, so a fresh partition or a table whose rows were all deleted was enough to make the surface serve
+/// an error instead of the index data.</para>
+///
+/// <para><b>Why BOTH assertions, and why the second is the one that earns its keep.</b> The cheapest fix that
+/// turns the read green is a <c>WHERE</c> that drops the row, and it would pass any test that only asked
+/// whether the read succeeded — while hiding a real index from the only surface that reports index bloat.
+/// The row-is-still-there assertion is the one that can tell those two fixes apart, so it is written as an
+/// accounting invariant (every seeded index appears in the output) rather than as a lookup of the row this
+/// test happens to know about.</para>
+///
+/// <para><b>The NaN is INDUCED, not typed in.</b> An empty index is one <c>CREATE INDEX</c> away, so the
+/// value under test is the one a real server produces rather than a literal that resembles it — which also
+/// makes the premise itself falsifiable here (<see cref="PgstatindexReportsNaN_ForARealEmptyBtreeIndex"/>)
+/// instead of quoted from the issue. <c>'NaN'::double precision</c> is the fallback for a rig where
+/// pgstattuple cannot be created, and the assertion message says which route produced the value, because a
+/// pin that cannot say what it measured is one round of confusion away from being believed about the wrong
+/// thing.</para>
+///
+/// <para><b>The float sweep is over the ROW TYPE, not over the two columns named in the issue.</b> A scan's
+/// blind spot is a property of its detector: asserting on <c>AvgLeafDensity</c> and
+/// <c>LeafFragmentation</c> by name would pass unchanged if a third <c>double?</c> column were added to this
+/// read without the normalisation. Reflecting over the record's <c>double?</c> properties makes the next
+/// column arrive already covered.</para>
+/// </summary>
+[Collection("live-postgres")]
+public sealed class DarlingPgIndexBloatNanLivePostgresTests
+{
+    /// <summary>Distinctive so a stray row cannot be confused with another live class's seed data.</summary>
+    private const int ServerId = 993_121;
+
+    private const string ServerName = "pg-index-bloat-nan-probe";
+
+    /* public, not a throwaway schema: LivePostgresStoreFixture's residue diff scans collect/config/public,
+       so a probe table that leaked would be ACCUSED rather than quietly surviving in a schema nothing
+       looks at. */
+    private const string ProbeTable = "public.pg_index_bloat_nan_probe_3121";
+
+    private const string ProbeIndexName = "pg_index_bloat_nan_probe_3121_ix";
+
+    private const string ProbeIndex = "public." + ProbeIndexName;
+
+    /* The empty index sorts LAST by design (nothing to reclaim), so the limit has to clear the seeded set
+       or arm 2 would be measuring the limit instead of the fix. */
+    private const int ReadLimit = 25;
+
+    /// <summary>
+    /// The premise, measured rather than quoted: <c>pgstatindex</c> really does report NaN — for BOTH float
+    /// columns — on a real empty b-tree index. Skips where pgstattuple cannot be created, which is a gap in
+    /// this test's provenance and not in the coverage below; the acceptance test still runs there.
+    /// </summary>
+    [Fact]
+    public async Task PgstatindexReportsNaN_ForARealEmptyBtreeIndex()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the live pgstatindex NaN premise test.");
+
+        var ct = TestContext.Current.CancellationToken;
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(ct);
+
+        var created = await TryCreatePgstattupleAsync(connection, ct);
+        Assert.SkipWhen(!created,
+            "pgstattuple could not be created on this cluster, so pgstatindex cannot be called here. The "
+            + "acceptance test in this class still runs, sourcing the NaN from 'NaN'::double precision.");
+
+        var bodySucceeded = false;
+        try
+        {
+            var measurement = await MeasureEmptyIndexAsync(connection, ct);
+
+            Assert.True(double.IsNaN(measurement.Density),
+                "pgstatindex is expected to report avg_leaf_density as NaN for an index with no leaf pages; "
+                + $"it reported {measurement.Density.ToString(CultureInfo.InvariantCulture)}. If this cluster "
+                + "returns NULL or 0 instead, the read's normalisation is still correct but this issue's "
+                + "premise is version-specific and the SQL comment should say so.");
+
+            /* The issue names avg_leaf_density only. leaf_fragmentation is NaN on the same row and is also
+               double precision in the store, so it reaches System.Text.Json by the same route - found by
+               running this rather than by reading the issue. */
+            Assert.True(double.IsNaN(measurement.Fragmentation),
+                "leaf_fragmentation is NaN on the same row, and is the second float column the read has to "
+                + $"normalise; it reported {measurement.Fragmentation.ToString(CultureInfo.InvariantCulture)}.");
+
+            /* An empty b-tree is the metapage and nothing else, which is why 0 reclaimable is a measurement
+               rather than a guess. */
+            Assert.True(measurement.Bytes > 0 && measurement.Bytes <= 64 * 1024,
+                $"an empty b-tree index should be a page or two; this one is {measurement.Bytes} bytes");
+
+            bodySucceeded = true;
+        }
+        finally
+        {
+            await LiveStoreCleanup.RunAsync(connectionString!, bodySucceeded, DropProbeIndexAsync);
+        }
+    }
+
+    /// <summary>
+    /// Both acceptance arms, through the shared reader AND through the <c>get_pg_index_bloat</c> tool the MCP
+    /// surface and the web page both call — the read succeeds, and the empty index is still in the answer.
+    ///
+    /// <para>Going through the tool as well as the reader is not belt-and-braces. The reader hands back a
+    /// <c>double?</c>, and a NaN that clears the SQL is only halfway out: <c>JsonSerializer</c>'s default
+    /// number handling REJECTS NaN, so the tool would catch it and return an error envelope having read the
+    /// data perfectly. The reader assertion cannot see that, and it is the same defect one layer up.</para>
+    ///
+    /// <para>Three unrelated indexes share the sample on purpose — empty, churned, and too-large-to-measure —
+    /// with names chosen so an alphabetical or insertion-order accident cannot look like correct ranking. A
+    /// fixture holding only the interesting row cannot catch a guard that damages the ordinary ones, and the
+    /// guard here sits inside the expression the ranking is built on.</para>
+    /// </summary>
+    [Fact]
+    public async Task TheReadServesAStoreCarryingNaN_AndTheEmptyIndexStillAppears()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DARLING_TEST_PG");
+        Assert.SkipWhen(string.IsNullOrEmpty(connectionString),
+            "Set DARLING_TEST_PG to a Postgres connection string to run the live pg_index_bloat NaN test.");
+
+        var ct = TestContext.Current.CancellationToken;
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(ct);
+        await PgMigrations.MigrateAsync(connection, ct);
+        await DeleteRowsAsync(connection, ct);
+
+        var bodySucceeded = false;
+        try
+        {
+            await DarlingMcpTestData.RegisterServerAsync(connection, ServerId, ServerName, ct);
+            await DarlingMcpTestData.ExecAsync(connection, ct, @"
+INSERT INTO config_monitored_servers (server_id, name, host, is_enabled) VALUES ($1, $2, $2, TRUE)
+ON CONFLICT (server_id) DO UPDATE SET is_enabled = TRUE", ServerId, ServerName);
+
+            /* Induced where possible; the message on every assertion below names which route ran. */
+            var measurement = await NanSourceAsync(connection, ct);
+
+            var capturedAt = DarlingMcpTestData.TruncateToSeconds(DateTime.UtcNow.AddMinutes(-5));
+
+            /* aaa_ sorts first alphabetically and the empty index must still come LAST, so an ordering that
+               fell back to any name or insertion order fails rather than coincidentally passing. */
+            await SeedAsync(connection, ct, capturedAt, "aaa_fresh_partition", "fresh_partition_pkey",
+                measurement.Bytes, treeLevel: 0, density: measurement.Density,
+                fragmentation: measurement.Fragmentation, skippedReason: null);
+
+            await SeedAsync(connection, ct, capturedAt, "zzz_churned", "churned_ix",
+                1_000_000_000L, treeLevel: 3, density: 45.0, fragmentation: 30.0, skippedReason: null);
+
+            await SeedAsync(connection, ct, capturedAt, "mmm_over_ceiling", "over_ceiling_ix",
+                90_000_000_000L, treeLevel: null, density: null, fragmentation: null,
+                skippedReason: "index is larger than the measurement ceiling; pgstatindex reads every page, "
+                             + "so it is recorded but not measured");
+
+            await using var postgres = NpgsqlDataSource.Create(connectionString!);
+
+            // ── ARM 1: the read serves at all ────────────────────────────────────────────────────────
+            var rows = await DarlingPgIndexBloatReader.GetPgIndexBloatAsync(
+                postgres, ServerId, DarlingMcpTestData.Naive(DateTime.UtcNow.AddHours(-24)),
+                DarlingMcpTestData.Naive(DateTime.UtcNow.AddHours(1)), ReadLimit, ct);
+
+            // ── ARM 2: nothing was dropped to achieve arm 1 ──────────────────────────────────────────
+            /* Stated as accounting over the whole seeded set rather than as a lookup of the NaN row: a
+               filter written to make arm 1 pass has to survive THIS, and "every stored row is accounted
+               for by some read" is the invariant a scenario-shaped assertion keeps missing. */
+            Assert.Equal(
+                new[] { "aaa_fresh_partition", "mmm_over_ceiling", "zzz_churned" },
+                rows.Select(r => r.TableName).OrderBy(n => n, StringComparer.Ordinal).ToArray());
+
+            var empty = rows.Single(r => r.TableName == "aaa_fresh_partition");
+
+            /* A sensible reclaimable figure or an explicit null. 0 is the sensible one and is what this
+               reports: the index was measured, and what it holds is nothing. */
+            Assert.Equal(0L, empty.EstimatedReclaimableBytes);
+
+            /* It was MEASURED. A read that reached the second arm by labelling the row skipped would have
+               hoisted it to the top of the grid, above every real bloat candidate. */
+            Assert.Null(empty.SkippedReason);
+            Assert.Equal("mmm_over_ceiling", rows[0].TableName);
+            Assert.Equal("aaa_fresh_partition", rows[^1].TableName);
+
+            /* NO NaN leaves the read, on any float column of the row type - see the class summary for why
+               this is over the type and not over the two columns the issue names. */
+            foreach (var row in rows)
+            {
+                foreach (var property in NullableDoubleProperties)
+                {
+                    var value = (double?)property.GetValue(row);
+                    Assert.False(value is double d && double.IsNaN(d),
+                        $"{property.Name} came back NaN on {row.TableName}. Every double precision column of "
+                        + "collect.pg_index_bloat has to be normalised on the way out: NaN survives the SQL "
+                        + "quietly and is then rejected by System.Text.Json, which fails the MCP read and "
+                        + $"the web page. NaN source for this run: {measurement.Provenance}.");
+                }
+            }
+
+            /* The neighbours are untouched. (90 - 45) / 90 * 1e9 = 500,000,000. */
+            Assert.Equal(500_000_000L, rows.Single(r => r.TableName == "zzz_churned").EstimatedReclaimableBytes);
+            Assert.Null(rows.Single(r => r.TableName == "mmm_over_ceiling").EstimatedReclaimableBytes);
+
+            // ── ARM 1, one layer up: the surface the operator actually calls ─────────────────────────
+            var json = await DarlingMcpPgIndexTools.GetPgIndexBloat(
+                postgres, ServerName, hours_back: 24, limit: ReadLimit);
+
+            using var document = JsonDocument.Parse(json);
+            Assert.False(
+                document.RootElement.TryGetProperty("status", out var status)
+                && string.Equals(status.GetString(), "error", StringComparison.Ordinal),
+                $"get_pg_index_bloat returned an error envelope for a store carrying a NaN density "
+                + $"(NaN source: {measurement.Provenance}): {json}");
+
+            var payload = document.RootElement.GetProperty("indexes").EnumerateArray().ToList();
+            Assert.Equal(3, payload.Count);
+
+            var emptyPayload = payload.Single(
+                i => i.GetProperty("table_name").GetString() == "aaa_fresh_partition");
+            Assert.Equal(JsonValueKind.Null, emptyPayload.GetProperty("avg_leaf_density").ValueKind);
+            Assert.Equal(0L, emptyPayload.GetProperty("estimated_reclaimable_bytes").GetInt64());
+            Assert.Equal(JsonValueKind.Null, emptyPayload.GetProperty("skipped_reason").ValueKind);
+
+            /* And the payload SAYS what that null density means, because nothing else in it can: a null
+               density with no skipped_reason is the one row where the note's "a null measurement is absence
+               of data" lesson is wrong. */
+            var note = document.RootElement.GetProperty("note").GetString();
+            Assert.Contains("EMPTY", note!, StringComparison.Ordinal);
+
+            bodySucceeded = true;
+        }
+        finally
+        {
+            await LiveStoreCleanup.RunAsync(connectionString!, bodySucceeded, async (cleanup, cleanupCt) =>
+            {
+                await DeleteRowsAsync(cleanup, cleanupCt);
+                await DropProbeIndexAsync(cleanup, cleanupCt);
+            });
+        }
+    }
+
+    /* ── helpers ─────────────────────────────────────────────────────────────────────────────────── */
+
+    /// <summary>
+    /// The <c>double?</c> columns of the row the surfaces consume, read off the type so a column added later
+    /// is covered without anyone remembering to add it here.
+    /// </summary>
+    private static readonly PropertyInfo[] NullableDoubleProperties =
+        [.. typeof(DarlingPgIndexBloatReader.PgIndexBloatRow)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.PropertyType == typeof(double?))];
+
+    private readonly record struct NanMeasurement(
+        double Density, double Fragmentation, long Bytes, string Provenance);
+
+    /// <summary>
+    /// A real NaN if pgstatindex can produce one here, and a literal one otherwise — carrying which, so an
+    /// assertion that fires can say what it was measuring.
+    /// </summary>
+    private static async Task<NanMeasurement> NanSourceAsync(NpgsqlConnection connection, CancellationToken ct)
+    {
+        if (await TryCreatePgstattupleAsync(connection, ct))
+        {
+            return await MeasureEmptyIndexAsync(connection, ct);
+        }
+
+        /* PostgreSQL raises division_by_zero rather than yielding NaN, so a literal is the only other route
+           to the value. Same IEEE bits, weaker provenance - hence the label. */
+        return new NanMeasurement(double.NaN, double.NaN, 8_192L,
+            "'NaN'::double precision (pgstattuple is not creatable on this cluster)");
+    }
+
+    /// <summary>
+    /// Whether <c>public.pgstatindex</c> can be CALLED here, which is a different question from whether the
+    /// CREATE succeeded.
+    ///
+    /// <para><b>WITH SCHEMA public is load-bearing, and the store's own search_path is why.</b> pgstattuple
+    /// is relocatable, so a bare <c>CREATE EXTENSION</c> installs into the first schema on the path — which
+    /// on a migrated store is <c>collect</c>, not <c>public</c>. The CREATE then succeeds and
+    /// <c>public.pgstatindex(...)</c> fails with 42883, which is how this presented. The collector qualifies
+    /// the call <c>public.</c> for its own documented reasons, so <c>public</c> is the placement under test
+    /// rather than an arbitrary choice.</para>
+    ///
+    /// <para>The catalog probe is the verdict, not the CREATE's exit: <c>IF NOT EXISTS</c> is a no-op on a
+    /// store where the extension already sits somewhere else, and reporting success off that would send the
+    /// caller at a function it cannot reach.</para>
+    /// </summary>
+    private static async Task<bool> TryCreatePgstattupleAsync(NpgsqlConnection connection, CancellationToken ct)
+    {
+        try
+        {
+            await using var create = new NpgsqlCommand(
+                "CREATE EXTENSION IF NOT EXISTS pgstattuple WITH SCHEMA public", connection);
+            await create.ExecuteNonQueryAsync(ct);
+        }
+        catch (PostgresException)
+        {
+            /* Not in this cluster's share/extension, or the login cannot create it, or it already exists
+               elsewhere. All are legitimate rigs and none is this test's subject - the probe below decides. */
+        }
+
+        await using var probe = new NpgsqlCommand("""
+            SELECT EXISTS (
+                SELECT 1
+                FROM pg_catalog.pg_proc AS p
+                JOIN pg_catalog.pg_namespace AS n
+                  ON n.oid = p.pronamespace
+                WHERE p.proname = 'pgstatindex'
+                AND   n.nspname = 'public')
+            """, connection);
+        return await probe.ExecuteScalarAsync(ct) is true;
+    }
+
+    /// <summary>Creates a real empty b-tree index and returns what <c>pgstatindex</c> says about it.</summary>
+    private static async Task<NanMeasurement> MeasureEmptyIndexAsync(
+        NpgsqlConnection connection, CancellationToken ct)
+    {
+        await using (var ddl = new NpgsqlCommand($"""
+            DROP TABLE IF EXISTS {ProbeTable} CASCADE;
+            CREATE TABLE {ProbeTable} (probe_id bigint);
+            CREATE INDEX {ProbeIndexName} ON {ProbeTable} (probe_id);
+            """, connection))
+        {
+            await ddl.ExecuteNonQueryAsync(ct);
+        }
+
+        await using var command = new NpgsqlCommand($"""
+            SELECT s.avg_leaf_density, s.leaf_fragmentation, pg_catalog.pg_relation_size('{ProbeIndex}')
+            FROM public.pgstatindex('{ProbeIndex}') AS s
+            """, connection);
+        await using var reader = await command.ExecuteReaderAsync(ct);
+        Assert.True(await reader.ReadAsync(ct), "pgstatindex returned no row for the probe index");
+
+        return new NanMeasurement(
+            reader.GetDouble(0), reader.GetDouble(1), reader.GetInt64(2),
+            "pgstatindex on a real empty b-tree index");
+    }
+
+    private static Task SeedAsync(
+        NpgsqlConnection connection, CancellationToken ct, DateTime collectionTimeUtc,
+        string tableName, string indexName, long indexBytes, int? treeLevel,
+        double? density, double? fragmentation, string? skippedReason) =>
+        DarlingMcpTestData.ExecAsync(connection, ct, @"
+INSERT INTO pg_index_bloat
+    (collection_id, collection_time, server_id, server_name, database_name, schema_name,
+     table_name, index_name, index_bytes, tree_level, internal_pages, leaf_pages,
+     empty_pages, deleted_pages, avg_leaf_density, leaf_fragmentation, skipped_reason)
+VALUES ($1::bigint, $2::timestamp, $3::integer, $4::text, $5::text, $6::text,
+        $7::text, $8::text, $9::bigint, $10::integer, $11::bigint, $12::bigint,
+        $13::bigint, $14::bigint, $15::double precision, $16::double precision, $17::text)",
+            CollectionIdGenerator.Next(), DarlingMcpTestData.Naive(collectionTimeUtc), ServerId, ServerName,
+            "appdb", "public", tableName, indexName, indexBytes, treeLevel, null, null, 0L, 0L,
+            density, fragmentation, skippedReason);
+
+    private static async Task DeleteRowsAsync(NpgsqlConnection connection, CancellationToken ct)
+    {
+        await DarlingMcpTestData.ExecAsync(
+            connection, ct, "DELETE FROM pg_index_bloat WHERE server_id = $1", ServerId);
+        await DarlingMcpTestData.ExecAsync(
+            connection, ct, "DELETE FROM config_monitored_servers WHERE server_id = $1", ServerId);
+        await DarlingMcpTestData.ExecAsync(
+            connection, ct, "DELETE FROM servers WHERE server_id = $1", ServerId);
+    }
+
+    /// <summary>
+    /// Through <see cref="LiveCleanupBatch"/> rather than a bare DROP: the probe table lives in a schema the
+    /// fixture's residue diff scans, so a removal that lost is an accusation with this test's name on it
+    /// instead of an anonymous leftover the next run inherits.
+    ///
+    /// <para>pgstattuple is deliberately LEFT in place. Dropping it is a database-level change racing
+    /// nothing, and a teardown that can fail for a reason unrelated to the subject buys a red run rather
+    /// than a clean store — the extension itself creates no relation the diff can see.</para>
+    /// </summary>
+    private static Task DropProbeIndexAsync(NpgsqlConnection connection, CancellationToken ct) =>
+        new LiveCleanupBatch(connection).RemoveAsync(
+            $"probe table {ProbeTable}",
+            $"DROP TABLE IF EXISTS {ProbeTable} CASCADE",
+            $"SELECT to_regclass('{ProbeTable}') IS NOT NULL",
+            ct);
+}

--- a/Darling/Darling.Tests/DarlingPgIndexBloatNanLivePostgresTests.cs
+++ b/Darling/Darling.Tests/DarlingPgIndexBloatNanLivePostgresTests.cs
@@ -58,8 +58,13 @@ namespace Darling.Tests;
 [Collection("live-postgres")]
 public sealed class DarlingPgIndexBloatNanLivePostgresTests
 {
-    /// <summary>Distinctive so a stray row cannot be confused with another live class's seed data.</summary>
-    private const int ServerId = 993_121;
+    /// <summary>
+    /// NEGATIVE, which is the convention the live classes here follow and not decoration: this test's
+    /// teardown deletes from <c>servers</c> by id, and a real store assigns ids from a sequence, so a
+    /// positive sentinel is one collision away from removing an operator's own registry row. No sequence
+    /// ever reaches this one.
+    /// </summary>
+    private const int ServerId = -993_121;
 
     private const string ServerName = "pg-index-bloat-nan-probe";
 

--- a/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpPgIndexTools.cs
+++ b/Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpPgIndexTools.cs
@@ -71,6 +71,12 @@ public sealed class DarlingMcpPgIndexTools
 
             var truncated = rows.Count >= limit;
             var measured = rows.Count(r => r.SkippedReason is null);
+            /* An EMPTY index is the one row whose null density does NOT mean "not measured", and nothing
+               else in the payload distinguishes it: pgstatindex has no leaf pages to derive a density from,
+               so the read nulls it, while skipped_reason stays null because the measurement succeeded. Named
+               here because the note below spends two sentences teaching the reader that a null measurement
+               is absence of data, and on this row that lesson is wrong. */
+            var empty = rows.Count(r => r.SkippedReason is null && r.AvgLeafDensity is null);
 
             var indexes = rows.Select(r => new
             {
@@ -81,7 +87,9 @@ public sealed class DarlingMcpPgIndexTools
                 index_bytes = r.IndexBytes,
                 index_mb = Math.Round(r.IndexBytes / 1024.0 / 1024.0, 1),
                 /* Null on a skipped row, and deliberately not zero: zero density would read as a
-                   catastrophically bloated index, which is the opposite of "we did not look". */
+                   catastrophically bloated index, which is the opposite of "we did not look". Also null on
+                   an empty index, where there are no leaf pages to have a density - the note distinguishes
+                   the two, since only one of them means the index was not looked at. */
                 avg_leaf_density = r.AvgLeafDensity,
                 leaf_fragmentation = r.LeafFragmentation,
                 tree_level = r.TreeLevel,
@@ -110,6 +118,12 @@ public sealed class DarlingMcpPgIndexTools
                      + "absence of data, never a clean result."
                      + (measured < rows.Count
                          ? $" {rows.Count - measured} of the {rows.Count} row(s) RETURNED are labelled rather than measured."
+                         : string.Empty)
+                     + (empty > 0
+                         ? $" {empty} row(s) have NO skipped_reason and a null avg_leaf_density: those "
+                           + "indexes are EMPTY. pgstatindex has no leaf pages to derive a density from, so "
+                           + "there is no density to report — the measurement succeeded and found nothing, "
+                           + "which is why estimated_reclaimable_bytes is 0 rather than null."
                          : string.Empty)
                      + (truncated
                          ? " TRUNCATED at the row limit: there are more indexes than this. Raise the limit "

--- a/Darling/PerformanceMonitor.Darling.Storage/DarlingPgIndexBloatReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/DarlingPgIndexBloatReader.cs
@@ -88,8 +88,9 @@ public static class DarlingPgIndexBloatReader
        on a table with no rows, which is an entirely ordinary object (a fresh partition, a table whose rows
        were all deleted, a constraint index on an unpopulated table). avg_leaf_density is double precision in
        the store, so NaN is representable, persists, and is re-read on every later call. An IS NULL guard
-       reads as "handle the missing case" and covers only two of the three states a float column has, and
-       the surviving NaN reached a ::bigint cast that raises 22003 - failing the WHOLE read, not the row.
+       alone is not enough here, and it is not enough for a reason its own vocabulary hides: "handle the
+       missing case" covers two of the three states a float column has, and a NaN that reaches the ::bigint
+       cast below raises 22003, which fails the WHOLE read rather than the row.
 
        nullif(x, 'NaN'::double precision) is the whole normalisation, and it turns on a PostgreSQL semantic
        that is the opposite of the C one: NaN compares EQUAL to itself here, so nullif catches it and
@@ -108,10 +109,10 @@ public static class DarlingPgIndexBloatReader
        unmeasured and claim its bloat was unknown when it is known to be nil.
 
        THE ESTIMATE IS COMPUTED ONCE, in the inner scope, and the outer projection and the outer ORDER BY
-       both reference that one column. Two copies of the expression is what made a three-state guard a
-       correctness hazard rather than a typo: they have to agree, and the failure of a disagreement is the
-       ordering raising while the projection succeeds - a read that half works, for a reason no reader could
-       see. One expression cannot drift from itself. */
+       both reference that one column. Two copies of the expression would be a correctness hazard rather
+       than a duplication: they have to agree, and the failure of a disagreement is the ordering raising
+       while the projection succeeds - a read that half works, for a reason no reader could see. One
+       expression cannot drift from itself. */
     public const string PgIndexBloatSql = """
         SELECT database_name, schema_name, table_name, index_name, index_bytes, tree_level,
                empty_pages, deleted_pages,

--- a/Darling/PerformanceMonitor.Darling.Storage/DarlingPgIndexBloatReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/DarlingPgIndexBloatReader.cs
@@ -33,16 +33,27 @@ namespace PerformanceMonitor.Darling.Storage;
 /// the one most likely to be holding reclaimable space, so a read that filtered it out would hide the
 /// biggest candidate behind a performance optimisation.</para>
 ///
+/// <para><b>An EMPTY index has no density, and it still gets a row (#3121).</b> <c>pgstatindex</c> returns
+/// NaN for both float columns when there are no leaf pages to average over, so the read normalises NaN to
+/// NULL and reports 0 reclaimable — the index is measured, and what it holds is nothing. Filtering the row
+/// out instead would serve the read successfully while hiding a real index, which is the failure mode that
+/// looks most like a fix.</para>
+///
 /// <para>Shared by the WPF tab and the MCP surface so there is one copy of this SQL, per #2530.</para>
 /// </summary>
 public static class DarlingPgIndexBloatReader
 {
-    /// <param name="AvgLeafDensity">The server's raw figure. NULL when the index was skipped.</param>
+    /// <param name="AvgLeafDensity">The server's raw figure. NULL when the index was skipped, and NULL when
+    /// the index is EMPTY — <c>pgstatindex</c> divides by a leaf-page count of zero and returns NaN, which
+    /// is not a density and cannot be carried to any consumer here (see the SQL's own note).</param>
+    /// <param name="LeafFragmentation">As above, and NaN on an empty index for the same reason.</param>
     /// <param name="EstimatedReclaimableBytes">What a rebuild might return, derived from the density
-    /// shortfall against a 90% healthy floor. NULL when not measured, and 0 when the index is at or above
-    /// that floor.</param>
+    /// shortfall against a 90% healthy floor. NULL when not measured, and 0 both when the index is at or
+    /// above that floor and when it is empty — an index with no leaf pages holds nothing to reclaim, which
+    /// is a measurement rather than an absence of one.</param>
     /// <param name="SkippedReason">Non-null means this index was NOT measured — its bloat is unknown rather
-    /// than zero.</param>
+    /// than zero. An empty index leaves this NULL: it was measured, and the measurement is that it is
+    /// empty.</param>
     public sealed record PgIndexBloatRow(
         string? DatabaseName,
         string? SchemaName,
@@ -70,22 +81,56 @@ public static class DarlingPgIndexBloatReader
        91.48.
 
        NULLIF guards the division: a density of 0 is not something pgstatindex returns for a live index, but
-       a divide-by-zero would turn one odd row into a failed read for the whole grid. */
+       a divide-by-zero would turn one odd row into a failed read for the whole grid.
+
+       THE THIRD STATE OF A FLOAT COLUMN (#3121). pgstatindex reports avg_leaf_density and
+       leaf_fragmentation as NaN for an EMPTY b-tree index - verified on PostgreSQL 18.6 against a real index
+       on a table with no rows, which is an entirely ordinary object (a fresh partition, a table whose rows
+       were all deleted, a constraint index on an unpopulated table). avg_leaf_density is double precision in
+       the store, so NaN is representable, persists, and is re-read on every later call. An IS NULL guard
+       reads as "handle the missing case" and covers only two of the three states a float column has, and
+       the surviving NaN reached a ::bigint cast that raises 22003 - failing the WHOLE read, not the row.
+
+       nullif(x, 'NaN'::double precision) is the whole normalisation, and it turns on a PostgreSQL semantic
+       that is the opposite of the C one: NaN compares EQUAL to itself here, so nullif catches it and
+       IS NOT DISTINCT FROM would too, while an IEEE-style self-inequality check (x <> x) is false and
+       catches nothing. It is identity on a real density and on NULL, so the two states that already worked
+       are untouched.
+
+       Normalising is not optional decoration on the density columns themselves: a NaN that clears the SQL
+       still reaches System.Text.Json, whose default number handling REJECTS NaN, so it would take down the
+       MCP read and the web page one layer up from the cast. Nothing may leave this read as NaN.
+
+       AN EMPTY INDEX REPORTS 0 RECLAIMABLE, NOT NULL. NULL in this column means "not measured" - that is
+       what a skipped row carries, and the read hoists those to the top on the strength of it. An empty
+       index WAS measured, and what was measured is that it holds nothing to reclaim, so it takes the same 0
+       an above-floor index takes and ranks where a 0 belongs. Reporting NULL would sort it among the
+       unmeasured and claim its bloat was unknown when it is known to be nil.
+
+       THE ESTIMATE IS COMPUTED ONCE, in the inner scope, and the outer projection and the outer ORDER BY
+       both reference that one column. Two copies of the expression is what made a three-state guard a
+       correctness hazard rather than a typo: they have to agree, and the failure of a disagreement is the
+       ordering raising while the projection succeeds - a read that half works, for a reason no reader could
+       see. One expression cannot drift from itself. */
     public const string PgIndexBloatSql = """
         SELECT database_name, schema_name, table_name, index_name, index_bytes, tree_level,
-               empty_pages, deleted_pages, avg_leaf_density, leaf_fragmentation,
-               CASE
-                   WHEN avg_leaf_density IS NULL THEN NULL
-                   ELSE GREATEST(
-                       0,
-                       (index_bytes * (90.0 - avg_leaf_density) / NULLIF(90.0, 0))::bigint)
-               END AS estimated_reclaimable_bytes,
+               empty_pages, deleted_pages,
+               nullif(avg_leaf_density, 'NaN'::double precision) AS avg_leaf_density,
+               nullif(leaf_fragmentation, 'NaN'::double precision) AS leaf_fragmentation,
+               estimated_reclaimable_bytes,
                skipped_reason,
                collection_time
         FROM (
             SELECT DISTINCT ON (database_name, schema_name, table_name, index_name)
                    database_name, schema_name, table_name, index_name, index_bytes, tree_level,
                    empty_pages, deleted_pages, avg_leaf_density, leaf_fragmentation,
+                   CASE
+                       WHEN avg_leaf_density IS NULL THEN NULL
+                       WHEN avg_leaf_density = 'NaN'::double precision THEN 0::bigint
+                       ELSE GREATEST(
+                           0,
+                           (index_bytes * (90.0 - avg_leaf_density) / NULLIF(90.0, 0))::bigint)
+                   END AS estimated_reclaimable_bytes,
                    skipped_reason, collection_time
             FROM pg_index_bloat
             WHERE server_id = $1
@@ -97,9 +142,7 @@ public static class DarlingPgIndexBloatReader
            ones by a reclaimable figure it does not have. Then by reclaimable bytes, never by density: a
            small index at 40% is worth nothing next to a large one at 70%. */
         ORDER BY (skipped_reason IS NOT NULL) DESC,
-                 CASE WHEN avg_leaf_density IS NULL THEN NULL
-                      ELSE GREATEST(0, (index_bytes * (90.0 - avg_leaf_density) / 90.0)::bigint)
-                 END DESC NULLS LAST,
+                 latest.estimated_reclaimable_bytes DESC NULLS LAST,
                  index_bytes DESC
         LIMIT $4
         """;

--- a/Darling/PerformanceMonitor.Darling.Storage/DarlingPgIndexBloatReader.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/DarlingPgIndexBloatReader.cs
@@ -92,7 +92,7 @@ public static class DarlingPgIndexBloatReader
        missing case" covers two of the three states a float column has, and a NaN that reaches the ::bigint
        cast below raises 22003, which fails the WHOLE read rather than the row.
 
-       nullif(x, 'NaN'::double precision) is the whole normalisation, and it turns on a PostgreSQL semantic
+       NULLIF(x, 'NaN'::double precision) is the whole normalisation, and it turns on a PostgreSQL semantic
        that is the opposite of the C one: NaN compares EQUAL to itself here, so nullif catches it and
        IS NOT DISTINCT FROM would too, while an IEEE-style self-inequality check (x <> x) is false and
        catches nothing. It is identity on a real density and on NULL, so the two states that already worked
@@ -116,8 +116,8 @@ public static class DarlingPgIndexBloatReader
     public const string PgIndexBloatSql = """
         SELECT database_name, schema_name, table_name, index_name, index_bytes, tree_level,
                empty_pages, deleted_pages,
-               nullif(avg_leaf_density, 'NaN'::double precision) AS avg_leaf_density,
-               nullif(leaf_fragmentation, 'NaN'::double precision) AS leaf_fragmentation,
+               NULLIF(avg_leaf_density, 'NaN'::double precision) AS avg_leaf_density,
+               NULLIF(leaf_fragmentation, 'NaN'::double precision) AS leaf_fragmentation,
                estimated_reclaimable_bytes,
                skipped_reason,
                collection_time


### PR DESCRIPTION
`pgstatindex` reports `avg_leaf_density` as **NaN** for an empty b-tree index. `DarlingPgIndexBloatReader` guarded that column with `IS NULL`, NaN passes that guard, and the surviving `::bigint` cast raises `22003` — which fails the **whole** `get_pg_index_bloat` read, not the row. `avg_leaf_density` is `double precision` in the store, so the NaN is representable, persists, and is re-read on every later call until the row ages out.

#3114 merged while this was in flight, so the collector now returns rows and this is live rather than latent. Its own comment records the mechanism from the other side: *"an empty one reports avg_leaf_density as NaN, which is not NULL"* — the collector sees the value and deliberately stores it raw.

## What changed

`Darling/PerformanceMonitor.Darling.Storage/DarlingPgIndexBloatReader.cs` — `PgIndexBloatSql`:

- `nullif(avg_leaf_density, 'NaN'::double precision)` and the same on `leaf_fragmentation`, in the outer projection.
- `estimated_reclaimable_bytes` gains an explicit `WHEN avg_leaf_density = 'NaN'::double precision THEN 0::bigint` arm, ahead of the `IS NULL` arm.
- That estimate is now computed **once**, in the inner `latest` scope, and both the outer projection and the outer `ORDER BY` reference the one column.
- Record and class documentation for the new state.

`Darling/PerformanceMonitor.Darling.Service/Mcp/DarlingMcpPgIndexTools.cs` — the payload note gains a clause when rows with no `skipped_reason` and a null density are present, naming them as EMPTY indexes.

`Darling/Darling.Tests/DarlingPgIndexBloatNanLivePostgresTests.cs` — new, two live tests.

## Why the read and not the collector

The issue lays out the tradeoff and the read wins on three counts, only the first of which is about elegance.

**A write-side guard cannot satisfy the acceptance criterion.** The criterion is a store that *already contains* a NaN row. Rejecting NaN at collection does nothing for stored rows, and because the column is `double precision` those rows keep failing every call until retention removes them. The read guard is required whether or not a write guard also exists, so the choice is really "read only" versus "read plus write".

**Writing NULL loses information the surface needs.** `skipped_reason` non-null means NOT MEASURED — the read hoists those to the top of the ranking on the strength of it, and `get_pg_index_bloat` derives `measured_count` from it. An empty index *was* measured. Carrying it as skipped would sort it above every real bloat candidate and claim its bloat was unknown; carrying a NULL density with no reason is the honest shape, and the note now says what that combination means because nothing else in the payload can (the read does not project `leaf_pages`).

**The collector is another lane's file.** #3114 rewrote 231 lines of it and merged today. Editing it here would have collided for no gain the read guard does not already provide.

The residual cost the issue names is real and unfixed: a *future* read site writing its own SQL over `collect.pg_index_bloat` hits the raw NaN again. The durable answer to that is a normalising passthrough view on a migration rung, which is a much larger change (rung + `SchemaVersion` + four pinned literals + the viewer probe) with a live rung-numbering collision risk, and it would not help any non-store consumer. Left out deliberately, named here rather than dropped.

## The NaN is not decoration on the density columns

Fixing only the cast leaves the surface broken one layer up. `avg_leaf_density` reaches `JsonSerializer.Serialize` with `McpHelpers.JsonOptions`, whose default number handling **rejects** NaN — so the tool would read the data perfectly and return an error envelope. `DarlingWebEndpoints` calls the same method, so the web page fails the same way. `leaf_fragmentation` is NaN on the same row and travels the same route; the issue does not mention it, and it was found by running the probe rather than by reading the code.

## One expression, not two agreeing copies

The issue's warning that the projection and the `ORDER BY` "must agree, or the ordering fails while the projection succeeds" is a property of there being two copies. Computing the estimate once in the inner scope removes the failure mode instead of fixing it twice, and a third reference added later cannot drift either. Both copies were verified to raise independently against a real NaN before the change.

## PostgreSQL NaN semantics, measured

On PostgreSQL 18.6, read off a real empty index rather than assumed:

| expression | result |
|---|---|
| `avg_leaf_density` from `pgstatindex` on an empty b-tree | `NaN` (with `leaf_pages = 0`, `index_size = 8192`) |
| `leaf_fragmentation` on the same row | `NaN` |
| `d IS NULL` — the shipped guard | `f` |
| `d = 'NaN'::double precision` | `t` |
| `d IS NOT DISTINCT FROM 'NaN'::double precision` | `t` |
| `d <> d` — IEEE-style self-inequality | `f` |
| `NOT (d = d)` | `f` |

`nullif(d, 'NaN'::double precision)` therefore normalises NaN and is identity on a real density (`87.31` in, `87.31` out) and on NULL.

## Verification

An empty index is one `CREATE INDEX` away, so the value under test is induced rather than typed in: the tests create a real table with no rows, index it, and take the NaN from `pgstatindex`. Every assertion message reports which route produced the value, and `'NaN'::double precision` is the fallback only where `public.pgstatindex` cannot be resolved.

`WITH SCHEMA public` on the `CREATE EXTENSION` is load-bearing and cost a round: pgstattuple is relocatable, so a bare create lands it in `collect` (first on the store's `search_path`), the create succeeds, and `public.pgstatindex(...)` then fails `42883`. The helper's verdict is a catalog probe rather than the create's exit, because `IF NOT EXISTS` is a no-op on a store where the extension already sits elsewhere.

Both acceptance arms are asserted, and arm 2 is written as accounting over the whole seeded set — every seeded index appears in the output — rather than as a lookup of the row the test knows about. A `WHERE` that drops the NaN row is the cheapest fix that turns arm 1 green, and only that shape of assertion can tell it apart from a real one. The NaN sweep is over the `double?` properties of `PgIndexBloatRow` by reflection, so a third float column added to this read without the normalisation arrives already covered instead of slipping past a check that names two columns.

The sentinel `ServerId` is negative, which is the convention the live classes here follow: this test's teardown deletes from `servers` by id, and a real store assigns ids from a sequence, so a positive sentinel is one collision away from removing an operator's own registry row.

Three orderings are deliberately distinct in the fixture, which is what makes the ranking assertions falsifiable: insert order is `aaa, zzz, mmm`; the inner `DISTINCT ON` order is alphabetical `aaa, mmm, zzz`; the asserted read order is `mmm` first and `aaa` last. The asserted order matches neither of the other two, and the mutation above confirms it rather than arguing it.

The fixture holds three unrelated indexes in one sample — empty, churned, over-ceiling — named `aaa_`/`zzz_`/`mmm_` so an alphabetical or insertion-order accident cannot look like correct ranking. The empty index must sort **last**, the over-ceiling one **first**.

### Mutations run, each seen red

Each mutation was applied to the committed tree, the real test file was run against live PostgreSQL through an xunit shim, and the tree restored. Baseline and post-restore are `Failed: 0, Skipped: 0, Not Run: 0`; the premise test stays green throughout, which is itself a discriminating signal. The whole suite was re-run on the final head after the merge, so the table below describes the tree that merges rather than an earlier one.

| mutation | outcome |
|---|---|
| the read restored to its pre-change form | red — `PostgresException 22003: bigint out of range` |
| estimate arm kept, `nullif` removed from both float columns | red — `AvgLeafDensity came back NaN on aaa_fresh_partition` |
| as above, with the reflection sweep also disabled | red — `get_pg_index_bloat returned an error envelope`, so the JSON assertion is not merely shielded by the sweep ahead of it |
| the NaN row filtered out with a `WHERE` instead of guarded | red — arm 2 collection mismatch, arm 1 green |
| `avg_leaf_density <> avg_leaf_density` instead of `= 'NaN'` | red — `22003`, so the PostgreSQL equality semantics are load-bearing |
| the MCP note's empty-index clause removed | red — `Assert.Contains` on the note |
| the outer `ORDER BY` removed entirely | red — `rows[0]` came back `aaa_fresh_partition` instead of `mmm_over_ceiling`, so the sorts-last assertion is on the ordering the READ produces, not on insert order |

Also run locally: `dotnet build Darling/Darling.Tests` (0 errors, no warnings in any changed file) and the `Darling Linux build` job's own `dotnet publish ... -r linux-x64` (exit 0). The doc-comment hygiene rules were replicated over the three changed files — one `<summary>` opening per doc run, balanced, and both crefs resolve against identifiers the tree spells.

## What CI will and will not cover here

`Darling whole-tree guards` gates on the build job having left `Darling.Tests` unrun. This diff is entirely under `Darling/`, so the build job runs the suite and this job reports `success` with its substantive steps `skipped` — expected, not a pass to read as coverage. `Darling PostgreSQL tests` is where the two new live tests actually execute.

`PgstatindexReportsNaN_ForARealEmptyBtreeIndex` skips if `public.pgstatindex` cannot be resolved on the bundled EDB runtime. It resolved on PostgreSQL 18.6 locally; if it skips in CI, the acceptance test still runs and sources its NaN from the literal, and the skip is a gap in provenance rather than in coverage.

## Review findings

- **`nullif` casing** — fixed. `NULLIF(` outnumbers `nullif(` 176 to 7 in this tree and the same query already carried an uppercase one, so the two new calls were mixing conventions inside one statement. Verified the count rather than taking it on trust; SQL keywords are case-insensitive, so the pin was re-run afterwards rather than assumed.
- **`CHANGELOG.md` not touched** — declined, deliberately. Entry text goes in this description for the release coordinator to apply; every lane appending to the same `[Unreleased]` block produces a conflict per lane. The drafted text below is the deliverable, not an oversight.

## CHANGELOG entry text

### Fixed

- **`get_pg_index_bloat` no longer fails outright on an empty index.** `pgstatindex` reports `avg_leaf_density` and `leaf_fragmentation` as NaN when an index has no leaf pages, the read's `IS NULL` guard passed it, and the `::bigint` cast raised — failing the whole read rather than the row, and doing so on every later call because the value persists in a `double precision` column. Both float columns are now normalised on the way out, an empty index reports 0 reclaimable and still appears in the result, and the reclaimable estimate is computed once so the projection and the ordering cannot disagree.
