### PR TITLE
Count a qualified receiver in the repo-file reader census, and declare the one exemption it makes visible

### DIFF
--- a/Darling/Darling.Tests/RepoFileAdoptionTests.cs
+++ b/Darling/Darling.Tests/RepoFileAdoptionTests.cs
@@ -37,7 +37,7 @@ namespace Darling.Tests;
 /// <c>DoesNotContain</c> would stop being ABLE to fire and report clean forever. Switching a pin off the LF
 /// reader is therefore a decision, and it reds here so it gets made on purpose.</para>
 ///
-/// <para><b>What this scan cannot see, stated rather than implied.</b> Three things, and the first is a
+/// <para><b>What this scan cannot see, stated rather than implied.</b> Four things, and the first is a
 /// boundary rather than a limitation.</para>
 ///
 /// <para><b>It sweeps <c>Darling.Tests</c> only</b>, because <see cref="TestDirectory"/> is this file's own
@@ -56,6 +56,17 @@ namespace Darling.Tests;
 /// private re-implementation under some other name evades it. The regex anchors on the name, and a name is
 /// all one file's text offers.</para>
 ///
+/// <para><b>It matches a CALL by NAME AND RECEIVER</b> — the bare name, or a receiver whose last segment is
+/// <c>RepoFile</c>. An aliased receiver (<c>using RF = RepoFile;</c>) and a call reached through a delegate
+/// captured from the method are both outside it. <b>The failure direction is why this is worth stating:</b>
+/// the raw and LF lists are decided by subtracting one count from the other, so a call matching neither
+/// pattern makes a file absent from BOTH lists rather than present in the wrong one — and an exact-set
+/// equality is satisfied by a file it cannot see just as well as by a file that belongs outside it. That is
+/// not hypothetical: while the receiver was excluded rather than consumed,
+/// <see cref="RepoFileResolutionEquivalenceTests"/> called the LF reader twice and sat outside the LF
+/// equality, which is the correct answer arrived at by not looking. It is now declared in
+/// <see cref="s_lfSubjects"/>, and the exemption is asserted to name a file the census can see.</para>
+///
 /// <para><b>It says nothing about the fifty-three classes here that carry their own repo-ROOT walk</b>
 /// without a reader on top of it. That is the same duplication one layer down, it is a larger population
 /// than this one was, and it is deliberately not in scope.</para>
@@ -72,11 +83,20 @@ public sealed class RepoFileAdoptionTests
         @"^[ \t]*(?:private|internal|public|protected)[^\r\n;=]*?\bReadRepoFile(?:Lf)?\s*\(",
         RegexOptions.Multiline | RegexOptions.Compiled);
 
-    private static readonly Regex RawCall = new(
-        @"(?<![\w.])ReadRepoFile\s*\(", RegexOptions.Compiled);
+    /// <summary>Every CALL to either reader, counted so the LF calls can be subtracted out below. The
+    /// receiver group is what makes a qualified call visible, and it has to be part of the MATCH rather than
+    /// permitted by the lookbehind: the lookbehind's job is excluding an unrelated
+    /// <c>Something.ReadRepoFile(</c>, and it does that by refusing a preceding <c>.</c>. Consuming our own
+    /// receiver moves the match start to before the dot, so the call is inside the match instead of behind
+    /// it, and every other receiver stays out.</summary>
+    private static readonly Regex AnyCall = new(
+        @"(?<![\w.])(?:[\w.]*\bRepoFile\.)?ReadRepoFile(?:Lf)?\s*\(", RegexOptions.Compiled);
 
+    /// <summary>The LF spelling alone, same receiver rule. <c>(?:Lf)?</c> above is what makes it a subset
+    /// rather than a disjoint pattern — the trailing <c>\s*\(</c> would otherwise separate the two names on
+    /// its own, and the count comparison below would then be comparing populations that never overlap.</summary>
     private static readonly Regex LfCall = new(
-        @"(?<![\w.])ReadRepoFileLf\s*\(", RegexOptions.Compiled);
+        @"(?<![\w.])(?:[\w.]*\bRepoFile\.)?ReadRepoFileLf\s*\(", RegexOptions.Compiled);
 
     /// <summary>
     /// The pins whose anchors span a line break, and which therefore read LF-normalised text.
@@ -99,6 +119,31 @@ public sealed class RepoFileAdoptionTests
         "StoreCopyPhaseTests.cs",
         "ViewTemplatesTests.cs",
         "ViewerSidebarDotRendersTheCardStatusTests.cs",
