### PR TITLE
Describe the refresh routine band by its constant instead of by a census of readings

### DIFF
--- a/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
+++ b/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
@@ -72,6 +72,13 @@ namespace Darling.Tests;
 /// the pattern still matches, so a mutation that merely broke a regex cannot pass as a caught drift. And
 /// <see cref="Verify"/> requires that it CONSUMED every pin in <see cref="Pins"/>, because a pattern defined
 /// in the list and never asserted against anything looks exactly like a pattern doing work.</para>
+///
+/// <para><b>And the SCOPING rule, held file-wide rather than only where it is stated (#3133).</b>
+/// <see cref="Verify"/> requires the ceiling paragraph's own enumeration to carry a CLOSED scope;
+/// <see cref="NoOpenPopulationClaim_SurvivesOutsideTheSentenceThatRejectsIt"/> requires the rest of the
+/// file not to break the same rule. Two copies of one universal described the routine refresh band with
+/// the sentence rejecting them sitting between them, so where the rule is stated is not where it needs
+/// enforcing.</para>
 /// </summary>
 public sealed class RefreshCeilingProvenancePinTests
 {
@@ -472,6 +479,71 @@ public sealed class RefreshCeilingProvenancePinTests
         Assert.True(Ceiling < WatchLine,
             "the ceiling now classifies as a warning, so the doc comment's claim that the watch line sits "
             + "above the observed range is stale.");
+    }
+
+    /// <summary>
+    /// The scoping rule <see cref="Verify"/> enforces for the ceiling's own paragraph, applied to the whole
+    /// file (#3133). A scope has to CLOSE a population: <c>every reading</c> closes nothing, and
+    /// <c>the readings so far</c> is relative to a reading time a doc comment does not have. Both forms
+    /// described the routine refresh band in this file while the sentence rejecting them sat in it too.
+    ///
+    /// <para><b>Matched against JOINED doc prose, which is why this is a test and not a grep.</b> One of the
+    /// two sites wrapped as "the one every / reading taken so far falls in", so a line-oriented search for
+    /// the phrase found the other one and returned a confident count that was short by one. Runs are joined
+    /// before any pattern runs, the same normalisation <see cref="DocProseFor"/> applies to a single
+    /// declaration.</para>
+    ///
+    /// <para><b>The one permitted occurrence is ANCHORED to the sentence that rejects it, not exempted by
+    /// location.</b> Exempting the doc run the rule lives in would let a fresh universal be added to that
+    /// run and pass. Requiring the quotation instead means a reworded rule turns this red and the allowance
+    /// gets re-decided rather than quietly widening — and it is what makes the scan non-vacuous, because a
+    /// walk that read nothing fails that same assertion.</para>
+    ///
+    /// <para><b>What this does NOT hold, said plainly rather than left looking covered.</b> It guards the
+    /// two PHRASINGS the rule names, not staleness itself: nothing in the code can know the live series, so
+    /// no assertion can recognise an open population claim in wording it has never seen, and a third
+    /// phrasing of the same claim passes this and still breaks the rule. What carries the rest is that the
+    /// claim is ABSENT rather than reworded — the band is described by
+    /// <see cref="TimescaleSupport.RefreshSlotWarningSeconds"/> and by what the level means, so there is no
+    /// census for a later edit to keep current. The population that IS published carries its own assertion
+    /// in <see cref="TheDerivedFiguresAreExactlyStateable_AndTheConstantIsThePopulationMaximum"/>.</para>
+    /// </summary>
+    [Fact]
+    public void NoOpenPopulationClaim_SurvivesOutsideTheSentenceThatRejectsIt()
+    {
+        AssertNoOpenPopulationClaim(ReadTimescaleSupportSource());
+    }
+
+    /// <summary>
+    /// Each shape the guard forbids, injected ONE AT A TIME into a copy of the source with the guard
+    /// required to fail on it — a bundled mutation reports that something fired, not which clause did.
+    ///
+    /// <para>The first case goes back in WRAPPED across two <c>///</c> lines, so it proves the joining is
+    /// load-bearing rather than tidy: unjoined, that mutation is invisible, which is how the original pair
+    /// came to be counted as one.</para>
+    /// </summary>
+    [Fact]
+    public void TheOpenPopulationGuard_ReportsEachForbiddenShape()
+    {
+        var source = ReadTimescaleSupportSource();
+
+        /* Clean first. Without this, every case below could be reporting a violation that was already
+           there, which is indistinguishable from a caught mutation. */
+        AssertNoOpenPopulationClaim(source);
+
+        Assert.ThrowsAny<Exception>(() => AssertNoOpenPopulationClaim(
+            InjectDocLines(source, InsideSlotMember, "/// and the one every", "/// reading taken so far falls in.")));
+
+        Assert.ThrowsAny<Exception>(() => AssertNoOpenPopulationClaim(
+            InjectDocLines(source, InsideSlotMember, "/// The readings so far are all inside it.")));
+
+        /* And the anchor: reword the rule's own quotation and the allowance stops being granted. */
+        var unanchored = source.Replace(
+            @"""the readings so far"" carries a scope",
+            @"""a scope read against now"" carries a scope",
+            StringComparison.Ordinal);
+        Assert.NotEqual(source, unanchored);
+        Assert.ThrowsAny<Exception>(() => AssertNoOpenPopulationClaim(unanchored));
     }
 
     /* ─────────────────────────────── verification ─────────────────────────────── */
