### PR TITLE
Let the host declare LocalDataService's write-lock budget instead of every caller inheriting the dispatcher's

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -329,9 +329,25 @@ jobs:
       # (#1694) that subset runs in ~1 minute, so the split — and the narrower lite_analysis path
       # gate that let non-analysis Lite changes skip it — stopped earning its second test-host
       # spin-up and its filter-drift risk.
+      # L3134 TEMPORARY INSTRUMENTATION - reverted before merge. Issue #3134 needs two figures:
+      # the suite's per-test intervals under the normal parallel run, and its wall clock when the
+      # classes are fully serialised. Both TRX files are uploaded for offline analysis.
       - name: Run Lite tests
         if: steps.filter.outputs.lite == 'true' || steps.filter.outputs.core == 'true' || steps.filter.outputs.root == 'true' || github.event_name == 'release'
-        run: dotnet run --project Lite.Tests/Lite.Tests.csproj -c Release --no-build
+        run: dotnet run --project Lite.Tests/Lite.Tests.csproj -c Release --no-build -- -trx TestResults/L3134-lite-parallel.trx
+
+      - name: L3134 measurement - Lite suite fully serialised
+        if: (steps.filter.outputs.lite == 'true' || steps.filter.outputs.core == 'true' || steps.filter.outputs.root == 'true') && always()
+        continue-on-error: true
+        run: dotnet run --project Lite.Tests/Lite.Tests.csproj -c Release --no-build -- -parallel none -trx TestResults/L3134-lite-serial.trx
+
+      - name: L3134 measurement - upload TRX
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: L3134-lite-trx
+          path: TestResults/L3134-lite-*.trx
+          if-no-files-found: warn
 
       - name: Run Installer tests
         if: steps.filter.outputs.installer == 'true' || steps.filter.outputs.installer_core == 'true' || steps.filter.outputs.root == 'true' || github.event_name == 'release'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -329,25 +329,9 @@ jobs:
       # (#1694) that subset runs in ~1 minute, so the split — and the narrower lite_analysis path
       # gate that let non-analysis Lite changes skip it — stopped earning its second test-host
       # spin-up and its filter-drift risk.
-      # L3134 TEMPORARY INSTRUMENTATION - reverted before merge. Issue #3134 needs two figures:
-      # the suite's per-test intervals under the normal parallel run, and its wall clock when the
-      # classes are fully serialised. Both TRX files are uploaded for offline analysis.
       - name: Run Lite tests
         if: steps.filter.outputs.lite == 'true' || steps.filter.outputs.core == 'true' || steps.filter.outputs.root == 'true' || github.event_name == 'release'
-        run: dotnet run --project Lite.Tests/Lite.Tests.csproj -c Release --no-build -- -trx TestResults/L3134-lite-parallel.trx
-
-      - name: L3134 measurement - Lite suite fully serialised
-        if: (steps.filter.outputs.lite == 'true' || steps.filter.outputs.core == 'true' || steps.filter.outputs.root == 'true') && always()
-        continue-on-error: true
-        run: dotnet run --project Lite.Tests/Lite.Tests.csproj -c Release --no-build -- -parallel none -trx TestResults/L3134-lite-serial.trx
-
-      - name: L3134 measurement - upload TRX
-        if: always()
-        uses: actions/upload-artifact@v6
-        with:
-          name: L3134-lite-trx
-          path: TestResults/L3134-lite-*.trx
-          if-no-files-found: warn
+        run: dotnet run --project Lite.Tests/Lite.Tests.csproj -c Release --no-build
 
       - name: Run Installer tests
         if: steps.filter.outputs.installer == 'true' || steps.filter.outputs.installer_core == 'true' || steps.filter.outputs.root == 'true' || github.event_name == 'release'

--- a/Lite.Tests/Lite.Tests.csproj
+++ b/Lite.Tests/Lite.Tests.csproj
@@ -19,14 +19,19 @@
 
   <ItemGroup>
     <!-- #3134: LocalDataService.OpenWriteConnectionAsync bounds its write-lock wait so a WPF dispatcher
-         cannot freeze behind an archival. This host has no dispatcher, and DuckDbInitializer's lock is
-         process-wide - so a store test's acquisition queues behind every other class in the suite,
+         cannot freeze behind an archival. There is no dispatcher in this host, and the lock on
+         DuckDbInitializer is process-wide - so a store test waits behind every other class in the suite,
          including the test methods that take the exclusive lock deliberately and hold it for seconds
-         while they assert on timing. A dispatcher's budget expiring inside a neighbour's hold is a
-         failure with no user behind it, so this host states a budget orders of magnitude larger: the
-         acquisition waits the hold out. Short of forever on purpose - a wedged lock still fails, with
-         OpenWriteConnectionAsync's own message, rather than hanging the suite. The shipped app declares
-         nothing here and keeps LocalDataService.DefaultWriteLockBudget. -->
+         while they assert on timing. A budget sized for a dispatcher, expiring inside a hold taken by a
+         neighbour, is a failure with no user behind it; so this host states a budget orders of magnitude
+         larger and the acquisition waits the hold out. Short of forever on purpose - a wedged lock still
+         fails, with the same message, rather than hanging the suite. The shipped app declares nothing
+         here and keeps LocalDataService.DefaultWriteLockBudget.
+
+         This comment carries no apostrophe, deliberately. CrossAppGuardCiGateTests reads this file with
+         a regex that treats one as an attribute delimiter, so an unbalanced pair swallows the quoted
+         attribute values after it - including the linked cross-app Compile below, whose absence the
+         guard reports as a moved blind spot rather than as a comment. -->
     <RuntimeHostConfigurationOption Include="PerformanceMonitorLite.WriteLockBudgetSeconds" Value="120" />
   </ItemGroup>
 

--- a/Lite.Tests/Lite.Tests.csproj
+++ b/Lite.Tests/Lite.Tests.csproj
@@ -18,6 +18,19 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- #3134: LocalDataService.OpenWriteConnectionAsync bounds its write-lock wait so a WPF dispatcher
+         cannot freeze behind an archival. This host has no dispatcher, and DuckDbInitializer's lock is
+         process-wide - so a store test's acquisition queues behind every other class in the suite,
+         including the test methods that take the exclusive lock deliberately and hold it for seconds
+         while they assert on timing. A dispatcher's budget expiring inside a neighbour's hold is a
+         failure with no user behind it, so this host states a budget orders of magnitude larger: the
+         acquisition waits the hold out. Short of forever on purpose - a wedged lock still fails, with
+         OpenWriteConnectionAsync's own message, rather than hanging the suite. The shipped app declares
+         nothing here and keeps LocalDataService.DefaultWriteLockBudget. -->
+    <RuntimeHostConfigurationOption Include="PerformanceMonitorLite.WriteLockBudgetSeconds" Value="120" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- The shared C# source walk (#2913), compiled into this assembly rather than copied into it. Lite.Tests
          cannot ProjectReference Darling.Tests - both are xunit executables and CI would discover the Darling
          suite twice - and a second COPY is the exact thing #2913 removed: five pins each carried their own

--- a/Lite.Tests/SharedDuckDbFixture.cs
+++ b/Lite.Tests/SharedDuckDbFixture.cs
@@ -38,10 +38,13 @@ namespace PerformanceMonitorLite.Tests;
 /// the write sites — archival, compaction, CHECKPOINT, the mute and alert-history stores —
 /// rather than a flat tax on every database call.</para>
 ///
-/// <para>That distinction decides what a fix could even look like: a collection fixture
-/// would serialize the READERS as well, so it does not address writer-driven contention and
-/// would cost more than it saves. Nobody has measured how much of the suite's ~190-220s is
-/// this, and the honest answer is that it may be very little.</para>
+/// <para>That distinction decides what a fix could even look like, and it rules out the
+/// obvious one. A shared collection over the classes that use this fixture serializes the
+/// READERS as well, which is where the wall clock goes, and it still would not bound the
+/// contention: the test methods that hold this lock EXCLUSIVELY for seconds at a time — the
+/// ones asserting on how a writer, a status-bar read or a cancellable read behaves while a
+/// writer holds it — build their own <c>DuckDbInitializer</c> and are not classes of this
+/// fixture at all, so a collection they are not in cannot stop them running alongside it.</para>
 ///
 /// <para>That lock is correct and must not be narrowed to fix this: production creates
 /// several <c>DuckDbInitializer</c> instances over the same <c>App.DatabasePath</c>
@@ -50,10 +53,14 @@ namespace PerformanceMonitorLite.Tests;
 /// suite for a real data race.</para>
 ///
 /// <para>The practical consequence is worth knowing when a test here fails oddly: a