+    };
+
+    /// <summary>
+    /// The files that call the LF reader without ANCHORING on it, and are therefore outside the set above
+    /// while being inside the census.
+    ///
+    /// <para>The distinction is the one <see cref="s_lfReaders"/> is keyed on: membership there is a property
+    /// of a pin's anchors. A file that calls the LF reader to EXERCISE it has no anchors spanning a line
+    /// break, so moving it between the two readers changes nothing about what its assertions can match, and
+    /// declaring it would state a property it does not have.</para>
+    ///
+    /// <para><b>Declared rather than left to fall out of the scan.</b> The one entry here was outside the
+    /// equality before the census could see a qualified receiver — the right answer produced by a scan that
+    /// could not see the file at all, which is indistinguishable from a scan that considered it. So each
+    /// entry is asserted to be VISIBLE to the census in
+    /// <see cref="TheLfReadingPins_AreExactlyTheOnesDeclaredHere"/>: an exemption for a file the scan cannot
+    /// find is an exemption doing no work, and it reds rather than reading as a decision.</para>
+    /// </summary>
+    private static readonly string[] s_lfSubjects =
+    {
+        /* The equivalence test FOR the reader, parameterised over both spellings and calling each of them
+           directly. It compares the reader's output against the bytes on disk put through the same
+           transform, so it performs the CRLF-to-LF normalisation itself rather than depending on the
+           reader's — which is the property membership above is about. */
+        "RepoFileResolutionEquivalenceTests.cs",
     };
 
     [Fact]
