### PR TITLE
Assert collection size with Assert.Single and Assert.Empty in the source-scanning pins

### DIFF
--- a/Darling/Darling.Tests/CollectorRuntimeStateTests.cs
+++ b/Darling/Darling.Tests/CollectorRuntimeStateTests.cs
@@ -393,7 +393,7 @@ public sealed class CollectorRuntimeStateTests
             + $"managed-bootstrap and store-connect stand-downs; found {terminal}.");
 
         /* Exactly one publish clears the failure phases, and it is the one that says collection started. */
-        Assert.Equal(1, Regex.Matches(code, @"_collectorState\.PublishCollecting\(").Count);
+        Assert.Single(Regex.Matches(code, @"_collectorState\.PublishCollecting\("));
     }
 
     // ── helpers ───────────────────────────────────────────────────────────────────────────

--- a/Darling/Darling.Tests/CollectorStallProbeStoreTests.cs
+++ b/Darling/Darling.Tests/CollectorStallProbeStoreTests.cs
@@ -237,7 +237,7 @@ public class CollectorStallProbeStoreTests
 
         /* Exactly one arm in the runner: a second call site would be a second concurrent probe per server,
            which is the pool bound this design promises not to exceed. */
-        Assert.Equal(1, Regex.Matches(runner, @"StallProbeArm\.Start\(").Count);
+        Assert.Single(Regex.Matches(runner, @"StallProbeArm\.Start\("));
 
         /* Both gates reach the policy from the call site. */
         Assert.Contains("StallProbeArm.Start(\n                    server.Target.Engine,\n                    definition.PerItemWallClockBudget,",

--- a/Darling/Darling.Tests/ControlPlaneReloadDurabilityTests.cs
+++ b/Darling/Darling.Tests/ControlPlaneReloadDurabilityTests.cs
@@ -258,9 +258,7 @@ public sealed class ControlPlaneReloadDurabilityTests
 
         /* And exactly one assignment from the applied version, so a second one outside the branch cannot
            re-introduce the early advance alongside the correct one. */
-        Assert.Equal(
-            1,
-            Regex.Matches(code, @"_lastConfigVersion\s*=\s*appliedVersion\.Value\s*;").Count);
+        Assert.Single(Regex.Matches(code, @"_lastConfigVersion\s*=\s*appliedVersion\.Value\s*;"));
 
         /* Positive control on the negative above, through the identical pattern: an assertion that can
            only pass is not an assertion. */
@@ -288,7 +286,7 @@ public sealed class ControlPlaneReloadDurabilityTests
             + "caller's guard always succeeds and the config_version watermark advances on a reload that "
             + "applied nothing — the original defect, reachable again through the new return value");
 
-        Assert.Equal(1, Regex.Matches(reloadBody, @"return null\s*;").Count);
+        Assert.Single(Regex.Matches(reloadBody, @"return null\s*;"));
 
         /* And what it returns on SUCCESS is the view's own version, so the watermark, the log line and the
            applied config can never disagree. A method returning any other long would satisfy every
@@ -314,7 +312,7 @@ public sealed class ControlPlaneReloadDurabilityTests
 
         /* Exactly one reset, and it is on the success path — a reset in the catch would make every failure
            look like a first failure and restore the flood. */
-        Assert.Equal(1, Regex.Matches(code, @"_viewReadFailureStreak\s*=\s*0\s*;").Count);
+        Assert.Single(Regex.Matches(code, @"_viewReadFailureStreak\s*=\s*0\s*;"));
 
         /* Scoped to LoadViewAsync's own body. Searching the FILE for that catch signature finds an
            earlier member's copy of it — which made this comparison meaningless on the first run, and is

--- a/Darling/Darling.Tests/DarlingWebTlsTests.cs
+++ b/Darling/Darling.Tests/DarlingWebTlsTests.cs
@@ -290,7 +290,7 @@ public sealed class DarlingWebTlsTests
 
             Assert.Equal(leaf.Thumbprint, loaded.Leaf.Thumbprint);
             Assert.True(loaded.Leaf.HasPrivateKey);
-            Assert.Equal(1, loaded.Chain.Count);
+            Assert.Single(loaded.Chain);
             Assert.Equal(intermediate.Thumbprint, loaded.Chain[0].Thumbprint);
         }
     }
@@ -322,7 +322,7 @@ public sealed class DarlingWebTlsTests
 
             Assert.True(loaded.Leaf.HasPrivateKey);
             Assert.Equal("CN=localhost", loaded.Leaf.Subject);
-            Assert.Equal(1, loaded.Chain.Count);
+            Assert.Single(loaded.Chain);
             Assert.Equal(intermediate.Thumbprint, loaded.Chain[0].Thumbprint);
         }
     }

--- a/Darling/Darling.Tests/IlCallSiteScannerTests.cs
+++ b/Darling/Darling.Tests/IlCallSiteScannerTests.cs
@@ -79,7 +79,7 @@ public sealed class IlCallSiteScannerTests
         /* What the scanner does now: one call site, at the real instruction boundary. */
         var decoded = IlCallSiteScanner.DecodeCallSites(il, nameof(TheSkippingByteScanLosesARealCall_WhichIsWhyTheScannerDecodesInstructions));
 