-/// scheduling-pressure window can starve the 5-second write-lock acquisition in
-/// <c>LocalDataService.GetDatabaseStateDeviationsAsync</c>, whose maintenance block is
-/// best-effort and simply SKIPS on timeout. That is #2374 — a test that assumed the
-/// maintenance had run, rather than waiting for it, failed a nightly.</para>
+/// scheduling-pressure window can starve <c>LocalDataService.OpenWriteConnectionAsync</c>'s
+/// acquisition past a budget sized for a UI thread, which is #2374 —
+/// <c>GetDatabaseStateDeviationsAsync</c>'s maintenance block is best-effort and simply SKIPS
+/// on timeout, and a test that assumed the maintenance had run rather than waiting for it
+/// failed a nightly. This host therefore states its own budget
+/// (<c>LocalDataService.WriteLockBudgetConfigKey</c> in <c>Lite.Tests.csproj</c>): the wait a
+/// dispatcher cannot afford is one there is nothing here to protect, so an acquisition queued
+/// behind a neighbour's deliberate hold waits it out instead of expiring inside it.</para>
 /// </summary>
 public sealed class SharedDuckDbFixture : IAsyncLifetime
 {

--- a/Lite.Tests/WriteLockBudgetTests.cs
+++ b/Lite.Tests/WriteLockBudgetTests.cs
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2026 Erik Darling, Darling Data LLC
+ *
+ * This file is part of the SQL Server Performance Monitor Lite.
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using PerformanceMonitorLite.Services;
+using Xunit;
+
+namespace Lite.Tests;
+
+/// <summary>
+/// #3134: <c>LocalDataService.OpenWriteConnectionAsync</c>'s write-lock wait is the host's number, not the
+/// method's.
+///
+/// <para>The wait exists to keep a WPF dispatcher responsive behind an in-flight archival, and
+/// <c>DuckDbInitializer</c>'s lock is process-wide — so in a host with no dispatcher, a store call queues
+/// behind every other class in the process and then fails on a budget sized for a user who is not there.
+/// That is a real failure with nothing behind it, and it is what these pin against: the app keeps the
+/// dispatcher's five seconds, this host declares its own, and the declaration demonstrably ARRIVES rather
+/// than falling back to the default while looking configured.</para>
+/// </summary>
+public sealed class WriteLockBudgetTests
+{
+    /// <summary>
+    /// The one project file in the repo that states a budget, and it is not the app's.
+    ///
+    /// <para>Whole-tree rather than "the app's csproj does not declare it": the value is a runtime
+    /// configuration property, so a shared <c>Directory.Build.props</c> or an imported <c>.targets</c>
+    /// would reach the shipped app just as effectively as its own project file, and the acceptance
+    /// criterion is that the app's protection is unchanged — not that one file was left alone.</para>
+    /// </summary>
+    [Fact]
+    public void OnlyTheTestHostDeclaresABudget()
+    {
+        var declaring = BuildFiles()
+            .Where(f => File.ReadAllText(f).Contains(LocalDataService.WriteLockBudgetConfigKey, StringComparison.Ordinal))
+            .Select(Relative)
+            .OrderBy(p => p, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.Equal(new[] { "Lite.Tests/Lite.Tests.csproj" }, declaring);
+    }
+
+    /// <summary>
+    /// The budget a host that declares nothing gets — which, by the pin above, is the shipped app.
+    /// </summary>
+    [Fact]
+    public void TheAppKeepsTheDispatchersFiveSeconds()
+    {
+        Assert.Equal(TimeSpan.FromSeconds(5), LocalDataService.DefaultWriteLockBudget);
+        Assert.Equal(LocalDataService.DefaultWriteLockBudget, LocalDataService.ResolveWriteLockBudget(null));
+    }
+
+    /// <summary>
+    /// The end-to-end one, and the only one here that can catch a seam that is wired but inert.
+    ///
+    /// <para>A <c>RuntimeHostConfigurationOption</c> that never reaches <c>AppContext</c> — a renamed key,
+    /// a value MSBuild declines to emit, an option written into the wrong project — resolves the default
+    /// SILENTLY, which is indistinguishable from the pre-#3134 behaviour and would leave the flake in place
+    /// while every other pin here stayed green. So the expected value is read out of the project file and
+    /// compared against what this running host actually resolved, and the budget is additionally required to
+    /// DIFFER from the default: matching the default is exactly what a dead seam looks like.</para>
+    /// </summary>
+    [Fact]
+    public void ThisHostResolvedTheBudgetItsProjectFileDeclares()
+    {
+        var declared = DeclaredBudgetSeconds("Lite.Tests/Lite.Tests.csproj");
+
+        Assert.Equal(TimeSpan.FromSeconds(declared), LocalDataService.WriteLockBudget);
+        Assert.NotEqual(LocalDataService.DefaultWriteLockBudget, LocalDataService.WriteLockBudget);
+    }
+
+    /// <summary>
+    /// This host's budget outlasts every deliberate lock hold its own suite can queue in front of one
+    /// acquisition, which is what makes the wait BOUNDED rather than merely longer.
+    ///
+    /// <para>The bar is derived, not restated: for each test file that takes the write lock with no timeout,
+    /// the largest wall-clock literal in that file stands in for how long it can hold, and the bar is their
+    /// SUM — a writer can queue behind all of them. Both approximations round the bar UP (an unrelated
+    /// literal in a holder's file inflates its share; nothing here can shrink it), so this fails toward "the
+    /// budget is too small" and never toward "the budget is fine".</para>
+    /// </summary>
+    [Fact]
+    public void TheBudgetOutlastsEveryDeliberateHoldInThisSuite()
+    {
+        var holds = DeliberateHolds();
+        Assert.NotEmpty(holds);
+
+        var queued = TimeSpan.FromSeconds(holds.Values.Sum(h => h.TotalSeconds));
+
+        Assert.True(
+            LocalDataService.WriteLockBudget > queued,
+            $"this host's write-lock budget is {LocalDataService.WriteLockBudget.TotalSeconds:F0}s, but its own " +
+            $"tests can hold the process-wide lock for {queued.TotalSeconds:F0}s in front of one acquisition: " +
+            string.Join(", ", holds.OrderByDescending(h => h.Value).Select(h => $"{h.Key} {h.Value.TotalSeconds:F0}s")));
+    }
+
+    /// <summary>
+    /// A declaration is honoured only when it is usable, and every unusable shape resolves the app's budget
+    /// rather than disabling the wait. Losing dispatcher protection is the failure worth refusing; a host
+    /// that merely fails to lengthen its own wait gets a flake back, which is loud.
+    /// </summary>
+    [Theory]
+    [InlineData(null, 5d)]
+    [InlineData("", 5d)]
+    [InlineData("   ", 5d)]
+    [InlineData("later", 5d)]
+    [InlineData("0", 5d)]
+    [InlineData("-30", 5d)]
+    /* A project file is not written in the machine's locale, so a decimal comma is not a decimal point. */
+    [InlineData("1,5", 5d)]
+    [InlineData("120", 120d)]
+    [InlineData("0.5", 0.5d)]
+    public void OnlyAUsableDeclarationDisplacesTheDefault(string? declared, double expectedSeconds)
+    {
+        Assert.Equal(TimeSpan.FromSeconds(expectedSeconds), LocalDataService.ResolveWriteLockBudget(declared));
+    }
+
+    /// <summary>
+    /// The parse reads the project file's spelling, not the machine's. A build agent or a workstation with a
+    /// comma-decimal locale must resolve the same budget as this one, and the only way to tell an invariant
+    /// parse from an ambient one is to make the ambient culture disagree.
+    /// </summary>
+    [Fact]
+    public void TheDeclarationIsReadInTheInvariantCulture()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            /* de-DE reads "1,5" as one and a half and "1.5" as fifteen - both the opposite of this parse. */
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+
+            Assert.Equal(TimeSpan.FromSeconds(1.5), LocalDataService.ResolveWriteLockBudget("1.5"));
+            Assert.Equal(LocalDataService.DefaultWriteLockBudget, LocalDataService.ResolveWriteLockBudget("1,5"));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    /// <summary>
+    /// The host hands the property back as a string whatever JSON type MSBuild wrote, which is why the
+    /// resolver parses rather than casts. A value arriving as anything else resolves the default, so this
+    /// records that a caller passing a number gets the app's budget and not its own.
+    /// </summary>
+    [Fact]
+    public void ANonStringDeclarationResolvesTheDefault()
+    {
+        Assert.Equal(LocalDataService.DefaultWriteLockBudget, LocalDataService.ResolveWriteLockBudget(120));
+        Assert.Equal(LocalDataService.DefaultWriteLockBudget, LocalDataService.ResolveWriteLockBudget(TimeSpan.FromSeconds(120)));
+    }
+
+    /// <summary>
+    /// The call site takes the budget. A literal timeout there is the regression this whole file exists to
+    /// notice, and it is invisible to every behavioural pin above when the host happens to declare 5.
+    /// </summary>
+    [Fact]
+    public void TheCallSiteTakesTheBudgetRatherThanALiteral()
+    {
+        var source = ParitySource.ReadFile("Lite/Services/LocalDataService.cs");
+
+        Assert.Contains("AcquireWriteLock(timeout: WriteLockBudget)", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("AcquireWriteLock(timeout: TimeSpan.", source, StringComparison.Ordinal);
+    }
+
+    /* ── derivations ── */
+
+    /// <summary>
+    /// Every build file in the repo, minus build output — where restore writes <c>.props</c> and
+    /// <c>.targets</c> of its own, and where a copy of a project file proves nothing about what ships.
+    /// Segment-wise rather than a substring match, so a directory merely NAMED like output stays in.
+    /// </summary>
+    private static IEnumerable<string> BuildFiles()
+    {
+        var root = ParitySource.RepoRoot();
+        var options = new EnumerationOptions
+        {
+            RecurseSubdirectories = true,
+            IgnoreInaccessible = true,
+        };
+
+        return new[] { "*.csproj", "*.props", "*.targets" }
+            .SelectMany(pattern => Directory.EnumerateFiles(root, pattern, options))
+            .Where(f => !Relative(f).Split('/').Any(segment =>
+                segment.Equals("bin", StringComparison.OrdinalIgnoreCase) ||
+                segment.Equals("obj", StringComparison.OrdinalIgnoreCase)));
+    }
+
+    private static string Relative(string full) =>
+        Path.GetRelativePath(ParitySource.RepoRoot(), full).Replace(Path.DirectorySeparatorChar, '/');
+
+    /// <summary>The seconds a project file declares for the budget property.</summary>
+    private static double DeclaredBudgetSeconds(string projectRelativePath)
+    {
+        var project = XDocument.Parse(ParitySource.ReadFile(projectRelativePath));
+
+        var value = project.Descendants("RuntimeHostConfigurationOption")
+            .Where(o => (string?)o.Attribute("Include") == LocalDataService.WriteLockBudgetConfigKey)
+            .Select(o => (string?)o.Attribute("Value"))
+            .SingleOrDefault();
+
+        Assert.False(
+            string.IsNullOrWhiteSpace(value),
+            $"{projectRelativePath} declares no {LocalDataService.WriteLockBudgetConfigKey}");
+
+        return double.Parse(value!, CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
+    /// Per test file that takes the write lock with no timeout, the largest wall-clock literal it contains.
+    /// </summary>
+    private static Dictionary<string, TimeSpan> DeliberateHolds()
+    {
+        var holds = new Dictionary<string, TimeSpan>(StringComparer.Ordinal);
+        var testDirectory = Path.Combine(ParitySource.RepoRoot(), "Lite.Tests");
+
+        foreach (var file in Directory.EnumerateFiles(testDirectory, "*.cs", SearchOption.TopDirectoryOnly))
+        {
+            var source = File.ReadAllText(file);
+            if (!Regex.IsMatch(source, @"AcquireWriteLock\(\s*\)"))
+            {
+                continue;
+            }
+
+            var longest = Waits(source).DefaultIfEmpty(TimeSpan.Zero).Max();
+            holds[Path.GetFileName(file)] = longest;
+        }
+
+        return holds;
+    }
+
+    private static IEnumerable<TimeSpan> Waits(string source)
+    {
+        foreach (Match m in Regex.Matches(source, @"TimeSpan\.FromSeconds\(\s*([0-9]+(?:\.[0-9]+)?)\s*\)"))
+            yield return TimeSpan.FromSeconds(double.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture));
+
+        foreach (Match m in Regex.Matches(source, @"TimeSpan\.FromMinutes\(\s*([0-9]+(?:\.[0-9]+)?)\s*\)"))
+            yield return TimeSpan.FromMinutes(double.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture));
+
+        foreach (Match m in Regex.Matches(source, @"TimeSpan\.FromMilliseconds\(\s*([0-9]+(?:\.[0-9]+)?)\s*\)"))
+            yield return TimeSpan.FromMilliseconds(double.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture));
+
+        /* Thread.Join takes bare milliseconds, and it is how two of the holders bound their own wait. */
+        foreach (Match m in Regex.Matches(source, @"\.Join\(\s*([0-9]+)\s*\)"))
+            yield return TimeSpan.FromMilliseconds(double.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture));
+    }
+}

--- a/Lite.Tests/WriteLockBudgetTests.cs
+++ b/Lite.Tests/WriteLockBudgetTests.cs
@@ -127,6 +127,82 @@ public sealed class WriteLockBudgetTests
     }
 
     /// <summary>