@@ -133,8 +178,26 @@ public sealed class RepoFileAdoptionTests
     {
         var (_, _, _, lfAdopters) = Survey();
 
+        /* Asserted BEFORE the equality, because it is the failure the equality cannot report. A file the
+           census cannot see is absent from lfAdopters and absent from the expectation, so both sides agree
+           and the equality passes — while the exemption that was supposed to be a decision about a visible
+           file is instead a coincidence about an invisible one. */
+        foreach (var subject in s_lfSubjects)
+        {
+            Assert.True(
+                lfAdopters.Contains(subject, StringComparer.Ordinal),
+                $"{subject} is exempted from the LF-reading set, but the census does not see it calling the "
+              + "LF reader. Either the call is gone, in which case delete the exemption — or the scan cannot "
+              + "see the spelling it uses, in which case this exemption is not the decision it claims to be "
+              + "and neither is the equality below");
+        }
+
+        /* Disjoint, so the concatenation below is a set. A file in both lists would duplicate in the
+           expectation and red the equality anyway, but on a length mismatch rather than on the mistake. */
+        Assert.Empty(s_lfReaders.Intersect(s_lfSubjects, StringComparer.Ordinal));
+
         Assert.Equal(
-            s_lfReaders.OrderBy(f => f, StringComparer.Ordinal).ToArray(),
+            s_lfReaders.Concat(s_lfSubjects).OrderBy(f => f, StringComparer.Ordinal).ToArray(),
             lfAdopters.ToArray());
 
         /* The floor that makes the equality above mean something. An empty tree satisfies an empty
@@ -187,10 +250,11 @@ public sealed class RepoFileAdoptionTests
                 lfAdopters.Add(name);
             }
 
-            /* RawCall matches the Lf spelling too — its name is a prefix — so a file is a raw adopter only
-               once every Lf call is accounted for. Counted by occurrence rather than by presence, so a class
-               that legitimately uses both readers lands in both lists instead of one arbitrarily. */
-            if (RawCall.Matches(code).Count > LfCall.Matches(code).Count)
+            /* AnyCall counts the Lf spelling too, so a file is a raw adopter exactly when its calls are not
+               all accounted for by the Lf pattern. Counted by occurrence rather than by presence, so a class
+               that legitimately uses both readers lands in both lists instead of one arbitrarily — which is
+               the difference between a subtraction and a comparison of two disjoint populations. */
+            if (AnyCall.Matches(code).Count > LfCall.Matches(code).Count)
             {
                 rawAdopters.Add(name);
             }


### PR DESCRIPTION
`RepoFileAdoptionTests`' two call-site patterns excluded a preceding `.`, so `RepoFile.ReadRepoFile(` and `RepoFile.ReadRepoFileLf(` matched neither. Because the raw list is decided by comparing two counts, a file spelling its receiver was absent from **both** lists rather than in the wrong one — so the exact-set equality `TheLfReadingPins_AreExactlyTheOnesDeclaredHere` passed with an undeclared LF-reading file in the tree.

## The patterns

The receiver is now consumed by the match instead of refused by the lookbehind, and the raw pattern takes `(?:Lf)?` so the two populations overlap the way the comparison below them assumes:

```
AnyCall = (?<![\w.])(?:[\w.]*\bRepoFile\.)?ReadRepoFile(?:Lf)?\s*\(
LfCall  = (?<![\w.])(?:[\w.]*\bRepoFile\.)?ReadRepoFileLf\s*\(
```

**The lookbehind is still what excludes an unrelated receiver, and it has to be.** Drop it and `Something.ReadRepoFile(` matches at the `R`, its receiver sitting behind the match. Consuming our own receiver moves the match start to before the dot, so `RepoFile.` is inside the match and every other receiver is still refused. `\w` in the lookbehind continues to reject an identifier that merely ends in the name (`MyReadRepoFile(`).

**`(?:Lf)?` is what separates the two names, and the mandatory `\s*\(` was doing it before.** Measured against the shipped patterns rather than argued: `(?<![\w.])ReadRepoFile\s*\(` does **not** match `ReadRepoFileLf(`, because `\s*\(` finds `L` where it needs a paren. So `AnyCall` and `LfCall` were disjoint on `dev`, and `AnyCall.Count > LfCall.Count` was comparing populations that never overlapped — which reads as a subtraction and behaves as a comparison, and drops a file making fewer raw calls than LF calls. With `(?:Lf)?` the comparison is a real subtraction: every one of the nine declared LF readers now reports `any == lf` (`ServerPageTabsTests` 13/13), and a probe file with one qualified raw call and two qualified LF calls classifies raw at 3 > 2 where the disjoint form scored 1 > 2 and dropped it.

## The reconciliation

`RepoFileResolutionEquivalenceTests.cs` becomes visible: two qualified LF calls at lines 164 and 184, three qualified raw calls at 164, 183 and 191.

**It stays out of `s_lfReaders`, and now says so.** Membership there is a property of a pin's anchors, and this file has none spanning a line break: it is the equivalence test *for* the reader, parameterised over both spellings, comparing the reader's output against the bytes on disk put through the same transform — so it performs the CRLF-to-LF normalisation itself at line 171 rather than depending on the reader's. Declaring it would state a property it does not have.

That was already the right answer on `dev`, reached by a scan that could not see the file — which is indistinguishable from a scan that considered it and decided. So the exclusion is now declared in `s_lfSubjects`, and **every entry there is asserted to be visible to the census**: an exemption naming a file the scan cannot find is an exemption doing no work, and it reds instead of reading as a decision. That assertion is what fails if the patterns regress, and it is checked before the equality because it is the failure the equality cannot report — an invisible file is absent from both sides, so both sides agree.

`PostgresCancelOriginTests.cs` becomes visible as a raw adopter (two qualified calls, 304 and 342). It is correctly outside the LF set and it now counts toward the adopter floor.

## Census, before and after

Both derived from the shipped `Regex` objects over the real tree, and the whole point is that nothing is **lost**:

| | `dev` | this branch |
|---|---|---|
| declarers | 1 | 1 |
| lf adopters | 9 | 10 (`+RepoFileResolutionEquivalenceTests`) |
| raw adopters | 29 | 31 (`+PostgresCancelOriginTests`, `+RepoFileResolutionEquivalenceTests`) |
| union, against a floor of 30 | 38 | 40 |

## What the summary now admits

The class enumerated its blind spots and did not carry this one. It now states that a call is matched by **name and receiver** — the bare name, or a receiver whose last segment is `RepoFile` — that an aliased receiver and a delegate captured from the method are outside it, and why the failure direction is the one worth stating: a call matching neither pattern makes a file absent from both lists, and an exact-set equality is satisfied by a file it cannot see just as well as by one that belongs outside it.

## Verification, and its scope

`Darling.Tests` cannot execute on macOS, so the five source-scanning classes most exposed to this change were compiled **unmodified** into a `net10.0` console host with an xUnit shim and their real `[Fact]`/`[Theory]` methods invoked: `RepoFileAdoptionTests`, `RepoFileResolutionEquivalenceTests`, `DocCommentHygieneTests`, `CommentFilterAdoptionTests`, `FleetIdentifierScrubTests` — 31 cases, `Failed: 0, Not Run: 0`. `Darling.Tests.csproj` rebuilds clean with no new analyzer warning. This does not cover execution under xunit.v3/MTP; CI is the arbiter for that.

Four mutations, each applied and reversed **alone**, against those real assertions:

| mutation | what reddened |
|---|---|
| a new file making only `RepoFile.ReadRepoFileLf(` calls, undeclared | the set equality, naming it as unexpected |
| the two patterns reverted to `dev`'s, everything else kept | the `s_lfSubjects` visibility assertion — the fix and the exemption are coupled |
| `RepoFileResolutionEquivalenceTests.cs` removed from `s_lfSubjects` | the set equality, naming it — so it is genuinely seen, not merely declared |
| `PostgresCancelOriginTests.cs`' two qualified raw calls switched to LF | the set equality, naming it — the qualified raw form is genuinely seen too |

A fifth probe measured the mixed-count case above; it moves no assertion, because `rawAdopters` carries a floor rather than an exact set.

## Left out

The `adopters.Length >= 30` floor and the `files.Count >= 400` floor are untouched. `rawAdopters` still has no exact-set assertion, so the raw side of the census is pinned only by that floor — the mixed-count correction is therefore measured rather than guarded, and a pin for it belongs with whoever wants the raw set pinned exactly. The `Declaration` pattern is untouched: it uses `\b` rather than the lookbehind, so it never had this blind spot.

## CHANGELOG entry text (not applied here)

```
- Fixed: the repo-file reader census in `Darling.Tests` could not see a qualified call to either reader, so its exact-set equality passed with an undeclared LF-reading file in the tree.
```