@@ -941,5 +1013,129 @@ public sealed class RefreshCeilingProvenancePinTests
             + "[CallerFilePath], so there is no copy to go stale); restore the path rather than pointing it "
             + "at a fixture.");
         return File.ReadAllText(path);
+    }
+
+    /* ─────────────────────────────── the scoping rule, file-wide ─────────────────────────────── */
+
+    /// <summary>The enum member whose summary carried one of the two universals, and the coordinate
+    /// <see cref="TheOpenPopulationGuard_ReportsEachForbiddenShape"/> injects at. Its own declaration line,
+    /// indentation included, so the injected lines land in that member's doc run.</summary>
+    private const string InsideSlotMember = "        InsideSlot,";
+
+    /// <summary>
+    /// The universal-quantifier form: a claim over a series that gains a reading every hour the job runs,
+    /// carrying no scope at all.
+    /// </summary>
+    private static readonly Regex UniversalOverAnOpenSeries =
+        new("every reading", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary>
+    /// The relative-scope form. It looks scoped and is not: a doc comment has no timestamp of its own for
+    /// "so far" to be read against.
+    /// </summary>
+    private static readonly Regex RelativeScope =
+        new("readings so far", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary>
+    /// The rule sentence's own quotation of <see cref="RelativeScope"/>, which it names in order to reject
+    /// it — the single permitted occurrence, and the anchor the permission is measured against.
+    /// </summary>
+    private static readonly Regex RelativeScopeRejected =
+        new(@"""the readings so far"" carries a scope", RegexOptions.Compiled);
+
+    /// <summary>
+    /// The rule, checked against every doc-comment run in TimescaleSupport.cs at once.
+    /// </summary>
+    private static void AssertNoOpenPopulationClaim(string source)
+    {
+        var prose = JoinedDocProse(source);
+
+        /* THE ANCHOR, first, because both clauses below are measured against it - and because a scan that
+           read nothing produces zero here, which is what stops them passing vacuously. */
+        var rejected = RelativeScopeRejected.Matches(prose).Count;
+        Assert.True(rejected == 1,
+            $"the sentence quoting \"the readings so far\" in order to REJECT it appears {rejected} times "
+            + "rather than once, so this guard's single allowance is no longer anchored to it. If the rule "
+            + "is being reworded, move this anchor with it deliberately; do not drop the assertion, because "
+            + "zero here is also what a scan that read no doc comments at all looks like.");
+
+        var universal = UniversalOverAnOpenSeries.Matches(prose).Count;
+        Assert.True(universal == 0,
+            $"{universal} doc comment(s) in TimescaleSupport.cs claim something of \"every reading\", which "
+            + "closes no population: that series gains a reading every hour this job runs, so the claim is "
+            + "false as soon as one reading falls outside it and nothing in the file can notice. Say what "
+            + "the band IS - it is defined by its constant and needs no census. If a population claim is "
+            + "genuinely wanted, CLOSE it (\"up to <hh:mmZ>\") and pin it here the way Verify pins the "
+            + "ceiling paragraph's; a closed claim with no assertion rots just as fast.");
+
+        var relative = RelativeScope.Matches(prose).Count;
+        Assert.True(relative == rejected,
+            $"\"readings so far\" appears {relative} times against the {rejected} the rule sentence quotes, "
+            + "so a doc comment is now USING the form that sentence rejects. It reads as a scope and is "
+            + "not one: a doc comment has no timestamp of its own for \"so far\" to be relative to.");
+    }
+
+    /// <summary>
+    /// Every doc-comment run in the file, each joined to one line and normalised the way
+    /// <see cref="DocProseFor"/> normalises a single declaration's — so a phrase that wraps across
+    /// <c>///</c> lines is one string, and neither emphasis nor dash style can hide a match.
+    ///
+    /// <para>Runs are kept newline-separated from each other rather than run together, so two adjacent
+    /// runs cannot manufacture a phrase that neither of them contains.</para>
+    /// </summary>
+    private static string JoinedDocProse(string source)
+    {
+        var runs = new List<string>();
+        var current = new List<string>();
+
+        foreach (var raw in source.Split('\n'))
+        {
+            var line = raw.Trim('\r', ' ', '\t');
+            if (line.StartsWith("///", StringComparison.Ordinal))
+            {
+                current.Add(line.Length > 3 ? line[3..].Trim() : string.Empty);
+                continue;
+            }
+
+            if (current.Count > 0)
+            {
+                runs.Add(string.Join(" ", current));
+                current.Clear();
+            }
+        }
+
+        if (current.Count > 0)
+        {
+            runs.Add(string.Join(" ", current));
+        }
+
+        var prose = string.Join("\n", runs)
+            .Replace("<b>", string.Empty, StringComparison.Ordinal)
+            .Replace("</b>", string.Empty, StringComparison.Ordinal)
+            .Replace('—', '-')
+            .Replace('–', '-');
+        return Regex.Replace(prose, "[ \t]+", " ").Trim();
+    }
+
+    /// <summary>
+    /// Inserts <paramref name="docLines"/> immediately above <paramref name="member"/>'s declaration line in
+    /// a COPY of <paramref name="source"/>, extending that member's doc run — the coordinate the whole-file
+    /// scan reads, so a mutation lands where the guard looks. Indentation comes from the declaration itself
+    /// rather than being written in, so a reindented file cannot produce a line the scan quietly skips.
+    /// </summary>
+    private static string InjectDocLines(string source, string member, params string[] docLines)
+    {
+        var index = source.IndexOf(member, StringComparison.Ordinal);
+        Require(index > 0,
+            $"{ParseMiss}: could not find '{member}' in TimescaleSupport.cs, so no mutation was injected and "
+            + "the case that follows would pass on a file it never changed");
+        Require(source.IndexOf(member, index + 1, StringComparison.Ordinal) < 0,
+            $"{ParseMiss}: '{member}' appears more than once, so a mutation aimed at it is not aimed at one "
+            + "known doc run");
+
+        var indent = member[..(member.Length - member.TrimStart().Length)];
+        var mutated = source.Insert(index, string.Concat(docLines.Select(line => indent + line + "\r\n")));
+        Assert.NotEqual(source, mutated);
+        return mutated;
     }
 }

--- a/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
+++ b/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
@@ -499,11 +499,12 @@ public sealed class RefreshCeilingProvenancePinTests
     /// gets re-decided rather than quietly widening — and it is what makes the scan non-vacuous, because a
     /// walk that read nothing fails that same assertion.</para>
     ///
-    /// <para><b>What this does NOT hold, said plainly rather than left looking covered.</b> It guards the
-    /// two PHRASINGS the rule names, not staleness itself: nothing in the code can know the live series, so
-    /// no assertion can recognise an open population claim in wording it has never seen, and a third
-    /// phrasing of the same claim passes this and still breaks the rule. What carries the rest is that the
-    /// claim is ABSENT rather than reworded — the band is described by
+    /// <para><b>What this does NOT hold, said plainly rather than left looking covered.</b> It guards two
+    /// SHAPES — a quantifier over a population of observations, and the relative-scope form — not staleness
+    /// itself. Nothing in the code can know the live series, so no assertion can recognise an open
+    /// population claim in a construction it has never seen; a claim built out of neither shape passes this
+    /// and still breaks the rule. What carries the rest is that the claim is ABSENT rather than reworded —
+    /// the band is described by
     /// <see cref="TimescaleSupport.RefreshSlotWarningSeconds"/> and by what the level means, so there is no
     /// census for a later edit to keep current. The population that IS published carries its own assertion
     /// in <see cref="TheDerivedFiguresAreExactlyStateable_AndTheConstantIsThePopulationMaximum"/>.</para>
@@ -536,6 +537,11 @@ public sealed class RefreshCeilingProvenancePinTests
 
         Assert.ThrowsAny<Exception>(() => AssertNoOpenPopulationClaim(
             InjectDocLines(source, InsideSlotMember, "/// The readings so far are all inside it.")));
+
+        /* A THIRD wording of the same claim, and the reason the pattern matches a shape rather than the
+           phrases that were found: none of the three sites said it the same way. */
+        Assert.ThrowsAny<Exception>(() => AssertNoOpenPopulationClaim(
+            InjectDocLines(source, InsideSlotMember, "/// Zero exceptions on every sample since.")));
 
         /* And the anchor: reword the rule's own quotation and the allowance stops being granted. */
         var unanchored = source.Replace(
@@ -1023,11 +1029,29 @@ public sealed class RefreshCeilingProvenancePinTests
     private const string InsideSlotMember = "        InsideSlot,";
 
     /// <summary>
-    /// The universal-quantifier form: a claim over a series that gains a reading every hour the job runs,
-    /// carrying no scope at all.
+    /// The universal-quantifier form: a quantifier over a population of OBSERVATIONS, which is a series
+    /// that gains a member every hour this job runs.
+    ///
+    /// <para><b>The shape rather than the phrases that were found (#3133).</b> Three sites stated this
+    /// claim and no two of them said it the same way — "every reading", "every reading taken so far",
+    /// "every sample since". A pattern listing the phrasings found would be a frozen list beside a defect
+    /// that keeps rewording itself, so the quantifier and the population noun are matched
+    /// separately.</para>
+    ///
+    /// <para><b><c>run</c> is deliberately NOT a population noun here.</b> This file uses it for closed
+    /// censuses ("every run that day after the boundary"), for the exclusion rule ("every run that started
+    /// at or before the narrowing boundary") and for a statement about a SOURCE's completeness ("read as
+    /// every run since the boundary rather than sampled") — none of which is the defect, and the third of
+    /// which is the source-versus-reading distinction the rule paragraph itself draws. Including it would
+    /// make this guard red on correct prose, which is how a guard gets edited away.</para>
+    ///
+    /// <para>A CLOSED claim in this shape ("every reading up to <c>04:20Z</c>") also matches, and that is
+    /// intended rather than a false positive: a closed claim still needs an assertion, so it should arrive
+    /// here to acquire one.</para>
     /// </summary>
     private static readonly Regex UniversalOverAnOpenSeries =
-        new("every reading", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        new(@"\b(?:every|each|all)\s+(?:reading|readings|sample|samples|snapshot|snapshots)\b",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     /// <summary>
     /// The relative-scope form. It looks scoped and is not: a doc comment has no timestamp of its own for
@@ -1061,8 +1085,8 @@ public sealed class RefreshCeilingProvenancePinTests
 
         var universal = UniversalOverAnOpenSeries.Matches(prose).Count;
         Assert.True(universal == 0,
-            $"{universal} doc comment(s) in TimescaleSupport.cs claim something of \"every reading\", which "
-            + "closes no population: that series gains a reading every hour this job runs, so the claim is "
+            $"{universal} doc comment(s) in TimescaleSupport.cs quantify over a population of readings "
+            + "without closing it: that series gains a member every hour this job runs, so the claim is "
             + "false as soon as one reading falls outside it and nothing in the file can notice. Say what "
             + "the band IS - it is defined by its constant and needs no census. If a population claim is "
             + "genuinely wanted, CLOSE it (\"up to <hh:mmZ>\") and pin it here the way Verify pins the "

--- a/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
+++ b/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
@@ -76,9 +76,8 @@ namespace Darling.Tests;
 /// <para><b>And the SCOPING rule, held file-wide rather than only where it is stated (#3133).</b>
 /// <see cref="Verify"/> requires the ceiling paragraph's own enumeration to carry a CLOSED scope;
 /// <see cref="NoOpenPopulationClaim_SurvivesOutsideTheSentenceThatRejectsIt"/> requires the rest of the
-/// file not to break the same rule. Two copies of one universal described the routine refresh band with
-/// the sentence rejecting them sitting between them, so where the rule is stated is not where it needs
-/// enforcing.</para>
+/// file not to break the same rule. A rule stated in one paragraph binds nothing in the paragraphs a
+/// reader meets thousands of lines away, so where it is stated is not where it needs enforcing.</para>
 /// </summary>
 public sealed class RefreshCeilingProvenancePinTests
 {
@@ -484,14 +483,14 @@ public sealed class RefreshCeilingProvenancePinTests
     /// <summary>
     /// The scoping rule <see cref="Verify"/> enforces for the ceiling's own paragraph, applied to the whole
     /// file (#3133). A scope has to CLOSE a population: <c>every reading</c> closes nothing, and
-    /// <c>the readings so far</c> is relative to a reading time a doc comment does not have. Both forms
-    /// described the routine refresh band in this file while the sentence rejecting them sat in it too.
+    /// <c>the readings so far</c> is relative to a reading time a doc comment does not have. The rule is
+    /// stated in one paragraph of this file and breakable in every other one.
     ///
-    /// <para><b>Matched against JOINED doc prose, which is why this is a test and not a grep.</b> One of the
-    /// two sites wrapped as "the one every / reading taken so far falls in", so a line-oriented search for
-    /// the phrase found the other one and returned a confident count that was short by one. Runs are joined
-    /// before any pattern runs, the same normalisation <see cref="DocProseFor"/> applies to a single
-    /// declaration.</para>
+    /// <para><b>Matched against JOINED doc prose, which is why this is a test and not a grep.</b> A claim of
+    /// this shape wraps across <c>///</c> lines as readily as it fits on one — "the one every / reading
+    /// taken so far falls in" exists on no single line — so a line-oriented search returns a confident
+    /// count short by however many wrapped. Runs are joined before any pattern runs, the same normalisation
+    /// <see cref="DocProseFor"/> applies to a single declaration.</para>
     ///
     /// <para><b>The one permitted occurrence is ANCHORED to the sentence that rejects it, not exempted by
     /// location.</b> Exempting the doc run the rule lives in would let a fresh universal be added to that
@@ -520,8 +519,8 @@ public sealed class RefreshCeilingProvenancePinTests
     /// required to fail on it — a bundled mutation reports that something fired, not which clause did.
     ///
     /// <para>The first case goes back in WRAPPED across two <c>///</c> lines, so it proves the joining is
-    /// load-bearing rather than tidy: unjoined, that mutation is invisible, which is how the original pair
-    /// came to be counted as one.</para>
+    /// load-bearing rather than tidy: unjoined, that mutation is invisible, and a guard that cannot see a
+    /// wrapped claim reports a clean file for a broken one.</para>
     /// </summary>
     [Fact]
     public void TheOpenPopulationGuard_ReportsEachForbiddenShape()
@@ -538,8 +537,8 @@ public sealed class RefreshCeilingProvenancePinTests
         Assert.ThrowsAny<Exception>(() => AssertNoOpenPopulationClaim(
             InjectDocLines(source, InsideSlotMember, "/// The readings so far are all inside it.")));
 
-        /* A THIRD wording of the same claim, and the reason the pattern matches a shape rather than the
-           phrases that were found: none of the three sites said it the same way. */
+        /* A THIRD wording of the same claim, and the reason the pattern matches a shape rather than a list
+           of phrasings: this claim has as many wordings as it has sites. */
         Assert.ThrowsAny<Exception>(() => AssertNoOpenPopulationClaim(
             InjectDocLines(source, InsideSlotMember, "/// Zero exceptions on every sample since.")));
 
@@ -1023,20 +1022,19 @@ public sealed class RefreshCeilingProvenancePinTests
 
     /* ─────────────────────────────── the scoping rule, file-wide ─────────────────────────────── */
 
-    /// <summary>The enum member whose summary carried one of the two universals, and the coordinate
-    /// <see cref="TheOpenPopulationGuard_ReportsEachForbiddenShape"/> injects at. Its own declaration line,
-    /// indentation included, so the injected lines land in that member's doc run.</summary>
+    /// <summary>The member <see cref="TheOpenPopulationGuard_ReportsEachForbiddenShape"/> injects at, named
+    /// by its own declaration line with the indentation included, so the injected lines land inside that
+    /// member's doc run.</summary>
     private const string InsideSlotMember = "        InsideSlot,";
 
     /// <summary>
     /// The universal-quantifier form: a quantifier over a population of OBSERVATIONS, which is a series
     /// that gains a member every hour this job runs.
     ///
-    /// <para><b>The shape rather than the phrases that were found (#3133).</b> Three sites stated this
-    /// claim and no two of them said it the same way — "every reading", "every reading taken so far",
-    /// "every sample since". A pattern listing the phrasings found would be a frozen list beside a defect
-    /// that keeps rewording itself, so the quantifier and the population noun are matched
-    /// separately.</para>
+    /// <para><b>The SHAPE rather than a list of phrasings (#3133).</b> One claim has as many wordings as
+    /// it has sites — "every reading", "every reading taken so far", "every sample since" all say it — so a
+    /// pattern enumerating wordings is a frozen list against a defect that rewords itself freely. The
+    /// quantifier and the population noun are matched separately instead.</para>
     ///
     /// <para><b><c>run</c> is deliberately NOT a population noun here.</b> This file uses it for closed
     /// censuses ("every run that day after the boundary"), for the exclusion rule ("every run that started

--- a/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
+++ b/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
@@ -551,6 +551,34 @@ public sealed class RefreshCeilingProvenancePinTests
         Assert.ThrowsAny<Exception>(() => AssertNoOpenPopulationClaim(unanchored));
     }
 
+    /// <summary>
+    /// Two doc runs cannot combine into a claim neither of them makes, checked on an arranged pair rather
+    /// than on the tree — the same way <see cref="DashNormalisationProbe"/> checks the normalisation it
+    /// depends on.
+    ///
+    /// <para><b>Why an arranged pair and not a hopeful comment.</b> <c>\s</c> matches <c>\n</c> in .NET, so
+    /// a newline between runs is NOT a barrier: a run ending in a quantifier and the next one opening with
+    /// a population noun would match as one claim across it. The only shape that can bridge the separator
+    /// is the one built here, and the separator has to be something no whitespace class can absorb.</para>
+    /// </summary>
+    [Fact]
+    public void TwoDocRuns_CannotCombineIntoAClaimNeitherOfThemMakes()
+    {
+        /* The first run ENDS in the quantifier and the second OPENS with the population noun. Neither run
+           states a population claim; only their concatenation could. */
+        var prose = JoinedDocProse(
+            "    /// a band every\r\n    int first;\r\n\r\n    /// readings arrive hourly\r\n    int second;\r\n");
+
+        /* Both halves present first, so a pass cannot come from the scan having read nothing. */
+        Assert.Contains("every", prose, StringComparison.Ordinal);
+        Assert.Contains("readings", prose, StringComparison.Ordinal);
+
+        Assert.False(UniversalOverAnOpenSeries.IsMatch(prose),
+            "two doc runs combined into a population claim neither of them makes, so the run separator is "
+            + "being absorbed by a pattern's whitespace class. Keep the separator non-whitespace: \\s "
+            + "matches \\n in .NET, so a newline cannot hold two runs apart.");
+    }
+
     /* ─────────────────────────────── verification ─────────────────────────────── */
 
     /// <summary>
@@ -1028,6 +1056,21 @@ public sealed class RefreshCeilingProvenancePinTests
     private const string InsideSlotMember = "        InsideSlot,";
 
     /// <summary>
+    /// What holds one doc run apart from the next in <see cref="JoinedDocProse"/>. Deliberately NOT
+    /// whitespace: <c>\s</c> matches <c>\n</c> in .NET, so a newline separator is crossed by any pattern
+    /// written with <c>\s+</c> — a run ending in "every" and an unrelated run opening with "readings" would
+    /// then match as one claim and fail this guard over prose that states nothing of the kind. A
+    /// non-whitespace sentinel cannot be absorbed by a whitespace class, so the property holds for every
+    /// pattern here rather than only for the ones written carefully — and
+    /// <see cref="TwoDocRuns_CannotCombineIntoAClaimNeitherOfThemMakes"/> is what says so, rather than this
+    /// paragraph.
+    ///
+    /// <para>A <c>NUL</c> rather than a printable sentinel, because it cannot occur in source prose —
+    /// so no comment can contain the thing that holds comments apart.</para>
+    /// </summary>
+    private const string DocRunSeparator = "\u0000";
+
+    /// <summary>
     /// The universal-quantifier form: a quantifier over a population of OBSERVATIONS, which is a series
     /// that gains a member every hour this job runs.
     ///
@@ -1048,7 +1091,7 @@ public sealed class RefreshCeilingProvenancePinTests
     /// here to acquire one.</para>
     /// </summary>
     private static readonly Regex UniversalOverAnOpenSeries =
-        new(@"\b(?:every|each|all)\s+(?:reading|readings|sample|samples|snapshot|snapshots)\b",
+        new(@"\b(?:every|each|all)[ \t]+(?:reading|readings|sample|samples|snapshot|snapshots)\b",
             RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     /// <summary>
@@ -1102,8 +1145,8 @@ public sealed class RefreshCeilingProvenancePinTests
     /// <see cref="DocProseFor"/> normalises a single declaration's — so a phrase that wraps across
     /// <c>///</c> lines is one string, and neither emphasis nor dash style can hide a match.
     ///
-    /// <para>Runs are kept newline-separated from each other rather than run together, so two adjacent
-    /// runs cannot manufacture a phrase that neither of them contains.</para>
+    /// <para>Runs are held apart by <see cref="DocRunSeparator"/> rather than run together, so no two of
+    /// them can manufacture a phrase that neither one contains.</para>
     /// </summary>
     private static string JoinedDocProse(string source)
     {
@@ -1131,7 +1174,7 @@ public sealed class RefreshCeilingProvenancePinTests
             runs.Add(string.Join(" ", current));
         }
 
-        var prose = string.Join("\n", runs)
+        var prose = string.Join(DocRunSeparator, runs)
             .Replace("<b>", string.Empty, StringComparison.Ordinal)
             .Replace("</b>", string.Empty, StringComparison.Ordinal)
             .Replace('—', '-')

--- a/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
+++ b/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
@@ -503,10 +503,10 @@ public sealed class RefreshCeilingProvenancePinTests
     /// itself. Nothing in the code can know the live series, so no assertion can recognise an open
     /// population claim in a construction it has never seen; a claim built out of neither shape passes this
     /// and still breaks the rule. What carries the rest is that the claim is ABSENT rather than reworded —
-    /// the band is described by
-    /// <see cref="TimescaleSupport.RefreshSlotWarningSeconds"/> and by what the level means, so there is no
-    /// census for a later edit to keep current. The population that IS published carries its own assertion
-    /// in <see cref="TheDerivedFiguresAreExactlyStateable_AndTheConstantIsThePopulationMaximum"/>.</para>
+    /// the band is described by <see cref="TimescaleSupport.RefreshSlotWarningSeconds"/> and by what the
+    /// level means, so there is no census for a later edit to keep current. The population that IS
+    /// published carries its own assertion in
+    /// <see cref="TheDerivedFiguresAreExactlyStateable_AndTheConstantIsThePopulationMaximum"/>.</para>
     /// </summary>
     [Fact]
     public void NoOpenPopulationClaim_SurvivesOutsideTheSentenceThatRejectsIt()

--- a/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
+++ b/Darling/Darling.Tests/RefreshCeilingProvenancePinTests.cs
@@ -848,6 +848,31 @@ public sealed class RefreshCeilingProvenancePinTests
     }
 
     /// <summary>
+    /// The normalisation every pattern in this file is written against: <c>&lt;b&gt;</c> emphasis removed
+    /// and dash variants flattened to a plain hyphen, then runs of spaces and tabs collapsed to one. That
+    /// is #3077's review complaint met at the extractor rather than argued with — bolding or unbolding a
+    /// figure, and em versus en versus plain hyphen, are copy-edits that must not be able to break a pin.
+    ///
+    /// <para><b>One implementation because <see cref="DocProseFor"/> and <see cref="JoinedDocProse"/> feed
+    /// the SAME patterns.</b> Two copies could drift into normalising differently, and a pattern would then
+    /// match through one reader and not the other for a reason nothing in the file states. Sharing it makes
+    /// them equivalent by construction rather than by a claim in a summary.</para>
+    ///
+    /// <para><b>Line breaks are deliberately left alone.</b> Collapsing them would erase
+    /// <see cref="DocRunSeparator"/>, which is the only thing keeping two doc runs from combining into a
+    /// claim neither of them makes. <see cref="DocProseFor"/> is unaffected either way, because it has
+    /// already joined its own run to a single line before calling in.</para>
+    /// </summary>
+    private static string NormaliseDocProse(string prose) =>
+        Regex.Replace(
+            prose.Replace("<b>", string.Empty, StringComparison.Ordinal)
+                .Replace("</b>", string.Empty, StringComparison.Ordinal)
+                .Replace('—', '-')
+                .Replace('–', '-'),
+            "[ \t]+",
+            " ").Trim();
+
+    /// <summary>
     /// The doc-comment run immediately above <paramref name="declaration"/>, stripped of its <c>///</c>
     /// markers and collapsed to one line so a pattern can span the wrapping.
     ///
@@ -884,12 +909,7 @@ public sealed class RefreshCeilingProvenancePinTests
            #3077's review complaint met at the extractor rather than argued with. What a pattern still has
            to name is the handful of words that identify WHICH CLAIM a number belongs to, and that is not
            removable — see the class summary on why a claim-blind numeral bag cannot do this job. */
-        var prose = string.Join(" ", run)
-            .Replace("<b>", string.Empty, StringComparison.Ordinal)
-            .Replace("</b>", string.Empty, StringComparison.Ordinal)
-            .Replace('\u2014', '-')
-            .Replace('\u2013', '-');
-        prose = Regex.Replace(prose, @"\s+", " ").Trim();
+        var prose = NormaliseDocProse(string.Join(" ", run));
         Require(prose.StartsWith("<summary>", StringComparison.Ordinal),
             $"{ParseMiss}: the doc run above '{declaration}' does not begin at its <summary>, so the walk "
             + "reached the top of a truncated block");
@@ -1141,9 +1161,9 @@ public sealed class RefreshCeilingProvenancePinTests
     }
 
     /// <summary>
-    /// Every doc-comment run in the file, each joined to one line and normalised the way
-    /// <see cref="DocProseFor"/> normalises a single declaration's — so a phrase that wraps across
-    /// <c>///</c> lines is one string, and neither emphasis nor dash style can hide a match.
+    /// Every doc-comment run in the file, each joined to one line and put through
+    /// <see cref="NormaliseDocProse"/> — so a phrase that wraps across <c>///</c> lines is one string, and
+    /// neither emphasis nor dash style can hide a match.
     ///
     /// <para>Runs are held apart by <see cref="DocRunSeparator"/> rather than run together, so no two of
     /// them can manufacture a phrase that neither one contains.</para>
@@ -1174,12 +1194,7 @@ public sealed class RefreshCeilingProvenancePinTests
             runs.Add(string.Join(" ", current));
         }
 
-        var prose = string.Join(DocRunSeparator, runs)
-            .Replace("<b>", string.Empty, StringComparison.Ordinal)
-            .Replace("</b>", string.Empty, StringComparison.Ordinal)
-            .Replace('—', '-')
-            .Replace('–', '-');
-        return Regex.Replace(prose, "[ \t]+", " ").Trim();
+        return NormaliseDocProse(string.Join(DocRunSeparator, runs));
     }
 
     /// <summary>

--- a/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
+++ b/Darling/PerformanceMonitor.Darling.Storage/TimescaleSupport.cs
@@ -1651,7 +1651,7 @@ WITH NO DATA";
     ///
     /// <para><b>15 minutes over four slots is the configuration that was measured</b>, not a round number: the
     /// production store's <c>query_store_stats</c> job family was moved to :00/:15/:30/:45 and the first full
-    /// staggered cycle came back 26 s / 2 s / 864 s / 140 s with zero ungranted locks on every sample since —
+    /// staggered cycle came back 26 s / 2 s / 864 s / 140 s with zero ungranted locks on it —
     /// a cycle that STRADDLES the narrowing boundary
     /// (<see cref="HeaviestHourlyRefreshObservedCeilingSeconds"/>), so its four figures record what the
     /// stagger did to lock waits and are not samples of the narrowed regime's cost.
@@ -1949,8 +1949,8 @@ WITH NO DATA";
     /// </summary>
     public enum RefreshSlotHeadroom
     {
-        /// <summary>Under <see cref="RefreshSlotWarningSeconds"/> — the routine band, and the one every
-        /// reading taken so far falls in. Not worth a line above Debug.</summary>
+        /// <summary>Under <see cref="RefreshSlotWarningSeconds"/> — the routine band, and therefore inside
+        /// the slot the refresh has to fit in. Not worth a line above Debug.</summary>
         InsideSlot,
 
         /// <summary>At or past <see cref="RefreshSlotWarningSeconds"/> but still inside
@@ -4289,12 +4289,12 @@ AND   js.last_run_status = 'Success'";
     /// A line derived from the slot, keyed on the view, naming the actual remedy, is the form that stays
     /// correct when either of those numbers moves.</para>
     ///
-    /// <para><b>Levels.</b> The routine band is Debug — every reading taken so far is in it, and an hourly
-    /// Information line about a healthy job is how a signal gets buried (the discipline
-    /// <see cref="LogCompressionActivity"/> already states). Approaching the slot is a Warning: still true,
-    /// still time to act. At or past the slot it is an Error, because a documented precondition of the shipped
-    /// compression grid is now FALSE — the highest level a log line has, and still not an alert, because the
-    /// action it calls for is re-deriving #3035's grid rather than anything an operator does tonight.</para>
+    /// <para><b>Levels.</b> The routine band is Debug — an hourly Information line about a healthy job is
+    /// how a signal gets buried (the discipline <see cref="LogCompressionActivity"/> already states).
+    /// Approaching the slot is a Warning: still true, still time to act. At or past the slot it is an Error,
+    /// because a documented precondition of the shipped compression grid is now FALSE — the highest level a
+    /// log line has, and still not an alert, because the action it calls for is re-deriving #3035's grid
+    /// rather than anything an operator does tonight.</para>
     /// </summary>
     public static void LogHeaviestRefreshSlotHeadroom(HeaviestRefreshSlotReading? reading, ILogger? logger)
     {


### PR DESCRIPTION
`TimescaleSupport.cs` states the rule that a scope has to CLOSE a population rather than merely date it, and three doc comments in the same file described the routine refresh band as a universal over a population that gains a reading every hour the job runs. The rule was enforced only for the paragraph that states it.

## The three sites, and how they were enumerated

Read from `origin/dev`:

- **line 1952**, `RefreshSlotHeadroom.InsideSlot` — "the routine band, and the one every reading taken so far falls in"
- **line 4292**, the `<para><b>Levels.</b>` block — "The routine band is Debug — every reading taken so far is in it"
- **line 1654**, `RefreshPhaseStepMinutes` — "with zero ungranted locks on every sample since", a half-open window over the same growing series

A line-oriented grep for the phrasing finds only two of these: line 1952 wraps as `the one every` / `reading taken so far falls in`, so the phrase does not exist on any single line. The third site was found by joining each contiguous `///` run into one string first and scanning the reconstructed prose for quantifiers, relative-scope adverbials and universal constructions — a pass that also confirmed nothing else in the file carries the shape. `every run since the boundary` is a statement about a SOURCE's completeness, which the rule paragraph itself distinguishes from a claim about readings, and stays.

## What replaced them

None of the three carried a population claim that was doing work, so all three lost the dependence rather than gaining a closing timestamp.

- `InsideSlot` now reads "the routine band, and therefore inside the slot the refresh has to fit in". That is an entailment of `RefreshSlotWarningSeconds < RefreshPhaseSlotSeconds`, which `TimescaleSupportTests` already pins, so it is derivable from the constants and there is no census for a later edit to keep current.
- The `Levels.` block keeps the reason it already gave — an hourly Information line about a healthy job is how a signal gets buried — which never needed a count of observations to hold.
- The measured stagger cycle now reports "zero ungranted locks on it". That cycle is a completed event, so the claim is closed and will read the same next year; it is also what the paragraph's own next sentence already treats as its subject.

The one surviving population claim in the file, `Together 16 runs spanning 194 s to 594 s ... every one of them below RefreshSlotWarningSeconds`, is closed by an enumerated count and already carries its assertion in `RefreshCeilingProvenancePinTests.TheDerivedFiguresAreExactlyStateable_AndTheConstantIsThePopulationMaximum`.

## The pin

`RefreshCeilingProvenancePinTests` already required the ceiling paragraph's own enumeration to carry a closed scope. It now also holds the rest of the file to the same rule.

The scan reads **joined** doc prose, because the wrapped site is invisible to a line-oriented search and that is exactly how the pair came to be counted as one. The pattern matches the defect's **shape** — a quantifier (`every`/`each`/`all`) over a population of observations (`reading`/`sample`/`snapshot`) — rather than the phrasings that were found, because no two of the three sites said it the same way and a list of found phrasings is a frozen list beside a defect that keeps rewording itself. `run` is deliberately excluded as a population noun: the file uses it for closed censuses, for the exclusion rule and for the source-completeness statement above, so including it would red on correct prose.

The single permitted occurrence is **anchored** to the sentence that quotes the rejected form in order to reject it, not exempted by location — exempting the doc run the rule lives in would let a fresh universal be added to that run and pass. The anchor doubles as the anti-vacuity check, since a scan that read nothing produces the same zero.

Doc runs are held apart by a NUL rather than a newline, because `\s` matches `\n` in .NET: with a newline separator, any pattern written `\s+` crosses it, so a run ending in a quantifier and an unrelated run opening with a population noun match as one claim and fail the guard over prose that states nothing of the kind. A non-whitespace sentinel cannot be absorbed by a whitespace class, so the property holds for every pattern in the file rather than only the carefully written ones, and the pattern additionally spans only spaces and tabs. `TwoDocRuns_CannotCombineIntoAClaimNeitherOfThemMakes` asserts that property on an arranged pair, the way the file's existing dash-normalisation probe does, so the separator's reason is checked rather than merely written down.

Both doc readers now share one prose normaliser rather than carrying a copy each. They feed the same patterns, so two copies could drift into normalising differently and a pattern would match through one reader and not the other; sharing it makes them equivalent by construction instead of by a claim in a summary.

What it does not hold is stated in its own summary rather than left looking covered: it guards two shapes, not staleness, and a claim built out of neither shape passes it. What carries the rest is that the claim is absent rather than reworded.

## Verification

`Darling.Tests` targets `net10.0-windows`, so the real test files were compiled into a throwaway `net10.0` console harness behind a minimal xUnit attribute shim, linked in place so `[CallerFilePath]` still resolves to the repository. **175 passed, 0 failed** across `RefreshCeilingProvenancePinTests`, `DocCommentHygieneTests`, `CommentFilterAdoptionTests`, `TimescaleContinuousAggregateTests` and `TimescaleSupportTests`. The gated-live cases in the last of those are inert without a store and prove nothing here.

The new guard was mutated to red five times, each in isolation with the tree restored between:

| mutation | result |
| --- | --- |
| line 1952's original wrapped form restored | red |
| line 1654's `every sample since` restored | red |
| line 4292's original form restored | red |
| the rule's own quotation reworded (the anchor clause) | red |
| `AssertNoOpenPopulationClaim` neutered to a no-op | the mutation sweep goes red |

A mutation sweep that cannot fail is worth nothing, which is why the last row is there. The cross-run property was proved the other way round: the assertion was written first and went red against a newline separator, then green once the separator became a NUL.

## Not in this change

`#3119`'s subject — a measured run reached 778.4 s, above `RefreshSlotWarningSeconds` — is what falsified the claim, and the envelope itself is untouched here.

## CHANGELOG entry text

Under `Fixed`:

- `TimescaleSupport.cs` described the routine refresh band as a universal over a population that grows every hour, in three places. The band is described by its constant instead, and the file's own scoping rule is now held across the whole file rather than only where it is stated.