+    /// The resolver is TOTAL: every input returns a budget, none throws.
+    ///
+    /// <para>This is the one arm that discriminates a THIRD outcome from the two the change is argued on.
+    /// A budget either lets the wait succeed or fails it loudly — unless resolution itself throws, and it
+    /// can: <c>NumberStyles.Float</c> admits exponents and .NET parses the invariant <c>Infinity</c>
+    /// symbol whatever the style, so <c>"1e300"</c> and <c>"Infinity"</c> arrive as positive doubles that
+    /// overflow <see cref="TimeSpan.FromSeconds"/>. Out of a static initializer that is a
+    /// <see cref="TypeInitializationException"/> on the first store call anywhere in the process, which
+    /// is strictly worse than the timeout it replaces. Positivity alone does not reach it — it bounds the
+    /// other end.</para>
+    ///
+    /// <para>Asserted over inputs rather than by construction, and the band is read off
+    /// <c>MaxWriteLockBudget</c> rather than restated, so a ceiling that moves moves the bar with it.</para>
+    /// </summary>
+    [Fact]
+    public void TheResolverIsTotalAndAlwaysReturnsAUsableBudget()
+    {
+        var hostile = new object?[]
+        {
+            null, "", "   ", "later", "0", "-0", "-30", "1,5", "NaN", "Infinity", "-Infinity",
+            "1e300", "-1e300", "1E+15", "  120  ", "+120", ".5",
+            TimeSpan.MaxValue.TotalSeconds.ToString("R", CultureInfo.InvariantCulture),
+            double.MaxValue.ToString("R", CultureInfo.InvariantCulture),
+            double.Epsilon.ToString("R", CultureInfo.InvariantCulture),
+            120, 120d, TimeSpan.FromSeconds(120), new object(),
+        };
+
+        var broke = new List<string>();
+        foreach (var input in hostile)
+        {
+            var name = input is null ? "<null>" : $"{input.GetType().Name} \"{input}\"";
+            try
+            {
+                var resolved = LocalDataService.ResolveWriteLockBudget(input);
+                if (resolved <= TimeSpan.Zero || resolved > LocalDataService.MaxWriteLockBudget)
+                {
+                    broke.Add($"{name} -> {resolved}");
+                }
+            }
+            catch (Exception ex)
+            {
+                broke.Add($"{name} -> {ex.GetType().Name}");
+            }
+        }
+
+        Assert.True(
+            broke.Count == 0,
+            "resolving the write-lock budget must never throw and must never leave " +
+            $"(TimeSpan.Zero, {LocalDataService.MaxWriteLockBudget}]: " + string.Join("; ", broke));
+    }
+
+    /// <summary>
+    /// The ceiling is inclusive and anything past it resolves the default, derived from the constant so
+    /// neither figure is written down twice.
+    ///
+    /// <para>The bound is deliberately NOT <see cref="TimeSpan"/>'s representable range, which reaches
+    /// about 29,000 years and would accept a budget that makes a wedged lock hang for the life of the
+    /// process — the silent outcome, where the whole point of a number is the loud one.</para>
+    /// </summary>
+    [Fact]
+    public void TheCeilingIsAcceptedAndAnythingPastItResolvesTheDefault()
+    {
+        var ceiling = LocalDataService.MaxWriteLockBudget;
+
+        Assert.Equal(ceiling, Resolve(ceiling.TotalSeconds));
+        Assert.Equal(LocalDataService.DefaultWriteLockBudget, Resolve(ceiling.TotalSeconds * 2));
+        Assert.Equal(LocalDataService.DefaultWriteLockBudget, Resolve(TimeSpan.MaxValue.TotalSeconds));
+
+        /* And this host is inside the band, so the pin above is not passing on a ceiling nothing meets. */
+        Assert.InRange(LocalDataService.WriteLockBudget, TimeSpan.FromTicks(1), ceiling);
+
+        static TimeSpan Resolve(double seconds) =>
+            LocalDataService.ResolveWriteLockBudget(seconds.ToString("R", CultureInfo.InvariantCulture));
+    }
+
+    /// <summary>
     /// The parse reads the project file's spelling, not the machine's. A build agent or a workstation with a
     /// comma-decimal locale must resolve the same budget as this one, and the only way to tell an invariant
     /// parse from an ambient one is to make the ambient culture disagree.

--- a/Lite.Tests/WriteLockBudgetTests.cs
+++ b/Lite.Tests/WriteLockBudgetTests.cs
@@ -13,6 +13,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
+using Darling.Tests;
 using PerformanceMonitorLite.Services;
 using Xunit;
 
@@ -81,19 +82,53 @@ public sealed class WriteLockBudgetTests
     }
 
     /// <summary>
+    /// Every duration-shaped call site in a file that holds this lock is one the scan below can READ.
+    ///
+    /// <para>This is the arm that makes the bound a measurement rather than a shape. The scan recognises a
+    /// set of spellings, and a spelling outside it does not merely go uncounted — the file still matches the
+    /// write-lock scan, so it joins the population and contributes ZERO. <c>gate.Wait(TimeSpan.FromSeconds(30))</c>
+    /// and <c>gate.Wait(30000)</c> are the same thirty-second hold; only one of them used to be visible, and
+    /// the other reported itself as no hold at all. A zero that looks like a measurement is worse than an
+    /// absence, because the sum then names a population it did not measure.</para>
+    ///
+    /// <para>So an unreadable site FAILS here rather than being silently scored, which is the same move as
+    /// checking the <c>TimeSpan</c> the resolver constructed instead of the double it parsed: make the
+    /// derivation total, rather than enumerate the ways it can be wrong. A file with no duration site at all
+    /// is a real zero — it holds the lock across straight-line code — and that is distinguishable from a
+    /// file whose duration could not be read, which is the distinction that was missing.</para>
+    ///
+    /// <para>Read off <c>CSharpSourceWalker.StripCommentsAndStrings</c> rather than raw text, so a duration
+    /// written in a comment cannot raise the bar and <c>string.Join</c> cannot be mistaken for
+    /// <c>Thread.Join</c>.</para>
+    /// </summary>
+    [Fact]
+    public void EveryDeliberateHoldInThisSuiteIsReadable()
+    {
+        var (holds, unreadable) = ScanDeliberateHolds();
+
+        Assert.NotEmpty(holds);
+        Assert.True(
+            unreadable.Count == 0,
+            "these call sites bound a deliberate hold of the process-wide lock in a spelling the hold scan " +
+            "cannot read, so they would be counted as no hold at all. Teach the scan the spelling, or give " +
+            "the site a duration it already reads: " + string.Join("; ", unreadable));
+    }
+
+    /// <summary>
     /// This host's budget outlasts every deliberate lock hold its own suite can queue in front of one
     /// acquisition, which is what makes the wait BOUNDED rather than merely longer.
     ///
     /// <para>The bar is derived, not restated: for each test file that takes the write lock with no timeout,