-        Assert.Equal(1, decoded.Count);
+        Assert.Single(decoded);
         Assert.Equal(GenuineOffset, decoded[0].Offset);
         Assert.Equal(ContrivedToken, decoded[0].Token);
 
@@ -134,7 +134,7 @@ public sealed class IlCallSiteScannerTests
         var decoded = IlCallSiteScanner.DecodeCallSites(il, nameof(ATwoByteOpcodeIsDecodedAsTwoBytes_NotAsTheOneByteInlineNonePrefixEntry));
 
         /* ldftn is InlineMethod but is neither call nor callvirt, so it is correctly not a call site. */
-        Assert.Equal(1, decoded.Count);
+        Assert.Single(decoded);
         Assert.Equal(6, decoded[0].Offset);
         Assert.Equal(ContrivedToken, decoded[0].Token);
     }

--- a/Darling/Darling.Tests/PostgresCancelOriginTests.cs
+++ b/Darling/Darling.Tests/PostgresCancelOriginTests.cs
@@ -307,15 +307,15 @@ public sealed class PostgresCancelOriginTests
 
         /* Exactly one origin decision, so a second arm cannot grow its own opinion about the same
            question — the shape #3111's store-write exclusion is pinned with. */
-        Assert.Equal(1, Regex.Matches(code, @"CollectorFaultCancelOrigin\.For\(ex\)").Count);
+        Assert.Single(Regex.Matches(code, @"CollectorFaultCancelOrigin\.For\(ex\)"));
 
         /* And it is the argument the sentence is built from, not a value computed beside it. The window
            has to admit the two intervening arguments and their comments — the walker blanks a comment's
            TEXT and keeps its length, so the measured span is 995 characters, not the 80 the code reads as.
            It would not admit a call moved out of the argument list. */
-        Assert.Equal(1, Regex.Matches(
+        Assert.Single(Regex.Matches(
             code,
-            @"PostgresTimeoutExplanation\([\s\S]{0,1500}?CollectorFaultCancelOrigin\.For\(ex\)\)").Count);
+            @"PostgresTimeoutExplanation\([\s\S]{0,1500}?CollectorFaultCancelOrigin\.For\(ex\)\)"));
 
         var inCode = Regex.Matches(code, CollectorFaultCancelOrigin.QueryCanceled).Count;
         var inLiterals = CSharpSourceWalker.StringLiteralBodies(worker)

--- a/Darling/Darling.Tests/PostgresFaultOutcomeTests.cs
+++ b/Darling/Darling.Tests/PostgresFaultOutcomeTests.cs
@@ -535,13 +535,13 @@ public class PostgresFaultOutcomeTests
             "Darling", "PerformanceMonitor.Darling.Service", "DarlingWorker.cs"));
 
         /* Refused ON the target: the statement got there, so the wall clock is target-side. */