-    /// the largest wall-clock literal in that file stands in for how long it can hold, and the bar is their
-    /// SUM — a writer can queue behind all of them. Both approximations round the bar UP (an unrelated
-    /// literal in a holder's file inflates its share; nothing here can shrink it), so this fails toward "the
-    /// budget is too small" and never toward "the budget is fine".</para>
+    /// the largest duration in that file stands in for how long it can hold, and the bar is their SUM — a
+    /// writer can queue behind all of them. The remaining approximation rounds the bar UP, since an
+    /// unrelated duration in a holder's file inflates that file's share and nothing here can shrink it. What
+    /// keeps that honest is the companion pin above: a duration this scan cannot read is a failure there
+    /// rather than a zero here.</para>
     /// </summary>
     [Fact]
     public void TheBudgetOutlastsEveryDeliberateHoldInThisSuite()
     {
-        var holds = DeliberateHolds();
+        var (holds, _) = ScanDeliberateHolds();
         Assert.NotEmpty(holds);
 
         var queued = TimeSpan.FromSeconds(holds.Values.Sum(h => h.TotalSeconds));
@@ -103,27 +138,6 @@ public sealed class WriteLockBudgetTests
             $"this host's write-lock budget is {LocalDataService.WriteLockBudget.TotalSeconds:F0}s, but its own " +
             $"tests can hold the process-wide lock for {queued.TotalSeconds:F0}s in front of one acquisition: " +
             string.Join(", ", holds.OrderByDescending(h => h.Value).Select(h => $"{h.Key} {h.Value.TotalSeconds:F0}s")));
-    }
-
-    /// <summary>
-    /// A declaration is honoured only when it is usable, and every unusable shape resolves the app's budget
-    /// rather than disabling the wait. Losing dispatcher protection is the failure worth refusing; a host
-    /// that merely fails to lengthen its own wait gets a flake back, which is loud.
-    /// </summary>
-    [Theory]
-    [InlineData(null, 5d)]
-    [InlineData("", 5d)]
-    [InlineData("   ", 5d)]
-    [InlineData("later", 5d)]
-    [InlineData("0", 5d)]
-    [InlineData("-30", 5d)]
-    /* A project file is not written in the machine's locale, so a decimal comma is not a decimal point. */
-    [InlineData("1,5", 5d)]
-    [InlineData("120", 120d)]
-    [InlineData("0.5", 0.5d)]
-    public void OnlyAUsableDeclarationDisplacesTheDefault(string? declared, double expectedSeconds)
-    {
-        Assert.Equal(TimeSpan.FromSeconds(expectedSeconds), LocalDataService.ResolveWriteLockBudget(declared));
     }
 
     /// <summary>
@@ -203,6 +217,27 @@ public sealed class WriteLockBudgetTests
     }
 
     /// <summary>
+    /// A declaration is honoured only when it is usable, and every unusable shape resolves the app's budget
+    /// rather than disabling the wait. Losing dispatcher protection is the failure worth refusing; a host
+    /// that merely fails to lengthen its own wait gets a flake back, which is loud.
+    /// </summary>
+    [Theory]
+    [InlineData(null, 5d)]
+    [InlineData("", 5d)]
+    [InlineData("   ", 5d)]
+    [InlineData("later", 5d)]
+    [InlineData("0", 5d)]
+    [InlineData("-30", 5d)]
+    /* A project file is not written in the machine's locale, so a decimal comma is not a decimal point. */
+    [InlineData("1,5", 5d)]
+    [InlineData("120", 120d)]
+    [InlineData("0.5", 0.5d)]
+    public void OnlyAUsableDeclarationDisplacesTheDefault(string? declared, double expectedSeconds)
+    {
+        Assert.Equal(TimeSpan.FromSeconds(expectedSeconds), LocalDataService.ResolveWriteLockBudget(declared));
+    }
+
+    /// <summary>
     /// The parse reads the project file's spelling, not the machine's. A build agent or a workstation with a
     /// comma-decimal locale must resolve the same budget as this one, and the only way to tell an invariant
     /// parse from an ambient one is to make the ambient culture disagree.
@@ -268,9 +303,7 @@ public sealed class WriteLockBudgetTests
 
         return new[] { "*.csproj", "*.props", "*.targets" }
             .SelectMany(pattern => Directory.EnumerateFiles(root, pattern, options))
-            .Where(f => !Relative(f).Split('/').Any(segment =>
-                segment.Equals("bin", StringComparison.OrdinalIgnoreCase) ||
-                segment.Equals("obj", StringComparison.OrdinalIgnoreCase)));
+            .Where(f => !IsBuildOutput(f));
     }
 
     private static string Relative(string full) =>
@@ -294,41 +327,170 @@ public sealed class WriteLockBudgetTests
     }
 
     /// <summary>
-    /// Per test file that takes the write lock with no timeout, the largest wall-clock literal it contains.
+    /// The durations named at every wait in every test file that takes the write lock with no timeout, plus
+    /// the sites whose duration could not be read.
+    ///
+    /// <para>Recursive, matching <see cref="BuildFiles"/>: <c>Lite.Tests</c> has subdirectories, and a helper
+    /// under one of them taking this lock would otherwise never be scanned at all.</para>
     /// </summary>
-    private static Dictionary<string, TimeSpan> DeliberateHolds()
+    private static (Dictionary<string, TimeSpan> Holds, List<string> Unreadable) ScanDeliberateHolds()
     {
         var holds = new Dictionary<string, TimeSpan>(StringComparer.Ordinal);
-        var testDirectory = Path.Combine(ParitySource.RepoRoot(), "Lite.Tests");
+        var unreadable = new List<string>();
+        var options = new EnumerationOptions { RecurseSubdirectories = true, IgnoreInaccessible = true };
 
-        foreach (var file in Directory.EnumerateFiles(testDirectory, "*.cs", SearchOption.TopDirectoryOnly))
+        foreach (var file in Directory.EnumerateFiles(
+            Path.Combine(ParitySource.RepoRoot(), "Lite.Tests"), "*.cs", options))
         {
-            var source = File.ReadAllText(file);
-            if (!Regex.IsMatch(source, @"AcquireWriteLock\(\s*\)"))
+            if (IsBuildOutput(file))
             {
                 continue;
             }
 
-            var longest = Waits(source).DefaultIfEmpty(TimeSpan.Zero).Max();
-            holds[Path.GetFileName(file)] = longest;
+            var code = CSharpSourceWalker.StripCommentsAndStrings(File.ReadAllText(file));
+            if (!Regex.IsMatch(code, @"AcquireWriteLock\(\s*\)"))
+            {
+                continue;
+            }
+
+            var name = Path.GetFileName(file);
+            var durations = new List<TimeSpan>();
+            var namedDurations = new HashSet<string>(StringComparer.Ordinal);
+
+            /* TimeSpan.From*(literal), wherever it appears: it is also how a named hold constant such as
+               StatusBarSizeReadLockTests.WriteLockHold gets its value, so taking the file's maximum counts
+               the constant without having to resolve the identifier at its use site. */
+            foreach (Match constructed in Regex.Matches(code, ConstructedDurationPattern))
+            {
+                if (TryScale(constructed.Groups["unit"].Value, constructed.Groups["value"].Value, out var span))
+                {
+                    durations.Add(span);
+                    var declared = Regex.Match(
+                        constructed.Value,
+                        @"^(?<name>\w+)\s*=",
+                        RegexOptions.None);
+                    if (declared.Success)
+                    {
+                        namedDurations.Add(declared.Groups["name"].Value);
+                    }
+                }
+                else
+                {
+                    unreadable.Add($"{name}: {Collapse(constructed.Value)}");
+                }
+            }
+
+            foreach (Match declaration in Regex.Matches(code, DurationConstantPattern))
+            {
+                namedDurations.Add(declaration.Groups["name"].Value);
+            }
+
+            foreach (Match site in Regex.Matches(code, WaitSitePattern))
+            {
+                var arguments = site.Groups["args"].Value;
+                var first = FirstArgument(arguments);
+
+                if (first.Length == 0)
+                {
+                    /* Nothing readable in the first position. With further arguments behind it that is a
+                       separator-shaped call the walker blanked — string.Join, not Thread.Join — and not a
+                       wait at all. Alone, it is a wait with no bound, which no hold of this lock may be. */
+                    if (arguments.Contains(',', StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    unreadable.Add($"{name}: {Collapse(site.Value)} names no duration");
+                    continue;
+                }
+
+                if (double.TryParse(first, NumberStyles.Float, CultureInfo.InvariantCulture, out var milliseconds))
+                {
+                    /* Wait, Join, Sleep and Delay all take bare milliseconds, which is the spelling that
+                       used to read as no hold. */
+                    durations.Add(TimeSpan.FromMilliseconds(milliseconds));
+                    continue;
+                }
+
+                /* A constructed duration was already counted above; a named one is counted through its
+                   declaration. Anything else is a duration this scan cannot see the value of. */
+                if (!first.Contains("TimeSpan.", StringComparison.Ordinal) && !namedDurations.Contains(first))
+                {
+                    unreadable.Add($"{name}: {Collapse(site.Value)}");
+                }
+            }
+
+            holds[name] = durations.Count == 0 ? TimeSpan.Zero : durations.Max();
         }
 
-        return holds;
+        return (holds, unreadable);
     }
 
-    private static IEnumerable<TimeSpan> Waits(string source)
+    /// <summary><c>TimeSpan.From&lt;unit&gt;(&lt;value&gt;)</c>, with one level of nesting allowed inside the
+    /// argument so a non-literal argument is captured rather than skipped.</summary>
+    private const string ConstructedDurationPattern =
+        @"(?:(?<name>\w+)\s*=\s*)?TimeSpan\.From(?<unit>Days|Hours|Minutes|Seconds|Milliseconds|Ticks)" +
+        @"\(\s*(?<value>(?:[^()]|\([^()]*\))*?)\s*\)";
+
+    /// <summary>A field or local bound to a constructed duration, so a wait naming it reads as bounded.</summary>
+    private const string DurationConstantPattern =
+        @"\b(?<name>\w+)\s*=\s*TimeSpan\.From(?:Days|Hours|Minutes|Seconds|Milliseconds|Ticks)\(";
+
+    /// <summary>The calls that make a hold last: a wait, a join, a sleep, a delay, or a timed lock entry.</summary>
+    private const string WaitSitePattern =
+        @"\.(?:Wait|WaitAsync|WaitOne|Join|Sleep|Delay|TryEnterWriteLock|TryEnterReadLock)" +
+        @"\(\s*(?<args>(?:[^()]|\([^()]*\))*?)\s*\)";
+
+    private static bool TryScale(string unit, string value, out TimeSpan span)
     {
-        foreach (Match m in Regex.Matches(source, @"TimeSpan\.FromSeconds\(\s*([0-9]+(?:\.[0-9]+)?)\s*\)"))
-            yield return TimeSpan.FromSeconds(double.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture));
+        span = TimeSpan.Zero;
+        if (!double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var magnitude))
+        {
+            return false;
+        }
 
-        foreach (Match m in Regex.Matches(source, @"TimeSpan\.FromMinutes\(\s*([0-9]+(?:\.[0-9]+)?)\s*\)"))
-            yield return TimeSpan.FromMinutes(double.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture));
-
-        foreach (Match m in Regex.Matches(source, @"TimeSpan\.FromMilliseconds\(\s*([0-9]+(?:\.[0-9]+)?)\s*\)"))
-            yield return TimeSpan.FromMilliseconds(double.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture));
-
-        /* Thread.Join takes bare milliseconds, and it is how two of the holders bound their own wait. */
-        foreach (Match m in Regex.Matches(source, @"\.Join\(\s*([0-9]+)\s*\)"))
-            yield return TimeSpan.FromMilliseconds(double.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture));
+        span = unit switch
+        {
+            "Days" => TimeSpan.FromDays(magnitude),
+            "Hours" => TimeSpan.FromHours(magnitude),
+            "Minutes" => TimeSpan.FromMinutes(magnitude),
+            "Seconds" => TimeSpan.FromSeconds(magnitude),
+            "Milliseconds" => TimeSpan.FromMilliseconds(magnitude),
+            _ => TimeSpan.FromTicks((long)magnitude),
+        };
+        return true;
     }
+
+    /// <summary>The first argument of a call, respecting one level of nesting.</summary>
+    private static string FirstArgument(string arguments)
+    {
+        var depth = 0;
+        for (var i = 0; i < arguments.Length; i++)
+        {
+            var character = arguments[i];
+            if (character == '(')
+            {
+                depth++;
+            }
+            else if (character == ')')
+            {
+                depth--;
+            }
+            else if (character == ',' && depth == 0)
+            {
+                return arguments[..i].Trim();
+            }
+        }
+
+        return arguments.Trim();
+    }
+
+    /// <summary>One line, for a failure message: the walker leaves blanks where it removed text.</summary>
+    private static string Collapse(string text) =>
+        Regex.Replace(text, @"\s+", " ").Trim();
+
+    private static bool IsBuildOutput(string path) =>
+        Relative(path).Split('/').Any(segment =>
+            segment.Equals("bin", StringComparison.OrdinalIgnoreCase) ||
+            segment.Equals("obj", StringComparison.OrdinalIgnoreCase));
 }

--- a/Lite.Tests/WriteLockBudgetTests.cs
+++ b/Lite.Tests/WriteLockBudgetTests.cs
@@ -134,7 +134,7 @@ public sealed class WriteLockBudgetTests
     /// can: <c>NumberStyles.Float</c> admits exponents and .NET parses the invariant <c>Infinity</c>
     /// symbol whatever the style, so <c>"1e300"</c> and <c>"Infinity"</c> arrive as positive doubles that
     /// overflow <see cref="TimeSpan.FromSeconds"/>. Out of a static initializer that is a
-    /// <see cref="TypeInitializationException"/> on the first store call anywhere in the process, which
+    /// <c>TypeInitializationException</c> on the first store call anywhere in the process, which
     /// is strictly worse than the timeout it replaces. Positivity alone does not reach it — it bounds the
     /// other end.</para>
     ///

--- a/Lite/Database/DuckDbInitializer.cs
+++ b/Lite/Database/DuckDbInitializer.cs
@@ -85,8 +85,10 @@ public class DuckDbInitializer
     /// timeout waits behind an archival for however long the archival takes. Eleven current callers do
     /// that, and can: they are alert-sweep and mute-CRUD paths whose failures are caught, logged and
     /// non-fatal. <c>LocalDataService.OpenWriteConnectionAsync</c> is the one that cannot, because it is on
-    /// the path the UI thread awaits, so it passes 5 seconds and #2208's maintenance block treats the
-    /// timeout as "skip this cycle". If you are adding a caller, decide which of those two you are.</para>
+    /// the path the UI thread awaits, so it passes <c>LocalDataService.WriteLockBudget</c> — five seconds
+    /// in the shipped app, and whatever a host with no dispatcher to protect states instead — and #2208's
+    /// maintenance block treats the timeout as "skip this cycle". If you are adding a caller, decide which
+    /// of those two you are.</para>
     /// </summary>
     private static readonly ReaderWriterLockSlim s_dbLock = new(LockRecursionPolicy.NoRecursion);
 

--- a/Lite/Services/LocalDataService.cs
+++ b/Lite/Services/LocalDataService.cs
@@ -68,6 +68,20 @@ public partial class LocalDataService
     internal const string WriteLockBudgetConfigKey = "PerformanceMonitorLite.WriteLockBudgetSeconds";
 
     /// <summary>
+    /// The largest budget a host can state. A wait that outlives the process or the job containing it
+    /// cannot produce <see cref="OpenWriteConnectionAsync"/>'s timeout at all — something else kills the
+    /// run first — so beyond this a declared budget is indistinguishable from no timeout, and being short
+    /// of forever is the whole reason there is a number here. It is also what keeps the resolver total:
+    /// <c>NumberStyles.Float</c> admits exponents, and .NET parses the invariant <c>Infinity</c> symbol
+    /// whatever the style, so <c>1e300</c> and <c>Infinity</c> both reach
+    /// <see cref="TimeSpan.FromSeconds"/> as positive doubles that overflow it. Out of a static
+    /// initializer that throw is a <see cref="TypeInitializationException"/> on the first store call in
+    /// the process — worse than the timeout it would be replacing, and a third outcome besides "the wait
+    /// succeeded" and "fail loudly".
+    /// </summary>
+    internal static readonly TimeSpan MaxWriteLockBudget = TimeSpan.FromHours(1);
+
+    /// <summary>
     /// How long <see cref="OpenWriteConnectionAsync"/> waits for the write lock in THIS host.
     ///
     /// <para><b>The wait belongs to the host, because the thing it protects does.</b>
@@ -93,22 +107,38 @@ public partial class LocalDataService
         ResolveWriteLockBudget(AppContext.GetData(WriteLockBudgetConfigKey));
 
     /// <summary>
-    /// The seconds a host declared, as a budget. Absent, unparseable and non-positive all resolve
+    /// The seconds a host declared, as a budget. Absent, unparseable, non-positive, above
+    /// <see cref="MaxWriteLockBudget"/>, and small enough to round away all resolve
     /// <see cref="DefaultWriteLockBudget"/>: the failure worth guarding against is a host quietly losing
-    /// its dispatcher protection, not a host quietly gaining a longer wait.
+    /// its dispatcher protection, not a host quietly gaining a longer wait. TOTAL — every input returns a
+    /// budget in <c>(TimeSpan.Zero, MaxWriteLockBudget]</c> and none throws, which matters because this
+    /// runs in a static initializer, where an exception takes the whole type down rather than one call.
     ///
     /// <para>Takes the raw value rather than reading the key itself, so the parse can be exercised without
     /// a second host. MSBuild types it as a JSON number in <c>runtimeconfig.json</c> and the host hands it
     /// back as a string, which is why it is parsed rather than cast — and parsed against the invariant
     /// culture, because a project file is not written in the machine's locale.</para>
+    ///
+    /// <para>The upper bound is not <see cref="TimeSpan"/>'s representable range, which reaches roughly
+    /// 29,000 years: a budget that large parses, converts and then makes a wedged lock hang for the life
+    /// of the process, turning a loud failure into a silent one. The bound has to mean something for the
+    /// refusal to be worth having.</para>
     /// </summary>
     internal static TimeSpan ResolveWriteLockBudget(object? configured)
     {
         if (configured is string declared &&
             double.TryParse(declared, NumberStyles.Float, CultureInfo.InvariantCulture, out var seconds) &&
-            seconds > 0)
+            seconds > 0 &&
+            seconds <= MaxWriteLockBudget.TotalSeconds)
         {
-            return TimeSpan.FromSeconds(seconds);
+            /* The BUDGET is what gets checked, not the number that produced it. A positive double under
+               the ceiling can still round to TimeSpan.Zero - double.Epsilon does - and a zero timeout is
+               TryEnterWriteLock giving up without waiting, which is a budget in name only. */
+            var budget = TimeSpan.FromSeconds(seconds);
+            if (budget > TimeSpan.Zero)
+            {
+                return budget;
+            }
         }
 
         return DefaultWriteLockBudget;