-        Assert.Equal(1, Regex.Matches(worker, @"""SESSION_MISSING"", 0, runClock\.ElapsedMilliseconds, 0").Count);
-        Assert.Equal(1, Regex.Matches(worker, @"""YIELDED"", 0, runClock\.ElapsedMilliseconds, 0").Count);
-        Assert.Equal(1, Regex.Matches(worker, @"""PERMISSIONS"", 0, runClock\.ElapsedMilliseconds, 0, message").Count);
+        Assert.Single(Regex.Matches(worker, @"""SESSION_MISSING"", 0, runClock\.ElapsedMilliseconds, 0"));
+        Assert.Single(Regex.Matches(worker, @"""YIELDED"", 0, runClock\.ElapsedMilliseconds, 0"));
+        Assert.Single(Regex.Matches(worker, @"""PERMISSIONS"", 0, runClock\.ElapsedMilliseconds, 0, message"));
 
         /* The SQLSTATE arm passes a COMPUTED status rather than a literal, which is why it is invisible to a
            census keyed on the status strings and earns its own pin here. */
-        Assert.Equal(1, Regex.Matches(worker, @"collectorName, status, 0, runClock\.ElapsedMilliseconds, 0").Count);
+        Assert.Single(Regex.Matches(worker, @"collectorName, status, 0, runClock\.ElapsedMilliseconds, 0"));
 
         /* Never queried the target - the RDS log API and Performance Insights are both HTTPS. */
         Assert.Equal(2, Regex.Matches(worker, @"""PERMISSIONS"", 0, 0, runClock\.ElapsedMilliseconds").Count);
@@ -556,8 +556,8 @@ public class PostgresFaultOutcomeTests
            any unrelated four-argument call elsewhere in this 6,600-line file, and a pin that reds on a
            change it does not guard is a pin someone eventually loosens. This form still catches a new arm
            whether it passes a literal status or a computed one. */
-        Assert.Equal(1, Regex.Matches(worker, @"collectorName, (?:""[A-Z_]+""|status), 0, 0, 0,").Count);
-        Assert.Equal(1, Regex.Matches(worker, @"""PERMISSIONS"", 0, 0, 0, ex\.Message").Count);
+        Assert.Single(Regex.Matches(worker, @"collectorName, (?:""[A-Z_]+""|status), 0, 0, 0,"));
+        Assert.Single(Regex.Matches(worker, @"""PERMISSIONS"", 0, 0, 0, ex\.Message"));
     }
 
     private static string ReadSource(string relativePath)

--- a/Darling/Darling.Tests/StoreCopyPhaseTests.cs
+++ b/Darling/Darling.Tests/StoreCopyPhaseTests.cs
@@ -214,7 +214,7 @@ public class StoreCopyPhaseTests
 
         /* Exactly one transition, and it is to Data. Two would mean a second, unreviewed opinion about
            which phase is in force. */
-        Assert.Equal(1, Regex.Matches(runner, @"copyPhase\s*=\s*StoreCopyPhase\.Data;").Count);
+        Assert.Single(Regex.Matches(runner, @"copyPhase\s*=\s*StoreCopyPhase\.Data;"));
 
         /* And exactly one assignment of Start — the declaration itself, which this pattern matches as a
            substring of `var copyPhase = ...`. SYMMETRIC with the Data count above, and it closes the one
@@ -234,7 +234,7 @@ public class StoreCopyPhaseTests
            literal form. Low probability — a formatter normalises it and this repo's style is consistent —
            but the cost of closing it is four characters, and a pin that a reformat can slip past is not a
            pin. */
-        Assert.Equal(1, Regex.Matches(runner, @"copyPhase\s*=\s*StoreCopyPhase\.Start;").Count);
+        Assert.Single(Regex.Matches(runner, @"copyPhase\s*=\s*StoreCopyPhase\.Start;"));
 
         /* The fault arm stamps whatever phase was live and rethrows BARE — no wrapping, so the type,
            message, stack and inner chain reaching the handlers upstream are unchanged. */
@@ -270,8 +270,8 @@ public class StoreCopyPhaseTests
             "Darling", "PerformanceMonitor.Darling.Service", "DarlingWorker.cs");
 
         /* Composed once, from the helper, inside the general arm. */
-        Assert.Equal(1, Regex.Matches(
-            worker, @"var message = CollectorFaultCopyPhase\.Describe\(ex\);").Count);
+        Assert.Single(Regex.Matches(
+            worker, @"var message = CollectorFaultCopyPhase\.Describe\(ex\);"));
 
         /* The app log line takes it. */
         Assert.Matches(
@@ -280,9 +280,9 @@ public class StoreCopyPhaseTests
             worker);
 
         /* And so does the collection_log row this arm writes — exactly one such row. */
-        Assert.Equal(1, Regex.Matches(
+        Assert.Single(Regex.Matches(
             worker,
-            @"collectorName, ""ERROR"", 0, runClock\.ElapsedMilliseconds, 0, message, fanout: null").Count);
+            @"collectorName, ""ERROR"", 0, runClock\.ElapsedMilliseconds, 0, message, fanout: null"));
 
         /* Neither reverts to the bare message. These are the two expressions this arm carried before, and
            they are what a revert would restore — a revert that compiles, runs, and reports both phases
@@ -292,12 +292,12 @@ public class StoreCopyPhaseTests
            Several arms in this method pass a bare `ex.Message` legitimately — the XE-capture-down warning
            logs one and its SESSION_MISSING row stores one — so a bare substring would fail on a
            neighbour and read as a defect here. */
-        Assert.Equal(0, Regex.Matches(
+        Assert.Empty(Regex.Matches(
             worker,
-            @"=> ERROR: \{Message\}"",\s*\n\s*server\.Config\.DisplayName, collectorName, ex\.Message\);").Count);
-        Assert.Equal(0, Regex.Matches(
+            @"=> ERROR: \{Message\}"",\s*\n\s*server\.Config\.DisplayName, collectorName, ex\.Message\);"));
+        Assert.Empty(Regex.Matches(
             worker,
-            @"collectorName, ""ERROR"", 0, runClock\.ElapsedMilliseconds, 0, ex\.Message, fanout: null").Count);
+            @"collectorName, ""ERROR"", 0, runClock\.ElapsedMilliseconds, 0, ex\.Message, fanout: null"));
     }
 
     /// <summary>
@@ -579,8 +579,8 @@ public class StoreCopyPhaseTests
             "Darling", "PerformanceMonitor.Darling.Service", "DarlingWorker.cs");
 
         /* Exactly one exclusion, so a second arm cannot grow its own opinion about the same question. */
-        Assert.Equal(1, Regex.Matches(
-            worker, @"&& !CollectorFaultCopyPhase\.IsProvenStoreWrite\(ex\)").Count);
+        Assert.Single(Regex.Matches(
+            worker, @"&& !CollectorFaultCopyPhase\.IsProvenStoreWrite\(ex\)"));
 
         /* A filter term of the engine-gated arm, above the Classify call, and reached before the arm's
            body — the window admits the intervening comment and would not admit a term moved after the


### PR DESCRIPTION
Closes out the `xUnit2013` population: the analyzer's *"Do not use `Assert.Equal()` to check for collection size"* warnings are at zero. `Assert.Equal(0, …)` became `Assert.Empty(…)` and `Assert.Equal(1, …)` became `Assert.Single(…)` at the 24 sites the analyzer names, across 8 files. Assertion form only — no pin's subject, pattern, window or commentary changes, and no `[0]` index was removed.

Every count of 2 or more is untouched. So is `Assert.Equal(copySites.Keys.ToArray(), stampSites.ToArray())` in `StoreCopyPhaseTests.cs`, which is a set equality rather than a size check and is not flagged.

## The counts, and a correction to the issue's headline figure

Measured from the build log of `dotnet build Darling/Darling.Tests -p:EnableWindowsTargeting=true`, cold on both sides (every `obj`/`bin` purged, all 13 projects recompiled — verified by `CoreCompile` appearing for each).

| | before (`641c4db7f`) | after |
|---|---|---|
| `xUnit2013` raw log lines | 48 | **0** |
| `xUnit2013` distinct `file(line,col)` sites | 24 | **0** |
| MSBuild's own deduplicated `N Warning(s)` total | 59 | 35 |

Two counting units that fail differently agree: the distinct-site count goes 24 → 0, and MSBuild's independent deduplicated summary falls by exactly 24. Warning ownership per project is otherwise byte-identical (`Darling.Tests` 100 → 52 raw lines, a drop of exactly the 48 `xUnit2013` lines; `Common` 8, `Darling.Service` 6, `Ui` 4 unchanged). Every other analyzer ID is unchanged: `xUnit1025` 2, `xUnit2000` 6, `xUnit2008` 6, `xUnit2029` 4, `xUnit2030` 2, `xUnit2031` 32, `CA1416` 6, `CA1720` 8, `CA1859` 2, `CS8848` 2. Nothing was introduced.

**The issue's "190" is not the `xUnit2013` count.** On run 34071817028 it is the raw grep count of *all* `xUnit*` rules across the whole log — `80 xUnit2013 + 66 xUnit2031 + 12 xUnit2008 + 12 xUnit2000 + 8 xUnit2029 + 6 xUnit1025 + 4 xUnit2030 + 2 xUnit1031 = 190`. The issue's own per-file table is a genuine `xUnit2013` measurement but is inflated 4x by log multiplicity (2 jobs x body-plus-summary), which is why it sums to 80 rather than to the 20 sites the analyzer reported. Two further notes on that citation: the run id is at `a3b24307b`, not the `2f62b8850` the issue names, and the distribution has since moved — `StoreCopyPhaseTests` gained 2 sites and `PostgresCancelOriginTests.cs` (an 8th file, not in the issue's table) gained 2, via #3095 and #3118.

I validated the local instrument against CI before trusting it: built at CI's own commit `a3b24307b` and got 20 distinct sites, 40 raw lines, and CI's exact per-file split. Same instrument, same answer.

## Sites deliberately left as `Assert.Equal`

Four of the 24 are plain collection `.Count` checks rather than `Regex.Matches(…).Count`, and each indexes `[0]` immediately after. All four took the minimal change — bare `Assert.Single(collection);`, index left alone:

- `DarlingWebTlsTests.cs:293` and `:325` — `Chain[0].Thumbprint` is read once each, so the return value *could* have absorbed the index.
- `IlCallSiteScannerTests.cs:82` and `:137` — `decoded[0]` is read twice each, and `decoded.Count` is separately load-bearing at `:102`, so using the return would need a new local. That is restructuring, not an assertion-form change.

The reason for going minimal at all four rather than only the last two: **all four approved sites already in the tree discard the return** — `ControlPlaneReloadDurabilityTests.cs:257,267` and `ViewerQueriesRestTests.cs:98-99` are bare statements. Using the return anywhere would have introduced a second spelling while removing one, which is how this drift started.

One formatting change beyond the assertion name, called out because it is the only one: `ControlPlaneReloadDurabilityTests.cs:261` was a three-line `Assert.Equal(\n 1,\n Regex.Matches(…).Count);` and is now a single line, so it reads symmetrically with the `Assert.Empty` four lines above it that asserts the same shape about the same field. 98 characters, against a 132-character longest line in that file.

## Proving the pins still bite

`Darling.Tests` targets `net10.0-windows` and cannot run on macOS, so I compiled the **actual test files** into a throwaway `net10.0` console harness referencing the real `xunit.v3.assert` package — the shipped assertions, not a retyped copy. Only the `[Fact]`/`[Theory]`/`[InlineData]` discovery attributes are shimmed; every assertion executed is xUnit's own. The harness assembly is named `Darling.Tests` so the Service project's `InternalsVisibleTo` applies and the real test source compiles unmodified.

**140 facts and theory cases pass** across all 8 edited files plus `RepoFileAdoptionTests` — both of its facts, including the exact-set equality on the LF-reading pin list, which names `StoreCopyPhaseTests.cs`.

Three mutations, each applied alone against a committed tree and restored before the next, restoration verified by content rather than diffstat:

| mutation | expected to red | result |
|---|---|---|
| a second `copyPhase = StoreCopyPhase.Data;` after `CompleteAsync` | the `Data` count pin | **red** — `SingleException`, "The collection contained 2 items", the `Start` pin still green |
| a bare `copyPhase = StoreCopyPhase.Start;` below the row loop | the symmetric `Start` count pin | **red** — `SingleException`, 2 items, the `Data` pin still green |
| a second `"ERROR"` row reverting to bare `ex.Message`, leaving the `message` form in place | the `Assert.Empty` pin | **red** — `EmptyException`, "Collection was not empty", and it was the *only* failure of the 11 |

The symmetric pair discriminates independently — each mutation reds its own half and leaves the other green, which is what "keep both, keep them symmetric" has to mean operationally. Mutations 1 and 2 also red `EveryStoreCopyInTheServiceStampsTheCopyPhase`, a separate guard over the same invariant; its message is distinct, so attribution is unambiguous. The third mutation was shaped specifically to isolate `Assert.Empty`: reverting the existing call instead would have tripped the `Assert.Single` above it first and the `Assert.Empty` would never have executed.

`Assert.Single`'s failure output is strictly more diagnostic than what it replaced — it prints the matched strings (`[copyPhase = StoreCopyPhase.Data;, copyPhase = StoreCopyPhase.Data;]`) where `Assert.Equal(1, …)` printed only `Expected: 1 / Actual: 2`.

## Is anything now unfailable?

Asked and answered empirically rather than assumed. I compared verdicts pairwise — `Assert.Equal(0, coll.Count)` against `Assert.Empty(coll)`, and `Assert.Equal(1, coll.Count)` against `Assert.Single(coll)` — over the three collection types this change actually touches (`MatchCollection`, `List<T>`, `X509Certificate2Collection`) at sizes 0, 1 and 2. **All 18 verdict pairs agree.** In particular `Assert.Single` fails at size 0 and `Assert.Empty` fails at sizes 1 and 2, so no assertion lost the ability to fail.

The one real behavioural difference is a performance one in our favour and never a verdict one: `.Count` on a `MatchCollection` forces the regex over the entire input, while `Assert.Single` stops enumerating after the second match.

## CHANGELOG

Not edited here, since every lane appends to the same `[Unreleased]` block. Entry text:

```
- Assert collection size with `Assert.Single` and `Assert.Empty` in the source-scanning test pins,
  clearing all 24 `xUnit2013` analyzer warnings. Assertion form only; counts of 2 or more, and the
  set-equality comparisons the analyzer does not flag, are unchanged.
```