--- a/Lite/Services/LocalDataService.cs
+++ b/Lite/Services/LocalDataService.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Numerics;
@@ -53,8 +54,69 @@ public partial class LocalDataService
     }
 
     /// <summary>
-    /// Creates and opens a DuckDB connection wrapped in an exclusive write lock, with a 5-second timeout
-    /// so the UI thread cannot freeze behind an in-flight archival.
+    /// The write-lock wait <see cref="OpenWriteConnectionAsync"/> gets in a host that declares none: what a
+    /// WPF dispatcher can afford to spend before <see cref="GetDatabaseStateDeviationsAsync"/> skips a
+    /// maintenance cycle rather than stall the window. The shipped app declares none, so this is the app's.
+    /// </summary>
+    internal static readonly TimeSpan DefaultWriteLockBudget = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// The runtime configuration property a host sets, in seconds, to state its own
+    /// <see cref="WriteLockBudget"/>. Declared as a <c>RuntimeHostConfigurationOption</c> in the host's
+    /// project file, which lands it in that host's <c>runtimeconfig.json</c>.
+    /// </summary>
+    internal const string WriteLockBudgetConfigKey = "PerformanceMonitorLite.WriteLockBudgetSeconds";
+
+    /// <summary>
+    /// How long <see cref="OpenWriteConnectionAsync"/> waits for the write lock in THIS host.
+    ///
+    /// <para><b>The wait belongs to the host, because the thing it protects does.</b>
+    /// <c>DuckDbInitializer.s_dbLock</c> is process-wide, so an acquisition here queues behind every other
+    /// holder in the process however few rows it means to touch, and a dispatcher awaiting this call cannot
+    /// afford an unbounded queue — which is the entire reason this one caller passes a timeout while the
+    /// app's other write-lock callers pass none. A host with no dispatcher to protect is in the position of
+    /// those other callers: waiting is the correct answer, and expiring is the wrong one.</para>
+    ///
+    /// <para>So the host states it in its own project file, where the value is fixed before <c>Main</c> and
+    /// out of reach of anything that runs afterwards. That matters more than it looks: this number governs
+    /// every caller in the process at once, so a settable static would let one component — or one test —
+    /// put every concurrent neighbour on whatever fuse it picked, which is a smaller copy of the problem
+    /// rather than a fix for it.</para>
+    ///
+    /// <para><c>Lite.Tests</c> is the host that declares one. Its classes hold their own DuckDB files but
+    /// share this lock, several of its test methods take the exclusive lock deliberately and hold it for
+    /// seconds while they assert on timing, and its acquisitions have no dispatcher behind them. Its budget
+    /// is two minutes — orders of magnitude above the holds its own suite takes, and still short enough to
+    /// fail loudly, with this method's own message, if a holder wedges rather than merely being slow.</para>
+    /// </summary>
+    internal static readonly TimeSpan WriteLockBudget =
+        ResolveWriteLockBudget(AppContext.GetData(WriteLockBudgetConfigKey));
+
+    /// <summary>
+    /// The seconds a host declared, as a budget. Absent, unparseable and non-positive all resolve
+    /// <see cref="DefaultWriteLockBudget"/>: the failure worth guarding against is a host quietly losing
+    /// its dispatcher protection, not a host quietly gaining a longer wait.
+    ///
+    /// <para>Takes the raw value rather than reading the key itself, so the parse can be exercised without
+    /// a second host. MSBuild types it as a JSON number in <c>runtimeconfig.json</c> and the host hands it
+    /// back as a string, which is why it is parsed rather than cast — and parsed against the invariant
+    /// culture, because a project file is not written in the machine's locale.</para>
+    /// </summary>
+    internal static TimeSpan ResolveWriteLockBudget(object? configured)
+    {
+        if (configured is string declared &&
+            double.TryParse(declared, NumberStyles.Float, CultureInfo.InvariantCulture, out var seconds) &&
+            seconds > 0)
+        {
+            return TimeSpan.FromSeconds(seconds);
+        }
+
+        return DefaultWriteLockBudget;
+    }
+
+    /// <summary>
+    /// Creates and opens a DuckDB connection wrapped in an exclusive write lock, bounded by
+    /// <see cref="WriteLockBudget"/> so the UI thread cannot freeze behind an in-flight archival.
     ///
     /// <para><b>This doc comment used to say "use for UPDATE/DELETE/INSERT operations that must not race
     /// with archival or compaction", and was read as the house rule for the whole app (#2463).</b> It is
@@ -66,14 +128,14 @@ public partial class LocalDataService
     /// <c>DuckDbInitializer.s_dbLock</c>; the fourteen callers here are UPDATE, DELETE and #2208's
     /// multi-statement maintenance block, and all of them sit on the right side of it.</para>
     ///
-    /// <para>The 5-second timeout is this method's own contribution and is not part of the lock rule:
-    /// every other write-lock caller in the app waits indefinitely, which they can afford and the UI
-    /// thread cannot. See <see cref="LocalDataService.GetDatabaseStateDeviationsAsync"/> for what a
-    /// caller does when it expires.</para>
+    /// <para>The timeout is this method's own contribution and is not part of the lock rule: every other
+    /// write-lock caller in the app waits indefinitely, which they can afford and the UI thread cannot.
+    /// See <see cref="LocalDataService.GetDatabaseStateDeviationsAsync"/> for what a caller does when it
+    /// expires.</para>
     /// </summary>
     internal async Task<LockedConnection> OpenWriteConnectionAsync()
     {
-        var writeLock = _duckDb.AcquireWriteLock(timeout: TimeSpan.FromSeconds(5));
+        var writeLock = _duckDb.AcquireWriteLock(timeout: WriteLockBudget);
         try
         {
             var connection = _duckDb.CreateConnection();

--- a/Lite/Services/LocalDataService.cs
+++ b/Lite/Services/LocalDataService.cs
@@ -75,7 +75,7 @@ public partial class LocalDataService
     /// <c>NumberStyles.Float</c> admits exponents, and .NET parses the invariant <c>Infinity</c> symbol
     /// whatever the style, so <c>1e300</c> and <c>Infinity</c> both reach
     /// <see cref="TimeSpan.FromSeconds"/> as positive doubles that overflow it. Out of a static
-    /// initializer that throw is a <see cref="TypeInitializationException"/> on the first store call in
+    /// initializer that throw is a <c>TypeInitializationException</c> on the first store call in
     /// the process — worse than the timeout it would be replacing, and a third outcome besides "the wait
     /// succeeded" and "fail loudly".
     /// </summary>


### PR DESCRIPTION
`LocalDataService.OpenWriteConnectionAsync` is the one write-lock caller in Lite that passes a timeout, and its own remarks say why: it sits on the path a WPF dispatcher awaits, so it cannot afford the unbounded wait the app's other nineteen write-lock acquisitions take. `DuckDbInitializer.s_dbLock` is process-wide. Put those two facts in a host with no dispatcher and the timeout is protecting nobody while still deciding outcomes — a store call queues behind every other class in the process and then fails on a budget sized for a user who is not there.

The budget now resolves from a runtime configuration property the host declares in its own project file. The shipped app declares none and resolves `LocalDataService.DefaultWriteLockBudget`, five seconds, unchanged. `Lite.Tests` declares 120 seconds, so an acquisition queued behind a neighbour's deliberate hold waits it out instead of expiring inside it.

## Why the wait is now bounded rather than merely luckier

Four test methods in three classes take the process-wide lock EXCLUSIVELY and hold it while they assert on timing — `AnalysisPassTokenThreadingTests.TheReadLockWaitIsAbandonableWhileAWriterHoldsIt` (holder net 30 s), `StatusBarSizeReadLockTests.GetUsedDataSizeMb_WhenTheWriteLockIsHeld_GivesUpInsteadOfBlocking` (15 s), and `DismissReliabilityTests`' two `WriteLock_*` methods (2 s each). Every one of those nets is a safety valve on an event wait, so the hold length is decided by scheduling rather than by the ceiling, and three of the four ceilings sit at or above five seconds. Their file-wise maxima sum to 47 s, which is the most that can queue in front of one acquisition; 120 s clears it by 2.5x. Two pins carry that. `EveryDeliberateHoldInThisSuiteIsReadable` requires every duration-shaped call site in a holder file to be one the scan can READ, and `TheBudgetOutlastsEveryDeliberateHoldInThisSuite` derives the sum from the suite's own source on every run rather than restating it. The readability pin is what makes the sum a measurement rather than a shape: a spelling outside the recognised set does not go uncounted, it joins the population and contributes zero, so an unreadable duration fails loudly instead.

Short of infinite on purpose: a genuinely wedged lock — the leaked-reader failure `DuckDbInitializer.LockReleaser` documents — still fails, with this method's own message, instead of hanging the step.

It does not hide a product regression that the old budget would have caught. A five-second fuse that fires in 1 of 194 runs is a coin flip rather than a detector, and the tests that exist to pin lock-hold behaviour pass their own explicit timeouts — `DismissReliabilityTests`' 50 ms and 100 ms, `DuckDbInitializer.StatusBarReadLockTimeout`'s 100 ms — none of which this touches. A product path that genuinely started holding the lock for tens of seconds would show up as suite duration, which is measured here to the second.

## The two measurements the issue asked for, and how they were taken

**A shared collection costs the Lite suite +186 s, roughly doubling the step.** Measured on one runner, one commit, back to back, by running the suite twice in the `build` job — once normally, once with `-parallel none` — and uploading both TRX files (run [34122782002](https://github.com/erikdarlingdata/PerformanceMonitor/actions/runs/34122782002); the instrumentation is commit `65b4065af`, reverted in `9446d754e`, so it is not in this diff). Parallel span 231.7 s, fully serialised 449.3 s: **+217.6 s, 1.94x**, at an effective 2.90-way parallelism. Those two ratios are different quantities and neither is derived from the other: 2.90 is observed concurrency (summed per-test durations over the parallel span), 1.94 is end-to-end speedup. The +186 s below rests on the summed per-class intervals rather than on either ratio. Charging each class the serialised interval since the previous test ended — which bills it for its own fixture schema build — the 75 classes that touch `s_dbLock` carry **417.9 s of that 449.3 s, 93.0%**. Leaving the other 232 classes parallel recovers only ~21 s, so a collection over the set that would actually have to be in it lands at **≈418 s: +186 s, 1.80x**, which would put the step's new median above today's p95 (389 s). That +186 s is a LOWER bound on option 1 rather than an estimate of it: the per-class costs come from a run with no contention at all, while a collection would still have 232 classes running alongside it.

**The timeout fires in 1 of 194 runs, 0.52%.** Across the last 300 `build.yml` runs (2026-09-05T13:17Z to 2026-09-07T10:14Z, ~45 h) the `Run Lite tests` step executed 194 times — 63 skipped by the path gate, 41 cancelled by a re-push. Five of the 194 failed, and reading each failure's log: two were genuine pin failures (`WatermarkPolicyTests`, `CrossAppMcpToolInventoryPinTests`), two were `CrossAppGuardCiGateTests` file-in-use `IOException`s, and **exactly one was this timeout** — run [34091806113](https://github.com/erikdarlingdata/PerformanceMonitor/actions/runs/34091806113), whose 487 s step sits at **p97.9** of the 194 step durations against a p50 of 262 s. It is a slow-runner failure, and four runs that were slower still passed.

## The choice, against those figures

The collection was not chosen, and cost is the second reason rather than the first. **As scoped in the issue it cannot bound the race at all**: `[Collection]` only stops classes in the same collection running concurrently with each other, and three of the four longest holders build their own `DuckDbInitializer` and are not classes of `SharedDuckDbFixture`, so a collection over the store-touching classes leaves the 30 s and 15 s holders running alongside it. `DatabaseStateWriteLockTests`' own remarks already say this — "`DisableParallelization` only orders collections inside the non-parallel bucket — it cannot stop other classes from contending on a static lock". Widening it to all 75 lock-touching classes is what the +186 s buys, and it stays unenforceable: nothing makes the next store test remember to join.

Against that, the host budget costs no wall clock, applies at the one choke point every caller already goes through so no future test class can forget it, and turns the failure into a bounded wait. It also does what `DatabaseStateWriteLockTests` records as needed — "that arm needs the timeout injected, i.e. production shape changed for testability. Left visible rather than implied-covered."

The per-database lock was not chosen either, and what `s_dbLock` protects across instances was established first rather than assumed. The rule on the field says: "ONE lock for the whole process, deliberately: Lite constructs several `DuckDbInitializer` instances over the same file (MainWindow, DatabaseStateOverridesWindow, DuckDbAlertHistoryStore), and making it per-instance would trade a slow test suite for a real data race." So it protects instances over the SAME FILE, and keying it per path would preserve that in an app that has exactly one `App.DatabasePath`. It was still refused: its failure mode is two spellings of one path resolving to two locks, which is silent data corruption rather than a loud timeout — the wrong direction for a mistake to fail in — and it would additionally rewrite the #2463 rule and the four-file source pin (`DuckDbLockModelTests.TheLockRuleIsWrittenWhereEveryCallerAlreadyLooks`) that keeps it findable.

## This is a product change, deliberately

Option 1 would have been test-only; this is not. The measurement is what justifies crossing that line: the test-only option is a permanent +186 s on every Lite run, does not cover the holders it needs to, and cannot be enforced — so "cheaper class of change" was not available at any price worth paying. What crossing it costs is a demonstration that the app is unchanged, and that is what the first two pins are for: `OnlyTheTestHostDeclaresABudget` scans every `.csproj`, `.props` and `.targets` in the repo outside build output and requires that `Lite.Tests/Lite.Tests.csproj` is the only one naming the key — whole-tree, because a shared `Directory.Build.props` would reach the shipped app just as effectively as its own project file — and `TheAppKeepsTheDispatchersFiveSeconds` pins the value a host that declares nothing resolves.

`ThisHostResolvedTheBudgetItsProjectFileDeclares` is the one that catches a seam that is wired but inert. A property that never reaches `AppContext` resolves the default silently, which is indistinguishable from the pre-change behaviour and would leave the flake in place with every other pin green; so the expected value is read out of the project file and compared against what the running host resolved, and the budget is additionally required to differ from the default, because matching the default is exactly what a dead seam looks like.

## The seam had a third outcome, at both ends

Review caught that the resolver bounded the wrong end, and it bears directly on the thesis above: the argument for this change is that a budget either lets the wait succeed or fails loudly, and a declared value that throws during resolution is neither. `NumberStyles.Float` admits exponents and .NET parses the invariant `Infinity` symbol whatever the style, so `"1e300"` and `"Infinity"` arrive as positive doubles and overflow `TimeSpan.FromSeconds`. Out of a static initializer that is a `TypeInitializationException` on the first store call anywhere in the process — strictly worse than the timeout it replaces. `seconds > 0` is mutation-tested and bounds the other end.

Fixed rather than justified, and the fix is not the obvious one. **Bounding by `TimeSpan`'s representable range would have been wrong**: measured, `TimeSpan.MaxValue.TotalSeconds` is 9.22e11 — about 29,000 years, not the 9.22e14 an eye-estimate gives — and `FromSeconds` of it round-trips without complaint. That bound accepts a budget which makes a wedged lock hang for the life of the process, converting the loud failure into a silent one. So the ceiling is one hour, on the ground that a wait outliving the process or the job containing it cannot produce this method's timeout at all, and being short of forever is the whole reason there is a number.

**Writing the hostile-input pin then found the same hole at the low end**, which neither the review nor the original guard covered: `double.Epsilon` (`"5E-324"`) parses, is positive, is far under any ceiling, and `TimeSpan.FromSeconds` rounds it to `TimeSpan.Zero` — a timeout that gives up without waiting, a budget in name only. So the resolver now checks **the `TimeSpan` it constructed, not the double it parsed**, which is the shape that catches both ends by construction rather than by enumerating them.

The framework exception is named as prose rather than as a cref throughout, which `DocCommentHygieneTests` requires: a cref names a symbol this repository spells, and `TypeInitializationException` is declared nowhere here. The two mentions that predate this change both spell it `<c>`.

Two pins, and they are not redundant. `TheResolverIsTotalAndAlwaysReturnsAUsableBudget` asserts over hostile inputs that resolution never throws and never leaves `(TimeSpan.Zero, MaxWriteLockBudget]`. `TheCeilingIsAcceptedAndAnythingPastItResolvesTheDefault` derives both figures from the constant. **Setting the ceiling to `TimeSpan.MaxValue` leaves the totality pin GREEN** — nothing throws and everything is in-band once the band is 29,000 years wide — and only the ceiling pin reds. The totality pin alone would have accepted the bound that was wrong.

## The derivation claimed to round up. It rounded down, twice.

Review turned the "what legal spelling would this miss" question on the scan I wrote and found two gaps, both in the unsafe direction — which falsifies the justification I gave for the bound, not merely its coverage.

**It searched only the top level of `Lite.Tests` while the build-file scan recursed.** `Lite.Tests/Helpers/` already exists with `.cs` files, so a helper there taking the write lock would never be scanned. Verified with a positive control: the same 200 s holder placed under `Helpers/` reds the bound with recursion on, and with recursion off is **entirely invisible** — 31 green, no finding at all.

**The worse one is a different failure: a zero that looks like a measurement.** The scan read `TimeSpan.From*` and `.Join(<int>)` but not a bare-millisecond `.Wait(30000)`. Such a file still matches the write-lock scan, so it joins the population and contributes `TimeSpan.Zero` through `DefaultIfEmpty`. Measured against the old parser: `gate.Wait(TimeSpan.FromSeconds(30))` scores **30.0 s** and `gate.Wait(30000)` scores **0.0 s** — the same thirty-second hold, one visible and one reporting itself as no hold at all. Gap one omits a file; gap two names a population it did not measure, which is worse.

Fixed structurally rather than by documenting the blind spots, because a labelled wrong sum is still a wrong sum. **The scan now recurses, reads the bare-millisecond spellings, and reports a duration it cannot read as a FAILURE rather than a zero** — so a file with no duration site at all remains a real zero (it holds the lock across straight-line code) and stays distinguishable from a file whose duration was unreadable. That distinction is what was missing, and it is the same move as checking the `TimeSpan` the resolver constructed instead of the double it parsed: make the derivation total rather than enumerate the ways it can be wrong.

It reads `CSharpSourceWalker.StripCommentsAndStrings` — the shared walk this project already compiles in, rather than a fifth private copy — so a duration written in a comment cannot raise the bar and `string.Join` is not mistaken for `Thread.Join`. That is load-bearing: reading raw text instead reds the readability pin on exactly that `string.Join`.

The bar itself is unchanged at 47 s, so the 120 s budget and its 2.5x margin stand. What changed is that the figure is now a measurement of a population the scan can actually see.

## Two figures worth accounting for before they are read as evidence

**`Lite.Tests Total` 3437 to 3457 is fully accounted and none of it is drift.** The issue quotes 3437 from an older `dev`; at this branch's measurement base (`641c4db7f`) the suite was already **3441**, measured on both passes of run 34122782002. `WriteLockBudgetTests` adds seven `[Fact]` plus nine `[Theory]` cases — sixteen — and 3441 + 16 = 3457 exactly. The two dev merges in this branch brought only `Darling/Darling.Tests` changes (assertion shapes in eight files, then `RepoFileAdoptionTests`), which move no Lite count.

**The suite did not get twice as fast; the 485 s in the issue is the outlier.** Across the 194 executions the step's p50 is 262 s and its p90 is 346 s; the failing run the issue was filed from sits at p97.9. On one runner, back to back, this branch measured 231.9 s parallel and 449.4 s serialised, and the 259.8 s run is the median of the population, not a halving of it. Nothing in this diff changes how the suite is invoked: `.github/workflows/build.yml` is byte-identical to `dev` (`git diff origin/dev -- .github/workflows/build.yml` is empty). The instrumentation commit did alter the invocation — a `-trx` argument and a second `-parallel none` pass — and that is precisely why it is not in this diff.

**Instrumenting the workflow did not break a guard that reads the workflow.** Both passes of the instrumented run reported `Failed: 0` with `build.yml` modified, so the measurement was taken on a green suite and is not a reading off a failing one. `CrossAppGuardCiGateTests` does read `build.yml` — in `EveryCrossAppSourceRead_IsReachableByTheFilterThatGatesItsSuite`, which stayed green throughout — and the arm that failed later reads project files, not workflows.

## One self-inflicted red, isolated

The first push of this fix failed `CrossAppGuardCiGateTests.TheEvaluatedSet_ContainsEverythingAParseOfTheSameXmlFinds` with `Set: []` (run 34124608714), and it was this change rather than the class's known parallelism flake — which is a file-in-use `IOException` in a different method. **The empty set at line 878 is `parsedCross`, the CRUDE XML PARSE side, not the evaluated side.** `ParsedProjectXmlPaths` scans with `"(?<dq>[^"]*)"|'(?<sq>[^']*)'|>(?<text>[^<>]*)<`, so an apostrophe is an attribute delimiter: the five in the new project-file comment left the pairing unbalanced and swallowed every quoted attribute value after it, including `Include="..\Darling\Darling.Tests\CSharpSourceWalker.cs"`. Established by a single-variable revert — `Lite.Tests/Lite.Tests.csproj` back to `dev` with everything else unchanged turns the real test green in 0.7 s in a `net10.0` host, and restoring the ItemGroup reds it in 0.3 s — not by re-running. The comment now carries no apostrophe and says why, next to the constraint.

**That guard under-reads, and its own doc says it cannot.** It is written to be crude in the safe direction — "it over-reads — a path inside a comment ... counts — and it under-reads anything needing evaluation" — but an unbalanced apostrophe makes it under-read arbitrary quoted values, which is the unsafe direction, and it reports the result as a moved blind spot rather than as a parse it could not complete. Not touched here: it is a pre-existing defect in a guard with its own issue lineage (#3063, #3074, #3076, #3082), and folding it in would put a change to the cross-app guard inside a write-lock PR. Left as a finding.

## Verification

`Lite.Tests` is `net10.0-windows` and cannot run on macOS, so `Lite.Tests/WriteLockBudgetTests.cs` and `Lite.Tests/ParitySource.cs` were compiled unmodified into a `net10.0` xunit.v3 console host, with the budget members sliced byte-for-byte out of `Lite/Services/LocalDataService.cs` by an extractor that asserts on the real file's text. 31 tests green. Eighteen mutations, each applied and reverted on its own, each verified to have actually landed before the run — one first attempt was a no-op substitution and was redone rather than counted as a pass, and one `--no-build` run reported 28 green off a stale binary while the build was failing, which is why the runner rebuilds every time:

| mutation | red |
| --- | --- |
| `DefaultWriteLockBudget` 5 s to 10 s | `TheAppKeepsTheDispatchersFiveSeconds` + the 7 default-resolving `OnlyAUsableDeclarationDisplacesTheDefault` cases |
| host declaration deleted | `OnlyTheTestHostDeclaresABudget`, `ThisHostResolvedTheBudgetItsProjectFileDeclares` |
| declared 120 changed to 300, host still resolving 120 | `ThisHostResolvedTheBudgetItsProjectFileDeclares` only |
| the app's csproj also declares a budget | `OnlyTheTestHostDeclaresABudget` only |
| call site back to `AcquireWriteLock(timeout: TimeSpan.FromSeconds(5))` | `TheCallSiteTakesTheBudgetRatherThanALiteral` only |
| resolver drops `seconds > 0` | the `"0"` and `"-30"` cases only |
| resolver parses in `CurrentCulture` | `TheDeclarationIsReadInTheInvariantCulture` only |
| resolver accepts any object via `ToString()` | `ANonStringDeclarationResolvesTheDefault` only |
| host budget 120 s to 20 s | `TheBudgetOutlastsEveryDeliberateHoldInThisSuite` only |
| a new test file holding the lock for 200 s | `TheBudgetOutlastsEveryDeliberateHoldInThisSuite` only |
| a 200 s holder under `Lite.Tests/Helpers/` | `TheBudgetOutlasts…` — and nothing at all with recursion off |
| a holder spelling its wait `.Wait(200000)` | `TheBudgetOutlasts…` — scored zero under the old scan |
| a holder whose duration is an opaque identifier | `EveryDeliberateHoldInThisSuiteIsReadable`, naming the site |
| raw text instead of `StripCommentsAndStrings` | `EveryDeliberateHoldInThisSuiteIsReadable` on a `string.Join` |
| upper bound dropped (the review finding) | `TheResolverIsTotal...`, `TheCeilingIsAccepted...` |
| round-to-zero check dropped | `TheResolverIsTotal...` only |
| ceiling set to `TimeSpan.MaxValue` | `TheCeilingIsAccepted...` only — totality stays green |
| positivity guard dropped | `TheResolverIsTotal...` only |

The `RuntimeHostConfigurationOption` to `AppContext.GetData` path was verified separately: MSBuild writes it into `configProperties` as a JSON number and the host hands it back as `System.String`, which is why the resolver parses rather than casts, and an absent key returns null.

The real `CrossAppGuardCiGateTests` was compiled into the same host for the apostrophe diagnosis above; it and `WriteLockBudgetTests` are 30 green together on the merged tree. The parse and overflow behaviour above was measured in the same way rather than reasoned about.

## The sibling flake is a different mechanism, and this does not fix it

`CrossAppGuardCiGateTests.TheEvaluatedRead_FailsLoudlyRatherThanReturningNothing` fails with a file-in-use `IOException` at `CrossAppGuardCiGateTests.cs:811` — the `finally`'s `Directory.Delete(scratch, recursive: true)`. Its last arm deliberately runs `dotnet msbuild` with a 1 ms deadline to prove a hung child fails rather than hangs; `RunDotnet` then does a best-effort `process.Kill(entireProcessTree: true)`, and the delete races the OS releasing the killed tree's handles on that scratch directory. Same family in the sense that a test manufactures an adverse timing condition and then loses to it under runner load, but the contended resource is a filesystem handle rather than `s_dbLock`, so nothing here reaches it — and neither would either of the issue's other two options. It fired twice in the 194 runs (34004387846, 34048086326), so it is the more frequent of the two.

## Left out

- **The #2208 best-effort skip arm is still uncovered.** `DatabaseStateWriteLockTests` records that it needs the timeout injected; a host-wide property is the wrong seam for it, because forcing a short budget to observe the skip would put every parallel neighbour on that fuse — a smaller copy of this defect. Covering it wants a per-instance override, which is a separate change from this one.
- **No pin asserts that a future write-lock caller passes the budget rather than its own literal.** `TheCallSiteTakesTheBudgetRatherThanALiteral` guards the existing call site by text; a second caller with its own `TimeSpan.FromSeconds` would slip past it.

## CHANGELOG entry text

Not applied here — every lane appends to the same `[Unreleased]` block. Under `### Fixed`:

```
- **A UI-thread timeout was deciding `Lite.Tests` outcomes in a host with no UI thread** ([#3134]) - `LocalDataService.OpenWriteConnectionAsync` is the only one of Lite's twenty write-lock acquisitions that passes a timeout, and its own remarks say why: it is on the path a WPF dispatcher awaits. `DuckDbInitializer.s_dbLock` is process-wide, so in the test host that five seconds could expire inside an unrelated class's deliberate hold - four test methods take the lock exclusively and hold it for up to 30 s while they assert on timing, and three of them are not classes of `SharedDuckDbFixture`, so no collection over the store-touching classes reaches them. **The timeout fired in 1 of 194 `Run Lite tests` executions across 300 `build.yml` runs, on a step at p97.9 of the duration distribution (487 s against a p50 of 262 s).** The budget now resolves from a `RuntimeHostConfigurationOption` the host declares: the shipped app declares none and keeps `DefaultWriteLockBudget`'s five seconds, `Lite.Tests` declares 120 s, and the suite's deliberate holds sum to 47 s - so the acquisition waits them out and still fails loudly on a wedged lock. The resolver is total: absent, unparseable, non-positive, above a one-hour ceiling, or small enough to round to `TimeSpan.Zero` all resolve the default, because `NumberStyles.Float` admits exponents and the invariant `Infinity` symbol, and `TimeSpan.FromSeconds` throws on both - out of a static initializer that is a `TypeInitializationException` on every store call, not one timeout. **The alternative was measured rather than argued: one runner, one commit, back to back, the suite ran 231.7 s parallel and 449.3 s with `-parallel none`, and the 75 classes that touch the lock carry 417.9 s of that 449.3 s, so a collection over them costs ~+186 s (1.80x) on every run to prevent one failure in 194.**
```

Needs `[#3134]: https://github.com/erikdarlingdata/PerformanceMonitor/issues/3134` in the link block.
